### PR TITLE
Fix evaluating driver assembly references

### DIFF
--- a/src/Compiler/Program.cs
+++ b/src/Compiler/Program.cs
@@ -115,9 +115,18 @@ public class Program
                 syntaxTrees.Add(SyntaxTree.Load(fullPath));
             }
 
-            var references = parsed.References.Count > 0
-                ? ReferenceResolver.WithReferences(parsed.References)
-                : null;
+            if (!ReferenceResolver.TryValidateDriverReferencePaths(parsed.References, out var referenceError))
+            {
+                Console.Error.WriteLine(referenceError);
+                return Error;
+            }
+
+            var referencePaths = ReferenceResolver.ResolveDriverReferencePaths(parsed.References);
+            var references = parsed.OutputPath is null
+                ? ReferenceResolver.WithRuntimeReferences(referencePaths)
+                : parsed.References.Count > 0
+                    ? ReferenceResolver.WithReferences(referencePaths)
+                    : ReferenceResolver.WithRuntimeReferences(referencePaths);
             ILogger logger = parsed.LogPath is not null ? new FileLogger(parsed.LogPath) : NullLogger.Instance;
 
             try
@@ -157,7 +166,7 @@ public class Program
                     // Legacy / no-output mode (ADR-0156 Phase 1): compile with
                     // the real emitter into memory and execute in-process,
                     // preserving the historical evaluate-mode driver protocol.
-                    return ExecuteInMemory(compilation, parsed);
+                    return ExecuteInMemory(compilation, parsed, referencePaths);
                 }
 
                 return Emit(compilation, parsed);
@@ -316,9 +325,12 @@ public class Program
     // driver protocol: diagnostics to stdout, "Success."/"Failed." trailer,
     // exit code 0 on success (the program's own return value is discarded,
     // as evaluate mode always did — use /out: for a real executable).
