### PR TITLE
Fix canonical primitive static receiver emission

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
@@ -1222,7 +1222,11 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
-        classSymbol = new ImportedClassSymbol(typeSymbol.ClrType, declaration, references: scope.References);
+        // Primitive symbols hold host-runtime CLR types. Project the receiver
+        // into the active reference context so its overload parameter types
+        // share identity with imported argument types under SDK compilation.
+        var receiverType = scope.References.MapClrTypeToReferences(typeSymbol.ClrType);
+        classSymbol = new ImportedClassSymbol(receiverType, declaration, references: scope.References);
         return true;
     }
 

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -2262,6 +2262,14 @@ internal sealed partial class ExpressionBinder
                 return new BoundErrorExpression(null);
             }
 
+            // An argument that already failed to bind cannot participate in
+            // overload resolution. Preserve its primary diagnostic instead of
+            // adding a misleading "cannot find function" cascade at this call.
+            if (arguments.Any(static argument => argument.Type == TypeSymbol.Error))
+            {
+                return new BoundErrorExpression(ce);
+            }
+
             Diagnostics.ReportUnableToFindFunction(ce.Location, methodName);
             return new BoundErrorExpression(null);
         }

--- a/test/Compiler.Tests/Emit/Issue3085PrimitiveStaticParseEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3085PrimitiveStaticParseEmitTests.cs
@@ -1,0 +1,143 @@
+// <copyright file="Issue3085PrimitiveStaticParseEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #3085: canonical primitive type receivers bind imported CLR static
+/// methods, and an already-invalid argument does not add a misleading call
+/// resolution diagnostic.
+/// </summary>
+public class Issue3085PrimitiveStaticParseEmitTests
+{
+    [Fact]
+    public void Int32Parse_CanonicalReceiver_CompilesAndRuns()
+    {
+        const string source = """
+            package Issue3085
+            import System
+
+            Console.WriteLine(int32.Parse("314159"))
+            """;
+
+        var compilation = Compile(source, executable: true);
+        try
+        {
+            Assert.True(compilation.ExitCode == 0, compilation.Output);
+            IlVerifier.Verify(compilation.AssemblyPath);
+            Assert.Equal("314159\n", Run(compilation.AssemblyPath, compilation.WorkDirectory));
+        }
+        finally
+        {
+            DeleteDirectory(compilation.WorkDirectory);
+        }
+    }
+
+    [Fact]
+    public void InvalidStaticCallArgument_DoesNotCascadeCannotFindFunction()
+    {
+        const string source = """
+            package Issue3085
+
+            class Host {
+                shared {
+                    func Run() int32 {
+                        return int32.Parse(Host.Missing)
+                    }
+                }
+            }
+            """;
+
+        var compilation = Compile(source, executable: false);
+        try
+        {
+            Assert.NotEqual(0, compilation.ExitCode);
+            Assert.Contains("GS0158", compilation.Output, StringComparison.Ordinal);
+            Assert.DoesNotContain("Cannot find function Parse", compilation.Output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteDirectory(compilation.WorkDirectory);
+        }
+    }
+
+    private static (string WorkDirectory, string AssemblyPath, int ExitCode, string Output) Compile(
+        string source,
+        bool executable)
+    {
+        string workDirectory = Path.Combine(
+            AppContext.BaseDirectory,
+            "issue3085",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workDirectory);
+
+        string sourcePath = Path.Combine(workDirectory, "test.gs");
+        string assemblyPath = Path.Combine(workDirectory, "test.dll");
+        File.WriteAllText(sourcePath, source);
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        TextWriter previousOut = Console.Out;
+        TextWriter previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        int exitCode;
+        try
+        {
+            exitCode = Program.Main(new[]
+            {
+                "/out:" + assemblyPath,
+                executable ? "/target:exe" : "/target:library",
+                "/targetframework:net10.0",
+                sourcePath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+
+        return (workDirectory, assemblyPath, exitCode, stdout.ToString() + stderr.ToString());
+    }
+
+    private static string Run(string assemblyPath, string workDirectory)
+    {
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = workDirectory,
+        };
+        startInfo.ArgumentList.Add("exec");
+        startInfo.ArgumentList.Add("--runtimeconfig");
+        startInfo.ArgumentList.Add(Path.ChangeExtension(assemblyPath, ".runtimeconfig.json"));
+        startInfo.ArgumentList.Add(assemblyPath);
+
+        using Process process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start compiled program.");
+        string stdout = process.StandardOutput.ReadToEnd();
+        string stderr = process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), "Compiled program timed out.");
+        Assert.True(process.ExitCode == 0, $"Program exited {process.ExitCode}:\n{stderr}");
+        return stdout.Replace("\r\n", "\n", StringComparison.Ordinal);
+    }
+
+    private static void DeleteDirectory(string path)
+    {
+        try
+        {
+            Directory.Delete(path, recursive: true);
+        }
+        catch
+        {
+        }
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1281RedundantNumericArgumentWrapTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1281RedundantNumericArgumentWrapTests.cs
@@ -147,7 +147,7 @@ namespace Demo
         }
     }
 }");
