### PR TITLE
Fix symbolic channel element metadata emission

### DIFF
--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Calls.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Calls.cs
@@ -478,7 +478,8 @@ internal sealed partial class MethodBodyEmitter
 
     private void EmitMakeChannelExpression(BoundMakeChannelExpression node)
     {
-        var elementClr = ResolveChannelElementClrType(node.ChannelType.ElementType);
+        var elementType = node.ChannelType.ElementType;
+        var elementClr = ResolveChannelElementClrType(elementType);
         if (node.Capacity == null)
         {
             var openCreate = typeof(System.Threading.Channels.Channel)
@@ -487,7 +488,7 @@ internal sealed partial class MethodBodyEmitter
                     && m.IsGenericMethodDefinition
                     && m.GetParameters().Length == 0);
             var create = openCreate.MakeGenericMethod(elementClr);
-            this.il.Call(this.outer.memberRefs.GetMethodEntityHandle(create));
+            this.il.Call(this.GetChannelGenericMethodEntityHandle(create, elementType));
             return;
         }
 
@@ -504,7 +505,7 @@ internal sealed partial class MethodBodyEmitter
                 && m.GetParameters().Length == 1
                 && m.GetParameters()[0].ParameterType.IsSameAs(typeof(System.Threading.Channels.BoundedChannelOptions)));
         var bounded = openBounded.MakeGenericMethod(elementClr);
-        this.il.Call(this.outer.memberRefs.GetMethodEntityHandle(bounded));
+        this.il.Call(this.GetChannelGenericMethodEntityHandle(bounded, elementType));
     }
 
     // Issue #2283: entry point used from expression-position emit
@@ -559,23 +560,23 @@ internal sealed partial class MethodBodyEmitter
 
         this.EmitExpression(node.Channel);
         this.il.OpCode(ILOpCode.Callvirt);
-        this.il.Token(this.outer.memberRefs.GetMethodReference(getReader));
+        this.il.Token(this.GetChannelMethodEntityHandle(getReader, chType.ElementType));
 
         this.EmitCancellationTokenNone();
         this.il.OpCode(ILOpCode.Callvirt);
-        this.il.Token(this.outer.memberRefs.GetMethodReference(readAsync));
+        this.il.Token(this.GetChannelMethodEntityHandle(readAsync, chType.ElementType));
 
         this.il.StoreLocal(vtSlot);
         this.il.LoadLocalAddress(vtSlot);
         this.il.OpCode(ILOpCode.Call);
-        this.il.Token(this.outer.memberRefs.GetMethodReference(asTaskGeneric));
+        this.il.Token(this.GetChannelMethodEntityHandle(asTaskGeneric, chType.ElementType));
 
         this.il.OpCode(ILOpCode.Callvirt);
-        this.il.Token(this.outer.memberRefs.GetMethodReference(taskGetAwaiter));
+        this.il.Token(this.GetChannelMethodEntityHandle(taskGetAwaiter, chType.ElementType));
         this.il.StoreLocal(taSlot);
         this.il.LoadLocalAddress(taSlot);
         this.il.OpCode(ILOpCode.Call);
-        this.il.Token(this.outer.memberRefs.GetMethodReference(taskGetResult));
+        this.il.Token(this.GetChannelMethodEntityHandle(taskGetResult, chType.ElementType));
         this.il.StoreLocal(resultSlot);
         this.il.Branch(ILOpCode.Leave, endLabel);
         this.il.MarkLabel(tryEnd);
@@ -603,10 +604,10 @@ internal sealed partial class MethodBodyEmitter
 
         this.EmitExpression(node.Channel);
         this.il.OpCode(ILOpCode.Callvirt);
-        this.il.Token(this.outer.memberRefs.GetMethodReference(getWriter));
+        this.il.Token(this.GetChannelMethodEntityHandle(getWriter, chType.ElementType));
         this.il.OpCode(ILOpCode.Ldnull);
         this.il.OpCode(ILOpCode.Callvirt);
