### PR TITLE
Fix implicit BCL dispatch for object overrides

### DIFF
--- a/src/Core/CodeAnalysis/Evaluator.Calls.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Calls.cs
@@ -1003,42 +1003,16 @@ public sealed partial class Evaluator
 
         if (receiver is StructValue sv)
         {
-            static MethodInfo FindExternalOverrideRoot(FunctionSymbol method)
-            {
-                while (method.OverriddenMethod != null)
-                {
-                    method = method.OverriddenMethod;
-                }
-
-                return method.ExternalOverriddenMethod;
-            }
-
-            FunctionSymbol externalOverride = null;
-            for (var type = sv.StructType; type != null && externalOverride == null; type = type.BaseClass)
-            {
-                externalOverride = type.Methods.FirstOrDefault(method =>
-                    method.IsOverride && FindExternalOverrideRoot(method)?.Equals(node.Method) == true);
-            }
-
+            var externalOverride = FindExternalOverride(sv.StructType, node.Method);
             if (externalOverride != null)
             {
-                var frame = new ConcurrentDictionary<VariableSymbol, object>
-                {
-                    [externalOverride.ThisParameter] = receiver,
-                };
-
-                var parameterOffset = externalOverride.ExplicitReceiverParameter == null ? 0 : 1;
+                var arguments = new object[node.Arguments.Length];
                 for (var i = 0; i < node.Arguments.Length; i++)
                 {
-                    var parameter = externalOverride.Parameters[i + parameterOffset];
-                    frame[parameter] = EvaluateExpression(node.Arguments[i]);
+                    arguments[i] = EvaluateExpression(node.Arguments[i]);
                 }
 
-                using (PushFrame(frame))
-                {
-                    var statement = program.Functions[externalOverride];
-                    return EvaluateUserMethodBody(externalOverride, statement);
-                }
+                return EvaluateExternalOverride(sv, externalOverride, arguments);
             }
         }
 
@@ -1081,6 +1055,71 @@ public sealed partial class Evaluator
         var result = InvokeReflective(method, receiver, args, node);
         WriteBackRefSlots(refSlots, args);
         return result;
+    }
+
+    private StructValue CreateStructValue(StructSymbol structType) =>
+        new(structType, TryEvaluateExternalOverride);
+
+    private bool TryEvaluateExternalOverride(
+        StructValue receiver,
+        MethodInfo method,
+        object[] arguments,
+        out object result)
+    {
+        var externalOverride = FindExternalOverride(receiver.StructType, method);
+        if (externalOverride == null)
+        {
+            result = null;
+            return false;
+        }
+
+        result = EvaluateExternalOverride(receiver, externalOverride, arguments);
+        return true;
+    }
+
+    private object EvaluateExternalOverride(
+        StructValue receiver,
+        FunctionSymbol externalOverride,
+        object[] arguments)
+    {
+        var frame = new ConcurrentDictionary<VariableSymbol, object>
+        {
+            [externalOverride.ThisParameter] = receiver,
+        };
+
+        var parameterOffset = externalOverride.ExplicitReceiverParameter == null ? 0 : 1;
+        for (var i = 0; i < arguments.Length; i++)
+        {
+            frame[externalOverride.Parameters[i + parameterOffset]] = arguments[i];
+        }
+
+        using (PushFrame(frame))
+        {
+            var statement = program.Functions[externalOverride];
+            return EvaluateUserMethodBody(externalOverride, statement);
+        }
+    }
+
+    private static FunctionSymbol FindExternalOverride(StructSymbol type, MethodInfo externalMethod)
+    {
+        FunctionSymbol externalOverride = null;
+        for (; type != null && externalOverride == null; type = type.BaseClass)
+        {
+            externalOverride = type.Methods.FirstOrDefault(method =>
+                method.IsOverride && FindExternalOverrideRoot(method)?.Equals(externalMethod) == true);
+        }
+
+        return externalOverride;
+    }
+
+    private static MethodInfo FindExternalOverrideRoot(FunctionSymbol method)
+    {
+        while (method.OverriddenMethod != null)
+        {
+            method = method.OverriddenMethod;
+        }
+
+        return method.ExternalOverriddenMethod;
     }
 
     // Issue #814 / ADR-0084 §L5: when an open generic extension method is

