### PR TITLE
gsi: coerce closures at CLR delegate boundaries

### DIFF
--- a/src/Core/CodeAnalysis/Evaluator.Calls.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Calls.cs
@@ -835,7 +835,7 @@ public sealed partial class Evaluator
     private object EvaluateImportedCallExpression(BoundImportedCallExpression node)
     {
         var args = new object[node.Arguments.Length];
-        var refSlots = BuildRefSlots(node.Arguments, node.ArgumentRefKinds, args);
+        var refSlots = BuildRefSlots(node.Arguments, node.ArgumentRefKinds, args, node.Function.Method);
 
         // Issue #1599: a generic BCL method closed over a same-compilation user
         // value type (e.g. `Enum.TryParse[Color]`) was closed over a value-type
@@ -949,10 +949,9 @@ public sealed partial class Evaluator
         }
 
         receiver = UnwrapClrReceiver(receiver);
-        var args = new object[node.Arguments.Length];
-        var refSlots = BuildRefSlots(node.Arguments, node.ArgumentRefKinds, args);
-
         var method = ResolveMethodForReceiver(node.Method, receiver);
+        var args = new object[node.Arguments.Length];
+        var refSlots = BuildRefSlots(node.Arguments, node.ArgumentRefKinds, args, method);
 
         // concurrency: see TryGetInterpreterMapLock — routes `range m`'s
         // `GetEnumerator()`/`MoveNext()`, `m.ContainsKey(k)`, `m.Remove(k)`,
@@ -1121,9 +1120,11 @@ public sealed partial class Evaluator
     private List<(int Index, BoundExpression Operand)> BuildRefSlots(
         ImmutableArray<BoundExpression> arguments,
         ImmutableArray<RefKind> refKinds,
-        object[] args)
+        object[] args,
+        MethodBase method = null)
     {
         List<(int Index, BoundExpression Operand)> refSlots = null;
+        var parameters = method?.GetParameters();
 
         for (int i = 0; i < arguments.Length; i++)
         {
@@ -1147,6 +1148,23 @@ public sealed partial class Evaluator
             else
             {
                 args[i] = EvaluateExpression(arg);
+            }
+
+            if (parameters != null && args[i] is ClosureValue closure)
+            {
+                var parameterType = parameters[i].ParameterType;
+                if (parameterType.IsByRef)
+                {
+                    parameterType = parameterType.GetElementType();
+                }
+
+                if (parameterType?.GetMethod(nameof(Action.Invoke)) != null
+                    && typeof(Delegate).IsAssignableFrom(parameterType))
+                {
+                    args[i] = CreateInterpreterDelegate(
+                        parameterType,
+                        invokeArgs => InvokeMaterializedClosure(closure, invokeArgs));
+                }
             }
         }
 

--- a/src/Core/CodeAnalysis/Evaluator.Calls.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Calls.cs
@@ -63,7 +63,8 @@ public sealed partial class Evaluator
                 : BuildRefSlots(
                     node.Arguments,
                     node.Function.Parameters.Select(p => p.RefKind).ToImmutableArray(),
-                    args);
+                    args,
+                    null);
             var locals = new ConcurrentDictionary<VariableSymbol, object>();
 
             for (int i = 0; i < node.Arguments.Length; i++)
@@ -949,9 +950,9 @@ public sealed partial class Evaluator
         }
 
         receiver = UnwrapClrReceiver(receiver);
-        var method = ResolveMethodForReceiver(node.Method, receiver);
         var args = new object[node.Arguments.Length];
-        var refSlots = BuildRefSlots(node.Arguments, node.ArgumentRefKinds, args, method);
+        var refSlots = BuildRefSlots(node.Arguments, node.ArgumentRefKinds, args, node.Method);
+        var method = ResolveMethodForReceiver(node.Method, receiver);
 
         // concurrency: see TryGetInterpreterMapLock — routes `range m`'s
         // `GetEnumerator()`/`MoveNext()`, `m.ContainsKey(k)`, `m.Remove(k)`,
@@ -1121,7 +1122,7 @@ public sealed partial class Evaluator
         ImmutableArray<BoundExpression> arguments,
         ImmutableArray<RefKind> refKinds,
         object[] args,
