### PR TITLE
Cover async struct channel select integration

### DIFF
--- a/test/Compiler.Tests/Emit/Issue2965ChannelElementSlotTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2965ChannelElementSlotTests.cs
@@ -90,6 +90,19 @@ public class Issue2965ChannelElementSlotTests
                 return (<-ch).Value
             }
 
+            async func asyncSelectPair() int32 {
+                let ch = make(chan Pair, 1)
+                ch <- Pair(56)
+                var result = 0
+                select {
+                    case let value = <-ch {
+                        await Task.Delay(1)
+                        result = value.Value
+                    }
+                }
+                return result
+            }
+
             let plainReceive = make(chan Pair, 1)
             plainReceive <- Pair(41)
             Console.WriteLine((<-plainReceive).Value)
@@ -177,12 +190,13 @@ public class Issue2965ChannelElementSlotTests
 
             Console.WriteLine(echo(Pair(53)).Value)
             Console.WriteLine(asyncPair().Result)
+            Console.WriteLine(asyncSelectPair().Result)
             """;
 
         AssertRuns(
             Source,
             nameof(ChannelElementMatrix_LoadsVerifiesAndRuns),
-            "41\n42\n55\n43\n44\n45\n46\n47\n54\n48\n49\n2020\n0\n0\n51\n52\n53\n50\n");
+            "41\n42\n55\n43\n44\n45\n46\n47\n54\n48\n49\n2020\n0\n0\n51\n52\n53\n50\n56\n");
     }
 
     private static void AssertRuns(string source, string name, string expected)


### PR DESCRIPTION
## Summary

PR #3026 fixed symbolic channel element metadata, while #2967 independently changed async select receive bindings. This test pins their combined path: an async select receives a same-compilation struct, awaits inside the arm, then reads the hoisted binding.

## Evidence

`dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release --no-restore --nologo --verbosity minimal -p:ContinuousIntegrationBuild=true --filter FullyQualifiedName~Issue2965ChannelElementSlotTests`

Result: **2/2 passed** with assembly loading, bounded execution, exact output, and IL verification.

Test-only; no production changes.

Related to #2965 and #2967.
