### PR TITLE
Add deinit inheritance boundary coverage

### DIFF
--- a/test/Core.Tests/CodeAnalysis/Binding/Issue698DeinitBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue698DeinitBinderTests.cs
@@ -52,6 +52,7 @@ class Resource {
 }
 ";
         var (result, _) = EvaluateAndGetStructs(source);
+        Assert.Single(result.Diagnostics, diagnostic => diagnostic.Id == "GS0510");
         Assert.All(result.Diagnostics, diagnostic => Assert.Equal("GS0510", diagnostic.Id));
     }
 

--- a/test/Interpreter.Tests/Issue2988DeinitInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2988DeinitInterpreterTests.cs
@@ -14,6 +14,7 @@ namespace GSharp.Interpreter.Tests;
 /// <summary>
 /// Interpreter boundary coverage for CLR GC finalizers declared with <c>deinit</c>.
 /// </summary>
+[Collection("ConsoleIo")]
 public class Issue2988DeinitInterpreterTests
 {
     [Fact]
@@ -63,10 +64,14 @@ public class Issue2988DeinitInterpreterTests
         Assert.DoesNotContain(next.Diagnostics, diagnostic => diagnostic.Id == "GS0510");
     }
 
-    [Fact]
-    public void InheritedDeinitializersWarnOncePerDeclaringClass()
+    [Theory]
+    [InlineData(Issue3010EntryPointDriverMatrixTests.Driver.CompilerEvaluation)]
+    [InlineData(Issue3010EntryPointDriverMatrixTests.Driver.CompilerEmission)]
+    [InlineData(Issue3010EntryPointDriverMatrixTests.Driver.Interpreter)]
+    public void InheritedDeinitializersWarnOncePerDeclaringClass(
+        Issue3010EntryPointDriverMatrixTests.Driver driver)
     {
-        var source = """
+        const string Source = """
             import System
 
             open class Resource(Tag string) {
@@ -89,18 +94,48 @@ public class Issue2988DeinitInterpreterTests
             GC.KeepAlive(resource)
             """;
 
-        var cell = new SessionEngine { CaptureConsole = true }.Evaluate(source);
+        var emitted = Issue3010EntryPointDriverMatrixTests.Run(
+            "inherited-deinit-emitted",
+            Source,
+            Issue3010EntryPointDriverMatrixTests.Driver.CompilerEmission);
+        Assert.Equal(0, emitted.ExitCode);
+        Assert.NotEmpty(emitted.StandardOutput);
+        Assert.Equal(string.Empty, emitted.StandardError);
 
-        Assert.False(cell.HasError);
-        Assert.Equal("body-44\n", cell.Output);
-        var warnings = cell.Diagnostics
-            .Where(diagnostic => diagnostic.Id == "GS0510")
-            .OrderBy(diagnostic => diagnostic.Message)
-            .ToArray();
-        Assert.Collection(
-            warnings,
-            warning => AssertWarning(warning, "CachedResource"),
-            warning => AssertWarning(warning, "Resource"));
+        var result = driver == Issue3010EntryPointDriverMatrixTests.Driver.CompilerEmission
+            ? emitted
+            : Issue3010EntryPointDriverMatrixTests.Run(
+                "inherited-deinit-" + driver,
+                Source,
+                driver);
+        Assert.Equal(0, result.ExitCode);
+
+        string warningOutput;
+        switch (driver)
+        {
+            case Issue3010EntryPointDriverMatrixTests.Driver.CompilerEvaluation:
+                Assert.StartsWith(emitted.StandardOutput + "\n", result.StandardOutput, StringComparison.Ordinal);
+                Assert.EndsWith("Success.\n", result.StandardOutput, StringComparison.Ordinal);
+                warningOutput = result.StandardOutput[emitted.StandardOutput.Length..];
+                break;
+            case Issue3010EntryPointDriverMatrixTests.Driver.CompilerEmission:
+                Assert.Equal(emitted.StandardOutput, result.StandardOutput);
+                Assert.Equal(string.Empty, result.StandardError);
+                return;
+            case Issue3010EntryPointDriverMatrixTests.Driver.Interpreter:
+                Assert.Equal(emitted.StandardOutput, result.StandardOutput);
+                warningOutput = result.StandardError;
+                break;
+            default:
+                throw new InvalidOperationException($"Unexpected driver {driver}.");
+        }
+
+        Assert.Equal(
+            2,
+            warningOutput.Split('\n')
+                .Count(line => line.Contains("warning GS0510", StringComparison.Ordinal)));
+        Assert.Contains("class 'CachedResource'", warningOutput, StringComparison.Ordinal);
+        Assert.Contains("class 'Resource'", warningOutput, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/test/Interpreter.Tests/Issue2988DeinitInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2988DeinitInterpreterTests.cs
@@ -64,6 +64,46 @@ public class Issue2988DeinitInterpreterTests
     }
 
     [Fact]
+    public void InheritedDeinitializersWarnOncePerDeclaringClass()
+    {
+        var source = """
+            import System
+
+            open class Resource(Tag string) {
+                deinit {
+                    Console.WriteLine("base-deinit-11")
+                }
+            }
+
+            class CachedResource : Resource {
+                init(tag string) : base(tag) {
+                }
+
+                deinit {
+                    Console.WriteLine("derived-deinit-22")
+                }
+            }
+
+            var resource = CachedResource("held-33")
+            Console.WriteLine("body-44")
+            GC.KeepAlive(resource)
+            """;
+
+        var cell = new SessionEngine { CaptureConsole = true }.Evaluate(source);
+
+        Assert.False(cell.HasError);
+        Assert.Equal("body-44\n", cell.Output);
+        var warnings = cell.Diagnostics
+            .Where(diagnostic => diagnostic.Id == "GS0510")
+            .OrderBy(diagnostic => diagnostic.Message)
+            .ToArray();
+        Assert.Collection(
+            warnings,
+            warning => AssertWarning(warning, "CachedResource"),
+            warning => AssertWarning(warning, "Resource"));
+    }
+
+    [Fact]
     public void EscapingInstanceIsNotFinalizedAtScopeExitOrWhileReachable()
     {
         var source = """

--- a/test/Interpreter.Tests/Issue3010EntryPointDriverMatrixTests.cs
+++ b/test/Interpreter.Tests/Issue3010EntryPointDriverMatrixTests.cs
@@ -154,7 +154,7 @@ public class Issue3010EntryPointDriverMatrixTests
         Assert.Equal(string.Empty, result.StandardError);
     }
 
-    private static (int ExitCode, string StandardOutput, string StandardError) Run(
+    internal static (int ExitCode, string StandardOutput, string StandardError) Run(
         string name,
         string source,
         Driver driver)


### PR DESCRIPTION
## Summary

- add the reported `CachedResource : Resource` inheritance shape to deinitializer boundary tests
- assert exactly two `GS0510` warnings, one for each declaring class
- exercise compiler evaluation, compiler emission, and interpreter drivers through the existing driver matrix helper
- use emitted execution output as the oracle for both evaluating drivers instead of freezing a literal output
- strengthen the binder diagnostic check so an empty collection cannot pass vacuously
- test-only change; no product code changed

Fixes #3131

## Driver matrix

Measured on `main` `787166a9` and this head:

| Driver | RC | `GS0510` | Output |
|---|---:|---:|---|
| bare `gsc` | 0 | 2 | equals emitted execution output, plus compiler diagnostic rendering and `Success.` |
| `gsc /out:` | 0 | 0 | emitted execution oracle; assembly runs successfully |
| `gsi` | 0 | 2 | equals emitted execution output |

This matrix regression-proofs the boundary against future restructuring; the columns are not three independent live risk paths today. `Compilation.Emit()` contains no call to `Evaluate()`, while `GS0510` is reported only inside `Evaluate()`, so an emit false positive is structurally impossible. Bare `gsc` and `gsi` both use `Compilation.Evaluate`, so they share the relevant product path.

## Mutation proof

Both product mutants were applied at exactly one site on `main` `787166a9` and the merged tree, built successfully, then restored.

| Mutant | Main without PR | Merged tree |
|---|---|---|
| M1: skip a derived deinitializer when its base declares one | `Issue2988DeinitInterpreterTests`: 4/4 pass | 2 failures of 7: compiler evaluation and interpreter each observe one warning instead of two |
| M2: invert the source-tree membership condition so `GS0510` is absent | `Issue698DeinitBinderTests`: 6/6 pass under old vacuous `Assert.All` | 1 failure of 6: `Assert.Single`, `Collection: []` |

The emitted matrix row remains green under M1, as expected: emission is the oracle and does not evaluate or report `GS0510`.

## Validation

Merged tree over `main` `787166a9` equals head tree `4cb09a91ff7d64bcb0edb584c3a9f63ecf501b15`.

- solution build: 0 warnings, 0 errors
- unfiltered `Interpreter.Tests`: 1,204 passed, 0 failed
- unfiltered `Core.Tests`: 7,106 passed, 1 skipped, 0 failed
- M1 two-sided mutation: main green, merged red
- M2 two-sided mutation: main green, merged red
