### PR TITLE
Fix plain struct Object overrides

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExternalClrOverrideResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/ExternalClrOverrideResolver.cs
@@ -153,7 +153,7 @@ internal static class ExternalClrOverrideResolver
             }
         }
 
-        return type?.IsClass == true ? TypeSymbol.Object : null;
+        return type != null ? TypeSymbol.Object : null;
     }
 
     private static Type GetReflectionBaseType(TypeSymbol importedBase)

--- a/src/Core/CodeAnalysis/Evaluator.Calls.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Calls.cs
@@ -1003,11 +1003,24 @@ public sealed partial class Evaluator
 
         if (receiver is StructValue sv)
         {
+            static MethodInfo FindExternalOverrideRoot(FunctionSymbol method)
+            {
+                for (var current = method; current != null; current = current.OverriddenMethod)
+                {
+                    if (current.ExternalOverriddenMethod != null)
+                    {
+                        return current.ExternalOverriddenMethod;
+                    }
+                }
+
+                return null;
+            }
+
             FunctionSymbol externalOverride = null;
             for (var type = sv.StructType; type != null && externalOverride == null; type = type.BaseClass)
             {
                 externalOverride = type.Methods.FirstOrDefault(method =>
-                    method.IsOverride && method.ExternalOverriddenMethod?.Equals(node.Method) == true);
+                    method.IsOverride && FindExternalOverrideRoot(method)?.Equals(node.Method) == true);
             }
 
             if (externalOverride != null)

