### PR TITLE
Fix Oahu cs2gs nullability and return flow

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs
+++ b/src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs
@@ -414,8 +414,20 @@ public sealed class ControlFlowGraph
                     continue;
                 }
 
+                HashSet<BoundLabel> bodyLabels = CollectLabels(body);
+
                 void RouteThroughFinally(BoundStatement transfer)
                 {
+                    // Issue #3061: loop and switch lowering emits gotos whose
+                    // targets remain inside the try body; they do not leave the
+                    // protected region and therefore must not run finally.
+                    if (transfer is BoundGotoStatement gotoStatement
+                        && bodyLabels.Contains(gotoStatement.Label))
+                    {
+                        builder.Add(transfer);
+                        return;
+                    }
+
                     Add(CloneWithFreshLabels(tryStatement.FinallyBlock), outerRoute);
                     Add(transfer, outerRoute);
                 }
@@ -857,41 +869,39 @@ public sealed class ControlFlowGraph
 
         private void RemoveUnreachableBlocks(List<BasicBlock> blocks)
         {
-            // ponytail: single-pass worklist replacing the old goto-restart
-            // scan (was O(n^2)). Peels blocks whose incoming-branch count
-            // hits zero, cascading through their outgoing edges, same fixpoint
-            // as the original "remove and rescan" loop.
-            var removed = new HashSet<BasicBlock>();
+            // Issue #3061: incoming-edge peeling cannot remove an unreachable
+            // cycle. Walk from Start so dead loop SCCs are discarded too.
+            var reachable = new HashSet<BasicBlock> { start };
             var queue = new Queue<BasicBlock>();
-            foreach (var block in blocks)
-            {
-                if (!block.Incoming.Any())
-                {
-                    removed.Add(block);
-                    queue.Enqueue(block);
-                }
-            }
-
+            queue.Enqueue(start);
             while (queue.Count > 0)
             {
                 var block = queue.Dequeue();
                 foreach (var branch in block.Outgoing)
                 {
-                    branch.To.Incoming.Remove(branch);
-                    if (!removed.Contains(branch.To) && !branch.To.Incoming.Any())
+                    if (reachable.Add(branch.To))
                     {
-                        removed.Add(branch.To);
                         queue.Enqueue(branch.To);
                     }
                 }
             }
 
+            var removed = blocks.Where(block => !reachable.Contains(block)).ToHashSet();
             if (removed.Count == 0)
             {
                 return;
             }
 
-            branches.RemoveAll(branch => removed.Contains(branch.From) || removed.Contains(branch.To));
+            var removedBranches = branches
+                .Where(branch => removed.Contains(branch.From) || removed.Contains(branch.To))
+                .ToArray();
+            foreach (var branch in removedBranches)
+            {
+                branch.From.Outgoing.Remove(branch);
+                branch.To.Incoming.Remove(branch);
+            }
+
+            branches.RemoveAll(removedBranches.Contains);
             blocks.RemoveAll(block => removed.Contains(block));
         }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2891TryRegionFlowTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2891TryRegionFlowTests.cs
