### PR TITLE
Restore Roslyn fixed-pointer lowering after #2964

### DIFF
--- a/docs/adr/0125-fixed-pinned-statement.md
+++ b/docs/adr/0125-fixed-pinned-statement.md
@@ -112,8 +112,7 @@ brfalse NULL
 ldloc pinned; ldlen; conv.i4; brtrue NOTEMPTY
 NULL:     ldc.i4.0; conv.u; stloc ptr       // empty/null ⇒ null pointer
           br AFTER
-NOTEMPTY: ldloc pinned; ldc.i4.0; ldelema <elem>
-          call void* Unsafe.AsPointer<elem>(ref elem); stloc ptr
+NOTEMPTY: ldloc pinned; ldc.i4.0; ldelema <elem>; conv.u; stloc ptr
 AFTER:    <body>
           leave DONE
 FINALLY:  ldnull; stloc pinned              // release on every exit
@@ -126,7 +125,7 @@ DONE:
 ```
 EmitExpr(source); dup; stloc pinned; brfalse NULL
 ldloc pinned; call char& string.GetPinnableReference()
-call void* Unsafe.AsPointer<char>(ref char); stloc ptr
+conv.u; stloc ptr
 br AFTER
 NULL: ldc.i4.0; conv.u; stloc ptr
 AFTER:
@@ -136,9 +135,7 @@ try { <body> } finally {
 ```
 
 `string.GetPinnableReference()` returns `ref readonly char`; the MemberRef