--- a/src/Core/CodeAnalysis/Evaluator.Calls.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Calls.cs
@@ -1005,15 +1005,12 @@ public sealed partial class Evaluator
         {
             static MethodInfo FindExternalOverrideRoot(FunctionSymbol method)
             {
-                for (var current = method; current != null; current = current.OverriddenMethod)
+                while (method.OverriddenMethod != null)
                 {
-                    if (current.ExternalOverriddenMethod != null)
-                    {
-                        return current.ExternalOverriddenMethod;
-                    }
+                    method = method.OverriddenMethod;
                 }
 
-                return null;
+                return method.ExternalOverriddenMethod;
             }
 
             FunctionSymbol externalOverride = null;

--- a/src/Core/CodeAnalysis/Evaluator.Calls.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Calls.cs
@@ -1001,6 +1001,37 @@ public sealed partial class Evaluator
     {
         var receiver = EvaluateExpression(node.Receiver);
 
+        if (receiver is StructValue sv)
+        {
+            FunctionSymbol externalOverride = null;
+            for (var type = sv.StructType; type != null && externalOverride == null; type = type.BaseClass)
+            {
+                externalOverride = type.Methods.FirstOrDefault(method =>
+                    method.IsOverride && method.ExternalOverriddenMethod?.Equals(node.Method) == true);
+            }
+
+            if (externalOverride != null)
+            {
+                var frame = new ConcurrentDictionary<VariableSymbol, object>
+                {
+                    [externalOverride.ThisParameter] = receiver,
+                };
+
+                var parameterOffset = externalOverride.ExplicitReceiverParameter == null ? 0 : 1;
+                for (var i = 0; i < node.Arguments.Length; i++)
+                {
+                    var parameter = externalOverride.Parameters[i + parameterOffset];
+                    frame[parameter] = EvaluateExpression(node.Arguments[i]);
+                }
+
+                using (PushFrame(frame))
+                {
+                    var statement = program.Functions[externalOverride];
+                    return EvaluateUserMethodBody(externalOverride, statement);
+                }
+            }
+        }
+
         // Issue #517: Nullable<T> instance methods (e.g. `GetValueOrDefault`,
         // `Equals`, `ToString`) cannot dispatch through `MethodInfo.Invoke`
         // because the interpreter stores nullables as the underlying boxed T

--- a/test/Compiler.Tests/Emit/Issue2443ExternalClrOverrideEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2443ExternalClrOverrideEmitTests.cs
@@ -8,6 +8,9 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Reflection.Emit;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
@@ -90,6 +93,296 @@ public sealed class Issue2443ExternalClrOverrideEmitTests
     }
 
     [Fact]
+    public void PlainStructObjectOverrides_AllShapes_DispatchReflectAndEmitExpectedCallSites()
+    {
+        const string Source = """
+            package Issue2896
+            import System
+
+            interface IMarker {
+                func Marker() string;
+            }
+
+            struct ToStringOnly {
+                var Number int32
+                override func ToString() string -> "OVERRIDDEN-11"
+            }
+
+            struct EqualsOnly {
+                var Number int32
+                override func Equals(value object) bool -> false
+            }
+
+            struct HashOnly {
+                var Number int32
+                override func GetHashCode() int32 -> 289613
+            }
+
+            struct AllValue {
+                var Number int32
+                override func ToString() string -> "ALL-OVERRIDDEN-17"
+                override func Equals(value object) bool -> false
+                override func GetHashCode() int32 -> 289617
+            }
+
+            struct GenericValue[T any] {
+                var Item T
+                override func ToString() string -> "GENERIC-OVERRIDDEN-23"
+            }
+
+            struct InterfaceValue : IMarker {
+                var Number int32
+                func Marker() string -> "MARKER-31"
+                override func ToString() string -> "INTERFACE-OVERRIDDEN-31"
+            }
+
+            struct OperatorValue : IEquatable[OperatorValue] {
+                var Number int32
+                func Equals(other OperatorValue) bool -> Number == other.Number
+                override func Equals(value object) bool -> false
+                override func GetHashCode() int32 -> 289637
+            }
+
+            func (left OperatorValue) operator ==(right OperatorValue) bool ->
+                left.Number == right.Number
+
+            func (left OperatorValue) operator !=(right OperatorValue) bool ->
+                left.Number != right.Number
+
+            class Container {
+                struct NestedValue {
+                    var Number int32
+                    override func ToString() string -> "NESTED-OVERRIDDEN-41"
+                }
+            }
+
+            struct SharedValue {
+                var Number int32
+                shared {
+                    func Label() string -> "SHARED-43"
+                }
+                override func ToString() string -> "SHARED-OVERRIDDEN-43"
+            }
+
+            data struct DataValue {
+                var Number int32
+            }
+
+            struct DefaultValue {
+                var Number int32
+            }
+
+            func PrintGeneric[T any](value T) {
+                Console.WriteLine(value.ToString())
+            }
+
+            func CallSiteProbe(value AllValue, boxed object, peer object) {
+                Console.WriteLine(value.ToString())
+                Console.WriteLine(boxed.ToString())
+                Console.WriteLine(value.Equals(peer))
+                Console.WriteLine(boxed.Equals(peer))
+                Console.WriteLine(value.GetHashCode())
+                Console.WriteLine(boxed.GetHashCode())
+            }
+
+            let toStringValue = ToStringOnly{Number: 7}
+            let boxedToString object = toStringValue
+            Console.WriteLine(toStringValue.ToString())
+            Console.WriteLine(boxedToString.ToString())
+
+            let equalsValue = EqualsOnly{Number: 7}
+            let equalsPeer object = EqualsOnly{Number: 7}
+            let boxedEquals object = equalsValue
+            Console.WriteLine(equalsValue.Equals(equalsPeer))
+            Console.WriteLine(boxedEquals.Equals(equalsPeer))
+
+            let hashValue = HashOnly{Number: 7}
+            let boxedHash object = hashValue
+            Console.WriteLine(hashValue.GetHashCode())
+            Console.WriteLine(boxedHash.GetHashCode())
+
+            let allValue = AllValue{Number: 7}
+            let allPeer object = AllValue{Number: 7}
+            let boxedAll object = allValue
+            Console.WriteLine(allValue.ToString())
+            Console.WriteLine(boxedAll.ToString())
+            Console.WriteLine(allValue.Equals(allPeer))
+            Console.WriteLine(boxedAll.Equals(allPeer))
+            Console.WriteLine(allValue.GetHashCode())
+            Console.WriteLine(boxedAll.GetHashCode())
+            CallSiteProbe(allValue, boxedAll, allPeer)
+
+            let genericValue = GenericValue[int32]{Item: 7}
+            Console.WriteLine(genericValue.ToString())
+            PrintGeneric(genericValue)
+
+            let interfaceValue = InterfaceValue{Number: 7}
+            let boxedInterface object = interfaceValue
+            Console.WriteLine(interfaceValue.Marker())
+            Console.WriteLine(interfaceValue.ToString())
+            Console.WriteLine(boxedInterface.ToString())
+
+            let operatorLeft = OperatorValue{Number: 7}
+            let operatorRight = OperatorValue{Number: 7}
+            let boxedOperator object = operatorLeft
+            Console.WriteLine(operatorLeft == operatorRight)
+            Console.WriteLine(operatorLeft.Equals(operatorRight))
+            Console.WriteLine(boxedOperator.Equals(operatorRight))
+            Console.WriteLine(boxedOperator.GetHashCode())
+
+            let nestedValue = Container.NestedValue{Number: 7}
+            let boxedNested object = nestedValue
+            Console.WriteLine(nestedValue.ToString())
+            Console.WriteLine(boxedNested.ToString())
+
+            let sharedValue = SharedValue{Number: 7}
+            let boxedShared object = sharedValue
+            Console.WriteLine(SharedValue.Label())
+            Console.WriteLine(sharedValue.ToString())
+            Console.WriteLine(boxedShared.ToString())
+
+            let dataValue = DataValue{Number: 7}
+            let boxedData object = dataValue
+            Console.WriteLine(dataValue.ToString())
+            Console.WriteLine(boxedData.ToString())
+
+            let defaultValue = DefaultValue{Number: 7}
+            let boxedDefault object = defaultValue
+            Console.WriteLine(defaultValue.ToString())
+            Console.WriteLine(boxedDefault.ToString())
+            """;
+
+        var result = Compile(Source, target: "exe");
+        try
+        {
+            Assert.Equal(
+                """
+                OVERRIDDEN-11
+                OVERRIDDEN-11
+                False
+                False
+                289613
+                289613
+                ALL-OVERRIDDEN-17
+                ALL-OVERRIDDEN-17
+                False
+                False
+                289617
+                289617
+                ALL-OVERRIDDEN-17
+                ALL-OVERRIDDEN-17
+                False
+                False
+                289617
+                289617
+                GENERIC-OVERRIDDEN-23
+                GENERIC-OVERRIDDEN-23
+                MARKER-31
+                INTERFACE-OVERRIDDEN-31
+                INTERFACE-OVERRIDDEN-31
+                True
+                True
+                False
+                289637
+                NESTED-OVERRIDDEN-41
+                NESTED-OVERRIDDEN-41
+                SHARED-43
+                SHARED-OVERRIDDEN-43
+                SHARED-OVERRIDDEN-43
+                DataValue(Number=7)
+                DataValue(Number=7)
+                Issue2896.DefaultValue
+                Issue2896.DefaultValue
+                """.Replace("\r\n", "\n", StringComparison.Ordinal) + "\n",
+                Run(result.OutputPath));
+
+            var assembly = Assembly.Load(File.ReadAllBytes(result.OutputPath));
+            var types = assembly.GetTypes();
+            var objectToString = typeof(object).GetMethod(nameof(object.ToString))!;
+            var objectEquals = typeof(object).GetMethod(nameof(object.Equals), new[] { typeof(object) })!;
+            var objectGetHashCode = typeof(object).GetMethod(nameof(object.GetHashCode))!;
+
+            AssertValueTypeObjectOverride(
+                types.Single(type => type.FullName == "Issue2896.ToStringOnly").GetMethod(nameof(object.ToString))!,
+                objectToString);
+            AssertValueTypeObjectOverride(
+                types.Single(type => type.FullName == "Issue2896.EqualsOnly").GetMethod(nameof(object.Equals), new[] { typeof(object) })!,
+                objectEquals);
+            AssertValueTypeObjectOverride(
+                types.Single(type => type.FullName == "Issue2896.HashOnly").GetMethod(nameof(object.GetHashCode))!,
+                objectGetHashCode);
+
+            var allType = types.Single(type => type.FullName == "Issue2896.AllValue");
+            AssertValueTypeObjectOverride(allType.GetMethod(nameof(object.ToString))!, objectToString);
+            AssertValueTypeObjectOverride(allType.GetMethod(nameof(object.Equals), new[] { typeof(object) })!, objectEquals);
+            AssertValueTypeObjectOverride(allType.GetMethod(nameof(object.GetHashCode))!, objectGetHashCode);
+
+            AssertValueTypeObjectOverride(
+                types.Single(type => type.FullName == "Issue2896.GenericValue`1").GetMethod(nameof(object.ToString))!,
+                objectToString);
+            AssertValueTypeObjectOverride(
+                types.Single(type => type.FullName == "Issue2896.InterfaceValue").GetMethod(nameof(object.ToString))!,
+                objectToString);
+
+            var operatorType = types.Single(type => type.FullName == "Issue2896.OperatorValue");
+            AssertValueTypeObjectOverride(operatorType.GetMethod(nameof(object.Equals), new[] { typeof(object) })!, objectEquals);
+            AssertValueTypeObjectOverride(operatorType.GetMethod(nameof(object.GetHashCode))!, objectGetHashCode);
+            AssertValueTypeObjectOverride(
+                types.Single(type => type.FullName == "Issue2896.Container+NestedValue").GetMethod(nameof(object.ToString))!,
+                objectToString);
+            AssertValueTypeObjectOverride(
+                types.Single(type => type.FullName == "Issue2896.SharedValue").GetMethod(nameof(object.ToString))!,
+                objectToString);
+
+            var dataType = types.Single(type => type.FullName == "Issue2896.DataValue");
+            AssertValueTypeObjectOverride(dataType.GetMethod(nameof(object.ToString))!, objectToString);
+            var defaultType = types.Single(type => type.FullName == "Issue2896.DefaultValue");
+            Assert.Null(defaultType.GetMethod(
+                nameof(object.ToString),
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly));
+
+            using var peReader = new PEReader(File.OpenRead(result.OutputPath));
+            var metadata = peReader.GetMetadataReader();
+            AssertMethodImplCount(metadata, "ToStringOnly", 1);
+            AssertMethodImplCount(metadata, "EqualsOnly", 1);
+            AssertMethodImplCount(metadata, "HashOnly", 1);
+            AssertMethodImplCount(metadata, "AllValue", 3);
+            AssertMethodImplCount(metadata, "GenericValue`1", 1);
+            AssertMethodImplCount(metadata, "InterfaceValue", 1);
+            AssertMethodImplCount(metadata, "OperatorValue", 2);
+            AssertMethodImplCount(metadata, "NestedValue", 1);
+            AssertMethodImplCount(metadata, "SharedValue", 1);
+
+            var programType = types.Single(type => type.Name == "<Program>");
+            var callSiteProbe = programType.GetMethod("CallSiteProbe", BindingFlags.Static | BindingFlags.Public)!;
+            var callSiteInstructions = IlInstructionReader.Read(callSiteProbe.GetMethodBody()!.GetILAsByteArray()!);
+            Assert.Contains(
+                callSiteInstructions,
+                instruction => instruction.OpCode == OpCodes.Call
+                    && callSiteProbe.Module.ResolveMethod(instruction.MetadataToken!.Value)?.DeclaringType == allType);
+            Assert.Contains(
+                callSiteInstructions,
+                instruction => instruction.OpCode == OpCodes.Callvirt
+                    && callSiteProbe.Module.ResolveMethod(instruction.MetadataToken!.Value)?.DeclaringType == typeof(object));
+
+            var printGeneric = programType.GetMethod("PrintGeneric", BindingFlags.Static | BindingFlags.Public)!;
+            var genericInstructions = IlInstructionReader.Read(printGeneric.GetMethodBody()!.GetILAsByteArray()!);
+            var constrainedIndex = Array.FindIndex(
+                genericInstructions,
+                instruction => instruction.OpCode == OpCodes.Constrained);
+            Assert.True(constrainedIndex >= 0);
+            Assert.Equal(OpCodes.Callvirt, genericInstructions[constrainedIndex + 1].OpCode);
+            Assert.Equal(
+                typeof(object),
+                printGeneric.Module.ResolveMethod(genericInstructions[constrainedIndex + 1].MetadataToken!.Value)?.DeclaringType);
+        }
+        finally
+        {
+            result.Dispose();
+        }
+    }
+
+    [Fact]
     public void MatchingImplicitObjectVirtualWithoutOverride_RemainsAnAcceptedShadow()
     {
         const string Source = """
@@ -137,12 +430,6 @@ public sealed class Issue2443ExternalClrOverrideEmitTests
         package Issue2486
         class Bad {
             override func Missing() string -> "bad"
-        }
-        """, "GS0183")]
-    [InlineData("""
-        package Issue2486
-        struct Bad {
-            override func ToString() string -> "bad"
         }
         """, "GS0183")]
     public void ImplicitObjectOverride_InvalidShapesRetainSpecificDiagnostics(string source, string diagnosticId)