-        this.il.Token(this.outer.memberRefs.GetMethodReference(complete));
+        this.il.Token(this.GetChannelMethodEntityHandle(complete, chType.ElementType));
     }
 
     private void EmitCancellationTokenNone()

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
@@ -1257,19 +1257,11 @@ internal sealed partial class MethodBodyEmitter
 
     private void EmitZeroInit(int slot, TypeSymbol gsharpType, Type clrType)
     {
-        if (clrType.IsValueType)
-        {
-            this.il.LoadLocalAddress(slot);
-            this.il.OpCode(ILOpCode.Initobj);
-            var initType = gsharpType.ClrType == null
-                ? TypeSymbol.FromClrType(clrType)
-                : gsharpType;
-            this.il.Token(this.outer.memberRefs.GetElementTypeToken(initType));
-        }
-        else
-        {
-            this.il.OpCode(ILOpCode.Ldnull);
-            this.il.StoreLocal(slot);
-        }
+        this.il.LoadLocalAddress(slot);
+        this.il.OpCode(ILOpCode.Initobj);
+        var initType = ChannelElementNeedsSymbolicType(gsharpType)
+            ? gsharpType
+            : TypeSymbol.FromClrType(clrType);
+        this.il.Token(this.outer.memberRefs.GetElementTypeToken(initType));
     }
 }

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Statements.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Statements.cs
@@ -636,10 +636,10 @@ internal sealed partial class MethodBodyEmitter
 
         this.il.LoadLocal(slots.ChannelSlots[index]);
         this.il.OpCode(ILOpCode.Callvirt);
-        this.il.Token(this.outer.memberRefs.GetMethodReference(getReader));
+        this.il.Token(this.GetChannelMethodEntityHandle(getReader, chType.ElementType));
         this.il.LoadLocalAddress(slots.OutSlots[index]);
         this.il.OpCode(ILOpCode.Callvirt);
-        this.il.Token(this.outer.memberRefs.GetMethodReference(tryRead));
+        this.il.Token(this.GetChannelMethodEntityHandle(tryRead, chType.ElementType));
         this.il.Branch(ILOpCode.Brfalse, closedLabel);
         this.EmitStatement(arm.Body);
         this.il.Branch(ILOpCode.Br, endLabel);
@@ -647,9 +647,9 @@ internal sealed partial class MethodBodyEmitter
         this.il.MarkLabel(closedLabel);
         this.il.LoadLocal(slots.ChannelSlots[index]);
         this.il.OpCode(ILOpCode.Callvirt);
-        this.il.Token(this.outer.memberRefs.GetMethodReference(getReader));
+        this.il.Token(this.GetChannelMethodEntityHandle(getReader, chType.ElementType));
         this.il.OpCode(ILOpCode.Callvirt);
-        this.il.Token(this.outer.memberRefs.GetMethodReference(completion));
+        this.il.Token(this.GetChannelMethodEntityHandle(completion, chType.ElementType));
         this.il.OpCode(ILOpCode.Callvirt);
         this.il.Token(this.outer.memberRefs.GetMethodReference(isCompleted));
         this.il.Branch(ILOpCode.Brfalse, nextLabel);
@@ -675,10 +675,10 @@ internal sealed partial class MethodBodyEmitter
 
         this.il.LoadLocal(slots.ChannelSlots[index]);
         this.il.OpCode(ILOpCode.Callvirt);
-        this.il.Token(this.outer.memberRefs.GetMethodReference(getWriter));
+        this.il.Token(this.GetChannelMethodEntityHandle(getWriter, chType.ElementType));
         this.il.LoadLocal(slots.ValueSlots[index]);
         this.il.OpCode(ILOpCode.Callvirt);
-        this.il.Token(this.outer.memberRefs.GetMethodReference(tryWrite));
+        this.il.Token(this.GetChannelMethodEntityHandle(tryWrite, chType.ElementType));
         this.il.Branch(ILOpCode.Brfalse, nextLabel);
         this.EmitStatement(arm.Body);
         this.il.Branch(ILOpCode.Br, endLabel);
@@ -756,10 +756,10 @@ internal sealed partial class MethodBodyEmitter
                 new[] { typeof(System.Threading.CancellationToken) });
             this.il.LoadLocal(slots.ChannelSlots[index]);
             this.il.OpCode(ILOpCode.Callvirt);
-            this.il.Token(this.outer.memberRefs.GetMethodReference(getWriter));
+            this.il.Token(this.GetChannelMethodEntityHandle(getWriter, chType.ElementType));
             this.EmitCancellationTokenNone();
             this.il.OpCode(ILOpCode.Callvirt);
