### PR TITLE
Fix nested struct CLR arity suffixes

### DIFF
--- a/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
@@ -585,12 +585,16 @@ internal sealed class TypeDefEmitter
         FieldDefinitionHandle firstField,
         int methodListRow)
     {
-        // ADR-0087 §3 R1: a generic user type's TypeDef name is mangled with
-        // backtick-arity per ECMA-335 II.10.3.1 (`Box` becomes `Box`1`) and one
-        // GenericParam row is emitted per type parameter immediately after
-        // AddTypeDefinition. Type-erased non-generic structs keep the unmangled
-        // name and have no GenericParam rows.
-        var typeDefName = MangleGenericName(structSym.Name, structSym.TypeParameters);
+        // ADR-0087 §3 R1: the suffix counts parameters declared by this type,
+        // while nested TypeDefs still carry GenericParam rows copied from their
+        // enclosing types. Synthesized types have no declaration, so all of
+        // their TypeParameters are their own.
+        var ownArity = structSym.Declaration == null
+            ? structSym.TypeParameters.Length
+            : structSym.Declaration.TypeParameterList?.Parameters.Count ?? 0;
+        var typeDefName = ownArity == 0
+            ? structSym.Name
+            : structSym.Name + "`" + ownArity.ToString(System.Globalization.CultureInfo.InvariantCulture);
         var handle2 = this.emitCtx.Metadata.AddTypeDefinition(
             attributes: typeAttrs,
             @namespace: structNamespace,

--- a/test/Compiler.Tests/Emit/Issue2916NestedStructArityEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2916NestedStructArityEmitTests.cs
@@ -1,0 +1,183 @@
+// <copyright file="Issue2916NestedStructArityEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+using GsCompilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
+using GsSyntaxTree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>Regression coverage for issue #2916.</summary>
+public sealed class Issue2916NestedStructArityEmitTests
+{
+    [Fact]
+    public void CSharpConsumer_NamesAndRunsNestedStructsByOwnArity()
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            nameof(Issue2916NestedStructArityEmitTests) + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            var libraryPath = Path.Combine(directory, "Issue2916.Library.dll");
+            var consumerPath = Path.Combine(directory, "Issue2916.Consumer.dll");
+
+            EmitGSharpLibrary(libraryPath);
+            EmitCSharpConsumer(libraryPath, consumerPath);
+            AssertMetadataNames(libraryPath);
+            Assert.Equal("11\n22\n33\n", RunConsumer(directory, consumerPath));
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    private static void EmitGSharpLibrary(string outputPath)
+    {
+        const string source = """
+            package Issue2916
+
+            public struct Outer[T any] {
+                public struct Inner {
+                    public var Value int32
+                }
+
+                public struct Middle {
+                    public struct Deep {
+                        public var Value int32
+                    }
+                }
+
+                public struct GenericInner[U any] {
+                    public var Value int32
+                }
+            }
+            """;
+
+        using var resolver = ReferenceResolver.WithReferences(Array.Empty<string>());
+        var compilation = new GsCompilation(resolver, GsSyntaxTree.Parse(SourceText.From(source)))
+        {
+            IsLibrary = true,
+        };
+        using var output = File.Create(outputPath);
+        var result = compilation.Emit(
+            output,
+            pdbStream: null,
+            refStream: null,
+            assemblyName: "Issue2916.Library");
+
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+
+    private static void EmitCSharpConsumer(string libraryPath, string outputPath)
+    {
+        const string source = """
+            using System;
+            using Issue2916;
+
+            public static class Program
+            {
+                public static void Main()
+                {
+                    var direct = new Outer<int>.Inner { Value = 11 };
+                    var throughNonGenericMiddle = new Outer<int>.Middle.Deep { Value = 22 };
+                    var ownGeneric = new Outer<int>.GenericInner<string> { Value = 33 };
+
+                    Console.WriteLine(direct.Value);
+                    Console.WriteLine(throughNonGenericMiddle.Value);
+                    Console.WriteLine(ownGeneric.Value);
+                }
+            }
+            """;
+
+        var references = ((AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string)
+                ?.Split(Path.PathSeparator)
+                ?? Array.Empty<string>())
+            .Where(File.Exists)
+            .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path))
+            .Append(MetadataReference.CreateFromFile(libraryPath));
+        var compilation = CSharpCompilation.Create(
+            "Issue2916.Consumer",
+            new[] { CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest)) },
+            references,
+            new CSharpCompilationOptions(OutputKind.ConsoleApplication));
+
+        using var output = File.Create(outputPath);
+        var result = compilation.Emit(output);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+
+    private static void AssertMetadataNames(string libraryPath)
+    {
+        using var stream = File.OpenRead(libraryPath);
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+
+        AssertType(reader, "Outer`1", genericParameterCount: 1);
+        AssertType(reader, "Inner", genericParameterCount: 1);
+        AssertType(reader, "Middle", genericParameterCount: 1);
+        AssertType(reader, "Deep", genericParameterCount: 1);
+        AssertType(reader, "GenericInner`1", genericParameterCount: 2);
+    }
+
+    private static void AssertType(MetadataReader reader, string name, int genericParameterCount)
+    {
+        var type = reader.TypeDefinitions
+            .Select(reader.GetTypeDefinition)
+            .Single(definition => reader.GetString(definition.Name) == name);
+        Assert.Equal(genericParameterCount, type.GetGenericParameters().Count);
+    }
+
+    private static string RunConsumer(string directory, string consumerPath)
+    {
+        var runtimeConfigPath = Path.ChangeExtension(consumerPath, ".runtimeconfig.json");
+        File.WriteAllText(runtimeConfigPath, """
+            {
+              "runtimeOptions": {
+                "tfm": "net10.0",
+                "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+              }
+            }
+            """);
+
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = directory,
+        };
+        startInfo.ArgumentList.Add("exec");
+        startInfo.ArgumentList.Add("--runtimeconfig");
+        startInfo.ArgumentList.Add(runtimeConfigPath);
+        startInfo.ArgumentList.Add(consumerPath);
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start C# consumer");
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), "C# consumer timed out");
+        Assert.True(
+            process.ExitCode == 0,
+            $"C# consumer exited {process.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout.Replace("\r\n", "\n");
+    }
+}


### PR DESCRIPTION
## Summary
- mangle user struct/class TypeDefs by parameters declared on that type
- retain enclosing generic parameter rows without counting them in nested names
- cover direct, non-generic-middle, and own-generic shapes through a running C# consumer

## Validation
- `dotnet build`
- 17 targeted nested-generic emit tests
- mutation: reverting the emitter hunk restores CS0426 for all three C# names

Fixes #2916