### PR TITLE
Fix interpreter imported-base bridging

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -249,8 +249,8 @@ internal sealed partial class ExpressionBinder
     /// is bound into a synthetic local; each element lowers to an
     /// <c>Add(...)</c> call (bare / <c>key: value</c> entries) or an indexer set
     /// (<c>[key] = value</c> entries); the block yields the local. The lowering
-    /// uses only existing bound nodes, so emit and the interpreter both work
-    /// without a new bound-node kind.
+    /// uses only existing bound nodes; each backend must still preserve the
+    /// constructor-before-initializers ordering represented by those nodes.
     /// </summary>
     private BoundExpression BindCollectionInitializerExpression(CollectionInitializerExpressionSyntax syntax)
     {

--- a/src/Core/CodeAnalysis/Evaluator.Expressions.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Expressions.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
+using System.Reflection.Emit;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
@@ -29,6 +30,7 @@ public sealed partial class Evaluator
 {
     private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<Type, Func<Func<object[], object>, Delegate>> InterpreterDelegateFactories = new();
     private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<Delegate, ClosureValue> InterpreterClosures = new();
+    private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<StructSymbol, Type> ClrBackingTypes = new();
 
     private object EvaluateExpression(BoundExpression node)
     {
@@ -651,21 +653,31 @@ public sealed partial class Evaluator
 
     private object EvaluateStructLiteralExpression(BoundStructLiteralExpression node)
     {
-        var sv = new StructValue(node.StructType);
+        var constructedClass = node.StructType.IsClass && node.StructType.ClrType == null;
+        var sv = constructedClass
+            ? (StructValue)EvaluateConstructorCallExpression(
+                new BoundConstructorCallExpression(
+                    node.Syntax,
+                    node.StructType,
+                    ImmutableArray<BoundExpression>.Empty))
+            : new StructValue(node.StructType);
 
-        // Default-initialize all fields (walking inheritance), then apply explicit initializers.
-        for (var t = node.StructType; t != null; t = t.BaseClass)
+        if (!constructedClass)
         {
-            foreach (var f in t.Fields)
+            // Default-initialize all fields (walking inheritance), then apply explicit initializers.
+            for (var t = node.StructType; t != null; t = t.BaseClass)
             {
-                if (!sv.Fields.ContainsKey(f.Name))
+                foreach (var f in t.Fields)
                 {
-                    sv.Fields[f.Name] = ClrDefaultValue(f.Type);
+                    if (!sv.Fields.ContainsKey(f.Name))
+                    {
+                        sv.Fields[f.Name] = ClrDefaultValue(f.Type);
+                    }
                 }
             }
-        }
 
-        ApplyClassFieldInitializers(sv, node.StructType);
+            ApplyClassFieldInitializers(sv, node.StructType);
+        }
 
         foreach (var init in node.Initializers)
         {
@@ -1066,7 +1078,7 @@ public sealed partial class Evaluator
                     }
                 }
 
-                // Issue #319: instantiate the CLR base instance (when the class
+                // Issue #319: instantiate the CLR backing object (when the class
                 // ultimately derives from a CLR type) so inherited CLR instance
                 // state — such as Exception.Message — is set per the emit path.
                 AllocateClrBacking(sv, node.StructType, baseInit);
@@ -1101,10 +1113,12 @@ public sealed partial class Evaluator
     }
 
     /// <summary>
-    /// Issue #319: instantiate the imported CLR base for a GSharp class instance
+    /// Issue #319: instantiate a CLR backing object for a GSharp class instance
     /// when the class ultimately derives from a CLR type, so inherited CLR
     /// instance state (e.g. <see cref="System.Exception.Message"/>) is observable
-    /// under the interpreter. The chosen base constructor mirrors the emit path:
+    /// under the interpreter. The backing object's runtime type preserves the
+    /// GSharp class identity for inherited virtual dispatch. The chosen base
+    /// constructor mirrors the emit path:
     /// the resolved <see cref="BaseConstructorInitializer.ClrConstructor"/> when
     /// the class declared <c>: Base(args)</c>, otherwise the imported base's
     /// accessible parameterless constructor. The base-ctor argument expressions
@@ -1115,7 +1129,7 @@ public sealed partial class Evaluator
         // If an explicit `: base(args)` targets a CLR constructor, prefer that.
         if (activeInit is { IsClrBase: true } clrInit && clrInit.ClrConstructor != null)
         {
-            sv.ClrBacking = InvokeClrCtor(clrInit.ClrConstructor, clrInit.Arguments, clrInit.ArgumentRefKinds);
+            sv.ClrBacking = InvokeClrCtor(structType, clrInit.ClrConstructor, clrInit.Arguments, clrInit.ArgumentRefKinds);
             return;
         }
 
@@ -1143,7 +1157,7 @@ public sealed partial class Evaluator
                 var parameterless = ResolveParameterlessCtor(clrBase);
                 if (parameterless != null)
                 {
-                    sv.ClrBacking = parameterless.Invoke(Array.Empty<object>());
+                    sv.ClrBacking = InvokeClrBackingConstructor(structType, parameterless, Array.Empty<object>());
                 }
 
                 return;
@@ -1152,13 +1166,64 @@ public sealed partial class Evaluator
     }
 
     /// <summary>Issue #319: invoke a CLR base constructor with the bound G# argument expressions.</summary>
