### PR TITLE
Fix lambda body-only generic closure parameters

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ClosureEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ClosureEmitter.cs
@@ -393,7 +393,10 @@ internal sealed class ClosureEmitter
         // capture site. Reify the display class generic over exactly the
         // referenced enclosing parameters (mirroring the state-machine
         // treatment); the emitter's outer-TP → own-TP remap then routes every
-        // field / Invoke signature through a valid `VAR(idx)` slot, and the
+        // field / Invoke signature and body through a valid `VAR(idx)` slot.
+        // Issue #2894 extends discovery to parameters referenced only by the
+        // body; they are otherwise absent from every signature while still
+        // requiring a valid slot in Invoke. The
         // returned constructed instance carries the original parameters as type
         // arguments for the capture-site `newobj`/field stores/delegate ctor.
         var enclosingRefSink = new List<TypeSymbol>();
@@ -408,6 +411,9 @@ internal sealed class ClosureEmitter
         }
 
         enclosingRefSink.Add(returnType);
+        var bodyTypeParameters = new List<TypeParameterSymbol>();
+        LambdaEnclosingTypeParameterCollector.Collect(body, bodyTypeParameters);
+        enclosingRefSink.AddRange(bodyTypeParameters);
         var origTPs = SynthesizedClosureReifier.CollectOrdered(enclosingRefSink);
         StructSymbol constructedClass = closureClass;
         if (!origTPs.IsDefaultOrEmpty)

--- a/src/Core/CodeAnalysis/Emit/LambdaEnclosingTypeParameterCollector.cs
+++ b/src/Core/CodeAnalysis/Emit/LambdaEnclosingTypeParameterCollector.cs
@@ -9,15 +9,16 @@ using GSharp.Core.CodeAnalysis.Symbols;
 namespace GSharp.Core.CodeAnalysis.Emit;
 
 /// <summary>
-/// Issue #2118: walks a non-capturing lambda body and gathers every
+/// Walks a lambda body and gathers every
 /// <see cref="TypeParameterSymbol"/> it references (through expression types,
 /// declared-local types, type arguments, <c>is</c>/pattern target types, and
