### PR TITLE
Address composite literal review cleanup

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundFieldInitializer.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundFieldInitializer.cs
@@ -42,7 +42,7 @@ public sealed record BoundFieldInitializer
     /// <summary>Gets the targeted field, or <see langword="null"/> when this initializer targets a property.</summary>
     public FieldSymbol Field { get; }
 
-    /// <summary>Gets the type that declares <see cref="Field"/>, or <see langword="null"/> when the initializer targets a property.</summary>
+    /// <summary>Gets the inherited type that declares <see cref="Field"/>, or <see langword="null"/> for a direct field or property.</summary>
     public StructSymbol FieldDeclaringType { get; }
 
     /// <summary>Gets the targeted property, or <see langword="null"/> when this initializer targets a field.</summary>

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
@@ -1343,7 +1343,9 @@ internal sealed partial class MethodBodyEmitter
                 continue;
             }
 
-            // Keep inherited-field resolution aligned pending imported generic-record support.
+            // This branch executes but resolves to the same token as the else-arm for every
+            // expressible program. The !isGeneric guard above excludes imported and user-authored
+            // generics, so both that guard and generic-record support must change before this discriminates.
             var fieldHandle = init.FieldDeclaringType != null
                 ? this.ResolveStructLiteralFieldToken(literal, init)
                 : this.outer.userTokens.ResolveFieldToken(literal.StructType, init.Field);

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
@@ -1343,6 +1343,7 @@ internal sealed partial class MethodBodyEmitter
                 continue;
             }
 
+            // Keep inherited-field resolution aligned pending imported generic-record support.
             var fieldHandle = init.FieldDeclaringType != null
                 ? this.ResolveStructLiteralFieldToken(literal, init)
                 : this.outer.userTokens.ResolveFieldToken(literal.StructType, init.Field);

--- a/src/Core/CodeAnalysis/Emit/StateMachineEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/StateMachineEmitter.cs
@@ -1355,8 +1355,7 @@ internal sealed class StateMachineEmitter
         // Builder: AsyncIteratorMethodBuilder.Create()
         var createMethod = typeof(System.Runtime.CompilerServices.AsyncIteratorMethodBuilder)
             .GetMethod("Create", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static, null, Type.EmptyTypes, null);
-        initializers.Add(new BoundFieldInitializer(
-            builderField,
+        initializers.Add(new BoundFieldInitializer(builderField,
             new BoundClrStaticCallExpression(null, createMethod, TypeSymbol.FromClrType(typeof(System.Runtime.CompilerServices.AsyncIteratorMethodBuilder)), ImmutableArray<BoundExpression>.Empty)));
 
         foreach (var parameter in parameters)


### PR DESCRIPTION
Post-merge cleanup from the review of #3123:

- remove the StateMachineEmitter formatting-only hunk
- document when FieldDeclaringType is null accurately
- explain why imported positional records retain inherited-field resolution

No behavioral changes.