-            this.il.Token(this.outer.memberRefs.GetMethodReference(waitToWrite));
+            this.il.Token(this.GetChannelMethodEntityHandle(waitToWrite, chType.ElementType));
         }
         else
         {
@@ -770,10 +770,10 @@ internal sealed partial class MethodBodyEmitter
                 new[] { typeof(System.Threading.CancellationToken) });
             this.il.LoadLocal(slots.ChannelSlots[index]);
             this.il.OpCode(ILOpCode.Callvirt);
-            this.il.Token(this.outer.memberRefs.GetMethodReference(getReader));
+            this.il.Token(this.GetChannelMethodEntityHandle(getReader, chType.ElementType));
             this.EmitCancellationTokenNone();
             this.il.OpCode(ILOpCode.Callvirt);
-            this.il.Token(this.outer.memberRefs.GetMethodReference(waitToRead));
+            this.il.Token(this.GetChannelMethodEntityHandle(waitToRead, chType.ElementType));
         }
 
         this.il.StoreLocal(slots.WaitValueTaskSlot);
@@ -800,13 +800,13 @@ internal sealed partial class MethodBodyEmitter
 
         this.EmitExpression(node.Channel);
         this.il.OpCode(ILOpCode.Callvirt);
-        this.il.Token(this.outer.memberRefs.GetMethodReference(getWriter));
+        this.il.Token(this.GetChannelMethodEntityHandle(getWriter, chType.ElementType));
 
         this.EmitExpression(node.Value);
         this.EmitCancellationTokenNone();
 
         this.il.OpCode(ILOpCode.Callvirt);
-        this.il.Token(this.outer.memberRefs.GetMethodReference(writeAsync));
+        this.il.Token(this.GetChannelMethodEntityHandle(writeAsync, chType.ElementType));
 
         this.il.StoreLocal(vtSlot);
         this.il.LoadLocalAddress(vtSlot);

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
@@ -1390,11 +1390,46 @@ internal sealed partial class MethodBodyEmitter
     // .AsTask().GetAwaiter().GetResult() to match the synchronous
     // evaluator surface.
     //
-    // Element types lacking a ClrType (e.g. user-defined class
-    // values) are erased to object, mirroring the interpreter's
-    // `ElementType.ClrType ?? typeof(object)` fallback.
-    private static Type ResolveChannelElementClrType(TypeSymbol elementType)
+    // Reflection still needs a closed carrier type to find channel members.
+    // Metadata emission separately retains symbolic element types that the
+    // carrier cannot represent.
+    internal static Type ResolveChannelElementClrType(TypeSymbol elementType)
+        => NullableTypeSymbol.GetEffectiveClrType(elementType) ?? typeof(object);
+
+    internal static bool ChannelElementNeedsSymbolicType(TypeSymbol elementType)
+        => elementType?.ClrType == null || TypeSymbol.RequiresSymbolicProjection(elementType);
+
+    private static TypeSymbol ResolveChannelContainerSymbol(
+        Type closedCarrier,
+        Type openDefinition,
+        TypeSymbol elementType)
+        => ChannelElementNeedsSymbolicType(elementType)
+            ? ImportedTypeSymbol.GetConstructed(
+                closedCarrier,
+                openDefinition,
+                // Channel<T>.Reader/Writer are declared on Channel<T, T>.
+                ImmutableArray.CreateRange(
+                    Enumerable.Repeat(elementType, openDefinition.GetGenericArguments().Length)))
+            : null;
+
+    private static ImmutableArray<TypeSymbol> ResolveChannelMethodTypeArguments(TypeSymbol elementType)
+        => ChannelElementNeedsSymbolicType(elementType)
+            ? ImmutableArray.Create(elementType)
+            : default;
+
+    private EntityHandle GetChannelMethodEntityHandle(
+        MethodInfo method,
+        TypeSymbol elementType)
     {
-        return elementType.ClrType ?? typeof(object);
+        var closedCarrier = method.DeclaringType;
+        var openDefinition = closedCarrier.GetGenericTypeDefinition();
+        return this.outer.memberRefs.GetMethodEntityHandle(
+            method,
+            ResolveChannelContainerSymbol(closedCarrier, openDefinition, elementType));
     }
