### PR TITLE
Fix explicit constructor accessibility emission

### DIFF
--- a/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
@@ -1695,7 +1695,7 @@ internal sealed class TypeDefEmitter
         var firstCtorParamHandle = this.AddRefKindAwareParameterRows(function.Parameters, out var ctorParamHandles);
 
         var ctorHandle = this.emitCtx.Metadata.AddMethodDefinition(
-            attributes: MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.SpecialName
+            attributes: AccessibilityMap.ToMethodVisibility(function.Accessibility) | MethodAttributes.HideBySig | MethodAttributes.SpecialName
                 | MethodAttributes.RTSpecialName,
             implAttributes: MethodImplAttributes.IL | MethodImplAttributes.Managed,
             name: this.emitCtx.Metadata.GetOrAddString(".ctor"),

--- a/test/Compiler.Tests/Emit/Issue2893ConstructorAccessibilityEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2893ConstructorAccessibilityEmitTests.cs
@@ -1,0 +1,241 @@
+// <copyright file="Issue2893ConstructorAccessibilityEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>Regression coverage for issue #2893.</summary>
+public sealed class Issue2893ConstructorAccessibilityEmitTests
+{
+    private const string Source = """
+        package Issue2893
+        import System
+
+        class PublicCtor {
+            var Value int32
+            public init(value int32) { Value = value }
+        }
+
+        class InternalCtor {
+            internal init(value int32) {}
+        }
+
+        open class ProtectedCtor {
+            protected init(value int32) {}
+        }
+
+        class PrivateCtor {
+            private init(value int32) {}
+        }
+
+        class DefaultCtor {
+            var Value int32
+            init(value int32) { Value = value }
+        }
+
+        class FuncInitInternal {
+            internal func init(value int32) {}
+        }
+
+        class ConvenienceCtor {
+            public init(value int32, other int32) {}
+            private convenience init(value int32) { init(value, 0) }
+        }
+
+        class Outer {
+            class NestedPrivate {
+                private init(value int32) {}
+            }
+        }
+
+        class GenericPrivate[T] {
+            private init(value int32) {}
+        }
+
+        data class DataPrivate {
+            private init(value int32) {}
+        }
+
+        struct StructPrivate {
+            private init(value int32) {}
+        }
+
+        class SynthesizedDefault {
+            var Value int32 = 33
+        }
+
+        class PrimaryCtor(value int32) {}
+
+        class StaticInitializer {
+            shared {
+                var Value int32
+                init { Value = 44 }
+                func Read() int32 -> Value
+            }
+        }
+
+        func Main() {
+            Console.WriteLine(PublicCtor(11).Value)
+            Console.WriteLine(DefaultCtor(22).Value)
+            Console.WriteLine(SynthesizedDefault().Value)
+            Console.WriteLine(PrimaryCtor(34).value)
+            Console.WriteLine(StaticInitializer.Read())
+        }
+        """;
+
+    [Fact]
+    public void NonPublicExplicitConstructors_EmitDeclaredAccessibility()
+    {
+        Verify(types =>
+        {
+            AssertConstructorVisibility(types, "Issue2893.InternalCtor", MethodAttributes.Assembly, typeof(int));
+            AssertConstructorVisibility(types, "Issue2893.ProtectedCtor", MethodAttributes.Family, typeof(int));
+            AssertConstructorVisibility(types, "Issue2893.PrivateCtor", MethodAttributes.Private, typeof(int));
+            AssertConstructorVisibility(types, "Issue2893.FuncInitInternal", MethodAttributes.Assembly, typeof(int));
+            AssertConstructorVisibility(types, "Issue2893.ConvenienceCtor", MethodAttributes.Private, typeof(int));
+            AssertConstructorVisibility(types, "Issue2893.Outer+NestedPrivate", MethodAttributes.Private, typeof(int));
+            AssertConstructorVisibility(types, "Issue2893.GenericPrivate`1", MethodAttributes.Private, typeof(int));
+            AssertConstructorVisibility(types, "Issue2893.DataPrivate", MethodAttributes.Private, typeof(int));
+            AssertConstructorVisibility(types, "Issue2893.StructPrivate", MethodAttributes.Private, typeof(int));
+        });
+    }
+
+    [Fact]
+    public void PublicDefaultAndStaticConstructors_RemainUnchanged()
+    {
+        Verify(types =>
+        {
+            AssertConstructorVisibility(types, "Issue2893.PublicCtor", MethodAttributes.Public, typeof(int));
+            AssertConstructorVisibility(types, "Issue2893.DefaultCtor", MethodAttributes.Public, typeof(int));
+            AssertConstructorVisibility(types, "Issue2893.SynthesizedDefault", MethodAttributes.Public);
+            AssertConstructorVisibility(types, "Issue2893.PrimaryCtor", MethodAttributes.Public, typeof(int));
+
+            var staticInitializer = types.Single(type => type.FullName == "Issue2893.StaticInitializer").TypeInitializer;
+            Assert.NotNull(staticInitializer);
+            Assert.Equal(
+                MethodAttributes.Private,
+                staticInitializer.Attributes & MethodAttributes.MemberAccessMask);
+            Assert.True(staticInitializer.IsStatic);
+        });
+    }
+
+    private static void Verify(Action<Type[]> assertions)
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            nameof(Issue2893ConstructorAccessibilityEmitTests),
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            var assemblyPath = Compile(Source, directory);
+            IlVerifier.Verify(assemblyPath);
+
+            var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+            var types = assembly.GetTypes();
+            Assert.Equal(16, types.Length);
+            assertions(types);
+            Assert.Equal("11\n22\n33\n34\n44\n", Run(assemblyPath, directory));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static string Compile(string source, string directory)
+    {
+        var sourcePath = Path.Combine(directory, "Program.gs");
+        var assemblyPath = Path.Combine(directory, "Program.dll");
+        File.WriteAllText(sourcePath, source);
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        int exitCode;
+        try
+        {
+            exitCode = Program.Main(new[]
+            {
+                "/out:" + assemblyPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                sourcePath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+
+        Assert.True(
+            exitCode == 0,
+            $"gsc exited {exitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return assemblyPath;
+    }
+
+    private static void AssertConstructorVisibility(
+        Type[] types,
+        string typeName,
+        MethodAttributes expected,
+        params Type[] parameterTypes)
+    {
+        var type = types.Single(candidate => candidate.FullName == typeName);
+        var constructor = type.GetConstructor(
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly,
+            binder: null,
+            parameterTypes,
+            modifiers: null);
+
+        Assert.NotNull(constructor);
+        Assert.Equal(expected, constructor.Attributes & MethodAttributes.MemberAccessMask);
+    }
+
+    private static string Run(string assemblyPath, string directory)
+    {
+        var runtimeConfigPath = Path.ChangeExtension(assemblyPath, "runtimeconfig.json");
+        File.WriteAllText(
+            runtimeConfigPath,
+            """
+            {
+              "runtimeOptions": {
+                "tfm": "net10.0",
+                "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+              }
+            }
+            """);
+
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = directory,
+        };
+        startInfo.ArgumentList.Add("exec");
+        startInfo.ArgumentList.Add("--runtimeconfig");
+        startInfo.ArgumentList.Add(runtimeConfigPath);
+        startInfo.ArgumentList.Add(assemblyPath);
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start emitted program.");
+        var stdout = process.StandardOutput.ReadToEndAsync();
+        var stderr = process.StandardError.ReadToEndAsync();
+        Assert.True(process.WaitForExit(30_000), "Emitted program timed out.");
+        Assert.True(
+            process.ExitCode == 0,
+            $"emitted program exited {process.ExitCode}\nstdout:\n{stdout.Result}\nstderr:\n{stderr.Result}");
+        return stdout.Result.Replace("\r\n", "\n");
+    }
+}


### PR DESCRIPTION
Fixes #2893

## Root cause and fix

`DeclarationBinder` already preserves the declared constructor accessibility on `ConstructorSymbol.Function.Accessibility`. `TypeDefEmitter.EmitClassConstructorWithBody` discarded it and always emitted `MethodAttributes.Public`.

The emitter now reuses the existing canonical `AccessibilityMap.ToMethodVisibility` mapping. No new accessibility mapper or diagnostic was added.

## Accessibility and declaration-context matrix

All emitted results were read through `Assembly.Load(File.ReadAllBytes(...))`, `Assembly.GetTypes()`, and `ConstructorInfo.Attributes`/visibility properties. The emitted executable also ran in a child `dotnet exec` process and printed `11`, `22`, `33`, `34`, `44`.

| Source shape | Before | After | Expected |
|---|---|---|---|
| top-level `public init` | `Public` | `Public` | `Public` |
| top-level `internal init` | `Public` | `Assembly` | `Assembly` |
| top-level `protected init` | `Public` | `Family` | `Family` |
| top-level `private init` | `Public` | `Private` | `Private` |
| top-level `init` with no modifier | `Public` | `Public` | `Public` |
| `internal func init` alternate syntax | `Public` | `Assembly` | `Assembly` |
| `private convenience init` | `Public` | `Private` | `Private` |
| nested-class `private init` | `Public` | `Private` | `Private` |
| generic-class `private init` | `Public` | `Private` | `Private` |
| data-class `private init` | `Public` | `Private` | `Private` |
| plain-struct `private init` | `Public` | `Private` | `Private` |
| synthesized default constructor | `Public` | `Public` | `Public` |
| primary constructor | `Public` | `Public` | `Public` |
| shared static initializer `.cctor` | `Private, Static` | `Private, Static` | `Private, Static` |
| interface constructor | parser rejects with `GS0005` | unchanged | not expressible |
| data/inline-struct explicit constructor | parser rejects with `GS0005` | unchanged | not expressible |

`gsi` and `gsc` agree: public/internal/default construction produced `11/22/33`; external private construction produced `GS0472`; external protected construction produced `GS0379`.

## Emitter-site denominator

I temporarily added a required parameter to `EmitClassConstructorWithBody`. The compiler reported `CS7036` at **2 unique source call sites**:

1. class explicit constructors: `ReflectionMetadataEmitter.cs:3367`
2. plain-struct explicit constructors: `ReflectionMetadataEmitter.cs:3541`

The solution build printed 8 duplicated diagnostic lines across build targets, but the counted population is 2 unique source sites. Both flow through the single fixed attribute-setting hunk.

## Mutation testing

| Product hunk | Build-green mutant | Detection | Guard | Restore |
|---|---|---|---|---|
| explicit constructor `MethodAttributes` | replaced accessibility mapping with `MethodAttributes.Public` | `NonPublicExplicitConstructors_EmitDeclaredAccessibility` failed: expected `Assembly`, actual `Public` | `PublicDefaultAndStaticConstructors_RemainUnchanged` passed | full rebuild restored clean Core DLL hash; both tests passed 2/2 |

The mutant build succeeded with 0 warnings/errors and changed `GSharp.Core.dll`; restoration rebuilt again and round-tripped to the clean hash.

## Verification

- Latest merge base: `5ad0109c04608f627e35d797d1735ca21d8311f2`
- `git merge-tree --write-tree origin/main HEAD`: exit 0; merged tree matched `HEAD` tree (1/1 comparison)
- Release CI build: 0 warnings, 0 errors; five driver/test Core DLL copies fresh together; 0 zero-byte Core DLLs
- Targeted tests: failed 1/1 on unfixed product; passed 2/2 on HEAD
- Full `Compiler.Tests`: **0 failed, 4047 passed, 0 skipped, 4047 total**
- Full `Cs2Gs.Tests`: **0 failed, 1863 passed, 0 skipped, 1863 total**
- cs2gs corpus gate: 19/20 green; known baseline 1, new 0, regressed 0, stale 0; `G11-Linq-Console` passed all stages
