### PR TITLE
Fix inherited fields in composite literals

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundFieldInitializer.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundFieldInitializer.cs
@@ -18,10 +18,11 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// </summary>
 public sealed record BoundFieldInitializer
 {
-    public BoundFieldInitializer(FieldSymbol field, BoundExpression value)
+    public BoundFieldInitializer(FieldSymbol field, BoundExpression value, StructSymbol fieldDeclaringType = null)
     {
         Field = field;
         Value = value;
+        FieldDeclaringType = fieldDeclaringType;
     }
 
     /// <summary>
@@ -40,6 +41,9 @@ public sealed record BoundFieldInitializer
 
     /// <summary>Gets the targeted field, or <see langword="null"/> when this initializer targets a property.</summary>
     public FieldSymbol Field { get; }
+
+    /// <summary>Gets the type that declares <see cref="Field"/>, or <see langword="null"/> when the initializer targets a property.</summary>
+    public StructSymbol FieldDeclaringType { get; }
 
     /// <summary>Gets the targeted property, or <see langword="null"/> when this initializer targets a field.</summary>
     public PropertySymbol Property { get; }

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -1486,7 +1486,7 @@ public abstract class BoundTreeRewriter
                 builder.Add(newValue == init.Value
                     ? init
                     : (init.Field != null
-                        ? new BoundFieldInitializer(init.Field, newValue)
+                        ? new BoundFieldInitializer(init.Field, newValue, init.FieldDeclaringType)
                         : new BoundFieldInitializer(init.Property, newValue)));
             }
         }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -1346,7 +1346,10 @@ internal sealed partial class ExpressionBinder
             var valueExpr = BindExpression(initSyntax.Value);
             valueExpr = conversions.BindConversion(initSyntax.Value.Location, valueExpr, memberType);
             inits.Add(hasField
-                ? new BoundFieldInitializer(field, valueExpr)
+                ? new BoundFieldInitializer(
+                    field,
+                    valueExpr,
+                    ReferenceEquals(fieldDeclaringType, structSymbol) ? null : fieldDeclaringType)
                 : new BoundFieldInitializer(property, valueExpr));
         }
 

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
@@ -1183,7 +1183,11 @@ internal sealed partial class MethodBodyEmitter
                 }
 
                 EntityHandle fieldHandle;
-                if (isGeneric || literal.StructType.ClrType != null)
+                if (init.FieldDeclaringType != null)
+                {
+                    fieldHandle = this.ResolveStructLiteralFieldToken(literal, init);
+                }
+                else if (isGeneric || literal.StructType.ClrType != null)
                 {
                     fieldHandle = this.outer.userTokens.ResolveFieldToken(literal.StructType, init.Field);
                 }
@@ -1236,7 +1240,11 @@ internal sealed partial class MethodBodyEmitter
             }
 
             EntityHandle fieldHandle;
-            if (isGeneric || literal.StructType.ClrType != null)
+            if (init.FieldDeclaringType != null)
+            {
+                fieldHandle = this.ResolveStructLiteralFieldToken(literal, init);
+            }
+            else if (isGeneric || literal.StructType.ClrType != null)
             {
                 fieldHandle = this.outer.userTokens.ResolveFieldToken(literal.StructType, init.Field);
             }
@@ -1258,6 +1266,17 @@ internal sealed partial class MethodBodyEmitter
 
         // Leave the constructed struct value on the stack.
         this.il.LoadLocal(slot);
+    }
+
+    private EntityHandle ResolveStructLiteralFieldToken(
+        BoundStructLiteralExpression literal,
+        BoundFieldInitializer initializer)
+    {
+        var fieldContainer = ResolveFieldReferenceContainer(
+            initializer.FieldDeclaringType,
+            literal.StructType,
+            initializer.Field);
+        return this.outer.userTokens.ResolveFieldToken(fieldContainer, initializer.Field);
     }
 
     /// <summary>
@@ -1324,7 +1343,9 @@ internal sealed partial class MethodBodyEmitter
                 continue;
             }
 
-            var fieldHandle = this.outer.userTokens.ResolveFieldToken(literal.StructType, init.Field);
+            var fieldHandle = init.FieldDeclaringType != null
+                ? this.ResolveStructLiteralFieldToken(literal, init)
+                : this.outer.userTokens.ResolveFieldToken(literal.StructType, init.Field);
             this.il.OpCode(ILOpCode.Dup);
             this.EmitExpression(init.Value);
             this.il.OpCode(ILOpCode.Stfld);

