### PR TITLE
[gsc] Property patterns bind readable properties and nested nullable members

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
@@ -804,7 +804,7 @@ public static class BoundNodePrinter
                         writer.WriteSpace();
                     }
 
-                    writer.WriteIdentifier(property.Fields[i].Field.Name);
+                    writer.WriteIdentifier(property.Fields[i].Name);
                     writer.WritePunctuation(SyntaxKind.ColonToken);
                     writer.WriteSpace();
                     WritePattern(property.Fields[i].Pattern, writer);

--- a/src/Core/CodeAnalysis/Binding/BoundPropertyPattern.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundPropertyPattern.cs
@@ -19,6 +19,11 @@ public sealed class BoundPropertyPattern : BoundPattern
         : base(syntax, type)
     {
         Fields = fields;
+        InputVariable = new LocalVariableSymbol("<property-pattern-input>", isReadOnly: true, type);
+        if (type is NullableTypeSymbol nullable && NullableLifting.IsAnyValueTypeNullable(nullable))
+        {
+            UnwrappedVariable = new LocalVariableSymbol("<property-pattern-value>", isReadOnly: true, nullable.UnderlyingType);
+        }
     }
 
     /// <inheritdoc/>
@@ -26,4 +31,10 @@ public sealed class BoundPropertyPattern : BoundPattern
 
     /// <summary>Gets the field patterns.</summary>
     public ImmutableArray<BoundPropertyPatternField> Fields { get; }
+
+    /// <summary>Gets the temporary holding the pattern input exactly once.</summary>
+    public LocalVariableSymbol InputVariable { get; }
+
+    /// <summary>Gets the unwrapped nullable value-type temporary, when required.</summary>
+    public LocalVariableSymbol UnwrappedVariable { get; }
 }

--- a/src/Core/CodeAnalysis/Binding/BoundPropertyPattern.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundPropertyPattern.cs
@@ -19,10 +19,25 @@ public sealed class BoundPropertyPattern : BoundPattern
         : base(syntax, type)
     {
         Fields = fields;
-        InputVariable = new LocalVariableSymbol("<property-pattern-input>", isReadOnly: true, type);
         if (type is NullableTypeSymbol nullable && NullableLifting.IsAnyValueTypeNullable(nullable))
         {
             UnwrappedVariable = new LocalVariableSymbol("<property-pattern-value>", isReadOnly: true, nullable.UnderlyingType);
+        }
+
+        // Field reads are side-effect free and keep the existing direct emit path.
+        // Capture only when a getter must run once or Nullable<T> needs an address.
+        foreach (var field in fields)
+        {
+            if (field.IsProperty)
+            {
+                InputVariable = new LocalVariableSymbol("<property-pattern-input>", isReadOnly: true, type);
+                break;
+            }
+        }
+
+        if (InputVariable == null && UnwrappedVariable != null)
+        {
+            InputVariable = new LocalVariableSymbol("<property-pattern-input>", isReadOnly: true, type);
         }
     }
 
@@ -32,7 +47,7 @@ public sealed class BoundPropertyPattern : BoundPattern
     /// <summary>Gets the field patterns.</summary>
     public ImmutableArray<BoundPropertyPatternField> Fields { get; }
 
-    /// <summary>Gets the temporary holding the pattern input exactly once.</summary>
+    /// <summary>Gets the temporary holding the pattern input when a getter or nullable value requires capture.</summary>
     public LocalVariableSymbol InputVariable { get; }
 
     /// <summary>Gets the unwrapped nullable value-type temporary, when required.</summary>

--- a/src/Core/CodeAnalysis/Binding/BoundPropertyPatternField.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundPropertyPatternField.cs
@@ -4,6 +4,7 @@
 
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
+using System.Reflection;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -15,10 +16,23 @@ public sealed class BoundPropertyPatternField : BoundNode
     /// <param name="field">The matched field.</param>
     /// <param name="pattern">The nested pattern.</param>
     public BoundPropertyPatternField(SyntaxNode syntax, FieldSymbol field, BoundPattern pattern)
+        : this(syntax, field, declaringType: null, pattern)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="BoundPropertyPatternField"/> class.</summary>
+    /// <param name="syntax">The originating syntax.</param>
+    /// <param name="field">The matched field.</param>
+    /// <param name="declaringType">The type that declares the field.</param>
+    /// <param name="pattern">The nested pattern.</param>
+    public BoundPropertyPatternField(SyntaxNode syntax, FieldSymbol field, TypeSymbol declaringType, BoundPattern pattern)
         : base(syntax)
     {
         Field = field;
+        DeclaringType = declaringType;
+        Type = field.Type;
         Pattern = pattern;
+        ValueVariable = new LocalVariableSymbol("<property-pattern-member>", isReadOnly: true, Type);
     }
 
     /// <summary>Initializes a new instance of the <see cref="BoundPropertyPatternField"/> class.</summary>
@@ -26,10 +40,37 @@ public sealed class BoundPropertyPatternField : BoundNode
     /// <param name="property">The matched property.</param>
     /// <param name="pattern">The nested pattern.</param>
     public BoundPropertyPatternField(SyntaxNode syntax, PropertySymbol property, BoundPattern pattern)
+        : this(syntax, property, declaringType: null, pattern)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="BoundPropertyPatternField"/> class.</summary>
+    /// <param name="syntax">The originating syntax.</param>
+    /// <param name="property">The matched property.</param>
+    /// <param name="declaringType">The type that declares the property.</param>
+    /// <param name="pattern">The nested pattern.</param>
+    public BoundPropertyPatternField(SyntaxNode syntax, PropertySymbol property, TypeSymbol declaringType, BoundPattern pattern)
         : base(syntax)
     {
         Property = property;
+        DeclaringType = declaringType;
+        Type = property.Type;
         Pattern = pattern;
+        ValueVariable = new LocalVariableSymbol("<property-pattern-member>", isReadOnly: true, Type);
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="BoundPropertyPatternField"/> class.</summary>
+    /// <param name="syntax">The originating syntax.</param>
+    /// <param name="clrMember">The matched CLR field or property.</param>
+    /// <param name="type">The matched member type.</param>
+    /// <param name="pattern">The nested pattern.</param>
+    public BoundPropertyPatternField(SyntaxNode syntax, MemberInfo clrMember, TypeSymbol type, BoundPattern pattern)
+        : base(syntax)
+    {
+        ClrMember = clrMember;
+        Type = type;
+        Pattern = pattern;
+        ValueVariable = new LocalVariableSymbol("<property-pattern-member>", isReadOnly: true, Type);
     }
 
     /// <inheritdoc/>
@@ -41,9 +82,21 @@ public sealed class BoundPropertyPatternField : BoundNode
     /// <summary>Gets the matched property symbol, when this member is property-backed.</summary>
     public PropertySymbol Property { get; }
 
+    /// <summary>Gets the matched CLR field or property, when metadata-backed.</summary>
+    public MemberInfo ClrMember { get; }
+
+    /// <summary>Gets the user type that declares the matched field or property.</summary>
+    public TypeSymbol DeclaringType { get; }
+
+    /// <summary>Gets the matched member name.</summary>
+    public string Name => ClrMember?.Name ?? Property?.Name ?? Field.Name;
+
     /// <summary>Gets the matched member type.</summary>
-    public TypeSymbol Type => Property?.Type ?? Field.Type;
+    public TypeSymbol Type { get; }
 
     /// <summary>Gets the nested field pattern.</summary>
     public BoundPattern Pattern { get; }
+
+    /// <summary>Gets the temporary holding one evaluation of the matched member.</summary>
+    public LocalVariableSymbol ValueVariable { get; }
 }

--- a/src/Core/CodeAnalysis/Binding/BoundPropertyPatternField.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundPropertyPatternField.cs
@@ -32,7 +32,6 @@ public sealed class BoundPropertyPatternField : BoundNode
         DeclaringType = declaringType;
         Type = field.Type;
         Pattern = pattern;
