### PR TITLE
Fix evaluator explicit field overlap

### DIFF
--- a/src/Core/CodeAnalysis/StructValue.cs
+++ b/src/Core/CodeAnalysis/StructValue.cs
@@ -3,8 +3,15 @@
 // </copyright>
 
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading;
 using GSharp.Core.CodeAnalysis.Symbols;
 
 namespace GSharp.Core.CodeAnalysis;
@@ -17,18 +24,39 @@ namespace GSharp.Core.CodeAnalysis;
 /// </summary>
 public sealed class StructValue
 {
+    private readonly LayoutRuntime explicitLayout;
+    private object explicitLayoutValue;
+
     /// <summary>Initializes a new instance of the <see cref="StructValue"/> class.</summary>
     /// <param name="structType">The struct type symbol.</param>
     public StructValue(StructSymbol structType)
     {
         StructType = structType;
-        Fields = new ConcurrentDictionary<string, object>();
+        Fields = new FieldCollection(this);
+
+        if (structType.LayoutMetadata?.Layout == LayoutKind.Explicit)
+        {
+            explicitLayout = LayoutRuntime.Get(structType);
+            explicitLayoutValue = explicitLayout.CreateDefault();
+            explicitLayout.ReadFields(explicitLayoutValue, Fields);
+        }
     }
 
-    private StructValue(StructSymbol structType, ConcurrentDictionary<string, object> fields)
+    private StructValue(
+        StructSymbol structType,
+        ConcurrentDictionary<string, object> fields,
+        LayoutRuntime explicitLayout = null,
+        object explicitLayoutValue = null)
     {
         StructType = structType;
-        Fields = fields;
+        Fields = new FieldCollection(this);
+        foreach (var field in fields)
+        {
+            Fields.SetRaw(field.Key, field.Value);
+        }
+
+        this.explicitLayout = explicitLayout;
+        this.explicitLayoutValue = explicitLayoutValue;
     }
 
     /// <summary>Gets the struct type.</summary>
@@ -45,7 +73,7 @@ public sealed class StructValue
     // Dictionary&lt;,&gt; is not thread-safe under concurrent writes.
 
     /// <summary>Gets the mutable field dictionary backing this instance.</summary>
-    public ConcurrentDictionary<string, object> Fields { get; }
+    public FieldCollection Fields { get; }
 
     /// <summary>
     /// Gets or sets the CLR backing instance for a GSharp class that inherits an
@@ -62,6 +90,22 @@ public sealed class StructValue
     /// <returns>A new instance with the same fields.</returns>
     public StructValue Copy()
     {
+        if (explicitLayout != null)
+        {
+            object layoutCopy;
+            lock (explicitLayoutValue)
+            {
+                layoutCopy = RuntimeHelpers.GetObjectValue(explicitLayoutValue);
+            }
+
+            var fieldsCopy = new ConcurrentDictionary<string, object>();
+            explicitLayout.ReadFields(layoutCopy, fieldsCopy);
+            return new StructValue(StructType, fieldsCopy, explicitLayout, layoutCopy)
+            {
+                ClrBacking = this.ClrBacking,
+            };
+        }
+
         var copy = new ConcurrentDictionary<string, object>();
         foreach (var kvp in Fields)
         {
@@ -141,6 +185,23 @@ public sealed class StructValue
         return sb.ToString();
     }
 
+    private void SetField(string name, object value)
+    {
+        if (explicitLayout != null)
+        {
+            lock (explicitLayoutValue)
+            {
+                if (explicitLayout.TrySetField(explicitLayoutValue, name, value))
+                {
+                    explicitLayout.ReadFields(explicitLayoutValue, Fields);
+                    return;
+                }
+            }
+        }
+
+        Fields.SetRaw(name, value);
+    }
+
     // Rubber-duck follow-up to issue #2224: an anonymous-class literal's
     // synthesized type exposes get-only auto-properties, not plain fields
     // (see AnonymousTypeCache); its runtime storage in Fields lives under
@@ -165,5 +226,242 @@ public sealed class StructValue
                 yield return (property.Name, property.BackingField.Name);
             }
         }
