### PR TITLE
[gsc] Preserve generic call metadata across async spilling

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -1904,15 +1904,22 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        // Issue #502 (sub-bug 502-a/b): preserve the call's return-type override
-        // (e.g. the Task / Task[T] lift applied by BindUserInstanceCall for async
-        // members). Dropping it here caused the rewritten call's static type to
-        // collapse to the bare method-declared type (e.g. int32 instead of
-        // Task[int32]), which then mis-typed the receiver of `GetAwaiter()` and
-        // produced an invalid box at the call boundary — leading to a hang
-        // because the inner async member's task never visibly completed from
-        // the caller's perspective.
-        return new BoundUserInstanceCallExpression(null, receiver, node.Method, builder?.ToImmutable() ?? node.Arguments, node.Type, node.ConstrainedReceiverTypeParameter, node.ConstrainedInterfaceType);
+        // Preserve every call-site property while replacing only receiver and
+        // arguments. The return-type override carries async Task lifting (#502);
+        // constrained metadata controls generic-interface dispatch (#1052); and
+        // method type arguments are the authoritative bind-time substitution
+        // when emit-time structural re-inference is impossible (#1931).
+        return new BoundUserInstanceCallExpression(
+            null,
+            receiver,
+            node.Method,
+            builder?.ToImmutable() ?? node.Arguments,
+            node.Type,
+            node.ConstrainedReceiverTypeParameter,
+            node.ConstrainedInterfaceType)
+        {
+            MethodTypeArguments = node.MethodTypeArguments,
+        };
     }
 
     /// <summary>Rewrites an explicit-base interface call (ADR-0091).</summary>

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Blocks.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Blocks.cs
@@ -567,7 +567,10 @@ internal sealed partial class StatementBinder
                     CaptureArguments(call.Arguments, prefix),
                     call.Type,
                     call.ConstrainedReceiverTypeParameter,
-                    call.ConstrainedInterfaceType);
+                    call.ConstrainedInterfaceType)
+                {
+                    MethodTypeArguments = call.MethodTypeArguments,
+                };
             case BoundImportedCallExpression call:
                 return new BoundImportedCallExpression(
                     null,

--- a/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
@@ -989,7 +989,13 @@ public static class SpillSequenceSpiller
                 return Trivial(call);
             }
 
-            var value = new BoundImportedCallExpression(null, call.Function, args.ToImmutable(), call.ArgumentRefKinds);
+            var value = new BoundImportedCallExpression(
+                null,
+                call.Function,
+                args.ToImmutable(),
+                call.ArgumentRefKinds,
+                call.TypeArgumentSymbols,
+                call.StaticContainerType);
             return new BoundSpillSequenceExpression(
                 null,
                 locals.ToImmutable(),
@@ -1052,7 +1058,17 @@ public static class SpillSequenceSpiller
                 return Trivial(call);
             }
 
-            var value = new BoundImportedInstanceCallExpression(null, receiver, call.Method, call.Type, args, call.ArgumentRefKinds);
+            var value = new BoundImportedInstanceCallExpression(
+                null,
+                receiver,
+                call.Method,
+                call.Type,
+                args,
+                call.ArgumentRefKinds,
+                call.TypeArgumentSymbols,
+                call.ConstrainedReceiverTypeParameter,
+                call.ConstrainedInterfaceType,
+                call.IsNonVirtualBaseCall);
             return new BoundSpillSequenceExpression(null, locals, sideEffects, value);
         }
 

--- a/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
@@ -1080,7 +1080,17 @@ public static class SpillSequenceSpiller
                 return Trivial(call);
             }
 
-            var value = new BoundUserInstanceCallExpression(null, receiver, call.Method, args, call.Type);
+            var value = new BoundUserInstanceCallExpression(
+                null,
+                receiver,
+                call.Method,
+                args,
+                call.Type,
+                call.ConstrainedReceiverTypeParameter,
+                call.ConstrainedInterfaceType)
+            {
+                MethodTypeArguments = call.MethodTypeArguments,
+            };
             return new BoundSpillSequenceExpression(null, locals, sideEffects, value);
         }
 

--- a/test/Compiler.Tests/Emit/Issue1635DeferCaptureMetadataEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1635DeferCaptureMetadataEmitTests.cs
@@ -77,6 +77,30 @@ public class Issue1635DeferCaptureMetadataEmitTests
         Assert.Equal("body\n1\n2\n3\n", output);
     }
 
