### PR TITLE
Pin interface indexer mismatch diagnostics

### DIFF
--- a/test/Compiler.Tests/Emit/Issue2888InterfacePropertyTypeMismatchTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2888InterfacePropertyTypeMismatchTests.cs
@@ -103,6 +103,52 @@ public class Issue2888InterfacePropertyTypeMismatchTests
     }
 
     [Fact]
+    public void PlainInterfaceIndexerParameterMismatch_ReportsGS0187()
+    {
+        const string source = """
+            package ParameterMismatch
+
+            interface ILookup {
+                prop this[key string] int32 { get; }
+            }
+            class Lookup : ILookup {
+                prop this[key int32] int32 -> key
+            }
+            """;
+
+        var output = CompileExpectingFailure(source);
+
+        Assert.Equal(1, CountOccurrences(output, "error GS0187:"));
+        Assert.Contains(
+            "Class 'Lookup' does not implement interface method 'ILookup.Item'.",
+            output,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("GS0504", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NullableIndexerRejected_ReportsGS0504()
+    {
+        const string source = """
+            package NullableIndexerRejected
+
+            interface I[T] { prop this[key string] T? { get; } }
+            class C : I[int32] {
+                prop this[key string] int32? { get { return nil } }
+            }
+            """;
+
+        var output = CompileExpectingFailure(source);
+
+        Assert.Equal(1, CountOccurrences(output, "error GS0504:"));
+        Assert.Contains(
+            "Type 'C' cannot use property 'Item' to implement interface property 'I[int32].Item': expected type 'int32', actual type 'int32?'.",
+            output,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("GS0187", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void CompatibleBaselineSiblingShapes_EmitVerifyAndLoad()
     {
         const string source = """
@@ -307,13 +353,6 @@ public class Issue2888InterfacePropertyTypeMismatchTests
             package NullableImplicitSetRejected
             interface I[T] { prop Value T? { get; set; } }
             class C : I[int32] { prop Value int32? { get; set; } }
-            """,
-            """
-            package NullableIndexerRejected
-            interface I[T] { prop this[key string] T? { get; } }
-            class C : I[int32] {
-                prop this[key string] int32? { get { return nil } }
-            }
             """,
             """
             package NullableSliceRejected


### PR DESCRIPTION
## Summary

- Pin `GS0187` when a plain interface indexer implementation has the wrong index-parameter type.
- Move the existing nullable-indexer rejection case into a dedicated test that pins `GS0504`, its exact message, and the absence of `GS0187`.

PR #2968 merged before these final review tests could be added; this test-only PR closes that coverage gap. Its production PR declared and closed #2915, #2954, #2960, and #3001.

## Validation

- Rebased onto current `main` `1ea847ebe`; old/new commit patch IDs match in 1 of 1 comparison.
- Targeted filter: 2 passed, 0 failed.
- `GS0504` → `GS0187` descriptor mutation: `NullableIndexerRejected_ReportsGS0504` failed while `PlainInterfaceIndexerParameterMismatch_ReportsGS0187` passed (1 failed / 1 passed). Restore returned 2/2 green.
- Mutation DLL MD5: `03cdf27ccb096a3b4d312e47e2e1f4b3 → 6c80c82eff6b38d4b0f58ef43c381538 → 03cdf27ccb096a3b4d312e47e2e1f4b3`.
- Earlier parameter-comparison mutation: `PlainInterfaceIndexerParameterMismatch_ReportsGS0187` failed while the value-type guard passed; restore returned both green.
