### PR TITLE
Scope all IL verifier suppressions to affected methods

### DIFF
--- a/test/Compiler.Tests/Emit/Issue1019StaticInterfacePropertyEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1019StaticInterfacePropertyEmitTests.cs
@@ -184,7 +184,7 @@ public class Issue1019StaticInterfacePropertyEmitTests
             }
             """;
 
-        var output = CompileAndRun(source);
+        var output = CompileAndRun(source, ignoredErrorScope: @"<Program>\.Describe$");
         Assert.Equal("apple\n", output);
     }
 
@@ -293,11 +293,11 @@ public class Issue1019StaticInterfacePropertyEmitTests
             compileExit == 0,
             $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
 
-        IlVerifier.Verify(outPath, ignoredErrorCodes: IlVerifier.KnownIssues.StaticVirtualInterface);
+        IlVerifier.Verify(outPath);
         return outPath;
     }
 
-    private static string CompileAndRun(string source)
+    private static string CompileAndRun(string source, string ignoredErrorScope = null)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_sviprop_exe_").FullName;
         try
@@ -335,7 +335,12 @@ public class Issue1019StaticInterfacePropertyEmitTests
                 compileExit == 0,
                 $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
 
-            IlVerifier.Verify(dllPath, ignoredErrorCodes: IlVerifier.KnownIssues.StaticVirtualInterface);
+            IlVerifier.Verify(
+                dllPath,
+                ignoredErrorCodes: ignoredErrorScope is null
+                    ? null
+                    : IlVerifier.KnownIssues.StaticVirtualInterface,
+                ignoredErrorScope: ignoredErrorScope);
 
             var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
             if (!File.Exists(rtConfig))

--- a/test/Compiler.Tests/Emit/Issue1030InterfaceStaticMembersEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1030InterfaceStaticMembersEmitTests.cs
@@ -164,7 +164,7 @@ public class Issue1030InterfaceStaticMembersEmitTests
             }
             """;
 
-        var output = CompileAndRun(source);
+        var output = CompileAndRun(source, ignoredErrorScope: @"<Program>\.Run$");
         Assert.Equal("3\n3\n", output);
     }
 
@@ -259,7 +259,7 @@ public class Issue1030InterfaceStaticMembersEmitTests
             }
             """;
 
-        var output = CompileAndRun(source);
+        var output = CompileAndRun(source, ignoredErrorScope: @"<Program>\.Describe$");
         Assert.Equal("default-name\nbanana\n", output);
     }
 
@@ -448,11 +448,11 @@ public class Issue1030InterfaceStaticMembersEmitTests
             compileExit == 0,
             $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
 
-        IlVerifier.Verify(outPath, ignoredErrorCodes: IlVerifier.KnownIssues.StaticVirtualInterface);
+        IlVerifier.Verify(outPath);
         return outPath;
     }
 
-    private static string CompileAndRun(string source)
+    private static string CompileAndRun(string source, string ignoredErrorScope = null)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_1030_exe_").FullName;
         try
@@ -490,7 +490,12 @@ public class Issue1030InterfaceStaticMembersEmitTests
                 compileExit == 0,
                 $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
 
-            IlVerifier.Verify(dllPath, ignoredErrorCodes: IlVerifier.KnownIssues.StaticVirtualInterface);
+            IlVerifier.Verify(
+                dllPath,
+                ignoredErrorCodes: ignoredErrorScope is null
+                    ? null
+                    : IlVerifier.KnownIssues.StaticVirtualInterface,
+                ignoredErrorScope: ignoredErrorScope);
 
             var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
             if (!File.Exists(rtConfig))

--- a/test/Compiler.Tests/Emit/Issue1162UserElementArrayEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1162UserElementArrayEmitTests.cs
@@ -262,7 +262,12 @@ public class Issue1162UserElementArrayEmitTests
                 compileExit == 0,
                 $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
 
-            IlVerifier.Verify(outPath, ignoredErrorCodes: ignoredIlErrorCodes);
+            IlVerifier.Verify(
+                outPath,
+                ignoredErrorCodes: ignoredIlErrorCodes,
+                ignoredErrorScope: ignoredIlErrorCodes?.Length > 0
+                    ? @"<Program>\.<Main>\$$"
+                    : null);
 
             var psi = new ProcessStartInfo("dotnet")
             {

--- a/test/Compiler.Tests/Emit/Issue1268StaticVirtualGenericInterfaceEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1268StaticVirtualGenericInterfaceEmitTests.cs
@@ -193,7 +193,10 @@ public class Issue1268StaticVirtualGenericInterfaceEmitTests
                 compileExit == 0,
                 $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
 
-            IlVerifier.Verify(dllPath, ignoredErrorCodes: IlVerifier.KnownIssues.StaticVirtualInterface);
+            IlVerifier.Verify(
+                dllPath,
+                ignoredErrorCodes: IlVerifier.KnownIssues.StaticVirtualInterface,
+                ignoredErrorScope: @"<Program>\.Use$");
 
             var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
             if (!File.Exists(rtConfig))

--- a/test/Compiler.Tests/Emit/Issue1301FromEndIndexUserElementEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1301FromEndIndexUserElementEmitTests.cs
@@ -22,15 +22,6 @@ namespace GSharp.Compiler.Tests.Emit;
 /// </summary>
 public class Issue1301FromEndIndexUserElementEmitTests
 {
-    // A value struct with an `init`-only auto-property is constructed via a
-    // struct literal whose property setters emit `stfld` to the backing
-    // readonly field outside the .ctor, which `dotnet-ilverify` flags as
-    // `InitOnly`. This is a pre-existing G# value-struct-literal emit
-    // characteristic, orthogonal to the issue #1301 binding fix; the runtime
-    // assertions below prove correct execution, so these cases verify with
-    // `InitOnly` treated as non-fatal.
-    private static readonly string[] InitOnlyStructLiteral = { "InitOnly" };
-
     [Fact]
     public void StructElementList_FromEndIndex_ReadsMember()
     {
@@ -50,7 +41,7 @@ public class Issue1301FromEndIndexUserElementEmitTests
             Console.WriteLine(l[^3].EndOffset)
             """;
 
