### PR TITLE
Fix imported generic interface diagnostic display

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -12,6 +12,7 @@ using GSharp.Core.CodeAnalysis.Documentation;
 using GSharp.Core.CodeAnalysis.Lowering;
 using GSharp.Core.CodeAnalysis.Lowering.Async;
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Symbols.Display;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
 
@@ -5734,17 +5735,17 @@ public sealed class Binder
         var flags = new System.Collections.Generic.List<string>();
         if (tp.InterfaceConstraint != null)
         {
-            flags.Add(tp.InterfaceConstraint.Name);
+            flags.Add(SymbolDisplay.ToTypeDisplayString(tp.InterfaceConstraint));
         }
 
         if (tp.ClrInterfaceConstraint != null)
         {
-            flags.Add(tp.ClrInterfaceConstraint.Name);
+            flags.Add(SymbolDisplay.ToTypeDisplayString(tp.ClrInterfaceConstraint));
         }
 
         if (tp.ClassConstraint != null)
         {
-            flags.Add(tp.ClassConstraint.Name);
+            flags.Add(SymbolDisplay.ToTypeDisplayString(tp.ClassConstraint));
         }
 
         if (tp.Constraint == TypeParameterConstraint.Comparable)

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.InterfaceVerification.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.InterfaceVerification.cs
@@ -14,6 +14,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Symbols.Display;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
 
@@ -1624,6 +1625,8 @@ internal sealed partial class DeclarationBinder
                 continue;
             }
 
+            var interfaceName = SymbolDisplay.ToTypeDisplayString(ifaceSym);
+
             // Issue #949: a CLR generic interface closed over a user-defined G#
             // type (e.g. the self-referential `class Shape : IEquatable[Shape]`)
             // is represented with a type-erased ClrType (`IEquatable<object>`)
@@ -1632,7 +1635,12 @@ internal sealed partial class DeclarationBinder
             // contract demands `Equals(Shape)` rather than `Equals(object)`.
             if (MemberLookup.TryGetSymbolicClrGenericInterface(ifaceSym, out var openDefinition, out var symbolicArgs))
             {
-                VerifySymbolicClrGenericInterface(syntax, structSymbol, clrIface, openDefinition, symbolicArgs);
+                VerifySymbolicClrGenericInterface(
+                    syntax,
+                    structSymbol,
+                    openDefinition,
+                    symbolicArgs,
+                    interfaceName);
                 continue;
             }
 
@@ -1662,7 +1670,7 @@ internal sealed partial class DeclarationBinder
                 Diagnostics.ReportInterfaceMethodNotImplemented(
                     syntax.Identifier.Location,
                     structSymbol.Name,
-                    clrIface.FullName ?? clrIface.Name,
+                    interfaceName,
                     FormatClrMethodSignature(clrMethod));
             }
 
@@ -1706,7 +1714,7 @@ internal sealed partial class DeclarationBinder
                     Diagnostics.ReportInterfaceMethodNotImplemented(
                         syntax.Identifier.Location,
                         structSymbol.Name,
-                        clrIface.FullName ?? clrIface.Name,
+                        interfaceName,
                         clrProp.Name);
                     continue;
                 }
@@ -1716,7 +1724,7 @@ internal sealed partial class DeclarationBinder
                     Diagnostics.ReportInterfaceMethodNotImplemented(
                         syntax.Identifier.Location,
                         structSymbol.Name,
-                        clrIface.FullName ?? clrIface.Name,
+                        interfaceName,
                         clrProp.Name + " (getter)");
                 }
 
@@ -1725,7 +1733,7 @@ internal sealed partial class DeclarationBinder
                     Diagnostics.ReportInterfaceMethodNotImplemented(
                         syntax.Identifier.Location,
                         structSymbol.Name,
-                        clrIface.FullName ?? clrIface.Name,
+                        interfaceName,
                         clrProp.Name + " (setter)");
                 }
                 else if (requiresSetter)
