### PR TITLE
Document lambda lowering cache and issue coverage

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundFunctionLiteralExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundFunctionLiteralExpression.cs
@@ -47,8 +47,9 @@ public sealed class BoundFunctionLiteralExpression : BoundExpression
 
     /// <summary>
     /// Gets or sets the evaluator's lazily lowered body. Concurrent first use
-    /// may compute equivalent bodies; <c>Lowerer</c> is stateless, so either
-    /// cached value is safe.
+    /// may compute equivalent bodies; <c>Lower</c> allocates a fresh
+    /// <c>Lowerer</c> per call and holds no static state, so either cached value
+    /// is safe.
     /// </summary>
     internal BoundBlockStatement LoweredBody { get; set; }
 }

--- a/src/Core/CodeAnalysis/Binding/BoundFunctionLiteralExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundFunctionLiteralExpression.cs
@@ -45,5 +45,10 @@ public sealed class BoundFunctionLiteralExpression : BoundExpression
 
     public override BoundNodeKind Kind => BoundNodeKind.FunctionLiteralExpression;
 
+    /// <summary>
+    /// Gets or sets the evaluator's lazily lowered body. Concurrent first use
+    /// may compute equivalent bodies; <c>Lowerer</c> is stateless, so either
+    /// cached value is safe.
+    /// </summary>
     internal BoundBlockStatement LoweredBody { get; set; }
 }

--- a/test/Interpreter.Tests/Issue750ConstraintOverloadInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue750ConstraintOverloadInterpreterTests.cs
@@ -102,6 +102,8 @@ public class Issue750ConstraintOverloadInterpreterTests
     [Fact]
     public void FlatMap_NullableReturningLambdaWithIf_RunsInInterpreter()
     {
+        // Issue #2995: the nullable-returning FlatMap lambda contains the
+        // control flow that previously reached the evaluator unlowered.
         var source = """
             import System
             import Gsharp.Extensions.Optional


### PR DESCRIPTION
## Summary
- explain why concurrent lazy initialization of `LoweredBody` is safe: `Lower` creates a fresh `Lowerer` per call and `Lowerer` has no static state
- make the #2995 regression discoverable from its reused interpreter test

Follow-up to review feedback on #3012.

## Verification
- rebased onto `main` at `a4a660f32`
- static audit: five mutable `Lowerer` instance fields; private constructor; exactly two `new Lowerer(...)` sites, one in each static `Lower` overload; zero static fields (the same field pattern matched two positive controls elsewhere in `Lowering`)
- Release solution build with `ContinuousIntegrationBuild=true`: 0 warnings, 0 errors
- targeted filter examined 3 tests: 3 passed
  - `LambdaBody_LowersIfAndAllForForms`
  - `LambdaBody_PreservesConditionForSwitchAndMethodGroupDelegate`
  - `FlatMap_NullableReturningLambdaWithIf_RunsInInterpreter`
- 40 `GSharp.Core.dll` copies checked nonempty; five ordinary copies shared md5 `b436c79a7940687180a13530ca48d5dd`

## Mutation

Both PR hunks are comments, so literal individual hunk reverts correctly killed no tests: the same 3 tests passed after each revert. The behavior described by each hunk was then mutated at the shared production site by returning `node.Body` without lowering:

- build succeeded; five ordinary `GSharp.Core.dll` copies changed from `b436c79a7940687180a13530ca48d5dd` to `00fa00c60cc6e85e46404c9e4d0821b8`
- `LambdaBody_LowersIfAndAllForForms` failed with `Unexpected node IfStatement`
- `FlatMap_NullableReturningLambdaWithIf_RunsInInterpreter` failed
- negative-space `LambdaBody_PreservesConditionForSwitchAndMethodGroupDelegate` passed

After restoring, the build succeeded, all five hashes returned to `b436c79a7940687180a13530ca48d5dd`, and all 3 tests passed again.