+
+    private EntityHandle GetChannelGenericMethodEntityHandle(MethodInfo method, TypeSymbol elementType)
+        => this.outer.memberRefs.GetMethodEntityHandle(
+            method,
+            ResolveChannelMethodTypeArguments(elementType));
 }

--- a/src/Core/CodeAnalysis/Emit/SignatureEncoder.cs
+++ b/src/Core/CodeAnalysis/Emit/SignatureEncoder.cs
@@ -487,12 +487,23 @@ internal sealed class SignatureEncoder
         else if (type is ChannelTypeSymbol chType)
         {
             // Phase E: chan T -> System.Threading.Channels.Channel<T>.
-            // For element types that lack a ClrType we erase to object,
-            // matching the interpreter's `ElementType.ClrType ?? typeof(object)`
-            // fallback (ADR-0022 §interpreter).
-            var elementClr = chType.ElementType.ClrType ?? typeof(object);
-            var channelClr = typeof(System.Threading.Channels.Channel<>).MakeGenericType(elementClr);
-            this.EncodeClrType(encoder, channelClr);
+            // Compiled metadata must retain symbolic element identity under
+            // generic invariance. The interpreter can independently keep its
+            // object fallback because channel values are boxed there.
+            var channelOpen = typeof(System.Threading.Channels.Channel<>);
+            if (MethodBodyEmitter.ChannelElementNeedsSymbolicType(chType.ElementType))
+            {
+                var genericInst = encoder.GenericInstantiation(
+                    this.outer.memberRefs.GetTypeReference(channelOpen),
+                    1,
+                    isValueType: false);
+                this.EncodeTypeSymbol(genericInst.AddArgument(), chType.ElementType);
+            }
+            else
+            {
+                var elementClr = MethodBodyEmitter.ResolveChannelElementClrType(chType.ElementType);
+                this.EncodeClrType(encoder, channelOpen.MakeGenericType(elementClr));
+            }
         }
         else if (type is TupleTypeSymbol tupleWithNullClr && tupleWithNullClr.ClrType == null)
         {

--- a/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
@@ -523,17 +523,30 @@ internal sealed class SlotPlanner
             }
 
             var chType = (ChannelTypeSymbol)node.Channel.Type;
-            var elementClr = chType.ElementType.ClrType ?? typeof(object);
-            var vtClr = typeof(System.Threading.Tasks.ValueTask<>).MakeGenericType(elementClr);
-            var taClr = typeof(System.Runtime.CompilerServices.TaskAwaiter<>).MakeGenericType(elementClr);
 
             var vt = localTypes.Count;
-            localTypes.Add(TypeSymbol.FromClrType(vtClr));
+            localTypes.Add(ConstructChannelOperationType(
+                typeof(System.Threading.Tasks.ValueTask<>),
+                chType.ElementType));
             var ta = localTypes.Count;
-            localTypes.Add(TypeSymbol.FromClrType(taClr));
+            localTypes.Add(ConstructChannelOperationType(
+                typeof(System.Runtime.CompilerServices.TaskAwaiter<>),
+                chType.ElementType));
             var result = localTypes.Count;
-            localTypes.Add(chType.ElementType.ClrType != null ? chType.ElementType : TypeSymbol.FromClrType(typeof(object)));
+            localTypes.Add(chType.ElementType);
             channelOpSlots[node] = (vt, ta, result, -1);
+        }
+
+        private static TypeSymbol ConstructChannelOperationType(Type openDefinition, TypeSymbol elementType)
+        {
+            var closedCarrier = openDefinition.MakeGenericType(
+                MethodBodyEmitter.ResolveChannelElementClrType(elementType));
+            return MethodBodyEmitter.ChannelElementNeedsSymbolicType(elementType)
+                ? ImportedTypeSymbol.GetConstructed(
+                    closedCarrier,
+                    openDefinition,
+                    ImmutableArray.Create(elementType))
+                : TypeSymbol.FromClrType(closedCarrier);
         }
 
         private static void AllocateSelectSlots(
@@ -587,7 +600,7 @@ internal sealed class SlotPlanner
                 else
                 {
                     outSlots[i] = localTypes.Count;
-                    localTypes.Add(chType.ElementType.ClrType != null ? chType.ElementType : TypeSymbol.FromClrType(typeof(object)));
+                    localTypes.Add(chType.ElementType);
                 }
             }
 