-        ValueVariable = new LocalVariableSymbol("<property-pattern-member>", isReadOnly: true, Type);
     }
 
     /// <summary>Initializes a new instance of the <see cref="BoundPropertyPatternField"/> class.</summary>
@@ -70,7 +69,10 @@ public sealed class BoundPropertyPatternField : BoundNode
         ClrMember = clrMember;
         Type = type;
         Pattern = pattern;
-        ValueVariable = new LocalVariableSymbol("<property-pattern-member>", isReadOnly: true, Type);
+        if (clrMember is PropertyInfo)
+        {
+            ValueVariable = new LocalVariableSymbol("<property-pattern-member>", isReadOnly: true, Type);
+        }
     }
 
     /// <inheritdoc/>
@@ -94,9 +96,12 @@ public sealed class BoundPropertyPatternField : BoundNode
     /// <summary>Gets the matched member type.</summary>
     public TypeSymbol Type { get; }
 
+    /// <summary>Gets a value indicating whether matching reads through a property getter.</summary>
+    public bool IsProperty => Property != null || ClrMember is PropertyInfo;
+
     /// <summary>Gets the nested field pattern.</summary>
     public BoundPattern Pattern { get; }
 
-    /// <summary>Gets the temporary holding one evaluation of the matched member.</summary>
+    /// <summary>Gets the temporary holding one getter evaluation, when property-backed.</summary>
     public LocalVariableSymbol ValueVariable { get; }
 }

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -828,9 +828,11 @@ public abstract class BoundTreeRewriter
                         }
                     }
 
-                    fieldsBuilder?.Add(field.Property is null
-                        ? new BoundPropertyPatternField(null, field.Field, pattern)
-                        : new BoundPropertyPatternField(null, field.Property, pattern));
+                    fieldsBuilder?.Add(field.ClrMember != null
+                        ? new BoundPropertyPatternField(null, field.ClrMember, field.Type, pattern)
+                        : field.Property != null
+                            ? new BoundPropertyPatternField(null, field.Property, field.DeclaringType, pattern)
+                            : new BoundPropertyPatternField(null, field.Field, field.DeclaringType, pattern));
                 }
 
                 return fieldsBuilder == null ? node : new BoundPropertyPattern(null, node.Type, fieldsBuilder.MoveToImmutable());

--- a/src/Core/CodeAnalysis/Binding/PatternBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/PatternBinder.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Numerics;
+using System.Reflection;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 
@@ -320,12 +321,19 @@ internal sealed class PatternBinder
     {
         var fields = ImmutableArray.CreateBuilder<BoundPropertyPatternField>();
 
+        // Recursive property patterns never match null. Member lookup therefore
+        // runs against the non-null underlying type for both nullable references
+        // and Nullable<T>; emitter/evaluator perform the corresponding guard.
+        var lookupType = discriminantType is NullableTypeSymbol nullableDiscriminant
+            ? nullableDiscriminant.UnderlyingType
+            : discriminantType;
+
         // Issue #1887: cs2gs lowers a C# positional pattern over a raw tuple
         // subject (`(0, 0) => ...`) to a G# property pattern keyed on the
         // tuple's always-present Item1..ItemN fields (`{ Item1: 0, Item2: 0 }`).
         // A ValueTuple is neither a StructSymbol nor a class, so it needs its
         // own lookup path alongside the struct/class one below.
-        if (discriminantType is TupleTypeSymbol tupleType)
+        if (lookupType is TupleTypeSymbol tupleType)
         {
             foreach (var tupleFieldSyntax in syntax.Fields)
             {
@@ -342,20 +350,7 @@ internal sealed class PatternBinder
             return new BoundPropertyPattern(syntax, discriminantType, fields.ToImmutable());
         }
 
-        // Issue #1923: a property pattern against a nullable CLASS-typed
-        // subject (`Address?`) is legal — it implicitly requires the value to
-        // be non-null (mirroring C#'s recursive-pattern rule that `null`
-        // never matches `{ ... }`). Unwrap to the underlying struct/class for
-        // field lookup; the emitter inserts the corresponding null guard
-        // before reading any field. A nullable VALUE-type struct (`Nullable<T>`
-        // CLR boxing) is a different, more involved shape and is not unwrapped
-        // here — it still reports GS0172.
-        var lookupType = discriminantType is NullableTypeSymbol nullableDiscriminant
-            && IsReferenceType(nullableDiscriminant.UnderlyingType)
-            ? nullableDiscriminant.UnderlyingType
-            : discriminantType;
-
-        if (lookupType is not StructSymbol structType)
+        if (!SupportsPropertyPattern(lookupType))
         {
             Diagnostics.ReportPropertyPatternRequiresStructOrClass(syntax.OpenBraceToken.Location, discriminantType);
             return new BoundPropertyPattern(syntax, discriminantType, fields.ToImmutable());
@@ -363,47 +358,181 @@ internal sealed class PatternBinder
 
         foreach (var fieldSyntax in syntax.Fields)
         {
-            if (!TypeMemberModel.TryGetFieldIncludingInherited(structType, fieldSyntax.Identifier.Text, MemberQuery.Instance(MemberKinds.Field), out var field, out _))
+            if (!TryBindPropertyPatternMember(lookupType, fieldSyntax, out var field))
             {
-                if (!TypeMemberModel.TryGetProperty(structType, fieldSyntax.Identifier.Text, out var property)
-                    || property.Declaration is not null
-                    || property.BackingField is null
-                    || !TypeMemberModel.TryGetPrimaryConstructorParameter(structType, property.Name, out _))
-                {
-                    Diagnostics.ReportUndefinedFieldOnType(fieldSyntax.Identifier.Location, fieldSyntax.Identifier.Text, discriminantType);
-                    fields.Add(new BoundPropertyPatternField(syntax, new FieldSymbol(fieldSyntax.Identifier.Text, TypeSymbol.Error, Accessibility.Public), BindPattern(fieldSyntax.Pattern, TypeSymbol.Error)));
-                    continue;
-                }
-
+                Diagnostics.ReportUndefinedFieldOnType(fieldSyntax.Identifier.Location, fieldSyntax.Identifier.Text, discriminantType);
                 fields.Add(new BoundPropertyPatternField(
                     syntax,
-                    property,
-                    BindPattern(fieldSyntax.Pattern, property.Type)));
+                    new FieldSymbol(fieldSyntax.Identifier.Text, TypeSymbol.Error, Accessibility.Public),
+                    BindPattern(fieldSyntax.Pattern, TypeSymbol.Error)));
                 continue;
             }
 
-            fields.Add(new BoundPropertyPatternField(syntax, field, BindPattern(fieldSyntax.Pattern, field.Type)));
+            fields.Add(field);
         }
 
         return new BoundPropertyPattern(syntax, discriminantType, fields.ToImmutable());
     }
 
