### PR TITLE
Fix inherited field owners in generic derived classes

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -474,7 +474,7 @@ internal sealed partial class ExpressionBinder
 
                 var value = BindExpression(initSyntax.Value);
                 var converted = conversions.BindConversion(initSyntax.Value.Location, value, field.Type);
-                return new BoundFieldAssignmentExpression(initSyntax, receiverLocal, structSymbol, field, converted);
+                return new BoundFieldAssignmentExpression(initSyntax, receiverLocal, fieldDeclaringType, field, converted);
             }
 
             if (TypeMemberModel.TryGetProperty(structSymbol, propertyName, out var prop, out var propDeclaringType))
@@ -991,10 +991,10 @@ internal sealed partial class ExpressionBinder
 
         if (usesExpressionReceiver)
         {
-            return BoundFieldAssignmentExpression.WithExpressionReceiver(null, assignmentReceiver, structSymbol, field, converted);
+            return BoundFieldAssignmentExpression.WithExpressionReceiver(null, assignmentReceiver, fieldDeclaringType, field, converted);
         }
 
-        return new BoundFieldAssignmentExpression(null, variable, structSymbol, field, converted);
+        return new BoundFieldAssignmentExpression(null, variable, fieldDeclaringType, field, converted);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
@@ -1977,8 +1977,9 @@ internal sealed partial class MethodBodyEmitter
     // reachable from the receiver's hierarchy instead — this yields the
     // concrete base (`FrameFilterBase`1<int32>`) for a non-generic leaf and the
     // self-instantiation (`FrameFilterBase`1<!0>`) when accessed from within the
-    // generic type itself. Returns null when the bare FieldDef should be used
-    // (a non-generic declaring type with no generic base in scope).
+    // generic type itself. A non-generic declaring type is returned unchanged;
+    // ResolveFieldToken will then select its bare FieldDef instead of guessing
+    // from a generic derived receiver.
     private static StructSymbol ResolveFieldReferenceContainer(StructSymbol declaringType, StructSymbol receiver, FieldSymbol field)
     {
         if (declaringType == null)
@@ -2000,15 +2001,7 @@ internal sealed partial class MethodBodyEmitter
             return constructed;
         }
 
-        // No receiver-reachable constructed base (e.g. a null/static receiver):
-        // fall back to the declaring type when it is itself generic.
-        if (!declaringType.TypeArguments.IsDefaultOrEmpty)
-        {
-            return declaringType;
-        }
-
-        var def = declaringType.Definition ?? declaringType;
-        return def.TypeParameters.IsDefaultOrEmpty ? null : declaringType;
+        return declaringType;
     }
 
     // Issue #1467: the property analogue of ResolveFieldReferenceContainer.

