### PR TITLE
Reject truncated child exit expectations

### DIFF
--- a/test/Compiler.Tests/Emit/Issue2942ConditionalGotoFinallyFunnelTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2942ConditionalGotoFinallyFunnelTests.cs
@@ -378,6 +378,7 @@ public class Issue2942ConditionalGotoFinallyFunnelTests
             var stdout = stdoutTask.GetAwaiter().GetResult();
             var stderr = stderrTask.GetAwaiter().GetResult();
             Assert.True(exited, $"child execution timed out\nstdout:\n{stdout}\nstderr:\n{stderr}");
+            Assert.InRange(expectedExitCode, 0, byte.MaxValue);
             Assert.Equal(expectedExitCode, process.ExitCode);
             Assert.Equal(string.Empty, stdout);
             Assert.Equal(string.Empty, stderr);


### PR DESCRIPTION
Follow-up to merged #2997. Replaces closed no-op #3037 with the independent review finding worth keeping.

## Change

Add `Assert.InRange(expectedExitCode, 0, byte.MaxValue)` before comparing the emitted program's child-process exit code. This fails loudly if a future test expects a value that POSIX would truncate to eight bits.

## Verification

- Clean issue suite: 10/10 passed.
- Perturbed `selectedTarget: 3` expectation from `200` to `320`: 1 failed / 9 passed with `Assert.InRange() Failure`.
- Restored issue suite: 10/10 passed.
- Scope: one file, one added line.