-        Assert.Equal("30\n20\n10\n", CompileAndRun(source, InitOnlyStructLiteral));
+        Assert.Equal("30\n20\n10\n", CompileAndRun(source));
     }
 
     [Fact]
@@ -72,7 +63,7 @@ public class Issue1301FromEndIndexUserElementEmitTests
             Console.WriteLine(last.EndOffset)
             """;
 
-        Assert.Equal("9\n", CompileAndRun(source, InitOnlyStructLiteral));
+        Assert.Equal("9\n", CompileAndRun(source));
     }
 
     [Fact]
@@ -142,7 +133,7 @@ public class Issue1301FromEndIndexUserElementEmitTests
         Assert.Equal("30\n20\n10\n", CompileAndRun(source));
     }
 
-    private static string CompileAndRun(string source, string[] ignoredIlErrorCodes = null)
+    private static string CompileAndRun(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_issue1301_").FullName;
         try
@@ -178,7 +169,7 @@ public class Issue1301FromEndIndexUserElementEmitTests
                 compileExit == 0,
                 $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
 
-            IlVerifier.Verify(outPath, ignoredErrorCodes: ignoredIlErrorCodes);
+            IlVerifier.Verify(outPath);
 
             var psi = new ProcessStartInfo("dotnet")
             {

--- a/test/Compiler.Tests/Emit/Issue1302EnumeratorInterfaceUserElementEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1302EnumeratorInterfaceUserElementEmitTests.cs
@@ -24,8 +24,6 @@ namespace GSharp.Compiler.Tests.Emit;
 /// </summary>
 public class Issue1302EnumeratorInterfaceUserElementEmitTests
 {
-    private static readonly string[] InitOnlyStructLiteral = { "InitOnly" };
-
     [Fact]
     public void StructElementList_EnumeratorToInterface_Iterates()
     {
@@ -50,7 +48,7 @@ public class Issue1302EnumeratorInterfaceUserElementEmitTests
             Console.WriteLine(n)
             """;
 
-        Assert.Equal("3\n", CompileAndRun(source, InitOnlyStructLiteral));
+        Assert.Equal("3\n", CompileAndRun(source));
     }
 
     [Fact]
@@ -138,7 +136,7 @@ public class Issue1302EnumeratorInterfaceUserElementEmitTests
 
     // The struct case prints the iteration count over a three-element list,
     // proving the converted IEnumerator[Ch] yields every element at runtime.
