### PR TITLE
Fix named delegate reification through erased generic slots

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -1207,7 +1207,7 @@ internal sealed partial class ExpressionBinder
             }
 
             var parameters = resolution.Best.GetParameters();
-            var targets = new Dictionary<int, FunctionTypeSymbol>();
+            var targets = new Dictionary<int, (FunctionTypeSymbol FunctionType, TypeSymbol DelegateType)>();
             var allMapped = true;
             foreach (var idx in deferredIndices)
             {
@@ -1232,7 +1232,7 @@ internal sealed partial class ExpressionBinder
                     break;
                 }
 
-                targets[idx] = fn;
+                targets[idx] = (fn, TypeSymbol.FromClrType(parameterType));
             }
 
             if (!allMapped)
@@ -1245,7 +1245,12 @@ internal sealed partial class ExpressionBinder
                 var inner = OverloadResolver.UnwrapNamedArgumentValue(ce.Arguments[idx]);
                 if (inner is LambdaExpressionSyntax lambdaSyntax)
                 {
-                    boundArgs[idx] = lambdas.BindLambdaExpression(lambdaSyntax, targets[idx]);
+                    var target = targets[idx];
+                    boundArgs[idx] = BindLambdaWithDelegateTarget(
+                        ce.Arguments[idx],
+                        lambdaSyntax,
+                        target.FunctionType,
+                        target.DelegateType);
                 }
             }
 
@@ -2244,8 +2249,21 @@ internal sealed partial class ExpressionBinder
                     if (!delegateTargetCandidatesComputed)
                     {
                         delegateTargetCandidatesComputed = true;
-                        delegateTargetCandidateParams = CollectDelegateTargetCandidateParameterLists(receiver, classSymbol, methodName);
+                        delegateTargetCandidateParams = CollectDelegateTargetCandidateParameterLists(
+                            receiver,
+                            classSymbol,
+                            methodName);
                     }
+
+                    var hasClosedTarget = TryResolveDelegateTargetFromCandidates(
+                        delegateTargetCandidateParams,
+                        paramOffset: 0,
+                        sourceArgIndex: argSlot,
+                        argName: argName,
+                        target: out var target,
+                        nominalTarget: out var nominalTarget,
+                        blockedByOpenGenericParameter: out var blocked,
+                        sawOpenGenericParameter: out var sawOpen);
 
                     // Issue #2345: an explicitly-typed lambda whose matching
                     // delegate parameter is an *open* generic (e.g. an imported
@@ -2270,17 +2288,28 @@ internal sealed partial class ExpressionBinder
                     // delegate target (its own explicit parameter types are
                     // unaffected — only return-type inference depends on the
                     // target).
-                    if (inner is LambdaExpressionSyntax { Body: BlockExpressionSyntax } blockLambda
-                        && !TryResolveDelegateTargetFromCandidates(delegateTargetCandidateParams, paramOffset: 0, sourceArgIndex: argSlot, argName: argName, target: out _, blockedByOpenGenericParameter: out var blocked)
-                        && blocked)
+                    //
+                    // Issue #3149: a mixed open/closed set must also wait for
+                    // overload resolution. The closed candidate supplies the
+                    // shared function shape, but only the selected method can
+                    // determine whether the lambda needs a named delegate.
+                    if ((inner is LambdaExpressionSyntax { Body: BlockExpressionSyntax } && !hasClosedTarget && blocked)
+                        || (hasClosedTarget && sawOpen))
                     {
                         deferredArrowLambdaIndices.Add(argSlot);
-                        boundArguments.Add(new BoundErrorExpression(blockLambda));
+                        boundArguments.Add(new BoundErrorExpression(inner));
+                    }
+                    else if (inner is LambdaExpressionSyntax lambdaSyntax && hasClosedTarget)
+                    {
+                        boundArguments.Add(BindLambdaWithDelegateTarget(
+                            argument,
+                            lambdaSyntax,
+                            target,
+                            nominalTarget));
                     }
                     else
                     {
-                        boundArguments.Add(BindCallArgumentWithDelegateTargetTyping(
-                            argument, delegateTargetCandidateParams, sourceArgIndex: argSlot, argName: argName, paramOffset: 0));
+                        boundArguments.Add(BindExpression(inner));
                     }
                 }
             }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -1754,105 +1754,43 @@ internal sealed partial class ExpressionBinder
     {
         var inner = OverloadResolver.UnwrapNamedArgumentValue(argumentSyntax);
         if (inner is LambdaExpressionSyntax lambdaSyntax
-            && TryResolveDelegateTargetFromCandidates(candidateParameterLists, paramOffset, sourceArgIndex, argName, out var target))
-        {
-            var literal = lambdas.BindLambdaExpression(lambdaSyntax, target);
-            var nominalTarget = TryResolveUniqueNominalDelegateTarget(
+            && TryResolveDelegateTargetFromCandidates(
                 candidateParameterLists,
                 paramOffset,
                 sourceArgIndex,
-                argName);
-            return nominalTarget != null && ShouldConvertToNominalDelegate(nominalTarget)
-                ? conversions.BindConversion(argumentSyntax.Location, literal, nominalTarget)
-                : literal;
+                argName,
+                out var target,
+                out var nominalTarget,
+                out _,
+                out _))
+        {
+            return BindLambdaWithDelegateTarget(
+                argumentSyntax,
+                lambdaSyntax,
+                target,
+                nominalTarget);
         }
 
         return BindExpression(inner);
     }
 
