### PR TITLE
Fix gsi generic type argument reification

### DIFF
--- a/src/Core/CodeAnalysis/Evaluator.Expressions.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Expressions.cs
@@ -31,6 +31,7 @@ public sealed partial class Evaluator
     private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<FunctionSymbol, ConcurrentDictionary<Type, Func<Func<object[], object>, Delegate>>> InterpreterDelegateFactoriesBySite = new();
     private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<Delegate, ClosureValue> InterpreterClosures = new();
     private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<StructSymbol, Type> ClrBackingTypes = new();
+    private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<TypeSymbol, Type> ClrReifiedTypes = new();
     private static int clrBackingAssemblyOrdinal;
 
     private object EvaluateExpression(BoundExpression node)
@@ -1266,15 +1267,20 @@ public sealed partial class Evaluator
 
     private static Type CreateClrBackingType(StructSymbol structType, Type clrBase)
     {
-        var assemblyOrdinal = Interlocked.Increment(ref clrBackingAssemblyOrdinal);
-        var assemblyName = new AssemblyName(string.Format(
-            System.Globalization.CultureInfo.InvariantCulture,
-            "GSharp.Interpreter.ClrBacking.{0}",
-            assemblyOrdinal));
-        var assembly = System.Reflection.Emit.AssemblyBuilder.DefineDynamicAssembly(
-            assemblyName,
-            System.Reflection.Emit.AssemblyBuilderAccess.RunAndCollect);
-        var module = assembly.DefineDynamicModule(assemblyName.Name);
+        return CreateClrType(
+            structType,
+            clrBase,
+            TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.Sealed,
+            emitBaseConstructors: true);
+    }
+
+    private static Type CreateClrType(
+        StructSymbol structType,
+        Type clrBase,
+        TypeAttributes attributes,
+        bool emitBaseConstructors)
+    {
+        var module = CreateClrBackingModule();
         var definition = structType.Definition ?? structType;
         var arity = definition.TypeParameters.Length;
         var enclosingTypes = new Stack<StructSymbol>();
@@ -1317,38 +1323,41 @@ public sealed partial class Evaluator
                 string.IsNullOrEmpty(structType.PackageName)
                     ? metadataName
                     : $"{structType.PackageName}.{metadataName}",
-                TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.Sealed,
+                attributes,
                 clrBase)
             : parentBuilder.DefineNestedType(
                 metadataName,
-                TypeAttributes.NestedPublic | TypeAttributes.Class | TypeAttributes.Sealed,
+                (attributes & ~TypeAttributes.VisibilityMask) | TypeAttributes.NestedPublic,
                 clrBase);
         if (arity > 0)
         {
             typeBuilder.DefineGenericParameters(definition.TypeParameters.Select(static parameter => parameter.Name).ToArray());
         }
 