-        Assert.Contains("int32(UInt16.MaxValue)", printed);
+        Assert.Contains("int32(uint16.MaxValue)", printed);
     }
 
     private static string TranslateUnit(string source)

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3085PrimitiveStaticReceiverTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3085PrimitiveStaticReceiverTranslationTests.cs
@@ -26,6 +26,7 @@ public class Issue3085PrimitiveStaticReceiverTranslationTests
         using System;
 
         Console.WriteLine(int.Parse("314159"));
+        Console.WriteLine(string.Join(",", new[] { 10, 20, 30 }));
         """;
 
     [Theory]
@@ -66,7 +67,7 @@ public class Issue3085PrimitiveStaticReceiverTranslationTests
     }
 
     [Fact]
-    public async Task IntParseFixture_EmitsCanonicalReceiver_RoundTripsCompilesAndRuns()
+    public async Task PrimitiveStaticReceiverFixture_EmitsCanonicalReceiver_RoundTripsCompilesAndRuns()
     {
         string compiler = FindSiblingTool("Compiler", "gsc.dll");
         string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
@@ -92,7 +93,7 @@ public class Issue3085PrimitiveStaticReceiverTranslationTests
             """);
         File.WriteAllText(Path.Combine(projectDirectory, "Program.cs"), IntParseSource);
         string stdoutGolden = Path.Combine(projectDirectory, "baseline.stdout.golden");
-        File.WriteAllText(stdoutGolden, "314159\n");
+        File.WriteAllText(stdoutGolden, "314159\n10,20,30\n");
 
         string outputRoot = NewDirectory("pipeline-tests");
         var pipeline = new MigrationPipeline(
@@ -113,7 +114,9 @@ public class Issue3085PrimitiveStaticReceiverTranslationTests
             "*.gs",
             SearchOption.AllDirectories)));
         Assert.Contains("int32.Parse(\"314159\")", emitted, StringComparison.Ordinal);
+        Assert.Contains("string.Join(", emitted, StringComparison.Ordinal);
         Assert.DoesNotContain("Int32.Parse", emitted, StringComparison.Ordinal);
