### PR TITLE
Fix generic tuple collection projection

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -4160,6 +4160,16 @@ public sealed class Binder
         if (TypeSymbol.RequiresSymbolicProjection(type) || type.ClrType == null)
         {
             hasSymbolicArgument = true;
+
+            // Issue #3087: a tuple must retain its ValueTuple shape while its
+            // symbolic elements ride through erased CLR placeholders.
+            if ((type is TupleTypeSymbol
+                    or NullableTypeSymbol { UnderlyingType: TupleTypeSymbol })
+                && MemberLookup.TryProjectErasedClrType(type, out var projected))
+            {
+                return scope.References.MapClrTypeToReferences(projected);
+            }
+
             return TypeSymbol.ContainsTypeParameter(type)
                 || TypeSymbol.ContainsSameCompilationUserType(type)
                 || type.ClrType == null

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -937,12 +937,22 @@ internal sealed partial class ExpressionBinder
 
             if (ta.ClrType == null)
             {
-                // Issue #313: in-scope type parameter, or issue #671: G#
-                // user-defined type whose ClrType is null at bind time.
-                // Both project onto System.Object under the type-erased
-                // model; the real symbolic argument is preserved separately.
+                // Issue #3087: retain the erased shape of symbolic tuple
+                // arguments. Flattening the whole argument to object made
+                // List[(...)].Add and LINQ receiver inference see List<object>
+                // instead of List<ValueTuple<...>>.
                 hasSymbolicArg = true;
-                clrArgs[i] = scope.References.GetCoreType("System.Object");
+                if ((ta is TupleTypeSymbol
+                        or NullableTypeSymbol { UnderlyingType: TupleTypeSymbol })
+                    && MemberLookup.TryProjectErasedClrType(ta, out var projected))
+                {
+                    clrArgs[i] = scope.References.MapClrTypeToReferences(projected);
+                }
+                else
+                {
+                    clrArgs[i] = scope.References.GetCoreType("System.Object");
+                }
+
                 continue;
             }
 

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -1554,6 +1554,15 @@ internal sealed partial class ExpressionBinder
             return typeof(int?);
         }
 
+        if ((typeSymbol is TupleTypeSymbol
+                or NullableTypeSymbol { UnderlyingType: TupleTypeSymbol })
+            && MemberLookup.TryProjectErasedClrType(typeSymbol, out var erasedTuple))
+        {
+            // Issue #3087: imported instance-method applicability still needs
+            // the full erased ValueTuple shape when an element is symbolic.
+            return erasedTuple;
+        }
+
         // Issue #903: a delegate-typed argument (an untyped/typed arrow lambda,
         // a func literal, or a named delegate value) whose parameter or return
         // type is a same-compilation user type has no CLR backing —

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -2019,22 +2019,7 @@ internal sealed class MemberLookup
                         erasedElements[i] = erasedElement;
                     }
 
-                    Type tupleOpenDefinition = erasedElements.Length switch
-                    {
-                        2 => typeof(ValueTuple<,>),
-                        3 => typeof(ValueTuple<,,>),
-                        4 => typeof(ValueTuple<,,,>),
-                        5 => typeof(ValueTuple<,,,,>),
-                        6 => typeof(ValueTuple<,,,,,>),
-                        7 => typeof(ValueTuple<,,,,,,>),
-                        _ => null,
-                    };
-                    if (tupleOpenDefinition == null)
-                    {
-                        return false;
-                    }
-
-                    erased = tupleOpenDefinition.MakeGenericType(erasedElements);
+                    erased = TupleTypeSymbol.BuildClrType(erasedElements);
                     return true;
                 }
 
