### PR TITLE
Preserve field shape on reified CLR type arguments

### DIFF
--- a/src/Core/CodeAnalysis/Evaluator.Expressions.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Expressions.cs
@@ -1283,6 +1283,7 @@ public sealed partial class Evaluator
         var module = CreateClrBackingModule();
         var definition = structType.Definition ?? structType;
         var arity = definition.TypeParameters.Length;
+        var reifiedTypeParameters = new Dictionary<TypeParameterSymbol, Type>();
         var enclosingTypes = new Stack<StructSymbol>();
         for (var containing = definition.ContainingType as StructSymbol;
              containing != null;
@@ -1331,7 +1332,27 @@ public sealed partial class Evaluator
                 clrBase);
         if (arity > 0)
         {
-            typeBuilder.DefineGenericParameters(definition.TypeParameters.Select(static parameter => parameter.Name).ToArray());
+            var parameters = typeBuilder.DefineGenericParameters(
+                definition.TypeParameters.Select(static parameter => parameter.Name).ToArray());
+            for (var i = 0; i < parameters.Length; i++)
+            {
+                reifiedTypeParameters[definition.TypeParameters[i]] = parameters[i];
+            }
+        }
+
+        // Issue #3137: reified type arguments must expose the same instance-field shape as emitted types.
+        foreach (var field in definition.Fields)
+        {
+            var fieldAttributes = Emit.AccessibilityMap.MapFieldAccessibility(field.Accessibility);
+            if (field.IsReadOnly)
+            {
+                fieldAttributes |= FieldAttributes.InitOnly;
+            }
+
+            typeBuilder.DefineField(
+                field.Name,
+                ResolveClrBackingTypeArgument(field.Type, reifiedTypeParameters),
+                fieldAttributes);
         }
 
         if (emitBaseConstructors)
@@ -1380,8 +1401,16 @@ public sealed partial class Evaluator
         return backingType.MakeGenericType(typeArguments);
     }
 
-    private static Type ResolveClrBackingTypeArgument(TypeSymbol argument)
+    private static Type ResolveClrBackingTypeArgument(
+        TypeSymbol argument,
+        IReadOnlyDictionary<TypeParameterSymbol, Type> reifiedTypeParameters = null)
     {
+        if (argument is TypeParameterSymbol typeParameter
+            && reifiedTypeParameters?.TryGetValue(typeParameter, out var reifiedTypeParameter) == true)
+        {
+            return reifiedTypeParameter;
+        }
+
         if (argument is NullableTypeSymbol nullable)
         {
             var underlying = ResolveClrBackingTypeArgument(nullable.UnderlyingType);
@@ -1397,7 +1426,9 @@ public sealed partial class Evaluator
             try
             {
                 return openDefinition.MakeGenericType(
-                    imported.TypeArguments.Select(ResolveClrBackingTypeArgument).ToArray());
+                    imported.TypeArguments
+                        .Select(typeArgument => ResolveClrBackingTypeArgument(typeArgument, reifiedTypeParameters))
+                        .ToArray());
             }
             catch (ArgumentException)
             {
@@ -1407,12 +1438,12 @@ public sealed partial class Evaluator
 
         if (argument is SliceTypeSymbol slice)
         {
-            return ResolveClrBackingTypeArgument(slice.ElementType).MakeArrayType();
+            return ResolveClrBackingTypeArgument(slice.ElementType, reifiedTypeParameters).MakeArrayType();
         }
 
         if (argument is ArrayTypeSymbol array)
         {
-            return ResolveClrBackingTypeArgument(array.ElementType).MakeArrayType();
+            return ResolveClrBackingTypeArgument(array.ElementType, reifiedTypeParameters).MakeArrayType();
         }
 
         if (argument.ClrType is Type clrType)

--- a/src/Core/CodeAnalysis/Evaluator.Expressions.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Expressions.cs
@@ -1340,19 +1340,35 @@ public sealed partial class Evaluator
             }
         }
 