-    /// <summary>
-    /// Issue #3149: preserves a named delegate's identity when all matching
-    /// delegate parameters agree. Binding only to their shared function shape
-    /// erases the literal to Func/Action before overload resolution.
-    /// </summary>
-    private static TypeSymbol TryResolveUniqueNominalDelegateTarget(
-        IReadOnlyList<ParameterInfo[]> candidateParameterLists,
-        int paramOffset,
-        int sourceArgIndex,
-        string argName)
+    private BoundExpression BindLambdaWithDelegateTarget(
+        ExpressionSyntax argumentSyntax,
+        LambdaExpressionSyntax lambdaSyntax,
+        FunctionTypeSymbol target,
+        TypeSymbol nominalTarget)
     {
-        TypeSymbol target = null;
-        foreach (var parameters in candidateParameterLists)
-        {
-            var paramIndex = string.IsNullOrEmpty(argName)
-                ? sourceArgIndex + paramOffset
-                : Array.FindIndex(
-                    parameters,
-                    parameter => string.Equals(parameter.Name, argName, StringComparison.Ordinal));
-            if (paramIndex < 0 || paramIndex >= parameters.Length)
-            {
-                continue;
-            }
-
-            var parameterType = parameters[paramIndex].ParameterType;
-            if (parameterType == null)
-            {
-                continue;
-            }
-
-            if (parameterType.ContainsGenericParameters)
-            {
-                return null;
-            }
-
-            if (!MemberLookup.TryGetLambdaTargetFunctionType(parameterType, out _))
-            {
-                continue;
-            }
-
-            var candidate = TypeSymbol.FromClrType(parameterType);
-            if (target == null)
-            {
-                target = candidate;
-            }
-            else if (!SameDelegateIdentity(target, candidate))
-            {
-                return null;
-            }
-        }
-
-        return target;
+        var literal = lambdas.BindLambdaExpression(lambdaSyntax, target);
+        return nominalTarget != null && ShouldConvertToNominalDelegate(nominalTarget)
+            ? conversions.BindConversion(argumentSyntax.Location, literal, nominalTarget)
+            : literal;
     }
 
     /// <summary>
-    /// Issue #891: discovers the (non-generic) delegate function type that a
-    /// given argument position maps to across all candidate parameter lists.
-    /// Named arguments are matched by parameter name; positional arguments by
-    /// index (after <paramref name="paramOffset"/>, e.g. an extension method's
-    /// receiver). Returns false when no candidate exposes a closed delegate
-    /// parameter there, or when candidates disagree on the delegate shape.
-    /// </summary>
-    private static bool TryResolveDelegateTargetFromCandidates(
-        IReadOnlyList<ParameterInfo[]> candidateParameterLists,
-        int paramOffset,
-        int sourceArgIndex,
-        string argName,
-        out FunctionTypeSymbol target)
-        => TryResolveDelegateTargetFromCandidates(candidateParameterLists, paramOffset, sourceArgIndex, argName, out target, out _);
-
-    /// <summary>
-    /// Issue #2345: overload of <see cref="TryResolveDelegateTargetFromCandidates(IReadOnlyList{ParameterInfo[]}, int, int, string, out FunctionTypeSymbol)"/>
-    /// that also reports whether resolution failed specifically because every
-    /// matching candidate parameter at this slot is an <em>open</em> generic
-    /// delegate (<c>ParameterType.ContainsGenericParameters</c>) — e.g. an
-    /// imported generic method's <c>Action&lt;Builder&lt;TColumns&gt;&gt;</c>
-    /// parameter whose <c>TColumns</c> is only closed once the method's type
-    /// arguments are inferred from the call's other arguments. Callers use
-    /// this signal to defer such a lambda (mirroring the existing untyped-
-    /// arrow-lambda deferral) instead of binding it immediately with no
-    /// target, which is what previously produced a wrong (non-void) inferred
-    /// delegate shape for a block-bodied lambda whose trailing statement calls
-    /// a fluent/self-returning method.
+    /// Issue #891 / #2345 / #3149: discovers the closed delegate function shape
+    /// and nominal identity shared by a lambda argument's candidate parameters.
+    /// Open generic candidates are reported separately so all-open block lambdas
+    /// and mixed open/closed sets can wait for overload resolution.
     /// </summary>
     private static bool TryResolveDelegateTargetFromCandidates(
         IReadOnlyList<ParameterInfo[]> candidateParameterLists,
@@ -1860,10 +1798,15 @@ internal sealed partial class ExpressionBinder
         int sourceArgIndex,
         string argName,
         out FunctionTypeSymbol target,
-        out bool blockedByOpenGenericParameter)
+        out TypeSymbol nominalTarget,
+        out bool blockedByOpenGenericParameter,
+        out bool sawOpenGenericParameter)
     {
         target = null;
+        nominalTarget = null;
         blockedByOpenGenericParameter = false;
+        sawOpenGenericParameter = false;
+        var nominalTargetsAgree = true;
         var sawAnyMatchingSlot = false;
         foreach (var parameters in candidateParameterLists)
         {
@@ -1906,6 +1849,7 @@ internal sealed partial class ExpressionBinder
                 // Open generic delegate parameters are resolved later, once the
                 // generic method's type arguments have been inferred.
                 blockedByOpenGenericParameter = true;
+                sawOpenGenericParameter = true;
                 continue;
             }
 
@@ -1918,7 +1862,9 @@ internal sealed partial class ExpressionBinder
                 || string.Equals(parameterFullName, "System.MulticastDelegate", StringComparison.Ordinal))
             {
                 target = null;
+                nominalTarget = null;
                 blockedByOpenGenericParameter = false;
+                sawOpenGenericParameter = false;
                 return false;
             }
 
@@ -1936,8 +1882,24 @@ internal sealed partial class ExpressionBinder
                 // Candidates disagree on the delegate shape — leave the lambda
                 // to be bound without a target (overload resolution decides).
                 target = null;
+                nominalTarget = null;
                 blockedByOpenGenericParameter = false;
+                sawOpenGenericParameter = false;
                 return false;
+            }
+
+            var nominalCandidate = TypeSymbol.FromClrType(parameterType);
+            if (nominalTargetsAgree)
+            {
+                if (nominalTarget == null)
+                {
+                    nominalTarget = nominalCandidate;
+                }
+                else if (!SameDelegateIdentity(nominalTarget, nominalCandidate))
+                {
+                    nominalTarget = null;
+                    nominalTargetsAgree = false;
+                }
             }
         }
 
@@ -1945,6 +1907,10 @@ internal sealed partial class ExpressionBinder
         // if some candidate produced a usable closed target, that target wins
         // and there is nothing left to defer.
         blockedByOpenGenericParameter = blockedByOpenGenericParameter && target == null && sawAnyMatchingSlot;
