### PR TITLE
Fix async nullable tuple interface returns

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -2422,6 +2422,21 @@ public sealed class Conversion
             case MapTypeSymbol fromMap when to is MapTypeSymbol toMap:
                 return IsCrossContextIdenticalElement(fromMap.KeyType, toMap.KeyType)
                     && IsCrossContextIdenticalElement(fromMap.ValueType, toMap.ValueType);
+            case TupleTypeSymbol fromTuple when to is TupleTypeSymbol toTuple:
+                if (fromTuple.Arity != toTuple.Arity)
+                {
+                    return false;
+                }
+
+                for (var i = 0; i < fromTuple.Arity; i++)
+                {
+                    if (!IsCrossContextIdenticalElement(fromTuple.ElementTypes[i], toTuple.ElementTypes[i]))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
             default:
                 return false;
         }

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -676,10 +676,8 @@ internal sealed class ConversionClassifier
         // BoundDefaultExpression produces uniformly verifiable IL.
         if (expression.Type == TypeSymbol.Null
             && type is NullableTypeSymbol nilTargetNullable
-            && (nilTargetNullable.UnderlyingType?.ClrType is { IsValueType: true }
-                || nilTargetNullable.UnderlyingType is TypeParameterSymbol
-                || nilTargetNullable.UnderlyingType is EnumSymbol
-                || (nilTargetNullable.UnderlyingType is StructSymbol nilTargetStruct && !nilTargetStruct.IsClass)))
+            && (NullableLifting.IsAnyValueTypeNullable(nilTargetNullable)
+                || nilTargetNullable.UnderlyingType is TypeParameterSymbol))
         {
             return new BoundDefaultExpression(null, type);
         }

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -5449,6 +5449,20 @@ internal sealed class MemberLookup
             return true;
         }
 
+        // Issue #3088: reference-nullable tuple elements make the tuple's
+        // direct ClrType unavailable even when every element has an exact CLR
+        // identity. Reuse the structural tuple/nullable projection before
+        // falling back to method-type-parameter matching.
+        if (effectiveClr == null
+            && candidate is TupleTypeSymbol or NullableTypeSymbol { UnderlyingType: TupleTypeSymbol }
+            && !TypeSymbol.ContainsTypeParameter(candidate)
+            && !TypeSymbol.ContainsSameCompilationUserType(candidate)
+            && TryProjectErasedClrType(candidate, out var projectedClr)
+            && ClrTypeUtilities.AreSame(projectedClr, openType))
+        {
+            return true;
+        }
+
         // Slow path: a constructed generic contract position nests the
         // method's own type parameter (e.g. `Func<TState, Exception, string>`
         // in `Log<TState>(..., Func<TState, Exception, string> formatter)`),

--- a/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
+++ b/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
@@ -137,13 +137,12 @@ internal sealed class ImportedMemberRefFactory
         // token consumed by `box Nullable<E>` in the lifted enum-equality emit
         // (and by `initobj` when zero-initialising such a slot).
         //
-        // Issue #1475: the same TypeSpec form applies to `S?` over a
-        // user-declared value-type struct (no runtime `ClrType`). Recognise
-        // both user value-type underlyings here so the null-conditional emit
-        // can `initobj`/`box` the `Nullable<UserT>` slot.
+        // Issues #1475/#3088: the same TypeSpec form applies to any symbolic
+        // value-type underlying, including a tuple whose nullable-reference
+        // elements suppress its direct ClrType.
         if (element is NullableTypeSymbol nullableUserVtElement
-            && (nullableUserVtElement.UnderlyingType is EnumSymbol
-                || (nullableUserVtElement.UnderlyingType is StructSymbol userVtStruct && !userVtStruct.IsClass)))
+            && NullableLifting.RequiresSymbolicNullableGetValue(nullableUserVtElement)
+            && nullableUserVtElement.UnderlyingType is not TypeParameterSymbol)
         {
             var sigBlob = new BlobBuilder();
             this.signatures.EncodeTypeSymbol(new BlobEncoder(sigBlob).TypeSpecificationSignature(), nullableUserVtElement);
@@ -1523,15 +1522,13 @@ internal sealed class ImportedMemberRefFactory
     }
 
     /// <summary>