-/// <c>typeof</c>/<c>sizeof</c> operands). The lambda itself declares no type
-/// parameters, so any type parameter reachable from its body is necessarily an
-/// enclosing one that must be promoted onto the synthesized static method as a
-/// generic method type parameter for the emitted IL to verify. Mirrors the node
-/// coverage of <c>LambdaBinder.EnclosingTypeParameterReferenceWalker</c> but
-/// accumulates ALL references instead of stopping at the first.
+/// <c>typeof</c>/<c>sizeof</c> operands). Issue #2118 uses the result to promote
+/// non-capturing lambdas to generic static methods; issue #2894 uses it to
+/// reify capturing display classes. Nested ordinary lambda bodies are included
+/// because the outer lambda materializes their constructed display classes.
+/// Mirrors the node coverage of
+/// <c>LambdaBinder.EnclosingTypeParameterReferenceWalker</c> but accumulates all
+/// references instead of stopping at the first.
 /// </summary>
 internal sealed class LambdaEnclosingTypeParameterCollector : BoundTreeWalker
 {
@@ -56,6 +57,9 @@ internal sealed class LambdaEnclosingTypeParameterCollector : BoundTreeWalker
         TypeSymbol.CollectReferencedTypeParameters(node.Type, this.sink);
         switch (node)
         {
+            case BoundFunctionLiteralExpression literal when literal.Function?.IsGeneric != true:
+                this.VisitStatement(literal.Body);
+                break;
             case BoundCallExpression call:
                 this.CheckTypeArguments(call.MethodTypeArguments);
                 break;

--- a/test/Compiler.Tests/Emit/Issue2894LambdaBodyGenericClosureTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2894LambdaBodyGenericClosureTests.cs
@@ -1,0 +1,333 @@
+// <copyright file="Issue2894LambdaBodyGenericClosureTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2894: type parameters referenced only from a lambda body must be
+/// reified onto its synthesized closure class.
+/// </summary>
+public class Issue2894LambdaBodyGenericClosureTests
+{
+    public static IEnumerable<object[]> Contexts()
+    {
+        yield return Case(
+            "generic-function",
+            "11",
+            1,
+            ["T", "TBox"],
+            """
+            package Issue2894.GenericFunction
+            import System
+            open class Box {}
+            open class Box[T any] : Box { var Value T = default(T) }
+            class IntBox : Box[int32] {}
+            class Descriptor { var Factory (() -> Box)? }
+            func Make[T any, TBox Box[T] init()](input T) Descriptor {
+                return Descriptor{
+                    Factory: func() Box {
+                        let value = TBox()
+                        value.Value = input
+                        return value
+                    },
+                }
+            }
+            func Main() int32 {
+                let descriptor = Make[int32, IntBox](11)
+                guard let factory = descriptor.Factory else { return 1 }
+                let value = factory() as IntBox
+                Console.WriteLine(value.Value)
+                return value.Value == 11 ? 0 : 2
+            }
+            """);
+
+        yield return Case(
+            "generic-class-method",
+            "22",
+            1,
+            ["T", "TBox"],
+            """
+            package Issue2894.GenericClass
+            import System
+            open class Box {}
+            open class Box[T any] : Box { var Value T = default(T) }
+            class IntBox : Box[int32] {}
+            class Descriptor { var Factory (() -> Box)? }
+            class Maker[T any, TBox Box[T] init()] {
+                func Make(input T) Descriptor {
+                    return Descriptor{
+                        Factory: func() Box {
+                            let value = TBox()
+                            value.Value = input
+                            return value
+                        },
+                    }
+                }
+            }
+            func Main() int32 {
+                let descriptor = Maker[int32, IntBox]().Make(22)
+                guard let factory = descriptor.Factory else { return 1 }
+                let value = factory() as IntBox
+                Console.WriteLine(value.Value)
+                return value.Value == 22 ? 0 : 2
+            }
+            """);
+
+        yield return Case(
+            "nested-lambda",
+            "33",
+            2,
+            ["T", "TBox"],
+            """
+            package Issue2894.NestedLambda
+            import System
+            open class Box {}
+            open class Box[T any] : Box { var Value T = default(T) }
+            class IntBox : Box[int32] {}
+            class Descriptor { var Factory (() -> Box)? }
+            func Make[T any, TBox Box[T] init()](input T) Descriptor {
+                return Descriptor{
+                    Factory: func() Box {
+                        let inner (() -> Box) = func() Box {
+                            let value = TBox()
+                            value.Value = input
+                            return value
+                        }
+                        return inner()
+                    },
+                }
+            }
+            func Main() int32 {
+                let descriptor = Make[int32, IntBox](33)
+                guard let factory = descriptor.Factory else { return 1 }
+                let value = factory() as IntBox
+                Console.WriteLine(value.Value)
+                return value.Value == 33 ? 0 : 2
+            }
+            """);
+
+        yield return Case(
+            "generic-local-function-top-level",
+            "44",
+            1,
+            ["T", "TBox"],
+            """
+            package Issue2894.GenericLocalTopLevel
+            import System
+            open class Box {}
+            open class Box[T any] : Box { var Value T = default(T) }
+            class IntBox : Box[int32] {}
+            class Descriptor { var Factory (() -> Box)? }
+            let Make[T any, TBox Box[T] init()] = func(input T) Descriptor {
+                return Descriptor{
+                    Factory: func() Box {
+                        let value = TBox()
+                        value.Value = input
+                        return value
+                    },
+                }
+            }
+            let descriptor = Make[int32, IntBox](44)
+            let factory = descriptor.Factory!!
+            let value = factory() as IntBox
+            Console.WriteLine(value.Value)
+            """);
+
+        yield return Case(
+            "generic-local-function-in-function",
+            "55",
+            1,
+            ["T", "TBox"],
+            """
+            package Issue2894.GenericLocalInFunction
+            import System
+            open class Box {}
+            open class Box[T any] : Box { var Value T = default(T) }
+            class IntBox : Box[int32] {}
+            class Descriptor { var Factory (() -> Box)? }
+            func Run() int32 {
+                let Make[T any, TBox Box[T] init()] = func(input T) Descriptor {
+                    return Descriptor{
+                        Factory: func() Box {
+                            let value = TBox()
+                            value.Value = input
+                            return value
+                        },
+                    }
+                }
+                let descriptor = Make[int32, IntBox](55)
+                guard let factory = descriptor.Factory else { return 1 }
+                let value = factory() as IntBox
+                Console.WriteLine(value.Value)
+                return value.Value == 55 ? 0 : 2
+            }
+            func Main() int32 -> Run()
+            """);
+
+        yield return Case(
+            "iterator-state-machine",
+            "66",
+            1,
+            ["TBox"],
+            """
+            package Issue2894.Iterator
+            import System
+            open class Box { var Value int32 = 0 }
+            class Descriptor { var Factory (() -> Box)? }
+            func Make[TBox any](input int32) sequence[Descriptor] {
+                yield Descriptor{
+                    Factory: func() Box {
+                        let ignored = default(TBox)
+                        return Box{ Value: input }
+                    },
+                }
+            }
+            func Main() int32 {
+                for descriptor in Make[string](66) {
+                    guard let factory = descriptor.Factory else { return 1 }
+                    let value = factory()
+                    Console.WriteLine(value.Value)
+                    return value.Value == 66 ? 0 : 2
+                }
+                return 3
+            }
+            """);
+
+        yield return Case(
+            "async-state-machine",
+            "77",
+            1,
+            ["T", "TBox"],
+            """
+            package Issue2894.Async
+            import System
+            import System.Threading.Tasks
+            open class Box {}
+            open class Box[T any] : Box { var Value T = default(T) }
+            class IntBox : Box[int32] {}
+            class Descriptor { var Factory (() -> Box)? }
+            async func Make[T any, TBox Box[T] init()](input T) Task[Descriptor] {
+                await Task.CompletedTask
+                return Descriptor{
+                    Factory: func() Box {
+                        let value = TBox()
+                        value.Value = input
+                        return value
+                    },
+                }
+            }
+            func Main() int32 {
+                let descriptor = Make[int32, IntBox](77).GetAwaiter().GetResult()
+                guard let factory = descriptor.Factory else { return 1 }
+                let value = factory() as IntBox
+                Console.WriteLine(value.Value)
+                return value.Value == 77 ? 0 : 2
+            }
+            """);
+    }
+
+    [Theory]
+    [MemberData(nameof(Contexts))]
+    public void BodyOnlyGenericParameter_ClosureDeclaresParameterAndRuns(
+        string name,
+        string expectedOutput,
+        int expectedClosureCount,
+        string[] expectedTypeParameters,
+        string source)
+    {
+        var directory = Directory.CreateDirectory(
+            Path.Combine(AppContext.BaseDirectory, "issue2894", Guid.NewGuid().ToString("N"))).FullName;
+        try
+        {
+            var sourcePath = Path.Combine(directory, name + ".gs");
+            var assemblyPath = Path.Combine(directory, name + ".dll");
+            File.WriteAllText(sourcePath, source);
+
+            var exitCode = Program.Main(
+            [
+                "/out:" + assemblyPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                sourcePath,
+            ]);
+            Assert.Equal(0, exitCode);
+
+            Assert.Equal(expectedOutput + "\n", Run(assemblyPath, directory));
+
+            var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+            var closureTypes = assembly.GetTypes()
+                .Where(type => type.Name.StartsWith("<closure_", StringComparison.Ordinal))
+                .ToArray();
+            Assert.Equal(expectedClosureCount, closureTypes.Length);
+            foreach (var closureType in closureTypes)
+            {
+                Assert.Equal(
+                    expectedTypeParameters,
+                    closureType.GetGenericArguments().Select(parameter => parameter.Name));
+            }
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    private static object[] Case(
+        string name,
+        string expectedOutput,
+        int expectedClosureCount,
+        string[] expectedTypeParameters,
+        string source) =>
+        [name, expectedOutput, expectedClosureCount, expectedTypeParameters, source];
+
+    private static string Run(string assemblyPath, string directory)
+    {
+        var runtimeConfig = Path.ChangeExtension(assemblyPath, ".runtimeconfig.json");
+        using var process = Process.Start(new ProcessStartInfo("dotnet")
+        {
+            ArgumentList =
+            {
+                "exec",
+                "--runtimeconfig",
+                runtimeConfig,
+                assemblyPath,
+            },
+            WorkingDirectory = directory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        }) ?? throw new InvalidOperationException("Failed to start dotnet child process.");
+
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+        if (!process.WaitForExit(30_000))
+        {
+            process.Kill(entireProcessTree: true);
+            process.WaitForExit();
+            throw new TimeoutException("dotnet child process timed out.");
+        }
+
+        var stdout = stdoutTask.GetAwaiter().GetResult().Replace("\r\n", "\n");
+        var stderr = stderrTask.GetAwaiter().GetResult();
+        Assert.True(
+            process.ExitCode == 0,
+            $"dotnet exited {process.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout;
+    }
+}

--- a/test/Interpreter.Tests/Issue2894LambdaBodyGenericClosureInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2894LambdaBodyGenericClosureInterpreterTests.cs
@@ -1,0 +1,94 @@
+// <copyright file="Issue2894LambdaBodyGenericClosureInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #2894: body-only generic parameters retain interpreter parity at both
+/// top-level and function-local generic local-function sites.
+/// </summary>
+public class Issue2894LambdaBodyGenericClosureInterpreterTests
+{
+    [Fact]
+    public void BodyOnlyGenericParameter_TopLevel_Runs()
+    {
+        const string Source = """
+            open class Box { var Value int32 }
+            class IntBox : Box {}
+            class Descriptor { var Factory (() -> Box)? }
+            let Make[TBox Box] = func(input Box) Descriptor {
+                return Descriptor{
+                    Factory: func() Box {
+                        let marker = default(TBox)
+                        if marker == nil {
+                            return input
+                        }
+                        return marker
+                    },
+                }
+            }
+            let descriptor = Make[IntBox](Box{ Value: 99 })
+            let factory = descriptor.Factory!!
+            Console.WriteLine(factory().Value)
+            """;
+
+        Assert.Equal("99\n", Evaluate(Source));
+    }
+
+    [Fact]
+    public void BodyOnlyGenericParameter_InsideFunction_Runs()
+    {
+        const string Source = """
+            open class Box { var Value int32 }
+            class IntBox : Box {}
+            class Descriptor { var Factory (() -> Box)? }
+            func Run() int32 {
+                let Make[TBox Box] = func(input Box) Descriptor {
+                    return Descriptor{
+                        Factory: func() Box {
+                            let marker = default(TBox)
+                            if marker == nil {
+                                return input
+                            }
+                            return marker
+                        },
+                    }
+                }
+                let descriptor = Make[IntBox](Box{ Value: 111 })
+                let factory = descriptor.Factory!!
+                return factory().Value
+            }
+            Console.WriteLine(Run())
+            """;
+
+        Assert.Equal("111\n", Evaluate(Source));
+    }
+
+    private static string Evaluate(string source)
+    {
+        using var output = new StringWriter();
+        var previous = Console.Out;
+        Console.SetOut(output);
+        try
+        {
+            var result = new Compilation(SyntaxTree.Parse(source))
+                .Evaluate(new Dictionary<VariableSymbol, object>());
+            Assert.Empty(result.Diagnostics);
+        }
+        finally
+        {
+            Console.SetOut(previous);
+        }
+
+        return output.ToString().Replace("\r\n", "\n");
+    }
+}


### PR DESCRIPTION
## Summary

- collect enclosing type parameters referenced only from a capturing lambda body before synthesizing its display class
- propagate nested ordinary-lambda body references to the outer closure that materializes the nested constructed display class
- cover generic function, generic class, nested lambda, generic local-function, iterator, async, and interpreter contexts
- inspect emitted closure generic parameters with `Assembly.Load(File.ReadAllBytes(...)).GetTypes()` and execute every compiler probe in a bounded child process

Fixes #2894

## Exact-base reproduction

All probes were compiled with the exact `1ea847ebe` compiler. Compilation returned 0 for all seven; every emitted program then returned 134 with `BadImageFormatException`.

| Context | Base compile | Base runtime | Fixed runtime |
|---|---:|---:|---:|
| Generic function | 0 | 134, `BadImageFormatException` | 0, `11` |
| Generic class method | 0 | 134, `BadImageFormatException` | 0, `22` |
| Nested lambda | 0 | 134, `BadImageFormatException` | 0, `33` |
| Generic local function at top level | 0 | 134, `BadImageFormatException` | 0, `44` |
| Generic local function inside function | 0 | 134, `BadImageFormatException` | 0, `55` |
| Iterator/state machine | 0 | 134, `BadImageFormatException` | 0, `66` |
| Async body | 0 | 134, `BadImageFormatException` | 0, `77` |

The iterator probe uses an unconstrained body-only `TBox`; this isolates #2894 from the separate constrained state-machine metadata defect filed as #3067. No `MethodSpec` cache change is involved, distinguishing this fix from #3065.

## Driver × position matrix

| Position | `gsc` at base | `gsc` fixed | `gsi` at base | `gsi` fixed |
|---|---|---|---|---|
| Top level | rc 134, `BadImageFormatException` | rc 0, `99` | rc 0, `99` | rc 0, `99` |
| Inside function | rc 134, `BadImageFormatException` | rc 0, `111` | rc 0, `111` | rc 0, `111` |

## Call-site count

Adding a required parameter to `ClosureEmitter.SynthesizeDisplayClass` produced six rendered `CS7036` lines (errors plus build summary) at **3 unique call sites**: fieldless accessibility host, captured lambda closure, and `go` closure. The temporary parameter was removed after measurement.

## Product mutation

| Product hunk | Mutant | Result |
|---|---|---|
| Feed body type parameters into closure reification | Delete only those three lines | Killed: all 7 compiler rows fail in emitted programs with rc 134 and `BadImageFormatException` |
| Traverse nested ordinary lambda bodies | Invert `IsGeneric != true` to `IsGeneric == true` | Killed: nested-lambda row fails in emitted program with rc 134 and `BadImageFormatException`; other 6 rows pass |

Both mutations built successfully. Each clean artifact was rebuilt after restoration and matched its pre-mutation hash exactly.

## Validation

Merged tree equals the branch tree over `main` `185431c4` (`git merge-tree`), with merge base `185431c4`.

- Release solution build: 0 warnings, 0 errors
- Core.Tests: 7067 passed, 1 skipped, 0 failed
- Compiler.Tests: 4036 passed, 0 failed
- Interpreter.Tests: 595 passed, 0 failed
- Diagnostic documentation gate: 4 passed, 0 failed
- cs2gs corpus: 19/20 green; baseline 1 known, 0 new, 0 regressed, 0 stale; gate rc 0
