### PR TITLE
Fix evaluator class reference identity

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
@@ -39,13 +39,20 @@ public sealed record BoundBinaryOperator
     {
     }
 
-    private BoundBinaryOperator(SyntaxKind syntaxKind, BoundBinaryOperatorKind kind, TypeSymbol leftType, TypeSymbol rightType, TypeSymbol resultType)
+    private BoundBinaryOperator(
+        SyntaxKind syntaxKind,
+        BoundBinaryOperatorKind kind,
+        TypeSymbol leftType,
+        TypeSymbol rightType,
+        TypeSymbol resultType,
+        bool isReferenceEquality = false)
     {
         SyntaxKind = syntaxKind;
         Kind = kind;
         LeftType = leftType;
         RightType = rightType;
         Type = resultType;
+        IsReferenceEquality = isReferenceEquality;
     }
 
     /// <summary>
@@ -72,6 +79,9 @@ public sealed record BoundBinaryOperator
     /// Gets the bound binary operator type symbol.
     /// </summary>
     public TypeSymbol Type { get; }
+
+    /// <summary>Gets a value indicating whether equality compares reference identity.</summary>
+    internal bool IsReferenceEquality { get; }
 
     /// <summary>
     /// Binds a syntax kind and a type symbol to the corresponding bound binary operator, or
@@ -367,7 +377,7 @@ public sealed record BoundBinaryOperator
         var kind = syntaxKind == SyntaxKind.EqualsEqualsToken
             ? BoundBinaryOperatorKind.Equals
             : BoundBinaryOperatorKind.NotEquals;
-        return new BoundBinaryOperator(syntaxKind, kind, leftType, rightType, TypeSymbol.Bool);
+        return new BoundBinaryOperator(syntaxKind, kind, leftType, rightType, TypeSymbol.Bool, isReferenceEquality: true);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Evaluator.Operators.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Operators.cs
@@ -174,9 +174,9 @@ public sealed partial class Evaluator
         switch (b.Op.Kind)
         {
             case BoundBinaryOperatorKind.Equals:
-                return NumericEquals(left, right);
+                return b.Op.IsReferenceEquality ? ReferenceEquals(left, right) : NumericEquals(left, right);
             case BoundBinaryOperatorKind.NotEquals:
-                return !NumericEquals(left, right);
+                return b.Op.IsReferenceEquality ? !ReferenceEquals(left, right) : !NumericEquals(left, right);
             case BoundBinaryOperatorKind.LogicalAnd:
                 return (bool)left && (bool)right;
             case BoundBinaryOperatorKind.LogicalOr:

--- a/src/Core/CodeAnalysis/StructValue.cs
+++ b/src/Core/CodeAnalysis/StructValue.cs
@@ -162,6 +162,11 @@ public sealed class StructValue
             return (bool)result;
         }
 