-    private static string CompileAndRun(string source, string[] ignoredIlErrorCodes = null)
+    private static string CompileAndRun(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_issue1302_").FullName;
         try
@@ -174,7 +172,7 @@ public class Issue1302EnumeratorInterfaceUserElementEmitTests
                 compileExit == 0,
                 $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
 
-            IlVerifier.Verify(outPath, ignoredErrorCodes: ignoredIlErrorCodes);
+            IlVerifier.Verify(outPath);
 
             var psi = new ProcessStartInfo("dotnet")
             {

--- a/test/Compiler.Tests/Emit/Issue1304MemberErasureEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1304MemberErasureEmitTests.cs
@@ -21,8 +21,6 @@ namespace GSharp.Compiler.Tests.Emit;
 /// </summary>
 public class Issue1304MemberErasureEmitTests
 {
-    private static readonly string[] InitOnlyStructLiteral = { "InitOnly" };
-
     [Fact]
     public void StructElementEnumerator_ReadCurrentMember_Sums()
     {
@@ -50,7 +48,7 @@ public class Issue1304MemberErasureEmitTests
             Console.WriteLine(SumV(GetE(l)))
             """;
 
-        Assert.Equal("21\n", CompileAndRun(source, InitOnlyStructLiteral));
+        Assert.Equal("21\n", CompileAndRun(source));
     }
 
     [Fact]
@@ -77,7 +75,7 @@ public class Issue1304MemberErasureEmitTests
             Console.WriteLine(c.V)
             """;
 
-        Assert.Equal("42\n", CompileAndRun(source, InitOnlyStructLiteral));
+        Assert.Equal("42\n", CompileAndRun(source));
     }
 
     [Fact]
@@ -143,7 +141,7 @@ public class Issue1304MemberErasureEmitTests
         Assert.Equal("6\n", CompileAndRun(source));
     }
 
-    private static string CompileAndRun(string source, string[] ignoredIlErrorCodes = null)
+    private static string CompileAndRun(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_issue1304_").FullName;
         try
@@ -179,7 +177,7 @@ public class Issue1304MemberErasureEmitTests
                 compileExit == 0,
                 $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
 
-            IlVerifier.Verify(outPath, ignoredErrorCodes: ignoredIlErrorCodes);
+            IlVerifier.Verify(outPath);
 
             var psi = new ProcessStartInfo("dotnet")
             {

--- a/test/Compiler.Tests/Emit/Issue1305ChainedLinqEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1305ChainedLinqEmitTests.cs
@@ -28,8 +28,6 @@ public class Issue1305ChainedLinqEmitTests
     // the (host-keyed) FunctionTypeSymbol cache for `Func<TStruct, …>` selector
     // delegates is not torn down between compilations; a shared struct name
     // would alias a prior compilation's struct symbol into the next emit.
-    private static readonly string[] InitOnlyStructLiteral = { "InitOnly" };
-
     [Fact]
     public void StructElement_WhereThenSelect_SumsKept()
     {
@@ -59,7 +57,7 @@ public class Issue1305ChainedLinqEmitTests
             """;
 
         // Keeps V>1 → 5 + 9 = 14.
-        Assert.Equal("14\n", CompileAndRun(source, InitOnlyStructLiteral));
+        Assert.Equal("14\n", CompileAndRun(source));
     }
 
     [Fact]
@@ -91,7 +89,7 @@ public class Issue1305ChainedLinqEmitTests
             """;
 
         // V>0 keeps all three; V>3 keeps 5 and 9 → 2.
-        Assert.Equal("2\n", CompileAndRun(source, InitOnlyStructLiteral));
+        Assert.Equal("2\n", CompileAndRun(source));
     }
 
     [Fact]
@@ -125,7 +123,7 @@ public class Issue1305ChainedLinqEmitTests
         Assert.Equal("28\n", CompileAndRun(source));
     }
 
-    private static string CompileAndRun(string source, string[] ignoredIlErrorCodes = null)
+    private static string CompileAndRun(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_issue1305_").FullName;
         try
@@ -161,7 +159,7 @@ public class Issue1305ChainedLinqEmitTests
                 compileExit == 0,
                 $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
 
-            IlVerifier.Verify(outPath, ignoredErrorCodes: ignoredIlErrorCodes);
+            IlVerifier.Verify(outPath);
 
             var psi = new ProcessStartInfo("dotnet")
             {

--- a/test/Compiler.Tests/Emit/Issue1320UserElementGetEnumeratorEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1320UserElementGetEnumeratorEmitTests.cs
@@ -119,7 +119,7 @@ public class Issue1320UserElementGetEnumeratorEmitTests
         Assert.Equal("6\n", CompileAndRun(source));
     }
 
-    private static string CompileAndRun(string source, string[] ignoredIlErrorCodes = null)
+    private static string CompileAndRun(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_issue1320_").FullName;
         try
@@ -155,7 +155,7 @@ public class Issue1320UserElementGetEnumeratorEmitTests
                 compileExit == 0,
                 $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
 
-            IlVerifier.Verify(outPath, ignoredErrorCodes: ignoredIlErrorCodes);
+            IlVerifier.Verify(outPath);
 
             var psi = new ProcessStartInfo("dotnet")
             {

--- a/test/Compiler.Tests/Emit/Issue1328DictionaryUserElementErasureEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1328DictionaryUserElementErasureEmitTests.cs
@@ -174,7 +174,7 @@ public class Issue1328DictionaryUserElementErasureEmitTests
         Assert.Equal("14\n", CompileAndRun(source));
     }
 
-    private static string CompileAndRun(string source, string[] ignoredIlErrorCodes = null)
+    private static string CompileAndRun(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_issue1328_").FullName;
         try
@@ -210,7 +210,7 @@ public class Issue1328DictionaryUserElementErasureEmitTests
                 compileExit == 0,
                 $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
 
-            IlVerifier.Verify(outPath, ignoredErrorCodes: ignoredIlErrorCodes);
+            IlVerifier.Verify(outPath);
 
             var psi = new ProcessStartInfo("dotnet")
             {

--- a/test/Compiler.Tests/Emit/Issue1334DictionaryLinqReceiverErasureEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1334DictionaryLinqReceiverErasureEmitTests.cs
@@ -162,7 +162,7 @@ public class Issue1334DictionaryLinqReceiverErasureEmitTests
         Assert.Equal("14\n", CompileAndRun(source));
     }
 
-    private static string CompileAndRun(string source, string[] ignoredIlErrorCodes = null)
+    private static string CompileAndRun(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_issue1334_").FullName;
         try
@@ -198,7 +198,7 @@ public class Issue1334DictionaryLinqReceiverErasureEmitTests
                 compileExit == 0,
                 $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
 
-            IlVerifier.Verify(outPath, ignoredErrorCodes: ignoredIlErrorCodes);
+            IlVerifier.Verify(outPath);
 
             var psi = new ProcessStartInfo("dotnet")
             {

--- a/test/Compiler.Tests/Emit/Issue1433InterfaceStaticMemberCallEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1433InterfaceStaticMemberCallEmitTests.cs
@@ -206,7 +206,7 @@ public class Issue1433InterfaceStaticMemberCallEmitTests
                 compileExit == 0,
                 $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
 
-            IlVerifier.Verify(dllPath, ignoredErrorCodes: IlVerifier.KnownIssues.StaticVirtualInterface);
+            IlVerifier.Verify(dllPath);
 
             var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
             if (!File.Exists(rtConfig))

--- a/test/Compiler.Tests/Emit/Issue1507SliceUntypedLambdaLinqEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1507SliceUntypedLambdaLinqEmitTests.cs
@@ -156,7 +156,7 @@ public class Issue1507SliceUntypedLambdaLinqEmitTests
         Assert.Equal("30\n", CompileAndRun(source));
     }
 
-    private static string CompileAndRun(string source, string[] ignoredIlErrorCodes = null)
+    private static string CompileAndRun(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_issue1507_").FullName;
         try
@@ -192,7 +192,7 @@ public class Issue1507SliceUntypedLambdaLinqEmitTests
                 compileExit == 0,
                 $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
 
-            IlVerifier.Verify(outPath, ignoredErrorCodes: ignoredIlErrorCodes);
+            IlVerifier.Verify(outPath);
 
             var psi = new ProcessStartInfo("dotnet")
             {

--- a/test/Compiler.Tests/Emit/Issue1522StackAllocArgEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1522StackAllocArgEmitTests.cs
@@ -167,7 +167,10 @@ public class Issue1522StackAllocArgEmitTests
                 compileExit == 0,
                 $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
 
-            IlVerifier.Verify(dllPath, ignoredErrorCodes: LocallocIlVerifyIgnored);
+            IlVerifier.Verify(
+                dllPath,
+                ignoredErrorCodes: LocallocIlVerifyIgnored,
+                ignoredErrorScope: @"<Program>\.Use$");
 
             var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
             if (!File.Exists(rtConfig))

--- a/test/Compiler.Tests/Emit/Issue1644BoundTreeRewriterClonePreservationEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1644BoundTreeRewriterClonePreservationEmitTests.cs
@@ -136,7 +136,7 @@ public class Issue1644BoundTreeRewriterClonePreservationEmitTests
                 compileExit == 0,
                 $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
 
-            IlVerifier.Verify(dllPath, ignoredErrorCodes: IlVerifier.KnownIssues.StaticVirtualInterface);
+            IlVerifier.Verify(dllPath);
 
             var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
             if (!File.Exists(rtConfig))

--- a/test/Compiler.Tests/Emit/Issue1716DelegateOverInterfaceRowReservationEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1716DelegateOverInterfaceRowReservationEmitTests.cs
@@ -187,11 +187,15 @@ public class Issue1716DelegateOverInterfaceRowReservationEmitTests
         // the IL correctly, confirmed by the successful run below.
         var output = CompileAndRun(
             source,
-            ignoredIlVerifyErrorCodes: new[] { "LdftnNonFinalVirtual" });
+            ignoredIlVerifyErrorCodes: new[] { "LdftnNonFinalVirtual" },
+            ignoredErrorScope: @"IConverter1716\.GetDoubler$");
         Assert.Equal("42\n", output);
     }
 
-    private static string CompileAndRun(string source, IEnumerable<string> ignoredIlVerifyErrorCodes = null)
+    private static string CompileAndRun(
+        string source,
+        IEnumerable<string> ignoredIlVerifyErrorCodes = null,
+        string ignoredErrorScope = null)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_1716mg_exe_").FullName;
         try
@@ -229,7 +233,10 @@ public class Issue1716DelegateOverInterfaceRowReservationEmitTests
                 compileExit == 0,
                 $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
 
-            IlVerifier.Verify(dllPath, ignoredErrorCodes: ignoredIlVerifyErrorCodes);
+            IlVerifier.Verify(
+                dllPath,
+                ignoredErrorCodes: ignoredIlVerifyErrorCodes,
+                ignoredErrorScope: ignoredErrorScope);
 
             var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
             if (!File.Exists(rtConfig))

--- a/test/Compiler.Tests/Emit/Issue1988NarrowedStructAddressOfEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1988NarrowedStructAddressOfEmitTests.cs
@@ -19,21 +19,13 @@ namespace GSharp.Compiler.Tests.Emit;
 /// through that address recreates the exact #1917 ilverify defect
 /// (<c>StackUnexpected: [found address of 'object'][expected ... 'Money']</c>).
 /// Migrating to <see cref="object"/>-narrowing-aware <c>TryLoadStructVariableAddress</c>
-/// fixes it. This is genuinely-unsafe pointer code (ADR-0122), so the residual
-/// managed-pointer-to-unmanaged-pointer conversion errors are pre-existing,
-/// accepted ilverify limitations (see <see cref="IlVerifier.KnownIssues"/> and
-/// Issue1034StructPointerEmitTests) — the test asserts the SPECIFIC #1917-style
-/// "address of 'object'" mismatch is gone, plus correct runtime behavior.
+/// fixes it. The test checks the remaining pointer errors do not contain that
+/// signature, scopes their suppression to <c>run</c>, and verifies runtime behavior.
 /// </summary>
 public class Issue1988NarrowedStructAddressOfEmitTests
 {
-    private static readonly string[] UnsafePointerIgnoredErrorCodes =
-    {
-        "UnmanagedPointer",
-        "StackUnexpected",
-        "StackByRef",
-        "ExpectedPtr",
-    };
+    private static readonly string[] PointerIlVerifyIgnored =
+        { "StackUnexpected", "UnmanagedPointer" };
 
     [Fact]
     public void AddressOf_NarrowedStructLocal_RunsAndDoesNotMistypeAsObjectAddress()
@@ -58,34 +50,11 @@ public class Issue1988NarrowedStructAddressOfEmitTests
             run()
             """;
 
-        var (output, assemblyPath) = CompileAndRun(source);
+        var output = CompileAndRun(source);
         Assert.Equal("100\n", output);
-
-        // Verify ilverify no longer reports the #1917-style "address of
-        // 'object'" stack-shape mismatch (only the inherent, pre-existing
-        // unsafe-pointer-conversion errors remain).
-        var stdout = RunIlVerifyRaw(assemblyPath);
-        Assert.DoesNotContain("address of 'object'", stdout, StringComparison.Ordinal);
     }
 
-    private static string RunIlVerifyRaw(string assemblyPath)
-    {
-        // Re-run ilverify directly (bypassing the throw-on-error helper) so we
-        // can inspect the exact error text for the absence of the #1917
-        // signature, while IlVerifier.Verify (below) still gates on the
-        // known/accepted unsafe-pointer error set.
-        try
-        {
-            IlVerifier.Verify(assemblyPath, ignoredErrorCodes: UnsafePointerIgnoredErrorCodes);
-            return string.Empty;
-        }
-        catch (Xunit.Sdk.XunitException ex)
-        {
-            return ex.Message;
-        }
-    }
-
-    private static (string Output, string AssemblyPath) CompileAndRun(string source)
+    private static string CompileAndRun(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_issue1988_").FullName;
         try
@@ -122,6 +91,19 @@ public class Issue1988NarrowedStructAddressOfEmitTests
             Assert.True(
                 compileExit == 0,
                 $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            try
+            {
+                IlVerifier.Verify(outPath);
+            }
+            catch (Xunit.Sdk.XunitException ex)
+            {
+                Assert.DoesNotContain("address of 'object'", ex.Message, StringComparison.Ordinal);
+            }
+
+            IlVerifier.Verify(
+                outPath,
+                ignoredErrorCodes: PointerIlVerifyIgnored,
+                ignoredErrorScope: @"<Program>\.run$");
 
             var psi = new ProcessStartInfo("dotnet")
             {
@@ -144,7 +126,7 @@ public class Issue1988NarrowedStructAddressOfEmitTests
                 proc.ExitCode == 0,
                 $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
 
-            return (stdout.Replace("\r\n", "\n"), outPath);
+            return stdout.Replace("\r\n", "\n");
         }
         finally
         {

--- a/test/Compiler.Tests/Emit/Issue2323GenericSliceInterfaceEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2323GenericSliceInterfaceEmitTests.cs
@@ -198,7 +198,7 @@ public class Issue2323GenericSliceInterfaceEmitTests
         Assert.DoesNotContain("GS9998", stderr);
     }
 
-    private static (int ExitCode, string Stderr) Compile(string source, string[] ignoredIlErrorCodes = null)
+    private static (int ExitCode, string Stderr) Compile(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_issue2323_").FullName;
         try
@@ -240,7 +240,7 @@ public class Issue2323GenericSliceInterfaceEmitTests
         }
     }
 
-    private static string CompileAndRun(string source, string[] ignoredIlErrorCodes = null)
+    private static string CompileAndRun(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_issue2323_").FullName;
         try
@@ -278,7 +278,7 @@ public class Issue2323GenericSliceInterfaceEmitTests
                 compileExit == 0,
                 $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
 
-            IlVerifier.Verify(outPath, ignoredErrorCodes: ignoredIlErrorCodes);
+            IlVerifier.Verify(outPath);
 
             var psi = new ProcessStartInfo("dotnet")
             {

--- a/test/Compiler.Tests/Emit/Issue2370ExplicitInterfaceStaticMemberEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2370ExplicitInterfaceStaticMemberEmitTests.cs
@@ -77,7 +77,7 @@ public class Issue2370ExplicitInterfaceStaticMemberEmitTests
             }
             """;
 
-        var output = CompileAndRun(source);
+        var output = CompileAndRun(source, ignoredErrorScope: @"<Program>\.Use$");
         Assert.Equal("11\n", output);
     }
 
@@ -109,7 +109,7 @@ public class Issue2370ExplicitInterfaceStaticMemberEmitTests
             }
             """;
 
-        var output = CompileAndRun(source);
+        var output = CompileAndRun(source, ignoredErrorScope: @"<Program>\.Use$");
         Assert.Equal("7\n", output);
     }
 
@@ -161,7 +161,7 @@ public class Issue2370ExplicitInterfaceStaticMemberEmitTests
             }
             """;
 
-        var output = CompileAndRun(source);
+        var output = CompileAndRun(source, ignoredErrorScope: @"<Program>\.(UseFoo|UseBar)$");
         Assert.Equal("1\n2\n", output);
     }
 
@@ -210,7 +210,7 @@ public class Issue2370ExplicitInterfaceStaticMemberEmitTests
             }
             """;
 
-        var output = CompileAndRun(source);
+        var output = CompileAndRun(source, ignoredErrorScope: @"<Program>\.(UseFoo|UseBar)$");
         Assert.Equal("10\n20\n", output);
     }
 
@@ -249,7 +249,7 @@ public class Issue2370ExplicitInterfaceStaticMemberEmitTests
             }
             """;
 
-        var output = CompileAndRun(source);
+        var output = CompileAndRun(source, ignoredErrorScope: @"<Program>\.Use$");
         Assert.Equal("5\n", output);
     }
 
@@ -391,7 +391,7 @@ public class Issue2370ExplicitInterfaceStaticMemberEmitTests
             compileExit == 0,
             $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
 
-        IlVerifier.Verify(outPath, ignoredErrorCodes: IlVerifier.KnownIssues.StaticVirtualInterface);
+        IlVerifier.Verify(outPath);
         return outPath;
     }
 
@@ -430,7 +430,7 @@ public class Issue2370ExplicitInterfaceStaticMemberEmitTests
         return (compileExit, stdoutWriter.ToString() + stderrWriter.ToString());
     }
 
-    private static string CompileAndRun(string source)
+    private static string CompileAndRun(string source, string ignoredErrorScope = null)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_issue2370_static_exe_").FullName;
         try
@@ -468,7 +468,12 @@ public class Issue2370ExplicitInterfaceStaticMemberEmitTests
                 compileExit == 0,
                 $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
 
-            IlVerifier.Verify(dllPath, ignoredErrorCodes: IlVerifier.KnownIssues.StaticVirtualInterface);
+            IlVerifier.Verify(
+                dllPath,
+                ignoredErrorCodes: ignoredErrorScope is null
+                    ? null
+                    : IlVerifier.KnownIssues.StaticVirtualInterface,
+                ignoredErrorScope: ignoredErrorScope);
 
             var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
             if (!File.Exists(rtConfig))

--- a/test/Compiler.Tests/Emit/Issue2883FixedEscapingBranchEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2883FixedEscapingBranchEmitTests.cs
@@ -21,17 +21,6 @@ namespace GSharp.Compiler.Tests.Emit;
 /// </summary>
 public class Issue2883FixedEscapingBranchEmitTests
 {
-    private static readonly string[] FixedIlVerifyIgnored =
-    {
-        "Unverifiable",
-        "UnmanagedPointer",
-        "StackUnexpected",
-        "StackByRef",
-        "ExpectedPtr",
-        "StackUnexpectedArrayType",
-        "ExpectedNumericType",
-    };
-
     [Fact]
     public void BreakOutOfFixed_WithoutReturn_ReportsGs0100AndEmitsNothing()
     {
@@ -199,10 +188,7 @@ public class Issue2883FixedEscapingBranchEmitTests
         try
         {
             File.WriteAllBytes(assemblyPath, peStream.ToArray());
-            IlVerifier.Verify(
-                assemblyPath,
-                additionalReferences: null,
-                ignoredErrorCodes: fixedBody ? FixedIlVerifyIgnored : null);
+            IlVerifier.Verify(assemblyPath);
         }
         finally
         {

--- a/test/Compiler.Tests/Emit/Issue2900FixedPinReleaseEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2900FixedPinReleaseEmitTests.cs
@@ -233,7 +233,10 @@ public class Issue2900FixedPinReleaseEmitTests
             }
             """;
 
-        using var program = Compile(Source, "return_throw");
+        using var program = Compile(
+            Source,
+            "return_throw",
+            ignoredErrorScope: @"(Box\.\.ctor|<Program>\.(ComputedReturn|MixedReturn))$");
         Assert.Equal("42\n9\nvoid\n20\n5\n20\n2\n", program.Run());
 
         var returned = program.ReadMethod("ComputedReturn");
@@ -285,7 +288,10 @@ public class Issue2900FixedPinReleaseEmitTests
             }
             """;
 
-        using var program = Compile(Source, "static_initializer");
+        using var program = Compile(
+            Source,
+            "static_initializer",
+            ignoredErrorScope: @"Holder\.\.cctor$");
         Assert.Equal("41\n", program.Run());
         AssertEscapingLeave(program.ReadMethod(".cctor"), expectedFinallyCount: 1);
     }
@@ -334,7 +340,10 @@ public class Issue2900FixedPinReleaseEmitTests
             }
             """;
 
-        using var program = Compile(Source, "movement");
+        using var program = Compile(
+            Source,
+            "movement",
+            ignoredErrorScope: @"<Program>\.Released$");
         Assert.Equal("True\n", program.Run());
         var method = program.ReadMethod("Released");
         var regions = method.Regions.Where(region => region.Kind == ExceptionRegionKind.Finally).ToArray();
@@ -531,7 +540,11 @@ public class Issue2900FixedPinReleaseEmitTests
             Console.WriteLine(trace)
             """;
 
-        using var program = Compile(Source, "shapes");
+        using var program = Compile(
+            Source,
+            "shapes",
+            ignoredErrorScope:
+                @"<Program>\.(ArrayPin|FixedArrayPin|EmptyPin|StringPin|SpanPin|TryInsideFixed|FixedInsideTry)$");
         Assert.Equal("7\n8\n0\n65\n7\n7\n7\nTRCFBLESGUW1\n", program.Run());
 
         var spanPin = program.ReadMethod("SpanPin");
@@ -590,7 +603,10 @@ public class Issue2900FixedPinReleaseEmitTests
             }
             """;
 
-        using var program = Compile(Source, "switch_return");
+        using var program = Compile(
+            Source,
+            "switch_return",
+            ignoredErrorScope: @"<Program>\.FromSwitch$");
         Assert.Equal("8\n", program.Run());
         AssertEscapingLeave(program.ReadMethod("FromSwitch"), expectedFinallyCount: 1);
     }
@@ -623,7 +639,10 @@ public class Issue2900FixedPinReleaseEmitTests
             }
             """;
 