@@ -353,6 +640,21 @@ public sealed class Issue2443ExternalClrOverrideEmitTests
     {
         Assert.True(implementation.IsVirtual);
         Assert.False((implementation.Attributes & MethodAttributes.NewSlot) != 0);
+    }
+
+    private static void AssertValueTypeObjectOverride(MethodInfo implementation, MethodInfo declaration)
+    {
+        AssertOverrideSlot(implementation, declaration);
+        Assert.True(implementation.IsFinal);
+        Assert.True(implementation.IsHideBySig);
+    }
+
+    private static void AssertMethodImplCount(MetadataReader reader, string typeName, int expected)
+    {
+        var type = reader.TypeDefinitions
+            .Select(reader.GetTypeDefinition)
+            .Single(definition => reader.GetString(definition.Name) == typeName);
+        Assert.Equal(expected, type.GetMethodImplementations().Count);
     }
 
     private static CompilationResult Compile(string source, string target, params string[] references)
@@ -579,9 +881,17 @@ public sealed class Issue2443ExternalClrOverrideEmitTests
             UseShellExecute = false,
         };
         using var process = Process.Start(startInfo)!;
-        var stdout = process.StandardOutput.ReadToEnd();
-        var stderr = process.StandardError.ReadToEnd();
-        process.WaitForExit();
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+        if (!process.WaitForExit(30_000))
+        {
+            process.Kill(entireProcessTree: true);
+            process.WaitForExit();
+            throw new Xunit.Sdk.XunitException("child process timed out after 30000 ms");
+        }
+
+        var stdout = stdoutTask.GetAwaiter().GetResult();
+        var stderr = stderrTask.GetAwaiter().GetResult();
         Assert.True(process.ExitCode == 0, $"exit {process.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
         return stdout.Replace("\r\n", "\n", StringComparison.Ordinal);
     }

