### PR TITLE
Preserve user TargetInvocationException in interpreter catches

### DIFF
--- a/src/Core/CodeAnalysis/Evaluator.Statements.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Statements.cs
@@ -697,8 +697,9 @@ public sealed partial class Evaluator
     /// EvaluatorException to attach node context (for GS9999 reporting when
     /// nothing catches it). That wrapping must not leak into typed catch
     /// matching or handler-variable binding, so unwrap repeatedly down to the
-    /// innermost real exception. TargetInvocationException (thrown by
-    /// reflection-based CLR calls) gets the same treatment.
+    /// real exception. Reflection-generated TargetInvocationException wrappers
+    /// get the same treatment, while a user-thrown TargetInvocationException
+    /// remains visible to catch matching and handler-variable binding.
     /// </summary>
     private static Exception UnwrapRuntimeException(Exception ex)
     {
@@ -710,7 +711,8 @@ public sealed partial class Evaluator
                 continue;
             }
 
-            if (ex is TargetInvocationException { InnerException: { } tieInner })
+            if (ex is TargetInvocationException { InnerException: { } tieInner } tie
+                && IsReflectionInvocationWrapper(tie))
             {
                 ex = tieInner;
                 continue;
@@ -719,6 +721,9 @@ public sealed partial class Evaluator
             return ex;
         }
     }
+
+    private static bool IsReflectionInvocationWrapper(TargetInvocationException ex)
+        => ex.TargetSite?.DeclaringType?.Assembly == typeof(TargetInvocationException).Assembly;
 
     private static bool TryFindCatchHandler(BoundTryStatement node, Exception ex, out BoundCatchClause matched)
     {

--- a/src/Core/CodeAnalysis/Evaluator.Statements.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Statements.cs
@@ -723,7 +723,8 @@ public sealed partial class Evaluator
     }
 
     private static bool IsReflectionInvocationWrapper(TargetInvocationException ex)
-        => ex.TargetSite?.DeclaringType?.Assembly == typeof(TargetInvocationException).Assembly;
+        => ex.TargetSite?.DeclaringType?.Assembly is not { } assembly
+            || assembly == typeof(TargetInvocationException).Assembly;
 
     private static bool TryFindCatchHandler(BoundTryStatement node, Exception ex, out BoundCatchClause matched)
     {

--- a/test/Interpreter.Tests/Issue2999TargetInvocationExceptionInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2999TargetInvocationExceptionInterpreterTests.cs
@@ -1,0 +1,88 @@
+// <copyright file="Issue2999TargetInvocationExceptionInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #2999: distinguish reflection wrappers from user exceptions.
+/// </summary>
+public class Issue2999TargetInvocationExceptionInterpreterTests
+{
+    [Fact]
+    public void UserThrownTargetInvocationException_IsCatchable()
+    {
+        const string Source = """
+            import System
+            import System.Reflection
+
+            let handler () -> int32 = () -> throw TargetInvocationException(
+                "outer",
+                InvalidOperationException("inner"))
+
+            var caught = false
+            try {
+                handler()
+            } catch (ex TargetInvocationException) {
+                caught = true
+            }
+            caught
+            """;
+
+        var result = Evaluate(Source);
+
+        Assert.Equal(true, result.Value);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void ReflectionWrapper_UnwrapsOnlyToUserTargetInvocationException()
+    {
+        const string Source = """
+            import System
+            import System.Reflection
+            import GSharp.Interpreter.Tests
+
+            var message = ""
+            try {
+                Issue2999ExceptionProbe.ThrowUserTargetInvocationException()
+            } catch (ex TargetInvocationException) {
+                message = ex.Message
+            }
+            message
+            """;
+
+        var result = Evaluate(Source);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("outer", result.Value);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+        => new Compilation(SyntaxTree.Parse(source))
+            .Evaluate(new Dictionary<VariableSymbol, object>());
+}
+
+/// <summary>
+/// CLR exception probes for issue #2999.
+/// </summary>
+public static class Issue2999ExceptionProbe
+{
+    /// <summary>
+    /// Throws a deliberate target-invocation exception.
+    /// </summary>
+    /// <returns>This method never returns.</returns>
+    public static int ThrowUserTargetInvocationException()
+        => throw new TargetInvocationException(
+            "outer",
+            new InvalidOperationException("inner"));
+}

--- a/test/Interpreter.Tests/Issue2999TargetInvocationExceptionInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2999TargetInvocationExceptionInterpreterTests.cs
@@ -67,6 +67,27 @@ public class Issue2999TargetInvocationExceptionInterpreterTests
         Assert.Equal("outer", result.Value);
     }
 
+    [Fact]
+    public void ReflectionWrappedFormatException_IsCatchable()
+    {
+        const string Source = """
+            import System
+
+            var caught = false
+            try {
+                Convert.ToInt32("x")
+            } catch (ex FormatException) {
+                caught = true
+            }
+            caught
+            """;
+
+        var result = Evaluate(Source);
+
+        Assert.Equal(true, result.Value);
+        Assert.Empty(result.Diagnostics);
+    }
+
     private static EvaluationResult Evaluate(string source)
         => new Compilation(SyntaxTree.Parse(source))
             .Evaluate(new Dictionary<VariableSymbol, object>());


### PR DESCRIPTION
## Summary

- Preserve user-thrown `TargetInvocationException` during catch matching and handler binding.
- Continue recursively peeling reflection-created invocation wrappers; unknown/null target metadata defaults to wrapper behavior to preserve existing catches.
- Cover direct user throws, reflection wrappers around user TIEs, and the motivating `FormatException` reflection catch.

## #2995 scope measurement

At #3012 head `fae05b403`, plain `gsi samples/GsharpExtensionsOptional.gs` cannot load `Gsharp.Extensions` and exits `1` with 19 `GS0159` binding errors. Loading the already-built extension assembly into the same `gsi` process before evaluation produced:

```text
ADA
A
default
computed
<filtered out>
present: ada
ada
14
-1
7
count present: 7
```

Saved status: `0`. All 11 output lines match the issue's compiled output. #3012 therefore fixes #2995; this PR contains no #2995 or lambda-lowering changes.

## #2999 before/after

| Repro | Before | After |
|---|---|---|
| Exact user-thrown catch | `Value = null`, diagnostic `outer`, test exit `1` | `Value = true`, no diagnostics, exit `0` |
| Reflection wrapper around user TIE | wrapper diagnostic, exit `1` | caught user exception message `outer`, exit `0` |
| `FormatException` from `Convert.ToInt32("x")` | uncaught wrapper when reflection unwrapping is disabled | caught, `Value = true` |

## Verification

- Targeted tests: 3 examined, 3 passed, exit `0`.
- New `FormatException` test: baseline passed; mutant `IsReflectionInvocationWrapper => false` failed (`expected true`, `actual null`), exit `1`; restored test passed, exit `0`.
- Original unconditional-recursive-unwrapping perturbation: 2 examined, 2 failed, exit `1`; restored: 2 passed, exit `0`.

Fixes #2999