@@ -370,6 +370,51 @@ public class Issue2891TryRegionFlowTests
     /// <summary>Gets try-region shapes that must not report GS0100.</summary>
     public static IEnumerable<object[]> CompleteCases()
     {
+        yield return Case("FinallyLoopAfterWhileTrue", """
+            import System
+            func F(exit bool) int32 {
+                try {
+                    while true {
+                        if exit {
+                            return 1
+                        }
+                    }
+                } finally {
+                    for var i = 0; i < 1; i++ {
+                        try {
+                            var cleaned = i
+                        } catch (ex Exception) {
+                        }
+                    }
+                }
+            }
+            """);
+        yield return Case("WhileTrueInsideTryFinally", """
+            import System
+            func F(exit bool) int32 {
+                try {
+                    try {
+                        var initialized = true
+                    } catch (ex Exception) {
+                    }
+                    while true {
+                        if exit {
+                            return 1
+                        }
+                        if !exit {
+                            continue
+                        }
+                    }
+                } finally {
+                    for var i = 0; i < 1; i++ {
+                        try {
+                            var cleaned = i
+                        } catch (ex Exception) {
+                        }
+                    }
+                }
+            }
+            """);
         yield return Case("TryContinue", """
             func F() int32 {
                 for {

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2285InterfaceImplementationNullabilityTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2285InterfaceImplementationNullabilityTests.cs
@@ -153,6 +153,38 @@ namespace Demo
     }
 
     [Fact]
+    public void EfEntityProperty_PromotesInterfaceAndImplementation()
+    {
+        string printed = TranslateOblivious(@"
+namespace Microsoft.EntityFrameworkCore
+{
+    public class DbSet<T> { }
+}
+
+namespace Demo
+{
+    using Microsoft.EntityFrameworkCore;
+
+    public interface IPerson
+    {
+        string Name { get; set; }
+    }
+
+    public class Author : IPerson
+    {
+        public string Name { get; set; }
+    }
+
+    public class Context
+    {
+        public DbSet<Author> Authors { get; set; }
+    }
+}");
+
+        Assert.Equal(2, printed.Split("prop Name string?", StringSplitOptions.None).Length - 1);
+    }
+
+    [Fact]
     public void NullableEnabledCompilation_IsUnaffected()
     {
         // The oblivious taint analysis is gated to nullable-DISABLED

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Declarations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Declarations.cs
@@ -531,30 +531,6 @@ public sealed partial class CSharpToGSharpTranslator
             return false;
         }
 
-        private static HashSet<INamedTypeSymbol> CollectEfEntityTypes(CSharpCompilation compilation)
-        {
-            var entities = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
-            foreach (SyntaxTree tree in compilation.SyntaxTrees)
-            {
-                SemanticModel model = compilation.GetSemanticModel(tree);
-                foreach (PropertyDeclarationSyntax property in tree.GetRoot().DescendantNodes().OfType<PropertyDeclarationSyntax>())
-                {
-                    var dbSet = model.GetDeclaredSymbol(property)?.Type as INamedTypeSymbol;
-                    if (dbSet?.Name != "DbSet"
-                        || dbSet.Arity != 1
-                        || dbSet.ContainingNamespace?.ToDisplayString() != "Microsoft.EntityFrameworkCore"
-                        || dbSet.TypeArguments[0] is not INamedTypeSymbol entity)
-                    {
-                        continue;
-                    }
-
-                    entities.Add(entity.OriginalDefinition);
-                }
-            }
-
-            return entities;
-        }
-
         /// <summary>
         /// Determines whether <paramref name="type"/> will be emitted as an
         /// <c>open class</c> in G#. Mirrors the class-declaration openness logic in

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -1085,7 +1085,7 @@ public sealed partial class CSharpToGSharpTranslator
             this.ownedExtensions = ownedExtensions ?? new OwnedExtensionRegistry(context.Compilation.Assembly);
             this.preservePartialParts = preservePartialParts;
             this.markMergedTypePartial = markMergedTypePartial;
-            this.efEntityTypes = CollectEfEntityTypes(context.Compilation);
+            this.efEntityTypes = ObliviousNullabilityAnalyzer.CollectEfEntityTypes(context.Compilation);
 
             // `entryPoint` is threaded in by the caller (`TranslateDocument`)
             // instead of being recomputed here: `Compilation.GetEntryPoint`

--- a/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
@@ -248,6 +248,30 @@ internal static class ObliviousNullabilityAnalyzer
             new HashSet<TupleElementQuery>(TupleElementQueryComparer.Instance));
     }
 
+    public static HashSet<INamedTypeSymbol> CollectEfEntityTypes(Compilation compilation)
+    {
+        var entities = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+        foreach (SyntaxTree tree in compilation.SyntaxTrees)
+        {
+            SemanticModel model = compilation.GetSemanticModel(tree);
+            foreach (PropertyDeclarationSyntax property in tree.GetRoot().DescendantNodes().OfType<PropertyDeclarationSyntax>())
+            {
+                var dbSet = model.GetDeclaredSymbol(property)?.Type as INamedTypeSymbol;
+                if (dbSet?.Name != "DbSet"
+                    || dbSet.Arity != 1
+                    || dbSet.ContainingNamespace?.ToDisplayString() != "Microsoft.EntityFrameworkCore"
+                    || dbSet.TypeArguments[0] is not INamedTypeSymbol entity)
+                {
+                    continue;
+                }
+
+                entities.Add(entity.OriginalDefinition);
+            }
+        }
+
+        return entities;
+    }
+
     private static bool IsTaintedCore(
         CSharpCompilation compilation,
         ISymbol symbol,
@@ -547,6 +571,11 @@ internal static class ObliviousNullabilityAnalyzer
                 tupleEdges);
         }
 
+        // Issue #3060: EF entity properties are promoted by policy rather than
+        // syntax evidence, so seed them before contract edges synchronize
+        // interface and implementation nullability.
+        SeedEfEntityPropertyTaint(compilation, tainted);
+
         // Issue #2285: an interface member and every member that implements it
         // (across the whole compilation) must reach the SAME tainted-ness, so
         // cs2gs never promotes one endpoint (e.g. a record's primary-ctor
@@ -605,6 +634,22 @@ internal static class ObliviousNullabilityAnalyzer
             tupleScalarEdges,
             scalarTupleEdges,
             delegateReturnEdges);
+    }
+
+    private static void SeedEfEntityPropertyTaint(
+        Compilation compilation,
+        HashSet<ISymbol> tainted)
+    {
+        foreach (INamedTypeSymbol entity in CollectEfEntityTypes(compilation))
+        {
+            foreach (IPropertySymbol property in entity.GetMembers().OfType<IPropertySymbol>())
+            {
+                if (IsEligibleScalarTarget(property))
+                {
+                    tainted.Add(Canonical(property));
+                }
+            }
+        }
     }
 
     // Seeds direct null evidence for a value declaration symbol (field /


### PR DESCRIPTION
## Summary

- seed EF entity property nullability into cs2gs's shared oblivious-nullability graph so interface contracts and implementations stay synchronized
- preserve gotos that remain inside a protected region instead of routing them through `finally`
- remove unreachable CFG cycles using reachability from the start block
- add regression coverage for the Oahu entity/interface and `while true` inside `try/finally` shapes

## Validation

- full `Cs2Gs.Tests`: 1,861 passed
- full `Core.Tests`: 7,067 passed, 1 skipped
- fresh Oahu migration with direct current `gsc`: `Oahu.Data`, `Oahu.Cli.Tui`, and `Oahu.Cli` compile without manual compatibility edits

Fixes #3060
Fixes #3061