--- a/test/Interpreter.Tests/Interpreter.Tests.csproj
+++ b/test/Interpreter.Tests/Interpreter.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="@(GsharpCompiler)" />
     <ProjectReference Include="@(GsharpRepl)" />
     <ProjectReference Include="..\..\src\Sdk\Gsharp.Extensions\Gsharp.Extensions.csproj" />
   </ItemGroup>

--- a/test/Interpreter.Tests/Issue2896StructObjectOverrideTests.cs
+++ b/test/Interpreter.Tests/Issue2896StructObjectOverrideTests.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
@@ -85,14 +86,14 @@ public class Issue2896StructObjectOverrideTests
     [InlineData(true, "gsc-evaluate")]
     [InlineData(true, "gsc-emit")]
     [InlineData(true, "gsi")]
-    public void ClassObjectOverrideChain_UsesMostDerivedOverrideAcrossDrivers(
+    public async Task ClassObjectOverrideChain_UsesMostDerivedOverrideAcrossDrivers(
         bool insideFunction,
         string driver)
     {
         var suffix = Guid.NewGuid().ToString("N");
         var source = BuildClassOverrideChainSource(insideFunction, suffix);
 
-        Assert.Equal("L0-11\nL1-22\nL2-33\n", RunDriver(source, suffix, driver));
+        Assert.Equal("L0-11\nL1-22\nL2-33\n", await RunDriverAsync(source, suffix, driver));
     }
 
     [Fact]
@@ -286,13 +287,15 @@ public class Issue2896StructObjectOverrideTests
             : declarations + "\n" + calls;
     }
 
