### PR TITLE
Strengthen constructed nested enum regression coverage

### DIFF
--- a/test/Compiler.Tests/Emit/Issue2898NestedEnumConstructedOuterEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2898NestedEnumConstructedOuterEmitTests.cs
@@ -25,18 +25,18 @@ public class Issue2898NestedEnumConstructedOuterEmitTests
             import System.Collections.Generic
 
             struct Outer[T] {
-                enum Color { Red }
-                func MakeColor() Color { return Color.Red }
+                enum Color { Red = 11, Green = 22, Blue = 33 }
+                func MakeColor() Color { return Color.Green }
             }
 
             func I(c Outer[int32].Color) Outer[int32].Color { return c }
             func S(c Outer[string].Color) Outer[string].Color { return c }
             func NI(c Outer[int32].Color?) Outer[int32].Color? { return c }
             func NS(c Outer[string].Color?) Outer[string].Color? { return c }
-            func RI() Outer[int32].Color { return Outer[int32].Color.Red }
-            func RS() Outer[string].Color { return Outer[string].Color.Red }
+            func RI() Outer[int32].Color { return Outer[int32].Color.Green }
+            func RS() Outer[string].Color { return Outer[string].Color.Blue }
             func BI() object { return Outer[int32].Color.Red }
-            func BS() object { return Outer[string].Color.Red }
+            func BS() object { return Outer[string].Color.Green }
             func Capture[T](c Outer[T].Color) () -> Outer[T].Color -> () -> c
             func Remap[A, B](c Outer[B].Color) int32 {
                 var outer = List[Outer[B].Color]()
@@ -49,6 +49,11 @@ public class Issue2898NestedEnumConstructedOuterEmitTests
                     return int32(inner[0]) + int32(innerRed)
                 }
                 return int32(outerRed) + f(outer[0])
+            }
+            func Iterate[A, B](c Outer[B].Color) sequence[int32] {
+                var values = List[Outer[B].Color]()
+                values.Add(c)
+                yield int32(values[0])
             }
             struct Holder {
                 var IntRed Outer[int32].Color
@@ -87,8 +92,8 @@ public class Issue2898NestedEnumConstructedOuterEmitTests
         Assert.NotNull(intRed);
         Assert.NotNull(stringRed);
         Assert.Equal(intRed.MetadataToken, stringRed.MetadataToken);
-        Assert.Equal(0, intRed.GetRawConstantValue());
-        Assert.Equal(0, stringRed.GetRawConstantValue());
+        Assert.Equal(11, intRed.GetRawConstantValue());
+        Assert.Equal(11, stringRed.GetRawConstantValue());
         Assert.Equal(intEnum, intRed.FieldType);
         Assert.Equal(stringEnum, stringRed.FieldType);
 
@@ -99,13 +104,14 @@ public class Issue2898NestedEnumConstructedOuterEmitTests
         var outerDefinition = allTypes.Single(t => t.Name == "Outer`1");
         var intOuter = outerDefinition.MakeGenericType(typeof(int));
         Assert.Equal(intEnum, GetMethod(intOuter, "MakeColor").ReturnType);
+        Assert.Equal(22, Convert.ToInt32(GetMethod(intOuter, "MakeColor").Invoke(Activator.CreateInstance(intOuter), null)));
 
         var intValue = GetMethod(program, "RI").Invoke(null, null);
         var stringValue = GetMethod(program, "RS").Invoke(null, null);
         Assert.Equal(intEnum, intValue.GetType());
         Assert.Equal(stringEnum, stringValue.GetType());
-        Assert.Equal(0, Convert.ToInt32(intValue));
-        Assert.Equal(0, Convert.ToInt32(stringValue));
+        Assert.Equal(22, Convert.ToInt32(intValue));
+        Assert.Equal(33, Convert.ToInt32(stringValue));
         Assert.Equal(intEnum, GetMethod(program, "BI").Invoke(null, null).GetType());
         Assert.Equal(stringEnum, GetMethod(program, "BS").Invoke(null, null).GetType());
 
@@ -116,7 +122,12 @@ public class Issue2898NestedEnumConstructedOuterEmitTests
 
         var remap = GetMethod(program, "Remap").MakeGenericMethod(typeof(int), typeof(string));
         Assert.Equal(stringEnum, Assert.Single(remap.GetParameters()).ParameterType);
-        Assert.Equal(0, remap.Invoke(null, new[] { stringValue }));
+        Assert.Equal(55, remap.Invoke(null, new[] { stringValue }));
+
+        var iterate = GetMethod(program, "Iterate").MakeGenericMethod(typeof(int), typeof(string));
+        Assert.Equal(stringEnum, Assert.Single(iterate.GetParameters()).ParameterType);
+        var sequence = Assert.IsAssignableFrom<IEnumerable>(iterate.Invoke(null, new[] { stringValue }));
+        Assert.Equal(new[] { 33 }, sequence.Cast<object>().Select(Convert.ToInt32));
     }
 
     [Fact]


### PR DESCRIPTION
## Context

PR #2912 merged and closed #2946 while this branch was in progress. Its production implementation matches the independently verified root cause in `EnumSymbol`, so this follow-up avoids duplicating that code and keeps only missing regression strength.

## Changes

- Replace the all-zero nested enum fixture with distinct values `11/22/33` and assert values through metadata, methods, boxing, and lambda-remapped generic containers.
- Add a generic iterator path using `List[Outer[B].Color]` and assert the yielded value remains `33` after state-machine lowering.

## Mutation evidence

Forcing `TypeDefEmitter` to emit `0` for every enum literal now fails `NestedEnumConstructedThroughGenericOuter_LoadsWithDistinctClosedSignatures` with `expected 11, actual 0`. Core DLL md5 round-trip: `27570b27894ad0d31c9789dd7f3b4d36 -> 5134e170524c2e216628608e4f880ade -> 27570b27894ad0d31c9789dd7f3b4d36`.

## Verification

- Focused compiler class: 10/10 passed.
- Release solution build: 0 warnings, 0 errors.
- No zero-byte release artifacts.
- All 22 ordinary `out/bin/Release/**/GSharp.Core.dll` copies matched md5 `62b3ac88a4d316c112e7e8ed41540732`.

#2947 is **no longer reproducible on `main`**: a cross-assembly `gsc /r:` repro shows all 5 `GS0156` sites rendering correctly (`Outer[T]`, `Outer[U]`, `Outer[int32]`, `[int32]`->`[string]`, `Outer[B]`) with zero `object`. Verified non-vacuously by a positive control - inverting `FormatImportedType` (`SymbolDisplay.cs:890`) reproduces #2947 verbatim as `'glib.Outer[object].Color'`. #2947 should be closed; this PR does not reference it.
