### PR TITLE
gsi: preserve lambda method identity per site

### DIFF
--- a/src/Core/CodeAnalysis/Evaluator.Expressions.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Expressions.cs
@@ -28,6 +28,7 @@ public sealed partial class Evaluator
 #pragma warning restore CA1001
 {
     private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<Type, Func<Func<object[], object>, Delegate>> InterpreterDelegateFactories = new();
+    private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<FunctionSymbol, ConcurrentDictionary<Type, Func<Func<object[], object>, Delegate>>> InterpreterDelegateFactoriesBySite = new();
     private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<Delegate, ClosureValue> InterpreterClosures = new();
 
     private object EvaluateExpression(BoundExpression node)
@@ -780,7 +781,9 @@ public sealed partial class Evaluator
         }
 
         var body = node.LoweredBody ??= (BoundBlockStatement)Lowering.Lowerer.Lower(node.Body);
-        return MaterializeClosure(new ClosureValue(node.Function, body, node.FunctionType, captured));
+        return MaterializeClosure(
+            new ClosureValue(node.Function, body, node.FunctionType, captured),
+            GetLambdaMethodName(node));
     }
 
     private object EvaluateMethodGroupExpression(BoundMethodGroupExpression node)
@@ -799,7 +802,9 @@ public sealed partial class Evaluator
             captured[node.Function.ThisParameter] = EvaluateExpression(node.Receiver);
         }
 
-        return MaterializeClosure(new ClosureValue(node.Function, body, node.FunctionType, captured));
+        return MaterializeClosure(
+            new ClosureValue(node.Function, body, node.FunctionType, captured),
+            node.Function.Name);
     }
 
     private object EvaluateClrMethodGroupExpression(BoundClrMethodGroupExpression node)
@@ -847,22 +852,51 @@ public sealed partial class Evaluator
         return InvokeClosure((ClosureValue)targetValue, arguments);
     }
 
-    private object MaterializeClosure(ClosureValue closure)
+    private object MaterializeClosure(ClosureValue closure, string methodName)
     {
         if (closure.FunctionType.ClrType is not Type delegateType)
         {
             return closure;
         }
 
-        var result = CreateInterpreterDelegate(delegateType, args => InvokeMaterializedClosure(closure, args));
+        var result = CreateInterpreterDelegate(
+            delegateType,
+            closure.Function,
+            methodName,
+            args => InvokeMaterializedClosure(closure, args));
         InterpreterClosures.Add(result, closure);
         return result;
     }
+
+    private static string GetLambdaMethodName(BoundFunctionLiteralExpression node)
+    {
+        if (node.CapturedVariables.Length != 0
+            || (!node.Function.IsGeneric
+                && node.Function.LexicalEnclosingType is StructSymbol enclosingType
+                && enclosingType.TypeParameters.IsDefaultOrEmpty))
+        {
+            return "Invoke";
+        }
+
+        return node.Function.Name;
+    }
+
+    private static Delegate CreateInterpreterDelegate(
+        Type delegateType,
+        FunctionSymbol function,
+        string methodName,
+        Func<object[], object> invoke)
+        => InterpreterDelegateFactoriesBySite
+            .GetValue(function, _ => new ConcurrentDictionary<Type, Func<Func<object[], object>, Delegate>>())
+            .GetOrAdd(delegateType, type => BuildInterpreterDelegateFactory(type, methodName))(invoke);
 
     private static Delegate CreateInterpreterDelegate(Type delegateType, Func<object[], object> invoke)
         => InterpreterDelegateFactories.GetValue(delegateType, BuildInterpreterDelegateFactory)(invoke);
 
     private static Func<Func<object[], object>, Delegate> BuildInterpreterDelegateFactory(Type delegateType)