-    private static string RunDriver(string source, string suffix, string driver)
+    private static async Task<string> RunDriverAsync(string source, string suffix, string driver)
     {
         var directory = Path.Combine(
             AppContext.BaseDirectory,
             nameof(Issue2896StructObjectOverrideTests),
             suffix);
+        Assert.False(Directory.Exists(directory));
         Directory.CreateDirectory(directory);
+        Assert.Empty(Directory.EnumerateFileSystemEntries(directory));
         try
         {
             var sourcePath = Path.Combine(directory, "test.gs");
@@ -301,7 +304,7 @@ public class Issue2896StructObjectOverrideTests
             return driver switch
             {
                 "gsc-evaluate" => RunCompilerEvaluation(sourcePath),
-                "gsc-emit" => RunEmittedBinary(directory, sourcePath, suffix),
+                "gsc-emit" => await RunEmittedBinaryAsync(directory, sourcePath, suffix),
                 "gsi" => RunInterpreter(sourcePath),
                 _ => throw new ArgumentOutOfRangeException(nameof(driver), driver, null),
             };
@@ -335,7 +338,7 @@ public class Issue2896StructObjectOverrideTests
         return result.StandardOutput;
     }
 
-    private static string RunEmittedBinary(string directory, string sourcePath, string suffix)
+    private static async Task<string> RunEmittedBinaryAsync(string directory, string sourcePath, string suffix)
     {
         var assemblyName = "Issue2896Driver" + suffix;
         var outputPath = Path.Combine(directory, assemblyName + ".dll");
@@ -377,9 +380,21 @@ public class Issue2896StructObjectOverrideTests
 
         using var process = Process.Start(startInfo)
             ?? throw new InvalidOperationException("Failed to start emitted assembly");
-        var stdout = process.StandardOutput.ReadToEnd();
-        var stderr = process.StandardError.ReadToEnd();
-        Assert.True(process.WaitForExit(30_000), "Emitted assembly timed out");
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+        try
+        {
+            await process.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(30));
+        }
+        catch (TimeoutException)
+        {
+            process.Kill(entireProcessTree: true);
+            await process.WaitForExitAsync();
+            throw new Xunit.Sdk.XunitException("Emitted assembly timed out");
+        }
+
+        var stdout = await stdoutTask;
+        var stderr = await stderrTask;
         Assert.Equal(0, process.ExitCode);
         Assert.Equal(string.Empty, stderr);
         return stdout.Replace("\r\n", "\n", StringComparison.Ordinal);

--- a/test/Interpreter.Tests/Issue2896StructObjectOverrideTests.cs
+++ b/test/Interpreter.Tests/Issue2896StructObjectOverrideTests.cs
@@ -1,0 +1,234 @@
+// <copyright file="Issue2896StructObjectOverrideTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #2896: plain structs may override Object virtual methods, including
+/// calls dispatched through an object-typed receiver.
+/// </summary>
+public class Issue2896StructObjectOverrideTests
+{
+    [Theory]
+    [InlineData("""
+        package Issue2896.TopLevel
+        import System
+
+        struct Value {
+            var Number int32
+            override func ToString() string -> "OVERRIDDEN-11"
+            override func Equals(value object) bool -> false
+            override func GetHashCode() int32 -> 289611
+        }
+
+        let direct = Value{Number: 7}
+        let peer object = Value{Number: 7}
+        let boxed object = direct
+        Console.WriteLine(direct.ToString())
+        Console.WriteLine(boxed.ToString())
+        Console.WriteLine(direct.Equals(peer))
+        Console.WriteLine(boxed.Equals(peer))
+        Console.WriteLine(direct.GetHashCode())
+        Console.WriteLine(boxed.GetHashCode())
+        """)]
+    [InlineData("""
+        package Issue2896.Function
+        import System
+
+        struct Value {
+            var Number int32
+            override func ToString() string -> "OVERRIDDEN-11"
+            override func Equals(value object) bool -> false
+            override func GetHashCode() int32 -> 289611
+        }
+
+        func Run() {
+            let direct = Value{Number: 7}
+            let peer object = Value{Number: 7}
+            let boxed object = direct
+            Console.WriteLine(direct.ToString())
+            Console.WriteLine(boxed.ToString())
+            Console.WriteLine(direct.Equals(peer))
+            Console.WriteLine(boxed.Equals(peer))
+            Console.WriteLine(direct.GetHashCode())
+            Console.WriteLine(boxed.GetHashCode())
+        }
+
+        Run()
+        """)]
+    public void AllObjectOverrides_DirectAndBoxed_DispatchAtTopLevelAndInsideFunction(string source)
+    {
+        Assert.Equal(
+            "OVERRIDDEN-11\nOVERRIDDEN-11\nFalse\nFalse\n289611\n289611\n",
+            Evaluate(source));
+    }
+
+    [Fact]
+    public void GenericInterfaceOperatorNestedAndSharedShapes_DispatchOverrides()
+    {
+        const string Source = """
+            package Issue2896.Shapes
+            import System
+
+            interface IMarker {
+                func Marker() string;
+            }
+
+            struct GenericValue[T any] {
+                var Item T
+                override func ToString() string -> "GENERIC-OVERRIDDEN-23"
+            }
+
+            struct InterfaceValue : IMarker {
+                var Number int32
+                func Marker() string -> "MARKER-31"
+                override func ToString() string -> "INTERFACE-OVERRIDDEN-31"
+            }
+
+            struct OperatorValue : IEquatable[OperatorValue] {
+                var Number int32
+                func Equals(other OperatorValue) bool -> Number == other.Number
+                override func Equals(value object) bool -> false
+                override func GetHashCode() int32 -> 289637
+            }
+
+            func (left OperatorValue) operator ==(right OperatorValue) bool ->
+                left.Number == right.Number
+
+            func (left OperatorValue) operator !=(right OperatorValue) bool ->
+                left.Number != right.Number
+
+            class Container {
+                struct NestedValue {
+                    var Number int32
+                    override func ToString() string -> "NESTED-OVERRIDDEN-41"
+                }
+            }
+
+            struct SharedValue {
+                var Number int32
+                shared {
+                    func Label() string -> "SHARED-43"
+                }
+                override func ToString() string -> "SHARED-OVERRIDDEN-43"
+            }
+
+            func PrintGeneric[T any](value T) {
+                Console.WriteLine(value.ToString())
+            }
+
+            let genericValue = GenericValue[int32]{Item: 7}
+            Console.WriteLine(genericValue.ToString())
+            PrintGeneric(genericValue)
+
+            let interfaceValue = InterfaceValue{Number: 7}
+            let boxedInterface object = interfaceValue
+            Console.WriteLine(interfaceValue.Marker())
+            Console.WriteLine(interfaceValue.ToString())
+            Console.WriteLine(boxedInterface.ToString())
+
+            let operatorLeft = OperatorValue{Number: 7}
+            let operatorRight = OperatorValue{Number: 7}
+            let boxedOperator object = operatorLeft
+            Console.WriteLine(operatorLeft == operatorRight)
+            Console.WriteLine(operatorLeft.Equals(operatorRight))
+            Console.WriteLine(boxedOperator.Equals(operatorRight))
+            Console.WriteLine(boxedOperator.GetHashCode())
+
+            let nestedValue = Container.NestedValue{Number: 7}
+            let boxedNested object = nestedValue
+            Console.WriteLine(nestedValue.ToString())
+            Console.WriteLine(boxedNested.ToString())
+
+            let sharedValue = SharedValue{Number: 7}
+            let boxedShared object = sharedValue
+            Console.WriteLine(SharedValue.Label())
+            Console.WriteLine(sharedValue.ToString())
+            Console.WriteLine(boxedShared.ToString())
+            """;
+
+        Assert.Equal(
+            """
+            GENERIC-OVERRIDDEN-23
+            GENERIC-OVERRIDDEN-23
+            MARKER-31
+            INTERFACE-OVERRIDDEN-31
+            INTERFACE-OVERRIDDEN-31
+            True
+            True
+            False
+            289637
+            NESTED-OVERRIDDEN-41
+            NESTED-OVERRIDDEN-41
+            SHARED-43
+            SHARED-OVERRIDDEN-43
+            SHARED-OVERRIDDEN-43
+            """.Replace("\r\n", "\n", StringComparison.Ordinal) + "\n",
+            Evaluate(Source));
+    }
+
+    [Fact]
+    public void DataAndDefaultStructBehavior_RemainsUnchanged()
+    {
+        const string Source = """
+            package Issue2896.Controls
+            import System
+
+            data struct DataValue {
+                var Number int32
+            }
+
+            struct DefaultValue {
+                var Number int32
+            }
+
+            let dataValue = DataValue{Number: 7}
+            let boxedData object = dataValue
+            Console.WriteLine(dataValue.ToString())
+            Console.WriteLine(boxedData.ToString())
+
+            let defaultValue = DefaultValue{Number: 7}
+            let boxedDefault object = defaultValue
+            Console.WriteLine(defaultValue.ToString())
+            Console.WriteLine(boxedDefault.ToString())
+            """;
+
+        Assert.Equal(
+            "DataValue(Number=7)\nDataValue(Number=7)\n"
+                + "DefaultValue(Number=7)\nDefaultValue(Number=7)\n",
+            Evaluate(Source));
+    }
+
+    private static string Evaluate(string source)
+    {
+        var compilation = new Compilation(SyntaxTree.Parse(source));
+
+        using var outWriter = new StringWriter();
+        var previousOut = Console.Out;
+        Console.SetOut(outWriter);
+        try
+        {
+            var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+            var errors = result.Diagnostics.Where(diagnostic => diagnostic.IsError).ToArray();
+            Assert.True(
+                errors.Length == 0,
+                "evaluation failed:\n" + string.Join("\n", errors.Select(diagnostic => diagnostic.ToString())));
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+        }
+
+        return outWriter.ToString().Replace("\r\n", "\n", StringComparison.Ordinal);
+    }
+}

--- a/test/Interpreter.Tests/Issue2896StructObjectOverrideTests.cs
+++ b/test/Interpreter.Tests/Issue2896StructObjectOverrideTests.cs
@@ -4,19 +4,24 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using Xunit;
+using CompilerProgram = GSharp.Compiler.Program;
 
 namespace GSharp.Interpreter.Tests;
 
 /// <summary>
 /// Issue #2896: plain structs may override Object virtual methods, including
-/// calls dispatched through an object-typed receiver.
+/// calls dispatched through an object-typed receiver. The evaluator's shared
+/// user-type dispatch path also preserves most-derived class overrides.
 /// </summary>
+[Collection("ConsoleIo")]
 public class Issue2896StructObjectOverrideTests
 {
     [Theory]
@@ -71,6 +76,23 @@ public class Issue2896StructObjectOverrideTests
         Assert.Equal(
             "OVERRIDDEN-11\nOVERRIDDEN-11\nFalse\nFalse\n289611\n289611\n",
             Evaluate(source));
+    }
+
+    [Theory]
+    [InlineData(false, "gsc-evaluate")]
+    [InlineData(false, "gsc-emit")]
+    [InlineData(false, "gsi")]
+    [InlineData(true, "gsc-evaluate")]
+    [InlineData(true, "gsc-emit")]
+    [InlineData(true, "gsi")]
+    public void ClassObjectOverrideChain_UsesMostDerivedOverrideAcrossDrivers(
+        bool insideFunction,
+        string driver)
+    {
+        var suffix = Guid.NewGuid().ToString("N");
+        var source = BuildClassOverrideChainSource(insideFunction, suffix);
+
+        Assert.Equal("L0-11\nL1-22\nL2-33\n", RunDriver(source, suffix, driver));
     }
 
     [Fact]
@@ -230,5 +252,159 @@ public class Issue2896StructObjectOverrideTests
         }
 
         return outWriter.ToString().Replace("\r\n", "\n", StringComparison.Ordinal);