@@ -4448,21 +4433,38 @@ internal sealed class MemberLookup
     /// <returns>The erased closed tuple CLR type, or <see langword="null"/> when none could be built.</returns>
     private static Type BuildErasedTupleInContext(TupleTypeSymbol tuple, Type contextObject)
     {
-        Type tupleOpenDefinition = ResolveErasedValueTupleOpenDefinition(contextObject, tuple.ElementTypes.Length);
-        if (tupleOpenDefinition == null)
-        {
-            return null;
-        }
-
         var erasedElements = new Type[tuple.ElementTypes.Length];
         for (int i = 0; i < tuple.ElementTypes.Length; i++)
         {
             erasedElements[i] = ProjectSymbolicArgToErasedClr(tuple.ElementTypes[i], contextObject) ?? contextObject;
         }
 
+        return BuildErasedTupleInContext(erasedElements, 0, erasedElements.Length, contextObject);
+    }
+
+    private static Type BuildErasedTupleInContext(Type[] elementTypes, int start, int count, Type contextObject)
+    {
+        var tupleOpenDefinition = ResolveErasedValueTupleOpenDefinition(contextObject, count <= 7 ? count : 8);
+        if (tupleOpenDefinition == null)
+        {
+            return null;
+        }
+
+        var arguments = new Type[Math.Min(count, 8)];
+        var directCount = Math.Min(count, 7);
+        Array.Copy(elementTypes, start, arguments, 0, directCount);
+        if (count > 7)
+        {
+            arguments[7] = BuildErasedTupleInContext(elementTypes, start + 7, count - 7, contextObject);
+            if (arguments[7] == null)
+            {
+                return null;
+            }
+        }
+
         try
         {
-            return tupleOpenDefinition.MakeGenericType(erasedElements);
+            return tupleOpenDefinition.MakeGenericType(arguments);
         }
         catch
         {
@@ -4484,18 +4486,20 @@ internal sealed class MemberLookup
     /// <see cref="ArgumentException"/>).
     /// </summary>
     /// <param name="contextObject">The <c>object</c> placeholder resolved in the target context.</param>
-    /// <param name="arity">The tuple arity (2–7; the BCL <c>ValueTuple</c> family's generic range).</param>
+    /// <param name="arity">The CLR tuple-node arity (1–8).</param>
     /// <returns>The open <c>ValueTuple`N</c> definition, or <see langword="null"/> when unsupported/unresolvable.</returns>
     private static Type ResolveErasedValueTupleOpenDefinition(Type contextObject, int arity)
     {
         Type hostOpenDefinition = arity switch
         {
+            1 => typeof(ValueTuple<>),
             2 => typeof(ValueTuple<,>),
             3 => typeof(ValueTuple<,,>),
             4 => typeof(ValueTuple<,,,>),
             5 => typeof(ValueTuple<,,,,>),
             6 => typeof(ValueTuple<,,,,,>),
             7 => typeof(ValueTuple<,,,,,,>),
+            8 => typeof(ValueTuple<,,,,,,,>),
             _ => null,
         };
         if (hostOpenDefinition == null)

--- a/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
+++ b/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
@@ -1872,35 +1872,36 @@ internal sealed class ImportedMemberRefFactory
     /// are correctly referenced by their TypeDef handles.
     /// </summary>
     private EntityHandle GetTupleTypeSpec(TupleTypeSymbol tupleType)
+        => this.GetTupleTypeSpec(tupleType, 0, tupleType.Arity);
+
+    private EntityHandle GetTupleTypeSpec(TupleTypeSymbol tupleType, int start, int count)
     {
         var sigBlob = new BlobBuilder();
-        this.signatures.EncodeTypeSymbol(new BlobEncoder(sigBlob).TypeSpecificationSignature(), tupleType);
+        this.signatures.EncodeTupleType(
+            new BlobEncoder(sigBlob).TypeSpecificationSignature(),
+            tupleType.ElementTypes,
+            start,
+            count);
         return this.emitCtx.Metadata.AddTypeSpecification(
             this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
     }
 
     /// <summary>
-    /// Issue #649: Gets a MemberRef for a tuple field (<c>Item1</c>...<c>Item7</c>) when
-    /// the tuple's <see cref="TypeSymbol.ClrType"/> is null (element types include
-    /// G#-defined types). Builds the field MemberRef against the symbolically-constructed
-    /// <c>ValueTuple</c> TypeSpec.
+    /// Issue #649: Gets a MemberRef for a tuple field when the tuple's
+    /// <see cref="TypeSymbol.ClrType"/> is null (element types include
+    /// G#-defined types). Builds the field MemberRef against the appropriate
+    /// symbolically-constructed <c>ValueTuple</c> node TypeSpec.
     /// </summary>
-    internal MemberReferenceHandle GetTupleFieldReference(TupleTypeSymbol tupleType, string fieldName)
+    internal MemberReferenceHandle GetTupleFieldReference(
+        TupleTypeSymbol tupleType,
+        int start,
+        int count,
+        string fieldName)
     {
-        var parent = this.GetTupleTypeSpec(tupleType);
+        var parent = this.GetTupleTypeSpec(tupleType, start, count);
 
         // Get the open field from the BCL ValueTuple generic definition for signature encoding.
-        var openType = tupleType.Arity switch
-        {
-            2 => typeof(ValueTuple<,>),
-            3 => typeof(ValueTuple<,,>),
-            4 => typeof(ValueTuple<,,,>),
-            5 => typeof(ValueTuple<,,,,>),
-            6 => typeof(ValueTuple<,,,,,>),
-            7 => typeof(ValueTuple<,,,,,,>),
-            _ => throw new NotSupportedException(
-                $"Symbolic tuple field ref not supported for arity {tupleType.Arity}."),
-        };
+        var openType = TupleTypeSymbol.GetOpenClrType(count <= 7 ? count : 8);
 
         var openField = openType.GetField(
             fieldName,
@@ -1923,27 +1924,19 @@ internal sealed class ImportedMemberRefFactory
     /// types). Builds the ctor MemberRef against the symbolically-constructed
     /// <c>ValueTuple</c> TypeSpec.
     /// </summary>
-    internal MemberReferenceHandle GetTupleCtorReference(TupleTypeSymbol tupleType)
+    internal MemberReferenceHandle GetTupleCtorReference(
+        TupleTypeSymbol tupleType,
+        int start,
+        int count)
     {
-        var parent = this.GetTupleTypeSpec(tupleType);
-        var arity = tupleType.Arity;
-
-        var openType = arity switch
-        {
-            2 => typeof(ValueTuple<,>),
-            3 => typeof(ValueTuple<,,>),
-            4 => typeof(ValueTuple<,,,>),
-            5 => typeof(ValueTuple<,,,,>),
-            6 => typeof(ValueTuple<,,,,,>),
-            7 => typeof(ValueTuple<,,,,,,>),
-            _ => throw new NotSupportedException(
-                $"Symbolic tuple ctor ref not supported for arity {arity}."),
-        };
+        var parent = this.GetTupleTypeSpec(tupleType, start, count);
+        var physicalArity = count <= 7 ? count : 8;
+        var openType = TupleTypeSymbol.GetOpenClrType(physicalArity);
 
         ConstructorInfo openCtor = null;
         foreach (var c in openType.GetConstructors())
         {
-            if (c.GetParameters().Length == arity)
+            if (c.GetParameters().Length == physicalArity)
             {
                 openCtor = c;
                 break;
@@ -1953,7 +1946,7 @@ internal sealed class ImportedMemberRefFactory
         if (openCtor == null)
         {
             throw new InvalidOperationException(
-                $"Open ValueTuple type of arity {arity} has no matching constructor.");
+                $"Open ValueTuple type of arity {physicalArity} has no matching constructor.");
         }
 
         var sigBlob = new BlobBuilder();
@@ -1985,7 +1978,7 @@ internal sealed class ImportedMemberRefFactory
     /// and the body construction must be parented at this reified TypeSpec so
     /// the value stored into the iterator state machine's reified
     /// <c>Dictionary&lt;…, !0&gt;</c> field verifies. Mirrors
-    /// <see cref="GetTupleTypeSpec"/>.
+    /// <see cref="GetTupleTypeSpec(TupleTypeSymbol)"/>.
     /// </summary>
     private EntityHandle GetMapTypeSpec(MapTypeSymbol mapType)
     {
@@ -2007,7 +2000,7 @@ internal sealed class ImportedMemberRefFactory
     /// <c>Dictionary`2::.ctor()</c> parented at the reified
     /// <see cref="GetMapTypeSpec"/> TypeSpec, for a <c>map[K, V]</c> literal
     /// whose <see cref="TypeSymbol.ClrType"/> is null. Mirrors
-    /// <see cref="GetTupleCtorReference"/>.
+    /// <see cref="GetTupleCtorReference(TupleTypeSymbol, int, int)"/>.
     /// </summary>
     internal MemberReferenceHandle GetMapCtorReference(MapTypeSymbol mapType)
     {

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
@@ -1588,27 +1588,36 @@ internal sealed partial class MethodBodyEmitter
         var clrType = tuple.TupleType.ClrType;
         var arity = tuple.TupleType.Arity;
 
-        if (clrType == null && arity >= 2 && arity <= 7)
+        if (clrType == null)
         {
-            // Issue #649: G#-defined types lack a ClrType, so we build the
-            // tuple TypeSpec and ctor MemberRef symbolically.
-            foreach (var elem in tuple.Elements)
-            {
-                this.EmitExpression(elem);
-            }
-
-            this.il.OpCode(ILOpCode.Newobj);
-            this.il.Token(this.outer.memberRefs.GetTupleCtorReference(tuple.TupleType));
+            // Issues #649/#3087: build every canonical ValueTuple node
+            // symbolically when an element lacks a CLR type.
+            this.EmitSymbolicTupleLiteral(tuple.Elements, tuple.TupleType, 0, arity);
             return;
         }
 
-        if (clrType == null)
+        this.EmitTupleLiteral(tuple.Elements, 0, tuple.Elements.Length, clrType);
+    }
+
+    private void EmitSymbolicTupleLiteral(
+        ImmutableArray<BoundExpression> elements,
+        TupleTypeSymbol tupleType,
+        int start,
+        int count)
+    {
+        var directCount = Math.Min(count, 7);
+        for (var i = 0; i < directCount; i++)
         {
-            throw new NotSupportedException(
-                $"Tuple of arity {arity} has no CLR backing type; emit not supported.");
+            this.EmitExpression(elements[start + i]);
         }
 
-        this.EmitTupleLiteral(tuple.Elements, 0, tuple.Elements.Length, clrType);
+        if (count > 7)
+        {
+            this.EmitSymbolicTupleLiteral(elements, tupleType, start + 7, count - 7);
+        }
+
+        this.il.OpCode(ILOpCode.Newobj);
+        this.il.Token(this.outer.memberRefs.GetTupleCtorReference(tupleType, start, count));
     }
 
     private void EmitTupleElementAccess(BoundTupleElementAccessExpression access)
@@ -1620,23 +1629,16 @@ internal sealed partial class MethodBodyEmitter
         // common cases (locals/params/temps) go through
         // EmitInstanceReceiver to prefer the address form.
         var clrType = access.TupleType.ClrType;
-        var arity = access.TupleType.Arity;
-        var fieldName = "Item" + (access.Index + 1).ToString(System.Globalization.CultureInfo.InvariantCulture);
-
-        if (clrType == null && arity >= 2 && arity <= 7)
-        {
-            // Issue #649: G#-defined types lack a ClrType, so we build the
-            // tuple TypeSpec and field MemberRef symbolically.
-            this.EmitInstanceReceiver(access.Receiver);
-            this.il.OpCode(ILOpCode.Ldfld);
-            this.il.Token(this.outer.memberRefs.GetTupleFieldReference(access.TupleType, fieldName));
-            return;
-        }
 
         if (clrType == null)
         {
-            throw new NotSupportedException(
-                $"Tuple of arity {arity} has no CLR backing type; emit not supported.");
+            // Issues #649/#3087: traverse canonical Rest nodes using
+            // symbolic TypeSpecs when an element lacks a CLR type.
+            this.EmitSymbolicTupleElementAccess(
+                access.TupleType,
+                access.Index,
+                () => this.EmitInstanceReceiver(access.Receiver));
+            return;
         }
 
         this.EmitInstanceReceiver(access.Receiver);
@@ -1649,7 +1651,7 @@ internal sealed partial class MethodBodyEmitter
             remainingIndex -= 7;
         }
 
-        fieldName = "Item" + (remainingIndex + 1).ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var fieldName = "Item" + (remainingIndex + 1).ToString(System.Globalization.CultureInfo.InvariantCulture);
         this.il.OpCode(ILOpCode.Ldfld);
         if (clrType.IsConstructedGenericType)
         {
@@ -1661,6 +1663,29 @@ internal sealed partial class MethodBodyEmitter
             ?? throw new InvalidOperationException(
                 $"ValueTuple type '{clrType.FullName}' has no public field '{fieldName}'.");
         this.il.Token(this.outer.memberRefs.GetFieldReference(field));
+    }
+
+    private void EmitSymbolicTupleElementAccess(
+        TupleTypeSymbol tupleType,
+        int index,
+        Action emitReceiver,
+        bool takeRestAddress = true)
+    {
+        emitReceiver();
+        var start = 0;
+        var count = tupleType.Arity;
+        while (index >= 7)
+        {
+            this.il.OpCode(takeRestAddress ? ILOpCode.Ldflda : ILOpCode.Ldfld);
+            this.il.Token(this.outer.memberRefs.GetTupleFieldReference(tupleType, start, count, "Rest"));
+            start += 7;
+            count -= 7;
+            index -= 7;
+        }
+
+        var fieldName = "Item" + (index + 1).ToString(System.Globalization.CultureInfo.InvariantCulture);
+        this.il.OpCode(ILOpCode.Ldfld);
+        this.il.Token(this.outer.memberRefs.GetTupleFieldReference(tupleType, start, count, fieldName));
     }
 
     private void EmitTupleLiteral(

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Patterns.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Patterns.cs
@@ -355,33 +355,37 @@ internal sealed partial class MethodBodyEmitter
             // fields. ValueTuple exposes those as public fields, so each field
             // is a plain ldfld — same token resolution as EmitTupleElementAccess.
             var tupleClr = tupleType.ClrType;
-            var arity = tupleType.Arity;
             foreach (var field in pp.Fields)
             {
                 var fieldName = field.Field.Name;
                 Action loadTupleChild = () =>
                 {
-                    loadValue();
-                    this.il.OpCode(ILOpCode.Ldfld);
-                    if (tupleClr == null && arity is >= 2 and <= 7)
+                    if (tupleClr == null)
                     {
-                        this.il.Token(this.outer.memberRefs.GetTupleFieldReference(tupleType, fieldName));
-                    }
-                    else if (tupleClr == null)
-                    {
-                        throw new NotSupportedException(
-                            $"Tuple of arity {arity} has no CLR backing type; emit not supported.");
-                    }
-                    else if (tupleClr.IsConstructedGenericType)
-                    {
-                        this.il.Token(this.outer.memberRefs.GetFieldReferenceOnConstructedGeneric(tupleClr, fieldName));
+                        var index = int.Parse(
+                            fieldName.AsSpan("Item".Length),
+                            System.Globalization.CultureInfo.InvariantCulture) - 1;
+                        this.EmitSymbolicTupleElementAccess(
+                            tupleType,
+                            index,
+                            loadValue,
+                            takeRestAddress: false);
                     }
                     else
                     {
-                        var clrField = tupleClr.GetField(fieldName)
-                            ?? throw new InvalidOperationException(
-                                $"ValueTuple type '{tupleClr.FullName}' has no public field '{fieldName}'.");
-                        this.il.Token(this.outer.memberRefs.GetFieldReference(clrField));
+                        loadValue();
+                        this.il.OpCode(ILOpCode.Ldfld);
+                        if (tupleClr.IsConstructedGenericType)
+                        {
+                            this.il.Token(this.outer.memberRefs.GetFieldReferenceOnConstructedGeneric(tupleClr, fieldName));
+                        }
+                        else
+                        {
+                            var clrField = tupleClr.GetField(fieldName)
+                                ?? throw new InvalidOperationException(
+                                    $"ValueTuple type '{tupleClr.FullName}' has no public field '{fieldName}'.");
+                            this.il.Token(this.outer.memberRefs.GetFieldReference(clrField));
+                        }
                     }
                 };
 

--- a/src/Core/CodeAnalysis/Emit/SignatureEncoder.cs
+++ b/src/Core/CodeAnalysis/Emit/SignatureEncoder.cs
@@ -584,7 +584,7 @@ internal sealed class SignatureEncoder
         }
     }
 
-    private void EncodeTupleType(
+    internal void EncodeTupleType(
         SignatureTypeEncoder encoder,
         ImmutableArray<TypeSymbol> elementTypes,
         int start,

--- a/src/Core/CodeAnalysis/Symbols/TupleTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/TupleTypeSymbol.cs
@@ -90,6 +90,9 @@ public sealed class TupleTypeSymbol : TypeSymbol
             _ => throw new ArgumentOutOfRangeException(nameof(arity)),
         };
 
+    internal static Type BuildClrType(Type[] elementTypes)
+        => BuildClrType(elementTypes, 0, elementTypes.Length);
+
     private static string BuildName(ImmutableArray<TypeSymbol> elementTypes)
     {
         var sb = new StringBuilder("(");
@@ -118,7 +121,7 @@ public sealed class TupleTypeSymbol : TypeSymbol
         }
 
         var clrTypes = elementTypes.Select(t => t.ClrType).ToArray();
-        return BuildClrType(clrTypes, 0, clrTypes.Length);
+        return BuildClrType(clrTypes);
     }
 
     private static Type BuildClrType(Type[] elementTypes, int start, int count)

--- a/test/Compiler.Tests/Emit/Issue3087GenericTupleCollectionTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3087GenericTupleCollectionTests.cs
@@ -1,0 +1,195 @@
+// <copyright file="Issue3087GenericTupleCollectionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+public sealed class Issue3087GenericTupleCollectionTests
+{
+    [Fact]
+    public void FourElementTuple_ListAndDictionaryWhere_CompileVerifyAndRun()
+    {
+        const string Source = """
+            package Issue3087
+
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            let values = List[(int32, int32, float64, TimeSpan)]()
+            values.Add((1, 2, 0.5, TimeSpan.Zero))
+            values.Add((3, 4, 1.5, TimeSpan.FromSeconds(2)))
+
+            let filtered = values.Where((value) -> value.Item3 > 1.0).ToList()
+            if filtered.Count != 1 { Environment.Exit(11) }
+            let item = filtered[0]
+            if item.Item1 != 3 { Environment.Exit(12) }
+            if item.Item2 != 4 { Environment.Exit(13) }
+            if item.Item3 != 1.5 { Environment.Exit(14) }
+            if item.Item4 != TimeSpan.FromSeconds(2) { Environment.Exit(15) }
+
+            let dictionary = Dictionary[string, (int32, int32, float64, TimeSpan)]()
+            dictionary.Add("low", (1, 2, 0.5, TimeSpan.Zero))
+            dictionary.Add("high", (3, 4, 1.5, TimeSpan.FromSeconds(2)))
+
+            let filteredValues = dictionary.Values.Where((value) -> value.Item3 > 1.0).ToList()
+            if filteredValues.Count != 1 { Environment.Exit(21) }
+            let dictionaryItem = filteredValues[0]
+            if dictionaryItem.Item1 != 3 { Environment.Exit(22) }
+            if dictionaryItem.Item2 != 4 { Environment.Exit(23) }
+            if dictionaryItem.Item3 != 1.5 { Environment.Exit(24) }
+            if dictionaryItem.Item4 != TimeSpan.FromSeconds(2) { Environment.Exit(25) }
+
+            Console.WriteLine("ok")
+            """;
+
+        Assert.Equal("ok\n", CompileVerifyAndRun(Source));
+    }
+
+    [Fact]
+    public void SymbolicTupleCollections_AllClrTupleNodes_CompileVerifyAndRun()
+    {
+        Assert.Equal("ok\n", CompileVerifyAndRun(BuildSymbolicTupleMatrixSource()));
+    }
+
+    private static string BuildSymbolicTupleMatrixSource()
+    {
+        var source = new StringBuilder("""
+            package Issue3087Symbolic
+
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            class Box(Value int32) { }
+
+            """);
+
+        for (var arity = 2; arity <= 16; arity++)
+        {
+            var types = new string[arity];
+            var values = new string[arity];
+            types[0] = "Box";
+            values[0] = $"Box({arity})";
+            for (var index = 1; index < arity - 1; index++)
+            {
+                types[index] = "int32";
+                values[index] = (index + 1).ToString(System.Globalization.CultureInfo.InvariantCulture);
+            }
+
+            types[^1] = "TimeSpan";
+            values[^1] = $"TimeSpan.FromSeconds({arity})";
+            var tupleType = "(" + string.Join(", ", types) + ")";
+            var tupleValue = "(" + string.Join(", ", values) + ")";
+
+            source.AppendLine($"let list{arity} List[{tupleType}] = List[{tupleType}]()");
+            source.AppendLine($"list{arity}.Add({tupleValue})");
+            source.AppendLine($"let filtered{arity} = list{arity}.Where((value) -> value.Item1.Value > 0).ToList()");
+            source.AppendLine($"if filtered{arity}.Count != 1 {{ Environment.Exit({100 + arity}) }}");
+            source.AppendLine($"if filtered{arity}[0].Item1.Value != {arity} {{ Environment.Exit({120 + arity}) }}");
+            source.AppendLine($"if filtered{arity}[0].Item{arity} != TimeSpan.FromSeconds({arity}) {{ Environment.Exit({140 + arity}) }}");
+            source.AppendLine($"let dictionary{arity} = Dictionary[string, {tupleType}]()");
+            source.AppendLine($"dictionary{arity}.Add(\"value\", {tupleValue})");
+            source.AppendLine($"let values{arity} = dictionary{arity}.Values.Where((value) -> value.Item1.Value > 0).ToList()");
+            source.AppendLine($"if values{arity}.Count != 1 {{ Environment.Exit({160 + arity}) }}");
+            source.AppendLine($"if values{arity}[0].Item{arity} != TimeSpan.FromSeconds({arity}) {{ Environment.Exit({180 + arity}) }}");
+            source.AppendLine();
+        }
+
+        source.AppendLine("""
+            let queue = Queue[(Box, int32, int32, int32, int32, int32, int32, TimeSpan)]()
+            queue.Enqueue((Box(8), 2, 3, 4, 5, 6, 7, TimeSpan.FromSeconds(8)))
+            if queue.Dequeue().Item8 != TimeSpan.FromSeconds(8) { Environment.Exit(208) }
+
+            let patternTuple = (Box(8), 2, 3, 4, 5, 6, 7, 8)
+            let patternResult = switch patternTuple { case { Item8: 8 }: "hit" default: "miss" }
+            if patternResult != "hit" { Environment.Exit(209) }
+
+            Console.WriteLine("ok")
+            """);
+        return source.ToString();
+    }
+
+    private static string CompileVerifyAndRun(string source)
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            nameof(Issue3087GenericTupleCollectionTests),
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            var sourcePath = Path.Combine(directory, "Program.gs");
+            var outputPath = Path.Combine(directory, "Issue3087.dll");
+            File.WriteAllText(sourcePath, source);
+
+            var arguments = new List<string>
+            {
+                "/out:" + outputPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+            foreach (var reference in ReferenceResolver.HostTrustedPlatformAssemblyPaths())
+            {
+                arguments.Add("/r:" + reference);
+            }
+
+            arguments.Add(sourcePath);
+
+            using var standardOut = new StringWriter();
+            using var standardError = new StringWriter();
+            var previousOut = Console.Out;
+            var previousError = Console.Error;
+            Console.SetOut(standardOut);
+            Console.SetError(standardError);
+            int exitCode;
+            try
+            {
+                exitCode = Program.Main(arguments.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+                Console.SetError(previousError);
+            }
+
+            Assert.True(
+                exitCode == 0,
+                $"gsc failed:{Environment.NewLine}{standardOut}{standardError}");
+            IlVerifier.Verify(outputPath);
+
+            using var process = Process.Start(new ProcessStartInfo("dotnet")
+            {
+                ArgumentList =
+                {
+                    "exec",
+                    "--runtimeconfig",
+                    Path.ChangeExtension(outputPath, ".runtimeconfig.json"),
+                    outputPath,
+                },
+                WorkingDirectory = directory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            });
+            var output = process.StandardOutput.ReadToEnd();
+            var error = process.StandardError.ReadToEnd();
+            Assert.True(process.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(process.ExitCode == 0, error);
+            return output.Replace("\r\n", "\n", StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- preserve symbolic `ValueTuple` shape when constructing imported generic collections instead of flattening the element type to `object`
- carry canonical `ValueTuple<T1,...,T7,TRest>` shapes through overload inference, dictionary `Values`, tuple member access, patterns, and emission for all tuple arities
- add compile-run + ILVerify coverage for the requested four-element `List`/`Where` and dictionary `Values.Where` scenario, plus symbolic tuple arities 2-16 and a sibling `Queue` API under metadata references

## Testing

- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj --no-restore --filter FullyQualifiedName~Issue3087GenericTupleCollectionTests`
- Compiler generic/tuple suites: 725 passed
- Core generic/tuple suites: 886 passed
- Interpreter generic/tuple suites: 70 passed
- Generic projection regression controls: 7 passed
- `dotnet build src/Compiler/Compiler.csproj --no-restore`

Fixes #3087
