### PR TITLE
Interpret Span and ReadOnlySpan values

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -1177,11 +1177,12 @@ compiler error. It applies even when the declaration is not called because
 
 | ID | Severity | Description |
 |----|----------|-------------|
-| GS0511 | Error | The interpreter cannot represent a stack-only (`ByRefLike`) CLR value such as `Span[T]` or `ReadOnlySpan[T]`. |
+| GS0511 | Error | The interpreter cannot represent this stack-only (`ByRefLike`) CLR value. Array-backed `Span[T]` and `ReadOnlySpan[T]` values are supported. |
 
 Interpreter values use boxed storage, which cannot hold stack-only CLR values
-or preserve their interior references. Compile the program with `gsc /out:<file>`
-to use these types.
+or preserve their interior references. The interpreter emulates spans created
+from arrays; CLR methods and properties returning stack-only values remain
+unsupported. Compile the program with `gsc /out:<file>` to use those values.
 
 ## Interpreter deinitializer boundary (GS0510)
 

--- a/samples/SpanIndexing.gs
+++ b/samples/SpanIndexing.gs
@@ -6,8 +6,6 @@
 // and a `Span[T]` element write `s[i] = v` stores through the returned `ref T`.
 // Spans are stack-only (GS0219), so the span locals live inside functions and
 // are exercised from top-level statements.
-// The tree-walk interpreter cannot represent these values and reports GS0511;
-// compile this sample with gsc /out:<file>.
 
 package GSharp.Samples.SpanIndexing
 

--- a/src/Core/CodeAnalysis/Evaluator.Expressions.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Expressions.cs
@@ -2280,6 +2280,11 @@ public sealed partial class Evaluator
             return sv;
         }
 
+        if (type?.ClrType != null && IsSpanType(type.ClrType))
+        {
+            return InterpretedSpanValue.Empty(type.ClrType);
+        }
+
         // Issue #1652: every other value type (bool, all sized/unsigned ints,
         // float32/float64, decimal, char, nint/nuint, and user value structs
         // that slipped through as plain ClrType) gets its real CLR default via

--- a/src/Core/CodeAnalysis/Evaluator.Reflection.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Reflection.cs
@@ -262,6 +262,9 @@ public sealed partial class Evaluator
             return new InterpretedSpanValue(this.array, this.start + start, length, IsReadOnly);
         }
 
