### PR TITLE
Fix GeneratedRegex partial method migration

### DIFF
--- a/docs/adr/0143-source-generators-in-cs2gs-migration.md
+++ b/docs/adr/0143-source-generators-in-cs2gs-migration.md
@@ -78,6 +78,15 @@ largely does:
   reproduce the members. (This is exactly the loop ADR-0145's end-to-end test
   proves for `@ObservableProperty`.)
 
+**`GeneratedRegex` partial methods (issue #3086).** Their trigger is itself a
+non-void partial-method definition. G# has no partial methods, so the generic
+ADR-0143 §D rule would erase the declaration while value-position calls such as
+`Pattern().Match(...)` remain. cs2gs instead emits one private cached `Regex`
+constructed from the bound attribute's pattern, options, and timeout, plus the
+original method as a private accessor, and removes the generator attribute to
+avoid duplicate output from gsgen. This preserves runtime behavior without
+back-translating the generator's large specialized runner.
+
 **File/options-driven generators (Avalonia `.axaml`, issue #2223).** Some
 generators consume non-source inputs rather than attributes — Avalonia's XAML
 name generator reads each `.axaml` (a Roslyn `AdditionalText`) and, guided by

--- a/docs/adr/0143-source-generators-in-cs2gs-migration.md
+++ b/docs/adr/0143-source-generators-in-cs2gs-migration.md
@@ -85,6 +85,9 @@ ADR-0143 §D rule would erase the declaration while value-position calls such as
 constructed from the bound attribute's pattern, options, and timeout, plus an
 accessor preserving the original method's static/instance shape and visibility,
 and removes the generator attribute to avoid duplicate output from gsgen.
+An omitted timeout uses the two-argument `Regex` constructor so
+`REGEX_DEFAULT_MATCH_TIMEOUT` still applies; an explicitly supplied `-1` remains
+`Regex.InfiniteMatchTimeout`.
 Culture-sensitive ignore-case patterns — including inline `(?i)` option groups —
 are reported unsupported unless invariant construction preserves their
 semantics. This preserves runtime behavior without back-translating the

--- a/docs/adr/0143-source-generators-in-cs2gs-migration.md
+++ b/docs/adr/0143-source-generators-in-cs2gs-migration.md
@@ -82,10 +82,13 @@ largely does:
 non-void partial-method definition. G# has no partial methods, so the generic
 ADR-0143 §D rule would erase the declaration while value-position calls such as
 `Pattern().Match(...)` remain. cs2gs instead emits one private cached `Regex`
-constructed from the bound attribute's pattern, options, and timeout, plus the
-original method as a private accessor, and removes the generator attribute to
-avoid duplicate output from gsgen. This preserves runtime behavior without
-back-translating the generator's large specialized runner.
+constructed from the bound attribute's pattern, options, and timeout, plus an
+accessor preserving the original method's static/instance shape and visibility,
+and removes the generator attribute to avoid duplicate output from gsgen.
+Culture-sensitive ignore-case patterns — including inline `(?i)` option groups —
+are reported unsupported unless invariant construction preserves their
+semantics. This preserves runtime behavior without back-translating the
+generator's large specialized runner.
 
 **File/options-driven generators (Avalonia `.axaml`, issue #2223).** Some
 generators consume non-source inputs rather than attributes — Avalonia's XAML

--- a/tools/cs2gs/Cs2Gs.Tests/Fixtures/Issue3086GeneratedRegex/Issue3086GeneratedRegex.csproj
+++ b/tools/cs2gs/Cs2Gs.Tests/Fixtures/Issue3086GeneratedRegex/Issue3086GeneratedRegex.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+  </PropertyGroup>
+</Project>

--- a/tools/cs2gs/Cs2Gs.Tests/Fixtures/Issue3086GeneratedRegex/Program.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Fixtures/Issue3086GeneratedRegex/Program.cs
@@ -35,11 +35,40 @@ public sealed partial record GitHubUrl(string Owner, string Name, int? PrNumber)
             object.ReferenceEquals(regex, Pattern());
     }
 
+    public static bool HasDefaultRegexSemantics()
+    {
+        Regex regex = DefaultPattern();
+        return regex.ToString() == "^default$" &&
+            regex.Options == RegexOptions.None &&
+            regex.MatchTimeout == Regex.InfiniteMatchTimeout &&
+            object.ReferenceEquals(regex, DefaultPattern());
+    }
+
+    public static bool HasInvariantInlineIgnoreCaseSemantics()
+    {
+        Regex regex = InvariantPattern();
+        return regex.IsMatch("INVARIANT") &&
+            regex.Options == RegexOptions.CultureInvariant &&
+            object.ReferenceEquals(regex, InvariantPattern());
+    }
+
     [GeneratedRegex(
         PatternText,
         RegexOptions.ExplicitCapture,
         matchTimeoutMilliseconds: 1000)]
     private static partial Regex Pattern();
+
+    [GeneratedRegex("^default$")]
+    private static partial Regex DefaultPattern();
+
+    [GeneratedRegex("(?i)^invariant$", RegexOptions.CultureInvariant)]
+    private static partial Regex InvariantPattern();
+}
+
+public sealed partial class InstanceRegexOwner
+{
+    [GeneratedRegex("^[a-z]+$")]
+    public partial Regex LowercaseWords();
 }
 
 public static class Program
@@ -52,6 +81,23 @@ public static class Program
         if (!GitHubUrl.HasExpectedRegexSemantics())
         {
             throw new InvalidOperationException("GeneratedRegex semantics changed.");
+        }
+
+        if (!GitHubUrl.HasDefaultRegexSemantics() ||
+            !GitHubUrl.HasInvariantInlineIgnoreCaseSemantics())
+        {
+            throw new InvalidOperationException("GeneratedRegex default semantics changed.");
+        }
+
+        var firstOwner = new InstanceRegexOwner();
+        var secondOwner = new InstanceRegexOwner();
+        Regex firstRegex = firstOwner.LowercaseWords();
+        if (!firstRegex.IsMatch("lowercase") ||
+            firstRegex.IsMatch("UPPERCASE") ||
+            !object.ReferenceEquals(firstRegex, firstOwner.LowercaseWords()) ||
+            !object.ReferenceEquals(firstRegex, secondOwner.LowercaseWords()))
+        {
+            throw new InvalidOperationException("GeneratedRegex instance lowering changed.");
         }
 
         Console.WriteLine("repository+pull-request+regex-ok");

--- a/tools/cs2gs/Cs2Gs.Tests/Fixtures/Issue3086GeneratedRegex/Program.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Fixtures/Issue3086GeneratedRegex/Program.cs
@@ -37,11 +37,14 @@ public sealed partial record GitHubUrl(string Owner, string Name, int? PrNumber)
 
     public static bool HasDefaultRegexSemantics()
     {
-        Regex regex = DefaultPattern();
-        return regex.ToString() == "^default$" &&
-            regex.Options == RegexOptions.None &&
-            regex.MatchTimeout == Regex.InfiniteMatchTimeout &&
-            object.ReferenceEquals(regex, DefaultPattern());
+        Regex defaultRegex = DefaultPattern();
+        Regex infiniteRegex = InfinitePattern();
+        return defaultRegex.ToString() == "^default$" &&
+            defaultRegex.Options == RegexOptions.None &&
+            defaultRegex.MatchTimeout.TotalMilliseconds == 250 &&
+            object.ReferenceEquals(defaultRegex, DefaultPattern()) &&
+            infiniteRegex.MatchTimeout == Regex.InfiniteMatchTimeout &&
+            object.ReferenceEquals(infiniteRegex, InfinitePattern());
     }
 
     public static bool HasInvariantInlineIgnoreCaseSemantics()
@@ -61,6 +64,9 @@ public sealed partial record GitHubUrl(string Owner, string Name, int? PrNumber)
     [GeneratedRegex("^default$")]
     private static partial Regex DefaultPattern();
 
+    [GeneratedRegex("^infinite$", RegexOptions.None, matchTimeoutMilliseconds: -1)]
+    private static partial Regex InfinitePattern();
+
     [GeneratedRegex("(?i)^invariant$", RegexOptions.CultureInvariant)]
     private static partial Regex InvariantPattern();
 }
