### PR TITLE
Surface gsi non-void fallthrough guard

### DIFF
--- a/src/Core/CodeAnalysis/Compilation/Compilation.cs
+++ b/src/Core/CodeAnalysis/Compilation/Compilation.cs
@@ -367,12 +367,8 @@ public class Compilation
         }
         catch (EvaluatorException ex)
         {
-            TextLocation location;
-            if (ex.Node?.Syntax != null)
-            {
-                location = ex.Node.Syntax.Location;
-            }
-            else
+            var location = ex.Location ?? ex.Node?.Syntax?.Location;
+            if (location == null)
             {
                 using var textWriter = new StringWriter();
                 ex.Node?.WriteTo(textWriter);
@@ -381,7 +377,7 @@ public class Compilation
             }
 
             var message = Evaluator.UnwrapDiagnosticException(ex).Message;
-            var diagnostic = new Diagnostic(location, ex.DiagnosticId, ex.Severity, message);
+            var diagnostic = new Diagnostic(location.Value, ex.DiagnosticId, ex.Severity, message);
             return new EvaluationResult(allWarnings.Add(diagnostic), null);
         }
     }

--- a/src/Core/CodeAnalysis/DiagnosticDescriptors.cs
+++ b/src/Core/CodeAnalysis/DiagnosticDescriptors.cs
@@ -8,6 +8,7 @@ internal static class DiagnosticDescriptors
 {
     internal const string AmbiguousOverloadCandidatesMessageFormat = " Candidates: {0}.";
     internal const string GoBuiltinSuggestionMessageFormat = " or call '{0}' directly";
+    internal const string NonVoidFallthroughGuardMessage = "Compiler-generated guard reached: non-void function fell through without returning a value.";
     internal const string ObsoleteUseDetailMessageFormat = ": '{0}'";
 
     internal static readonly DiagnosticDescriptor BadCharacter = new("GS0001", DiagnosticSeverity.Error, "Bad character input: '{0}'.");

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
@@ -266,9 +266,9 @@ internal sealed partial class MethodBodyEmitter
         }
         else if (emitFallthroughGuard)
         {
-            const string Message = "Compiler-generated guard reached: non-void function fell through without returning a value.";
             var constructor = typeof(InvalidOperationException).GetConstructor(new[] { typeof(string) });
-            this.il.LoadString(this.outer.emitCtx.Metadata.GetOrAddUserString(Message));
+            this.il.LoadString(this.outer.emitCtx.Metadata.GetOrAddUserString(
+                DiagnosticDescriptors.NonVoidFallthroughGuardMessage));
             this.il.OpCode(ILOpCode.Newobj);
             this.il.Token(this.outer.memberRefs.GetCtorReference(constructor));
             this.il.OpCode(ILOpCode.Throw);

--- a/src/Core/CodeAnalysis/Evaluator.Calls.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Calls.cs
@@ -80,20 +80,12 @@ public sealed partial class Evaluator
             var statement = program.Functions.TryGetValue(node.Function, out var functionBody)
                 ? functionBody
                 : localFunctionBodies[node.Function];
-            var isIterator = IsIteratorFunction(node.Function, statement);
             object result;
             RegisterRuntimeTypeArguments(locals, node.Function.TypeParameters, node.MethodTypeArguments);
             RegisterRuntimeTypeArguments(locals, node.StaticGenericOwnerType);
             using (PushFrame(locals))
             {
-                if (isIterator)
-                {
-                    result = EvaluateIteratorFunction(node.Function, statement);
-                }
-                else
-                {
-                    result = EvaluateFunctionBody(statement);
-                }
+                result = EvaluateUserMethodBody(node.Function, statement);
             }
 
             // ADR-0060 item #7: write the final parameter slot value back to
@@ -106,16 +98,6 @@ public sealed partial class Evaluator
                     var finalValue = locals.TryGetValue(parameter, out var v) ? v : null;
                     WriteBackToOperand(operand, finalValue);
                 }
-            }
-
-            if (isIterator)
-            {
-                return result;
-            }
-
-            if (node.Function.IsAsync)
-            {
-                return WrapAsyncResult(node.Function.Type, result);
             }
 
             return result;
@@ -173,7 +155,7 @@ public sealed partial class Evaluator
             return EvaluateIteratorFunction(function, body);
         }
 
