### PR TITLE
Fix value-position assignments in conditional branches

### DIFF
--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GExpression.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GExpression.cs
@@ -981,11 +981,20 @@ public sealed class IfExpression : GExpression
     /// <param name="condition">The condition expression.</param>
     /// <param name="thenExpression">The value of the then-branch.</param>
     /// <param name="elseExpression">The value of the else-branch.</param>
-    public IfExpression(GExpression condition, GExpression thenExpression, GExpression elseExpression)
+    /// <param name="thenStatements">Statements evaluated before the then-branch value.</param>
+    /// <param name="elseStatements">Statements evaluated before the else-branch value.</param>
+    public IfExpression(
+        GExpression condition,
+        GExpression thenExpression,
+        GExpression elseExpression,
+        IReadOnlyList<GStatement> thenStatements = null,
+        IReadOnlyList<GStatement> elseStatements = null)
     {
         Condition = condition;
         ThenExpression = thenExpression;
         ElseExpression = elseExpression;
+        ThenStatements = thenStatements ?? new List<GStatement>();
+        ElseStatements = elseStatements ?? new List<GStatement>();
     }
 
     /// <summary>Gets the condition expression.</summary>
@@ -996,6 +1005,12 @@ public sealed class IfExpression : GExpression
 
     /// <summary>Gets the else-branch value expression.</summary>
     public GExpression ElseExpression { get; }
+
+    /// <summary>Gets statements evaluated before the then-branch value.</summary>
+    public IReadOnlyList<GStatement> ThenStatements { get; }
+
+    /// <summary>Gets statements evaluated before the else-branch value.</summary>
+    public IReadOnlyList<GStatement> ElseStatements { get; }
 }
 
 /// <summary>

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -601,7 +601,9 @@ public static class GSharpPrinter
                 return RenderSwitchExpression(switchExpression, indent);
 
             case IfExpression ifExpression:
-                return $"if {RenderExpression(ifExpression.Condition, indent)} {{ {RenderBranchValue(ifExpression.ThenExpression, indent)} }} else {{ {RenderBranchValue(ifExpression.ElseExpression, indent)} }}";
+                return $"if {RenderExpression(ifExpression.Condition, indent)} " +
+                    $"{RenderBranch(ifExpression.ThenStatements, ifExpression.ThenExpression, indent)} else " +
+                    $"{RenderBranch(ifExpression.ElseStatements, ifExpression.ElseExpression, indent)}";
 
             case IfLetExpression ifLetExpression:
                 return RenderIfLetExpression(ifLetExpression, indent);
@@ -699,6 +701,33 @@ public static class GSharpPrinter
         }
 
         return RenderExpression(expression, indent);
+    }
+
+    private static string RenderBranch(
+        IReadOnlyList<GStatement> statements,
+        GExpression value,
+        int indent)
+    {
+        if (statements.Count == 0)
+        {
+            return $"{{ {RenderBranchValue(value, indent)} }}";
+        }
+
+        var sb = new StringBuilder();
+        sb.Append('{');
+        foreach (GStatement statement in statements)
+        {
+            sb.Append('\n');
+            sb.Append(RenderStatement(statement, indent + 1));
+        }
+
+        sb.Append('\n');
+        sb.Append(Indent(indent + 1));
+        sb.Append(RenderBranchValue(value, indent));
+        sb.Append('\n');
+        sb.Append(Indent(indent));
+        sb.Append('}');
+        return sb.ToString();
     }
 
     private static string RenderCollectionInitializer(CollectionInitializerExpression collection, int indent)

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1723ValuePositionAssignmentTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1723ValuePositionAssignmentTranslationTests.cs
@@ -416,6 +416,87 @@ namespace Demo
     }
 
     [Fact]