@@ -75,6 +81,8 @@ public static class Program
 {
     public static void Main()
     {
+        AppContext.SetData("REGEX_DEFAULT_MATCH_TIMEOUT", TimeSpan.FromMilliseconds(250));
+
         AssertUrl("https://github.com/DavidObando/gsharp", null);
         AssertUrl("https://github.com/DavidObando/gsharp/pull/3086", 3086);
 

--- a/tools/cs2gs/Cs2Gs.Tests/Fixtures/Issue3086GeneratedRegex/Program.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Fixtures/Issue3086GeneratedRegex/Program.cs
@@ -1,0 +1,70 @@
+using System.Text.RegularExpressions;
+
+namespace Issue3086;
+
+public sealed partial record GitHubUrl(string Owner, string Name, int? PrNumber)
+{
+    private const string PatternText =
+        @"^https://(www\.)?github\.com/(?<owner>[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)/(?<name>[A-Za-z0-9._-]+?)(\.git)?(/(pull/(?<pr>\d+))?)?/?$";
+
+    public static bool TryParse(string? url, out GitHubUrl parsed)
+    {
+        parsed = new GitHubUrl(string.Empty, string.Empty, null);
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return false;
+        }
+
+        var match = Pattern().Match(url.Trim());
+        if (!match.Success)
+        {
+            return false;
+        }
+
+        int? prNumber = match.Groups["pr"].Success ? int.Parse(match.Groups["pr"].Value) : null;
+        parsed = new GitHubUrl(match.Groups["owner"].Value, match.Groups["name"].Value, prNumber);
+        return true;
+    }
+
+    public static bool HasExpectedRegexSemantics()
+    {
+        Regex regex = Pattern();
+        return regex.ToString() == PatternText &&
+            regex.Options == RegexOptions.ExplicitCapture &&
+            regex.MatchTimeout.TotalMilliseconds == 1000 &&
+            object.ReferenceEquals(regex, Pattern());
+    }
+
+    [GeneratedRegex(
+        PatternText,
+        RegexOptions.ExplicitCapture,
+        matchTimeoutMilliseconds: 1000)]
+    private static partial Regex Pattern();
+}
+
+public static class Program
+{
+    public static void Main()
+    {
+        AssertUrl("https://github.com/DavidObando/gsharp", null);
+        AssertUrl("https://github.com/DavidObando/gsharp/pull/3086", 3086);
+
+        if (!GitHubUrl.HasExpectedRegexSemantics())
+        {
+            throw new InvalidOperationException("GeneratedRegex semantics changed.");
+        }
+
+        Console.WriteLine("repository+pull-request+regex-ok");
+    }
+
+    private static void AssertUrl(string url, int? expectedPullRequest)
+    {
+        if (!GitHubUrl.TryParse(url, out GitHubUrl parsed) ||
+            parsed.Owner != "DavidObando" ||
+            parsed.Name != "gsharp" ||
+            parsed.PrNumber != expectedPullRequest)
+        {
+            throw new InvalidOperationException("GitHub URL parse failed: " + url);
+        }
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Fixtures/Issue3086GeneratedRegex/baseline.stdout.golden
+++ b/tools/cs2gs/Cs2Gs.Tests/Fixtures/Issue3086GeneratedRegex/baseline.stdout.golden
@@ -1,0 +1,1 @@
+repository+pull-request+regex-ok

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3086GeneratedRegexPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3086GeneratedRegexPipelineTests.cs
@@ -1,0 +1,141 @@
+// <copyright file="Issue3086GeneratedRegexPipelineTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>Issue #3086: GeneratedRegex partial declarations survive migration as equivalent cached regexes.</summary>
+[Collection(IlVerifyPipelineCollection.Name)]
+public sealed class Issue3086GeneratedRegexPipelineTests
+{
+    [Fact]
+    public async Task PartialRecord_GeneratedRegex_TranslatesCompilesVerifiesAndRuns()
+    {
+        string compiler = FindCompiler();
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null ||
+            repoRoot is null ||
+            GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null ||
+            !IlVerifyToolAvailable())
+        {
+            return;
+        }
+
+        string sourceRoot = NewDirectory("scratch-projects");
+        File.WriteAllText(Path.Combine(sourceRoot, "Directory.Build.props"), "<Project></Project>");
+        string projectDirectory = Path.Combine(sourceRoot, "Issue3086GeneratedRegex");
+        CopyFixture(projectDirectory);
+
+        string projectPath = Path.Combine(projectDirectory, "Issue3086GeneratedRegex.csproj");
+        string goldenPath = Path.Combine(projectDirectory, "baseline.stdout.golden");
+        string outputRoot = NewDirectory("pipeline-tests");
+        var app = new CorpusApp(
+            "test/Issue3086GeneratedRegex",
+            projectPath,
+            TargetKind.Exe,
+            stdoutGolden: goldenPath);
+        var pipeline = new MigrationPipeline(
+            new PipelineOptions
+            {
+                GscPath = compiler,
+                OutputRoot = outputRoot,
+                SourceRoot = sourceRoot,
+            },
+            new IMigrationStage[]
+            {
+                new TranslateStage(),
+                new CompileStage(),
+                new IlVerifyStage(),
+                new TestParityStage(),
+            });
+
+        RunResult result = await pipeline.RunAsync(new[] { app });
+        AppResult appResult = Assert.Single(result.Apps);
+        string appDirectory = Path.Combine(
+            outputRoot,
+            result.RunId,
+            MigrationPipeline.SanitizeAppId(app.Id));
+        string translated = string.Join(
+            Environment.NewLine,
+            Directory.GetFiles(appDirectory, "*.gs", SearchOption.AllDirectories)
+                .Select(File.ReadAllText));
+
+        Assert.Contains("let __generatedRegex_Pattern Regex = Regex(", translated, StringComparison.Ordinal);
+        Assert.Contains("RegexOptions.ExplicitCapture", translated, StringComparison.Ordinal);
+        Assert.Contains("TimeSpan.FromMilliseconds(1000.0)", translated, StringComparison.Ordinal);
+        Assert.Contains("func Pattern() Regex -> __generatedRegex_Pattern", translated, StringComparison.Ordinal);
+        Assert.DoesNotContain("@GeneratedRegex", translated, StringComparison.Ordinal);
+        Assert.True(
+            appResult.Succeeded,
+            string.Join("; ", appResult.Stages.Select(stage => stage.Stage + "=" + stage.Status)));
+        Assert.Equal(
+            new[] { "passed", "passed", "passed", "passed" },
+            appResult.Stages.Select(stage => stage.Status).ToArray());
+    }
+
+    private static void CopyFixture(string destination)
+    {
+        string source = Path.Combine(AppContext.BaseDirectory, "Fixtures", "Issue3086GeneratedRegex");
+        Directory.CreateDirectory(destination);
+        foreach (string file in Directory.GetFiles(source))
+        {
+            File.Copy(file, Path.Combine(destination, Path.GetFileName(file)));
+        }
+    }
+
+    private static bool IlVerifyToolAvailable()
+    {
+        try
+        {
+            return !IlVerifyRunner.IsEnabled || new IlVerifyRunner().EnsureToolAvailable();
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static string NewDirectory(string category)
+    {
+        string root = Path.Combine(
+            AppContext.BaseDirectory,
+            category,
+            "issue3086",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindCompiler()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            foreach (string configuration in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(
+                    directory.FullName,
+                    "out",
+                    "bin",
+                    configuration,
+                    "Compiler",
+                    "gsc.dll");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3086GeneratedRegexPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3086GeneratedRegexPipelineTests.cs
@@ -69,6 +69,10 @@ public sealed class Issue3086GeneratedRegexPipelineTests
             Environment.NewLine,
             Directory.GetFiles(appDirectory, "*.gs", SearchOption.AllDirectories)
                 .Select(File.ReadAllText));
+        string defaultPatternField = translated.Split('\n').Single(
+            line => line.Contains("__generatedRegex_DefaultPattern Regex =", StringComparison.Ordinal));
+        string infinitePatternField = translated.Split('\n').Single(
+            line => line.Contains("__generatedRegex_InfinitePattern Regex =", StringComparison.Ordinal));
 
         Assert.Contains("let __generatedRegex_Pattern Regex = Regex(", translated, StringComparison.Ordinal);
         Assert.Contains("RegexOptions.ExplicitCapture", translated, StringComparison.Ordinal);
@@ -76,9 +80,18 @@ public sealed class Issue3086GeneratedRegexPipelineTests
         Assert.Contains("func Pattern() Regex -> __generatedRegex_Pattern", translated, StringComparison.Ordinal);
         Assert.Contains("let __generatedRegex_DefaultPattern Regex = Regex(", translated, StringComparison.Ordinal);
         Assert.Contains("RegexOptions.None", translated, StringComparison.Ordinal);
-        Assert.Contains("Regex.InfiniteMatchTimeout", translated, StringComparison.Ordinal);
+        Assert.DoesNotContain("Regex.InfiniteMatchTimeout", defaultPatternField, StringComparison.Ordinal);
         Assert.Contains(
             "func DefaultPattern() Regex -> __generatedRegex_DefaultPattern",
+            translated,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "let __generatedRegex_InfinitePattern Regex = Regex(",
+            translated,
+            StringComparison.Ordinal);
+        Assert.Contains("Regex.InfiniteMatchTimeout", infinitePatternField, StringComparison.Ordinal);
+        Assert.Contains(
+            "func InfinitePattern() Regex -> __generatedRegex_InfinitePattern",
             translated,
             StringComparison.Ordinal);
         Assert.Contains("RegexOptions.CultureInvariant", translated, StringComparison.Ordinal);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3086GeneratedRegexPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3086GeneratedRegexPipelineTests.cs
@@ -6,7 +6,10 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Cs2Gs.CodeModel.Printing;
 using Cs2Gs.Pipeline;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
 using Xunit;
 
 namespace Cs2Gs.Tests;
@@ -71,6 +74,23 @@ public sealed class Issue3086GeneratedRegexPipelineTests
         Assert.Contains("RegexOptions.ExplicitCapture", translated, StringComparison.Ordinal);
         Assert.Contains("TimeSpan.FromMilliseconds(1000.0)", translated, StringComparison.Ordinal);
         Assert.Contains("func Pattern() Regex -> __generatedRegex_Pattern", translated, StringComparison.Ordinal);
+        Assert.Contains("let __generatedRegex_DefaultPattern Regex = Regex(", translated, StringComparison.Ordinal);
+        Assert.Contains("RegexOptions.None", translated, StringComparison.Ordinal);
+        Assert.Contains("Regex.InfiniteMatchTimeout", translated, StringComparison.Ordinal);
+        Assert.Contains(
+            "func DefaultPattern() Regex -> __generatedRegex_DefaultPattern",
+            translated,
+            StringComparison.Ordinal);
+        Assert.Contains("RegexOptions.CultureInvariant", translated, StringComparison.Ordinal);
+        Assert.Contains(
+            "let __generatedRegex_LowercaseWords Regex = Regex(",
+            translated,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "partial class InstanceRegexOwner {" + Environment.NewLine +
+            "    func LowercaseWords() Regex -> __generatedRegex_LowercaseWords",
+            translated,
+            StringComparison.Ordinal);
         Assert.DoesNotContain("@GeneratedRegex", translated, StringComparison.Ordinal);
         Assert.True(
             appResult.Succeeded,
@@ -78,6 +98,81 @@ public sealed class Issue3086GeneratedRegexPipelineTests
         Assert.Equal(
             new[] { "passed", "passed", "passed", "passed" },
             appResult.Stages.Select(stage => stage.Status).ToArray());
+    }
+
+    [Fact]
+    public async Task InlineIgnoreCaseWithoutInvariant_ReportsUnsupported()
+    {
+        string sourceRoot = NewDirectory("scratch-projects");
+        File.WriteAllText(Path.Combine(sourceRoot, "Directory.Build.props"), "<Project></Project>");
+        string projectDirectory = Path.Combine(sourceRoot, "Issue3086InlineIgnoreCase");
+        CopyFixture(projectDirectory);
+        File.WriteAllText(
+            Path.Combine(projectDirectory, "Program.cs"),
+            """
+            using System.Text.RegularExpressions;
+
+            public static partial class Patterns
+            {
+                [GeneratedRegex("(?i)abc")]
+                private static partial Regex GlobalIgnoreCase();
+
+                [GeneratedRegex("(?i:abc)")]
+                private static partial Regex ScopedIgnoreCase();
+
+                [GeneratedRegex("(?-i)(?m-i)(?im-s:abc)")]
+                private static partial Regex ToggledIgnoreCase();
+
+                [GeneratedRegex("(?-i:abc)")]
+                private static partial Regex DisabledIgnoreCase();
+
+                [GeneratedRegex(@"\(\?i\)")]
+                private static partial Regex EscapedLiteral();
+
+                [GeneratedRegex("[(?i)]")]
+                private static partial Regex CharacterClassLiteral();
+
+                [GeneratedRegex("(?i)abc", RegexOptions.CultureInvariant)]
+                private static partial Regex InvariantIgnoreCase();
+            }
+
+            public static class Program
+            {
+                public static void Main()
+                {
+                }
+            }
+            """);
+
+        string projectPath = Path.Combine(projectDirectory, "Issue3086GeneratedRegex.csproj");
+        LoadedCSharpProject project = await CSharpProjectLoader.LoadProjectAsync(projectPath);
+        Assert.True(
+            project.BoundWithoutErrors,
+            string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = project.Documents.Single(
+            candidate => Path.GetFileName(candidate.FilePath) == "Program.cs");
+        var context = new TranslationContext(
+            project.Compilation,
+            document.SemanticModel,
+            document.FilePath);
+        string translated = GSharpPrinter.Print(
+            new CSharpToGSharpTranslator().TranslateDocument(document, context));
+        TranslationDiagnostic[] diagnostics = context.Diagnostics
+            .Where(diagnostic => diagnostic.Severity == TranslationSeverity.Unsupported)
+            .ToArray();
+
+        Assert.Equal(3, diagnostics.Length);
+        Assert.All(
+            diagnostics,
+            diagnostic => Assert.Contains(
+                "including inline option groups",
+                diagnostic.Message,
+                StringComparison.Ordinal));
+        Assert.Contains("func DisabledIgnoreCase()", translated, StringComparison.Ordinal);
+        Assert.Contains("func EscapedLiteral()", translated, StringComparison.Ordinal);
+        Assert.Contains("func CharacterClassLiteral()", translated, StringComparison.Ordinal);
+        Assert.Contains("func InvariantIgnoreCase()", translated, StringComparison.Ordinal);
     }
 
     private static void CopyFixture(string destination)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
@@ -281,6 +281,7 @@ public sealed partial class CSharpToGSharpTranslator
             ITypeSymbol optionsType = this.context.Compilation.GetTypeByMetadataName(
                 "System.Text.RegularExpressions.RegexOptions");
             int timeoutMilliseconds = -1;
+            bool hasMatchTimeoutArgument = false;
             string cultureName = string.Empty;
 
             ImmutableArray<IParameterSymbol> constructorParameters = attribute.AttributeConstructor.Parameters;
@@ -304,6 +305,7 @@ public sealed partial class CSharpToGSharpTranslator
                         break;
                     case "matchTimeoutMilliseconds" when value is int timeoutArgument:
                         timeoutMilliseconds = timeoutArgument;
+                        hasMatchTimeoutArgument = true;
                         break;
                     case "cultureName":
                         cultureName = value as string ?? string.Empty;
@@ -345,20 +347,31 @@ public sealed partial class CSharpToGSharpTranslator
                 return false;
             }
 
-            string regexTypeName = regexType is NamedTypeReference namedRegex
-                ? namedRegex.Name
-                : "Regex";
-            GExpression milliseconds = LiteralExpression.Float(
-                timeoutMilliseconds.ToString(CultureInfo.InvariantCulture) + ".0");
-            GExpression matchTimeout = timeoutMilliseconds == -1
-                ? new MemberAccessExpression(
-                    new IdentifierExpression(regexTypeName),
-                    "InfiniteMatchTimeout")
-                : new InvocationExpression(
-                    new MemberAccessExpression(
-                        new IdentifierExpression("TimeSpan"),
-                        "FromMilliseconds"),
-                    new[] { milliseconds });
+            var constructionArguments = new List<GExpression>
+            {
+                LiteralExpression.String(pattern),
+                options,
+            };
+            if (hasMatchTimeoutArgument)
+            {
+                string regexTypeName = regexType is NamedTypeReference namedRegex
+                    ? namedRegex.Name
+                    : "Regex";
+                GExpression matchTimeout = timeoutMilliseconds == -1
+                    ? new MemberAccessExpression(
+                        new IdentifierExpression(regexTypeName),
+                        "InfiniteMatchTimeout")
+                    : new InvocationExpression(
+                        new MemberAccessExpression(
+                            new IdentifierExpression("TimeSpan"),
+                            "FromMilliseconds"),
+                        new[]
+                        {
+                            LiteralExpression.Float(
+                                timeoutMilliseconds.ToString(CultureInfo.InvariantCulture) + ".0"),
+                        });
+                constructionArguments.Add(matchTimeout);
+            }
 
             string cacheName = "__generatedRegex_" + SanitizeIdentifier(node.Identifier.Text);
             var occupiedNames = new HashSet<string>(
@@ -373,14 +386,7 @@ public sealed partial class CSharpToGSharpTranslator
                 BindingKind.Let,
                 cacheName,
                 regexType,
-                BuildConstruction(
-                    regexType,
-                    new GExpression[]
-                    {
-                        LiteralExpression.String(pattern),
-                        options,
-                        matchTimeout,
-                    }),
+                BuildConstruction(regexType, constructionArguments),
                 Visibility.Private);
 
             List<AttributeUse> attributes = this.MapAttributes(node.AttributeLists)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
@@ -56,7 +56,9 @@ public sealed partial class CSharpToGSharpTranslator
                         out MethodDeclaration generatedRegexMethod))
                     {
                         yield return (generatedRegexField, true);
-                        yield return (generatedRegexMethod, true);
+                        yield return (
+                            generatedRegexMethod,
+                            method.Modifiers.Any(SyntaxKind.StaticKeyword));
                         break;
                     }
 
@@ -260,7 +262,6 @@ public sealed partial class CSharpToGSharpTranslator
             var symbol = this.context.GetDeclaredSymbol(node) as IMethodSymbol;
             if (symbol == null ||
                 !symbol.IsPartialDefinition ||
-                !symbol.IsStatic ||
                 symbol.Parameters.Length != 0 ||
                 symbol.TypeParameters.Length != 0)
             {
@@ -318,11 +319,14 @@ public sealed partial class CSharpToGSharpTranslator
             long optionBits = Convert.ToInt64(optionsValue, CultureInfo.InvariantCulture);
             const long IgnoreCase = 1;
             const long CultureInvariant = 512;
-            if ((optionBits & IgnoreCase) != 0 &&
+            bool usesIgnoreCase = (optionBits & IgnoreCase) != 0 ||
+                PatternEnablesInlineIgnoreCase(pattern);
+            if (usesIgnoreCase &&
                 ((optionBits & CultureInvariant) == 0 || cultureName.Length > 0))
             {
-                const string Message = "GeneratedRegex with culture-sensitive IgnoreCase cannot be lowered to " +
-                    "Regex construction without changing culture or Regex.Options semantics.";
+                const string Message = "GeneratedRegex with culture-sensitive IgnoreCase, including inline " +
+                    "option groups, cannot be lowered to Regex construction without changing culture or " +
+                    "Regex.Options semantics.";
                 this.context.ReportUnsupported(node, Message);
                 return false;
             }
@@ -395,6 +399,122 @@ public sealed partial class CSharpToGSharpTranslator
         {
             string simpleName = name.Substring(name.LastIndexOf('.') + 1);
             return simpleName == "GeneratedRegex" || simpleName == "GeneratedRegexAttribute";
+        }
+
+        private static bool PatternEnablesInlineIgnoreCase(string pattern)
+        {
+            bool inCharacterClass = false;
+            bool firstCharacterInClass = false;
+
+            for (int i = 0; i < pattern.Length; i++)
+            {
+                char current = pattern[i];
+                if (current == '\\')
+                {
+                    if (inCharacterClass)
+                    {
+                        firstCharacterInClass = false;
+                    }
+
+                    i++;
+                    continue;
+                }
+
+                if (inCharacterClass)
+                {
+                    if (current == ']' && !firstCharacterInClass)
+                    {
+                        inCharacterClass = false;
+                    }
+                    else if (current != '^' || !firstCharacterInClass)
+                    {
+                        firstCharacterInClass = false;
+                    }
+
+                    continue;
+                }
+
+                if (current == '[')
+                {
+                    inCharacterClass = true;
+                    firstCharacterInClass = true;
+                    continue;
+                }
+
+                if (current != '(' ||
+                    i + 2 >= pattern.Length ||
+                    pattern[i + 1] != '?')
+                {
+                    continue;
+                }
+
+                if (pattern[i + 2] == '#')
+                {
+                    int commentEnd = pattern.IndexOf(')', i + 3);
+                    if (commentEnd < 0)
+                    {
+                        return false;
+                    }
+
+                    i = commentEnd;
+                    continue;
+                }
+
+                if (InlineOptionsEnableIgnoreCase(pattern, i + 2))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool InlineOptionsEnableIgnoreCase(string pattern, int start)
+        {
+            bool disabling = false;
+            bool sawOption = false;
+            bool sawDisabledOption = false;
+            bool enabledIgnoreCase = false;
+            bool disabledIgnoreCase = false;
+            int i = start;
+
+            for (; i < pattern.Length; i++)
+            {
+                char option = pattern[i];
+                if (option == '-')
+                {
+                    if (disabling)
+                    {
+                        return false;
+                    }
+
+                    disabling = true;
+                    continue;
+                }
+
+                if (option is not ('i' or 'm' or 'n' or 's' or 'x'))
+                {
+                    break;
+                }
+
+                sawOption = true;
+                if (disabling)
+                {
+                    sawDisabledOption = true;
+                    disabledIgnoreCase |= option == 'i';
+                }
+                else
+                {
+                    enabledIgnoreCase |= option == 'i';
+                }
+            }
+
+            return sawOption &&
+                (!disabling || sawDisabledOption) &&
+                i < pattern.Length &&
+                pattern[i] is ')' or ':' &&
+                enabledIgnoreCase &&
+                !disabledIgnoreCase;
         }
 
         private bool CanLowerOwnedExtension(MethodDeclarationSyntax method)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
@@ -47,6 +47,19 @@ public sealed partial class CSharpToGSharpTranslator
                         break;
                     }
 
+                    // A GeneratedRegex trigger is a non-void partial definition,
+                    // so ordinary partial-method elision would drop its declaration
+                    // while value-position calls remain.
+                    if (this.TryTranslateGeneratedRegex(
+                        method,
+                        out FieldDeclaration generatedRegexField,
+                        out MethodDeclaration generatedRegexMethod))
+                    {
+                        yield return (generatedRegexField, true);
+                        yield return (generatedRegexMethod, true);
+                        break;
+                    }
+
                     (GMember methodMember, bool methodIsStatic) = this.TranslateMethod(
                         method,
                         ownerKind,
@@ -234,6 +247,154 @@ public sealed partial class CSharpToGSharpTranslator
                         $"member '{member.Kind()}' has no canonical G# mapping yet (ADR-0115 §B.11).");
                     break;
             }
+        }
+
+        private bool TryTranslateGeneratedRegex(
+            MethodDeclarationSyntax node,
+            out FieldDeclaration cacheField,
+            out MethodDeclaration method)
+        {
+            cacheField = null;
+            method = null;
+
+            var symbol = this.context.GetDeclaredSymbol(node) as IMethodSymbol;
+            if (symbol == null ||
+                !symbol.IsPartialDefinition ||
+                !symbol.IsStatic ||
+                symbol.Parameters.Length != 0 ||
+                symbol.TypeParameters.Length != 0)
+            {
+                return false;
+            }
+
+            AttributeData attribute = symbol.GetAttributes().FirstOrDefault(
+                candidate => candidate.AttributeClass?.ToDisplayString() ==
+                    "System.Text.RegularExpressions.GeneratedRegexAttribute");
+            if (attribute?.AttributeConstructor == null)
+            {
+                return false;
+            }
+
+            string pattern = null;
+            object optionsValue = 0;
+            ITypeSymbol optionsType = this.context.Compilation.GetTypeByMetadataName(
+                "System.Text.RegularExpressions.RegexOptions");
+            int timeoutMilliseconds = -1;
+            string cultureName = string.Empty;
+
+            ImmutableArray<IParameterSymbol> constructorParameters = attribute.AttributeConstructor.Parameters;
+            ImmutableArray<TypedConstant> constructorArguments = attribute.ConstructorArguments;
+            if (constructorParameters.Length != constructorArguments.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < constructorParameters.Length; i++)
+            {
+                object value = constructorArguments[i].Value;
+                switch (constructorParameters[i].Name)
+                {
+                    case "pattern":
+                        pattern = value as string;
+                        break;
+                    case "options":
+                        optionsValue = value;
+                        optionsType = constructorArguments[i].Type ?? optionsType;
+                        break;
+                    case "matchTimeoutMilliseconds" when value is int timeoutArgument:
+                        timeoutMilliseconds = timeoutArgument;
+                        break;
+                    case "cultureName":
+                        cultureName = value as string ?? string.Empty;
+                        break;
+                }
+            }
+
+            if (pattern == null || optionsType == null)
+            {
+                return false;
+            }
+
+            long optionBits = Convert.ToInt64(optionsValue, CultureInfo.InvariantCulture);
+            const long IgnoreCase = 1;
+            const long CultureInvariant = 512;
+            if ((optionBits & IgnoreCase) != 0 &&
+                ((optionBits & CultureInvariant) == 0 || cultureName.Length > 0))
+            {
+                const string Message = "GeneratedRegex with culture-sensitive IgnoreCase cannot be lowered to " +
+                    "Regex construction without changing culture or Regex.Options semantics.";
+                this.context.ReportUnsupported(node, Message);
+                return false;
+            }
+
+            GTypeReference regexType = this.typeMapper.Map(
+                symbol.ReturnType,
+                this.context,
+                node.ReturnType.GetLocation());
+            GExpression options = this.MapConstantValue(
+                optionsValue,
+                optionsType,
+                node,
+                "GeneratedRegex options");
+            if (options == null)
+            {
+                return false;
+            }
+
+            string regexTypeName = regexType is NamedTypeReference namedRegex
+                ? namedRegex.Name
+                : "Regex";
+            GExpression milliseconds = LiteralExpression.Float(
+                timeoutMilliseconds.ToString(CultureInfo.InvariantCulture) + ".0");
+            GExpression matchTimeout = timeoutMilliseconds == -1
+                ? new MemberAccessExpression(
+                    new IdentifierExpression(regexTypeName),
+                    "InfiniteMatchTimeout")
+                : new InvocationExpression(
+                    new MemberAccessExpression(
+                        new IdentifierExpression("TimeSpan"),
+                        "FromMilliseconds"),
+                    new[] { milliseconds });
+
+            string cacheName = "__generatedRegex_" + SanitizeIdentifier(node.Identifier.Text);
+            var occupiedNames = new HashSet<string>(
+                symbol.ContainingType.GetMembers().Select(member => member.Name),
+                StringComparer.Ordinal);
+            while (occupiedNames.Contains(cacheName))
+            {
+                cacheName += "_";
+            }
+
+            cacheField = new FieldDeclaration(
+                BindingKind.Let,
+                cacheName,
+                regexType,
+                BuildConstruction(
+                    regexType,
+                    new GExpression[]
+                    {
+                        LiteralExpression.String(pattern),
+                        options,
+                        matchTimeout,
+                    }),
+                Visibility.Private);
+
+            List<AttributeUse> attributes = this.MapAttributes(node.AttributeLists)
+                .Where(mapped => !IsGeneratedRegexAttributeName(mapped.Name))
+                .ToList();
+            method = new MethodDeclaration(
+                SanitizeIdentifier(node.Identifier.Text),
+                returnType: regexType,
+                visibility: MapVisibility(symbol, this.context, node),
+                attributes: attributes,
+                expressionBody: new ReturnStatement(new IdentifierExpression(cacheName)));
+            return true;
+        }
+
+        private static bool IsGeneratedRegexAttributeName(string name)
+        {
+            string simpleName = name.Substring(name.LastIndexOf('.') + 1);
+            return simpleName == "GeneratedRegex" || simpleName == "GeneratedRegexAttribute";
         }
 
         private bool CanLowerOwnedExtension(MethodDeclarationSyntax method)


### PR DESCRIPTION
## Summary
- materialize `[GeneratedRegex]` partial definitions as private cached `Regex` instances plus original method accessors
- preserve bound pattern, `RegexOptions`, timeout, and singleton behavior while removing generator trigger to avoid duplicate gsgen output
- add reduced partial-record corpus covering `Pattern()` calls, repository and pull-request URLs, translation, compile, IL verification, and runtime behavior
- document migration exception in ADR-0143

## Validation
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj --no-restore --nologo -v:minimal` — 1,893 passed
- focused partial-method, analyzer-forwarding, primitive static receiver, and GeneratedRegex tests — 25 passed
- prerequisite #3082/#3085 compiler regressions — 3 passed
- `GeneratorHostEndToEndTests` — 3 passed
- `dotnet build GSharp.sln --no-restore --nologo -v:minimal` — succeeded, 0 warnings/errors
- `dotnet build ~/GitHub/DavidObando/code-exploder/codeexploder.slnx` — succeeded, 0 warnings/errors

## Code Exploder migration
`CodeExploder.Domain` diagnostic migration: translate PASS, compile PASS, ILVerify PASS, test parity PASS. Pattern fingerprint `sha256:1be6d896bbccf0a31baffbd06afd160ab13414b6feb89d397d80102d3dcd0068` is absent. Remaining failures: none.

Fixes #3086
