### PR TITLE
gsc: enable JIT optimization for release builds

### DIFF
--- a/src/Compiler/Program.cs
+++ b/src/Compiler/Program.cs
@@ -128,6 +128,7 @@ public class Program
                 {
                     ImplicitSystemImport = parsed.ImplicitSystemImport,
                     IsLibrary = parsed.Target == OutputTarget.Library,
+                    Optimize = parsed.Optimize,
                     Logger = logger,
 
                     // Issue #1929/#1953: set as early as possible (right at
@@ -765,6 +766,7 @@ public class Program
           /noimplicitimports            Disable implicit System import (alias: /no-implicit-imports).
           /nowarn:<ids>                 Suppress the given diagnostic IDs (comma/semicolon separated).
           /warnaserror[+|-][:<ids>]     Treat warnings as errors, globally or for specific IDs.
+          /optimize[+|-]                Enable/disable JIT optimization (default: enabled).
           /debug[+|-][:<value>]         Emit debug info: none, portable, full, pdbonly, embedded.
           /pdb:<file>                   Sidecar PDB path.
           /doc:<file>                   XML documentation output path.
@@ -969,6 +971,18 @@ public class Program
                             result.WarnNotAsErrorIds.Add(id);
                         }
 
+                        break;
+
+                    case "optimize":
+                        result.Optimize = ParseBoolFlag(value, defaultIfEmpty: true);
+                        break;
+
+                    case "optimize+":
+                        result.Optimize = true;
+                        break;
+
+                    case "optimize-":
+                        result.Optimize = false;
                         break;
 
                     case "debug":
@@ -1287,6 +1301,9 @@ public class Program
 
         /// <summary>Gets or sets the requested PDB emit format (from /debug, /debug:&lt;value&gt;, /debug+/-). Defaults to None.</summary>
         public DebugInformationFormat DebugFormat { get; set; } = DebugInformationFormat.None;
+
+        /// <summary>Gets or sets a value indicating whether emitted assemblies allow JIT optimization (from /optimize, /optimize+/-). Defaults to true.</summary>
+        public bool Optimize { get; set; } = true;
 
         /// <summary>Gets or sets a value indicating whether a /debug, /debug+, or /debug- switch was observed on the command line. Used so that a bare /pdb:&lt;path&gt; can default the format to Portable without overriding a later /debug-.</summary>
         public bool DebugFlagSeen { get; set; }

--- a/src/Core/CodeAnalysis/Compilation/Compilation.cs
+++ b/src/Core/CodeAnalysis/Compilation/Compilation.cs
@@ -103,6 +103,12 @@ public class Compilation
     public bool IsLibrary { get; set; } = false;
 
     /// <summary>
+    /// Gets or sets a value indicating whether emitted runtime assemblies
+    /// allow JIT optimization. Defaults to <see langword="true"/>.
+    /// </summary>
+    public bool Optimize { get; set; } = true;
+
+    /// <summary>
     /// Gets or sets the active preprocessor symbol set used by
     /// <c>[Conditional("SYMBOL")]</c> call-site elision (ADR-0047 §6 /
     /// issue #176). A call to a function marked
@@ -716,9 +722,9 @@ public class Compilation
         };
     }
 
