### PR TITLE
Improve GS0159 for nullable receivers

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -121,7 +121,7 @@ IDs may be given as `GS0001`, `0001`, or the bare integer `1`; all three forms a
 | GS0156 | Error | Cannot convert implicitly; explicit conversion exists. | `int x = 3.14` — an explicit cast is available but was not written. |
 | GS0157 | Error | Cannot find type (possibly missing import). | A package-qualified type name that resolves to nothing. |
 | GS0158 | Error | Cannot find member. | A field or property access that does not resolve. |
-| GS0159 | Error | Cannot find function. | A package-qualified function name that resolves to nothing. |
+| GS0159 | Error | Cannot resolve function call. | A function name does not resolve, or its nullable receiver lacks valid non-null narrowing. |
 | GS0160 | Error | Ambiguous overload. | A call that matches more than one overload equally well. |
 | GS0161 | Error | `copy`/`with` receiver is not a `data struct`. | `.copy(…)` used on a plain `struct`. |
 | GS0162 | Error | Named arguments only supported for `data struct` `.copy(…)`. | Named arguments passed to a regular function. |

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
@@ -87,7 +87,8 @@ internal sealed partial class ExpressionBinder
         BoundExpression receiver,
         ImportedClassSymbol classSymbol,
         ExpressionSyntax rightPart,
-        ExpressionSyntax receiverSyntax = null)
+        ExpressionSyntax receiverSyntax = null,
+        int? receiverStart = null)
     {
         switch (rightPart)
         {
@@ -154,7 +155,8 @@ internal sealed partial class ExpressionBinder
                     return BindNullConditionalAccessExpressionCore(head, nested.RightPart);
                 }
 
-                return BindAccessorStep(head, null, nested.RightPart, nested.LeftPart);
+                var fullReceiverStart = receiverStart ?? receiverSyntax?.Span.Start ?? nested.LeftPart.Span.Start;
+                return BindAccessorStep(head, null, nested.RightPart, nested.LeftPart, fullReceiverStart);
 
             case CallExpressionSyntax ce:
                 // Issue #3084: bind tuple fields symbolically when their CLR
@@ -177,7 +179,7 @@ internal sealed partial class ExpressionBinder
                         nullSafeInvocation: "?(...)");
                 }
 
-                var callResult = BindAccessorCall(receiver, classSymbol, ce, receiverSyntax);
+                var callResult = BindAccessorCall(receiver, classSymbol, ce, receiverSyntax, receiverStart);
                 CheckValueTaskGetAwaiterGetResult(callResult, ce);
                 return callResult;
 

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -2552,7 +2552,19 @@ internal sealed partial class ExpressionBinder
                 return ifaceObjectCall;
             }
 
-            Diagnostics.ReportUnableToFindFunction(ce.Location, methodName);
+            if (receiver?.Type is NullableTypeSymbol)
+            {
+                var effectiveReceiverSyntax = receiverSyntax ?? receiver.Syntax;
+                var receiverName = effectiveReceiverSyntax == null
+                    ? "receiver"
+                    : effectiveReceiverSyntax.SyntaxTree.Text.ToString(effectiveReceiverSyntax.Span);
+                Diagnostics.ReportUnableToFindFunction(ce.Location, methodName, receiverName);
+            }
+            else
+            {
+                Diagnostics.ReportUnableToFindFunction(ce.Location, methodName);
+            }
+
             return new BoundErrorExpression(null);
         }
 

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -2555,12 +2555,21 @@ internal sealed partial class ExpressionBinder
 
             var effectiveReceiverSyntax = receiverSyntax ?? receiver?.Syntax;
             if (receiver?.Type is NullableTypeSymbol nullableRecvType
-                && (nullableRecvType.UnderlyingType as StructSymbol)?.GetMethods(methodName).Length > 0
+                && IsApplicableNullableUnderlyingCall(
+                    receiver,
+                    nullableRecvType.UnderlyingType,
+                    methodName,
+                    arguments,
+                    ce,
+                    argumentNames,
+                    explicitTypeArgs,
+                    typeArgSymbols)
                 && effectiveReceiverSyntax != null)
             {
                 var receiverName = effectiveReceiverSyntax.SyntaxTree.Text.ToString(TextSpan.FromBounds(
                     receiverStart ?? effectiveReceiverSyntax.Span.Start,
                     effectiveReceiverSyntax.Span.End));
+                receiverName = string.Join(" ", receiverName.Split((char[])null, StringSplitOptions.RemoveEmptyEntries));
                 Diagnostics.ReportUnableToFindFunction(ce.Location, methodName, receiverName);
             }
             else
@@ -2864,5 +2873,189 @@ internal sealed partial class ExpressionBinder
 
         Diagnostics.ReportUnableToFindFunction(ce.Location, methodName);
         return new BoundErrorExpression(null);