+    private bool TryBindPropertyPatternMember(
+        TypeSymbol lookupType,
+        PropertyPatternFieldSyntax syntax,
+        out BoundPropertyPatternField boundField)
+    {
+        var name = syntax.Identifier.Text;
+        if (lookupType is StructSymbol structType)
+        {
+            for (var current = structType; current != null; current = current.BaseClass)
+            {
+                foreach (var field in current.Fields)
+                {
+                    if (field.Name == name)
+                    {
+                        boundField = new BoundPropertyPatternField(
+                            syntax,
+                            field,
+                            current,
+                            BindPattern(syntax.Pattern, field.Type));
+                        return true;
+                    }
+                }
+
+                foreach (var property in current.Properties)
+                {
+                    if (property.Name != name)
+                    {
+                        continue;
+                    }
+
+                    if (property.IsIndexer || property.IsStatic || !property.HasGetter)
+                    {
+                        boundField = null;
+                        return false;
+                    }
+
+                    boundField = new BoundPropertyPatternField(
+                        syntax,
+                        property,
+                        current,
+                        BindPattern(syntax.Pattern, property.Type));
+                    return true;
+                }
+            }
+
+            var importedBase = TypeMemberModel.GetNearestImportedBase(structType);
+            if (importedBase?.ClrType != null
+                && TryBindClrPropertyPatternMember(importedBase, importedBase.ClrType, syntax, out boundField))
+            {
+                return true;
+            }
+        }
+        else if (lookupType is InterfaceSymbol interfaceType)
+        {
+            foreach (var current in interfaceType.SelfAndAllBaseInterfaces())
+            {
+                current.EnsureMembersResolved();
+                foreach (var property in current.Properties)
+                {
+                    if (property.Name != name)
+                    {
+                        continue;
+                    }
+
+                    if (property.IsIndexer || property.IsStatic || !property.HasGetter)
+                    {
+                        boundField = null;
+                        return false;
+                    }
+
+                    boundField = new BoundPropertyPatternField(
+                        syntax,
+                        property,
+                        current,
+                        BindPattern(syntax.Pattern, property.Type));
+                    return true;
+                }
+            }
+
+            foreach (var importedBase in MemberLookup.GetTransitiveClrBaseInterfaces(interfaceType))
+            {
+                var importedBaseType = ImportedTypeSymbol.Get(importedBase);
+                if (TryBindClrPropertyPatternMember(importedBaseType, importedBase, syntax, out boundField))
+                {
+                    return true;
+                }
+            }
+        }
+        else if (lookupType.ClrType is Type clrType
+            && TryBindClrPropertyPatternMember(lookupType, clrType, syntax, out boundField))
+        {
+            return true;
+        }
+
+        boundField = null;
+        return false;
+    }
+
+    private bool TryBindClrPropertyPatternMember(
+        TypeSymbol receiverType,
+        Type clrType,
+        PropertyPatternFieldSyntax syntax,
+        out BoundPropertyPatternField boundField)
+    {
+        var name = syntax.Identifier.Text;
+        var property = ClrTypeUtilities.SafeGetPropertyIncludingInterfaces(
+            clrType,
+            name,
+            BindingFlags.Public | BindingFlags.Instance);
+        if (property != null)
+        {
+            if (property.GetIndexParameters().Length != 0
+                || property.GetGetMethod(nonPublic: false) == null)
+            {
+                boundField = null;
+                return false;
+            }
+
+            var propertyType = MemberLookup.GetClrPropertyTypeSymbol(receiverType, property);
+            boundField = new BoundPropertyPatternField(
+                syntax,
+                property,
+                propertyType,
+                BindPattern(syntax.Pattern, propertyType));
+            return true;
+        }
+
+        var field = ClrTypeUtilities.SafeGetFieldIncludingInterfaces(
+            clrType,
+            name,
+            BindingFlags.Public | BindingFlags.Instance);
+        if (field != null)
+        {
+            var fieldType = ClrNullability.GetFieldTypeSymbol(field);
+            boundField = new BoundPropertyPatternField(
+                syntax,
+                field,
+                fieldType,
+                BindPattern(syntax.Pattern, fieldType));
+            return true;
+        }
+
+        boundField = null;
+        return false;
+    }
+
+    private static bool SupportsPropertyPattern(TypeSymbol type)
+    {
+        if (type is StructSymbol or InterfaceSymbol or TupleTypeSymbol)
+        {
+            return true;
+        }
+
+        return type.ClrType is Type clrType && !clrType.IsPrimitive && !clrType.IsEnum;
+    }
+
     // Issue #1887: resolve a tuple's synthetic Item1..ItemN field by name so a
     // property/positional pattern (`{ Item1: 0, Item2: 0 }`) binds against a
     // ValueTuple subject the same way it does against a struct's real fields.
