### PR TITLE
Fix constant-pattern equality across drivers

### DIFF
--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Patterns.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Patterns.cs
@@ -229,6 +229,60 @@ internal sealed partial class MethodBodyEmitter
             return;
         }
 
+        var isObject = valueType?.ClrType.IsSameAs(typeof(object)) == true;
+        var isValueNullable = valueType is NullableTypeSymbol nullable
+            && ReflectionMetadataEmitter.IsValueTypeNullable(nullable);
+        if (isObject || isValueNullable)
+        {
+            // PatternBinder adds at most one conversion to the discriminant type.
+            // Strip only that carrier; inner conversions determine the runtime value type.
+            var patternValue = cp.Value is BoundConversionExpression conversion && conversion.Type == valueType
+                ? conversion.Expression
+                : cp.Value;
+            if (patternValue.Type == TypeSymbol.Float32 || patternValue.Type == TypeSymbol.Float64)
+            {
+                loadValue();
+                if (isValueNullable)
+                {
+                    this.il.OpCode(ILOpCode.Box);
+                    this.il.Token(this.outer.memberRefs.GetElementTypeToken(valueType));
+                }
+
+                this.il.OpCode(ILOpCode.Isinst);
+                this.il.Token(this.outer.memberRefs.GetElementTypeToken(patternValue.Type));
+                var typeMatched = this.il.DefineLabel();
+                this.il.OpCode(ILOpCode.Dup);
+                this.il.Branch(ILOpCode.Brtrue, typeMatched);
+                this.il.OpCode(ILOpCode.Pop);
+                this.il.Branch(ILOpCode.Br, failLabel);
+                this.il.MarkLabel(typeMatched);
+                this.il.OpCode(ILOpCode.Unbox_any);
+                this.il.Token(this.outer.memberRefs.GetElementTypeToken(patternValue.Type));
+                this.EmitExpression(patternValue);
+                this.il.OpCode(ILOpCode.Ceq);
+                this.il.Branch(ILOpCode.Brfalse, failLabel);
+                return;
+            }
+
+            loadValue();
+            if (isValueNullable)
+            {
+                this.il.OpCode(ILOpCode.Box);
+                this.il.Token(this.outer.memberRefs.GetElementTypeToken(valueType));
+            }
+
+            this.EmitExpression(cp.Value);
+            if (isValueNullable)
+            {
+                this.il.OpCode(ILOpCode.Box);
+                this.il.Token(this.outer.memberRefs.GetElementTypeToken(valueType));
+            }
+
+            this.il.Call(this.outer.wellKnown.GetObjectStaticEqualsReference());
+            this.il.Branch(ILOpCode.Brfalse, failLabel);
+            return;
+        }
+
         // int / bool / other primitives lowered to ceq + brfalse.
         loadValue();
         this.EmitExpression(cp.Value);