-        var result = EvaluateFunctionBody(body);
+        var result = EvaluateFunctionBody(body, function.Type, function.Declaration?.Identifier.Location);
         return function.IsAsync ? WrapAsyncResult(function.Type, result) : result;
     }
 

--- a/src/Core/CodeAnalysis/Evaluator.Expressions.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Expressions.cs
@@ -1790,7 +1790,10 @@ public sealed partial class Evaluator
             locals[node.Function.Parameters[1]] = rightValue;
             using (PushFrame(locals))
             {
-                return EvaluateFunctionBody(program.Functions[node.Function]);
+                return EvaluateFunctionBody(
+                    program.Functions[node.Function],
+                    node.Function.Type,
+                    node.Function.Declaration?.Identifier.Location);
             }
         }
 
@@ -1970,7 +1973,10 @@ public sealed partial class Evaluator
                 var frame = new ConcurrentDictionary<Symbols.VariableSymbol, object>();
                 using (PushFrame(frame))
                 {
-                    return EvaluateFunctionBody(staticGetterBody);
+                    return EvaluateFunctionBody(
+                        staticGetterBody,
+                        node.Property.GetterSymbol.Type,
+                        node.Property.Declaration?.Identifier.Location);
                 }
             }
 
@@ -2028,7 +2034,10 @@ public sealed partial class Evaluator
             };
             using (PushFrame(frame))
             {
-                return EvaluateFunctionBody(getterBody);
+                return EvaluateFunctionBody(
+                    getterBody,
+                    property.GetterSymbol.Type,
+                    property.Declaration?.Identifier.Location);
             }
         }
 

--- a/src/Core/CodeAnalysis/Evaluator.Statements.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Statements.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 using GSharp.Core.CodeAnalysis.Binding;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
 using Emit = GSharp.Core.CodeAnalysis.Emit;
 
 namespace GSharp.Core.CodeAnalysis;
@@ -243,13 +244,34 @@ public sealed partial class Evaluator
     /// parked goto reaching the boundary would mean a `break`/`continue`
     /// escaped a function body, which the binder rejects — but we clear
     /// defensively so a stale flag from a partially-evaluated previous
-    /// call cannot corrupt the next invocation on this evaluator.
+    /// call cannot corrupt the next invocation on this evaluator. Issue
+    /// #3006: when a non-void function reaches this boundary without a
+    /// return, surface the same compiler-generated guard used by emitted
+    /// code instead of returning the CLR default value.
     /// </summary>
-    private object EvaluateFunctionBody(BoundBlockStatement body)
+    /// <param name="body">The lowered function body.</param>
+    /// <param name="returnType">The declared return type, or null for top-level and constructor bodies.</param>
+    /// <param name="location">The source location of the function declaration, when available.</param>
+    /// <returns>The function's return value.</returns>
+    private object EvaluateFunctionBody(
+        BoundBlockStatement body,
+        TypeSymbol returnType = null,
+        TextLocation? location = null)
     {
         var result = EvaluateStatement(body);
+        var returned = IsReturning;
         IsReturning = false;
         PendingGotoLabel = null;
+
+        if (!returned && returnType != null && returnType != TypeSymbol.Void)
+        {
+            throw EvaluatorException.CreateDiagnostic(
+                DiagnosticDescriptors.AllPathsMustReturn,
+                new InvalidOperationException(DiagnosticDescriptors.NonVoidFallthroughGuardMessage),
+                body,
+                location);
+        }
+
         return result;
     }
 

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -203,7 +203,7 @@ public sealed partial class Evaluator
     {
         if (!useEntryPointReturnType)
         {
-            return EvaluateFunctionBody(body);
+            return EvaluateFunctionBody(body, entryPoint.Type, entryPoint.Declaration?.Identifier.Location);
         }
 
         if (entryPoint.Type != TypeSymbol.Void
@@ -213,7 +213,7 @@ public sealed partial class Evaluator
             throw new InvalidOperationException("Entry point must have a return type of void, int32, or uint32.");
         }
 
-        var value = EvaluateFunctionBody(body);
+        var value = EvaluateFunctionBody(body, entryPoint.Type, entryPoint.Declaration?.Identifier.Location);
         return entryPoint.Type == TypeSymbol.Void ? null : value;
     }
 