-        // Issue #3137: reified type arguments must expose the same instance-field shape as emitted types.
-        foreach (var field in definition.Fields)
+        // Issue #3137: reified type arguments must expose the same field shape as emitted types.
+        foreach (var field in definition.Fields.Concat(definition.StaticFields).Concat(definition.ConstFields))
         {
             var fieldAttributes = Emit.AccessibilityMap.MapFieldAccessibility(field.Accessibility);
-            if (field.IsReadOnly)
+            if (field.IsConst)
             {
-                fieldAttributes |= FieldAttributes.InitOnly;
+                fieldAttributes |= FieldAttributes.Static | FieldAttributes.Literal | FieldAttributes.HasDefault;
+            }
+            else
+            {
+                if (field.IsStatic)
+                {
+                    fieldAttributes |= FieldAttributes.Static;
+                }
+
+                if (field.IsReadOnly)
+                {
+                    fieldAttributes |= FieldAttributes.InitOnly;
+                }
             }
 
-            typeBuilder.DefineField(
+            var fieldBuilder = typeBuilder.DefineField(
                 field.Name,
                 ResolveClrBackingTypeArgument(field.Type, reifiedTypeParameters),
                 fieldAttributes);
+            if (field.IsConst)
+            {
+                fieldBuilder.SetConstant(field.ConstantValue);
+            }
         }
 
         if (emitBaseConstructors)
@@ -1413,7 +1429,7 @@ public sealed partial class Evaluator
 
         if (argument is NullableTypeSymbol nullable)
         {
-            var underlying = ResolveClrBackingTypeArgument(nullable.UnderlyingType);
+            var underlying = ResolveClrBackingTypeArgument(nullable.UnderlyingType, reifiedTypeParameters);
             return underlying.IsValueType
                 ? typeof(Nullable<>).MakeGenericType(underlying)
                 : underlying;

--- a/test/Interpreter.Tests/Issue3099TypeArgumentReificationTests.cs
+++ b/test/Interpreter.Tests/Issue3099TypeArgumentReificationTests.cs
@@ -29,7 +29,7 @@ public class Issue3099TypeArgumentReificationTests
         yield return ["string", string.Empty, "string"];
         yield return ["nested-class", "class Owner {\n    class Payload {\n        let Eleven int32\n        var TwentyTwo string\n    }\n}", "Owner.Payload"];
         yield return ["nested-struct", "class Owner {\n    struct Payload {\n        let Eleven int32\n        var TwentyTwo string\n    }\n}", "Owner.Payload"];
-        yield return ["gsharp-generic", "struct Payload[T] {\n    let Value T\n    var Imported List[T]\n    var Slice []T\n    var Array [3]T\n}", "Payload[int32]"];
+        yield return ["gsharp-generic", "struct Payload[T] {\n    let Value T\n    var Imported List[T]\n    var Slice []T\n    var Nullable T?\n    var Array [3]T\n    shared {\n        var Stat int32\n    }\n    const Kilo int32 = 1000\n}", "Payload[int32]"];
         yield return ["imported-generic", "struct Payload {\n    let Eleven int32\n    var TwentyTwo string\n}", "List[Payload]"];
         yield return ["nullable", "struct Payload {\n    let Eleven int32\n    var TwentyTwo string\n}", "Payload?"];
         yield return ["slice", "struct Payload {\n    let Eleven int32\n    var TwentyTwo string\n}", "[]Payload"];
@@ -90,9 +90,15 @@ public class Issue3099TypeArgumentReificationTests
             });
 
             var expected = NormalizeGenericTypeNames(emitted);
-            Assert.Matches(@"44\n[1-9][0-9]*\|", expected);
-            Assert.Equal(expected, NormalizeGenericTypeNames(compilerEvaluation));
-            Assert.Equal(expected, NormalizeGenericTypeNames(interpreter));
+            var evaluated = NormalizeGenericTypeNames(compilerEvaluation);
+            var interpreted = NormalizeGenericTypeNames(interpreter);
+            const string ControlShape =
+                "44\n2|Eleven:System.Int32:True:False:False|TwentyTwo:System.String:False:False:False\n";
+            Assert.Contains(ControlShape, expected, StringComparison.Ordinal);
+            Assert.Contains(ControlShape, evaluated, StringComparison.Ordinal);
+            Assert.Contains(ControlShape, interpreted, StringComparison.Ordinal);
+            Assert.Equal(expected, evaluated);
+            Assert.Equal(expected, interpreted);
             Assert.Contains("11\n", expected);
             Assert.Contains("22\n", expected);
             Assert.Contains("33\n", expected);
@@ -115,6 +121,11 @@ public class Issue3099TypeArgumentReificationTests
 
             __DECLARATION__
 
+            struct ReflectionControl {
+                let Eleven int32
+                var TwentyTwo string
+            }
+
             class Box[T] : EventArgs {
             }
 
@@ -124,7 +135,10 @@ public class Issue3099TypeArgumentReificationTests
             func FieldShape(t Type) string {
                 var shape = t.GetFields().Length.ToString()
                 for field in t.GetFields() {
-                    shape = shape + "|" + field.Name + ":" + field.FieldType.FullName + ":" + field.IsInitOnly.ToString()
+                    shape = shape + "|" + field.Name + ":" + field.FieldType.FullName + ":" + field.IsInitOnly.ToString() + ":" + field.IsStatic.ToString() + ":" + field.IsLiteral.ToString()
+                    if field.IsLiteral {
+                        shape = shape + ":" + field.GetRawConstantValue().ToString()
+                    }
                 }
                 return shape
             }