+    }
+
+    private bool IsApplicableNullableUnderlyingCall(
+        BoundExpression receiver,
+        TypeSymbol underlyingType,
+        string methodName,
+        ImmutableArray<BoundExpression> arguments,
+        CallExpressionSyntax ce,
+        ImmutableArray<string> argumentNames,
+        Type[] explicitTypeArgs,
+        ImmutableArray<TypeSymbol> typeArgSymbols)
+    {
+        var narrowedReceiver = new BoundConversionExpression(receiver.Syntax, underlyingType, receiver);
+        var diagnosticMark = Diagnostics.Count;
+
+        // Reuse normal call binding as an applicability probe, then discard its
+        // diagnostics so only the nullable-receiver diagnostic reaches users.
+        bool Succeeded(BoundExpression call) =>
+            call is not null and not BoundErrorExpression && Diagnostics.Count == diagnosticMark;
+
+        try
+        {
+            if (underlyingType is InterfaceSymbol ifaceRecv)
+            {
+                var candidates = TypeMemberModel.GetMethods(ifaceRecv, methodName, MemberQuery.Instance(MemberKinds.Method));
+                if (!candidates.IsDefaultOrEmpty)
+                {
+                    var method = overloads.SelectInstanceOverloadOrReport(candidates, arguments, ce, methodName, argumentNames);
+                    return method != null
+                        && Succeeded(overloads.BindUserInstanceCall(narrowedReceiver, method, arguments, ce, argumentNames));
+                }
+            }
+
+            if (underlyingType is TypeParameterSymbol tpRecv)
+            {
+                var candidates = MemberLookup.CollectSourceInstanceMethods(tpRecv, methodName);
+                if (!candidates.IsDefaultOrEmpty)
+                {
+                    var method = overloads.SelectInstanceOverloadOrReport(candidates, arguments, ce, methodName, argumentNames);
+                    return method != null
+                        && Succeeded(overloads.BindUserInstanceCall(
+                            narrowedReceiver,
+                            method,
+                            arguments,
+                            ce,
+                            argumentNames,
+                            constrainedReceiverTypeParameter: tpRecv));
+                }
+
+                if (tpRecv.ClrInterfaceConstraint != null
+                    && TryBindConstrainedClrInterfaceCall(narrowedReceiver, tpRecv, methodName, arguments, ce, argumentNames, out var constrainedCall))
+                {
+                    return Succeeded(constrainedCall);
+                }
+            }
+
+            if (underlyingType is StructSymbol structRecv)
+            {
+                var candidates = MemberLookup.CollectSourceInstanceMethods(structRecv, methodName);
+                if (!candidates.IsDefaultOrEmpty)
+                {
+                    var method = overloads.SelectInstanceOverloadOrReport(candidates, arguments, ce, methodName, argumentNames);
+                    return method != null
+                        && Succeeded(overloads.BindUserInstanceCall(narrowedReceiver, method, arguments, ce, argumentNames));
+                }
+
+                var defaultInterfaceMethod = TryFindDefaultInterfaceMethod(structRecv, methodName, arguments, ce, argumentNames);
+                if (defaultInterfaceMethod != null)
+                {
+                    return Succeeded(overloads.BindUserInstanceCall(
+                        narrowedReceiver,
+                        defaultInterfaceMethod,
+                        arguments,
+                        ce,
+                        argumentNames));
+                }
+            }
+
+            if (underlyingType is StructSymbol or InterfaceSymbol
+                && TryBindUserDelegateMemberInvocation(
+                    narrowedReceiver,
+                    underlyingType,
+                    methodName,
+                    arguments,
+                    ce,
+                    isStatic: false,
+                    out var delegateCall))
+            {
+                return Succeeded(delegateCall);
+            }
+
+            if (TryBindExtensionFunctionOverload(narrowedReceiver, methodName, arguments, ce, argumentNames, out var extensionCall))
+            {
+                return Succeeded(extensionCall);
+            }
+
+            if (underlyingType is StructSymbol inheritedDerived
+                && (GetInheritedClrBaseType(inheritedDerived) ?? typeof(object)) is Type inheritedBaseClr
+                && TryBindInheritedClrInstanceCall(
+                    narrowedReceiver,
+                    inheritedBaseClr,
+                    methodName,
+                    arguments,
+                    ce,
+                    out var inheritedCall,
+                    explicitTypeArgs,
+                    typeArgSymbols,
+                    argumentNames,
+                    allowProtectedInherited: IsCurrentThisReceiver(receiver)))
+            {
+                return Succeeded(inheritedCall);
+            }
+
+            if (underlyingType is EnumSymbol
+                && TryBindInheritedClrInstanceCall(
+                    narrowedReceiver,
+                    typeof(Enum),
+                    methodName,
+                    arguments,
+                    ce,
+                    out var enumCall,
+                    explicitTypeArgs,
+                    typeArgSymbols,
+                    argumentNames,
+                    mapEnumArgumentsToBaseClr: true))
+            {
+                return Succeeded(enumCall);
+            }
+
+            if (TryBindImportedExtensionCall(
+                narrowedReceiver,
+                methodName,
+                arguments,
+                ce,
+                out var importedExtensionCall,
+                explicitTypeArgs,
+                typeArgSymbols,
+                argumentNames))
+            {
+                return Succeeded(importedExtensionCall);
+            }
+
+            if (underlyingType is InterfaceSymbol importedBaseIface
+                && TryBindInterfaceImportedBaseInstanceCall(
+                    narrowedReceiver,
+                    importedBaseIface,
+                    methodName,
+                    arguments,
+                    ce,
+                    out var importedBaseCall,
+                    explicitTypeArgs,
+                    typeArgSymbols,
+                    argumentNames))
+            {
+                return Succeeded(importedBaseCall);
+            }
+
+            if (underlyingType is TypeParameterSymbol tpObject
+                && TryBindConstrainedObjectMemberCall(
+                    narrowedReceiver,
+                    tpObject,
+                    methodName,
+                    arguments,
+                    ce,
+                    argumentNames,
+                    out var objectCall))
+            {
+                return Succeeded(objectCall);
+            }
+
+            return underlyingType is InterfaceSymbol
+                && TryBindInterfaceObjectMemberCall(
+                    narrowedReceiver,
+                    methodName,
+                    arguments,
+                    ce,
+                    argumentNames,
+                    out var interfaceObjectCall)
+                && Succeeded(interfaceObjectCall);
+        }
+        finally
+        {
+            Diagnostics.TruncateTo(diagnosticMark);
+        }
     }
 }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -1913,7 +1913,8 @@ internal sealed partial class ExpressionBinder
         BoundExpression receiver,
         ImportedClassSymbol classSymbol,
         CallExpressionSyntax ce,
-        ExpressionSyntax receiverSyntax = null)
+        ExpressionSyntax receiverSyntax = null,
+        int? receiverStart = null)
     {
         var methodName = ce.Identifier.Text;
         if (string.Equals(methodName, "Invoke", System.StringComparison.Ordinal))
@@ -2552,12 +2553,14 @@ internal sealed partial class ExpressionBinder
                 return ifaceObjectCall;
             }
 
-            if (receiver?.Type is NullableTypeSymbol)
+            var effectiveReceiverSyntax = receiverSyntax ?? receiver?.Syntax;
+            if (receiver?.Type is NullableTypeSymbol nullableRecvType
+                && (nullableRecvType.UnderlyingType as StructSymbol)?.GetMethods(methodName).Length > 0
+                && effectiveReceiverSyntax != null)
             {
-                var effectiveReceiverSyntax = receiverSyntax ?? receiver.Syntax;
-                var receiverName = effectiveReceiverSyntax == null
-                    ? "receiver"
-                    : effectiveReceiverSyntax.SyntaxTree.Text.ToString(effectiveReceiverSyntax.Span);
+                var receiverName = effectiveReceiverSyntax.SyntaxTree.Text.ToString(TextSpan.FromBounds(
+                    receiverStart ?? effectiveReceiverSyntax.Span.Start,
+                    effectiveReceiverSyntax.Span.End));
                 Diagnostics.ReportUnableToFindFunction(ce.Location, methodName, receiverName);
             }
             else

