### PR TITLE
Fix async function tuple Item4 binding

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
@@ -61,6 +61,28 @@ internal sealed partial class ExpressionBinder
             ? "Item" + (index + 1).ToString(System.Globalization.CultureInfo.InvariantCulture)
             : memberName ?? string.Empty;
 
+    private static bool RequiresSymbolicTupleElementInvocation(
+        TupleTypeSymbol tupleType,
+        int index)
+    {
+        if (!MemberLookup.TryGetDelegateFunctionTypeFromSymbol(tupleType.ElementTypes[index], out _))
+        {
+            return false;
+        }
+
+        if (tupleType.ClrType == null)
+        {
+            return true;
+        }
+
+        var fieldName = "Item" + (index + 1).ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var field = ClrTypeUtilities.SafeGetField(
+            tupleType.ClrType,
+            fieldName,
+            BindingFlags.Public | BindingFlags.Instance);
+        return field == null || !ClrTypeUtilities.IsDelegateType(field.FieldType);
+    }
+
     private BoundExpression BindAccessorStep(
         BoundExpression receiver,
         ImportedClassSymbol classSymbol,
@@ -135,6 +157,26 @@ internal sealed partial class ExpressionBinder
                 return BindAccessorStep(head, null, nested.RightPart, nested.LeftPart);
 
             case CallExpressionSyntax ce:
+                // Issue #3084: bind tuple fields symbolically when their CLR
+                // projection cannot expose the stored function as a delegate.
+                if (ce.NullableQuestionToken == null
+                    && receiver?.Type is TupleTypeSymbol tupleType
+                    && TryGetTupleElementIndex(ce.Identifier.Text, tupleType, out var tupleIndex)
+                    && RequiresSymbolicTupleElementInvocation(tupleType, tupleIndex))
+                {
+                    var tupleElement = new BoundTupleElementAccessExpression(
+                        null,
+                        receiver,
+                        tupleType,
+                        tupleIndex);
+                    return overloads.BindIndirectCallExpression(
+                        ce,
+                        tupleElement,
+                        ce.Identifier.Text,
+                        ce.Identifier.Location,
+                        nullSafeInvocation: "?(...)");
+                }
+
                 var callResult = BindAccessorCall(receiver, classSymbol, ce, receiverSyntax);
                 CheckValueTaskGetAwaiterGetResult(callResult, ce);
                 return callResult;

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.Invocations.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.Invocations.cs
@@ -679,7 +679,24 @@ internal sealed partial class OverloadResolver
     /// </summary>
     private BoundExpression BindIndirectCallExpression(CallExpressionSyntax syntax)
     {
-        var callee = bindExpression(syntax.Callee);
+        var calleeSyntax = syntax.Callee;
+        var callee = bindExpression(calleeSyntax);
+        var calleeName = calleeSyntax.SyntaxTree.Text.ToString(calleeSyntax.Span);
+        return BindIndirectCallExpression(
+            syntax,
+            callee,
+            calleeName,
+            calleeSyntax.Location,
+            GetNullableDelegateNullSafeInvocation(calleeSyntax));
+    }
+
+    internal BoundExpression BindIndirectCallExpression(
+        CallExpressionSyntax syntax,
+        BoundExpression callee,
+        string calleeName,
+        TextLocation calleeLocation,
+        string nullSafeInvocation)
+    {
         if (callee is BoundErrorExpression)
         {
             return callee;
@@ -710,10 +727,6 @@ internal sealed partial class OverloadResolver
             }
         }
 
-        // The verbatim source spelling of the callee (`(value)`, `handler!!`, ...)
-        // used in diagnostics — SyntaxNode.ToString() pretty-prints the whole tree.
-        var calleeName = syntax.Callee.SyntaxTree.Text.ToString(syntax.Callee.Span);
-
         BoundExpression CompleteInvocation(BoundExpression invocation) =>
             nullConditionalCallee == null
                 ? invocation
@@ -732,7 +745,7 @@ internal sealed partial class OverloadResolver
 
         if (!argumentNames.IsDefault)
         {
-            Diagnostics.ReportNamedArgumentParameterNotFound(syntax.Callee.Location, calleeName, FirstNamedArgumentName(argumentNames));
+            Diagnostics.ReportNamedArgumentParameterNotFound(calleeLocation, calleeName, FirstNamedArgumentName(argumentNames));
             return new BoundErrorExpression(null);
         }
 
@@ -767,9 +780,9 @@ internal sealed partial class OverloadResolver
 
         if (TryReportNullableDelegateReceiver(
             callee.Type,
-            syntax.Callee.Location,
+            calleeLocation,
             calleeName,
-            GetNullableDelegateNullSafeInvocation(syntax.Callee)))
+            nullSafeInvocation))
         {
             return new BoundErrorExpression(null);
         }
@@ -815,7 +828,7 @@ internal sealed partial class OverloadResolver
             }
         }
 
-        Diagnostics.ReportNotAFunction(syntax.Callee.Location, calleeName);
+        Diagnostics.ReportNotAFunction(calleeLocation, calleeName);
         return new BoundErrorExpression(null);
     }
 