-    /// Issue #1475: gets a MemberRef for <c>System.Nullable`1&lt;S&gt;::.ctor(!0)</c>
-    /// where <c>S</c> is a user-declared value-type struct emitted in this
-    /// assembly (or a user enum, by delegation). The struct has no runtime CLR
-    /// type, so the BCL-backed ctor path cannot construct it; instead the
-    /// parent TypeSpec closes <c>Nullable&lt;&gt;</c> over the struct's emitted
-    /// TypeDef/TypeSpec and the ctor signature refers to that argument as
-    /// <c>!0</c>. Mirrors <see cref="GetNullableCtorMemberRefForUserEnum"/>.
+    /// Issues #1475/#3088: gets a MemberRef for
+    /// <c>System.Nullable`1&lt;T&gt;::.ctor(!0)</c> where <c>T</c> requires
+    /// symbolic encoding. The parent TypeSpec closes <c>Nullable&lt;&gt;</c>
+    /// over that encoded underlying and the ctor signature refers to it as
+    /// <c>!0</c>.
     /// </summary>
-    /// <param name="nullableOfUserVt">A <c>Nullable&lt;S&gt;</c> over a user value type (enum or value struct).</param>
+    /// <param name="nullableOfUserVt">A nullable over a symbolically encoded value type.</param>
     /// <returns>The constructor MemberRef.</returns>
     internal MemberReferenceHandle GetNullableCtorMemberRefForUserValueType(NullableTypeSymbol nullableOfUserVt)
     {
@@ -1543,13 +1540,16 @@ internal sealed class ImportedMemberRefFactory
             return this.GetNullableCtorMemberRefForUserEnum(nullableOfUserVt);
         }
 
-        if (nullableOfUserVt?.UnderlyingType is not StructSymbol structSym || structSym.IsClass)
+        if (nullableOfUserVt == null
+            || !NullableLifting.RequiresSymbolicNullableGetValue(nullableOfUserVt)
+            || nullableOfUserVt.UnderlyingType is TypeParameterSymbol)
         {
             throw new InvalidOperationException(
-                "GetNullableCtorMemberRefForUserValueType requires Nullable<user enum or value struct>.");
+                "GetNullableCtorMemberRefForUserValueType requires Nullable<symbolic value type>.");
         }
 
-        if (this.cache.NullableUserStructCtorMemberRefs.TryGetValue(structSym, out var cached))
+        var underlying = nullableOfUserVt.UnderlyingType;
+        if (this.cache.NullableUserStructCtorMemberRefs.TryGetValue(underlying, out var cached))
         {
             return cached;
         }
@@ -1572,7 +1572,7 @@ internal sealed class ImportedMemberRefFactory
             parent: parent,
             name: this.emitCtx.Metadata.GetOrAddString(".ctor"),
             signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
-        this.cache.NullableUserStructCtorMemberRefs[structSym] = handle;
+        this.cache.NullableUserStructCtorMemberRefs[underlying] = handle;
         return handle;
     }
 
@@ -1597,7 +1597,7 @@ internal sealed class ImportedMemberRefFactory
         if (nullableOfUserVt == null || !NullableLifting.RequiresSymbolicNullableGetValue(nullableOfUserVt))
         {
             throw new InvalidOperationException(
-                "GetNullableGetValueMemberRefForUserValueType requires Nullable<user enum, value struct, or struct-constrained type parameter>.");
+                "GetNullableGetValueMemberRefForUserValueType requires Nullable<symbolic value type>.");
         }
 
         var underlying = nullableOfUserVt.UnderlyingType;
@@ -1645,7 +1645,7 @@ internal sealed class ImportedMemberRefFactory
         if (nullableOfUserVt == null || !NullableLifting.RequiresSymbolicNullableGetValue(nullableOfUserVt))
         {
             throw new InvalidOperationException(
-                "GetNullableGetHasValueMemberRefForUserValueType requires Nullable<user enum, value struct, or struct-constrained type parameter>.");
+                "GetNullableGetHasValueMemberRefForUserValueType requires Nullable<symbolic value type>.");
         }
 
         var underlying = nullableOfUserVt.UnderlyingType;