--- a/src/Core/CodeAnalysis/EvaluatorException.cs
+++ b/src/Core/CodeAnalysis/EvaluatorException.cs
@@ -4,6 +4,7 @@
 
 using System;
 using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Text;
 
 namespace GSharp.Core.CodeAnalysis;
 
@@ -67,6 +68,11 @@ public class EvaluatorException : Exception
     public BoundNode Node { get; }
 
     /// <summary>
+    /// Gets the source location associated with the exception, when available.
+    /// </summary>
+    internal TextLocation? Location { get; private set; }
+
+    /// <summary>
     /// Gets the stable diagnostic identifier.
     /// </summary>
     internal string DiagnosticId { get; private set; } = "GS9999";
@@ -102,16 +108,19 @@ public class EvaluatorException : Exception
     /// <param name="descriptor">The diagnostic descriptor.</param>
     /// <param name="innerException">The evaluated exception.</param>
     /// <param name="node">The bound node associated with the exception.</param>
+    /// <param name="location">The source location associated with the exception.</param>
     /// <returns>The evaluator exception.</returns>
     internal static EvaluatorException CreateDiagnostic(
         DiagnosticDescriptor descriptor,
         Exception innerException,
-        BoundNode node)
+        BoundNode node,
+        TextLocation? location = null)
     {
         return new EvaluatorException(innerException.Message, innerException, node)
         {
             DiagnosticId = descriptor.Id,
             Severity = descriptor.Severity,
+            Location = location,
         };
     }
 }

--- a/src/Core/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/Lowerer.cs
@@ -1432,7 +1432,6 @@ public sealed class Lowerer : BoundTreeRewriter
         var preEmitAnalysisBody = Flatten(ProtectedRegionBranchRewriter.Rewrite(flattened));
         if (this.returnValueLocal != null)
         {
-            const string Message = "Compiler-generated guard reached: non-void function fell through without returning a value.";
             var exceptionType = typeof(System.InvalidOperationException);
             var constructor = exceptionType.GetConstructor(new[] { typeof(string) });
             var statements = ImmutableArray.CreateBuilder<BoundStatement>(flattened.Statements.Length + 1);
@@ -1447,7 +1446,9 @@ public sealed class Lowerer : BoundTreeRewriter
                             null,
                             exceptionType,
                             constructor,
-                            ImmutableArray.Create<BoundExpression>(new BoundLiteralExpression(null, Message)),
+                            ImmutableArray.Create<BoundExpression>(new BoundLiteralExpression(
+                                null,
+                                DiagnosticDescriptors.NonVoidFallthroughGuardMessage)),
                             TypeSymbol.FromClrType(exceptionType)),
                         DiagnosticDescriptors.AllPathsMustReturn));
                 }

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -14,6 +14,8 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="GSharp.Core.Tests" />
+    <InternalsVisibleTo Include="GSharp.Compiler.Tests" />
+    <InternalsVisibleTo Include="GSharp.Interpreter.Tests" />
     <InternalsVisibleTo Include="GSharp.LanguageServer" />
   </ItemGroup>
 

