### PR TITLE
Fix gsi imported-base derived type identity

### DIFF
--- a/src/Core/CodeAnalysis/Evaluator.Expressions.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Expressions.cs
@@ -30,6 +30,8 @@ public sealed partial class Evaluator
     private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<Type, Func<Func<object[], object>, Delegate>> InterpreterDelegateFactories = new();
     private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<FunctionSymbol, ConcurrentDictionary<Type, Func<Func<object[], object>, Delegate>>> InterpreterDelegateFactoriesBySite = new();
     private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<Delegate, ClosureValue> InterpreterClosures = new();
+    private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<StructSymbol, Type> ClrBackingTypes = new();
+    private static int clrBackingAssemblyOrdinal;
 
     private object EvaluateExpression(BoundExpression node)
     {
@@ -1170,18 +1172,21 @@ public sealed partial class Evaluator
     /// Issue #319: instantiate the imported CLR base for a GSharp class instance
     /// when the class ultimately derives from a CLR type, so inherited CLR
     /// instance state (e.g. <see cref="System.Exception.Message"/>) is observable
-    /// under the interpreter. The chosen base constructor mirrors the emit path:
-    /// the resolved <see cref="BaseConstructorInitializer.ClrConstructor"/> when
-    /// the class declared <c>: Base(args)</c>, otherwise the imported base's
-    /// accessible parameterless constructor. The base-ctor argument expressions
-    /// must be evaluated within whatever frame the caller has just pushed.
+    /// under the interpreter. Issue #3015: instantiate a runtime-derived proxy
+    /// rather than the imported base itself so inherited virtual dispatch also
+    /// observes the GSharp class's emitted type identity. The chosen base
+    /// constructor mirrors the emit path: the resolved
+    /// <see cref="BaseConstructorInitializer.ClrConstructor"/> when the class
+    /// declared <c>: Base(args)</c>, otherwise the imported base's accessible
+    /// parameterless constructor. The base-ctor argument expressions must be
+    /// evaluated within whatever frame the caller has just pushed.
     /// </summary>
     private void AllocateClrBacking(StructValue sv, StructSymbol structType, BaseConstructorInitializer activeInit)
     {
         // If an explicit `: base(args)` targets a CLR constructor, prefer that.
         if (activeInit is { IsClrBase: true } clrInit && clrInit.ClrConstructor != null)
         {
-            sv.ClrBacking = InvokeClrCtor(clrInit.ClrConstructor, clrInit.Arguments, clrInit.ArgumentRefKinds);
+            sv.ClrBacking = InvokeClrCtor(structType, clrInit.ClrConstructor, clrInit.Arguments, clrInit.ArgumentRefKinds);
             return;
         }
 
@@ -1209,7 +1214,7 @@ public sealed partial class Evaluator
                 var parameterless = ResolveParameterlessCtor(clrBase);
                 if (parameterless != null)
                 {
-                    sv.ClrBacking = parameterless.Invoke(Array.Empty<object>());
+                    sv.ClrBacking = InvokeClrBackingCtor(structType, parameterless, Array.Empty<object>());
                 }
 
                 return;
@@ -1218,13 +1223,148 @@ public sealed partial class Evaluator
     }
 
     /// <summary>Issue #319: invoke a CLR base constructor with the bound G# argument expressions.</summary>
-    private object InvokeClrCtor(ConstructorInfo ctor, ImmutableArray<BoundExpression> arguments, ImmutableArray<RefKind> argumentRefKinds)
+    private object InvokeClrCtor(StructSymbol structType, ConstructorInfo ctor, ImmutableArray<BoundExpression> arguments, ImmutableArray<RefKind> argumentRefKinds)
     {
         var args = new object[arguments.Length];
         var refSlots = BuildRefSlots(arguments, argumentRefKinds, args, ctor);
-        var instance = ctor.Invoke(args);
+        var instance = InvokeClrBackingCtor(structType, ctor, args);
         WriteBackRefSlots(refSlots, args);
         return instance;
+    }
+
+    private static object InvokeClrBackingCtor(StructSymbol structType, ConstructorInfo baseCtor, object[] args)
+    {
+        var clrBase = baseCtor.DeclaringType
+            ?? throw new InvalidOperationException("Imported base constructor has no declaring type.");
+        var backingType = ClrBackingTypes.GetValue(
+            structType,
+            _ => CreateClrBackingType(structType, clrBase));
+        var parameterTypes = Array.ConvertAll(baseCtor.GetParameters(), static parameter => parameter.ParameterType);
+        var proxyCtor = backingType.GetConstructor(parameterTypes)
+            ?? throw new InvalidOperationException($"Generated CLR backing type '{backingType.FullName}' has no matching constructor.");
+        return proxyCtor.Invoke(args);
+    }
+
+    private static Type CreateClrBackingType(StructSymbol structType, Type clrBase)
+    {
+        var assemblyOrdinal = Interlocked.Increment(ref clrBackingAssemblyOrdinal);
+        var assemblyName = new AssemblyName(string.Format(
+            System.Globalization.CultureInfo.InvariantCulture,
+            "GSharp.Interpreter.ClrBacking.{0}",
+            assemblyOrdinal));
+        var assembly = System.Reflection.Emit.AssemblyBuilder.DefineDynamicAssembly(
+            assemblyName,
+            System.Reflection.Emit.AssemblyBuilderAccess.RunAndCollect);
+        var module = assembly.DefineDynamicModule(assemblyName.Name);
+        var definition = structType.Definition ?? structType;
+        var arity = definition.TypeParameters.Length;
+        var enclosingTypes = new Stack<StructSymbol>();
+        for (var containing = definition.ContainingType as StructSymbol;
+             containing != null;
+             containing = containing.ContainingType as StructSymbol)
+        {
+            enclosingTypes.Push(containing.Definition ?? containing);
+        }
+
+        var enclosingBuilders = new List<System.Reflection.Emit.TypeBuilder>();
+        System.Reflection.Emit.TypeBuilder parentBuilder = null;
+        while (enclosingTypes.Count > 0)
+        {
+            var enclosing = enclosingTypes.Pop();
+            var enclosingName = GetClrMetadataTypeName(enclosing);
+            var enclosingBuilder = parentBuilder == null
+                ? module.DefineType(
+                    string.IsNullOrEmpty(structType.PackageName)
+                        ? enclosingName
+                        : $"{structType.PackageName}.{enclosingName}",
+                    TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.Sealed,
+                    typeof(object))
+                : parentBuilder.DefineNestedType(
+                    enclosingName,
+                    TypeAttributes.NestedPublic | TypeAttributes.Class | TypeAttributes.Sealed,
+                    typeof(object));
+            if (enclosing.TypeParameters.Length > 0)
+            {
+                enclosingBuilder.DefineGenericParameters(enclosing.TypeParameters.Select(static parameter => parameter.Name).ToArray());
+            }
+
+            enclosingBuilders.Add(enclosingBuilder);
+            parentBuilder = enclosingBuilder;
+        }
+
+        var metadataName = GetClrMetadataTypeName(definition);
+        var typeBuilder = parentBuilder == null
+            ? module.DefineType(
+                string.IsNullOrEmpty(structType.PackageName)
+                    ? metadataName
+                    : $"{structType.PackageName}.{metadataName}",
+                TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.Sealed,
+                clrBase)
+            : parentBuilder.DefineNestedType(
+                metadataName,
+                TypeAttributes.NestedPublic | TypeAttributes.Class | TypeAttributes.Sealed,
+                clrBase);
+        if (arity > 0)
+        {
+            typeBuilder.DefineGenericParameters(definition.TypeParameters.Select(static parameter => parameter.Name).ToArray());
+        }
+
+        foreach (var baseCtor in clrBase.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+        {
+            if (!baseCtor.IsPublic && !baseCtor.IsFamily && !baseCtor.IsFamilyOrAssembly)
+            {
+                continue;
+            }
+
+            var parameterTypes = Array.ConvertAll(baseCtor.GetParameters(), static parameter => parameter.ParameterType);
+            var ctorBuilder = typeBuilder.DefineConstructor(
+                MethodAttributes.Public,
+                CallingConventions.Standard,
+                parameterTypes);
+            var il = ctorBuilder.GetILGenerator();
+            il.Emit(System.Reflection.Emit.OpCodes.Ldarg_0);
+            for (var i = 0; i < parameterTypes.Length; i++)
+            {
+                il.Emit(System.Reflection.Emit.OpCodes.Ldarg, i + 1);
+            }
+
+            il.Emit(System.Reflection.Emit.OpCodes.Call, baseCtor);
+            il.Emit(System.Reflection.Emit.OpCodes.Ret);
+        }
+
+        var backingType = typeBuilder.CreateType();
+        for (var i = enclosingBuilders.Count - 1; i >= 0; i--)
+        {
+            enclosingBuilders[i].CreateType();
+        }
+
+        if (arity == 0)
+        {
+            return backingType;
+        }
+
+        var typeArguments = new Type[structType.TypeArguments.Length];
+        for (var i = 0; i < typeArguments.Length; i++)
+        {
+            var argument = structType.TypeArguments[i];
+            typeArguments[i] = argument is NullableTypeSymbol nullable
+                && nullable.UnderlyingType.ClrType is { IsValueType: true } valueClr
+                    ? typeof(Nullable<>).MakeGenericType(valueClr)
+                    : argument.ClrType ?? typeof(object);
+        }
+
+        return backingType.MakeGenericType(typeArguments);
+    }
+
+    private static string GetClrMetadataTypeName(StructSymbol type)
+    {
+        return type.TypeParameters.Length == 0
+            ? type.Name
+            : string.Format(
+                System.Globalization.CultureInfo.InvariantCulture,
+                "{0}`{1}",
+                type.Name,
+                type.TypeParameters.Length);
     }
 
     /// <summary>Issue #319: resolves the imported CLR base's accessible parameterless constructor (matches the emit path's <c>GetImportedBaseDefaultCtorReference</c>).</summary>

--- a/src/Core/CodeAnalysis/Evaluator.Expressions.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Expressions.cs
@@ -1346,14 +1346,43 @@ public sealed partial class Evaluator
         var typeArguments = new Type[structType.TypeArguments.Length];
         for (var i = 0; i < typeArguments.Length; i++)
         {
-            var argument = structType.TypeArguments[i];
-            typeArguments[i] = argument is NullableTypeSymbol nullable
-                && nullable.UnderlyingType.ClrType is { IsValueType: true } valueClr
-                    ? typeof(Nullable<>).MakeGenericType(valueClr)
-                    : argument.ClrType ?? typeof(object);
+            typeArguments[i] = ResolveClrBackingTypeArgument(structType.TypeArguments[i]);
         }
 
         return backingType.MakeGenericType(typeArguments);
+    }
+
+    private static Type ResolveClrBackingTypeArgument(TypeSymbol argument)
+    {
+        if (argument is NullableTypeSymbol nullable
+            && nullable.UnderlyingType.ClrType is { IsValueType: true } valueClr)
+        {
+            return typeof(Nullable<>).MakeGenericType(valueClr);
+        }
+
+        if (argument.ClrType is Type clrType)
+        {
+            return clrType;
+        }
+
+        if (argument is StructSymbol { IsClass: true } gsharpClass)
+        {
+            var clrBase = typeof(object);
+            for (var type = gsharpClass; type != null; type = type.BaseClass)
+            {
+                if (type.ImportedBaseType?.ClrType is Type importedBase)
+                {
+                    clrBase = importedBase;
+                    break;
+                }
+            }
+
+            return ClrBackingTypes.GetValue(
+                gsharpClass,
+                _ => CreateClrBackingType(gsharpClass, clrBase));
+        }
+
+        return typeof(object);
     }
 
     private static string GetClrMetadataTypeName(StructSymbol type)

--- a/test/Interpreter.Tests/Interpreter.Tests.csproj
+++ b/test/Interpreter.Tests/Interpreter.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="@(GsharpCompiler)" />
     <ProjectReference Include="@(GsharpRepl)" />
     <ProjectReference Include="..\..\src\Sdk\Gsharp.Extensions\Gsharp.Extensions.csproj" />
   </ItemGroup>

--- a/test/Interpreter.Tests/Issue2990ClrDelegateBoundaryTests.cs
+++ b/test/Interpreter.Tests/Issue2990ClrDelegateBoundaryTests.cs
@@ -84,14 +84,20 @@ public class Issue2990ClrDelegateBoundaryTests
     public void InvokeClrCtor_CoercesClosureWithUserTypeParameter()
     {
         var evaluator = new Evaluator(null, new Dictionary<VariableSymbol, object>());
+        var structType = new StructSymbol(
+            "ConstructorProbeDerived",
+            ImmutableArray<FieldSymbol>.Empty,
+            GSharp.Core.CodeAnalysis.Symbols.Accessibility.Private,
+            declaration: null,
+            packageName: "Issue2990");
         var constructor = typeof(ConstructorProbe).GetConstructor([typeof(Func<object, int>)]);
         var invoke = typeof(Evaluator).GetMethod("InvokeClrCtor", BindingFlags.Instance | BindingFlags.NonPublic);
 
         Assert.NotNull(constructor);
         Assert.NotNull(invoke);
-        var result = Assert.IsType<ConstructorProbe>(invoke.Invoke(
+        var result = Assert.IsAssignableFrom<ConstructorProbe>(invoke.Invoke(
             evaluator,
-            [constructor, ImmutableArray.Create<BoundExpression>(CreateErasedClosure(77)), ImmutableArray<RefKind>.Empty]));
+            [structType, constructor, ImmutableArray.Create<BoundExpression>(CreateErasedClosure(77)), ImmutableArray<RefKind>.Empty]));
 
         Assert.Equal(77, result.Value);
     }
@@ -202,7 +208,7 @@ public class Issue2990ClrDelegateBoundaryTests
         return outWriter.ToString().Replace("\r\n", "\n", StringComparison.Ordinal);
     }
 
