### PR TITLE
Make inherited deinit driver boundary observable

### DIFF
--- a/test/Interpreter.Tests/Issue2988DeinitInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2988DeinitInterpreterTests.cs
@@ -68,7 +68,7 @@ public class Issue2988DeinitInterpreterTests
     [InlineData(Issue3010EntryPointDriverMatrixTests.Driver.CompilerEvaluation)]
     [InlineData(Issue3010EntryPointDriverMatrixTests.Driver.CompilerEmission)]
     [InlineData(Issue3010EntryPointDriverMatrixTests.Driver.Interpreter)]
-    public void InheritedDeinitializersWarnOncePerDeclaringClass(
+    public void InheritedDeinitializersExposeDriverBoundaryPerDeclaringClass(
         Issue3010EntryPointDriverMatrixTests.Driver driver)
     {
         const string Source = """
@@ -89,41 +89,41 @@ public class Issue2988DeinitInterpreterTests
                 }
             }
 
-            var resource = CachedResource("held-33")
-            Console.WriteLine("body-44")
-            GC.KeepAlive(resource)
+            func Allocate() {
+                var resource = CachedResource("held-33")
+                Console.WriteLine("body-44")
+                GC.KeepAlive(resource)
+            }
+
+            Allocate()
+            GC.Collect()
+            GC.WaitForPendingFinalizers()
+            Console.WriteLine("end-55")
             """;
+        const string InterpretedOutput = "body-44\nend-55\n";
+        const string EmittedOutput = "body-44\nderived-deinit-22\nbase-deinit-11\nend-55\n";
 
-        var emitted = Issue3010EntryPointDriverMatrixTests.Run(
-            "inherited-deinit-emitted",
+        var result = Issue3010EntryPointDriverMatrixTests.Run(
+            "inherited-deinit-" + driver,
             Source,
-            Issue3010EntryPointDriverMatrixTests.Driver.CompilerEmission);
-        Assert.Equal(0, emitted.ExitCode);
-        Assert.NotEmpty(emitted.StandardOutput);
-        Assert.Equal(string.Empty, emitted.StandardError);
-
-        var result = driver == Issue3010EntryPointDriverMatrixTests.Driver.CompilerEmission
-            ? emitted
-            : Issue3010EntryPointDriverMatrixTests.Run(
-                "inherited-deinit-" + driver,
-                Source,
-                driver);
+            driver);
         Assert.Equal(0, result.ExitCode);
 
         string warningOutput;
         switch (driver)
         {
             case Issue3010EntryPointDriverMatrixTests.Driver.CompilerEvaluation:
-                Assert.StartsWith(emitted.StandardOutput + "\n", result.StandardOutput, StringComparison.Ordinal);
+                Assert.StartsWith(InterpretedOutput + "\n", result.StandardOutput, StringComparison.Ordinal);
                 Assert.EndsWith("Success.\n", result.StandardOutput, StringComparison.Ordinal);
-                warningOutput = result.StandardOutput[emitted.StandardOutput.Length..];
+                Assert.Equal(string.Empty, result.StandardError);
+                warningOutput = result.StandardOutput[InterpretedOutput.Length..];
                 break;
             case Issue3010EntryPointDriverMatrixTests.Driver.CompilerEmission:
-                Assert.Equal(emitted.StandardOutput, result.StandardOutput);
+                Assert.Equal(EmittedOutput, result.StandardOutput);
                 Assert.Equal(string.Empty, result.StandardError);
                 return;
             case Issue3010EntryPointDriverMatrixTests.Driver.Interpreter:
-                Assert.Equal(emitted.StandardOutput, result.StandardOutput);
+                Assert.Equal(InterpretedOutput, result.StandardOutput);
                 warningOutput = result.StandardError;
                 break;
             default:


### PR DESCRIPTION
Fixes #3150

## Decision

Interpreter/emit deinitializer divergence is intentional, not an interpreter defect. ADR-0068 already specifies that `deinit` requires CLR GC finalization, runs only in emitted code, and is skipped by interpreted execution with GS0510. Scope-exit execution would finalize reachable objects; emulating CLR finalization would require evaluator re-entry from a finalizer thread.

## Change

- make the inherited-deinit probe create an unreachable object, force collection, and print an end marker
- assert the established boundary directly per driver instead of comparing every result to a vacuous emitted oracle
- run the emission row independently instead of comparing the emitted result to itself

Measured outputs:

| driver | stdout | diagnostic output |
|---|---|---|
| bare `gsc` evaluation | `body-44`, `end-55`, `Success.` | 2×GS0510 in stdout |
| `gsc /out:` emission | `body-44`, `derived-deinit-22`, `base-deinit-11`, `end-55` | none |
| `gsi` | `body-44`, `end-55` | 2×GS0510 in stderr |

## Mutation

Product mutant: remove `emitter.EmitBlock(body)` from `EmitClassDeinitializerBodyBytes`. Release solution build remained green (0 warnings/errors); matrix changed from 3/3 passing to 2/3 passing. `CompilerEmission` failed because output became `body-44/end-55`, proving deinit bodies are observed. Restored tree returned to 3/3 passing.

## Verification

Base/merged target: `faca348a36e7c4f9f35a3f57bde43c47f958b603`  
Head: `c47f82f816d29585140e811a0d824f5cf38d6b17`

- Release solution build with `ContinuousIntegrationBuild=true`: 0 warnings, 0 errors
- Core.Tests: 7116 passed, 1 skipped, 0 failed
- Compiler.Tests: 4232 passed, 0 failed
- Interpreter.Tests: 1214 passed, 0 failed
- LanguageServer.Tests: 462 passed, 0 failed
- Extensions.Tests: 104 passed, 0 failed
- InternalAnalyzers.Tests: 7 passed, 0 failed
- Cs2Gs.Tests: 1903 passed, 0 failed
- GSharp.GeneratorHost.Tests: 31 passed, 0 failed
- Sdk.Tests: not run; prohibited SDK-cache boundary
- `git merge-tree --write-tree`: clean, predicted tree `1aff1dea67974244033ef987250fde7d4a3ab0c0`
