### PR TITLE
Make finally funnel dispatch targets observable

### DIFF
--- a/test/Compiler.Tests/Emit/Issue2942ConditionalGotoFinallyFunnelTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2942ConditionalGotoFinallyFunnelTests.cs
@@ -79,8 +79,8 @@ public class Issue2942ConditionalGotoFinallyFunnelTests
 
     [Theory]
     [InlineData(1, 11)]
-    [InlineData(2, 61)]
-    [InlineData(3, 200)]
+    [InlineData(2, 121)]
+    [InlineData(3, 320)]
     public void EmittedMultipleConditionalExits_DispatchSelectedTarget_AndRunFinallyOnce(
         int selectedTarget,
         int expectedExitCode)
@@ -264,11 +264,11 @@ public class Issue2942ConditionalGotoFinallyFunnelTests
             new BoundLabelStatement(null, secondExit),
             new BoundReturnStatement(
                 null,
-                Binary(Read(result), SyntaxKind.PlusToken, Literal(40))),
+                Binary(Read(result), SyntaxKind.PlusToken, Literal(100))),
             new BoundLabelStatement(null, returnLabel),
             new BoundReturnStatement(
                 null,
-                Binary(Read(result), SyntaxKind.PlusToken, Literal(80))),
+                Binary(Read(result), SyntaxKind.PlusToken, Literal(200))),
             new BoundLabelStatement(null, finallyExit),
             new BoundReturnStatement(null, Literal(-1)));
     }
@@ -378,7 +378,10 @@ public class Issue2942ConditionalGotoFinallyFunnelTests
             var stdout = stdoutTask.GetAwaiter().GetResult();
             var stderr = stderrTask.GetAwaiter().GetResult();
             Assert.True(exited, $"child execution timed out\nstdout:\n{stdout}\nstderr:\n{stderr}");
-            Assert.Equal(expectedExitCode, process.ExitCode);
+            var expectedProcessExitCode = OperatingSystem.IsWindows()
+                ? expectedExitCode
+                : expectedExitCode & 0xff;
+            Assert.Equal(expectedProcessExitCode, process.ExitCode);
             Assert.Equal(string.Empty, stdout);
             Assert.Equal(string.Empty, stderr);
         }


### PR DESCRIPTION
Follow-up to #2997.

## Summary

- Make each multi-target dispatch destination return a distinct value (`11`, `121`, or `320`).
- Normalize Unix child-process exit status to its low eight bits while retaining full logical expectations in test data.

This closes the remaining test gap where routing every discriminator to the first arm still passed all ten issue tests.

## Mutation evidence

Clean control passed 10/10 before mutation. M-B changed `ExitPlan.GetDiscriminator` to return `arms[0].Discriminator`; it failed 1/10 (`selectedTarget: 2`, expected `121`, actual `21`). Restored control passed 10/10. Source md5 restored to `8cd5644a127a866db2d8bd3e9bf75c7a`.

Re-measured serially with `FullyQualifiedName~Issue2942ConditionalGotoFinallyFunnelTests`:

| Mutant | Semantic branch | Result |
|---|---|---:|
| M1 | preserve internal target | 4 failed |
| M2 | route escaping target | 7 failed |
| M3 | preserve polarity | 8 failed |
| M4 | preserve condition value | 6 failed |
| M5 | evaluate condition once | 6 failed |
| M6 | assign discriminator | 5 failed |
| M7 | transfer to finally tail | 5 failed |
| M8 | preserve not-taken skip path | 4 failed |
| M9 | detector records conditional branches | 10 failed |
| M10 | discriminator selects the matching target | 1 failed |

Each run examined all 10 issue tests. All mutants were restored; final control passed 10/10.

## Verification

- Release solution build: 0 warnings, 0 errors.
- Zero-byte gate: 0 of 40 `GSharp.Core.dll` copies.
- Five ordinary `GSharp.Core.dll` paths: uniform md5 `3844b206b7144f27c281d4a7a01b3307`.