### PR TITLE
Pin constructor ref-struct liveness analysis

### DIFF
--- a/test/Interpreter.Tests/Issue3145ConstructorRefStructLivenessTests.cs
+++ b/test/Interpreter.Tests/Issue3145ConstructorRefStructLivenessTests.cs
@@ -1,0 +1,167 @@
+// <copyright file="Issue3145ConstructorRefStructLivenessTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>Issue #3145: constructor bodies run async ref-struct liveness analysis.</summary>
+[Collection("ConsoleIo")]
+public class Issue3145ConstructorRefStructLivenessTests
+{
+    private const string UnsafeSource = """
+        import System
+        import System.Threading.Tasks
+
+        class Holder {
+            var Value int32
+
+            init(values []int32) {
+                let read = async func() int32 {
+                    var span ReadOnlySpan[int32] = values
+                    await Task.Yield()
+                    return span.Length
+                }
+                Value = read().Result
+            }
+        }
+
+        """;
+
+    private const string SafeSource = """
+        import System
+        import System.Threading.Tasks
+
+        class Holder {
+            var Value int32
+
+            init(values []int32) {
+                let read = async func() int32 {
+                    var span ReadOnlySpan[int32] = values
+                    var length = span.Length
+                    await Task.Yield()
+                    return length
+                }
+                Value = read().Result
+            }
+        }
+
+        """;
+
+    public static IEnumerable<object[]> Drivers()
+    {
+        foreach (var driver in Enum.GetValues<Driver>())
+        {
+            yield return new object[] { driver };
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(Drivers))]
+    public void ConstructorAsyncLambda_RefStructLiveAcrossAwait_ReportsGS0219(Driver driver)
+    {
+        var result = Run(UnsafeSource, driver);
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Equal(new[] { "GS0219" }, result.DiagnosticIds);
+    }
+
+    [Theory]
+    [MemberData(nameof(Drivers))]
+    public void ConstructorAsyncLambda_RefStructDeadBeforeAwait_HasNoDiagnostics(Driver driver)
+    {
+        var result = Run(SafeSource, driver);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Empty(result.DiagnosticIds);
+    }
+
+    public enum Driver
+    {
+        CompilerEvaluation,
+        CompilerEmission,
+        Interpreter,
+    }
+
+    private static DriverResult Run(string source, Driver driver)
+    {
+        var root = Path.Combine(
+            GetRepositoryRoot(),
+            "out",
+            "test-artifacts",
+            $"issue3145-{driver}-{Guid.NewGuid():N}");
+        Assert.False(Directory.Exists(root));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var sourceDirectory = Directory.CreateDirectory(Path.Combine(root, "source")).FullName;
+            var outputDirectory = Directory.CreateDirectory(Path.Combine(root, "output")).FullName;
+            Assert.Empty(Directory.EnumerateFileSystemEntries(outputDirectory));
+
+            var sourcePath = Path.Combine(sourceDirectory, "Probe.gs");
+            File.WriteAllText(sourcePath, source);
+            var result = driver switch
+            {
+                Driver.CompilerEvaluation => Capture(() => GSharp.Compiler.Program.Main(new[] { sourcePath })),
+                Driver.CompilerEmission => Capture(() => GSharp.Compiler.Program.Main(new[]
+                {
+                    "/out:" + Path.Combine(outputDirectory, "Probe.dll"),
+                    sourcePath,
+                })),
+                Driver.Interpreter => Capture(() => GSharp.Repl.Program.Main(new[] { sourcePath })),
+                _ => throw new InvalidOperationException($"Unexpected driver {driver}."),
+            };
+
+            var ids = Regex.Matches(result.StandardOutput + result.StandardError, @"\bGS\d{4}\b")
+                .Select(match => match.Value)
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(id => id, StringComparer.Ordinal)
+                .ToArray();
+            return new DriverResult(result.ExitCode, ids);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static (int ExitCode, string StandardOutput, string StandardError) Capture(Func<int> action)
+    {
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+        var previousOutput = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(output);
+        Console.SetError(error);
+        try
+        {
+            return (action(), output.ToString(), error.ToString());
+        }
+        finally
+        {
+            Console.SetOut(previousOutput);
+            Console.SetError(previousError);
+        }
+    }
+
+    private static string GetRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null && !File.Exists(Path.Combine(directory.FullName, "GSharp.sln")))
+        {
+            directory = directory.Parent;
+        }
+
+        return directory?.FullName
+            ?? throw new InvalidOperationException("Could not locate repository root.");
+    }
+
+    private sealed record DriverResult(int ExitCode, string[] DiagnosticIds);
+}


### PR DESCRIPTION
Fixes #3145

## Summary
- cover ref-struct liveness inside async lambdas declared in constructor bodies
- verify unsafe live-across-await and safe dead-before-await shapes
- exercise bare `gsc`, emitted `gsc /out:`, and `gsi` with isolated output directories

## Two-sided mutation
On rebased head `c2677d87`, reverting `Binder.cs:1600` was asserted applied and changed the focused matrix from **6/6 green** to **3 failed / 3 passed**. All unsafe driver rows changed from rc 1 + `GS0219` to rc 0 + no diagnostic; safe rows stayed green. Restoring product source returned **6/6 green**.

## Validation
- focused driver matrix on `faca348a`: **6 passed / 0 failed**
- full Release suite on immediately prior merged base `f6f8acc0`: **15,125 passed / 0 failed / 1 skipped / 15,126 total**
- all nine projects ran: Core.Tests, Compiler.Tests, Interpreter.Tests, LanguageServer.Tests, Sdk.Tests, Extensions.Tests, InternalAnalyzers.Tests, Cs2Gs.Tests, GSharp.GeneratorHost.Tests
- final CI run `30827260970`: every non-skipped job passed, including `cs2gs-oahu` and all nine test-project shards