--- a/src/Core/CodeAnalysis/Emit/StateMachineEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/StateMachineEmitter.cs
@@ -1355,7 +1355,8 @@ internal sealed class StateMachineEmitter
         // Builder: AsyncIteratorMethodBuilder.Create()
         var createMethod = typeof(System.Runtime.CompilerServices.AsyncIteratorMethodBuilder)
             .GetMethod("Create", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static, null, Type.EmptyTypes, null);
-        initializers.Add(new BoundFieldInitializer(builderField,
+        initializers.Add(new BoundFieldInitializer(
+            builderField,
             new BoundClrStaticCallExpression(null, createMethod, TypeSymbol.FromClrType(typeof(System.Runtime.CompilerServices.AsyncIteratorMethodBuilder)), ImmutableArray<BoundExpression>.Empty)));
 
         foreach (var parameter in parameters)

--- a/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
@@ -2026,7 +2026,7 @@ public static class SpillSequenceSpiller
             {
                 var original = structLiteral.Initializers[i];
                 initializers.Add(original.Field != null
-                    ? new BoundFieldInitializer(original.Field, spilledValues[i])
+                    ? new BoundFieldInitializer(original.Field, spilledValues[i], original.FieldDeclaringType)
                     : new BoundFieldInitializer(original.Property, spilledValues[i]));
             }
 

--- a/test/Compiler.Tests/Compiler.Tests.csproj
+++ b/test/Compiler.Tests/Compiler.Tests.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="@(GsharpCompiler)" />
+    <Compile Include="..\Shared\Issue3081CompositeLiteralCases.cs" Link="Issue3081CompositeLiteralCases.cs" />
     <!-- Issue #2215: only this test project needs a real gsgen.dll build output
          (to resolve via /gsgentool:) plus Roslyn (to compile a fixture
          generator DLL for the /analyzer: end-to-end test). gsc itself

--- a/test/Compiler.Tests/Emit/Issue3081CompositeLiteralInheritedFieldTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3081CompositeLiteralInheritedFieldTests.cs
@@ -1,0 +1,188 @@
+// <copyright file="Issue3081CompositeLiteralInheritedFieldTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using GSharp.Tests;
+using Xunit;
+using CompilerProgram = GSharp.Compiler.Program;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #3081: composite literals preserve inherited field declaring types.
+/// </summary>
+public class Issue3081CompositeLiteralInheritedFieldTests
+{
+    [Fact]
+    public void CompositeLiteralFieldMatrix_GscEvaluateAndEmit()
+    {
+        AssertCompilerDrivers(
+            "TopLevel",
+            Issue3081CompositeLiteralCases.BuildMatrixSource(inFunction: false),
+            Issue3081CompositeLiteralCases.BuildMatrixOutput(100));
+        AssertCompilerDrivers(
+            "InFunction",
+            Issue3081CompositeLiteralCases.BuildMatrixSource(inFunction: true),
+            Issue3081CompositeLiteralCases.BuildMatrixOutput(200));
+    }
+
+    [Fact]
+    public void CompositeLiteralFalsePositiveCorpus_GscEvaluateAndEmit()
+    {
+        AssertCompilerDrivers(
+            "Controls",
+            Issue3081CompositeLiteralCases.Controls,
+            Issue3081CompositeLiteralCases.ControlsOutput);
+    }
+
+    [Fact]
+    public void ObjectInitializerInheritedGenericBaseField_GscEvaluateAndEmit()
+    {
+        AssertCompilerDrivers(
+            "ObjectInitializer",
+            Issue3081CompositeLiteralCases.ObjectInitializer,
+            Issue3081CompositeLiteralCases.ObjectInitializerOutput);
+    }
+
+    [Fact]
+    public void CompositeLiteralLowering_PreservesInheritedFieldDeclaringType()
+    {
+        AssertCompilerDrivers(
+            "Lowering",
+            Issue3081CompositeLiteralCases.Lowering,
+            Issue3081CompositeLiteralCases.LoweringOutput);
+    }
+
+    [Fact]
+    public void CompositeLiteralAsyncSpill_PreservesInheritedFieldDeclaringType()
+    {
+        AssertCompilerDrivers(
+            "AsyncSpill",
+            Issue3081CompositeLiteralCases.AsyncSpill,
+            Issue3081CompositeLiteralCases.AsyncSpillOutput);
+    }
+
+    private static void AssertCompilerDrivers(string name, string source, string expected)
+    {
+        AssertBareCompiler(name, source, expected);
+        AssertEmittedCompiler(name, source, expected);
+    }
+
+    private static void AssertBareCompiler(string name, string source, string expected)
+    {
+        var result = InEmptyDirectory(name + "-gsc", directory =>
+        {
+            var sourcePath = Path.Combine(directory, "test.gs");
+            File.WriteAllText(sourcePath, source);
+            return CaptureConsole(() => CompilerProgram.Main(new[] { "/nowarn:GS9100", sourcePath }));
+        });
+
+        Assert.True(result.ExitCode == 0, $"{name} gsc failed:\n{result.Stdout}\n{result.Stderr}");
+        Assert.Equal(expected + "Success.\n", result.Stdout);
+        Assert.Equal(string.Empty, result.Stderr);
+    }
+
+    private static void AssertEmittedCompiler(string name, string source, string expected)
+    {
+        InEmptyDirectory(name + "-emit", directory =>
+        {
+            var sourcePath = Path.Combine(directory, "test.gs");
+            var assemblyPath = Path.Combine(directory, "program.dll");
+            File.WriteAllText(sourcePath, source);
+            var compile = CaptureConsole(() => CompilerProgram.Main(new[]
+            {
+                "/out:" + assemblyPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+                sourcePath,
+            }));
+
+            Assert.True(compile.ExitCode == 0, $"{name} emit failed:\n{compile.Stdout}\n{compile.Stderr}");
+            Assert.Equal(string.Empty, compile.Stderr);
+            var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+            Assert.NotEmpty(assembly.GetTypes());
+
+            using var process = Process.Start(new ProcessStartInfo("dotnet")
+            {
+                ArgumentList = { assemblyPath },
+                WorkingDirectory = directory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            });
+            Assert.NotNull(process);
+            var stdoutTask = process.StandardOutput.ReadToEndAsync();
+            var stderrTask = process.StandardError.ReadToEndAsync();
+            var exited = process.WaitForExit(30_000);
+            if (!exited)
+            {
+                process.Kill(entireProcessTree: true);
+                process.WaitForExit();
+            }
+
+            var stdout = Normalize(stdoutTask.GetAwaiter().GetResult());
+            var stderr = Normalize(stderrTask.GetAwaiter().GetResult());
+            Assert.True(exited, $"{name} emitted program timed out.");
+            Assert.True(process.ExitCode == 0, $"{name} emitted program exited {process.ExitCode}:\n{stdout}\n{stderr}");
+            Assert.Equal(expected, stdout);
+            Assert.Equal(string.Empty, stderr);
+            IlVerifier.Verify(assemblyPath);
+            return 0;
+        });
+    }
+
+    private static DriverResult CaptureConsole(Func<int> action)
+    {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            return new DriverResult(action(), Normalize(stdout.ToString()), Normalize(stderr.ToString()));
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+    }
+
+    private static T InEmptyDirectory<T>(string name, Func<string, T> action)
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            nameof(Issue3081CompositeLiteralInheritedFieldTests),
+            name + "-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        Assert.Empty(Directory.EnumerateFileSystemEntries(directory));
+        try
+        {
+            return action(directory);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+    }
+
+    private static string Normalize(string text) => text.Replace("\r\n", "\n", StringComparison.Ordinal);
+
+    private readonly record struct DriverResult(int ExitCode, string Stdout, string Stderr);
+}

--- a/test/Interpreter.Tests/Interpreter.Tests.csproj
+++ b/test/Interpreter.Tests/Interpreter.Tests.csproj
@@ -10,6 +10,7 @@
     <ProjectReference Include="@(GsharpCompiler)" />
     <ProjectReference Include="@(GsharpRepl)" />
     <ProjectReference Include="..\..\src\Sdk\Gsharp.Extensions\Gsharp.Extensions.csproj" />
+    <Compile Include="..\Shared\Issue3081CompositeLiteralCases.cs" Link="Issue3081CompositeLiteralCases.cs" />
   </ItemGroup>
 
 </Project>

--- a/test/Interpreter.Tests/Issue3081CompositeLiteralInheritedFieldTests.cs
+++ b/test/Interpreter.Tests/Issue3081CompositeLiteralInheritedFieldTests.cs
@@ -1,0 +1,122 @@
+// <copyright file="Issue3081CompositeLiteralInheritedFieldTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using GSharp.Tests;
+using Xunit;
+using ReplProgram = GSharp.Repl.Program;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #3081: interpreter results remain aligned with both compiler modes.
+/// </summary>
+public class Issue3081CompositeLiteralInheritedFieldTests
+{
+    [Fact]
+    public void CompositeLiteralFieldMatrix_Gsi()
+    {
+        AssertInterpreter(
+            "TopLevel",
+            Issue3081CompositeLiteralCases.BuildMatrixSource(inFunction: false),
+            Issue3081CompositeLiteralCases.BuildMatrixOutput(100));
+        AssertInterpreter(
+            "InFunction",
+            Issue3081CompositeLiteralCases.BuildMatrixSource(inFunction: true),
+            Issue3081CompositeLiteralCases.BuildMatrixOutput(200));
+    }
+
+    [Fact]
+    public void CompositeLiteralFalsePositiveCorpus_Gsi()
+        => AssertInterpreter(
+            "Controls",
+            Issue3081CompositeLiteralCases.Controls,
+            Issue3081CompositeLiteralCases.ControlsOutput);
+
+    [Fact]
+    public void ObjectInitializerInheritedGenericBaseField_Gsi()
+        => AssertInterpreter(
+            "ObjectInitializer",
+            Issue3081CompositeLiteralCases.ObjectInitializer,
+            Issue3081CompositeLiteralCases.ObjectInitializerOutput);
+
+    [Fact]
+    public void CompositeLiteralLowering_Gsi()
+        => AssertInterpreter(
+            "Lowering",
+            Issue3081CompositeLiteralCases.Lowering,
+            Issue3081CompositeLiteralCases.LoweringOutput);
+
+    [Fact]
+    public void CompositeLiteralAsyncSpill_Gsi()
+        => AssertInterpreter(
+            "AsyncSpill",
+            Issue3081CompositeLiteralCases.AsyncSpill,
+            Issue3081CompositeLiteralCases.AsyncSpillOutput);
+
+    private static void AssertInterpreter(string name, string source, string expected)
+    {
+        var result = InEmptyDirectory(name, directory =>
+        {
+            var sourcePath = Path.Combine(directory, "test.gs");
+            File.WriteAllText(sourcePath, source);
+            return CaptureConsole(() => ReplProgram.Main(new[] { sourcePath }));
+        });
+
+        Assert.True(result.ExitCode == 0, $"{name} gsi failed:\n{result.Stdout}\n{result.Stderr}");
+        Assert.Equal(expected, result.Stdout);
+        Assert.Equal(string.Empty, result.Stderr);
+    }
+
+    private static DriverResult CaptureConsole(Func<int> action)
+    {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            return new DriverResult(action(), Normalize(stdout.ToString()), Normalize(stderr.ToString()));
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+    }
+
+    private static T InEmptyDirectory<T>(string name, Func<string, T> action)
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            nameof(Issue3081CompositeLiteralInheritedFieldTests),
+            name + "-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        Assert.Empty(Directory.EnumerateFileSystemEntries(directory));
+        try
+        {
+            return action(directory);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+    }
+
+    private static string Normalize(string text) => text.Replace("\r\n", "\n", StringComparison.Ordinal);
+
+    private readonly record struct DriverResult(int ExitCode, string Stdout, string Stderr);
+}

--- a/test/Shared/Issue3081CompositeLiteralCases.cs
+++ b/test/Shared/Issue3081CompositeLiteralCases.cs
@@ -1,0 +1,207 @@
+// <copyright file="Issue3081CompositeLiteralCases.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+
+namespace GSharp.Tests;
+
+internal static class Issue3081CompositeLiteralCases
+{
+    public const string Controls = """
+        package Issue3081Controls
+        import System
+
+        open class Base[T] {
+            var inherited int32
+            var shadowed int32
+            prop inheritedProperty int32 { get; set; }
+        }
+
+        class Derived[T] : Base[T] {
+            var own int32
+            var shadowed int32
+        }
+
+        struct Value[T] {
+            var own int32
+        }
+
+        func RunControls() {
+            let localValue = Value[int32]{ own: 555 }
+            Console.WriteLine(localValue.own)
+            let localOwn = Derived[int32]{ own: 566 }
+            Console.WriteLine(localOwn.own)
+            let localShadowed = Derived[int32]{ shadowed: 577 }
+            Console.WriteLine(localShadowed.shadowed)
+        }
+
+        let own = Derived[string]{ own: 511 }
+        Console.WriteLine(own.own)
+        let shadowed = Derived[string]{ shadowed: 522 }
+        Console.WriteLine(shadowed.shadowed)
+        let value = Value[string]{ own: 533 }
+        Console.WriteLine(value.own)
+        let property = Derived[string]{ inheritedProperty: 544 }
+        Console.WriteLine(property.inheritedProperty)
+        RunControls()
+        """;
+
+    public const string ControlsOutput = "511\n522\n533\n544\n555\n566\n577\n";
+
+    public const string ObjectInitializer = """
+        package Issue3081ObjectInitializer
+        import System
+
+        open class Base[T] {
+            var inherited int32
+        }
+
+        class Derived[T] : Base[T] {
+        }
+
+        let value = Derived[string]() { inherited = 611 }
+        Console.WriteLine(value.inherited)
+        """;
+
+    public const string ObjectInitializerOutput = "611\n";
+
+    public const string Lowering = """
+        package Issue3081Lowering
+        import System
+
+        open class Base {
+            var inherited int32
+        }
+
+        class Derived[T] : Base {
+            prop source int32 { get; set; }
+
+            func Build() Derived[T] {
+                return Derived[T]{ inherited: source }
+            }
+        }
+
+        let owner = Derived[string]() { source = 711 }
+        Console.WriteLine(owner.Build().inherited)
+        """;
+
+    public const string LoweringOutput = "711\n";
+
+    public const string AsyncSpill = """
+        package Issue3081AsyncSpill
+        import System
+        import System.Threading.Tasks
+
+        open class Base {
+            var inherited int32
+        }
+
+        class Derived[T] : Base {
+        }
+
+        async func Build() Derived[string] {
+            return Derived[string]{ inherited: await Task.FromResult(811) }
+        }
+
+        let value = Build().Result
+        Console.WriteLine(value.inherited)
+        """;
+
+    public const string AsyncSpillOutput = "811\n";
+
+    public static string BuildMatrixSource(bool inFunction)
+    {
+        var body = """
+            let forwardedOwn = Forwarded[string]{ own: OFFSET11 }
+            Console.WriteLine(forwardedOwn.own)
+            let forwardedShadowed = Forwarded[string]{ shadowed: OFFSET12 }
+            Console.WriteLine(forwardedShadowed.shadowed)
+            let forwardedInherited = Forwarded[string]{ inherited: OFFSET13 }
+            Console.WriteLine(forwardedInherited.inherited)
+
+            let closedOwn = Closed[int32]{ own: OFFSET21 }
+            Console.WriteLine(closedOwn.own)
+            let closedShadowed = Closed[int32]{ shadowed: OFFSET22 }
+            Console.WriteLine(closedShadowed.shadowed)
+            let closedInherited = Closed[int32]{ inherited: OFFSET23 }
+            Console.WriteLine(closedInherited.inherited)
+
+            let plainOwn = Plain[string]{ own: OFFSET31 }
+            Console.WriteLine(plainOwn.own)
+            let plainShadowed = Plain[string]{ shadowed: OFFSET32 }
+            Console.WriteLine(plainShadowed.shadowed)
+            let plainInherited = Plain[string]{ inherited: OFFSET33 }
+            Console.WriteLine(plainInherited.inherited)
+            """;
+        var offset = inFunction ? 200 : 100;
+        for (var tens = 1; tens <= 3; tens++)
+        {
+            for (var ones = 1; ones <= 3; ones++)
+            {
+                body = body.Replace(
+                    $"OFFSET{tens}{ones}",
+                    (offset + (tens * 10) + ones).ToString(System.Globalization.CultureInfo.InvariantCulture),
+                    StringComparison.Ordinal);
+            }
+        }
+
+        if (inFunction)
+        {
+            body = "func RunMatrix() {\n" + Indent(body) + "}\n\nRunMatrix()\n";
+        }
+
+        return """
+            package Issue3081Matrix
+            import System
+
+            open class ForwardBase[T] {
+                var inherited int32
+                var shadowed int32
+            }
+
+            class Forwarded[T] : ForwardBase[T] {
+                var own int32
+                var shadowed int32
+            }
+
+            open class ClosedBase[T] {
+                var inherited int32
+                var shadowed int32
+            }
+
+            class Closed[T] : ClosedBase[string] {
+                var own int32
+                var shadowed int32
+            }
+
+            open class PlainBase {
+                var inherited int32
+                var shadowed int32
+            }
+
+            class Plain[T] : PlainBase {
+                var own int32
+                var shadowed int32
+            }
+
+            """ + body;
+    }
+
+    public static string BuildMatrixOutput(int offset)
+    {
+        using var writer = new StringWriter();
+        for (var tens = 1; tens <= 3; tens++)
+        {
+            for (var ones = 1; ones <= 3; ones++)
+            {
+                writer.WriteLine(offset + (tens * 10) + ones);
+            }
+        }
+
+        return writer.ToString().Replace("\r\n", "\n", StringComparison.Ordinal);
+    }
+
+    private static string Indent(string text) => "    " + text.Replace("\n", "\n    ", StringComparison.Ordinal);
+}


### PR DESCRIPTION
## Summary
- carry inherited field declaring types through composite-literal binding and lowering
- resolve emitted field tokens against the constructed declaring base type
- cover compiler evaluation/emission and interpreter axes, controls, lowering, and async spilling

Fixes #3081