--- a/src/Core/CodeAnalysis/DiagnosticBag.Reports.Expressions.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.Reports.Expressions.cs
@@ -317,7 +317,20 @@ public sealed partial class DiagnosticBag
     /// <param name="location">The text location where the error was found.</param>
     /// <param name="text">The text associated to the function.</param>
     public void ReportUnableToFindFunction(TextLocation location, string text)
-    => Report(location, DiagnosticDescriptors.UnableToFindFunction, text);
+    => Report(location, DiagnosticDescriptors.UnableToFindFunction, $"Cannot find function {text}.");
+
+    /// <summary>Reports a function call whose receiver lacks a valid non-null narrowing.</summary>
+    /// <param name="location">The text location where the error was found.</param>
+    /// <param name="functionName">The called function.</param>
+    /// <param name="receiverName">The nullable receiver spelling.</param>
+    public void ReportUnableToFindFunction(
+        TextLocation location,
+        string functionName,
+        string receiverName)
+    => Report(
+        location,
+        DiagnosticDescriptors.UnableToFindFunction,
+        $"Cannot call function {functionName} because receiver '{receiverName}' may be nil. Use '?.' for a null-safe call, bind it with 'if let', or re-narrow it before calling.");
 
     /// <summary>
     /// Reports that an overloaded call (constructor, static method, or

--- a/src/Core/CodeAnalysis/DiagnosticBag.Reports.Expressions.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.Reports.Expressions.cs
@@ -330,7 +330,7 @@ public sealed partial class DiagnosticBag
     => Report(
         location,
         DiagnosticDescriptors.UnableToFindFunction,
-        $"Cannot call function {functionName} because receiver '{receiverName}' may be nil. Use '?.' for a null-safe call, bind it with 'if let', or re-narrow it before calling.");
+        $"Cannot call function {functionName} because receiver '{receiverName}' may be nil. Use '?.' for a null-safe call or bind it with 'if let'.");
 
     /// <summary>
     /// Reports that an overloaded call (constructor, static method, or

--- a/src/Core/CodeAnalysis/DiagnosticDescriptors.cs
+++ b/src/Core/CodeAnalysis/DiagnosticDescriptors.cs
@@ -74,7 +74,7 @@ internal static class DiagnosticDescriptors
     internal static readonly DiagnosticDescriptor CannotConvertImplicitly = new("GS0156", DiagnosticSeverity.Error, "Cannot convert type '{0}' to '{1}'. An explicit conversion exists (are you missing a cast?)");
     internal static readonly DiagnosticDescriptor UnableToFindType = new("GS0157", DiagnosticSeverity.Error, "Cannot find type {0}. Are you missing an import?");
     internal static readonly DiagnosticDescriptor UnableToFindMember = new("GS0158", DiagnosticSeverity.Error, "Cannot find member {0}.");
-    internal static readonly DiagnosticDescriptor UnableToFindFunction = new("GS0159", DiagnosticSeverity.Error, "Cannot find function {0}.");
+    internal static readonly DiagnosticDescriptor UnableToFindFunction = new("GS0159", DiagnosticSeverity.Error, "{0}");
     internal static readonly DiagnosticDescriptor AmbiguousOverload = new("GS0160", DiagnosticSeverity.Error, "Call to '{0}' is ambiguous between {1} applicable overloads.{2}");
     internal static readonly DiagnosticDescriptor CopyOrWithNotDataStruct = new("GS0161", DiagnosticSeverity.Error, "copy/with requires a data class or data struct receiver, but got '{0}'.");
     internal static readonly DiagnosticDescriptor NamedArgumentOnlyValidForCopy = new("GS0162", DiagnosticSeverity.Error, "Named arguments are only supported for data-struct .copy(...).");

--- a/test/Compiler.Tests/Binding/Issue3034NullableNarrowingDiagnosticTests.cs
+++ b/test/Compiler.Tests/Binding/Issue3034NullableNarrowingDiagnosticTests.cs
@@ -62,6 +62,46 @@ public class Issue3034NullableNarrowingDiagnosticTests
     }
 
     [Fact]
+    public void MissingMethodOnNullableReceiver_KeepsLookupMessage()
+    {
+        var diagnostic = GetGs0159("""
+            class C {
+                func M() { }
+            }
+
+            func Run() {
+                var c C? = nil
+                c.Frobnicate()
+            }
+            """);
+
+        Assert.Equal("Cannot find function Frobnicate.", diagnostic.Message);
+    }
+
+    [Fact]
+    public void QualifiedNullableReceiver_PreservesQualifier()
+    {
+        var diagnostic = GetGs0159("""
+            class C {
+                func M() { }
+            }
+
+            class Box {
+                var Inner C?
+            }
+
+            func Run() {
+                var b Box = Box()
+                b.Inner.M()
+            }
+            """);
+
+        Assert.Equal(
+            "Cannot call function M because receiver 'b.Inner' may be nil. Use '?.' for a null-safe call, bind it with 'if let', or re-narrow it before calling.",
+            diagnostic.Message);
+    }
+
+    [Fact]
     public void InvalidExplicitTypeArgument_KeepsLookupMessage()
     {
         var diagnostic = GetGs0159("""

--- a/test/Compiler.Tests/Binding/Issue3034NullableNarrowingDiagnosticTests.cs
+++ b/test/Compiler.Tests/Binding/Issue3034NullableNarrowingDiagnosticTests.cs
@@ -38,6 +38,21 @@ public class Issue3034NullableNarrowingDiagnosticTests
             """);
 
         Assert.Equal(NullableReceiverMessage, diagnostic.Message);
+        AssertDiagnosticSpan(diagnostic, line: 6, startCharacter: 6, endCharacter: 9, text: "M()");
+    }
+
+    [Fact]
+    public void TopLevelNullableReceiver_ExplainsMissingNarrowing()
+    {
+        var diagnostic = GetGs0159("""
+            class C { func M() { } }
+
+            var c C? = nil
+            c.M()
+            """, isLibrary: false);
+
+        Assert.Equal(NullableReceiverMessage, diagnostic.Message);
+        AssertDiagnosticSpan(diagnostic, line: 3, startCharacter: 2, endCharacter: 5, text: "M()");
     }
 
     [Fact]
@@ -79,6 +94,125 @@ public class Issue3034NullableNarrowingDiagnosticTests
     }
 
     [Fact]