-    // Issue #1923: true when `type` is a CLR reference type — either a
-    // user-declared `class` (StructSymbol.IsClass) or an imported/CLR type
-    // whose ClrType reports IsValueType == false. Used to decide whether a
-    // nullable discriminant (`T?`) can be unwrapped for a property pattern
-    // (nullable value-type structs, which box as `Nullable<T>`, are a
-    // different shape and are intentionally excluded).
-    private static bool IsReferenceType(TypeSymbol type) => type switch
-    {
-        StructSymbol s => s.IsClass,
-        { ClrType: { IsValueType: false } } => true,
-        _ => false,
-    };
-
     private static bool TryGetTupleField(TupleTypeSymbol tupleType, string name, out FieldSymbol field)
     {
         field = null;

--- a/src/Core/CodeAnalysis/DiagnosticDescriptors.cs
+++ b/src/Core/CodeAnalysis/DiagnosticDescriptors.cs
@@ -89,7 +89,7 @@ internal static class DiagnosticDescriptors
     internal static readonly DiagnosticDescriptor SwitchCaseValueNotConstant = new("GS0170", DiagnosticSeverity.Error, "Switch case value must be a constant expression.");
     internal static readonly DiagnosticDescriptor SwitchCaseTypeMismatch = new("GS0171", DiagnosticSeverity.Error, "Switch case value of type '{0}' is incompatible with switch expression of type '{1}'.");
     internal static readonly DiagnosticDescriptor PropertyPatternRequiresStructOrClass = new("GS0172", DiagnosticSeverity.Error, "Property pattern requires a struct or class value, not '{0}'.");
-    internal static readonly DiagnosticDescriptor UndefinedFieldOnType = new("GS0173", DiagnosticSeverity.Error, "Type '{0}' does not define a field named '{1}'.");
+    internal static readonly DiagnosticDescriptor UndefinedFieldOnType = new("GS0173", DiagnosticSeverity.Error, "Type '{0}' does not define a readable instance field or property named '{1}'.");
     internal static readonly DiagnosticDescriptor RelationalPatternOperatorUndefined = new("GS0174", DiagnosticSeverity.Error, "Relational pattern operator '{0}' is not defined for type '{1}'.");
     internal static readonly DiagnosticDescriptor ListPatternRequiresArrayOrSlice = new("GS0175", DiagnosticSeverity.Error, "List pattern requires an array or slice value, not '{0}'.");
     internal static readonly DiagnosticDescriptor SwitchExpressionMissingDefault = new("GS0176", DiagnosticSeverity.Error, "Switch expression must have a 'default' arm.");

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Patterns.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Patterns.cs
@@ -329,26 +329,60 @@ internal sealed partial class MethodBodyEmitter
 
     private void EmitPropertyPattern(BoundPropertyPattern pp, Action loadValue, TypeSymbol valueType, LabelHandle failLabel)
     {
-        // Property patterns apply to GSharp struct/class discriminants.
-        // Fields are accessed via ldfld on the value (struct: ldfld on
-        // value, class: ldfld through ref).
-        //
-        // Issue #1923: a nullable CLASS-typed subject (`Address?`) is
-        // accepted by the binder (PatternBinder.BindPropertyPattern) on the
-        // understanding that `null` never matches `{ ... }` — mirroring C#'s
-        // recursive-pattern rule. Emit that guard here: load the value once
-        // and branch to failLabel when it is null (empty stack on the
-        // failure path, matching every other pattern's contract), then
-        // continue field emission against the underlying reference type.
-        if (valueType is NullableTypeSymbol nullableValueType
-            && !ReflectionMetadataEmitter.IsValueTypeSymbol(nullableValueType.UnderlyingType))
+        var inputSlot = this.locals[pp.InputVariable];
+        loadValue();
+        this.il.StoreLocal(inputSlot);
+
+        var receiverSlot = inputSlot;
+        var receiverType = valueType;
+        if (valueType is NullableTypeSymbol nullableValueType)
         {
-            loadValue();
+            if (NullableLifting.IsAnyValueTypeNullable(nullableValueType))
+            {
+                this.il.LoadLocal(inputSlot);
+                this.il.OpCode(ILOpCode.Box);
+                this.il.Token(this.outer.memberRefs.GetElementTypeToken(nullableValueType));
+                this.il.Branch(ILOpCode.Brfalse, failLabel);
+
+                receiverSlot = this.locals[pp.UnwrappedVariable];
+                this.il.LoadLocalAddress(inputSlot);
+                if (NullableLifting.RequiresSymbolicNullableGetValue(nullableValueType))
+                {
+                    this.il.OpCode(ILOpCode.Call);
+                    this.il.Token(this.outer.memberRefs.GetNullableGetValueMemberRefForUserValueType(nullableValueType));
+                }
+                else
+                {
+                    var underlyingClr = nullableValueType.UnderlyingType.ClrType
+                        ?? throw new InvalidOperationException(
+                            $"Nullable property-pattern input '{nullableValueType}' has no CLR underlying type.");
+                    this.il.OpCode(ILOpCode.Call);
+                    this.il.Token(this.outer.wellKnown.GetNullableGetValueOrDefaultReference(underlyingClr));
+                }
+
+                this.il.StoreLocal(receiverSlot);
+            }
+            else
+            {
+                this.il.LoadLocal(inputSlot);
+                this.il.Branch(ILOpCode.Brfalse, failLabel);
+            }
+
+            receiverType = nullableValueType.UnderlyingType;
+        }
+        else if (!ReflectionMetadataEmitter.IsValueTypeSymbol(valueType))
+        {
+            // Recursive patterns reject null even when the source annotation is
+            // non-nullable; runtime values can still arrive from oblivious code.
+            this.il.LoadLocal(inputSlot);
             this.il.Branch(ILOpCode.Brfalse, failLabel);
-            valueType = nullableValueType.UnderlyingType;
         }
 
-        if (valueType is TupleTypeSymbol tupleType)
+        Action loadReceiver = ReflectionMetadataEmitter.IsValueTypeSymbol(receiverType)
+            ? () => this.il.LoadLocalAddress(receiverSlot)
+            : () => this.il.LoadLocal(receiverSlot);
+
+        if (receiverType is TupleTypeSymbol tupleType)
         {
             // Issue #1887: cs2gs lowers a C# positional pattern over a raw
             // tuple to a G# property pattern keyed on the tuple's Item1..ItemN
@@ -358,100 +392,151 @@ internal sealed partial class MethodBodyEmitter
             foreach (var field in pp.Fields)
             {
                 var fieldName = field.Field.Name;
-                Action loadTupleChild = () =>
+                if (tupleClr == null)
                 {
-                    if (tupleClr == null)
+                    var index = int.Parse(
+                        fieldName.AsSpan("Item".Length),
+                        System.Globalization.CultureInfo.InvariantCulture) - 1;
+                    this.EmitSymbolicTupleElementAccess(
+                        tupleType,
+                        index,
+                        loadReceiver,
+                        takeRestAddress: false);
+                }
+                else
+                {
+                    loadReceiver();
+                    this.il.OpCode(ILOpCode.Ldfld);
+                    if (tupleClr.IsConstructedGenericType)
                     {
-                        var index = int.Parse(
-                            fieldName.AsSpan("Item".Length),
-                            System.Globalization.CultureInfo.InvariantCulture) - 1;
-                        this.EmitSymbolicTupleElementAccess(
-                            tupleType,
-                            index,
-                            loadValue,
-                            takeRestAddress: false);
+                        this.il.Token(this.outer.memberRefs.GetFieldReferenceOnConstructedGeneric(tupleClr, fieldName));
                     }
                     else
                     {
-                        loadValue();
-                        this.il.OpCode(ILOpCode.Ldfld);
-                        if (tupleClr.IsConstructedGenericType)
-                        {
-                            this.il.Token(this.outer.memberRefs.GetFieldReferenceOnConstructedGeneric(tupleClr, fieldName));
-                        }
-                        else
-                        {
-                            var clrField = tupleClr.GetField(fieldName)
-                                ?? throw new InvalidOperationException(
-                                    $"ValueTuple type '{tupleClr.FullName}' has no public field '{fieldName}'.");
-                            this.il.Token(this.outer.memberRefs.GetFieldReference(clrField));
-                        }
+                        var clrField = tupleClr.GetField(fieldName)
+                            ?? throw new InvalidOperationException(
+                                $"ValueTuple type '{tupleClr.FullName}' has no public field '{fieldName}'.");
+                        this.il.Token(this.outer.memberRefs.GetFieldReference(clrField));
                     }
-                };
+                }
 
-                this.EmitPattern(field.Pattern, loadTupleChild, field.Field.Type, failLabel);
+                var memberSlot = this.locals[field.ValueVariable];
+                this.il.StoreLocal(memberSlot);
+                this.EmitPattern(field.Pattern, () => this.il.LoadLocal(memberSlot), field.Type, failLabel);
             }
 
-            return;
-        }
-
-        if (valueType is not StructSymbol)
-        {
-            // Defensive: every property-pattern operand should be a
-            // struct/class; the binder rejects others. Branch to fail
-            // rather than emit a verifier-illegal sequence.
-            this.il.Branch(ILOpCode.Br, failLabel);
             return;
         }
 
         foreach (var field in pp.Fields)
         {
-            if (field.Property != null)
-            {
-                if (ReflectionMetadataEmitter.IsValueTypeSymbol(valueType)
-                    && field.Property.BackingField != null
-                    && this.outer.cache.StructFieldDefs.TryGetValue(field.Property.BackingField, out var backingField))
-                {
-                    Action loadBackingField = () =>
-                    {
-                        loadValue();
-                        this.il.OpCode(ILOpCode.Ldfld);
-                        this.il.Token(backingField);
-                    };
-                    this.EmitPattern(field.Pattern, loadBackingField, field.Type, failLabel);
-                    continue;
-                }
+            this.EmitPropertyPatternMember(field, receiverType, loadReceiver);
+            var memberSlot = this.locals[field.ValueVariable];
+            this.il.StoreLocal(memberSlot);
+            this.EmitPattern(field.Pattern, () => this.il.LoadLocal(memberSlot), field.Type, failLabel);
+        }
+    }
 
-                var getter = this.outer.userTokens.ResolveUserPropertyAccessorToken(
-                    valueType as StructSymbol,
+    private void EmitPropertyPatternMember(
+        BoundPropertyPatternField field,
+        TypeSymbol receiverType,
+        Action loadReceiver)
+    {
+        var receiverIsValueType = ReflectionMetadataEmitter.IsValueTypeSymbol(receiverType);
+        if (field.ClrMember != null)
+        {
+            switch (field.ClrMember)
+            {
+                case PropertyInfo property:
+                    var getter = ImportedMemberRefFactory.GetTypeBuilderSafePropertyAccessor(
+                        property,
+                        wantSetter: false)
+                        ?? throw new InvalidOperationException(
+                            $"Property '{property.DeclaringType?.FullName}.{property.Name}' has no public getter.");
+                    loadReceiver();
+                    this.il.OpCode(receiverIsValueType ? ILOpCode.Call : ILOpCode.Callvirt);
+                    this.il.Token(this.outer.memberRefs.GetMethodEntityHandle(getter, receiverType));
+                    if (!this.outer.userTokens.TryGetSymbolicSubstitutedPropertyReturn(receiverType, property, out _))
+                    {
+                        this.EmitErasedObjectReturnWidening(
+                            TypeSymbol.FromClrType(getter.ReturnType),
+                            field.Type);
+                    }
+
+                    return;
+                case FieldInfo clrField:
+                    loadReceiver();
+                    this.il.OpCode(ILOpCode.Ldfld);
+                    this.il.Token(this.outer.memberRefs.GetFieldReference(clrField));
+                    return;
+                default:
+                    throw new NotSupportedException(
+                        $"CLR property-pattern member '{field.ClrMember.GetType().Name}' is not supported.");
+            }
+        }
+
+        if (field.Property != null)
+        {
+            EntityHandle getterHandle;
+            var declaringStruct = field.DeclaringType as StructSymbol;
+            var receiverStruct = receiverType as StructSymbol;
+            var getterContainer = ResolvePropertyReferenceContainer(
+                declaringStruct,
+                receiverStruct,
+                field.Property);
+            if (getterContainer != null)
+            {
+                getterHandle = this.outer.userTokens.ResolveUserPropertyAccessorToken(
+                    getterContainer,
                     field.Property,
                     wantSetter: false);
-                Action loadProperty = () =>
-                {
-                    loadValue();
-                    this.il.OpCode(ILOpCode.Callvirt);
-                    this.il.Token(getter);
-                };
-                this.EmitPattern(field.Pattern, loadProperty, field.Type, failLabel);
-                continue;
             }
-
-            if (!this.outer.cache.StructFieldDefs.TryGetValue(field.Field, out var fieldHandle))
+            else if (this.outer.cache.PropertyAccessorHandles.TryGetValue(field.Property, out var handles)
+                && handles.Getter.HasValue)
+            {
+                getterHandle = handles.Getter.Value;
+            }
+            else if (declaringStruct?.ClrType != null)
+            {
+                getterHandle = this.outer.userTokens.ResolveUserPropertyAccessorToken(
+                    declaringStruct,
+                    field.Property,
+                    wantSetter: false);
+            }
+            else
             {
                 throw new InvalidOperationException(
-                    $"Property pattern field '{field.Field.Name}' has no emitted FieldDef.");
+                    $"Property pattern property '{field.Property.Name}' has no emitted getter.");
             }
 
-            // Compose: child loader is "load receiver, ldfld FieldHandle".
-            Action loadChild = () =>
-            {
-                loadValue();
-                this.il.OpCode(ILOpCode.Ldfld);
-                this.il.Token(fieldHandle);
-            };
-
-            this.EmitPattern(field.Pattern, loadChild, field.Type, failLabel);
+            loadReceiver();
+            this.il.OpCode(receiverIsValueType ? ILOpCode.Call : ILOpCode.Callvirt);
+            this.il.Token(getterHandle);
+            return;
         }
+
+        EntityHandle fieldHandle;
+        var fieldContainer = ResolveFieldReferenceContainer(
+            field.DeclaringType as StructSymbol,
+            receiverType as StructSymbol,
+            field.Field);
+        if (fieldContainer != null)
+        {
+            fieldHandle = this.outer.userTokens.ResolveFieldToken(fieldContainer, field.Field);
+        }
+        else if (this.outer.cache.StructFieldDefs.TryGetValue(field.Field, out var fieldDefinition))
+        {
+            fieldHandle = fieldDefinition;
+        }
+        else
+        {
+            throw new InvalidOperationException(
+                $"Property pattern field '{field.Field.Name}' has no emitted field token.");
+        }
+
+        loadReceiver();
+        this.il.OpCode(ILOpCode.Ldfld);
+        this.il.Token(fieldHandle);
     }
 
     private void EmitRelationalPattern(BoundRelationalPattern rp, Action loadValue, LabelHandle failLabel)

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Patterns.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Patterns.cs
@@ -329,16 +329,21 @@ internal sealed partial class MethodBodyEmitter
 
     private void EmitPropertyPattern(BoundPropertyPattern pp, Action loadValue, TypeSymbol valueType, LabelHandle failLabel)
     {
-        var inputSlot = this.locals[pp.InputVariable];
-        loadValue();
-        this.il.StoreLocal(inputSlot);
+        int? receiverSlot = null;
+        if (pp.InputVariable != null)
+        {
+            receiverSlot = this.locals[pp.InputVariable];
+            loadValue();
+            this.il.StoreLocal(receiverSlot.Value);
+        }
 
-        var receiverSlot = inputSlot;
         var receiverType = valueType;
         if (valueType is NullableTypeSymbol nullableValueType)
         {
             if (NullableLifting.IsAnyValueTypeNullable(nullableValueType))
             {
+                var inputSlot = receiverSlot
+                    ?? throw new InvalidOperationException("Nullable value property pattern requires an input slot.");
                 this.il.LoadLocal(inputSlot);
                 this.il.OpCode(ILOpCode.Box);
                 this.il.Token(this.outer.memberRefs.GetElementTypeToken(nullableValueType));
@@ -360,11 +365,19 @@ internal sealed partial class MethodBodyEmitter
                     this.il.Token(this.outer.wellKnown.GetNullableGetValueOrDefaultReference(underlyingClr));
                 }
 
-                this.il.StoreLocal(receiverSlot);
+                this.il.StoreLocal(receiverSlot.Value);
             }
             else
             {
-                this.il.LoadLocal(inputSlot);
+                if (receiverSlot.HasValue)
+                {
+                    this.il.LoadLocal(receiverSlot.Value);
+                }
+                else
+                {
+                    loadValue();
+                }
+
                 this.il.Branch(ILOpCode.Brfalse, failLabel);
             }
 
@@ -374,13 +387,30 @@ internal sealed partial class MethodBodyEmitter
         {
             // Recursive patterns reject null even when the source annotation is
             // non-nullable; runtime values can still arrive from oblivious code.
-            this.il.LoadLocal(inputSlot);
+            if (receiverSlot.HasValue)
+            {
+                this.il.LoadLocal(receiverSlot.Value);
+            }
+            else
+            {
+                loadValue();
+            }
+
             this.il.Branch(ILOpCode.Brfalse, failLabel);
         }
 
-        Action loadReceiver = ReflectionMetadataEmitter.IsValueTypeSymbol(receiverType)
-            ? () => this.il.LoadLocalAddress(receiverSlot)
-            : () => this.il.LoadLocal(receiverSlot);
+        Action loadReceiver;
+        if (receiverSlot.HasValue)
+        {
+            var slot = receiverSlot.Value;
+            loadReceiver = ReflectionMetadataEmitter.IsValueTypeSymbol(receiverType)
+                ? () => this.il.LoadLocalAddress(slot)
+                : () => this.il.LoadLocal(slot);
+        }
+        else
+        {
+            loadReceiver = loadValue;
+        }
 
         if (receiverType is TupleTypeSymbol tupleType)
         {
@@ -392,37 +422,38 @@ internal sealed partial class MethodBodyEmitter
             foreach (var field in pp.Fields)
             {
                 var fieldName = field.Field.Name;
-                if (tupleClr == null)
+                Action loadTupleChild = () =>
                 {
-                    var index = int.Parse(
-                        fieldName.AsSpan("Item".Length),
-                        System.Globalization.CultureInfo.InvariantCulture) - 1;
-                    this.EmitSymbolicTupleElementAccess(
-                        tupleType,
-                        index,
-                        loadReceiver,
-                        takeRestAddress: false);
-                }
-                else
-                {
-                    loadReceiver();
-                    this.il.OpCode(ILOpCode.Ldfld);
-                    if (tupleClr.IsConstructedGenericType)
+                    if (tupleClr == null)
                     {
-                        this.il.Token(this.outer.memberRefs.GetFieldReferenceOnConstructedGeneric(tupleClr, fieldName));
+                        var index = int.Parse(
+                            fieldName.AsSpan("Item".Length),
+                            System.Globalization.CultureInfo.InvariantCulture) - 1;
+                        this.EmitSymbolicTupleElementAccess(
+                            tupleType,
+                            index,
+                            loadReceiver,
+                            takeRestAddress: false);
                     }
                     else
                     {
-                        var clrField = tupleClr.GetField(fieldName)
-                            ?? throw new InvalidOperationException(
-                                $"ValueTuple type '{tupleClr.FullName}' has no public field '{fieldName}'.");
-                        this.il.Token(this.outer.memberRefs.GetFieldReference(clrField));
+                        loadReceiver();
+                        this.il.OpCode(ILOpCode.Ldfld);
+                        if (tupleClr.IsConstructedGenericType)
+                        {
+                            this.il.Token(this.outer.memberRefs.GetFieldReferenceOnConstructedGeneric(tupleClr, fieldName));
+                        }
+                        else
+                        {
+                            var clrField = tupleClr.GetField(fieldName)
+                                ?? throw new InvalidOperationException(
+                                    $"ValueTuple type '{tupleClr.FullName}' has no public field '{fieldName}'.");
+                            this.il.Token(this.outer.memberRefs.GetFieldReference(clrField));
+                        }
                     }
-                }
+                };
 
-                var memberSlot = this.locals[field.ValueVariable];
-                this.il.StoreLocal(memberSlot);
-                this.EmitPattern(field.Pattern, () => this.il.LoadLocal(memberSlot), field.Type, failLabel);
+                this.EmitPattern(field.Pattern, loadTupleChild, field.Type, failLabel);
             }
 
             return;
@@ -430,10 +461,18 @@ internal sealed partial class MethodBodyEmitter
 
         foreach (var field in pp.Fields)
         {
-            this.EmitPropertyPatternMember(field, receiverType, loadReceiver);
-            var memberSlot = this.locals[field.ValueVariable];
-            this.il.StoreLocal(memberSlot);
-            this.EmitPattern(field.Pattern, () => this.il.LoadLocal(memberSlot), field.Type, failLabel);
+            if (field.IsProperty)
+            {
+                this.EmitPropertyPatternMember(field, receiverType, loadReceiver);
+                var memberSlot = this.locals[field.ValueVariable];
+                this.il.StoreLocal(memberSlot);
+                this.EmitPattern(field.Pattern, () => this.il.LoadLocal(memberSlot), field.Type, failLabel);
+            }
+            else
+            {
+                Action loadMember = () => this.EmitPropertyPatternMember(field, receiverType, loadReceiver);
+                this.EmitPattern(field.Pattern, loadMember, field.Type, failLabel);
+            }
         }
     }
 

--- a/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
@@ -650,7 +650,11 @@ internal sealed class SlotPlanner
 
                     break;
                 case BoundPropertyPattern pp:
-                    AllocatePatternLocal(pp.InputVariable, locals, localTypes);
+                    if (pp.InputVariable != null)
+                    {
+                        AllocatePatternLocal(pp.InputVariable, locals, localTypes);
+                    }
+
                     if (pp.UnwrappedVariable != null)
                     {
                         AllocatePatternLocal(pp.UnwrappedVariable, locals, localTypes);
@@ -658,7 +662,11 @@ internal sealed class SlotPlanner
 
                     foreach (var field in pp.Fields)
                     {
-                        AllocatePatternLocal(field.ValueVariable, locals, localTypes);
+                        if (field.ValueVariable != null)
+                        {
+                            AllocatePatternLocal(field.ValueVariable, locals, localTypes);
+                        }
+
                         AllocatePatternBindings(field.Pattern, locals, localTypes, typePatternScratchSlots);
                     }
 

--- a/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
@@ -650,8 +650,15 @@ internal sealed class SlotPlanner
 
                     break;
                 case BoundPropertyPattern pp:
+                    AllocatePatternLocal(pp.InputVariable, locals, localTypes);
+                    if (pp.UnwrappedVariable != null)
+                    {
+                        AllocatePatternLocal(pp.UnwrappedVariable, locals, localTypes);
+                    }
+
                     foreach (var field in pp.Fields)
                     {
+                        AllocatePatternLocal(field.ValueVariable, locals, localTypes);
                         AllocatePatternBindings(field.Pattern, locals, localTypes, typePatternScratchSlots);
                     }
 
@@ -686,6 +693,18 @@ internal sealed class SlotPlanner
                 case BoundNotPattern np:
                     AllocatePatternBindings(np.Pattern, locals, localTypes, typePatternScratchSlots);
                     break;
+            }
+        }
+
+        private static void AllocatePatternLocal(
+            LocalVariableSymbol variable,
+            Dictionary<VariableSymbol, int> locals,
+            List<TypeSymbol> localTypes)
+        {
+            if (!locals.ContainsKey(variable))
+            {
+                locals[variable] = localTypes.Count;
+                localTypes.Add(variable.Type);
             }
         }
     }

