### PR TITLE
gsi: use integer entry-point results as exit codes

### DIFF
--- a/src/Core/CodeAnalysis/Compilation/Compilation.cs
+++ b/src/Core/CodeAnalysis/Compilation/Compilation.cs
@@ -290,7 +290,7 @@ public class Compilation
     /// <param name="variables">The symbol table with actual values.</param>
     /// <returns>An evaluation result.</returns>
     public EvaluationResult Evaluate(Dictionary<VariableSymbol, object> variables) =>
-        Evaluate(variables, evaluateEntryPoint: true);
+        Evaluate(variables, evaluateEntryPoint: true, useEntryPointReturnType: false);
 
     /// <summary>
     /// Evaluates the current compilation provided a symbol table with actual values.
@@ -298,7 +298,20 @@ public class Compilation
     /// <param name="variables">The symbol table with actual values.</param>
     /// <param name="evaluateEntryPoint">Whether to invoke an explicit program entry point.</param>
     /// <returns>An evaluation result.</returns>
-    public EvaluationResult Evaluate(Dictionary<VariableSymbol, object> variables, bool evaluateEntryPoint)
+    public EvaluationResult Evaluate(Dictionary<VariableSymbol, object> variables, bool evaluateEntryPoint) =>
+        Evaluate(variables, evaluateEntryPoint, useEntryPointReturnType: evaluateEntryPoint);
+
+    /// <summary>
+    /// Evaluates the current compilation provided a symbol table with actual values.
+    /// </summary>
+    /// <param name="variables">The symbol table with actual values.</param>
+    /// <param name="evaluateEntryPoint">Whether to invoke an explicit program entry point.</param>
+    /// <param name="useEntryPointReturnType">Whether the declared entry-point return type controls the result.</param>
+    /// <returns>An evaluation result.</returns>
+    public EvaluationResult Evaluate(
+        Dictionary<VariableSymbol, object> variables,
+        bool evaluateEntryPoint,
+        bool useEntryPointReturnType)
     {
         var parseDiagnostics = SyntaxTrees.SelectMany(st => st.Diagnostics);
         var diagnostics = parseDiagnostics.Concat(GlobalScope.Diagnostics).ToImmutableArray();
@@ -342,7 +355,11 @@ public class Compilation
             program,
             (References ?? Symbols.ReferenceResolver.Default()).MapClrTypeToReferences);
 