@@ -1733,7 +1741,7 @@ internal sealed partial class DeclarationBinder
                     ReportClrInterfacePropertySetterKindMismatchIfNeeded(
                         syntax,
                         structSymbol,
-                        clrIface.FullName ?? clrIface.Name,
+                        interfaceName,
                         clrProp.Name,
                         clrProp.SetMethod,
                         implProp);
@@ -1797,10 +1805,13 @@ internal sealed partial class DeclarationBinder
                 }
 
                 reported.Add(slotKey);
+                var interfaceName = declaringType == null
+                    ? "interface"
+                    : SymbolDisplay.ToTypeDisplayString(ImportedTypeSymbol.Get(declaringType));
                 Diagnostics.ReportInterfaceMethodNotImplemented(
                     syntax.Identifier.Location,
                     structSymbol.Name,
-                    declaringType?.FullName ?? declaringType?.Name ?? "interface",
+                    interfaceName,
                     MemberLookup.FormatClrSlotSignature(slot.Method));
             }
         }
@@ -1846,9 +1857,9 @@ internal sealed partial class DeclarationBinder
     private void VerifySymbolicClrGenericInterface(
         StructDeclarationSyntax syntax,
         StructSymbol structSymbol,
-        System.Type clrIface,
         System.Type openDefinition,
-        ImmutableArray<TypeSymbol> symbolicArgs)
+        ImmutableArray<TypeSymbol> symbolicArgs,
+        string interfaceName)
     {
         foreach (var openMethod in openDefinition.GetMethods(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance))
         {
@@ -1865,7 +1876,7 @@ internal sealed partial class DeclarationBinder
             Diagnostics.ReportInterfaceMethodNotImplemented(
                 syntax.Identifier.Location,
                 structSymbol.Name,
-                clrIface.FullName ?? clrIface.Name,
+                interfaceName,
                 FormatClrMethodSignature(openMethod));
         }
 
@@ -1877,7 +1888,7 @@ internal sealed partial class DeclarationBinder
                 Diagnostics.ReportInterfaceMethodNotImplemented(
                     syntax.Identifier.Location,
                     structSymbol.Name,
-                    clrIface.FullName ?? clrIface.Name,
+                    interfaceName,
                     openProp.Name);
                 continue;
             }
@@ -1887,7 +1898,7 @@ internal sealed partial class DeclarationBinder
                 Diagnostics.ReportInterfaceMethodNotImplemented(
                     syntax.Identifier.Location,
                     structSymbol.Name,
-                    clrIface.FullName ?? clrIface.Name,
+                    interfaceName,
                     openProp.Name + " (getter)");
             }
 
@@ -1896,7 +1907,7 @@ internal sealed partial class DeclarationBinder
                 Diagnostics.ReportInterfaceMethodNotImplemented(
                     syntax.Identifier.Location,
                     structSymbol.Name,
-                    clrIface.FullName ?? clrIface.Name,
+                    interfaceName,
                     openProp.Name + " (setter)");
             }
             else if (openProp.SetMethod != null)
@@ -1904,7 +1915,7 @@ internal sealed partial class DeclarationBinder
                 ReportClrInterfacePropertySetterKindMismatchIfNeeded(
                     syntax,
                     structSymbol,
-                    clrIface.FullName ?? clrIface.Name,
+                    interfaceName,
                     openProp.Name,
                     openProp.SetMethod,
                     implProp);

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.InterfaceVerification.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.InterfaceVerification.cs
@@ -1807,12 +1807,12 @@ internal sealed partial class DeclarationBinder
                 reported.Add(slotKey);
                 var interfaceName = declaringType == null
                     ? "interface"
-                    : SymbolDisplay.ToTypeDisplayString(ImportedTypeSymbol.Get(declaringType));
+                    : SymbolDisplay.ToTypeDisplayString(declaringType);
                 Diagnostics.ReportInterfaceMethodNotImplemented(
                     syntax.Identifier.Location,
                     structSymbol.Name,
                     interfaceName,
-                    MemberLookup.FormatClrSlotSignature(slot.Method));
+                    FormatClrMethodSignature(slot.Method));
             }
         }
     }