--- a/src/Core/CodeAnalysis/Evaluator.Concurrency.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Concurrency.cs
@@ -137,31 +137,38 @@ public sealed partial class Evaluator
                 return true;
             case BoundNodeKind.PropertyPattern:
                 var property = (BoundPropertyPattern)pattern;
-                if (value is not StructValue sv)
+                if (value == null)
                 {
-                    // Issue #1887: a positional pattern over a raw tuple lowers
-                    // to a property pattern keyed on Item1..ItemN. Tuple values
-                    // are CLR ValueTuple instances (arity 2-7) or object[].
-                    if (value != null && property.Type is TupleTypeSymbol)
-                    {
-                        foreach (var tupleField in property.Fields)
-                        {
-                            var tupleFieldValue = GetTupleFieldValue(value, tupleField.Field.Name);
-                            if (!TryMatchPattern(tupleField.Pattern, tupleFieldValue, outBindings))
-                            {
-                                return false;
-                            }
-                        }
+                    return false;
+                }
 
-                        return true;
+                // Issue #1887: a positional pattern over a raw tuple lowers
+                // to a property pattern keyed on Item1..ItemN. Tuple values
+                // are CLR ValueTuple instances (arity 2-7) or object[].
+                var propertyType = property.Type is NullableTypeSymbol nullablePropertyType
+                    ? nullablePropertyType.UnderlyingType
+                    : property.Type;
+                if (propertyType is TupleTypeSymbol)
+                {
+                    foreach (var tupleField in property.Fields)
+                    {
+                        var tupleFieldValue = GetTupleFieldValue(value, tupleField.Field.Name);
+                        if (!TryMatchPattern(tupleField.Pattern, tupleFieldValue, outBindings))
+                        {
+                            return false;
+                        }
                     }
 
-                    return false;
+                    return true;
                 }
 
                 foreach (var field in property.Fields)
                 {
-                    sv.Fields.TryGetValue(field.Property?.Name ?? field.Field.Name, out var fieldValue);
+                    if (!TryEvaluatePropertyPatternMember(property, field, value, out var fieldValue))
+                    {
+                        return false;
+                    }
+
                     if (!TryMatchPattern(field.Pattern, fieldValue, outBindings))
                     {
                         return false;
@@ -274,6 +281,65 @@ public sealed partial class Evaluator
             default:
                 throw new EvaluatorException($"Unexpected pattern node {pattern.Kind}.", pattern);
         }
+    }
+
+    private bool TryEvaluatePropertyPatternMember(
+        BoundPropertyPattern pattern,
+        BoundPropertyPatternField field,
+        object receiver,
+        out object value)
+    {
+        var receiverType = pattern.Type is NullableTypeSymbol nullable
+            ? nullable.UnderlyingType
+            : pattern.Type;
+
+        if (field.ClrMember != null)
+        {
+            value = EvaluateClrMemberAccess(field.ClrMember, receiver, receiverType, field);
+            return true;
+        }
+
+        if (field.Property != null)
+        {
+            if (receiver is not StructValue
+                && field.DeclaringType is StructSymbol { ClrType: Type clrType })
+            {
+                var clrProperty = ClrTypeUtilities.SafeGetPropertyIncludingInterfaces(
+                    clrType,
+                    field.Property.Name,
+                    BindingFlags.Public | BindingFlags.Instance);
+                if (clrProperty != null)
+                {
+                    value = EvaluateClrMemberAccess(clrProperty, receiver, field.DeclaringType, field);
+                    return true;
+                }
+            }
+
+            value = EvaluateUserPropertyValue(field.Property, receiver);
+            return true;
+        }
+
+        if (receiver is StructValue structValue)
+        {
+            structValue.Fields.TryGetValue(field.Field.Name, out value);
+            return true;
+        }
+
+        if (field.DeclaringType is StructSymbol { ClrType: Type fieldClrType })
+        {
+            var clrField = ClrTypeUtilities.SafeGetFieldIncludingInterfaces(
+                fieldClrType,
+                field.Field.Name,
+                BindingFlags.Public | BindingFlags.Instance);
+            if (clrField != null)
+            {
+                value = EvaluateClrMemberAccess(clrField, receiver, field.DeclaringType, field);
+                return true;
+            }
+        }
+
+        value = null;
+        return false;
     }
 
     private static bool MatchesType(TypeSymbol targetType, object value)

--- a/src/Core/CodeAnalysis/Evaluator.Expressions.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Expressions.cs
@@ -1581,6 +1581,19 @@ public sealed partial class Evaluator
             return nullableResult;
         }
 