-        var evaluator = new Evaluator(program, variables, evaluateEntryPoint);
+        var evaluator = new Evaluator(
+            program,
+            variables,
+            evaluateEntryPoint,
+            useEntryPointReturnType);
         try
         {
             var value = evaluator.Evaluate();

--- a/src/Core/CodeAnalysis/Compilation/Compilation.cs
+++ b/src/Core/CodeAnalysis/Compilation/Compilation.cs
@@ -289,7 +289,16 @@ public class Compilation
     /// </summary>
     /// <param name="variables">The symbol table with actual values.</param>
     /// <returns>An evaluation result.</returns>
-    public EvaluationResult Evaluate(Dictionary<VariableSymbol, object> variables)
+    public EvaluationResult Evaluate(Dictionary<VariableSymbol, object> variables) =>
+        Evaluate(variables, evaluateEntryPoint: true);
+
+    /// <summary>
+    /// Evaluates the current compilation provided a symbol table with actual values.
+    /// </summary>
+    /// <param name="variables">The symbol table with actual values.</param>
+    /// <param name="evaluateEntryPoint">Whether to invoke an explicit program entry point.</param>
+    /// <returns>An evaluation result.</returns>
+    public EvaluationResult Evaluate(Dictionary<VariableSymbol, object> variables, bool evaluateEntryPoint)
     {
         var parseDiagnostics = SyntaxTrees.SelectMany(st => st.Diagnostics);
         var diagnostics = parseDiagnostics.Concat(GlobalScope.Diagnostics).ToImmutableArray();
@@ -333,7 +342,7 @@ public class Compilation
             program,
             (References ?? Symbols.ReferenceResolver.Default()).MapClrTypeToReferences);
 
-        var evaluator = new Evaluator(program, variables);
+        var evaluator = new Evaluator(program, variables, evaluateEntryPoint);
         try
         {
             var value = evaluator.Evaluate();

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -154,6 +154,23 @@ public sealed partial class Evaluator
     /// <returns>The evaluation result.</returns>
     public object Evaluate()
     {
+        // The binder has already resolved top-level-statement versus explicit-Main precedence.
+        // A null declaration identifies the synthesized top-level entry point.
+        if (program.EntryPoint?.Declaration != null
+            && program.Functions.TryGetValue(program.EntryPoint, out var entryPointBody))
+        {
+            var locals = new ConcurrentDictionary<VariableSymbol, object>();
+            if (program.EntryPoint.Parameters.Length > 0)
+            {
+                locals[program.EntryPoint.Parameters[0]] = Array.Empty<string>();
+            }
+
+            using (PushFrame(locals))
+            {
+                return EvaluateFunctionBody(entryPointBody);
+            }
+        }
+
         return EvaluateFunctionBody(program.Statement);
     }
 

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -38,6 +38,7 @@ public sealed partial class Evaluator
     private readonly BoundProgram program;
     private readonly Dictionary<VariableSymbol, object> globals;
     private readonly bool evaluateEntryPoint;
+    private readonly bool useEntryPointReturnType;
 
     // Issue #1651: everything below this point used to be an ordinary
     // instance field. That is correct only because the interpreter was
@@ -101,21 +102,24 @@ public sealed partial class Evaluator
     /// <param name="program">The program.</param>
     /// <param name="variables">The variables.</param>
     public Evaluator(BoundProgram program, Dictionary<VariableSymbol, object> variables)
-        : this(program, variables, evaluateEntryPoint: true)
+        : this(
+            program,
+            variables,
+            evaluateEntryPoint: true,
+            useEntryPointReturnType: false)
     {
     }
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="Evaluator"/> class.
-    /// </summary>
-    /// <param name="program">The program.</param>
-    /// <param name="variables">The variables.</param>
-    /// <param name="evaluateEntryPoint">Whether to invoke an explicit program entry point.</param>
-    public Evaluator(BoundProgram program, Dictionary<VariableSymbol, object> variables, bool evaluateEntryPoint)
+    internal Evaluator(
+        BoundProgram program,
+        Dictionary<VariableSymbol, object> variables,
+        bool evaluateEntryPoint,
+        bool useEntryPointReturnType)
     {
         this.program = program;
         globals = variables;
         this.evaluateEntryPoint = evaluateEntryPoint;
+        this.useEntryPointReturnType = useEntryPointReturnType;
         Locals.Push(new ConcurrentDictionary<VariableSymbol, object>());
     }
 
@@ -197,6 +201,11 @@ public sealed partial class Evaluator
 
     private object EvaluateEntryPointBody(FunctionSymbol entryPoint, BoundBlockStatement body)
     {
+        if (!useEntryPointReturnType)
+        {
+            return EvaluateFunctionBody(body);
+        }
+
         if (entryPoint.Type != TypeSymbol.Void
             && entryPoint.Type != TypeSymbol.Int32
             && entryPoint.Type != TypeSymbol.UInt32)

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -37,6 +37,7 @@ public sealed partial class Evaluator
 {
     private readonly BoundProgram program;
     private readonly Dictionary<VariableSymbol, object> globals;
+    private readonly bool evaluateEntryPoint;
 
     // Issue #1651: everything below this point used to be an ordinary
     // instance field. That is correct only because the interpreter was
@@ -100,9 +101,21 @@ public sealed partial class Evaluator
     /// <param name="program">The program.</param>
     /// <param name="variables">The variables.</param>
     public Evaluator(BoundProgram program, Dictionary<VariableSymbol, object> variables)
+        : this(program, variables, evaluateEntryPoint: true)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Evaluator"/> class.
+    /// </summary>
+    /// <param name="program">The program.</param>
+    /// <param name="variables">The variables.</param>
+    /// <param name="evaluateEntryPoint">Whether to invoke an explicit program entry point.</param>
+    public Evaluator(BoundProgram program, Dictionary<VariableSymbol, object> variables, bool evaluateEntryPoint)
     {
         this.program = program;
         globals = variables;
+        this.evaluateEntryPoint = evaluateEntryPoint;
         Locals.Push(new ConcurrentDictionary<VariableSymbol, object>());
     }
 
@@ -156,11 +169,14 @@ public sealed partial class Evaluator
     {
         // The binder has already resolved top-level-statement versus explicit-Main precedence.
         // A null declaration identifies the synthesized top-level entry point.
-        if (program.EntryPoint?.Declaration != null
-            && program.Functions.TryGetValue(program.EntryPoint, out var entryPointBody))
+        if (evaluateEntryPoint && program.EntryPoint?.Declaration != null)
         {
+            // Every resolved explicit entry point must have a bound body; fail loudly if that
+            // invariant is broken rather than silently evaluating an empty top-level block.
+            var entryPointBody = program.Functions[program.EntryPoint];
             var locals = new ConcurrentDictionary<VariableSymbol, object>();
-            if (program.EntryPoint.Parameters.Length > 0)
+            if (program.EntryPoint.Parameters.Length == 1
+                && program.EntryPoint.Parameters[0].Type == SliceTypeSymbol.Get(TypeSymbol.String))
             {
                 locals[program.EntryPoint.Parameters[0]] = Array.Empty<string>();
             }

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -169,25 +169,43 @@ public sealed partial class Evaluator
     {
         // The binder has already resolved top-level-statement versus explicit-Main precedence.
         // A null declaration identifies the synthesized top-level entry point.
-        if (evaluateEntryPoint && program.EntryPoint?.Declaration != null)
+        if (evaluateEntryPoint && program.EntryPoint is { } entryPoint)
         {
-            // Every resolved explicit entry point must have a bound body; fail loudly if that
-            // invariant is broken rather than silently evaluating an empty top-level block.
-            var entryPointBody = program.Functions[program.EntryPoint];
-            var locals = new ConcurrentDictionary<VariableSymbol, object>();
-            if (program.EntryPoint.Parameters.Length == 1
-                && program.EntryPoint.Parameters[0].Type == SliceTypeSymbol.Get(TypeSymbol.String))
+            if (entryPoint.Declaration != null)
             {
-                locals[program.EntryPoint.Parameters[0]] = Array.Empty<string>();
+                // Every resolved explicit entry point must have a bound body; fail loudly if that
+                // invariant is broken rather than silently evaluating an empty top-level block.
+                var entryPointBody = program.Functions[entryPoint];
+                var locals = new ConcurrentDictionary<VariableSymbol, object>();
+                if (entryPoint.Parameters.Length == 1
+                    && entryPoint.Parameters[0].Type == SliceTypeSymbol.Get(TypeSymbol.String))
+                {
+                    locals[entryPoint.Parameters[0]] = Array.Empty<string>();
+                }
+
+                using (PushFrame(locals))
+                {
+                    return EvaluateEntryPointBody(entryPoint, entryPointBody);
+                }
             }
 
-            using (PushFrame(locals))
-            {
-                return EvaluateFunctionBody(entryPointBody);
-            }
+            return EvaluateEntryPointBody(entryPoint, program.Statement);
         }
 
         return EvaluateFunctionBody(program.Statement);
+    }
+
+    private object EvaluateEntryPointBody(FunctionSymbol entryPoint, BoundBlockStatement body)
+    {
+        if (entryPoint.Type != TypeSymbol.Void
+            && entryPoint.Type != TypeSymbol.Int32
+            && entryPoint.Type != TypeSymbol.UInt32)
+        {
+            throw new InvalidOperationException("Entry point must have a return type of void, int32, or uint32.");
+        }
+
+        var value = EvaluateFunctionBody(body);
+        return entryPoint.Type == TypeSymbol.Void ? null : value;
     }
 
     // Issue #1651: goroutines run with their own locals/control-transfer

--- a/src/Repl/Engine/SessionEngine.cs
+++ b/src/Repl/Engine/SessionEngine.cs
@@ -157,6 +157,12 @@ public sealed class SessionEngine
     public bool CaptureConsole { get; set; }
 
     /// <summary>
+    /// When <see langword="true"/>, invokes an explicit program entry point. Script mode enables
+    /// this; interactive submissions leave it disabled so declaring <c>Main</c> has no side effect.
+    /// </summary>
+    public bool RunEntryPoint { get; set; }
+
+    /// <summary>
     /// Optional provider that supplies a line of standard input when evaluated code reads from
     /// <see cref="Console.In"/> (e.g. <c>Console.ReadLine()</c>). Returning <see langword="null"/>
     /// signals end-of-input. When unset, <see cref="Console.In"/> is left untouched.
@@ -211,7 +217,7 @@ public sealed class SessionEngine
             {
                 var tree = SyntaxTree.Parse(SourceText.From(text, fileName));
                 var compilation = previous == null ? new Compilation(tree) : previous.ContinueWith(tree);
-                var result = compilation.Evaluate(variables);
+                var result = compilation.Evaluate(variables, evaluateEntryPoint: RunEntryPoint);
 
                 var hasError = result.Diagnostics.Any(d => d.IsError);
 

--- a/src/Repl/Program.cs
+++ b/src/Repl/Program.cs
@@ -54,7 +54,7 @@ public static class Program
             return 1;
         }
 
-        var engine = new SessionEngine();
+        var engine = new SessionEngine { RunEntryPoint = true };
         var cell = engine.Evaluate(File.ReadAllText(arg), arg);
         if (cell.Diagnostics.Length > 0)
         {

--- a/src/Repl/Program.cs
+++ b/src/Repl/Program.cs
@@ -61,11 +61,21 @@ public static class Program
             Console.Error.WriteDiagnostics(cell.Diagnostics);
         }
 
-        if (!cell.HasError && cell.Value is not null)
+        if (cell.HasError)
+        {
+            return 1;
+        }
+
+        if (cell.Value is int exitCode)
+        {
+            return exitCode;
+        }
+
+        if (cell.Value is not null)
         {
             Console.WriteLine(cell.Value);
         }
 
-        return cell.HasError ? 1 : 0;
+        return 0;
     }
 }

--- a/src/Repl/Program.cs
+++ b/src/Repl/Program.cs
@@ -71,9 +71,9 @@ public static class Program
             return exitCode;
         }
 
-        if (cell.Value is not null)
+        if (cell.Value is uint unsignedExitCode)
         {
-            Console.WriteLine(cell.Value);
+            return unchecked((int)unsignedExitCode);
         }
 
         return 0;

--- a/test/Interpreter.Tests/Issue2984MainEntryPointInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2984MainEntryPointInterpreterTests.cs
@@ -37,6 +37,37 @@ public class Issue2984MainEntryPointInterpreterTests
     }
 
     [Fact]
+    public void EvaluatorDefaultRunsEntryPoint()
+    {
+        const string Source = """
+            import System
+
+            func Main() {
+                Console.WriteLine("evaluator-main")
+            }
+            """;
+
+        using var output = new StringWriter();
+        var previousOutput = Console.Out;
+        Console.SetOut(output);
+        try
+        {
+            var compilation = new Compilation(SyntaxTree.Parse(Source));
+            var evaluator = new Evaluator(
+                compilation.BoundProgram,
+                new Dictionary<VariableSymbol, object>());
+
+            evaluator.Evaluate();
+
+            Assert.Equal("evaluator-main\n", output.ToString().Replace("\r\n", "\n"));
+        }
+        finally
+        {
+            Console.SetOut(previousOutput);
+        }
+    }
+
+    [Fact]
     public void ClassScopedSharedMainRuns()
     {
         const string Source = """

--- a/test/Interpreter.Tests/Issue2984MainEntryPointInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2984MainEntryPointInterpreterTests.cs
@@ -1,0 +1,128 @@
+// <copyright file="Issue2984MainEntryPointInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #2984: the interpreter invokes the entry point selected by the binder.
+/// </summary>
+[Collection("ConsoleIo")]
+public class Issue2984MainEntryPointInterpreterTests
+{
+    [Fact]
+    public void PackageScopeMainRuns()
+    {
+        const string Source = """
+            import System
+
+            func Main() {
+                Console.WriteLine("package-main")
+            }
+            """;
+
+        var (result, output) = Evaluate(Source);
+
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+        Assert.Equal("package-main\n", output);
+    }
+
+    [Fact]
+    public void ClassScopedSharedMainRuns()
+    {
+        const string Source = """
+            import System
+
+            class Launcher {
+                shared {
+                    func Main() {
+                        Console.WriteLine("class-main")
+                    }
+                }
+            }
+            """;
+
+        var (result, output) = Evaluate(Source);
+
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+        Assert.Equal("class-main\n", output);
+    }
+
+    [Fact]
+    public void TopLevelStatementsStillRun()
+    {
+        const string Source = """
+            import System
+
+            Console.WriteLine("top-level")
+            """;
+
+        var (result, output) = Evaluate(Source);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("top-level\n", output);
+    }
+
+    [Fact]
+    public void TopLevelStatementsWinOverExplicitMain()
+    {
+        const string Source = """
+            import System
+
+            Console.WriteLine("top-level")
+
+            func Main() {
+                Console.WriteLine("explicit-main")
+            }
+            """;
+
+        var (result, output) = Evaluate(Source);
+
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0166");
+        Assert.Equal("top-level\n", output);
+    }
+
+    [Fact]
+    public void MainArgsReceivesEmptyArray()
+    {
+        const string Source = """
+            import System
+
+            func Main(args []string) {
+                Console.WriteLine(args.Length)
+            }
+            """;
+
+        var (result, output) = Evaluate(Source);
+
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+        Assert.Equal("0\n", output);
+    }
+
+    private static (EvaluationResult Result, string Output) Evaluate(string source)
+    {
+        using var output = new StringWriter();
+        var previousOutput = Console.Out;
+        Console.SetOut(output);
+        try
+        {
+            var result = new Compilation(SyntaxTree.Parse(source))
+                .Evaluate(new Dictionary<VariableSymbol, object>());
+            return (result, output.ToString().Replace("\r\n", "\n"));
+        }
+        finally
+        {
+            Console.SetOut(previousOutput);
+        }
+    }
+}

--- a/test/Interpreter.Tests/Issue2984MainEntryPointInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2984MainEntryPointInterpreterTests.cs
@@ -109,6 +109,28 @@ public class Issue2984MainEntryPointInterpreterTests
         Assert.Equal("0\n", output);
     }
 
+    [Fact]
+    public void NonArgsMainParameterIsNotSeededWithStringArray()
+    {
+        const string Source = """
+            import System
+
+            func Main(x int32) {
+                Console.WriteLine(x)
+            }
+            """;
+
+        var (result, output) = Evaluate(Source);
+
+        Assert.Contains(
+            result.Diagnostics,
+            diagnostic => diagnostic.IsError && diagnostic.Message.Contains("x int32"));
+        Assert.DoesNotContain(
+            result.Diagnostics,
+            diagnostic => diagnostic.Message.Contains("System.String[]"));
+        Assert.Equal(string.Empty, output);
+    }
+
     private static (EvaluationResult Result, string Output) Evaluate(string source)
     {
         using var output = new StringWriter();

--- a/test/Interpreter.Tests/Issue2984MainEntryPointInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2984MainEntryPointInterpreterTests.cs
@@ -68,6 +68,27 @@ public class Issue2984MainEntryPointInterpreterTests
     }
 
     [Fact]
+    public void CompilationEvaluationPreservesTopLevelExpressionValue()
+    {
+        var result = new Compilation(SyntaxTree.Parse("40 + 2"))
+            .Evaluate(new Dictionary<VariableSymbol, object>());
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void EvaluatorDefaultPreservesTopLevelExpressionValue()
+    {
+        var compilation = new Compilation(SyntaxTree.Parse("40 + 2"));
+        var evaluator = new Evaluator(
+            compilation.BoundProgram,
+            new Dictionary<VariableSymbol, object>());
+
+        Assert.Equal(42, evaluator.Evaluate());
+    }
+
+    [Fact]
     public void ClassScopedSharedMainRuns()
     {
         const string Source = """

--- a/test/Interpreter.Tests/Issue2984ReplEntryPointTests.cs
+++ b/test/Interpreter.Tests/Issue2984ReplEntryPointTests.cs
@@ -1,0 +1,37 @@
+// <copyright file="Issue2984ReplEntryPointTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Repl.Engine;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #2984: interactive declarations do not execute a script entry point.
+/// </summary>
+[Collection("ConsoleIo")]
+public class Issue2984ReplEntryPointTests
+{
+    [Fact]
+    public void DeclarationOnlySubmissionsDoNotRunMain()
+    {
+        var engine = new SessionEngine { CaptureConsole = true };
+
+        var mainDeclaration = engine.Evaluate(
+            """
+            import System
+
+            func Main() {
+                Console.WriteLine("main")
+            }
+            """);
+        var nextDeclaration = engine.Evaluate("func Helper() { }");
+
+        Assert.False(mainDeclaration.HasError);
+        Assert.False(nextDeclaration.HasError);
+        Assert.Equal(
+            (string.Empty, string.Empty),
+            (mainDeclaration.Output, nextDeclaration.Output));
+    }
+}

--- a/test/Interpreter.Tests/Issue2984ReplEntryPointTests.cs
+++ b/test/Interpreter.Tests/Issue2984ReplEntryPointTests.cs
@@ -34,4 +34,33 @@ public class Issue2984ReplEntryPointTests
             (string.Empty, string.Empty),
             (mainDeclaration.Output, nextDeclaration.Output));
     }
+
+    [Fact]
+    public void ScriptEntryPointRunsOnlyOnDeclaringSubmission()
+    {
+        var engine = new SessionEngine { CaptureConsole = true, RunEntryPoint = true };
+
+        var mainDeclaration = engine.Evaluate(
+            """
+            import System
+
+            func Main() int32 {
+                Console.WriteLine("main-once")
+                return 7
+            }
+            """);
+        var nextDeclaration = engine.Evaluate("func Helper() { }");
+        var nextExpression = engine.Evaluate("40 + 2");
+
+        Assert.False(mainDeclaration.HasError);
+        Assert.False(nextDeclaration.HasError);
+        Assert.False(nextExpression.HasError);
+        Assert.Equal(7, mainDeclaration.Value);
+        Assert.Null(nextDeclaration.Value);
+        Assert.Null(nextExpression.Value);
+        Assert.Equal("main-once\n", mainDeclaration.Output);
+        Assert.Equal(
+            (string.Empty, string.Empty),
+            (nextDeclaration.Output, nextExpression.Output));
+    }
 }

