### PR TITLE
Fix generic iterator remap precedence

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
+++ b/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
@@ -272,10 +272,9 @@ internal sealed class ImportedMemberRefFactory
             var sigBlob = new BlobBuilder();
             var encoder = new BlobEncoder(sigBlob).TypeSpecificationSignature();
 
-            // Issue #810: inside an iterator state-machine method body,
-            // outer-method TPs are remapped to the SM class's own TPs.
+            // Issue #810: inside an iterator state-machine member,
+            // source TPs are remapped to the SM class's own TPs.
             if (this.remaps.ActiveIteratorStateMachineRemap != null
-                && tpSym.IsMethodTypeParameter
                 && this.remaps.ActiveIteratorStateMachineRemap.TryGetValue(tpSym, out var smClassOrd))
             {
                 encoder.GenericTypeParameter(smClassOrd);

--- a/src/Core/CodeAnalysis/Emit/SignatureEncoder.cs
+++ b/src/Core/CodeAnalysis/Emit/SignatureEncoder.cs
@@ -265,9 +265,8 @@ internal sealed class SignatureEncoder
             // emits `<Empty>d__0<T>` where the body's `!!0` becomes
             // `!0` on the SM class. The remap is pushed by
             // EmitIteratorStateMachineMember and is keyed by the
-            // method TP's instance identity.
+            // source TP's instance identity.
             if (this.remaps.ActiveIteratorStateMachineRemap != null
-                && tp.IsMethodTypeParameter
                 && this.remaps.ActiveIteratorStateMachineRemap.TryGetValue(tp, out var classOrdinal))
             {
                 encoder.GenericTypeParameter(classOrdinal);

--- a/test/Compiler.Tests/Emit/Issue2957FunctionLiteralIteratorTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2957FunctionLiteralIteratorTests.cs
@@ -6,7 +6,10 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -195,8 +198,155 @@ public sealed class Issue2957FunctionLiteralIteratorTests
         Assert.Equal(expectedOutput, RunBounded(name, assemblyPath));
     }
 
+    [Fact]
+    public void GenericReceiverStateMachineMemberSignatures_UseSourceTypeParameterOrdinals()
+    {
+        const string name = "GenericStateMachineMemberSignatures";
+        const string source = """
+            package GenericSignatures
+            import System
+
+            class Factory[T any] {
+                func make[U any]() (T, U) -> sequence[U] {
+                    return func(first T, second U) sequence[U] {
+                        yield second
+                    }
+                }
+            }
+
+            for value in Factory[int32]().make[string]()(42, "ok") {
+                Console.WriteLine(value)
+            }
+            """;
+
+        var assemblyPath = Compile(name, source);
+        using (var stream = File.OpenRead(assemblyPath))
+        using (var peReader = new PEReader(stream))
+        {
+            var metadata = peReader.GetMetadataReader();
+            var stateMachine = metadata.TypeDefinitions
+                .Select(metadata.GetTypeDefinition)
+                .Single(type => metadata.GetString(type.Name).Contains(">d__", StringComparison.Ordinal));
+
+            Assert.Equal(2, stateMachine.GetGenericParameters().Count);
+            AssertFieldTypeParameterOrdinal(metadata, stateMachine, "<>3__first", 0);
+            AssertFieldTypeParameterOrdinal(metadata, stateMachine, "<>3__second", 1);
+            AssertFieldTypeParameterOrdinal(metadata, stateMachine, "<>2__current", 1);
+            AssertMemberReferenceTypeParameterEncoding(
+                metadata,
+                "<>3__first",
+                SignatureTypeCode.GenericTypeParameter,
+                0);
+            AssertMemberReferenceTypeParameterEncoding(
+                metadata,
+                "<>3__second",
+                SignatureTypeCode.GenericTypeParameter,
+                1);
+
+            var currentOrdinal = stateMachine.GetMethods()
+                .Select(metadata.GetMethodDefinition)
+                .Where(method => metadata.GetString(method.Name) == "get_Current")
+                .Select(method => ReadMethodReturnTypeParameterOrdinal(metadata, method))
+                .Single(ordinal => ordinal.HasValue);
+            Assert.Equal(1, currentOrdinal);
+        }
+
+        IlVerifier.Verify(assemblyPath);
+        Assert.NotEmpty(Assembly.Load(File.ReadAllBytes(assemblyPath)).GetTypes());
+        Assert.Equal("ok\n", RunBounded(name, assemblyPath));
+    }
+
     private static object[] Case(string name, string source, string expectedOutput)
         => new object[] { name, source, expectedOutput };
+
+    private static void AssertFieldTypeParameterOrdinal(
+        MetadataReader metadata,
+        TypeDefinition stateMachine,
+        string fieldName,
+        int expectedOrdinal)
+    {
+        var field = stateMachine.GetFields()
+            .Select(metadata.GetFieldDefinition)
+            .Single(candidate => metadata.GetString(candidate.Name) == fieldName);
+        var signature = metadata.GetBlobReader(field.Signature);
+
+        Assert.Equal(SignatureKind.Field, signature.ReadSignatureHeader().Kind);
+        Assert.Equal(SignatureTypeCode.GenericTypeParameter, signature.ReadSignatureTypeCode());
+        Assert.Equal(expectedOrdinal, signature.ReadCompressedInteger());
+        Assert.Equal(0, signature.RemainingBytes);
+    }
+
+    private static void AssertMemberReferenceTypeParameterEncoding(
+        MetadataReader metadata,
+        string memberName,
+        SignatureTypeCode expectedCode,
+        int expectedOrdinal)
+    {
+        foreach (var handle in metadata.MemberReferences)
+        {
+            var member = metadata.GetMemberReference(handle);
+            if (metadata.GetString(member.Name) != memberName)
+            {
+                continue;
+            }
+
+            var signature = metadata.GetBlobReader(member.Signature);
+            if (signature.ReadSignatureHeader().Kind == SignatureKind.Field
+                && signature.ReadSignatureTypeCode() == expectedCode
+                && signature.ReadCompressedInteger() == expectedOrdinal
+                && ParentUsesGenericMethodTypeArguments(metadata, member.Parent))
+            {
+                return;
+            }
+        }
+
+        Assert.Fail(
+            $"Member reference '{memberName}' did not encode {expectedCode}({expectedOrdinal}).");
+    }
+
+    private static bool ParentUsesGenericMethodTypeArguments(
+        MetadataReader metadata,
+        EntityHandle parent)
+    {
+        const byte GenericInstance = 0x15;
+        const byte GenericMethodParameter = 0x1e;
+        if (parent.Kind != HandleKind.TypeSpecification)
+        {
+            return false;
+        }
+
+        var specification = metadata.GetTypeSpecification((TypeSpecificationHandle)parent);
+        var signature = metadata.GetBlobReader(specification.Signature);
+        if (signature.ReadByte() != GenericInstance)
+        {
+            return false;
+        }
+
+        signature.ReadByte();
+        signature.ReadCompressedInteger();
+        return signature.ReadCompressedInteger() > 0
+            && signature.ReadByte() == GenericMethodParameter;
+    }
+
+    private static int? ReadMethodReturnTypeParameterOrdinal(
+        MetadataReader metadata,
+        MethodDefinition method)
+    {
+        var signature = metadata.GetBlobReader(method.Signature);
+        var header = signature.ReadSignatureHeader();
+        if (header.IsGeneric)
+        {
+            signature.ReadCompressedInteger();
+        }
+
+        signature.ReadCompressedInteger();
+        if (signature.ReadSignatureTypeCode() != SignatureTypeCode.GenericTypeParameter)
+        {
+            return null;
+        }
+
+        return signature.ReadCompressedInteger();
+    }
 
     private static string Compile(string name, string source)
     {

--- a/test/Core.Tests/CodeAnalysis/Emit/GenericRemapPrecedenceTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/GenericRemapPrecedenceTests.cs
@@ -40,7 +40,26 @@ public sealed class GenericRemapPrecedenceTests
     }
 
     [Fact]
-    public void ImportedElementToken_ClassTypeParameter_UsesLambdaRemap()
+    public void ImportedElementToken_MethodTypeParameter_UsesLambdaRemapWithoutStateMachine()
+    {
+        var typeParameter = new TypeParameterSymbol(
+            "T",
+            0,
+            TypeParameterConstraint.Any,
+            TypeParameterVariance.None)
+        {
+            IsMethodTypeParameter = true,
+        };
+
+        AssertEncoding(
+            typeParameter,
+            SignatureTypeCode.GenericMethodParameter,
+            expectedOrdinal: 2,
+            includeStateMachineRemap: false);
+    }
+
+    [Fact]
+    public void ImportedElementToken_ClassTypeParameter_PrefersStateMachineRemap()
     {
         var typeParameter = new TypeParameterSymbol(
             "T",
@@ -50,14 +69,15 @@ public sealed class GenericRemapPrecedenceTests
 
         AssertEncoding(
             typeParameter,
-            SignatureTypeCode.GenericMethodParameter,
-            expectedOrdinal: 2);
+            SignatureTypeCode.GenericTypeParameter,
+            expectedOrdinal: 1);
     }
 
     private static void AssertEncoding(
         TypeParameterSymbol typeParameter,
         SignatureTypeCode expectedCode,
-        int expectedOrdinal)
+        int expectedOrdinal,
+        bool includeStateMachineRemap = true)
     {
         var emitter = CreateEmitter();
         var stateMachine = new StructSymbol(
@@ -75,9 +95,13 @@ public sealed class GenericRemapPrecedenceTests
             TypeSymbol.Void,
             package: Package);
 
-        emitter.remaps.RegisterClassRemap(
-            stateMachine,
-            new Dictionary<TypeParameterSymbol, int> { [typeParameter] = 1 });
+        if (includeStateMachineRemap)
+        {
+            emitter.remaps.RegisterClassRemap(
+                stateMachine,
+                new Dictionary<TypeParameterSymbol, int> { [typeParameter] = 1 });
+        }
+
         emitter.remaps.RegisterLambdaMethodRemap(
             lambda,
             new Dictionary<TypeParameterSymbol, int> { [typeParameter] = 2 });


### PR DESCRIPTION
## Summary

Follow-up to #3000 after it merged while blocker verification was still running.

Generic iterator-literal kickoff code constructs a state-machine `TypeSpec` with the lambda method's `MVAR` arguments, but each field `MemberRef` signature must match the state-machine `FieldDef`'s `VAR` slot. The `IsMethodTypeParameter` guards in `SignatureEncoder` and `ImportedMemberRefFactory` let receiver class parameters fall through to the lambda remap, producing:

```text
MissingFieldException: Field not found: '<<lambda1>>d__1`2.<>3__first'
```

This change removes both guards. While a state-machine remap scope is active, every mapped source parameter uses the state-machine class's `VAR` slot. The lambda remap remains the fallback when no state-machine remap is active.

## Dropped remap rewrite

The earlier `ReflectionMetadataEmitter` rewrite has been removed because it is equivalent to the existing offset calculation:

- `SourceTypeParameters` is the receiver parameter prefix followed by `Function.TypeParameters`.
- `BuildRemap()` maps each source parameter to its array index.
- A lambda remap maps each original parameter to the corresponding function-parameter index `i`.
- Therefore `BuildRemap()[Function.TypeParameters[i]]` equals `SourceTypeParameters.Length - Function.TypeParameters.Length + i`.

The lambda remap is registered only when at least one referenced type parameter was promoted, so its production path also guarantees a non-empty function/source parameter list. Keeping the rewrite added null and missing-key paths without changing a reachable ordinal. The reviewer’s deletion mutant surviving 14/14 was correct evidence; the hunk is gone.

The anchor remains `ReflectionMetadataEmitter.RegisterGeneratedGenericRemaps`, now at lines 1271-1295 on `61b7a08c1`.

### Measured path audit

A temporary probe changed the receiver to `Factory[Unused, T]` while the iterator literal referenced only `T` and method parameter `U`: a strict subset of the enclosing type parameters. The observed path was:

```text
source=2 function=2 hasLambda=True lambda=2 remapNull=False missing=0 offset=0
```

The function literal carries only its promoted referenced parameters; it has no generic receiver/static-owner prefix, so the requested `offset != 0` lambda shape is not constructible. Across all ten iterator-literal cases, the probe examined ten state machines:

- 8: `source=0 function=0 hasLambda=False remapNull=True`
- 2: `source=1 function=1 hasLambda=True lambda=1 remapNull=False missing=0 offset=0`

This measures all three proposed failure classes. A null `BuildRemap()` occurs only without a lambda remap, where the existing null guard deliberately skips registration. Every observed lambda remap was non-empty, had a non-null state-machine remap, and every function parameter was present, so neither the NRE, missing-key read, nor silent empty registration path is reachable. The deleted rewrite would create those paths; current code preserves the initializer and guarded registration.

## Metadata regression

`GenericReceiverStateMachineMemberSignatures_UseSourceTypeParameterOrdinals` compiles an iterator literal inside `Factory[T].make[U]`, reads emitted PE metadata, and asserts:

- state-machine `FieldDef` signatures: `first = VAR 0`, `second = VAR 1`, `current = VAR 1`
- generic `get_Current` return: `VAR 1`
- kickoff field `MemberRef` signatures: `first = VAR 0`, `second = VAR 1`
- kickoff parent `TypeSpec` uses the lambda method's `MVAR` arguments

It then runs `IlVerifier`, loads the assembly with `Assembly.Load(File.ReadAllBytes(...))`, calls `GetTypes()`, and executes through the bounded dual-pipe runner, producing `ok`.

## Independent mutants

- Restore the `ImportedMemberRefFactory` guard: `ImportedElementToken_ClassTypeParameter_PrefersStateMachineRemap` fails, expected `GenericTypeParameter`, actual `GenericMethodParameter` (1 failed / 2 passed).
- Restore the `SignatureEncoder` guard: `GenericReceiverStateMachineMemberSignatures_UseSourceTypeParameterOrdinals` fails with `Member reference '<>3__first' did not encode GenericTypeParameter(0)` (1 failed / 0 passed).
- Restore either hunk afterward: its narrow selector passes.

## Verification

- Rebased onto `main` at `61b7a08c1`; `git range-diff` reports the patch unchanged
- Receiver metadata/runtime test: 1/1
- Remap precedence tests: 3/3
- Full solution build with `ContinuousIntegrationBuild=true`: 0 warnings, 0 errors
- Zero-byte gate: 0 found across 51 `GSharp.Core.dll` copies
- Five ordinary copies agree: `c72f16c677a60afa659718a275bc4854`
- Three-dot diff: 4 files, +184/-12

#2930's pending cache fix is in `MetadataTokenCache.CtorRefSymbolKey`; this PR changes `SignatureEncoder.EncodeTypeSymbol` and `ImportedMemberRefFactory.GetElementTypeToken`, so the root causes do not land in the same function.
