### PR TITLE
Test generic local functions returning lambdas

### DIFF
--- a/test/Interpreter.Tests/Issue3030LocalFunctionDeclarationInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue3030LocalFunctionDeclarationInterpreterTests.cs
@@ -13,7 +13,7 @@ using Xunit;
 namespace GSharp.Interpreter.Tests;
 
 /// <summary>
-/// Issue #3030: generic local-function declarations are evaluator no-ops.
+/// Issues #3030 and #3050: generic local-function declarations register bodies for direct calls.
 /// </summary>
 public class Issue3030LocalFunctionDeclarationInterpreterTests
 {
@@ -44,6 +44,23 @@ public class Issue3030LocalFunctionDeclarationInterpreterTests
             PrintValues()
             """,
             "42\nnested\n");
+
+        yield return Case(
+            """
+            data struct Item {
+                var Value int32
+            }
+
+            let MakeIdentity[T] = func() (T) -> T {
+                return (value T) -> value
+            }
+
+            let identity = MakeIdentity[Item]()
+            Console.WriteLine(identity(Item{ Value: 11 }).Value)
+            Console.WriteLine(identity(Item{ Value: 22 }).Value)
+            Console.WriteLine(identity(Item{ Value: 33 }).Value)
+            """,
+            "11\n22\n33\n");
     }
 
     [Theory]


### PR DESCRIPTION
## Summary

- Add regression coverage for a generic local function returning a zero-capture lambda whose signature contains a G#-declared type.
- Assert distinct `11/22/33` values and `gsc`/`gsi` parity.

## Root cause correction

The issue body says “generic method,” but a generic member method returning the same lambda already prints `7` in both engines at the stated pre-fix base `fd34166a8`, including with a G#-declared type.

The actual failing shape is a generic **local function**:

```gsharp
let MakeIdentity[T] = func() (T) -> T {
    return (value T) -> value
}
```

At `fd34166a8`, `gsi` reports `GS9999: Unexpected node LocalFunctionDeclaration`. The production fix already landed in #3042: `Evaluator.Statements.cs:74` registers the lowered `BoundLocalFunctionDeclaration` body, and `Evaluator.Calls.cs:76` falls back to that body for direct calls. Current `main` therefore needs only the missing #3050 regression pin.

## Validation

- `dotnet build` — 0 warnings, 0 errors
- `dotnet test test/Interpreter.Tests/Interpreter.Tests.csproj --filter 'FullyQualifiedName~Issue3030LocalFunctionDeclarationInterpreterTests'` — 3 passed
- Differential: `gsc` and `gsi` both print `11 / 22 / 33`

## Mutation

Each existing root-fix hunk was reverted independently; every mutant built successfully and the new #3050 case failed:

- Remove `LocalFunctionDeclaration` dispatch — Core hash `01b5c736…`; fails with `Unexpected node LocalFunctionDeclaration`.
- Keep dispatch but remove body registration — Core hash `e8701787…`; fails with missing `MakeIdentity` body.
- Remove call-site fallback to `localFunctionBodies` — Core hash `1040c759…`; fails with missing `MakeIdentity` body.
- Restored Core hash: `4990ad1f…`.

No production overlap with #3046 or #3020; this PR changes one interpreter test file only.

Fixes #3050