--- a/src/Core/CodeAnalysis/Emit/MetadataTokenCache.cs
+++ b/src/Core/CodeAnalysis/Emit/MetadataTokenCache.cs
@@ -158,15 +158,14 @@ internal sealed class MetadataTokenCache
         = new Dictionary<EnumSymbol, MemberReferenceHandle>();
 
     /// <summary>
-    /// Gets the cache mapping a user-defined value-type <see cref="StructSymbol"/>
-    /// to the <see cref="MemberReferenceHandle"/> for
-    /// <c>System.Nullable`1&lt;S&gt;::.ctor(!0)</c> (issue #1475). The parent
-    /// TypeSpec closes <c>Nullable&lt;&gt;</c> over the struct's emitted
-    /// TypeDef/TypeSpec, so one MemberRef per struct serves every
-    /// null-conditional / <c>S -&gt; S?</c> lift site.
+    /// Gets the cache mapping a symbolic value-type underlying to the
+    /// <see cref="MemberReferenceHandle"/> for
+    /// <c>System.Nullable`1&lt;T&gt;::.ctor(!0)</c>. The parent TypeSpec closes
+    /// <c>Nullable&lt;&gt;</c> over the encoded underlying, so one MemberRef
+    /// serves every matching nullable lift site.
     /// </summary>
-    public Dictionary<StructSymbol, MemberReferenceHandle> NullableUserStructCtorMemberRefs { get; }
-        = new Dictionary<StructSymbol, MemberReferenceHandle>();
+    public Dictionary<TypeSymbol, MemberReferenceHandle> NullableUserStructCtorMemberRefs { get; }
+        = new Dictionary<TypeSymbol, MemberReferenceHandle>();
 
     /// <summary>
     /// Gets the cache mapping a user-defined value-type underlying

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
@@ -242,11 +242,13 @@ internal sealed partial class MethodBodyEmitter
         // `Nullable<>` over the type's emitted TypeDef/TypeSpec. Mirrors the
         // open-type-parameter branch in the value-type lift below.
         if (to is NullableTypeSymbol toUserVtNullableLift
-            && NullableLifting.IsUserValueTypeNullable(toUserVtNullableLift)
-            && from == toUserVtNullableLift.UnderlyingType)
+            && NullableLifting.RequiresSymbolicNullableGetValue(toUserVtNullableLift)
+            && Conversion.ClassifyNonStructural(from, toUserVtNullableLift.UnderlyingType).IsIdentity)
         {
             this.il.OpCode(ILOpCode.Newobj);
-            this.il.Token(this.outer.memberRefs.GetNullableCtorMemberRefForUserValueType(toUserVtNullableLift));
+            this.il.Token(toUserVtNullableLift.UnderlyingType is TypeParameterSymbol
+                ? this.outer.memberRefs.GetNullableCtorMemberRefForOpenTypeParameter(toUserVtNullableLift)
+                : this.outer.memberRefs.GetNullableCtorMemberRefForUserValueType(toUserVtNullableLift));
             return;
         }
 

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -5001,6 +5001,11 @@ internal sealed class ReflectionMetadataEmitter
             return true;
         }
 
+        if (type is NullableTypeSymbol { UnderlyingType: TupleTypeSymbol })
+        {
+            return true;
+        }
+
         // Issue #806: a `T?` over a value-type-constrained type parameter
         // lowers to `Nullable<T>` (a struct). Without recognising this
         // symbolic form, instance-method calls on the receiver would emit

--- a/src/Core/CodeAnalysis/Emit/SignatureEncoder.cs
+++ b/src/Core/CodeAnalysis/Emit/SignatureEncoder.cs
@@ -191,6 +191,16 @@ internal sealed class SignatureEncoder
                 return;
             }
 