--- a/test/Interpreter.Tests/Issue3010EntryPointExitCodeTests.cs
+++ b/test/Interpreter.Tests/Issue3010EntryPointExitCodeTests.cs
@@ -103,7 +103,9 @@ public class Issue3010EntryPointExitCodeTests
 
         Assert.Equal(1, result.ExitCode);
         Assert.Equal(string.Empty, result.StandardOutput);
-        Assert.Equal("GS0100: Not all code paths return a value.\n", result.StandardError);
+        Assert.Contains(
+            "error GS0100: Not all code paths return a value.",
+            result.StandardError);
     }
 
     [Fact]
@@ -210,8 +212,8 @@ public class Issue3010EntryPointExitCodeTests
 
         Assert.Equal(1, result.ExitCode);
         Assert.Equal(string.Empty, result.StandardOutput);
-        Assert.Equal(
-            "GSI001: Evaluation error: Entry point must have a return type of void, int32, or uint32.\n",
+        Assert.Contains(
+            "error GSI001: Evaluation error: Entry point must have a return type of void, int32, or uint32.",
             result.StandardError);
     }
 
@@ -235,8 +237,8 @@ public class Issue3010EntryPointExitCodeTests
 
         Assert.Equal(1, result.ExitCode);
         Assert.Equal(string.Empty, result.StandardOutput);