+    }
+
+    private static string BuildClassOverrideChainSource(bool insideFunction, string suffix)
+    {
+        var declarations = $$"""
+            package Issue2896.Driver{{suffix}}
+            import System
+
+            open class L0{{suffix}} {
+                open override func ToString() string -> "L0-11"
+            }
+
+            open class L1{{suffix}} : L0{{suffix}} {
+                open override func ToString() string -> "L1-22"
+            }
+
+            class L2{{suffix}} : L1{{suffix}} {
+                override func ToString() string -> "L2-33"
+            }
+            """;
+        var calls = $$"""
+            let l0 object = L0{{suffix}}()
+            let l1 object = L1{{suffix}}()
+            let l2 object = L2{{suffix}}()
+            Console.WriteLine(l0.ToString())
+            Console.WriteLine(l1.ToString())
+            Console.WriteLine(l2.ToString())
+            """;
+
+        return insideFunction
+            ? declarations + "\nfunc Run" + suffix + "() {\n" + calls + "\n}\nRun" + suffix + "()\n"
+            : declarations + "\n" + calls;
+    }
+
+    private static string RunDriver(string source, string suffix, string driver)
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            nameof(Issue2896StructObjectOverrideTests),
+            suffix);
+        Directory.CreateDirectory(directory);
+        try
+        {
+            var sourcePath = Path.Combine(directory, "test.gs");
+            File.WriteAllText(sourcePath, source);
+
+            return driver switch
+            {
+                "gsc-evaluate" => RunCompilerEvaluation(sourcePath),
+                "gsc-emit" => RunEmittedBinary(directory, sourcePath, suffix),
+                "gsi" => RunInterpreter(sourcePath),
+                _ => throw new ArgumentOutOfRangeException(nameof(driver), driver, null),
+            };
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    private static string RunCompilerEvaluation(string sourcePath)
+    {
+        var result = CaptureConsole(() => CompilerProgram.Main(new[] { sourcePath }));
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(string.Empty, result.StandardError);
+        Assert.EndsWith("Success.\n", result.StandardOutput, StringComparison.Ordinal);
+        return result.StandardOutput[..^"Success.\n".Length];
+    }
+
+    private static string RunInterpreter(string sourcePath)
+    {
+        var result = CaptureConsole(() => GSharp.Repl.Program.Main(new[] { sourcePath }));
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(string.Empty, result.StandardError);
+        return result.StandardOutput;
+    }
+
+    private static string RunEmittedBinary(string directory, string sourcePath, string suffix)
+    {
+        var assemblyName = "Issue2896Driver" + suffix;
+        var outputPath = Path.Combine(directory, assemblyName + ".dll");
+        var compile = CaptureConsole(() => CompilerProgram.Main(new[]
+        {
+            "/out:" + outputPath,
+            "/assemblyname:" + assemblyName,
+            "/target:exe",
+            "/targetframework:net10.0",
+            sourcePath,
+        }));
+        Assert.Equal(0, compile.ExitCode);
+        Assert.Equal(string.Empty, compile.StandardError);
+
+        var assembly = Assembly.Load(File.ReadAllBytes(outputPath));
+        Assert.NotEmpty(assembly.GetTypes());
+
+        var runtimeConfigPath = Path.ChangeExtension(outputPath, ".runtimeconfig.json");
+        File.WriteAllText(runtimeConfigPath, """
+            {
+              "runtimeOptions": {
+                "tfm": "net10.0",
+                "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+              }
+            }
+            """);
+
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = directory,
+        };
+        startInfo.ArgumentList.Add("exec");
+        startInfo.ArgumentList.Add("--runtimeconfig");
+        startInfo.ArgumentList.Add(runtimeConfigPath);
+        startInfo.ArgumentList.Add(outputPath);
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start emitted assembly");
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), "Emitted assembly timed out");
+        Assert.Equal(0, process.ExitCode);
+        Assert.Equal(string.Empty, stderr);
+        return stdout.Replace("\r\n", "\n", StringComparison.Ordinal);
+    }
+
+    private static (int ExitCode, string StandardOutput, string StandardError) CaptureConsole(Func<int> action)
+    {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        try
+        {
+            Console.SetOut(stdout);
+            Console.SetError(stderr);
+            var exitCode = action();
+            return (
+                exitCode,
+                stdout.ToString().Replace("\r\n", "\n", StringComparison.Ordinal),
+                stderr.ToString().Replace("\r\n", "\n", StringComparison.Ordinal));
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
     }
 }