-    private object InvokeClrCtor(ConstructorInfo ctor, ImmutableArray<BoundExpression> arguments, ImmutableArray<RefKind> argumentRefKinds)
+    private object InvokeClrCtor(StructSymbol structType, ConstructorInfo ctor, ImmutableArray<BoundExpression> arguments, ImmutableArray<RefKind> argumentRefKinds)
     {
         var args = new object[arguments.Length];
         var refSlots = BuildRefSlots(arguments, argumentRefKinds, args);
-        var instance = ctor.Invoke(args);
+        var instance = InvokeClrBackingConstructor(structType, ctor, args);
         WriteBackRefSlots(refSlots, args);
         return instance;
+    }
+
+    private static object InvokeClrBackingConstructor(StructSymbol structType, ConstructorInfo baseConstructor, object[] arguments)
+    {
+        var parameterTypes = baseConstructor.GetParameters().Select(parameter => parameter.ParameterType).ToArray();
+        var backingType = ClrBackingTypes.GetValue(
+            structType,
+            _ => CreateClrBackingType(structType, baseConstructor.DeclaringType));
+        var constructor = backingType.GetConstructor(parameterTypes)
+            ?? throw new InvalidOperationException($"CLR backing type '{backingType}' has no matching constructor.");
+        return constructor.Invoke(arguments);
+    }
+
+    private static Type CreateClrBackingType(StructSymbol structType, Type clrBase)
+    {
+        // A raw clrBase instance loses the GSharp derived type identity during
+        // virtual dispatch. This minimal runtime subclass only forwards the
+        // accessible constructors; GSharp-declared members remain interpreter-owned.
+        var assembly = AssemblyBuilder.DefineDynamicAssembly(
+            new AssemblyName($"GSharp.Interpreter.{Guid.NewGuid():N}"),
+            AssemblyBuilderAccess.RunAndCollect);
+        var module = assembly.DefineDynamicModule("Main");
+        var fullName = string.IsNullOrEmpty(structType.PackageName)
+            ? structType.Name
+            : $"{structType.PackageName}.{structType.Name}";
+        var type = module.DefineType(fullName, TypeAttributes.Public | TypeAttributes.Class, clrBase);
+
+        foreach (var baseConstructor in clrBase.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+        {
+            if (!baseConstructor.IsPublic && !baseConstructor.IsFamily && !baseConstructor.IsFamilyOrAssembly)
+            {
+                continue;
+            }
+
+            var parameterTypes = baseConstructor.GetParameters().Select(parameter => parameter.ParameterType).ToArray();
+            var constructor = type.DefineConstructor(
+                MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName,
+                CallingConventions.Standard,
+                parameterTypes);
+            var il = constructor.GetILGenerator();
+            il.Emit(OpCodes.Ldarg_0);
+            for (var i = 0; i < parameterTypes.Length; i++)
+            {
+                il.Emit(OpCodes.Ldarg, i + 1);
+            }
+
+            il.Emit(OpCodes.Call, baseConstructor);
+            il.Emit(OpCodes.Ret);
+        }
+
+        return type.CreateType();
     }
 
     /// <summary>Issue #319: resolves the imported CLR base's accessible parameterless constructor (matches the emit path's <c>GetImportedBaseDefaultCtorReference</c>).</summary>
@@ -1193,7 +1258,7 @@ public sealed partial class Evaluator
     /// <summary>
     /// Issue #319: unwraps a GSharp class value to its CLR backing instance when
     /// the value carries one. Reflection-based reads/writes/calls against members
-    /// declared on an imported CLR base must target the real CLR object, not the
+    /// declared on an imported CLR base must target the CLR backing object, not the
     /// interpreter's <see cref="StructValue"/> field dictionary.
     /// </summary>
     private static object UnwrapClrReceiver(object value)

--- a/src/Core/CodeAnalysis/StructValue.cs
+++ b/src/Core/CodeAnalysis/StructValue.cs
@@ -51,8 +51,9 @@ public sealed class StructValue
     /// Gets or sets the CLR backing instance for a GSharp class that inherits an
     /// imported CLR base type (issue #319). When non-null, the interpreter routes
     /// reflection-based access to inherited CLR instance state (properties, fields,
-    /// methods) through this real CLR object so the base constructor's side-effects
-    /// (e.g. <see cref="System.Exception.Message"/>) are observable. Always null
+    /// methods) through this CLR object so the base constructor's side-effects
+    /// (e.g. <see cref="System.Exception.Message"/>) and the GSharp derived type
+    /// identity are observable. Always null
     /// for value-type structs and for class instances whose ultimate base is
     /// <c>object</c> or another GSharp class.
     /// </summary>

--- a/test/Interpreter.Tests/Issue2993ImportedBaseBridgingInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2993ImportedBaseBridgingInterpreterTests.cs
@@ -1,0 +1,158 @@
+// <copyright file="Issue2993ImportedBaseBridgingInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+public class Issue2993ImportedBaseBridgingInterpreterTests
+{
+    [Fact]
+    public void ClassLiteral_RunsConstructorBeforeScalarInitializer()
+    {
+        var source = """
+            import System
+
+            class Counter {
+                prop N int32 { get; init; }
+                prop M int32 { get; set; }
+
+                init() {
+                    Console.WriteLine("ctor-ran")
+                    N = 7
+                }
+            }
+
+            var counter = Counter{ M: 1 }
+            Console.WriteLine(counter.N)
+            Console.WriteLine(counter.M)
+            """;
+
+        Assert.Equal("ctor-ran\n7\n1\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void ClassLiteral_InitializesGetOnlyCollection()
+    {
+        var source = """
+            import System
+            import System.Collections.Generic
+
+            class Bag {
+                prop Items IList[int32] { get; init; }
+
+                init() {
+                    Items = List[int32]()
+                }
+            }
+
+            var empty = Bag{ Items: {} }
+            var filled = Bag{ Items: {1, 2} }
+            var ordinary = Bag()
+            ordinary.Items.Add(3)
+            Console.WriteLine(empty.Items.Count)
+            Console.WriteLine(filled.Items.Count)
+            Console.WriteLine(ordinary.Items.Count)
+            """;
+
+        Assert.Equal("0\n2\n1\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void ImportedBaseLiteral_UsesClrBacking()
+    {
+        var source = """
+            import System
+            import System.IO
+
+            class Buffer : MemoryStream {
+            }
+
+            var literal = Buffer{}
+            var ordinary = Buffer()
+            Console.WriteLine(literal.CanRead)
+            literal.SetLength(3)
+            Console.WriteLine(literal.Length)
+            Console.WriteLine(ordinary.CanRead)
+            """;
+
+        Assert.Equal("True\n3\nTrue\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void ImportedBase_ObjectToString_PreservesGSharpTypeIdentity()
+    {
+        var source = """
+            package Issue3015.Identity
+            import System
+
+            class Args : EventArgs {
+            }
+
+            Console.WriteLine(Args().ToString())
+            Console.WriteLine(Args{}.ToString())
+            Console.WriteLine(Args().GetType().FullName)
+            """;
+
+        Assert.Equal(
+            "Issue3015.Identity.Args\nIssue3015.Identity.Args\nIssue3015.Identity.Args\n",
+            RunSubmission(source));
+    }
+
+    [Fact]
+    public void ImportedBase_ToStringOverride_IsHonored()
+    {
+        var source = """
+            import System
+            import System.IO
+
+            class Writer : StringWriter {
+            }
+
+            var writer = Writer{}
+            writer.Write("ok")
+            Console.WriteLine(writer.ToString())
+            """;
+
+        Assert.Equal("ok\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void ImportedBase_ToStringOverride_ObservesGSharpTypeIdentity()
+    {
+        var source = """
+            package Issue3015.Identity
+            import System
+
+            class Problem : Exception {
+                init() : base("boom") {
+                }
+            }
+
+            Console.WriteLine(Problem().ToString().StartsWith("Issue3015.Identity.Problem: boom"))
+            """;
+
+        Assert.Equal("True\n", RunSubmission(source));
+    }
+
+    private static string RunSubmission(string text)
+    {
+        using var outWriter = new StringWriter();
+        var previousOut = Console.Out;
+        Console.SetOut(outWriter);
+        try
+        {
+            var repl = new GSharpRepl();
+            repl.EvaluateSubmission(text);
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+        }
+
+        return outWriter.ToString().Replace("\r\n", "\n");
+    }
+}


### PR DESCRIPTION
Fixes #2993
Fixes #2996
Fixes #3015

## Summary
- construct G# class literals through the existing constructor evaluator before applying literal initializers
- allocate lightweight CLR-derived backing types so inherited virtual calls retain the G# runtime type identity
- keep imported-base constructor state and inherited reflection dispatch on one backing object
- correct the stale collection-initializer backend comment

## Validation
- `dotnet build GSharp.sln -p:ContinuousIntegrationBuild=true` (0 warnings, 0 errors)
- focused interpreter regressions: 6/6 passed
- existing CLR-base interpreter tests: 9/9 passed
- production mutations flipped 3/3 construction tests and 2/3 identity tests; restoration returned 6/6 green
- direct `gsi` probes now match compiled outputs for scalar/collection literals, `MemoryStream` inheritance, type identity, and `samples/ImportedBaseClass.gs`