+        if (StructType.IsClass && !StructType.IsData)
+        {
+            return ReferenceEquals(this, obj);
+        }
+
         if (obj is not StructValue other)
         {
             return false;
@@ -191,6 +196,11 @@ public sealed class StructValue
         if (TryInvokeObjectOverride(ObjectGetHashCodeMethod, [], out var result))
         {
             return (int)result;
+        }
+
+        if (StructType.IsClass && !StructType.IsData)
+        {
+            return RuntimeHelpers.GetHashCode(this);
         }
 
         var hash = default(HashCode);

--- a/test/Interpreter.Tests/Issue2896StructObjectOverrideTests.cs
+++ b/test/Interpreter.Tests/Issue2896StructObjectOverrideTests.cs
@@ -122,6 +122,7 @@ public class Issue2896StructObjectOverrideTests
     [InlineData("dictionary")]
     [InlineData("hashSet")]
     [InlineData("listContains")]
+    [InlineData("operatorEquals")]
     [InlineData("equals")]
     [InlineData("getHashCode")]
     public async Task Issue3134_ClassIdentityAndStructValueEqualityMatchEmitter(string surface)
@@ -452,6 +453,19 @@ public class Issue2896StructObjectOverrideTests
                     {{prefix}}Values.Contains({{prefix}}B),
                     {{prefix}}Values.Contains({{prefix}}Other)))
                 """,
+            "operatorEquals" when isClass => $$"""
+                Console.WriteLine(String.Format(
+                    "{{label}}|{0}|{1}|{2}|{3}|{4}|{5}",
+                    {{prefix}}A == {{prefix}}B,
+                    {{prefix}}A == {{prefix}}C,
+                    {{prefix}}A == {{prefix}}Other,
+                    {{prefix}}A != {{prefix}}B,
+                    {{prefix}}A != {{prefix}}C,
+                    {{prefix}}A != {{prefix}}Other))
+                """,
+            "operatorEquals" => $$"""
+                Console.WriteLine("{{label}}|N/A")
+                """,
             "equals" => $$"""
                 Console.WriteLine(String.Format(
                     "{{label}}|{0}|{1}|{2}",
@@ -498,6 +512,14 @@ public class Issue2896StructObjectOverrideTests
                 "DataClass|1|11|True|True|False",
                 "StructWithOverrides|1|11|True|True|True",
                 "StructWithoutOverrides|1|11|True|True|False",
+            },
+            "operatorEquals" => new[]
+            {
+                "ClassWithOverrides|False|True|False|True|False|True",
+                "ClassWithoutOverrides|False|True|False|True|False|True",
+                "DataClass|True|True|False|False|False|True",
+                "StructWithOverrides|N/A",
+                "StructWithoutOverrides|N/A",
             },
             "equals" => new[]
             {

--- a/test/Interpreter.Tests/Issue2896StructObjectOverrideTests.cs
+++ b/test/Interpreter.Tests/Issue2896StructObjectOverrideTests.cs
@@ -119,6 +119,23 @@ public class Issue2896StructObjectOverrideTests
     }
 
     [Theory]
+    [InlineData("dictionary")]
+    [InlineData("hashSet")]
+    [InlineData("listContains")]
+    [InlineData("equals")]
+    [InlineData("getHashCode")]
+    public async Task Issue3134_ClassIdentityAndStructValueEqualityMatchEmitter(string surface)
+    {
+        var suffix = Guid.NewGuid().ToString("N");
+        var source = BuildIssue3134Source(surface, suffix);
+        var emitted = await RunDriverAsync(source, suffix + "Emit", "gsc-emit");
+
+        AssertIssue3134EmittedSemantics(surface, emitted);
+        Assert.Equal(emitted, await RunDriverAsync(source, suffix + "Evaluate", "gsc-evaluate"));
+        Assert.Equal(emitted, await RunDriverAsync(source, suffix + "Gsi", "gsi"));
+    }
+
+    [Theory]
     [InlineData(false, "gsc-evaluate")]
     [InlineData(false, "gsc-emit")]
     [InlineData(false, "gsi")]
@@ -292,6 +309,216 @@ public class Issue2896StructObjectOverrideTests
         }
 
         return outWriter.ToString().Replace("\r\n", "\n", StringComparison.Ordinal);