### PR DESCRIPTION
Fixes #2896

## Root cause

This was a binder rejection, not an emitter slot-loss bug. On the base commit, every positive plain-struct probe failed before emission with `GS0183`. `ExternalClrOverrideResolver.FindExternalBaseType` supplied the implicit `System.Object` base only for classes, so plain structs never reached the existing external override matcher.

The compiler emitter already handled the unlocked path correctly: emitted value-type overrides are virtual, final, hide-by-signature, reuse the `System.Object` slot, and carry explicit `MethodImpl` rows. The interpreter needed a parallel runtime fix because object-typed calls were reflection-dispatched against `StructValue` instead of the binder-recorded G# override. The evaluator follows `FunctionSymbol.OverriddenMethod` to the transitive root, then matches its binder-recorded `ExternalOverriddenMethod`, preserving the most-derived implementation in depth-3 user override chains without adding another signature matcher.

## Fresh-directory repro matrix

Every cell below compiled or evaluated from its own asserted-empty directory after a full solution build. `Core/`, `Compiler/`, and `Repl/` Core DLL mtimes matched. Results are unchanged from the provisional reused-directory run.

| Shape | bare `gsc` evaluate | `gsc /out:` emit/run | `gsi` |
|---|---|---|---|
| `ToString` only | `OVERRIDDEN-11` ×2 | same | same |
| `Equals(object)` only | `False` ×2 | same | same |
| `GetHashCode` only | `289613` ×2 | same | same |
| all three, top level | six expected values | same | same |
| all three, in function | six expected values | same | same |
| generic struct | `GENERIC-OVERRIDDEN-23` ×2 | same | same |
| interface implementation | marker + override ×2 | same | same |
| operators / `IEquatable` | `True, True, False, 289637` | same | same |
| nested struct | `NESTED-OVERRIDDEN-41` ×2 | same | same |
| shared member | `SHARED-43` + override ×2 | same | same |
| data-struct control | structural value ×2 | same | same |
| default-struct control | structural value ×2 | CLR type name ×2 | structural value ×2 |