--- a/src/Core/CodeAnalysis/Evaluator.Concurrency.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Concurrency.cs
@@ -123,7 +123,7 @@ public sealed partial class Evaluator
         switch (pattern.Kind)
         {
             case BoundNodeKind.ConstantPattern:
-                return object.Equals(value, EvaluateExpression(((BoundConstantPattern)pattern).Value));
+                return NumericEquals(value, EvaluateExpression(((BoundConstantPattern)pattern).Value));
             case BoundNodeKind.DiscardPattern:
                 return true;
             case BoundNodeKind.TypePattern:

--- a/test/Interpreter.Tests/Issue3110And3113ConstantPatternEqualityTests.cs
+++ b/test/Interpreter.Tests/Issue3110And3113ConstantPatternEqualityTests.cs
@@ -1,0 +1,373 @@
+// <copyright file="Issue3110And3113ConstantPatternEqualityTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>Issues #3110 and #3113: constant-pattern equality must agree across all three drivers.</summary>
+[Collection("ConsoleIo")]
+public class Issue3110And3113ConstantPatternEqualityTests
+{
+    [Fact]
+    public async Task TwentyRowCorpus_AgreesAcrossDrivers()
+    {
+        const string Expected = """
+            11
+            11
+            11
+            11
+            11
+            11
+            11
+            11
+            11
+            11
+            11
+            11
+            11
+            11
+            11
+            11
+            11
+            11
+            11
+            11
+            """;
+        await AssertDriverMatrixAsync(SourceForTwentyRowCorpus(), Expected, nameof(TwentyRowCorpus_AgreesAcrossDrivers));
+    }
+
+    [Fact]
+    public async Task FloatingAndNullableWidthControls_AgreeAcrossDrivers()
+    {
+        const string Expected = """
+            33
+            33
+            11
+            11
+            11
+            11
+            11
+            11
+            11
+            11
+            11
+            33
+            33
+            33
+            33
+            11
+            11
+            11
+            """;
+        await AssertDriverMatrixAsync(SourceForFloatingAndNullableWidthControls(), Expected, nameof(FloatingAndNullableWidthControls_AgreeAcrossDrivers));
+    }
+
+    [Fact]
+    public async Task NonLiteralNaNConstants_AgreeAcrossDrivers()
+    {
+        const string Expected = """
+            33
+            33
+            33
+            33
+            33
+            11
+            """;
+        await AssertDriverMatrixAsync(SourceForNonLiteralNaNConstants(), Expected, nameof(NonLiteralNaNConstants_AgreeAcrossDrivers));
+    }
+
+    private static async Task AssertDriverMatrixAsync(string source, string expected, string testName)
+    {
+        var root = CreateEmptyDirectory(testName);
+        try
+        {
+            var bare = RunBareGsc(source, CreateEmptyDirectory(root, "bare"));
+            var emitted = await RunEmittedAsync(source, CreateEmptyDirectory(root, "emit"));
+            var interpreted = RunGsi(source, CreateEmptyDirectory(root, "gsi"));
+
+            Assert.True(
+                expected == bare && expected == emitted && expected == interpreted,
+                $"driver mismatch\nexpected:\n{expected}\nbare gsc:\n{bare}\nemitted:\n{emitted}\ngsi:\n{interpreted}");
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static string RunBareGsc(string source, string directory)
+    {
+        var sourcePath = Path.Combine(directory, "probe.gs");
+        File.WriteAllText(sourcePath, source);
+        var (exitCode, stdout, stderr) = CaptureConsole(
+            () => GSharp.Compiler.Program.Main([sourcePath]));
+
+        Assert.True(exitCode == 0, $"bare gsc failed ({exitCode})\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return NormalizeValues(stdout);
+    }
+
+    private static string RunGsi(string source, string directory)
+    {
+        var sourcePath = Path.Combine(directory, "probe.gs");
+        File.WriteAllText(sourcePath, source);
+        var (exitCode, stdout, stderr) = CaptureConsole(
+            () => GSharp.Repl.Program.Main([sourcePath]));
+
+        Assert.True(exitCode == 0, $"gsi failed ({exitCode})\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return NormalizeValues(stdout);
+    }
+
+    private static async Task<string> RunEmittedAsync(string source, string directory)
+    {
+        var sourcePath = Path.Combine(directory, "probe.gs");
+        var outputPath = Path.Combine(directory, $"Issue3110And3113{Guid.NewGuid():N}.dll");
+        File.WriteAllText(sourcePath, source);
+
+        var (compileExit, stdout, stderr) = CaptureConsole(
+            () => GSharp.Compiler.Program.Main(
+                ["/out:" + outputPath, "/target:exe", "/targetframework:net10.0", sourcePath]));
+        Assert.True(compileExit == 0, $"emit failed ({compileExit})\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+        var assembly = Assembly.Load(File.ReadAllBytes(outputPath));
+        _ = assembly.GetTypes();
+
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = directory,
+        };
+        startInfo.ArgumentList.Add(outputPath);
+
+        using var process = Process.Start(startInfo);
+        Assert.NotNull(process);
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+        using var timeout = new CancellationTokenSource(30_000);
+        try
+        {
+            await process.WaitForExitAsync(timeout.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            process.Kill(entireProcessTree: true);
+            using var killTimeout = new CancellationTokenSource(5_000);
+            try
+            {
+                await process.WaitForExitAsync(killTimeout.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                Assert.Fail("emitted program did not exit after kill");
+            }
+
+            Assert.Fail("emitted program timed out after 30000 ms");
+        }
+
+        var runOut = await stdoutTask;
+        var runErr = await stderrTask;
+        Assert.True(process.ExitCode == 0, $"emitted program failed ({process.ExitCode})\nstdout:\n{runOut}\nstderr:\n{runErr}");
+        return NormalizeValues(runOut);
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) CaptureConsole(Func<int> action)
+    {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            return (action(), stdout.ToString(), stderr.ToString());
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+    }
+
+    private static string NormalizeValues(string output) =>
+        string.Join(
+            "\n",
+            output.Replace("\r\n", "\n", StringComparison.Ordinal)
+                .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+                .Where(line => line != "Success."));
+
+    private static string CreateEmptyDirectory(string name)
+    {
+        var parent = Path.Combine(AppContext.BaseDirectory, "issue3110-3113-probes");
+        return CreateEmptyDirectory(parent, $"{name}-{Guid.NewGuid():N}");
+    }
+
+    private static string CreateEmptyDirectory(string parent, string name)
+    {
+        var path = Path.Combine(parent, name);
+        Directory.CreateDirectory(path);
+        Assert.Empty(Directory.EnumerateFileSystemEntries(path));
+        return path;
+    }
+
+    private static string SourceForTwentyRowCorpus() => """
+        package Issue3110And3113.Corpus
+        import System
+
+        enum Shade { Light, Dark }
+
+        var i32 int32 = 1
+        switch i32 { case 1 { Console.WriteLine(11) } case 2 { Console.WriteLine(22) } default { Console.WriteLine(33) } }
+
+        var i64 int64 = int64(2)
+        switch i64 { case 2 { Console.WriteLine(11) } case 3 { Console.WriteLine(22) } default { Console.WriteLine(33) } }
+
+        var u32 uint32 = uint32(3)
+        switch u32 { case 3 { Console.WriteLine(11) } case 4 { Console.WriteLine(22) } default { Console.WriteLine(33) } }
+
+        var u64 uint64 = uint64(4)
+        switch u64 { case 4 { Console.WriteLine(11) } case 5 { Console.WriteLine(22) } default { Console.WriteLine(33) } }
+
+        var dec decimal = 1.5m
+        switch dec { case 1.5m { Console.WriteLine(11) } case 2.5m { Console.WriteLine(22) } default { Console.WriteLine(33) } }
+
+        var text string = "s"
+        switch text { case "s" { Console.WriteLine(11) } case "t" { Console.WriteLine(22) } default { Console.WriteLine(33) } }
+
+        var empty string = ""
+        switch empty { case "" { Console.WriteLine(11) } case "x" { Console.WriteLine(22) } default { Console.WriteLine(33) } }
+
+        var nilText string? = nil
+        switch nilText { case nil { Console.WriteLine(11) } case "x" { Console.WriteLine(22) } default { Console.WriteLine(33) } }
+
+        var truth bool = true
+        switch truth { case true { Console.WriteLine(11) } case false { Console.WriteLine(22) } default { Console.WriteLine(33) } }
+
+        var letter char = 'x'
+        switch letter { case 'x' { Console.WriteLine(11) } case 'y' { Console.WriteLine(22) } default { Console.WriteLine(33) } }
+
+        var shade Shade = Shade.Dark
+        switch shade { case Shade.Dark { Console.WriteLine(11) } case Shade.Light { Console.WriteLine(22) } default { Console.WriteLine(33) } }
+
+        var boxedInt object = 1
+        switch boxedInt { case 1 { Console.WriteLine(11) } case 2 { Console.WriteLine(22) } default { Console.WriteLine(33) } }
+
+        var boxedBool object = true
+        switch boxedBool { case true { Console.WriteLine(11) } case false { Console.WriteLine(22) } default { Console.WriteLine(33) } }
+
+        var boxedString object = "s"
+        switch boxedString { case "s" { Console.WriteLine(11) } case "t" { Console.WriteLine(22) } default { Console.WriteLine(33) } }
+
+        var nullableInt32 int32? = 1
+        switch nullableInt32 { case 1 { Console.WriteLine(11) } case 2 { Console.WriteLine(22) } default { Console.WriteLine(33) } }
+
+        var nullableChar char? = 'x'
+        switch nullableChar { case 'x' { Console.WriteLine(11) } case 'y' { Console.WriteLine(22) } default { Console.WriteLine(33) } }
+
+        var nullableBool bool? = true
+        switch nullableBool { case true { Console.WriteLine(11) } case false { Console.WriteLine(22) } default { Console.WriteLine(33) } }
+
+        var nullableInt64 int64? = int64(3)
+        switch nullableInt64 { case 3 { Console.WriteLine(11) } case 4 { Console.WriteLine(22) } default { Console.WriteLine(33) } }
+
+        var nullableFloat64 float64? = 1.5
+        switch nullableFloat64 { case 1.5 { Console.WriteLine(11) } case 2.5 { Console.WriteLine(22) } default { Console.WriteLine(33) } }
+
+        var nilFloat64 float64? = nil
+        switch nilFloat64 { case nil { Console.WriteLine(11) } case 1.5 { Console.WriteLine(22) } default { Console.WriteLine(33) } }
+        """;
+
+    private static string SourceForFloatingAndNullableWidthControls() => """
+        package Issue3110And3113.Controls
+        import System
+
+        enum ControlShade { Light, Dark }
+
+        var nan32 float32 = Single.NaN
+        switch nan32 { case Single.NaN { Console.WriteLine(11) } case Single.PositiveInfinity { Console.WriteLine(22) } default { Console.WriteLine(33) } }
+
+        var nan64 float64 = Double.NaN
+        switch nan64 { case Double.NaN { Console.WriteLine(11) } case Double.PositiveInfinity { Console.WriteLine(22) } default { Console.WriteLine(33) } }
+
+        var negativeZero float64 = -0.0
+        switch negativeZero { case 0.0 { Console.WriteLine(11) } case 1.0 { Console.WriteLine(22) } default { Console.WriteLine(33) } }
+
+        var epsilon32 float32 = Single.Epsilon
+        switch epsilon32 { case Single.Epsilon { Console.WriteLine(11) } case Single.PositiveInfinity { Console.WriteLine(22) } default { Console.WriteLine(33) } }
+
+        var positiveInfinity float64 = Double.PositiveInfinity
+        switch positiveInfinity { case Double.PositiveInfinity { Console.WriteLine(11) } case Double.NegativeInfinity { Console.WriteLine(22) } default { Console.WriteLine(33) } }
+
+        var negativeInfinity float64 = Double.NegativeInfinity
+        switch negativeInfinity { case Double.NegativeInfinity { Console.WriteLine(11) } case Double.PositiveInfinity { Console.WriteLine(22) } default { Console.WriteLine(33) } }
+
+        var nullableInt8 int8? = int8(1)
+        switch nullableInt8 { case 1 { Console.WriteLine(11) } case 2 { Console.WriteLine(22) } default { Console.WriteLine(33) } }
+
+        var nullableInt16 int16? = int16(1)
+        switch nullableInt16 { case 1 { Console.WriteLine(11) } case 2 { Console.WriteLine(22) } default { Console.WriteLine(33) } }
+
+        var nullableUInt32 uint32? = uint32(1)
+        switch nullableUInt32 { case 1 { Console.WriteLine(11) } case 2 { Console.WriteLine(22) } default { Console.WriteLine(33) } }
+
+        var nullableUInt64 uint64? = uint64(1)
+        switch nullableUInt64 { case 1 { Console.WriteLine(11) } case 2 { Console.WriteLine(22) } default { Console.WriteLine(33) } }
+
+        var nullableFloat32 float32? = Single.Epsilon
+        switch nullableFloat32 { case Single.Epsilon { Console.WriteLine(11) } case Single.PositiveInfinity { Console.WriteLine(22) } default { Console.WriteLine(33) } }
+
+        var nullableNaN32 float32? = Single.NaN
+        switch nullableNaN32 { case Single.NaN { Console.WriteLine(11) } case Single.PositiveInfinity { Console.WriteLine(22) } default { Console.WriteLine(33) } }
+
+        var nullableNaN64 float64? = Double.NaN
+        switch nullableNaN64 { case Double.NaN { Console.WriteLine(11) } case Double.PositiveInfinity { Console.WriteLine(22) } default { Console.WriteLine(33) } }
+
+        var boxedNaN32 object = Single.NaN
+        switch boxedNaN32 { case Single.NaN { Console.WriteLine(11) } case Single.PositiveInfinity { Console.WriteLine(22) } default { Console.WriteLine(33) } }
+
+        var boxedNaN64 object = Double.NaN
+        switch boxedNaN64 { case Double.NaN { Console.WriteLine(11) } case Double.PositiveInfinity { Console.WriteLine(22) } default { Console.WriteLine(33) } }
+
+        var boxedDecimal object = 1.5m
+        switch boxedDecimal { case 1.5m { Console.WriteLine(11) } case 2.5m { Console.WriteLine(22) } default { Console.WriteLine(33) } }
+
+        var boxedChar object = 'x'
+        switch boxedChar { case 'x' { Console.WriteLine(11) } case 'y' { Console.WriteLine(22) } default { Console.WriteLine(33) } }
+
+        var boxedEnum object = ControlShade.Dark
+        switch boxedEnum { case ControlShade.Dark { Console.WriteLine(11) } case ControlShade.Light { Console.WriteLine(22) } default { Console.WriteLine(33) } }
+        """;
+
+    private static string SourceForNonLiteralNaNConstants() => """
+        package Issue3110And3113.NonLiteralNaN
+        import System
+
+        var divided object = Double.NaN
+        switch divided { case 0.0 / 0.0 { Console.WriteLine(11) } default { Console.WriteLine(33) } }
+
+        var multiplied object = Double.NaN
+        switch multiplied { case Double.NaN * 1.0 { Console.WriteLine(11) } default { Console.WriteLine(33) } }
+
+        var negated object = Double.NaN
+        switch negated { case -Double.NaN { Console.WriteLine(11) } default { Console.WriteLine(33) } }
+
+        var nullable float64? = Double.NaN
+        switch nullable { case 0.0 / 0.0 { Console.WriteLine(11) } default { Console.WriteLine(33) } }
+
+        var chainedNaN object = float64(float32(Single.NaN))
+        switch chainedNaN { case (float64(float32(Single.NaN))) { Console.WriteLine(11) } default { Console.WriteLine(33) } }
+
+        var chainedControl object = float64(float32(1.00000001))
+        switch chainedControl { case (float64(float32(1.00000001))) { Console.WriteLine(11) } default { Console.WriteLine(33) } }
+        """;
+}


### PR DESCRIPTION
## Summary

- Use runtime numeric equality for evaluator constant patterns, preserving IEEE `NaN != NaN` behavior.
- Emit boxed/object and value-type-nullable constant patterns through runtime type-safe equality.
- Select floating comparison from the pattern value's static type, not bound-node shape.
- Cover bare `gsc`, emitted `gsc /out:`, and `gsi`, including computed NaN and chained conversions.

Fixes #3110
Fixes #3113

## Why one wrapper is correct

`PatternBinder.BindConstantPattern` first binds the source expression, then introduces exactly zero or one carrier conversion to the discriminant type:

```csharp
var value = conversion.IsIdentity
    ? expression
    : conversions.BindConversion(syntax.Expression.Location, expression, discriminantType);
```

The emitter removes only that outer conversion when its type equals the discriminant type. Every remaining `BoundExpression` has a static `Type`, so literal, folded, unary, binary, field, and other node shapes need no enumeration.

Unwrapping to a fixed point would be wrong: inner conversions are semantic. The pinned specimen `float64(float32(1.00000001))` rounds through `float32`; stripping both conversions changes the compared value. A PRODUCT mutant that unwrapped every `BoundConversionExpression` built successfully and failed only emitted output (`33` instead of `11`), while bare `gsc` and `gsi` remained `11`. The paired chained-NaN specimen remains unequal across all drivers.

## Three-driver measurement

Original four-case blocker corpus: division, multiplication, unary negation, and nullable division producing NaN.

| tree | bare `gsc` | `gsc /out:` | `gsi` |
|---|---|---|---|
| current main `61fe9cb9` | `11 11 11 11` | `33 33 33 33` | `11 11 11 11` |
| fixed `82da671d` | `33 33 33 33` | `33 33 33 33` | `33 33 33 33` |

Chained conversion pair (`NaN`, precision-sensitive non-NaN control):

| tree | bare `gsc` | `gsc /out:` | `gsi` |
|---|---|---|---|
| current main `61fe9cb9` | `11 / 11` | `33 / 33` | `11 / 11` |
| fixed `82da671d` | `33 / 11` | `33 / 11` | `33 / 11` |

Values name arms: `11` match, `22` alternate, `33` default. Emit is oracle.

## Product mutations

Each mutant was asserted applied, built to test execution, produced RED, then was restored. Restored final tree passed 3/3 targeted tests.

| hunk mutant | killed by | RED measurement |
|---|---|---|
| evaluator `NumericEquals` → `object.Equals` | `NonLiteralNaNConstants_AgreeAcrossDrivers` | bare/gsi NaN rows became `11`; emit remained correct |
| remove object route by condition inversion | `TwentyRowCorpus_AgreesAcrossDrivers` | emitted boxed int32/bool rows became `33` |
| remove value-nullable route by condition inversion | `TwentyRowCorpus_AgreesAcrossDrivers` | emitted int64?/float64?/nil float64? rows became `33` |
| invert floating static-type route (control mutant) | `NonLiteralNaNConstants_AgreeAcrossDrivers` | emitted five NaN rows became `11` |
| unwrap conversions to fixed point | `NonLiteralNaNConstants_AgreeAcrossDrivers` | emitted precision control became `33`; bare/gsi stayed `11` |

Current main without this PR independently supplies the opposite-side product controls shown above: emit keeps IEEE NaN output `33`, while boxed and nullable equality remains broken.

## Validation

- Rebased onto `origin/main` `61fe9cb9`.
- Head `82da671d`.
- `git merge-tree --write-tree origin/main HEAD`: `1f0c6fc54df6516e436d09e7b08ba5a40636be6d`, equal to `HEAD^{tree}`.
- Release solution build: `BUILD_RC=0`, 0 warnings, 0 errors.
- Final targeted tests: 3 passed, 0 failed.
- Original local final-tree test-project coverage was 1 of 9, enumerated from `GSharp.sln` using the same source as `build/generate-ci-test-matrix.py`. No Oahu coverage is claimed from local `Cs2Gs.Tests`.


## Addendum: `Sdk.Tests` correction

Earlier fleet guidance incorrectly classified `Sdk.Tests` as out of bounds. It runs SDK task logic in-process and does not spawn `dotnet build` against the shared SDK package directory. Unfiltered `Sdk.Tests` on head `82da671d`: 59 passed, 0 failed, 0 skipped (`TEST_RC=0`). Local final-tree coverage is therefore 2 of 9 projects; remaining seven were not rerun locally after the final rebase. CI's complete nine-project matrix passed on this head.