-        using var program = Compile(Source, "select_return");
+        using var program = Compile(
+            Source,
+            "select_return",
+            ignoredErrorScope: @"<Program>\.FromSelect$");
         Assert.Equal("9\n", program.Run());
         AssertEscapingLeave(program.ReadMethod("FromSelect"), expectedFinallyCount: 1);
     }
@@ -683,7 +702,11 @@ public class Issue2900FixedPinReleaseEmitTests
             }
             """;
 
-        using var program = Compile(Source, "state_machines");
+        using var program = Compile(
+            Source,
+            "state_machines",
+            ignoredErrorScope:
+                @"<(Values|AfterFixed|ReturnFromFixed)>d__\d+\.MoveNext$");
         Assert.Equal("11\n10\n12\n10\n11\n", program.Run());
         Assert.True(
             program.ReadAllMethods().Any(method =>
@@ -859,7 +882,10 @@ public class Issue2900FixedPinReleaseEmitTests
     private static bool IsLeave(OpCode opcode)
         => opcode == OpCodes.Leave || opcode == OpCodes.Leave_S;
 
-    private static CompiledProgram Compile(string source, string tag)
+    private static CompiledProgram Compile(
+        string source,
+        string tag,
+        string ignoredErrorScope = null)
     {
         var directory = Directory.CreateTempSubdirectory($"gs_i2900_{tag}_").FullName;
         var sourcePath = Path.Combine(directory, "test.gs");
@@ -892,7 +918,11 @@ public class Issue2900FixedPinReleaseEmitTests
         Assert.True(
             exitCode == 0,
             $"gsc failed:\nstdout:\n{stdout}\nstderr:\n{stderr}");
-        IlVerifier.Verify(assemblyPath, additionalReferences: null, ignoredErrorCodes: FixedIlVerifyIgnored);
+        IlVerifier.Verify(
+            assemblyPath,
+            additionalReferences: null,
+            ignoredErrorCodes: ignoredErrorScope is null ? null : FixedIlVerifyIgnored,
+            ignoredErrorScope: ignoredErrorScope);
         return new CompiledProgram(directory, assemblyPath);
     }
 

--- a/test/Compiler.Tests/Emit/Issue2945StaticVirtualNullableErasureTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2945StaticVirtualNullableErasureTests.cs
@@ -189,9 +189,7 @@ public class Issue2945StaticVirtualNullableErasureTests
             _ = Assembly.Load(File.ReadAllBytes(libraryPath)).GetTypes();
             var consumerPath = CompileCSharpConsumer(consumer, libraryPath, directory);
             Assert.Equal(expected + "\n", RunChild(consumerPath, directory));
-            IlVerifier.Verify(
-                libraryPath,
-                ignoredErrorCodes: IlVerifier.KnownIssues.StaticVirtualInterface);
+            IlVerifier.Verify(libraryPath);
         }
         finally
         {
@@ -232,7 +230,8 @@ public class Issue2945StaticVirtualNullableErasureTests
             Assert.Equal("ok\n", RunChild(outputPath, directory));
             IlVerifier.Verify(
                 outputPath,
-                ignoredErrorCodes: IlVerifier.KnownIssues.StaticVirtualInterface);
+                ignoredErrorCodes: IlVerifier.KnownIssues.StaticVirtualInterface,
+                ignoredErrorScope: @"<Program>\.Touch$");
         }
         finally
         {

--- a/test/Compiler.Tests/Emit/Issue903SameCompilationLambdaInferenceEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue903SameCompilationLambdaInferenceEmitTests.cs
@@ -287,7 +287,10 @@ public class Issue903SameCompilationLambdaInferenceEmitTests
             // LINQ at all). The gate still catches any NEW IL regression — most
             // importantly a value-type StackObjRef/StackUnexpected from a faulty
             // type-erased LINQ emit.
-            IlVerifier.Verify(outPath, ignoredErrorCodes: new[] { "InitOnly" });
+            IlVerifier.Verify(
+                outPath,
+                ignoredErrorCodes: new[] { "InitOnly" },
+                ignoredErrorScope: @"<Program>\.<Main>\$$");
 
             var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
             File.WriteAllText(runtimeConfigPath, """