+        if (sawOpenGenericParameter)
+        {
+            nominalTarget = null;
+        }
 
         return target != null;
     }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -1756,10 +1756,72 @@ internal sealed partial class ExpressionBinder
         if (inner is LambdaExpressionSyntax lambdaSyntax
             && TryResolveDelegateTargetFromCandidates(candidateParameterLists, paramOffset, sourceArgIndex, argName, out var target))
         {
-            return lambdas.BindLambdaExpression(lambdaSyntax, target);
+            var literal = lambdas.BindLambdaExpression(lambdaSyntax, target);
+            var nominalTarget = TryResolveUniqueNominalDelegateTarget(
+                candidateParameterLists,
+                paramOffset,
+                sourceArgIndex,
+                argName);
+            return nominalTarget != null && ShouldConvertToNominalDelegate(nominalTarget)
+                ? conversions.BindConversion(argumentSyntax.Location, literal, nominalTarget)
+                : literal;
         }
 
         return BindExpression(inner);
+    }
+
+    /// <summary>
+    /// Issue #3149: preserves a named delegate's identity when all matching
+    /// delegate parameters agree. Binding only to their shared function shape
+    /// erases the literal to Func/Action before overload resolution.
+    /// </summary>
+    private static TypeSymbol TryResolveUniqueNominalDelegateTarget(
+        IReadOnlyList<ParameterInfo[]> candidateParameterLists,
+        int paramOffset,
+        int sourceArgIndex,
+        string argName)
+    {
+        TypeSymbol target = null;
+        foreach (var parameters in candidateParameterLists)
+        {
+            var paramIndex = string.IsNullOrEmpty(argName)
+                ? sourceArgIndex + paramOffset
+                : Array.FindIndex(
+                    parameters,
+                    parameter => string.Equals(parameter.Name, argName, StringComparison.Ordinal));
+            if (paramIndex < 0 || paramIndex >= parameters.Length)
+            {
+                continue;
+            }
+
+            var parameterType = parameters[paramIndex].ParameterType;
+            if (parameterType == null)
+            {
+                continue;
+            }
+
+            if (parameterType.ContainsGenericParameters)
+            {
+                return null;
+            }
+
+            if (!MemberLookup.TryGetLambdaTargetFunctionType(parameterType, out _))
+            {
+                continue;
+            }
+
+            var candidate = TypeSymbol.FromClrType(parameterType);
+            if (target == null)
+            {
+                target = candidate;
+            }
+            else if (!SameDelegateIdentity(target, candidate))
+            {
+                return null;
+            }
+        }
+
+        return target;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -1897,6 +1897,8 @@ internal sealed partial class ExpressionBinder
                 }
                 else if (!SameDelegateIdentity(nominalTarget, nominalCandidate))
                 {
+                    // Issue #3149: reached but not mutation-pinned. TryBindClrConstructorCall
+                    // is the sole constructor caller; BindAccessorCall also consumes this output.
                     nominalTarget = null;
                     nominalTargetsAgree = false;
                 }
@@ -1907,6 +1909,9 @@ internal sealed partial class ExpressionBinder
         // if some candidate produced a usable closed target, that target wins
         // and there is nothing left to defer.
         blockedByOpenGenericParameter = blockedByOpenGenericParameter && target == null && sawAnyMatchingSlot;
+
+        // Issue #3149: reached but not mutation-pinned. BindAccessorCall consumes
+        // sawOpen to defer mixed open/closed candidates, so this reset must remain.
         if (sawOpenGenericParameter)
         {
             nominalTarget = null;

--- a/test/Interpreter.Tests/Issue3149MixedDelegateExtensions.cs
+++ b/test/Interpreter.Tests/Issue3149MixedDelegateExtensions.cs
@@ -1,0 +1,16 @@
+// <copyright file="Issue3149MixedDelegateExtensions.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+
+namespace GSharp.Interpreter.Tests.Issue3149Mixed;
+
+/// <summary>Open generic extension candidate mixed with <see cref="List{T}.Add(T)"/>.</summary>
+public static class Issue3149MixedDelegateExtensions
+{
+    /// <summary>Must lose to the closed instance <c>Add</c> candidate.</summary>
+    public static void Add<T>(this List<Issue3149Greeter> callbacks, Func<T, int> callback) =>
+        throw new InvalidOperationException("Open generic extension candidate was selected.");
+}

--- a/test/Interpreter.Tests/Issue3149NamedDelegateReificationDriverTests.cs
+++ b/test/Interpreter.Tests/Issue3149NamedDelegateReificationDriverTests.cs
@@ -136,10 +136,12 @@ public sealed class Issue3149NamedDelegateReificationDriverTests
             var referencePath = typeof(Issue3149Greeter).Assembly.Location;
             var copiedReferencePath = Path.Combine(directory, Path.GetFileName(referencePath));
             File.Copy(referencePath, copiedReferencePath);
+            var consumerSource = CreateConsumerSource(consumerPackage, generic);
+            Assert.DoesNotContain("import GSharp.Interpreter.Tests.Issue3149Mixed", consumerSource, StringComparison.Ordinal);
             var sourcePath = WriteSource(
                 directory,
                 "consumer.gs",
-                CreateConsumerSource(consumerPackage, generic));
+                consumerSource);
             var expectedOutput = generic
                 ? $"{typeof(Issue3149Mapper<>).FullName}\n{typeof(Issue3149Item).FullName}\n24\n"
                 : $"{typeof(Issue3149Greeter).FullName}\n13\n";

--- a/test/Interpreter.Tests/Issue3149NamedDelegateReificationDriverTests.cs
+++ b/test/Interpreter.Tests/Issue3149NamedDelegateReificationDriverTests.cs
@@ -21,6 +21,24 @@ public delegate int Issue3149Greeter(string value);
 /// <typeparam name="T">Delegate argument type.</typeparam>
 public delegate int Issue3149Mapper<T>(T value);
 