+    }
+
+    private static string BuildIssue3134Source(string surface, string suffix)
+    {
+        var declarations = $$"""
+            package Issue3134{{suffix}}
+            import System
+            import System.Collections.Generic
+
+            class ClassWithOverrides{{suffix}} {
+                var Number int32
+                override func Equals(value object) bool -> true
+                override func GetHashCode() int32 -> 313401
+            }
+
+            class ClassWithoutOverrides{{suffix}} {
+                var Number int32
+            }
+
+            data class DataClass{{suffix}}(Number int32) {
+            }
+
+            struct StructWithOverrides{{suffix}} {
+                var Number int32
+                override func Equals(value object) bool -> true
+                override func GetHashCode() int32 -> 313402
+            }
+
+            struct StructWithoutOverrides{{suffix}} {
+                var Number int32
+            }
+            """;
+
+        return declarations + "\n"
+            + BuildIssue3134TypeProbe(
+                surface,
+                "ClassWithOverrides",
+                "cwo",
+                "ClassWithOverrides" + suffix,
+                isClass: true,
+                secondNumber: 22)
+            + BuildIssue3134TypeProbe(
+                surface,
+                "ClassWithoutOverrides",
+                "cno",
+                "ClassWithoutOverrides" + suffix,
+                isClass: true,
+                secondNumber: 11)
+            + BuildIssue3134TypeProbe(
+                surface,
+                "DataClass",
+                "data",
+                "DataClass" + suffix,
+                isClass: true,
+                secondNumber: 11,
+                usePrimaryConstructor: true)
+            + BuildIssue3134TypeProbe(
+                surface,
+                "StructWithOverrides",
+                "swo",
+                "StructWithOverrides" + suffix,
+                isClass: false,
+                secondNumber: 22)
+            + BuildIssue3134TypeProbe(
+                surface,
+                "StructWithoutOverrides",
+                "sno",
+                "StructWithoutOverrides" + suffix,
+                isClass: false,
+                secondNumber: 11);
+    }
+
+    private static string BuildIssue3134TypeProbe(
+        string surface,
+        string label,
+        string prefix,
+        string typeName,
+        bool isClass,
+        int secondNumber,
+        bool usePrimaryConstructor = false)
+    {
+        var setup = usePrimaryConstructor
+            ? $$"""
+                let {{prefix}}A = {{typeName}}(11)
+                let {{prefix}}B = {{typeName}}({{secondNumber}})
+                let {{prefix}}C = {{prefix}}A
+                let {{prefix}}Other = {{typeName}}(33)
+                """
+            : isClass
+            ? $$"""
+                let {{prefix}}A = {{typeName}}()
+                {{prefix}}A.Number = 11
+                let {{prefix}}B = {{typeName}}()
+                {{prefix}}B.Number = {{secondNumber}}
+                let {{prefix}}C = {{prefix}}A
+                let {{prefix}}Other = {{typeName}}()
+                {{prefix}}Other.Number = 33
+                """
+            : $$"""
+                let {{prefix}}A = {{typeName}}{Number: 11}
+                let {{prefix}}B = {{typeName}}{Number: {{secondNumber}}}
+                let {{prefix}}C = {{prefix}}A
+                let {{prefix}}Other = {{typeName}}{Number: 33}
+                """;
+
+        var probe = surface switch
+        {
+            "dictionary" => $$"""
+                let {{prefix}}Values = Dictionary[{{typeName}}, string]()
+                {{prefix}}Values[{{prefix}}A] = "A-11"
+                {{prefix}}Values[{{prefix}}B] = "B-{{secondNumber}}"
+                {{prefix}}Values[{{prefix}}C] = "C-11"
+                Console.WriteLine(String.Format(
+                    "{{label}}|{0}|{1}|{2}|{3}",
+                    {{prefix}}Values.Count,
+                    {{prefix}}Values[{{prefix}}A],
+                    {{prefix}}Values[{{prefix}}B],
+                    {{prefix}}Values.ContainsKey({{prefix}}Other)))
+                """,
+            "hashSet" => $$"""
+                let {{prefix}}Values = HashSet[{{typeName}}]()
+                let {{prefix}}AddedA = {{prefix}}Values.Add({{prefix}}A)
+                let {{prefix}}AddedB = {{prefix}}Values.Add({{prefix}}B)
+                let {{prefix}}AddedC = {{prefix}}Values.Add({{prefix}}C)
+                Console.WriteLine(String.Format(
+                    "{{label}}|{0}|{1}|{2}|{3}|{4}",
+                    {{prefix}}Values.Count,
+                    {{prefix}}AddedA,
+                    {{prefix}}AddedB,
+                    {{prefix}}AddedC,
+                    {{prefix}}Values.Contains({{prefix}}Other)))
+                """,
+            "listContains" => $$"""
+                let {{prefix}}Values = List[{{typeName}}]()
+                {{prefix}}Values.Add({{prefix}}A)
+                Console.WriteLine(String.Format(
+                    "{{label}}|{0}|{1}|{2}|{3}|{4}",
+                    {{prefix}}Values.Count,
+                    {{prefix}}Values[0].Number,
+                    {{prefix}}Values.Contains({{prefix}}A),
+                    {{prefix}}Values.Contains({{prefix}}B),
+                    {{prefix}}Values.Contains({{prefix}}Other)))
+                """,
+            "equals" => $$"""
+                Console.WriteLine(String.Format(
+                    "{{label}}|{0}|{1}|{2}",
+                    {{prefix}}A.Equals({{prefix}}B),
+                    {{prefix}}A.Equals({{prefix}}C),
+                    {{prefix}}A.Equals({{prefix}}Other)))
+                """,
+            "getHashCode" => $$"""
+                Console.WriteLine(String.Format(
+                    "{{label}}|{0}|{1}",
+                    {{prefix}}A.GetHashCode() == {{prefix}}B.GetHashCode(),
+                    {{prefix}}A.GetHashCode() == {{prefix}}C.GetHashCode()))
+                """,
+            _ => throw new ArgumentOutOfRangeException(nameof(surface), surface, null),
+        };
+
+        return setup + "\n" + probe + "\n";
+    }
+
+    private static void AssertIssue3134EmittedSemantics(string surface, string output)
+    {
+        var expected = surface switch
+        {
+            "dictionary" => new[]
+            {
+                "ClassWithOverrides|1|C-11|C-11|True",
+                "ClassWithoutOverrides|2|C-11|B-11|False",
+                "DataClass|1|C-11|C-11|False",
+                "StructWithOverrides|1|C-11|C-11|True",
+                "StructWithoutOverrides|1|C-11|C-11|False",
+            },
+            "hashSet" => new[]
+            {
+                "ClassWithOverrides|1|True|False|False|True",
+                "ClassWithoutOverrides|2|True|True|False|False",
+                "DataClass|1|True|False|False|False",
+                "StructWithOverrides|1|True|False|False|True",
+                "StructWithoutOverrides|1|True|False|False|False",
+            },
+            "listContains" => new[]
+            {
+                "ClassWithOverrides|1|11|True|True|True",
+                "ClassWithoutOverrides|1|11|True|False|False",
+                "DataClass|1|11|True|True|False",
+                "StructWithOverrides|1|11|True|True|True",
+                "StructWithoutOverrides|1|11|True|True|False",
+            },
+            "equals" => new[]
+            {
+                "ClassWithOverrides|True|True|True",
+                "ClassWithoutOverrides|False|True|False",
+                "DataClass|True|True|False",
+                "StructWithOverrides|True|True|True",
+                "StructWithoutOverrides|True|True|False",
+            },
+            "getHashCode" => new[]
+            {
+                "ClassWithOverrides|True|True",
+                "ClassWithoutOverrides|False|True",
+                "DataClass|True|True",
+                "StructWithOverrides|True|True",
+                "StructWithoutOverrides|True|True",
+            },
+            _ => throw new ArgumentOutOfRangeException(nameof(surface), surface, null),
+        };
+
+        Assert.Equal(expected, output.Split('\n', StringSplitOptions.RemoveEmptyEntries));
     }
 
     private static string BuildClassOverrideChainSource(bool insideFunction, string suffix)