+        return EvaluateClrMemberAccess(
+            node.Member,
+            receiver,
+            node.Receiver?.Type ?? node.StaticContainerType,
+            node);
+    }
+
+    private object EvaluateClrMemberAccess(
+        System.Reflection.MemberInfo sourceMember,
+        object receiver,
+        TypeSymbol symbolicReceiverType,
+        BoundNode node)
+    {
         receiver = UnwrapClrReceiver(receiver);
 
         // Issue #608: when the receiver is a StructValue (a G# class instance)
@@ -1588,7 +1601,7 @@ public sealed partial class Evaluator
         // field (the #573/#606 field-satisfies-property contract), reflection
         // cannot invoke the interface property on the StructValue. Route the
         // read through the struct's field dictionary instead.
-        if (receiver is StructValue sv && TryReadStructFieldForClrMember(sv, node.Member, out var fieldValue))
+        if (receiver is StructValue sv && TryReadStructFieldForClrMember(sv, sourceMember, out var fieldValue))
         {
             return fieldValue;
         }
@@ -1599,8 +1612,8 @@ public sealed partial class Evaluator
         // from `int[].GetEnumerator()`) fails because the receiver doesn't
         // implement `IEnumerator<object>`. Route through the matching
         // closed-generic interface on the receiver's runtime type.
-        var runtimeType = ResolveRuntimeClrType(node.Receiver?.Type ?? node.StaticContainerType);
-        var member = ResolvePropertyOrFieldForReceiver(node.Member, receiver, runtimeType);
+        var runtimeType = ResolveRuntimeClrType(symbolicReceiverType);
+        var member = ResolvePropertyOrFieldForReceiver(sourceMember, receiver, runtimeType);
 
         // concurrency: see TryGetInterpreterMapLock — routes `m.Count`,
         // `m.Keys`, `m.Values`, etc. through the same per-map lock as
@@ -2073,14 +2086,18 @@ public sealed partial class Evaluator
         }
 
         var receiverValue = EvaluateExpression(node.Receiver);
