### PR TITLE
Add Oahu cs2gs gate and parallelize CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,7 +102,7 @@ jobs:
           global-json-file: global.json
 
       - name: Restore
-        run: dotnet restore "${{ matrix.project }}"
+        run: dotnet restore GSharp.sln
 
       - name: Restore .NET local tools
         run: dotnet tool restore
@@ -179,7 +179,7 @@ jobs:
           global-json-file: global.json
 
       - name: Restore
-        run: dotnet restore tools/cs2gs/Cs2Gs.Cli/Cs2Gs.Cli.csproj
+        run: dotnet restore GSharp.sln
 
       - name: Restore .NET local tools
         # dotnet-ilverify for the pipeline's stage 3.
@@ -231,7 +231,7 @@ jobs:
           global-json-file: global.json
 
       - name: Restore
-        run: dotnet restore tools/cs2gs/Cs2Gs.Cli/Cs2Gs.Cli.csproj
+        run: dotnet restore GSharp.sln
 
       - name: Restore .NET local tools
         run: dotnet tool restore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,6 +107,9 @@ jobs:
       - name: Restore .NET local tools
         run: dotnet tool restore
 
+      - name: Build
+        run: dotnet build GSharp.sln --configuration Release --no-restore -graph
+
       - name: Test
         env:
           MSBUILDDISABLENODEREUSE: 1
