### PR TITLE
Fix generic CLR static stores

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundClrPropertyAssignmentExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundClrPropertyAssignmentExpression.cs
@@ -26,9 +26,9 @@ public sealed class BoundClrPropertyAssignmentExpression : BoundExpression
         MemberInfo member,
         BoundExpression value,
         TypeSymbol resultType,
+        TypeSymbol staticContainerType,
         TypeParameterSymbol constrainedReceiverTypeParameter = null,
-        TypeSymbol constrainedInterfaceType = null,
-        TypeSymbol staticContainerType = null)
+        TypeSymbol constrainedInterfaceType = null)
         : base(syntax)
     {
         Receiver = receiver;

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -1681,6 +1681,7 @@ public abstract class BoundTreeRewriter
             node.Member,
             value,
             node.Type,
+            node.StaticContainerType,
             node.ConstrainedReceiverTypeParameter,
             node.ConstrainedInterfaceType);
     }

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -3153,7 +3153,8 @@ internal sealed class ConversionClassifier
                     receiver,
                     slot.TargetClrMember,
                     value,
-                    slot.TargetType);
+                    slot.TargetType,
+                    staticContainerType: null);
             }
 
             statements.Add(new BoundExpressionStatement(expression.Syntax, assignment));

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -457,7 +457,7 @@ internal sealed partial class ExpressionBinder
             var value = BindExpression(initSyntax.Value);
             var converted = conversions.BindConversion(initSyntax.Value.Location, value, instTargetSymbol);
             var receiverExpr = new BoundVariableExpression(initSyntax, receiverLocal);
-            return new BoundClrPropertyAssignmentExpression(initSyntax, receiverExpr, instanceMember, converted, instTargetSymbol);
+            return new BoundClrPropertyAssignmentExpression(initSyntax, receiverExpr, instanceMember, converted, instTargetSymbol, staticContainerType: null);
         }
 
         if (receiverType is StructSymbol structSymbol)
@@ -518,7 +518,7 @@ internal sealed partial class ExpressionBinder
                     var value = BindExpression(initSyntax.Value);
                     var converted = conversions.BindConversion(initSyntax.Value.Location, value, inhTargetSymbol);
                     var receiverExpr = new BoundVariableExpression(initSyntax, receiverLocal);
-                    return new BoundClrPropertyAssignmentExpression(initSyntax, receiverExpr, inhMember, converted, inhTargetSymbol);
+                    return new BoundClrPropertyAssignmentExpression(initSyntax, receiverExpr, inhMember, converted, inhTargetSymbol, staticContainerType: null);
                 }
             }
 
@@ -611,7 +611,7 @@ internal sealed partial class ExpressionBinder
                 {
                     var inheritedValue = BindAssignmentRhs(syntax.Value, inheritedTarget);
                     var inheritedConverted = conversions.BindConversion(syntax.Value.Location, inheritedValue, inheritedTarget);
-                    return new BoundClrPropertyAssignmentExpression(null, receiver: null, inheritedStaticMember, inheritedConverted, inheritedTarget);
+                    return new BoundClrPropertyAssignmentExpression(null, receiver: null, inheritedStaticMember, inheritedConverted, inheritedTarget, staticContainerType: null);
                 }
             }
 
@@ -665,7 +665,7 @@ internal sealed partial class ExpressionBinder
             _ = staticTargetType;
             var staticValue = BindAssignmentRhs(syntax.Value, staticTargetSymbol);
             var staticConverted = conversions.BindConversion(syntax.Value.Location, staticValue, staticTargetSymbol);
-            return new BoundClrPropertyAssignmentExpression(null, receiver: null, staticMember, staticConverted, staticTargetSymbol);
+            return new BoundClrPropertyAssignmentExpression(null, receiver: null, staticMember, staticConverted, staticTargetSymbol, staticContainerType: null);
         }
 
         var variable = BindVariableReference(receiverName, syntax.Receiver.Location);
@@ -756,7 +756,7 @@ internal sealed partial class ExpressionBinder
             _ = instWritable;
             _ = instTargetType;
             var instConverted = conversions.BindConversion(syntax.Value.Location, BindValue(instTargetSymbol), instTargetSymbol);
-            return new BoundClrPropertyAssignmentExpression(null, assignmentReceiver, instanceMember, instConverted, instTargetSymbol);
+            return new BoundClrPropertyAssignmentExpression(null, assignmentReceiver, instanceMember, instConverted, instTargetSymbol, staticContainerType: null);
         }
 
         // Issue #1068: an interface-typed variable receiver (`d.W = v` where
@@ -861,8 +861,9 @@ internal sealed partial class ExpressionBinder
                         clrProperty,
                         constrainedConverted,
                         propertyType,
-                        tpVarType,
-                        declaringInterface);
+                        staticContainerType: null,
+                        constrainedReceiverTypeParameter: tpVarType,
+                        constrainedInterfaceType: declaringInterface);
                 }
             }
 