+        return EvaluateUserPropertyValue(node.Property, receiverValue);
+    }
 
+    private object EvaluateUserPropertyValue(PropertySymbol sourceProperty, object receiverValue)
+    {
         // Issue #1235 / issue #1068: when the statically-bound property is
         // declared on an interface (or, for a constrained type parameter, on the
         // constraint type), resolve the concrete property implementation from
         // the receiver's runtime type so the read dispatches virtually — the
         // interpreter analogue of `callvirt get_X`. Walking the base chain also
         // honours property overrides.
-        var property = node.Property;
+        var property = sourceProperty;
         if (receiverValue is StructValue concreteSv && concreteSv.StructType != null)
         {
             for (var t = concreteSv.StructType; t != null; t = t.BaseClass)

--- a/test/Compiler.Tests/Emit/Issue3091PropertyPatternPropertiesTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3091PropertyPatternPropertiesTests.cs
@@ -1,0 +1,196 @@
+// <copyright file="Issue3091PropertyPatternPropertiesTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>Runtime and ILVerify coverage for issue #3091.</summary>
+public sealed class Issue3091PropertyPatternPropertiesTests
+{
+    [Fact]
+    public void IssueRepro_PropertiesAndNestedNullableProperty_ReturnOneTwoZero()
+    {
+        const string Source = """
+            package Issue3091
+            import System
+            import System.Collections.Generic
+
+            class Message {
+                prop Role string { get; init; }
+                prop Calls IReadOnlyList[string]? { get; init; }
+            }
+
+            func Classify(message Message) int32 {
+                return switch message {
+                    case { Role: "tool" }: 1
+                    case { Calls: { Count: > 0 } }: 2
+                    default: 0
+                }
+            }
+
+            let calls = List[string]()
+            calls.Add("invoke")
+            Console.WriteLine(Classify(Message{Role: "tool", Calls: nil}))
+            Console.WriteLine(Classify(Message{Role: "assistant", Calls: calls}))
+            Console.WriteLine(Classify(Message{Role: "assistant", Calls: nil}))
+            """;
+
+        Assert.Equal("1\n2\n0\n", CompileAndRun(Source));
+    }
+
+    [Fact]
+    public void GetterDispatchSingleEvaluationAndNullShortCircuit_VerifyAndRun()
+    {
+        const string Source = """
+            package Issue3091.Semantics
+            import System
+
+            class Counter {
+                shared {
+                    var Reads int32
+                }
+            }
+
+            open class BaseProbe {
+                open prop Value int32 {
+                    get {
+                        Counter.Reads += 1
+                        return 1
+                    }
+                }
+            }
+
+            class DerivedProbe : BaseProbe {
+                override prop Value int32 {
+                    get {
+                        Counter.Reads += 1
+                        return 5
+                    }
+                }
+            }
+
+            struct Payload {
+                prop Count int32 { get -> 2 }
+            }
+
+            class Holder {
+                prop Child BaseProbe? { get; init; }
+                prop Item Payload? { get; init; }
+            }
+
+            func MatchProbe(value BaseProbe) int32 {
+                return switch value {
+                    case { Value: > 0 and < 10 }: 1
+                    default: 0
+                }
+            }
+
+            func MatchHolder(value Holder) int32 {
+                return switch value {
+                    case { Child: { Value: > 0 } }: 1
+                    default: 0
+                }
+            }
+
+            func MatchDiscard(value BaseProbe) int32 {
+                return switch value {
+                    case { Value: _ }: 1
+                    default: 0
+                }
+            }
+
+            func MatchPayload(value Holder) int32 {
+                return switch value {
+                    case { Item: { Count: 2 } }: 1
+                    default: 0
+                }
+            }
+
+            Console.WriteLine(MatchProbe(DerivedProbe{}))
+            Console.WriteLine(Counter.Reads)
+            Console.WriteLine(MatchDiscard(DerivedProbe{}))
+            Console.WriteLine(Counter.Reads)
+            Console.WriteLine(MatchHolder(Holder{Child: nil, Item: nil}))
+            Console.WriteLine(Counter.Reads)
+            Console.WriteLine(MatchPayload(Holder{Child: nil, Item: Payload{}}))
+            Console.WriteLine(MatchPayload(Holder{Child: nil, Item: nil}))
+            """;
+
+        Assert.Equal("1\n1\n1\n2\n0\n2\n1\n0\n", CompileAndRun(Source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            nameof(Issue3091PropertyPatternPropertiesTests),
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            var sourcePath = Path.Combine(directory, "test.gs");
+            var outputPath = Path.Combine(directory, "test.dll");
+            File.WriteAllText(sourcePath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var previousOut = Console.Out;
+            var previousErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int exitCode;
+            try
+            {
+                exitCode = Program.Main(
+                [
+                    "/out:" + outputPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    sourcePath,
+                ]);
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+                Console.SetError(previousErr);
+            }
+
+            Assert.True(
+                exitCode == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            IlVerifier.Verify(outputPath);
+
+            var startInfo = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = directory,
+            };
+            startInfo.ArgumentList.Add("exec");
+            startInfo.ArgumentList.Add("--runtimeconfig");
+            startInfo.ArgumentList.Add(Path.ChangeExtension(outputPath, ".runtimeconfig.json"));
+            startInfo.ArgumentList.Add(outputPath);
+
+            using var process = Process.Start(startInfo)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec.");
+            var stdout = process.StandardOutput.ReadToEnd();
+            var stderr = process.StandardError.ReadToEnd();
+            Assert.True(process.WaitForExit(30_000), "dotnet exec timed out.");
+            Assert.True(
+                process.ExitCode == 0,
+                $"exited {process.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3091PropertyPatternPropertyTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3091PropertyPatternPropertyTests.cs
@@ -1,0 +1,241 @@
+// <copyright file="Issue3091PropertyPatternPropertyTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>Binder and interpreter coverage for issue #3091.</summary>
+public sealed class Issue3091PropertyPatternPropertyTests
+{
+    [Fact]
+    public void ReadableProperties_BindAcrossUserAndImportedInheritance()
+    {
+        const string Source = """
+            import System.Collections.Generic
+
+            open class BaseMessage {
+                prop Role string { get -> "tool" }
+            }
+
+            class Message : BaseMessage {
+                prop Calls IReadOnlyList[string]? { get; init; }
+            }
+
+            func Classify(message Message) int32 {
+                return switch message {
+                    case { Role: "tool" }: 1
+                    case { Calls: { Count: > 0 } }: 2
+                    default: 0
+                }
+            }
+            """;
+
+        Assert.Empty(Bind(Source));
+    }
+
+    [Fact]
+    public void StaticWriteOnlyAndIndexerProperties_AreNotPatternMembers()
+    {
+        const string Source = """
+            class StaticOnly {
+                shared {
+                    prop Value int32 { get -> 1 }
+                }
+            }
+
+            class WriteOnly {
+                prop Value int32 { set { } }
+            }
+
+            class Indexed {
+                prop this[i int32] int32 { get -> i }
+            }
+
+            let staticOnly = StaticOnly{}
+            let writeOnly = WriteOnly{}
+            let indexed = Indexed{}
+            let a = switch staticOnly { case { Value: _ }: 1 default: 0 }
+            let b = switch writeOnly { case { Value: _ }: 1 default: 0 }
+            let c = switch indexed { case { Item: _ }: 1 default: 0 }
+            """;
+
+        var diagnostics = Bind(Source);
+        Assert.True(
+            diagnostics.Count(diagnostic => diagnostic.Id == "GS0173") == 3,
+            string.Join(System.Environment.NewLine, diagnostics.Select(diagnostic => diagnostic.ToString())));
+    }
+
+    [Fact]
+    public void ComputedProperty_IsEvaluatedOnceForCompoundSubpattern()
+    {
+        AssertEvaluates(
+            """
+            class Probe {
+                var Reads int32
+                prop Value int32 {
+                    get {
+                        this.Reads += 1
+                        return 5
+                    }
+                }
+            }
+
+            let probe = Probe{}
+            let result = switch probe {
+                case { Value: > 0 and < 10 }: 10
+                default: 0
+            }
+            result + probe.Reads
+            """,
+            11);
+    }
+
+    [Fact]
+    public void DiscardSubpattern_StillEvaluatesGetterOnce()
+    {
+        AssertEvaluates(
+            """
+            class Probe {
+                var Reads int32
+                prop Value int32 {
+                    get {
+                        this.Reads += 1
+                        return 5
+                    }
+                }
+            }
+
+            let probe = Probe{}
+            let result = switch probe {
+                case { Value: _ }: 10
+                default: 0
+            }
+            result + probe.Reads
+            """,
+            11);
+    }
+
+    [Fact]
+    public void NullNestedProperty_ShortCircuitsBeforeGetter()
+    {
+        AssertEvaluates(
+            """
+            class Counter {
+                shared {
+                    var Reads int32
+                }
+            }
+
+            class Child {
+                prop Count int32 {
+                    get {
+                        Counter.Reads += 1
+                        return 1
+                    }
+                }
+            }
+
+            class Holder {
+                prop Child Child? { get; init; }
+            }
+
+            let holder = Holder{Child: nil}
+            let result = switch holder {
+                case { Child: { Count: > 0 } }: 1
+                default: 0
+            }
+            result + Counter.Reads
+            """,
+            0);
+    }
+
+    [Fact]
+    public void ImportedInheritedProperty_EvaluatesThroughNullableUserProperty()
+    {
+        AssertEvaluates(
+            """
+            import System.Collections.Generic
+
+            class Message {
+                prop Calls IReadOnlyList[string]? { get; init; }
+            }
+
+            func Match(message Message) int32 {
+                return switch message {
+                    case { Calls: { Count: > 0 } }: 1
+                    default: 0
+                }
+            }
+
+            let calls = List[string]()
+            calls.Add("invoke")
+            let present = Match(Message{Calls: calls})
+            let missing = Match(Message{Calls: nil})
+            present * 10 + missing
+            """,
+            10);
+    }
+
+    [Fact]
+    public void NullableValueProperty_UnwrapsBeforeNestedPattern()
+    {
+        AssertEvaluates(
+            """
+            struct Payload {
+                prop Count int32 { get -> 2 }
+            }
+
+            class Holder {
+                prop Item Payload? { get; init; }
+            }
+
+            func Match(holder Holder) int32 {
+                return switch holder {
+                    case { Item: { Count: 2 } }: 1
+                    default: 0
+                }
+            }
+
+            let present = Match(Holder{Item: Payload{}})
+            let missing = Match(Holder{Item: nil})
+            present * 10 + missing
+            """,
+            10);
+    }
+
+    private static void AssertEvaluates(string source, object expected)
+    {
+        var result = new Compilation(SyntaxTree.Parse(SourceText.From(source)))
+            .Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(expected, result.Value);
+    }
+
+    private static ImmutableArray<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        if (tree.Diagnostics.Any())
+        {
+            return tree.Diagnostics;
+        }
+
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+        if (globalScope.Diagnostics.Any())
+        {
+            return globalScope.Diagnostics;
+        }
+
+        return Binder.BindProgram(globalScope).Diagnostics.ToImmutableArray();
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/PatternTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/PatternTests.cs
@@ -43,7 +43,7 @@ class User { var Name string }
 let u = User{Name: ""x""}
 let x = switch u { case { Missing: 1 }: 1 default: 0 }
 ");
-        Assert.Contains(diagnostics, d => d.Message.Contains("does not define a field named 'Missing'", System.StringComparison.Ordinal));
+        Assert.Contains(diagnostics, d => d.Message.Contains("does not define a readable instance field or property named 'Missing'", System.StringComparison.Ordinal));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Bind readable instance properties and fields across user, inherited, interface, and imported CLR types.
- Evaluate each receiver/member once, dispatch getters correctly, and null-guard nullable references plus `Nullable<T>` before nested matching.
- Keep emitter and interpreter behavior aligned; reject static, write-only, and indexer properties.
- Add exact compile/run regression producing `1`, `2`, `0` with ILVerify plus focused getter/nullability tests.

## Tests
- `dotnet test test/Core.Tests/Core.Tests.csproj --no-restore --filter FullyQualifiedName~Pattern`
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj --no-restore --filter FullyQualifiedName~Pattern`
- `dotnet test test/Interpreter.Tests/Interpreter.Tests.csproj --no-restore --filter FullyQualifiedName~Pattern`
- Lowering/record/tuple sibling tests: 7 passed

Fixes #3091