### PR TITLE
Fix imported constructor cache remap identity

### DIFF
--- a/src/Core/CodeAnalysis/Emit/MetadataTokenCache.cs
+++ b/src/Core/CodeAnalysis/Emit/MetadataTokenCache.cs
@@ -455,10 +455,11 @@ internal sealed class MetadataTokenCache
     }
 
     /// <summary>
-    /// Issue #671: structural cache key for ctor MemberRef rows whose parent
-    /// TypeSpec carries G# user-defined symbolic type arguments. Includes both
-    /// active generic-remap scopes because the same symbols can encode to
-    /// different VAR/MVAR ordinals. Counterpart to <see cref="MethodSpecSymbolKey"/>.
+    /// Issues #671 and #2930: structural cache key for ctor MemberRef rows
+    /// whose parent TypeSpec carries G# user-defined symbolic type arguments.
+    /// Includes both active generic-remap scopes because the same symbols can
+    /// encode to different VAR/MVAR ordinals. Issue #3065 tracks equivalent
+    /// remap discrimination for <see cref="MethodSpecSymbolKey"/>.
     /// </summary>
     internal readonly struct CtorRefSymbolKey : IEquatable<CtorRefSymbolKey>
     {

--- a/test/Compiler.Tests/Emit/Issue2930ImportedConstructorCacheRemapTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2930ImportedConstructorCacheRemapTests.cs
@@ -1,0 +1,153 @@
+// <copyright file="Issue2930ImportedConstructorCacheRemapTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2930: imported symbolic constructor cache entries include active
+/// generic remap identities.
+/// </summary>
+public class Issue2930ImportedConstructorCacheRemapTests
+{
+    [Fact]
+    public void ImportedConstructorCache_SeparatesLambdaMethodRemaps()
+    {
+        const string Source = """
+            package Issue2930Method
+
+            import System
+            import System.Collections.Generic
+
+            func Remap[A, B](first A, value B) B {
+                var outer = List[B]()
+                outer.Add(value)
+                let f (B) -> B = (innerValue B) -> {
+                    var inner = List[B]()
+                    inner.Add(innerValue)
+                    return inner[0]
+                }
+                return f(outer[0])
+            }
+
+            Console.WriteLine(Remap[int32, int32](0, 11))
+            Console.WriteLine(Remap[int32, int32](0, 22))
+            """;
+
+        AssertRunsWithExactOutput(Source, nameof(ImportedConstructorCache_SeparatesLambdaMethodRemaps), "11\n22\n");
+    }
+
+    [Fact]
+    public void ImportedConstructorCache_SeparatesClosureClassRemaps()
+    {
+        const string Source = """
+            package Issue2930Class
+
+            import System
+            import System.Collections.Generic
+
+            func Remap[A, B](first A, value B) B {
+                var outer = List[B]()
+                outer.Add(value)
+                var calls = 0
+                let f (B) -> B = (innerValue B) -> {
+                    calls++
+                    var inner = List[B]()
+                    inner.Add(innerValue)
+                    return inner[0]
+                }
+                return f(outer[0])
+            }
+
+            Console.WriteLine(Remap[int32, int32](0, 33))
+            Console.WriteLine(Remap[int32, int32](0, 44))
+            """;
+
+        AssertRunsWithExactOutput(Source, nameof(ImportedConstructorCache_SeparatesClosureClassRemaps), "33\n44\n");
+    }
+
+    private static void AssertRunsWithExactOutput(string source, string name, string expected)
+    {
+        var assemblyPath = Compile(source, name);
+        var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+        Assert.NotEmpty(assembly.GetTypes());
+        Assert.Equal(expected, Run(assemblyPath, name));
+        IlVerifier.Verify(assemblyPath);
+    }
+
+    private static string Compile(string source, string name)
+    {
+        var directory = Path.Combine(AppContext.BaseDirectory, nameof(Issue2930ImportedConstructorCacheRemapTests), name);
+        Directory.CreateDirectory(directory);
+        var sourcePath = Path.Combine(directory, "test.gs");
+        var assemblyPath = Path.Combine(directory, name + ".dll");
+        File.WriteAllText(sourcePath, source);
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousErr = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        int exitCode;
+        try
+        {
+            exitCode = Program.Main(new[]
+            {
+                "/out:" + assemblyPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                sourcePath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousErr);
+        }
+
+        Assert.True(exitCode == 0, $"{name}: gsc failed:\n{stdout}\n{stderr}");
+        return assemblyPath;
+    }
+
+    private static string Run(string assemblyPath, string name)
+    {
+        using var process = Process.Start(new ProcessStartInfo("dotnet")
+        {
+            ArgumentList =
+            {
+                "exec",
+                "--runtimeconfig",
+                Path.ChangeExtension(assemblyPath, ".runtimeconfig.json"),
+                assemblyPath,
+            },
+            WorkingDirectory = Path.GetDirectoryName(assemblyPath),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        });
+
+        Assert.NotNull(process);
+        var outputTask = process.StandardOutput.ReadToEndAsync();
+        var errorTask = process.StandardError.ReadToEndAsync();
+        var exited = process.WaitForExit(30_000);
+        if (!exited)
+        {
+            process.Kill(entireProcessTree: true);
+            process.WaitForExit();
+        }
+
+        Assert.True(exited, $"{name}: emitted program timed out");
+        var output = outputTask.GetAwaiter().GetResult();
+        var error = errorTask.GetAwaiter().GetResult();
+        Assert.True(process.ExitCode == 0, $"{name}: emitted program failed:\n{error}");
+        return output.Replace("\r\n", "\n");
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Emit/MetadataTokenCacheTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/MetadataTokenCacheTests.cs
@@ -1,0 +1,37 @@
+// <copyright file="MetadataTokenCacheTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Emit;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+public class MetadataTokenCacheTests
+{
+    [Fact]
+    public void CtorRefSymbolKey_EqualsDistinguishesRemapIdentities()
+    {
+        var ctor = typeof(List<>).GetConstructors().Single(c => c.GetParameters().Length == 0);
+        var typeArgs = ImmutableArray<TypeSymbol>.Empty;
+        var classRemap = new Dictionary<TypeParameterSymbol, int>();
+        var methodRemap = new Dictionary<TypeParameterSymbol, int>();
+        var key = new MetadataTokenCache.CtorRefSymbolKey(ctor, typeArgs, classRemap, methodRemap);
+
+        Assert.False(key.Equals(new MetadataTokenCache.CtorRefSymbolKey(
+            ctor,
+            typeArgs,
+            new Dictionary<TypeParameterSymbol, int>(),
+            methodRemap)));
+        Assert.False(key.Equals(new MetadataTokenCache.CtorRefSymbolKey(
+            ctor,
+            typeArgs,
+            classRemap,
+            new Dictionary<TypeParameterSymbol, int>())));
+    }
+}


### PR DESCRIPTION
## Summary

**This PR is now regression coverage plus a doc-comment correction.** The production cache-key change it originally carried has already landed in `main` via #2912 (`da0e2067b`), so the duplicate hunk was dropped here as planned. What remains:

- `test/.../Issue2930ImportedConstructorCacheRemapTests.cs` — executes emitted programs across both remap channels, asserting distinct two-call values (`11/22`, `33/44`), and loads emitted assemblies with `Assembly.Load` + `GetTypes()` before runtime execution (ILVerify remains supplemental, not sufficient on its own).
- `test/.../MetadataTokenCacheTests.cs` — direct key-equality coverage for `CtorRefSymbolKey`.
- `src/Core/CodeAnalysis/Emit/MetadataTokenCache.cs` — **doc comment only, no behaviour change.** The old comment claimed `CtorRefSymbolKey` was the "Counterpart to `MethodSpecSymbolKey`". That is now false and reads as false assurance: `MethodSpecSymbolKey` is still 2-arg and carries no remap identity. The comment now says so and points at #3065, which tracks the equivalent fix.

## ⚠️ Do not delete `SeparatesClosureClassRemaps` as a duplicate of the Issue2898 tests

`main`'s shipped fix has two halves — a **method** remap identity (MVAR) and a **class** remap identity (VAR). Partial-mutant measurement of the two halves independently:

| mutant applied to `main` | Issue2898 tests | `SeparatesClosureClassRemaps` |
|---|---|---|
| drop `methodRemap` (MVAR) from equality + hash | **dies** | dies |
| drop `classRemap` (VAR) from equality + hash | **survives** | **dies — sole failure** |

So the `classRemap` half of the shipped production fix is pinned by **this test and nothing else**. It is not redundant with the nested-enum coverage added by #3063 either: `Remap[A,B]` and `Iterate[A,B]` are separate declarations, so their `B` are different `TypeParameterSymbol` *instances*, and the cache key compares `typeArgs` **by reference** — they can never collide. A collision requires **one symbol crossing a remap boundary**, which only the closure test in this PR constructs. Adding more call sites in more methods cannot reach it.

## Root cause (for context; fix already in `main`)

`CtorRefSymbolKey` keyed only constructor + symbolic type arguments. The same symbols encode to different `VAR`/`MVAR` ordinals under different active remaps, so a second constructor lookup reused a MemberRef parented by the first scope's TypeSpec.

## Validation

- `dotnet build GSharp.sln` — 0 warnings/errors
- issue tests — 2/2 pass
- related #2793/#671/#693 cache tests — 24/24 pass
- Bulletin #3 audit: probes are not wrapped in `func Main()`; both top-level and in-function shapes exercised under `gsc` and `gsi`.

## Overlap

#3036 touches `ImportedMemberRefFactory.GetElementTypeToken`; no hunk collision with the test files or the doc comment here.

Fixes #2930