+    public void WrongArityOnNullableReceiver_KeepsLookupMessage()
+    {
+        var diagnostic = GetGs0159("""
+            class C { func M(value int32) { } }
+
+            func Run() {
+                var c C? = nil
+                c.M()
+            }
+            """);
+
+        Assert.Equal("Cannot find function M.", diagnostic.Message);
+        AssertDiagnosticSpan(diagnostic, line: 4, startCharacter: 6, endCharacter: 9, text: "M()");
+    }
+
+    [Fact]
+    public void WrongArgumentTypeOnNullableReceiver_KeepsLookupMessage()
+    {
+        var diagnostic = GetGs0159("""
+            class C { func M(value int32) { } }
+
+            func Run() {
+                var c C? = nil
+                c.M("x")
+            }
+            """);
+
+        Assert.Equal("Cannot find function M.", diagnostic.Message);
+        AssertDiagnosticSpan(diagnostic, line: 4, startCharacter: 6, endCharacter: 12, text: "M(\"x\")");
+    }
+
+    [Fact]
+    public void StructNullableReceiver_ExplainsMissingNarrowing()
+    {
+        var diagnostic = GetGs0159("""
+            struct S { func M() { } }
+
+            func Run() {
+                var s S? = nil
+                s.M()
+            }
+            """);
+
+        Assert.Equal(
+            "Cannot call function M because receiver 's' may be nil. Use '?.' for a null-safe call, bind it with 'if let', or re-narrow it before calling.",
+            diagnostic.Message);
+    }
+
+    [Fact]
+    public void InterfaceNullableReceiver_ExplainsMissingNarrowing()
+    {
+        var diagnostic = GetGs0159("""
+            interface I { func M(); }
+
+            func Run() {
+                var value I? = nil
+                value.M()
+            }
+            """);
+
+        Assert.Equal(
+            "Cannot call function M because receiver 'value' may be nil. Use '?.' for a null-safe call, bind it with 'if let', or re-narrow it before calling.",
+            diagnostic.Message);
+    }
+
+    [Fact]
+    public void EnumNullableReceiver_ExplainsMissingNarrowing()
+    {
+        var diagnostic = GetGs0159("""
+            enum E { A }
+
+            func Run() {
+                var value E? = nil
+                value.ToString()
+            }
+            """);
+
+        Assert.Equal(
+            "Cannot call function ToString because receiver 'value' may be nil. Use '?.' for a null-safe call, bind it with 'if let', or re-narrow it before calling.",
+            diagnostic.Message);
+    }
+
+    [Fact]
+    public void ConstrainedTypeParameterNullableReceiver_ExplainsMissingNarrowing()
+    {
+        var diagnostic = GetGs0159("""
+            interface I { func M(); }
+
+            func Use[T I](value T?) {
+                value.M()
+            }
+            """);
+
+        Assert.Equal(
+            "Cannot call function M because receiver 'value' may be nil. Use '?.' for a null-safe call, bind it with 'if let', or re-narrow it before calling.",
+            diagnostic.Message);
+    }
+
+    [Fact]
+    public void ImportedAndArrayNullableReceivers_KeepExistingSuccessfulBinding()
+    {
+        Assert.Empty(GetDiagnostics("""
+            import System.Text
+
+            func Run() {
+                var value StringBuilder? = nil
+                value.ToString()
+            }
+            """));
+
+        Assert.Empty(GetDiagnostics("""
+            func Run() {
+                var values []?int32 = nil
+                values.ToString()
+            }
+            """));
+    }
+
+    [Fact]
     public void QualifiedNullableReceiver_PreservesQualifier()
     {
         var diagnostic = GetGs0159("""
@@ -102,9 +236,29 @@ public class Issue3034NullableNarrowingDiagnosticTests
     }
 
     [Fact]
-    public void InvalidExplicitTypeArgument_KeepsLookupMessage()
+    public void MultilineNullableReceiver_CollapsesWhitespace()
     {
         var diagnostic = GetGs0159("""
+            class C { func M() { } }
+            class Box { var Inner C? }
+            func Run() {
+                var b Box = Box()
+                b.
+                    Inner.M()
+            }
+            """);
+
+        Assert.Equal(
+            "Cannot call function M because receiver 'b. Inner' may be nil. Use '?.' for a null-safe call, bind it with 'if let', or re-narrow it before calling.",
+            diagnostic.Message);
+        Assert.DoesNotContain('\n', diagnostic.Message);
+        AssertDiagnosticSpan(diagnostic, line: 5, startCharacter: 14, endCharacter: 17, text: "M()");
+    }
+
+    [Fact]
+    public void InvalidExplicitTypeArgument_KeepsLookupMessage()
+    {
+        var diagnostic = GetGs0159AllowingOtherDiagnostics("""
             import System
 
             func Run() {
@@ -157,15 +311,39 @@ public class Issue3034NullableNarrowingDiagnosticTests
         Assert.Equal("Cannot find function Handler.", diagnostic.Message);
     }
 
-    private static Diagnostic GetGs0159(string source)
+    private static Diagnostic GetGs0159(string source, bool isLibrary = true)
+    {
+        var diagnostic = Assert.Single(GetDiagnostics(source, isLibrary));
+        Assert.Equal("GS0159", diagnostic.Id);
+        return diagnostic;
+    }
+
+    private static Diagnostic GetGs0159AllowingOtherDiagnostics(string source)
+        => Assert.Single(GetDiagnostics(source), diagnostic => diagnostic.Id == "GS0159");
+
+    private static Diagnostic[] GetDiagnostics(string source, bool isLibrary = true)
     {
         var sourceText = SourceText.From(source, "issue3034.gs");
         var tree = SyntaxTree.Parse(sourceText);
-        var compilation = new Compilation(ReferenceResolver.Default(), tree) { IsLibrary = true };
+        var compilation = new Compilation(ReferenceResolver.Default(), tree) { IsLibrary = isLibrary };
 
         using var peStream = new MemoryStream();
         var result = compilation.Emit(peStream, refStream: null);
-        return Assert.Single(result.Diagnostics.Where(diagnostic => diagnostic.Id == "GS0159"));
+        return result.Diagnostics.ToArray();
+    }
+
+    private static void AssertDiagnosticSpan(
+        Diagnostic diagnostic,
+        int line,
+        int startCharacter,
+        int endCharacter,
+        string text)
+    {
+        Assert.Equal(line, diagnostic.Location.StartLine);
+        Assert.Equal(line, diagnostic.Location.EndLine);
+        Assert.Equal(startCharacter, diagnostic.Location.StartCharacter);
+        Assert.Equal(endCharacter, diagnostic.Location.EndCharacter);
+        Assert.Equal(text, diagnostic.Location.Text.ToString(diagnostic.Location.Span));
     }
 }
 

--- a/test/Compiler.Tests/Binding/Issue3034NullableNarrowingDiagnosticTests.cs
+++ b/test/Compiler.Tests/Binding/Issue3034NullableNarrowingDiagnosticTests.cs
@@ -21,37 +21,44 @@ namespace GSharp.Compiler.Tests.Binding;
 public class Issue3034NullableNarrowingDiagnosticTests
 {
     private const string NullableReceiverMessage =
-        "Cannot call function M because receiver 'c' may be nil. Use '?.' for a null-safe call, bind it with 'if let', or re-narrow it before calling.";
+        "Cannot call function M because receiver 'c' may be nil. Use '?.' for a null-safe call or bind it with 'if let'.";
 
     [Theory]
-    [InlineData("function")]
-    [InlineData("top-level")]
-    public void NullableReceiver_ExplainsMissingNarrowing(string scope)
+    [MemberData(nameof(ReceiverKindCases))]
+    public void NullableReceiverGuidance_MatchesReceiverNarrowability(
+        string receiverKind,
+        string state,
+        string scope,
+        bool expectDiagnostic)
     {
-        var source = scope == "top-level"
-            ? """
-            class C { func M() { } }
+        var source = CreateReceiverKindSource(receiverKind, state, scope);
+        var diagnostics = GetDiagnostics(
+            source,
+            isLibrary: scope != "top-level" && receiverKind != "global");
+        if (!expectDiagnostic)
+        {
+            Assert.Empty(diagnostics);
+            return;
+        }
 
-            var c C? = nil
-            c.M()
-            """
-            : """
-            class C { func M() { } }
+        if (receiverKind == "parameter" && state == "narrowed-before-call")
+        {
+            Assert.Equal(2, diagnostics.Length);
+            Assert.Contains(
+                diagnostics,
+                diagnostic => diagnostic.Message == "Variable 'c' is read-only and cannot be assigned to.");
+        }
+        else
+        {
+            Assert.Single(diagnostics);
+        }
 
-            func Run() {
-                var c C? = nil
-                c.M()
-            }
-            """;
-        var diagnostic = GetGs0159(source, isLibrary: scope != "top-level");
-
-        Assert.Equal(NullableReceiverMessage, diagnostic.Message);
-        AssertDiagnosticSpan(
-            diagnostic,
-            line: scope == "top-level" ? 3 : 4,
-            startCharacter: scope == "top-level" ? 2 : 6,
-            endCharacter: scope == "top-level" ? 5 : 9,
-            text: "M()");
+        var diagnostic = Assert.Single(diagnostics, diagnostic => diagnostic.Id == "GS0159");
+        var receiver = receiverKind == "field" ? "b.Inner" : "c";
+        Assert.Equal(
+            $"Cannot call function M because receiver '{receiver}' may be nil. Use '?.' for a null-safe call or bind it with 'if let'.",
+            diagnostic.Message);
+        Assert.DoesNotContain("re-narrow", diagnostic.Message, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -167,7 +174,7 @@ public class Issue3034NullableNarrowingDiagnosticTests
             """);
 
         Assert.Equal(
-            "Cannot call function M because receiver 's' may be nil. Use '?.' for a null-safe call, bind it with 'if let', or re-narrow it before calling.",
+            "Cannot call function M because receiver 's' may be nil. Use '?.' for a null-safe call or bind it with 'if let'.",
             diagnostic.Message);
     }
 
@@ -184,7 +191,7 @@ public class Issue3034NullableNarrowingDiagnosticTests
             """);
 
         Assert.Equal(
-            "Cannot call function M because receiver 'value' may be nil. Use '?.' for a null-safe call, bind it with 'if let', or re-narrow it before calling.",
+            "Cannot call function M because receiver 'value' may be nil. Use '?.' for a null-safe call or bind it with 'if let'.",
             diagnostic.Message);
     }
 
@@ -201,7 +208,7 @@ public class Issue3034NullableNarrowingDiagnosticTests
             """);
 
         Assert.Equal(
-            "Cannot call function ToString because receiver 'value' may be nil. Use '?.' for a null-safe call, bind it with 'if let', or re-narrow it before calling.",
+            "Cannot call function ToString because receiver 'value' may be nil. Use '?.' for a null-safe call or bind it with 'if let'.",
             diagnostic.Message);
     }
 
@@ -217,7 +224,7 @@ public class Issue3034NullableNarrowingDiagnosticTests
             """);
 
         Assert.Equal(
-            "Cannot call function M because receiver 'value' may be nil. Use '?.' for a null-safe call, bind it with 'if let', or re-narrow it before calling.",
+            "Cannot call function M because receiver 'value' may be nil. Use '?.' for a null-safe call or bind it with 'if let'.",
             diagnostic.Message);
     }
 