+        public override string ToString()
+            => $"System.{(IsReadOnly ? "ReadOnlySpan" : "Span")}<{this.array.GetType().GetElementType().Name}>[{Length}]";
+
         private int CheckedIndex(int index)
         {
             if ((uint)index >= (uint)Length)

--- a/src/Core/CodeAnalysis/Evaluator.Reflection.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Reflection.cs
@@ -18,6 +18,12 @@ public sealed partial class Evaluator
 {
     private object InvokeReflective(MethodBase target, object receiver, object[] args, BoundNode node)
     {
+        object result;
+        if (TryInvokeSpanConversion(target, args, out result))
+        {
+            return result;
+        }
+
         ThrowIfByRefLikeSignature(target, node);
         return target is ConstructorInfo constructor
             ? constructor.Invoke(args)
@@ -26,6 +32,20 @@ public sealed partial class Evaluator
 
     private object GetReflective(MemberInfo member, object receiver, object[] index, BoundNode node)
     {
+        var span = receiver as InterpretedSpanValue;
+        if (span != null && member is PropertyInfo spanProperty)
+        {
+            if (spanProperty.Name == "Length")
+            {
+                return span.Length;
+            }
+
+            if (spanProperty.Name == "Item" && index.Length == 1)
+            {
+                return span[(int)index[0]];
+            }
+        }
+
         ThrowIfByRefLikeSignature(member, node);
         return member switch
         {
@@ -37,6 +57,13 @@ public sealed partial class Evaluator
 
     private void SetReflective(MemberInfo member, object receiver, object value, object[] index, BoundNode node)
     {
+        var span = receiver as InterpretedSpanValue;
+        if (span != null && member is PropertyInfo spanProperty && spanProperty.Name == "Item" && index.Length == 1)
+        {
+            span[(int)index[0]] = value;
+            return;
+        }
+
         ThrowIfByRefLikeSignature(member, node);
         switch (member)
         {
@@ -50,6 +77,46 @@ public sealed partial class Evaluator
                 throw new EvaluatorException($"Unsupported CLR member kind '{member.MemberType}'.", node);
         }
     }
+
+    private static bool TryInvokeSpanConversion(MethodBase target, object[] args, out object result)
+    {
+        if (target is MethodInfo conversion
+            && conversion.Name == "op_Implicit"
+            && IsSpanType(conversion.ReturnType)
+            && args.Length == 1)
+        {
+            var readOnly = IsReadOnlySpanType(conversion.ReturnType);
+            if (args[0] is Array array)
+            {
+                result = new InterpretedSpanValue(array, readOnly);
+                return true;
+            }
+
+            if (args[0] is InterpretedSpanValue source && (readOnly || !source.IsReadOnly))
+            {
+                result = source.As(readOnly);
+                return true;
+            }
+        }
+
+        result = null;
+        return false;
+    }
+
+    private static bool IsSpanType(Type type)
+    {
+        if (!type.IsGenericType)
+        {
+            return false;
+        }
+
+        var definition = type.GetGenericTypeDefinition();
+        return definition.IsSameAs(typeof(Span<>))
+            || definition.IsSameAs(typeof(ReadOnlySpan<>));
+    }
+
+    private static bool IsReadOnlySpanType(Type type)
+        => type.IsGenericType && type.GetGenericTypeDefinition().IsSameAs(typeof(ReadOnlySpan<>));
 
     private static void ThrowIfByRefLikeSignature(MemberInfo member, BoundNode node)
     {
@@ -136,5 +203,73 @@ public sealed partial class Evaluator
         }
 
         return null;
+    }
+
+    private sealed class InterpretedSpanValue
+    {
+        private readonly Array array;
+        private readonly int start;
+
+        public InterpretedSpanValue(Array array, bool readOnly)
+            : this(array, 0, array.Length, readOnly)
+        {
+        }
+
+        private InterpretedSpanValue(Array array, int start, int length, bool readOnly)
+        {
+            this.array = array;
+            this.start = start;
+            Length = length;
+            IsReadOnly = readOnly;
+        }
+
+        public int Length { get; }
+
+        public bool IsReadOnly { get; }
+
+        public object this[int index]
+        {
+            get => this.array.GetValue(CheckedIndex(index));
+            set
+            {
+                if (IsReadOnly)
+                {
+                    throw new InvalidOperationException("Cannot write through a ReadOnlySpan.");
+                }
+
+                this.array.SetValue(value, CheckedIndex(index));
+            }
+        }
+
+        public static InterpretedSpanValue Empty(Type type)
+            => new(
+                Array.CreateInstance(type.GetGenericArguments()[0], 0),
+                IsReadOnlySpanType(type));
+
+        public InterpretedSpanValue As(bool readOnly)
+            => new(this.array, this.start, Length, readOnly);
+
+        public InterpretedSpanValue Slice(int start)
+            => Slice(start, Length - start);
+
+        public InterpretedSpanValue Slice(int start, int length)
+        {
+            if ((uint)start > (uint)Length || (uint)length > (uint)(Length - start))
+            {
+                throw new ArgumentOutOfRangeException();
+            }
+
+            return new InterpretedSpanValue(this.array, this.start + start, length, IsReadOnly);
+        }
+
+        private int CheckedIndex(int index)
+        {
+            if ((uint)index >= (uint)Length)
+            {
+                throw new IndexOutOfRangeException();
+            }
+
+            return this.start + index;
+        }
     }
 }

--- a/src/Core/CodeAnalysis/Evaluator.Reflection.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Reflection.cs
@@ -263,7 +263,9 @@ public sealed partial class Evaluator
         }
 
         public override string ToString()
-            => $"System.{(IsReadOnly ? "ReadOnlySpan" : "Span")}<{this.array.GetType().GetElementType().Name}>[{Length}]";
+            => this.array is char[] chars
+                ? new string(chars, this.start, Length)
+                : $"System.{(IsReadOnly ? "ReadOnlySpan" : "Span")}<{this.array.GetType().GetElementType().Name}>[{Length}]";
 
         private int CheckedIndex(int index)
         {

--- a/test/Compiler.Tests/LanguageConformance/SampleConformanceTests.cs
+++ b/test/Compiler.Tests/LanguageConformance/SampleConformanceTests.cs
@@ -63,19 +63,7 @@ public class SampleConformanceTests
             ["PInvokeLibraryImportStringReturn.gs"] = NativeCallDifference(),
             ["PInvokeMarshalAs.gs"] = NativeCallDifference(),
             ["PInvokeRefOutIn.gs"] = NativeCallDifference(),
-            ["RefStructGenericField.gs"] = SameDifference(
-                Expected(1, string.Empty, "GS0511"),
-                "docs/diagnostics.md GS0511 / #3114",
-                "the evaluator invokes func Main but rejects ByRefLike signatures"),
             ["RefStructSpan.gs"] = SameDifference(
-                Expected(1, string.Empty, "GS0511"),
-                "docs/diagnostics.md GS0511 / #3114",
-                "reflection cannot invoke ByRefLike signatures"),
-            ["SpanComprehensive.gs"] = SameDifference(
-                Expected(1, string.Empty, "GS0511"),
-                "docs/diagnostics.md GS0511 / #3114",
-                "the evaluator invokes func Main but rejects ByRefLike signatures"),
-            ["SpanIndexing.gs"] = SameDifference(
                 Expected(1, string.Empty, "GS0511"),
                 "docs/diagnostics.md GS0511 / #3114",
                 "reflection cannot invoke ByRefLike signatures"),
@@ -199,9 +187,6 @@ public class SampleConformanceTests
             var golden = SampleConformanceData.ReadNormalizedFile(
                 Path.Combine(samplesDirectory, Path.ChangeExtension(sample, ".golden")));
             Assert.False(string.IsNullOrEmpty(golden), $"{sample} must have non-empty golden output.");
-            Assert.True(
-                ExpectedDifferences.ContainsKey(sample),
-                $"{sample} declares an explicit Main with non-empty golden output; declare any driver difference explicitly.");
         }
     }
 

--- a/test/Interpreter.Tests/Issue2987ByRefLikeBoundaryInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2987ByRefLikeBoundaryInterpreterTests.cs
@@ -63,19 +63,6 @@ public class Issue2987ByRefLikeBoundaryInterpreterTests
             """,
             "System.Span[int32]"
         },
-        {
-            """
-            import System
-
-            func value(values []int32) int32 {
-                var span ReadOnlySpan[int32] = values
-                return 22
-            }
-
-            value([]int32{11, 22, 33})
-            """,
-            "System.ReadOnlySpan[int32]"
-        },
     };
 
     [Theory]

--- a/test/Interpreter.Tests/Issue3114ReadOnlySpanInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue3114ReadOnlySpanInterpreterTests.cs
@@ -46,6 +46,12 @@ public class Issue3114ReadOnlySpanInterpreterTests
         }
     }
 
+    public static IEnumerable<object[]> InterpretingDrivers()
+    {
+        yield return new object[] { Driver.CompilerEvaluation };
+        yield return new object[] { Driver.Interpreter };
+    }
+
     [Theory]
     [MemberData(nameof(SampleDriverCases))]
     public void ShippedSpanSample_MatchesGoldenAcrossDrivers(string sample, string expected, Driver driver)
@@ -96,6 +102,8 @@ public class Issue3114ReadOnlySpanInterpreterTests
                 Console.WriteLine(readOnly.Length)
                 Console.WriteLine(readOnly[1])
                 Console.WriteLine(window[1])
+                Console.WriteLine(writable.ToString())
+                Console.WriteLine(readOnly.ToString())
             }
             """;
 
@@ -119,7 +127,56 @@ public class Issue3114ReadOnlySpanInterpreterTests
 
             Assert.Equal(0, result.ExitCode);
             Assert.Equal(
-                driver == Driver.CompilerEvaluation ? "3\n44\n33\nSuccess.\n" : "3\n44\n33\n",
+                driver == Driver.CompilerEvaluation
+                    ? "3\n44\n33\nSystem.Span<Int32>[3]\nSystem.ReadOnlySpan<Int32>[3]\nSuccess.\n"
+                    : "3\n44\n33\nSystem.Span<Int32>[3]\nSystem.ReadOnlySpan<Int32>[3]\n",
+                result.StandardOutput);
+            Assert.Equal(string.Empty, result.StandardError);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(InterpretingDrivers))]
+    public void SpanInterpolation_UsesPublicSpanName(Driver driver)
+    {
+        const string Source = """
+            import System
+
+            func Main() {
+                var values = []int32{11, 22, 33}
+                var writable Span[int32] = values
+                var readOnly ReadOnlySpan[int32] = writable
+                Console.WriteLine("writable=${writable}")
+                Console.WriteLine("readonly=${readOnly}")
+            }
+            """;
+
+        var root = Path.Combine(Environment.CurrentDirectory, $".issue3114-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        Assert.Empty(Directory.EnumerateFileSystemEntries(root));
+        var sourcePath = Path.Combine(root, "span-interpolation.gs");
+        File.WriteAllText(sourcePath, Source);
+
+        try
+        {
+            var result = driver switch
+            {
+                Driver.CompilerEvaluation => CaptureConsole(
+                    () => GSharp.Compiler.Program.Main([sourcePath])),
+                Driver.Interpreter => CaptureConsole(
+                    () => GSharp.Repl.Program.Main([sourcePath])),
+                _ => throw new InvalidOperationException($"Unexpected driver {driver}."),
+            };
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.Equal(
+                driver == Driver.CompilerEvaluation
+                    ? "writable=System.Span<Int32>[3]\nreadonly=System.ReadOnlySpan<Int32>[3]\nSuccess.\n"
+                    : "writable=System.Span<Int32>[3]\nreadonly=System.ReadOnlySpan<Int32>[3]\n",
                 result.StandardOutput);
             Assert.Equal(string.Empty, result.StandardError);
         }

--- a/test/Interpreter.Tests/Issue3114ReadOnlySpanInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue3114ReadOnlySpanInterpreterTests.cs
@@ -99,11 +99,17 @@ public class Issue3114ReadOnlySpanInterpreterTests
                 writable[1] = 44
                 var tail = readOnly.Slice(1)
                 var window = tail.Slice(0, 2)
+                var letters = []char{'a', 'b', 'c'}
+                var writableChars Span[char] = letters
+                var readOnlyChars ReadOnlySpan[char] = writableChars
                 Console.WriteLine(readOnly.Length)
                 Console.WriteLine(readOnly[1])
                 Console.WriteLine(window[1])
                 Console.WriteLine(writable.ToString())
                 Console.WriteLine(readOnly.ToString())
+                Console.WriteLine(window.ToString())
+                Console.WriteLine(writableChars.ToString())
+                Console.WriteLine(readOnlyChars.ToString())
             }
             """;
 
@@ -128,8 +134,8 @@ public class Issue3114ReadOnlySpanInterpreterTests
             Assert.Equal(0, result.ExitCode);
             Assert.Equal(
                 driver == Driver.CompilerEvaluation
-                    ? "3\n44\n33\nSystem.Span<Int32>[3]\nSystem.ReadOnlySpan<Int32>[3]\nSuccess.\n"
-                    : "3\n44\n33\nSystem.Span<Int32>[3]\nSystem.ReadOnlySpan<Int32>[3]\n",
+                    ? "3\n44\n33\nSystem.Span<Int32>[3]\nSystem.ReadOnlySpan<Int32>[3]\nSystem.ReadOnlySpan<Int32>[2]\nabc\nabc\nSuccess.\n"
+                    : "3\n44\n33\nSystem.Span<Int32>[3]\nSystem.ReadOnlySpan<Int32>[3]\nSystem.ReadOnlySpan<Int32>[2]\nabc\nabc\n",
                 result.StandardOutput);
             Assert.Equal(string.Empty, result.StandardError);
         }

--- a/test/Interpreter.Tests/Issue3114ReadOnlySpanInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue3114ReadOnlySpanInterpreterTests.cs
@@ -1,0 +1,209 @@
+// <copyright file="Issue3114ReadOnlySpanInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>Issue #3114: shipped Span samples agree across all three drivers.</summary>
+[Collection("ConsoleIo")]
+public class Issue3114ReadOnlySpanInterpreterTests
+{
+    public enum Driver
+    {
+        CompilerEvaluation,
+        CompilerEmission,
+        Interpreter,
+    }
+
+    public static IEnumerable<object[]> SampleDriverCases()
+    {
+        foreach (var (sample, expected) in new[]
+        {
+            ("SpanComprehensive.gs", "60\n10\n2\n"),
+            ("RefStructGenericField.gs", "3\n"),
+            ("SpanIndexing.gs", "60\n402\n"),
+        })
+        {
+            foreach (var driver in Enum.GetValues<Driver>())
+            {
+                yield return new object[] { sample, expected, driver };
+            }
+        }
+    }
+
+    public static IEnumerable<object[]> Drivers()
+    {
+        foreach (var driver in Enum.GetValues<Driver>())
+        {
+            yield return new object[] { driver };
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(SampleDriverCases))]
+    public void ShippedSpanSample_MatchesGoldenAcrossDrivers(string sample, string expected, Driver driver)
+    {
+        var sourcePath = Path.Combine(LocateSamplesDirectory(), sample);
+        var root = Path.Combine(Environment.CurrentDirectory, $".issue3114-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        Assert.Empty(Directory.EnumerateFileSystemEntries(root));
+
+        try
+        {
+            var result = driver switch
+            {
+                Driver.CompilerEvaluation => CaptureConsole(
+                    () => GSharp.Compiler.Program.Main([sourcePath])),
+                Driver.CompilerEmission => CompileAndRun(root, sample, sourcePath),
+                Driver.Interpreter => CaptureConsole(
+                    () => GSharp.Repl.Program.Main([sourcePath])),
+                _ => throw new InvalidOperationException($"Unexpected driver {driver}."),
+            };
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.Equal(
+                driver == Driver.CompilerEvaluation ? expected + "Success.\n" : expected,
+                result.StandardOutput);
+            Assert.Equal(string.Empty, result.StandardError);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(Drivers))]
+    public void SpanConversionMutationAndSlicing_AgreeAcrossDrivers(Driver driver)
+    {
+        const string Source = """
+            import System
+
+            func Main() {
+                var values = []int32{11, 22, 33}
+                var writable Span[int32] = values
+                var readOnly ReadOnlySpan[int32] = writable
+                writable[1] = 44
+                var tail = readOnly.Slice(1)
+                var window = tail.Slice(0, 2)
+                Console.WriteLine(readOnly.Length)
+                Console.WriteLine(readOnly[1])
+                Console.WriteLine(window[1])
+            }
+            """;
+
+        var root = Path.Combine(Environment.CurrentDirectory, $".issue3114-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        Assert.Empty(Directory.EnumerateFileSystemEntries(root));
+        var sourcePath = Path.Combine(root, "span-operations.gs");
+        File.WriteAllText(sourcePath, Source);
+
+        try
+        {
+            var result = driver switch
+            {
+                Driver.CompilerEvaluation => CaptureConsole(
+                    () => GSharp.Compiler.Program.Main([sourcePath])),
+                Driver.CompilerEmission => CompileAndRun(root, "span-operations.gs", sourcePath),
+                Driver.Interpreter => CaptureConsole(
+                    () => GSharp.Repl.Program.Main([sourcePath])),
+                _ => throw new InvalidOperationException($"Unexpected driver {driver}."),
+            };
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.Equal(
+                driver == Driver.CompilerEvaluation ? "3\n44\n33\nSuccess.\n" : "3\n44\n33\n",
+                result.StandardOutput);
+            Assert.Equal(string.Empty, result.StandardError);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static (int ExitCode, string StandardOutput, string StandardError) CompileAndRun(
+        string root,
+        string sample,
+        string sourcePath)
+    {
+        var outputDirectory = Path.Combine(root, "emit");
+        Directory.CreateDirectory(outputDirectory);
+        Assert.Empty(Directory.EnumerateFileSystemEntries(outputDirectory));
+        var assemblyPath = Path.Combine(outputDirectory, Path.GetFileNameWithoutExtension(sample) + ".dll");
+        var compile = CaptureConsole(
+            () => GSharp.Compiler.Program.Main(
+                ["/out:" + assemblyPath, "/target:exe", "/targetframework:net10.0", sourcePath]));
+
+        Assert.Equal(0, compile.ExitCode);
+        Assert.True(File.Exists(assemblyPath), compile.StandardOutput + compile.StandardError);
+        Assert.NotEmpty(Assembly.Load(File.ReadAllBytes(assemblyPath)).GetTypes());
+
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = outputDirectory,
+        };
+        startInfo.ArgumentList.Add(assemblyPath);
+
+        using var process = Process.Start(startInfo);
+        Assert.NotNull(process);
+        var standardOutput = process.StandardOutput.ReadToEnd();
+        var standardError = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        return (
+            process.ExitCode,
+            standardOutput.Replace("\r\n", "\n"),
+            standardError.Replace("\r\n", "\n"));
+    }
+
+    private static (int ExitCode, string StandardOutput, string StandardError) CaptureConsole(
+        Func<int> action)
+    {
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+        var previousOutput = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(output);
+        Console.SetError(error);
+        try
+        {
+            return (
+                action(),
+                output.ToString().Replace("\r\n", "\n"),
+                error.ToString().Replace("\r\n", "\n"));
+        }
+        finally
+        {
+            Console.SetOut(previousOutput);
+            Console.SetError(previousError);
+        }
+    }
+
+    private static string LocateSamplesDirectory()
+    {
+        var directory = new DirectoryInfo(Environment.CurrentDirectory);
+        while (directory != null)
+        {
+            var samples = Path.Combine(directory.FullName, "samples");
+            if (Directory.Exists(samples) && File.Exists(Path.Combine(directory.FullName, "GSharp.sln")))
+            {
+                return samples;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate the samples directory.");
+    }
+}

--- a/website/docs/ref/diagnostics.md
+++ b/website/docs/ref/diagnostics.md
@@ -1878,8 +1878,9 @@ above retain their longer explanations and examples.
 
 | ID | Severity | Description |
 |----|----------|-------------|
-| GS0511 | Error | The interpreter cannot represent a stack-only (`ByRefLike`) CLR value such as `Span[T]` or `ReadOnlySpan[T]`. |
+| GS0511 | Error | The interpreter cannot represent this stack-only (`ByRefLike`) CLR value. Array-backed `Span[T]` and `ReadOnlySpan[T]` values are supported. |
 
 Interpreter values use boxed storage, which cannot hold stack-only CLR values
-or preserve their interior references. Compile the program with `gsc /out:<file>`
-to use these types.
+or preserve their interior references. The interpreter emulates spans created
+from arrays; CLR methods and properties returning stack-only values remain
+unsupported. Compile the program with `gsc /out:<file>` to use those values.


### PR DESCRIPTION
## Root cause

Before PR #3055 converted this failure to `GS0511`, the exception behind `GS9999` was:

```
System.NotSupportedException: Specified method is not supported.
  RuntimeMethodInfo.ThrowNoInvokeException
  RuntimeMethodInfo.Invoke
  Evaluator.InvokeReflective
  Evaluator.EvaluateClrConversionCallExpression
  Evaluator.EvaluateExpression
```

Reflection cannot invoke an array-to-`ReadOnlySpan<T>` conversion because its ByRefLike result cannot be boxed into the evaluator's `object` slots.

## Fix

Represent interpreted `Span<T>`/`ReadOnlySpan<T>` values with an evaluator-owned array, offset, length, and read-only state. The reflection boundary handles array and Span conversions, `Length`, indexing, writes, slicing, and default Span fields while preserving `GS0511` for unsupported CLR-returned ByRefLike values.

`InterpretedSpanValue.ToString()` now matches the emitted BCL shape, so direct formatting and evaluator interpolation no longer expose the internal wrapper type. The GS0511 documentation now states the surviving boundary: array-backed spans work; CLR methods and properties returning stack-only values remain unsupported.

PR #3077 merged while this PR was under review. Its three stale Span expected-difference entries are removed here; the all-driver sample gate is now 125/125.

## Driver evidence

All outputs below are program output; bare `gsc` additionally writes its normal `Success.` protocol line.

| sample | bare `gsc` evaluates | `gsc /out:` emits | `gsi` interprets |
|---|---|---|---|
| `SpanComprehensive.gs` | rc0, `60 / 10 / 2` | rc0, `60 / 10 / 2` | rc0, `60 / 10 / 2` |
| `RefStructGenericField.gs` | rc0, `3` | rc0, `3` | rc0, `3` |
| `SpanIndexing.gs` | rc0, `60 / 402` | rc0, `60 / 402` | rc0, `60 / 402` |

Every emitted probe used its own asserted-empty output directory. Test probes load emitted assemblies with `Assembly.Load` and `GetTypes()` before execution.

### Formatting

| shape | bare `gsc` | emit oracle | `gsi` |
|---|---|---|---|
| `Span<int32>.ToString()` | rc0 `System.Span<Int32>[3]` | rc0 `System.Span<Int32>[3]` | rc0 `System.Span<Int32>[3]` |
| `ReadOnlySpan<int32>.ToString()` | rc0 `System.ReadOnlySpan<Int32>[3]` | rc0 `System.ReadOnlySpan<Int32>[3]` | rc0 `System.ReadOnlySpan<Int32>[3]` |
| direct interpolation | rc0 with the same public names | rc1 `GS9998` (pre-existing emit limitation) | rc0 with the same public names |

## All 122 shipped single-file samples

Measured before and after on the same live base, `2dea578b1d3a43e964ebe5ce14ddc763bbe1628f`, with 122/122 samples executed in each interpreting column:

| driver | base golden matches | head golden matches | rc0 executions |
|---|---:|---:|---:|
| bare `gsc` | 95 / 122 | 98 / 122 | 109 → 112 |
| `gsi` | 108 / 122 | 111 / 122 | 109 → 112 |

Exactly six cells changed: `RefStructGenericField.gs`, `SpanComprehensive.gs`, and `SpanIndexing.gs` under both interpreting drivers. Each moved from rc1 `GS0511` to rc0 with golden output; no other vector changed.

## Product mutations

Each mutation was asserted to apply and built successfully.

| mutation | result |
|---|---|
| default Span detection | killed by `ShippedSpanSample_MatchesGoldenAcrossDrivers` |
| conversion dispatch route | killed by `ShippedSpanSample_MatchesGoldenAcrossDrivers` |
| `Length` recognition | killed by `SpanConversionMutationAndSlicing_AgreeAcrossDrivers` |
| indexer read recognition | killed by `SpanConversionMutationAndSlicing_AgreeAcrossDrivers` |
| indexer write recognition | killed by `SpanConversionMutationAndSlicing_AgreeAcrossDrivers` |
| implicit-conversion recognition | killed by `ShippedSpanSample_MatchesGoldenAcrossDrivers` |
| slice bounds | killed by `SpanConversionMutationAndSlicing_AgreeAcrossDrivers` |
| index bounds | killed by `SpanConversionMutationAndSlicing_AgreeAcrossDrivers` |
| `ToString()` read-only selector inversion | killed: 4 failures in the 14-case issue matrix |
| read-only write guard removal | **survived 734/734**; binder rejects the source first with `GS0226` |
| writable-conversion guard removal | **survived 734/734**; binder rejects the source first with `GS0155` |

The two surviving guards are defense in depth and are unreachable through binder-approved source. The earlier 10/10 claim was incorrect.

## Validation

Current base: `61fe9cb943d15c0f5ba747dabd562e66fb132058`  
Head: `d9eee3bc86b2619679bbc418dfc2cab2872d4b5d`  
`git merge-tree` output: `52f74eb9fb21aca930ade8c5e8e3f95cf253a0c3`, exactly matching the head tree.

Serial Release rebuild: `BUILD_RC=0`, 0 warnings, 0 errors. Core/Compiler/Repl and all three test-consumer `GSharp.Core.dll` copies were fresh by epoch mtime, non-zero, and hash-identical (`4a0be6009a61713835f7726e3d50cffb`).

Three-driver `Span[char]` and `ReadOnlySpan[char]` formatting:

- bare `gsc`: rc0, `abc` / `abc` (then `Success.`)
- emitted oracle: compile rc0, run rc0, `abc` / `abc`
- `gsi`: rc0, `abc` / `abc`

Issue matrix: 14/14 passed. Sliced `ReadOnlySpan[int32]` now asserts `System.ReadOnlySpan<Int32>[2]`. Product mutant `{Length}` → `{this.array.Length}` was asserted applied, built with rc0, and killed 2/14 by `SpanConversionMutationAndSlicing_AgreeAcrossDrivers` (bare `gsc` evaluation and `gsi`); actual `[3]` versus expected/oracle `[2]`.

All nine unfiltered test projects enumerated from `GSharp.sln` passed. Eight projects were run at anchor `faca348a36e7c4f9f35a3f57bde43c47f958b603`; SDK was run after rebasing to `61fe9cb943d15c0f5ba747dabd562e66fb132058` (the intervening main change only added a Compiler test file):

- Core: 7,116 passed, 1 skipped
- Compiler: 4,232 passed
- Cs2Gs: 1,903 passed
- Interpreter: 1,227 passed
- Language Server: 462 passed
- Extensions: 104 passed
- GeneratorHost: 31 passed
- Internal analyzers: 7 passed
- SDK: 59 passed (`61fe9cb943d15c0f5ba747dabd562e66fb132058`)

Correction: `Sdk.Tests` invokes `Program.Main` in-process and does not write the shared SDK package cache. The earlier NOT RUN statement was based on a docstring, not executable code.

Fixes #3114