-    private static int ExecuteInMemory(Compilation compilation, CommandLineArgs args)
+    private static int ExecuteInMemory(
+        Compilation compilation,
+        CommandLineArgs args,
+        IReadOnlyList<string> referencePaths)
     {
-        var result = EmittedProgramHost.Run(compilation, args.References);
+        var result = EmittedProgramHost.Run(compilation, referencePaths);
         if (result.Diagnostics.Any())
         {
             var effective = ApplySuppressPromote(result.Diagnostics, args);

--- a/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
+++ b/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
@@ -14,6 +14,7 @@ using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Runtime.CompilerServices;
+using System.Runtime.Loader;
 using GSharp.Core.CodeAnalysis.Binding;
 using GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
 
@@ -56,6 +57,7 @@ public sealed class ReferenceResolver : IDisposable
 
     private readonly ImmutableArray<Assembly> assemblies;
     private readonly MetadataLoadContext metadataContext;
+    private readonly AssemblyLoadContext runtimeContext;
     private readonly ImmutableArray<string> missingTransitiveReferences;
 
     // Process-wide registry of original on-disk paths for assemblies loaded
@@ -165,10 +167,15 @@ public sealed class ReferenceResolver : IDisposable
     {
     }
 
-    private ReferenceResolver(ImmutableArray<Assembly> assemblies, MetadataLoadContext metadataContext, ImmutableArray<string> missingTransitiveReferences)
+    private ReferenceResolver(
+        ImmutableArray<Assembly> assemblies,
+        MetadataLoadContext metadataContext,
+        ImmutableArray<string> missingTransitiveReferences,
+        AssemblyLoadContext runtimeContext = null)
     {
         this.assemblies = assemblies;
         this.metadataContext = metadataContext;
+        this.runtimeContext = runtimeContext;
         this.missingTransitiveReferences = missingTransitiveReferences;
         this.typeNameIndex = new Lazy<Dictionary<string, Type>>(
             this.BuildTypeNameIndex,
@@ -177,6 +184,36 @@ public sealed class ReferenceResolver : IDisposable
 
     private sealed class NotFoundSentinel
     {
+    }
+
+    private sealed class DriverReferenceLoadContext : AssemblyLoadContext
+    {
+        private readonly HashSet<string> directories = new(StringComparer.OrdinalIgnoreCase);
+
+        public DriverReferenceLoadContext()
+            : base(isCollectible: true)
+        {
+        }
+
+        public Assembly LoadReference(string path)
+        {
+            directories.Add(Path.GetDirectoryName(path) ?? string.Empty);
+            return LoadFromAssemblyPath(path);
+        }
+
+        protected override Assembly Load(AssemblyName assemblyName)
+        {
+            foreach (var directory in directories)
+            {
+                var path = Path.Combine(directory, assemblyName.Name + ".dll");
+                if (File.Exists(path))
+                {
+                    return LoadFromAssemblyPath(path);
+                }
+            }
+
+            return null;
+        }
     }
 
     /// <summary>
@@ -193,12 +230,13 @@ public sealed class ReferenceResolver : IDisposable
     /// </remarks>
     public void Dispose()
     {
-        if (metadataContext is null)
+        if (metadataContext is null && runtimeContext is null)
         {
             return;
         }
 
-        metadataContext.Dispose();
+        metadataContext?.Dispose();
+        runtimeContext?.Unload();
 
         // The static ImportedTypeSymbol cache may hold Type instances that
         // originated from the now-disposed MetadataLoadContext. Those entries
@@ -337,6 +375,109 @@ public sealed class ReferenceResolver : IDisposable
     public static ReferenceResolver Default()
     {
         return new ReferenceResolver(BuildHostAssemblies(), metadataContext: null);
+    }
+
+    /// <summary>
+    /// Resolves the references supplied to a driver and appends the bundled
+    /// Gsharp.Extensions assembly when it is available.
+    /// </summary>
+    /// <param name="referencePaths">Explicit reference paths.</param>
+    /// <returns>The effective reference paths.</returns>
+    public static IReadOnlyList<string> ResolveDriverReferencePaths(IEnumerable<string> referencePaths)
+    {
+        var paths = referencePaths?
+            .Where(path => !string.IsNullOrWhiteSpace(path))
+            .ToList()
+            ?? new List<string>();
+
+        var extensionPath = FindBundledExtensionPath(AppContext.BaseDirectory);
+        if (extensionPath != null
+            && !paths.Any(path => string.Equals(Path.GetFullPath(path), extensionPath, StringComparison.OrdinalIgnoreCase)))
+        {
+            paths.Add(extensionPath);
+        }
+
+        return paths;
+    }
+
+    /// <summary>
+    /// Validates explicit driver references before implicit bundled references
+    /// are appended.
+    /// </summary>
+    /// <param name="referencePaths">Explicit reference paths.</param>
+    /// <param name="error">A command-line error when validation fails.</param>
+    /// <returns><see langword="true"/> when every reference is a readable .NET assembly.</returns>
+    public static bool TryValidateDriverReferencePaths(IEnumerable<string> referencePaths, out string error)
+    {
+        foreach (var path in referencePaths)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                error = "/reference requires a path.";
+                return false;
+            }
+
+            try
+            {
+                var fullPath = Path.GetFullPath(path);
+                if (!File.Exists(fullPath))
+                {
+                    error = $"Unable to load reference '{path}': file does not exist.";
+                    return false;
+                }
+
+                _ = AssemblyName.GetAssemblyName(fullPath);
+            }
+            catch (BadImageFormatException)
+            {
+                error = $"Unable to load reference '{path}': file is not a valid .NET assembly.";
+                return false;
+            }
+            catch (Exception ex) when (ex is ArgumentException or IOException or NotSupportedException or UnauthorizedAccessException)
+            {
+                error = $"Unable to load reference '{path}': {ex.Message}";
+                return false;
+            }
+        }
+
+        error = string.Empty;
+        return true;
+    }
+
+    /// <summary>
+    /// Gets a resolver for evaluated code by loading explicit references into
+    /// the runtime context rather than a metadata-only context.
+    /// </summary>
+    /// <param name="referencePaths">Paths to runtime assemblies.</param>
+    /// <returns>A resolver over the loaded assemblies and host BCL.</returns>
+    public static ReferenceResolver WithRuntimeReferences(IEnumerable<string> referencePaths)
+    {
+        var runtimeContext = new DriverReferenceLoadContext();
+        var runtimeAssemblies = new List<Assembly>();
+        if (referencePaths is not null)
+        {
+            foreach (var path in referencePaths.Where(path => !string.IsNullOrWhiteSpace(path)))
+            {
+                var fullPath = Path.GetFullPath(path);
+                var assembly = runtimeContext.LoadReference(fullPath);
+                RegisterAssemblyOriginalPath(assembly, fullPath);
+                runtimeAssemblies.Add(assembly);
+            }
+        }
+
+        var runtimeNames = runtimeAssemblies
+            .Select(assembly => assembly.GetName().FullName)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var assemblies = BuildHostAssemblies()
+            .Where(assembly => !runtimeNames.Contains(assembly.GetName().FullName))
+            .Concat(runtimeAssemblies)
+            .ToImmutableArray();
+
+        return new ReferenceResolver(
+            assemblies,
+            metadataContext: null,
+            missingTransitiveReferences: ImmutableArray<string>.Empty,
+            runtimeContext: runtimeContext);
     }
 
     /// <summary>
@@ -824,6 +965,22 @@ public sealed class ReferenceResolver : IDisposable
         return true;
     }
 
+    internal static string FindBundledExtensionPath(string baseDirectory)
+    {
+        // Compiler cannot ProjectReference Gsharp.Extensions because its bootstrap
+        // build already references Compiler; solution and SDK layouts provide it.
+        var candidates = new[]
+        {
+            Path.Combine(baseDirectory, "Gsharp.Extensions.dll"),
+            Path.Combine(baseDirectory, "..", "Gsharp.Extensions", "Gsharp.Extensions.dll"),
+            Path.Combine(baseDirectory, "..", "extensions", "Gsharp.Extensions.dll"),
+        };
+
+        return candidates
+            .Select(Path.GetFullPath)
+            .FirstOrDefault(File.Exists);
+    }
+
     // Raw resolution shared by the public/internal TryResolveType overloads: it
     // performs the reference-set name lookup (warm/cold index + cache) without
     // applying the external-visibility gate, which the callers layer on top.
@@ -1066,7 +1223,7 @@ public sealed class ReferenceResolver : IDisposable
 
         foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
         {
-            if (asm.IsDynamic)
+            if (asm.IsDynamic || AssemblyLoadContext.GetLoadContext(asm) is DriverReferenceLoadContext)
             {
                 continue;
             }

--- a/src/Repl/Engine/SessionEngine.cs
+++ b/src/Repl/Engine/SessionEngine.cs
@@ -26,7 +26,15 @@ public sealed class SessionEngine : ISessionEngine
 {
     private readonly Dictionary<VariableSymbol, object> variables = new();
     private readonly List<Cell> cells = new();
+    private readonly ReferenceResolver? references;
     private Compilation? previous;
+
+    /// <summary>Initializes a new instance of the <see cref="SessionEngine"/> class.</summary>
+    /// <param name="references">Runtime references available to every cell.</param>
+    public SessionEngine(ReferenceResolver? references = null)
+    {
+        this.references = references;
+    }
 
     public IReadOnlyList<Cell> Cells => cells;
 
@@ -216,7 +224,9 @@ public sealed class SessionEngine : ISessionEngine
             try
             {
                 var tree = SyntaxTree.Parse(SourceText.From(text, fileName));
-                var compilation = previous == null ? new Compilation(tree) : previous.ContinueWith(tree);
+                var compilation = previous == null
+                    ? references is null ? new Compilation(tree) : new Compilation(references, tree)
+                    : previous.ContinueWith(tree);
                 var result = compilation.Evaluate(variables, evaluateEntryPoint: RunEntryPoint);
 
                 var hasError = result.Diagnostics.Any(d => d.IsError);

--- a/src/Repl/Program.cs
+++ b/src/Repl/Program.cs
@@ -33,7 +33,8 @@ public static class Program
             case "/?":
                 Console.WriteLine("Usage: gsi [file.gs] [/r:<assembly> ...] [--engine <name>] [--help] [--version]");
                 Console.WriteLine("  file.gs                Run the given G# script and exit.");
-                Console.WriteLine("  /r:<file>              Reference an assembly (alias: /reference:<file>; repeatable).");
+                Console.WriteLine("  /r:<file>              Reference an assembly (repeatable).");
+                Console.WriteLine("  /reference:<file>      Alias for /r: (also -r: and --reference:).");
                 Console.WriteLine("  --engine <name>        Interactive engine: 'evaluator' (default) or 'emit'");
                 Console.WriteLine("                         (ADR-0156 Phase 2 opt-in; also via GSI_ENGINE).");
                 Console.WriteLine("  --help, -h             Show this help and exit.");
@@ -86,6 +87,12 @@ public static class Program
             return 1;
         }
 
+        if (!ReferenceResolver.TryValidateDriverReferencePaths(references, out var referenceError))
+        {
+            Console.Error.WriteLine(referenceError);
+            return 1;
+        }
+
         if (scriptPath is null)
         {
             return RunInteractive(engineChoice, references);
@@ -116,18 +123,14 @@ public static class Program
             return 1;
         }
 
+        var effectiveReferences = ReferenceResolver.ResolveDriverReferencePaths(references);
         if (engineChoice == "emit")
         {
-            return ReplHost.Run(new Engine.EmittedSessionEngine(references));
+            return ReplHost.Run(new Engine.EmittedSessionEngine(effectiveReferences));
         }
 
-        if (references.Count > 0)
-        {
-            Console.Error.WriteLine("/r: references in interactive mode require --engine emit (ADR-0156 Phase 2).");
-            return 1;
-        }
-
-        return ReplHost.Run();
+        using var resolver = ReferenceResolver.WithRuntimeReferences(effectiveReferences);
+        return ReplHost.Run(new Engine.SessionEngine(resolver));
     }
 
     /// <summary>
@@ -140,49 +143,43 @@ public static class Program
     private static int RunScript(string scriptPath, List<string> references)
     {
         var tree = SyntaxTree.Parse(SourceText.From(File.ReadAllText(scriptPath), scriptPath));
-        var resolver = references.Count > 0 ? ReferenceResolver.WithReferences(references) : null;
+        var effectiveReferences = ReferenceResolver.ResolveDriverReferencePaths(references);
+        using var resolver = ReferenceResolver.WithRuntimeReferences(effectiveReferences);
+        var compilation = new Compilation(resolver, tree);
+        EmittedProgramResult result;
         try
         {
-            var compilation = new Compilation(resolver, tree);
-            EmittedProgramResult result;
-            try
-            {
-                result = EmittedProgramHost.Run(compilation, references);
-            }
-            catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
-            {
-                // 6.2 SilentEmitFailure invariant, gsi edition: a compiler
-                // exception that escapes the emit pipeline (e.g. #3183) must
-                // surface as gsc's canonical GS9998 line rather than a raw
-                // driver crash. User-code exceptions never reach here — the
-                // host reports those via UnhandledException below.
-                Console.Error.WriteLine($"{scriptPath}(1,1,1,1): error GS9998: {ex.GetType().Name}: {ex.Message}");
-                return 1;
-            }
-            if (result.Diagnostics.Any())
-            {
-                Console.Error.WriteDiagnostics(result.Diagnostics);
-            }
-
-            if (!result.Success)
-            {
-                return 1;
-            }
-
-            if (result.UnhandledException is not null)
-            {
-                // Mirror the CLR host's unhandled-exception protocol so gsi
-                // and `dotnet exec` render crashes identically.
-                Console.Error.WriteLine(EmittedProgramHost.FormatUnhandledException(result.UnhandledException));
-                return EmittedProgramHost.UnhandledExceptionExitCode;
-            }
-
-            return result.ExitCode;
+            result = EmittedProgramHost.Run(compilation, effectiveReferences);
         }
-        finally
+        catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
         {
-            resolver?.Dispose();
+            // 6.2 SilentEmitFailure invariant, gsi edition: a compiler
+            // exception that escapes the emit pipeline (e.g. #3183) must
+            // surface as gsc's canonical GS9998 line rather than a raw
+            // driver crash. User-code exceptions never reach here — the
+            // host reports those via UnhandledException below.
+            Console.Error.WriteLine($"{scriptPath}(1,1,1,1): error GS9998: {ex.GetType().Name}: {ex.Message}");
+            return 1;
         }
+        if (result.Diagnostics.Any())
+        {
+            Console.Error.WriteDiagnostics(result.Diagnostics);
+        }
+
+        if (!result.Success)
+        {
+            return 1;
+        }
+
+        if (result.UnhandledException is not null)
+        {
+            // Mirror the CLR host's unhandled-exception protocol so gsi
+            // and `dotnet exec` render crashes identically.
+            Console.Error.WriteLine(EmittedProgramHost.FormatUnhandledException(result.UnhandledException));
+            return EmittedProgramHost.UnhandledExceptionExitCode;
+        }
+
+        return result.ExitCode;
     }
 
     /// <summary>
@@ -197,7 +194,7 @@ public static class Program
             return false;
         }
 
-        var body = arg.Substring(1);
+        var body = arg.Substring(arg.StartsWith("--", StringComparison.Ordinal) ? 2 : 1);
         var separator = body.IndexOfAny(new[] { ':', '=' });
         if (separator <= 0)
         {

--- a/src/Repl/Repl.csproj
+++ b/src/Repl/Repl.csproj
@@ -40,6 +40,7 @@
   <ItemGroup>
     <ProjectReference Include="@(GsharpCore)" />
     <ProjectReference Include="@(GsharpLanguageServer)" />
+    <ProjectReference Include="..\Sdk\Gsharp.Extensions\Gsharp.Extensions.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Repl/packages.lock.json
+++ b/src/Repl/packages.lock.json
@@ -107,6 +107,12 @@
           "System.Reflection.MetadataLoadContext": "[9.0.0, )"
         }
       },
+      "GSharp.Gsharp.Extensions": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.VisualStudio.Validation": "[17.8.8, )"
+        }
+      },
       "GSharp.LanguageServer": {
         "type": "Project",
         "dependencies": {

--- a/test/Interpreter.Tests/Issue3130DriverReferenceTests.cs
+++ b/test/Interpreter.Tests/Issue3130DriverReferenceTests.cs
@@ -1,0 +1,536 @@
+// <copyright file="Issue3130DriverReferenceTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Threading.Tasks;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Repl.Engine;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>Issue #3130: real evaluating drivers resolve bundled and explicit references.</summary>
+public sealed class Issue3130DriverReferenceTests
+{
+    private static readonly string[] ExtensionSamples =
+    {
+        "GsharpExtensionsOptional",
+        "GsharpExtensionsMixed",
+        "GsharpExtensionsSequences",
+    };
+
+    [Fact]
+    public async Task ExtensionSamples_MatchEmitAcrossRealDrivers()
+    {
+        var samplesDirectory = LocateSamplesDirectory();
+        var gscPath = typeof(GSharp.Compiler.Program).Assembly.Location;
+        var gsiPath = typeof(GSharp.Repl.Program).Assembly.Location;
+        var extensionsPath = Path.Combine(Path.GetDirectoryName(gsiPath)!, "Gsharp.Extensions.dll");
+        Assert.True(File.Exists(extensionsPath), $"Missing {extensionsPath}");
+
+        foreach (var sample in ExtensionSamples)
+        {
+            var directory = CreateEmptyTestDirectory(sample);
+            try
+            {
+                var sourcePath = Path.Combine(directory, sample + ".gs");
+                var outputPath = Path.Combine(directory, sample + ".dll");
+                File.Copy(Path.Combine(samplesDirectory, sample + ".gs"), sourcePath);
+                var expected = Normalize(File.ReadAllText(Path.Combine(samplesDirectory, sample + ".golden")));
+
+                var emit = await RunAsync(
+                    directory,
+                    gscPath,
+                    "/nowarn:GS9100",
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    "/out:" + outputPath,
+                    sourcePath);
+                AssertSucceeded(emit, sample + " emit");
+
+                var assembly = Assembly.Load(File.ReadAllBytes(outputPath));
+                Assert.NotEmpty(assembly.GetTypes());
+
+                File.Copy(extensionsPath, Path.Combine(directory, "Gsharp.Extensions.dll"), overwrite: true);
+                var emitted = await RunAsync(
+                    directory,
+                    "exec",
+                    "--runtimeconfig",
+                    Path.ChangeExtension(outputPath, ".runtimeconfig.json"),
+                    outputPath);
+                AssertSucceeded(emitted, sample + " emitted execution");
+                Assert.Equal(expected, Normalize(emitted.StandardOutput));
+
+                var evaluated = await RunAsync(directory, gscPath, "/nowarn:GS9100", sourcePath);
+                AssertSucceeded(evaluated, sample + " bare gsc");
+                Assert.Equal(expected + "Success.\n", Normalize(evaluated.StandardOutput));
+
+                var interpreted = await RunAsync(directory, gsiPath, sourcePath);
+                AssertSucceeded(interpreted, sample + " gsi");
+                Assert.Equal(expected, Normalize(interpreted.StandardOutput));
+            }
+            finally
+            {
+                DeleteDirectory(directory);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task FullyQualifiedExtensionUse_MatchesEmitAcrossRealDrivers()
+    {
+        var directory = CreateEmptyTestDirectory("fully-qualified");
+        try
+        {
+            var gscPath = typeof(GSharp.Compiler.Program).Assembly.Location;
+            var gsiPath = typeof(GSharp.Repl.Program).Assembly.Location;
+            var extensionsPath = Path.Combine(Path.GetDirectoryName(gsiPath)!, "Gsharp.Extensions.dll");
+            var sourcePath = Path.Combine(directory, "probe.gs");
+            var outputPath = Path.Combine(directory, "probe.dll");
+            File.WriteAllText(
+                sourcePath,
+                """
+                package FullyQualifiedProbe
+                import System
+
+                let values = Gsharp.Extensions.Sequences.Sequences.Of(11, 22, 33)
+                Console.WriteLine(values[0])
+                """);
+
+            var emit = await RunAsync(
+                directory,
+                gscPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/out:" + outputPath,
+                sourcePath);
+            AssertSucceeded(emit, "fully-qualified emit");
+
+            File.Copy(extensionsPath, Path.Combine(directory, "Gsharp.Extensions.dll"), overwrite: true);
+            var emitted = await RunAsync(
+                directory,
+                "exec",
+                "--runtimeconfig",
+                Path.ChangeExtension(outputPath, ".runtimeconfig.json"),
+                outputPath);
+            AssertSucceeded(emitted, "fully-qualified emitted execution");
+            Assert.Equal("11\n", Normalize(emitted.StandardOutput));
+
+            var evaluated = await RunAsync(directory, gscPath, sourcePath);
+            AssertSucceeded(evaluated, "fully-qualified bare gsc");
+            Assert.Equal("11\nSuccess.\n", Normalize(evaluated.StandardOutput));
+
+            var interpreted = await RunAsync(directory, gsiPath, sourcePath);
+            AssertSucceeded(interpreted, "fully-qualified gsi");
+            Assert.Equal("11\n", Normalize(interpreted.StandardOutput));
+        }
+        finally
+        {
+            DeleteDirectory(directory);
+        }
+    }
+
+    [Fact]
+    public async Task ExplicitReference_WorksAcrossRealDrivers()
+    {
+        var directory = CreateEmptyTestDirectory("explicit");
+        try
+        {
+            var gscPath = typeof(GSharp.Compiler.Program).Assembly.Location;
+            var gsiPath = typeof(GSharp.Repl.Program).Assembly.Location;
+            var referencePath = Path.Combine(directory, "ExternalProbe.dll");
+            var sourcePath = Path.Combine(directory, "probe.gs");
+            var outputPath = Path.Combine(directory, "probe.dll");
+            EmitProbeAssembly(referencePath);
+            File.WriteAllText(
+                sourcePath,
+                """
+                package ReferenceProbe
+                import System
+                import ExternalProbe
+
+                Console.WriteLine(Values.Answer())
+                """);
+
+            var bareWithoutReference = await RunAsync(directory, gscPath, sourcePath);
+            Assert.NotEqual(0, bareWithoutReference.ExitCode);
+            Assert.Contains("error GS", bareWithoutReference.Combined);
+            var gsiWithoutReference = await RunAsync(directory, gsiPath, sourcePath);
+            Assert.NotEqual(0, gsiWithoutReference.ExitCode);
+            Assert.Contains("error GS", gsiWithoutReference.Combined);
+
+            var emit = await RunAsync(
+                directory,
+                gscPath,
+                "/nowarn:GS9100",
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/out:" + outputPath,
+                "/r:" + referencePath,
+                sourcePath);
+            AssertSucceeded(emit, "explicit-reference emit");
+
+            var emitted = await RunAsync(
+                directory,
+                "exec",
+                "--runtimeconfig",
+                Path.ChangeExtension(outputPath, ".runtimeconfig.json"),
+                outputPath);
+            AssertSucceeded(emitted, "explicit-reference emitted execution");
+            Assert.Equal("42\n", Normalize(emitted.StandardOutput));
+
+            var evaluated = await RunAsync(directory, gscPath, "/nowarn:GS9100", "/r:" + referencePath, sourcePath);
+            AssertSucceeded(evaluated, "explicit-reference bare gsc");
+            Assert.Equal("42\nSuccess.\n", Normalize(evaluated.StandardOutput));
+
+            var interpreted = await RunAsync(directory, gsiPath, "/r:" + referencePath, sourcePath);
+            AssertSucceeded(interpreted, "explicit-reference gsi");
+            Assert.Equal("42\n", Normalize(interpreted.StandardOutput));
+
+            var help = await RunAsync(directory, gsiPath, "--help");
+            AssertSucceeded(help, "gsi help");
+            Assert.Contains("/r:<file>", help.StandardOutput);
+
+            var misplacedHelp = await RunAsync(directory, gsiPath, sourcePath, "--help");
+            Assert.NotEqual(0, misplacedHelp.ExitCode);
+            Assert.Contains("Unrecognized argument: --help", misplacedHelp.StandardError);
+        }
+        finally
+        {
+            DeleteDirectory(directory);
+        }
+    }
+
+    [Fact]
+    public void GsiRuntimeManifest_IncludesExtensionsAssembly()
+    {
+        var gsiPath = typeof(GSharp.Repl.Program).Assembly.Location;
+        var dependenciesPath = Path.ChangeExtension(gsiPath, ".deps.json");
+        Assert.Contains("Gsharp.Extensions", File.ReadAllText(dependenciesPath));
+    }
+
+    [Fact]
+    public async Task UnrelatedEmit_DoesNotAcquireImplicitExtensionWarnings()
+    {
+        var directory = CreateEmptyTestDirectory("unrelated-emit");
+        try
+        {
+            var sourcePath = Path.Combine(directory, "probe.gs");
+            File.WriteAllText(sourcePath, "import System\nConsole.WriteLine(42)");
+            var result = await RunAsync(
+                directory,
+                typeof(GSharp.Compiler.Program).Assembly.Location,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/out:" + Path.Combine(directory, "probe.dll"),
+                sourcePath);
+
+            AssertSucceeded(result, "unrelated emit");
+            Assert.DoesNotContain("GS9100", result.Combined);
+        }
+        finally
+        {
+            DeleteDirectory(directory);
+        }
+    }
+
+    [Fact]
+    public async Task BundledExtensionEmit_UsesInvokableRuntimeTypes()
+    {
+        var directory = CreateEmptyTestDirectory("runtime-emit");
+        try
+        {
+            var gsiPath = typeof(GSharp.Repl.Program).Assembly.Location;
+            var extensionsPath = Path.Combine(Path.GetDirectoryName(gsiPath)!, "Gsharp.Extensions.dll");
+            var sourcePath = Path.Combine(directory, "probe.gs");
+            var outputPath = Path.Combine(directory, "probe.dll");
+            File.WriteAllText(
+                sourcePath,
+                """
+                package RuntimeEmitProbe
+                import System
+                import Gsharp.Extensions.Go
+
+                let values = make(chan DateTime, 1)
+                values <- DateTime(2020, 1, 1)
+                Console.WriteLine((<-values).Year)
+                """);
+
+            var emit = await RunAsync(
+                directory,
+                typeof(GSharp.Compiler.Program).Assembly.Location,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/out:" + outputPath,
+                sourcePath);
+            AssertSucceeded(emit, "runtime extension emit");
+
+            File.Copy(extensionsPath, Path.Combine(directory, "Gsharp.Extensions.dll"), overwrite: true);
+            var emitted = await RunAsync(
+                directory,
+                "exec",
+                "--runtimeconfig",
+                Path.ChangeExtension(outputPath, ".runtimeconfig.json"),
+                outputPath);
+            AssertSucceeded(emitted, "runtime extension execution");
+            Assert.Equal("2020\n", Normalize(emitted.StandardOutput));
+        }
+        finally
+        {
+            DeleteDirectory(directory);
+        }
+    }
+
+    [Fact]
+    public async Task BadReferences_AreRejectedAcrossRealDrivers()
+    {
+        foreach (var kind in new[] { "missing", "junk" })
+        {
+            var directory = CreateEmptyTestDirectory("bad-" + kind);
+            try
+            {
+                var gscPath = typeof(GSharp.Compiler.Program).Assembly.Location;
+                var gsiPath = typeof(GSharp.Repl.Program).Assembly.Location;
+                var sourcePath = Path.Combine(directory, "probe.gs");
+                var referencePath = Path.Combine(directory, kind + ".dll");
+                File.WriteAllText(sourcePath, "import System\nConsole.WriteLine(42)");
+                if (kind == "junk")
+                {
+                    File.WriteAllText(referencePath, "not an assembly");
+                }
+
+                var referenceArgument = "/r:" + referencePath;
+                AssertRejectedReference(
+                    await RunAsync(directory, gscPath, referenceArgument, sourcePath),
+                    referencePath,
+                    "bare gsc " + kind);
+                AssertRejectedReference(
+                    await RunAsync(
+                        directory,
+                        gscPath,
+                        "/target:exe",
+                        "/targetframework:net10.0",
+                        "/out:" + Path.Combine(directory, "probe.dll"),
+                        referenceArgument,
+                        sourcePath),
+                    referencePath,
+                    "emit " + kind);
+                AssertRejectedReference(
+                    await RunAsync(directory, gsiPath, referenceArgument, sourcePath),
+                    referencePath,
+                    "gsi " + kind);
+            }
+            finally
+            {
+                DeleteDirectory(directory);
+            }
+        }
+    }
+
+    [Fact]
+    public void BundledExtensionProbe_PrefersDriverSiblingThenBuildThenSdkLayout()
+    {
+        var directory = CreateEmptyTestDirectory("layouts");
+        try
+        {
+            var driverDirectory = Path.Combine(directory, "compiler");
+            var driverSibling = Path.Combine(driverDirectory, "Gsharp.Extensions.dll");
+            var buildSibling = Path.Combine(directory, "Gsharp.Extensions", "Gsharp.Extensions.dll");
+            var sdkSibling = Path.Combine(directory, "extensions", "Gsharp.Extensions.dll");
+            Directory.CreateDirectory(driverDirectory);
+            Directory.CreateDirectory(Path.GetDirectoryName(buildSibling)!);
+            Directory.CreateDirectory(Path.GetDirectoryName(sdkSibling)!);
+            File.WriteAllText(driverSibling, string.Empty);
+            File.WriteAllText(buildSibling, string.Empty);
+            File.WriteAllText(sdkSibling, string.Empty);
+
+            Assert.Equal(driverSibling, ReferenceResolver.FindBundledExtensionPath(driverDirectory));
+            File.Delete(driverSibling);
+            Assert.Equal(buildSibling, ReferenceResolver.FindBundledExtensionPath(driverDirectory));
+            File.Delete(buildSibling);
+            Assert.Equal(sdkSibling, ReferenceResolver.FindBundledExtensionPath(driverDirectory));
+        }
+        finally
+        {
+            DeleteDirectory(directory);
+        }
+    }
+
+    [Fact]
+    public void RuntimeReferenceResolver_DoesNotSilenceInvalidReferences()
+    {
+        var directory = CreateEmptyTestDirectory("runtime-invalid");
+        try
+        {
+            var missingPath = Path.Combine(directory, "missing.dll");
+            var junkPath = Path.Combine(directory, "junk.dll");
+            File.WriteAllText(junkPath, "not an assembly");
+
+            Assert.Throws<FileNotFoundException>(() => ReferenceResolver.WithRuntimeReferences([missingPath]));
+            Assert.Throws<BadImageFormatException>(() => ReferenceResolver.WithRuntimeReferences([junkPath]));
+        }
+        finally
+        {
+            DeleteDirectory(directory);
+        }
+    }
+
+    [Fact]
+    public void RuntimeReferenceResolver_DoesNotLeakExplicitReferences()
+    {
+        var directory = CreateEmptyTestDirectory("runtime-isolation");
+        try
+        {
+            var referencePath = Path.Combine(directory, "ExternalProbe.dll");
+            EmitProbeAssembly(referencePath);
+
+            using (var referenced = ReferenceResolver.WithRuntimeReferences([referencePath]))
+            {
+                Assert.True(referenced.TryResolveType("ExternalProbe.Values", out _));
+            }
+
+            using var clean = ReferenceResolver.WithRuntimeReferences([]);
+            Assert.False(clean.TryResolveType("ExternalProbe.Values", out _));
+        }
+        finally
+        {
+            DeleteDirectory(directory);
+        }
+    }
+
+    [Fact]
+    public void SessionEngine_UsesProvidedRuntimeReferences()
+    {
+        var directory = CreateEmptyTestDirectory("session-reference");
+        try
+        {
+            var referencePath = Path.Combine(directory, "ExternalProbe.dll");
+            EmitProbeAssembly(referencePath);
+
+            using var references = ReferenceResolver.WithRuntimeReferences([referencePath]);
+            var engine = new SessionEngine(references);
+            var cell = engine.Evaluate(
+                "package SessionReference\nimport ExternalProbe\nvar answer = Values.Answer()",
+                Path.Combine(directory, "probe.gs"));
+
+            Assert.False(cell.HasError, string.Join(Environment.NewLine, cell.Diagnostics));
+        }
+        finally
+        {
+            DeleteDirectory(directory);
+        }
+    }
+
+    private static void EmitProbeAssembly(string outputPath)
+    {
+        var builder = new PersistedAssemblyBuilder(new AssemblyName("ExternalProbe"), typeof(object).Assembly);
+        var module = builder.DefineDynamicModule("ExternalProbe");
+        var type = module.DefineType(
+            "ExternalProbe.Values",
+            TypeAttributes.Public | TypeAttributes.Abstract | TypeAttributes.Sealed);
+        var answer = type.DefineMethod(
+            "Answer",
+            MethodAttributes.Public | MethodAttributes.Static,
+            typeof(int),
+            Type.EmptyTypes);
+        var il = answer.GetILGenerator();
+        il.Emit(OpCodes.Ldc_I4, 42);
+        il.Emit(OpCodes.Ret);
+        type.CreateType();
+        builder.Save(outputPath);
+    }
+
+    private static async Task<ProcessResult> RunAsync(string workingDirectory, params string[] arguments)
+    {
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = workingDirectory,
+        };
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start dotnet");
+        var standardOutput = process.StandardOutput.ReadToEndAsync();
+        var standardError = process.StandardError.ReadToEndAsync();
+        try
+        {
+            await process.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(30));
+        }
+        catch (TimeoutException)
+        {
+            process.Kill(entireProcessTree: true);
+            throw new TimeoutException("dotnet process timed out");
+        }
+
+        return new ProcessResult(
+            process.ExitCode,
+            await standardOutput,
+            await standardError);
+    }
+
+    private static void AssertSucceeded(ProcessResult result, string operation)
+        => Assert.True(
+            result.ExitCode == 0,
+            $"{operation} exited {result.ExitCode}\nstdout:\n{result.StandardOutput}\nstderr:\n{result.StandardError}");
+
+    private static void AssertRejectedReference(ProcessResult result, string referencePath, string operation)
+    {
+        Assert.True(result.ExitCode != 0, $"{operation} unexpectedly succeeded");
+        Assert.Contains("Unable to load reference", result.Combined);
+        Assert.Contains(referencePath, result.Combined);
+    }
+
+    private static string LocateSamplesDirectory()
+    {
+        for (var directory = new DirectoryInfo(AppContext.BaseDirectory); directory != null; directory = directory.Parent)
+        {
+            var candidate = Path.Combine(directory.FullName, "samples");
+            if (Directory.Exists(candidate) && File.Exists(Path.Combine(directory.FullName, "GSharp.sln")))
+            {
+                return candidate;
+            }
+        }
+
+        throw new DirectoryNotFoundException("Unable to locate samples directory");
+    }
+
+    private static string CreateEmptyTestDirectory(string suffix)
+    {
+        var root = Path.Combine(
+            AppContext.BaseDirectory,
+            nameof(Issue3130DriverReferenceTests),
+            suffix + "-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        Assert.Empty(Directory.GetFileSystemEntries(root));
+        return root;
+    }
+
+    private static void DeleteDirectory(string directory)
+    {
+        try
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+        catch
+        {
+        }
+    }
+
+    private static string Normalize(string text) => text.Replace("\r\n", "\n", StringComparison.Ordinal);
+
+    private sealed record ProcessResult(int ExitCode, string StandardOutput, string StandardError)
+    {
+        public string Combined => StandardOutput + StandardError;
+    }
+}

--- a/test/Interpreter.Tests/packages.lock.json
+++ b/test/Interpreter.Tests/packages.lock.json
@@ -210,6 +210,7 @@
         "type": "Project",
         "dependencies": {
           "GSharp.Core": "[1.0.0, )",
+          "GSharp.Gsharp.Extensions": "[1.0.0, )",
           "GSharp.LanguageServer": "[1.0.0, )",
           "Microsoft.VisualStudio.Validation": "[17.8.8, )",
           "Spectre.Console": "[0.55.2, )"

--- a/website/docs/tooling/repl.md
+++ b/website/docs/tooling/repl.md
@@ -33,11 +33,13 @@ dotnet tool uninstall --global Gsharp.Repl
 ## Command-line usage
 
 ```text
-Usage: gsi [file.gs] [--help] [--version]
-  file.gs      Run the given G# script and exit.
-  --help, -h   Show this help and exit.
-  --version    Show the gsi version and exit.
-  (no args)    Start the interactive REPL.
+Usage: gsi [options] [file.gs]
+  file.gs                       Run the given G# script and exit.
+  /r:<file>, /reference:<file>  Reference an assembly (repeatable).
+  -r:<file>, --reference:<file> Reference an assembly (repeatable).
+  --help, -h                    Show this help and exit.
+  --version                     Show the gsi version and exit.
+  (no file)                     Start the interactive REPL.
 ```
 
 ### Interactive REPL
@@ -99,6 +101,17 @@ Console.WriteLine(greet("world"))
 Diagnostics are written to standard error, and the process exits with a
 non-zero status if evaluation fails, so `gsi file.gs` composes cleanly in
 scripts and CI checks.
+
+Use `/r:<path>` or `/reference:<path>` to load an external runtime
+assembly before evaluation:
+
+```sh
+gsi /r:/path/to/MyLibrary.dll hello.gs
+```
+
+The installed `Gsharp.Repl` tool bundles and loads `Gsharp.Extensions`
+automatically, so scripts can use its optional and sequence helpers
+without adding an explicit reference.
 
 ## How it relates to `gsc`
 


### PR DESCRIPTION
## Summary

- make bundled `Gsharp.Extensions` available by default to bare `gsc`, `gsc /out:`, and `gsi`
- add `gsi` reference switches matching `gsc` (`/r:`, `/reference:`, `-r:`, `--reference:`)
- validate explicit references consistently and isolate runtime references between invocations
- pass effective dependency paths into emit-to-memory execution
- package `Gsharp.Extensions.dll` with `gsi` and document the reference surface
- add real-process coverage for all three driver columns

## Supersession check

ADR-0156 Phase 1 (`3d5ba7af`, #3182) moved bare `gsc` and `gsi` script files onto the emitter. Phase 2 (`ed6ae55e`, #3186) added opt-in emitted interactive submissions. Neither change makes the bundled Extensions assembly an implicit driver reference.

Measured on freshly rebuilt current `main` `16f97229dc1cca01efc48aa66f234fc56e5ae551`:

| sample | bare `gsc` | `gsc /out:` | `gsi` |
|---|---|---|---|
| `GsharpExtensionsOptional.gs` | rc1 `GS0159` | rc1 `GS0159` | rc1 `GS0159` |
| `GsharpExtensionsMixed.gs` | rc1 `GS0157`, `GS0159` | rc1 `GS0157`, `GS0159` | rc1 `GS0157`, `GS0159` |
| `GsharpExtensionsSequences.gs` | rc1 `GS0157`, `GS0158`, `GS0159` | rc1 `GS0157`, `GS0158`, `GS0159` | rc1 `GS0157`, `GS0158`, `GS0159` |

The prior syntactic `ImportSyntax.StartsWith("Gsharp.Extensions")` gate no longer exists on `main`. Fully qualified no-import use fails uniformly on all three drivers with rc1 `GS0157`, so the narrower asymmetry is gone only because every column is still broken.

Conclusion: #3130 was closed prematurely; #3182/#3186 changed execution engines but did not fix bundled reference discovery. This PR remains a product fix, not tests-only salvage.

## Resolution

`ResolveDriverReferencePaths` appends the bundled assembly from the existing driver-sibling, solution-build, or SDK layouts. File drivers compile through the emitter, while the default interactive engine remains evaluator-based; both paths receive the same effective references. Explicit metadata references stay isolated, and emitted in-memory execution receives the corresponding runtime dependency paths.

On this head, all three shipped samples return rc0 and byte-match their golden files across bare `gsc`, emitted execution, and `gsi`. Fully qualified no-import use returns rc0 on all three and prints `11` (`gsc` also emits its existing `Success.` status line).

## Tests retained

`Issue3130DriverReferenceTests` keeps 11 durable regressions covering:

- all three shipped samples across all real drivers
- fully qualified Extensions use without an import
- explicit and invalid `/r:` behavior across all drivers
- bundled probe precedence and `gsi` packaging
- no unrelated `GS9100` warning pollution
- invokable runtime types and resolver isolation
- interactive evaluator reference injection

No workaround-only tests were split or dropped. No tests-only PR was opened because clean `main` still needs the product change.

## Validation

- head `2cfa21f9ca529aef8418121ee5058aeaf6fc42cc`
- base `16f97229dc1cca01efc48aa66f234fc56e5ae551`
- clean-main rebuild: 0 warnings, 0 errors; fresh nonzero `GSharp.Core.dll`
- final-head rebuild: 0 warnings, 0 errors; fresh nonzero `GSharp.Core.dll`
- exact final-head issue filter: 14/14
- exact final-head real-process matrix: three shipped samples plus no-import probe, all three columns rc0 with expected output
- unfiltered 9/9 solution projects, enumerated from `GSharp.sln`: **15,364 passed, 1 skipped, 0 failed**
  - Core 7,128 passed / 1 skipped
  - Compiler 4,260
  - Interpreter 1,404
  - LanguageServer 462
  - SDK 59
  - Extensions 104
  - Cs2Gs 1,907
  - GeneratorHost 31
  - InternalAnalyzers 9

The 9/9 local run preceded a final amend that only removed accidental reversions of two `main` test-name changes; final-head build and issue tests were rerun afterward.

## Product mutation evidence

Each mutant was asserted applied, built successfully, killed, restored, rebuilt, and returned green. No build-failing attempt was scored.

- restore syntactic import gate: killed by fully qualified no-import test
- invert bundled probe precedence: killed by layout test
- accept missing/junk reference: killed by bad-reference tests
- replace collectible runtime context with `Assembly.LoadFrom`: killed by isolation test
- invert compiler reference mode: killed by real-driver tests
- omit emit-to-memory runtime paths: killed by extension sample execution
- break `gsi` reference parsing/propagation: killed by explicit-reference tests
- drop interactive resolver injection: killed by `SessionEngine_UsesProvidedRuntimeReferences`
- use metadata-only implicit extension types: killed by runtime-type invocation test
- remove Repl Extensions dependency: killed by runtime manifest test

Fixes #3130