--- a/test/Compiler.Tests/Emit/Issue938InBodyStructMethodEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue938InBodyStructMethodEmitTests.cs
@@ -235,7 +235,7 @@ public class Issue938InBodyStructMethodEmitTests
         Assert.True(
             compileExit == 0,
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
-        IlVerifier.Verify(outPath, ignoredErrorCodes: IlVerifier.KnownIssues.RefStruct);
+        IlVerifier.Verify(outPath);
 
         var bytes = File.ReadAllBytes(outPath);
         return (Assembly.Load(bytes), diagnostics);

--- a/test/Compiler.Tests/Emit/StaticVirtualInterfaceMembersEmitTests.cs
+++ b/test/Compiler.Tests/Emit/StaticVirtualInterfaceMembersEmitTests.cs
@@ -246,7 +246,7 @@ public class StaticVirtualInterfaceMembersEmitTests
             }
             """;
 
-        var output = CompileAndRun(source);
+        var output = CompileAndRun(source, ignoredErrorScope: @"<Program>\.Compute$");
         Assert.Equal("7\n", output);
     }
 
@@ -279,7 +279,7 @@ public class StaticVirtualInterfaceMembersEmitTests
             }
             """;
 
-        var output = CompileAndRun(source);
+        var output = CompileAndRun(source, ignoredErrorScope: @"<Program>\.Use$");
         Assert.Equal("default-hello\n", output);
     }
 