@@ -260,7 +267,7 @@ public class Issue3034NullableNarrowingDiagnosticTests
             """);
 
         Assert.Equal(
-            "Cannot call function M because receiver 'b.Inner' may be nil. Use '?.' for a null-safe call, bind it with 'if let', or re-narrow it before calling.",
+            "Cannot call function M because receiver 'b.Inner' may be nil. Use '?.' for a null-safe call or bind it with 'if let'.",
             diagnostic.Message);
     }
 
@@ -278,7 +285,7 @@ public class Issue3034NullableNarrowingDiagnosticTests
             """);
 
         Assert.Equal(
-            "Cannot call function M because receiver 'b. Inner' may be nil. Use '?.' for a null-safe call, bind it with 'if let', or re-narrow it before calling.",
+            "Cannot call function M because receiver 'b. Inner' may be nil. Use '?.' for a null-safe call or bind it with 'if let'.",
             diagnostic.Message);
         Assert.DoesNotContain('\n', diagnostic.Message);
         AssertDiagnosticSpan(diagnostic, line: 5, startCharacter: 14, endCharacter: 17, text: "M()");
@@ -359,6 +366,92 @@ public class Issue3034NullableNarrowingDiagnosticTests
         using var peStream = new MemoryStream();
         var result = compilation.Emit(peStream, refStream: null);
         return result.Diagnostics.ToArray();