--- a/test/Compiler.Tests/Emit/Issue2906ExhaustiveSwitchReturnEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2906ExhaustiveSwitchReturnEmitTests.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
@@ -276,13 +277,13 @@ public class Issue2906ExhaustiveSwitchReturnEmitTests
             try {
                 F(E(99))
             } catch (ex InvalidOperationException) {
-                result = ex.Message == "Compiler-generated guard reached: non-void function fell through without returning a value."
+                result = ex.Message == "__NON_VOID_FALLTHROUGH_GUARD__"
                     ? 7
                     : -1
             }
             """;
 
-        var assembly = CompileVerifyLoadAndRun("Unnamed", Source);
+        var assembly = CompileVerifyLoadAndRun("Unnamed", WithGuardMessage(Source));
         Assert.Equal(7, GetField(assembly, "result"));
     }
 
@@ -309,7 +310,7 @@ public class Issue2906ExhaustiveSwitchReturnEmitTests
             try {
                 F(DateTimeKind(99), []int32{7})
             } catch (ex InvalidOperationException) {
-                result = ex.Message == "Compiler-generated guard reached: non-void function fell through without returning a value."
+                result = ex.Message == "__NON_VOID_FALLTHROUGH_GUARD__"
                     ? 7
                     : -1
             }
@@ -317,7 +318,7 @@ public class Issue2906ExhaustiveSwitchReturnEmitTests
 
         var assembly = CompileVerifyLoadAndRun(
             "UnnamedFixed",
-            Source,
+            WithGuardMessage(Source),
             ignoredVerificationErrors: new[] { "UnmanagedPointer", "StackByRef" },
             ignoredVerificationScope: @"<Program>\.F$");
         Assert.Equal(7, GetField(assembly, "result"));
@@ -325,6 +326,12 @@ public class Issue2906ExhaustiveSwitchReturnEmitTests
 
     private static object[] Case(string name, int expected, string body)
         => new object[] { name, expected, $"package Issue2906.Emit{name}{Environment.NewLine}{body}" };
+
+    private static string WithGuardMessage(string source)
+        => source.Replace(
+            "__NON_VOID_FALLTHROUGH_GUARD__",
+            DiagnosticDescriptors.NonVoidFallthroughGuardMessage,
+            StringComparison.Ordinal);
 
     private static Assembly CompileVerifyLoadAndRun(
         string name,

--- a/test/Compiler.Tests/Emit/Issue2953FixedReturnFallthroughGuardTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2953FixedReturnFallthroughGuardTests.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
@@ -21,8 +22,7 @@ namespace GSharp.Compiler.Tests.Emit;
 /// </summary>
 public class Issue2953FixedReturnFallthroughGuardTests
 {
-    private const string GuardMessage =
-        "Compiler-generated guard reached: non-void function fell through without returning a value.";
+    private const string GuardMessage = DiagnosticDescriptors.NonVoidFallthroughGuardMessage;
 
     /// <summary>Gets fixed and protected-return shapes that must reach the fallthrough guard.</summary>
     public static IEnumerable<object[]> FallthroughCases()

--- a/test/Interpreter.Tests/Issue2953ProtectedReturnFallthroughInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2953ProtectedReturnFallthroughInterpreterTests.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
@@ -40,9 +41,7 @@ public class Issue2953ProtectedReturnFallthroughInterpreterTests
 
         var diagnostic = Assert.Single(result.Diagnostics);
         Assert.Equal("GS0100", diagnostic.Id);
-        Assert.Equal(
-            "Compiler-generated guard reached: non-void function fell through without returning a value.",
-            diagnostic.Message);
+        Assert.Equal(DiagnosticDescriptors.NonVoidFallthroughGuardMessage, diagnostic.Message);
         Assert.Null(result.Value);
     }
 }

--- a/test/Interpreter.Tests/Issue3006FallthroughGuardDriverTests.cs
+++ b/test/Interpreter.Tests/Issue3006FallthroughGuardDriverTests.cs
@@ -1,0 +1,592 @@
+// <copyright file="Issue3006FallthroughGuardDriverTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using GSharp.Compiler;
+using GSharp.Core.CodeAnalysis;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #3006: every user-function invocation path must surface the non-void
+/// fallthrough guard instead of returning <c>default(T)</c>.
+/// </summary>
+public class Issue3006FallthroughGuardDriverTests
+{
+    private const string GuardMessage = DiagnosticDescriptors.NonVoidFallthroughGuardMessage;
+
+    public static IEnumerable<object[]> FallthroughCases()
+    {
+        yield return Case("DirectFunction", """
+            import System
+
+            func F(x DateTimeKind) int32 {
+                switch x {
+                    case DateTimeKind.Unspecified { return 11 }
+                    case DateTimeKind.Utc { return 22 }
+                    case DateTimeKind.Local { return 33 }
+                }
+            }
+
+            Console.WriteLine(F(DateTimeKind(99)))
+            """);
+
+        yield return Case("EntryPoint", """
+            import System
+
+            func Main() int32 {
+                let x = DateTimeKind(99)
+                switch x {
+                    case DateTimeKind.Unspecified { return 11 }
+                    case DateTimeKind.Utc { return 22 }
+                    case DateTimeKind.Local { return 33 }
+                }
+            }
+            """);
+
+        yield return Case("NestedFunctionCall", """
+            import System
+
+            func F(x DateTimeKind) int32 {
+                switch x {
+                    case DateTimeKind.Unspecified { return 11 }
+                    case DateTimeKind.Utc { return 22 }
+                    case DateTimeKind.Local { return 33 }
+                }
+            }
+
+            func Invoke() int32 {
+                return F(DateTimeKind(99))
+            }
+
+            Console.WriteLine(Invoke())
+            """);
+
+        yield return Case("FixedArm", """
+            import System
+
+            func F(x DateTimeKind, values []int32) int32 {
+                switch x {
+                    case DateTimeKind.Unspecified {
+                        unsafe {
+                            fixed p *int32 = values {
+                                return *p
+                            }
+                        }
+                    }
+                    case DateTimeKind.Utc { return 22 }
+                    case DateTimeKind.Local { return 33 }
+                }
+            }
+
+            Console.WriteLine(F(DateTimeKind(99), []int32{11}))
+            """);
+
+        yield return Case("ProtectedFinally", """
+            import System
+
+            func F(x DateTimeKind) int32 {
+                try {
+                    switch x {
+                        case DateTimeKind.Unspecified { return 11 }
+                        case DateTimeKind.Utc { return 22 }
+                        case DateTimeKind.Local { return 33 }
+                    }
+                } finally {
+                }
+            }
+
+            Console.WriteLine(F(DateTimeKind(99)))
+            """);
+
+        yield return Case("LambdaInvoke", """
+            import System
+
+            let f = func(x DateTimeKind) int32 {
+                switch x {
+                    case DateTimeKind.Unspecified { return 11 }
+                    case DateTimeKind.Utc { return 22 }
+                    case DateTimeKind.Local { return 33 }
+                }
+            }
+
+            Console.WriteLine(f(DateTimeKind(99)))
+            """);
+
+        yield return Case("InstanceMethod", """
+            import System
+
+            class C {
+                func F(x DateTimeKind) int32 {
+                    switch x {
+                        case DateTimeKind.Unspecified { return 11 }
+                        case DateTimeKind.Utc { return 22 }
+                        case DateTimeKind.Local { return 33 }
+                    }
+                }
+            }
+
+            Console.WriteLine(C().F(DateTimeKind(99)))
+            """);
+
+        yield return Case("PropertyGetter", """
+            import System
+
+            class C {
+                prop Kind DateTimeKind
+                prop Value int32 {
+                    get {
+                        switch this.Kind {
+                            case DateTimeKind.Unspecified { return 11 }
+                            case DateTimeKind.Utc { return 22 }
+                            case DateTimeKind.Local { return 33 }
+                        }
+                    }
+                }
+            }
+
+            let c = C{}
+            c.Kind = DateTimeKind(99)
+            Console.WriteLine(c.Value)
+            """);
+
+        yield return Case("StaticPropertyGetter", """
+            import System
+
+            class C {
+                shared {
+                    prop Kind DateTimeKind -> DateTimeKind(99)
+                    prop Value int32 {
+                        get {
+                            switch Kind {
+                                case DateTimeKind.Unspecified { return 11 }
+                                case DateTimeKind.Utc { return 22 }
+                                case DateTimeKind.Local { return 33 }
+                            }
+                        }
+                    }
+                }
+            }
+
+            Console.WriteLine(C.Value)
+            """);
+
+        yield return Case("IndexerGetter", """
+            import System
+
+            class C {
+                prop this[x DateTimeKind] int32 {
+                    get {
+                        switch x {
+                            case DateTimeKind.Unspecified { return 11 }
+                            case DateTimeKind.Utc { return 22 }
+                            case DateTimeKind.Local { return 33 }
+                        }
+                    }
+                }
+            }
+
+            Console.WriteLine(C{}[DateTimeKind(99)])
+            """);
+
+        yield return Case("UserOperator", """
+            import System
+
+            struct Choice {
+                var Kind DateTimeKind
+            }
+
+            func (left Choice) operator +(right Choice) int32 {
+                switch left.Kind {
+                    case DateTimeKind.Unspecified { return 11 }
+                    case DateTimeKind.Utc { return 22 }
+                    case DateTimeKind.Local { return 33 }
+                }
+            }
+
+            Console.WriteLine(Choice{Kind: DateTimeKind(99)} + Choice{})
+            """);
+
+        yield return Case("LiftedNullableOperator", """
+            import System
+
+            struct Choice(Kind DateTimeKind) {
+            }
+
+            func (left Choice) operator +(right Choice) int32 {
+                switch left.Kind {
+                    case DateTimeKind.Unspecified { return 11 }
+                    case DateTimeKind.Utc { return 22 }
+                    case DateTimeKind.Local { return 33 }
+                }
+            }
+
+            let left Choice? = Choice(DateTimeKind(99))
+            let right Choice? = Choice(DateTimeKind.Utc)
+            Console.WriteLine((left + right)!!)
+            """);
+    }
+
+    [Theory]
+    [MemberData(nameof(FallthroughCases))]
+    public async Task UnmatchedExhaustiveSwitch_AllDriversSurfaceGuard(string name, string source)
+    {
+        var root = CreateEmptyProbeRoot(name);
+        try
+        {
+            var compilerEvaluation = RunSourceDriver(
+                CreateEmptyDirectory(root, "gsc-eval"),
+                source,
+                Program.Main);
+            Assert.Equal(1, compilerEvaluation.ExitCode);
+            Assert.Contains("GS0100", compilerEvaluation.StandardOutput);
+            Assert.Contains(GuardMessage, compilerEvaluation.StandardOutput);
+            Assert.Equal($"Failed.{Environment.NewLine}", compilerEvaluation.StandardError);
+
+            var interpreter = RunSourceDriver(
+                CreateEmptyDirectory(root, "gsi"),
+                source,
+                GSharp.Repl.Program.Main);
+            Assert.Equal(1, interpreter.ExitCode);
+            Assert.Equal(string.Empty, interpreter.StandardOutput);
+            Assert.Contains("GS0100", interpreter.StandardError);
+            Assert.Contains(GuardMessage, interpreter.StandardError);
+
+            var emitted = await CompileAndRunAsync(
+                CreateEmptyDirectory(root, "gsc-emit"),
+                source);
+            Assert.Equal(0, emitted.Compile.ExitCode);
+            Assert.Equal(string.Empty, emitted.Compile.StandardError);
+            Assert.Equal(ExpectedUnhandledExceptionExitCode, emitted.Execution.ExitCode);
+            Assert.Equal(string.Empty, emitted.Execution.StandardOutput);
+            Assert.Contains($"System.InvalidOperationException: {GuardMessage}", emitted.Execution.StandardError);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ExhaustiveControlFlow_AllDriversReturnDistinctValues()
+    {
+        const string Source = """
+            import System
+
+            enum E { A, B, C }
+
+            func EnumSwitch(x E) int32 {
+                switch x {
+                    case E.A { return 11 }
+                    case E.B { return 22 }
+                    case E.C { return 33 }
+                }
+            }
+
+            func IntSwitch(x int32) int32 {
+                switch x {
+                    case 1 { return 44 }
+                    default { return 55 }
+                }
+            }
+
+            func StringIf(x string) int32 {
+                if x == "first" {
+                    return 66
+                } else {
+                    return 77
+                }
+            }
+
+            func ProtectedReturn() int32 {
+                try {
+                    return 88
+                } finally {
+                }
+            }
+
+            func Generic[T any](value T) T {
+                return value
+            }
+
+            func ExpressionSwitch(x E) int32 {
+                return switch x {
+                    case E.A: 111
+                    case E.B: 222
+                    case E.C: 333
+                }
+            }
+
+            func InfiniteLoop() int32 {
+                for {
+                }
+            }
+
+            Console.WriteLine(EnumSwitch(E.B))
+            Console.WriteLine(IntSwitch(9))
+            Console.WriteLine(StringIf("other"))
+            Console.WriteLine(ProtectedReturn())
+            Console.WriteLine(Generic("generic"))
+            Console.WriteLine(ExpressionSwitch(E.C))
+            """;
+        var expected = $"22{Environment.NewLine}"
+            + $"55{Environment.NewLine}"
+            + $"77{Environment.NewLine}"
+            + $"88{Environment.NewLine}"
+            + $"generic{Environment.NewLine}"
+            + $"333{Environment.NewLine}";
+        var root = CreateEmptyProbeRoot("Valid");
+
+        try
+        {
+            var compilerEvaluation = RunSourceDriver(
+                CreateEmptyDirectory(root, "gsc-eval"),
+                Source,
+                Program.Main);
+            Assert.Equal(0, compilerEvaluation.ExitCode);
+            Assert.Equal(expected + $"Success.{Environment.NewLine}", compilerEvaluation.StandardOutput);
+            Assert.Equal(string.Empty, compilerEvaluation.StandardError);
+
+            var interpreter = RunSourceDriver(
+                CreateEmptyDirectory(root, "gsi"),
+                Source,
+                GSharp.Repl.Program.Main);
+            Assert.Equal(0, interpreter.ExitCode);
+            Assert.Equal(expected, interpreter.StandardOutput);
+            Assert.Equal(string.Empty, interpreter.StandardError);
+
+            var emitted = await CompileAndRunAsync(
+                CreateEmptyDirectory(root, "gsc-emit"),
+                Source);
+            Assert.Equal(0, emitted.Compile.ExitCode);
+            Assert.Equal(string.Empty, emitted.Compile.StandardError);
+            Assert.Equal(0, emitted.Execution.ExitCode);
+            Assert.Equal(expected, emitted.Execution.StandardOutput);
+            Assert.Equal(string.Empty, emitted.Execution.StandardError);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task FallthroughGuard_PreservesInvalidOperationExceptionType()
+    {
+        const string Source = """
+            import System
+
+            func F(x DateTimeKind) int32 {
+                switch x {
+                    case DateTimeKind.Unspecified { return 11 }
+                    case DateTimeKind.Utc { return 22 }
+                    case DateTimeKind.Local { return 33 }
+                }
+            }
+
+            try {
+                F(DateTimeKind(99))
+            } catch (ex InvalidOperationException) {
+                Console.WriteLine(ex.Message)
+            }
+            """;
+        var expected = GuardMessage + Environment.NewLine;
+        var root = CreateEmptyProbeRoot("Caught");
+
+        try
+        {
+            var compilerEvaluation = RunSourceDriver(
+                CreateEmptyDirectory(root, "gsc-eval"),
+                Source,
+                Program.Main);
+            Assert.Equal(0, compilerEvaluation.ExitCode);
+            Assert.Equal(expected + $"Success.{Environment.NewLine}", compilerEvaluation.StandardOutput);
+            Assert.Equal(string.Empty, compilerEvaluation.StandardError);
+
+            var interpreter = RunSourceDriver(
+                CreateEmptyDirectory(root, "gsi"),
+                Source,
+                GSharp.Repl.Program.Main);
+            Assert.Equal(0, interpreter.ExitCode);
+            Assert.Equal(expected, interpreter.StandardOutput);
+            Assert.Equal(string.Empty, interpreter.StandardError);
+
+            var emitted = await CompileAndRunAsync(
+                CreateEmptyDirectory(root, "gsc-emit"),
+                Source);
+            Assert.Equal(0, emitted.Compile.ExitCode);
+            Assert.Equal(string.Empty, emitted.Compile.StandardError);
+            Assert.Equal(0, emitted.Execution.ExitCode);
+            Assert.Equal(expected, emitted.Execution.StandardOutput);
+            Assert.Equal(string.Empty, emitted.Execution.StandardError);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData(0, 3)]
+    [InlineData(9, 12)]
+    public void FallthroughGuard_ReportsFunctionDeclarationLocation(int paddingLines, int functionLine)
+    {
+        var source = "import System\n\n"
+            + new string('\n', paddingLines)
+            + """
+            func F(x DateTimeKind) int32 {
+                switch x {
+                    case DateTimeKind.Unspecified { return 11 }
+                    case DateTimeKind.Utc { return 22 }
+                    case DateTimeKind.Local { return 33 }
+                }
+            }
+
+            F(DateTimeKind(99))
+            """;
+        var root = CreateEmptyProbeRoot($"Location-{functionLine}");
+
+        try
+        {
+            var compilerDirectory = CreateEmptyDirectory(root, "gsc-eval");
+            var compilerEvaluation = RunSourceDriver(compilerDirectory, source, Program.Main);
+            var sourcePath = Path.Combine(compilerDirectory, "Probe.gs");
+            Assert.Equal(1, compilerEvaluation.ExitCode);
+            Assert.Contains(
+                $"{sourcePath}({functionLine},6,{functionLine},7): error GS0100",
+                compilerEvaluation.StandardOutput);
+            Assert.Contains("func F(x DateTimeKind) int32 {", compilerEvaluation.StandardOutput);
+
+            var interpreter = RunSourceDriver(
+                CreateEmptyDirectory(root, "gsi"),
+                source,
+                GSharp.Repl.Program.Main);
+            Assert.Equal(1, interpreter.ExitCode);
+            Assert.Contains(
+                $"({functionLine},6,{functionLine},7): error GS0100",
+                interpreter.StandardError);
+            Assert.Contains("func F(x DateTimeKind) int32 {", interpreter.StandardError);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static int ExpectedUnhandledExceptionExitCode
+        => OperatingSystem.IsWindows() ? unchecked((int)0xE0434352) : 134;
+
+    private static object[] Case(string name, string source) => new object[] { name, source };
+
+    private static string CreateEmptyProbeRoot(string name)
+    {
+        var root = Path.Combine(
+            GetRepositoryRoot(),
+            "out",
+            "test-artifacts",
+            $"issue3006-{name}-{Guid.NewGuid():N}");
+        Assert.False(Directory.Exists(root));
+        Directory.CreateDirectory(root);
+        Assert.Empty(Directory.EnumerateFileSystemEntries(root));
+        return root;
+    }
+
+    private static string CreateEmptyDirectory(string root, string name)
+    {
+        var directory = Path.Combine(root, name);
+        Assert.False(Directory.Exists(directory));
+        Directory.CreateDirectory(directory);
+        Assert.Empty(Directory.EnumerateFileSystemEntries(directory));
+        return directory;
+    }
+
+    private static DriverResult RunSourceDriver(
+        string directory,
+        string source,
+        Func<string[], int> driver)
+    {
+        var sourcePath = Path.Combine(directory, "Probe.gs");
+        File.WriteAllText(sourcePath, source);
+        return CaptureDriver(() => driver(new[] { sourcePath }));
+    }
+
+    private static async Task<(DriverResult Compile, DriverResult Execution)> CompileAndRunAsync(
+        string directory,
+        string source)
+    {
+        var sourcePath = Path.Combine(directory, "Probe.gs");
+        var assemblyPath = Path.Combine(directory, "Probe.dll");
+        File.WriteAllText(sourcePath, source);
+        var compile = CaptureDriver(() => Program.Main(new[]
+        {
+            "/out:" + assemblyPath,
+            "/target:exe",
+            "/targetframework:net10.0",
+            sourcePath,
+        }));
+        if (compile.ExitCode != 0)
+        {
+            return (compile, new DriverResult(-1, string.Empty, string.Empty));
+        }
+
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = directory,
+        };
+        startInfo.ArgumentList.Add(assemblyPath);
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Could not start emitted program.");
+        var stdout = process.StandardOutput.ReadToEndAsync();
+        var stderr = process.StandardError.ReadToEndAsync();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await process.WaitForExitAsync(timeout.Token);
+        return (compile, new DriverResult(
+            process.ExitCode,
+            await stdout,
+            await stderr));
+    }
+
+    private static DriverResult CaptureDriver(Func<int> driver)
+    {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            var exitCode = driver();
+            return new DriverResult(exitCode, stdout.ToString(), stderr.ToString());
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+    }
+
+    private static string GetRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null && !File.Exists(Path.Combine(directory.FullName, "GSharp.sln")))
+        {
+            directory = directory.Parent;
+        }
+
+        return directory?.FullName
+            ?? throw new InvalidOperationException("Could not locate repository root.");
+    }
+
+    private sealed record DriverResult(int ExitCode, string StandardOutput, string StandardError);
+}


### PR DESCRIPTION
## Summary
- detect non-void evaluator fallthrough at shared function boundary, including integer entry points
- thread declared return types and source declaration locations through direct calls, computed getters, and lifted operators
- share emitted/interpreted guard text from one constant
- add three-driver parity, entry-point, real-location, and exhaustive-flow regression coverage

## Validation
- merged-tree `dotnet build` (`BUILD_RC=0`, 0 warnings/errors)
- unfiltered `Interpreter.Tests` (730/730)
- unfiltered `Compiler.Tests` (4152/4152)
- 6 original product mutants plus entry-point routing and location-precedence mutants killed

Fixes #3006