### PR DESCRIPTION
## Summary

- give ordinary G# classes reference identity for evaluator `==`, `!=`, `Equals`, and `GetHashCode`
- preserve explicit `Equals`/`GetHashCode` overrides
- preserve structural semantics for `data class`, data/value structs, and inline structs
- compare bare `gsc` and `gsi` against emitted execution across six surfaces

Closes #3134.

## Root semantics

`StructDeclarationSyntax.IsClass` comes directly from the declaration keyword (`StructKeyword.Kind == ClassKeyword`). `DeclarationBinder.CreateAndRegisterStructShell` copies it into immutable `StructSymbol.IsClass`, and generic construction copies the definition flag. The identity branch therefore reads semantic type identity, not a bound-node-shape enumeration.

`IsData` similarly comes from the `data` keyword. Existing tests proved that `data class` deliberately keeps structural equality, so the default identity guard is `IsClass && !IsData`.

Operator resolution needs one extra construction tag: `MakeReferenceEquality` marks only the reference-equality fallback created after built-in, user-defined, and CLR operator resolution. The evaluator reads that tag instead of guessing from runtime values or enumerating expression shapes.

## Measured three-driver table

Tuples use `(equal-field B, same-reference C, different-value Other)`. Collection rows assert contents as well as counts.

| Phase | Driver | `==` | `.Equals` | hash equal `(B,C)` | Dictionary `(count,A,B)` | HashSet `(count,addA,addB)` |
|---|---|---|---|---|---|---|
| before | bare `gsc` | `T,T,F` | `T,T,F` | `T,T` | `1,B-11,B-11` | `1,T,F` |
| before | `gsc /out:` | `F,T,F` | `F,T,F` | `F,T` | `2,A-11,B-11` | `2,T,T` |
| before | `gsi` | `T,T,F` | `T,T,F` | `T,T` | `1,B-11,B-11` | `1,T,F` |
| after | bare `gsc` | `F,T,F` | `F,T,F` | `F,T` | `2,A-11,B-11` | `2,T,T` |
| after | `gsc /out:` | `F,T,F` | `F,T,F` | `F,T` | `2,A-11,B-11` | `2,T,T` |
| after | `gsi` | `F,T,F` | `F,T,F` | `F,T` | `2,A-11,B-11` | `2,T,T` |