-retains its `modreq(InAttribute)` return signature. `Unsafe.AsPointer<T>`
-converts that managed pointer to the numeric native pointer stored in the
-user-visible `*T` local.
+retains its `modreq(InAttribute)` return signature.
 
 **Span-like / `GetPinnableReference`** (`T& pinned`, issue #1043):
 
@@ -146,7 +143,7 @@ user-visible `*T` local.
 EmitExpr(span); stloc src                    // spill the source for addressing
 ldloca src; call instance T& GetPinnableReference()
 stloc pinned                                 // T& pinned = ref
-ldloc pinned; call void* Unsafe.AsPointer<T>(ref T); stloc ptr
+ldloc pinned; conv.u; stloc ptr
 try { <body> } finally {
     ldc.i4.0; conv.u; stloc pinned            // release on every exit
 }
@@ -165,10 +162,12 @@ return-signature encoder reproduces required custom modifiers on by-ref returns
 (the same mechanism used for `ref readonly` indexers in ADR-0056), so the call
 binds at runtime instead of throwing `MissingMethodException`.
 
-The `Unsafe.AsPointer<T>` call is deliberate for every managed-pointer source.
-Emitting `conv.u` directly after `ldelema` or a ref-return leaves a managed
-pointer at an instruction that requires a numeric stack value, producing
-ilverify's `ExpectedNumericType` error even though RyuJIT accepts the method.
+ECMA-335 III.1.6 permits `conv.u` on a managed pointer, and current .NET 10
+`csc` emits the same sequence for array and span pins. The resulting unsafe IL
+is unverifiable: `ilverify` reports `ExpectedNumericType` for the byte-identical
+array and span sequence from both compilers. Emit tests classify that diagnostic
+as a known unsafe-code limitation rather than moving the conversion into a
+framework helper.
 
 ### 5. New node kinds, exhaustiveness, coverage matrix
 

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Statements.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Statements.cs
@@ -15,7 +15,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -97,7 +96,7 @@ internal sealed partial class MethodBodyEmitter
 
     // Array-pin form: pin the array reference (`T[] pinned`) and derive
     // `&a[0]` via `ldelema`, guarding the null / zero-length array (→ null
-    // pointer).
+    // pointer), exactly as Roslyn emits for fixed array pins in .NET 10.
     private void EmitFixedArrayPin(BoundFixedStatement node, int pinnedSlot, int pointerSlot)
     {
         var elementType = ((Symbols.PointerTypeSymbol)node.PointerVariable.Type).PointeeType;
@@ -128,7 +127,7 @@ internal sealed partial class MethodBodyEmitter
         this.il.LoadConstantI4(0);
         this.il.OpCode(ILOpCode.Ldelema);
         this.il.Token(this.outer.memberRefs.GetElementTypeToken(elementType));
-        this.EmitManagedPointerAsUnmanagedPointer(elementType);
+        this.il.OpCode(ILOpCode.Conv_u);
         this.il.StoreLocal(pointerSlot);
 
         this.il.MarkLabel(afterLabel);
@@ -155,7 +154,7 @@ internal sealed partial class MethodBodyEmitter
             types: Type.EmptyTypes,
             modifiers: null);
         this.il.Call(this.outer.memberRefs.GetMethodReference(getPinnableReference));
-        this.EmitManagedPointerAsUnmanagedPointer(TypeSymbol.Char);
+        this.il.OpCode(ILOpCode.Conv_u);
         this.il.StoreLocal(pointerSlot);
         this.il.Branch(ILOpCode.Br, afterLabel);
 
@@ -169,9 +168,9 @@ internal sealed partial class MethodBodyEmitter
     // Span-like pin form (ADR-0125 / issue #1043): pin the `T&` returned by a
     // public instance `ref T GetPinnableReference()` (e.g. `System.Span[T]` /
     // `System.ReadOnlySpan[T]`) into a `T& pinned` local, then derive `*T` via
-    // `Unsafe.AsPointer<T>`. `GetPinnableReference()` already returns the data
-    // pointer for an empty span (a ref to where element 0 would be), so no
-    // null/empty guard is required.
+    // `conv.u`, matching Roslyn's .NET 10 output. `GetPinnableReference()`
+    // already returns the data pointer for an empty span (a ref to where
+    // element 0 would be), so no null/empty guard is required.
     private void EmitFixedPinnableReferencePin(BoundFixedStatement node, int pinnedSlot, int pointerSlot)
     {
         var sourceSlot = this.locals[node.SourceVariable];
@@ -207,22 +206,8 @@ internal sealed partial class MethodBodyEmitter
         this.il.Token(this.outer.memberRefs.GetMethodEntityHandle(getPinnableReference, node.PinnedSource.Type)); // -> T&
         this.il.StoreLocal(pinnedSlot);          // T& pinned = ref
         this.il.LoadLocal(pinnedSlot);
-        this.EmitManagedPointerAsUnmanagedPointer(
-            ((Symbols.PointerTypeSymbol)node.PointerVariable.Type).PointeeType);
+        this.il.OpCode(ILOpCode.Conv_u);
         this.il.StoreLocal(pointerSlot);         // p = (T*)ref
-    }
-
-    private void EmitManagedPointerAsUnmanagedPointer(TypeSymbol pointeeType)
-    {
-        var openAsPointer = typeof(System.Runtime.CompilerServices.Unsafe)
-            .GetMethods(BindingFlags.Public | BindingFlags.Static)
-            .Single(method => method.Name == "AsPointer"
-                && method.IsGenericMethodDefinition
-                && method.GetParameters().Length == 1);
-        var closedAsPointer = openAsPointer.MakeGenericMethod(pointeeType.ClrType ?? typeof(object));
-        this.il.Call(this.outer.memberRefs.GetMethodEntityHandle(
-            closedAsPointer,
-            ImmutableArray.Create(pointeeType)));
     }
 
     private void EmitTryStatement(BoundTryStatement node)

--- a/test/Compiler.Tests/Emit/Issue1033VoidPointerEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1033VoidPointerEmitTests.cs
@@ -29,6 +29,10 @@ public class Issue1033VoidPointerEmitTests
 {
     private static readonly string[] UnsafeIlVerifyIgnored =
     {
+        // Roslyn emits the same managed-pointer + conv.u sequence for fixed
+        // array and span pins. ilverify reports ExpectedNumericType even though
+        // ECMA-335 III.1.6 permits this unverifiable unsafe conversion.
+        "ExpectedNumericType",
         "UnmanagedPointer",
         "StackUnexpected",
         "StackByRef",

--- a/test/Compiler.Tests/Emit/Issue2906ExhaustiveSwitchReturnEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2906ExhaustiveSwitchReturnEmitTests.cs
@@ -311,7 +311,7 @@ public class Issue2906ExhaustiveSwitchReturnEmitTests
         var assembly = CompileVerifyLoadAndRun(
             "UnnamedFixed",
             Source,
-            ignoredVerificationErrors: new[] { "UnmanagedPointer", "StackByRef" },
+            ignoredVerificationErrors: new[] { "ExpectedNumericType" },
             ignoredVerificationScope: @"<Program>\.F$");
         // Known limitation (#2953): the fixed-return epilogue must be emitted first,
         // so fixed-containing non-void functions bypass the fall-through guard and

--- a/test/Compiler.Tests/Emit/Issue2922FixedSwitchIlTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2922FixedSwitchIlTests.cs
@@ -3,12 +3,13 @@
 // </copyright>
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
 using System.Threading.Tasks;
 using GSharp.Compiler;
 using Xunit;
@@ -16,8 +17,8 @@ using Xunit;
 namespace GSharp.Compiler.Tests.Emit;
 
 /// <summary>
-/// Issue #2922: fixed sources must become numeric unmanaged pointers before
-/// switch control flow is emitted.
+/// Issue #2922: string pins use <c>GetPinnableReference</c>; array and span
+/// pins retain Roslyn's managed-pointer + <c>conv.u</c> lowering.
 /// </summary>
 public class Issue2922FixedSwitchIlTests
 {
@@ -247,129 +248,208 @@ public class Issue2922FixedSwitchIlTests
         Console.WriteLine(trace)
         """;
 
-    /// <summary>Gets fixed source kinds whose old conv.u lowering failed verification.</summary>
-    public static IEnumerable<object[]> PinKinds()
+    [Fact]
+    public void FixedControlFlowMatrix_VerifiesLoadsAndRuns()
     {
-        yield return new object[]
-        {
-            "Slice",
-            """
-            package Issue2922.Slice
-            import System
-            func F(x int32, xs []int32) int32 {
-                unsafe {
-                    fixed p *int32 = xs {
-                        switch x {
-                            case 0 { return xs.Length }
-                            default { return 1 }
-                        }
-                    }
-                }
-            }
-            Console.WriteLine(F(0, []int32{1, 2}))
-            """,
-            "2\n",
-            Array.Empty<string>(),
-        };
-        yield return new object[]
-        {
-            "String",
-            """
-            package Issue2922.String
-            import System
-            func F(x int32, text string) int32 {
-                unsafe {
-                    fixed p *uint16 = text {
-                        switch x {
-                            case 0 { return text.Length }
-                            default { return 1 }
-                        }
-                    }
-                }
-            }
-            Console.WriteLine(F(0, "AB"))
-            Console.WriteLine(F(0, ""))
-            """,
-            "2\n0\n",
-            Array.Empty<string>(),
-        };
-        yield return new object[]
-        {
-            "Span",
-            """
-            package Issue2922.Span
-            import System
-            func F(x int32, xs []int32) int32 {
-                var span Span[int32] = xs
-                unsafe {
-                    fixed p *int32 = span {
-                        switch x {
-                            case 0 { return xs.Length }
-                            default { return 1 }
-                        }
-                    }
-                }
-            }
-            Console.WriteLine(F(0, []int32{1, 2}))
-            """,
-            "2\n",
-            new[] { "StackUnexpected" },
-        };
-    }
-
-    [Theory]
-    [MemberData(nameof(PinKinds))]
-    public void FixedSource_VerifiesLoadsAndRuns(
-        string name,
-        string source,
-        string expectedOutput,
-        string[] ignoredVerificationErrors)
-    {
-        using var program = Compile(name, source);
+        using var program = Compile("Matrix", MatrixSource);
         IlVerifier.Verify(
             program.AssemblyPath,
             additionalReferences: null,
-            ignoredErrorCodes: ignoredVerificationErrors,
-            ignoredErrorScope: ignoredVerificationErrors.Length == 0 ? null : @"<Program>\.F$");
-        program.AssertLoadable();
-        Assert.Equal(expectedOutput, program.Run());
-    }
-
-    [Fact]
-    public void FixedControlFlowMatrix_Verifies()
-    {
-        using var program = Compile("MatrixVerify", MatrixSource);
-        IlVerifier.Verify(program.AssemblyPath);
-    }
-
-    [Fact]
-    public void FixedControlFlowMatrix_LoadsAndRuns()
-    {
-        using var program = Compile("MatrixRun", MatrixSource);
+            ignoredErrorCodes: new[] { "ExpectedNumericType" },
+            ignoredErrorScope: @"<Program>\.");
         program.AssertLoadable();
         Assert.Equal(ExpectedMatrixOutput, program.Run());
     }
 
     [Fact]
-    public void SlicePin_ConvertsManagedPointerThroughUnsafeAsPointer()
+    public void ArrayPointerDereference_VerifiesLoadsAndRuns()
     {
-        using var program = Compile("Instruction", PinKinds().First()[1].ToString()!);
-        var assembly = program.Load();
-        var method = assembly.GetTypes()
-            .Single(type => type.Name == "<Program>")
-            .GetMethod("F", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)!;
-        var instructions = IlInstructionReader.Read(method.GetMethodBody()!.GetILAsByteArray()!);
-        var loadElementAddressIndex = Array.FindIndex(
+        const string Source = """
+            package Issue2922.Array
+            import System
+
+            func F(xs []int32) int32 {
+                unsafe {
+                    fixed p *int32 = xs {
+                        switch xs.Length {
+                            case 2 { return *p + p[1] }
+                            default { return -1 }
+                        }
+                    }
+                }
+            }
+
+            Console.WriteLine(F([]int32{10, 20}))
+            """;
+
+        using var program = Compile("Array", Source);
+        IlVerifier.Verify(
+            program.AssemblyPath,
+            additionalReferences: null,
+            ignoredErrorCodes: new[] { "ExpectedNumericType" },
+            ignoredErrorScope: @"<Program>\.F$");
+        program.AssertLoadable();
+        Assert.Equal("30\n", program.Run());
+
+        var instructions = program.ReadMethod("F");
+        var loadElementAddress = Array.FindIndex(
             instructions,
             instruction => instruction.OpCode == OpCodes.Ldelema);
+        Assert.True(loadElementAddress >= 0);
+        Assert.Equal(OpCodes.Conv_U, instructions[loadElementAddress + 1].OpCode);
+        Assert.DoesNotContain(program.MemberReferenceNames(), name => name == "AsPointer");
+    }
 
-        Assert.True(loadElementAddressIndex >= 0);
-        Assert.True(loadElementAddressIndex + 1 < instructions.Length);
-        var call = instructions[loadElementAddressIndex + 1];
-        Assert.Equal(OpCodes.Call, call.OpCode);
-        Assert.True(call.MetadataToken.HasValue);
-        var calledMethod = method.Module.ResolveMethod(call.MetadataToken.Value);
-        Assert.Equal("AsPointer", calledMethod!.Name);
+    [Fact]
+    public void StructPointerDereference_VerifiesLoadsAndRuns()
+    {
+        const string Source = """
+            package Issue2922.Struct
+            import System
+            import System.Runtime.InteropServices
+
+            @StructLayout(LayoutKind.Sequential)
+            struct Point {
+                var x int32
+                var y int32
+            }
+
+            func F(values []Point) int32 {
+                unsafe {
+                    fixed p *Point = values {
+                        switch values.Length {
+                            case 1 { return p->x + p->y }
+                            default { return -1 }
+                        }
+                    }
+                }
+            }
+
+            Console.WriteLine(F([]Point{Point{x: 30, y: 47}}))
+            """;
+
+        using var program = Compile("Struct", Source);
+        IlVerifier.Verify(
+            program.AssemblyPath,
+            additionalReferences: null,
+            ignoredErrorCodes: new[] { "ExpectedNumericType" },
+            ignoredErrorScope: @"<Program>\.F$");
+        program.AssertLoadable();
+        Assert.Equal("77\n", program.Run());
+    }
+
+    [Fact]
+    public void SpanPointerDereference_VerifiesLoadsAndRuns()
+    {
+        const string Source = """
+            package Issue2922.Span
+            import System
+
+            func F(xs []int32) int32 {
+                var span Span[int32] = xs
+                unsafe {
+                    fixed p *int32 = span {
+                        switch xs.Length {
+                            case 1 { return *p }
+                            default { return -1 }
+                        }
+                    }
+                }
+            }
+
+            Console.WriteLine(F([]int32{5}))
+            """;
+
+        using var program = Compile("Span", Source);
+        IlVerifier.Verify(
+            program.AssemblyPath,
+            additionalReferences: null,
+            ignoredErrorCodes: new[] { "ExpectedNumericType" },
+            ignoredErrorScope: @"<Program>\.F$");
+        program.AssertLoadable();
+        Assert.Equal("5\n", program.Run());
+        Assert.DoesNotContain(program.MemberReferenceNames(), name => name == "AsPointer");
+    }
+
+    [Fact]
+    public void StringPin_UsesPinnableReferenceAndPreservesModreq()
+    {
+        const string Source = """
+            package Issue2922.String
+            import System
+
+            func F(text string) int32 {
+                unsafe {
+                    fixed p *uint16 = text {
+                        switch text.Length {
+                            case 1 { return int32(*p) }
+                            default { return -1 }
+                        }
+                    }
+                }
+            }
+
+            Console.WriteLine(F("Z"))
+            """;
+
+        using var program = Compile("String", Source);
+        IlVerifier.Verify(
+            program.AssemblyPath,
+            additionalReferences: null,
+            ignoredErrorCodes: new[] { "ExpectedNumericType" },
+            ignoredErrorScope: @"<Program>\.F$");
+        program.AssertLoadable();
+        Assert.Equal("90\n", program.Run());
+
+        using var stream = File.OpenRead(program.AssemblyPath);
+        using var pe = new PEReader(stream);
+        var metadata = pe.GetMetadataReader();
+        var stringPinnableReference = Assert.Single(
+            metadata.MemberReferences,
+            handle =>
+            {
+                var reference = metadata.GetMemberReference(handle);
+                return metadata.GetString(reference.Name) == "GetPinnableReference"
+                    && reference.Parent.Kind == HandleKind.TypeReference
+                    && metadata.GetString(
+                        metadata.GetTypeReference((TypeReferenceHandle)reference.Parent).Name) == "String";
+            });
+        var signature = metadata.GetBlobBytes(
+            metadata.GetMemberReference(stringPinnableReference).Signature);
+        Assert.Contains((byte)0x1F, signature); // ELEMENT_TYPE_CMOD_REQD
+        Assert.DoesNotContain(
+            metadata.MemberReferences,
+            handle => metadata.GetString(metadata.GetMemberReference(handle).Name)
+                == "get_OffsetToStringData");
+    }
+
+    [Fact]
+    public void NullStringPin_LoadsAndRuns()
+    {
+        const string Source = """
+            package Issue2922.NullString
+            import System
+
+            func F(text string) int32 {
+                unsafe {
+                    fixed p *uint16 = text {
+                        return 7
+                    }
+                }
+            }
+
+            let missing string = default
+            Console.WriteLine(F(missing))
+            """;
+
+        using var program = Compile("NullString", Source);
+        IlVerifier.Verify(
+            program.AssemblyPath,
+            additionalReferences: null,
+            ignoredErrorCodes: new[] { "ExpectedNumericType" },
+            ignoredErrorScope: @"<Program>\.F$");
+        program.AssertLoadable();
+        Assert.Equal("7\n", program.Run());
     }
 
     [Fact]
@@ -443,6 +523,29 @@ public class Issue2922FixedSwitchIlTests
         public Assembly Load() => Assembly.Load(File.ReadAllBytes(AssemblyPath));
 
         public void AssertLoadable() => Assert.NotEmpty(Load().GetTypes());
+
+        public IlInstruction[] ReadMethod(string name)
+        {
+            using var stream = File.OpenRead(AssemblyPath);
+            using var pe = new PEReader(stream);
+            var metadata = pe.GetMetadataReader();
+            var handle = Assert.Single(
+                metadata.MethodDefinitions,
+                candidate => metadata.GetString(metadata.GetMethodDefinition(candidate).Name) == name);
+            var definition = metadata.GetMethodDefinition(handle);
+            return IlInstructionReader.Read(
+                pe.GetMethodBody(definition.RelativeVirtualAddress).GetILBytes());
+        }
+
+        public string[] MemberReferenceNames()
+        {
+            using var stream = File.OpenRead(AssemblyPath);
+            using var pe = new PEReader(stream);
+            var metadata = pe.GetMetadataReader();
+            return metadata.MemberReferences
+                .Select(handle => metadata.GetString(metadata.GetMemberReference(handle).Name))
+                .ToArray();
+        }
 
         public string Run()
         {


### PR DESCRIPTION
## Summary

PR #2964 merged before its requested rework landed. This follow-up keeps its genuine string-pin fix, removes the `Unsafe.AsPointer<T>` laundering, and restores the Roslyn-compatible `conv.u` lowering for array, string, and span pins.

Fixes #2922

## IL mechanism

The original string path emitted:

```il
ldloc stringValue
conv.i                         // IL_0003: operand is a string reference
call RuntimeHelpers.get_OffsetToStringData
add
conv.u
```

`ilverify` reported `ExpectedNumericType` at `conv.i` because the stack held a `string` reference. The corrected sequence is:

```il
ldloc pinnedString
call instance char& modreq(InAttribute) String::GetPinnableReference()
conv.u
stloc pointer
```

The emitted MemberRef retains `modreq(System.Runtime.InteropServices.InAttribute)`. Null strings branch around the call and store a null pointer.

Array and span paths now again match .NET 10 Roslyn:

```il
ldloc pinnedArray
ldc.i4.0
ldelema T
conv.u
stloc pointer
```

```il
call instance T& GetPinnableReference()
stloc pinnedByRef
ldloc pinnedByRef
conv.u
stloc pointer
```

ECMA-335 III.1.6 permits `conv.u` on `&`. This unsafe IL is unverifiable; `ilverify` reports `ExpectedNumericType` for byte-identical `csc` output. `Unsafe.AsPointer<T>` only moved the conversion into CoreLib and unmasked `UnmanagedPointer`/`StackByRef` errors at pointer dereferences.

## Verification classification

`Issue2906ExhaustiveSwitchReturnEmitTests` returns from one suppressed code to exactly one `ExpectedNumericType`; suppressions decrease from two (`UnmanagedPointer`, `StackByRef`) to one. The suppression cannot be removed because Roslyn-identical unsafe `conv.u` still triggers it. The test-local unsafe bundle documents this limitation, and every suppression is method-scoped; `IlVerifier.cs` is untouched.

## Tests

Green CI merge-tree base: `26b55f562057`.

| Suite | Base | Head |
|---|---:|---:|
| Core.Tests | 7033 passed, 1 skipped | 7033 passed, 1 skipped |
| Compiler.Tests | 3962 passed | 3962 passed |
| Interpreter.Tests | 502 passed | 502 passed |
| LanguageServer.Tests | 452 passed | 452 passed |

Issue tests use both `ilverify` and real `Assembly.Load`/`GetTypes()` plus bounded child-process execution. Runtime outputs cover array dereference (`30`), user-struct dereference (`77`), span dereference (`5`), null string (`7`), and string dereference (`90`). Control-flow coverage includes all/some-arm returns, break, nested switch, loops, multiple pins, array/string/struct-field sources, equivalent `if` forms, and void forms.

Pins against the merge-tree base (fail on base, pass on head):

- array pointer dereference
- user-defined struct pointee dereference
- span pointer dereference
- string `GetPinnableReference`/`modreq` plus dereference

Guards (pass on base and head):

- fixed control-flow matrix
- runtime-null string pin
- IL instruction-reader operand decoding

Mutation probes, each rebuilt after restore:

- old `OffsetToStringData` lowering: string metadata pin failed
- string null branch changed from `brfalse` to `pop`: null-string execution failed with `NullReferenceException`
- array `Unsafe.AsPointer<T>`: failed with `UnmanagedPointer` + `StackByRef`
- span `Unsafe.AsPointer<T>`: failed with `UnmanagedPointer` + `StackByRef`
- dropped symbolic pointee map (`AsPointer<object>`): struct test failed with `StackUnexpected` plus pointer errors

Release solution build: 0 warnings, 0 errors.

## Non-regression

- 148-sample corpus: 0 diagnostic/exit/output/SHA-256 differences; 142 binaries per side.
- Samples using `fixed`: **0/148**.
- `gsi` still rejects `fixed` with its explicit GS9999 unsupported-path diagnostic, tracked by #2956; compiled execution is verified here.
- Runtime-null string behavior is correct in return and assignment forms and is not #2953.
- #2953 behavior and #2926 fixed-return epilogue ordering are unchanged.

## Delta

- `MethodBodyEmitter.Statements.cs`: +7/-22 production lines; deletes the reflection lookup/helper and restores direct `conv.u`.
- ADR-0125: +10/-11, recording actual Roslyn output and verifier classification.
- Tests: pointer-dereference, struct-pointee, null-string, metadata, control-flow, and classification coverage.