+            if (inner is TupleTypeSymbol nullableTuple)
+            {
+                var giNullableTuple = encoder.GenericInstantiation(
+                    this.outer.memberRefs.GetTypeReference(typeof(System.Nullable<>)),
+                    genericArgumentCount: 1,
+                    isValueType: true);
+                this.EncodeTypeSymbol(giNullableTuple.AddArgument(), nullableTuple);
+                return;
+            }
+
             if (inner is StructSymbol nestedStruct && !nestedStruct.IsClass)
             {
                 // Issue #1475: `S?` over a user-declared value-type struct

--- a/src/Core/CodeAnalysis/Symbols/NullableLifting.cs
+++ b/src/Core/CodeAnalysis/Symbols/NullableLifting.cs
@@ -116,9 +116,14 @@ public static class NullableLifting
     /// for object widening — none of which the reference-type path handles.
     /// </summary>
     /// <param name="nullable">The wrapper to test.</param>
-    /// <returns><see langword="true"/> when the underlying type is a CLR value type.</returns>
+    /// <returns><see langword="true"/> when the underlying type has a CLR value-type representation.</returns>
     internal static bool IsValueTypeNullable(NullableTypeSymbol nullable)
     {
+        if (nullable?.UnderlyingType is TupleTypeSymbol)
+        {
+            return true;
+        }
+
         if (nullable?.UnderlyingType?.ClrType is { IsValueType: true })
         {
             return true;
@@ -165,7 +170,7 @@ public static class NullableLifting
     /// wraps an underlying whose <c>Nullable&lt;T&gt;::get_Value()</c> MemberRef
     /// cannot be built from a runtime <see cref="Type"/> (the emit-side
     /// <c>WellKnownReferences.GetNullableGetValueReference</c> helper) because
-    /// the underlying has no <c>ClrType</c> during emit. Two shapes qualify:
+    /// the underlying has no <c>ClrType</c> during emit. Three shapes qualify:
     /// <list type="bullet">
     ///   <item><description>a user-declared value-kind struct or enum (see
     ///     <see cref="IsUserValueTypeNullable"/>);</description></item>
@@ -173,8 +178,11 @@ public static class NullableLifting
     ///     <c>struct</c> — its <c>Nullable&lt;T&gt;</c> instantiation closes
     ///     over a generic-parameter var/mvar signature slot, not a resolvable
     ///     host <c>Type</c>.</description></item>
+    ///   <item><description>a tuple whose symbolic element annotations prevent
+    ///     a direct <c>ClrType</c>, while its runtime representation remains
+    ///     <c>System.ValueTuple</c>.</description></item>
     /// </list>
-    /// Both shapes route through the emit-side
+    /// All shapes route through the emit-side
     /// <c>ReflectionMetadataEmitter.GetNullableGetValueMemberRefForUserValueType</c>
     /// helper, which builds the MemberRef symbolically off the
     /// emitted/encoded parent TypeSpec instead. Callers that must pick
@@ -188,6 +196,7 @@ public static class NullableLifting
     internal static bool RequiresSymbolicNullableGetValue(NullableTypeSymbol nullable)
     {
         return IsUserValueTypeNullable(nullable)
+            || nullable?.UnderlyingType is TupleTypeSymbol { ClrType: null }
             || (nullable?.UnderlyingType is TypeParameterSymbol tp && tp.HasValueTypeConstraint);
     }
 

--- a/test/Compiler.Tests/Emit/Issue3088AsyncNullableTupleInterfaceTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3088AsyncNullableTupleInterfaceTests.cs
@@ -1,0 +1,168 @@
+// <copyright file="Issue3088AsyncNullableTupleInterfaceTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+public sealed class Issue3088AsyncNullableTupleInterfaceTests
+{
+    [Fact]
+    public void ImportedInterface_AsyncNullableTupleReturn_DispatchesVerifiesAndRuns()
+    {
+        const string ContractSource = """
+            #nullable enable
+            using System;
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            namespace Issue3088.Contract;
+
+            public sealed class Item
+            {
+                public Item(int value) => Value = value;
+
+                public int Value { get; }
+            }
+
+            public interface IStore
+            {
+                Task<(Item Item, string? Name)?> GetAsync(
+                    Guid id,
+                    CancellationToken ct = default);
+            }
+            """;
+
+        const string Source = """
+            package Issue3088
+
+            import System
+            import System.Threading
+            import System.Threading.Tasks
+            import Issue3088.Contract
+
+            class Store : IStore {
+                public async func GetAsync(id Guid, ct CancellationToken = default(CancellationToken)) (Item, string?)? {
+                    await Task.Yield()
+                    return id == Guid.Empty ? nil : (Item(42), default(string?))
+                }
+            }
+
+            async func Verify(store IStore) {
+                let missing = await store.GetAsync(Guid.Empty)
+                Console.WriteLine(missing == nil)
+
+                let found = await store.GetAsync(Guid.NewGuid())
+                if found == nil {
+                    Environment.Exit(12)
+                }
+
+                let value = found!!
+                Console.WriteLine(value.Item1.Value)
+                Console.WriteLine(value.Item2 == nil)
+            }
+
+            Verify(Store()).GetAwaiter().GetResult()
+            """;
+
+        Assert.Equal("True\n42\nTrue\n", CompileVerifyAndRun(ContractSource, Source));
+    }
+
+    private static string CompileVerifyAndRun(string contractSource, string source)
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            nameof(Issue3088AsyncNullableTupleInterfaceTests),
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            var contractPath = CompileContract(directory, contractSource);
+            var sourcePath = Path.Combine(directory, "Program.gs");
+            var outputPath = Path.Combine(directory, "Issue3088.dll");
+            File.WriteAllText(sourcePath, source);
+
+            var arguments = new List<string>
+            {
+                "/out:" + outputPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+                "/reference:" + contractPath,
+            };
+            arguments.AddRange(ReferenceResolver.HostTrustedPlatformAssemblyPaths().Select(path => "/reference:" + path));
+            arguments.Add(sourcePath);
+
+            using var stdout = new StringWriter();
+            using var stderr = new StringWriter();
+            var previousOut = Console.Out;
+            var previousError = Console.Error;
+            Console.SetOut(stdout);
+            Console.SetError(stderr);
+            int exitCode;
+            try
+            {
+                exitCode = Program.Main(arguments.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+                Console.SetError(previousError);
+            }
+
+            Assert.True(exitCode == 0, $"gsc failed:{Environment.NewLine}{stdout}{stderr}");
+            IlVerifier.Verify(outputPath, new[] { contractPath });
+
+            using var process = Process.Start(new ProcessStartInfo("dotnet")
+            {
+                ArgumentList =
+                {
+                    "exec",
+                    "--runtimeconfig",
+                    Path.ChangeExtension(outputPath, ".runtimeconfig.json"),
+                    outputPath,
+                },
+                WorkingDirectory = directory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            });
+            var output = process.StandardOutput.ReadToEnd();
+            var error = process.StandardError.ReadToEnd();
+            Assert.True(process.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(process.ExitCode == 0, $"exited {process.ExitCode}:{Environment.NewLine}{error}");
+            return output.Replace("\r\n", "\n", StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static string CompileContract(string directory, string source)
+    {
+        var references = ReferenceResolver.HostTrustedPlatformAssemblyPaths()
+            .Select(path => MetadataReference.CreateFromFile(path));
+        var compilation = CSharpCompilation.Create(
+            "GSharp.Issue3088.Contract",
+            new[] { CSharpSyntaxTree.ParseText(source) },
+            references,
+            new CSharpCompilationOptions(
+                OutputKind.DynamicallyLinkedLibrary,
+                nullableContextOptions: NullableContextOptions.Enable));
+        var path = Path.Combine(directory, "GSharp.Issue3088.Contract.dll");
+        using var stream = File.Create(path);
+        var result = compilation.Emit(stream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        return path;
+    }
+}


### PR DESCRIPTION
## Summary
- Match symbolic nullable-tuple async results against imported CLR interface `Task<T>` envelopes.
- Preserve `Nullable<ValueTuple<...>>` through conversion, async state-machine, and metadata emission.
- Add interface-dispatch compile/run coverage for null and non-null results, tuple elements, nullable second element, and IL verification.

## Tests
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj --filter FullyQualifiedName~Issue3088AsyncNullableTupleInterfaceTests`
- Related compiler regressions: 48 passed
- Related core regressions: 57 passed
- Full Core.Tests: 7,088 passed, 1 skipped
- Full Compiler.Tests: passed

Fixes #3088