-    private static void EmitAssembly(BoundProgram program, Stream peStream, ReferenceResolver references, string assemblyName = null, string assemblyVersion = null, bool metadataOnly = false, Lowering.Async.AsyncStateMachineRewriteResult asyncRewriteResult = null, IteratorRewriteResult iteratorRewriteResult = null, AsyncIteratorRewriteResult asyncIteratorRewriteResult = null, DebugInformationOptions debugInformation = null, Stream pdbStream = null, string targetFrameworkMoniker = null, IReadOnlyList<(string Name, byte[] Data, bool IsPublic)> embeddedResources = null)
+    private void EmitAssembly(BoundProgram program, Stream peStream, ReferenceResolver references, string assemblyName = null, string assemblyVersion = null, bool metadataOnly = false, Lowering.Async.AsyncStateMachineRewriteResult asyncRewriteResult = null, IteratorRewriteResult iteratorRewriteResult = null, AsyncIteratorRewriteResult asyncIteratorRewriteResult = null, DebugInformationOptions debugInformation = null, Stream pdbStream = null, string targetFrameworkMoniker = null, IReadOnlyList<(string Name, byte[] Data, bool IsPublic)> embeddedResources = null)
     {
-        ReflectionMetadataEmitter.Emit(program, peStream, references, assemblyName, metadataOnly, asyncRewriteResult, iteratorRewriteResult, asyncIteratorRewriteResult, debugInformation, pdbStream, assemblyVersion, targetFrameworkMoniker, embeddedResources);
+        ReflectionMetadataEmitter.Emit(program, peStream, references, assemblyName, metadataOnly, asyncRewriteResult, iteratorRewriteResult, asyncIteratorRewriteResult, debugInformation, pdbStream, assemblyVersion, targetFrameworkMoniker, embeddedResources, Optimize);
     }
 
     private void PrepareReferencesForBinding(string assemblyName)

--- a/src/Core/CodeAnalysis/Emit/AssemblyAttributeEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/AssemblyAttributeEmitter.cs
@@ -43,8 +43,8 @@ namespace GSharp.Core.CodeAnalysis.Emit;
 /// <item><c>EmitGSharpTypeSemantics</c> — the
 /// <c>AssemblyMetadataAttribute</c> type-semantics payload consumed by
 /// <see cref="ImportedAssemblySemantics"/>.</item>
-/// <item><c>EmitDebuggableAttribute</c> — <c>DebuggableAttribute(true, true)</c>
-/// when debug information is present.</item>
+/// <item><c>EmitDebuggableAttribute</c> — stamps optimized or non-optimized
+/// CLR debugging flags independently from PDB presence.</item>
 /// <item><c>EmitNullableContextAttribute</c> — assembly-level
 /// <c>NullableContextAttribute(1)</c>.</item>
 /// </list>
@@ -322,23 +322,23 @@ internal sealed class AssemblyAttributeEmitter
     }
 
     /// <summary>
-    /// Emits <c>System.Diagnostics.DebuggableAttribute(true, true)</c> when
-    /// debug information is present so managed debuggers treat the assembly as
-    /// JIT-tracked and non-optimized.
+    /// Emits the CLR debugging flags for an optimized or non-optimized runtime
+    /// assembly.
     /// </summary>