+    public void ConditionalFalseBranchStaticPropertyAssignment_CompilesAndReturnsAssignedValue()
+    {
+        string printed = TranslateUnit(
+            """
+            namespace Demo
+            {
+                public static class Store
+                {
+                    private static int backing;
+
+                    public static int P
+                    {
+                        get => backing + 100;
+                        set { backing = value; }
+                    }
+
+                    public static int Backing => backing;
+                }
+
+                public static class C
+                {
+                    private static int calls;
+
+                    private static int Next()
+                    {
+                        calls++;
+                        return 42;
+                    }
+
+                    public static string Run()
+                    {
+                        calls = 0;
+                        Store.P = 0;
+                        int result = false ? -1 : Store.P = Next();
+                        return calls + "," + result + "," + Store.Backing + "," + Store.P;
+                    }
+                }
+            }
+            """);
+
+        Assert.Equal("1,42,42,142", CompileAndRun(printed, "C.Run()").Trim());
+    }
+
+    [Fact]
+    public void ReturnStaticFieldAssignment_CompilesAndReturnsAssignedValue()
+    {
+        string printed = TranslateUnit(
+            """
+            namespace Demo
+            {
+                public static class C
+                {
+                    private static int calls;
+                    public static int Stored;
+
+                    private static int Next()
+                    {
+                        calls++;
+                        return 9;
+                    }
+
+                    private static int AssignAndReturn()
+                    {
+                        return C.Stored = Next();
+                    }
+
+                    public static string Run()
+                    {
+                        calls = 0;
+                        Stored = 0;
+                        int result = AssignAndReturn();
+                        return calls + "," + result + "," + Stored;
+                    }
+                }
+            }
+            """);
+
+        Assert.Equal("1,9,9", CompileAndRun(printed, "C.Run()").Trim());
+    }
+
+    [Fact]
     public void ConditionalFalseBranchAssignment_WithIfLetCandidate_StaysInsideElseArm()
     {
         string printed = TranslateUnit(

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1723ValuePositionAssignmentTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1723ValuePositionAssignmentTranslationTests.cs
@@ -3,6 +3,9 @@
 // </copyright>
 
 using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
 using Cs2Gs.CodeModel.Ast;
 using Cs2Gs.CodeModel.Printing;
 using Cs2Gs.CodeModel.RoundTrip;
@@ -221,6 +224,94 @@ namespace Demo
         Assert.Equal(1, CountOccurrences(printed, "= C.F()"));
         Assert.Contains("x = C.F()", printed);
         Assert.Contains("return (x)", printed);
+    }
+
+    /// <summary>
+    /// An assignment in a conditional-expression arm must stay inside that arm.
+    /// The false branch writes the dictionary exactly once and yields the written
+    /// value as the conditional result.
+    /// </summary>
+    [Fact]
+    public void ConditionalFalseBranchDictionaryAssignment_RunsOnceAndYieldsAssignedValue()
+    {
+        string printed = TranslateUnit(
+            """
+            using System;
+            using System.Collections.Generic;
+
+            namespace Demo
+            {
+                public static class C
+                {
+                    private static int calls;
+
+                    private static int Next()
+                    {
+                        calls++;
+                        return 42;
+                    }
+
+                    private static int GetOrAdd(Dictionary<string, int> map, string key)
+                    {
+                        var value = map.TryGetValue(key, out var existing)
+                            ? existing
+                            : map[key] = Next();
+                        return value;
+                    }
+
+                    public static string Run()
+                    {
+                        calls = 0;
+                        var map = new Dictionary<string, int>();
+                        string key = "k";
+                        int first = GetOrAdd(map, key);
+                        int second = GetOrAdd(map, key);
+                        return calls + "," + map.Count + "," + first + "," + second + "," + map[key];
+                    }
+                }
+            }
+            """,
+            out TranslationContext context);
+
+        Assert.DoesNotContain(
+            context.Diagnostics,
+            diagnostic => diagnostic.Severity == TranslationSeverity.Unsupported);
+        Assert.Equal(1, CountOccurrences(printed, "map_[key] = C.Next()"));
+        Assert.Equal(1, CountOccurrences(printed, "C.Next()"));
+        Assert.Contains("else {\n", printed, StringComparison.Ordinal);
+
+        Assert.Equal("1,1,42,42,42", CompileAndRun(printed, "C.Run()").Trim());
+    }
+
+    [Fact]
+    public void ConditionalFalseBranchAssignment_WithIfLetCandidate_StaysInsideElseArm()
+    {
+        string printed = TranslateUnit(
+            """
+            #nullable enable
+
+            namespace Demo
+            {
+                public static class C
+                {
+                    public static int Pick(string? candidate)
+                    {
+                        int x = 0;
+                        int value = candidate is { } text ? text.Length : (x = 5);
+                        return value + x;
+                    }
+                }
+            }
+            """,
+            out TranslationContext context);
+
+        Assert.DoesNotContain(
+            context.Diagnostics,
+            diagnostic => diagnostic.Severity == TranslationSeverity.Unsupported);
+        int elseArm = printed.IndexOf("else {", StringComparison.Ordinal);
+        int assignment = printed.IndexOf("x = 5", StringComparison.Ordinal);
+        Assert.True(elseArm >= 0 && assignment > elseArm, printed);
+        Assert.Equal(1, CountOccurrences(printed, "x = 5"));
     }
 
     /// <summary>
@@ -674,7 +765,10 @@ namespace Demo
         return count;
     }
 
-    private static string TranslateUnit(string source)
+    private static string TranslateUnit(string source) =>
+        TranslateUnit(source, out _);
+
+    private static string TranslateUnit(string source, out TranslationContext context)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
         Assert.True(
@@ -683,7 +777,7 @@ namespace Demo
                 string.Join(Environment.NewLine, project.ErrorDiagnostics));
 
         LoadedDocument document = Assert.Single(project.Documents);
-        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
@@ -693,5 +787,94 @@ namespace Demo
             "Translated G# must round-trip. Errors:\n" +
                 string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
         return printed;