@@ -930,7 +931,7 @@ internal sealed partial class ExpressionBinder
                     _ = inhWritable;
                     _ = inhTargetType;
                     var inhConverted = conversions.BindConversion(syntax.Value.Location, BindValue(inhTargetSymbol), inhTargetSymbol);
-                    return new BoundClrPropertyAssignmentExpression(null, assignmentReceiver, clrMember, inhConverted, inhTargetSymbol);
+                    return new BoundClrPropertyAssignmentExpression(null, assignmentReceiver, clrMember, inhConverted, inhTargetSymbol, staticContainerType: null);
                 }
             }
 
@@ -1577,7 +1578,7 @@ internal sealed partial class ExpressionBinder
         }
 
         var converted = conversions.BindConversion(syntax.Value.Location, binary, targetSymbol);
-        return new BoundClrPropertyAssignmentExpression(null, boundReceiver, instanceMember, converted, targetSymbol);
+        return new BoundClrPropertyAssignmentExpression(null, boundReceiver, instanceMember, converted, targetSymbol, staticContainerType: null);
     }
 
     /// <summary>
@@ -2147,7 +2148,7 @@ internal sealed partial class ExpressionBinder
                     _ = inhWritable;
                     _ = inhTargetType;
                     var inhConverted = conversions.BindConversion(syntax.Value.Location, BindValue(inhTargetSymbol), inhTargetSymbol);
-                    return new BoundClrPropertyAssignmentExpression(null, receiver, clrMember, inhConverted, inhTargetSymbol);
+                    return new BoundClrPropertyAssignmentExpression(null, receiver, clrMember, inhConverted, inhTargetSymbol, staticContainerType: null);
                 }
             }
 
@@ -2209,8 +2210,9 @@ internal sealed partial class ExpressionBinder
                     clrProperty,
                     constrainedConverted,
                     propertyType,
-                    tpReceiver,
-                    declaringInterface);
+                    staticContainerType: null,
+                    constrainedReceiverTypeParameter: tpReceiver,
+                    constrainedInterfaceType: declaringInterface);
             }
 
             Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, fieldName);
@@ -2243,7 +2245,7 @@ internal sealed partial class ExpressionBinder
             _ = instWritable;
             _ = instTargetType;
             var instConverted = conversions.BindConversion(syntax.Value.Location, BindValue(instTargetSymbol), instTargetSymbol);
-            return new BoundClrPropertyAssignmentExpression(null, receiver, instanceMember, instConverted, instTargetSymbol);
+            return new BoundClrPropertyAssignmentExpression(null, receiver, instanceMember, instConverted, instTargetSymbol, staticContainerType: null);
         }
 
         Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, fieldName);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -1682,7 +1682,7 @@ internal sealed partial class ExpressionBinder
             var receiverExpr = new BoundVariableExpression(initSyntax, tempVar);
             statements.Add(new BoundExpressionStatement(
                 initSyntax,
-                new BoundClrPropertyAssignmentExpression(initSyntax, receiverExpr, member, converted, targetSymbol)));
+                new BoundClrPropertyAssignmentExpression(initSyntax, receiverExpr, member, converted, targetSymbol, staticContainerType: null)));
         }
 
         var resultExpr = new BoundVariableExpression(syntax, tempVar);
@@ -1810,8 +1810,9 @@ internal sealed partial class ExpressionBinder
                             clrProperty,
                             converted,
                             propertyType,
-                            tp,
-                            declaringInterface)));
+                            staticContainerType: null,
+                            constrainedReceiverTypeParameter: tp,
+                            constrainedInterfaceType: declaringInterface)));
                     continue;
                 }
             }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -1951,7 +1951,7 @@ internal sealed partial class ExpressionBinder
 
         var value = BindAssignmentRhs(valueSyntax, targetSymbol);
         var converted = conversions.BindConversion(valueSyntax.Location, value, targetSymbol);
-        bound = new BoundClrPropertyAssignmentExpression(null, receiver, member, converted, targetSymbol);
+        bound = new BoundClrPropertyAssignmentExpression(null, receiver, member, converted, targetSymbol, staticContainerType: null);
         return true;
     }
 

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Jumps.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Jumps.cs
@@ -867,8 +867,23 @@ internal sealed partial class StatementBinder
                 var receiver = clrPropAccess.Receiver == null
                     ? null
                     : CaptureReceiver(syntax, clrPropAccess.Receiver, preStatements);