+        Assert.DoesNotContain("String.Join", emitted, StringComparison.Ordinal);
         AssertRoundTrip(emitted);
         Assert.True(
             app.Succeeded,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3085PrimitiveStaticReceiverTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3085PrimitiveStaticReceiverTranslationTests.cs
@@ -1,0 +1,182 @@
+// <copyright file="Issue3085PrimitiveStaticReceiverTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Pipeline;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3085: predefined C# type receivers use the same canonical spelling
+/// as G# type clauses.
+/// </summary>
+public class Issue3085PrimitiveStaticReceiverTranslationTests
+{
+    private const string IntParseSource = """
+        using System;
+
+        Console.WriteLine(int.Parse("314159"));
+        """;
+
+    [Theory]
+    [InlineData("bool.TrueString", "bool.TrueString")]
+    [InlineData("byte.MaxValue", "uint8.MaxValue")]
+    [InlineData("sbyte.MinValue", "int8.MinValue")]
+    [InlineData("short.MinValue", "int16.MinValue")]
+    [InlineData("ushort.MaxValue", "uint16.MaxValue")]
+    [InlineData("int.MinValue", "int32.MinValue")]
+    [InlineData("uint.MaxValue", "uint32.MaxValue")]
+    [InlineData("long.MinValue", "int64.MinValue")]
+    [InlineData("ulong.MaxValue", "uint64.MaxValue")]
+    [InlineData("nint.MinValue", "nint.MinValue")]
+    [InlineData("nuint.MaxValue", "nuint.MaxValue")]
+    [InlineData("float.NaN", "float32.NaN")]
+    [InlineData("double.NaN", "float64.NaN")]
+    [InlineData("decimal.Zero", "decimal.Zero")]
+    [InlineData("char.MaxValue", "char.MaxValue")]
+    [InlineData("string.Empty", "string.Empty")]
+    [InlineData("object.ReferenceEquals(null, null)", "object.ReferenceEquals(nil, nil)")]
+    public void PredefinedStaticReceiver_UsesCanonicalGSharpType(
+        string expression,
+        string expected)
+    {
+        string printed = Translate($$"""
+            using System;
+
+            namespace Issue3085;
+
+            public static class Host
+            {
+                public static void Run() => Console.WriteLine({{expression}});
+            }
+            """);
+
+        Assert.Contains(expected, printed, StringComparison.Ordinal);
+        AssertRoundTrip(printed);
+    }
+
+    [Fact]
+    public async Task IntParseFixture_EmitsCanonicalReceiver_RoundTripsCompilesAndRuns()
+    {
+        string compiler = FindSiblingTool("Compiler", "gsc.dll");
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null
+            || repoRoot is null
+            || GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
+        {
+            return;
+        }
+
+        string sourceRoot = NewDirectory("scratch-projects");
+        File.WriteAllText(Path.Combine(sourceRoot, "Directory.Build.props"), "<Project></Project>");
+        string projectDirectory = Path.Combine(sourceRoot, "Issue3085");
+        Directory.CreateDirectory(projectDirectory);
+        string projectPath = Path.Combine(projectDirectory, "Issue3085.csproj");
+        File.WriteAllText(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <OutputType>Exe</OutputType>
+                <TargetFramework>net10.0</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(projectDirectory, "Program.cs"), IntParseSource);
+        string stdoutGolden = Path.Combine(projectDirectory, "baseline.stdout.golden");
+        File.WriteAllText(stdoutGolden, "314159\n");
+
+        string outputRoot = NewDirectory("pipeline-tests");
+        var pipeline = new MigrationPipeline(
+            new PipelineOptions
+            {
+                Config = "Debug",
+                GscPath = compiler,
+                OutputRoot = outputRoot,
+                SourceRoot = sourceRoot,
+            },
+            new IMigrationStage[] { new TranslateStage(), new CompileStage(), new TestParityStage() });
+        RunResult result = await pipeline.RunAsync(
+            new[] { new CorpusApp("test/Issue3085", projectPath, TargetKind.Exe, stdoutGolden) });
+        AppResult app = Assert.Single(result.Apps);
+
+        string emitted = File.ReadAllText(Assert.Single(Directory.GetFiles(
+            Path.Combine(outputRoot, result.RunId, MigrationPipeline.SanitizeAppId(app.AppId)),
+            "*.gs",
+            SearchOption.AllDirectories)));
+        Assert.Contains("int32.Parse(\"314159\")", emitted, StringComparison.Ordinal);
+        Assert.DoesNotContain("Int32.Parse", emitted, StringComparison.Ordinal);
+        AssertRoundTrip(emitted);
+        Assert.True(
+            app.Succeeded,
+            "Expected translated int.Parse fixture to compile and run. Stages: "
+                + string.Join("; ", app.Stages.Select(stage => stage.Stage + "=" + stage.Status)));
+    }
+
+    private static string Translate(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Source.cs", source) });
+        Assert.True(project.BoundWithoutErrors, string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.DoesNotContain(
+            context.Diagnostics,
+            diagnostic => diagnostic.Severity == TranslationSeverity.Unsupported);
+        return GSharpPrinter.Print(unit);
+    }
+
+    private static void AssertRoundTrip(string printed)
+    {
+        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            roundTrip.Success,
+            string.Join(Environment.NewLine, roundTrip.Errors) + Environment.NewLine + printed);
+    }
+
+    private static string NewDirectory(string category)
+    {
+        string root = Path.Combine(
+            AppContext.BaseDirectory,
+            category,
+            "issue3085",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindSiblingTool(string projectDirectoryName, string dllName)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            foreach (string configuration in new[] { "Debug", "Release" })
+            {
+                string candidate = Path.Combine(
+                    directory.FullName,
+                    "out",
+                    "bin",
+                    configuration,
+                    projectDirectoryName,
+                    dllName);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue914NumericCoercionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914NumericCoercionTranslationTests.cs
@@ -529,7 +529,7 @@ namespace Demo
         }
     }
 }");
-        Assert.Contains("int32(UInt16.MaxValue)", printed);
+        Assert.Contains("int32(uint16.MaxValue)", printed);
     }
 
     private static string TranslateUnit(string source)

--- a/tools/cs2gs/Cs2Gs.Tests/L3TranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/L3TranslationTests.cs
@@ -286,11 +286,10 @@ namespace Demo
 
     /// <summary>
     /// ADR-0115 §B.24: a predefined type used as a static-call receiver
-    /// (<c>string.Concat(...)</c>) emits the BCL type name (<c>String</c>) so the
-    /// receiver resolves.
+    /// (<c>string.Concat(...)</c>) keeps the canonical G# type name.
     /// </summary>
     [Fact]
-    public void PredefinedTypeReceiver_EmitsBclTypeName()
+    public void PredefinedTypeReceiver_EmitsCanonicalTypeName()
     {
         string printed = TranslateUnit(@"
 namespace Demo
@@ -302,7 +301,7 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("String.Concat(parts)", printed);
+        Assert.Contains("string.Concat(parts)", printed);
         Assert.DoesNotContain("nil", printed);
     }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
@@ -399,11 +399,16 @@ public sealed partial class CSharpToGSharpTranslator
         private GExpression TranslatePredefinedTypeExpression(PredefinedTypeSyntax predefined)
         {
             // A C# predefined type used as an expression receiver (`string.Concat`,
-            // `int.Parse`) is a static-call target; G# resolves the BCL type name
-            // (`String`, `Int32`) there, not the lowercase value keyword, so emit
-            // the framework type name (ADR-0115 §B.12 receiver form).
+            // `int.Parse`) is a static-call target. Reuse the type mapper so the
+            // receiver and every type-clause position share one canonical G#
+            // spelling (`string`, `int32`, ...; ADR-0115 §B.12).
             ITypeSymbol symbol = this.context.GetTypeInfo(predefined).Type;
-            string name = symbol?.Name ?? predefined.Keyword.Text;
+            GTypeReference mapped = symbol == null
+                ? null
+                : this.typeMapper.Map(symbol, this.context, predefined.GetLocation());
+            string name = mapped is NamedTypeReference { TypeArguments.Count: 0 } named
+                ? named.Name
+                : symbol?.Name ?? predefined.Keyword.Text;
             return new IdentifierExpression(name);
         }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -610,6 +610,10 @@ public sealed class CSharpTypeMapper
                 return "int64";
             case SpecialType.System_UInt64:
                 return "uint64";
+            case SpecialType.System_IntPtr:
+                return "nint";
+            case SpecialType.System_UIntPtr:
+                return "nuint";
             case SpecialType.System_Single:
                 return "float32";
             case SpecialType.System_Double:


### PR DESCRIPTION
## Summary
- emit C# predefined static receivers through the canonical G# type mapper (`int.Parse` → `int32.Parse`, plus sibling primitive aliases)
- map native integer receiver/type spellings to `nint` and `nuint`
- project primitive receivers into the active reference context so SDK/MetadataLoadContext overload resolution stays correct (`string.Join` included)
- suppress misleading `GS0159` call-resolution cascades when an argument already failed to bind
- add compiler runtime coverage and a cs2gs round-trip/compile/run fixture

## Root cause
cs2gs used a separate receiver speller based on Roslyn's CLR symbol name, so predefined receivers diverged from type-clause spelling (`Int32` versus `int32`). Lowercase primitive receiver binding also reflected over host-runtime types rather than the active SDK reference context, which could select the wrong overload for imported arguments. The Domain migration's remaining `Parse` diagnostic was additionally a secondary cascade from unresolved GeneratedRegex `Pattern()` tracked by #3086.

## Validation
- `dotnet build GSharp.sln --configuration Debug --no-restore --nologo --verbosity:minimal`
- full local suites: Core.Tests 7,088 passed / 1 skipped; Compiler.Tests 4,148 passed; Cs2Gs.Tests 1,892 passed
- post-follow-up targeted suites: Core 74 passed; Compiler 13 passed; Cs2Gs 21 passed
- exact `cs2gs-corpus` CI command locally: 19/20 apps green, baseline 1 known / 0 new / 0 regressed / 0 stale
- Code Exploder Domain migration at `b4f6be83be664f02965f0363ec41f8946b56ff1d`: translation passes; `GS0159 Parse` and both old/current Parse fingerprints are absent; #3082's `GS0201` fingerprint remains absent. Only unrelated #3086 remains (`GS0158 Pattern`, `sha256:1c7e7d47e4f50029f02871de6e31d07fa8884cf096870015be0371c8615809e1`).

Fixes #3085