--- a/src/Core/CodeAnalysis/Evaluator.Concurrency.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Concurrency.cs
@@ -453,7 +453,7 @@ public sealed partial class Evaluator
         return BlockOnValueTask(operand);
     }
 
-    private static object EvaluateDefaultExpression(BoundDefaultExpression node)
+    private object EvaluateDefaultExpression(BoundDefaultExpression node)
     {
         // Issue #148: the `await for` lowering uses `default(CancellationToken)`
         // for the `GetAsyncEnumerator` token; more generally, BoundDefaultExpression

--- a/src/Core/CodeAnalysis/Evaluator.Expressions.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Expressions.cs
@@ -675,7 +675,7 @@ public sealed partial class Evaluator
                     node.StructType,
                     ImmutableArray<BoundExpression>.Empty,
                     constructor))
-            : new StructValue(node.StructType);
+            : CreateStructValue(node.StructType);
 
         // Primary-constructor literals use default construction before applying
         // named initializers, matching the emitter's newobj/stfld sequence.
@@ -1009,7 +1009,7 @@ public sealed partial class Evaluator
 
     private object EvaluateConstructorCallExpression(BoundConstructorCallExpression node)
     {
-        var sv = new StructValue(node.StructType);
+        var sv = CreateStructValue(node.StructType);
 
         // Default-initialize all fields first (including inherited), then bind primary-ctor args.
         for (var t = node.StructType; t != null; t = t.BaseClass)
@@ -1906,7 +1906,7 @@ public sealed partial class Evaluator
 
         var current = ResolveReceiverValue(node.ReceiverExpression, node.Receiver);
 
-        var sv = current as StructValue ?? new StructValue(node.StructType);
+        var sv = current as StructValue ?? CreateStructValue(node.StructType);
 
         // Class types are reference types: mutate the existing instance in
         // place so other references observe the write. Structs preserve
@@ -2071,7 +2071,7 @@ public sealed partial class Evaluator
                     ? GetGlobal(receiverVar)
                     : Locals.Peek()[receiverVar];
 
-                var sv = current as StructValue ?? new StructValue(node.StructType);
+                var sv = current as StructValue ?? CreateStructValue(node.StructType);
 
                 if (node.StructType.IsClass)
                 {
@@ -2112,13 +2112,13 @@ public sealed partial class Evaluator
         return value;
     }
 
-    private static object DefaultValue(Symbols.TypeSymbol type)
+    private object DefaultValue(Symbols.TypeSymbol type)
         => GetDefaultValue(type, useLanguageStringZero: true);
 
-    private static object ClrDefaultValue(Symbols.TypeSymbol type)
+    private object ClrDefaultValue(Symbols.TypeSymbol type)
         => GetDefaultValue(type, useLanguageStringZero: false);
 
-    private static object GetDefaultValue(Symbols.TypeSymbol type, bool useLanguageStringZero)
+    private object GetDefaultValue(Symbols.TypeSymbol type, bool useLanguageStringZero)
     {
         // Issue #504/#1652: NullableTypeSymbol.ClrType aliases the underlying
         // type's ClrType (e.g. `int?` reports `typeof(int)`), so it must be
@@ -2156,7 +2156,7 @@ public sealed partial class Evaluator
                 return null;
             }
 
-            var sv = new StructValue(s);
+            var sv = CreateStructValue(s);
             foreach (var f in s.Fields)
             {
                 sv.Fields[f.Name] = GetDefaultValue(f.Type, useLanguageStringZero);

--- a/src/Core/CodeAnalysis/StructValue.cs
+++ b/src/Core/CodeAnalysis/StructValue.cs
@@ -24,31 +24,52 @@ namespace GSharp.Core.CodeAnalysis;
 /// </summary>
 public sealed class StructValue
 {
+    private static readonly MethodInfo ObjectEqualsMethod = typeof(object).GetMethod(
+        nameof(object.Equals),
+        [typeof(object)]);
+
+    private static readonly MethodInfo ObjectGetHashCodeMethod = typeof(object).GetMethod(
+        nameof(object.GetHashCode),
+        Type.EmptyTypes);
+
+    private static readonly MethodInfo ObjectToStringMethod = typeof(object).GetMethod(
+        nameof(object.ToString),
+        Type.EmptyTypes);
+
+    private readonly ObjectOverrideDispatcher objectOverrideDispatcher;
     private readonly LayoutRuntime explicitLayout;
     private object explicitLayoutValue;
 
     /// <summary>Initializes a new instance of the <see cref="StructValue"/> class.</summary>
     /// <param name="structType">The struct type symbol.</param>
     public StructValue(StructSymbol structType)
+        : this(structType, (ObjectOverrideDispatcher)null)
+    {
+    }
+
+    internal StructValue(StructSymbol structType, ObjectOverrideDispatcher objectOverrideDispatcher)
     {
         StructType = structType;
+        this.objectOverrideDispatcher = objectOverrideDispatcher;
         Fields = new FieldCollection(this);
 
         if (structType.LayoutMetadata?.Layout == LayoutKind.Explicit)
         {
             explicitLayout = LayoutRuntime.Get(structType);
             explicitLayoutValue = explicitLayout.CreateDefault();
-            explicitLayout.ReadFields(explicitLayoutValue, Fields);
+            explicitLayout.ReadFields(explicitLayoutValue, Fields, objectOverrideDispatcher);
         }
     }
 
     private StructValue(
         StructSymbol structType,
         ConcurrentDictionary<string, object> fields,
+        ObjectOverrideDispatcher objectOverrideDispatcher,
         LayoutRuntime explicitLayout = null,
         object explicitLayoutValue = null)
     {
         StructType = structType;
+        this.objectOverrideDispatcher = objectOverrideDispatcher;
         Fields = new FieldCollection(this);
         foreach (var field in fields)
         {
@@ -58,6 +79,12 @@ public sealed class StructValue
         this.explicitLayout = explicitLayout;
         this.explicitLayoutValue = explicitLayoutValue;
     }
+
+    internal delegate bool ObjectOverrideDispatcher(
+        StructValue receiver,
+        MethodInfo method,
+        object[] arguments,
+        out object result);
 
     /// <summary>Gets the struct type.</summary>
     public StructSymbol StructType { get; }
@@ -99,8 +126,13 @@ public sealed class StructValue
             }
 
             var fieldsCopy = new ConcurrentDictionary<string, object>();
-            explicitLayout.ReadFields(layoutCopy, fieldsCopy);
-            return new StructValue(StructType, fieldsCopy, explicitLayout, layoutCopy)
+            explicitLayout.ReadFields(layoutCopy, fieldsCopy, objectOverrideDispatcher);
+            return new StructValue(
+                StructType,
+                fieldsCopy,
+                objectOverrideDispatcher,
+                explicitLayout,
+                layoutCopy)
             {
                 ClrBacking = this.ClrBacking,
             };
@@ -112,7 +144,7 @@ public sealed class StructValue
             copy[kvp.Key] = kvp.Value is StructValue inner ? inner.Copy() : kvp.Value;
         }
 
-        return new StructValue(StructType, copy)
+        return new StructValue(StructType, copy, objectOverrideDispatcher)
         {
             // Issue #319: copy carries the same CLR backing reference. A copy is
             // only ever created for value-type structs (Evaluator.Assign skips it
@@ -125,6 +157,11 @@ public sealed class StructValue
     /// <inheritdoc/>
     public override bool Equals(object obj)
     {
+        if (TryInvokeObjectOverride(ObjectEqualsMethod, [obj], out var result))
+        {
+            return (bool)result;
+        }
+
         if (obj is not StructValue other)
         {
             return false;
@@ -151,6 +188,11 @@ public sealed class StructValue
     /// <inheritdoc/>
     public override int GetHashCode()
     {
+        if (TryInvokeObjectOverride(ObjectGetHashCodeMethod, [], out var result))
+        {
+            return (int)result;
+        }
+
         var hash = default(HashCode);
         hash.Add(StructType);
         foreach (var (_, storageKey) in GetDisplayMembers(StructType))
@@ -165,6 +207,11 @@ public sealed class StructValue
     /// <inheritdoc/>
     public override string ToString()
     {
+        if (TryInvokeObjectOverride(ObjectToStringMethod, [], out var result))
+        {
+            return (string)result;
+        }
+
         var sb = new StringBuilder();
         sb.Append(StructType.Name).Append('(');
         var first = true;
@@ -185,6 +232,17 @@ public sealed class StructValue
         return sb.ToString();
     }
 
+    private bool TryInvokeObjectOverride(MethodInfo method, object[] arguments, out object result)
+    {
+        if (objectOverrideDispatcher == null)
+        {
+            result = null;
+            return false;
+        }
+
+        return objectOverrideDispatcher(this, method, arguments, out result);
+    }
+
     private void SetField(string name, object value)
     {
         if (explicitLayout != null)
@@ -193,7 +251,7 @@ public sealed class StructValue
             {
                 if (explicitLayout.TrySetField(explicitLayoutValue, name, value))
                 {
-                    explicitLayout.ReadFields(explicitLayoutValue, Fields);
+                    explicitLayout.ReadFields(explicitLayoutValue, Fields, objectOverrideDispatcher);
                     return;
                 }
             }
@@ -304,24 +362,38 @@ public sealed class StructValue
             return true;
         }
 
-        public void ReadFields(object source, FieldCollection destination)
+        public void ReadFields(
+            object source,
+            FieldCollection destination,
+            ObjectOverrideDispatcher objectOverrideDispatcher)
         {
             foreach (var field in symbol.Fields)
             {
                 if (fields.TryGetValue(field.Name, out var runtimeField))
                 {
-                    destination.SetRaw(field.Name, ToInterpreterValue(field.Type, runtimeField.GetValue(source)));
+                    destination.SetRaw(
+                        field.Name,
+                        ToInterpreterValue(
+                            field.Type,
+                            runtimeField.GetValue(source),
+                            objectOverrideDispatcher));
                 }
             }
         }
 
-        public void ReadFields(object source, ConcurrentDictionary<string, object> destination)
+        public void ReadFields(
+            object source,
+            ConcurrentDictionary<string, object> destination,
+            ObjectOverrideDispatcher objectOverrideDispatcher)
         {
             foreach (var field in symbol.Fields)
             {
                 if (fields.TryGetValue(field.Name, out var runtimeField))
                 {
-                    destination[field.Name] = ToInterpreterValue(field.Type, runtimeField.GetValue(source));
+                    destination[field.Name] = ToInterpreterValue(
+                        field.Type,
+                        runtimeField.GetValue(source),
+                        objectOverrideDispatcher);
                 }
             }
         }
@@ -425,7 +497,10 @@ public sealed class StructValue
             return value;
         }
 
-        private static object ToInterpreterValue(TypeSymbol type, object value)
+        private static object ToInterpreterValue(
+            TypeSymbol type,
+            object value,
+            ObjectOverrideDispatcher objectOverrideDispatcher)
         {
             if (type is StructSymbol nested
                 && !nested.IsClass
@@ -433,11 +508,12 @@ public sealed class StructValue
             {
                 var runtime = Get(nested);
                 var fields = new ConcurrentDictionary<string, object>();
-                runtime.ReadFields(value, fields);
+                runtime.ReadFields(value, fields, objectOverrideDispatcher);
                 var keepBacking = nested.LayoutMetadata?.Layout == LayoutKind.Explicit;
                 return new StructValue(
                     nested,
                     fields,
+                    objectOverrideDispatcher,
                     keepBacking ? runtime : null,
                     keepBacking ? RuntimeHelpers.GetObjectValue(value) : null);
             }

--- a/test/Interpreter.Tests/Issue2896StructObjectOverrideTests.cs
+++ b/test/Interpreter.Tests/Issue2896StructObjectOverrideTests.cs
@@ -21,6 +21,7 @@ namespace GSharp.Interpreter.Tests;
 /// Issue #2896: plain structs may override Object virtual methods, including
 /// calls dispatched through an object-typed receiver. The evaluator's shared
 /// user-type dispatch path also preserves most-derived class overrides.
+/// Issue #3116 extends that dispatch to Object virtuals invoked by the BCL.
 /// </summary>
 [Collection("ConsoleIo")]
 public class Issue2896StructObjectOverrideTests
@@ -94,6 +95,44 @@ public class Issue2896StructObjectOverrideTests
         var source = BuildClassOverrideChainSource(insideFunction, suffix);
 
         Assert.Equal("L0-11\nL1-22\nL2-33\n", await RunDriverAsync(source, suffix, driver));
+    }
+
+    [Theory]
+    [MemberData(nameof(ImplicitBclOverrideCases))]
+    public async Task ImplicitBclCalls_DispatchStructObjectOverridesAcrossDrivers(
+        string surface,
+        bool insideFunction,
+        string driver)
+    {
+        var suffix = Guid.NewGuid().ToString("N");
+        var source = BuildImplicitBclOverrideSource(surface, insideFunction, suffix);
+
+        var expected = surface switch
+        {
+            "dictionary" => "DICT-1\n",
+            "hashSet" => "HASHSET-1\n",
+            "listContains" => "LIST-True\n",
+            "format" => "FORMAT-TOSTRING-33\nINTERP-TOSTRING-33\n",
+            _ => throw new ArgumentOutOfRangeException(nameof(surface), surface, null),
+        };
+        Assert.Equal(expected, await RunDriverAsync(source, suffix, driver));
+    }
+
+    [Theory]
+    [InlineData(false, "gsc-evaluate")]
+    [InlineData(false, "gsc-emit")]
+    [InlineData(false, "gsi")]
+    [InlineData(true, "gsc-evaluate")]
+    [InlineData(true, "gsc-emit")]
+    [InlineData(true, "gsi")]
+    public async Task ImplicitBclToString_DepthFourOverrideChain_UsesMostDerivedOverrideAcrossDrivers(
+        bool insideFunction,
+        string driver)
+    {
+        var suffix = Guid.NewGuid().ToString("N");
+        var source = BuildDepthFourBclOverrideSource(insideFunction, suffix);
+
+        Assert.Equal("FORMAT-LEVEL-44\nINTERP-LEVEL-44\n", await RunDriverAsync(source, suffix, driver));
     }
 
     [Fact]
@@ -287,6 +326,104 @@ public class Issue2896StructObjectOverrideTests
             : declarations + "\n" + calls;
     }
 
+    /// <summary>Gets all four implicit-BCL surfaces across both source positions and all drivers.</summary>
+    public static IEnumerable<object[]> ImplicitBclOverrideCases()
+    {
+        var surfaces = new[] { "dictionary", "hashSet", "listContains", "format" };
+        var drivers = new[] { "gsc-evaluate", "gsc-emit", "gsi" };
+        foreach (var surface in surfaces)
+        {
+            foreach (var insideFunction in new[] { false, true })
+            {
+                foreach (var driver in drivers)
+                {
+                    yield return new object[] { surface, insideFunction, driver };
+                }
+            }
+        }
+    }
+
+    private static string BuildImplicitBclOverrideSource(string surface, bool insideFunction, string suffix)
+    {
+        var declarations = $$"""
+            package Issue3116{{suffix}}
+            import System
+            import System.Collections.Generic
+
+            struct Value{{suffix}} {
+                var Number int32
+                override func ToString() string -> "TOSTRING-33"
+                override func Equals(value object) bool -> true
+                override func GetHashCode() int32 -> 7
+            }
+            """;
+        var calls = surface switch
+        {
+            "dictionary" => $$"""
+                let values = Dictionary[Value{{suffix}}, string]()
+                values[Value{{suffix}}{Number: 11}] = "first"
+                values[Value{{suffix}}{Number: 22}] = "second"
+                Console.WriteLine(String.Format("DICT-{0}", values.Count))
+                """,
+            "hashSet" => $$"""
+                let values = HashSet[Value{{suffix}}]()
+                values.Add(Value{{suffix}}{Number: 11})
+                values.Add(Value{{suffix}}{Number: 22})
+                Console.WriteLine(String.Format("HASHSET-{0}", values.Count))
+                """,
+            "listContains" => $$"""
+                let values = List[Value{{suffix}}]()
+                values.Add(Value{{suffix}}{Number: 11})
+                Console.WriteLine(String.Format(
+                    "LIST-{0}",
+                    values.Contains(Value{{suffix}}{Number: 22})))
+                """,
+            "format" => $$"""
+                let value = Value{{suffix}}{Number: 11}
+                Console.WriteLine(String.Format("FORMAT-{0}", value))
+                Console.WriteLine("INTERP-$value")
+                """,
+            _ => throw new ArgumentOutOfRangeException(nameof(surface), surface, null),
+        };
+
+        return insideFunction
+            ? declarations + "\nfunc Run" + suffix + "() {\n" + calls + "\n}\nRun" + suffix + "()\n"
+            : declarations + "\n" + calls;
+    }
+
+    private static string BuildDepthFourBclOverrideSource(bool insideFunction, string suffix)
+    {
+        var declarations = $$"""
+            package Issue3116Depth{{suffix}}
+            import System
+
+            open class L0{{suffix}} {
+                open override func ToString() string -> "LEVEL-11"
+            }
+
+            open class L1{{suffix}} : L0{{suffix}} {
+                open override func ToString() string -> "LEVEL-22"
+            }
+
+            open class L2{{suffix}} : L1{{suffix}} {
+                open override func ToString() string -> "LEVEL-33"
+            }
+
+            class L3{{suffix}} : L2{{suffix}} {
+                override func ToString() string -> "LEVEL-44"
+            }
+            """;
+        var calls = $$"""
+            let value object = L3{{suffix}}()
+            Console.WriteLine(String.Format("FORMAT-{0}", value))
+            Console.WriteLine("INTERP-$value")
+            """;
+
+        return insideFunction
+            ? declarations + "\nfunc Run" + suffix + "() {\n" + calls + "\n}\nRun" + suffix + "()\n"
+            : declarations + "\n" + calls;
+    }
+
     private static async Task<string> RunDriverAsync(string source, string suffix, string driver)
     {
         var directory = Path.Combine(
@@ -324,7 +461,9 @@ public class Issue2896StructObjectOverrideTests
     private static string RunCompilerEvaluation(string sourcePath)
     {
         var result = CaptureConsole(() => CompilerProgram.Main(new[] { sourcePath }));
-        Assert.Equal(0, result.ExitCode);
+        Assert.True(
+            result.ExitCode == 0,
+            $"gsc evaluation failed ({result.ExitCode})\nstdout:\n{result.StandardOutput}\nstderr:\n{result.StandardError}");
         Assert.Equal(string.Empty, result.StandardError);
         Assert.EndsWith("Success.\n", result.StandardOutput, StringComparison.Ordinal);
         return result.StandardOutput[..^"Success.\n".Length];
@@ -333,7 +472,9 @@ public class Issue2896StructObjectOverrideTests
     private static string RunInterpreter(string sourcePath)
     {
         var result = CaptureConsole(() => GSharp.Repl.Program.Main(new[] { sourcePath }));
-        Assert.Equal(0, result.ExitCode);
+        Assert.True(
+            result.ExitCode == 0,
+            $"gsi failed ({result.ExitCode})\nstdout:\n{result.StandardOutput}\nstderr:\n{result.StandardError}");
         Assert.Equal(string.Empty, result.StandardError);
         return result.StandardOutput;
     }
@@ -350,7 +491,9 @@ public class Issue2896StructObjectOverrideTests
             "/targetframework:net10.0",
             sourcePath,
         }));
-        Assert.Equal(0, compile.ExitCode);
+        Assert.True(
+            compile.ExitCode == 0,
+            $"gsc emit failed ({compile.ExitCode})\nstdout:\n{compile.StandardOutput}\nstderr:\n{compile.StandardError}");
         Assert.Equal(string.Empty, compile.StandardError);
 
         var assembly = Assembly.Load(File.ReadAllBytes(outputPath));


### PR DESCRIPTION
## Summary

- Attach one evaluator override dispatcher when `StructValue` instances are created.
- Route CLR `Equals`, `GetHashCode`, and `ToString` calls back through the existing transitive external-override lookup.
- Preserve dispatch through value copies and explicit-layout/nested-struct materialization.
- Add `{top-level, function} × {gsc evaluate, gsc emit, gsi}` coverage for `Dictionary`, `HashSet`, `List.Contains`, formatting/interpolation, plus a depth-four override chain.

## Root cause

Explicit G# calls already passed through evaluator override dispatch. BCL code instead received `StructValue` and invoked its structural CLR overrides directly, bypassing the G# method body. All five evaluator construction roots now use one factory; `StructValue` is the single BCL boundary.

Compiler census found 10 construction sites: 8 product sites (5 evaluator roots, 3 copy/layout paths) and 2 direct unit-test sites.

## Behavior

Assignment-base `main` (`60076cc3`):

| Surface | gsc evaluate | gsc emit | gsi |
|---|---:|---:|---:|
| Dictionary, top/function | 2 | 1 | 2 |
| HashSet, top/function | 2 | 1 | 2 |
| List.Contains, top/function | False | True | False |
| Format/interpolation, top/function | structural text | override text | structural text |

Head: every cell matches emit (`1`, `1`, `True`, override text). All 24 surface cells and all 6 depth-four cells pass with empty stderr; emitted cases load bytes, enumerate `GetTypes()`, and execute in child processes.

## Validation

- Release solution build: `BUILD_RC=0`, 0 warnings, 0 errors.
- Live-main merge prediction at `4469e323`: tree `9226992ad031d02f21cb9af96bd24ded548d75d9`, exactly equal to HEAD tree; merged-tree build `BUILD_RC=0`.
- Unfiltered test projects:
  - InternalAnalyzers.Tests: 7 passed
  - Extensions.Tests: 104 passed
  - LanguageServer.Tests: 462 passed
  - Interpreter.Tests: 744 passed
  - Core.Tests: 7089 passed, 1 skipped
  - Compiler.Tests: 4152 passed
  - Sdk.Tests: 57 passed
- Diagnostic documentation gate: 1 passed.
- cs2gs corpus gate: rc 0; 19/20 green, 1 known ledgered gap, 0 new, 0 regressed, 0 stale.
- `cs2gs-oahu` was not run locally because its script executes `Oahu.Cli.E2E.Tests`; the required CI check remains authoritative.

Mutation checks, each asserted applied and round-tripped by SHA-256:

- Invert `StructValue` dispatcher-null guard: `ImplicitBclCalls_DispatchStructObjectOverridesAcrossDrivers` / depth-four tests fail 20/30 cells; 10 emit cells survive.
- Invert evaluator external-override guard: same 20/30 evaluator/interpreter cells fail.
- Change transitive root walk `while` to `if`: `ImplicitBclToString_DepthFourOverrideChain_UsesMostDerivedOverrideAcrossDrivers` fails exactly 4/6 evaluator/interpreter cells; 2 emit cells survive.

Fixes #3116