+/// <summary>Open generic extension candidate mixed with <see cref="List{T}.Add(T)"/>.</summary>
+public static class Issue3149MixedDelegateExtensions
+{
+    /// <summary>Must lose to the closed instance <c>Add</c> candidate.</summary>
+    public static void Add<T>(this List<Issue3149Greeter> callbacks, Func<T, int> callback) =>
+        throw new InvalidOperationException("Open generic extension candidate was selected.");
+}
+
+/// <summary>Mixed overloads whose second parameter selects open or closed candidate.</summary>
+public static class Issue3149MixedDelegateOverloads
+{
+    /// <summary>Returns the closed named delegate.</summary>
+    public static Issue3149Greeter Choose(Issue3149Greeter callback, string marker) => callback;
+
+    /// <summary>Returns the inferred open-generic delegate.</summary>
+    public static Func<T, int> Choose<T>(Func<T, int> callback, int marker) => callback;
+}
+
 /// <summary>Imported type argument for <see cref="Issue3149Mapper{T}"/>.</summary>
 public sealed class Issue3149Item
 {
@@ -39,6 +57,79 @@ public sealed class Issue3149Item
 [Collection("ConsoleIo")]
 public sealed class Issue3149NamedDelegateReificationDriverTests
 {
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task MixedOpenAndClosedCandidates_ReifySelectedDelegateAcrossDrivers(bool selectOpen)
+    {
+        var suffix = selectOpen ? "Open" : "Closed";
+        var consumerPackage = "Issue3149Mixed" + suffix;
+        var directory = CreateEmptyTestDirectory("Mixed" + suffix);
+        try
+        {
+            var referencePath = typeof(Issue3149Greeter).Assembly.Location;
+            File.Copy(referencePath, Path.Combine(directory, Path.GetFileName(referencePath)));
+            var statements = selectOpen
+                ? """
+                    let callback = Issue3149MixedDelegateOverloads.Choose((value string) -> value.Length + 50, 1)
+                    Console.WriteLine(callback.GetType().FullName)
+                    Console.WriteLine(callback!!("abc"))
+                    """
+                : """
+                    let callbacks = List[Issue3149Greeter]()
+                    callbacks.Add((value string) -> value.Length + 40)
+                    let callback = callbacks[0]
+                    Console.WriteLine(callback.GetType().FullName)
+                    Console.WriteLine(callback("abc"))
+                    """;
+            var sourcePath = WriteSource(
+                directory,
+                "consumer.gs",
+                $$"""
+                package {{consumerPackage}}
+                import System
+                import System.Collections.Generic
+                import GSharp.Interpreter.Tests
+
+                public class Probe {
+                    shared {
+                        public func Run() {
+                            {{statements}}
+                        }
+                    }
+                }
+
+                Probe.Run()
+                """);
+            var expectedOutput = selectOpen
+                ? $"{typeof(Func<string, int>).FullName}\n53\n"
+                : $"{typeof(Issue3149Greeter).FullName}\n43\n";
+
+            var bare = RunCompiler("/nowarn:GS9100", "/r:" + referencePath, sourcePath);
+            var assemblyPath = Path.Combine(directory, consumerPackage + ".dll");
+            var emitCompile = RunCompiler(
+                "/target:exe",
+                "/nowarn:GS9100",
+                "/out:" + assemblyPath,
+                "/r:" + referencePath,
+                sourcePath);
+            var emitted = emitCompile.ExitCode == 0
+                ? await RunAssemblyAsync(directory, assemblyPath)
+                : emitCompile;
+            var interpreted = RunInterpreter(sourcePath);
+
+            var failures = new List<string>();
+            CheckBareDriver(bare, expectedOutput, failures);
+            CheckDriver("gsc /out:", emitted, expectedOutput, failures);
+            CheckDriver("gsi", interpreted, expectedOutput, failures);
+            Assert.True(failures.Count == 0, string.Join("\n\n", failures));
+        }
+        finally
+        {
+            DeleteDirectory(directory);
+        }
+    }
+
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
@@ -234,7 +325,7 @@ public sealed class Issue3149NamedDelegateReificationDriverTests
         bool generic)
     {
         var failures = new List<string>();
-        CheckBareDriverBoundary(bare, failures);
+        CheckBareDriver(bare, expectedOutput, failures);
         CheckDriver("gsc /out:", emitted, expectedOutput, failures);
         CheckDriver("gsi", interpreted, expectedOutput, failures);
 
@@ -263,23 +354,32 @@ public sealed class Issue3149NamedDelegateReificationDriverTests
         Assert.True(failures.Count == 0, string.Join("\n\n", failures));
     }
 
-    private static void CheckBareDriverBoundary(DriverResult result, List<string> failures)
+    private static void CheckBareDriver(
+        DriverResult result,
+        string expectedOutput,
+        List<string> failures)
     {
-        // Issue #3130: bare evaluation has a reference but cannot execute the
-        // MetadataLoadContext-backed List<T> constructor. Keep this column
-        // explicit while emit and gsi execute the delegate-producing path.
-        if (result.ExitCode != 1
-            || !result.StandardOutput.Contains(
+        // Bare evaluation currently hits an unrelated MetadataLoadContext
+        // invocation boundary. Accept that GS9999 or the expected successful
+        // result when the boundary is removed.
+        var normalizedOutput = Normalize(result.StandardOutput);
+        var succeeded = result.ExitCode == 0
+            && string.Equals(normalizedOutput, expectedOutput + "Success.\n", StringComparison.Ordinal)
+            && result.StandardError.Length == 0;
+        var hitBoundary = result.ExitCode == 1
+            && normalizedOutput.Contains(
                 "GS9999: Cannot invoke a method on objects loaded by a MetadataLoadContext.",
                 StringComparison.Ordinal)
-            || result.StandardOutput.Contains("ArgumentException", StringComparison.Ordinal)
-            || result.StandardOutput.Contains("System.Func", StringComparison.Ordinal)
-            || !string.Equals(Normalize(result.StandardError), "Failed.\n", StringComparison.Ordinal))
+            && !normalizedOutput.Contains("ArgumentException", StringComparison.Ordinal)
+            && (expectedOutput.Contains("System.Func", StringComparison.Ordinal)
+                || !normalizedOutput.Contains("System.Func", StringComparison.Ordinal))
+            && string.Equals(Normalize(result.StandardError), "Failed.\n", StringComparison.Ordinal);
+        if (!succeeded && !hitBoundary)
         {
             failures.Add(
-                "gsc boundary changed:"
+                "gsc failed:"
                 + $"\n  exit: {result.ExitCode}"
-                + $"\n  stdout:\n{Normalize(result.StandardOutput)}"
+                + $"\n  stdout:\n{normalizedOutput}"
                 + $"\n  stderr:\n{result.StandardError}");
         }
     }

--- a/test/Interpreter.Tests/Issue3149NamedDelegateReificationDriverTests.cs
+++ b/test/Interpreter.Tests/Issue3149NamedDelegateReificationDriverTests.cs
@@ -1,0 +1,433 @@
+// <copyright file="Issue3149NamedDelegateReificationDriverTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>Non-generic named-delegate fixture imported by the G# consumer.</summary>
+public delegate int Issue3149Greeter(string value);
+
+/// <summary>Generic named-delegate fixture imported by the G# consumer.</summary>
+/// <typeparam name="T">Delegate argument type.</typeparam>
+public delegate int Issue3149Mapper<T>(T value);
+
+/// <summary>Imported type argument for <see cref="Issue3149Mapper{T}"/>.</summary>
+public sealed class Issue3149Item
+{
+    /// <summary>Initializes a new instance of the <see cref="Issue3149Item"/> class.</summary>
+    /// <param name="value">Stored value.</param>
+    public Issue3149Item(int value) => Value = value;
+
+    /// <summary>Gets the stored value.</summary>
+    public int Value { get; }
+}
+
+/// <summary>
+/// Issue #3149: lambdas flowing through imported erased generic slots retain
+/// their declared named-delegate type.
+/// </summary>
+[Collection("ConsoleIo")]
+public sealed class Issue3149NamedDelegateReificationDriverTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task CrossAssemblyNamedDelegateThroughErasedListSlot_AllDriversReifyAndInvoke(bool generic)
+    {
+        var suffix = generic ? "Generic" : "NonGeneric";
+        var consumerPackage = "Issue3149Consumer" + suffix;
+        var directory = CreateEmptyTestDirectory(suffix);
+        try
+        {
+            var referencePath = typeof(Issue3149Greeter).Assembly.Location;
+            var copiedReferencePath = Path.Combine(directory, Path.GetFileName(referencePath));
+            File.Copy(referencePath, copiedReferencePath);
+            var sourcePath = WriteSource(
+                directory,
+                "consumer.gs",
+                CreateConsumerSource(consumerPackage, generic));
+            var expectedOutput = generic
+                ? $"{typeof(Issue3149Mapper<>).FullName}\n{typeof(Issue3149Item).FullName}\n24\n"
+                : $"{typeof(Issue3149Greeter).FullName}\n13\n";
+
+            var bare = RunCompiler(
+                "/nowarn:GS9100",
+                "/r:" + referencePath,
+                sourcePath);
+
+            var assemblyPath = Path.Combine(directory, consumerPackage + ".dll");
+            var emitCompile = RunCompiler(
+                "/target:exe",
+                "/nowarn:GS9100",
+                "/out:" + assemblyPath,
+                "/r:" + referencePath,
+                sourcePath);
+            var emitted = emitCompile.ExitCode == 0
+                ? await RunAssemblyAsync(directory, assemblyPath)
+                : emitCompile;
+
+            var interpreted = RunInterpreter(sourcePath);
+
+            var inspection = emitCompile.ExitCode == 0
+                ? InspectProducedDelegate(
+                    copiedReferencePath,
+                    assemblyPath,
+                    consumerPackage,
+                    generic)
+                : InspectionResult.Failed("emit compilation failed");
+
+            AssertAllResults(
+                bare,
+                emitted,
+                interpreted,
+                inspection,
+                expectedOutput,
+                generic);
+        }
+        finally
+        {
+            DeleteDirectory(directory);
+        }
+    }
+
+    private static string CreateConsumerSource(string consumerPackage, bool generic) =>
+        generic
+            ? $$"""
+                package {{consumerPackage}}
+                import System
+                import System.Collections.Generic
+                import GSharp.Interpreter.Tests
+
+                public class Probe {
+                    shared {
+                        public func Create() Issue3149Mapper[Issue3149Item] {
+                            let callbacks = List[Issue3149Mapper[Issue3149Item]]()
+                            callbacks.Add((value Issue3149Item) -> value.Value + 20)
+                            return callbacks[0]
+                        }
+
+                        public func Run() {
+                            let callback = Create()
+                            let callbackType = callback.GetType()
+                            Console.WriteLine(callbackType.GetGenericTypeDefinition().FullName)
+                            Console.WriteLine(callbackType.GetGenericArguments()[0].FullName)
+                            Console.WriteLine(callback(Issue3149Item(4)))
+                        }
+                    }
+                }
+
+                Probe.Run()
+                """
+            : $$"""
+                package {{consumerPackage}}
+                import System
+                import System.Collections.Generic
+                import GSharp.Interpreter.Tests
+
+                public class Probe {
+                    shared {
+                        public func Create() Issue3149Greeter {
+                            let callbacks = List[Issue3149Greeter]()
+                            callbacks.Add((value string) -> value.Length + 10)
+                            return callbacks[0]
+                        }
+
+                        public func Run() {
+                            let callback = Create()
+                            Console.WriteLine(callback.GetType().FullName)
+                            Console.WriteLine(callback("abc"))
+                        }
+                    }
+                }
+
+                Probe.Run()
+                """;
+
+    private static InspectionResult InspectProducedDelegate(
+        string referencePath,
+        string assemblyPath,
+        string consumerPackage,
+        bool generic)
+    {
+        try
+        {
+            Assert.NotEmpty(typeof(Issue3149Greeter).Assembly.GetTypes());
+            Assert.NotEmpty(Assembly.Load(File.ReadAllBytes(assemblyPath)).GetTypes());
+
+            var loadContext = new AssemblyLoadContext(
+                "Issue3149_" + Guid.NewGuid().ToString("N"),
+                isCollectible: true);
+            try
+            {
+                var library = loadContext.LoadFromAssemblyPath(referencePath);
+                loadContext.Resolving += (_, name) =>
+                {
+                    if (name.Name == library.GetName().Name)
+                    {
+                        return library;
+                    }
+
+                    var dependencyPath = Path.Combine(AppContext.BaseDirectory, name.Name + ".dll");
+                    return File.Exists(dependencyPath)
+                        ? loadContext.LoadFromAssemblyPath(dependencyPath)
+                        : null;
+                };
+
+                var consumer = loadContext.LoadFromAssemblyPath(assemblyPath);
+                Assert.NotEmpty(consumer.GetTypes());
+                var probe = consumer.GetType(consumerPackage + ".Probe")
+                    ?? throw new InvalidOperationException("Emitted Probe type was not found.");
+                var create = probe.GetMethod(
+                    "Create",
+                    BindingFlags.Public | BindingFlags.Static)
+                    ?? throw new InvalidOperationException("Emitted Probe.Create method was not found.");
+                var value = create.Invoke(null, null) as Delegate
+                    ?? throw new InvalidOperationException("Probe.Create did not return a delegate.");
+                var actualType = value.GetType();
+                var actualDefinition = actualType.IsGenericType
+                    ? actualType.GetGenericTypeDefinition().FullName
+                    : actualType.FullName;
+                var actualArgument = generic
+                    ? actualType.GetGenericArguments()[0].FullName
+                    : null;
+                var invocationArgument = generic
+                    ? Activator.CreateInstance(
+                        library.GetType(typeof(Issue3149Item).FullName!)
+                            ?? throw new InvalidOperationException("Imported Item type was not found."),
+                        4)
+                    : "abc";
+                var invocationResult = value.DynamicInvoke(invocationArgument);
+
+                return new InspectionResult(
+                    actualDefinition,
+                    actualArgument,
+                    invocationResult,
+                    null);
+            }
+            finally
+            {
+                loadContext.Unload();
+            }
+        }
+        catch (Exception ex)
+        {
+            return InspectionResult.Failed(ex.ToString());
+        }
+    }
+
+    private static void AssertAllResults(
+        DriverResult bare,
+        DriverResult emitted,
+        DriverResult interpreted,
+        InspectionResult inspection,
+        string expectedOutput,
+        bool generic)
+    {
+        var failures = new List<string>();
+        CheckBareDriverBoundary(bare, failures);
+        CheckDriver("gsc /out:", emitted, expectedOutput, failures);
+        CheckDriver("gsi", interpreted, expectedOutput, failures);
+
+        var expectedDefinition = generic
+            ? typeof(Issue3149Mapper<>).FullName
+            : typeof(Issue3149Greeter).FullName;
+        var expectedArgument = generic ? typeof(Issue3149Item).FullName : null;
+        if (!string.Equals(inspection.ActualDefinition, expectedDefinition, StringComparison.Ordinal)
+            || !string.Equals(
+                inspection.ActualArgument,
+                expectedArgument,
+                StringComparison.Ordinal)
+            || !Equals(inspection.InvocationResult, generic ? 24 : 13)
+            || inspection.Error != null)
+        {
+            failures.Add(
+                "delegate inspection failed:"
+                + $"\n  expected type: {expectedDefinition}"
+                + $"\n  actual type: {inspection.ActualDefinition ?? "<none>"}"
+                + $"\n  expected argument: {expectedArgument ?? "<none>"}"
+                + $"\n  actual argument: {inspection.ActualArgument ?? "<none>"}"
+                + $"\n  invocation: {inspection.InvocationResult ?? "<none>"}"
+                + $"\n  error: {inspection.Error ?? "<none>"}");
+        }
+
+        Assert.True(failures.Count == 0, string.Join("\n\n", failures));
+    }
+
+    private static void CheckBareDriverBoundary(DriverResult result, List<string> failures)
+    {
+        // Issue #3130: bare evaluation has a reference but cannot execute the
+        // MetadataLoadContext-backed List<T> constructor. Keep this column
+        // explicit while emit and gsi execute the delegate-producing path.
+        if (result.ExitCode != 1
+            || !result.StandardOutput.Contains(
+                "GS9999: Cannot invoke a method on objects loaded by a MetadataLoadContext.",
+                StringComparison.Ordinal)
+            || result.StandardOutput.Contains("ArgumentException", StringComparison.Ordinal)
+            || result.StandardOutput.Contains("System.Func", StringComparison.Ordinal)
+            || !string.Equals(Normalize(result.StandardError), "Failed.\n", StringComparison.Ordinal))
+        {
+            failures.Add(
+                "gsc boundary changed:"
+                + $"\n  exit: {result.ExitCode}"
+                + $"\n  stdout:\n{Normalize(result.StandardOutput)}"
+                + $"\n  stderr:\n{result.StandardError}");
+        }
+    }
+
+    private static void CheckDriver(
+        string name,
+        DriverResult result,
+        string expectedOutput,
+        List<string> failures)
+    {
+        if (result.ExitCode != 0
+            || !string.Equals(Normalize(result.StandardOutput), expectedOutput, StringComparison.Ordinal)
+            || result.StandardError.Length != 0)
+        {
+            failures.Add(
+                $"{name} failed:"
+                + $"\n  exit: {result.ExitCode}"
+                + $"\n  stdout:\n{Normalize(result.StandardOutput)}"
+                + $"\n  stderr:\n{result.StandardError}");
+        }
+    }
+
+    private static DriverResult RunCompiler(params string[] arguments) =>
+        Capture(() => GSharp.Compiler.Program.Main(arguments));
+
+    private static DriverResult RunInterpreter(string sourcePath) =>
+        Capture(() => GSharp.Repl.Program.Main(new[] { sourcePath }));
+
+    private static DriverResult Capture(Func<int> action)
+    {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        try
+        {
+            Console.SetOut(stdout);
+            Console.SetError(stderr);
+            try
+            {
+                return new DriverResult(action(), stdout.ToString(), stderr.ToString());
+            }
+            catch (Exception ex)
+            {
+                return new DriverResult(-1, stdout.ToString(), stderr + ex.ToString());
+            }
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+    }
+
+    private static async Task<DriverResult> RunAssemblyAsync(string directory, string assemblyPath)
+    {
+        var runtimeConfigPath = Path.ChangeExtension(assemblyPath, ".runtimeconfig.json");
+        File.WriteAllText(
+            runtimeConfigPath,
+            """
+            {
+              "runtimeOptions": {
+                "tfm": "net10.0",
+                "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+              }
+            }
+            """);
+
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = directory,
+        };
+        startInfo.ArgumentList.Add("exec");
+        startInfo.ArgumentList.Add("--runtimeconfig");
+        startInfo.ArgumentList.Add(runtimeConfigPath);
+        startInfo.ArgumentList.Add(assemblyPath);
+
+        try
+        {
+            using var process = Process.Start(startInfo)
+                ?? throw new InvalidOperationException("Failed to start emitted assembly.");
+            var stdout = process.StandardOutput.ReadToEndAsync();
+            var stderr = process.StandardError.ReadToEndAsync();
+            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            try
+            {
+                await process.WaitForExitAsync(timeout.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                process.Kill(entireProcessTree: true);
+                return new DriverResult(-1, await stdout, "timed out\n" + await stderr);
+            }
+
+            return new DriverResult(
+                process.ExitCode,
+                await stdout,
+                await stderr);
+        }
+        catch (Exception ex)
+        {
+            return new DriverResult(-1, string.Empty, ex.ToString());
+        }
+    }
+
+    private static string WriteSource(string directory, string fileName, string source)
+    {
+        var path = Path.Combine(directory, fileName);
+        File.WriteAllText(path, source);
+        return path;
+    }
+
+    private static string CreateEmptyTestDirectory(string suffix)
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            "Issue3149_" + suffix + "_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        Assert.Empty(Directory.EnumerateFileSystemEntries(directory));
+        return directory;
+    }
+
+    private static void DeleteDirectory(string directory)
+    {
+        try
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+        catch
+        {
+        }
+    }
+
+    private static string Normalize(string value) =>
+        value.Replace("\r\n", "\n", StringComparison.Ordinal);
+
+    private sealed record DriverResult(int ExitCode, string StandardOutput, string StandardError);
+
+    private sealed record InspectionResult(
+        string ActualDefinition,
+        string ActualArgument,
+        object InvocationResult,
+        string Error)
+    {
+        public static InspectionResult Failed(string error) =>
+            new(null, null, null, error);
+    }
+}

--- a/test/Interpreter.Tests/Issue3149NamedDelegateReificationDriverTests.cs
+++ b/test/Interpreter.Tests/Issue3149NamedDelegateReificationDriverTests.cs
@@ -21,14 +21,6 @@ public delegate int Issue3149Greeter(string value);
 /// <typeparam name="T">Delegate argument type.</typeparam>
 public delegate int Issue3149Mapper<T>(T value);
 
-/// <summary>Open generic extension candidate mixed with <see cref="List{T}.Add(T)"/>.</summary>
-public static class Issue3149MixedDelegateExtensions
-{
-    /// <summary>Must lose to the closed instance <c>Add</c> candidate.</summary>
-    public static void Add<T>(this List<Issue3149Greeter> callbacks, Func<T, int> callback) =>
-        throw new InvalidOperationException("Open generic extension candidate was selected.");
-}
-
 /// <summary>Mixed overloads whose second parameter selects open or closed candidate.</summary>
 public static class Issue3149MixedDelegateOverloads
 {
@@ -90,6 +82,7 @@ public sealed class Issue3149NamedDelegateReificationDriverTests
                 import System
                 import System.Collections.Generic
                 import GSharp.Interpreter.Tests
+                import GSharp.Interpreter.Tests.Issue3149Mixed
 
                 public class Probe {
                     shared {
@@ -116,12 +109,12 @@ public sealed class Issue3149NamedDelegateReificationDriverTests
             var emitted = emitCompile.ExitCode == 0
                 ? await RunAssemblyAsync(directory, assemblyPath)
                 : emitCompile;
-            var interpreted = RunInterpreter(sourcePath);
+            var script = RunScriptDriver(sourcePath);
 
             var failures = new List<string>();
             CheckBareDriver(bare, expectedOutput, failures);
             CheckDriver("gsc /out:", emitted, expectedOutput, failures);
-            CheckDriver("gsi", interpreted, expectedOutput, failures);
+            CheckDriver("gsi", script, expectedOutput, failures);
             Assert.True(failures.Count == 0, string.Join("\n\n", failures));
         }
         finally
@@ -133,7 +126,7 @@ public sealed class Issue3149NamedDelegateReificationDriverTests
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
-    public async Task CrossAssemblyNamedDelegateThroughErasedListSlot_AllDriversReifyAndInvoke(bool generic)
+    public async Task SingleCandidateNamedDelegateThroughErasedListSlot_AllDriversReifyAndInvoke(bool generic)
     {
         var suffix = generic ? "Generic" : "NonGeneric";
         var consumerPackage = "Issue3149Consumer" + suffix;
@@ -167,7 +160,7 @@ public sealed class Issue3149NamedDelegateReificationDriverTests
                 ? await RunAssemblyAsync(directory, assemblyPath)
                 : emitCompile;
 
-            var interpreted = RunInterpreter(sourcePath);
+            var script = RunScriptDriver(sourcePath);
 
             var inspection = emitCompile.ExitCode == 0
                 ? InspectProducedDelegate(
@@ -180,7 +173,7 @@ public sealed class Issue3149NamedDelegateReificationDriverTests
             AssertAllResults(
                 bare,
                 emitted,
-                interpreted,
+                script,
                 inspection,
                 expectedOutput,
                 generic);
@@ -319,7 +312,7 @@ public sealed class Issue3149NamedDelegateReificationDriverTests
     private static void AssertAllResults(
         DriverResult bare,
         DriverResult emitted,
-        DriverResult interpreted,
+        DriverResult script,
         InspectionResult inspection,
         string expectedOutput,
         bool generic)
@@ -327,7 +320,7 @@ public sealed class Issue3149NamedDelegateReificationDriverTests
         var failures = new List<string>();
         CheckBareDriver(bare, expectedOutput, failures);
         CheckDriver("gsc /out:", emitted, expectedOutput, failures);
-        CheckDriver("gsi", interpreted, expectedOutput, failures);
+        CheckDriver("gsi", script, expectedOutput, failures);
 
         var expectedDefinition = generic
             ? typeof(Issue3149Mapper<>).FullName
@@ -357,32 +350,8 @@ public sealed class Issue3149NamedDelegateReificationDriverTests
     private static void CheckBareDriver(
         DriverResult result,
         string expectedOutput,
-        List<string> failures)
-    {
-        // Bare evaluation currently hits an unrelated MetadataLoadContext
-        // invocation boundary. Accept that GS9999 or the expected successful
-        // result when the boundary is removed.
-        var normalizedOutput = Normalize(result.StandardOutput);
-        var succeeded = result.ExitCode == 0
-            && string.Equals(normalizedOutput, expectedOutput + "Success.\n", StringComparison.Ordinal)
-            && result.StandardError.Length == 0;
-        var hitBoundary = result.ExitCode == 1
-            && normalizedOutput.Contains(
-                "GS9999: Cannot invoke a method on objects loaded by a MetadataLoadContext.",
-                StringComparison.Ordinal)
-            && !normalizedOutput.Contains("ArgumentException", StringComparison.Ordinal)
-            && (expectedOutput.Contains("System.Func", StringComparison.Ordinal)
-                || !normalizedOutput.Contains("System.Func", StringComparison.Ordinal))
-            && string.Equals(Normalize(result.StandardError), "Failed.\n", StringComparison.Ordinal);
-        if (!succeeded && !hitBoundary)
-        {
-            failures.Add(
-                "gsc failed:"
-                + $"\n  exit: {result.ExitCode}"
-                + $"\n  stdout:\n{normalizedOutput}"
-                + $"\n  stderr:\n{result.StandardError}");
-        }
-    }
+        List<string> failures) =>
+        CheckDriver("gsc", result, expectedOutput + "Success.\n", failures);
 
     private static void CheckDriver(
         string name,
@@ -405,7 +374,7 @@ public sealed class Issue3149NamedDelegateReificationDriverTests
     private static DriverResult RunCompiler(params string[] arguments) =>
         Capture(() => GSharp.Compiler.Program.Main(arguments));
 
-    private static DriverResult RunInterpreter(string sourcePath) =>
+    private static DriverResult RunScriptDriver(string sourcePath) =>
         Capture(() => GSharp.Repl.Program.Main(new[] { sourcePath }));
 
     private static DriverResult Capture(Func<int> action)


### PR DESCRIPTION
## Summary

Fixes #3149.

Imported candidate discovery recovered a lambda's callable shape but could lose its nominal delegate identity. The lambda became `System.Func<...>`; an erased `IList.Add(object)` accepted it; execution then threw `ArgumentException`.

Closed candidate sets now carry both function shape and `nominalTarget`; eager lambda binding uses `BindLambdaWithDelegateTarget`. Mixed open+closed sets defer until overload resolution, then use the selected parameter's nominal delegate. This covers both single-candidate and mixed-candidate paths.

## Round 4 correction

Round 3 incorrectly inferred that a surviving `nominalTarget` mutant proved dead code. The fixture's extension method leaked through `namespace GSharp.Interpreter.Tests`, injecting an open-generic candidate into every row and making every specimen take the mixed path.

This revision:

- restores the round-2 `src/` implementation exactly;
- makes round 3 test-only;
- moves `Issue3149MixedDelegateExtensions` to `GSharp.Interpreter.Tests.Issue3149Mixed`, imported only by mixed tests;
- turns the existing cross-assembly rows into explicit single-candidate pins;
- keeps `CheckBareDriver` strict success-only. The `GS9999` hatch remains deleted.

## RED / GREEN pin

Command:

```bash
dotnet test test/Interpreter.Tests/Interpreter.Tests.csproj \
  -c Release -p:ContinuousIntegrationBuild=true \
  --filter 'FullyQualifiedName~SingleCandidateNamedDelegateThroughErasedListSlot' \
  --logger 'console;verbosity=normal'
```

With namespace isolation applied atop broken round-3 source (`8aec592e` content): **rc=1, 2/2 failed**. Exact failure includes:

```text
System.ArgumentException: The value "System.Func`2[System.String,System.Int32]" is not of type "GSharp.Interpreter.Tests.Issue3149Greeter" and cannot be used in this generic collection. (Parameter 'value')
```

Generic row likewise reports `System.Func<...,int>` where `Issue3149Mapper<Issue3149Item>` is required.

After restoring `nominalTarget` and both eager bind sites: **rc=0, 2/2 passed**. Full issue filter: **4/4 passed**.

Strict bare-driver oracle survived:

```csharp
CheckDriver("gsc", result, expectedOutput + "Success.\n", failures);
```

## Independent 8-cell runtime matrix

Final head `907f6ed26bf18c6ea66af9a1c79c8be4ff69d25a`. Each cell executes and checks exact delegate identity plus invocation result `43` across bare `gsc`, emitted `gsc /out:`, and `gsi /r:`.

| Reference | A: `DuckGreeter` | B: `DuckMapper<DuckItem>` | C: `DuckMapper<string>` | D: `DuckTaker` |
|---|---|---|---|---|
| without extension | `gsc=0 / gsc-out=0 / gsi=0` | `gsc=0 / gsc-out=0 / gsi=0` | `gsc=0 / gsc-out=0 / gsi=0` | `gsc=0 / gsc-out=0 / gsi=0` |
| with extension | `gsc=0 / gsc-out=0 / gsi=0` | `gsc=0 / gsc-out=0 / gsi=0` | `gsc=0 / gsc-out=0 / gsi=0` | `gsc=0 / gsc-out=0 / gsi=0` |

All three file drivers emit and execute emitted IL. `gsi` accepts `/r:`; bare `gsc` adds `Success.`. No evaluator API, engine, or retired diagnostic is referenced; the test harness names this path `script`, not `interpreter`.

## Verification

Rebased onto fetched live main `6b8096197` (including #3269/#3270). Current PR patch ID: `e486ef33a8158da6bde1a581915166374585f33e`; reviewer rework adds comments and an isolation assertion only.

Release CI-flavour build:

```bash
dotnet build GSharp.sln -c Release -p:ContinuousIntegrationBuild=true
```

Result: **0 warnings, 0 errors**.

- build SHA: `1319f1981bbae8b9341100705d510f5dd0fdbabb`
- `GSharp.Core.dll` MD5: `81a4ca1b66a74781f51858bc8d390988`

Nine projects, enumerated from `dotnet sln GSharp.sln list` (CI source: `build/generate-ci-test-matrix.py`):

| Test project | Result |
|---|---:|
| Compiler.Tests | 4,267 passed |
| Core.Tests | 7,178 passed, 1 skipped |
| Extensions.Tests | 104 passed |
| InternalAnalyzers.Tests | 9 passed |
| Interpreter.Tests | 1,350 passed, 3 skipped |
| LanguageServer.Tests | 468 passed |
| Sdk.Tests | 59 passed |
| Cs2Gs.Tests | 1,907 passed |
| GSharp.GeneratorHost.Tests | 31 passed |

Total: **15,373 passed, 4 skipped, 0 failed (9/9)**. `Cs2Gs.Tests` covers self-contained fixtures, not the separate Oahu gate.

Additional gates:

- ILVerify: **123/123**, 2 documented suppressions, 0 failures;
- merge-tree output: `75283d494e74f41a612ad2efb8308c2e69035911`, 0 `CONFLICT` lines;
- worktree clean; local and remote heads match.

Round-3 D1 survival is retained only as evidence that the old corpus could not observe the line; it is no longer treated as dead-code evidence.
- final CI run `31028303256`: **30 passed, 2 skipped, 0 failed**; PR `MERGEABLE` / `CLEAN` against base `6b8096197`.