Emit is the oracle. Each driver runs the same top-level source from its own asserted-empty directory.

### Controls

- class overriding `Equals`/`GetHashCode`: `==` remains reference identity (`F,T,F`); `.Equals` remains `T,T,T`; equal hashes collapse Dictionary/HashSet as specified by the override
- `data class`: `==` and `.Equals` remain structural (`T,T,F`), equal hashes remain equal, Dictionary/HashSet still collapse equal-field instances
- structs with and without overrides retain their prior value/override semantics across Dictionary, HashSet, List.Contains, `.Equals`, and hashing

## Product mutation

| Hunk mutant | Build | Killed surfaces | Surviving surfaces |
|---|---|---|---|
| invert ordinary-class `Equals` guard | rc 0 | Dictionary, HashSet, List.Contains, `.Equals` | `==`, GetHashCode |
| invert ordinary-class hash guard | rc 0 | Dictionary, HashSet, GetHashCode | `==`, List.Contains, `.Equals` |
| invert reference-operator construction tag | rc 0 | `==`/`!=` | other five |
| invert evaluator reference-tag branch | rc 0 | `==`/`!=`, hash comparison | Dictionary, HashSet, List.Contains, `.Equals` |

No product mutant survives the complete matrix. On main-without-this-PR, the override/data/struct control rows remain green across all three drivers; only the issue row differs from emit.

## Verification

- head: `d9303ce9a520071f84f7fa3ad69a7589b4c8cb2e`
- current-main merge tree exactly matched `git merge-tree` prediction against main `d957ba71`
- final solution build: 0 warnings, 0 errors
- final issue matrix: 6/6 passed
- unfiltered local denominator from `dotnet sln GSharp.sln list`: 9 test projects
- 8/9 projects run unfiltered on immediately preceding merged tree: 15,081 passed, 1 skipped, 0 failed
- `Sdk.Tests`: NOT RUN locally
- actual no-commit merge with main `d957ba71` built with 0 warnings/errors and passed the 6/6 issue matrix
- non-zero `GSharp.Core.dll` copies matched across Core, Compiler, Repl, Core.Tests, Compiler.Tests, and Interpreter.Tests; mtimes compared as epoch seconds

- final CI run `30854692245`: all required checks green, including SDK, e2e, cs2gs corpus, and Oahu