+    }
+
+    public static TheoryData<string, string, string, bool> ReceiverKindCases => new()
+    {
+        { "local", "never-narrowed", "function", true },
+        { "local", "narrowed-before-call", "function", false },
+        { "parameter", "never-narrowed", "function", true },
+        { "parameter", "narrowed-before-call", "function", true },
+        { "field", "never-narrowed", "top-level", true },
+        { "field", "narrowed-before-call", "top-level", true },
+        { "field", "never-narrowed", "function", true },
+        { "field", "narrowed-before-call", "function", true },
+        { "global", "never-narrowed", "top-level", true },
+        { "global", "narrowed-before-call", "top-level", false },
+        { "global", "never-narrowed", "function", true },
+        { "global", "narrowed-before-call", "function", false },
+        { "let", "never-narrowed", "top-level", true },
+        { "let", "narrowed-before-call", "top-level", true },
+        { "let", "never-narrowed", "function", true },
+        { "let", "narrowed-before-call", "function", true },
+    };
+
+    private static string CreateReceiverKindSource(string receiverKind, string state, string scope)
+    {
+        var setNonNull = state == "narrowed-before-call";
+        return (receiverKind, scope) switch
+        {
+            ("local", "function") => $$"""
+                class C { func M() { } }
+                func Run() {
+                    var c C? = nil
+                    {{(setNonNull ? "c = C()" : string.Empty)}}
+                    c.M()
+                }
+                """,
+            ("parameter", "function") => $$"""
+                class C { func M() { } }
+                func Run(c C?) {
+                    {{(setNonNull ? "c = C()" : string.Empty)}}
+                    c.M()
+                }
+                """,
+            ("field", "top-level") => $$"""
+                class C { func M() { } }
+                class Box { var Inner C? }
+                var b Box = Box()
+                {{(setNonNull ? "b.Inner = C()" : string.Empty)}}
+                b.Inner.M()
+                """,
+            ("field", "function") => $$"""
+                class C { func M() { } }
+                class Box { var Inner C? }
+                func Run() {
+                    var b Box = Box()
+                    {{(setNonNull ? "b.Inner = C()" : string.Empty)}}
+                    b.Inner.M()
+                }
+                """,
+            ("global", "top-level") => $$"""
+                class C { func M() { } }
+                var c C? = nil
+                {{(setNonNull ? "c = C()" : string.Empty)}}
+                c.M()
+                """,
+            ("global", "function") => $$"""
+                class C { func M() { } }
+                var c C? = nil
+                func Run() {
+                    {{(setNonNull ? "c = C()" : string.Empty)}}
+                    c.M()
+                }
+                """,
+            ("let", "top-level") => $$"""
+                class C { func M() { } }
+                let c C? = {{(setNonNull ? "C()" : "nil")}}
+                c.M()
+                """,
+            ("let", "function") => $$"""
+                class C { func M() { } }
+                func Run() {
+                    let c C? = {{(setNonNull ? "C()" : "nil")}}
+                    c.M()
+                }
+                """,
+            _ => throw new ArgumentOutOfRangeException(nameof(receiverKind)),
+        };
     }
 
     private static void AssertDiagnosticSpan(

--- a/test/Compiler.Tests/Binding/Issue3034NullableNarrowingDiagnosticTests.cs
+++ b/test/Compiler.Tests/Binding/Issue3034NullableNarrowingDiagnosticTests.cs
@@ -23,36 +23,35 @@ public class Issue3034NullableNarrowingDiagnosticTests
     private const string NullableReceiverMessage =
         "Cannot call function M because receiver 'c' may be nil. Use '?.' for a null-safe call, bind it with 'if let', or re-narrow it before calling.";
 
-    [Fact]
-    public void NullableReceiver_ExplainsMissingNarrowing()
+    [Theory]
+    [InlineData("function")]
+    [InlineData("top-level")]
+    public void NullableReceiver_ExplainsMissingNarrowing(string scope)
     {
-        var diagnostic = GetGs0159("""
-            class C {
-                func M() { }
-            }
+        var source = scope == "top-level"
+            ? """
+            class C { func M() { } }
+
+            var c C? = nil
+            c.M()
+            """
+            : """
+            class C { func M() { } }
 
             func Run() {
                 var c C? = nil
                 c.M()
             }
-            """);
+            """;
+        var diagnostic = GetGs0159(source, isLibrary: scope != "top-level");
 
         Assert.Equal(NullableReceiverMessage, diagnostic.Message);
-        AssertDiagnosticSpan(diagnostic, line: 6, startCharacter: 6, endCharacter: 9, text: "M()");
-    }
-
-    [Fact]
-    public void TopLevelNullableReceiver_ExplainsMissingNarrowing()
-    {
-        var diagnostic = GetGs0159("""
-            class C { func M() { } }
-
-            var c C? = nil
-            c.M()
-            """, isLibrary: false);
-
-        Assert.Equal(NullableReceiverMessage, diagnostic.Message);
-        AssertDiagnosticSpan(diagnostic, line: 3, startCharacter: 2, endCharacter: 5, text: "M()");
+        AssertDiagnosticSpan(
+            diagnostic,
+            line: scope == "top-level" ? 3 : 4,
+            startCharacter: scope == "top-level" ? 2 : 6,
+            endCharacter: scope == "top-level" ? 5 : 9,
+            text: "M()");
     }
 
     [Fact]
@@ -93,36 +92,66 @@ public class Issue3034NullableNarrowingDiagnosticTests
         Assert.Equal("Cannot find function Frobnicate.", diagnostic.Message);
     }
 
-    [Fact]
-    public void WrongArityOnNullableReceiver_KeepsLookupMessage()
+    [Theory]
+    [InlineData("function")]
+    [InlineData("top-level")]
+    public void WrongArityOnNullableReceiver_KeepsLookupMessage(string scope)
     {
-        var diagnostic = GetGs0159("""
+        var source = scope == "top-level"
+            ? """
+            class C { func M(value int32) { } }
+
+            var c C? = nil
+            c.M()
+            """
+            : """
             class C { func M(value int32) { } }
 
             func Run() {
                 var c C? = nil
                 c.M()
             }
-            """);
+            """;
+        var diagnostic = GetGs0159(source, isLibrary: scope != "top-level");
 
         Assert.Equal("Cannot find function M.", diagnostic.Message);
-        AssertDiagnosticSpan(diagnostic, line: 4, startCharacter: 6, endCharacter: 9, text: "M()");
+        AssertDiagnosticSpan(
+            diagnostic,
+            line: scope == "top-level" ? 3 : 4,
+            startCharacter: scope == "top-level" ? 2 : 6,
+            endCharacter: scope == "top-level" ? 5 : 9,
+            text: "M()");
     }
 
-    [Fact]
-    public void WrongArgumentTypeOnNullableReceiver_KeepsLookupMessage()
+    [Theory]
+    [InlineData("function")]
+    [InlineData("top-level")]
+    public void WrongArgumentTypeOnNullableReceiver_KeepsLookupMessage(string scope)
     {
-        var diagnostic = GetGs0159("""
+        var source = scope == "top-level"
+            ? """
+            class C { func M(value int32) { } }
+
+            var c C? = nil
+            c.M("x")
+            """
+            : """
             class C { func M(value int32) { } }
 
             func Run() {
                 var c C? = nil
                 c.M("x")
             }
-            """);
+            """;
+        var diagnostic = GetGs0159(source, isLibrary: scope != "top-level");
 
         Assert.Equal("Cannot find function M.", diagnostic.Message);
-        AssertDiagnosticSpan(diagnostic, line: 4, startCharacter: 6, endCharacter: 12, text: "M(\"x\")");
+        AssertDiagnosticSpan(
+            diagnostic,
+            line: scope == "top-level" ? 3 : 4,
+            startCharacter: scope == "top-level" ? 2 : 6,
+            endCharacter: scope == "top-level" ? 8 : 12,
+            text: "M(\"x\")");
     }
 
     [Fact]

--- a/test/Compiler.Tests/Binding/Issue3034NullableNarrowingDiagnosticTests.cs
+++ b/test/Compiler.Tests/Binding/Issue3034NullableNarrowingDiagnosticTests.cs
@@ -1,0 +1,137 @@
+// <copyright file="Issue3034NullableNarrowingDiagnosticTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Binding;
+
+/// <summary>
+/// Issue #3034: GS0159 distinguishes a nullable receiver from unrelated
+/// function-lookup failures and explains how to make the call safe.
+/// </summary>
+public class Issue3034NullableNarrowingDiagnosticTests
+{
+    private const string NullableReceiverMessage =
+        "Cannot call function M because receiver 'c' may be nil. Use '?.' for a null-safe call, bind it with 'if let', or re-narrow it before calling.";
+
+    [Fact]
+    public void NullableReceiver_ExplainsMissingNarrowing()
+    {
+        var diagnostic = GetGs0159("""
+            class C {
+                func M() { }
+            }
+
+            func Run() {
+                var c C? = nil
+                c.M()
+            }
+            """);
+
+        Assert.Equal(NullableReceiverMessage, diagnostic.Message);
+    }
+
+    [Fact]
+    public void ExpiredBranchNarrowing_ExplainsNeedToRenarrow()
+    {
+        var diagnostic = GetGs0159("""
+            class C {
+                func M() { }
+            }
+
+            func Run() {
+                var c C? = C()
+                if c != nil {
+                    c.M()
+                }
+
+                c.M()
+            }
+            """);
+
+        Assert.Equal(NullableReceiverMessage, diagnostic.Message);
+    }
+
+    [Fact]
+    public void InvalidExplicitTypeArgument_KeepsLookupMessage()
+    {
+        var diagnostic = GetGs0159("""
+            import System
+
+            func Run() {
+                Array.Empty[Missing]()
+            }
+            """);
+
+        Assert.Equal("Cannot find function Empty.", diagnostic.Message);
+    }
+
+    [Fact]
+    public void MissingImportedStaticMethod_KeepsLookupMessage()
+    {
+        var diagnostic = GetGs0159("""
+            import System
+
+            func Run() {
+                Console.Nope()
+            }
+            """);
+
+        Assert.Equal("Cannot find function Nope.", diagnostic.Message);
+    }
+
+    [Fact]
+    public void MissingImportedInstanceMethod_KeepsLookupMessage()
+    {
+        var diagnostic = GetGs0159("""
+            func Run() {
+                "x".Nope()
+            }
+            """);
+
+        Assert.Equal("Cannot find function Nope.", diagnostic.Message);
+    }
+
+    [Fact]
+    public void ImportedDelegateMemberMismatch_KeepsLookupMessage()
+    {
+        var diagnostic = GetGs0159("""
+            import GSharp.Compiler.Tests.Binding
+
+            func Run() {
+                var bag = Issue3034DelegateBag()
+                bag.Handler = (value int32) -> value
+                bag.Handler?("x")
+            }
+            """);
+
+        Assert.Equal("Cannot find function Handler.", diagnostic.Message);
+    }
+
+    private static Diagnostic GetGs0159(string source)
+    {
+        var sourceText = SourceText.From(source, "issue3034.gs");
+        var tree = SyntaxTree.Parse(sourceText);
+        var compilation = new Compilation(ReferenceResolver.Default(), tree) { IsLibrary = true };
+
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream, refStream: null);
+        return Assert.Single(result.Diagnostics.Where(diagnostic => diagnostic.Id == "GS0159"));
+    }
+}
+
+/// <summary>Provides an imported delegate member for the GS0159 call-site matrix.</summary>
+public struct Issue3034DelegateBag
+{
+    /// <summary>Delegate member invoked with an incompatible argument.</summary>
+    public Func<int, int> Handler;
+}

--- a/test/Interpreter.Tests/Issue3034NullableNarrowingDiagnosticInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue3034NullableNarrowingDiagnosticInterpreterTests.cs
@@ -16,7 +16,7 @@ namespace GSharp.Interpreter.Tests;
 public class Issue3034NullableNarrowingDiagnosticInterpreterTests
 {
     private const string NullableReceiverMessage =
-        "Cannot call function M because receiver 'c' may be nil. Use '?.' for a null-safe call, bind it with 'if let', or re-narrow it before calling.";
+        "Cannot call function M because receiver 'c' may be nil. Use '?.' for a null-safe call or bind it with 'if let'.";
 
     [Theory]
     [InlineData("function", "M()", NullableReceiverMessage, null)]

--- a/test/Interpreter.Tests/Issue3034NullableNarrowingDiagnosticInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue3034NullableNarrowingDiagnosticInterpreterTests.cs
@@ -1,0 +1,56 @@
+// <copyright file="Issue3034NullableNarrowingDiagnosticInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>Interpreter diagnostic parity for issue #3034 nullable receivers.</summary>
+public class Issue3034NullableNarrowingDiagnosticInterpreterTests
+{
+    private const string NullableReceiverMessage =
+        "Cannot call function M because receiver 'c' may be nil. Use '?.' for a null-safe call, bind it with 'if let', or re-narrow it before calling.";
+
+    [Theory]
+    [InlineData("function", "M()", NullableReceiverMessage, null)]
+    [InlineData("top-level", "M()", NullableReceiverMessage, null)]
+    [InlineData("function", "M()", "Cannot find function M.", "value int32")]
+    [InlineData("top-level", "M()", "Cannot find function M.", "value int32")]
+    [InlineData("function", "M(\"x\")", "Cannot find function M.", "value int32")]
+    [InlineData("top-level", "M(\"x\")", "Cannot find function M.", "value int32")]
+    public void NullableReceiverDiagnostic_MatchesCompiler(
+        string scope,
+        string call,
+        string expectedMessage,
+        string parameter = null)
+    {
+        var source = scope == "top-level"
+            ? $$"""
+                class C { func M({{parameter}}) { } }
+
+                var c C? = nil
+                c.{{call}}
+                """
+            : $$"""
+                class C { func M({{parameter}}) { } }
+
+                func Run() {
+                    var c C? = nil
+                    c.{{call}}
+                }
+                """;
+
+        var evaluation = new Compilation(SyntaxTree.Parse(source))
+            .Evaluate(new Dictionary<VariableSymbol, object>());
+        var diagnostic = Assert.Single(evaluation.Diagnostics.Where(diagnostic => diagnostic.Id == "GS0159"));
+
+        Assert.Equal(expectedMessage, diagnostic.Message);
+    }
+}

--- a/website/docs/ref/diagnostics.md
+++ b/website/docs/ref/diagnostics.md
@@ -121,7 +121,7 @@ IDs may be given as `GS0001`, `0001`, or the bare integer `1`; all three forms a
 | GS0156 | Error | Cannot convert implicitly; explicit conversion exists. | `int x = 3.14` — an explicit cast is available but was not written. |
 | GS0157 | Error | Cannot find type (possibly missing import). | A package-qualified type name that resolves to nothing. |
 | GS0158 | Error | Cannot find member. | A field or property access that does not resolve. |
-| GS0159 | Error | Cannot find function. | A package-qualified function name that resolves to nothing. |
+| GS0159 | Error | Cannot resolve function call. | A function name does not resolve, or its nullable receiver lacks valid non-null narrowing. |
 | GS0160 | Error | Ambiguous overload. | A call that matches more than one overload equally well. Generic candidates are filtered against their `where`-constraints; the constraint-disjoint case usually resolves to one candidate, but two candidates with mutually-incomparable constraint specificity remain ambiguous and report this code. |
 | GS0161 | Error | `copy`/`with` receiver is not a `data struct`. | `.copy(…)` used on a plain `struct`. |
 | GS0162 | Error | Named arguments only supported for `data struct` `.copy(…)`. | Named arguments passed to a regular function. |


### PR DESCRIPTION
## Summary

- distinguish nullable-receiver failures from unrelated GS0159 lookup failures
- ask normal binder whether exact call is applicable on underlying non-nullable receiver
- preserve legacy GS0159 for wrong arity, wrong argument type, missing members, and unrelated paths
- support source classes/structs/interfaces, enums, constrained type parameters, extensions, inherited methods, and default interface methods
- preserve qualified receiver spelling and collapse multiline whitespace
- give universally actionable guidance: use `?.` or bind with `if let`

Fixes #3034

## Review blockers

Applicability requires a non-error speculative bind with no new diagnostics. This keeps `Cannot find function M.` for wrong arity and wrong argument type while improving valid calls on nullable receivers.

The latest blocker removed `or re-narrow it before calling`. Assignment-based narrowing is unavailable or ineffective for several receiver kinds, so that advice was false. GS0159 now says:

> Cannot call function M because receiver 'c' may be nil. Use '?.' for a null-safe call or bind it with 'if let'.

## Receiver-kind matrix

`NullableReceiverGuidance_MatchesReceiverNarrowability` covers receiver kind × prior non-null action × valid scope. Local and parameter receivers have no top-level source position; field, global, and `let` receivers cover both top-level and function bodies.

| Receiver | Never narrowed | Non-null immediately before call |
|---|---|---|
| mutable local | GS0159, no re-narrow clause | compiles and runs |
| parameter | GS0159, no clause | read-only assignment diagnostic + GS0159, no clause |
| field | GS0159, no clause | GS0159, no clause |
| global | GS0159, no clause | compiles and runs |
| `let` | GS0159, no clause | GS0159, no clause |

Fresh measurement on `main` `f7d9a5d3` differs from the earlier review report for globals: `c = C(); c.M()` now compiles at top level and inside a function. All three drivers agree.

## Driver matrix

All 48 valid receiver/state/scope/driver cells ran in separately created, asserted-empty directories:

- bare `gsc`: evaluate, success marker `11`
- `gsc /out:`: emit then run, success marker `22`
- `gsi`: interpret, success marker `33`

Expected diagnostic cells returned nonzero with GS0159 and never contained the false clause. Successful local/global narrowing cells returned zero and printed their distinct marker.

## Product mutation

One new product hunk: diagnostic text. Restoring the false re-narrow clause applied exactly once, built successfully, and killed `NullableReceiverGuidance_MatchesReceiverNarrowability`: 13 failed / 3 passed. Passing cells are the three receiver/scope combinations that emit no GS0159 after successful narrowing.

Earlier applicability, receiver-span, whitespace, and diagnostic-rollback mutations remain covered by their focused tests.

## Latest-main merged-tree validation

- head: `a859039d4ad49353fabe58abc140ed0a07d9b28c`
- main / merge base: `f7d9a5d34a35abaeb78818afec20fc60c8c68fed`
- `git merge-tree --write-tree origin/main HEAD`: `53beb1c3d2ed273ccda5f91f7bd9742c84173a85`
- merged tree equals `HEAD^{tree}` exactly
- solution build with warnings as errors: `BUILD_RC=0`, 0 warnings, 0 errors
- full Compiler suite: 4,190 passed
- full Interpreter suite: 729 passed
- full Core suite: 7,089 passed, 1 skipped
- final merged-tree three-driver matrix: 48/48

No interaction claim rests on file lists alone: fetched main was rebased, predicted merged tree was reproduced exactly, then built and tested.