+    }
+
+    private static string CompileAndRun(string printed, string callExpression)
+    {
+        string compiler = FindCompiler();
+        Assert.True(compiler != null, "gsc.dll must be built before running this test.");
+
+        string workDir = Path.Combine(
+            AppContext.BaseDirectory,
+            "issue-1723-e2e",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workDir);
+        try
+        {
+            string gsPath = Path.Combine(workDir, "Snippet.gs");
+            string dllPath = Path.Combine(workDir, "Snippet.dll");
+            File.WriteAllText(
+                gsPath,
+                printed + Environment.NewLine +
+                    $"Console.WriteLine({callExpression})" + Environment.NewLine);
+
+            (int compileExit, string compileOutput) = RunDotnet(
+                compiler,
+                "/target:exe",
+                $"/out:{dllPath}",
+                gsPath);
+            Assert.True(
+                compileExit == 0 &&
+                    !compileOutput.Contains("error", StringComparison.OrdinalIgnoreCase),
+                "gsc must compile the translated snippet with zero errors. Output:\n" +
+                    compileOutput + "\n\nTranslated G#:\n" + printed);
+
+            (int runExit, string runOutput) = RunDotnet(dllPath);
+            Assert.True(
+                runExit == 0,
+                "Translated snippet must run successfully. Output:\n" + runOutput);
+            return runOutput;
+        }
+        finally
+        {
+            Directory.Delete(workDir, recursive: true);
+        }
+    }
+
+    private static (int Exit, string Output) RunDotnet(params string[] arguments)
+    {
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        foreach (string argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        using var process = Process.Start(startInfo);
+        var output = new StringBuilder();
+        output.Append(process.StandardOutput.ReadToEnd());
+        output.Append(process.StandardError.ReadToEnd());
+        process.WaitForExit();
+        return (process.ExitCode, output.ToString());
+    }
+
+    private static string FindCompiler()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            foreach (string configuration in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(
+                    directory.FullName,
+                    "out",
+                    "bin",
+                    configuration,
+                    "Compiler",
+                    "gsc.dll");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
     }
 }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1723ValuePositionAssignmentTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1723ValuePositionAssignmentTranslationTests.cs
@@ -276,11 +276,143 @@ namespace Demo
         Assert.DoesNotContain(
             context.Diagnostics,
             diagnostic => diagnostic.Severity == TranslationSeverity.Unsupported);
-        Assert.Equal(1, CountOccurrences(printed, "map_[key] = C.Next()"));
+        Assert.Equal(1, CountOccurrences(printed, "map_[key] = __spill"));
         Assert.Equal(1, CountOccurrences(printed, "C.Next()"));
         Assert.Contains("else {\n", printed, StringComparison.Ordinal);
 
         Assert.Equal("1,1,42,42,42", CompileAndRun(printed, "C.Run()").Trim());
+    }
+
+    [Fact]
+    public void PropertyAssignmentResult_UsesAssignedValueWithoutCallingGetter()
+    {
+        string printed = TranslateUnit(
+            """
+            namespace Demo
+            {
+                public sealed class Holder
+                {
+                    private int stored;
+                    private int gets;
+
+                    public int P
+                    {
+                        get
+                        {
+                            this.gets++;
+                            return this.stored + 100;
+                        }
+
+                        set
+                        {
+                            this.stored = value;
+                        }
+                    }
+
+                    public int Stored => this.stored;
+
+                    public int Gets => this.gets;
+
+                    private static int Echo(int value) => value;
+
+                    private int AssignAndReturn()
+                    {
+                        return P = 8;
+                    }
+
+                    public string Assign()
+                    {
+                        int argument = Echo(P = 7);
+                        int returned = AssignAndReturn();
+                        return argument + "," + returned + "," + this.Stored + "," + this.Gets;
+                    }
+                }
+
+                public static class C
+                {
+                    public static string Run() => new Holder().Assign();
+                }
+            }
+            """);
+
+        Assert.Equal(2, CountOccurrences(printed, "P = __spill"));
+        Assert.Equal("7,8,8,0", CompileAndRun(printed, "C.Run()").Trim());
+    }
+
+    [Fact]
+    public void SetOnlyIndexerAssignment_SideEffectingTargetAndValueRunOnce()
+    {
+        string printed = TranslateUnit(
+            """
+            namespace Demo
+            {
+                public sealed class Holder
+                {
+                    private int[] values = new int[2];
+                    private int writes;
+
+                    public int this[int index]
+                    {
+                        set
+                        {
+                            this.writes++;
+                            this.values[index] = value;
+                        }
+                    }
+
+                    public int Read(int index) => this.values[index];
+
+                    public int Writes => this.writes;
+                }
+
+                public static class C
+                {
+                    private static Holder current = new Holder();
+                    private static int receiverCalls;
+                    private static int indexCalls;
+                    private static int valueCalls;
+                    private static string trace = "";
+
+                    private static Holder Receiver()
+                    {
+                        trace += "R";
+                        receiverCalls++;
+                        return current;
+                    }
+
+                    private static int NextIndex()
+                    {
+                        trace += "I";
+                        indexCalls++;
+                        return 1;
+                    }
+
+                    private static int NextValue()
+                    {
+                        trace += "V";
+                        valueCalls++;
+                        return 42;
+                    }
+
+                    public static string Run()
+                    {
+                        current = new Holder();
+                        receiverCalls = 0;
+                        indexCalls = 0;
+                        valueCalls = 0;
+                        trace = "";
+                        int result = Receiver()[NextIndex()] = NextValue();
+                        return trace + "," + receiverCalls + "," + indexCalls + "," + valueCalls + ","
+                            + current.Writes + "," + result + "," + current.Read(1);
+                    }
+                }
+            }
+            """);
+
+        Assert.Equal(1, CountOccurrences(printed, "C.Receiver()"));
+        Assert.Equal(1, CountOccurrences(printed, "C.NextIndex()"));
+        Assert.Equal(1, CountOccurrences(printed, "C.NextValue()"));
+        Assert.Equal("RIV,1,1,1,1,42,42", CompileAndRun(printed, "C.Run()").Trim());
     }
 
     [Fact]
@@ -300,6 +432,8 @@ namespace Demo
                         int value = candidate is { } text ? text.Length : (x = 5);
                         return value + x;
                     }