@@ -147,7 +161,7 @@ public class Issue3099TypeArgumentReificationTests
             var nested = Box[Box[__TYPE__]]()
             Console.WriteLine(nested.GetType().FullName)
             Console.WriteLine(FieldShape(nested.GetType().GenericTypeArguments[0].GenericTypeArguments[0]))
-            var control = Box[ConsoleColor]()
+            var control = Box[ReflectionControl]()
             Console.WriteLine(44)
             Console.WriteLine(FieldShape(control.GetType().GenericTypeArguments[0]))
             """;

--- a/test/Interpreter.Tests/Issue3099TypeArgumentReificationTests.cs
+++ b/test/Interpreter.Tests/Issue3099TypeArgumentReificationTests.cs
@@ -16,23 +16,24 @@ namespace GSharp.Interpreter.Tests;
 /// <summary>
 /// Issue #3099: interpreter-created generic backing types must preserve every
 /// G# type-argument kind instead of erasing value types to <see cref="object"/>.
+/// Issue #3137 extends the same emit-oracle matrix to reflected field shape.
 /// </summary>
 [Collection("ConsoleIo")]
 public class Issue3099TypeArgumentReificationTests
 {
     public static IEnumerable<object[]> TypeArgumentCases()
     {
-        yield return ["class", "class Payload {\n}", "Payload"];
-        yield return ["struct", "struct Payload {\n    var Value int32\n}", "Payload"];
+        yield return ["class", "class Payload {\n    let Eleven int32\n    var TwentyTwo string\n}", "Payload"];
+        yield return ["struct", "struct Payload {\n    let Eleven int32\n    var TwentyTwo string\n}", "Payload"];
         yield return ["enum", "enum Payload {\n    Eleven = 11,\n    TwentyTwo = 22,\n    ThirtyThree = 33,\n}", "Payload"];
         yield return ["string", string.Empty, "string"];
-        yield return ["nested-class", "class Owner {\n    class Payload {\n    }\n}", "Owner.Payload"];
-        yield return ["nested-struct", "class Owner {\n    struct Payload {\n        var Value int32\n    }\n}", "Owner.Payload"];
-        yield return ["gsharp-generic", "struct Payload[T] {\n    var Value T\n}", "Payload[int32]"];
-        yield return ["imported-generic", "struct Payload {\n    var Value int32\n}", "List[Payload]"];
-        yield return ["nullable", "struct Payload {\n    var Value int32\n}", "Payload?"];
-        yield return ["slice", "struct Payload {\n    var Value int32\n}", "[]Payload"];
-        yield return ["array", "struct Payload {\n    var Value int32\n}", "[3]Payload"];
+        yield return ["nested-class", "class Owner {\n    class Payload {\n        let Eleven int32\n        var TwentyTwo string\n    }\n}", "Owner.Payload"];
+        yield return ["nested-struct", "class Owner {\n    struct Payload {\n        let Eleven int32\n        var TwentyTwo string\n    }\n}", "Owner.Payload"];
+        yield return ["gsharp-generic", "struct Payload[T] {\n    let Value T\n    var Imported List[T]\n    var Slice []T\n    var Array [3]T\n}", "Payload[int32]"];
+        yield return ["imported-generic", "struct Payload {\n    let Eleven int32\n    var TwentyTwo string\n}", "List[Payload]"];
+        yield return ["nullable", "struct Payload {\n    let Eleven int32\n    var TwentyTwo string\n}", "Payload?"];
+        yield return ["slice", "struct Payload {\n    let Eleven int32\n    var TwentyTwo string\n}", "[]Payload"];
+        yield return ["array", "struct Payload {\n    let Eleven int32\n    var TwentyTwo string\n}", "[3]Payload"];
     }
 
     [Theory]
@@ -89,6 +90,7 @@ public class Issue3099TypeArgumentReificationTests
             });
 
             var expected = NormalizeGenericTypeNames(emitted);
+            Assert.Matches(@"44\n[1-9][0-9]*\|", expected);
             Assert.Equal(expected, NormalizeGenericTypeNames(compilerEvaluation));
             Assert.Equal(expected, NormalizeGenericTypeNames(interpreter));
             Assert.Contains("11\n", expected);
@@ -119,20 +121,35 @@ public class Issue3099TypeArgumentReificationTests
             class Pair[TFirst, TSecond] : EventArgs {
             }
 
+            func FieldShape(t Type) string {
+                var shape = t.GetFields().Length.ToString()
+                for field in t.GetFields() {
+                    shape = shape + "|" + field.Name + ":" + field.FieldType.FullName + ":" + field.IsInitOnly.ToString()
+                }
+                return shape
+            }
+
             var single = Box[__TYPE__]()
             Console.WriteLine(11)
             Console.WriteLine(single.GetType().FullName)
             Console.WriteLine(single.GetType().GenericTypeArguments[0].IsValueType)
             Console.WriteLine(single.GetType().GenericTypeArguments[0].IsEnum)
             Console.WriteLine(single.GetType().GenericTypeArguments[0].IsLayoutSequential)
+            Console.WriteLine(FieldShape(single.GetType().GenericTypeArguments[0]))
             var multiple = Pair[__TYPE__, int32]()
             Console.WriteLine(22)
             Console.WriteLine(multiple.GetType().FullName)
             Console.WriteLine(Object.ReferenceEquals(
                 single.GetType().GenericTypeArguments[0],
                 multiple.GetType().GenericTypeArguments[0]))
+            Console.WriteLine(FieldShape(multiple.GetType().GenericTypeArguments[0]))
             Console.WriteLine(33)
-            Console.WriteLine(Box[Box[__TYPE__]]().GetType().FullName)
+            var nested = Box[Box[__TYPE__]]()
+            Console.WriteLine(nested.GetType().FullName)
+            Console.WriteLine(FieldShape(nested.GetType().GenericTypeArguments[0].GenericTypeArguments[0]))
+            var control = Box[ConsoleColor]()
+            Console.WriteLine(44)
+            Console.WriteLine(FieldShape(control.GetType().GenericTypeArguments[0]))
             """;
 
         return Template


