### PR TITLE
Fix imported nested generic type arguments

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
@@ -688,14 +688,15 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
-        nestedClassSymbol = CloseImportedNestedType(importedBase, nestedClassSymbol, syntax.RightPart);
+        nestedClassSymbol = CloseImportedNestedType(importedBase, nestedClassSymbol, syntax.RightPart, symbolicOuter: null);
         return true;
     }
 
     private ImportedClassSymbol CloseImportedNestedType(
         Type constructedOuter,
         ImportedClassSymbol nested,
-        ExpressionSyntax syntax)
+        ExpressionSyntax syntax,
+        ImportedTypeSymbol symbolicOuter)
     {
         var nestedType = nested?.ClassType;
         if (constructedOuter?.IsConstructedGenericType != true
@@ -713,7 +714,17 @@ internal sealed partial class ExpressionBinder
         try
         {
             var closedType = nestedType.MakeGenericType(outerArguments);
-            return new ImportedClassSymbol(closedType, syntax, references: scope.References);
+            ImportedTypeSymbol symbolicNested = null;
+            if (symbolicOuter?.HasTypeParameterArgument == true
+                && symbolicOuter.TypeArguments.Length == nestedType.GetGenericArguments().Length)
+            {
+                symbolicNested = ImportedTypeSymbol.GetConstructed(
+                    closedType,
+                    nestedType,
+                    symbolicOuter.TypeArguments);
+            }
+
+            return new ImportedClassSymbol(closedType, syntax, symbolicNested, scope.References);
         }
         catch (ArgumentException)
         {
@@ -1937,7 +1948,7 @@ internal sealed partial class ExpressionBinder
                     var importedBaseSymbol = new ImportedClassSymbol(importedBase, nested.LeftPart, references: scope.References);
                     if (TryResolveNestedTypeFromAccessorLeft(importedBaseSymbol, nested.LeftPart, out var importedNested))
                     {
-                        importedNested = CloseImportedNestedType(importedBase, importedNested, nested.LeftPart);
+                        importedNested = CloseImportedNestedType(importedBase, importedNested, nested.LeftPart, symbolicOuter: null);
                         return BindAccessorStep(receiver: null, importedNested, nested.RightPart);
                     }
                 }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
@@ -259,15 +259,6 @@ internal sealed partial class ExpressionBinder
                         return BindExtensionMethodGroupOrError(receiver, ne);
                     }
 
-                    // Stream B: static field/property read on imported type.
-                    // `Receiver == null` flags the access as static. Literal
-                    // (const) fields aren't real runtime fields, so we inline
-                    // their constant value rather than emit `ldsfld`.
-                    if (staticMember is FieldInfo litField && litField.IsLiteral)
-                    {
-                        return new BoundLiteralExpression(null, litField.GetRawConstantValue(), TypeSymbol.FromClrType(litField.FieldType));
-                    }
-
                     var staticType = staticMember switch
                     {
                         PropertyInfo sp => ClrNullability.GetPropertyTypeSymbol(sp),
@@ -293,7 +284,22 @@ internal sealed partial class ExpressionBinder
                             staticType = symbolicMemberType;
                         }
 
+                        if (staticMember is FieldInfo symbolicLiteral && symbolicLiteral.IsLiteral)
+                        {
+                            var literalType = classSymbol.ClassType.IsEnum
+                                ? classSymbol.SymbolicReceiver
+                                : staticType;
+                            return new BoundLiteralExpression(null, symbolicLiteral.GetRawConstantValue(), literalType);
+                        }
+
                         return new BoundClrPropertyAccessExpression(null, null, staticMember, staticType, classSymbol.SymbolicReceiver);
+                    }
+
+                    // Literal (const) fields aren't real runtime fields, so
+                    // inline their constant value rather than emit `ldsfld`.
+                    if (staticMember is FieldInfo literal && literal.IsLiteral)
+                    {
+                        return new BoundLiteralExpression(null, literal.GetRawConstantValue(), staticType);
                     }
 
                     return new BoundClrPropertyAccessExpression(null, null, staticMember, staticType);
