### PR TITLE
Fix instance out parameter write-back

### DIFF
--- a/src/Core/CodeAnalysis/Evaluator.Calls.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Calls.cs
@@ -345,20 +345,19 @@ public sealed partial class Evaluator
         };
 
         var parameterOffset = method.ExplicitReceiverParameter == null ? 0 : 1;
-        for (int i = 0; i < node.Arguments.Length; i++)
-        {
-            var parameter = method.Parameters[i + parameterOffset];
-            var value = EvaluateExpression(node.Arguments[i]);
-            frame[parameter] = value;
-        }
+        var args = PopulateUserCallFrame(node.Arguments, method, parameterOffset, frame, out var refSlots);
 
         RegisterRuntimeTypeArguments(frame, method.TypeParameters, node.MethodTypeArguments);
         RegisterRuntimeTypeArguments(frame, node.Receiver.Type);
+        object result;
         using (PushFrame(frame))
         {
             var statement = program.Functions[method];
-            return EvaluateUserMethodBody(method, statement);
+            result = EvaluateUserMethodBody(method, statement);
         }
+
+        WriteBackUserCallFrame(refSlots, args, method, parameterOffset, frame);
+        return result;
     }
 
     /// <summary>
@@ -446,18 +445,17 @@ public sealed partial class Evaluator
         };
 
         var parameterOffset = method.ExplicitReceiverParameter == null ? 0 : 1;
-        for (int i = 0; i < node.Arguments.Length; i++)
-        {
-            var parameter = method.Parameters[i + parameterOffset];
-            var value = EvaluateExpression(node.Arguments[i]);
-            frame[parameter] = value;
-        }
+        var args = PopulateUserCallFrame(node.Arguments, method, parameterOffset, frame, out var refSlots);
 
+        object result;
         using (PushFrame(frame))
         {
             var statement = program.Functions[method];
-            return EvaluateUserMethodBody(method, statement);
+            result = EvaluateUserMethodBody(method, statement);
         }
+
+        WriteBackUserCallFrame(refSlots, args, method, parameterOffset, frame);
+        return result;
     }
 
     /// <summary>
@@ -1474,6 +1472,55 @@ public sealed partial class Evaluator
         }
 
         return refSlots;
+    }
+
+    private object[] PopulateUserCallFrame(
+        ImmutableArray<BoundExpression> arguments,
+        FunctionSymbol function,
+        int parameterOffset,
+        ConcurrentDictionary<VariableSymbol, object> frame,
+        out List<(int Index, BoundExpression Operand)> refSlots)
+    {
+        var refKinds = function.Parameters
+            .Skip(parameterOffset)
+            .Take(arguments.Length)
+            .Select(parameter => parameter.RefKind)
+            .ToImmutableArray();
+        var args = refKinds.Any(refKind => refKind != RefKind.None)
+            ? new object[arguments.Length]
+            : null;
+        refSlots = args == null
+            ? null
+            : BuildRefSlots(arguments, refKinds, args, method: null);
+
+        for (var i = 0; i < arguments.Length; i++)
+        {
+            frame[function.Parameters[i + parameterOffset]] = args == null
+                ? EvaluateExpression(arguments[i])
+                : args[i];
+        }
+
+        return args;
+    }
+
+    private void WriteBackUserCallFrame(
+        List<(int Index, BoundExpression Operand)> refSlots,
+        object[] args,
+        FunctionSymbol function,
+        int parameterOffset,
+        ConcurrentDictionary<VariableSymbol, object> frame)
+    {
+        if (refSlots == null)
+        {
+            return;
+        }
+
+        foreach (var (index, _) in refSlots)
+        {
+            args[index] = frame[function.Parameters[index + parameterOffset]];
+        }
+
+        WriteBackRefSlots(refSlots, args);
     }
 
     private bool IsBoundLvalue(BoundExpression operand)