@@ -1957,7 +1957,7 @@ internal sealed partial class DeclarationBinder
         var names = new string[ps.Length];
         for (var i = 0; i < ps.Length; i++)
         {
-            names[i] = ps[i].ParameterType.Name;
+            names[i] = SymbolDisplay.ToTypeDisplayString(ps[i].ParameterType);
         }
 
         return $"{method.Name}({string.Join(", ", names)})";

--- a/src/Core/CodeAnalysis/Symbols/Display/SymbolDisplay.cs
+++ b/src/Core/CodeAnalysis/Symbols/Display/SymbolDisplay.cs
@@ -73,6 +73,16 @@ public static class SymbolDisplay
     }
 
     /// <summary>
+    /// Renders an imported CLR <paramref name="type"/> without a declaration descriptor.
+    /// </summary>
+    /// <param name="type">The reflected CLR type.</param>
+    /// <returns>The source-compatible G# type name.</returns>
+    public static string ToTypeDisplayString(Type type)
+    {
+        return FormatClrTypeName(type, qualifyNames: true);
+    }
+
+    /// <summary>
     /// Renders <paramref name="symbol"/> to classified display parts under <paramref name="format"/>.
     /// </summary>
     /// <param name="symbol">The symbol to render.</param>

--- a/test/Compiler.Tests/Emit/Issue2875DataClassSettableInterfaceTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2875DataClassSettableInterfaceTests.cs
@@ -193,7 +193,9 @@ public class Issue2875DataClassSettableInterfaceTests
 
             interface IGBox[T] : IBase[T] {
                 prop V T { get; init; }
+                prop OnlyGet T { get; }
                 func Echo(v T) T;
+                func Take(v IBase[T]) void;
             }
             """;
         const string source = """
@@ -225,11 +227,19 @@ public class Issue2875DataClassSettableInterfaceTests
                 output,
                 StringComparison.Ordinal);
             Assert.Contains(
-                "Class 'Box' does not implement interface method 'GLib2.IGBox[int32].Echo(Int32)'.",
+                "Class 'Box' does not implement interface method 'GLib2.IGBox[int32].OnlyGet'.",
                 output,
                 StringComparison.Ordinal);
             Assert.Contains(
-                "Class 'Box' does not implement interface method 'GLib2.IBase[int32].BaseEcho(Int32)'.",
+                "Class 'Box' does not implement interface method 'GLib2.IGBox[int32].Echo(int32)'.",
+                output,
+                StringComparison.Ordinal);
+            Assert.Contains(
+                "Class 'Box' does not implement interface method 'GLib2.IGBox[int32].Take(GLib2.IBase[int32])'.",
+                output,
+                StringComparison.Ordinal);
+            Assert.Contains(
+                "Class 'Box' does not implement interface method 'GLib2.IBase[int32].BaseEcho(int32)'.",
                 output,
                 StringComparison.Ordinal);
             Assert.DoesNotContain("GLib2.IGBox`1[[", output, StringComparison.Ordinal);
@@ -239,6 +249,50 @@ public class Issue2875DataClassSettableInterfaceTests
         {
             Directory.Delete(directory, recursive: true);
         }