@@ -115,6 +118,7 @@ jobs:
           args=(
             "${{ matrix.project }}"
             --configuration Release
+            --no-build
             --no-restore
             --logger "trx"
             --results-directory TestResults

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,6 +158,11 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
           exit "$exit_code"
 
+      - name: Migrate and run pinned Oahu
+        env:
+          OAHU_GATE_ROOT: ${{ runner.temp }}/cs2gs-oahu-pinned
+        run: ./build/run-cs2gs-oahu.sh
+
       - name: Upload migration report
         if: always()
         uses: actions/upload-artifact@v5
@@ -167,6 +172,11 @@ jobs:
             cs2gs-ci-runs/**/report.html
             cs2gs-ci-runs/**/summary.json
             cs2gs-ci-runs/**/run.json
+            ${{ runner.temp }}/cs2gs-oahu-pinned/migrate.log
+            ${{ runner.temp }}/cs2gs-oahu-pinned/runs/**/report.html
+            ${{ runner.temp }}/cs2gs-oahu-pinned/runs/**/summary.json
+            ${{ runner.temp }}/cs2gs-oahu-pinned/runs/**/run.json
+            ${{ runner.temp }}/cs2gs-oahu-pinned/smoke/*
 
   vscode-extension:
     name: vscode-extension (${{ matrix.os }})

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,20 +57,6 @@ jobs:
         # GenerateRuntimeConfigurationFiles writing `gsc.runtimeconfig.json`.
         run: dotnet build GSharp.sln --configuration Release --no-restore -graph
 
-      - name: Test
-        env:
-          # Cs2Gs.Tests launches many nested SDK builds; reusable MSBuild
-          # workers eventually exhaust the test host's resources (#2407).
-          MSBUILDDISABLENODEREUSE: 1
-        run: dotnet test GSharp.sln --configuration Release --no-build --logger "trx" --results-directory TestResults
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v5
-        with:
-          name: test-results
-          path: TestResults/**/*.trx
-
       - name: Upload NuGet packages
         uses: actions/upload-artifact@v5
         with:
@@ -80,9 +66,73 @@ jobs:
           # them co-located in ./nupkgs to pick them up).
           path: out/bin/Release/nupkgs/*
 
+  discover-tests:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v5
+        with:
+          global-json-file: global.json
+
+      - name: Generate test matrix
+        id: matrix
+        run: echo "matrix=$(python3 build/generate-ci-test-matrix.py)" >> "$GITHUB_OUTPUT"
+
+  tests:
+    name: tests (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    needs: discover-tests
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.discover-tests.outputs.matrix) }}
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v5
+        with:
+          global-json-file: global.json
+
+      - name: Restore
+        run: dotnet restore "${{ matrix.project }}"
+
+      - name: Restore .NET local tools
+        run: dotnet tool restore
+
+      - name: Test
+        env:
+          MSBUILDDISABLENODEREUSE: 1
+          TEST_FILTER: ${{ matrix.filter }}
+        run: |
+          args=(
+            "${{ matrix.project }}"
+            --configuration Release
+            --no-restore
+            --logger "trx"
+            --results-directory TestResults
+          )
+          if [[ -n "$TEST_FILTER" ]]; then
+            args+=(--filter "$TEST_FILTER")
+          fi
+          dotnet test "${args[@]}"
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: test-results-${{ matrix.name }}
+          path: TestResults/**/*.trx
+
   e2e:
     runs-on: ubuntu-latest
-    needs: build
 
     steps:
       - uses: actions/checkout@v5
@@ -110,14 +160,13 @@ jobs:
       - name: Run end-to-end tests
         run: ./build/run-e2e-tests.sh
 
-  cs2gs:
+  cs2gs-corpus:
     # ADR-0138: the C#→G# migration quality gate. Runs the full in-repo corpus
     # (L1–L5 + the conformance grid) through translate → compile → ilverify →
     # test-parity and gates on the gap ledger: any fingerprint NOT ledgered in
     # tools/cs2gs/triage/gaps.json (NEW) or ledgered as resolved but
     # reproducing (REGRESSED) fails the job; known-open gaps do not.
     runs-on: ubuntu-latest
-    needs: build
 
     steps:
       - uses: actions/checkout@v5
@@ -130,14 +179,14 @@ jobs:
           global-json-file: global.json
 
       - name: Restore
-        run: dotnet restore GSharp.sln
+        run: dotnet restore tools/cs2gs/Cs2Gs.Cli/Cs2Gs.Cli.csproj
 
       - name: Restore .NET local tools
         # dotnet-ilverify for the pipeline's stage 3.
         run: dotnet tool restore
 
       - name: Build
-        run: dotnet build GSharp.sln --configuration Release --no-restore -graph
+        run: dotnet build tools/cs2gs/Cs2Gs.Cli/Cs2Gs.Cli.csproj --configuration Release --no-restore -graph
 
       - name: Migrate corpus (ledger-gated)
         run: |
@@ -158,6 +207,38 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
           exit "$exit_code"
 
+      - name: Upload migration report
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: cs2gs-corpus-report
+          path: |
+            cs2gs-ci-runs/**/report.html
+            cs2gs-ci-runs/**/summary.json
+            cs2gs-ci-runs/**/run.json
+
+  cs2gs-oahu:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET SDK (main)
+        uses: actions/setup-dotnet@v5
+        with:
+          global-json-file: global.json
+
+      - name: Restore
+        run: dotnet restore tools/cs2gs/Cs2Gs.Cli/Cs2Gs.Cli.csproj
+
+      - name: Restore .NET local tools
+        run: dotnet tool restore
+
+      - name: Build
+        run: dotnet build tools/cs2gs/Cs2Gs.Cli/Cs2Gs.Cli.csproj --configuration Release --no-restore -graph
+
       - name: Migrate and run pinned Oahu
         env:
           OAHU_GATE_ROOT: ${{ runner.temp }}/cs2gs-oahu-pinned
@@ -167,11 +248,8 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v5
         with:
-          name: cs2gs-report
+          name: cs2gs-oahu-report
           path: |
-            cs2gs-ci-runs/**/report.html
-            cs2gs-ci-runs/**/summary.json
-            cs2gs-ci-runs/**/run.json
             ${{ runner.temp }}/cs2gs-oahu-pinned/migrate.log
             ${{ runner.temp }}/cs2gs-oahu-pinned/runs/**/report.html
             ${{ runner.temp }}/cs2gs-oahu-pinned/runs/**/summary.json
@@ -303,7 +381,7 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
-    needs: [e2e, vsix, visual-studio-extension]
+    needs: [build, tests, e2e, cs2gs-corpus, cs2gs-oahu, vsix, visual-studio-extension]
     if: startsWith(github.ref, 'refs/tags/v')
 
     permissions:

--- a/.github/workflows/cs2gs-nightly.yml
+++ b/.github/workflows/cs2gs-nightly.yml
@@ -1,10 +1,10 @@
 name: cs2gs-nightly
 
-# ADR-0138: the deep C#→G# coverage run. Unlike the PR gate (build.yml `cs2gs`
-# job), the nightly runs the ledger in STRICT mode (stale open entries fail so
-# the ledger cannot rot) and then AUTO-FILES GitHub issues for any new gap
-# fingerprints (clustered by root cause, capped per run), pushing the updated
-# ledger back as a pull request for review.
+# ADR-0138: the deep C#→G# coverage run. Unlike the PR gates (build.yml
+# `cs2gs-corpus` and `cs2gs-oahu` jobs), the nightly runs the ledger in STRICT
+# mode (stale open entries fail so the ledger cannot rot) and then AUTO-FILES
+# GitHub issues for any new gap fingerprints (clustered by root cause, capped
+# per run), pushing the updated ledger back as a pull request for review.
 
 on:
   schedule:

--- a/.github/workflows/cs2gs-nightly.yml
+++ b/.github/workflows/cs2gs-nightly.yml
@@ -65,6 +65,28 @@ jobs:
           # so a red night still files its issues first.
           exit 0
 
+      - name: Migrate and run pinned Oahu
+        id: oahu_pinned
+        env:
+          OAHU_GATE_ROOT: ${{ runner.temp }}/cs2gs-oahu-pinned
+        run: |
+          set +e
+          ./build/run-cs2gs-oahu.sh | tee cs2gs-oahu-pinned.log
+          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Migrate and run latest Oahu
+        id: oahu_latest
+        env:
+          OAHU_GATE_LABEL: latest
+          OAHU_GATE_ROOT: ${{ runner.temp }}/cs2gs-oahu-latest
+          OAHU_REF: main
+        run: |
+          set +e
+          ./build/run-cs2gs-oahu.sh | tee cs2gs-oahu-latest.log
+          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+          exit 0
+
       - name: File issues for new gaps (automated, ADR-0138 guardrails)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -111,7 +133,22 @@ jobs:
             cs2gs-nightly-runs/**/report.html
             cs2gs-nightly-runs/**/summary.json
             cs2gs-nightly-runs/**/run.json
+            cs2gs-oahu-pinned.log
+            cs2gs-oahu-latest.log
+            ${{ runner.temp }}/cs2gs-oahu-pinned/migrate.log
+            ${{ runner.temp }}/cs2gs-oahu-pinned/runs/**/report.html
+            ${{ runner.temp }}/cs2gs-oahu-pinned/runs/**/summary.json
+            ${{ runner.temp }}/cs2gs-oahu-pinned/runs/**/run.json
+            ${{ runner.temp }}/cs2gs-oahu-pinned/smoke/*
+            ${{ runner.temp }}/cs2gs-oahu-latest/migrate.log
+            ${{ runner.temp }}/cs2gs-oahu-latest/runs/**/report.html
+            ${{ runner.temp }}/cs2gs-oahu-latest/runs/**/summary.json
+            ${{ runner.temp }}/cs2gs-oahu-latest/runs/**/run.json
+            ${{ runner.temp }}/cs2gs-oahu-latest/smoke/*
 
       - name: Enforce gate outcome
         run: |
-          exit "${{ steps.migrate.outputs.migrate_exit }}"
+          if [[ "${{ steps.migrate.outputs.migrate_exit }}" != "0" ||
+                "${{ steps.oahu_pinned.outputs.exit_code }}" != "0" ]]; then
+            exit 1
+          fi

--- a/build/generate-ci-test-matrix.py
+++ b/build/generate-ci-test-matrix.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+SPECIAL_PROJECTS = {
+    "test/Compiler.Tests/Compiler.Tests.csproj",
+    "tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj",
+}
+
+
+def project_name(project: str) -> str:
+    stem = Path(project).stem.removesuffix(".Tests")
+    return re.sub(r"[^a-z0-9]+", "-", stem.lower()).strip("-")
+
+
+def main() -> int:
+    solution = sys.argv[1] if len(sys.argv) > 1 else "GSharp.sln"
+    result = subprocess.run(
+        ["dotnet", "sln", solution, "list"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    projects = sorted(
+        line.strip().replace("\\", "/")
+        for line in result.stdout.splitlines()
+        if line.strip().lower().endswith(".tests.csproj")
+    )
+
+    missing = SPECIAL_PROJECTS.difference(projects)
+    if missing:
+        raise SystemExit(f"Missing sharded test projects: {sorted(missing)}")
+
+    entries = [
+        {"name": project_name(project), "project": project, "filter": ""}
+        for project in projects
+        if project not in SPECIAL_PROJECTS
+    ]
+    entries.extend(
+        [
+            {
+                "name": "compiler-issue1",
+                "project": "test/Compiler.Tests/Compiler.Tests.csproj",
+                "filter": "FullyQualifiedName~GSharp.Compiler.Tests.Emit.Issue1",
+            },
+            {
+                "name": "compiler-issue2",
+                "project": "test/Compiler.Tests/Compiler.Tests.csproj",
+                "filter": "FullyQualifiedName~GSharp.Compiler.Tests.Emit.Issue2",
+            },
+            {
+                "name": "compiler-issue5",
+                "project": "test/Compiler.Tests/Compiler.Tests.csproj",
+                "filter": "FullyQualifiedName~GSharp.Compiler.Tests.Emit.Issue5",
+            },
+            {
+                "name": "compiler-issue6",
+                "project": "test/Compiler.Tests/Compiler.Tests.csproj",
+                "filter": "FullyQualifiedName~GSharp.Compiler.Tests.Emit.Issue6",
+            },
+            {
+                "name": "compiler-issue7-9",
+                "project": "test/Compiler.Tests/Compiler.Tests.csproj",
+                "filter": "FullyQualifiedName~GSharp.Compiler.Tests.Emit.Issue7|FullyQualifiedName~GSharp.Compiler.Tests.Emit.Issue9",
+            },
+            {
+                "name": "compiler-remainder",
+                "project": "test/Compiler.Tests/Compiler.Tests.csproj",
+                "filter": "FullyQualifiedName!~GSharp.Compiler.Tests.Emit.Issue1&FullyQualifiedName!~GSharp.Compiler.Tests.Emit.Issue2&FullyQualifiedName!~GSharp.Compiler.Tests.Emit.Issue5&FullyQualifiedName!~GSharp.Compiler.Tests.Emit.Issue6&FullyQualifiedName!~GSharp.Compiler.Tests.Emit.Issue7&FullyQualifiedName!~GSharp.Compiler.Tests.Emit.Issue9",
+            },
+            {
+                "name": "cs2gs-issue25",
+                "project": "tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj",
+                "filter": "FullyQualifiedName~Cs2Gs.Tests.Issue25",
+            },
+            {
+                "name": "cs2gs-issue24",
+                "project": "tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj",
+                "filter": "FullyQualifiedName~Cs2Gs.Tests.Issue24",
+            },
+            {
+                "name": "cs2gs-issue1",
+                "project": "tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj",
+                "filter": "FullyQualifiedName~Cs2Gs.Tests.Issue1",
+            },
+            {
+                "name": "cs2gs-remainder",
+                "project": "tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj",
+                "filter": "FullyQualifiedName!~Cs2Gs.Tests.Issue25&FullyQualifiedName!~Cs2Gs.Tests.Issue24&FullyQualifiedName!~Cs2Gs.Tests.Issue1",
+            },
+        ]
+    )
+
+    names = [entry["name"] for entry in entries]
+    if len(names) != len(set(names)):
+        raise SystemExit("Generated test matrix contains duplicate names.")
+
+    print(json.dumps({"include": entries}, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/build/run-cs2gs-oahu.sh
+++ b/build/run-cs2gs-oahu.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+manifest="$repo_root/tools/cs2gs/external/oahu.json"
+label=${OAHU_GATE_LABEL:-pinned}
+work_root=${OAHU_GATE_ROOT:-"${TMPDIR:-/tmp}/gsharp-cs2gs-oahu/$label"}
+repository=$(jq -r '.repository' "$manifest")
+pinned_commit=$(jq -r '.commit' "$manifest")
+ref=${OAHU_REF:-$pinned_commit}
+
+case "$work_root" in
+  ""|"/"|"$repo_root")
+    echo "Refusing unsafe Oahu gate root: '$work_root'" >&2
+    exit 2
+    ;;
+esac
+
+rm -rf "$work_root"
+mkdir -p "$work_root"
+work_root=$(cd "$work_root" && pwd -P)
+source_dir="$work_root/source"
+migrated_dir="$work_root/migrated"
+runs_dir="$work_root/runs"
+smoke_dir="$work_root/smoke"
+log_file="$work_root/migrate.log"
+
+git init --quiet "$source_dir"
+git -C "$source_dir" remote add origin "$repository"
+git -C "$source_dir" fetch --quiet origin "$ref"
+git -C "$source_dir" checkout --quiet --detach FETCH_HEAD
+actual_commit=$(git -C "$source_dir" rev-parse HEAD)
+
+if [[ "$ref" == "$pinned_commit" && "$actual_commit" != "$pinned_commit" ]]; then
+  echo "Expected pinned Oahu commit $pinned_commit, got $actual_commit." >&2
+  exit 1
+fi
+
+echo "Oahu gate '$label': $actual_commit"
+
+dotnet restore "$source_dir/Oahu.sln"
+dotnet build "$source_dir/Oahu.sln" --configuration Release --no-restore
+dotnet test "$source_dir/tests/Oahu.Cli.Tests/Oahu.Cli.Tests.csproj" \
+  --configuration Release --no-build
+dotnet test "$source_dir/tests/Oahu.Foundation.Tests/Oahu.Foundation.Tests.csproj" \
+  --configuration Release --no-build
+dotnet test "$source_dir/tests/Oahu.Cli.E2E.Tests/Oahu.Cli.E2E.Tests.csproj" \
+  --configuration Release --no-build
+dotnet "$source_dir/src/Oahu.App/bin/Release/net10.0/Oahu.dll" --smoke-test
+
+set +e
+dotnet "$repo_root/out/bin/Release/Cs2Gs.Cli/cs2gs.dll" migrate \
+  --corpus "$source_dir" \
+  --out "$migrated_dir" \
+  --artifacts "$runs_dir" \
+  --config Release | tee "$log_file"
+migrate_exit=${PIPESTATUS[0]}
+set -e
+
+if (( migrate_exit != 0 )); then
+  exit "$migrate_exit"
+fi
+
+cli=$(find "$runs_dir" \
+  -path "*/src_Oahu.Cli_Oahu.Cli.csproj-*/bin/src/Oahu.Cli/bin/Release/net10.0/oahu-cli.dll" \
+  -print -quit)
+app=$(find "$runs_dir" \
+  -path "*/src_Oahu.App_Oahu.App.csproj-*/bin/src/Oahu.App/bin/Release/net10.0/Oahu.dll" \
+  -print -quit)
+if [[ -z "$cli" || -z "$app" ]]; then
+  echo "Could not locate migrated Oahu runtime binaries." >&2
+  exit 1
+fi
+
+mkdir -p "$smoke_dir/config" "$smoke_dir/data" "$smoke_dir/log" "$smoke_dir/home"
+
+export HOME="$smoke_dir/home"
+export DOTNET_CLI_HOME="$smoke_dir/home"
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+export XDG_CONFIG_HOME="$smoke_dir/config"
+export XDG_DATA_HOME="$smoke_dir/data"
+export XDG_STATE_HOME="$smoke_dir/log"
+export OAHU_NO_TUI=1
+export NO_COLOR=1
+
+dotnet "$cli" --version > "$smoke_dir/version.txt"
+dotnet "$cli" --help > "$smoke_dir/help.txt"
+dotnet "$cli" \
+  --config-dir "$smoke_dir/config" \
+  --log-dir "$smoke_dir/log" \
+  --json auth status > "$smoke_dir/auth-status.json"
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  # .NET resolves LocalApplicationData from the macOS account rather than HOME.
+  jq -e '
+    ._schemaVersion == "1" and
+    .resource == "auth-status" and
+    (.count | type == "number") and
+    (.items | type == "array") and
+    .count == (.items | length)
+  ' "$smoke_dir/auth-status.json" > /dev/null
+else
+  jq -e '
+    ._schemaVersion == "1" and
+    .resource == "auth-status" and
+    .count == 0 and
+    (.items | type == "array" and length == 0)
+  ' "$smoke_dir/auth-status.json" > /dev/null
+fi
+dotnet "$app" --smoke-test
+
+echo "Oahu C# and migrated G# validation passed."

--- a/build/run-cs2gs-oahu.sh
+++ b/build/run-cs2gs-oahu.sh
@@ -86,10 +86,13 @@ export NO_COLOR=1
 
 dotnet "$cli" --version > "$smoke_dir/version.txt"
 dotnet "$cli" --help > "$smoke_dir/help.txt"
+set +e
 dotnet "$cli" \
   --config-dir "$smoke_dir/config" \
   --log-dir "$smoke_dir/log" \
   --json auth status > "$smoke_dir/auth-status.json"
+auth_status_exit=$?
+set -e
 if [[ "$(uname -s)" == "Darwin" ]]; then
   # .NET resolves LocalApplicationData from the macOS account rather than HOME.
   jq -e '
@@ -106,6 +109,12 @@ else
     .count == 0 and
     (.items | type == "array" and length == 0)
   ' "$smoke_dir/auth-status.json" > /dev/null
+fi
+auth_count=$(jq -r '.count' "$smoke_dir/auth-status.json")
+expected_auth_exit=$((auth_count == 0 ? 3 : 0))
+if (( auth_status_exit != expected_auth_exit )); then
+  echo "Expected auth status exit $expected_auth_exit for $auth_count profiles, got $auth_status_exit." >&2
+  exit 1
 fi
 dotnet "$app" --smoke-test
 

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -289,9 +289,13 @@ internal sealed partial class ExpressionBinder
         out BoundExpression bound)
     {
         // Keep event handlers and assignment RHS binding on one target-typing path.
+        // An explicitly typed lambda already has a complete natural shape.
+        // Preserve the regular conversion diagnostic for nullable delegate
+        // targets instead of replacing it with target-parameter diagnostics.
         bound = null;
         if (syntax is not LambdaExpressionSyntax lambda
             || targetType == null
+            || (targetType is NullableTypeSymbol && lambda.Parameters.All(p => p.Type != null))
             || !MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(targetType, out var targetFunctionType))
         {
             return false;

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -2120,6 +2120,8 @@ internal sealed class MemberLookup
             case DelegateTypeSymbol del:
                 functionType = del.EquivalentFunctionType;
                 return functionType != null;
+            case NullableTypeSymbol nullable:
+                return TryGetDelegateFunctionTypeFromSymbol(nullable.UnderlyingType, out functionType);
 
             // Issue #2375: a constructed `Func`/`Action`/named-delegate
             // `ImportedTypeSymbol` closed over a same-compilation class or

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.Candidates.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.Candidates.cs
@@ -66,7 +66,15 @@ internal sealed partial class OverloadResolver
             }
         }
 