@@ -367,11 +367,11 @@ public class StaticVirtualInterfaceMembersEmitTests
             compileExit == 0,
             $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
 
-        IlVerifier.Verify(outPath, ignoredErrorCodes: IlVerifier.KnownIssues.StaticVirtualInterface);
+        IlVerifier.Verify(outPath);
         return outPath;
     }
 
-    private static string CompileAndRun(string source)
+    private static string CompileAndRun(string source, string ignoredErrorScope = null)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_svim_exe_").FullName;
         try
@@ -409,7 +409,12 @@ public class StaticVirtualInterfaceMembersEmitTests
                 compileExit == 0,
                 $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
 
-            IlVerifier.Verify(dllPath, ignoredErrorCodes: IlVerifier.KnownIssues.StaticVirtualInterface);
+            IlVerifier.Verify(
+                dllPath,
+                ignoredErrorCodes: ignoredErrorScope is null
+                    ? null
+                    : IlVerifier.KnownIssues.StaticVirtualInterface,
+                ignoredErrorScope: ignoredErrorScope);
 
             var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
             if (!File.Exists(rtConfig))
@@ -492,7 +497,7 @@ public class StaticVirtualInterfaceMembersEmitTests
                 compileExit == 0,
                 $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
 
-            IlVerifier.Verify(gDllPath, ignoredErrorCodes: IlVerifier.KnownIssues.StaticVirtualInterface);
+            IlVerifier.Verify(gDllPath);
 
             // Step 2: scaffold a C# console consumer.
             var csDir = Path.Combine(tempDir, "consumer");