--- a/test/Compiler.Tests/Emit/Issue3084TupleAsyncFunctionMemberTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3084TupleAsyncFunctionMemberTests.cs
@@ -1,0 +1,112 @@
+// <copyright file="Issue3084TupleAsyncFunctionMemberTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+public sealed class Issue3084TupleAsyncFunctionMemberTests
+{
+    [Fact]
+    public void TupleAsyncFunctionItem4_BindsVerifiesAndRuns()
+    {
+        const string source = """
+            package Issue3084
+
+            import System
+            import System.Linq
+            import System.Threading.Tasks
+
+            class Payload(Value string) { }
+
+            async func RunAsync() string {
+                let handler async (Payload) -> string = async (value Payload) -> {
+                    await Task.Yield()
+                    return value.Value
+                }
+                let state object = 42
+                let tuples = [](string, string, object, async (Payload) -> string){
+                    ("first", "second", state, handler)
+                }
+                let tuple = tuples!!.FirstOrDefault((candidate (string, string, object, async (Payload) -> string)) -> candidate.Item1 == "first")
+                Console.WriteLine(tuple.Item1)
+                return await tuple.Item4(Payload("result"))
+            }
+
+            Console.WriteLine(RunAsync().GetAwaiter().GetResult())
+            """;
+
+        Assert.Equal("first\nresult\n", CompileVerifyAndRun(source));
+    }
+
+    private static string CompileVerifyAndRun(string source)
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            nameof(Issue3084TupleAsyncFunctionMemberTests),
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            var sourcePath = Path.Combine(directory, "Program.gs");
+            var outputPath = Path.Combine(directory, "Issue3084.dll");
+            File.WriteAllText(sourcePath, source);
+
+            using var standardOut = new StringWriter();
+            using var standardError = new StringWriter();
+            var previousOut = Console.Out;
+            var previousError = Console.Error;
+            Console.SetOut(standardOut);
+            Console.SetError(standardError);
+            int exitCode;
+            try
+            {
+                exitCode = Program.Main(new[]
+                {
+                    "/out:" + outputPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    sourcePath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+                Console.SetError(previousError);
+            }
+
+            Assert.True(
+                exitCode == 0,
+                $"gsc failed:{Environment.NewLine}{standardOut}{standardError}");
+            IlVerifier.Verify(outputPath);
+
+            using var process = Process.Start(new ProcessStartInfo("dotnet")
+            {
+                ArgumentList =
+                {
+                    "exec",
+                    "--runtimeconfig",
+                    Path.ChangeExtension(outputPath, ".runtimeconfig.json"),
+                    outputPath,
+                },
+                WorkingDirectory = directory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            });
+            var output = process.StandardOutput.ReadToEnd();
+            var error = process.StandardError.ReadToEnd();
+            Assert.True(process.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(process.ExitCode == 0, error);
+            return output.Replace("\r\n", "\n", StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- bind synthetic tuple `ItemN` calls before CLR method lookup when the projected field cannot expose the stored callable as a delegate
- route tuple function/delegate values through shared indirect-call argument binding and emission
- add runtime regression covering `(string, string, object, async (...) -> string)`, `Item1`, awaited `Item4`, and IL verification

## Root cause
Plain `ItemN` access already synthesized `BoundTupleElementAccessExpression`. `ItemN(...)` instead entered CLR member-call lookup first. For tuples whose async function element retains a symbolic shape, the CLR projection cannot reliably surface that field as an invokable delegate, so lookup ended at GS0159 before tuple synthesis.

## Validation
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj --no-restore --configuration Debug --filter '(FullyQualifiedName~Issue3084TupleAsyncFunctionMemberTests)|(FullyQualifiedName~Issue2924TupleElementDelegateCallTests)|(FullyQualifiedName~Issue2928TupleFunctionParityTests)|(FullyQualifiedName~Issue2750AsyncTupleAwaiterEmitTests)'` — 13 passed
- `dotnet test test/Core.Tests/Core.Tests.csproj --no-restore --configuration Debug --filter '(FullyQualifiedName~Issue2924TupleElementDelegateCallTests)|(FullyQualifiedName~TupleTests)'` — 31 passed
- `dotnet test test/Interpreter.Tests/Interpreter.Tests.csproj --no-restore --configuration Debug` — 637 passed
- `dotnet build src/Sdk/Gsharp.NET.Sdk/Gsharp.NET.Sdk.csproj --no-restore --configuration Debug` — passed
- `dotnet format style GSharp.sln --no-restore --verify-no-changes --include ...` — passed

## Code Exploder migration
Re-ran `CodeExploder.Mcp` from `DavidObando/code-exploder@b4f6be83be664f02965f0363ec41f8946b56ff1d` with the SDK-backed diagnostic-run CLI. Translation, compilation, IL verification, and test parity all passed (`2026-08-02T18-01-26Z_d5e388`, `gsc 0.3.528+d39f26e38f`).

Fixes #3084