-                var read = new BoundClrPropertyAccessExpression(syntax, receiver, clrPropAccess.Member, clrPropAccess.Type);
-                var write = new BoundClrPropertyAssignmentExpression(syntax, receiver, clrPropAccess.Member, boundRhs, clrPropAccess.Type);
+                var read = new BoundClrPropertyAccessExpression(
+                    syntax,
+                    receiver,
+                    clrPropAccess.Member,
+                    clrPropAccess.Type,
+                    clrPropAccess.StaticContainerType,
+                    clrPropAccess.ConstrainedReceiverTypeParameter,
+                    clrPropAccess.ConstrainedInterfaceType);
+                var write = new BoundClrPropertyAssignmentExpression(
+                    syntax,
+                    receiver,
+                    clrPropAccess.Member,
+                    boundRhs,
+                    clrPropAccess.Type,
+                    clrPropAccess.StaticContainerType,
+                    clrPropAccess.ConstrainedReceiverTypeParameter,
+                    clrPropAccess.ConstrainedInterfaceType);
                 return (read, write);
             }
 

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
@@ -1173,12 +1173,16 @@ internal sealed partial class MethodBodyEmitter
                 // setter MemberRef parent is the constructed symbolic type when
                 // applicable. Falls back to the plain MemberRef path otherwise.
                 this.il.Token(isStatic
-                    ? (EntityHandle)this.outer.memberRefs.GetMethodReference(setter)
+                    ? (assn.StaticContainerType != null
+                        ? this.outer.memberRefs.GetMethodEntityHandle(setter, assn.StaticContainerType)
+                        : (EntityHandle)this.outer.memberRefs.GetMethodReference(setter))
                     : this.outer.memberRefs.GetMethodEntityHandle(setter, assn.Receiver.Type));
                 break;
             case FieldInfo field:
                 this.il.OpCode(isStatic ? ILOpCode.Stsfld : ILOpCode.Stfld);
-                this.il.Token(this.outer.memberRefs.GetFieldReference(field));
+                this.il.Token(assn.StaticContainerType != null
+                    ? this.outer.memberRefs.GetFieldReference(field, assn.StaticContainerType)
+                    : this.outer.memberRefs.GetFieldReference(field));
                 break;
             default:
                 throw new NotSupportedException(

--- a/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
@@ -506,6 +506,7 @@ public static class SpillSequenceSpiller
                             clrPropAssign.Member,
                             val,
                             clrPropAssign.Type,
+                            clrPropAssign.StaticContainerType,
                             clrPropAssign.ConstrainedReceiverTypeParameter,
                             clrPropAssign.ConstrainedInterfaceType));
                 case BoundClrBinaryOperatorExpression clrBinary:

--- a/src/Core/CodeAnalysis/Lowering/SideEffectSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/SideEffectSpiller.cs
@@ -276,6 +276,7 @@ internal sealed class SideEffectSpiller : NestedFunctionBodyRewriter
             rewritten.Member,
             value,
             rewritten.Type,
+            rewritten.StaticContainerType,
             rewritten.ConstrainedReceiverTypeParameter,
             rewritten.ConstrainedInterfaceType);
 