+    }
+
+    /// <summary>
+    /// Field storage that routes indexer writes through the owning value so
+    /// explicit-layout aliases stay synchronized.
+    /// </summary>
+    public sealed class FieldCollection : ConcurrentDictionary<string, object>
+    {
+        private readonly StructValue owner;
+
+        internal FieldCollection(StructValue owner)
+        {
+            this.owner = owner;
+        }
+
+        /// <summary>Gets or sets a field value.</summary>
+        /// <param name="key">Field name.</param>
+        /// <returns>Stored field value.</returns>
+        public new object this[string key]
+        {
+            get => base[key];
+            set => owner.SetField(key, value);
+        }
+
+        internal void SetRaw(string key, object value) => base[key] = value;
+    }
+
+    private sealed class LayoutRuntime
+    {
+        private static readonly object Gate = new();
+        private static readonly Dictionary<StructSymbol, LayoutRuntime> Cache = [];
+        private static readonly ModuleBuilder Module = AssemblyBuilder
+            .DefineDynamicAssembly(new AssemblyName("GSharp.Interpreter.Layouts"), AssemblyBuilderAccess.Run)
+            .DefineDynamicModule("Layouts");
+
+        private static int nextId;
+
+        private readonly StructSymbol symbol;
+        private readonly Dictionary<string, FieldInfo> fields;
+
+        private LayoutRuntime(StructSymbol symbol, Type type, Dictionary<string, FieldInfo> fields)
+        {
+            this.symbol = symbol;
+            Type = type;
+            this.fields = fields;
+        }
+
+        public Type Type { get; }
+
+        public static LayoutRuntime Get(StructSymbol symbol)
+        {
+            lock (Gate)
+            {
+                if (Cache.TryGetValue(symbol, out var runtime))
+                {
+                    return runtime;
+                }
+
+                runtime = Create(symbol);
+                Cache[symbol] = runtime;
+                return runtime;
+            }
+        }
+
+        public object CreateDefault() => Activator.CreateInstance(Type);
+
+        public bool TrySetField(object target, string name, object value)
+        {
+            if (!fields.TryGetValue(name, out var runtimeField))
+            {
+                return false;
+            }
+
+            var field = symbol.Fields.First(f => f.Name == name);
+            runtimeField.SetValue(target, ToRuntimeValue(field.Type, value));
+            return true;
+        }
+
+        public void ReadFields(object source, FieldCollection destination)
+        {
+            foreach (var field in symbol.Fields)
+            {
+                if (fields.TryGetValue(field.Name, out var runtimeField))
+                {
+                    destination.SetRaw(field.Name, ToInterpreterValue(field.Type, runtimeField.GetValue(source)));
+                }
+            }
+        }
+
+        public void ReadFields(object source, ConcurrentDictionary<string, object> destination)
+        {
+            foreach (var field in symbol.Fields)
+            {
+                if (fields.TryGetValue(field.Name, out var runtimeField))
+                {
+                    destination[field.Name] = ToInterpreterValue(field.Type, runtimeField.GetValue(source));
+                }
+            }
+        }
+
+        private object CreateValue(StructValue value)
+        {
+            if (value.explicitLayout == this)
+            {
+                return RuntimeHelpers.GetObjectValue(value.explicitLayoutValue);
+            }
+
+            var result = CreateDefault();
+            foreach (var field in symbol.Fields)
+            {
+                if (fields.TryGetValue(field.Name, out var runtimeField)
+                    && value.Fields.TryGetValue(field.Name, out var fieldValue))
+                {
+                    runtimeField.SetValue(result, ToRuntimeValue(field.Type, fieldValue));
+                }
+            }
+
+            return result;
+        }
+
+        private static LayoutRuntime Create(StructSymbol symbol)
+        {
+            var metadata = symbol.LayoutMetadata;
+            var attributes = TypeAttributes.Public
+                | TypeAttributes.Sealed
+                | TypeAttributes.BeforeFieldInit
+                | (metadata?.Layout == LayoutKind.Explicit
+                    ? TypeAttributes.ExplicitLayout
+                    : TypeAttributes.SequentialLayout);
+            var builder = Module.DefineType(
+                $"GSharpLayout_{Interlocked.Increment(ref nextId)}",
+                attributes,
+                symbol.IsClass ? typeof(object) : typeof(ValueType),
+                ToPackingSize(metadata?.Pack),
+                metadata?.Size ?? 0);
+
+            foreach (var field in symbol.Fields)
+            {
+                if (field.IsStatic || field.IsConst)
+                {
+                    continue;
+                }
+
+                var runtimeField = builder.DefineField(
+                    field.Name,
+                    ResolveRuntimeType(field.Type),
+                    FieldAttributes.Public);
+                if (field.ExplicitOffset is int offset)
+                {
+                    runtimeField.SetOffset(offset);
+                }
+            }
+
+            var type = builder.CreateType();
+            var fields = new Dictionary<string, FieldInfo>(StringComparer.Ordinal);
+            foreach (var field in symbol.Fields)
+            {
+                var runtimeField = type.GetField(field.Name, BindingFlags.Public | BindingFlags.Instance);
+                if (runtimeField != null)
+                {
+                    fields[field.Name] = runtimeField;
+                }
+            }
+
+            return new LayoutRuntime(symbol, type, fields);
+        }
+
+        private static Type ResolveRuntimeType(TypeSymbol type)
+        {
+            if (type is StructSymbol nested)
+            {
+                return nested.IsClass ? typeof(object) : Get(nested).Type;
+            }
+
+            if (type is EnumSymbol enumType)
+            {
+                return enumType.ClrType ?? enumType.UnderlyingType.ClrType;
+            }
+
+            return NullableTypeSymbol.GetEffectiveClrType(type) ?? typeof(object);
+        }
+
+        private static object ToRuntimeValue(TypeSymbol type, object value)
+        {
+            if (type is StructSymbol nested
+                && !nested.IsClass
+                && value is StructValue structValue)
+            {
+                return Get(nested).CreateValue(structValue);
+            }
+
+            if (type is EnumSymbol enumType && enumType.ClrType != null && value != null)
+            {
+                return Enum.ToObject(enumType.ClrType, value);
+            }
+
+            return value;
+        }
+
+        private static object ToInterpreterValue(TypeSymbol type, object value)
+        {
+            if (type is StructSymbol nested
+                && !nested.IsClass
+                && value != null)
+            {
+                var runtime = Get(nested);
+                var fields = new ConcurrentDictionary<string, object>();
+                runtime.ReadFields(value, fields);
+                var keepBacking = nested.LayoutMetadata?.Layout == LayoutKind.Explicit;
+                return new StructValue(
+                    nested,
+                    fields,
+                    keepBacking ? runtime : null,
+                    keepBacking ? RuntimeHelpers.GetObjectValue(value) : null);
+            }
+
+            if (type is EnumSymbol enumType && enumType.ClrType != null && value != null)
+            {
+                return Convert.ChangeType(value, enumType.UnderlyingType.ClrType, CultureInfo.InvariantCulture);
+            }
+
+            return value;
+        }
+
+        private static PackingSize ToPackingSize(int? pack) =>
+            pack switch
+            {
+                1 => PackingSize.Size1,
+                2 => PackingSize.Size2,
+                4 => PackingSize.Size4,
+                8 => PackingSize.Size8,
+                16 => PackingSize.Size16,
+                32 => PackingSize.Size32,
+                64 => PackingSize.Size64,
+                128 => PackingSize.Size128,
+                _ => PackingSize.Unspecified,
+            };
     }
 }