-        var selected = SelectBestInstanceOverload(overloads, arguments.Length, argumentNames, arguments, out var ambiguous, out var nullSafetyFailure, explicitTypeArgCount);
+        var selected = SelectBestInstanceOverload(
+            overloads,
+            arguments.Length,
+            argumentNames,
+            arguments,
+            out var ambiguous,
+            out var nullSafetyFailure,
+            explicitTypeArgCount,
+            boundTypeArguments);
         if (selected != null)
         {
             return selected;
@@ -178,7 +186,8 @@ internal sealed partial class OverloadResolver
         ImmutableArray<BoundExpression> boundArguments,
         out bool ambiguous,
         out NullSafetyArgumentMismatch nullSafetyFailure,
-        int explicitTypeArgCount = 0)
+        int explicitTypeArgCount = 0,
+        ImmutableArray<TypeSymbol> explicitTypeArguments = default)
     {
         ambiguous = false;
         nullSafetyFailure = null;
@@ -194,7 +203,15 @@ internal sealed partial class OverloadResolver
 
         var builder = ImmutableArray.CreateBuilder<BoundExpression>(boundArguments.Length);
         builder.AddRange(boundArguments);
-        return SelectBestUserOverloadCore(candidates, argumentCount, argumentNames, builder, out ambiguous, out nullSafetyFailure, explicitTypeArgCount);
+        return SelectBestUserOverloadCore(
+            candidates,
+            argumentCount,
+            argumentNames,
+            builder,
+            out ambiguous,
+            out nullSafetyFailure,
+            explicitTypeArgCount,
+            explicitTypeArguments);
     }
 
     private FunctionSymbol SelectBestUserOverloadCore(
@@ -204,7 +221,8 @@ internal sealed partial class OverloadResolver
         ImmutableArray<BoundExpression>.Builder boundArguments,
         out bool ambiguous,
         out NullSafetyArgumentMismatch nullSafetyFailure,
-        int explicitTypeArgCount = 0)
+        int explicitTypeArgCount = 0,
+        ImmutableArray<TypeSymbol> explicitTypeArguments = default)
     {
         ambiguous = false;
         nullSafetyFailure = null;
@@ -215,6 +233,25 @@ internal sealed partial class OverloadResolver
         // inputs. Memoize per candidate for this call so unification runs once
         // instead of twice per generic candidate.
         var substitutionCache = new Dictionary<FunctionSymbol, (bool Ok, Dictionary<TypeParameterSymbol, TypeSymbol> Substitution)>();
+        Dictionary<TypeParameterSymbol, TypeSymbol> GetCandidateSubstitution(FunctionSymbol candidate)
+        {
+            if (!explicitTypeArguments.IsDefaultOrEmpty
+                && candidate.TypeParameters.Length == explicitTypeArguments.Length)
+            {
+                return candidate.TypeParameters
+                    .Select((parameter, index) => (parameter, argument: explicitTypeArguments[index]))
+                    .ToDictionary(pair => pair.parameter, pair => pair.argument);
+            }
+
+            return GetCachedCandidateSubstitution(
+                candidate,
+                boundArguments,
+                argumentCount,
+                substitutionCache,
+                out var inferred)
+                    ? inferred
+                    : null;
+        }
 
         // Phase 1: applicability.
         var applicable = new List<FunctionSymbol>();
@@ -275,7 +312,7 @@ internal sealed partial class OverloadResolver
             foreach (var cand in applicable)
             {
                 if (!cand.IsGeneric
-                    || (GetCachedCandidateSubstitution(cand, boundArguments, argumentCount, substitutionCache, out var substitution)
+                    || (GetCandidateSubstitution(cand) is { } substitution
                         && cand.TypeParameters.All(tp => satisfiesConstraint(substitution[tp], tp))))
                 {
                     constrained.Add(cand);
@@ -303,7 +340,7 @@ internal sealed partial class OverloadResolver
             var convertible = new List<FunctionSymbol>(applicable.Count);
             foreach (var cand in applicable)
             {
-                if (IsConvertibilityApplicable(cand, argumentCount, boundArguments))
+                if (IsConvertibilityApplicable(cand, argumentCount, boundArguments, GetCandidateSubstitution(cand)))
                 {
                     convertible.Add(cand);
                 }
@@ -378,7 +415,7 @@ internal sealed partial class OverloadResolver
             Dictionary<TypeParameterSymbol, TypeSymbol> candSubstitution = null;
             if (cand.IsGeneric)
             {
-                GetCachedCandidateSubstitution(cand, boundArguments, argumentCount, substitutionCache, out candSubstitution);
+                candSubstitution = GetCandidateSubstitution(cand);
             }
 
             // Classify each supplied argument's conversion to its ACTUAL
@@ -430,6 +467,11 @@ internal sealed partial class OverloadResolver
 
                 var argType = boundArguments[i]?.Type;
                 var paramType = cand.Parameters[slot + parameterOffset].Type;
+                if (candSubstitution != null)
+                {
+                    paramType = Binder.SubstituteType(paramType, candSubstitution);
+                }
+
                 paramTypes[i] = paramType;
 
                 // Issue #1531 control: a value-returning delegate/method-group
@@ -913,11 +955,12 @@ internal sealed partial class OverloadResolver
     private bool IsConvertibilityApplicable(
         FunctionSymbol candidate,
         int argumentCount,
-        ImmutableArray<BoundExpression>.Builder boundArguments)
+        ImmutableArray<BoundExpression>.Builder boundArguments,
+        Dictionary<TypeParameterSymbol, TypeSymbol> substitution = null)
     {
         // Generic candidates may carry unsubstituted method type parameters in
         // their signature; rely on the existing #1124 inference filter instead.
-        if (candidate.IsGeneric)
+        if (candidate.IsGeneric && substitution == null)
         {
             return true;
         }
@@ -946,6 +989,10 @@ internal sealed partial class OverloadResolver
 
             var argType = boundArguments[i]?.Type;
             var paramType = parameter.Type;
+            if (substitution != null)
+            {
+                paramType = Binder.SubstituteType(paramType, substitution);
+            }
 
             // Unknown argument or parameter type — be conservative, do not reject.
             if (argType == null || paramType == null)

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.Candidates.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.Candidates.cs
@@ -466,13 +466,13 @@ internal sealed partial class OverloadResolver
                 }
 
                 var argType = boundArguments[i]?.Type;
-                var paramType = cand.Parameters[slot + parameterOffset].Type;
+                var openParamType = cand.Parameters[slot + parameterOffset].Type;
+                paramTypes[i] = openParamType;
+                var paramType = openParamType;
                 if (candSubstitution != null)
                 {
                     paramType = Binder.SubstituteType(paramType, candSubstitution);
                 }
-
-                paramTypes[i] = paramType;
 
                 // Issue #1531 control: a value-returning delegate/method-group
                 // argument that maps onto a `(...)->void` delegate parameter

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -3449,7 +3449,11 @@ internal sealed class ReflectionMetadataEmitter
 
             // ADR-0051 Phase 6: emit property accessor methods for classes.
             this.memberDefEmitter.EmitPropertyAccessors(c);
-            if (c.IsData)
+            // cs2gs uses this stable synthetic-name shape for translated C#
+            // anonymous types. Keep data-class value semantics, but omit the
+            // record-only EqualityContract PropertyInfo that reflection-based
+            // consumers such as EF Core would mistake for an anonymous member.
+            if (c.IsData && !IsTranslatedAnonymousType(c.Name))
             {
                 this.dataStructSynth.EmitDataClassEqualityContractProperty(c);
             }
@@ -4882,6 +4886,46 @@ internal sealed class ReflectionMetadataEmitter
         }
 
         return match;
+    }
+
+    private static bool IsTranslatedAnonymousType(string name)
+    {
+        const string Prefix = "AnonymousType";
+        if (name == null)
+        {
+            return false;
+        }
+
+        int start = name.LastIndexOf('.') + 1;
+        if (!name.AsSpan(start).StartsWith(Prefix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        int prefixEnd = start + Prefix.Length;
+        int separator = name.IndexOf('_', prefixEnd);
+        if (separator <= prefixEnd || name.Length - separator - 1 != 16)
+        {
+            return false;
+        }
+
+        for (int i = prefixEnd; i < separator; i++)
+        {
+            if (!char.IsDigit(name[i]))
+            {
+                return false;
+            }
+        }
+
+        for (int i = separator + 1; i < name.Length; i++)
+        {
+            if (!Uri.IsHexDigit(name[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     // Issue #1785: `async func f(...) T?` for a same-compilation user value

--- a/src/Sdk/Gsharp.NET.Sdk/build/Gsharp.NET.Core.Sdk.targets
+++ b/src/Sdk/Gsharp.NET.Sdk/build/Gsharp.NET.Core.Sdk.targets
@@ -23,14 +23,14 @@
   <PropertyGroup>
     <DocumentationFile Condition=" '$(GenerateDocumentationFile)' == 'true' and '$(DocumentationFile)' == '' ">$(IntermediateOutputPath)$(TargetName).xml</DocumentationFile>
     <_GsharpShouldGenerateRunSettings Condition=" '$(IsTestProject)' == 'true' and '$(RunSettingsFilePath)' == '' ">true</_GsharpShouldGenerateRunSettings>
-    <RunSettingsFilePath Condition=" '$(_GsharpShouldGenerateRunSettings)' == 'true' ">$(MSBuildProjectDirectory)\$(IntermediateOutputPath)gsharp.generated.runsettings</RunSettingsFilePath>
+    <RunSettingsFilePath Condition=" '$(_GsharpShouldGenerateRunSettings)' == 'true' ">$([MSBuild]::NormalizePath('$(IntermediateOutputPath)', 'gsharp.generated.runsettings'))</RunSettingsFilePath>
   </PropertyGroup>
 
   <!-- Visual Studio's legacy VSTest launcher does not infer a target framework
        for non-C#/VB CPS projects. Supply the same standard runsettings property
        framework adapters already honor, without overriding user runsettings. -->
   <Target Name="_GsharpGenerateRunSettings"
-          BeforeTargets="CoreCompile"
+          BeforeTargets="CoreCompile;VSTest"
           Condition=" '$(_GsharpShouldGenerateRunSettings)' == 'true' ">
     <ItemGroup>
       <_GsharpRunSettingsLine Include="&lt;RunSettings&gt;" />

--- a/test/Compiler.Tests/Emit/Issue1124GenericUninferableOverloadEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1124GenericUninferableOverloadEmitTests.cs
@@ -109,6 +109,35 @@ public class Issue1124GenericUninferableOverloadEmitTests
         Assert.Equal("99\n-1\n", CompileAndRun(source));
     }
 
+    [Fact]
+    public void ExplicitTypeArguments_RankUsingSubstitutedParameterTypes()
+    {
+        var source = """
+            package p
+            import System
+
+            interface IFormatter {
+                func Format[T](value T) string;
+                func Format[T](value object) string;
+            }
+
+            class Formatter : IFormatter {
+                func Format[T](value T) string { return "typed" }
+                func Format[T](value object) string { return "object" }
+            }
+
+            class C {
+                func Run(formatter IFormatter, value object) string {
+                    return formatter.Format[Enum](value)
+                }
+            }
+
+            Console.WriteLine(C().Run(Formatter(), "x"))
+            """;
+
+        Assert.Equal("object\n", CompileAndRun(source));
+    }
+
     private static string CompileAndRun(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_issue1124_emit_").FullName;

--- a/test/Compiler.Tests/Emit/Issue1503GenericDelegateEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1503GenericDelegateEmitTests.cs
@@ -52,6 +52,28 @@ public class Issue1503GenericDelegateEmitTests
         Assert.Equal("True\nFalse\n", output);
     }
 
+    [Fact]
+    public void NullableConstructedDelegate_AssignmentPreservesSymbolicParameterType()
+    {
+        var source = """
+            package Gen1503Nullable
+            import System
+
+            interface ICancellation { }
+            class Cancellation : ICancellation { }
+            type Convert1503N[T ICancellation] = delegate func(context T) void
+
+            func Main() {
+                var convert Convert1503N[Cancellation]? = nil
+                convert = (context Cancellation) -> Console.WriteLine(context.GetType().Name)
+                convert!!(Cancellation())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("Cancellation\n", output);
+    }
+
     // (a') construct the same generic delegate from a METHOD GROUP (not a
     // lambda) and invoke it.
     [Fact]

--- a/test/Sdk.Tests/SdkLayoutTests.cs
+++ b/test/Sdk.Tests/SdkLayoutTests.cs
@@ -125,9 +125,9 @@ public class SdkLayoutTests
 
         var runSettingsTarget = doc.Descendants(MsbuildNs + "Target")
             .Single(t => (string)t.Attribute("Name") == "_GsharpGenerateRunSettings");
-        Assert.Equal("CoreCompile", (string)runSettingsTarget.Attribute("BeforeTargets"));
-        Assert.Contains(
-            "$(MSBuildProjectDirectory)",
+        Assert.Equal("CoreCompile;VSTest", (string)runSettingsTarget.Attribute("BeforeTargets"));
+        Assert.Equal(
+            "$([MSBuild]::NormalizePath('$(IntermediateOutputPath)', 'gsharp.generated.runsettings'))",
             doc.Descendants(MsbuildNs + "RunSettingsFilePath").Single().Value);
         Assert.Contains(
             runSettingsTarget.Descendants(MsbuildNs + "_GsharpRunSettingsLine"),

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1174NestedTypeQualificationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1174NestedTypeQualificationTranslationTests.cs
@@ -23,7 +23,7 @@ namespace Cs2Gs.Tests;
 /// qualified <c>Container.Nested</c> form so the generated G# binds against the
 /// NESTED type (not the top-level homonym holding the simple key). This mirrors
 /// the cs2gs SttsBox.SampleEntry migration shape. A non-colliding source nested
-/// type is still emitted by its simple name (no gratuitous qualification).
+/// type is emitted by its simple name only inside its containing type.
 /// </summary>
 public class Issue1174NestedTypeQualificationTranslationTests
 {
@@ -69,6 +69,22 @@ namespace Corpus
 }
 ";
 
+    private const string ExternalReferenceSource = @"
+namespace Corpus
+{
+    public class Host
+    {
+        public interface IReader
+        {
+        }
+    }
+
+    public class Reader : Host.IReader
+    {
+    }
+}
+";
+
     [Fact]
     public void Collision_NestedType_IsEmittedQualified_AndBinds()
     {
@@ -97,6 +113,20 @@ namespace Corpus
         // Without a homonym the nested type keeps its simple name (no gratuitous
         // qualification) and still binds.
         Assert.DoesNotContain("SttsBox.Entry", printed);
+
+        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+        Assert.True(roundTrip.Success, string.Join(Environment.NewLine, roundTrip.Errors));
+
+        var diagnostics = BindDiagnostics(printed);
+        Assert.DoesNotContain(diagnostics, d => d.Severity == GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public void NoCollision_NestedTypeReferencedExternally_IsQualified()
+    {
+        string printed = Translate(ExternalReferenceSource);
+
+        Assert.Contains("class Reader : Host.IReader", printed);
 
         RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
         Assert.True(roundTrip.Success, string.Join(Environment.NewLine, roundTrip.Errors));

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2342CrossPackageAnonymousTypeCollisionTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2342CrossPackageAnonymousTypeCollisionTests.cs
@@ -166,10 +166,14 @@ namespace Oahu.BooksDatabase.Migrations
             Directory.GetFiles(runtimeDir, "*.dll").Concat(new[] { dllPath }));
         using var mlc = new System.Reflection.MetadataLoadContext(resolver, "System.Private.CoreLib");
         System.Reflection.Assembly asm = mlc.LoadFromAssemblyPath(dllPath);
+        Type emittedType = asm.GetType(fullTypeName, throwOnError: false);
         Assert.True(
-            asm.GetType(fullTypeName, throwOnError: false) != null,
+            emittedType != null,
             $"Expected emitted type '{fullTypeName}' not found. Available types: " +
                 string.Join(", ", Array.ConvertAll(asm.GetTypes(), t => t.FullName)));
+        Assert.Null(emittedType.GetProperty(
+            "EqualityContract",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic));
     }
 
     private static (int Exit, string Output) RunDotnet(string arguments)

--- a/tools/cs2gs/Cs2Gs.Tests/Issue914DecryptNarrowingTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914DecryptNarrowingTranslationTests.cs
@@ -136,6 +136,30 @@ namespace Demo
         Assert.DoesNotContain("else { nil }", printed);
     }
 
+    [Fact]
+    public void AsyncNullableReturn_DoesNotAssertNullTernaryResult()
+    {
+        string printed = TranslateUnit(@"
+#nullable enable
+using System.Threading.Tasks;
+
+namespace Demo
+{
+    public sealed class C
+    {
+        public async Task<string?> PickAsync(bool found)
+        {
+            await Task.Yield();
+            return found ? ""value"" : null;
+        }
+    }
+}");
+
+        Assert.Contains("async func PickAsync(found bool) string?", printed);
+        Assert.Contains("default(string?)", printed);
+        Assert.DoesNotContain("default(string?))!!", printed);
+    }
+
     private static string TranslateUnit(string source)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -912,11 +912,26 @@ public sealed partial class CSharpToGSharpTranslator
 
             ITypeSymbol targetType = target switch
             {
-                IMethodSymbol method => method.ReturnType,
+                IMethodSymbol method => GetEffectiveReturnType(method),
                 IPropertySymbol property => property.Type,
                 _ => this.context.GetTypeInfo(value).ConvertedType,
             };
             return (targetType, target);
+
+            static ITypeSymbol GetEffectiveReturnType(IMethodSymbol method)
+            {
+                if (method.IsAsync
+                    && method.ReturnType is INamedTypeSymbol taskLike
+                    && taskLike.IsGenericType
+                    && taskLike.TypeArguments.Length == 1
+                    && taskLike.Name is "Task" or "ValueTask"
+                    && taskLike.ContainingNamespace?.ToDisplayString() == "System.Threading.Tasks")
+                {
+                    return taskLike.TypeArguments[0];
+                }
+
+                return method.ReturnType;
+            }
         }
 
         // Issue #2511: element-access arguments are call-like value sinks too.

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -359,10 +359,10 @@ public sealed class CSharpTypeMapper
                 List<GTypeReference> delegateArgs = named.TypeArguments
                     .Select(a => this.Map(a, context, location))
                     .ToList();
-                return new NamedTypeReference(this.QualifiedTypeName(named, context), delegateArgs);
+                return new NamedTypeReference(this.QualifiedTypeName(named, context, location), delegateArgs);
             }
 
-            return new NamedTypeReference(this.QualifiedTypeName(named, context));
+            return new NamedTypeReference(this.QualifiedTypeName(named, context, location));
         }
 
         return this.Map(type, context, location);
@@ -720,9 +720,9 @@ public sealed class CSharpTypeMapper
                 {
                     return named.IsGenericType
                         ? new NamedTypeReference(
-                            this.QualifiedTypeName(named, context),
+                            this.QualifiedTypeName(named, context, location),
                             named.TypeArguments.Select(a => this.Map(a, context, location)).ToList())
-                        : new NamedTypeReference(this.QualifiedTypeName(named, context));
+                        : new NamedTypeReference(this.QualifiedTypeName(named, context, location));
                 }
 
                 return this.MapDelegate(named.DelegateInvokeMethod, context, location);
@@ -733,10 +733,10 @@ public sealed class CSharpTypeMapper
                 List<GTypeReference> args = named.TypeArguments
                     .Select(a => this.Map(a, context, location))
                     .ToList();
-                return new NamedTypeReference(this.QualifiedTypeName(named, context), args);
+                return new NamedTypeReference(this.QualifiedTypeName(named, context, location), args);
             }
 
-            return new NamedTypeReference(this.QualifiedTypeName(named, context));
+            return new NamedTypeReference(this.QualifiedTypeName(named, context, location));
         }
 
         return new NamedTypeReference(CSharpToGSharpTranslator.SanitizeIdentifier(type.Name));
@@ -759,7 +759,7 @@ public sealed class CSharpTypeMapper
     // language fix, so the qualified form round-trips under gsc. Issue #2509
     // additionally prefixes the namespace when the OUTERMOST containing type
     // itself collides across imported packages.
-    private string QualifiedTypeName(INamedTypeSymbol named, TranslationContext context)
+    private string QualifiedTypeName(INamedTypeSymbol named, TranslationContext context, Location location)
     {
         if (named.ContainingType == null)
         {
@@ -795,9 +795,12 @@ public sealed class CSharpTypeMapper
                 : simpleName;
         }
 
-        // A source nested type only needs qualifying when its simple name is
-        // ambiguous within the package (a same-named source homonym exists).
-        if (named.Locations.Any(l => l.IsInSource) && !this.HasSourceHomonym(named, context))
+        // A source nested type may use its simple name only from inside its
+        // containing type. External references still require `Outer.Nested`
+        // even when no homonym exists.
+        if (named.Locations.Any(l => l.IsInSource)
+            && !this.HasSourceHomonym(named, context)
+            && IsWithinContainingType(named, context, location))
         {
             return CSharpToGSharpTranslator.SanitizeIdentifier(named.Name);
         }
@@ -820,6 +823,30 @@ public sealed class CSharpTypeMapper
             && outermost.ContainingNamespace is { IsGlobalNamespace: false } outerNamespace
                 ? $"{outerNamespace.ToDisplayString()}.{nestedName}"
                 : nestedName;
+    }
+
+    private static bool IsWithinContainingType(
+        INamedTypeSymbol nestedType,
+        TranslationContext context,
+        Location location)
+    {
+        INamedTypeSymbol containingType = nestedType.ContainingType;
+        if (containingType == null || location == null || !location.IsInSource)
+        {
+            return false;
+        }
+
+        ISymbol enclosing = context.SemanticModel.GetEnclosingSymbol(location.SourceSpan.Start);
+        INamedTypeSymbol currentType = enclosing as INamedTypeSymbol ?? enclosing?.ContainingType;
+        for (INamedTypeSymbol current = currentType; current != null; current = current.ContainingType)
+        {
+            if (SymbolEqualityComparer.Default.Equals(current, containingType))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/tools/cs2gs/external/oahu.json
+++ b/tools/cs2gs/external/oahu.json
@@ -1,0 +1,4 @@
+{
+  "repository": "https://github.com/DavidObando/Oahu.git",
+  "commit": "0ac1fece4415d31955ae7a1dcf7da31e343d363d"
+}


### PR DESCRIPTION
## Summary
- add a pinned Oahu regression gate that validates the original C# application, migrates all 15 projects, verifies compilation/IL/tests, and runs CLI and application smoke tests
- fix compiler and cs2gs regressions exposed by Oahu, including nullable async returns, nullable delegates, nested source types, explicit generic overloads, anonymous-type reflection metadata, and SDK runsettings paths
- accept Oahu's documented `auth status` exit code 3 when CI has no signed-in profile while still validating its empty JSON response
- split the long Compiler and Cs2Gs test assemblies into parallel process shards, automatically discover ordinary test projects, and run E2E, corpus, and Oahu gates independently
- require build, all test shards, E2E, both cs2gs gates, and extension jobs before publishing

## CI impact
- removes the approximately 40-minute serial test bottleneck by distributing the two longest assemblies across ten independent runners
- runs corpus and Oahu migration gates concurrently instead of serially after the build
- new ordinary test projects are discovered automatically; new tests in sharded assemblies fall into a named or catch-all shard, so rebalancing is optional performance maintenance

## Validation
- full pinned Oahu gate: 15/15 migrated projects green with CLI and application smoke tests
- corpus migration: 19/20 green with the sole known compile gap matching the ledger and no new, regressed, or stale gaps
- representative Compiler, Cs2Gs, and SDK test shards pass
- generated matrix covers all solution test projects and historical tests map to exactly one shard