--- a/test/Compiler.Tests/Emit/Issue2895InheritedFieldDeclaringTypeTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2895InheritedFieldDeclaringTypeTests.cs
@@ -1,0 +1,437 @@
+// <copyright file="Issue2895InheritedFieldDeclaringTypeTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2895: inherited field references from generic derived classes must
+/// name the field's declaring base type, not the generic receiver type.
+/// </summary>
+public class Issue2895InheritedFieldDeclaringTypeTests
+{
+    private static readonly IReadOnlyDictionary<ushort, OpCode> OpCodesByValue =
+        typeof(OpCodes)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(field => field.FieldType == typeof(OpCode))
+            .Select(field => (OpCode)field.GetValue(null)!)
+            .ToDictionary(opCode => unchecked((ushort)opCode.Value));
+
+    [Fact]
+    public void UnqualifiedAccessesInsideGenericDerivedUseNonGenericBase()
+    {
+        const string source = """
+            package Issue2895Unqualified
+            import System
+
+            data struct Payload(Code int32)
+
+            open class Base {
+                internal var number int32 = 11
+                internal var payload Payload = Payload(44)
+            }
+
+            class Derived[T] : Base {
+                func Read() int32 { return number }
+                func Write() int32 {
+                    number = 22
+                    return number
+                }
+                func Compound() int32 {
+                    number += 11
+                    return number
+                }
+                func ReadPayload() int32 { return payload.Code }
+            }
+
+            let value = Derived[string]()
+            Console.WriteLine(value.Read())
+            Console.WriteLine(value.Write())
+            Console.WriteLine(value.Compound())
+            Console.WriteLine(value.ReadPayload())
+            """;
+
+        using var artifact = Compile(nameof(UnqualifiedAccessesInsideGenericDerivedUseNonGenericBase), source);
+        AssertFieldOwners(artifact.Assembly, "number", "Base", minimumReferences: 6);
+        AssertFieldOwners(artifact.Assembly, "payload", "Base", minimumReferences: 1);
+        AssertRuns(artifact.Path, "11\n22\n33\n44\n");
+    }
+
+    [Fact]
+    public void ExplicitReceiverWritesUseNonGenericBase()
+    {
+        const string source = """
+            package Issue2895Explicit
+            import System
+
+            open class Base {
+                internal var explicitValue int32
+            }
+
+            class Derived[T] : Base {
+            }
+
+            class Holder {
+                internal var child Derived[string] = Derived[string]()
+
+                func Write() int32 {
+                    child.explicitValue = 67
+                    return child.explicitValue
+                }
+            }
+
+            let top = Derived[string]()
+            top.explicitValue = 55
+            Console.WriteLine(top.explicitValue)
+
+            func Run() int32 {
+                let local = Derived[int32]()
+                local.explicitValue = 66
+                return local.explicitValue
+            }
+
+            Console.WriteLine(Run())
+            Console.WriteLine(Holder().Write())
+            """;
+
+        using var artifact = Compile(nameof(ExplicitReceiverWritesUseNonGenericBase), source);
+        AssertFieldOwners(artifact.Assembly, "explicitValue", "Base", minimumReferences: 6);
+        AssertRuns(artifact.Path, "55\n66\n67\n");
+    }
+
+    [Fact]
+    public void ObjectInitializerWriteUsesNonGenericBase()
+    {
+        const string source = """
+            package Issue2895Initializer
+            import System
+
+            open class Base {
+                internal var initializedValue int32
+            }
+
+            class Derived[T] : Base {
+            }
+
+            let value = Derived[string]() { initializedValue = 77 }
+            Console.WriteLine(value.initializedValue)
+            """;
+
+        using var artifact = Compile(nameof(ObjectInitializerWriteUsesNonGenericBase), source);
+        AssertFieldOwners(artifact.Assembly, "initializedValue", "Base", minimumReferences: 2);
+        AssertRuns(artifact.Path, "77\n");
+    }
+
+    [Fact]
+    public void MultiLevelAndNestedGenericDerivedUseTheirDeclaringBases()
+    {
+        const string source = """
+            package Issue2895Shapes
+            import System
+            import System.Collections.Generic
+
+            open class Root {
+                internal var deepValue int32 = 88
+            }
+
+            open class Mid[T] : Root {
+            }
+
+            class Deep[T] : Mid[List[T]] {
+                func Read() int32 { return deepValue }
+            }
+
+            open class NestedBase {
+                internal var nestedValue int32 = 99
+            }
+
+            class Container {
+                class Nested[T] : NestedBase {
+                    func Read() int32 { return nestedValue }
+                }
+            }
+
+            Console.WriteLine(Deep[string]().Read())
+            Console.WriteLine(Container.Nested[string]().Read())
+            """;
+
+        using var artifact = Compile(nameof(MultiLevelAndNestedGenericDerivedUseTheirDeclaringBases), source);
+        AssertFieldOwners(artifact.Assembly, "deepValue", "Root", minimumReferences: 1);
+        AssertFieldOwners(artifact.Assembly, "nestedValue", "NestedBase", minimumReferences: 1);
+        AssertRuns(artifact.Path, "88\n99\n");
+    }
+
+    [Fact]
+    public void GenericBaseShapesUseConstructedDeclaringBase()
+    {
+        const string source = """
+            package Issue2895GenericBases
+            import System
+            import System.Collections.Generic
+
+            data struct Payload(Code int32)
+
+            open class GenericBase[T] {
+                internal var genericValue T
+            }
+
+            class Forwarded[T] : GenericBase[T] {
+                func Set(value T) { genericValue = value }
+                func Read() T { return genericValue }
+            }
+
+            class Substituted[T] : GenericBase[int32] {
+                func Set(value int32) { genericValue = value }
+                func Read() int32 { return genericValue }
+            }
+
+            class NestedSubstitution[T] : GenericBase[List[T]] {
+                func Set(value List[T]) { genericValue = value }
+                func Read() List[T] { return genericValue }
+            }
+
+            let forwarded = Forwarded[Payload]()
+            forwarded.Set(Payload(11))
+            Console.WriteLine(forwarded.Read().Code)
+
+            let substituted = Substituted[string]()
+            substituted.Set(22)
+            Console.WriteLine(substituted.Read())
+
+            let values = List[string]()
+            values.Add("item")
+            let nested = NestedSubstitution[string]()
+            nested.Set(values)
+            Console.WriteLine(nested.Read().Count)
+            """;
+
+        using var artifact = Compile(nameof(GenericBaseShapesUseConstructedDeclaringBase), source);
+        AssertFieldOwners(artifact.Assembly, "genericValue", "GenericBase`1", minimumReferences: 6);
+        AssertRuns(artifact.Path, "11\n22\n1\n");
+    }
+
+    [Fact]
+    public void InheritedStaticFieldRemainsValid()
+    {
+        const string source = """
+            package Issue2895StaticGuard
+            import System
+
+            open class Base {
+                shared {
+                    internal var sharedValue int32
+                }
+            }
+
+            class Derived[T] : Base {
+            }
+
+            Derived[string].sharedValue = 44
+            Console.WriteLine(Derived[string].sharedValue)
+            """;
+
+        using var artifact = Compile(nameof(InheritedStaticFieldRemainsValid), source);
+        AssertFieldOwners(artifact.Assembly, "sharedValue", "Base", minimumReferences: 2);
+        AssertRuns(artifact.Path, "44\n");
+    }
+
+    [Fact]
+    public void InheritedFieldAddressRemainsValid()
+    {
+        const string source = """
+            package Issue2895AddressGuard
+            import System
+
+            open class Base {
+                internal var addressValue int32
+                func Read() int32 { return addressValue }
+            }
+
+            class Derived[T] : Base {
+            }
+
+            func SetAddress(out value int32) { value = 33 }
+
+            let value = Derived[string]()
+            SetAddress(&value.addressValue)
+            Console.WriteLine(value.Read())
+            """;
+
+        using var artifact = Compile(nameof(InheritedFieldAddressRemainsValid), source);
+        AssertFieldOwners(artifact.Assembly, "addressValue", "Base", minimumReferences: 2);
+        AssertRuns(artifact.Path, "33\n");
+    }
+
+    private static Artifact Compile(string name, string source)
+    {
+        var directory = Path.Combine(AppContext.BaseDirectory, nameof(Issue2895InheritedFieldDeclaringTypeTests), name);
+        if (Directory.Exists(directory))
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+
+        Directory.CreateDirectory(directory);
+        var sourcePath = Path.Combine(directory, "test.gs");
+        var assemblyPath = Path.Combine(directory, "test.dll");
+        File.WriteAllText(sourcePath, source);
+
+        var exitCode = Program.Main(new[]
+        {
+            "/out:" + assemblyPath,
+            "/target:exe",
+            "/targetframework:net10.0",
+            "/nowarn:GS9100",
+            sourcePath,
+        });
+        Assert.Equal(0, exitCode);
+
+        var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+        _ = assembly.GetTypes();
+        return new Artifact(directory, assemblyPath, assembly);
+    }
+
+    private static void AssertFieldOwners(
+        Assembly assembly,
+        string fieldName,
+        string expectedOwner,
+        int minimumReferences)
+    {
+        var fields = GetReferencedFields(assembly)
+            .Where(field => field.Name == fieldName)
+            .ToArray();
+
+        Assert.True(
+            fields.Length >= minimumReferences,
+            $"Expected at least {minimumReferences} references to '{fieldName}', found {fields.Length}.");
+        Assert.All(fields, field => Assert.Equal(expectedOwner, field.DeclaringType!.Name));
+    }
+
+    private static IEnumerable<FieldInfo> GetReferencedFields(Assembly assembly)
+    {
+        foreach (var type in assembly.GetTypes())
+        {
+            foreach (var method in type.GetMethods(
+                BindingFlags.Public
+                | BindingFlags.NonPublic
+                | BindingFlags.Static
+                | BindingFlags.Instance
+                | BindingFlags.DeclaredOnly))
+            {
+                var body = method.GetMethodBody();
+                var il = body?.GetILAsByteArray();
+                if (il == null)
+                {
+                    continue;
+                }
+
+                var offset = 0;
+                while (offset < il.Length)
+                {
+                    var value = (ushort)il[offset++];
+                    if (value == 0xfe)
+                    {
+                        value = (ushort)(0xfe00 | il[offset++]);
+                    }
+
+                    var opCode = OpCodesByValue[value];
+                    if (opCode.OperandType == OperandType.InlineField)
+                    {
+                        var token = BitConverter.ToInt32(il, offset);
+                        yield return method.Module.ResolveField(
+                            token,
+                            type.IsGenericType ? type.GetGenericArguments() : null,
+                            method.IsGenericMethod ? method.GetGenericArguments() : null)!;
+                    }
+
+                    offset += OperandSize(opCode.OperandType, il, offset);
+                }
+            }
+        }
+    }
+
+    private static int OperandSize(OperandType operandType, byte[] il, int offset) => operandType switch
+    {
+        OperandType.InlineNone => 0,
+        OperandType.ShortInlineBrTarget or OperandType.ShortInlineI or OperandType.ShortInlineVar => 1,
+        OperandType.InlineVar => 2,
+        OperandType.InlineI
+            or OperandType.InlineBrTarget
+            or OperandType.InlineField
+            or OperandType.InlineMethod
+            or OperandType.InlineSig
+            or OperandType.InlineString
+            or OperandType.InlineTok
+            or OperandType.InlineType
+            or OperandType.ShortInlineR => 4,
+        OperandType.InlineI8 or OperandType.InlineR => 8,
+        OperandType.InlineSwitch => 4 + (BitConverter.ToInt32(il, offset) * 4),
+        _ => throw new InvalidOperationException($"Unsupported IL operand type: {operandType}."),
+    };
+
+    private static void AssertRuns(string assemblyPath, string expectedOutput)
+    {
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        startInfo.ArgumentList.Add(assemblyPath);
+
+        using var process = Process.Start(startInfo)!;
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+        if (!process.WaitForExit(30_000))
+        {
+            process.Kill(entireProcessTree: true);
+            throw new Xunit.Sdk.XunitException("Child process timed out.");
+        }
+
+        var stdout = stdoutTask.GetAwaiter().GetResult().Replace("\r\n", "\n", StringComparison.Ordinal);
+        var stderr = stderrTask.GetAwaiter().GetResult().Replace("\r\n", "\n", StringComparison.Ordinal);
+        Assert.True(
+            process.ExitCode == 0,
+            $"Child exited {process.ExitCode}.\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        Assert.Equal(expectedOutput, stdout);
+        Assert.Equal(string.Empty, stderr);
+    }
+
+    private sealed class Artifact : IDisposable
+    {
+        public Artifact(string directory, string path, Assembly assembly)
+        {
+            Directory = directory;
+            Path = path;
+            Assembly = assembly;
+        }
+
+        public string Directory { get; }
+
+        public string Path { get; }
+
+        public Assembly Assembly { get; }
+
+        public void Dispose()
+        {
+            try
+            {
+                System.IO.Directory.Delete(Directory, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+    }
+}

--- a/test/Interpreter.Tests/Issue2895InheritedFieldDeclaringTypeTests.cs
+++ b/test/Interpreter.Tests/Issue2895InheritedFieldDeclaringTypeTests.cs
@@ -1,0 +1,74 @@
+// <copyright file="Issue2895InheritedFieldDeclaringTypeTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #2895 interpreter guards: inherited field access must agree with the compiler
+/// at top level and inside a function.
+/// </summary>
+[Collection("ConsoleIo")]
+public class Issue2895InheritedFieldDeclaringTypeTests
+{
+    [Theory]
+    [InlineData("TopLevel", """
+        import System
+
+        open class Base { internal var value int32 }
+        class Derived[T] : Base { }
+
+        let item = Derived[string]()
+        item.value = 121
+        Console.WriteLine(item.value)
+        """, "121\n")]
+    [InlineData("Function", """
+        import System
+
+        open class Base { internal var value int32 }
+        class Derived[T] : Base { }
+
+        func Run() int32 {
+            let item = Derived[string]()
+            item.value = 122
+            return item.value
+        }
+
+        Console.WriteLine(Run())
+        """, "122\n")]
+    public void InheritedFieldAccessRuns(string name, string source, string expected)
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            nameof(Issue2895InheritedFieldDeclaringTypeTests),
+            name);
+        Directory.CreateDirectory(directory);
+        var sourcePath = Path.Combine(directory, "test.gs");
+        File.WriteAllText(sourcePath, source);
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        int exitCode;
+        try
+        {
+            Console.SetOut(stdout);
+            Console.SetError(stderr);
+            exitCode = GSharp.Repl.Program.Main(new[] { sourcePath });
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(expected, stdout.ToString().Replace("\r\n", "\n", StringComparison.Ordinal));
+        Assert.Equal(string.Empty, stderr.ToString());
+    }
+}


### PR DESCRIPTION
## Summary

- preserve the field's declaring base type in object-initializer and explicit-receiver assignment bound nodes
- emit a non-generic declaring type directly instead of falling back to the generic receiver
- add metadata, load, child-process runtime, and interpreter coverage for the affected inheritance shapes

This changes inherited field reads/writes only. It does not change generic method-spec caching (#3065) or close any issue other than #2895.

Fixes #2895

## Root cause

`ResolveFieldReferenceContainer` represented a non-generic declaring type as `null`. Its callers interpreted `null` as “use the receiver,” so a field declared by `Base` was emitted as a MemberRef parented by `Derived<T>`. The assignment binder also discarded the declaring type already returned by `TryGetFieldIncludingInherited` in three write paths.

The fix keeps the declaring type end-to-end. Generic-base construction still uses the existing `FindConstructedGenericBase` path.

## Metadata and inheritance matrix

| Shape | Base metadata/runtime | HEAD metadata/runtime |
|---|---|---|
| `Derived[T] : Base`, unqualified read/write/compound | `Derived<T>::number`; invalid token / `MissingFieldException` | `Base::number`; `11`, `22`, `33` |
| G#-declared field type | `Derived<T>::payload`; invalid token | `Base::payload`; `44` |
| explicit receiver, top-level/function | `Derived<string>::explicitValue`; invalid token | `Base::explicitValue`; `55`, `66` |
| expression receiver (`child.explicitValue`) | `Derived<string>::explicitValue`; invalid token | `Base::explicitValue`; `67` |
| object initializer | `Derived<string>::initializedValue`; invalid token | `Base::initializedValue`; `77` |
| two levels via `Mid[List[T]]` | `Derived<T>::item`; invalid token | `Base::item`; correct value |
| nested generic derived class | nested `Derived<T>::item`; invalid token | `NestedPin.Base::item`; correct value |
| `Derived[T] : GenericBase[T]` | constructed `GenericBase<T>`; passes | unchanged; passes (`11`) |
| `Derived[T] : GenericBase[int32]` | constructed `GenericBase<int32>`; passes | unchanged; passes (`22`) |
| `Derived[T] : GenericBase[List[T]]` | constructed `GenericBase<List<T>>`; passes | unchanged; passes (`1`) |
| inherited static field | `Base::sharedValue`; passes | unchanged; passes (`44`) |
| inherited field address/out | `Base::addressValue`; passes | unchanged; passes (`33`) |
| struct base | rejected by the language (`GS0382`) | unchanged |

The base parents above were read from raw MemberRef metadata. HEAD field operands resolve through reflection to the listed `FieldInfo.DeclaringType`.

## Driver × position

| Driver / position | Base | HEAD |
|---|---|---|
| `gsc`, top-level | compile `0`; runtime `134`, `MissingFieldException` | compile `0`; runtime `0`, `121` |
| `gsc`, function | compile `0`; runtime `134`, `MissingFieldException` | compile `0`; runtime `0`, `122` |
| `gsi`, top-level | rc `0`, `121` | rc `0`, `121` |
| `gsi`, function | rc `0`, `122` | rc `0`, `122` |

## Base pins and guards

The seven compiler facts were run with all production hunks reverted:

- pins (fail at base, pass at HEAD): **4**
  - `UnqualifiedAccessesInsideGenericDerivedUseNonGenericBase`
  - `ExplicitReceiverWritesUseNonGenericBase`
  - `ObjectInitializerWriteUsesNonGenericBase`
  - `MultiLevelAndNestedGenericDerivedUseTheirDeclaringBases`
- guards (pass at base and HEAD): **3**
  - constructed generic-base shapes
  - inherited static field
  - inherited field address/out

The two actual-`gsi` position facts are guards and pass at base and HEAD.

## Consumer count

Making `ResolveFieldToken` require a third parameter produced **19 consumers** on the final merged tree:

- 16 direct calls (`CS7036`)
- 3 method-group/delegate uses (`CS1503`)

The production fix remains at the shared field-container resolution and bound-node owner points; it does not patch individual token consumers.

## Mutation results

Each mutant built successfully, changed `GSharp.Core.dll`, and was followed by a full rebuild whose hash returned to the clean value.

| Production arm | Build-green mutant | Killing test | Result |
|---|---|---|---|
| non-generic emitter fallback | restore `null` fallback | `UnqualifiedAccessesInsideGenericDerivedUseNonGenericBase` | killed: emitted field token cannot resolve |
| object-initializer owner | use receiver type | `ObjectInitializerWriteUsesNonGenericBase` | killed: emitted field token cannot resolve |
| simple-variable assignment owner | use receiver type | `ExplicitReceiverWritesUseNonGenericBase` | killed: emitted field token cannot resolve |
| expression-receiver assignment owner | use receiver type | `ExplicitReceiverWritesUseNonGenericBase` | killed: emitted field token cannot resolve |

Clean Core hash: `5417e6ad49a15dc356f4114f3b72fbb997926acfc9fc5a6df9cf5baab0e42520`.
Mutant hashes: `90f2f7d7`, `45286c47`, `abad8096`, `6a7bc03e`; every restored build returned to the clean hash.

## Validation

- merged tree: `git merge-tree --write-tree origin/main HEAD` equals `HEAD^{tree}`
- Release CI build: 0 warnings, 0 errors
- targeted compiler: 7 passed
- targeted interpreter: 2 passed
- full merged suite: **14,257 passed, 0 failed, 1 skipped**
- cs2gs corpus: 20 apps examined; 19 green; 1 known baseline gap; 0 new, 0 regressed, 0 stale
- artifacts: 4,637 production DLLs examined, 0 zero-byte; 12 intentional zero-byte pipeline fixtures excluded
- direct `GSharp.Core.dll` copies: 22 examined, one mtime and one hash

The local Oahu script was not run because it invokes e2e tests, which are prohibited for this worktree; the required `cs2gs-oahu` CI job passed.