-        foreach (var baseCtor in clrBase.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+        if (emitBaseConstructors)
         {
-            if (!baseCtor.IsPublic && !baseCtor.IsFamily && !baseCtor.IsFamilyOrAssembly)
+            foreach (var baseCtor in clrBase.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
             {
-                continue;
-            }
+                if (!baseCtor.IsPublic && !baseCtor.IsFamily && !baseCtor.IsFamilyOrAssembly)
+                {
+                    continue;
+                }
 
-            var parameterTypes = Array.ConvertAll(baseCtor.GetParameters(), static parameter => parameter.ParameterType);
-            var ctorBuilder = typeBuilder.DefineConstructor(
-                MethodAttributes.Public,
-                CallingConventions.Standard,
-                parameterTypes);
-            var il = ctorBuilder.GetILGenerator();
-            il.Emit(System.Reflection.Emit.OpCodes.Ldarg_0);
-            for (var i = 0; i < parameterTypes.Length; i++)
-            {
-                il.Emit(System.Reflection.Emit.OpCodes.Ldarg, i + 1);
-            }
+                var parameterTypes = Array.ConvertAll(baseCtor.GetParameters(), static parameter => parameter.ParameterType);
+                var ctorBuilder = typeBuilder.DefineConstructor(
+                    MethodAttributes.Public,
+                    CallingConventions.Standard,
+                    parameterTypes);
+                var il = ctorBuilder.GetILGenerator();
+                il.Emit(System.Reflection.Emit.OpCodes.Ldarg_0);
+                for (var i = 0; i < parameterTypes.Length; i++)
+                {
+                    il.Emit(System.Reflection.Emit.OpCodes.Ldarg, i + 1);
+                }
 
-            il.Emit(System.Reflection.Emit.OpCodes.Call, baseCtor);
-            il.Emit(System.Reflection.Emit.OpCodes.Ret);
+                il.Emit(System.Reflection.Emit.OpCodes.Call, baseCtor);
+                il.Emit(System.Reflection.Emit.OpCodes.Ret);
+            }
         }
 
         var backingType = typeBuilder.CreateType();
@@ -1373,10 +1382,37 @@ public sealed partial class Evaluator
 
     private static Type ResolveClrBackingTypeArgument(TypeSymbol argument)
     {
-        if (argument is NullableTypeSymbol nullable
-            && nullable.UnderlyingType.ClrType is { IsValueType: true } valueClr)
+        if (argument is NullableTypeSymbol nullable)
         {
-            return typeof(Nullable<>).MakeGenericType(valueClr);
+            var underlying = ResolveClrBackingTypeArgument(nullable.UnderlyingType);
+            return underlying.IsValueType
+                ? typeof(Nullable<>).MakeGenericType(underlying)
+                : underlying;
+        }
+
+        if (argument is ImportedTypeSymbol imported
+            && imported.OpenDefinition is Type openDefinition
+            && !imported.TypeArguments.IsDefaultOrEmpty)
+        {
+            try
+            {
+                return openDefinition.MakeGenericType(
+                    imported.TypeArguments.Select(ResolveClrBackingTypeArgument).ToArray());
+            }
+            catch (ArgumentException)
+            {
+                return imported.ClrType ?? typeof(object);
+            }
+        }
+
+        if (argument is SliceTypeSymbol slice)
+        {
+            return ResolveClrBackingTypeArgument(slice.ElementType).MakeArrayType();
+        }
+
+        if (argument is ArrayTypeSymbol array)
+        {
+            return ResolveClrBackingTypeArgument(array.ElementType).MakeArrayType();
         }
 
         if (argument.ClrType is Type clrType)
@@ -1386,22 +1422,75 @@ public sealed partial class Evaluator
 
         if (argument is StructSymbol { IsClass: true } gsharpClass)
         {
-            var clrBase = typeof(object);
-            for (var type = gsharpClass; type != null; type = type.BaseClass)
-            {
-                if (type.ImportedBaseType?.ClrType is Type importedBase)
-                {
-                    clrBase = importedBase;
-                    break;
-                }
-            }
-
             return ClrBackingTypes.GetValue(
                 gsharpClass,
-                _ => CreateClrBackingType(gsharpClass, clrBase));
+                _ => CreateClrBackingType(gsharpClass, FindImportedClrBase(gsharpClass)));
+        }
+
+        if (argument is StructSymbol or EnumSymbol)
+        {
+            return ClrReifiedTypes.GetValue(argument, CreateClrReifiedType);
         }
 
         return typeof(object);
+    }
+
+    private static Type CreateClrReifiedType(TypeSymbol type)
+    {
+        if (type is EnumSymbol enumType)
+        {
+            return CreateClrEnumType(enumType);
+        }
+
+        var structType = (StructSymbol)type;
+        return CreateClrType(
+            structType,
+            typeof(ValueType),
+            TypeAttributes.Public | TypeAttributes.SequentialLayout | TypeAttributes.Sealed,
+            emitBaseConstructors: false);
+    }
+
+    private static Type FindImportedClrBase(StructSymbol structType)
+    {
+        for (var type = structType; type != null; type = type.BaseClass)
+        {
+            if (type.ImportedBaseType?.ClrType is Type importedBase)
+            {
+                return importedBase;
+            }
+        }
+
+        return typeof(object);
+    }
+
+    private static Type CreateClrEnumType(EnumSymbol enumType)
+    {
+        var module = CreateClrBackingModule();
+        var enumBuilder = module.DefineEnum(
+            string.IsNullOrEmpty(enumType.PackageName)
+                ? enumType.Name
+                : $"{enumType.PackageName}.{enumType.Name}",
+            TypeAttributes.Public,
+            typeof(int));
+        foreach (var member in enumType.Members)
+        {
+            enumBuilder.DefineLiteral(member.Name, member.Value);
+        }
+
+        return enumBuilder.CreateTypeInfo().AsType();
+    }
+
+    private static System.Reflection.Emit.ModuleBuilder CreateClrBackingModule()
+    {
+        var assemblyOrdinal = Interlocked.Increment(ref clrBackingAssemblyOrdinal);
+        var assemblyName = new AssemblyName(string.Format(
+            System.Globalization.CultureInfo.InvariantCulture,
+            "GSharp.Interpreter.ClrBacking.{0}",
+            assemblyOrdinal));
+        var assembly = System.Reflection.Emit.AssemblyBuilder.DefineDynamicAssembly(
+            assemblyName,
+            System.Reflection.Emit.AssemblyBuilderAccess.RunAndCollect);
+        return assembly.DefineDynamicModule(assemblyName.Name);
     }
 
     private static string GetClrMetadataTypeName(StructSymbol type)

