### PR TITLE
Document gsc optimize switch

### DIFF
--- a/website/docs/tooling/gsc.md
+++ b/website/docs/tooling/gsc.md
@@ -79,6 +79,9 @@ This option list was checked against `dotnet out\bin\Release\Compiler\gsc.dll --
 | `/warnaserror:<ids>` | Promote the listed warning IDs to errors. |
 | `/warnaserror+:<ids>` | Alias for promoting the listed warning IDs to errors. |
 | `/warnaserror-:<ids>` | Keep the listed IDs as warnings even when global `/warnaserror` is set. |
+| `/optimize`, `/optimize+` | Enable JIT optimization for emitted assemblies. This is the default. |
+| `/optimize-` | Disable JIT optimization for emitted assemblies. |
+| `/optimize:true`, `/optimize:false` | Enable or disable JIT optimization. Also accepts `1`, `0`, `on`, `off`, `yes`, and `no`. |
 | `/debug` | Emit a sidecar Portable PDB. Equivalent to `/debug:portable`. |
 | `/debug+` | Emit a sidecar Portable PDB. |
 | `/debug-` | Disable debug information. |

--- a/website/versioned_docs/version-0.3/tooling/gsc.md
+++ b/website/versioned_docs/version-0.3/tooling/gsc.md
@@ -79,6 +79,9 @@ This option list was checked against `dotnet out\bin\Release\Compiler\gsc.dll --
 | `/warnaserror:<ids>` | Promote the listed warning IDs to errors. |
 | `/warnaserror+:<ids>` | Alias for promoting the listed warning IDs to errors. |
 | `/warnaserror-:<ids>` | Keep the listed IDs as warnings even when global `/warnaserror` is set. |
+| `/optimize`, `/optimize+` | Enable JIT optimization for emitted assemblies. This is the default. |
+| `/optimize-` | Disable JIT optimization for emitted assemblies. |
+| `/optimize:true`, `/optimize:false` | Enable or disable JIT optimization. Also accepts `1`, `0`, `on`, `off`, `yes`, and `no`. |
 | `/debug` | Emit a sidecar Portable PDB. Equivalent to `/debug:portable`. |
 | `/debug+` | Emit a sidecar Portable PDB. |
 | `/debug-` | Disable debug information. |


### PR DESCRIPTION
## Summary

- document `/optimize`, `/optimize+`, `/optimize-`, and boolean forms in the exhaustive `gsc` switch table;
- state that JIT optimization is enabled by default;
- update both the current and versioned 0.3 references with identical rows.

No equivalent switch table exists under the root `docs/` tree. I did not add a new completeness framework: the existing docs gate builds the website, but no current gate or shared switch catalogue offers a cheap source-of-truth comparison.

## Independent verification

Each assembly was compiled into its own asserted-empty output directory with `/debug:portable`, then loaded from bytes and inspected through `DebuggableAttribute`:

| invocation | `DebuggingFlags` |
|---|---:|
| `/optimize+` | `2` |
| `/optimize-` | `257` |
| no optimize switch | `2` |

The default therefore matches `/optimize+`.

- current and versioned `gsc.md`: byte-identical, 139 lines each;
- unfiltered docs gate: `npm ci` + `npm run build` passed.

Fixes #3136