### PR DESCRIPTION
## Summary

- extend the existing emit-parity oracle to compare reflected field count, names, CLR types, readonly state, static state, literal state, and constant values across every type-argument cell
- define G# instance, static, and const fields on evaluator-created CLR backing types with matching reflection metadata
- preserve generic field types recursively through nullable types, imported generics, slices, and arrays
- use a G#-defined two-instance-field reflection control, asserted independently in all three drivers

## Coverage

The oracle covers 11 type kinds across single, multiple, and nested generic placements under bare `gsc`, emitted `gsc /out:`, and `gsi`: 99 parity cells. Emitted output is the expected value. The generic specimen includes `T`, `List[T]`, `[]T`, `T?`, `[3]T`, a static field, and a const field.

| Generic field | Emit | Evaluate | Interpret |
|---|---|---|---|
| `Value T` | `System.Int32` | `System.Int32` | `System.Int32` |
| `Imported List[T]` | `List[Int32]` | `List[Int32]` | `List[Int32]` |
| `Slice []T` | `System.Int32[]` | `System.Int32[]` | `System.Int32[]` |
| `Nullable T?` | `System.Int32` | `System.Int32` | `System.Int32` |

| Field | Emit | Evaluate | Interpret |
|---|---|---|---|
| static `Stat` | `IsStatic=True, IsLiteral=False` | same | same |
| const `Kilo` | `IsStatic=True, IsLiteral=True, Value=1000` | same | same |

## Mutation testing

| Mutant | Result |
|---|---|
| invert readonly field handling | RED: 5 failed / 6 passed |
| invert generic type-parameter map lookup | RED: 1 failed / 10 passed |
| omit nullable recursive map argument | RED: 1 failed / 10 passed; `Nullable` became `System.Object` |
| invert static-field condition | RED: 11 failed / 0 passed |
| invert const `SetConstant` condition | RED: 11 failed / 0 passed with `GS9999` |
| scope reflection control to public static fields | RED: 11 failed / 0 passed |

Every mutation was asserted present before execution. Restored head is GREEN at 11/11. Main without this PR is GREEN at 11/11 on its unmodified oracle.

## Validation

- rebased onto main `61fe9cb943d15c0f5ba747dabd562e66fb132058`
- `git merge-tree --write-tree` output exactly matches the head tree
- solution build: rc 0, 0 warnings, 0 errors
- targeted parity oracle: 11 passed
- local tests: 15,134 passed, 1 skipped, 0 failed across 9 of 9 test projects enumerated from `GSharp.sln`
- correction addendum: `Sdk.Tests` runs in-process and is safe locally; it passed 59/59. The earlier 8-of-9 statement came from mistaking a docstring description for executed behavior.
- all required PR checks, including `Sdk.Tests`, are green
- emitted assemblies are loaded with `Assembly.Load`, enumerated with `GetTypes()`, and executed

Validated on head `8cd87cf48ef0788b8a3463ce4a0d799379b79b3f`.

Fixes #3137