--- a/test/Compiler.Tests/Emit/UserStructMethodEmitTests.cs
+++ b/test/Compiler.Tests/Emit/UserStructMethodEmitTests.cs
@@ -170,7 +170,10 @@ public class UserStructMethodEmitTests
             public var result = make().Show()
             """;
 
-        var assembly = CompileToAssembly(source, target: "exe");
+        var assembly = CompileToAssembly(
+            source,
+            target: "exe",
+            ignoredErrorScope: @"<Program>\.make$");
         var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
         var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
         var resultField = program.GetField("result", BindingFlags.Public | BindingFlags.Static);
@@ -392,7 +395,10 @@ public class UserStructMethodEmitTests
         Assert.Equal(7, (int)resultField!.GetValue(null)!);
     }
 
-    private static Assembly CompileToAssembly(string source, string target)
+    private static Assembly CompileToAssembly(
+        string source,
+        string target,
+        string ignoredErrorScope = null)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_user_method_emit_").FullName;
         var srcPath = Path.Combine(tempDir, "test.gs");
@@ -425,7 +431,10 @@ public class UserStructMethodEmitTests
         Assert.True(
             compileExit == 0,
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
-        IlVerifier.Verify(outPath, ignoredErrorCodes: IlVerifier.KnownIssues.RefStruct);
+        IlVerifier.Verify(
+            outPath,
+            ignoredErrorCodes: ignoredErrorScope is null ? null : IlVerifier.KnownIssues.RefStruct,
+            ignoredErrorScope: ignoredErrorScope);
 
         var bytes = File.ReadAllBytes(outPath);
         return Assembly.Load(bytes);

--- a/test/Compiler.Tests/IlVerifier.cs
+++ b/test/Compiler.Tests/IlVerifier.cs
@@ -104,6 +104,8 @@ internal static class IlVerifier
                 ignoredErrorCodes: null,
                 includedScope: null,
                 excludedScope: ignoredErrorScope);
+            // ponytail: -g remains category-wide inside the matched method;
+            // parse exact verifier instances only if method scope proves too broad.
             VerifyCore(
                 command,
                 leadingArgs,
@@ -345,33 +347,37 @@ internal static class IlVerifier
     }
 
     /// <summary>
-    /// Maps a sample name (as it appears under <c>samples/</c>) to the bundle
-    /// of ilverify error codes that the conformance harness should treat as
-    /// known issues. Samples not present in this map are verified strictly.
+    /// Maps a sample name (as it appears under <c>samples/</c>) to ilverify
+    /// error codes and the methods where the conformance harness should treat
+    /// them as known issues. Samples not present in this map are verified strictly.
     /// Keys are matched case-insensitively against the sample's base name
     /// without extension.
     /// </summary>
-    public static IReadOnlyList<string> GetKnownIssuesForSample(string sampleBaseName)
+    public static (IReadOnlyList<string> ErrorCodes, string? Scope) GetKnownIssuesForSample(
+        string sampleBaseName)
     {
         var key = sampleBaseName.TrimEnd('/');
-        if (SampleKnownIssues.TryGetValue(key, out var codes))
+        if (SampleKnownIssues.TryGetValue(key, out var knownIssues))
         {
-            return codes;
+            return knownIssues;
         }
 
-        return Array.Empty<string>();
+        return (Array.Empty<string>(), null);
     }
 
-    private static readonly Dictionary<string, string[]> SampleKnownIssues = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly Dictionary<string, (IReadOnlyList<string> ErrorCodes, string? Scope)> SampleKnownIssues =
+        new(StringComparer.OrdinalIgnoreCase)
     {
         // Ref struct emission: see KnownIssues.RefStruct.
-        ["UserRefStruct"] = KnownIssues.RefStruct,
+        ["UserRefStruct"] = (KnownIssues.RefStruct, @"<Program>\.add$"),
 
         // ADR-0089 / issue #755: static-virtual interface dispatch emits
         // the canonical `constrained. !!T  call <iface>::<method>` pattern
         // that pre-C#-11 ilverify rules don't understand. Identical errors
         // are produced by csc-emitted IL for the same C# 11 pattern.
-        ["StaticVirtualInterfaces"] = KnownIssues.StaticVirtualInterface,
+        ["StaticVirtualInterfaces"] = (
+            KnownIssues.StaticVirtualInterface,
+            @"<Program>\.(Apply|IdentityOf)$"),
     };
 
     private static (string Command, IReadOnlyList<string> LeadingArgs) LocateTool()

--- a/test/Compiler.Tests/IlVerifierTests.cs
+++ b/test/Compiler.Tests/IlVerifierTests.cs
@@ -183,6 +183,7 @@ public class IlVerifierTests
                     ignoredErrorCodes: new[] { "UnmanagedPointer", "StackByRef" },
                     ignoredErrorScope: @"<Program>\.Ignored$"));
             Assert.Contains("::Visible(", exception.Message, StringComparison.Ordinal);
+            Assert.DoesNotContain("::Ignored(", exception.Message, StringComparison.Ordinal);
         }
         finally
         {
@@ -221,6 +222,7 @@ public class IlVerifierTests
     public void RunProcess_LargeStdoutAndStderr_DrainsBothPipes()
     {
         // A regression that blocks in either drain before WaitForExit hangs this test.
+        // Starting a drain after the wait instead reaches the 10 s timeout and fails boundedly.
         // xUnit's Fact timeout is unavailable because this assembly disables test
         // parallelization, and RunProcess's timeout cannot cover a deadlock placed
         // before its wait. Treat such a hang as the regression, not a flake.

--- a/test/Compiler.Tests/LanguageConformance/SampleConformanceTests.cs
+++ b/test/Compiler.Tests/LanguageConformance/SampleConformanceTests.cs
@@ -163,10 +163,12 @@ public class SampleConformanceTests
                 compileExit == 0,
                 $"gsc failed for {sampleName}:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
             var ilVerifyAdditionalRefs = extensionsAssemblyPath != null ? new[] { extensionsAssemblyPath } : null;
+            var knownIlIssues = IlVerifier.GetKnownIssuesForSample(baseName);
             IlVerifier.Verify(
                 outPath,
                 additionalReferences: ilVerifyAdditionalRefs,
-                ignoredErrorCodes: IlVerifier.GetKnownIssuesForSample(baseName));
+                ignoredErrorCodes: knownIlIssues.ErrorCodes,
+                ignoredErrorScope: knownIlIssues.Scope);
             Assert.True(File.Exists(outPath), $"expected emitted assembly at {outPath}");
 
             var psi = new ProcessStartInfo("dotnet")


### PR DESCRIPTION
## Summary

- Audit every `IlVerifier.Verify` suppression left after #3014. The base had 37 named `ignoredErrorCodes` occurrences: one internal call plus 36 callers; three callers were already scoped, leaving 33 rather than the estimated 26.
- Migrate all 33 remaining callers: remove 19 obsolete blankets and add method scopes to the 14 callers that still need known ilverify limitations suppressed.
- Carry sample-specific scopes through the conformance harness.
- Strengthen the scope regression with `DoesNotContain("::Ignored(")` and document both the method-local `-g` ceiling and the bounded failure caused by starting a drain after `WaitForExit`.
- Fix the Issue1988 test while migrating it: it returned an assembly path after deleting its temp directory, so its caught `assembly not found` exception made the old assertion vacuous. Verification now runs before cleanup, preserves the specific `address of 'object'` check, and scopes the two known pointer categories to `<Program>.run`.

## Scope decisions

- No instance-level verifier matching was added. `-g` remains category-wide inside a matched method; the new `// ponytail:` comment records that ceiling and the exact-instance upgrade path.
- The existing 20-second escaped-descendant assertion remains unchanged. Measured worst case was about 12 seconds, so 20 seconds provides 8 seconds of contention headroom instead of 3.
- No unexpected compiler IL defect was exposed. Every unblanketed failure matched an established static-interface, ref-struct, fixed/pointer, `InitOnly`, or ilverify state-machine limitation.

## Evidence

- Post-rebase targeted run: **158 examined, 158 passed**, exit 0, with `-p:ContinuousIntegrationBuild=true` and a filter covering every changed test class plus the two affected samples.
- Repository audit: **2,884 tracked C# files**, **17** `IlVerifier.Verify` calls still passing `ignoredErrorCodes`, **0** missing `ignoredErrorScope`.
- Perturbation: changed Issue1268 scope from `<Program>\.Use$` to `<NoSuchType>\.Zzz$`; its targeted test failed with the expected `CallAbstract` and `Constrained` errors in `<Program>::Use`. Restored scope; same test passed.
- Three-dot net diff checked from computed merge base `7a6307a797eace2b27854c94b91d64fe7f7b474f`; `git diff --check` passed.

Follow-up to #3014.
