### PR TITLE
Fix nullable imported interface property slots

### DIFF
--- a/src/Core/CodeAnalysis/Emit/MemberDefEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MemberDefEmitter.cs
@@ -944,16 +944,16 @@ internal sealed class MemberDefEmitter
                 foreach (var clrProp in clrIface.GetProperties(BindingFlags.Public | BindingFlags.Instance))
                 {
                     var indexParameters = clrProp.GetIndexParameters();
+
+                    // Nullable reference annotations do not participate in CLR interface slots.
                     if (clrProp.Name != prop.Name
                         || prop.IsIndexer != (indexParameters.Length > 0)
                         || prop.Parameters.Length != indexParameters.Length
                         || (clrProp.GetMethod != null && !prop.HasGetter)
                         || (clrProp.SetMethod != null && !prop.HasSetter)
-                        || !DeclarationBinder.IsInterfacePropertyTypeCompatible(
-                            prop.Type,
-                            MemberLookup.GetClrPropertyTypeSymbol(ifaceSym, clrProp),
-                            clrProp.SetMethod != null,
-                            typeParameterMap: null))
+                        || !TypeSymbol.AreRuntimeEquivalentIgnoringReferenceNullability(
+                                prop.Type,
+                                MemberLookup.GetClrPropertyTypeSymbol(ifaceSym, clrProp)))
                     {
                         continue;
                     }

--- a/test/Compiler.Tests/Emit/Issue2888InterfacePropertyTypeMismatchTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2888InterfacePropertyTypeMismatchTests.cs
@@ -549,6 +549,30 @@ public class Issue2888InterfacePropertyTypeMismatchTests
     }
 
     [Fact]
+    public void ImportedObliviousInterfaceProperty_NullableImplementation_EmitsVerifyAndLoads()
+    {
+        const string source = """
+            package ImportedOblivious
+            import ClrContracts
+
+            class Book : IObliviousBook {
+                prop Asin string?
+            }
+            """;
+
+        var directory = CreateWorkDirectory();
+        try
+        {
+            var referencePath = CompileCSharpFixture(directory);
+            AssertEmitsAndLoads(source, referencePath);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
     public void ImportedClrInterfaceProperty_WrongType_ReportsGS0187AndDoesNotEmit()
     {
         const string source = """
@@ -738,6 +762,13 @@ public class Issue2888InterfacePropertyTypeMismatchTests
                     {
                         int Value { get; set; }
                     }
+
+                    #nullable disable
+                    public interface IObliviousBook
+                    {
+                        string Asin { get; }
+                    }
+                    #nullable restore
 
                     public class Base
                     {


### PR DESCRIPTION
Fixes CLR interface-slot emission when a nullable G# property implements a nullable-oblivious imported property. Nullable reference annotations do not affect the runtime signature, so the accessor must still be emitted `virtual newslot`.

This fixes the migrated Oahu `Book.get_Asin` TypeLoadException. With the corrected Oahu.Data assembly, Oahu.App starts successfully and `oahu-cli --json auth status` sees the active shared profile.

Adds a regression that emits, verifies, and loads the nullable implementation against an oblivious C# interface.