### PR TITLE
Make latest Oahu nightly result explicitly advisory

### DIFF
--- a/.github/workflows/cs2gs-nightly.yml
+++ b/.github/workflows/cs2gs-nightly.yml
@@ -75,7 +75,7 @@ jobs:
           echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
           exit 0
 
-      - name: Migrate and run latest Oahu
+      - name: Migrate and run latest Oahu (advisory)
         id: oahu_latest
         env:
           OAHU_GATE_LABEL: latest
@@ -146,8 +146,13 @@ jobs:
             ${{ runner.temp }}/cs2gs-oahu-latest/runs/**/run.json
             ${{ runner.temp }}/cs2gs-oahu-latest/smoke/*
 
-      - name: Enforce gate outcome
+      - name: Report advisory and enforce gate outcome
         run: |
+          # Latest Oahu detects upstream drift but stays advisory so upstream
+          # changes cannot break this repository's pinned compatibility gate.
+          if [[ "${{ steps.oahu_latest.outputs.exit_code }}" != "0" ]]; then
+            echo "::warning title=Latest Oahu compatibility::Latest Oahu gate failed (exit ${{ steps.oahu_latest.outputs.exit_code }}); pinned Oahu remains the enforced compatibility baseline."
+          fi
           if [[ "${{ steps.migrate.outputs.migrate_exit }}" != "0" ||
                 "${{ steps.oahu_pinned.outputs.exit_code }}" != "0" ]]; then
             exit 1


### PR DESCRIPTION
## Summary

- label latest-Oahu run as advisory
- read its exit code and emit a GitHub warning annotation when it fails
- keep pinned Oahu and corpus migration as enforced compatibility gates

Latest upstream Oahu is deliberately advisory: it gives early drift warning, but upstream changes outside this repository should not make our nightly permanently red and easy to ignore. Pinned revision remains compatibility contract this repository controls.

## Validation

Used extracted-shell-logic harness against exact final `run:` blocks from `origin/main` and this branch:

- `origin/main`, latest exit 17: rc 0, no output
- this branch, latest exit 17: rc 0, `::warning title=Latest Oahu compatibility::...`
- this branch, latest exit 0: rc 0, no output

Harness validates shell branching and emitted annotation command. It does not execute GitHub Actions or verify GitHub UI rendering.

Ruby Psych parsed workflow YAML; `git diff --check` passed. No solution tests run: 0 of 9 test projects. Denominator comes from `dotnet sln GSharp.sln list`, matching CI discovery in `build/generate-ci-test-matrix.py:26`; workflow-only change does not affect product/test code. `Sdk.Tests` NOT RUN.

Fixes #3154