+        => BuildInterpreterDelegateFactory(delegateType, null);
+
+    private static Func<Func<object[], object>, Delegate> BuildInterpreterDelegateFactory(Type delegateType, string methodName)
     {
         var invokeMethod = delegateType.GetMethod(nameof(Action.Invoke));
         var invokeParameter = System.Linq.Expressions.Expression.Parameter(typeof(Func<object[], object>), "invoke");
@@ -878,7 +912,9 @@ public sealed partial class Evaluator
         System.Linq.Expressions.Expression body = invokeMethod.ReturnType.IsSameAs(typeof(void))
             ? System.Linq.Expressions.Expression.Block(invocation, System.Linq.Expressions.Expression.Empty())
             : System.Linq.Expressions.Expression.Convert(invocation, invokeMethod.ReturnType);
-        var inner = System.Linq.Expressions.Expression.Lambda(delegateType, body, parameters);
+        var inner = methodName == null
+            ? System.Linq.Expressions.Expression.Lambda(delegateType, body, parameters)
+            : System.Linq.Expressions.Expression.Lambda(delegateType, body, methodName, parameters);
         return System.Linq.Expressions.Expression.Lambda<Func<Func<object[], object>, Delegate>>(
             inner,
             invokeParameter).Compile();

--- a/src/Core/CodeAnalysis/Evaluator.Expressions.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Expressions.cs
@@ -871,8 +871,7 @@ public sealed partial class Evaluator
     private static string GetLambdaMethodName(BoundFunctionLiteralExpression node)
     {
         if (node.CapturedVariables.Length != 0
-            || (!node.Function.IsGeneric
-                && node.Function.LexicalEnclosingType is StructSymbol enclosingType
+            || (node.Function.LexicalEnclosingType is StructSymbol enclosingType
                 && enclosingType.TypeParameters.IsDefaultOrEmpty))
         {
             return "Invoke";

--- a/test/Interpreter.Tests/Issue2928CallableMaterializationTests.cs
+++ b/test/Interpreter.Tests/Issue2928CallableMaterializationTests.cs
@@ -170,19 +170,19 @@ public class Issue2928CallableMaterializationTests
     }
 
     [Fact]
-    public void Callable_DelegateFactoryIsReusedPerType()
+    public void Callable_DelegateFactoryIsDistinctPerSite()
     {
         const string Source = """
-            let first (int32) -> int32 = (value int32) -> value + 1
-            let second (int32) -> int32 = (value int32) -> value + 2
+            let first () -> int32 = () -> 11
+            let second () -> int32 = () -> 22
             (first, second)
             """;
 
-        var pair = Assert.IsType<ValueTuple<Func<int, int>, Func<int, int>>>(Evaluate(Source));
+        var pair = Assert.IsType<ValueTuple<Func<int>, Func<int>>>(Evaluate(Source));
 
-        Assert.Equal(pair.Item1.Method, pair.Item2.Method);
-        Assert.Equal(2, pair.Item1(1));
-        Assert.Equal(3, pair.Item2(1));
+        Assert.NotEqual(pair.Item1.Method, pair.Item2.Method);
+        Assert.Equal(11, pair.Item1());
+        Assert.Equal(22, pair.Item2());
     }
 
     [Fact]

--- a/test/Interpreter.Tests/Issue2928CallableMaterializationTests.cs
+++ b/test/Interpreter.Tests/Issue2928CallableMaterializationTests.cs
@@ -173,16 +173,16 @@ public class Issue2928CallableMaterializationTests
     public void Callable_DelegateFactoryIsDistinctPerSite()
     {
         const string Source = """
-            let first () -> int32 = () -> 11
-            let second () -> int32 = () -> 22
+            let first (int32) -> int32 = (value int32) -> value + 1
+            let second (int32) -> int32 = (value int32) -> value + 2
             (first, second)
             """;
 
-        var pair = Assert.IsType<ValueTuple<Func<int>, Func<int>>>(Evaluate(Source));
+        var pair = Assert.IsType<ValueTuple<Func<int, int>, Func<int, int>>>(Evaluate(Source));
 
         Assert.NotEqual(pair.Item1.Method, pair.Item2.Method);
-        Assert.Equal(11, pair.Item1());
-        Assert.Equal(22, pair.Item2());
+        Assert.Equal(2, pair.Item1(1));
+        Assert.Equal(3, pair.Item2(1));
     }
 
     [Fact]

--- a/test/Interpreter.Tests/Issue2991LambdaMethodIdentityTests.cs
+++ b/test/Interpreter.Tests/Issue2991LambdaMethodIdentityTests.cs
@@ -1,0 +1,185 @@
+// <copyright file="Issue2991LambdaMethodIdentityTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Reflection;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #2991: interpreter delegates preserve compiler lambda method identity.
+/// </summary>
+public class Issue2991LambdaMethodIdentityTests
+{
+    [Fact]
+    public void Lambda_DistinctSites_HaveDistinctCompilerNames()
+    {
+        const string Source = """
+            let first () -> int32 = () -> 11
+            let second () -> int32 = () -> 22
+            (first, second)
+            """;
+
+        var pair = Assert.IsType<ValueTuple<Func<int>, Func<int>>>(Evaluate(Source));
+
+        Assert.Equal("<lambda1>", pair.Item1.Method.Name);
+        Assert.Equal("<lambda2>", pair.Item2.Method.Name);
+        Assert.NotEqual(pair.Item1.Method, pair.Item2.Method);
+        Assert.Equal(11, pair.Item1());
+        Assert.Equal(22, pair.Item2());
+    }
+
+    [Fact]
+    public void Lambda_SameSite_HasStableCompilerNameAndMethod()
+    {
+        const string Source = """
+            func make(value int32) () -> int32 {
+                return () -> value
+            }
+
+            let first = make(11)
+            let second = make(33)
+            (first, second)
+            """;
+
+        var pair = Assert.IsType<ValueTuple<Func<int>, Func<int>>>(Evaluate(Source));
+
+        Assert.Equal("Invoke", pair.Item1.Method.Name);
+        Assert.Equal(pair.Item1.Method.Name, pair.Item2.Method.Name);
+        Assert.Equal(pair.Item1.Method, pair.Item2.Method);
+        Assert.Equal(11, pair.Item1());
+        Assert.Equal(33, pair.Item2());
+    }
+
+    [Fact]
+    public void Lambda_DistinctCapturingSites_HaveDistinctMethods()
+    {
+        const string Source = """
+            func makeFirst(value int32) () -> int32 {
+                return () -> value
+            }
+
+            func makeSecond(value int32) () -> int32 {
+                return () -> value * 2
+            }
+
+            let first = makeFirst(11)
+            let second = makeSecond(11)
+            (first, second)
+            """;
+
+        var pair = Assert.IsType<ValueTuple<Func<int>, Func<int>>>(Evaluate(Source));
+
+        Assert.Equal("Invoke", pair.Item1.Method.Name);
+        Assert.Equal("Invoke", pair.Item2.Method.Name);
+        Assert.NotEqual(pair.Item1.Method, pair.Item2.Method);
+        Assert.Equal(11, pair.Item1());
+        Assert.Equal(22, pair.Item2());
+    }
+
+    [Fact]
+    public void Lambda_ZeroCaptureHost_UsesCompilerName()
+    {
+        const string Source = """
+            class Maker {
+                func make() () -> int32 {
+                    return () -> 33
+                }
+            }
+
+            let value = Maker{}.make()
+            (value.Method.Name, value())
+            """;
+
+        var result = Assert.IsType<ValueTuple<string, int>>(Evaluate(Source));
+
+        Assert.Equal("Invoke", result.Item1);
+        Assert.Equal(33, result.Item2);
+    }
+
+    [Fact]
+    public void Lambda_GenericZeroCaptureHost_UsesCompilerName()
+    {
+        const string Source = """
+            class Maker[T] {
+                func make() () -> int32 {
+                    return () -> 33
+                }
+            }
+
+            let value = Maker[string]().make()
+            (value.Method.Name, value())
+            """;
+
+        var result = Assert.IsType<ValueTuple<string, int>>(Evaluate(Source));
+
+        Assert.Equal("<lambda1>", result.Item1);
+        Assert.Equal(33, result.Item2);
+    }
+
+    [Fact]
+    public void MethodGroup_KeepsDeclaredMethodIdentity()
+    {
+        const string Source = """
+            func first() int32 { return 11 }
+            func second() int32 { return 22 }
+
+            let firstGroup () -> int32 = first
+            let secondGroup () -> int32 = second
+            (firstGroup, secondGroup)
+            """;
+
+        var pair = Assert.IsType<ValueTuple<Func<int>, Func<int>>>(Evaluate(Source));
+
+        Assert.Equal("first", pair.Item1.Method.Name);
+        Assert.Equal("second", pair.Item2.Method.Name);
+        Assert.NotEqual(pair.Item1.Method, pair.Item2.Method);
+        Assert.Equal(11, pair.Item1());
+        Assert.Equal(22, pair.Item2());
+    }
+
+    [Fact]
+    public void DelegateFactory_SameSite_SupportsDistinctDelegateTypes()
+    {
+        var create = typeof(Evaluator).GetMethod(
+            "CreateInterpreterDelegate",
+            BindingFlags.NonPublic | BindingFlags.Static,
+            null,
+            new[] { typeof(Type), typeof(FunctionSymbol), typeof(string), typeof(Func<object[], object>) },
+            null);
+        Assert.NotNull(create);
+        var function = new FunctionSymbol(
+            "<lambda1>",
+            ImmutableArray.Create(new ParameterSymbol("value", TypeSymbol.Int32)),
+            TypeSymbol.Int32);
+
+        var first = Assert.IsType<Func<int, int>>(create.Invoke(
+            null,
+            new object[] { typeof(Func<int, int>), function, "<lambda1>", new Func<object[], object>(args => (int)args[0] + 11) }));
+        var second = Assert.IsType<Converter<int, int>>(create.Invoke(
+            null,
+            new object[] { typeof(Converter<int, int>), function, "<lambda1>", new Func<object[], object>(args => (int)args[0] + 11) }));
+
+        Assert.Equal("<lambda1>", first.Method.Name);
+        Assert.Equal("<lambda1>", second.Method.Name);
+        Assert.Equal(11, first(0));
+        Assert.Equal(22, second(11));
+    }
+
+    private static object Evaluate(string source)
+    {
+        var result = new Compilation(SyntaxTree.Parse(source))
+            .Evaluate(new Dictionary<VariableSymbol, object>());
+
+        Assert.Empty(result.Diagnostics);
+        return result.Value;
+    }
+}


### PR DESCRIPTION
## Summary

- Cache interpreter delegate factories per function-literal site and CLR delegate type instead of per delegate type alone.
- Name generated methods with the compiler's existing scheme: `<lambdaN>` for ordinary non-capturing lambdas, `Invoke` for closure-hosted lambdas, and declared names for method groups.
- Replace the old test assertion that pinned the collision while retaining its original source; add identity, stability, naming, host-shape, and cache-shape coverage with distinct values.

The issue body overstates name uniqueness: `gsc` intentionally emits `Invoke` for distinct capturing sites and can reuse `<lambda1>` across scopes. The real parity rule is distinct `MethodInfo` per lambda site, stable `MethodInfo` for repeated evaluation of one site, and the same method name as `gsc`.

## Performance trade-off

The old cache compiled one expression factory per CLR delegate type. Correct per-site `MethodInfo` identity requires one `Expression.Compile()` per live `(FunctionSymbol, delegateType)`, so programs with many distinct lambda sites compile more factories. Repeated evaluation of one site still reuses its factory, and the outer `ConditionalWeakTable` lets entries disappear with unreachable symbols.

## Validation

- `dotnet build` — 0 warnings, 0 errors
- Full interpreter suite — 542 passed
- Targeted identity, callable-materialization, and generic-local-function tests — 24 passed
- `gsc` / `gsi` identity differential — exact match: `Invoke`, `Invoke`, `<lambda1>`, `False`, `True`, `11`, `22`, `7`
- `samples/FuncToSystemDelegate.gs`: `gsc` and `gsi` both print `<lambda1>` / `<lambda2>`
- Mutation review found `!node.Function.IsGeneric` survived the full suite. Source tracing proved generic local functions become `BoundLocalFunctionDeclaration` nodes and bypass lambda materialization, so the dead term was deleted. All remaining tested functional mutations fail the identity suite. Restored `GSharp.Core.dll` hash: `faab2ab47521d0605e9a4fa13741a374badd8b8e93b78cc3cf00bb176b2fd435`.

## Related work

- #3019: no textual overlap; its nominal delegate target selection happens in binding before this runtime per-site identity cache.
- #3035: adjacent conversion path only. This PR preserves the existing two-argument `CreateInterpreterDelegate` overload, while source-declared named delegates structurally equivalent to `Func`/`Action` retain the already named site delegate.
- #3050: `Evaluator.Expressions.cs` was not its failure site. On current `main`, both its original repro and a G#-declared-type variant now produce `7` in `gsc` and `gsi`; findings posted on the issue.

Fixes #2991