--- a/test/Interpreter.Tests/Issue3100FieldOffsetParityTests.cs
+++ b/test/Interpreter.Tests/Issue3100FieldOffsetParityTests.cs
@@ -1,0 +1,273 @@
+// <copyright file="Issue3100FieldOffsetParityTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>Issue #3100: explicit field overlap must match emitted CLR layout.</summary>
+[Collection("ConsoleIo")]
+public class Issue3100FieldOffsetParityTests
+{
+    public static TheoryData<string> LayoutCases => new()
+    {
+        "FullOverlap",
+        "PartialOverlap",
+        "DefaultNoOverlap",
+        "Sequential",
+        "ExplicitNoOverlap",
+    };
+
+    [Theory]
+    [MemberData(nameof(LayoutCases))]
+    public void FieldLayout_EmitEvaluateAndGsiAgree(string layoutCase)
+    {
+        var source = SourceFor(layoutCase);
+        var root = CreateEmptyDirectory(layoutCase);
+        try
+        {
+            var bare = RunBareGsc(source, CreateEmptyDirectory(root, "bare"));
+            var emitted = RunEmitted(source, layoutCase, CreateEmptyDirectory(root, "emit"));
+            var interpreted = RunGsi(source, CreateEmptyDirectory(root, "gsi"));
+
+            var expected = layoutCase is "FullOverlap" or "PartialOverlap"
+                ? "2\n11\n22\n33\n44\n44"
+                : "1\n11\n22\n33\n33\n44";
+            Assert.Equal(expected, emitted);
+            Assert.Equal(emitted, bare);
+            Assert.Equal(emitted, interpreted);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static string RunBareGsc(string source, string directory)
+    {
+        var sourcePath = Path.Combine(directory, "probe.gs");
+        File.WriteAllText(sourcePath, source);
+        var (exitCode, stdout, stderr) = CaptureConsole(
+            () => GSharp.Compiler.Program.Main([sourcePath]));
+
+        Assert.True(exitCode == 0, $"bare gsc failed ({exitCode})\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return NormalizeValues(stdout);
+    }
+
+    private static string RunGsi(string source, string directory)
+    {
+        var sourcePath = Path.Combine(directory, "probe.gs");
+        File.WriteAllText(sourcePath, source);
+        var (exitCode, stdout, stderr) = CaptureConsole(
+            () => GSharp.Repl.Program.Main([sourcePath]));
+
+        Assert.True(exitCode == 0, $"gsi failed ({exitCode})\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return NormalizeValues(stdout);
+    }
+
+    private static string RunEmitted(string source, string layoutCase, string directory)
+    {
+        var sourcePath = Path.Combine(directory, "probe.gs");
+        var outputPath = Path.Combine(directory, $"Issue3100{layoutCase}{Guid.NewGuid():N}.dll");
+        File.WriteAllText(sourcePath, source);
+
+        var (compileExit, stdout, stderr) = CaptureConsole(
+            () => GSharp.Compiler.Program.Main(
+                ["/out:" + outputPath, "/target:exe", "/targetframework:net10.0", sourcePath]));
+        Assert.True(compileExit == 0, $"emit failed ({compileExit})\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+        VerifyMetadata(outputPath, layoutCase);
+
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        startInfo.ArgumentList.Add(outputPath);
+
+        using var process = Process.Start(startInfo);
+        Assert.NotNull(process);
+        var runOut = process.StandardOutput.ReadToEnd();
+        var runErr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        Assert.True(process.ExitCode == 0, $"emitted program failed ({process.ExitCode})\nstdout:\n{runOut}\nstderr:\n{runErr}");
+        return NormalizeValues(runOut);
+    }
+
+    private static void VerifyMetadata(string assemblyPath, string layoutCase)
+    {
+        var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+        var types = assembly.GetTypes();
+        var cell = types.Single(t => t.Name == "Cell");
+        var wrapper = types.Single(t => t.Name == "Wrapper");
+
+        var expectedLayout = layoutCase is "FullOverlap" or "PartialOverlap" or "ExplicitNoOverlap"
+            ? LayoutKind.Explicit
+            : LayoutKind.Sequential;
+        Assert.Equal(expectedLayout, cell.StructLayoutAttribute?.Value);
+        Assert.Equal(LayoutKind.Sequential, wrapper.StructLayoutAttribute?.Value);
+        Assert.Equal(0, Marshal.OffsetOf(wrapper, "Value").ToInt32());
+        Assert.Equal(0, Marshal.OffsetOf(cell, "Nested").ToInt32());
+        Assert.Equal(
+            layoutCase switch
+            {
+                "FullOverlap" => 0,
+                "PartialOverlap" => 1,
+                _ => 4,
+            },
+            Marshal.OffsetOf(cell, "Alias").ToInt32());
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) CaptureConsole(Func<int> action)
+    {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            return (action(), stdout.ToString(), stderr.ToString());
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+    }
+
+    private static string NormalizeValues(string output) =>
+        string.Join(
+            "\n",
+            output.Replace("\r\n", "\n", StringComparison.Ordinal)
+                .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+                .Where(line => line != "Success."));
+
+    private static string CreateEmptyDirectory(string name)
+    {
+        var parent = Path.Combine(AppContext.BaseDirectory, "issue3100-probes");
+        return CreateEmptyDirectory(parent, $"{name}-{Guid.NewGuid():N}");
+    }
+
+    private static string CreateEmptyDirectory(string parent, string name)
+    {
+        var path = Path.Combine(parent, name);
+        Directory.CreateDirectory(path);
+        Assert.Empty(Directory.EnumerateFileSystemEntries(path));
+        return path;
+    }
+
+    private static string SourceFor(string layoutCase)
+    {
+        var package = $"Issue3100{layoutCase}";
+        return layoutCase switch
+        {
+            "FullOverlap" => $$$"""
+                package {{{package}}}
+                import System
+                import System.Runtime.InteropServices
+
+                struct Payload { var Value int32 }
+                @StructLayout(LayoutKind.Explicit, Size: 4)
+                struct Cell {
+                    @FieldOffset(0) var Nested Payload
+                    @FieldOffset(0) var Alias int32
+                }
+                struct Wrapper { var Value Cell }
+                func setAlias(ref value int32) { value = 44 }
+
+                var cell = Cell{Nested: Payload{Value: 1}, Alias: 2}
+                Console.WriteLine(cell.Nested.Value)
+                cell.Nested.Value = 11
+                Console.WriteLine(cell.Alias)
+                cell.Alias = 22
+                Console.WriteLine(cell.Nested.Value)
+                var wrapper = Wrapper{Value: Cell{Nested: Payload{Value: 3}, Alias: 4}}
+                wrapper.Value.Nested.Value = 33
+                Console.WriteLine(wrapper.Value.Alias)
+                setAlias(ref wrapper.Value.Alias)
+                Console.WriteLine(wrapper.Value.Nested.Value)
+                Console.WriteLine(wrapper.Value.Alias)
+                """,
+            "PartialOverlap" => $$$"""
+                package {{{package}}}
+                import System
+                import System.Runtime.InteropServices
+
+                struct Payload { var Head uint8 var Value uint8 var Tail uint8 }
+                @StructLayout(LayoutKind.Explicit, Size: 4)
+                struct Cell {
+                    @FieldOffset(0) var Nested Payload
+                    @FieldOffset(1) var Alias uint16
+                }
+                struct Wrapper { var Value Cell }
+                func setAlias(ref value uint16) { value = 44 }
+
+                var cell = Cell{Nested: Payload{Head: 0, Value: 1, Tail: 0}, Alias: 2}
+                Console.WriteLine(cell.Nested.Value)
+                cell.Nested.Value = 11
+                Console.WriteLine(cell.Alias)
+                cell.Alias = 22
+                Console.WriteLine(cell.Nested.Value)
+                var wrapper = Wrapper{Value: Cell{Nested: Payload{Head: 0, Value: 3, Tail: 0}, Alias: 4}}
+                wrapper.Value.Nested.Value = 33
+                Console.WriteLine(wrapper.Value.Alias)
+                setAlias(ref wrapper.Value.Alias)
+                Console.WriteLine(wrapper.Value.Nested.Value)
+                Console.WriteLine(wrapper.Value.Alias)
+                """,
+            "DefaultNoOverlap" => NonOverlappingSource(package, null),
+            "Sequential" => NonOverlappingSource(package, "@StructLayout(LayoutKind.Sequential)"),
+            "ExplicitNoOverlap" => NonOverlappingSource(package, "@StructLayout(LayoutKind.Explicit, Size: 8)"),
+            _ => throw new ArgumentOutOfRangeException(nameof(layoutCase)),
+        };
+    }
+
+    private static string NonOverlappingSource(string package, string layoutAttribute)
+    {
+        var fields = layoutAttribute?.Contains("Explicit", StringComparison.Ordinal) == true
+            ? """
+                    @FieldOffset(0) var Nested Payload
+                    @FieldOffset(4) var Alias int32
+                """
+            : """
+                    var Nested Payload
+                    var Alias int32
+                """;
+        var attribute = layoutAttribute == null ? string.Empty : layoutAttribute + "\n";
+        return $$$"""
+            package {{{package}}}
+            import System
+            import System.Runtime.InteropServices
+
+            struct Payload { var Value int32 }
+            {{{attribute}}}struct Cell {
+            {{{fields}}}
+            }
+            struct Wrapper { var Value Cell }
+            func setAlias(ref value int32) { value = 44 }
+
+            var cell = Cell{Nested: Payload{Value: 1}, Alias: 2}
+            Console.WriteLine(cell.Nested.Value)
+            cell.Nested.Value = 11
+            Console.WriteLine(cell.Nested.Value)
+            cell.Alias = 22
+            Console.WriteLine(cell.Alias)
+            var wrapper = Wrapper{Value: Cell{Nested: Payload{Value: 3}, Alias: 4}}
+            wrapper.Value.Nested.Value = 33
+            Console.WriteLine(wrapper.Value.Nested.Value)
+            setAlias(ref wrapper.Value.Alias)
+            Console.WriteLine(wrapper.Value.Nested.Value)
+            Console.WriteLine(wrapper.Value.Alias)
+            """;
+    }
+}

--- a/test/Interpreter.Tests/Issue759StructMarshallingInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue759StructMarshallingInterpreterTests.cs
@@ -11,8 +11,8 @@ namespace GSharp.Interpreter.Tests;
 /// <summary>
 /// ADR-0093 / issue #759: interpreter coverage for struct- and
 /// class-marshalling annotations. The G# interpreter does not call into
-/// native code, so the layout annotations are essentially "binder-only"
-/// metadata under the REPL. The acceptance contract:
+/// native code, but explicit field overlap still affects managed reads and
+/// writes. The acceptance contract:
 /// <list type="bullet">
 /// <item>Well-formed <c>@StructLayout</c> / <c>@FieldOffset</c> programs
 /// parse, bind, and run without diagnostics or crashes.</item>


### PR DESCRIPTION
## Summary
- make `StructValue` use a runtime-generated CLR backing type for explicit layouts
- route shared field storage writes through that backing so overlapping fields alias in bare `gsc` and `gsi`
- preserve explicit-layout value semantics when structs are copied, including nested structs
- add emit/evaluate/gsi parity coverage for full overlap, partial overlap, default and sequential controls, explicit non-overlap, writes through both aliases, ref writes, and nested structs
- verify emitted layout through `Assembly.Load`, `GetTypes()`, and `Marshal.OffsetOf`

## Design
Took faithful-semantics rung, not diagnostic rung. Evaluators already centralize user-defined aggregate values in `StructValue`; generating a CLR layout there reuses runtime field-layout semantics without separate engine patches or manual byte-layout rules. `FieldCollection` keeps all existing read/write consumers on one shared representation.

## Measured sample
`PInvokeStructMarshalling.gs` now prints identical values in all three drivers:

- bare `gsc`: `3 / 4 / 6153737367135073092`, rc 0
- emitted `gsc /out:`: `3 / 4 / 6153737367135073092`, compile/run rc 0
- `gsi`: `3 / 4 / 6153737367135073092`, rc 0

Before this change, both interpreting paths printed `3 / 4 / 0` with rc 0.

## Validation
- `Issue3100FieldOffsetParityTests` + issue #759 tests: 10/10
- full `Interpreter.Tests`: 638/638
- six product condition mutants built successfully and were killed by the overlap/parity rows (constructor activation, alias refresh, explicit copy, nested write conversion, nested read conversion, runtime layout kind)
- fresh post-clean `Core`, `Compiler`, and `Repl` artifacts verified by mtime

Fixes #3100