All 36 driver cells returned rc 0 with empty stderr.

## Depth-3 override matrix

`L0 -> L1 -> L2` returns distinct `L0-11`, `L1-22`, `L2-33` values:

| Position | bare `gsc` evaluate | `gsc /out:` emit/run | `gsi` |
|---|---|---|---|
| top level | pass | pass | pass |
| inside function, called at top level | pass | pass | pass |

## Emission checks

The compiler regression test loads emitted bytes with `Assembly.Load(File.ReadAllBytes(...))`, calls `GetTypes()`, executes the child process, and checks:

- direct calls and boxed virtual dispatch produce distinct expected values;
- `MethodInfo.IsVirtual`, `IsFinal`, `IsHideBySig`, `NewSlot`, and `GetBaseDefinition()`;
- explicit `MethodImpl` counts for every positive shape;
- concrete direct calls use `call`;
- object dispatch uses `callvirt System.Object`;
- unconstrained generic dispatch emits `constrained. !!T` followed by `callvirt System.Object.ToString`.

## Shared-helper site count

Making `FindExternalBaseType` take one additional required parameter produced six printed `CS7036` diagnostics at exactly three unique call sites: method, property, and event resolution. Denominator: **3/3 callers route through the fixed helper**.

## Product mutations

| Hunk | Applied mutant | Killing test / symptom | Core hash round trip |
|---|---|---|---|
| implicit Object fallback | restore class-only condition | compiler matrix fails with `GS0183` for `ToString`, `Equals`, `GetHashCode`, and remaining struct overrides | clean `82b6ae4c…`, mutant `2b0a954c…`, restored `82b6ae4c…` |
| external-slot identity | invert binder-recorded MethodInfo equality | top-level and function interpreter cases fail with emitted evaluation type mismatch | clean `82b6ae4c…`, mutant `70c05ed…`, restored `82b6ae4c…` |
| transitive override root | invert `OverriddenMethod` walk condition | depth-3 matrix: evaluator drivers fail; emit-only control remains green | clean `82b6ae4c…`, mutant `3d1203b1…`, restored `82b6ae4c…` |

Each mutation was asserted present at exactly one source site before building.

## Validation on `main` `4f7559dd`

- `git merge-tree --write-tree origin/main HEAD`: rc 0; predicted merged tree equals `HEAD` tree
- merged-tree Release build: **BUILD_RC=0, 0 warnings, 0 errors**
- full merged suite: **14,346 passed, 0 failed, 1 skipped**
- bidirectional diagnostic documentation gate: **1 passed, 0 failed**
- cs2gs required gate: **0 new, 0 regressed, 0 stale**; `G11-Linq-Console` passed all stages