+
+                    public static string Run() => Pick(null) + "," + Pick("abc");
                 }
             }
             """,
@@ -312,6 +446,7 @@ namespace Demo
         int assignment = printed.IndexOf("x = 5", StringComparison.Ordinal);
         Assert.True(elseArm >= 0 && assignment > elseArm, printed);
         Assert.Equal(1, CountOccurrences(printed, "x = 5"));
+        Assert.Equal("10,3", CompileAndRun(printed, "C.Run()").Trim());
     }
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1723ValuePositionAssignmentTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1723ValuePositionAssignmentTranslationTests.cs
@@ -340,6 +340,132 @@ namespace Demo
     }
 
     [Fact]
+    public void ConditionalCompoundPropertyAssignment_ReturnsCombinedValueWithoutGetterReadback()
+    {
+        string printed = TranslateUnit(
+            """
+            namespace Demo
+            {
+                public sealed class Holder
+                {
+                    private int backing = 1;
+                    private int gets;
+
+                    public int P
+                    {
+                        get
+                        {
+                            this.gets++;
+                            return this.backing + 10;
+                        }
+
+                        set { this.backing = value; }
+                    }
+
+                    public int Gets => this.gets;
+
+                    public int Stored => this.backing;
+                }
+
+                public static class C
+                {
+                    private static Holder current = new Holder();
+                    private static int receiverCalls;
+                    private static int rhsCalls;
+
+                    private static Holder Receiver()
+                    {
+                        receiverCalls++;
+                        return current;
+                    }
+
+                    private static int Next()
+                    {
+                        rhsCalls++;
+                        return 2;
+                    }
+
+                    public static string Run()
+                    {
+                        current = new Holder();
+                        receiverCalls = 0;
+                        rhsCalls = 0;
+                        int result = false ? -1 : Receiver().P += Next();
+                        return receiverCalls + "," + rhsCalls + "," + current.Gets + ","
+                            + result + "," + current.Stored;
+                    }
+                }
+            }
+            """);
+
+        Assert.Equal(1, CountOccurrences(printed, "C.Receiver()"));
+        Assert.Equal(1, CountOccurrences(printed, "C.Next()"));
+        Assert.Equal("1,1,1,13,13", CompileAndRun(printed, "C.Run()").Trim());
+    }
+
+    [Fact]
+    public void ReturnAndInvocationCompoundPropertyAssignments_ReuseCombinedValue()
+    {
+        string printed = TranslateUnit(
+            """
+            namespace Demo
+            {
+                public sealed class Holder
+                {
+                    private int backing = 1;
+                    private int gets;
+
+                    public int P
+                    {
+                        get
+                        {
+                            this.gets++;
+                            return this.backing + 10;
+                        }
+
+                        set { this.backing = value; }
+                    }
+
+                    public int Gets => this.gets;
+
+                    public int Stored => this.backing;
+                }
+
+                public static class C
+                {
+                    private static int rhsCalls;
+
+                    private static int Next()
+                    {
+                        rhsCalls++;
+                        return 2;
+                    }
+
+                    private static int Echo(int value) => value;
+
+                    private static int AddAndReturn(Holder holder)
+                    {
+                        return holder.P += Next();
+                    }
+
+                    public static string Run()
+                    {
+                        rhsCalls = 0;
+                        var holder = new Holder();
+                        int argument = Echo(holder.P += Next());
+                        int returned = AddAndReturn(holder);
+                        return rhsCalls + "," + holder.Gets + "," + argument + ","
+                            + returned + "," + holder.Stored;
+                    }
+                }
+            }
+            """);
+
+        Assert.Equal(2, CountOccurrences(printed, "C.Next()"));
+        Assert.Equal("2,2,13,25,25", CompileAndRun(printed, "C.Run()").Trim());
+    }
+
+    [Fact]
     public void SetOnlyIndexerAssignment_SideEffectingTargetAndValueRunOnce()
     {
         string printed = TranslateUnit(

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
@@ -290,7 +290,9 @@ public sealed partial class CSharpToGSharpTranslator
                 .ToList();
         }
 
-        private IEnumerable<GStatement> FlattenChainedAssignment(AssignmentExpressionSyntax assignment)
+        private IEnumerable<GStatement> FlattenChainedAssignment(
+            AssignmentExpressionSyntax assignment,
+            bool preserveValue = true)
         {
             // Follows the chain through ANY assignment operator (`=`, `+=`, …), not
             // just `=`: `a = b += c` is `a = (b += c)`, so the `+=` link must also be
@@ -385,6 +387,11 @@ public sealed partial class CSharpToGSharpTranslator
             for (int i = lefts.Count - 1; i >= 0; i--)
             {
                 bool hasOuterLink = i > 0;
+                bool captureRootValue =
+                    preserveValue &&
+                    i == 0 &&
+                    assignment.IsKind(SyntaxKind.SimpleAssignmentExpression) &&
+                    this.AssignmentTargetNeedsCapturedValue(lefts[i].Syntax);
                 GExpression assignedValue = value;
                 if (lefts[i].Op == "=")
                 {
@@ -416,7 +423,21 @@ public sealed partial class CSharpToGSharpTranslator
                         includePromotedValue: true);
                 }
 
-                if (hasOuterLink && lefts[i].Op == "=" && !valueIsShared)
+                if (captureRootValue)
+                {
+                    // C# yields the converted RHS, never a post-set target read.
+                    // A typed temp preserves that value for properties, set-only
+                    // storage, and targets whose receiver/index had to be spilled.
+                    string temp = $"__spill{this.state.SpillCounter++}";
+                    statements.Add(new LocalDeclarationStatement(
+                        BindingKind.Let,
+                        temp,
+                        this.ResolveExpressionType(assignment),
+                        assignedValue));
+                    assignedValue = new IdentifierExpression(temp);
+                    this.state.AssignmentValues[assignment] = assignedValue;
+                }
+                else if (hasOuterLink && lefts[i].Op == "=" && !valueIsShared)
                 {
                     // About to be assigned to more than one target — spill once
                     // so the RHS expression is evaluated exactly one time, then
@@ -468,6 +489,16 @@ public sealed partial class CSharpToGSharpTranslator
             }
 
             return statements;
+        }
+
+        private bool AssignmentTargetNeedsCapturedValue(ExpressionSyntax target)
+        {
+            if (this.context.GetSymbolInfo(target).Symbol is IPropertySymbol)
+            {
+                return true;
+            }
+
+            return target is not IdentifierNameSyntax;
         }
 
         // Maps a C# compound-assignment operator token (`+=`, `-=`, …) to its
@@ -1231,6 +1262,10 @@ public sealed partial class CSharpToGSharpTranslator
                     // `^n` is contextual index syntax: spilling the whole expression
                     // turns `target[^n]` into `let i = ^n; target[i]`, which loses
                     // from-end semantics. Spill only `n` and keep `^` at the access.
+                    GExpression safeTarget = this.MakeDuplicationSafeTarget(
+                        index.Target,
+                        prologue,
+                        (syntax as ElementAccessExpressionSyntax)?.Expression);
                     bool isFromEnd = syntax is ElementAccessExpressionSyntax elementAccess
                         && elementAccess.ArgumentList.Arguments.Count == 1
                         && elementAccess.ArgumentList.Arguments[0].Expression.IsKind(SyntaxKind.IndexExpression);
@@ -1239,10 +1274,7 @@ public sealed partial class CSharpToGSharpTranslator
                         ? new UnaryExpression("^", this.SpillOperand(fromEnd.Operand, prologue))
                         : this.SpillOperand(index.Index, prologue);
                     return new IndexExpression(
-                        this.MakeDuplicationSafeTarget(
-                            index.Target,
-                            prologue,
-                            (syntax as ElementAccessExpressionSyntax)?.Expression),
+                        safeTarget,
                         safeIndex);
 
                 default:

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
@@ -847,14 +847,15 @@ public sealed partial class CSharpToGSharpTranslator
         }
 
         // True when duplicating `expression` in the output has no observable
-        // effect — a bare identifier, `this`, or a literal never has a side
-        // effect and always reads the same value, so it is safe to embed at more
-        // than one output position without spilling it to a temp first (issue
-        // #1731). Anything else (a method/property/indexer read, an arithmetic
-        // expression, …) may run a side effect or re-read a mutable value and
-        // must be evaluated exactly once if it needs to appear more than once.
+        // effect — a bare identifier, `this`, literal, or type-name receiver never
+        // has a side effect and always denotes the same value/name, so it is safe
+        // to embed at more than one output position without spilling it to a temp
+        // first (issue #1731). Anything else (a method/property/indexer read, an
+        // arithmetic expression, …) may run a side effect or re-read a mutable
+        // value and must be evaluated exactly once if it needs to appear more than
+        // once.
         private static bool IsTrivialOperand(GExpression expression) =>
-            expression is IdentifierExpression or ThisExpression or LiteralExpression;
+            expression is IdentifierExpression or ThisExpression or LiteralExpression or TypeExpression;
 
         // Spills `operand` into a fresh `let` in the active statement seam's
         // prologue (see <see cref="pendingSpillPrologue"/>/<see

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
@@ -140,10 +140,11 @@ public sealed partial class CSharpToGSharpTranslator
         /// excluding ones inside a nested lambda/local function (their own
         /// statement seam) and — for chained links (`a = b = c`) — excluding the
         /// inner links of a chain already captured by the outer node (see
-        /// <see cref="FlattenChainedAssignment"/>). An assignment hidden inside the
-        /// short-circuited operand of `&amp;&amp;`/`||` or a `?:` branch would change
-        /// evaluation COUNT/order if hoisted, so it is flagged unsupported instead
-        /// (issue #1723).
+        /// <see cref="FlattenChainedAssignment"/>). Assignments inside a conditional
+        /// (`?:`) arm are left for that arm's native G# block-expression seam.
+        /// Assignments hidden inside any other short-circuited operand would change
+        /// evaluation COUNT/order if hoisted, so they are flagged unsupported
+        /// instead (issue #1723).
         /// </summary>
         private List<AssignmentExpressionSyntax> CollectEmbeddedAssignments(ExpressionSyntax expression, bool includeSelf)
         {
@@ -212,11 +213,16 @@ public sealed partial class CSharpToGSharpTranslator
             var safe = new List<AssignmentExpressionSyntax>();
             foreach (AssignmentExpressionSyntax candidate in candidates)
             {
-                if (IsInShortCircuitOrConditionalBranch(candidate, expression))
+                if (IsInsideConditionalExpressionBranch(candidate, expression))
+                {
+                    continue;
+                }
+
+                if (IsInShortCircuitedSubexpression(candidate, expression))
                 {
                     this.context.ReportUnsupported(
                         candidate,
-                        "assignment inside a short-circuited '&&'/'||' operand or a conditional ('?:') branch has no side-effect-preserving G# lowering yet (issue #1723).");
+                        "assignment inside a short-circuited '&&'/'||'/'??' operand or a conditional-access branch has no side-effect-preserving G# lowering yet (issue #1723).");
                     continue;
                 }
 
@@ -226,14 +232,30 @@ public sealed partial class CSharpToGSharpTranslator
             return safe;
         }
 
+        // A `?:` arm owns a native G# block-expression seam. An enclosing seam
+        // must not hoist the arm's assignment unconditionally; it leaves the node
+        // for TranslateConditionalBranch to lower inside the selected arm.
+        private static bool IsInsideConditionalExpressionBranch(SyntaxNode node, ExpressionSyntax root)
+        {
+            for (SyntaxNode current = node; current != null && current != root; current = current.Parent)
+            {
+                SyntaxNode parent = current.Parent;
+                if (parent is ConditionalExpressionSyntax conditional &&
+                    (current == conditional.WhenTrue || current == conditional.WhenFalse))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         // True when `node` is reached only through a not-always-evaluated operand
-        // inside `root`: the right operand of a `&&`/`||`, either branch of a
-        // `?:`, the right operand of `??`, or the "when not null" side of a
-        // `?.`/`?[...]` conditional-access chain (including any member/element
-        // access further chained off it). Hoisting such an assignment out in
-        // front of `root` would evaluate/mutate it unconditionally, changing C#
-        // semantics.
-        private static bool IsInShortCircuitOrConditionalBranch(SyntaxNode node, ExpressionSyntax root)
+        // inside `root`: the right operand of `&&`/`||`/`??`, or the "when not
+        // null" side of a `?.`/`?[...]` conditional-access chain (including any
+        // member/element access further chained off it). Unlike a `?:` arm, these
+        // positions have no native statement-hosting expression seam.
+        private static bool IsInShortCircuitedSubexpression(SyntaxNode node, ExpressionSyntax root)
         {
             for (SyntaxNode current = node; current != null && current != root; current = current.Parent)
             {
@@ -242,12 +264,6 @@ public sealed partial class CSharpToGSharpTranslator
                     (binary.IsKind(SyntaxKind.LogicalAndExpression) || binary.IsKind(SyntaxKind.LogicalOrExpression) ||
                      binary.IsKind(SyntaxKind.CoalesceExpression)) &&
                     current == binary.Right)
-                {
-                    return true;
-                }
-
-                if (parent is ConditionalExpressionSyntax conditional &&
-                    (current == conditional.WhenTrue || current == conditional.WhenFalse))
                 {
                     return true;
                 }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
@@ -387,11 +387,21 @@ public sealed partial class CSharpToGSharpTranslator
             for (int i = lefts.Count - 1; i >= 0; i--)
             {
                 bool hasOuterLink = i > 0;
-                bool captureRootValue =
+                bool targetNeedsCapturedValue =
+                    this.AssignmentTargetNeedsCapturedValue(lefts[i].Syntax);
+                bool captureRootSimpleValue =
                     preserveValue &&
                     i == 0 &&
                     assignment.IsKind(SyntaxKind.SimpleAssignmentExpression) &&
-                    this.AssignmentTargetNeedsCapturedValue(lefts[i].Syntax);
+                    targetNeedsCapturedValue;
+                string compoundBinaryOp = lefts[i].Op == "="
+                    ? null
+                    : CompoundToBinaryOperator(lefts[i].Op);
+                bool captureRootCompoundValue =
+                    preserveValue &&
+                    i == 0 &&
+                    targetNeedsCapturedValue &&
+                    compoundBinaryOp != null;
                 GExpression assignedValue = value;
                 if (lefts[i].Op == "=")
                 {
@@ -423,19 +433,15 @@ public sealed partial class CSharpToGSharpTranslator
                         includePromotedValue: true);
                 }
 
-                if (captureRootValue)
+                if (captureRootSimpleValue)
                 {
                     // C# yields the converted RHS, never a post-set target read.
                     // A typed temp preserves that value for properties, set-only
                     // storage, and targets whose receiver/index had to be spilled.
-                    string temp = $"__spill{this.state.SpillCounter++}";
-                    statements.Add(new LocalDeclarationStatement(
-                        BindingKind.Let,
-                        temp,
-                        this.ResolveExpressionType(assignment),
-                        assignedValue));
-                    assignedValue = new IdentifierExpression(temp);
-                    this.state.AssignmentValues[assignment] = assignedValue;
+                    assignedValue = this.CaptureAssignmentValue(
+                        assignment,
+                        assignedValue,
+                        statements);
                 }
                 else if (hasOuterLink && lefts[i].Op == "=" && !valueIsShared)
                 {
@@ -447,22 +453,23 @@ public sealed partial class CSharpToGSharpTranslator
                     valueIsShared = true;
                 }
 
-                if (hasOuterLink && lefts[i].Op != "=" &&
-                    !IsTrivialOperand(safeTargets[i]) &&
-                    CompoundToBinaryOperator(lefts[i].Op) is string binaryOp)
+                if ((hasOuterLink || captureRootCompoundValue) &&
+                    targetNeedsCapturedValue &&
+                    compoundBinaryOp is string binaryOp)
                 {
-                    // `c.P += d` reused above (`a = b = c.P += d`): re-embedding
-                    // a NON-trivial target (a property/indexer read, unlike a
-                    // bare local) would re-run its getter once per outer link
-                    // (issue #1875). Instead read c.P's getter exactly once,
-                    // combine it with the operand, and store the result — the
-                    // combined value (not a re-read of c.P) is what every
-                    // outer `=` link reuses, matching C#'s single-getter-call
-                    // semantics. A trivial target (bare local/`this`) has no
-                    // getter to protect, so it keeps the simpler read-back
-                    // below unchanged.
+                    // A non-trivial compound target must yield its computed value
+                    // without re-reading the getter: both an outer assignment chain
+                    // (`a = c.P += d`, issue #1875) and a standalone value position
+                    // (`Echo(c.P += d)`) reuse the captured combined value.
                     GExpression oldValue = this.SpillOperand(safeTargets[i], statements);
-                    GExpression newValue = this.SpillOperand(new BinaryExpression(oldValue, binaryOp, assignedValue), statements);
+                    GExpression combinedValue =
+                        new BinaryExpression(oldValue, binaryOp, assignedValue);
+                    GExpression newValue = captureRootCompoundValue
+                        ? this.CaptureAssignmentValue(
+                            assignment,
+                            combinedValue,
+                            statements)
+                        : this.SpillOperand(combinedValue, statements);
                     statements.Add(new AssignmentStatement(safeTargets[i], newValue, "="));
                     value = newValue;
                     valueIsShared = true;
@@ -489,6 +496,22 @@ public sealed partial class CSharpToGSharpTranslator
             }
 
             return statements;
+        }
+
+        private GExpression CaptureAssignmentValue(
+            AssignmentExpressionSyntax assignment,
+            GExpression value,
+            List<GStatement> statements)
+        {
+            string temp = $"__spill{this.state.SpillCounter++}";
+            statements.Add(new LocalDeclarationStatement(
+                BindingKind.Let,
+                temp,
+                this.ResolveExpressionType(assignment),
+                value));
+            var captured = new IdentifierExpression(temp);
+            this.state.AssignmentValues[assignment] = captured;
+            return captured;
         }
 
         private bool AssignmentTargetNeedsCapturedValue(ExpressionSyntax target)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.IfLet.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.IfLet.cs
@@ -71,11 +71,16 @@ public sealed partial class CSharpToGSharpTranslator
                 return false;
             }
 
-            // A guard/true-arm construct that hoists a spill `let` would have to
-            // put it OUTSIDE the `if let` — where it would run unconditionally
-            // and could not see the binding. Keep the conservative fallback.
+            // A guard/true-arm construct that hoists a spill `let` keeps the
+            // conservative fallback: the true arm can depend on the if-let
+            // binding, and existing spill rewrites are not binding-aware. A
+            // false-arm assignment owned by THIS conditional likewise falls
+            // back so the general if-expression lowering can host its write
+            // inside that arm. Assignments owned by a nested conditional arm
+            // are left to the nested conditional's own seam.
             if (guards.Any(ContainsSpillHoistingConstruct)
-                || ContainsSpillHoistingConstruct(conditional.WhenTrue))
+                || ContainsSpillHoistingConstruct(conditional.WhenTrue)
+                || ContainsAssignmentNeedingBranchSeam(conditional.WhenFalse))
             {
                 return false;
             }
@@ -131,6 +136,19 @@ public sealed partial class CSharpToGSharpTranslator
                 whenTrue,
                 whenFalse);
             return true;
+        }
+
+        private static bool ContainsAssignmentNeedingBranchSeam(ExpressionSyntax branch)
+        {
+            return branch.DescendantNodesAndSelf(
+                    descendIntoChildren: node =>
+                        node is not (AnonymousFunctionExpressionSyntax or LocalFunctionStatementSyntax))
+                .OfType<AssignmentExpressionSyntax>()
+                .Where(assignment =>
+                    assignment.Parent is not InitializerExpressionSyntax initializer ||
+                    (!initializer.IsKind(SyntaxKind.ObjectInitializerExpression) &&
+                     !initializer.IsKind(SyntaxKind.WithInitializerExpression)))
+                .Any(assignment => !IsInsideConditionalExpressionBranch(assignment, branch));
         }
 
         /// <summary>

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -377,9 +377,8 @@ public sealed partial class CSharpToGSharpTranslator
                     }
 
                     // No enclosing seam claimed this node (e.g. it lives inside a
-                    // short-circuited `&&`/`||` operand or a `?:` branch, already
-                    // flagged unsupported at the point of detection): fall back to
-                    // the RHS value so translation still completes.
+                    // short-circuited operand already flagged unsupported): fall
+                    // back to the RHS value so translation still completes.
                     return this.TranslateExpression(nestedAssignment.Right);
 
                 case ThrowExpressionSyntax throwExpression:

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -343,10 +343,21 @@ public sealed partial class CSharpToGSharpTranslator
                     // / TranslateConditionWithHoist / HoistLoopConditionClause)
                     // hoists the write into a preceding assignment statement and
                     // marks this node suppressed; reading it here means the write
-                    // already happened, so the expression's value is just the
-                    // (now up-to-date) target (issue #1723).
+                    // already happened (issue #1723).
                     if (this.state.SuppressedAssignments.Contains(nestedAssignment))
                     {
+                        // A property/indexer/non-trivial target cannot be read back:
+                        // doing so can invoke a getter, fail for set-only storage, or
+                        // re-evaluate its receiver/index. FlattenChainedAssignment
+                        // captured the converted RHS before writing it; return that
+                        // exact assignment result.
+                        if (this.state.AssignmentValues.TryGetValue(
+                                nestedAssignment,
+                                out GExpression assignmentValue))
+                        {
+                            return assignmentValue;
+                        }
+
                         // A deconstruction assignment (`(a, b) = ...`) has no
                         // single "target" to read back — LowerTupleAssignmentForValue
                         // already computed its value (a tuple of the assigned

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
@@ -1011,10 +1011,58 @@ public sealed partial class CSharpToGSharpTranslator
             }
 
             GExpression condition = this.TranslateExpression(conditional.Condition);
-            GExpression whenTrue = this.TranslateValueWithNullForgiveness(conditional.WhenTrue);
-            GExpression whenFalse = this.TranslateValueWithNullForgiveness(conditional.WhenFalse);
+            (GExpression whenTrue, List<GStatement> thenStatements) =
+                this.TranslateConditionalBranch(conditional.WhenTrue);
+            (GExpression whenFalse, List<GStatement> elseStatements) =
+                this.TranslateConditionalBranch(conditional.WhenFalse);
             (whenTrue, whenFalse) = this.CoerceConditionalArms(conditional, whenTrue, whenFalse);
-            return new IfExpression(condition, whenTrue, whenFalse);
+            return new IfExpression(
+                condition,
+                whenTrue,
+                whenFalse,
+                thenStatements,
+                elseStatements);
+        }
+
+        // A G# if-expression arm is a block expression: it can run statements,
+        // then yield its trailing expression. Keep every arm-local spill/write in
+        // that block so only the selected C# arm executes it (issue #1723).
+        private (GExpression Value, List<GStatement> Statements) TranslateConditionalBranch(
+            ExpressionSyntax branch)
+        {
+            List<GStatement> outerSpillPrologue = this.state.PendingSpillPrologue;
+            var statements = new List<GStatement>();
+            this.state.PendingSpillPrologue = statements;
+            try
+            {
+                List<AssignmentExpressionSyntax> embedded =
+                    this.CollectEmbeddedAssignments(branch, includeSelf: true);
+                foreach (AssignmentExpressionSyntax node in embedded)
+                {
+                    statements.AddRange(this.FlattenChainedAssignment(node));
+                }
+
+                foreach (AssignmentExpressionSyntax node in embedded)
+                {
+                    this.state.SuppressedAssignments.Add(node);
+                }
+
+                try
+                {
+                    return (this.TranslateValueWithNullForgiveness(branch), statements);
+                }
+                finally
+                {
+                    foreach (AssignmentExpressionSyntax node in embedded)
+                    {
+                        this.state.SuppressedAssignments.Remove(node);
+                    }
+                }
+            }
+            finally
+            {
+                this.state.PendingSpillPrologue = outerSpillPrologue;
+            }
         }
 
         // Shared by the general `IfExpression` lowering above and the ADR-0151

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
@@ -2070,7 +2070,7 @@ public sealed partial class CSharpToGSharpTranslator
             if (expression is AssignmentExpressionSyntax outerAssignment &&
                 Unwrap(outerAssignment.Right) is AssignmentExpressionSyntax)
             {
-                return this.FlattenChainedAssignment(outerAssignment);
+                return this.FlattenChainedAssignment(outerAssignment, preserveValue: false);
             }
 
             return this.WithHoistedAssignments(

--- a/tools/cs2gs/Cs2Gs.Translator/DocumentTranslationState.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/DocumentTranslationState.cs
@@ -72,10 +72,17 @@ internal sealed class DocumentTranslationState
     // surrounding statement/condition seam has hoisted into a preceding
     // assignment statement (G# assignment is a statement, not a
     // value-yielding expression; spec §Statements). While a node is in this
-    // set, `TranslateExpression` renders it as a bare read of its already-
-    // written target rather than dropping the write (issue #1723).
+    // set, `TranslateExpression` renders its preserved assignment value rather
+    // than dropping the write (issue #1723).
     public HashSet<SyntaxNode> SuppressedAssignments { get; } =
         new HashSet<SyntaxNode>();
+
+    // Exact result of a value-position simple assignment whose target cannot be
+    // safely read back (property/indexer, side-effecting receiver/index, etc.).
+    // FlattenChainedAssignment captures the converted RHS before the write, so
+    // the expression result never invokes a getter or re-evaluates the target.
+    public Dictionary<AssignmentExpressionSyntax, GExpression> AssignmentValues { get; } =
+        new Dictionary<AssignmentExpressionSyntax, GExpression>();
 
     // Caches the G# value expression a value-position deconstruction
     // assignment (`(a, b) = (1, 2)` used as a value, not a bare statement)


### PR DESCRIPTION
## Summary
- lower assignments in conditional-expression arms into native G# block-valued branches
- capture converted RHS values before non-trivial target writes, avoiding getter readback, set-only failures, and receiver/index re-evaluation
- extend #1875 combined-value capture to standalone value-position compound assignments
- preserve receiver → index/getter → RHS → write evaluation order
- keep static/type-name receivers unspilled so static property/field assignments emit valid G#
- add compile-and-run coverage across dictionary, simple/compound instance and static targets, set-only indexer, return/invocation, and if-let fallback paths

## Tests
- issue #1723 regression class: 24 passed
- combined compound/static/assignment/conditional/exhaustiveness suites: 312 passed

Fixes #1723