-    public void EmitDebuggableAttribute(AssemblyDefinitionHandle assemblyHandle)
+    public void EmitDebuggableAttribute(AssemblyDefinitionHandle assemblyHandle, bool optimize)
     {
         var attrType = this.emitCtx.References.TryResolveType("System.Diagnostics.DebuggableAttribute", requireExternalVisibility: false, out var resolved)
             ? resolved
             : typeof(System.Diagnostics.DebuggableAttribute);
         var attrTypeRef = this.getTypeReference(attrType);
+        var modesType = attrType.GetNestedType("DebuggingModes");
+        var modesTypeRef = this.getTypeReference(modesType);
 
         var ctorSig = new BlobBuilder();
         new BlobEncoder(ctorSig).MethodSignature(isInstanceMethod: true)
-            .Parameters(2, r => r.Void(), p =>
+            .Parameters(1, r => r.Void(), p =>
             {
-                p.AddParameter().Type().Boolean();
-                p.AddParameter().Type().Boolean();
+                p.AddParameter().Type().Type(modesTypeRef, isValueType: true);
             });
 
         var ctorRef = this.emitCtx.Metadata.AddMemberReference(
@@ -348,8 +348,11 @@ internal sealed class AssemblyAttributeEmitter
 
         var valueBlob = new BlobBuilder();
         valueBlob.WriteUInt16(0x0001); // Prolog
-        valueBlob.WriteBoolean(true);  // isJITTrackingEnabled
-        valueBlob.WriteBoolean(true);  // isJITOptimizerDisabled
+        var flags = optimize
+            ? System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints
+            : System.Diagnostics.DebuggableAttribute.DebuggingModes.Default
+                | System.Diagnostics.DebuggableAttribute.DebuggingModes.DisableOptimizations;
+        valueBlob.WriteInt32((int)flags);
         valueBlob.WriteUInt16(0);      // NumNamed
 
         this.emitCtx.Metadata.AddCustomAttribute(

--- a/src/Core/CodeAnalysis/Emit/EmitContext.cs
+++ b/src/Core/CodeAnalysis/Emit/EmitContext.cs
@@ -97,6 +97,12 @@ internal sealed class EmitContext
     public bool MetadataOnly { get; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether the emitted runtime assembly
+    /// allows JIT optimization.
+    /// </summary>
+    public bool Optimize { get; set; } = true;
+
+    /// <summary>
     /// Gets the ECMA-335 metadata builder used to assemble the PE's metadata
     /// tables for this emit.
     /// </summary>

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -790,6 +790,7 @@ internal sealed class ReflectionMetadataEmitter
     /// <c>TargetFrameworkAttribute</c>.
     /// </param>
     /// <param name="embeddedResources">Managed resources to embed in runtime assemblies.</param>
+    /// <param name="optimize">Whether the emitted runtime assembly allows JIT optimization.</param>
     public static void Emit(
         BoundProgram program,
         Stream peStream,
@@ -803,11 +804,13 @@ internal sealed class ReflectionMetadataEmitter
         Stream pdbStream = null,
         string assemblyVersion = null,
         string targetFrameworkMoniker = null,
-        IReadOnlyList<(string Name, byte[] Data, bool IsPublic)> embeddedResources = null)
+        IReadOnlyList<(string Name, byte[] Data, bool IsPublic)> embeddedResources = null,
+        bool optimize = true)
     {
         var emitter = new ReflectionMetadataEmitter(program, references, assemblyName, metadataOnly, embeddedResources);
         emitter.emitCtx.AssemblyVersionOverride = assemblyVersion;
         emitter.emitCtx.TargetFrameworkMoniker = targetFrameworkMoniker;
+        emitter.emitCtx.Optimize = optimize;
 
         emitter.emitCtx.DebugInformation = debugInformation ?? new DebugInformationOptions();
         emitter.emitCtx.PdbStream = pdbStream;
@@ -3902,9 +3905,9 @@ internal sealed class ReflectionMetadataEmitter
 
         // Phase 7.7b: emit cross-language interop attributes for NuGet consumability.
         this.assemblyAttrs.EmitAssemblyInteropAttributes(assemblyHandle);
-        if (!this.emitCtx.MetadataOnly && this.emitCtx.Pdb != null)
+        if (!this.emitCtx.MetadataOnly && (this.emitCtx.Pdb != null || !this.emitCtx.Optimize))
         {
-            this.assemblyAttrs.EmitDebuggableAttribute(assemblyHandle);
+            this.assemblyAttrs.EmitDebuggableAttribute(assemblyHandle, this.emitCtx.Optimize);
         }
 
         return mvidFixup;

--- a/src/Sdk/Gsharp.NET.Sdk/BuildTask.cs
+++ b/src/Sdk/Gsharp.NET.Sdk/BuildTask.cs
@@ -157,6 +157,8 @@ public class BuildTask : Microsoft.Build.Utilities.Task, ICancelableTask
             args.Add($"/targetframework:{this.TargetFramework}");
         }
 
+        args.Add(ParseBool(this.Optimization) ? "/optimize+" : "/optimize-");
+
         if (!string.IsNullOrEmpty(this.DebugType))
         {
             args.Add($"/debug:{this.DebugType}");

--- a/test/Compiler.Tests/Issue2920ReleaseJitOptimizerTests.cs
+++ b/test/Compiler.Tests/Issue2920ReleaseJitOptimizerTests.cs
@@ -1,0 +1,96 @@
+// <copyright file="Issue2920ReleaseJitOptimizerTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Metadata;
+using Xunit;
+
+namespace GSharp.Compiler.Tests;
+
+public class Issue2920ReleaseJitOptimizerTests
+{
+    [Theory]
+    [InlineData(
+        null,
+        "/debug:portable",
+        true,
+        (int)DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+    [InlineData(
+        "/optimize+",
+        "/debug:portable",
+        true,
+        (int)DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+    [InlineData(
+        "/optimize-",
+        "/debug:portable",
+        true,
+        (int)(DebuggableAttribute.DebuggingModes.Default | DebuggableAttribute.DebuggingModes.DisableOptimizations))]
+    [InlineData(
+        "/optimize-",
+        "/debug-",
+        false,
+        (int)(DebuggableAttribute.DebuggingModes.Default | DebuggableAttribute.DebuggingModes.DisableOptimizations))]
+    public void Main_OptimizeFlag_ControlsJitFlagsIndependentlyFromPdb(
+        string optimizeFlag,
+        string debugFlag,
+        bool expectPdb,
+        int expectedFlags)
+    {
+        var id = Guid.NewGuid().ToString("N");
+        var directory = Path.Combine(Directory.GetCurrentDirectory(), ".issue2920-" + id);
+        Assert.False(Directory.Exists(directory));
+        Directory.CreateDirectory(directory);
+
+        var sourcePath = Path.Combine(directory, "program.gs");
+        var outputPath = Path.Combine(directory, "Issue2920" + id + ".dll");
+        var pdbPath = Path.ChangeExtension(outputPath, ".pdb");
+        File.WriteAllText(
+            sourcePath,
+            $"package Issue2920{id}\n\nfunc Value() int {{\n    return 11\n}}\n");
+
+        try
+        {
+            var arguments = new[]
+            {
+                "/out:" + outputPath,
+                "/target:library",
+                debugFlag,
+                optimizeFlag,
+                sourcePath,
+            }.Where(argument => argument is not null).ToArray();
+
+            var exit = Program.Main(arguments);
+
+            Assert.Equal(0, exit);
+            Assert.True(File.Exists(outputPath));
+            Assert.Equal(expectPdb, File.Exists(pdbPath));
+            IlVerifier.Verify(outputPath);
+
+            var assembly = Assembly.Load(File.ReadAllBytes(outputPath));
+            Assert.NotEmpty(assembly.GetTypes());
+            var debuggable = assembly.GetCustomAttribute<DebuggableAttribute>();
+            Assert.NotNull(debuggable);
+            Assert.Equal((DebuggableAttribute.DebuggingModes)expectedFlags, debuggable!.DebuggingFlags);
+
+            if (expectPdb)
+            {
+                using var pdbStream = File.OpenRead(pdbPath);
+                using var provider = MetadataReaderProvider.FromPortablePdbStream(pdbStream);
+                var reader = provider.GetMetadataReader();
+                Assert.NotEmpty(reader.Documents);
+                Assert.Contains(
+                    reader.MethodDebugInformation,
+                    handle => reader.GetMethodDebugInformation(handle).GetSequencePoints().Any());
+            }
+        }
+        finally
+        {
+            try { Directory.Delete(directory, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Sdk.Tests/BuildTaskDesignTimeTests.cs
+++ b/test/Sdk.Tests/BuildTaskDesignTimeTests.cs
@@ -46,8 +46,35 @@ public class BuildTaskDesignTimeTests
         var arguments = task.CommandLineArgs.Select(item => item.ItemSpec).ToArray();
         Assert.Contains("/target:library", arguments);
         Assert.Contains("/targetframework:net10.0", arguments);
+        Assert.Contains("/optimize+", arguments);
         Assert.Contains("/r:Reference.dll", arguments);
         Assert.Contains("Program.gs", arguments);
+    }
+
+    [Theory]
+    [InlineData("true", "/optimize+")]
+    [InlineData("false", "/optimize-")]
+    public void Optimization_ForwardsCompilerFlag(string optimization, string expectedArgument)
+    {
+        var task = new BuildTask
+        {
+            GsharpCompilerFullPath = "missing-gsc.dll",
+            OutputPath = ".",
+            OutputName = "Issue2920",
+            TempOutputPath = ".",
+            TargetFramework = "net10.0",
+            BasePath = ".",
+            OutputType = "Library",
+            Optimization = optimization,
+            Compile = new[] { new TaskItem("Program.gs") },
+            References = Array.Empty<TaskItem>(),
+            ResponseFilePath = "issue2920.rsp",
+            SkipCompilerExecution = "true",
+            ProvideCommandLineArgs = "true",
+        };
+
+        Assert.True(task.Execute());
+        Assert.Contains(task.CommandLineArgs, item => item.ItemSpec == expectedArgument);
     }
 
     [Fact]

--- a/test/Sdk.Tests/SdkLayoutTests.cs
+++ b/test/Sdk.Tests/SdkLayoutTests.cs
@@ -106,6 +106,7 @@ public class SdkLayoutTests
         Assert.Equal("@(_GsharpCoreCompileResource)", attrs["Resources"]);
         Assert.Equal("$(OutputType)", attrs["OutputType"]);
         Assert.Equal("$(TargetFramework)", attrs["TargetFramework"]);
+        Assert.Equal("$(Optimize)", attrs["Optimization"]);
         Assert.Equal("$(SkipCompilerExecution)", attrs["SkipCompilerExecution"]);
         Assert.Equal("$(ProvideCommandLineArgs)", attrs["ProvideCommandLineArgs"]);
         Assert.Contains(


### PR DESCRIPTION
## Summary
- add `/optimize[+|-]`; emitted CLI output defaults to optimized
- forward existing SDK `$(Optimize)` signal instead of coupling optimization to PDB presence
- emit Roslyn-style `DebuggableAttribute` flags: `IgnoreSymbolStoreSequencePoints` for optimized PDB builds; `Default | DisableOptimizations` only for `/optimize-`

One `DebuggableAttribute` construction site and one caller exist; both changed.

## Verification
- `dotnet build GSharp.sln`: 0 warnings/errors
- issue tests: 4/4 compiler, 5/5 SDK
- metadata test loads assembly, calls `GetTypes()`, asserts exact `DebuggingFlags`, validates PDB documents and sequence points
- `/optimize- /debug-` still emits optimizer-disable metadata; `/debug:portable` stays usable in both modes
- driver values: bare `gsc` = 11, `gsc /out:` runtime = 11, `gsi` = 11
- quiet-window timing, min of 15 after 3 warmups: optimized 4,694,500 ticks vs MinOpts 10,887,792 ticks (2.32x), matching checksum 1,367,379,968

Full solution run passed Core 7087/7088 (1 existing skip), Compiler 4129/4129, Interpreter 633/633, SDK 59/59, and other projects. Only failure was unrelated `Issue2819_SameVersionPackedToolAndSdk_CompileTranslatedIfLet`: test requires `out/bin/Release/nupkgs`, while this required Debug build produced only Debug packages.

## Mutation
Each product mutant built clean before measurement:
- invert `Compilation.Optimize` flow: `Main_OptimizeFlag_ControlsJitFlagsIndependentlyFromPdb` failed 4/4
- invert optimized/debug flag selection: same test failed 4/4
- invert no-PDB debug guard: `/optimize-`, `/debug-` case failed
- invert CLI parsed option flow: same test failed 4/4
- invert SDK flag forwarding: `Optimization_ForwardsCompilerFlag` and default design-time test failed

Fixes #2920