--- a/test/Interpreter.Tests/Issue3140OutParameterWriteBackParityTests.cs
+++ b/test/Interpreter.Tests/Issue3140OutParameterWriteBackParityTests.cs
@@ -1,0 +1,370 @@
+// <copyright file="Issue3140OutParameterWriteBackParityTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>Issue #3140: evaluated user-method ref/out writes must match emitted execution.</summary>
+[Collection("ConsoleIo")]
+public class Issue3140OutParameterWriteBackParityTests
+{
+    /// <summary>Gets receiver and argument-shape matrix rows.</summary>
+    /// <returns>Matrix rows.</returns>
+    public static IEnumerable<object[]> ReceiverShapeMatrix()
+    {
+        foreach (var receiver in Enum.GetValues<ReceiverKind>())
+        {
+            foreach (var shape in Enum.GetValues<ArgumentShape>())
+            {
+                yield return new object[] { receiver, shape };
+            }
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(ReceiverShapeMatrix))]
+    public async Task OutParameterWriteBack_GscEvaluateAndGsiMatchEmit(
+        ReceiverKind receiver,
+        ArgumentShape shape)
+    {
+        var source = BuildSource(receiver, shape);
+        var root = CreateEmptyDirectory(receiver + "-" + shape);
+        try
+        {
+            var emitted = await RunEmittedAsync(source, CreateEmptyDirectory(root, "emit"));
+            var evaluated = RunSourceDriver(
+                source,
+                CreateEmptyDirectory(root, "evaluate"),
+                GSharp.Compiler.Program.Main,
+                stripCompilerSuccess: true);
+            var interpreted = RunSourceDriver(
+                source,
+                CreateEmptyDirectory(root, "gsi"),
+                GSharp.Repl.Program.Main,
+                stripCompilerSuccess: false);
+
+            Assert.NotEmpty(emitted);
+            Assert.Equal(emitted, evaluated);
+            Assert.Equal(emitted, interpreted);
+        }
+        finally
+        {
+            DeleteDirectory(root);
+        }
+    }
+
+    /// <summary>Call receiver shape.</summary>
+    public enum ReceiverKind
+    {
+        /// <summary>Free function.</summary>
+        Free,
+
+        /// <summary>Class shared method.</summary>
+        ClassShared,
+
+        /// <summary>Class instance method.</summary>
+        ClassInstance,
+
+        /// <summary>Struct shared method.</summary>
+        StructShared,
+
+        /// <summary>Struct instance method.</summary>
+        StructInstance,
+
+        /// <summary>Class implementation called through interface.</summary>
+        Interface,
+
+        /// <summary>Base-class method called through <c>base</c>.</summary>
+        BaseClass,
+
+        /// <summary>Generic class instance method.</summary>
+        GenericMethod,
+    }
+
+    /// <summary>Argument shape.</summary>
+    public enum ArgumentShape
+    {
+        /// <summary>One out argument.</summary>
+        SingleOut,
+
+        /// <summary>Two out arguments.</summary>
+        MultipleOut,
+
+        /// <summary>Out and ref arguments.</summary>
+        OutAndRef,
+
+        /// <summary>Out and normal arguments.</summary>
+        OutAndNormal,
+
+        /// <summary>Distinct assignments in conditional branches.</summary>
+        ConditionalOut,
+    }
+
+    private static string BuildSource(ReceiverKind receiver, ArgumentShape shape)
+    {
+        var spec = GetShape(shape);
+        var package = $"Issue3140{receiver}{shape}";
+        var method = $"func Fill({spec.Parameters}) {{\n{Indent(spec.Body, 4)}\n}}";
+        string declarations;
+        string target;
+        var callPrefix = string.Empty;
+
+        switch (receiver)
+        {
+            case ReceiverKind.Free:
+                declarations = method;
+                target = "Fill";
+                break;
+            case ReceiverKind.ClassShared:
+                declarations = $"class Target {{\n    shared {{\n{Indent(method, 8)}\n    }}\n}}";
+                target = "Target.Fill";
+                break;
+            case ReceiverKind.ClassInstance:
+                declarations = $"class Target {{\n{Indent(method, 4)}\n}}";
+                target = "target.Fill";
+                break;
+            case ReceiverKind.StructShared:
+                declarations = $"struct Target {{\n    shared {{\n{Indent(method, 8)}\n    }}\n}}";
+                target = "Target.Fill";
+                break;
+            case ReceiverKind.StructInstance:
+                declarations = $"struct Target {{\n{Indent(method, 4)}\n}}";
+                target = "target.Fill";
+                break;
+            case ReceiverKind.Interface:
+                declarations =
+                    $"interface Filler {{\n    func Fill({spec.Parameters});\n}}\n"
+                    + $"class Target : Filler {{\n{Indent(method, 4)}\n}}";
+                target = "target.Fill";
+                break;
+            case ReceiverKind.BaseClass:
+                declarations =
+                    $"open class Base {{\n{Indent(method, 4)}\n}}\n"
+                    + $"class Target : Base {{\n    func Invoke({spec.Parameters}) {{\n"
+                    + $"        base.Fill({spec.ForwardArguments})\n    }}\n}}";
+                target = "target.Invoke";
+                break;
+            case ReceiverKind.GenericMethod:
+                method = $"func Fill[T](marker T, {spec.Parameters}) {{\n{Indent(spec.Body, 4)}\n}}";
+                declarations = $"class Target {{\n{Indent(method, 4)}\n}}";
+                target = "target.Fill[string]";
+                callPrefix = "\"marker\", ";
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(receiver), receiver, null);
+        }
+
+        var receiverLocal = receiver switch
+        {
+            ReceiverKind.ClassInstance or ReceiverKind.BaseClass or ReceiverKind.GenericMethod =>
+                "var target = Target()",
+            ReceiverKind.StructInstance => "var target = Target{}",
+            ReceiverKind.Interface => "var target Filler = Target()",
+            _ => string.Empty,
+        };
+        var calls = string.Join(
+            Environment.NewLine,
+            spec.Calls.Select(call =>
+                $"{target}({callPrefix}{call.Arguments}){Environment.NewLine}{call.Output}"));
+
+        return $"""
+            package {package}
+            import System
+
+            {declarations}
+
+            {receiverLocal}
+            {spec.Locals}
+            {calls}
+            """;
+    }
+
+    private static ShapeSpec GetShape(ArgumentShape shape) => shape switch
+    {
+        ArgumentShape.SingleOut => new(
+            "out first int32",
+            "first = 11",
+            "var first = 101",
+            "&first",
+            [new("&first", "Console.WriteLine(first)")]),
+        ArgumentShape.MultipleOut => new(
+            "out first int32, out second int32",
+            "first = 21\nsecond = 22",
+            "var first = 201\nvar second = 202",
+            "&first, &second",
+            [new("&first, &second", "Console.WriteLine(first)\nConsole.WriteLine(second)")]),
+        ArgumentShape.OutAndRef => new(
+            "out first int32, ref second int32",
+            "first = 31\nsecond = second + 4",
+            "var first = 301\nvar second = 33",
+            "&first, &second",
+            [new("&first, &second", "Console.WriteLine(first)\nConsole.WriteLine(second)")]),
+        ArgumentShape.OutAndNormal => new(
+            "out first int32, input int32",
+            "first = input + 1",
+            "var first = 401\nlet input = 43",
+            "&first, input",
+            [new("&first, input", "Console.WriteLine(first)")]),
+        ArgumentShape.ConditionalOut => new(
+            "flag bool, out first int32",
+            "if flag {\n    first = 51\n} else {\n    first = 52\n}",
+            "var firstTrue = 501\nvar firstFalse = 502",
+            "flag, &first",
+            [
+                new("true, &firstTrue", "Console.WriteLine(firstTrue)"),
+                new("false, &firstFalse", "Console.WriteLine(firstFalse)"),
+            ]),
+        _ => throw new ArgumentOutOfRangeException(nameof(shape), shape, null),
+    };
+
+    private static string RunSourceDriver(
+        string source,
+        string directory,
+        Func<string[], int> driver,
+        bool stripCompilerSuccess)
+    {
+        var sourcePath = Path.Combine(directory, "probe.gs");
+        File.WriteAllText(sourcePath, source);
+        var result = CaptureConsole(() => driver([sourcePath]));
+
+        Assert.True(
+            result.ExitCode == 0,
+            $"driver failed ({result.ExitCode})\nstdout:\n{result.Stdout}\nstderr:\n{result.Stderr}");
+        Assert.Equal(string.Empty, result.Stderr);
+        return Normalize(result.Stdout, stripCompilerSuccess);
+    }
+
+    private static async Task<string> RunEmittedAsync(string source, string directory)
+    {
+        var sourcePath = Path.Combine(directory, "probe.gs");
+        var assemblyPath = Path.Combine(directory, "probe.dll");
+        File.WriteAllText(sourcePath, source);
+        var compile = CaptureConsole(
+            () => GSharp.Compiler.Program.Main(
+                ["/out:" + assemblyPath, "/target:exe", "/targetframework:net10.0", sourcePath]));
+
+        Assert.True(
+            compile.ExitCode == 0,
+            $"emit failed ({compile.ExitCode})\nstdout:\n{compile.Stdout}\nstderr:\n{compile.Stderr}");
+        Assert.Equal(string.Empty, compile.Stderr);
+        Assert.NotEmpty(Assembly.Load(File.ReadAllBytes(assemblyPath)).GetTypes());
+
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            WorkingDirectory = directory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        startInfo.ArgumentList.Add("exec");
+        startInfo.ArgumentList.Add("--runtimeconfig");
+        startInfo.ArgumentList.Add(Path.ChangeExtension(assemblyPath, ".runtimeconfig.json"));
+        startInfo.ArgumentList.Add(assemblyPath);
+
+        using var process = Process.Start(startInfo);
+        Assert.NotNull(process);
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        try
+        {
+            await process.WaitForExitAsync(timeout.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            process.Kill(entireProcessTree: true);
+            throw new TimeoutException("emitted program timed out");
+        }
+
+        var stdout = await stdoutTask;
+        var stderr = await stderrTask;
+        Assert.True(
+            process.ExitCode == 0,
+            $"emitted program failed ({process.ExitCode})\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        Assert.Equal(string.Empty, stderr);
+        return Normalize(stdout, stripCompilerSuccess: false);
+    }
+
+    private static DriverResult CaptureConsole(Func<int> action)
+    {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            return new DriverResult(action(), stdout.ToString(), stderr.ToString());
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+    }
+
+    private static string Normalize(string output, bool stripCompilerSuccess) =>
+        string.Join(
+            "\n",
+            output.Replace("\r\n", "\n", StringComparison.Ordinal)
+                .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+                .Where(line => !stripCompilerSuccess || line != "Success."));
+
+    private static string CreateEmptyDirectory(string name)
+    {
+        var parent = Path.Combine(AppContext.BaseDirectory, nameof(Issue3140OutParameterWriteBackParityTests));
+        return CreateEmptyDirectory(parent, name + "-" + Guid.NewGuid().ToString("N"));
+    }
+
+    private static string CreateEmptyDirectory(string parent, string name)
+    {
+        var path = Path.Combine(parent, name);
+        Directory.CreateDirectory(path);
+        Assert.Empty(Directory.EnumerateFileSystemEntries(path));
+        return path;
+    }
+
+    private static void DeleteDirectory(string path)
+    {
+        try
+        {
+            Directory.Delete(path, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+
+    private static string Indent(string value, int spaces)
+    {
+        var prefix = new string(' ', spaces);
+        return string.Join(
+            Environment.NewLine,
+            value.Split('\n').Select(line => prefix + line));
+    }
+
+    private sealed record ShapeSpec(
+        string Parameters,
+        string Body,
+        string Locals,
+        string ForwardArguments,
+        CallSpec[] Calls);
+
+    private sealed record CallSpec(string Arguments, string Output);
+
+    private readonly record struct DriverResult(int ExitCode, string Stdout, string Stderr);
+}


### PR DESCRIPTION
## Summary

- route user instance and base-class calls through existing evaluator ref/out slot handling
- copy final callee parameter slots back to caller operands after restoring caller frame
- add value-based emit-oracle parity matrix across receiver and argument shapes

Fixes #3140

## Root cause

Free functions already built ref/out slots and wrote final parameter values back after popping the callee frame. User instance and base-class call evaluators instead evaluated every argument by value, populated callee frames, and returned without write-back.

Fix reuses existing `BuildRefSlots` and `WriteBackRefSlots` paths. No parallel copy-back implementation.

Compiler-count audit: temporary required parameter on `EvaluateUserMethodBody` produced 7 unique `CS7036` invocation sites. Runtime-relevant user member paths fixed here: user-instance and base-class. Free calls already worked; static/shared calls bind through free-call path; interface calls dispatch through user-instance path.

## Receiver × shape matrix

Every cell compares bare `gsc` and `gsi` output to emitted execution, not hardcoded expected output. Each driver runs in its own asserted-empty directory.

| receiver | single out | multiple out | out + ref | out + normal | conditional out |
|---|---|---|---|---|---|
| free | `11` | `21,22` | `31,37` | `44` | `51,52` |
| class shared | `11` | `21,22` | `31,37` | `44` | `51,52` |
| class instance | `11` | `21,22` | `31,37` | `44` | `51,52` |
| struct shared | `11` | `21,22` | `31,37` | `44` | `51,52` |
| struct instance | `11` | `21,22` | `31,37` | `44` | `51,52` |
| interface method | `11` | `21,22` | `31,37` | `44` | `51,52` |
| base-class method | `11` | `21,22` | `31,37` | `44` | `51,52` |
| generic instance method | `11` | `21,22` | `31,37` | `44` | `51,52` |

All 40 cells: bare `gsc` = emit = `gsi`, rc 0.

Original issue probes after fix:

| shape | bare `gsc` | emit | `gsi` |
|---|---:|---:|---:|
| class instance | 55 | 55 | 55 |
| class shared control | 66 | 66 | 66 |
| free control | 77 | 77 | 77 |

## Two-sided mutation evidence

Tests on `main` without production fix: **25 failed / 15 passed**. Failures are every instance-dispatch receiver row; shared/free controls remain green.

| hunk | product mutant | result |
|---|---|---|
| user-instance write-back | invert write-back guard (`refSlots != null` → `refSlots == null`) | 25 failed / 15 passed |
| base-class write-back | invert write-back guard | 5 failed / 35 passed |
| shared frame/ref-slot helper | invert ref-kind allocation predicate | 25 failed / 15 passed |

Each mutant applied and built. Restored matrix: 40/40 green.

## Validation

Validated against `main` `faca348a36e7c4f9f35a3f57bde43c47f958b603`.

- full unfiltered suite: 15,152 passed, 1 skipped, 0 failed
- includes `Cs2Gs.Tests`: 1,903 passed
- full CIB solution build: 0 warnings, 0 errors
- Core/Compiler/Repl `GSharp.Core.dll` mtimes identical
- `git merge-tree --write-tree origin/main HEAD`: clean; merged tree `8fd4dad0c6ccdbd1b1c0f29abba6523f8b992e36`, identical to HEAD tree
