### PR TITLE
Fix property-target attributes on data-class members

### DIFF
--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Interfaces.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Interfaces.cs
@@ -979,15 +979,25 @@ internal sealed partial class DeclarationBinder
     // attribute silently never reached the emitter. Shared here so every
     // parameter-binding call site gets the same `@Attr` → ParameterSymbol
     // wiring the emitter already expects (AttributeTargetKind.Param).
-    private void BindAndAttachParameterAttributes(ParameterSyntax parameterSyntax, ParameterSymbol parameterSymbol)
+    // Issue #3082: data positional `@property:` annotations are excluded here
+    // and bound to the synthesized property in BindStructProperties.
+    private void BindAndAttachParameterAttributes(
+        ParameterSyntax parameterSyntax,
+        ParameterSymbol parameterSymbol,
+        bool isDataPositionalMember = false)
     {
         if (parameterSyntax.Annotations.IsDefaultOrEmpty)
         {
             return;
         }
 
+        var annotations = isDataPositionalMember
+            ? parameterSyntax.Annotations
+                .Where(annotation => !HasAttributeTarget(annotation, AttributeTargetKind.Property))
+                .ToImmutableArray()
+            : parameterSyntax.Annotations;
         var paramAttrs = BindAttributes(
-            parameterSyntax.Annotations,
+            annotations,
             AttributeTargetKind.Param,
             Binder.ParameterAllowedTargets,
             "a parameter declaration",
@@ -998,4 +1008,22 @@ internal sealed partial class DeclarationBinder
             parameterSymbol.SetAttributes(paramAttrs);
         }
     }
+
+    private ImmutableArray<BoundAttribute> BindDataPositionalPropertyAttributes(ParameterSyntax parameterSyntax)
+    {
+        var annotations = parameterSyntax.Annotations
+            .Where(annotation => HasAttributeTarget(annotation, AttributeTargetKind.Property))
+            .ToImmutableArray();
+        return BindAttributes(
+            annotations,
+            AttributeTargetKind.Property,
+            Binder.PropertyDeclarationAllowedTargets,
+            "a data positional property",
+            System.AttributeTargets.Property);
+    }
+
+    private static bool HasAttributeTarget(AnnotationSyntax annotation, AttributeTargetKind target)
+        => annotation.Target != null
+            && TryParseTargetKind(annotation.Target.KindIdentifier.Text, out var parsedTarget)
+            && parsedTarget == target;
 }

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
@@ -331,7 +331,10 @@ internal sealed partial class DeclarationBinder
 
                 // Issue #1913: primary-constructor parameters can carry
                 // `@Attr` annotations same as any other parameter list.
-                BindAndAttachParameterAttributes(paramSyntax, primaryCtorParam);
+                BindAndAttachParameterAttributes(
+                    paramSyntax,
+                    primaryCtorParam,
+                    isDataPositionalMember: syntax.IsData);
                 ctorBuilder.Add(primaryCtorParam);
 
                 // Data-type positional members are CLR properties (matching
@@ -1377,6 +1380,15 @@ internal sealed partial class DeclarationBinder
                         parameter.Type,
                         structSymbol.IsClass ? Accessibility.Private : Accessibility.Internal,
                         isReadOnly: false);
+
+                    var parameterSyntax = syntax.PrimaryConstructorParameters
+                        .First(candidate => candidate.Identifier.Text == parameter.Name);
+                    var propertyAttributes = BindDataPositionalPropertyAttributes(parameterSyntax);
+                    if (!propertyAttributes.IsDefaultOrEmpty)
+                    {
+                        property.SetAttributes(propertyAttributes);
+                    }
+
                     propertiesBuilder.Add(property);
                     existingNames.Add(parameter.Name);
                 }

--- a/test/Compiler.Tests/Emit/AttributeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/AttributeEmitTests.cs
@@ -6,6 +6,8 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -340,6 +342,41 @@ public class AttributeEmitTests
         Assert.DoesNotContain(
             foo.GetCustomAttributesData(),
             d => d.AttributeType.FullName == "System.ComponentModel.DescriptionAttribute");
