### PR TITLE
Fix interpreter ref alias storage capture

### DIFF
--- a/src/Core/CodeAnalysis/Evaluator.Expressions.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Expressions.cs
@@ -594,6 +594,12 @@ public sealed partial class Evaluator
 
     private object EvaluateBlockExpression(BoundBlockExpression node)
     {
+        EvaluateBlockExpressionStatements(node);
+        return EvaluateExpression(node.Expression);
+    }
+
+    private void EvaluateBlockExpressionStatements(BoundBlockExpression node)
+    {
         foreach (var statement in node.Statements)
         {
             if (statement is BoundVariableDeclaration declaration)
@@ -630,8 +636,6 @@ public sealed partial class Evaluator
 
             throw new EvaluatorException($"Unexpected block-expression statement {statement.Kind}", statement);
         }
-
-        return EvaluateExpression(node.Expression);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Evaluator.Statements.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Statements.cs
@@ -199,27 +199,54 @@ public sealed partial class Evaluator
 
     private void EvaluateVariableDeclaration(BoundVariableDeclaration node)
     {
-        // Issue #491 (ADR-0060 follow-up): a ref-aliasing local binds the symbol
+        // Issue #3022 (ADR-0060 follow-up): a ref-aliasing local binds the symbol
         // to an existing lvalue rather than copying its value. The initializer
-        // is a BoundAddressOfExpression whose operand is the aliased lvalue;
-        // store a RefAlias sentinel in the locals dictionary so subsequent
-        // reads re-evaluate the operand and writes route back to it.
+        // is a BoundAddressOfExpression whose operand is frozen to the storage
+        // location selected when the declaration runs.
         if (node.Variable is LocalVariableSymbol refLocal
             && refLocal.RefKind != RefKind.None
             && node.Initializer is BoundAddressOfExpression refAddr)
         {
-            var alias = new RefAlias(refAddr.Operand);
+            var alias = new RefAlias(FreezeRefOperand(refAddr.Operand));
             var locals = this.Locals.Peek();
             locals[node.Variable] = alias;
 
             // Mirror the read-through semantics for `lastValue` (used by REPL).
-            LastValue = EvaluateExpression(refAddr.Operand);
+            LastValue = EvaluateExpression(alias.Operand);
             return;
         }
 
         var value = EvaluateExpression(node.Initializer);
         LastValue = value;
         Assign(node.Variable, value);
+    }
+
+    private BoundExpression FreezeRefOperand(BoundExpression operand)
+    {
+        switch (operand)
+        {
+            case BoundFieldAccessExpression field when field.Receiver != null && !field.Field.IsConst:
+                return new BoundFieldAccessExpression(
+                    null,
+                    new BoundLiteralExpression(null, EvaluateExpression(field.Receiver), field.Receiver.Type),
+                    field.StructType,
+                    field.Field,
+                    field.NarrowedType);
+
+            case BoundIndexExpression index:
+                return new BoundIndexExpression(
+                    null,
+                    new BoundLiteralExpression(null, EvaluateExpression(index.Target), index.Target.Type),
+                    new BoundLiteralExpression(null, EvaluateExpression(index.Index), index.Index.Type),
+                    index.Type);
+
+            case BoundBlockExpression block:
+                EvaluateBlockExpressionStatements(block);
+                return FreezeRefOperand(block.Expression);
+
+            default:
+                return operand;
+        }
     }
 
     private void EvaluateGoStatement(BoundGoStatement node)

--- a/test/Interpreter.Tests/RefLocalAliasingInterpreterTests.cs
+++ b/test/Interpreter.Tests/RefLocalAliasingInterpreterTests.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.IO;
+using GSharp.Repl.Engine;
 using Xunit;
 
 namespace GSharp.Interpreter.Tests;
@@ -82,6 +83,130 @@ func tweak() {
 tweak()
 ");
         Assert.Contains("7", output);
+    }
+
+    [Fact]
+    public void LetRef_ArrayIndexRead_CapturesOriginalElement()
+    {
+        var output = RunSubmission(@"
+func probe() {
+    var arr = []int32{10, 20, 30}
+    var i int32 = 0
+    let ref r = arr[i]
+    i = 2
+    print(string(r))
+}
+probe()
+");
+        Assert.Equal($"10{Environment.NewLine}", output);
+    }
+
+    [Fact]
+    public void LetRef_ArrayIndexWrite_CapturesOriginalElement()
+    {
+        var output = RunSubmission(@"
+func probe() {
+    var arr = []int32{10, 20, 30}
+    var i int32 = 0
+    let ref r = arr[i]
+    i = 2
+    r = 99
+    print(string(arr[0]) + "","" + string(arr[1]) + "","" + string(arr[2]))
+}
+probe()
+");
+        Assert.Equal($"99,20,30{Environment.NewLine}", output);
+    }
+
+    [Fact]
+    public void LetRef_ArrayIndexWithoutIndexMutation_StillReadsAndWritesElement()
+    {
+        var output = RunSubmission(@"
+func probe() {
+    var arr = []int32{10, 20, 30}
+    var i int32 = 0
+    let ref r = arr[i]
+    r = 99
+    print(string(r) + "","" + string(arr[0]) + "","" + string(arr[1]) + "","" + string(arr[2]))
+}
+probe()
+");
+        Assert.Equal($"99,99,20,30{Environment.NewLine}", output);
+    }
+
+    [Fact]
+    public void LetRef_ClassField_CapturesReceiverBeforeReassignment()
+    {
+        var output = RunSubmission(@"
+class Box {
+    var Value int32
+}
+
+func probe() {
+    var first = Box{Value: 10}
+    var current = first
+    let ref r = current.Value
+    current = Box{Value: 20}
+    r = 99
+    print(string(r) + ""|"" + string(first.Value) + ""|"" + string(current.Value))
+}
+probe()
+");
+        Assert.Equal($"99|99|20{Environment.NewLine}", output);
+    }
+
+    [Fact]
+    public void LetRef_BlockExpression_EvaluatesPrefixOnceAndCapturesElement()
+    {
+        var output = RunSubmission(@"
+func probe() {
+    var original = []int32{10, 20, 30}
+    var current = original
+    let ref r = current[^1]
+    current = []int32{40, 50, 60}
+    r = 99
+    print(string(r) + ""|"" + string(original[0]) + "","" + string(original[1]) + "","" + string(original[2]) + ""|"" + string(current[0]) + "","" + string(current[1]) + "","" + string(current[2]))
+}
+probe()
+");
+        Assert.Equal($"99|10,20,99|40,50,60{Environment.NewLine}", output);
+    }
+
+    [Fact]
+    public void LetRef_GlobalVariable_RemainsAliasedToGlobalSlot()
+    {
+        var output = RunSubmission(@"
+var value int32 = 10
+
+func probe() {
+    let ref r = value
+    r = 55
+    print(string(r) + ""|"" + string(value))
+}
+probe()
+");
+        Assert.StartsWith($"55|55{Environment.NewLine}", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LetRef_UnmanagedPointerDereference_ReportsGs0513()
+    {
+        const string Source = """
+            func probe() {
+                unsafe {
+                    var p *int32 = nil
+                    let ref r = *p
+                    print(string(r))
+                }
+            }
+            probe()
+            """;
+
+        var cell = new SessionEngine().Evaluate(Source);
+
+        var diagnostic = Assert.Single(cell.Diagnostics);
+        Assert.True(cell.HasError);
+        Assert.Equal("GS0513", diagnostic.Id);
     }
 
     private static string RunSubmission(string text)


### PR DESCRIPTION
## Summary
- freeze only mutable ref-local initializer inputs: field receivers plus index targets and indices
- execute bound block-expression prefixes once, then freeze trailing lvalue recursively
- keep `RefAlias`, read/write consumers, `WriteBackToOperand`, and pointer dereference handling unchanged

## Content changes
- `Evaluator.Statements.cs`: freeze captured receiver/index values when ref local is declared; locals, globals, and dereferences retain existing stable-storage paths
- `Evaluator.Expressions.cs`: extract existing block-prefix evaluation so ref binding can execute prefix once without re-running it on reads
- interpreter tests: changed-index read/write, unchanged-index control, class-field receiver reassignment, block-expression capture, global slot, and `GS0513` dereference refusal

## Behavior changes
`let ref` / `var ref` now remain bound to field receiver or array element selected at declaration time. Bound block-expression prefixes run once before trailing lvalue is frozen. Reads and writes continue through existing `RefAlias` consumers and `WriteBackToOperand`.

Unmanaged pointer `&`/`*` behavior is unchanged. `let ref r = *p` with null unmanaged `p` reaches existing #3028 guard and returns `GS0513`, rc=1. No pointer reuse is added.

## Validation
- ref-local interpreter tests: 11 passed, 0 failed
- `gsi`: read `10`; write `99,20,30`; class field `99|99|20`; struct field `99|99`; global `55|55`; block operand `99|10,20,99|40,50,60`
- `gsi` dereference: `GS0513`, rc=1; `gsc`: `NullReferenceException`, rc=134
- `gsc` oracle: 5/5 non-pointer probes match
- mutation kills: field arm 1 failure; index arm 2 failures; block arm 1 failure; injected dereference-bypass arm 1 failure

Fixes #3022