+    }
+
+    [Fact]
+    public void SymbolicImportedGenericInterface_DiagnosticUsesSymbolicTypeArgument()
+    {
+        const string source = """
+            package Symbolic
+            import System
+
+            class Shape : IEquatable[Shape] {
+            }
+            """;
+
+        var output = CompileExpectingFailure(source);
+
+        Assert.Contains(
+            "Class 'Shape' does not implement interface method 'System.IEquatable[Shape].Equals(T)'.",
+            output,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("System.IEquatable`1[[", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ImportedConstructedGenericConstraint_DiagnosticUsesGSharpTypeSyntax()
+    {
+        const string source = """
+            package Constraint
+            import System.Collections.Generic
+
+            func F[T List[int32]](value T) {
+            }
+
+            func Use() {
+                F[string]("x")
+            }
+            """;
+
+        var output = CompileExpectingFailure(source);
+
+        Assert.Contains(
+            "Type argument 'string' for type parameter 'T' does not satisfy the 'System.Collections.Generic.List[int32]' constraint.",
+            output,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("System.Collections.Generic.List`1[[", output, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/test/Compiler.Tests/Emit/Issue2875DataClassSettableInterfaceTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2875DataClassSettableInterfaceTests.cs
@@ -169,10 +169,75 @@ public class Issue2875DataClassSettableInterfaceTests
             Assert.Equal(2, output.Split("GS0502", StringSplitOptions.None).Length - 1);
             Assert.Contains("uses accessor 'set'", output, StringComparison.Ordinal);
             Assert.Contains("requires 'init'", output, StringComparison.Ordinal);
+            Assert.Contains(
+                "interface property 'CsInit.IGenericBox[Item].Value'",
+                output,
+                StringComparison.Ordinal);
+            Assert.DoesNotContain("CsInit.IGenericBox`1[[", output, StringComparison.Ordinal);
         }
         finally
         {
             Directory.Delete(fixtureDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ImportedGSharpConstructedGenericInterface_DiagnosticUsesGSharpTypeSyntax()
+    {
+        const string library = """
+            package GLib2
+
+            interface IBase[T] {
+                func BaseEcho(v T) T;
+            }
+
+            interface IGBox[T] : IBase[T] {
+                prop V T { get; init; }
+                func Echo(v T) T;
+            }
+            """;
+        const string source = """
+            package Consumer
+            import GLib2
+
+            class Box : IGBox[int32] {
+                prop V int32 { get; set; }
+            }
+            """;
+
+        var directory = CreateWorkDirectory();
+        try
+        {
+            var librarySourcePath = Path.Combine(directory, "GLib2.gs");
+            var libraryPath = Path.Combine(directory, "GLib2.dll");
+            File.WriteAllText(librarySourcePath, library);
+            var (libraryExitCode, libraryOutput) = Compile(
+                "/out:" + libraryPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                librarySourcePath);
+            Assert.True(libraryExitCode == 0, "gsc failed:\n" + libraryOutput);
+
+            var output = CompileExpectingFailure(source, libraryPath);
+
+            Assert.Contains(
+                "interface property 'GLib2.IGBox[int32].V'",
+                output,
+                StringComparison.Ordinal);
+            Assert.Contains(
+                "Class 'Box' does not implement interface method 'GLib2.IGBox[int32].Echo(Int32)'.",
+                output,
+                StringComparison.Ordinal);
+            Assert.Contains(
+                "Class 'Box' does not implement interface method 'GLib2.IBase[int32].BaseEcho(Int32)'.",
+                output,
+                StringComparison.Ordinal);
+            Assert.DoesNotContain("GLib2.IGBox`1[[", output, StringComparison.Ordinal);
+            Assert.DoesNotContain("GLib2.IBase`1[[", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
         }
     }
 


### PR DESCRIPTION
## Summary
- route all imported CLR interface diagnostic names through shared `SymbolDisplay` across 11 rendering sites
- render imported generic method parameter types in G# syntax, including inherited slots
- render `GS0152` interface/class constraints through shared type display
- cover missing properties, symbolic generic interfaces, constructed parameter types, and constraint messages

## Validation
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj --filter "FullyQualifiedName~Issue2875DataClassSettableInterfaceTests"` (10/10)
- `dotnet test test/Core.Tests/Core.Tests.csproj --filter "FullyQualifiedName~SymbolDisplayImportedTypeTests|FullyQualifiedName~Issue2851GenericDiagnosticDisplayTests"` (13/13)
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj --filter "FullyQualifiedName~Issue2916NestedStructArityEmitTests"` (1/1)
- `dotnet build --verbosity:minimal`
- four `GSharp.Core.dll`-verified mutants killed by targeted tests

Fixes #2910