-        Assert.Equal(
-            "GSI001: Evaluation error: Entry point must have a return type of void, int32, or uint32.\n",
+        Assert.Contains(
+            "error GSI001: Evaluation error: Entry point must have a return type of void, int32, or uint32.",
             result.StandardError);
     }
 

--- a/test/Interpreter.Tests/Issue3010EntryPointExitCodeTests.cs
+++ b/test/Interpreter.Tests/Issue3010EntryPointExitCodeTests.cs
@@ -3,7 +3,11 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace GSharp.Interpreter.Tests;
@@ -14,201 +18,125 @@ namespace GSharp.Interpreter.Tests;
 [Collection("ConsoleIo")]
 public class Issue3010EntryPointExitCodeTests
 {
-    [Fact]
-    public void ExplicitMainIntegerResultBecomesExitCode()
+    public enum ProgramShape
     {
-        const string Source = """
-            import System
+        ExplicitMain,
+        TopLevel,
+    }
 
-            func Main() int32 {
-                Console.WriteLine("main")
-                return 7
-            }
-            """;
+    public static IEnumerable<object[]> IntegerExitCases()
+    {
+        foreach (var shape in Enum.GetValues<ProgramShape>())
+        {
+            yield return new object[] { shape, 0, 0 };
+            yield return new object[] { shape, 7, 7 };
+            yield return new object[] { shape, -1, NormalizeProcessExitCode(-1) };
+            yield return new object[] { shape, 256, NormalizeProcessExitCode(256) };
+        }
+    }
 
-        var result = RunScript(Source);
+    public static IEnumerable<object[]> FalsePositiveCases()
+    {
+        foreach (var shape in Enum.GetValues<ProgramShape>())
+        {
+            yield return new object[] { shape, "void", "void-22\n" };
+            yield return new object[] { shape, "trailing-int", "keep-22\n" };
+            yield return new object[] { shape, "trailing-string", "keep-22\n" };
+            yield return new object[] { shape, "ignored-int-call", "call-22\n" };
+        }
+    }
 
-        Assert.Equal(7, result.ExitCode);
-        Assert.Equal("main\n", result.StandardOutput);
-        Assert.Equal(string.Empty, result.StandardError);
+    [Theory]
+    [MemberData(nameof(IntegerExitCases))]
+    public async Task IntegerEntryPointResultMatchesEmittedProgramAsync(
+        ProgramShape shape,
+        int returnedValue,
+        int expectedProcessExitCode)
+    {
+        var source = shape == ProgramShape.ExplicitMain
+            ? $$"""
+                import System
+
+                func Main() int32 {
+                    Console.WriteLine("{{shape}}-11")
+                    return {{returnedValue}}
+                }
+                """
+            : $$"""
+                import System
+
+                Console.WriteLine("{{shape}}-11")
+                return {{returnedValue}}
+                """;
+
+        await AssertDriverMatrixAsync(
+            source,
+            $"{shape}-11\n",
+            expectedProcessExitCode);
+    }
+
+    [Theory]
+    [MemberData(nameof(FalsePositiveCases))]
+    public async Task NonExitValuesRemainDiscardedAsync(
+        ProgramShape shape,
+        string valueShape,
+        string expectedOutput)
+    {
+        var source = BuildFalsePositiveSource(shape, valueShape);
+
+        await AssertDriverMatrixAsync(source, expectedOutput, expectedProcessExitCode: 0);
     }
 
     [Fact]
-    public void TopLevelIntegerResultBecomesExitCode()
-    {
-        const string Source = """
-            import System
-
-            Console.WriteLine("tls")
-            return 7
-            """;
-
-        var result = RunScript(Source);
-
-        Assert.Equal(7, result.ExitCode);
-        Assert.Equal("tls\n", result.StandardOutput);
-        Assert.Equal(string.Empty, result.StandardError);
-    }
-
-    [Fact]
-    public void ExplicitMainIntegerZeroReturnsZero()
-    {
-        const string Source = """
-            import System
-
-            func Main() int32 {
-                Console.WriteLine("zero")
-                return 0
-            }
-            """;
-
-        var result = RunScript(Source);
-
-        Assert.Equal(0, result.ExitCode);
-        Assert.Equal("zero\n", result.StandardOutput);
-        Assert.Equal(string.Empty, result.StandardError);
-    }
-
-    [Fact]
-    public void ExplicitMainUnsignedIntegerResultBecomesExitCode()
+    public async Task ExplicitMainUnsignedIntegerResultBecomesExitCodeAsync()
     {
         const string Source = """
             import System
 
             func Main() uint32 {
-                Console.WriteLine("unsigned")
+                Console.WriteLine("unsigned-11")
                 return 7
             }
             """;
 
-        var result = RunScript(Source);
+        var result = await RunScriptProcessAsync(Source);
 
         Assert.Equal(7, result.ExitCode);
-        Assert.Equal("unsigned\n", result.StandardOutput);
+        Assert.Equal("unsigned-11\n", result.StandardOutput);
         Assert.Equal(string.Empty, result.StandardError);
     }
 
     [Fact]
-    public void ExplicitMainIntegerFalloffIsRejected()
+    public async Task ExplicitMainIntegerFalloffIsRejectedAsync()
     {
         const string Source = """
             import System
 
             func Main() int32 {
-                Console.WriteLine("must-not-run")
+                Console.WriteLine("must-not-run-11")
             }
             """;
 
-        var result = RunScript(Source);
+        var result = await RunScriptProcessAsync(Source);
 
         Assert.Equal(1, result.ExitCode);
         Assert.Equal(string.Empty, result.StandardOutput);
-        Assert.Contains(
-            "error GS0100: Not all code paths return a value.",
-            result.StandardError);
+        Assert.Contains("error GS0100: Not all code paths return a value.", result.StandardError);
     }
 
     [Fact]
-    public void ExplicitVoidMainDiscardsBareIntegerExpression()
-    {
-        const string Source = """
-            import System
-
-            func Main() {
-                Console.WriteLine("void-int")
-                40 + 2
-            }
-            """;
-
-        var result = RunScript(Source);
-
-        Assert.Equal(0, result.ExitCode);
-        Assert.Equal("void-int\n", result.StandardOutput);
-        Assert.Equal(string.Empty, result.StandardError);
-    }
-
-    [Fact]
-    public void ExplicitVoidMainDiscardsBareStringExpression()
-    {
-        const string Source = """
-            import System
-
-            func Main() {
-                Console.WriteLine("void-string")
-                "leaked"
-            }
-            """;
-
-        var result = RunScript(Source);
-
-        Assert.Equal(0, result.ExitCode);
-        Assert.Equal("void-string\n", result.StandardOutput);
-        Assert.Equal(string.Empty, result.StandardError);
-    }
-
-    [Fact]
-    public void ExplicitVoidMainDiscardsIgnoredIntegerCall()
-    {
-        const string Source = """
-            import System
-
-            func Compute() int32 {
-                return 11
-            }
-
-            func Main() {
-                Console.WriteLine("void-call-int")
-                Compute()
-            }
-            """;
-
-        var result = RunScript(Source);
-
-        Assert.Equal(0, result.ExitCode);
-        Assert.Equal("void-call-int\n", result.StandardOutput);
-        Assert.Equal(string.Empty, result.StandardError);
-    }
-
-    [Fact]
-    public void ExplicitVoidMainDiscardsIgnoredGSharpValueCall()
-    {
-        const string Source = """
-            import System
-
-            struct Marker {
-                var N int32
-            }
-
-            func Make() Marker {
-                return Marker{N: 33}
-            }
-
-            func Main() {
-                Console.WriteLine("void-call-type")
-                Make()
-            }
-            """;
-
-        var result = RunScript(Source);
-
-        Assert.Equal(0, result.ExitCode);
-        Assert.Equal("void-call-type\n", result.StandardOutput);
-        Assert.Equal(string.Empty, result.StandardError);
-    }
-
-    [Fact]
-    public void ExplicitStringMainIsRejectedBeforeExecution()
+    public async Task ExplicitStringMainIsRejectedBeforeExecutionAsync()
     {
         const string Source = """
             import System
 
             func Main() string {
-                Console.WriteLine("must-not-run")
-                return "invalid"
+                Console.WriteLine("must-not-run-11")
+                return "value-33"
             }
             """;
 
-        var result = RunScript(Source);
+        var result = await RunScriptProcessAsync(Source);
 
         Assert.Equal(1, result.ExitCode);
         Assert.Equal(string.Empty, result.StandardOutput);
@@ -218,135 +146,197 @@ public class Issue3010EntryPointExitCodeTests
     }
 
     [Fact]
-    public void ExplicitGSharpValueMainIsRejectedBeforeExecution()
+    public async Task DeclarationOnlyScriptReturnsZeroWithoutOutputAsync()
     {
-        const string Source = """
-            import System
+        var result = await RunScriptProcessAsync("func Helper() { }");
 
-            struct Marker {
-                var N int32
-            }
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(string.Empty, result.StandardOutput);
+        Assert.Equal(string.Empty, result.StandardError);
+    }
 
-            func Main() Marker {
-                Console.WriteLine("must-not-run")
-                return Marker{N: 33}
-            }
-            """;
-
-        var result = RunScript(Source);
+    [Fact]
+    public async Task ScriptDiagnosticRetainsSourcePathAsync()
+    {
+        var result = await RunScriptProcessAsync("not valid G# source");
 
         Assert.Equal(1, result.ExitCode);
-        Assert.Equal(string.Empty, result.StandardOutput);
-        Assert.Contains(
-            "error GSI001: Evaluation error: Entry point must have a return type of void, int32, or uint32.",
-            result.StandardError);
+        Assert.Contains(result.SourcePath, result.StandardError);
     }
 
-    [Fact]
-    public void TopLevelVoidEntryPointDiscardsBareIntegerExpression()
+    private static string BuildFalsePositiveSource(ProgramShape shape, string valueShape)
     {
-        const string Source = """
-            import System
+        var body = valueShape switch
+        {
+            "void" => "    Console.WriteLine(\"void-22\")",
+            "trailing-int" => "    Console.WriteLine(\"keep-22\")\n    33",
+            "trailing-string" => "    Console.WriteLine(\"keep-22\")\n    \"value-33\"",
+            "ignored-int-call" => "    Console.WriteLine(\"call-22\")\n    Compute()",
+            _ => throw new ArgumentOutOfRangeException(nameof(valueShape)),
+        };
+        var helper = valueShape == "ignored-int-call"
+            ? """
+                func Compute() int32 {
+                    return 33
+                }
 
-            Console.WriteLine("top-int")
-            40 + 2
-            """;
+                """
+            : string.Empty;
 
-        var result = RunScript(Source);
+        return shape == ProgramShape.ExplicitMain
+            ? $$"""
+                import System
 
-        Assert.Equal(0, result.ExitCode);
-        Assert.Equal("top-int\n", result.StandardOutput);
-        Assert.Equal(string.Empty, result.StandardError);
+                {{helper}}func Main() {
+                {{body}}
+                }
+                """
+            : $$"""
+                import System
+
+                {{helper}}{{body[4..]}}
+                """;
     }
 
-    [Fact]
-    public void TopLevelVoidEntryPointDiscardsBareStringExpression()
+    private static async Task AssertDriverMatrixAsync(
+        string source,
+        string expectedProgramOutput,
+        int expectedProcessExitCode)
     {
-        const string Source = """
-            import System
+        var root = Path.Combine(
+            Environment.CurrentDirectory,
+            "Issue3010Matrix",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        Assert.Empty(Directory.EnumerateFileSystemEntries(root));
 
-            Console.WriteLine("top-string")
-            "leaked"
-            """;
+        var sourcePath = Path.Combine(root, "program.gs");
+        var emitDirectory = Path.Combine(root, "emit");
+        Directory.CreateDirectory(emitDirectory);
+        Assert.Empty(Directory.EnumerateFileSystemEntries(emitDirectory));
+        File.WriteAllText(sourcePath, source);
 
-        var result = RunScript(Source);
+        var assemblyPath = Path.Combine(
+            emitDirectory,
+            $"Probe_{Guid.NewGuid():N}.dll");
+        var gsc = GetDriverPath("gsc");
+        var gsi = GetDriverPath("gsi");
 
-        Assert.Equal(0, result.ExitCode);
-        Assert.Equal("top-string\n", result.StandardOutput);
-        Assert.Equal(string.Empty, result.StandardError);
-    }
-
-    [Fact]
-    public void TopLevelVoidEntryPointDiscardsIgnoredIntegerCall()
-    {
-        const string Source = """
-            import System
-
-            func Compute() int32 {
-                return 22
-            }
-
-            Console.WriteLine("top-call-int")
-            Compute()
-            """;
-
-        var result = RunScript(Source);
-
-        Assert.Equal(0, result.ExitCode);
-        Assert.Equal("top-call-int\n", result.StandardOutput);
-        Assert.Equal(string.Empty, result.StandardError);
-    }
-
-    [Fact]
-    public void TopLevelNoResultReturnsZero()
-    {
-        const string Source = """
-            import System
-
-            Console.WriteLine("top-no-result")
-            """;
-
-        var result = RunScript(Source);
-
-        Assert.Equal(0, result.ExitCode);
-        Assert.Equal("top-no-result\n", result.StandardOutput);
-        Assert.Equal(string.Empty, result.StandardError);
-    }
-
-    [Fact]
-    public void DeclarationOnlyScriptReturnsZeroWithoutOutput()
-    {
-        var result = RunScript("func Helper() { }");
-
-        Assert.Equal(0, result.ExitCode);
-        Assert.Equal(string.Empty, result.StandardOutput);
-        Assert.Equal(string.Empty, result.StandardError);
-    }
-
-    private static (int ExitCode, string StandardOutput, string StandardError) RunScript(string source)
-    {
-        var path = Path.Combine(Environment.CurrentDirectory, $".issue3010-{Guid.NewGuid():N}.gs");
-        File.WriteAllText(path, source);
-
-        using var output = new StringWriter();
-        using var error = new StringWriter();
-        var previousOutput = Console.Out;
-        var previousError = Console.Error;
-        Console.SetOut(output);
-        Console.SetError(error);
         try
         {
-            var exitCode = GSharp.Repl.Program.Main(new[] { path });
-            return (
-                exitCode,
-                output.ToString().Replace("\r\n", "\n"),
-                error.ToString().Replace("\r\n", "\n"));
+            var evaluated = await RunProcessAsync(gsc, sourcePath);
+            Assert.Equal(0, evaluated.ExitCode);
+            Assert.Equal(expectedProgramOutput + "Success.\n", evaluated.StandardOutput);
+            Assert.Equal(string.Empty, evaluated.StandardError);
+
+            var emitted = await RunProcessAsync(gsc, sourcePath, $"/out:{assemblyPath}");
+            Assert.Equal(0, emitted.ExitCode);
+            Assert.Equal(string.Empty, emitted.StandardError);
+            Assert.True(File.Exists(assemblyPath));
+            Assert.NotEmpty(Assembly.Load(File.ReadAllBytes(assemblyPath)).GetTypes());
+
+            var compiled = await RunProcessAsync("dotnet", assemblyPath);
+            var interpreted = await RunProcessAsync(gsi, sourcePath);
+
+            Assert.Equal(expectedProcessExitCode, compiled.ExitCode);
+            Assert.Equal(expectedProcessExitCode, interpreted.ExitCode);
+            Assert.Equal(expectedProgramOutput, compiled.StandardOutput);
+            Assert.Equal(compiled.StandardOutput, interpreted.StandardOutput);
+            Assert.Equal(string.Empty, compiled.StandardError);
+            Assert.Equal(compiled.StandardError, interpreted.StandardError);
         }
         finally
         {
-            Console.SetOut(previousOutput);
-            Console.SetError(previousError);
-            File.Delete(path);
+            Directory.Delete(root, recursive: true);
         }
     }
+
+    private static async Task<ScriptResult> RunScriptProcessAsync(string source)
+    {
+        var root = Path.Combine(
+            Environment.CurrentDirectory,
+            "Issue3010",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        var path = Path.Combine(root, "program.gs");
+        File.WriteAllText(path, source);
+
+        try
+        {
+            var result = await RunProcessAsync(GetDriverPath("gsi"), path);
+            return new ScriptResult(
+                result.ExitCode,
+                result.StandardOutput,
+                result.StandardError,
+                path);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static string GetDriverPath(string driver)
+    {
+        var testDirectory = Path.GetDirectoryName(
+            typeof(Issue3010EntryPointExitCodeTests).Assembly.Location);
+        var executable = Path.GetFullPath(Path.Combine(
+            testDirectory,
+            driver == "gsi" ? ".." : ".",
+            driver == "gsi" ? "Repl" : string.Empty,
+            OperatingSystem.IsWindows() ? $"{driver}.exe" : driver));
+        Assert.True(File.Exists(executable), $"{driver} executable not found at {executable}.");
+        return executable;
+    }
+
+    private static async Task<ProcessResult> RunProcessAsync(
+        string executable,
+        params string[] arguments)
+    {
+        var startInfo = new ProcessStartInfo(executable)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        using var process = Process.Start(startInfo);
+        Assert.NotNull(process);
+
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+        if (!process.WaitForExit(30_000))
+        {
+            process.Kill(entireProcessTree: true);
+            Assert.True(process.WaitForExit(5_000), "Child process did not exit after it was killed.");
+            await Task.WhenAll(stdoutTask, stderrTask);
+            Assert.Fail($"Process timed out after 30 seconds: {executable}");
+        }
+
+        return new ProcessResult(
+            process.ExitCode,
+            Normalize(await stdoutTask),
+            Normalize(await stderrTask));
+    }
+
+    private static int NormalizeProcessExitCode(int value)
+        => OperatingSystem.IsWindows() ? value : value & 0xff;
+
+    private static string Normalize(string text)
+        => text.Replace("\r\n", "\n", StringComparison.Ordinal);
+
+    private sealed record ProcessResult(
+        int ExitCode,
+        string StandardOutput,
+        string StandardError);
+
+    private sealed record ScriptResult(
+        int ExitCode,
+        string StandardOutput,
+        string StandardError,
+        string SourcePath);
 }

--- a/test/Interpreter.Tests/Issue3010EntryPointExitCodeTests.cs
+++ b/test/Interpreter.Tests/Issue3010EntryPointExitCodeTests.cs
@@ -1,0 +1,99 @@
+// <copyright file="Issue3010EntryPointExitCodeTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #3010: integer script results are process exit codes, not displayed values.
+/// </summary>
+[Collection("ConsoleIo")]
+public class Issue3010EntryPointExitCodeTests
+{
+    [Fact]
+    public void ExplicitMainIntegerResultBecomesExitCode()
+    {
+        const string Source = """
+            import System
+
+            func Main() int32 {
+                Console.WriteLine("main")
+                return 3
+            }
+            """;
+
+        var result = RunScript(Source);
+
+        Assert.Equal(3, result.ExitCode);
+        Assert.Equal("main\n", result.StandardOutput);
+        Assert.Equal(string.Empty, result.StandardError);
+    }
+
+    [Fact]
+    public void TopLevelIntegerResultBecomesExitCode()
+    {
+        const string Source = """
+            import System
+
+            Console.WriteLine("tls")
+            return 3
+            """;
+
+        var result = RunScript(Source);
+
+        Assert.Equal(3, result.ExitCode);
+        Assert.Equal("tls\n", result.StandardOutput);
+        Assert.Equal(string.Empty, result.StandardError);
+    }
+
+    [Fact]
+    public void NonIntegerResultIsStillPrinted()
+    {
+        var result = RunScript("\"text-result\"");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("text-result\n", result.StandardOutput);
+        Assert.Equal(string.Empty, result.StandardError);
+    }
+
+    [Fact]
+    public void NoResultStillReturnsZeroWithoutOutput()
+    {
+        var result = RunScript("func Helper() { }");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(string.Empty, result.StandardOutput);
+        Assert.Equal(string.Empty, result.StandardError);
+    }
+
+    private static (int ExitCode, string StandardOutput, string StandardError) RunScript(string source)
+    {
+        var path = Path.Combine(Environment.CurrentDirectory, $".issue3010-{Guid.NewGuid():N}.gs");
+        File.WriteAllText(path, source);
+
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+        var previousOutput = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(output);
+        Console.SetError(error);
+        try
+        {
+            var exitCode = GSharp.Repl.Program.Main(new[] { path });
+            return (
+                exitCode,
+                output.ToString().Replace("\r\n", "\n"),
+                error.ToString().Replace("\r\n", "\n"));
+        }
+        finally
+        {
+            Console.SetOut(previousOutput);
+            Console.SetError(previousError);
+            File.Delete(path);
+        }
+    }
+}

--- a/test/Interpreter.Tests/Issue3010EntryPointExitCodeTests.cs
+++ b/test/Interpreter.Tests/Issue3010EntryPointExitCodeTests.cs
@@ -22,13 +22,13 @@ public class Issue3010EntryPointExitCodeTests
 
             func Main() int32 {
                 Console.WriteLine("main")
-                return 3
+                return 7
             }
             """;
 
         var result = RunScript(Source);
 
-        Assert.Equal(3, result.ExitCode);
+        Assert.Equal(7, result.ExitCode);
         Assert.Equal("main\n", result.StandardOutput);
         Assert.Equal(string.Empty, result.StandardError);
     }
@@ -40,28 +40,279 @@ public class Issue3010EntryPointExitCodeTests
             import System
 
             Console.WriteLine("tls")
-            return 3
+            return 7
             """;
 
         var result = RunScript(Source);
 
-        Assert.Equal(3, result.ExitCode);
+        Assert.Equal(7, result.ExitCode);
         Assert.Equal("tls\n", result.StandardOutput);
         Assert.Equal(string.Empty, result.StandardError);
     }
 
     [Fact]
-    public void NonIntegerResultIsStillPrinted()
+    public void ExplicitMainIntegerZeroReturnsZero()
     {
-        var result = RunScript("\"text-result\"");
+        const string Source = """
+            import System
+
+            func Main() int32 {
+                Console.WriteLine("zero")
+                return 0
+            }
+            """;
+
+        var result = RunScript(Source);
 
         Assert.Equal(0, result.ExitCode);
-        Assert.Equal("text-result\n", result.StandardOutput);
+        Assert.Equal("zero\n", result.StandardOutput);
         Assert.Equal(string.Empty, result.StandardError);
     }
 
     [Fact]
-    public void NoResultStillReturnsZeroWithoutOutput()
+    public void ExplicitMainUnsignedIntegerResultBecomesExitCode()
+    {
+        const string Source = """
+            import System
+
+            func Main() uint32 {
+                Console.WriteLine("unsigned")
+                return 7
+            }
+            """;
+
+        var result = RunScript(Source);
+
+        Assert.Equal(7, result.ExitCode);
+        Assert.Equal("unsigned\n", result.StandardOutput);
+        Assert.Equal(string.Empty, result.StandardError);
+    }
+
+    [Fact]
+    public void ExplicitMainIntegerFalloffIsRejected()
+    {
+        const string Source = """
+            import System
+
+            func Main() int32 {
+                Console.WriteLine("must-not-run")
+            }
+            """;
+
+        var result = RunScript(Source);
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Equal(string.Empty, result.StandardOutput);
+        Assert.Equal("GS0100: Not all code paths return a value.\n", result.StandardError);
+    }
+
+    [Fact]
+    public void ExplicitVoidMainDiscardsBareIntegerExpression()
+    {
+        const string Source = """
+            import System
+
+            func Main() {
+                Console.WriteLine("void-int")
+                40 + 2
+            }
+            """;
+
+        var result = RunScript(Source);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("void-int\n", result.StandardOutput);
+        Assert.Equal(string.Empty, result.StandardError);
+    }
+
+    [Fact]
+    public void ExplicitVoidMainDiscardsBareStringExpression()
+    {
+        const string Source = """
+            import System
+
+            func Main() {
+                Console.WriteLine("void-string")
+                "leaked"
+            }
+            """;
+
+        var result = RunScript(Source);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("void-string\n", result.StandardOutput);
+        Assert.Equal(string.Empty, result.StandardError);
+    }
+
+    [Fact]
+    public void ExplicitVoidMainDiscardsIgnoredIntegerCall()
+    {
+        const string Source = """
+            import System
+
+            func Compute() int32 {
+                return 11
+            }
+
+            func Main() {
+                Console.WriteLine("void-call-int")
+                Compute()
+            }
+            """;
+
+        var result = RunScript(Source);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("void-call-int\n", result.StandardOutput);
+        Assert.Equal(string.Empty, result.StandardError);
+    }
+
+    [Fact]
+    public void ExplicitVoidMainDiscardsIgnoredGSharpValueCall()
+    {
+        const string Source = """
+            import System
+
+            struct Marker {
+                var N int32
+            }
+
+            func Make() Marker {
+                return Marker{N: 33}
+            }
+
+            func Main() {
+                Console.WriteLine("void-call-type")
+                Make()
+            }
+            """;
+
+        var result = RunScript(Source);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("void-call-type\n", result.StandardOutput);
+        Assert.Equal(string.Empty, result.StandardError);
+    }
+
+    [Fact]
+    public void ExplicitStringMainIsRejectedBeforeExecution()
+    {
+        const string Source = """
+            import System
+
+            func Main() string {
+                Console.WriteLine("must-not-run")
+                return "invalid"
+            }
+            """;
+
+        var result = RunScript(Source);
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Equal(string.Empty, result.StandardOutput);
+        Assert.Equal(
+            "GSI001: Evaluation error: Entry point must have a return type of void, int32, or uint32.\n",
+            result.StandardError);
+    }
+
+    [Fact]
+    public void ExplicitGSharpValueMainIsRejectedBeforeExecution()
+    {
+        const string Source = """
+            import System
+
+            struct Marker {
+                var N int32
+            }
+
+            func Main() Marker {
+                Console.WriteLine("must-not-run")
+                return Marker{N: 33}
+            }
+            """;
+
+        var result = RunScript(Source);
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Equal(string.Empty, result.StandardOutput);
+        Assert.Equal(
+            "GSI001: Evaluation error: Entry point must have a return type of void, int32, or uint32.\n",
+            result.StandardError);
+    }
+
+    [Fact]
+    public void TopLevelVoidEntryPointDiscardsBareIntegerExpression()
+    {
+        const string Source = """
+            import System
+
+            Console.WriteLine("top-int")
+            40 + 2
+            """;
+
+        var result = RunScript(Source);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("top-int\n", result.StandardOutput);
+        Assert.Equal(string.Empty, result.StandardError);
+    }
+
+    [Fact]
+    public void TopLevelVoidEntryPointDiscardsBareStringExpression()
+    {
+        const string Source = """
+            import System
+
+            Console.WriteLine("top-string")
+            "leaked"
+            """;
+
+        var result = RunScript(Source);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("top-string\n", result.StandardOutput);
+        Assert.Equal(string.Empty, result.StandardError);
+    }
+
+    [Fact]
+    public void TopLevelVoidEntryPointDiscardsIgnoredIntegerCall()
+    {
+        const string Source = """
+            import System
+
+            func Compute() int32 {
+                return 22
+            }
+
+            Console.WriteLine("top-call-int")
+            Compute()
+            """;
+
+        var result = RunScript(Source);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("top-call-int\n", result.StandardOutput);
+        Assert.Equal(string.Empty, result.StandardError);
+    }
+
+    [Fact]
+    public void TopLevelNoResultReturnsZero()
+    {
+        const string Source = """
+            import System
+
+            Console.WriteLine("top-no-result")
+            """;
+
+        var result = RunScript(Source);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("top-no-result\n", result.StandardOutput);
+        Assert.Equal(string.Empty, result.StandardError);
+    }
+
+    [Fact]
+    public void DeclarationOnlyScriptReturnsZeroWithoutOutput()
     {
         var result = RunScript("func Helper() { }");
 


### PR DESCRIPTION
## Summary

- run binder-selected entry points in file-mode `gsi` without changing interactive REPL declaration behavior
- return declared `int32`/`uint32` entry-point values as process exit codes instead of printing them
- discard void and ordinary trailing expression values, while preserving source paths in diagnostics

`src/Repl/Program.cs` changes only lines 57 and 64-79. Line 58 remains `engine.Evaluate(File.ReadAllText(arg), arg)`, retaining the diagnostic filename added by #3024.

## Verification

- full solution build: 0 warnings, 0 errors
- full `Interpreter.Tests`: 665 passed
- three-driver matrix: `{explicit Main, top-level}` × integer `{0, 7, -1, 256}`; emitted program and `gsi` match on stdout and OS-visible exit code
- false-positive matrix: void, trailing integer, trailing string, and ignored integer call retain stdout and exit 0 in both shapes
- POSIX results: `-1 -> 255`, `256 -> 0`; Windows assertions retain the native full-width code
- emitted probes use fresh empty output directories and pass `Assembly.Load(File.ReadAllBytes(...)).GetTypes()` before bounded execution
- diagnostic probe confirms the source path remains present
- `cs2gs-corpus`: exit 0; 1 known gap, 0 new, 0 regressed, 0 stale
- predicted merge tree exactly matched tested HEAD tree

Product mutation round trips:

- compilation return-type gate: `8 pass -> 4 fail/4 pass -> 8 pass`
- evaluator entry-point gate: `8 pass -> 4 fail/4 pass -> 8 pass`
- session entry-point gate: `2 pass -> 2 fail -> 2 pass`
- program error branch: `1 pass -> 1 fail -> 1 pass`

Fixes #3010