+    [Fact]
+    public void Defer_OnUserGenericInstanceCall_PreservesMethodTypeArguments()
+    {
+        var source = """
+            package p
+            import System
+
+            class Marker1635 {
+                func Mark[T](value int32) {
+                    Console.WriteLine(value)
+                }
+            }
+
+            {
+                let marker = Marker1635()
+                defer marker.Mark[string](7)
+                Console.WriteLine("body")
+            }
+            """;
+
+        var output = CompileVerifyAndRun(source);
+        Assert.Equal("body\n7\n", output);
+    }
+
     private static string CompileVerifyAndRun(string source)
     {
         var workDir = Path.Combine(AppContext.BaseDirectory, "issue1635_defer_" + Guid.NewGuid().ToString("N"));

--- a/test/Compiler.Tests/Emit/Issue3095AwaitedReadOnlyListLinqEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3095AwaitedReadOnlyListLinqEmitTests.cs
@@ -1,0 +1,206 @@
+// <copyright file="Issue3095AwaitedReadOnlyListLinqEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>Runtime and ILVerify coverage for issue #3095.</summary>
+public sealed class Issue3095AwaitedReadOnlyListLinqEmitTests
+{
+    [Fact]
+    public void AwaitedReadOnlyList_WhereToList_ControlsRunAndVerify()
+    {
+        const string source = """
+            package Issue3095.Basic
+
+            import System
+            import System.Collections.Generic
+            import System.Linq
+            import System.Threading.Tasks
+
+            data class Notice3095(Active bool) {}
+
+            interface IStore3095 {
+                func ListAsync() Task[IReadOnlyList[Notice3095]];
+                func List() IReadOnlyList[Notice3095];
+            }
+
+            class Store3095 : IStore3095 {
+                public async func ListAsync() IReadOnlyList[Notice3095] {
+                    await Task.Yield()
+                    return []Notice3095{Notice3095(true), Notice3095(false), Notice3095(true)}
+                }
+
+                public func List() IReadOnlyList[Notice3095] ->
+                    []Notice3095{Notice3095(true), Notice3095(false), Notice3095(true)}
+            }
+
+            async func DirectAwaited(Store IStore3095) List[Notice3095] {
+                return (await Store.ListAsync())
+                    .Where((item Notice3095) -> item.Active)
+                    .ToList()
+            }
+
+            async func AwaitedLocal(Store IStore3095) List[Notice3095] {
+                let items = await Store.ListAsync()
+                return items.Where((item Notice3095) -> item.Active).ToList()
+            }
+
+            func LocalListControl() List[Notice3095] {
+                let items = List[Notice3095]{
+                    Notice3095(true),
+                    Notice3095(false),
+                    Notice3095(true),
+                }
+                return items.Where((item Notice3095) -> item.Active).ToList()
+            }
+
+            func InterfaceListControl(Store IStore3095) List[Notice3095] {
+                let items = Store.List()
+                return items.Where((item Notice3095) -> item.Active).ToList()
+            }
+
+            let Store IStore3095 = Store3095()
+            let direct = DirectAwaited(Store).GetAwaiter().GetResult()
+            Console.WriteLine(direct.Count)
+            Console.WriteLine(direct[0].Active)
+            Console.WriteLine(direct[1].Active)
+            Console.WriteLine(AwaitedLocal(Store).GetAwaiter().GetResult().Count)
+            Console.WriteLine(LocalListControl().Count)
+            Console.WriteLine(InterfaceListControl(Store).Count)
+            """;
+
+        Assert.Equal("2\nTrue\nTrue\n2\n2\n2\n", CompileVerifyAndRun(source));
+    }
+
+    [Fact]
+    public void AwaitedReadOnlyList_PreservesCovariantAndNestedGenericArguments()
+    {
+        const string source = """
+            package Issue3095.Siblings
+
+            import System
+            import System.Collections.Generic
+            import System.IO
+            import System.Linq
+            import System.Threading.Tasks
+
+            data class Leaf3095(Value int32) {}
+
+            interface ISiblingStore3095 {
+                func StreamsAsync() Task[IReadOnlyList[MemoryStream]];
+                func GroupsAsync() Task[IReadOnlyList[List[Leaf3095]]];
+            }
+
+            class SiblingStore3095 : ISiblingStore3095 {
+                public async func StreamsAsync() IReadOnlyList[MemoryStream] {
+                    await Task.Yield()
+                    return []MemoryStream{MemoryStream(), MemoryStream()}
+                }
+
+                public async func GroupsAsync() IReadOnlyList[List[Leaf3095]] {
+                    await Task.Yield()
+                    return []List[Leaf3095]{
+                        List[Leaf3095]{Leaf3095(1), Leaf3095(2)},
+                        List[Leaf3095]{Leaf3095(3)},
+                    }
+                }
+            }
+
+            async func Covariant(Store ISiblingStore3095) IEnumerable[Stream] {
+                return (await Store.StreamsAsync())
+                    .Where((stream MemoryStream) -> stream.CanRead)
+                    .ToList()
+            }
+
+            async func Nested(Store ISiblingStore3095) List[List[Leaf3095]] {
+                return (await Store.GroupsAsync())
+                    .Where((group List[Leaf3095]) -> group.Count > 1)
+                    .ToList()
+            }
+
+            let Store ISiblingStore3095 = SiblingStore3095()
+            Console.WriteLine(Covariant(Store).GetAwaiter().GetResult().Count())
+            let nested = Nested(Store).GetAwaiter().GetResult()
+            Console.WriteLine(nested.Count)
+            Console.WriteLine(nested[0][1].Value)
+            """;
+
+        Assert.Equal("2\n1\n2\n", CompileVerifyAndRun(source));
+    }
+
+    private static string CompileVerifyAndRun(string source)
+    {
+        var directory = Directory.CreateTempSubdirectory("gs_issue3095_").FullName;
+        try
+        {
+            var sourcePath = Path.Combine(directory, "test.gs");
+            var outputPath = Path.Combine(directory, "test.dll");
+            File.WriteAllText(sourcePath, source);
+
+            using var stdout = new StringWriter();
+            using var stderr = new StringWriter();
+            var previousOut = Console.Out;
+            var previousError = Console.Error;
+            Console.SetOut(stdout);
+            Console.SetError(stderr);
+            int exitCode;
+            try
+            {
+                exitCode = Program.Main(new[]
+                {
+                    "/out:" + outputPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    "/nowarn:GS9100",
+                    sourcePath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+                Console.SetError(previousError);
+            }
+
+            Assert.True(exitCode == 0, $"gsc failed:{Environment.NewLine}{stdout}{stderr}");
+            IlVerifier.Verify(outputPath);
+
+            using var process = Process.Start(new ProcessStartInfo("dotnet")
+            {
+                ArgumentList =
+                {
+                    "exec",
+                    "--runtimeconfig",
+                    Path.ChangeExtension(outputPath, ".runtimeconfig.json"),
+                    outputPath,
+                },
+                WorkingDirectory = directory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            }) ?? throw new InvalidOperationException("Failed to start dotnet exec.");
+            var output = process.StandardOutput.ReadToEnd();
+            var error = process.StandardError.ReadToEnd();
+            Assert.True(process.WaitForExit(30_000), "dotnet exec timed out.");
+            Assert.True(
+                process.ExitCode == 0,
+                $"exited {process.ExitCode}:{Environment.NewLine}{error}");
+            return output.Replace("\r\n", "\n", StringComparison.Ordinal);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue3095AwaitedReadOnlyListLinqEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3095AwaitedReadOnlyListLinqEmitTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
 
-/// <summary>Runtime and ILVerify coverage for issue #3095.</summary>
+/// <summary>Runtime and ILVerify coverage for async call metadata preservation.</summary>
 public sealed class Issue3095AwaitedReadOnlyListLinqEmitTests
 {
     [Fact]
@@ -132,6 +132,109 @@ public sealed class Issue3095AwaitedReadOnlyListLinqEmitTests
             """;
 
         Assert.Equal("2\n1\n2\n", CompileVerifyAndRun(source));
+    }
+
+    [Fact]
+    public void UserInstanceCalls_WithoutAwait_RunAndVerify()
+    {
+        const string source = """
+            package Issue3095.UserInstanceControls
+
+            import System
+
+            interface ICmp3095Control[T] {
+                func CompareTo(other T) int32;
+            }
+
+            struct Score3095Control : ICmp3095Control[Score3095Control] {
+                var Value int32
+
+                func CompareTo(other Score3095Control) int32 {
+                    return Value - other.Value
+                }
+            }
+
+            class Marker3095Control {
+                func Mark[T](value int32) string {
+                    return "mark:" + value.ToString()
+                }
+            }
+
+            func CompareDirect[T ICmp3095Control[T]](left T, right T) int32 {
+                return left.CompareTo(right)
+            }
+
+            let left = Score3095Control{Value: 9}
+            let right = Score3095Control{Value: 4}
+            Console.WriteLine(CompareDirect[Score3095Control](left, right))
+            Console.WriteLine(Marker3095Control().Mark[string](3))
+            """;
+
+        Assert.Equal("5\nmark:3\n", CompileVerifyAndRun(source));
+    }
+
+    [Fact]
+    public void AwaitedConstrainedUserInstanceCall_PreservesDispatchMetadata()
+    {
+        const string source = """
+            package Issue3095.AwaitedConstrainedUserInstance
+
+            import System
+            import System.Threading.Tasks
+
+            interface ICmp3095Await[T] {
+                func CompareTo(other T) int32;
+            }
+
+            struct Score3095Await : ICmp3095Await[Score3095Await] {
+                var Value int32
+
+                func CompareTo(other Score3095Await) int32 {
+                    return Value - other.Value
+                }
+            }
+
+            async func CompareAwaited[T ICmp3095Await[T]](left T, right Task[T]) int32 {
+                return left.CompareTo(await right)
+            }
+
+            let left = Score3095Await{Value: 9}
+            let right = Score3095Await{Value: 4}
+            let result = CompareAwaited[Score3095Await](
+                left,
+                Task.FromResult[Score3095Await](right)).GetAwaiter().GetResult()
+            Console.WriteLine(result)
+            """;
+
+        Assert.Equal("5\n", CompileVerifyAndRun(source));
+    }
+
+    [Fact]
+    public void AwaitedGenericUserInstanceCall_PreservesMethodTypeArguments()
+    {
+        const string source = """
+            package Issue3095.AwaitedGenericUserInstance
+
+            import System
+            import System.Threading.Tasks
+
+            class Marker3095Await {
+                func Mark[T](value int32) string {
+                    return "mark:" + value.ToString()
+                }
+            }
+
+            async func MarkAwaited(marker Marker3095Await, value Task[int32]) string {
+                return marker.Mark[string](await value)
+            }
+
+            let result = MarkAwaited(
+                Marker3095Await(),
+                Task.FromResult[int32](7)).GetAwaiter().GetResult()
+            Console.WriteLine(result)
+            """;
+
+        Assert.Equal("mark:7\n", CompileVerifyAndRun(source));
     }
 
     private static string CompileVerifyAndRun(string source)

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/Issue3095SpillSequenceSpillerTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/Issue3095SpillSequenceSpillerTests.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Lowering.Async;
 
-/// <summary>Verifies that await spilling preserves imported-call emission metadata.</summary>
+/// <summary>Verifies that await spilling preserves call-site emission metadata.</summary>
 public sealed class Issue3095SpillSequenceSpillerTests
 {
     [Fact]
@@ -45,7 +45,7 @@ public sealed class Issue3095SpillSequenceSpillerTests
         var rewritten = RewriteInitializer(call);
 
         var rewrittenCall = Assert.IsType<BoundImportedCallExpression>(rewritten);
-        Assert.Equal(typeArguments, rewrittenCall.TypeArgumentSymbols);
+        AssertImmutableArrayEqual(typeArguments, rewrittenCall.TypeArgumentSymbols);
         Assert.Same(staticContainerType, rewrittenCall.StaticContainerType);
     }
 
@@ -86,10 +86,63 @@ public sealed class Issue3095SpillSequenceSpillerTests
         var rewritten = RewriteInitializer(call);
 
         var rewrittenCall = Assert.IsType<BoundImportedInstanceCallExpression>(rewritten);
-        Assert.Equal(typeArguments, rewrittenCall.TypeArgumentSymbols);
+        AssertImmutableArrayEqual(typeArguments, rewrittenCall.TypeArgumentSymbols);
         Assert.Same(constrainedReceiver, rewrittenCall.ConstrainedReceiverTypeParameter);
         Assert.Same(constrainedInterface, rewrittenCall.ConstrainedInterfaceType);
         Assert.True(rewrittenCall.IsNonVirtualBaseCall);
+    }
+
+    [Fact]
+    public void UserInstanceCall_PreservesGenericAndDispatchMetadata()
+    {
+        var methodTypeParameter = new TypeParameterSymbol(
+            "TMethod",
+            0,
+            TypeParameterConstraint.Any,
+            TypeParameterVariance.None);
+        var method = new FunctionSymbol(
+            "Convert",
+            ImmutableArray.Create(new ParameterSymbol("value", TypeSymbol.Int32)),
+            TypeSymbol.String,
+            declaration: null,
+            package: null,
+            Accessibility.Public,
+            receiverType: TypeSymbol.Object)
+        {
+            TypeParameters = ImmutableArray.Create(methodTypeParameter),
+        };
+        var methodTypeArguments = ImmutableArray.Create<TypeSymbol>(TypeSymbol.String);
+        var constrainedReceiver = new TypeParameterSymbol(
+            "TReceiver",
+            0,
+            TypeParameterConstraint.Any,
+            TypeParameterVariance.None);
+        var constrainedInterface = TypeSymbol.Object;
+        var receiver = new BoundVariableExpression(
+            null,
+            new LocalVariableSymbol("receiver", isReadOnly: true, TypeSymbol.Object));
+        var call = new BoundUserInstanceCallExpression(
+            null,
+            receiver,
+            method,
+            ImmutableArray.Create<BoundExpression>(
+                new BoundAwaitExpression(
+                    null,
+                    new BoundLiteralExpression(null, 0),
+                    TypeSymbol.Int32)),
+            TypeSymbol.String,
+            constrainedReceiver,
+            constrainedInterface)
+        {
+            MethodTypeArguments = methodTypeArguments,
+        };
+
+        var rewritten = RewriteInitializer(call);
+
+        var rewrittenCall = Assert.IsType<BoundUserInstanceCallExpression>(rewritten);
+        AssertImmutableArrayEqual(methodTypeArguments, rewrittenCall.MethodTypeArguments);
+        Assert.Same(constrainedReceiver, rewrittenCall.ConstrainedReceiverTypeParameter);
+        Assert.Same(constrainedInterface, rewrittenCall.ConstrainedInterfaceType);
     }
 
     private static BoundExpression RewriteInitializer(BoundExpression initializer)
@@ -103,5 +156,14 @@ public sealed class Issue3095SpillSequenceSpillerTests
         var rewritten = SpillSequenceSpiller.Rewrite(body);
 
         return Assert.IsType<BoundVariableDeclaration>(rewritten.Statements[^1]).Initializer;
+    }
+
+    private static void AssertImmutableArrayEqual<T>(ImmutableArray<T> expected, ImmutableArray<T> actual)
+    {
+        Assert.Equal(expected.IsDefault, actual.IsDefault);
+        if (!expected.IsDefault)
+        {
+            Assert.Equal(expected.ToArray(), actual.ToArray());
+        }
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/Issue3095SpillSequenceSpillerTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/Issue3095SpillSequenceSpillerTests.cs
@@ -1,0 +1,107 @@
+// <copyright file="Issue3095SpillSequenceSpillerTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Lowering.Async;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Lowering.Async;
+
+/// <summary>Verifies that await spilling preserves imported-call emission metadata.</summary>
+public sealed class Issue3095SpillSequenceSpillerTests
+{
+    [Fact]
+    public void ImportedStaticCall_PreservesGenericArgumentsAndContainer()
+    {
+        var method = typeof(Enumerable)
+            .GetMethods()
+            .Single(candidate =>
+                candidate.Name == nameof(Enumerable.ToList)
+                && candidate.GetParameters().Length == 1)
+            .MakeGenericMethod(typeof(object));
+        var function = new ImportedFunctionSymbol(
+            method.Name,
+            new ImportedClassSymbol(typeof(Enumerable), null),
+            method,
+            null);
+        var typeArguments = ImmutableArray.Create<TypeSymbol>(TypeSymbol.String);
+        var staticContainerType = TypeSymbol.Object;
+        var call = new BoundImportedCallExpression(
+            null,
+            function,
+            ImmutableArray.Create<BoundExpression>(
+                new BoundAwaitExpression(
+                    null,
+                    new BoundLiteralExpression(null, 0),
+                    TypeSymbol.FromClrType(typeof(IEnumerable<object>)))),
+            typeArgumentSymbols: typeArguments,
+            staticContainerType: staticContainerType);
+
+        var rewritten = RewriteInitializer(call);
+
+        var rewrittenCall = Assert.IsType<BoundImportedCallExpression>(rewritten);
+        Assert.Equal(typeArguments, rewrittenCall.TypeArgumentSymbols);
+        Assert.Same(staticContainerType, rewrittenCall.StaticContainerType);
+    }
+
+    [Fact]
+    public void ImportedInstanceCall_PreservesGenericAndDispatchMetadata()
+    {
+        var method = typeof(List<object>)
+            .GetMethod(nameof(List<object>.ConvertAll))!
+            .MakeGenericMethod(typeof(object));
+        var typeArguments = ImmutableArray.Create<TypeSymbol>(TypeSymbol.String);
+        var constrainedReceiver = new TypeParameterSymbol(
+            "T",
+            0,
+            TypeParameterConstraint.Any,
+            TypeParameterVariance.None);
+        var constrainedInterface = ImportedTypeSymbol.Get(typeof(IComparable<object>));
+        var receiver = new BoundVariableExpression(
+            null,
+            new LocalVariableSymbol(
+                "items",
+                isReadOnly: true,
+                TypeSymbol.FromClrType(typeof(List<object>))));
+        var call = new BoundImportedInstanceCallExpression(
+            null,
+            receiver,
+            method,
+            TypeSymbol.FromClrType(typeof(List<object>)),
+            ImmutableArray.Create<BoundExpression>(
+                new BoundAwaitExpression(
+                    null,
+                    new BoundLiteralExpression(null, 0),
+                    TypeSymbol.FromClrType(typeof(Converter<object, object>)))),
+            typeArgumentSymbols: typeArguments,
+            constrainedReceiverTypeParameter: constrainedReceiver,
+            constrainedInterfaceType: constrainedInterface,
+            isNonVirtualBaseCall: true);
+
+        var rewritten = RewriteInitializer(call);
+
+        var rewrittenCall = Assert.IsType<BoundImportedInstanceCallExpression>(rewritten);
+        Assert.Equal(typeArguments, rewrittenCall.TypeArgumentSymbols);
+        Assert.Same(constrainedReceiver, rewrittenCall.ConstrainedReceiverTypeParameter);
+        Assert.Same(constrainedInterface, rewrittenCall.ConstrainedInterfaceType);
+        Assert.True(rewrittenCall.IsNonVirtualBaseCall);
+    }
+
+    private static BoundExpression RewriteInitializer(BoundExpression initializer)
+    {
+        var result = new LocalVariableSymbol("result", isReadOnly: true, initializer.Type);
+        var body = new BoundBlockStatement(
+            null,
+            ImmutableArray.Create<BoundStatement>(
+                new BoundVariableDeclaration(null, result, initializer)));
+
+        var rewritten = SpillSequenceSpiller.Rewrite(body);
+
+        return Assert.IsType<BoundVariableDeclaration>(rewritten.Statements[^1]).Initializer;
+    }
+}


### PR DESCRIPTION
## Summary
- preserve imported static/instance generic arguments, symbolic container data, and constrained-dispatch metadata when async lowering rebuilds calls around nested awaits
- preserve user-instance method type arguments and constrained-dispatch metadata through async spilling, bound-tree rewriting, and defer capture
- add compile/run/ILVerify coverage for awaited `IReadOnlyList<T>` LINQ plus local, interface, covariance, nested-generic, constrained-user-call, and generic-user-call controls

## Root cause
Binding was correct: extension inference recovered `TSource = Notice`, target-typed the lambda as `Func<Notice, bool>`, and stored `Notice` in `BoundImportedCallExpression.TypeArgumentSymbols`. The reflected `MethodInfo` remained the expected object-erased placeholder used during binding.

When `Where` received a direct `await` expression as its extension receiver, `SpillSequenceSpiller` rebuilt the imported call after lifting the await. That rebuild copied only the function, arguments, and ref kinds, dropping `TypeArgumentSymbols`. Emission therefore reconstructed the `MethodSpec` from the placeholder `MethodInfo` and wrote `Enumerable.Where<object>` / `ToList<object>` beside the correctly typed `Func<Notice, bool>`.

Review of every sibling call reconstruction found the same metadata-loss class on user-instance calls: async spilling, `BoundTreeRewriter`, and defer capture omitted bound method type arguments, and spilling also omitted constrained receiver/interface data. Those shared rebuild paths now replace only receivers/arguments while retaining every emission-relevant property.

No LINQ special case, object fallback, inference change, or verifier suppression is involved.

## Verification
- reduced repro runs correctly, passes ILVerify, and emits `Enumerable.Where<Notice>` / `Enumerable.ToList<Notice>`
- awaited-local, non-async local-list, and interface-returned-list controls pass
- covariance and nested generic regressions pass
- constrained and generic user-instance async/defer regressions pass
- full `Core.Tests`: **7116 passed, 1 skipped, 0 failed**
- full `Compiler.Tests`: **4232 passed, 0 failed**
- `dotnet build GSharp.sln -c Release --no-restore`: **0 warnings, 0 errors**
- GitHub Actions: **29 checks succeeded**, 2 publish-only checks skipped as expected; pinned Oahu migration **15/15 apps green**

Fixes #3095