+    }
+
+    [Fact]
+    public void Issue3082_PropertyTarget_On_DataPositionalMember_IsRuntimeObservable()
+    {
+        _ = typeof(JsonIgnoreAttribute).Assembly;
+        var source = """
+            package P
+            import System.Text.Json.Serialization
+
+            data class QuestionResult(
+                QuestionId string,
+                @property:JsonIgnore Points float64) {
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var resultType = assembly.GetTypes().Single(t => t.Name == "QuestionResult");
+        var pointsProperty = resultType.GetProperty("Points");
+        Assert.NotNull(pointsProperty);
+        Assert.Contains(
+            pointsProperty.GetCustomAttributesData(),
+            data => data.AttributeType == typeof(JsonIgnoreAttribute));
+
+        var constructor = resultType.GetConstructors()
+            .Single(ctor => ctor.GetParameters().Any(parameter => parameter.Name == "Points"));
+        var pointsParameter = constructor.GetParameters().Single(parameter => parameter.Name == "Points");
+        Assert.DoesNotContain(
+            pointsParameter.GetCustomAttributesData(),
+            data => data.AttributeType == typeof(JsonIgnoreAttribute));
+
+        var instance = Activator.CreateInstance(resultType, "question-1", 2.5);
+        var json = JsonSerializer.Serialize(instance, resultType);
+        Assert.Contains("\"QuestionId\":\"question-1\"", json);
+        Assert.DoesNotContain("\"Points\"", json);
     }
 
     [Fact]

--- a/test/Core.Tests/CodeAnalysis/Binding/AttributeBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/AttributeBinderTests.cs
@@ -138,6 +138,34 @@ public class AttributeBinderTests
     }
 
     [Fact]
+    public void Issue3082_PropertyTarget_On_DataPositionalMember_BindsToSynthesizedProperty()
+    {
+        _ = typeof(System.Text.Json.Serialization.JsonIgnoreAttribute).Assembly;
+        var source = """
+            import System.Text.Json.Serialization
+
+            data class QuestionResult(
+                QuestionId string,
+                @property:JsonIgnore Points float64) {
+            }
+            """;
+
+        var globalScope = BindSource(source);
+
+        Assert.DoesNotContain(GetBinderDiagnostics(globalScope), d => d.Id == "GS0201");
+        var result = globalScope.Structs.Single(s => s.Name == "QuestionResult");
+        var parameter = result.PrimaryConstructorParameters.Single(p => p.Name == "Points");
+        Assert.Empty(parameter.Attributes);
+
+        var property = result.Properties.Single(p => p.Name == "Points");
+        var attribute = Assert.Single(property.Attributes);
+        Assert.Equal(AttributeTargetKind.Property, attribute.Target);
+        Assert.Equal(
+            "System.Text.Json.Serialization.JsonIgnoreAttribute",
+            attribute.AttributeType.Name);
+    }
+
+    [Fact]
     public void Allows_Return_Use_Site_Target_On_Function()
     {
         // `[Description]` carries `[AttributeUsage(All)]`, which includes


### PR DESCRIPTION
## Summary
- bind `@property:` annotations on data positional members to synthesized property symbols
- keep constructor-parameter metadata free of property-targeted attributes
- add binding, reflection, and `System.Text.Json` runtime coverage

## Validation
- `dotnet test test/Core.Tests/Core.Tests.csproj --configuration Debug --filter "FullyQualifiedName~AttributeBinderTests|FullyQualifiedName~Issue2006ParamAttributeEmitTests" --no-restore` (65 passed)
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj --configuration Debug --filter "FullyQualifiedName~AttributeEmitTests" --no-restore` (18 passed)
- `dotnet build tools/cs2gs/Cs2Gs.Cli/Cs2Gs.Cli.csproj --configuration Debug --no-restore --nologo` (succeeded)
- Code Exploder Domain diagnostic migration: translation passed; `GS0201` and fingerprint `sha256:d8412bf18418f17f4338ab1e0f05c4754a831deee4181c91dba3500923989d91` disappeared. Remaining failures are unrelated known gaps: `GS0158` for generated-regex `Pattern` and `GS0159` for `Int32.Parse`.

Fixes #3082