--- a/test/Compiler.Tests/Emit/Issue2965ChannelElementSlotTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2965ChannelElementSlotTests.cs
@@ -1,0 +1,267 @@
+// <copyright file="Issue2965ChannelElementSlotTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2965: channel signatures, locals, and member references must retain
+/// same-compilation value-type element identities instead of erasing them to
+/// <see cref="object"/>.
+/// </summary>
+public class Issue2965ChannelElementSlotTests
+{
+    [Fact]
+    public void SendOnlyUserStructChannel_LoadsVerifiesAndRuns()
+    {
+        const string Source = """
+            package Issue2965SendOnly
+            import System
+            import Gsharp.Extensions.Go
+
+            data struct Pair(Value int32)
+
+            let ch = make(chan Pair, 1)
+            ch <- Pair(41)
+            Console.WriteLine(1)
+            """;
+
+        AssertRuns(Source, nameof(SendOnlyUserStructChannel_LoadsVerifiesAndRuns), "1\n");
+    }
+
+    [Fact]
+    public void ChannelElementMatrix_LoadsVerifiesAndRuns()
+    {
+        const string Source = """
+            package Issue2965Matrix
+            import System
+            import System.Threading
+            import System.Threading.Tasks
+            import Gsharp.Extensions.Go
+
+            data struct Pair(Value int32)
+
+            struct Plain {
+                var Value int32
+            }
+
+            data struct Box[T] {
+                var Value T
+            }
+
+            struct Inner {
+                var Value int32
+            }
+
+            struct Outer {
+                var Item Inner
+            }
+
+            class RefBox(Value int32) {}
+
+            func delayedSend(ch chan Pair) int32 {
+                Thread.Sleep(10)
+                ch <- Pair(51)
+                return 0
+            }
+
+            func delayedReceive(ch chan Pair) int32 {
+                Thread.Sleep(10)
+                return (<-ch).Value
+            }
+
+            func echo[T](value T) T {
+                let ch = make(chan T, 1)
+                ch <- value
+                return <-ch
+            }
+
+            async func asyncPair() int32 {
+                let ch = make(chan Pair, 1)
+                ch <- Pair(50)
+                await Task.Delay(1)
+                return (<-ch).Value
+            }
+
+            let plainReceive = make(chan Pair, 1)
+            plainReceive <- Pair(41)
+            Console.WriteLine((<-plainReceive).Value)
+            close(plainReceive)
+
+            let selectReceive = make(chan Pair, 1)
+            selectReceive <- Pair(42)
+            select {
+                case let value = <-selectReceive { Console.WriteLine(value.Value) }
+            }
+
+            let selectSend = make(chan Pair, 1)
+            select {
+                case selectSend <- Pair(43) {
+                    Console.Write("")
+                }
+            }
+            Console.WriteLine((<-selectSend).Value)
+
+            let plainStruct = make(chan Plain, 1)
+            plainStruct <- Plain{Value: 44}
+            Console.WriteLine((<-plainStruct).Value)
+
+            let genericStruct = make(chan Box[int32], 1)
+            genericStruct <- Box[int32]{Value: 45}
+            Console.WriteLine((<-genericStruct).Value)
+
+            let nestedStruct = make(chan Outer, 1)
+            nestedStruct <- Outer{Item: Inner{Value: 46}}
+            Console.WriteLine((<-nestedStruct).Item.Value)
+
+            let nullableValue = make(chan int32?, 1)
+            nullableValue <- 47
+            Console.WriteLine((<-nullableValue) ?? -1)
+
+            let nullablePair = make(chan Pair?, 1)
+            nullablePair <- Pair(54)
+            Console.WriteLine(((<-nullablePair) ?? Pair(-1)).Value)
+
+            let reference = make(chan RefBox, 1)
+            reference <- RefBox(48)
+            Console.WriteLine((<-reference).Value)
+
+            let primitive = make(chan int32, 1)
+            primitive <- 49
+            Console.WriteLine(<-primitive)
+
+            let imported = make(chan DateTime, 1)
+            imported <- DateTime(2020, 1, 1)
+            Console.WriteLine((<-imported).Year)
+
+            let closed = make(chan Pair, 1)
+            close(closed)
+            Console.WriteLine((<-closed).Value)
+
+            let closedSelect = make(chan Pair, 1)
+            close(closedSelect)
+            select {
+                case let value = <-closedSelect { Console.WriteLine(value.Value) }
+            }
+
+            let blockingReceive = make(chan Pair)
+            scope {
+                go delayedSend(blockingReceive)
+                select {
+                    case let value = <-blockingReceive { Console.WriteLine(value.Value) }
+                }
+            }
+
+            let blockingSend = make(chan Pair)
+            scope {
+                go delayedReceive(blockingSend)
+                select {
+                    case blockingSend <- Pair(52) {
+                        Console.WriteLine(52)
+                    }
+                }
+            }
+
+            Console.WriteLine(echo(Pair(53)).Value)
+            Console.WriteLine(asyncPair().Result)
+            """;
+
+        AssertRuns(
+            Source,
+            nameof(ChannelElementMatrix_LoadsVerifiesAndRuns),
+            "41\n42\n43\n44\n45\n46\n47\n54\n48\n49\n2020\n0\n0\n51\n52\n53\n50\n");
+    }
+
+    private static void AssertRuns(string source, string name, string expected)
+    {
+        var assemblyPath = Compile(source, name);
+        var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+        Assert.NotEmpty(assembly.GetTypes());
+
+        for (var i = 0; i < 3; i++)
+        {
+            Assert.Equal(expected, RunBounded(assemblyPath, name));
+        }
+
+        IlVerifier.Verify(assemblyPath);
+    }
+
+    private static string Compile(string source, string name)
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            nameof(Issue2965ChannelElementSlotTests),
+            name);
+        Directory.CreateDirectory(directory);
+        var sourcePath = Path.Combine(directory, "test.gs");
+        var assemblyPath = Path.Combine(directory, name + ".dll");
+        File.WriteAllText(sourcePath, source);
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousErr = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        int exitCode;
+        try
+        {
+            exitCode = Program.Main(new[]
+            {
+                "/out:" + assemblyPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                sourcePath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousErr);
+        }
+
+        Assert.True(exitCode == 0, $"{name}: gsc failed:\n{stdout}\n{stderr}");
+        return assemblyPath;
+    }
+
+    private static string RunBounded(string assemblyPath, string name)
+    {
+        using var process = Process.Start(new ProcessStartInfo("dotnet")
+        {
+            ArgumentList =
+            {
+                "exec",
+                "--runtimeconfig",
+                Path.ChangeExtension(assemblyPath, ".runtimeconfig.json"),
+                assemblyPath,
+            },
+            WorkingDirectory = Path.GetDirectoryName(assemblyPath),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        });
+
+        Assert.NotNull(process);
+        var outputTask = process.StandardOutput.ReadToEndAsync();
+        var errorTask = process.StandardError.ReadToEndAsync();
+        var exited = process.WaitForExit(10_000);
+        if (!exited)
+        {
+            process.Kill(entireProcessTree: true);
+            process.WaitForExit();
+        }
+
+        Assert.True(exited, $"{name}: emitted program timed out");
+        var output = outputTask.GetAwaiter().GetResult();
+        var error = errorTask.GetAwaiter().GetResult();
+        Assert.True(process.ExitCode == 0, $"{name}: emitted program failed:\n{error}");
+        return output.Replace("\r\n", "\n", StringComparison.Ordinal);
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue2965ChannelElementSlotTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2965ChannelElementSlotTests.cs
@@ -101,6 +101,12 @@ public class Issue2965ChannelElementSlotTests
                 case let value = <-selectReceive { Console.WriteLine(value.Value) }
             }
 
