### PR TITLE
Fix generic local function evaluation in gsi

### DIFF
--- a/src/Core/CodeAnalysis/Evaluator.Calls.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Calls.cs
@@ -86,7 +86,9 @@ public sealed partial class Evaluator
                 }
             }
 
-            var statement = program.Functions[node.Function];
+            var statement = program.Functions.TryGetValue(node.Function, out var functionBody)
+                ? functionBody
+                : localFunctionBodies[node.Function];
             var isIterator = IsIteratorFunction(node.Function, statement);
             object result;
             using (PushFrame(locals))

--- a/src/Core/CodeAnalysis/Evaluator.Statements.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Statements.cs
@@ -71,6 +71,14 @@ public sealed partial class Evaluator
                     EvaluateVariableDeclaration((BoundVariableDeclaration)s);
                     index++;
                     break;
+                case BoundNodeKind.LocalFunctionDeclaration:
+                    var declaration = (BoundLocalFunctionDeclaration)s;
+                    var literal = declaration.Literal;
+                    localFunctionBodies.TryAdd(
+                        literal.Function,
+                        literal.LoweredBody ??= (BoundBlockStatement)Lowering.Lowerer.Lower(literal.Body));
+                    index++;
+                    break;
                 case BoundNodeKind.ExpressionStatement:
                     EvaluateExpressionStatement((BoundExpressionStatement)s);
                     index++;

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -59,6 +59,7 @@ public sealed partial class Evaluator
     private readonly object globalsLock = new object();
 
     private readonly Dictionary<Symbols.FunctionSymbol, bool> iteratorFunctionCache = [];
+    private readonly ConcurrentDictionary<FunctionSymbol, BoundBlockStatement> localFunctionBodies = [];
     private readonly Dictionary<(Symbols.StructSymbol, Symbols.FieldSymbol), object> staticFields = [];
 
     // ADR-0089 / issue #1030: interface static-field storage. Keyed by the

--- a/test/Interpreter.Tests/Issue3030LocalFunctionDeclarationInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue3030LocalFunctionDeclarationInterpreterTests.cs
@@ -1,0 +1,73 @@
+// <copyright file="Issue3030LocalFunctionDeclarationInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #3030: generic local-function declarations are evaluator no-ops.
+/// </summary>
+public class Issue3030LocalFunctionDeclarationInterpreterTests
+{
+    public static IEnumerable<object[]> Cases()
+    {
+        yield return Case(
+            """
+            let Identity[T] = func(value T) T {
+                return value
+            }
+
+            Console.WriteLine(Identity(17))
+            Console.WriteLine(Identity("top-level"))
+            """,
+            "17\ntop-level\n");
+
+        yield return Case(
+            """
+            func PrintValues() {
+                let First[T] = func(first T, second T) T {
+                    return first
+                }
+
+                Console.WriteLine(First(42, 99))
+                Console.WriteLine(First("nested", "other"))
+            }
+
+            PrintValues()
+            """,
+            "42\nnested\n");
+    }
+
+    [Theory]
+    [MemberData(nameof(Cases))]
+    public void GenericLocalFunctionDeclaration_EvaluatesCalls(string source, string expectedOutput)
+    {
+        using var writer = new StringWriter();
+        var previousOut = Console.Out;
+        Console.SetOut(writer);
+        try
+        {
+            var result = new Compilation(SyntaxTree.Parse(source))
+                .Evaluate(new Dictionary<VariableSymbol, object>());
+
+            Assert.Empty(result.Diagnostics);
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+        }
+
+        Assert.Equal(expectedOutput, writer.ToString().Replace("\r\n", "\n", StringComparison.Ordinal));
+    }
+
+    private static object[] Case(string source, string expectedOutput)
+        => new object[] { source, expectedOutput };
+}


### PR DESCRIPTION
## Summary
- handle generic local-function declaration statements in evaluator
- register their lowered bodies for direct generic calls
- cover top-level and nested declarations with distinct outputs

Fixes #3030

## Validation
- `dotnet build --nologo`
- `dotnet test test/Interpreter.Tests/Interpreter.Tests.csproj --filter FullyQualifiedName~Issue3030LocalFunctionDeclarationInterpreterTests --nologo`
- declaration dispatch, body registration, and call fallback mutants each fail 2/2 cases