--- a/test/Interpreter.Tests/Issue3099TypeArgumentReificationTests.cs
+++ b/test/Interpreter.Tests/Issue3099TypeArgumentReificationTests.cs
@@ -1,0 +1,205 @@
+// <copyright file="Issue3099TypeArgumentReificationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #3099: interpreter-created generic backing types must preserve every
+/// G# type-argument kind instead of erasing value types to <see cref="object"/>.
+/// </summary>
+[Collection("ConsoleIo")]
+public class Issue3099TypeArgumentReificationTests
+{
+    public static IEnumerable<object[]> TypeArgumentCases()
+    {
+        yield return ["class", "class Payload {\n}", "Payload"];
+        yield return ["struct", "struct Payload {\n    var Value int32\n}", "Payload"];
+        yield return ["enum", "enum Payload {\n    Eleven = 11,\n    TwentyTwo = 22,\n    ThirtyThree = 33,\n}", "Payload"];
+        yield return ["string", string.Empty, "string"];
+        yield return ["nested-class", "class Owner {\n    class Payload {\n    }\n}", "Owner.Payload"];
+        yield return ["nested-struct", "class Owner {\n    struct Payload {\n        var Value int32\n    }\n}", "Owner.Payload"];
+        yield return ["gsharp-generic", "struct Payload[T] {\n    var Value T\n}", "Payload[int32]"];
+        yield return ["imported-generic", "struct Payload {\n    var Value int32\n}", "List[Payload]"];
+        yield return ["nullable", "struct Payload {\n    var Value int32\n}", "Payload?"];
+        yield return ["slice", "struct Payload {\n    var Value int32\n}", "[]Payload"];
+        yield return ["array", "struct Payload {\n    var Value int32\n}", "[3]Payload"];
+    }
+
+    [Theory]
+    [MemberData(nameof(TypeArgumentCases))]
+    public void TypeArguments_AgreeAcrossEvaluationEmitAndInterpretation(
+        string caseName,
+        string declaration,
+        string typeArgument)
+    {
+        var source = CreateSource(caseName, declaration, typeArgument);
+        var root = Path.Combine(
+            GetRepositoryRoot(),
+            "out",
+            "test-artifacts",
+            $"issue3099-{caseName}-{Guid.NewGuid():N}");
+
+        try
+        {
+            var compilerEvaluation = RunSourceDriver(
+                Path.Combine(root, "gsc-eval"),
+                source,
+                Program.Main);
+            Assert.EndsWith("Success.\n", compilerEvaluation);
+            compilerEvaluation = compilerEvaluation[..^"Success.\n".Length];
+
+            var interpreter = RunSourceDriver(
+                Path.Combine(root, "gsi"),
+                source,
+                GSharp.Repl.Program.Main);
+
+            var emitDirectory = PrepareEmptyDirectory(Path.Combine(root, "gsc-emit"));
+            var sourcePath = Path.Combine(emitDirectory, "Probe.gs");
+            var assemblyPath = Path.Combine(emitDirectory, "Probe.dll");
+            File.WriteAllText(sourcePath, source);
+            _ = CaptureDriver(() => Program.Main(new[]
+            {
+                "/out:" + assemblyPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                sourcePath,
+            }));
+
+            var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+            Assert.Contains(assembly.GetTypes(), type => type.FullName?.EndsWith(".Box`1", StringComparison.Ordinal) == true);
+            Assert.Contains(assembly.GetTypes(), type => type.FullName?.EndsWith(".Pair`2", StringComparison.Ordinal) == true);
+            var entryPoint = assembly.EntryPoint
+                ?? throw new InvalidOperationException("Emitted assembly has no entry point.");
+            var emitted = CaptureDriver(() =>
+            {
+                entryPoint.Invoke(
+                    null,
+                    entryPoint.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+                return 0;
+            });
+
+            var expected = NormalizeGenericTypeNames(emitted);
+            Assert.Equal(expected, NormalizeGenericTypeNames(compilerEvaluation));
+            Assert.Equal(expected, NormalizeGenericTypeNames(interpreter));
+            Assert.Contains("11\n", expected);
+            Assert.Contains("22\n", expected);
+            Assert.Contains("33\n", expected);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+
+    private static string CreateSource(string caseName, string declaration, string typeArgument)
+    {
+        const string Template = """
+            package Issue3099.__CASE__
+            import System
+            import System.Collections.Generic
+
+            __DECLARATION__
+
+            class Box[T] : EventArgs {
+            }
+
+            class Pair[TFirst, TSecond] : EventArgs {
+            }
+
+            var single = Box[__TYPE__]()
+            Console.WriteLine(11)
+            Console.WriteLine(single.GetType().FullName)
+            Console.WriteLine(single.GetType().GenericTypeArguments[0].IsValueType)
+            Console.WriteLine(single.GetType().GenericTypeArguments[0].IsEnum)
+            Console.WriteLine(single.GetType().GenericTypeArguments[0].IsLayoutSequential)
+            var multiple = Pair[__TYPE__, int32]()
+            Console.WriteLine(22)
+            Console.WriteLine(multiple.GetType().FullName)
+            Console.WriteLine(Object.ReferenceEquals(
+                single.GetType().GenericTypeArguments[0],
+                multiple.GetType().GenericTypeArguments[0]))
+            Console.WriteLine(33)
+            Console.WriteLine(Box[Box[__TYPE__]]().GetType().FullName)
+            """;
+
+        return Template
+            .Replace("__CASE__", "Case" + caseName.Replace("-", string.Empty, StringComparison.Ordinal), StringComparison.Ordinal)
+            .Replace("__DECLARATION__", declaration, StringComparison.Ordinal)
+            .Replace("__TYPE__", typeArgument, StringComparison.Ordinal);
+    }
+
+    private static string RunSourceDriver(string directory, string source, Func<string[], int> driver)
+    {
+        var probeDirectory = PrepareEmptyDirectory(directory);
+        var sourcePath = Path.Combine(probeDirectory, "Probe.gs");
+        File.WriteAllText(sourcePath, source);
+        return CaptureDriver(() => driver([sourcePath]));
+    }
+
+    private static string PrepareEmptyDirectory(string directory)
+    {
+        Assert.False(Directory.Exists(directory), $"probe directory already exists: {directory}");
+        Directory.CreateDirectory(directory);
+        Assert.Empty(Directory.EnumerateFileSystemEntries(directory));
+        return directory;
+    }
+
+    private static string CaptureDriver(Func<int> driver)
+    {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        int exit;
+        try
+        {
+            exit = driver();
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+
+        Assert.True(
+            exit == 0,
+            $"driver failed with exit {exit}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout.ToString().Replace("\r\n", "\n", StringComparison.Ordinal);
+    }
+
+    private static string NormalizeGenericTypeNames(string output)
+    {
+        return Regex.Replace(
+            output,
+            @", [^,\[\]]+, Version=[^,\[\]]+, Culture=[^,\[\]]+, PublicKeyToken=[^,\[\]]+",
+            string.Empty,
+            RegexOptions.CultureInvariant);
+    }
+
+    private static string GetRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null && !File.Exists(Path.Combine(directory.FullName, "GSharp.sln")))
+        {
+            directory = directory.Parent;
+        }
+
+        return directory?.FullName
+            ?? throw new InvalidOperationException("Could not locate repository root.");
+    }
+}


### PR DESCRIPTION
Fixes #3099

## Summary
- reify G# structs and enums as true CLR value/enum types instead of `System.Object`
- recursively preserve G#, imported-generic, nullable, slice, and fixed-array type arguments
- retain the existing class-proxy constructor path while caching value-type identities separately
- add top-level parity coverage for 11 type kinds across single, multiple, and nested generic arguments

## Validation
- final head `8cdafe8e875aa8c69a05f7ce81c24bde37bd9e31`, based on `4469e3237a30d2f7abc57f98620d885f64bc5d22`
- full solution: **14,521 passed / 0 failed / 14,522 total / 1 skipped**
- targeted interpreter regressions: **23/23 passed**
- bidirectional diagnostics docs gate: **1/1 passed**
- bare `gsc`, emitted `gsc`, and `gsi` produced identical struct/enum identity output
- emitted metadata is validated with `Assembly.Load(...).GetTypes()`
- all 11 product mutants were killed; every restore rebuilt successfully and round-tripped to clean Core hash `2d9be465901aa51c731c2c36bce67eaa`
- Core/Compiler/Repl artifacts were fresh and shared the same post-build mtime
- `git merge-tree --write-tree` clean against the base above

## Mutation coverage
| Mutant | Killing coverage |
|---|---|
| full production revert | 8/11 parity cells fail |
| remove reified-type cache | 8/11 fail |
| remove aggregate dispatch | 8/11 fail |
| emit structs as classes | 4/11 fail |
| erase enum to integer | enum cell fails |
| restore old nullable path | nullable cell fails |
| skip imported generic recursion | imported-generic cell fails |
| skip slice recursion | slice cell fails |
| skip fixed-array recursion | fixed-array cell fails |
| remove class constructors | 3 class identity tests fail |
| force class type attributes | 3 value-type cells fail |