--- a/test/Compiler.Tests/ImportedMemberMatrixTests.cs
+++ b/test/Compiler.Tests/ImportedMemberMatrixTests.cs
@@ -13,6 +13,162 @@ namespace GSharp.Compiler.Tests;
 
 public class ImportedMemberMatrixTests
 {
+    private const string Issue3076CsSource = """
+        namespace Issue3076.CSharp
+        {
+            public static class Issue3076GenericStaticSlot<T>
+            {
+                public static int Property { get; set; }
+                public static int Field;
+                public static string? TextProperty { get; set; }
+                public static string? TextField;
+
+                public static int ReadProperty() => Property;
+                public static int ReadField() => Field;
+            }
+
+            public static class Issue3076GenericPairSlot<TFirst, TSecond>
+            {
+                public static int Property { get; set; }
+                public static int Field;
+            }
+
+            public sealed class Issue3076GenericBox<T>
+            {
+            }
+
+            public static class Issue3076PlainStaticSlot
+            {
+                public static int Property { get; set; }
+                public static int Field;
+            }
+
+            public static class Issue3076AsyncValues
+            {
+                public static System.Threading.Tasks.Task<int> Get(int value)
+                    => System.Threading.Tasks.Task.FromResult(value);
+            }
+        }
+        """;
+
+    [Theory]
+    [InlineData(false, "301\n302\n311\n312\n321\n322\n331\n332\n341\n342\n351\n352\n")]
+    [InlineData(true, "201\n202\n211\n212\n121\n122\n221\n222\n231\n232\n241\n242\n")]
+    public void Issue3076_GenericStaticClrStores_CompileAndRun(bool throughTypeParameter, string expected)
+    {
+        var source = Issue3076Source("Issue3076.CSharp", throughTypeParameter);
+        Assert.Equal(expected, CompileAndRunWithSiblingCs(Issue3076CsSource, source, "Issue3076.CSharp"));
+    }
+
+    [Fact]
+    public void Issue3076_GenericStaticClrStores_PreserveContainerThroughSideEffectSpilling()
+    {
+        const string source = """
+            import Issue3076.CSharp
+            import System
+
+            func PropertyMarker() int32 { return 401 }
+            func FieldMarker() int32 { return 402 }
+
+            func Store[T]() {
+                Issue3076GenericStaticSlot[T].Property = PropertyMarker()
+                Issue3076GenericStaticSlot[T].Field = FieldMarker()
+            }
+
+            Issue3076GenericStaticSlot[int32].Property = 101
+            Issue3076GenericStaticSlot[int32].Field = 102
+            Issue3076GenericStaticSlot[object].Property = 121
+            Issue3076GenericStaticSlot[object].Field = 122
+            Store[int32]()
+            Console.WriteLine(Issue3076GenericStaticSlot[int32].Property)
+            Console.WriteLine(Issue3076GenericStaticSlot[int32].Field)
+            Console.WriteLine(Issue3076GenericStaticSlot[object].Property)
+            Console.WriteLine(Issue3076GenericStaticSlot[object].Field)
+            """;
+
+        Assert.Equal(
+            "401\n402\n121\n122\n",
+            CompileAndRunWithSiblingCs(Issue3076CsSource, source, "Issue3076.CSharp"));
+    }
+
+    [Fact]
+    public void Issue3076_GenericStaticClrStores_PreserveContainerThroughNullCoalescingAssignment()
+    {
+        const string source = """
+            import Issue3076.CSharp
+            import System
+
+            func StoreIfMissing[T]() {
+                Issue3076GenericStaticSlot[T].TextProperty ??= "property"
+                Issue3076GenericStaticSlot[T].TextField ??= "field"
+            }
+
+            Issue3076GenericStaticSlot[int32].TextProperty = nil
+            Issue3076GenericStaticSlot[int32].TextField = nil
+            Issue3076GenericStaticSlot[object].TextProperty = "object-property"
+            Issue3076GenericStaticSlot[object].TextField = "object-field"
+            StoreIfMissing[int32]()
+            Console.WriteLine(Issue3076GenericStaticSlot[int32].TextProperty)
+            Console.WriteLine(Issue3076GenericStaticSlot[int32].TextField)
+            Console.WriteLine(Issue3076GenericStaticSlot[object].TextProperty)
+            Console.WriteLine(Issue3076GenericStaticSlot[object].TextField)
+            """;
+
+        Assert.Equal(
+            "property\nfield\nobject-property\nobject-field\n",
+            CompileAndRunWithSiblingCs(Issue3076CsSource, source, "Issue3076.CSharp"));
+    }
+
+    [Fact]
+    public void Issue3076_GenericStaticClrStores_PreserveContainerThroughAsyncSpilling()
+    {
+        const string source = """
+            import Issue3076.CSharp
+            import System
+
+            async func StoreAsync[T]() {
+                Issue3076GenericStaticSlot[T].Property = await Issue3076AsyncValues.Get(501)
+                Issue3076GenericStaticSlot[T].Field = await Issue3076AsyncValues.Get(502)
+            }
+
+            Issue3076GenericStaticSlot[int32].Property = 101
+            Issue3076GenericStaticSlot[int32].Field = 102
+            Issue3076GenericStaticSlot[object].Property = 121
+            Issue3076GenericStaticSlot[object].Field = 122
+            StoreAsync[int32]().GetAwaiter().GetResult()
+            Console.WriteLine(Issue3076GenericStaticSlot[int32].Property)
+            Console.WriteLine(Issue3076GenericStaticSlot[int32].Field)
+            Console.WriteLine(Issue3076GenericStaticSlot[object].Property)
+            Console.WriteLine(Issue3076GenericStaticSlot[object].Field)
+            """;
+
+        Assert.Equal(
+            "501\n502\n121\n122\n",
+            CompileAndRunWithSiblingCs(Issue3076CsSource, source, "Issue3076.CSharp"));
+    }
+
+    [Theory]
+    [InlineData(false, "301\n302\n311\n312\n321\n322\n331\n332\n341\n342\n351\n352\n")]
+    [InlineData(true, "201\n202\n211\n212\n121\n122\n221\n222\n231\n232\n241\n242\n")]
+    public void Issue3076_GenericStaticClrStores_Evaluate(bool throughTypeParameter, string expected)
+    {
+        var workDir = CreateWorkDir("issue3076_evaluate_");
+        try
+        {
+            var sourcePath = Path.Combine(workDir, "test.gs");
+            File.WriteAllText(sourcePath, Issue3076Source("GSharp.Compiler.Tests", throughTypeParameter));
+
+            var (exitCode, output) = RunCompiler(new[] { sourcePath });
+
+            Assert.Equal(0, exitCode);
+            Assert.Equal(expected + "Success.\n", output.Replace("\r\n", "\n"));
+        }
+        finally
+        {
+            TryDelete(workDir);
+        }
+    }
+
     [Fact]
     public void ImportedMemberMatrix_GenericImportedInterfaceMethodAndInterfaceObjectMembers_CompileAndRun()
     {
@@ -946,6 +1102,113 @@ public class ImportedMemberMatrixTests
         {
             TryDelete(workDir);
         }
+    }
+
+    private static string Issue3076Source(string fixtureNamespace, bool throughTypeParameter)
+    {
+        if (!throughTypeParameter)
+        {
+            return $$"""
+                    import {{fixtureNamespace}}
+                    import System
+
+                    Issue3076GenericStaticSlot[int32].Property = 301
+                    Issue3076GenericStaticSlot[int32].Field = 302
+                    Issue3076GenericStaticSlot[string].Property = 311
+                    Issue3076GenericStaticSlot[string].Field = 312
+                    Issue3076GenericStaticSlot[object].Property = 321
+                    Issue3076GenericStaticSlot[object].Field = 322
+                    Issue3076GenericStaticSlot[Issue3076GenericBox[int32]].Property = 331
+                    Issue3076GenericStaticSlot[Issue3076GenericBox[int32]].Field = 332
+                    Issue3076GenericPairSlot[int32, string].Property = 341
+                    Issue3076GenericPairSlot[int32, string].Field = 342
+                    Issue3076PlainStaticSlot.Property = 351
+                    Issue3076PlainStaticSlot.Field = 352
+
+                    Console.WriteLine(Issue3076GenericStaticSlot[int32].Property)
+                    Console.WriteLine(Issue3076GenericStaticSlot[int32].Field)
+                    Console.WriteLine(Issue3076GenericStaticSlot[string].Property)
+                    Console.WriteLine(Issue3076GenericStaticSlot[string].Field)
+                    Console.WriteLine(Issue3076GenericStaticSlot[object].Property)
+                    Console.WriteLine(Issue3076GenericStaticSlot[object].Field)
+                    Console.WriteLine(Issue3076GenericStaticSlot[Issue3076GenericBox[int32]].Property)
+                    Console.WriteLine(Issue3076GenericStaticSlot[Issue3076GenericBox[int32]].Field)
+                    Console.WriteLine(Issue3076GenericPairSlot[int32, string].Property)
+                    Console.WriteLine(Issue3076GenericPairSlot[int32, string].Field)
+                    Console.WriteLine(Issue3076PlainStaticSlot.Property)
+                    Console.WriteLine(Issue3076PlainStaticSlot.Field)
+                """;
+        }
+
+        return $$"""
+                import {{fixtureNamespace}}
+                import System
+
+                func Store[T](propertyValue int32, fieldValue int32) {
+                    Issue3076GenericStaticSlot[T].Property = propertyValue
+                    Issue3076GenericStaticSlot[T].Field = fieldValue
+                }
+
+                func StorePropertyAndRead[T](value int32) int32 {
+                    Issue3076GenericStaticSlot[T].Property = value
+                    return Issue3076GenericStaticSlot[T].Property
+                }
+
+                func StoreFieldAndRead[T](value int32) int32 {
+                    Issue3076GenericStaticSlot[T].Field = value
+                    return Issue3076GenericStaticSlot[T].Field
+                }
+
+                func ReadProperty[T]() int32 {
+                    return Issue3076GenericStaticSlot[T].Property
+                }
+
+                func ReadField[T]() int32 {
+                    return Issue3076GenericStaticSlot[T].Field
+                }
+
+                func StoreNested[T](propertyValue int32, fieldValue int32) {
+                    Issue3076GenericStaticSlot[Issue3076GenericBox[T]].Property = propertyValue
+                    Issue3076GenericStaticSlot[Issue3076GenericBox[T]].Field = fieldValue
+                }
+
+                func StorePair[TFirst, TSecond](propertyValue int32, fieldValue int32) {
+                    Issue3076GenericPairSlot[TFirst, TSecond].Property = propertyValue
+                    Issue3076GenericPairSlot[TFirst, TSecond].Field = fieldValue
+                }
+
+                Issue3076GenericStaticSlot[int32].Property = 101
+                Issue3076GenericStaticSlot[int32].Field = 102
+                Issue3076GenericStaticSlot[string].Property = 111
+                Issue3076GenericStaticSlot[string].Field = 112
+                Issue3076GenericStaticSlot[object].Property = 121
+                Issue3076GenericStaticSlot[object].Field = 122
+                Issue3076GenericStaticSlot[Issue3076GenericBox[int32]].Property = 131
+                Issue3076GenericStaticSlot[Issue3076GenericBox[int32]].Field = 132
+                Issue3076GenericPairSlot[int32, string].Property = 141
+                Issue3076GenericPairSlot[int32, string].Field = 142
+
+                var intProperty = StorePropertyAndRead[int32](201)
+                var intField = StoreFieldAndRead[int32](202)
+                Store[string](211, 212)
+                StoreNested[int32](221, 222)
+                StorePair[int32, string](231, 232)
+                Issue3076PlainStaticSlot.Property = 241
+                Issue3076PlainStaticSlot.Field = 242
+
+                Console.WriteLine(intProperty)
+                Console.WriteLine(intField)
+                Console.WriteLine(ReadProperty[string]())
+                Console.WriteLine(ReadField[string]())
+                Console.WriteLine(Issue3076GenericStaticSlot[object].Property)
+                Console.WriteLine(Issue3076GenericStaticSlot[object].Field)
+                Console.WriteLine(Issue3076GenericStaticSlot[Issue3076GenericBox[int32]].ReadProperty())
+                Console.WriteLine(Issue3076GenericStaticSlot[Issue3076GenericBox[int32]].ReadField())
+                Console.WriteLine(Issue3076GenericPairSlot[int32, string].Property)
+                Console.WriteLine(Issue3076GenericPairSlot[int32, string].Field)
+                Console.WriteLine(Issue3076PlainStaticSlot.Property)
+                Console.WriteLine(Issue3076PlainStaticSlot.Field)
+            """;
     }
 
     private static List<string> CompileExpectingErrorsWithSiblingCs(string csSource, string gSource, string siblingName)

--- a/test/Compiler.Tests/Issue3076ProbeRefTypes.cs
+++ b/test/Compiler.Tests/Issue3076ProbeRefTypes.cs
@@ -1,0 +1,48 @@
+// <copyright file="Issue3076ProbeRefTypes.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Compiler.Tests;
+
+/// <summary>CLR generic static storage used by issue #3076 evaluation tests.</summary>
+public static class Issue3076GenericStaticSlot<T>
+{
+    /// <summary>Gets or sets per-construction property storage.</summary>
+    public static int Property { get; set; }
+
+    /// <summary>Per-construction field storage.</summary>
+    public static int Field;
+
+    /// <summary>Reads per-construction property storage from the fixture assembly.</summary>
+    /// <returns>The property value.</returns>
+    public static int ReadProperty() => Property;
+
+    /// <summary>Reads per-construction field storage from the fixture assembly.</summary>
+    /// <returns>The field value.</returns>
+    public static int ReadField() => Field;
+}
+
+/// <summary>CLR two-parameter generic static storage used by issue #3076 evaluation tests.</summary>
+public static class Issue3076GenericPairSlot<TFirst, TSecond>
+{
+    /// <summary>Gets or sets per-construction property storage.</summary>
+    public static int Property { get; set; }
+
+    /// <summary>Per-construction field storage.</summary>
+    public static int Field;
+}
+
+/// <summary>CLR generic type used as a nested type argument by issue #3076 tests.</summary>
+public sealed class Issue3076GenericBox<T>
+{
+}
+
+/// <summary>CLR non-generic static-storage control used by issue #3076 tests.</summary>
+public static class Issue3076PlainStaticSlot
+{
+    /// <summary>Gets or sets property storage.</summary>
+    public static int Property { get; set; }
+
+    /// <summary>Field storage.</summary>
+    public static int Field;
+}

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/Issue3076SpillSequenceSpillerTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/Issue3076SpillSequenceSpillerTests.cs
@@ -1,0 +1,45 @@
+// <copyright file="Issue3076SpillSequenceSpillerTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Lowering.Async;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Lowering.Async;
+
+public sealed class Issue3076SpillSequenceSpillerTests
+{
+    [Fact]
+    public void GenericStaticClrAssignmentPreservesContainerWhenAwaitIsSpilled()
+    {
+        var staticContainerType = TypeSymbol.String;
+        var member = typeof(GenericStaticSlot<>).GetProperty(nameof(GenericStaticSlot<int>.Value));
+        var assignment = new BoundClrPropertyAssignmentExpression(
+            syntax: null,
+            // Defensive contract test: current binder producers pair a static
+            // container with a null receiver, so source does not reach this
+            // rebuild. This sentinel forces it and checks metadata only.
+            receiver: new BoundLiteralExpression(null, 0),
+            member,
+            new BoundAwaitExpression(null, new BoundLiteralExpression(null, 1), TypeSymbol.Int32),
+            TypeSymbol.Int32,
+            staticContainerType: staticContainerType);
+        var body = new BoundBlockStatement(
+            syntax: null,
+            ImmutableArray.Create<BoundStatement>(new BoundExpressionStatement(null, assignment)));
+
+        var rewritten = SpillSequenceSpiller.Rewrite(body);
+
+        var statement = Assert.IsType<BoundExpressionStatement>(rewritten.Statements[^1]);
+        var rewrittenAssignment = Assert.IsType<BoundClrPropertyAssignmentExpression>(statement.Expression);
+        Assert.Same(staticContainerType, rewrittenAssignment.StaticContainerType);
+    }
+
+    private static class GenericStaticSlot<T>
+    {
+        public static int Value { get; set; }
+    }
+}

--- a/test/Interpreter.Tests/Issue3076GenericStaticClrStoreInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue3076GenericStaticClrStoreInterpreterTests.cs
@@ -1,0 +1,139 @@
+// <copyright file="Issue3076GenericStaticClrStoreInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.IO;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+public sealed class Issue3076GenericStaticClrStoreInterpreterTests
+{
+    [Theory]
+    [InlineData(false, "301\n302\n311\n312\n321\n322\n331\n332\n341\n342\n351\n352\n")]
+    [InlineData(true, "201\n202\n211\n212\n121\n122\n221\n222\n231\n232\n241\n242\n")]
+    public void GenericStaticClrStoresInterpret(bool throughTypeParameter, string expected)
+    {
+        using var outWriter = new StringWriter();
+        var previousOut = System.Console.Out;
+        System.Console.SetOut(outWriter);
+        try
+        {
+            var repl = new GSharpRepl();
+            repl.EvaluateSubmission(Source(throughTypeParameter));
+        }
+        finally
+        {
+            System.Console.SetOut(previousOut);
+        }
+
+        Assert.Equal(expected, outWriter.ToString().Replace("\r\n", "\n"));
+    }
+
+    private static string Source(bool throughTypeParameter)
+    {
+        if (!throughTypeParameter)
+        {
+            return """
+                import GSharp.Interpreter.Tests.Issue3076Probe
+                import System
+
+                GenericStaticSlot[int32].Property = 301
+                GenericStaticSlot[int32].Field = 302
+                GenericStaticSlot[string].Property = 311
+                GenericStaticSlot[string].Field = 312
+                GenericStaticSlot[object].Property = 321
+                GenericStaticSlot[object].Field = 322
+                GenericStaticSlot[GenericBox[int32]].Property = 331
+                GenericStaticSlot[GenericBox[int32]].Field = 332
+                GenericPairSlot[int32, string].Property = 341
+                GenericPairSlot[int32, string].Field = 342
+                PlainStaticSlot.Property = 351
+                PlainStaticSlot.Field = 352
+
+                Console.WriteLine(GenericStaticSlot[int32].Property)
+                Console.WriteLine(GenericStaticSlot[int32].Field)
+                Console.WriteLine(GenericStaticSlot[string].Property)
+                Console.WriteLine(GenericStaticSlot[string].Field)
+                Console.WriteLine(GenericStaticSlot[object].Property)
+                Console.WriteLine(GenericStaticSlot[object].Field)
+                Console.WriteLine(GenericStaticSlot[GenericBox[int32]].Property)
+                Console.WriteLine(GenericStaticSlot[GenericBox[int32]].Field)
+                Console.WriteLine(GenericPairSlot[int32, string].Property)
+                Console.WriteLine(GenericPairSlot[int32, string].Field)
+                Console.WriteLine(PlainStaticSlot.Property)
+                Console.WriteLine(PlainStaticSlot.Field)
+                """;
+        }
+
+        return """
+            import GSharp.Interpreter.Tests.Issue3076Probe
+            import System
+
+            func Store[T](propertyValue int32, fieldValue int32) {
+                GenericStaticSlot[T].Property = propertyValue
+                GenericStaticSlot[T].Field = fieldValue
+            }
+
+            func StorePropertyAndRead[T](value int32) int32 {
+                GenericStaticSlot[T].Property = value
+                return GenericStaticSlot[T].Property
+            }
+
+            func StoreFieldAndRead[T](value int32) int32 {
+                GenericStaticSlot[T].Field = value
+                return GenericStaticSlot[T].Field
+            }
+
+            func ReadProperty[T]() int32 {
+                return GenericStaticSlot[T].Property
+            }
+
+            func ReadField[T]() int32 {
+                return GenericStaticSlot[T].Field
+            }
+
+            func StoreNested[T](propertyValue int32, fieldValue int32) {
+                GenericStaticSlot[GenericBox[T]].Property = propertyValue
+                GenericStaticSlot[GenericBox[T]].Field = fieldValue
+            }
+
+            func StorePair[TFirst, TSecond](propertyValue int32, fieldValue int32) {
+                GenericPairSlot[TFirst, TSecond].Property = propertyValue
+                GenericPairSlot[TFirst, TSecond].Field = fieldValue
+            }
+
+            GenericStaticSlot[int32].Property = 101
+            GenericStaticSlot[int32].Field = 102
+            GenericStaticSlot[string].Property = 111
+            GenericStaticSlot[string].Field = 112
+            GenericStaticSlot[object].Property = 121
+            GenericStaticSlot[object].Field = 122
+            GenericStaticSlot[GenericBox[int32]].Property = 131
+            GenericStaticSlot[GenericBox[int32]].Field = 132
+            GenericPairSlot[int32, string].Property = 141
+            GenericPairSlot[int32, string].Field = 142
+
+            var intProperty = StorePropertyAndRead[int32](201)
+            var intField = StoreFieldAndRead[int32](202)
+            Store[string](211, 212)
+            StoreNested[int32](221, 222)
+            StorePair[int32, string](231, 232)
+            PlainStaticSlot.Property = 241
+            PlainStaticSlot.Field = 242
+
+            Console.WriteLine(intProperty)
+            Console.WriteLine(intField)
+            Console.WriteLine(ReadProperty[string]())
+            Console.WriteLine(ReadField[string]())
+            Console.WriteLine(GenericStaticSlot[object].Property)
+            Console.WriteLine(GenericStaticSlot[object].Field)
+            Console.WriteLine(GenericStaticSlot[GenericBox[int32]].ReadProperty())
+            Console.WriteLine(GenericStaticSlot[GenericBox[int32]].ReadField())
+            Console.WriteLine(GenericPairSlot[int32, string].Property)
+            Console.WriteLine(GenericPairSlot[int32, string].Field)
+            Console.WriteLine(PlainStaticSlot.Property)
+            Console.WriteLine(PlainStaticSlot.Field)
+            """;
+    }
+}

--- a/test/Interpreter.Tests/Issue3076ProbeRefTypes.cs
+++ b/test/Interpreter.Tests/Issue3076ProbeRefTypes.cs
@@ -1,0 +1,48 @@
+// <copyright file="Issue3076ProbeRefTypes.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Interpreter.Tests.Issue3076Probe;
+
+/// <summary>CLR generic static storage used by issue #3076 interpreter tests.</summary>
+public static class GenericStaticSlot<T>
+{
+    /// <summary>Gets or sets per-construction property storage.</summary>
+    public static int Property { get; set; }
+
+    /// <summary>Per-construction field storage.</summary>
+    public static int Field;
+
+    /// <summary>Reads per-construction property storage from the fixture assembly.</summary>
+    /// <returns>The property value.</returns>
+    public static int ReadProperty() => Property;
+
+    /// <summary>Reads per-construction field storage from the fixture assembly.</summary>
+    /// <returns>The field value.</returns>
+    public static int ReadField() => Field;
+}
+
+/// <summary>CLR two-parameter generic static storage used by issue #3076 interpreter tests.</summary>
+public static class GenericPairSlot<TFirst, TSecond>
+{
+    /// <summary>Gets or sets per-construction property storage.</summary>
+    public static int Property { get; set; }
+
+    /// <summary>Per-construction field storage.</summary>
+    public static int Field;
+}
+
+/// <summary>CLR generic type used as a nested type argument by issue #3076 tests.</summary>
+public sealed class GenericBox<T>
+{
+}
+
+/// <summary>CLR non-generic static-storage control used by issue #3076 tests.</summary>
+public static class PlainStaticSlot
+{
+    /// <summary>Gets or sets property storage.</summary>
+    public static int Property { get; set; }
+
+    /// <summary>Field storage.</summary>
+    public static int Field;
+}


### PR DESCRIPTION
## Summary

- parent imported generic static property setters and fields at the symbolic constructed container
- preserve `StaticContainerType` through normal, side-effect, async, and `??=` rewrites
- make `staticContainerType` required so future constructor sites cannot silently discard it
- cover top-level and generic-function stores across evaluator, emitter, and interpreter; the fixed defect itself is emit-only

## Root cause

The store was misrouted, not dropped. With `GenericStaticSlot[object]` initialized to `333`, a generic `GenericStaticSlot[T].Value = 222` left the requested `int32` slot unchanged and changed the `object` slot to `222`. Direct closed stores already worked.

Static reads used `StaticContainerType`; static writes ignored it and emitted member references against the erased `object` construction. Four reconstruction sites could also discard the metadata. A required-parameter compiler probe counted 20 constructor sites; all now pass the container explicitly, including explicit `null` where no symbolic static container exists.

## Validation

Measured on the merged tree with `main` `749775553eb964b6d4b8144df7f6c76193f343c8`:

- `dotnet build GSharp.sln -c Release -m:1 -p:ContinuousIntegrationBuild=true`: 0 warnings, 0 errors
- Compiler issue tests: 7 passed
- Interpreter issue tests: 2 passed
- Async spill metadata test: 1 passed
- clean-directory `{top-level, in-function} × {bare gsc, gsc /out:, gsi}` matrix: all six cells returned distinct expected values
- `git merge-tree --write-tree origin/main HEAD`: clean

Coverage includes independent value/reference/object slots; nested and two-parameter generics; same-method, another-method, and fixture-assembly read-back; non-generic controls; properties and fields; side-effect spilling; async spilling; and null-coalescing assignment.

Fixes #3076