### PR TITLE
Reject target-typed lambdas with mismatched arity

### DIFF
--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -626,6 +626,15 @@ internal sealed class LambdaBinder
 
         var isAsync = syntax.IsAsync;
         var arityMatchesTarget = targetFunctionType != null && targetFunctionType.Arity == syntax.Parameters.Count;
+        if (targetFunctionType != null && !arityMatchesTarget)
+        {
+            Diagnostics.ReportWrongArgumentCount(
+                syntax.Location,
+                "lambda",
+                targetFunctionType.Arity,
+                syntax.Parameters.Count);
+        }
+
         var parameterTypes = ImmutableArray.CreateBuilder<TypeSymbol>(syntax.Parameters.Count);
         var parameterSymbols = ImmutableArray.CreateBuilder<ParameterSymbol>(syntax.Parameters.Count);
         var seen = new HashSet<string>();

--- a/test/Compiler.Tests/Emit/Issue2918InlineLambdaErasedReceiverTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2918InlineLambdaErasedReceiverTests.cs
@@ -27,8 +27,6 @@ namespace GSharp.Compiler.Tests.Emit;
 /// </summary>
 public class Issue2918InlineLambdaErasedReceiverTests
 {
-    private const int KillGraceMilliseconds = 5_000;
-
     private const string Contracts = """
         using System;
 
@@ -787,35 +785,10 @@ public class Issue2918InlineLambdaErasedReceiverTests
         startInfo.ArgumentList.Add(runtimeConfigPath);
         startInfo.ArgumentList.Add(assemblyPath);
 
-        using var process = Process.Start(startInfo)
-            ?? throw new InvalidOperationException("Failed to start dotnet exec.");
-        var stdoutTask = process.StandardOutput.ReadToEndAsync();
-        var stderrTask = process.StandardError.ReadToEndAsync();
-        _ = stdoutTask.ContinueWith(
-            task => _ = task.Exception,
-            TaskContinuationOptions.OnlyOnFaulted);
-        _ = stderrTask.ContinueWith(
-            task => _ = task.Exception,
-            TaskContinuationOptions.OnlyOnFaulted);
-
-        static string Drain(Task<string> task) =>
-            task.Wait(KillGraceMilliseconds)
-                ? task.Result
-                : "<unavailable: pipe still open after kill>";
-
-        if (!process.WaitForExit(30_000))
-        {
-            process.Kill(entireProcessTree: true);
-            process.WaitForExit(KillGraceMilliseconds);
-            throw new XunitException(
-                $"dotnet exec timed out.\nstdout:\n{Drain(stdoutTask)}\nstderr:\n{Drain(stderrTask)}");
-        }
-
-        var stdout = Drain(stdoutTask);
-        var stderr = Drain(stderrTask);
+        var (exitCode, stdout, stderr) = IlVerifier.RunProcess(startInfo, assemblyPath, 30_000);
         Assert.True(
-            process.ExitCode == 0,
-            $"dotnet exec exited {process.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+            exitCode == 0,
+            $"dotnet exec exited {exitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
         return stdout.Replace("\r\n", "\n", StringComparison.Ordinal);
     }
 

--- a/test/Compiler.Tests/Emit/Issue2918InlineLambdaErasedReceiverTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2918InlineLambdaErasedReceiverTests.cs
@@ -183,6 +183,57 @@ public class Issue2918InlineLambdaErasedReceiverTests
     }
 
     [Fact]
+    public void MismatchedInlineLambdaArityThroughErasedSlot_IsRejected()
+    {
+        const string source = """
+            package LambdaArityErasure
+            import System
+            import System.Collections.Generic
+
+            class Src {
+                let N int32
+                init(n int32) { N = n }
+            }
+
+            func Main() {
+                let callbacks = List[System.Action[Src]]()
+                callbacks.Add((left Src, right Src) -> Console.WriteLine(left.N + right.N))
+            }
+            """;
+
+        var diagnostics = CompileExpectingFailure(source);
+        Assert.Contains(
+            "GS0144: Function 'lambda' requires 1 arguments but was given 2.",
+            diagnostics,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MatchingInlineLambdaArityThroughErasedSlot_VerifyLoadAndRun()
+    {
+        const string source = """
+            package LambdaArityMatch
+            import System
+            import System.Collections.Generic
+
+            class Src {
+                let N int32
+                init(n int32) { N = n }
+            }
+
+            func Main() {
+                let callbacks = List[System.Action[Src]]()
+                callbacks.Add((item Src) -> Console.WriteLine(item.N))
+                callbacks[0](Src(7))
+            }
+            """;
+
+        Assert.Equal(
+            "7\n",
+            CompileVerifyLoadAndRun(source, "LambdaArityMatch.Src"));
+    }
+
+    [Fact]
     public void ImportedGenericConstructor_TargetsInlineLambda_VerifyLoadAndRun()
     {
         const string source = """

--- a/test/Compiler.Tests/Emit/Issue2918InlineLambdaErasedReceiverTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2918InlineLambdaErasedReceiverTests.cs
@@ -27,6 +27,8 @@ namespace GSharp.Compiler.Tests.Emit;
 /// </summary>
 public class Issue2918InlineLambdaErasedReceiverTests
 {
+    private const int KillGraceMilliseconds = 5_000;
+
     private const string Contracts = """
         using System;
 
@@ -789,15 +791,28 @@ public class Issue2918InlineLambdaErasedReceiverTests
             ?? throw new InvalidOperationException("Failed to start dotnet exec.");
         var stdoutTask = process.StandardOutput.ReadToEndAsync();
         var stderrTask = process.StandardError.ReadToEndAsync();
+        _ = stdoutTask.ContinueWith(
+            task => _ = task.Exception,
+            TaskContinuationOptions.OnlyOnFaulted);
+        _ = stderrTask.ContinueWith(
+            task => _ = task.Exception,
+            TaskContinuationOptions.OnlyOnFaulted);
+
+        static string Drain(Task<string> task) =>
+            task.Wait(KillGraceMilliseconds)
+                ? task.Result
+                : "<unavailable: pipe still open after kill>";
+
         if (!process.WaitForExit(30_000))
         {
             process.Kill(entireProcessTree: true);
-            process.WaitForExit();
-            throw new XunitException("dotnet exec timed out.");
+            process.WaitForExit(KillGraceMilliseconds);
+            throw new XunitException(
+                $"dotnet exec timed out.\nstdout:\n{Drain(stdoutTask)}\nstderr:\n{Drain(stderrTask)}");
         }
 
-        var stdout = stdoutTask.GetAwaiter().GetResult();
-        var stderr = stderrTask.GetAwaiter().GetResult();
+        var stdout = Drain(stdoutTask);
+        var stderr = Drain(stderrTask);
         Assert.True(
             process.ExitCode == 0,
             $"dotnet exec exited {process.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");


### PR DESCRIPTION
## Summary
- reject target-typed lambdas when target and syntax arities differ
- reuse existing `GS0144` at `LambdaBinder.BindLambdaExpression`, shared by erased and non-erased target paths
- pin mismatched and matching arities
- reuse shared `IlVerifier.RunProcess` for bounded child execution; no duplicate drain helper or grace constant

Fixes #2937

## Root cause
`src/Core/CodeAnalysis/Binding/LambdaBinder.cs:628` used target parameter types only when arity matched, but silently ignored a mismatched target. Binding then fell back to erased `object`; compiler accepted an incompatible `Action<Src, Src>` for `Action<Src>` and runtime threw `ArgumentException`.

## Verification
Exact base `f70626452d6166811768ab4e500ac589878bd480` versus head `2c7049e64577b036c594e9dc36c25390de7ccde3`, using serial scratch-clone builds and each clone's `out/bin/Release/Compiler/gsc` directly:

| Probe | Base | Head |
|---|---|---|
| mismatched arity | compile exit 0; bounded run exits from `ArgumentException` | compile exit 1, `GS0144` |
| matching arity | compile/run exit 0, stdout `7` | compile/run exit 0, stdout `7` |

Targeted tests, rebuilt without `--no-build`:
- new mismatch + acceptance tests: 2 passed
- complete `Issue2918InlineLambdaErasedReceiverTests`: 13 passed
- rebased head `a1463d22d`: solution build 0 warnings/errors; 0/40 zero-byte Core DLLs; one MD5 group across all 5 ordinary paths

## Semantic mutations
| Mutation | Result |
|---|---|
| remove mismatch diagnostic | killed: mismatch changed `GS0144` to compile exit 0; restore changed back to `GS0144` |
| diagnose matching arity instead | killed: valid program changed stdout `7` to `GS0144`; restore changed back to stdout `7` |

Compiler MD5 round trips were exact: original/restored `41ba2355d9cbd3dea92c243f37f08ac3`; mutants `19b598aec7d030b54536c4caff6d3195` and `7cff7c3f972c35e24f2b5de2ed446ee2`.

## Collision notes
- `src/Core/CodeAnalysis/Binding/LambdaBinder.cs`
- `test/Compiler.Tests/Emit/Issue2918InlineLambdaErasedReceiverTests.cs`

