### PR TITLE
Fix MethodSpec cache remap identity

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
+++ b/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
@@ -876,7 +876,11 @@ internal sealed class ImportedMemberRefFactory
         }
         else
         {
-            var symbolKey = new MetadataTokenCache.MethodSpecSymbolKey(method, typeArgSymbols);
+            var symbolKey = new MetadataTokenCache.MethodSpecSymbolKey(
+                method,
+                typeArgSymbols,
+                this.remaps.ActiveIteratorStateMachineRemap,
+                this.remaps.ActiveLambdaMethodTypeParamRemap);
             if (this.cache.MethodSpecsWithSymbolArgs.TryGetValue(symbolKey, out var existingSym))
             {
                 return existingSym;
@@ -915,7 +919,12 @@ internal sealed class ImportedMemberRefFactory
         }
         else
         {
-            this.cache.MethodSpecsWithSymbolArgs[new MetadataTokenCache.MethodSpecSymbolKey(method, typeArgSymbols)] = spec;
+            this.cache.MethodSpecsWithSymbolArgs[
+                new MetadataTokenCache.MethodSpecSymbolKey(
+                    method,
+                    typeArgSymbols,
+                    this.remaps.ActiveIteratorStateMachineRemap,
+                    this.remaps.ActiveLambdaMethodTypeParamRemap)] = spec;
         }
 
         return spec;

--- a/src/Core/CodeAnalysis/Emit/MetadataTokenCache.cs
+++ b/src/Core/CodeAnalysis/Emit/MetadataTokenCache.cs
@@ -400,21 +400,28 @@ internal sealed class MetadataTokenCache
         = new Dictionary<StructSymbol, MethodDefinitionHandle>();
 
     /// <summary>
-    /// Issue #420 (P3-7): structural cache key for MethodSpec rows whose
-    /// generic arguments include user-defined type symbols. Uses reference
-    /// equality on the contained <see cref="TypeSymbol"/> entries (declared
-    /// user types are interned per compilation), combined with structural
-    /// equality on the array.
+    /// Issue #420 / #3065: structural cache key for MethodSpec rows whose
+    /// generic arguments include user-defined type symbols. Includes both
+    /// active generic-remap scopes because the same symbols can encode to
+    /// different VAR/MVAR ordinals. Uses reference equality throughout.
     /// </summary>
     internal readonly struct MethodSpecSymbolKey : IEquatable<MethodSpecSymbolKey>
     {
         private readonly MethodInfo method;
         private readonly ImmutableArray<TypeSymbol> typeArgs;
+        private readonly object classRemap;
+        private readonly object methodRemap;
 
-        public MethodSpecSymbolKey(MethodInfo method, ImmutableArray<TypeSymbol> typeArgs)
+        public MethodSpecSymbolKey(
+            MethodInfo method,
+            ImmutableArray<TypeSymbol> typeArgs,
+            object classRemap,
+            object methodRemap)
         {
             this.method = method;
             this.typeArgs = typeArgs.IsDefault ? ImmutableArray<TypeSymbol>.Empty : typeArgs;
+            this.classRemap = classRemap;
+            this.methodRemap = methodRemap;
         }
 
         public bool Equals(MethodSpecSymbolKey other)
@@ -424,7 +431,9 @@ internal sealed class MetadataTokenCache
                 return false;
             }
 
-            if (this.typeArgs.Length != other.typeArgs.Length)
+            if (!ReferenceEquals(this.classRemap, other.classRemap)
+                || !ReferenceEquals(this.methodRemap, other.methodRemap)
+                || this.typeArgs.Length != other.typeArgs.Length)
             {
                 return false;
             }
@@ -445,6 +454,8 @@ internal sealed class MetadataTokenCache
         public override int GetHashCode()
         {
             var hash = RuntimeHelpers.GetHashCode(this.method);
+            hash = unchecked((hash * 31) + RuntimeHelpers.GetHashCode(this.classRemap));
+            hash = unchecked((hash * 31) + RuntimeHelpers.GetHashCode(this.methodRemap));
             for (var i = 0; i < this.typeArgs.Length; i++)
             {
                 hash = unchecked((hash * 31) + RuntimeHelpers.GetHashCode(this.typeArgs[i]));

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue3065MethodSpecRemapKeyTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue3065MethodSpecRemapKeyTests.cs
@@ -1,0 +1,153 @@
+// <copyright file="Issue3065MethodSpecRemapKeyTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Emit;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+public class Issue3065MethodSpecRemapKeyTests
+{
+    private const string Source = """
+        package MsProbe
+        import System
+
+        func Remap[A, B](first A, value B) B {
+            var outer = Array.Empty[B]()
+            let f (B) -> B = (innerValue B) -> {
+                var inner = Array.Empty[B]()
+                return innerValue
+            }
+            return f(value)
+        }
+
+        Console.WriteLine(Remap[int32, int32](0, 11))
+        Console.WriteLine(Remap[int32, int32](0, 22))
+        """;
+
+    private const string RepeatedSource = """
+        package MsProbe
+        import System
+
+        func Remap[A, B](first A, value B) B {
+            var outer = Array.Empty[B]()
+            let f (B) -> B = (innerValue B) -> {
+                var inner = Array.Empty[B]()
+                var innerAgain = Array.Empty[B]()
+                return innerValue
+            }
+            return f(value)
+        }
+
+        Console.WriteLine(Remap[int32, int32](0, 11))
+        """;
+
+    [Fact]
+    public void MethodSpecSymbolKey_DifferentRemapScopes_AreNotEqual()
+    {
+        var method = typeof(Array)
+            .GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Single(candidate => candidate.Name == nameof(Array.Empty))
+            .MakeGenericMethod(typeof(object));
+        var typeArguments = ImmutableArray.Create<TypeSymbol>(TypeSymbol.Int32);
+        var classRemap = new Dictionary<TypeParameterSymbol, int>();
+        var methodRemap = new Dictionary<TypeParameterSymbol, int>();
+
+        var key = new MetadataTokenCache.MethodSpecSymbolKey(
+            method,
+            typeArguments,
+            classRemap,
+            methodRemap);
+        var sameScopes = new MetadataTokenCache.MethodSpecSymbolKey(
+            method,
+            typeArguments,
+            classRemap,
+            methodRemap);
+        var differentClassScope = new MetadataTokenCache.MethodSpecSymbolKey(
+            method,
+            typeArguments,
+            new Dictionary<TypeParameterSymbol, int>(),
+            methodRemap);
+        var differentMethodScope = new MetadataTokenCache.MethodSpecSymbolKey(
+            method,
+            typeArguments,
+            classRemap,
+            new Dictionary<TypeParameterSymbol, int>());
+
+        Assert.Equal(key, sameScopes);
+        Assert.NotEqual(key, differentClassScope);
+        Assert.NotEqual(key, differentMethodScope);
+    }
+
+    [Fact]
+    public void GenericLambdaMethodSpecs_WithDistinctRemaps_EmitRunnableAssembly()
+    {
+        var assembly = Assembly.Load(Emit());
+        Assert.NotEmpty(assembly.GetTypes());
+        var entryPoint = Assert.IsAssignableFrom<MethodInfo>(assembly.EntryPoint);
+
+        var previousOut = Console.Out;
+        using var output = new StringWriter();
+        Console.SetOut(output);
+        try
+        {
+            entryPoint.Invoke(
+                null,
+                entryPoint.GetParameters().Length == 0
+                    ? null
+                    : new object[] { Array.Empty<string>() });
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+        }
+
+        Assert.Equal("11\n22\n", output.ToString().Replace("\r\n", "\n"));
+    }
+
+    [Fact]
+    public void GenericLambdaMethodSpecs_RepeatedCallUsesCachedRow()
+    {
+        using var peReader = new PEReader(new MemoryStream(Emit(RepeatedSource)));
+        var metadata = peReader.GetMetadataReader();
+        var emptyMethodSpecs = Enumerable.Range(1, metadata.GetTableRowCount(TableIndex.MethodSpec))
+            .Select(row =>
+            {
+                var handle = MetadataTokens.MethodSpecificationHandle(row);
+                return metadata.GetMethodSpecification(handle);
+            })
+            .Count(spec =>
+                spec.Method.Kind == HandleKind.MemberReference
+                && metadata.GetString(metadata.GetMemberReference((MemberReferenceHandle)spec.Method).Name)
+                    == nameof(Array.Empty));
+
+        Assert.Equal(2, emptyMethodSpecs);
+    }
+
+    private static byte[] Emit(string source = Source)
+    {
+        using var peStream = new MemoryStream();
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(source)));
+        var emitResult = compilation.Emit(peStream);
+
+        Assert.True(
+            emitResult.Success,
+            "compilation should succeed: " +
+            string.Join("; ", emitResult.Diagnostics.Select(diagnostic => diagnostic.Message)));
+        return peStream.ToArray();
+    }
+}


### PR DESCRIPTION
Fixes #3065

## Summary
- Include the active state-machine and lambda-method remap dictionary identities in `MethodSpecSymbolKey`.
- Pass both remap scopes at every compiler-enumerated construction site.
- Add direct key-equality, emitted-assembly load/execute, and MethodSpec-row reuse regressions.

`ReferenceEquals` matches the existing remap-keyed cache pattern: each scope installs a distinct dictionary object, so stale identity only causes a safe cache miss.

## Repro

| Tree | `gsc` rc | runtime rc | Result |
|---|---:|---:|---|
| before | 0 | 134 | `BadImageFormatException` at `<lambda1>[B]` |
| after | 0 | 0 | `11` / `22` |

The after probe used a fresh full CIB solution build; the Core and Compiler copies of `GSharp.Core.dll` had the same build timestamp. The regression test also uses `Assembly.Load`, `GetTypes()`, and entry-point invocation.

## Construction-site denominator

Widening the key constructor first made the compiler enumerate **2 unique sites** (reported twice each because Core is built twice): the MethodSpec cache lookup and insertion in `ImportedMemberRefFactory`.

## Product mutations

| Mutant | Result | Killing test/evidence |
|---|---|---|
| Lookup site passes `null, null` | KILLED | `RepeatedMethodSpecInSeparateRemapScopes_EmitsValidAssembly`: emitted program raises `BadImageFormatException` |
| Insertion site passes `null, null` | KILLED | `RepeatedArrayEmptyInSameRemapScope_ReusesMethodSpecRow`: expected 2 MethodSpec rows, found 3 |
| Key constructor discards both remaps | KILLED (3/3) | Runtime, equality, and row-reuse regressions |
| Remove the two `ReferenceEquals` equality clauses | KILLED | `MethodSpecSymbolKey_DifferentRemapScopes_AreNotEqual` |
| Remove remap hash mixing | SURVIVED (expected) | Equality still preserves correctness; hash mixing affects distribution only |

## Validation
- Full suite: **14,214 passed, 0 failed, 14,215 total** (1 skipped).
- Focused MethodSpec regressions: **3/3 passed**.
- Release CIB solution build: **0 warnings, 0 errors**.
- cs2gs gate: **20 apps examined**, 19 green; positive-control known gap reproduced; **1 known, 0 new, 0 regressed, 0 stale**, rc 0.
- Bidirectional diagnostics gate: **377 descriptors + 7 allowlist = 384 expected**; both files have 0 missing and 0 unexpected IDs.
- `git merge-tree`: rc 0.
