### PR TITLE
Make #3028 ref-return probe an explicit fixture

### DIFF
--- a/test/Interpreter.Tests/Issue3004ManagedByRefAutoDereferenceFixture.cs
+++ b/test/Interpreter.Tests/Issue3004ManagedByRefAutoDereferenceFixture.cs
@@ -1,0 +1,25 @@
+// <copyright file="Issue3004ManagedByRefAutoDereferenceFixture.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Interpreter.Tests.Issue3004;
+
+/// <summary>
+/// CLR ref-return shapes used to guard managed-byref auto-dereference.
+/// </summary>
+public sealed class ManagedByRefAutoDereferenceFixture
+{
+    private readonly int[] values = [40, 41, 42];
+
+    /// <summary>Gets the first value by reference.</summary>
+    public ref int Property => ref values[0];
+
+    /// <summary>Gets a value by reference through an indexer.</summary>
+    /// <param name="index">The value index.</param>
+    public ref int this[int index] => ref values[index];
+
+    /// <summary>Gets a value by reference through an instance call.</summary>
+    /// <param name="index">The value index.</param>
+    /// <returns>A reference to the selected value.</returns>
+    public ref int GetValue(int index) => ref values[index];
+}

--- a/test/Interpreter.Tests/Issue3004PointerBoundaryInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue3004PointerBoundaryInterpreterTests.cs
@@ -37,9 +37,9 @@ public class Issue3004PointerBoundaryInterpreterTests
 
     public static TheoryData<string, int> ManagedByRefCases => new()
     {
-        { "RefReturnProbe().Property", 40 },
-        { "RefReturnProbe()[1]", 41 },
-        { "RefReturnProbe().GetValue(2)", 42 },
+        { "ManagedByRefAutoDereferenceFixture().Property", 40 },
+        { "ManagedByRefAutoDereferenceFixture()[1]", 41 },
+        { "ManagedByRefAutoDereferenceFixture().GetValue(2)", 42 },
     };
 
     [Theory]
@@ -83,7 +83,7 @@ public class Issue3004PointerBoundaryInterpreterTests
     public void ManagedByRefAutoDereference_RemainsSupported(string expression, int expected)
     {
         var source = $"""
-            import GSharp.Interpreter.Tests.ProbeRef
+            import GSharp.Interpreter.Tests.Issue3004
 
             {expression}
             """;

--- a/test/Interpreter.Tests/ProbeRefTypes.cs
+++ b/test/Interpreter.Tests/ProbeRefTypes.cs
@@ -51,23 +51,3 @@ public interface IReadWrite
     /// <summary>Gets or sets the value.</summary>
     string Value { get; set; }
 }
-
-/// <summary>
-/// CLR ref-return members used to pin managed-byref auto-dereference.
-/// </summary>
-public sealed class RefReturnProbe
-{
-    private readonly int[] values = [40, 41, 42];
-
-    /// <summary>Gets the first value by reference.</summary>
-    public ref int Property => ref values[0];
-
-    /// <summary>Gets a value by reference through an indexer.</summary>
-    /// <param name="index">The value index.</param>
-    public ref int this[int index] => ref values[index];
-
-    /// <summary>Gets a value by reference through an instance call.</summary>
-    /// <param name="index">The value index.</param>
-    /// <returns>A reference to the selected value.</returns>
-    public ref int GetValue(int index) => ref values[index];
-}


### PR DESCRIPTION
## Summary
- remove `RefReturnProbe` from the shared `ProbeRefTypes.cs` helper file
- retain its live coverage as issue-scoped `ManagedByRefAutoDereferenceFixture`
- update #3028 tests to use the explicitly named fixture

## Measurement
The probe is live, not scratch:
- deleting it: Interpreter.Tests **3 failed / 517 passed**; property, indexer, and imported instance-call cases could not resolve the type
- making managed-byref dereference fail like raw-pointer dereference: mutant built successfully, `GSharp.Core.dll` hash changed, and #3028 tests **3 failed / 5 passed**
- restoring production: source and `GSharp.Core.dll` hashes returned exactly; Interpreter.Tests **520/520 passed**

Scanned 45 `GS9999` occurrences across 18 files in `docs`, `website`, `src`, and `test`; found no additional pointer/dereference claim beyond the separately owned diagnostics text.

Follow-up cleanup for #3028. No issue closure intended.