### PR TITLE
[gsc] sequence[T] satisfies IEnumerable[T] interface contracts

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -129,6 +129,15 @@ public sealed class Conversion
             return Conversion.Identity;
         }
 
+        // Issue #3093: sequence[T] is an identity alias, not merely a
+        // reference conversion, for the matching enumerable interface.
+        if (SequenceTypeSymbol.TryGetEnumerableInterfaceShape(from, out _, out _)
+            && SequenceTypeSymbol.TryGetEnumerableInterfaceShape(to, out _, out _)
+            && TypeSymbol.AreRuntimeEquivalentIgnoringReferenceNullability(from, to))
+        {
+            return Conversion.Identity;
+        }
+
         // Issue #2290: a referenced (cross-assembly) type can be independently
         // re-minted into TWO non-reference-equal TypeSymbol wrappers for the
         // SAME underlying CLR type — e.g. an imported `data class`/`data

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Functions.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Functions.cs
@@ -1642,7 +1642,7 @@ internal sealed partial class DeclarationBinder
     /// viable generic match (mismatched arity) so the caller treats it as no
     /// match; returns an empty map when neither method is generic.
     /// </summary>
-    private static IReadOnlyDictionary<TypeParameterSymbol, TypeSymbol> TryBuildMethodTypeParameterMap(
+    internal static IReadOnlyDictionary<TypeParameterSymbol, TypeSymbol> TryBuildMethodTypeParameterMap(
         FunctionSymbol baseMethod,
         FunctionSymbol candidate)
     {
@@ -2412,7 +2412,9 @@ internal sealed partial class DeclarationBinder
     /// arguments. Reference identity is honoured first (covering plain type
     /// parameters, primitives and cached imported types); constructed generics
     /// are then compared by definition and ordered type arguments, recursing
-    /// through slice / array / nullable wrappers. The comparison stays strict —
+    /// through slice / array / nullable wrappers. Issue #3093 also projects
+    /// <c>sequence[T]</c> and <c>async sequence[T]</c> onto their matching CLR
+    /// enumerable interface shapes. The comparison stays strict —
     /// distinct type arguments (e.g. <c>IEnumerator[int32]</c> vs
     /// <c>IEnumerator[T]</c>) are not equated — so genuinely mismatched
     /// signatures are still rejected with GS0187.
@@ -2453,6 +2455,22 @@ internal sealed partial class DeclarationBinder
         if (a == null || b == null)
         {
             return false;
+        }
+
+        var aIsSequence = SequenceTypeSymbol.TryGetEnumerableInterfaceShape(
+            a,
+            out var aSequenceDefinition,
+            out var aSequenceElement);
+        var bIsSequence = SequenceTypeSymbol.TryGetEnumerableInterfaceShape(
+            b,
+            out var bSequenceDefinition,
+            out var bSequenceElement);
+        if (aIsSequence || bIsSequence)
+        {
+            return aIsSequence
+                && bIsSequence
+                && ClrTypeUtilities.AreSame(aSequenceDefinition, bSequenceDefinition)
+                && TypeSignaturesEquivalent(aSequenceElement, bSequenceElement, typeParamMap);
         }
 
         if (a is StructSymbol sa && b is StructSymbol sb)

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -4564,19 +4564,20 @@ internal sealed class MemberLookup
         // with the symbolic arguments at each nested position (mirrors the
         // #974 `InterfaceSymbol.SubstituteType` recursion on the G# path).
         if (openType.IsConstructedGenericType
-            && candidate is ImportedTypeSymbol importedCandidate
-            && importedCandidate.OpenDefinition != null
-            && !importedCandidate.TypeArguments.IsDefaultOrEmpty)
+            && TryGetSymbolicConstructedGenericShape(
+                candidate,
+                out var candidateOpenDefinition,
+                out var candidateTypeArguments))
         {
             var openDefinition = openType.GetGenericTypeDefinition();
-            if (importedCandidate.OpenDefinition.IsSameAs(openDefinition))
+            if (candidateOpenDefinition.IsSameAs(openDefinition))
             {
                 var openArgs = openType.GetGenericArguments();
-                if (openArgs.Length == importedCandidate.TypeArguments.Length)
+                if (openArgs.Length == candidateTypeArguments.Length)
                 {
                     for (var i = 0; i < openArgs.Length; i++)
                     {
-                        if (!ParameterTypeMatchesSubstituted(importedCandidate.TypeArguments[i], openArgs[i], symbolicArgs))
+                        if (!ParameterTypeMatchesSubstituted(candidateTypeArguments[i], openArgs[i], symbolicArgs))
                         {
                             return false;
                         }
@@ -4592,6 +4593,34 @@ internal sealed class MemberLookup
         // Non-generic contract position — compare against the CLR-projected
         // effective type, exactly as the erased path does.
         return ClrTypeUtilities.AreSame(NullableLifting.GetEffectiveClrType(candidate), openType);
+    }
+
+    private static bool TryGetSymbolicConstructedGenericShape(
+        TypeSymbol candidate,
+        out Type openDefinition,
+        out ImmutableArray<TypeSymbol> typeArguments)
+    {
+        if (candidate is ImportedTypeSymbol imported
+            && imported.OpenDefinition != null
+            && !imported.TypeArguments.IsDefaultOrEmpty)
+        {
+            openDefinition = imported.OpenDefinition;
+            typeArguments = imported.TypeArguments;
+            return true;
+        }
+
+        if (SequenceTypeSymbol.TryGetEnumerableInterfaceShape(
+            candidate,
+            out openDefinition,
+            out var elementType))
+        {
+            typeArguments = ImmutableArray.Create(elementType);
+            return true;
+        }
+
+        openDefinition = null;
+        typeArguments = default;
+        return false;
     }
 
     private static bool SameTypeSymbol(TypeSymbol a, TypeSymbol b)
@@ -5527,20 +5556,21 @@ internal sealed class MemberLookup
         // delegate-Invoke-shape branch above, generalized to any generic
         // type rather than just delegates.
         if (openType.IsConstructedGenericType
-            && candidate is ImportedTypeSymbol named
-            && named.OpenDefinition != null
-            && !named.TypeArguments.IsDefaultOrEmpty
-            && ClrTypeUtilities.AreSame(openType.GetGenericTypeDefinition(), named.OpenDefinition))
+            && TryGetSymbolicConstructedGenericShape(
+                candidate,
+                out var candidateOpenDefinition,
+                out var candidateTypeArguments)
+            && ClrTypeUtilities.AreSame(openType.GetGenericTypeDefinition(), candidateOpenDefinition))
         {
             var openArgs = openType.GetGenericArguments();
-            if (openArgs.Length != named.TypeArguments.Length)
+            if (openArgs.Length != candidateTypeArguments.Length)
             {
                 return false;
             }
 
             for (var i = 0; i < openArgs.Length; i++)
             {
-                if (!ClrParamTypeMatchesGenericMethodParam(named.TypeArguments[i], openArgs[i], methodGenericParams, candidateTypeParams))
+                if (!ClrParamTypeMatchesGenericMethodParam(candidateTypeArguments[i], openArgs[i], methodGenericParams, candidateTypeParams))
                 {
                     return false;
                 }

--- a/src/Core/CodeAnalysis/Emit/MethodInfoHelpers.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodInfoHelpers.cs
@@ -115,19 +115,6 @@ internal static class MethodInfoHelpers
 
         if (!structSym.ImplementedClrInterfaces.IsDefaultOrEmpty)
         {
-            var callable = CallableParameters(method);
-
-            // Issue #2380: use the effective (runtime-shape) CLR type, not the
-            // raw `ClrType` — `NullableTypeSymbol.ClrType` deliberately returns
-            // the *underlying* (unwrapped) type for a value-typed `T?` (see
-            // `NullableLifting.GetEffectiveClrType`'s remarks), so a struct
-            // method whose return or parameter type is `Nullable<T>` never
-            // matched an imported interface method of the same shape and was
-            // never promoted to Virtual|NewSlot via `RequiresVirtualOnValueType`
-            // (ILVerify: "Class implements interface but not method"). The
-            // binder-side `MemberLookup.ClrParamTypeMatchesGenericMethodParam`
-            // already gets this right; this brings the emitter in line with it.
-            var returnClr = NullableLifting.GetEffectiveClrType(method.Type);
             foreach (var ifaceSym in structSym.ImplementedClrInterfaces)
             {
                 // Issue #949: a CLR generic interface closed over a user G# type
@@ -167,43 +154,7 @@ internal static class MethodInfoHelpers
                         continue;
                     }
 
-                    var clrParams = clrMethod.GetParameters();
-                    if (clrParams.Length != callable.Length)
-                    {
-                        continue;
-                    }
-
-                    // Issue #1071: an `async func` implementing a CLR interface
-                    // method declared with an explicit `Task` / `Task[T]` return
-                    // type has a declared (awaited) CLR return of void / T.
-                    // Compare the contract's unwrapped awaited result.
-                    if (method.IsAsync
-                        && AsyncReturnTypeNormalizer.TryUnwrapTaskClrType(clrMethod.ReturnType, out var awaitedClr))
-                    {
-                        if (returnClr != null && !ClrTypeUtilities.AreSame(returnClr, awaitedClr))
-                        {
-                            continue;
-                        }
-                    }
-                    else if (returnClr != null && !ClrTypeUtilities.AreSame(returnClr, clrMethod.ReturnType))
-                    {
-                        continue;
-                    }
-
-                    var allMatch = true;
-                    for (var i = 0; i < clrParams.Length; i++)
-                    {
-                        // Issue #2380: same effective-CLR-type fix as `returnClr`
-                        // above, applied per-parameter (e.g. `Find(Guid? id)`).
-                        var paramClr = NullableLifting.GetEffectiveClrType(callable[i].Type);
-                        if (paramClr == null || !ClrTypeUtilities.AreSame(paramClr, clrParams[i].ParameterType))
-                        {
-                            allMatch = false;
-                            break;
-                        }
-                    }
-
-                    if (allMatch)
+                    if (MemberLookup.MethodMatchesClrSignature(method, clrMethod))
                     {
                         return true;
                     }
@@ -223,7 +174,12 @@ internal static class MethodInfoHelpers
     /// <returns>True if the signatures are equivalent.</returns>
     public static bool MethodSignaturesMatch(FunctionSymbol interfaceMethod, FunctionSymbol implementationMethod)
     {
-        if (interfaceMethod.Name != implementationMethod.Name || !ReturnTypesMatch(interfaceMethod, implementationMethod))
+        var typeParameterMap = DeclarationBinder.TryBuildMethodTypeParameterMap(
+            interfaceMethod,
+            implementationMethod);
+        if (typeParameterMap == null
+            || interfaceMethod.Name != implementationMethod.Name
+            || !ReturnTypesMatch(interfaceMethod, implementationMethod, typeParameterMap))
         {
             return false;
         }
@@ -237,7 +193,10 @@ internal static class MethodInfoHelpers
 
         for (var i = 0; i < interfaceParameters.Length; i++)
         {
-            if (interfaceParameters[i].Type != implementationParameters[i].Type)
+            if (!DeclarationBinder.TypeSignaturesEquivalent(
+                interfaceParameters[i].Type,
+                implementationParameters[i].Type,
+                typeParameterMap))
             {
                 return false;
             }
@@ -265,32 +224,38 @@ internal static class MethodInfoHelpers
     /// the implementing async method is promoted to a virtual interface slot at
     /// emit time.
     /// </summary>
-    private static bool ReturnTypesMatch(FunctionSymbol interfaceMethod, FunctionSymbol implementationMethod)
+    private static bool ReturnTypesMatch(
+        FunctionSymbol interfaceMethod,
+        FunctionSymbol implementationMethod,
+        System.Collections.Generic.IReadOnlyDictionary<TypeParameterSymbol, TypeSymbol> typeParameterMap)
     {
         if (AsyncIteratorDetection.IsAsyncIteratorReturnType(interfaceMethod.Type)
             && AsyncIteratorDetection.IsAsyncIteratorReturnType(implementationMethod.Type))
         {
-            return AwaitedTypesMatch(interfaceMethod.Type, implementationMethod.Type);
+            return TypesMatch(interfaceMethod.Type, implementationMethod.Type, typeParameterMap);
         }
 
         if (interfaceMethod.IsAsync == implementationMethod.IsAsync)
         {
-            return ReferenceEquals(interfaceMethod.Type, implementationMethod.Type);
+            return TypesMatch(interfaceMethod.Type, implementationMethod.Type, typeParameterMap);
         }
 
         if (implementationMethod.IsAsync)
         {
             return AsyncReturnTypeNormalizer.TryUnwrapTaskReturnType(interfaceMethod.Type, out var awaited)
-                && AwaitedTypesMatch(awaited, implementationMethod.Type);
+                && TypesMatch(awaited, implementationMethod.Type, typeParameterMap);
         }
 
         return AsyncReturnTypeNormalizer.TryUnwrapTaskReturnType(implementationMethod.Type, out var awaited2)
-            && AwaitedTypesMatch(interfaceMethod.Type, awaited2);
+            && TypesMatch(interfaceMethod.Type, awaited2, typeParameterMap);
     }
 
-    private static bool AwaitedTypesMatch(TypeSymbol a, TypeSymbol b)
+    private static bool TypesMatch(
+        TypeSymbol a,
+        TypeSymbol b,
+        System.Collections.Generic.IReadOnlyDictionary<TypeParameterSymbol, TypeSymbol> typeParameterMap)
     {
-        if (ReferenceEquals(a, b))
+        if (DeclarationBinder.TypeSignaturesEquivalent(a, b, typeParameterMap))
         {
             return true;
         }

--- a/src/Core/CodeAnalysis/Symbols/SequenceTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/SequenceTypeSymbol.cs
@@ -47,6 +47,58 @@ public sealed class SequenceTypeSymbol : TypeSymbol
     /// </summary>
     internal static void ClearCache() => Cache.Clear();
 
+    /// <summary>
+    /// Issue #3093: projects the G# sequence aliases and their CLR interface
+    /// spellings onto one common generic-interface shape.
+    /// </summary>
+    /// <param name="type">The type to inspect.</param>
+    /// <param name="openDefinition">
+    /// The matching <c>IEnumerable&lt;&gt;</c> or
+    /// <c>IAsyncEnumerable&lt;&gt;</c> definition.
+    /// </param>
+    /// <param name="elementType">The symbolic element type.</param>
+    /// <returns><see langword="true"/> when <paramref name="type"/> has a sequence-interface shape.</returns>
+    internal static bool TryGetEnumerableInterfaceShape(
+        TypeSymbol type,
+        out Type openDefinition,
+        out TypeSymbol elementType)
+    {
+        switch (type)
+        {
+            case SequenceTypeSymbol sequence:
+                openDefinition = typeof(IEnumerable<>);
+                elementType = sequence.ElementType;
+                return true;
+            case AsyncSequenceTypeSymbol sequence:
+                openDefinition = typeof(IAsyncEnumerable<>);
+                elementType = sequence.ElementType;
+                return true;
+            case ImportedTypeSymbol imported
+                when imported.OpenDefinition != null
+                    && imported.TypeArguments.Length == 1
+                    && IsEnumerableInterfaceDefinition(imported.OpenDefinition):
+                openDefinition = imported.OpenDefinition;
+                elementType = imported.TypeArguments[0];
+                return true;
+        }
+
+        var clrType = type?.ClrType;
+        if (clrType != null && clrType.IsGenericType && !clrType.IsGenericTypeDefinition)
+        {
+            var definition = clrType.GetGenericTypeDefinition();
+            if (IsEnumerableInterfaceDefinition(definition))
+            {
+                openDefinition = definition;
+                elementType = TypeSymbol.FromClrType(clrType.GetGenericArguments()[0]);
+                return true;
+            }
+        }
+
+        openDefinition = null;
+        elementType = null;
+        return false;
+    }
+
     private static Type MakeClrType(TypeSymbol elementType)
     {
         var elementClrType = NullableTypeSymbol.GetEffectiveClrType(elementType);
@@ -57,4 +109,8 @@ public sealed class SequenceTypeSymbol : TypeSymbol
 
         return typeof(IEnumerable<>).MakeGenericType(elementClrType);
     }
+
+    private static bool IsEnumerableInterfaceDefinition(Type type)
+        => type?.FullName == "System.Collections.Generic.IEnumerable`1"
+            || type?.FullName == "System.Collections.Generic.IAsyncEnumerable`1";
 }

--- a/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
@@ -725,6 +725,24 @@ public class TypeSymbol : Symbol
             return false;
         }
 
+        var leftIsSequence = SequenceTypeSymbol.TryGetEnumerableInterfaceShape(
+            left,
+            out var leftSequenceDefinition,
+            out var leftSequenceElement);
+        var rightIsSequence = SequenceTypeSymbol.TryGetEnumerableInterfaceShape(
+            right,
+            out var rightSequenceDefinition,
+            out var rightSequenceElement);
+        if (leftIsSequence || rightIsSequence)
+        {
+            return leftIsSequence
+                && rightIsSequence
+                && ClrTypeUtilities.AreSame(leftSequenceDefinition, rightSequenceDefinition)
+                && AreRuntimeEquivalentIgnoringReferenceNullability(
+                    leftSequenceElement,
+                    rightSequenceElement);
+        }
+
         if (left is NullableTypeSymbol || right is NullableTypeSymbol)
         {
             var leftNullable = left as NullableTypeSymbol;

--- a/test/Compiler.Tests/Emit/Issue3093SequenceInterfaceContractTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3093SequenceInterfaceContractTests.cs
@@ -1,0 +1,292 @@
+// <copyright file="Issue3093SequenceInterfaceContractTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+public sealed class Issue3093SequenceInterfaceContractTests
+{
+    [Fact]
+    public void UserInterface_IteratorAndExplicitSequence_DispatchRunAndIlVerify()
+    {
+        const string Source = """
+            package Issue3093.User
+            import System
+            import System.Collections.Generic
+
+            func One(value int32) sequence[int32] {
+                yield value
+            }
+
+            interface IDetector {
+                func Detect(text string) IEnumerable[int32];
+                func DetectExplicit(text string) IEnumerable[int32];
+            }
+
+            class Detector : IDetector {
+                func Detect(text string) sequence[int32] {
+                    yield text.Length
+                }
+
+                func DetectExplicit(text string) sequence[int32] {
+                    return One(text.Length)
+                }
+            }
+
+            var detector IDetector = Detector{}
+            for value in detector.Detect("abc") {
+                Console.WriteLine(value)
+            }
+            for value in detector.DetectExplicit("abc") {
+                Console.WriteLine(value)
+            }
+            """;
+
+        WithDirectory(directory =>
+        {
+            var assemblyPath = Compile(Source, directory);
+            Assert.Equal("3\n3\n", Run(assemblyPath));
+
+            var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+            var detector = assembly.GetType("Issue3093.User.Detector");
+            Assert.NotNull(detector);
+            Assert.All(
+                new[] { "Detect", "DetectExplicit" },
+                name => Assert.Equal(
+                    typeof(IEnumerable<int>),
+                    detector!.GetMethod(name, BindingFlags.Public | BindingFlags.Instance)!.ReturnType));
+
+            var stateMachine = detector!.GetNestedTypes(BindingFlags.Public | BindingFlags.NonPublic)
+                .Single(type => type.Name.StartsWith("<Detect>d__", StringComparison.Ordinal));
+            Assert.Contains(typeof(IEnumerable<int>), stateMachine.GetInterfaces());
+            Assert.Contains(typeof(IEnumerator<int>), stateMachine.GetInterfaces());
+        });
+    }
+
+    [Fact]
+    public void UserGenericInterface_ValueTypeIterator_DispatchesAndIlVerifies()
+    {
+        const string Source = """
+            package Issue3093.Generic
+            import System
+            import System.Collections.Generic
+
+            interface IDetector {
+                func Detect[T](value T) IEnumerable[T];
+            }
+
+            struct Detector : IDetector {
+                func Detect[T](value T) sequence[T] {
+                    yield value
+                }
+            }
+
+            var detector IDetector = Detector{}
+            for value in detector.Detect[int32](3) {
+                Console.WriteLine(value)
+            }
+            """;
+
+        WithDirectory(directory =>
+        {
+            var assemblyPath = Compile(Source, directory);
+            Assert.Equal("3\n", Run(assemblyPath));
+        });
+    }
+
+    [Fact]
+    public void ImportedGenericInterface_ValueTypeIterator_DispatchesAndIlVerifies()
+    {
+        const string ContractSource = """
+            #nullable enable
+            using System.Collections.Generic;
+
+            namespace Issue3093.Contracts;
+
+            public interface IDetector
+            {
+                IEnumerable<T> Detect<T>(T value);
+            }
+            """;
+        const string Source = """
+            package Issue3093.Imported
+            import System
+            import Issue3093.Contracts
+
+            struct Detector : IDetector {
+                func Detect[T](value T) sequence[T] {
+                    yield value
+                }
+            }
+
+            var detector IDetector = Detector{}
+            for value in detector.Detect[int32](3) {
+                Console.WriteLine(value)
+            }
+            """;
+
+        WithDirectory(directory =>
+        {
+            var contractPath = CompileContract(ContractSource, directory);
+            var assemblyPath = Compile(Source, directory, new[] { contractPath });
+            Assert.Equal("3\n", Run(assemblyPath));
+        });
+    }
+
+    [Fact]
+    public void ImportedConstructedGenericInterface_Iterator_DispatchesAndIlVerifies()
+    {
+        const string ContractSource = """
+            #nullable enable
+            using System.Collections.Generic;
+
+            namespace Issue3093.GenericContracts;
+
+            public interface IDetector<T>
+            {
+                IEnumerable<T> Detect(T value);
+            }
+            """;
+        const string Source = """
+            package Issue3093.ImportedConstructed
+            import System
+            import Issue3093.GenericContracts
+
+            struct Detector[T] : IDetector[T] {
+                func Detect(value T) sequence[T] {
+                    yield value
+                }
+            }
+
+            var detector IDetector[int32] = Detector[int32]{}
+            for value in detector.Detect(3) {
+                Console.WriteLine(value)
+            }
+            """;
+
+        WithDirectory(directory =>
+        {
+            var contractPath = CompileContract(ContractSource, directory);
+            var assemblyPath = Compile(Source, directory, new[] { contractPath });
+            Assert.Equal("3\n", Run(assemblyPath));
+        });
+    }
+
+    private static string Compile(
+        string source,
+        string directory,
+        IReadOnlyCollection<string> additionalReferences = null)
+    {
+        var sourcePath = Path.Combine(directory, "Program.gs");
+        var assemblyPath = Path.Combine(directory, "Issue3093.dll");
+        File.WriteAllText(sourcePath, source);
+
+        var arguments = new List<string>
+        {
+            "/out:" + assemblyPath,
+            "/target:exe",
+            "/targetframework:net10.0",
+        };
+        if (additionalReferences != null)
+        {
+            arguments.AddRange(additionalReferences.Select(path => "/reference:" + path));
+            arguments.AddRange(
+                ReferenceResolver.HostTrustedPlatformAssemblyPaths()
+                    .Select(path => "/reference:" + path));
+            arguments.Add("/nowarn:GS9100");
+        }
+
+        arguments.Add(sourcePath);
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        int exitCode;
+        try
+        {
+            exitCode = Program.Main(arguments.ToArray());
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+
+        Assert.True(exitCode == 0, $"gsc failed:{Environment.NewLine}{stdout}{stderr}");
+        IlVerifier.Verify(assemblyPath, additionalReferences);
+        return assemblyPath;
+    }
+
+    private static string CompileContract(string source, string directory)
+    {
+        var references = ReferenceResolver.HostTrustedPlatformAssemblyPaths()
+            .Select(path => MetadataReference.CreateFromFile(path));
+        var compilation = CSharpCompilation.Create(
+            "GSharp.Issue3093.Contracts",
+            new[] { CSharpSyntaxTree.ParseText(source) },
+            references,
+            new CSharpCompilationOptions(
+                OutputKind.DynamicallyLinkedLibrary,
+                nullableContextOptions: NullableContextOptions.Enable));
+        var path = Path.Combine(directory, "GSharp.Issue3093.Contracts.dll");
+        using var stream = File.Create(path);
+        var result = compilation.Emit(stream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        return path;
+    }
+
+    private static string Run(string assemblyPath)
+    {
+        using var process = Process.Start(new ProcessStartInfo("dotnet")
+        {
+            ArgumentList =
+            {
+                "exec",
+                "--runtimeconfig",
+                Path.ChangeExtension(assemblyPath, ".runtimeconfig.json"),
+                assemblyPath,
+            },
+            WorkingDirectory = Path.GetDirectoryName(assemblyPath),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        });
+        Assert.NotNull(process);
+        var output = process!.StandardOutput.ReadToEnd();
+        var error = process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), "dotnet exec timed out");
+        Assert.True(process.ExitCode == 0, $"exited {process.ExitCode}:{Environment.NewLine}{error}");
+        return output.Replace("\r\n", "\n", StringComparison.Ordinal);
+    }
+
+    private static void WithDirectory(Action<string> action)
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            nameof(Issue3093SequenceInterfaceContractTests),
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            action(directory);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3093SequenceInterfaceBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3093SequenceInterfaceBindingTests.cs
@@ -1,0 +1,150 @@
+// <copyright file="Issue3093SequenceInterfaceBindingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+public sealed class Issue3093SequenceInterfaceBindingTests
+{
+    [Fact]
+    public void GenericIteratorAndExplicitSequence_SatisfyIEnumerableContracts()
+    {
+        const string Source = """
+            import System.Collections.Generic
+
+            func One[T](value T) sequence[T] {
+                yield value
+            }
+
+            interface IDetector {
+                func Iterate[T](value T) IEnumerable[T];
+                func Explicit[T](value T) IEnumerable[T];
+            }
+
+            class Detector : IDetector {
+                func Iterate[T](value T) sequence[T] {
+                    yield value
+                }
+
+                func Explicit[T](value T) sequence[T] {
+                    return One(value)
+                }
+            }
+            """;
+
+        Assert.Empty(Evaluate(Source).Diagnostics);
+    }
+
+    [Fact]
+    public void GenericTypeSequence_SatisfiesConstructedInterfaceContract()
+    {
+        const string Source = """
+            import System.Collections.Generic
+
+            interface IDetector[T] {
+                func Detect(value T) IEnumerable[T];
+            }
+
+            class Detector[T] : IDetector[T] {
+                func Detect(value T) sequence[T] {
+                    yield value
+                }
+            }
+            """;
+
+        Assert.Empty(Evaluate(Source).Diagnostics);
+    }
+
+    [Fact]
+    public void SequenceAndIEnumerable_AreIdentityCompatibleForOpenTypeParameter()
+    {
+        const string Source = """
+            import System.Collections.Generic
+
+            func Adapt[T](values sequence[T]) IEnumerable[T] {
+                return values
+            }
+            """;
+
+        Assert.Empty(Evaluate(Source).Diagnostics);
+    }
+
+    [Fact]
+    public void AsyncSequence_SatisfiesIAsyncEnumerableContract()
+    {
+        const string Source = """
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            interface IDetector {
+                func Detect[T](value T) IAsyncEnumerable[T];
+            }
+
+            class Detector : IDetector {
+                async func Detect[T](value T) sequence[T] {
+                    await Task.Yield()
+                    yield value
+                }
+            }
+            """;
+
+        Assert.Empty(Evaluate(Source).Diagnostics);
+    }
+
+    [Theory]
+    [InlineData("IEnumerable[T]", "async func")]
+    [InlineData("IAsyncEnumerable[T]", "func")]
+    public void SyncAndAsyncSequenceContracts_RemainDistinct(string contractType, string implementationModifier)
+    {
+        var source = $$"""
+            import System.Collections.Generic
+
+            interface IDetector {
+                func Detect[T](value T) {{contractType}};
+            }
+
+            class Detector : IDetector {
+                {{implementationModifier}} Detect[T](value T) sequence[T] {
+                    yield value
+                }
+            }
+            """;
+
+        Assert.Contains(Evaluate(source).Diagnostics, diagnostic => diagnostic.Id == "GS0187");
+    }
+
+    [Fact]
+    public void CovariantElementConversion_DoesNotChangeInterfaceSignatureIdentity()
+    {
+        const string Source = """
+            import System.Collections.Generic
+
+            interface IStrings {
+                func Values() IEnumerable[object];
+            }
+
+            class Strings : IStrings {
+                func Values() sequence[string] {
+                    yield "value"
+                }
+            }
+            """;
+
+        Assert.Contains(Evaluate(Source).Diagnostics, diagnostic => diagnostic.Id == "GS0187");
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}

--- a/test/Interpreter.Tests/Issue3093SequenceInterfaceInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue3093SequenceInterfaceInterpreterTests.cs
@@ -1,0 +1,91 @@
+// <copyright file="Issue3093SequenceInterfaceInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+public sealed class Issue3093SequenceInterfaceInterpreterTests
+{
+    [Fact]
+    public void IteratorAndExplicitSequence_DispatchThroughInterface()
+    {
+        const string Source = """
+            import System.Collections.Generic
+
+            func One(value int32) sequence[int32] {
+                yield value
+            }
+
+            interface IDetector {
+                func Detect(text string) IEnumerable[int32];
+                func DetectExplicit(text string) IEnumerable[int32];
+            }
+
+            class Detector : IDetector {
+                func Detect(text string) sequence[int32] {
+                    yield text.Length
+                }
+
+                func DetectExplicit(text string) sequence[int32] {
+                    return One(text.Length)
+                }
+            }
+
+            var detector IDetector = Detector{}
+            for value in detector.Detect("abc") {
+                Console.WriteLine(value)
+            }
+            for value in detector.DetectExplicit("abc") {
+                Console.WriteLine(value)
+            }
+            """;
+
+        Assert.Equal("3\n3\n", RunSubmission(Source));
+    }
+
+    [Fact]
+    public void GenericIterator_DispatchesThroughInterface()
+    {
+        const string Source = """
+            import System.Collections.Generic
+
+            interface IDetector {
+                func Detect[T](value T) IEnumerable[T];
+            }
+
+            class Detector : IDetector {
+                func Detect[T](value T) sequence[T] {
+                    yield value
+                }
+            }
+
+            var detector IDetector = Detector{}
+            for value in detector.Detect[int32](3) {
+                Console.WriteLine(value)
+            }
+            """;
+
+        Assert.Equal("3\n", RunSubmission(Source));
+    }
+
+    private static string RunSubmission(string source)
+    {
+        using var output = new StringWriter();
+        var previousOut = Console.Out;
+        Console.SetOut(output);
+        try
+        {
+            new GSharpRepl().EvaluateSubmission(source);
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+        }
+
+        return output.ToString().Replace("\r\n", "\n", StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- project `sequence[T]` / async-sequence aliases onto their `IEnumerable<T>` / `IAsyncEnumerable<T>` CLR interface shapes for identity conversion and signature matching
- apply same symbolic projection to user and imported generic interfaces, then reuse binder matching for emitted value-type interface slots
- add binder, emitter, interpreter, runtime, metadata-signature, state-machine, and ILVerify coverage for iterator and non-iterator sequence methods

## Root cause
Alias identity, not iterator lowering. Iterator kickoff/state-machine emission already used the correct CLR enumerable signature. Interface checks failed when alias and CLR spellings had different symbolic shapes, especially open generic and metadata-load-context projections.

Sync/async aliases remain distinct, and covariant element conversions do not become signature identity.

## Validation
- `dotnet build GSharp.sln --configuration Release --no-restore -graph`
- Issue #3093 focused tests: 13 passed in Debug and Release
- binder/iterator/interface siblings: 114 passed
- emitter/ILVerify/interface/iterator siblings: 63 passed
- interpreter siblings: 21 passed

Fixes #3093