+            let discardReceive = make(chan Pair, 1)
+            discardReceive <- Pair(55)
+            select {
+                case <-discardReceive { Console.WriteLine(55) }
+            }
+
             let selectSend = make(chan Pair, 1)
             select {
                 case selectSend <- Pair(43) {
@@ -176,7 +182,7 @@ public class Issue2965ChannelElementSlotTests
         AssertRuns(
             Source,
             nameof(ChannelElementMatrix_LoadsVerifiesAndRuns),
-            "41\n42\n43\n44\n45\n46\n47\n54\n48\n49\n2020\n0\n0\n51\n52\n53\n50\n");
+            "41\n42\n55\n43\n44\n45\n46\n47\n54\n48\n49\n2020\n0\n0\n51\n52\n53\n50\n");
     }
 
     private static void AssertRuns(string source, string name, string expected)

--- a/test/Interpreter.Tests/Issue2965ChannelElementSlotTests.cs
+++ b/test/Interpreter.Tests/Issue2965ChannelElementSlotTests.cs
@@ -1,0 +1,61 @@
+// <copyright file="Issue2965ChannelElementSlotTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #2965 interpreter control: boxed channel storage already preserves
+/// same-compilation value-type values despite its CLR-object fallback.
+/// </summary>
+public class Issue2965ChannelElementSlotTests
+{
+    [Fact]
+    public void UserStructChannelsRemainCorrectInInterpreter()
+    {
+        const string Source = """
+            import System
+            import Gsharp.Extensions.Go
+
+            data struct Pair(Value int32)
+
+            let plain = make(chan Pair, 1)
+            plain <- Pair(41)
+            Console.WriteLine((<-plain).Value)
+
+            let selected = make(chan Pair, 1)
+            select {
+                case selected <- Pair(42) {
+                    Console.Write("")
+                }
+            }
+            select {
+                case let value = <-selected { Console.WriteLine(value.Value) }
+            }
+            """;
+
+        Assert.Equal("41\n42\n", RunSubmission(Source));
+    }
+
+    private static string RunSubmission(string source)
+    {
+        using var output = new StringWriter();
+        var previousOut = Console.Out;
+        Console.SetOut(output);
+        try
+        {
+            var repl = new GSharpRepl();
+            repl.EvaluateSubmission(source);
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+        }
+
+        return output.ToString().Replace("\r\n", "\n", StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary

- preserve symbolic channel element types in `Channel<T>` signatures, receive locals, method specifications, and generic-member parents
- keep `object` only as the reflection carrier used to discover BCL members
- cover create, send, receive, select, close, nullable/local/generic/nested structs, generic type parameters, async code, closed channels, and blocking select waits
- zero-initialize closed receive results with the symbolic element token

`Channel<T>.Reader` and `.Writer` are declared on the BCL base `Channel<T, T>`; the metadata helper therefore repeats the symbolic element for the declaring type's actual arity.

## Evidence

- Exact latest base `47a400359`: compiler pins **0/2 passed**; both bounded child executions failed with `InvalidProgramException`.
- Head `efae8b442`: compiler pins **2/2 passed** and interpreter guard **1/1 passed**.
- Compiler tests perform `Assembly.Load(File.ReadAllBytes(...))`, `GetTypes()`, three bounded child executions with concurrent pipe draining and exact output, then `IlVerifier.Verify`.
- Interpreter guard passes on both base and head, confirming its boxed `ClrType ?? object` fallback remains valid.
- Primitive and imported-struct controls are byte-identical base/head:
  - `chan int32`: `77d8ea39dc102bc0fd88e0a7d93647f8`
  - `chan DateTime`: `b56f11011411e7f8f93dde28e557b08d`
- Per-production-hunk mutation testing: **16/16 killed, 0 survived**. Every restore passed and every hunk round-tripped `9a29bdf13aa2fa580bf1645a98e6de95 -> distinct mutant hash -> 9a29bdf13aa2fa580bf1645a98e6de95`. The final rebase touched none of the patch files; all eight patch blob hashes matched before/after exactly.
- Release solution build with `ContinuousIntegrationBuild=true`: **0 warnings, 0 errors**.
- Build integrity: **40/40** `GSharp.Core.dll` copies non-zero; **23/23** ordinary implementation copies matched `bce351142acf5d0d6ea29a9546cacdc6`.

The stale `SignatureEncoder` comment was updated: compiler metadata no longer matches the interpreter's erasure, while the interpreter fallback itself remains intentionally unchanged.

Full solution test suites and SDK/e2e tests were not run, per the fleet throttle and the instruction not to touch the shared SDK cache; validation used the narrow issue-specific selectors.

Fixes #2965