-        MethodBase method = null)
+        MethodBase method)
     {
         List<(int Index, BoundExpression Operand)> refSlots = null;
         var parameters = method?.GetParameters();

--- a/src/Core/CodeAnalysis/Evaluator.Expressions.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Expressions.cs
@@ -1206,7 +1206,7 @@ public sealed partial class Evaluator
     private object InvokeClrCtor(ConstructorInfo ctor, ImmutableArray<BoundExpression> arguments, ImmutableArray<RefKind> argumentRefKinds)
     {
         var args = new object[arguments.Length];
-        var refSlots = BuildRefSlots(arguments, argumentRefKinds, args);
+        var refSlots = BuildRefSlots(arguments, argumentRefKinds, args, ctor);
         var instance = ctor.Invoke(args);
         WriteBackRefSlots(refSlots, args);
         return instance;
@@ -1265,7 +1265,7 @@ public sealed partial class Evaluator
     private object EvaluateClrStaticCallExpression(BoundClrStaticCallExpression node)
     {
         var args = new object[node.Arguments.Length];
-        var refSlots = BuildRefSlots(node.Arguments, node.ArgumentRefKinds, args);
+        var refSlots = BuildRefSlots(node.Arguments, node.ArgumentRefKinds, args, node.Method);
 
         var result = node.Method.Invoke(null, args);
         WriteBackRefSlots(refSlots, args);

--- a/src/Core/CodeAnalysis/Evaluator.Expressions.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Expressions.cs
@@ -1255,7 +1255,7 @@ public sealed partial class Evaluator
     private object EvaluateClrConstructorCallExpression(BoundClrConstructorCallExpression node)
     {
         var args = new object[node.Arguments.Length];
-        var refSlots = BuildRefSlots(node.Arguments, node.ArgumentRefKinds, args);
+        var refSlots = BuildRefSlots(node.Arguments, node.ArgumentRefKinds, args, node.Constructor);
 
         var result = node.Constructor.Invoke(args);
         WriteBackRefSlots(refSlots, args);

--- a/test/Interpreter.Tests/Issue2990ClrDelegateBoundaryTests.cs
+++ b/test/Interpreter.Tests/Issue2990ClrDelegateBoundaryTests.cs
@@ -1,0 +1,124 @@
+// <copyright file="Issue2990ClrDelegateBoundaryTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #2990: closures whose signatures contain G# types must be coerced to
+/// the delegate type expected by each reflection-invoked CLR boundary.
+/// </summary>
+public class Issue2990ClrDelegateBoundaryTests
+{
+    [Fact]
+    public void ImportedStaticCall_CoercesTypedAndUntypedClosures()
+    {
+        const string Source = """
+            import System
+            import System.Linq
+
+            data struct Item {
+                var V int32
+            }
+
+            var items = []Item{Item{V: 11}, Item{V: 22}, Item{V: 33}}
+            Console.WriteLine(items.Where((item) -> item.V != 22).First().V)
+            Console.WriteLine(items.Where((item Item) -> item.V == 22).First().V)
+            """;
+
+        Assert.Equal("11\n22\n", Evaluate(Source));
+    }
+
+    [Fact]
+    public void ImportedInstanceCall_CoercesTypedAndUntypedClosures()
+    {
+        const string Source = """
+            import System
+            import System.Collections.Generic
+
+            data struct Item {
+                var V int32
+            }
+
+            var items = List[Item]()
+            items.Add(Item{V: 33})
+            items.Add(Item{V: 44})
+            items.Add(Item{V: 55})
+            Console.WriteLine(items.Find((item) -> item.V == 44).V)
+            Console.WriteLine(items.Find((item Item) -> item.V == 55).V)
+            """;
+
+        Assert.Equal("44\n55\n", Evaluate(Source));
+    }
+
+    [Fact]
+    public void ClrConstructor_CoercesClosureWithUserTypeReturn()
+    {
+        const string Source = """
+            import System
+
+            data struct Item {
+                var V int32
+            }
+
+            var item = Lazy[Item](() -> Item{V: 66}).Value
+            Console.WriteLine(item.V)
+            """;
+
+        Assert.Equal("66\n", Evaluate(Source));
+    }
+
+    [Fact]
+    public void UserFunctionCall_PreservesRawClosure()
+    {
+        const string Source = """
+            import System
+
+            data struct Item {
+                var V int32
+            }
+
+            func Pick(items []Item, predicate (Item) -> bool) int32 {
+                for item in items {
+                    if predicate(item) {
+                        return item.V
+                    }
+                }
+                return -1
+            }
+
+            var items = []Item{Item{V: 77}, Item{V: 88}, Item{V: 99}}
+            Console.WriteLine(Pick(items, (item) -> item.V == 88))
+            """;
+
+        Assert.Equal("88\n", Evaluate(Source));
+    }
+
+    private static string Evaluate(string source)
+    {
+        using var outWriter = new StringWriter();
+        var previousOut = Console.Out;
+        Console.SetOut(outWriter);
+        try
+        {
+            var result = new Compilation(SyntaxTree.Parse(source))
+                .Evaluate(new Dictionary<VariableSymbol, object>());
+
+            Assert.Empty(result.Diagnostics);
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+        }
+
+        return outWriter.ToString().Replace("\r\n", "\n", StringComparison.Ordinal);
+    }
+}

--- a/test/Interpreter.Tests/Issue2990ClrDelegateBoundaryTests.cs
+++ b/test/Interpreter.Tests/Issue2990ClrDelegateBoundaryTests.cs
@@ -5,6 +5,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
+using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
@@ -100,6 +102,17 @@ public class Issue2990ClrDelegateBoundaryTests
             """;
 
         Assert.Equal("88\n", Evaluate(Source));
+    }
+
+    [Fact]
+    public void BuildRefSlots_RequiresMethodBaseArgument()
+    {
+        var method = typeof(Evaluator).GetMethod("BuildRefSlots", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Assert.NotNull(method);
+        var parameter = method.GetParameters()[3];
+        Assert.Equal(typeof(MethodBase), parameter.ParameterType);
+        Assert.False(parameter.IsOptional);
     }
 
     private static string Evaluate(string source)

--- a/test/Interpreter.Tests/Issue2990ClrDelegateBoundaryTests.cs
+++ b/test/Interpreter.Tests/Issue2990ClrDelegateBoundaryTests.cs
@@ -4,9 +4,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Reflection;
 using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
@@ -79,6 +81,44 @@ public class Issue2990ClrDelegateBoundaryTests
     }
 
     [Fact]
+    public void InvokeClrCtor_CoercesClosureWithUserTypeParameter()
+    {
+        var evaluator = new Evaluator(null, new Dictionary<VariableSymbol, object>());
+        var constructor = typeof(ConstructorProbe).GetConstructor([typeof(Func<object, int>)]);
+        var invoke = typeof(Evaluator).GetMethod("InvokeClrCtor", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Assert.NotNull(constructor);
+        Assert.NotNull(invoke);
+        var result = Assert.IsType<ConstructorProbe>(invoke.Invoke(
+            evaluator,
+            [constructor, ImmutableArray.Create<BoundExpression>(CreateErasedClosure(77)), ImmutableArray<RefKind>.Empty]));
+
+        Assert.Equal(77, result.Value);
+    }
+
+    [Fact]
+    public void ClrStaticCall_CoercesClosureWithUserTypeParameter()
+    {
+        var evaluator = new Evaluator(null, new Dictionary<VariableSymbol, object>());
+        var method = typeof(Issue2990ClrDelegateBoundaryTests).GetMethod(
+            nameof(InvokeSelector),
+            BindingFlags.Static | BindingFlags.NonPublic);
+        var evaluate = typeof(Evaluator).GetMethod(
+            "EvaluateClrStaticCallExpression",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Assert.NotNull(method);
+        Assert.NotNull(evaluate);
+        var node = new BoundClrStaticCallExpression(
+            null,
+            method,
+            TypeSymbol.Int32,
+            ImmutableArray.Create<BoundExpression>(CreateErasedClosure(99)));
+
+        Assert.Equal(99, evaluate.Invoke(evaluator, [node]));
+    }
+
+    [Fact]
     public void UserFunctionCall_PreservesRawClosure()
     {
         const string Source = """
@@ -115,6 +155,33 @@ public class Issue2990ClrDelegateBoundaryTests
         Assert.False(parameter.IsOptional);
     }
 
+    private static BoundFunctionLiteralExpression CreateErasedClosure(int value)
+    {
+        var erasedType = new StructSymbol(
+            "Issue2990Erased",
+            ImmutableArray<FieldSymbol>.Empty,
+            GSharp.Core.CodeAnalysis.Symbols.Accessibility.Private,
+            declaration: null,
+            packageName: "Issue2990");
+        var parameter = new ParameterSymbol("item", erasedType);
+        var function = new FunctionSymbol("<issue2990>", ImmutableArray.Create(parameter), TypeSymbol.Int32);
+        var functionType = FunctionTypeSymbol.Get(ImmutableArray.Create<TypeSymbol>(erasedType), TypeSymbol.Int32);
+        var body = new BoundBlockStatement(
+            null,
+            ImmutableArray.Create<BoundStatement>(
+                new BoundReturnStatement(null, new BoundLiteralExpression(null, value))));
+
+        Assert.Null(functionType.ClrType);
+        return new BoundFunctionLiteralExpression(
+            null,
+            function,
+            functionType,
+            body,
+            ImmutableArray<VariableSymbol>.Empty);
+    }
+
+    private static int InvokeSelector(Func<object, int> selector) => selector(new object());
+
     private static string Evaluate(string source)
     {
         using var outWriter = new StringWriter();
@@ -133,5 +200,15 @@ public class Issue2990ClrDelegateBoundaryTests
         }
 
         return outWriter.ToString().Replace("\r\n", "\n", StringComparison.Ordinal);
+    }
+
+    private sealed class ConstructorProbe
+    {
+        public ConstructorProbe(Func<object, int> selector)
+        {
+            Value = selector(new object());
+        }
+
+        public int Value { get; }
     }
 }


### PR DESCRIPTION
## Summary
- coerce raw interpreter closures to each reflection target parameter's concrete delegate type
- require every `BuildRefSlots` caller to provide its target explicitly; all five CLR sites pass a `MethodBase`, while the G# user-function path passes explicit `null`
- preserve original argument-evaluation order for imported instance calls

The issue title is too narrow: typed lambdas fail too. Trigger is a G#-declared type making the closure function type lack a CLR type.

## Validation
- `dotnet build -c Release`
- `dotnet test test/Interpreter.Tests/Interpreter.Tests.csproj -c Release --filter FullyQualifiedName~Issue2990ClrDelegateBoundaryTests` (5 CLR-site tests + 1 user-function guard + 1 required-parameter contract test)
- compiler/interpreter sample parity: `3 6 2 8 30 fig kiwi apple`
- each of the five CLR call-site mutants builds successfully and kills only its named site test
- optional-parameter mutant builds successfully and kills the required-parameter contract test

Fixes #2990