@@ -826,7 +832,11 @@ internal sealed partial class ExpressionBinder
             if (scope.References.TryResolveNestedType(classSymbol.ClassType, name, out var nestedType))
             {
                 var nested = new ImportedClassSymbol(nestedType, nameExpr, references: scope.References);
-                nestedClassSymbol = CloseImportedNestedType(classSymbol.ClassType, nested, nameExpr);
+                nestedClassSymbol = CloseImportedNestedType(
+                    classSymbol.ClassType,
+                    nested,
+                    nameExpr,
+                    classSymbol.SymbolicReceiver);
                 return true;
             }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2947ImportedNestedGenericTypeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2947ImportedNestedGenericTypeTests.cs
@@ -1,0 +1,162 @@
+// <copyright file="Issue2947ImportedNestedGenericTypeTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Symbols.Display;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>Issue #2947: imported nested types retain symbolic enclosing arguments.</summary>
+public class Issue2947ImportedNestedGenericTypeTests
+{
+    [Fact]
+    public void ImportedNestedEnumLiterals_RetainSymbolicOuterArgumentAtBothDepths()
+    {
+        var directory = CreateEmptyTestDirectory();
+        try
+        {
+            var libraryPath = Path.Combine(directory, "glib.dll");
+            EmitLibrary(libraryPath);
+
+            using (var resolver = ReferenceResolver.WithReferences(new[] { libraryPath }))
+            {
+                var compilation = new Compilation(
+                    resolver,
+                    SyntaxTree.Parse(SourceText.From(
+                        """
+                        package consumer
+
+                        func Take[T]() {
+                            var direct glib.Outer[T].Color = glib.Outer[T].Color.Green
+                            var deep glib.Outer[T].Mid.Tone = glib.Outer[T].Mid.Tone.Green
+                            var invalid int32 = direct
+                        }
+                        """)));
+
+                var errors = compilation.GlobalScope.Diagnostics
+                    .Concat(compilation.BoundProgram.Diagnostics)
+                    .Where(diagnostic => diagnostic.IsError)
+                    .ToArray();
+                var error = Assert.Single(errors);
+                Assert.Equal("GS0156", error.Id);
+                Assert.Equal(
+                    "Cannot convert type 'glib.Outer[T].Color' to 'int32'. An explicit conversion exists (are you missing a cast?)",
+                    error.Message);
+
+                var function = compilation.BoundProgram.Functions.Keys.Single(symbol => symbol.Name == "Take");
+                var collector = new EnumLiteralCollector();
+                collector.Visit(compilation.BoundProgram.Functions[function]);
+
+                AssertSymbolicImportedType(collector.Literals.Single(literal => Equals(literal.Value, 5)), "type glib.Outer[T].Color", compilation);
+                AssertSymbolicImportedType(collector.Literals.Single(literal => Equals(literal.Value, 8)), "type glib.Outer[T].Mid.Tone", compilation);
+            }
+
+            _ = Assembly.LoadFrom(libraryPath);
+            var runtimeCompilation = new Compilation(
+                SyntaxTree.Parse(SourceText.From(
+                    """
+                    package consumer
+
+                    struct Holder[T] {
+                        func Take() {
+                            var direct glib.Outer[T].Color = glib.Outer[T].Color.Green
+                            var invalid int32 = direct
+                        }
+                    }
+                    """)));
+            var runtimeErrors = runtimeCompilation.GlobalScope.Diagnostics
+                .Concat(runtimeCompilation.BoundProgram.Diagnostics)
+                .Where(diagnostic => diagnostic.IsError)
+                .ToArray();
+            Assert.Equal(
+                new[]
+                {
+                    "Cannot convert type 'glib.Outer[T].Color' to 'int32'. An explicit conversion exists (are you missing a cast?)",
+                },
+                runtimeErrors.Select(diagnostic => diagnostic.Message));
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    private static void AssertSymbolicImportedType(
+        BoundLiteralExpression literal,
+        string expectedDisplay,
+        Compilation compilation)
+    {
+        var imported = Assert.IsType<ImportedTypeSymbol>(literal.Type);
+        Assert.True(imported.HasTypeParameterArgument);
+        Assert.Equal("T", Assert.Single(imported.TypeArguments).Name);
+        Assert.Equal(
+            expectedDisplay,
+            SymbolDisplay.ToDisplayString(imported, SymbolDisplayFormat.Signature, compilation));
+    }
+
+    private static void EmitLibrary(string outputPath)
+    {
+        var compilation = new Compilation(
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package glib
+
+                public struct Outer[T] {
+                    public enum Color { Red = 4, Green = 5, Blue = 6 }
+
+                    public struct Mid {
+                        public enum Tone { Red = 7, Green = 8, Blue = 9 }
+                    }
+                }
+                """)))
+        {
+            IsLibrary = true,
+        };
+
+        using var output = File.Create(outputPath);
+        var result = compilation.Emit(output, pdbStream: null, refStream: null, assemblyName: "glib");
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+
+    private static string CreateEmptyTestDirectory()
+    {
+        var root = Path.Combine(Environment.CurrentDirectory, "TestArtifacts");
+        Directory.CreateDirectory(root);
+        var path = Path.Combine(root, $"{nameof(Issue2947ImportedNestedGenericTypeTests)}-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        Assert.Empty(Directory.GetFileSystemEntries(path));
+        return path;
+    }
+
+    private sealed class EnumLiteralCollector : BoundTreeWalker
+    {
+        public List<BoundLiteralExpression> Literals { get; } = new();
+
+        public override void VisitExpression(BoundExpression node)
+        {
+            if (node is BoundLiteralExpression literal)
+            {
+                Literals.Add(literal);
+            }
+
+            base.VisitExpression(node);
+        }
+    }
+}

--- a/test/Interpreter.Tests/Issue2947ImportedNestedGenericDriverTests.cs
+++ b/test/Interpreter.Tests/Issue2947ImportedNestedGenericDriverTests.cs
@@ -1,0 +1,359 @@
+// <copyright file="Issue2947ImportedNestedGenericDriverTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>Issue #2947 cross-assembly compiler/interpreter regression coverage.</summary>
+[Collection("ConsoleIo")]
+public class Issue2947ImportedNestedGenericDriverTests
+{
+    private const string LibrarySource = """
+        package glib
+
+        public struct Outer[T] {
+            public enum Color { Red = 4, Green = 5, Blue = 6 }
+            public struct Value { public var N int32 }
+            public class Ref { public var N int32 }
+
+            public struct Mid {
+                public enum Tone { Red = 7, Green = 8, Blue = 9 }
+                public struct Value { public var N int32 }
+                public class Ref { public var N int32 }
+            }
+        }
+        """;
+
+    private const string ReportedSource = """
+        package z2947b
+        struct Holder[T] {
+            public func Take() int32 {
+                var c glib.Outer[T].Color = glib.Outer[T].Color.Green
+                return int32(c)
+            }
+        }
+
+        17
+        """;
+
+    private const string ExecutedReportedSource = """
+        package z2947b
+        import System
+
+        struct Holder[T] {
+            public func Take() int32 {
+                var c glib.Outer[T].Color = glib.Outer[T].Color.Green
+                return int32(c)
+            }
+        }
+
+        Console.WriteLine(Holder[string]{}.Take())
+        """;
+
+    private const string DiagnosticSource = """
+        package z2947b
+
+        struct Holder[T] {
+            public func Take() int32 {
+                var exact glib.Outer[T].Color = glib.Outer[T].Color.Green
+                var maybe glib.Outer[T].Color? = exact
+                var c glib.Outer[T].Color = maybe
+                var i int32 = exact
+                return i
+            }
+        }
+
+        Holder[string]{}.Take()
+        """;
+
+    private static readonly string[] ExpectedDiagnostics =
+    {
+        "Cannot convert type 'glib.Outer[T].Color?' to 'glib.Outer[T].Color'. An explicit conversion exists (are you missing a cast?)",
+        "Cannot convert type 'glib.Outer[T].Color' to 'int32'. An explicit conversion exists (are you missing a cast?)",
+    };
+
+    [Fact]
+    public void ImportedNestedTypes_PreserveArgumentsAcrossMatrixAndAllDrivers()
+    {
+        var directory = CreateEmptyTestDirectory();
+        try
+        {
+            var libraryPath = Path.Combine(directory, "glib.dll");
+            var librarySourcePath = WriteSource(directory, "lib.gs", LibrarySource);
+            var library = RunCompiler(
+                "/target:library",
+                "/out:" + libraryPath,
+                librarySourcePath);
+            AssertSucceeded(library, "library");
+
+            var reportedPath = WriteSource(directory, "reported.gs", ReportedSource);
+            var bare = RunCompiler("/nowarn:GS9100", "/r:" + libraryPath, reportedPath);
+            AssertSucceeded(bare, "reported bare evaluation");
+            Assert.Equal("Success.\n", Normalize(bare.StandardOutput));
+            Assert.Equal(string.Empty, bare.StandardError);
+
+            var executedReportedPath = WriteSource(directory, "reported-executed.gs", ExecutedReportedSource);
+            var reportedAssemblyPath = Path.Combine(directory, "reported.dll");
+            var emitted = RunCompiler(
+                "/target:exe",
+                "/nowarn:GS9100",
+                "/out:" + reportedAssemblyPath,
+                "/r:" + libraryPath,
+                executedReportedPath);
+            AssertSucceeded(emitted, "reported emit");
+            Assert.Equal("5\n", RunAssembly(directory, reportedAssemblyPath));
+
+            _ = Assembly.LoadFrom(libraryPath);
+            var interpreted = RunInterpreter(executedReportedPath);
+            AssertSucceeded(interpreted, "reported interpreter");
+            Assert.Equal("5\n", Normalize(interpreted.StandardOutput));
+            Assert.Equal(string.Empty, interpreted.StandardError);
+
+            var diagnosticPath = WriteSource(directory, "diagnostic.gs", DiagnosticSource);
+            var bareDiagnostics = RunCompiler("/nowarn:GS9100", "/r:" + libraryPath, diagnosticPath);
+            var emitDiagnostics = RunCompiler(
+                "/target:exe",
+                "/nowarn:GS9100",
+                "/out:" + Path.Combine(directory, "diagnostic.dll"),
+                "/r:" + libraryPath,
+                diagnosticPath);
+            var interpreterDiagnostics = RunInterpreter(diagnosticPath);
+
+            Assert.Equal(1, bareDiagnostics.ExitCode);
+            Assert.Equal(1, emitDiagnostics.ExitCode);
+            Assert.Equal(1, interpreterDiagnostics.ExitCode);
+            Assert.Equal(ExpectedDiagnostics, ExtractDiagnosticMessages(bareDiagnostics.Combined));
+            Assert.Equal(ExpectedDiagnostics, ExtractDiagnosticMessages(emitDiagnostics.Combined));
+            Assert.Equal(ExpectedDiagnostics, ExtractDiagnosticMessages(interpreterDiagnostics.Combined));
+            Assert.DoesNotContain("object", bareDiagnostics.Combined, StringComparison.Ordinal);
+            Assert.DoesNotContain("object", emitDiagnostics.Combined, StringComparison.Ordinal);
+            Assert.DoesNotContain("object", interpreterDiagnostics.Combined, StringComparison.Ordinal);
+
+            var fullMatrix = CreateMatrixSource(includeReportedCells: true);
+            Assert.Equal(36, fullMatrix.SiteCount);
+            CompileAndRunMatrix(directory, libraryPath, "matrix-full", fullMatrix);
+
+            var falsePositiveMatrix = CreateMatrixSource(includeReportedCells: false);
+            Assert.Equal(34, falsePositiveMatrix.SiteCount);
+            CompileAndRunMatrix(directory, libraryPath, "matrix-controls", falsePositiveMatrix);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    private static MatrixSource CreateMatrixSource(bool includeReportedCells)
+    {
+        var source = new StringBuilder(
+            """
+            package matrix2947
+            import System
+            import System.Collections.Generic
+
+            public struct LocalOuter[T] {
+                public enum Color { Red = 1, Green = 2 }
+                public struct Value { public var N int32 }
+                public class Ref { public var N int32 }
+
+                public struct Mid {
+                    public enum Tone { Red = 3, Green = 4 }
+                    public struct Value { public var N int32 }
+                    public class Ref { public var N int32 }
+                }
+            }
+
+            struct Holder[T] {
+                func Check() int32 {
+                    var total int32 = 0
+            """);
+
+        var siteCount = 0;
+        var expected = 0;
+        foreach (var imported in new[] { true, false })
+        {
+            var outer = imported ? "glib.Outer" : "LocalOuter";
+            foreach (var argument in new[] { "T", "int32", "List[int32]" })
+            {
+                foreach (var depth in new[] { string.Empty, ".Mid" })
+                {
+                    foreach (var kind in new[] { "enum", "struct", "class" })
+                    {
+                        if (!includeReportedCells
+                            && imported
+                            && argument == "T"
+                            && kind == "enum")
+                        {
+                            continue;
+                        }
+
+                        siteCount++;
+                        var suffix = kind switch
+                        {
+                            "enum" => depth.Length == 0 ? "Color" : "Tone",
+                            "struct" => "Value",
+                            _ => "Ref",
+                        };
+                        var type = $"{outer}[{argument}]{depth}.{suffix}";
+                        var expression = kind == "enum" ? type + ".Green" : $"default({type})";
+                        source.AppendLine($"        var value{siteCount} {type} = {expression}");
+                        switch (kind)
+                        {
+                            case "enum":
+                                source.AppendLine($"        total += int32(value{siteCount})");
+                                expected += depth.Length == 0
+                                    ? imported ? 5 : 2
+                                    : imported ? 8 : 4;
+                                break;
+                            case "struct":
+                                source.AppendLine($"        total += value{siteCount}.N");
+                                break;
+                            default:
+                                source.AppendLine($"        if value{siteCount} == nil {{ total += 1 }}");
+                                expected++;
+                                break;
+                        }
+                    }
+                }
+            }
+        }
+
+        source.AppendLine("        return total");
+        source.AppendLine("    }");
+        source.AppendLine("}");
+        source.AppendLine("Console.WriteLine(Holder[string]{}.Check())");
+        return new MatrixSource(source.ToString(), siteCount, expected);
+    }
+
+    private static void CompileAndRunMatrix(
+        string directory,
+        string libraryPath,
+        string name,
+        MatrixSource matrix)
+    {
+        var sourcePath = WriteSource(directory, name + ".gs", matrix.Source);
+        var assemblyPath = Path.Combine(directory, name + ".dll");
+        var compilation = RunCompiler(
+            "/target:exe",
+            "/nowarn:GS9100",
+            "/out:" + assemblyPath,
+            "/r:" + libraryPath,
+            sourcePath);
+        AssertSucceeded(compilation, name);
+        Assert.Equal(matrix.ExpectedValue + "\n", RunAssembly(directory, assemblyPath));
+    }
+
+    private static DriverResult RunCompiler(params string[] arguments)
+        => Capture(() => GSharp.Compiler.Program.Main(arguments));
+
+    private static DriverResult RunInterpreter(string sourcePath)
+        => Capture(() => GSharp.Repl.Program.Main(new[] { sourcePath }));
+
+    private static DriverResult Capture(Func<int> action)
+    {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        try
+        {
+            Console.SetOut(stdout);
+            Console.SetError(stderr);
+            return new DriverResult(action(), stdout.ToString(), stderr.ToString());
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+    }
+
+    private static string RunAssembly(string directory, string assemblyPath)
+    {
+        var runtimeConfigPath = Path.ChangeExtension(assemblyPath, ".runtimeconfig.json");
+        File.WriteAllText(
+            runtimeConfigPath,
+            """
+            {
+              "runtimeOptions": {
+                "tfm": "net10.0",
+                "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+              }
+            }
+            """);
+
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = directory,
+        };
+        startInfo.ArgumentList.Add("exec");
+        startInfo.ArgumentList.Add("--runtimeconfig");
+        startInfo.ArgumentList.Add(runtimeConfigPath);
+        startInfo.ArgumentList.Add(assemblyPath);
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start emitted assembly");
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), "Emitted assembly timed out");
+        Assert.True(
+            process.ExitCode == 0,
+            $"Emitted assembly exited {process.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return Normalize(stdout);
+    }
+
+    private static string[] ExtractDiagnosticMessages(string output)
+        => Regex.Matches(output, @"error GS0156: (?<message>[^\r\n]+)")
+            .Select(match => match.Groups["message"].Value)
+            .ToArray();
+
+    private static void AssertSucceeded(DriverResult result, string operation)
+        => Assert.True(
+            result.ExitCode == 0,
+            $"{operation} exited {result.ExitCode}\nstdout:\n{result.StandardOutput}\nstderr:\n{result.StandardError}");
+
+    private static string WriteSource(string directory, string fileName, string source)
+    {
+        var path = Path.Combine(directory, fileName);
+        File.WriteAllText(path, source);
+        return path;
+    }
+
+    private static string CreateEmptyTestDirectory()
+    {
+        var root = Path.Combine(Environment.CurrentDirectory, "TestArtifacts");
+        Directory.CreateDirectory(root);
+        var path = Path.Combine(root, $"{nameof(Issue2947ImportedNestedGenericDriverTests)}-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        Assert.Empty(Directory.GetFileSystemEntries(path));
+        return path;
+    }
+
+    private static string Normalize(string value)
+        => value.Replace("\r\n", "\n", StringComparison.Ordinal);
+
+    private sealed record DriverResult(int ExitCode, string StandardOutput, string StandardError)
+    {
+        public string Combined => StandardOutput + StandardError;
+    }
+
+    private sealed record MatrixSource(string Source, int SiteCount, int ExpectedValue);
+}


### PR DESCRIPTION
## Summary
- preserve symbolic enclosing type arguments while resolving imported nested CLR types
- type imported enum literals with their symbolic containing enum instead of the CLR-erased `object` construction
- cover nested enum, struct, and class shapes across argument kinds, assembly boundaries, and two nesting depths

## Behavior change
Cross-assembly references such as `glib.Outer[T].Color.Green` now bind as `glib.Outer[T].Color`, not `glib.Outer[object].Color`. Bare `gsc`, emitted `gsc /out:`, and `gsi` now render the same symbolic type in diagnostics. Explicit enum-to-integer conversion remains required.

## Validation
- `Core.Tests`: 7089 passed, 1 skipped
- `Interpreter.Tests`: 638 passed
- full solution build: 0 warnings, 0 errors
- 36-site behavior matrix plus 34-site false-positive corpus
- both product condition mutants fail `ImportedNestedEnumLiterals_RetainSymbolicOuterArgumentAtBothDepths`; restored code passes

Fixes #2947