-    private sealed class ConstructorProbe
+    public class ConstructorProbe
     {
         public ConstructorProbe(Func<object, int> selector)
         {

--- a/test/Interpreter.Tests/Issue3015ImportedBaseIdentityTests.cs
+++ b/test/Interpreter.Tests/Issue3015ImportedBaseIdentityTests.cs
@@ -1,0 +1,234 @@
+// <copyright file="Issue3015ImportedBaseIdentityTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #3015: imported-base backing objects must retain the derived G# type
+/// identity without breaking inherited CLR member dispatch.
+/// </summary>
+public class Issue3015ImportedBaseIdentityTests
+{
+    [Fact]
+    public void OrdinaryConstruction_PreservesDerivedTypeIdentity()
+    {
+        const string Source = """
+            package Issue3015.Identity
+            import System
+
+            class OrdinarySentinel : EventArgs {
+            }
+
+            var value = OrdinarySentinel()
+            Console.WriteLine(value.ToString())
+            Console.WriteLine(value.GetType().FullName)
+            """;
+
+        Assert.Equal(
+            "Issue3015.Identity.OrdinarySentinel\nIssue3015.Identity.OrdinarySentinel\n",
+            Evaluate(Source));
+    }
+
+    [Fact]
+    public void LiteralConstruction_PreservesDerivedTypeIdentity()
+    {
+        const string Source = """
+            package Issue3015.Identity
+            import System
+
+            class LiteralSentinel : EventArgs {
+            }
+
+            var value = LiteralSentinel{}
+            Console.WriteLine(value.ToString())
+            Console.WriteLine(value.GetType().FullName)
+            """;
+
+        Assert.Equal(
+            "Issue3015.Identity.LiteralSentinel\nIssue3015.Identity.LiteralSentinel\n",
+            Evaluate(Source));
+    }
+
+    [Fact]
+    public void OrdinaryConstruction_PreservesImportedBaseMemberDispatch()
+    {
+        const string Source = """
+            package Issue3015.Bridge
+            import System
+            import System.IO
+
+            class OrdinaryBuffer : MemoryStream {
+            }
+
+            Console.WriteLine(OrdinaryBuffer().CanRead)
+            """;
+
+        Assert.Equal("True\n", Evaluate(Source));
+    }
+
+    [Fact]
+    public void LiteralConstruction_PreservesImportedBaseMemberDispatch()
+    {
+        const string Source = """
+            package Issue3015.Bridge
+            import System
+            import System.IO
+
+            class LiteralBuffer : MemoryStream {
+            }
+
+            Console.WriteLine(LiteralBuffer{}.CanRead)
+            """;
+
+        Assert.Equal("True\n", Evaluate(Source));
+    }
+
+    [Fact]
+    public void ExplicitImportedBaseConstructor_PreservesStateAndIdentity()
+    {
+        const string Source = """
+            package Issue3015.Constructor
+            import System
+
+            class MessageSentinel(message string) : Exception(message) {
+            }
+
+            var value = MessageSentinel("explicit-state-3015")
+            Console.WriteLine(value.Message)
+            Console.WriteLine(value.GetType().FullName)
+            """;
+
+        Assert.Equal(
+            "explicit-state-3015\nIssue3015.Constructor.MessageSentinel\n",
+            Evaluate(Source));
+    }
+
+    [Fact]
+    public void OverloadedBaseConstructors_ShareOneDerivedRuntimeType()
+    {
+        const string Source = """
+            package Issue3015.Constructor
+            import System
+            import GSharp.Interpreter.Tests
+
+            class OverloadedSentinel : Issue3015OverloadedBase {
+                init() : base() {
+                }
+
+                init(label string) : base(label) {
+                }
+            }
+
+            var first = OverloadedSentinel()
+            var second = OverloadedSentinel("explicit-3015")
+            Console.WriteLine(first.Label)
+            Console.WriteLine(second.Label)
+            Console.WriteLine(Object.ReferenceEquals(first.GetType(), second.GetType()))
+            """;
+
+        Assert.Equal(
+            "default-3015\nexplicit-3015\nTrue\n",
+            Evaluate(Source));
+    }
+
+    [Fact]
+    public void GenericConstruction_PreservesConstructedTypeIdentity()
+    {
+        const string Source = """
+            package Issue3015.Generic
+            import System
+
+            class OrdinaryGenericSentinel[T] : EventArgs {
+            }
+
+            class LiteralGenericSentinel[T] : EventArgs {
+            }
+
+            Console.WriteLine(OrdinaryGenericSentinel[int32]().ToString())
+            Console.WriteLine(LiteralGenericSentinel[string]{}.ToString())
+            """;
+
+        Assert.Equal(
+            "Issue3015.Generic.OrdinaryGenericSentinel`1[System.Int32]\n"
+                + "Issue3015.Generic.LiteralGenericSentinel`1[System.String]\n",
+            Evaluate(Source));
+    }
+
+    [Fact]
+    public void NestedConstruction_PreservesContainingTypeIdentity()
+    {
+        const string Source = """
+            package Issue3015.Nested
+            import System
+
+            class Outer {
+                class OrdinaryNestedSentinel : EventArgs {
+                }
+
+                class LiteralNestedSentinel : EventArgs {
+                }
+            }
+
+            Console.WriteLine(Outer.OrdinaryNestedSentinel().ToString())
+            Console.WriteLine(Outer.LiteralNestedSentinel{}.ToString())
+            """;
+
+        Assert.Equal(
+            "Issue3015.Nested.Outer+OrdinaryNestedSentinel\n"
+                + "Issue3015.Nested.Outer+LiteralNestedSentinel\n",
+            Evaluate(Source));
+    }
+
+    private static string Evaluate(string source)
+    {
+        var compilation = new Compilation(SyntaxTree.Parse(source));
+
+        using var outWriter = new StringWriter();
+        var previousOut = Console.Out;
+        Console.SetOut(outWriter);
+        try
+        {
+            var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+            var errors = result.Diagnostics.Where(d => d.IsError).ToArray();
+            Assert.True(
+                errors.Length == 0,
+                "evaluation failed:\n" + string.Join("\n", errors.Select(d => d.ToString())));
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+        }
+
+        return outWriter.ToString().Replace("\r\n", "\n");
+    }
+}
+
+/// <summary>Imported constructor-overload probe for issue #3015.</summary>
+public class Issue3015OverloadedBase
+{
+    /// <summary>Initializes a new instance of the <see cref="Issue3015OverloadedBase"/> class.</summary>
+    public Issue3015OverloadedBase()
+    {
+        Label = "default-3015";
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="Issue3015OverloadedBase"/> class.</summary>
+    /// <param name="label">Probe label.</param>
+    public Issue3015OverloadedBase(string label)
+    {
+        Label = label;
+    }
+
+    /// <summary>Gets constructor probe label.</summary>
+    public string Label { get; }
+}

--- a/test/Interpreter.Tests/Issue3015ImportedBaseIdentityTests.cs
+++ b/test/Interpreter.Tests/Issue3015ImportedBaseIdentityTests.cs
@@ -6,9 +6,11 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Compiler;
 using Xunit;
 
 namespace GSharp.Interpreter.Tests;
@@ -133,11 +135,12 @@ public class Issue3015ImportedBaseIdentityTests
             var second = OverloadedSentinel("explicit-3015")
             Console.WriteLine(first.Label)
             Console.WriteLine(second.Label)
+            Console.WriteLine(first.GetType().FullName)
             Console.WriteLine(Object.ReferenceEquals(first.GetType(), second.GetType()))
             """;
 
         Assert.Equal(
-            "default-3015\nexplicit-3015\nTrue\n",
+            "default-3015\nexplicit-3015\nIssue3015.Constructor.OverloadedSentinel\nTrue\n",
             Evaluate(Source));
     }
 
@@ -162,6 +165,74 @@ public class Issue3015ImportedBaseIdentityTests
             "Issue3015.Generic.OrdinaryGenericSentinel`1[System.Int32]\n"
                 + "Issue3015.Generic.LiteralGenericSentinel`1[System.String]\n",
             Evaluate(Source));
+    }
+
+    [Fact]
+    public void NullableGenericConstruction_PreservesNullableTypeArgument()
+    {
+        const string Source = """
+            package Issue3015.NullableGeneric
+            import System
+
+            class Box[T] : EventArgs {
+            }
+
+            var value = Box[int32?]()
+            Console.WriteLine(value.GetType().FullName)
+            """;
+
+        var output = Evaluate(Source);
+
+        Assert.Contains("Issue3015.NullableGeneric.Box`1", output);
+        Assert.Contains("System.Nullable`1", output);
+    }
+
+    [Fact]
+    public void CompilerAndInterpreter_AgreeOnDerivedRuntimeType()
+    {
+        const string Source = """
+            package Issue3015.CompilerParity
+            import System
+
+            class Sentinel : EventArgs {
+            }
+
+            var value = Sentinel()
+            Console.WriteLine(value.GetType().FullName)
+            """;
+
+        var interpreterTypeName = Evaluate(Source).Trim();
+        var artifactDirectory = Path.Combine(
+            GetRepositoryRoot(),
+            "out",
+            "test-artifacts",
+            $"issue3015-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(artifactDirectory);
+        var sourcePath = Path.Combine(artifactDirectory, "Issue3015.gs");
+        var assemblyPath = Path.Combine(artifactDirectory, "Issue3015.dll");
+
+        try
+        {
+            File.WriteAllText(sourcePath, Source);
+            var exit = Program.Main(new[]
+            {
+                "/out:" + assemblyPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                sourcePath,
+            });
+
+            Assert.Equal(0, exit);
+            var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+            var emittedType = Assert.Single(
+                assembly.GetTypes(),
+                static type => type.FullName == "Issue3015.CompilerParity.Sentinel");
+            Assert.Equal(emittedType.FullName, interpreterTypeName);
+        }
+        finally
+        {
+            Directory.Delete(artifactDirectory, recursive: true);
+        }
     }
 
     [Fact]
@@ -210,6 +281,18 @@ public class Issue3015ImportedBaseIdentityTests
         }
 
         return outWriter.ToString().Replace("\r\n", "\n");
+    }
+
+    private static string GetRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null && !File.Exists(Path.Combine(directory.FullName, "GSharp.sln")))
+        {
+            directory = directory.Parent;
+        }
+
+        return directory?.FullName
+            ?? throw new InvalidOperationException("Could not locate repository root.");
     }
 }
 

--- a/test/Interpreter.Tests/Issue3015ImportedBaseIdentityTests.cs
+++ b/test/Interpreter.Tests/Issue3015ImportedBaseIdentityTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
@@ -260,6 +261,100 @@ public class Issue3015ImportedBaseIdentityTests
             Evaluate(Source));
     }
 
+    [Fact]
+    public void GenericTypeArguments_AgreeAcrossCompilerEmitAndInterpreter()
+    {
+        const string Source = """
+            package Issue3015.GenericParity
+            import System
+
+            class Payload {
+            }
+
+            class Box[T] : EventArgs {
+            }
+
+            Console.WriteLine(Box[Payload]().GetType().FullName)
+            Console.WriteLine(Box[string]().GetType().FullName)
+            Console.WriteLine(Box[Box[Payload]]().GetType().FullName)
+            """;
+        const string Expected = """
+            Issue3015.GenericParity.Box`1[[Issue3015.GenericParity.Payload]]
+            Issue3015.GenericParity.Box`1[[System.String]]
+            Issue3015.GenericParity.Box`1[[Issue3015.GenericParity.Box`1[[Issue3015.GenericParity.Payload]]]]
+
+            """;
+
+        var root = Path.Combine(
+            GetRepositoryRoot(),
+            "out",
+            "test-artifacts",
+            $"issue3015-generic-parity-{Guid.NewGuid():N}");
+
+        try
+        {
+            var compilerEvaluation = RunSourceDriver(Path.Combine(root, "gsc-eval"), Source, Program.Main);
+            Assert.EndsWith("Success.\n", compilerEvaluation);
+            compilerEvaluation = compilerEvaluation[..^"Success.\n".Length];
+            var interpreter = RunSourceDriver(Path.Combine(root, "gsi"), Source, GSharp.Repl.Program.Main);
+            var emitDirectory = Path.Combine(root, "gsc-emit");
+            Directory.CreateDirectory(emitDirectory);
+            var emitSourcePath = Path.Combine(emitDirectory, "GenericParity.gs");
+            var assemblyPath = Path.Combine(emitDirectory, $"GenericParity-{Guid.NewGuid():N}.dll");
+            File.WriteAllText(emitSourcePath, Source);
+            _ = CaptureDriver(() => Program.Main(new[]
+            {
+                "/out:" + assemblyPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                emitSourcePath,
+            }));
+            var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+            Assert.NotEmpty(assembly.GetTypes());
+            var entryPoint = assembly.EntryPoint
+                ?? throw new InvalidOperationException("Emitted assembly has no entry point.");
+            var emitted = CaptureDriver(() =>
+            {
+                entryPoint.Invoke(
+                    null,
+                    entryPoint.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+                return 0;
+            });
+
+            Assert.Equal(Expected, NormalizeGenericTypeNames(compilerEvaluation));
+            Assert.Equal(Expected, NormalizeGenericTypeNames(emitted));
+            Assert.Equal(Expected, NormalizeGenericTypeNames(interpreter));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void ProtectedParameterizedBaseConstructor_PreservesStateAndIdentity()
+    {
+        const string Source = """
+            package Issue3015.ProtectedConstructor
+            import System
+            import GSharp.Interpreter.Tests
+
+            class ProtectedSentinel(value int32) : Issue3015ProtectedParameterizedBase(value) {
+            }
+
+            var instance = ProtectedSentinel(37)
+            Console.WriteLine(instance.Value)
+            Console.WriteLine(instance.GetType().FullName)
+            """;
+
+        Assert.Equal(
+            "37\nIssue3015.ProtectedConstructor.ProtectedSentinel\n",
+            Evaluate(Source));
+    }
+
     private static string Evaluate(string source)
     {
         var compilation = new Compilation(SyntaxTree.Parse(source));
@@ -281,6 +376,48 @@ public class Issue3015ImportedBaseIdentityTests
         }
 
         return outWriter.ToString().Replace("\r\n", "\n");
+    }
+
+    private static string RunSourceDriver(string directory, string source, Func<string[], int> driver)
+    {
+        Directory.CreateDirectory(directory);
+        var sourcePath = Path.Combine(directory, "Probe.gs");
+        File.WriteAllText(sourcePath, source);
+        return CaptureDriver(() => driver(new[] { sourcePath }));
+    }
+
+    private static string CaptureDriver(Func<int> driver)
+    {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        int exit;
+        try
+        {
+            exit = driver();
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+
+        Assert.True(
+            exit == 0,
+            $"driver failed with exit {exit}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout.ToString().Replace("\r\n", "\n");
+    }
+
+    private static string NormalizeGenericTypeNames(string output)
+    {
+        return Regex.Replace(
+            output,
+            @", [^,\[\]]+, Version=[^,\[\]]+, Culture=[^,\[\]]+, PublicKeyToken=[^,\[\]]+",
+            string.Empty,
+            RegexOptions.CultureInvariant);
     }
 
     private static string GetRepositoryRoot()
@@ -314,4 +451,18 @@ public class Issue3015OverloadedBase
 
     /// <summary>Gets constructor probe label.</summary>
     public string Label { get; }
+}
+
+/// <summary>Imported protected-constructor probe for issue #3015.</summary>
+public class Issue3015ProtectedParameterizedBase
+{
+    /// <summary>Initializes a new instance of the <see cref="Issue3015ProtectedParameterizedBase"/> class.</summary>
+    /// <param name="value">Probe value.</param>
+    protected Issue3015ProtectedParameterizedBase(int value)
+    {
+        Value = value;
+    }
+
+    /// <summary>Gets constructor probe value.</summary>
+    public int Value { get; }
 }


### PR DESCRIPTION
## Summary
- allocate a collectible runtime-derived CLR backing type per interpreted G# class instead of instantiating the imported base directly
- forward every accessible imported-base constructor while preserving generic and nested metadata names
- reify G#-declared generic arguments through their interpreted runtime backing types instead of erasing them to `System.Object`
- retain inherited CLR state/member dispatch and cover public plus protected parameterized constructors

## Three-driver generic parity
All sources execute at top level. Each driver uses its own empty artifact directory. Assembly qualifications are removed from `Type.FullName` only so dynamic and emitted assembly names do not obscure type identity.

| type argument | bare `gsc` (evaluate) | `gsc /out:` (emit) | `gsi` (interpret) |
|---|---|---|---|
| G# `Payload` | ``Box`1[[Payload]]`` | ``Box`1[[Payload]]`` | ``Box`1[[Payload]]`` |
| CLR `string` | ``Box`1[[System.String]]`` | ``Box`1[[System.String]]`` | ``Box`1[[System.String]]`` |
| nested `Box[Payload]` | ``Box`1[[Box`1[[Payload]]]]`` | ``Box`1[[Box`1[[Payload]]]]`` | ``Box`1[[Box`1[[Payload]]]]`` |

Full asserted names use package `Issue3015.GenericParity`. Emitted assembly is loaded from bytes and `GetTypes()` is asserted before invoking its entry point.

## Fresh per-clause mutations
Numbers are true of `main` `33bea4af`, head `3abddb46`, merged tree `cc7f49ff`.

| product clause | mutant | live product proof | killed by |
|---|---|---|---|
| G# generic argument backing resolution | return `typeof(object)` | all Core/Compiler/Repl `GSharp.Core.dll` copies refreshed; md5 `4b003c65` → `183c8516`; build reached tests | `GenericTypeArguments_AgreeAcrossCompilerEmitAndInterpreter` (1 failed / 11 passed) |
| protected/protected-internal ctor forwarding | retain public ctors only | all three copies refreshed; md5 `4b003c65` → `b9c5516a`; build reached tests | `ProtectedParameterizedBaseConstructor_PreservesStateAndIdentity` (1 failed / 11 passed) |

Protected test uses an imported base whose only constructor is `protected Issue3015ProtectedParameterizedBase(int)`, so Reflection Emission's automatic parameterless constructor cannot mask the clause.

Both mutations restored to exact source and `GSharp.Core.dll` hashes. Final targeted tests: 12/12. `git merge-tree` produced `cc7f49ff8555f4abac902cd50cbc47f477450e2a`, exactly the head tree. Exact merged-tree Interpreter.Tests: 622/622.

Passing a G# instance to a CLR API expecting its imported base remains unchanged and out of scope.

Fixes #3015
