### PR TITLE
gsi: convert delegate values to named delegate types

### DIFF
--- a/src/Core/CodeAnalysis/Evaluator.Calls.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Calls.cs
@@ -591,7 +591,8 @@ public sealed partial class Evaluator
             return value;
         }
         else if (value is Delegate sourceDelegate
-            && node.Type?.ClrType is Type delegateType
+            && (node.Type?.ClrType
+                ?? (node.Type as DelegateTypeSymbol)?.EquivalentFunctionType.ClrType) is Type delegateType
             && typeof(Delegate).IsAssignableFrom(delegateType))
         {
             return delegateType.IsInstanceOfType(sourceDelegate)

--- a/test/Interpreter.Tests/Issue2985NamedDelegateConversionTests.cs
+++ b/test/Interpreter.Tests/Issue2985NamedDelegateConversionTests.cs
@@ -1,0 +1,86 @@
+// <copyright file="Issue2985NamedDelegateConversionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #2985: function literals convert to user-declared named delegates.
+/// </summary>
+public class Issue2985NamedDelegateConversionTests
+{
+    public static TheoryData<string, string, object> Cases => new()
+    {
+        {
+            "void",
+            """
+            type Recorder = delegate func(value int32)
+
+            class Box {
+                var Value int32
+            }
+
+            let box = Box{}
+            var record Recorder = func(value int32) {
+                box.Value = value + 100
+            }
+            record.Invoke(7)
+            box.Value
+            """,
+            107
+        },
+        {
+            "value",
+            """
+            type Transformer = delegate func(value int32) int32
+
+            var transform Transformer = func(value int32) int32 {
+                return value * 2
+            }
+            transform.Invoke(23)
+            """,
+            46
+        },
+        {
+            "generic",
+            """
+            type Mapper[T any] = delegate func(value T) T
+
+            var mapper Mapper[string] = func(value string) string {
+                return value + "-generic"
+            }
+            mapper.Invoke("named")
+            """,
+            "named-generic"
+        },
+        {
+            "variadic",
+            """
+            type Scorer = delegate func(seed int32, values ...int32) int32
+
+            var score Scorer = func(seed int32, values ...int32) int32 {
+                return seed + values.Length * 10
+            }
+            score(2, 4, 5, 6)
+            """,
+            32
+        },
+    };
+
+    [Theory]
+    [MemberData(nameof(Cases))]
+    public void FunctionLiteral_ConvertsToNamedDelegate(string _, string source, object expected)
+    {
+        var result = new Compilation(SyntaxTree.Parse(source))
+            .Evaluate(new Dictionary<VariableSymbol, object>());
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(expected, result.Value);
+    }
+}

--- a/test/Interpreter.Tests/Issue2985NamedDelegateConversionTests.cs
+++ b/test/Interpreter.Tests/Issue2985NamedDelegateConversionTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 namespace GSharp.Interpreter.Tests;
 
 /// <summary>
-/// Issue #2985: function literals convert to user-declared named delegates.
+/// Issue #2985: delegate values convert to user-declared named delegates.
 /// </summary>
 public class Issue2985NamedDelegateConversionTests
 {
@@ -77,10 +77,101 @@ public class Issue2985NamedDelegateConversionTests
     [MemberData(nameof(Cases))]
     public void FunctionLiteral_ConvertsToNamedDelegate(string _, string source, object expected)
     {
+        Assert.Equal(expected, Evaluate(source));
+    }
+
+    [Fact]
+    public void ZeroParameterFunctionLiteral_ConvertsToNamedDelegate()
+    {
+        const string Source = """
+            type Ticker = delegate func() int32
+
+            var tick Ticker = func() int32 {
+                return 77
+            }
+            tick.Invoke()
+            """;
+
+        Assert.Equal(77, Evaluate(Source));
+    }
+
+    [Fact]
+    public void TwoParameterFunctionLiteral_ConvertsToNamedDelegate()
+    {
+        const string Source = """
+            type Adder = delegate func(left int32, right int32) int32
+
+            var add Adder = func(left int32, right int32) int32 {
+                return left * 100 + right
+            }
+            add.Invoke(3, 11)
+            """;
+
+        Assert.Equal(311, Evaluate(Source));
+    }
+
+    [Fact]
+    public void MethodGroup_ConvertsToNamedDelegate()
+    {
+        const string Source = """
+            type Transformer = delegate func(value int32) int32
+
+            func AddThree(value int32) int32 {
+                return value + 3
+            }
+
+            var transform Transformer = AddThree
+            transform.Invoke(30)
+            """;
+
+        Assert.Equal(33, Evaluate(Source));
+    }
+
+    [Fact]
+    public void FunctionDelegate_ConvertsToNamedDelegateArgument()
+    {
+        const string Source = """
+            type Transformer = delegate func(value int32) int32
+
+            func Apply(transform Transformer, value int32) int32 {
+                return transform.Invoke(value)
+            }
+
+            let increment (int32) -> int32 = func(value int32) int32 {
+                return value + 1
+            }
+            Apply(increment, 10)
+            """;
+
+        Assert.Equal(11, Evaluate(Source));
+    }
+
+    [Fact]
+    public void StructurallyEquivalentNamedDelegates_RemainDistinct()
+    {
+        const string Source = """
+            type Alpha = delegate func(value int32) int32
+            type Beta = delegate func(value int32) int32
+
+            var alpha Alpha = func(value int32) int32 {
+                return value * 2
+            }
+            var beta Beta = alpha
+            """;
+
+        var result = new Compilation(SyntaxTree.Parse(Source))
+            .Evaluate(new Dictionary<VariableSymbol, object>());
+
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal("GS0155", diagnostic.Id);
+    }
+
+    private static object Evaluate(string source)
+    {
         var result = new Compilation(SyntaxTree.Parse(source))
             .Evaluate(new Dictionary<VariableSymbol, object>());
 
         Assert.Empty(result.Diagnostics);
-        Assert.Equal(expected, result.Value);
+        return result.Value;
     }
 }


### PR DESCRIPTION
## Summary
- resolve user-declared named delegates through their existing equivalent function type during interpreter conversion
- cover function literals, method groups, function delegates passed to named-delegate parameters, generic delegates, and variadic delegates
- pin nominal identity: structurally identical named delegate types remain non-convertible with `GS0155`

Issue body fix sketch was too large: delegate values are already CLR delegates; only target CLR type resolution was missing.

## Validation
Rebased onto current `origin/main` (`f820484c3`, containing requested `a4a660f32`). Content remains one evaluator hunk plus regression tests.

- `dotnet build GSharp.sln` — 0 warnings/errors
- issue test class — 9/9 pass
- `Delegate|Closure|Lambda|Func` interpreter sweep — 104/104 pass
- reverted production hunk: build passes; 8 conversion tests fail and `GS0155` identity test still passes
- rebuilt `GSharp.Core.dll` MD5: fixed `fc8307af5ba884ea97d03e408a672468`; reverted `bc7efc7d504b26d2b4ee437cd30237cd`
- all three named-delegate samples produce expected values

No file or identity-guard overlap with #3019; imported named delegates take the non-null `ClrType` side and never reach this fallback.

Fixes #2985