### PR TITLE
[cs2gs] Add native initializer-safe collection spreads

### DIFF
--- a/docs/adr/0115-csharp-to-gsharp-migration-tool.md
+++ b/docs/adr/0115-csharp-to-gsharp-migration-tool.md
@@ -508,7 +508,11 @@ empirically (gsc **0.2.137+31ced6cfb7**) before adoption.
   canonical G# slice literal `[]T{ a, b, c }`, with the element type taken from
   the converted target type. Bare numeric literals are coerced to the element
   type (`byte[] = [0, 1]` → `[]uint8{ uint8(0), uint8(1) }`) to pin each element's
-  type at the slice-literal boundary (§B.12).
+  type at the slice-literal boundary (§B.12). Issue #3096 maps C# spread
+  elements directly to native G# ellipsis spreads:
+  `[before, ..source, after]` → `[]T{ before, ...source, after }`. This form is
+  expression-native and therefore works unchanged in field/property
+  initializers; cs2gs emits no statement-hosted build/append spill.
 - **Throw-expression `x ?? throw e` / `c ? v : throw e` → value-position throw
   lowering.** G# `throw` is **statement-only**; a C# `ThrowExpression` used in a
   value position is lowered to the uniform form `if true { throw e\n default(T) }

--- a/docs/adr/0117-collection-initializers.md
+++ b/docs/adr/0117-collection-initializers.md
@@ -4,7 +4,7 @@
 - **Date**: 2026-06-22
 - **Phase**: v0.2 — language surface
 - **Related**: ADR-0020 (Generic type-parameter brackets — Go-style `[T]`), ADR-0104 (Map type clause — canonical `map[K,V]`), issue #522 (object initializers `T(args){ Prop = v }`), ADR-0115 (C#→G# migration tool)
-- **Issue**: [#479](https://github.com/DavidObando/gsharp/issues/479)
+- **Issue**: [#479](https://github.com/DavidObando/gsharp/issues/479), [#3096](https://github.com/DavidObando/gsharp/issues/3096)
 
 ## Context
 
@@ -163,6 +163,7 @@ ConstructionTarget    ::= identifier TypeArgList                 (* List[int32] 
                         | identifier '(' Arguments? ')'           (* non-generic ctor + collection *)
 CollectionElementList ::= CollectionElement (',' CollectionElement)* ','?
 CollectionElement     ::= Expression                             (* bare:    1            *)
+                        | '...' Expression                       (* spread:  ...items     *)
                         | Expression ':' Expression              (* keyed:   "a": 1       *)
                         | '[' Expression ']' '=' Expression      (* indexed: ["a"] = 1    *)
 ```
@@ -177,11 +178,21 @@ xs := List[int32]{ 1, 2, 3 }
 d  := Dictionary[string, int32]{ "a": 1, "b": 2 }        // key: value (Swift-style pair)
 d2 := Dictionary[string, int32]{ ["a"] = 1, ["b"] = 2 }  // [key] = value (C#-style indexer)
 ci := Dictionary[string, int32](StringComparer.OrdinalIgnoreCase){ "Key": 5 }  // ctor args
+ys := List[int32](){ 0, ...xs, 9 }                              // spread
 ```
 
 The no-parentheses spelling `List[int32]{…}` is sugar for
 `List[int32](){…}`: the parser synthesizes a zero-argument constructor
 call as the initializer target.
+
+A spread uses G#'s existing ellipsis spelling: `...source`. Because a leading
+ellipsis in `Type[T]{ ...source }` already denotes structural projection on a
+generic composite literal, collection spreads retain the explicit empty
+constructor parentheses: `List[T](){ ...source }`. Array/slice literals are
+unambiguous and use `[]T{ ...source }`. The target must expose a usable
+single-element `Add` contract; dictionary spreads therefore consume
+`KeyValuePair[K,V]` elements through the dictionary's collection-interface
+`Add(KeyValuePair[K,V])` implementation.
 
 ### 2. Disambiguation from struct literals and object initializers
 
@@ -213,6 +224,8 @@ A collection initializer binds to a `BoundBlockExpression` that:
    (`$collinit«n»`),
 2. lowers each element in source order against that local:
    - **bare** `e` → `self.Add(e)`,
+   - **spread** `...source` → iterate `source` once and call `self.Add(item)`
+     for each element,
    - **keyed** `k: v` → `self.Add(k, v)`,
    - **indexed** `[k] = v` → indexer set `self[k] = v` (overwrite
      semantics; later duplicate keys win, matching C#'s indexed element
@@ -226,12 +239,26 @@ ordinary overload-resolution and conversion machinery — the synthesized
 hand-written `coll.Add(…)`, so generic-argument inference, params
 expansion, user-defined conversions, and diagnostics are identical.
 
-Because the lowering uses only pre-existing bound nodes
-(`BoundBlockExpression`, `BoundVariableDeclaration`,
-`BoundImportedInstanceCallExpression`, `BoundClrIndexAssignmentExpression`),
-**both** the IL emitter and the tree-walking interpreter execute it with
-no new bound-node kind, visitor, rewriter, or printer changes, and the
-emitted IL is verifiable.
+The lowering uses only pre-existing bound nodes
+(`BoundBlockExpression`, `BoundVariableDeclaration`, native for-range and
+function-literal calls, `BoundImportedInstanceCallExpression`, and
+`BoundClrIndexAssignmentExpression`). No new bound-node kind or IL opcode is
+required; the evaluator routes nested synthetic blocks through its ordinary
+statement evaluator, and emitted IL remains verifiable.
+
+Issue #3096 applies the same lowering to count-inferred array/slice literals.
+`[]T{ before, ...source, after }` builds elements in lexical order, applies
+the ordinary `Add(T)` conversion to each fixed or spread value, and yields the
+runtime `T[]` backing the G# slice. Empty and multiple spreads are legal;
+each source expression is evaluated exactly once. The binder normally keeps
+each iteration loop inside an immediately-invoked non-capturing synthesized
+lambda, so the outer literal remains a composable, verifiable expression even
+as a later call argument or field/property-assignment value. Interface static
+initializers use the loop directly because their `.cctor` starts with an empty
+evaluation stack. Ref-like sources are materialized through their native
+`ToArray()` before becoming helper arguments. Interpreter static-field access
+now runs class/struct/interface initializers once, in declaration order,
+matching emitted `.cctor` behavior; a failed initializer remains faulted.
 
 ### 4. Diagnostics (no ICE)
 

--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -228,6 +228,7 @@ SizeOfExpression
 SlashEqualsToken
 SlashToken
 SlicePattern
+SpreadElementExpression
 StackAllocExpression
 StarEqualsToken
 StarToken

--- a/docs/cs2gs-coverage-matrix.md
+++ b/docs/cs2gs-coverage-matrix.md
@@ -6,12 +6,12 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | Status | Count |
 | --- | --- |
 | Unclassified | 0 |
-| Translated | 239 |
+| Translated | 240 |
 | Lowered | 19 |
 | UnsupportedByDesign | 56 |
-| Gap | 7 |
+| Gap | 6 |
 
-## Translated (239)
+## Translated (240)
 
 | Kind | Node type | Rule | Rationale | Fixture | Issue | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -207,6 +207,7 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | SingleVariableDesignation | SingleVariableDesignationSyntax | ADR-0115 §B.30 |  | tools/cs2gs/corpus/grid/G09-Functions-Console/Constructs/DeclarationExpression.cs |  |  |
 | SizeOfExpression | SizeOfExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G12-Unsafe-Console/Constructs/SizeOfExpression.cs |  |  |
 | SlicePattern | SlicePatternSyntax | ADR-0115 §B.22 |  | tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/ListPattern.cs |  | is-test path materializes the slice-bound value via native G# range slicing (`receiver[prefix..^suffix]`, using new `RangeIndexExpression`/`FromEndIndexExpression` CodeModel nodes) and binds it by substitution; switch-arm path emits a native G# `SlicePattern` (`..rest`/`..`) since gsc has real runtime slice-capture support (issue #1889, resolved). |
+| SpreadElement | SpreadElementSyntax | ADR-0117 / ADR-0115 §B.36 |  | tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/CollectionExpression.cs | https://github.com/DavidObando/gsharp/issues/1897, https://github.com/DavidObando/gsharp/issues/3096 | Maps to native G# `...source` inside array/collection initializers; valid in field/property initializers with no translator spill. |
 | StackAllocArrayCreationExpression | StackAllocArrayCreationExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G12-Unsafe-Console/Constructs/StackAllocArrayCreationExpression.cs | https://github.com/DavidObando/gsharp/issues/1933 | Compiles end-to-end under the ilverify allow-unsafe policy (issue #1933); stackalloc's localloc IL is unverifiable by design, not a gsc defect. |
 | StringLiteralExpression | LiteralExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G01-Literals-Console/Constructs/StringLiteralExpression.cs |  |  |
 | StructConstraint | ClassOrStructConstraintSyntax | ADR-0115 §B.7 |  | tools/cs2gs/corpus/grid/G08-Generics-Console/Constructs/StructConstraint.cs |  |  |
@@ -340,7 +341,7 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | XmlText | XmlTextSyntax |  | ToolingScope |  |  | Documentation/tooling structure, not program semantics; doc-comment mapping is ADR-0057 scope. |
 | XmlTextAttribute | XmlTextAttributeSyntax |  | ToolingScope |  |  | Documentation/tooling structure, not program semantics; doc-comment mapping is ADR-0057 scope. |
 
-## Gap (7)
+## Gap (6)
 
 | Kind | Node type | Rule | Rationale | Fixture | Issue | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -350,4 +351,3 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | RangeExpression | RangeExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1896 | Lowers to .Slice(...) which gsc cannot resolve on arrays/strings. |
 | RefExpression | RefExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1900 | ref argument/return seam (&x pass-by-address). |
 | RefType | RefTypeSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1900 |  |
-| SpreadElement | SpreadElementSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1897 |  |

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Interfaces.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Interfaces.cs
@@ -774,6 +774,23 @@ internal sealed partial class DeclarationBinder
             // reference them through a TypeSpec for the closed construction, so
             // each construction (`IBox[int32]` vs `IBox[string]`) owns
             // independent storage — matching CLR static-field semantics.
+            var previousFunction = getCurrentFunction();
+
+            // Issue #3096: identify this bind as an interface .cctor context
+            // so native spread lowering keeps its loop directly in the
+            // stack-empty initializer instead of synthesizing a helper method
+            // that an interface cannot own in this path.
+            var initializerContext = new FunctionSymbol(
+                "<field-initializer>",
+                ImmutableArray<ParameterSymbol>.Empty,
+                TypeSymbol.Void)
+            {
+                IsStatic = true,
+                IsStaticInitializer = true,
+                StaticOwnerType = interfaceSymbol,
+            };
+            setCurrentFunction(initializerContext);
+            try
             {
                 var staticFieldsBuilder = ImmutableArray.CreateBuilder<FieldSymbol>();
                 var constFieldsBuilder = ImmutableArray.CreateBuilder<FieldSymbol>();
@@ -858,6 +875,10 @@ internal sealed partial class DeclarationBinder
                 {
                     interfaceSymbol.SetStaticFieldInitializers(initializersBuilder.ToImmutable());
                 }
+            }
+            finally
+            {
+                setCurrentFunction(previousFunction);
             }
         }
     }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -274,11 +274,14 @@ internal sealed partial class ExpressionBinder
 
         var resultType = target.Type;
         var hasNonIndexedElement = syntax.Elements.Any(e => e is not IndexedCollectionElementSyntax);
+        var hasSpreadElement = syntax.Elements.Any(
+            e => e is ExpressionCollectionElementSyntax { Expression: SpreadElementExpressionSyntax });
 
         // A collection initializer requires an accessible instance `Add` for the
         // bare / key:value element forms. Indexed `[k] = v` entries go through
         // the indexer-set path, which reports its own GS0226/indexability errors.
-        if (hasNonIndexedElement && !HasCollectionAdd(resultType))
+        if ((hasNonIndexedElement && !HasCollectionAdd(resultType)) ||
+            (hasSpreadElement && !HasUnaryCollectionAdd(resultType)))
         {
             Diagnostics.ReportTypeNotCollectionInitializable(syntax.OpenBraceToken.Location, resultType);
             BindCollectionElementsForDiagnostics(syntax);
@@ -286,7 +289,7 @@ internal sealed partial class ExpressionBinder
         }
 
         var tempName = "$collinit" + System.Threading.Interlocked.Increment(ref binderCtx.SyntheticLocalCounter).ToString(System.Globalization.CultureInfo.InvariantCulture);
-        var tempVar = new LocalVariableSymbol(tempName, isReadOnly: true, resultType);
+        var tempVar = new LocalVariableSymbol(tempName, isReadOnly: false, resultType);
         scope.TryDeclareVariable(tempVar);
 
         var statements = ImmutableArray.CreateBuilder<BoundStatement>();
@@ -301,7 +304,8 @@ internal sealed partial class ExpressionBinder
     /// Issue #479 / ADR-0117 (and #1567): lowers each collection element into an
     /// <c>Add(...)</c> call (bare / <c>key: value</c> entries) or an indexer set
     /// (<c>[key] = value</c> entries) against the collection held by
-    /// <paramref name="collectionLocal"/>, appending one statement per element.
+    /// <paramref name="collectionLocal"/>, appending the required statements
+    /// for each element.
     /// Shared by the standalone collection initializer and the member
     /// collection initializer that populates a get-only collection property.
     /// </summary>
@@ -315,6 +319,9 @@ internal sealed partial class ExpressionBinder
             BoundExpression bound;
             switch (element)
             {
+                case ExpressionCollectionElementSyntax { Expression: SpreadElementExpressionSyntax spread }:
+                    statements.AddRange(BindCollectionSpreadStatements(collectionLocal, spread));
+                    continue;
                 case ExpressionCollectionElementSyntax bare:
                     bound = BindCollectionAddCall(collectionLocal, element, ImmutableArray.Create(bare.Expression));
                     break;
@@ -331,6 +338,175 @@ internal sealed partial class ExpressionBinder
 
             statements.Add(new BoundExpressionStatement(element, bound));
         }
+    }
+
+    /// <summary>
+    /// Issue #3096: lowers <c>...source</c> to a compiler-synthesized lambda
+    /// that receives the collection and source as parameters, uses native
+    /// for-range plus the target's ordinary <c>Add</c> overload, and returns
+    /// the updated collection. Keeping the loop in a non-capturing lambda makes
+    /// the outer initializer straight-line and verifiable even when another
+    /// operand or assignment receiver is already on the IL evaluation stack.
+    /// </summary>
+    private ImmutableArray<BoundStatement> BindCollectionSpreadStatements(
+        LocalVariableSymbol collectionLocal,
+        SpreadElementExpressionSyntax spread)
+    {
+        var tree = spread.SyntaxTree;
+        var position = spread.Span.Start;
+        var sourceName = "$spreadsource" +
+            System.Threading.Interlocked.Increment(ref binderCtx.SyntheticLocalCounter)
+                .ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var sourceToken = new SyntaxToken(tree, SyntaxKind.IdentifierToken, position, sourceName, null);
+        var source = BindExpression(spread.Expression);
+        if (TypeSymbol.IsByRefLike(source.Type))
+        {
+            // A ref-like source cannot be captured by the synthesized lambda.
+            // Materialize its ordinary ToArray() value first; the call still
+            // evaluates the source exactly once and preserves element order.
+            source = BindAccessorCall(
+                source,
+                classSymbol: null,
+                SynthesizeInstanceCall(spread, "ToArray", ImmutableArray<ExpressionSyntax>.Empty));
+        }
+
+        var sourceLocal = new LocalVariableSymbol(sourceName, isReadOnly: true, source.Type);
+        scope.TryDeclareVariable(sourceLocal);
+        if (function?.IsStaticInitializer == true &&
+            function.StaticOwnerType is InterfaceSymbol)
+        {
+            return BindInterfaceStaticSpreadStatements(
+                collectionLocal,
+                spread,
+                sourceLocal,
+                sourceToken,
+                source);
+        }
+
+        var targetName = "$spreadtarget" +
+            System.Threading.Interlocked.Increment(ref binderCtx.SyntheticLocalCounter)
+                .ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var targetToken = new SyntaxToken(tree, SyntaxKind.IdentifierToken, position, targetName, null);
+        var sourceParameterName = "$spreaditems" +
+            System.Threading.Interlocked.Increment(ref binderCtx.SyntheticLocalCounter)
+                .ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var sourceParameterToken = new SyntaxToken(
+            tree,
+            SyntaxKind.IdentifierToken,
+            position,
+            sourceParameterName,
+            null);
+        var itemName = "$spreaditem" +
+            System.Threading.Interlocked.Increment(ref binderCtx.SyntheticLocalCounter)
+                .ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var itemToken = new SyntaxToken(tree, SyntaxKind.IdentifierToken, position, itemName, null);
+        var itemExpression = new NameExpressionSyntax(tree, itemToken);
+        var addCall = SynthesizeInstanceCall(
+            spread,
+            "Add",
+            ImmutableArray.Create<ExpressionSyntax>(itemExpression));
+        var body = new ExpressionStatementSyntax(
+            tree,
+            new AccessorExpressionSyntax(
+                tree,
+                new NameExpressionSyntax(tree, targetToken),
+                new SyntaxToken(tree, SyntaxKind.DotToken, position, ".", null),
+                addCall));
+        var loop = new ForRangeStatementSyntax(
+            tree,
+            new SyntaxToken(tree, SyntaxKind.ForKeyword, position, "for", null),
+            itemToken,
+            commaToken: null,
+            secondIdentifier: null,
+            colonEqualsToken: null,
+            rangeKeyword: null,
+            inToken: new SyntaxToken(tree, SyntaxKind.IdentifierToken, position, "in", null),
+            collection: new NameExpressionSyntax(tree, sourceParameterToken),
+            body: body);
+
+        var parameterNodes = ImmutableArray.CreateBuilder<SyntaxNode>();
+        parameterNodes.Add(new ParameterSyntax(tree, targetToken, type: null));
+        parameterNodes.Add(new SyntaxToken(tree, SyntaxKind.CommaToken, position, ",", null));
+        parameterNodes.Add(new ParameterSyntax(tree, sourceParameterToken, type: null));
+        var lambdaBody = new BlockExpressionSyntax(
+            tree,
+            new SyntaxToken(tree, SyntaxKind.OpenBraceToken, position, "{", null),
+            ImmutableArray.Create<StatementSyntax>(loop),
+            expression: new NameExpressionSyntax(tree, targetToken),
+            new SyntaxToken(tree, SyntaxKind.CloseBraceToken, position, "}", null));
+        var lambda = new LambdaExpressionSyntax(
+            tree,
+            new SyntaxToken(tree, SyntaxKind.OpenParenthesisToken, position, "(", null),
+            new SeparatedSyntaxList<ParameterSyntax>(parameterNodes.ToImmutable()),
+            new SyntaxToken(tree, SyntaxKind.CloseParenthesisToken, position, ")", null),
+            new SyntaxToken(tree, SyntaxKind.RightArrowToken, position, "->", null),
+            lambdaBody);
+        var functionType = FunctionTypeSymbol.Get(
+            ImmutableArray.Create(collectionLocal.Type, source.Type),
+            collectionLocal.Type);
+        var boundLambda = lambdas.BindLambdaExpression(lambda, functionType);
+        var invocation = new BoundIndirectCallExpression(
+            spread,
+            boundLambda,
+            functionType,
+            ImmutableArray.Create<BoundExpression>(
+                new BoundVariableExpression(spread, collectionLocal),
+                new BoundVariableExpression(spread, sourceLocal)));
+        var assignment = new BoundAssignmentExpression(spread, collectionLocal, invocation);
+
+        return ImmutableArray.Create<BoundStatement>(
+            new BoundVariableDeclaration(spread, sourceLocal, source),
+            new BoundExpressionStatement(spread, assignment));
+    }
+
+    private ImmutableArray<BoundStatement> BindInterfaceStaticSpreadStatements(
+        LocalVariableSymbol collectionLocal,
+        SpreadElementExpressionSyntax spread,
+        LocalVariableSymbol sourceLocal,
+        SyntaxToken sourceToken,
+        BoundExpression source)
+    {
+        var tree = spread.SyntaxTree;
+        var position = spread.Span.Start;
+        var itemName = "$spreaditem" +
+            System.Threading.Interlocked.Increment(ref binderCtx.SyntheticLocalCounter)
+                .ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var itemToken = new SyntaxToken(tree, SyntaxKind.IdentifierToken, position, itemName, null);
+        var addCall = SynthesizeInstanceCall(
+            spread,
+            "Add",
+            ImmutableArray.Create<ExpressionSyntax>(new NameExpressionSyntax(tree, itemToken)));
+        var loop = new ForRangeStatementSyntax(
+            tree,
+            new SyntaxToken(tree, SyntaxKind.ForKeyword, position, "for", null),
+            itemToken,
+            commaToken: null,
+            secondIdentifier: null,
+            colonEqualsToken: null,
+            rangeKeyword: null,
+            inToken: new SyntaxToken(tree, SyntaxKind.IdentifierToken, position, "in", null),
+            collection: new NameExpressionSyntax(tree, sourceToken),
+            body: new ExpressionStatementSyntax(
+                tree,
+                new AccessorExpressionSyntax(
+                    tree,
+                    new NameExpressionSyntax(
+                        tree,
+                        new SyntaxToken(
+                            tree,
+                            SyntaxKind.IdentifierToken,
+                            position,
+                            collectionLocal.Name,
+                            null)),
+                    new SyntaxToken(tree, SyntaxKind.DotToken, position, ".", null),
+                    addCall)));
+        var bound = bindStatementList(
+            ImmutableArray.Create<StatementSyntax>(loop),
+            null);
+
+        return ImmutableArray.Create<BoundStatement>(
+            new BoundVariableDeclaration(spread, sourceLocal, source),
+            Lowerer.Lower(bound.Single()));
     }
 
     /// <summary>
@@ -371,13 +547,17 @@ internal sealed partial class ExpressionBinder
             nestedObjectAssignments.Length > 0 &&
             nestedObjectAssignments.All(assignment => assignment != null);
         var hasNonIndexedElement = braced.Elements.Any(e => e is not IndexedCollectionElementSyntax);
-        if (!isNestedObjectInitializer && hasNonIndexedElement && !HasCollectionAdd(propRead.Type))
+        var hasSpreadElement = braced.Elements.Any(
+            e => e is ExpressionCollectionElementSyntax { Expression: SpreadElementExpressionSyntax });
+        if (!isNestedObjectInitializer &&
+            ((hasNonIndexedElement && !HasCollectionAdd(propRead.Type)) ||
+             (hasSpreadElement && !HasUnaryCollectionAdd(propRead.Type))))
         {
             return false;
         }
 
         var tempName = "$collinit" + System.Threading.Interlocked.Increment(ref binderCtx.SyntheticLocalCounter).ToString(System.Globalization.CultureInfo.InvariantCulture);
-        var memberLocal = new LocalVariableSymbol(tempName, isReadOnly: true, propRead.Type);
+        var memberLocal = new LocalVariableSymbol(tempName, isReadOnly: false, propRead.Type);
         scope.TryDeclareVariable(memberLocal);
         statements.Add(new BoundVariableDeclaration(braced, memberLocal, propRead));
 
@@ -413,6 +593,19 @@ internal sealed partial class ExpressionBinder
 
         return type.ClrType is { } clrType
             && MemberLookup.SafeGetMethodsIncludingSelfAndInterfaces(clrType, "Add").Count > 0;
+    }
+
+    private static bool HasUnaryCollectionAdd(TypeSymbol type)
+    {
+        if (TypeMemberModel.GetMethods(type, "Add", MemberQuery.Instance(MemberKinds.Method))
+            .Any(method => method.Parameters.Length == 1))
+        {
+            return true;
+        }
+
+        return type.ClrType is { } clrType &&
+            MemberLookup.SafeGetMethodsIncludingSelfAndInterfaces(clrType, "Add")
+                .Any(method => method.GetParameters().Length == 1);
     }
 
     /// <summary>
@@ -463,6 +656,9 @@ internal sealed partial class ExpressionBinder
         {
             switch (element)
             {
+                case ExpressionCollectionElementSyntax { Expression: SpreadElementExpressionSyntax spread }:
+                    _ = BindExpression(spread.Expression);
+                    break;
                 case ExpressionCollectionElementSyntax bare:
                     _ = BindExpression(bare.Expression);
                     break;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -372,6 +372,7 @@ internal sealed partial class ExpressionBinder
 
         var sourceLocal = new LocalVariableSymbol(sourceName, isReadOnly: true, source.Type);
         scope.TryDeclareVariable(sourceLocal);
+        _ = TryGetCollectionSpreadElementType(collectionLocal.Type, out var targetElementType);
         if (function?.IsStaticInitializer == true &&
             function.StaticOwnerType is InterfaceSymbol)
         {
@@ -380,7 +381,8 @@ internal sealed partial class ExpressionBinder
                 spread,
                 sourceLocal,
                 sourceToken,
-                source);
+                source,
+                targetElementType);
         }
 
         var targetName = "$spreadtarget" +
@@ -444,7 +446,13 @@ internal sealed partial class ExpressionBinder
         var functionType = FunctionTypeSymbol.Get(
             ImmutableArray.Create(collectionLocal.Type, source.Type),
             collectionLocal.Type);
-        var boundLambda = lambdas.BindLambdaExpression(lambda, functionType);
+        BoundExpression boundLambda = lambdas.BindLambdaExpression(lambda, functionType);
+        if (targetElementType != null &&
+            boundLambda is BoundFunctionLiteralExpression literal)
+        {
+            boundLambda = RewriteCollectionSpreadLambda(literal, targetElementType, spread);
+        }
+
         var invocation = new BoundIndirectCallExpression(
             spread,
             boundLambda,
@@ -464,7 +472,8 @@ internal sealed partial class ExpressionBinder
         SpreadElementExpressionSyntax spread,
         LocalVariableSymbol sourceLocal,
         SyntaxToken sourceToken,
-        BoundExpression source)
+        BoundExpression source,
+        TypeSymbol targetElementType)
     {
         var tree = spread.SyntaxTree;
         var position = spread.Span.Start;
@@ -500,13 +509,248 @@ internal sealed partial class ExpressionBinder
                             null)),
                     new SyntaxToken(tree, SyntaxKind.DotToken, position, ".", null),
                     addCall)));
-        var bound = bindStatementList(
+        BoundStatement bound = bindStatementList(
             ImmutableArray.Create<StatementSyntax>(loop),
-            null);
+            null).Single();
+        if (targetElementType != null)
+        {
+            bound = new CollectionSpreadLoopRewriter(
+                this,
+                collectionLocal,
+                targetElementType,
+                spread).Rewrite(bound);
+        }
 
         return ImmutableArray.Create<BoundStatement>(
             new BoundVariableDeclaration(spread, sourceLocal, source),
-            Lowerer.Lower(bound.Single()));
+            Lowerer.Lower(bound));
+    }
+
+    private BoundFunctionLiteralExpression RewriteCollectionSpreadLambda(
+        BoundFunctionLiteralExpression literal,
+        TypeSymbol targetElementType,
+        SpreadElementExpressionSyntax spread)
+    {
+        var body = (BoundBlockStatement)new CollectionSpreadLoopRewriter(
+            this,
+            literal.Function.Parameters[0],
+            targetElementType,
+            spread).Rewrite(literal.Body);
+        return new BoundFunctionLiteralExpression(
+            literal.Syntax,
+            literal.Function,
+            literal.FunctionType,
+            body,
+            literal.CapturedVariables);
+    }
+
+    private BoundExpression BindConvertedCollectionAddCall(
+        VariableSymbol receiverVariable,
+        VariableSymbol itemVariable,
+        TypeSymbol targetElementType,
+        SpreadElementExpressionSyntax spread)
+    {
+        var placeholderName = "$spreadconverted" +
+            System.Threading.Interlocked.Increment(ref binderCtx.SyntheticLocalCounter)
+                .ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var placeholderToken = new SyntaxToken(
+            spread.SyntaxTree,
+            SyntaxKind.IdentifierToken,
+            spread.Span.Start,
+            placeholderName,
+            null);
+        var placeholder = new LocalVariableSymbol(
+            placeholderName,
+            isReadOnly: true,
+            targetElementType);
+
+        BoundExpression add;
+        var previousScope = scope;
+        scope = new BoundScope(scope);
+        try
+        {
+            scope.TryDeclareVariable(receiverVariable);
+            scope.TryDeclareVariable(placeholder);
+            add = BindCollectionAddCall(
+                receiverVariable,
+                spread,
+                ImmutableArray.Create<ExpressionSyntax>(
+                    new NameExpressionSyntax(spread.SyntaxTree, placeholderToken)));
+        }
+        finally
+        {
+            scope = previousScope;
+        }
+
+        var convertedItem = conversions.BindConversion(
+            spread.Location,
+            new BoundVariableExpression(spread, itemVariable),
+            targetElementType);
+        return new CollectionSpreadItemSubstitutionRewriter(
+            placeholder,
+            convertedItem).Rewrite(add);
+    }
+
+    private static bool TryGetCollectionSpreadElementType(
+        TypeSymbol collectionType,
+        out TypeSymbol elementType)
+    {
+        switch (collectionType)
+        {
+            case SliceTypeSymbol slice:
+                elementType = slice.ElementType;
+                return true;
+            case ArrayTypeSymbol array:
+                elementType = array.ElementType;
+                return true;
+            case SequenceTypeSymbol sequence:
+                elementType = sequence.ElementType;
+                return true;
+            case ImportedTypeSymbol imported
+                when imported.OpenDefinition != null &&
+                     MemberLookup.TryGetClrEnumerableElementType(
+                         imported.OpenDefinition,
+                         out var openElement):
+                elementType = MemberLookup.MapOpenClrTypeToSymbolic(
+                    openElement,
+                    imported);
+                return true;
+            case NullabilityAnnotatedTypeSymbol annotated
+                when annotated.ClrType != null &&
+                     MemberLookup.TryGetClrEnumerableElementType(
+                         annotated.ClrType,
+                         out var annotatedElement):
+                elementType = annotated.GetTypeArgumentSymbolForClrType(
+                    annotatedElement);
+                return true;
+            case ImportedTypeSymbol imported
+                when imported.ClrType != null &&
+                     MemberLookup.TryGetClrEnumerableElementType(
+                         imported.ClrType,
+                         out var importedElement):
+                elementType = TypeSymbol.FromClrType(importedElement);
+                return true;
+            case StructSymbol user
+                when MemberLookup.TryGetUserPatternEnumerableElementType(
+                    user,
+                    out var userElement):
+                elementType = userElement;
+                return true;
+        }
+
+        var userParameterTypes = TypeMemberModel
+            .GetMethods(
+                collectionType,
+                "Add",
+                MemberQuery.Instance(MemberKinds.Method))
+            .Where(method => method.Parameters.Length == 1)
+            .Select(method => method.Parameters[0].Type)
+            .Distinct()
+            .ToArray();
+        if (userParameterTypes.Length == 1)
+        {
+            elementType = userParameterTypes[0];
+            return true;
+        }
+
+        elementType = null;
+        if (collectionType?.ClrType == null)
+        {
+            return false;
+        }
+
+        Type clrElement = null;
+        foreach (var method in MemberLookup.SafeGetMethodsIncludingSelfAndInterfaces(
+            collectionType.ClrType,
+            "Add"))
+        {
+            var parameters = method.GetParameters();
+            if (parameters.Length != 1)
+            {
+                continue;
+            }
+
+            if (clrElement != null &&
+                !clrElement.IsSameAs(parameters[0].ParameterType))
+            {
+                return false;
+            }
+
+            clrElement = parameters[0].ParameterType;
+        }
+
+        if (clrElement == null)
+        {
+            return false;
+        }
+
+        elementType = TypeSymbol.FromClrType(clrElement);
+        return true;
+    }
+
+    private sealed class CollectionSpreadLoopRewriter : BoundTreeRewriter
+    {
+        private readonly ExpressionBinder binder;
+        private readonly VariableSymbol receiver;
+        private readonly TypeSymbol targetElementType;
+        private readonly SpreadElementExpressionSyntax spread;
+
+        public CollectionSpreadLoopRewriter(
+            ExpressionBinder binder,
+            VariableSymbol receiver,
+            TypeSymbol targetElementType,
+            SpreadElementExpressionSyntax spread)
+        {
+            this.binder = binder;
+            this.receiver = receiver;
+            this.targetElementType = targetElementType;
+            this.spread = spread;
+        }
+
+        public BoundStatement Rewrite(BoundStatement statement)
+            => RewriteStatement(statement);
+
+        protected override BoundStatement RewriteForRangeStatement(
+            BoundForRangeStatement node)
+        {
+            var add = binder.BindConvertedCollectionAddCall(
+                receiver,
+                node.ValueVariable,
+                targetElementType,
+                spread);
+            return new BoundForRangeStatement(
+                node.Syntax,
+                node.KeyVariable,
+                node.ValueVariable,
+                node.Collection,
+                node.IterationKind,
+                new BoundExpressionStatement(spread, add),
+                node.BreakLabel,
+                node.ContinueLabel);
+        }
+    }
+
+    private sealed class CollectionSpreadItemSubstitutionRewriter : BoundTreeRewriter
+    {
+        private readonly VariableSymbol placeholder;
+        private readonly BoundExpression replacement;
+
+        public CollectionSpreadItemSubstitutionRewriter(
+            VariableSymbol placeholder,
+            BoundExpression replacement)
+        {
+            this.placeholder = placeholder;
+            this.replacement = replacement;
+        }
+
+        public BoundExpression Rewrite(BoundExpression expression)
+            => RewriteExpression(expression);
+
+        protected override BoundExpression RewriteVariableExpression(
+            BoundVariableExpression node)
+            => ReferenceEquals(node.Variable, placeholder)
+                ? replacement
+                : node;
     }
 
     /// <summary>
@@ -616,7 +860,7 @@ internal sealed partial class ExpressionBinder
     /// inference, and parameter conversions all match a hand-written
     /// <c>coll.Add(...)</c>.
     /// </summary>
-    private BoundExpression BindCollectionAddCall(LocalVariableSymbol receiverLocal, SyntaxNode anchor, ImmutableArray<ExpressionSyntax> arguments)
+    private BoundExpression BindCollectionAddCall(VariableSymbol receiverLocal, SyntaxNode anchor, ImmutableArray<ExpressionSyntax> arguments)
     {
         var receiver = new BoundVariableExpression(anchor, receiverLocal);
         var addCall = SynthesizeInstanceCall(anchor, "Add", arguments);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -2115,6 +2115,11 @@ internal sealed partial class ExpressionBinder
             elementType = CloseNestedEnumOverCurrentTypeParameters(bareElementEnum);
         }
 
+        if (syntax.Elements?.Any(element => element is SpreadElementExpressionSyntax) == true)
+        {
+            return BindSpreadArrayCreationExpression(syntax, elementType);
+        }
+
         var elements = ImmutableArray.CreateBuilder<BoundExpression>(syntax.Elements?.Count ?? 0);
 
         // Issue #1272: the runtime/zero-initialised allocation form `[n]T`
@@ -2150,6 +2155,90 @@ internal sealed partial class ExpressionBinder
         }
 
         return new BoundArrayCreationExpression(null, ArrayTypeSymbol.Get(elementType, length), elements.ToImmutable());
+    }
+
+    /// <summary>
+    /// Issue #3096: binds a count-inferred array literal containing one or more
+    /// native <c>...source</c> elements. A hidden <see cref="List{T}"/> receives
+    /// fixed elements and each spread's elements in lexical order, then
+    /// <c>ToArray()</c> yields the slice value.
+    /// </summary>
+    private BoundExpression BindSpreadArrayCreationExpression(
+        ArrayCreationExpressionSyntax syntax,
+        TypeSymbol elementType)
+    {
+        var construction = CreateSpreadListConstruction(syntax, elementType, out var listType);
+        var tempName = "$spreadbuilder" +
+            System.Threading.Interlocked.Increment(ref binderCtx.SyntheticLocalCounter)
+                .ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var temp = new LocalVariableSymbol(tempName, isReadOnly: false, listType);
+        scope.TryDeclareVariable(temp);
+
+        var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+        statements.Add(new BoundVariableDeclaration(syntax, temp, construction));
+        foreach (var element in syntax.Elements)
+        {
+            if (element is SpreadElementExpressionSyntax spread)
+            {
+                statements.AddRange(BindCollectionSpreadStatements(temp, spread));
+                continue;
+            }
+
+            statements.Add(new BoundExpressionStatement(
+                element,
+                BindCollectionAddCall(temp, element, ImmutableArray.Create(element))));
+        }
+
+        var receiver = new BoundVariableExpression(syntax, temp);
+        var toArray = BindAccessorCall(
+            receiver,
+            classSymbol: null,
+            SynthesizeInstanceCall(syntax, "ToArray", ImmutableArray<ExpressionSyntax>.Empty));
+        var result = conversions.BindConversion(
+            syntax.Location,
+            toArray,
+            SliceTypeSymbol.Get(elementType));
+        return new BoundBlockExpression(syntax, statements.ToImmutable(), result);
+    }
+
+    private BoundExpression CreateSpreadListConstruction(
+        SyntaxNode syntax,
+        TypeSymbol elementType,
+        out ImportedTypeSymbol listType)
+    {
+        var openListType = scope.References.MapClrTypeToReferences(typeof(List<>));
+        var clrElementType = resolveClrTypeForGenericArg(elementType);
+        if (clrElementType == null &&
+            MemberLookup.TryProjectErasedClrType(elementType, out var projectedElementType))
+        {
+            clrElementType = scope.References.MapClrTypeToReferences(projectedElementType);
+        }
+
+        clrElementType ??= scope.References.GetCoreType("System.Object");
+
+        Type closedListType;
+        try
+        {
+            closedListType = openListType.MakeGenericType(clrElementType);
+        }
+        catch (ArgumentException)
+        {
+            closedListType = openListType.MakeGenericType(scope.References.GetCoreType("System.Object"));
+        }
+
+        listType = ImportedTypeSymbol.GetConstructed(
+            closedListType,
+            openListType,
+            ImmutableArray.Create(elementType));
+        var constructor = ClrTypeUtilities
+            .SafeGetConstructors(closedListType, BindingFlags.Public | BindingFlags.Instance)
+            .Single(candidate => candidate.GetParameters().Length == 0);
+        return new BoundClrConstructorCallExpression(
+            syntax,
+            closedListType,
+            constructor,
+            ImmutableArray<BoundExpression>.Empty,
+            listType);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -348,6 +348,11 @@ internal sealed partial class ExpressionBinder
                 return BindObjectCreationExpression((ObjectCreationExpressionSyntax)syntax);
             case SyntaxKind.CollectionInitializerExpression:
                 return BindCollectionInitializerExpression((CollectionInitializerExpressionSyntax)syntax);
+            case SyntaxKind.SpreadElementExpression:
+                // Spread wrappers are normally consumed by their enclosing
+                // array/collection literal binder. Binding the node directly
+                // (e.g. a semantic-model query) yields its source expression.
+                return BindExpression(((SpreadElementExpressionSyntax)syntax).Expression, canBeVoid);
             case SyntaxKind.AccessorExpression:
                 return BindAccessorExpression((AccessorExpressionSyntax)syntax);
             case SyntaxKind.ArrayCreationExpression:

--- a/src/Core/CodeAnalysis/Evaluator.Calls.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Calls.cs
@@ -77,6 +77,18 @@ public sealed partial class Evaluator
                     : args[i];
             }
 
+            if (node.Function.IsStatic)
+            {
+                if (node.Function.StaticOwnerType is StructSymbol staticOwner)
+                {
+                    EnsureStaticTypeInitialized(staticOwner);
+                }
+                else if (node.Function.StaticOwnerType is InterfaceSymbol staticInterface)
+                {
+                    EnsureStaticTypeInitialized(staticInterface);
+                }
+            }
+
             var statement = program.Functions.TryGetValue(node.Function, out var functionBody)
                 ? functionBody
                 : localFunctionBodies[node.Function];
@@ -592,6 +604,15 @@ public sealed partial class Evaluator
         {
             throw new InvalidOperationException(
                 $"Static-virtual interface call '{node.InterfaceMethod.Name}' has no runtime body (no implementer found and no default).");
+        }
+
+        if (target.StaticOwnerType is StructSymbol staticOwner)
+        {
+            EnsureStaticTypeInitialized(staticOwner);
+        }
+        else if (target.StaticOwnerType is InterfaceSymbol staticInterface)
+        {
+            EnsureStaticTypeInitialized(staticInterface);
         }
 
         var frame2 = new ConcurrentDictionary<VariableSymbol, object>();

--- a/src/Core/CodeAnalysis/Evaluator.Expressions.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Expressions.cs
@@ -611,6 +611,12 @@ public sealed partial class Evaluator
     {
         foreach (var statement in node.Statements)
         {
+            if (statement is BoundBlockStatement block)
+            {
+                EvaluateStatement(block);
+                continue;
+            }
+
             if (statement is BoundVariableDeclaration declaration)
             {
                 EvaluateVariableDeclaration(declaration);
@@ -1010,6 +1016,13 @@ public sealed partial class Evaluator
 
     private object EvaluateConstructorCallExpression(BoundConstructorCallExpression node)
     {
+        var argumentValues = new object[node.Arguments.Length];
+        for (var i = 0; i < node.Arguments.Length; i++)
+        {
+            argumentValues[i] = EvaluateExpression(node.Arguments[i]);
+        }
+
+        EnsureStaticTypeInitialized(node.StructType);
         var sv = CreateStructValue(node.StructType);
 
         // Default-initialize all fields first (including inherited), then bind primary-ctor args.
@@ -1045,7 +1058,7 @@ public sealed partial class Evaluator
                 var primaryParams = node.StructType.PrimaryConstructorParameters;
                 for (var i = 0; i < primaryParams.Length; i++)
                 {
-                    sv.Fields[PrimaryCtorStorageFieldName(node.StructType, primaryParams[i].Name)] = EvaluateExpression(node.Arguments[i]);
+                    sv.Fields[PrimaryCtorStorageFieldName(node.StructType, primaryParams[i].Name)] = argumentValues[i];
                 }
 
                 // Forward an explicit class-level base initializer if present
@@ -1082,7 +1095,7 @@ public sealed partial class Evaluator
 
             for (var i = 0; i < ctorFunction.Parameters.Length; i++)
             {
-                frame2[ctorFunction.Parameters[i]] = EvaluateExpression(node.Arguments[i]);
+                frame2[ctorFunction.Parameters[i]] = argumentValues[i];
             }
 
             using (PushFrame(frame2))
@@ -1112,7 +1125,7 @@ public sealed partial class Evaluator
         var parameters = node.StructType.PrimaryConstructorParameters;
         for (var i = 0; i < parameters.Length; i++)
         {
-            sv.Fields[PrimaryCtorStorageFieldName(node.StructType, parameters[i].Name)] = EvaluateExpression(node.Arguments[i]);
+            sv.Fields[PrimaryCtorStorageFieldName(node.StructType, parameters[i].Name)] = argumentValues[i];
         }
 
         // Issue #306: forward an explicit base-constructor initializer to a GSharp
@@ -1964,6 +1977,7 @@ public sealed partial class Evaluator
             // (per closed construction for a generic interface).
             if (node.InterfaceType != null)
             {
+                EnsureStaticTypeInitialized(node.InterfaceType);
                 if (TryGetInterfaceStaticField(node.InterfaceType, node.Field, out var ifaceValue))
                 {
                     return ifaceValue;
@@ -1972,6 +1986,7 @@ public sealed partial class Evaluator
                 return ClrDefaultValue(node.Field.Type);
             }
 
+            EnsureStaticTypeInitialized(node.StructType);
             if (TryGetStaticField(node.StructType, node.Field, out var staticValue))
             {
                 return staticValue;
@@ -1996,6 +2011,14 @@ public sealed partial class Evaluator
         if (node.Receiver == null && node.ReceiverExpression == null)
         {
             var value = EvaluateExpression(node.Value);
+            if (node.InterfaceType != null)
+            {
+                EnsureStaticTypeInitialized(node.InterfaceType);
+            }
+            else
+            {
+                EnsureStaticTypeInitialized(node.StructType);
+            }
 
             // Issue #1030: interface static field — keyed per owning interface
             // (per closed construction for a generic interface).
@@ -2062,6 +2085,7 @@ public sealed partial class Evaluator
         // ADR-0053: static property access — receiver is null.
         if (node.Receiver == null)
         {
+            EnsureStaticTypeInitialized(node.StructType);
             if (node.Property.IsAutoProperty && node.Property.BackingField != null)
             {
                 if (TryGetStaticField(node.StructType, node.Property.BackingField, out var staticValue))
@@ -2153,6 +2177,10 @@ public sealed partial class Evaluator
     private object EvaluatePropertyAssignmentExpression(BoundPropertyAssignmentExpression node)
     {
         var value = EvaluateExpression(node.Value);
+        if (node.Receiver == null)
+        {
+            EnsureStaticTypeInitialized(node.StructType);
+        }
 
         // Issue #263: static property assignment (receiver is null).
         if (node.Receiver == null)

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
@@ -63,6 +64,12 @@ public sealed partial class Evaluator
     private readonly Dictionary<Symbols.FunctionSymbol, bool> iteratorFunctionCache = [];
     private readonly ConcurrentDictionary<FunctionSymbol, BoundBlockStatement> localFunctionBodies = [];
     private readonly Dictionary<(Symbols.StructSymbol, Symbols.FieldSymbol), object> staticFields = [];
+
+    // Issue #3096: mirror CLR .cctor once-only semantics so static field
+    // initializers execute in declaration order under the interpreter too.
+    private readonly HashSet<Symbols.TypeSymbol> initializedStaticTypes = [];
+    private readonly Dictionary<Symbols.TypeSymbol, int> initializingStaticTypes = [];
+    private readonly Dictionary<Symbols.TypeSymbol, ExceptionDispatchInfo> failedStaticTypes = [];
 
     // ADR-0089 / issue #1030: interface static-field storage. Keyed by the
     // owning interface symbol so each closed construction of a generic interface
@@ -260,6 +267,115 @@ public sealed partial class Evaluator
         lock (globalsLock)
         {
             staticFields[(structType, field)] = value;
+        }
+    }
+
+    private void EnsureStaticTypeInitialized(Symbols.StructSymbol structType)
+        => EnsureStaticTypeInitialized(
+            structType,
+            structType?.StaticFields ?? ImmutableArray<Symbols.FieldSymbol>.Empty,
+            structType?.StaticFieldInitializers ?? ImmutableDictionary<Symbols.FieldSymbol, BoundExpression>.Empty,
+            structType?.StaticInitializerStatements ?? ImmutableArray<BoundStatement>.Empty);
+
+    private void EnsureStaticTypeInitialized(Symbols.InterfaceSymbol interfaceType)
+        => EnsureStaticTypeInitialized(
+            interfaceType,
+            interfaceType?.StaticFields ?? ImmutableArray<Symbols.FieldSymbol>.Empty,
+            interfaceType?.StaticFieldInitializers ?? ImmutableDictionary<Symbols.FieldSymbol, BoundExpression>.Empty,
+            ImmutableArray<BoundStatement>.Empty);
+
+    private void EnsureStaticTypeInitialized(
+        Symbols.TypeSymbol type,
+        ImmutableArray<Symbols.FieldSymbol> fields,
+        ImmutableDictionary<Symbols.FieldSymbol, BoundExpression> initializers,
+        ImmutableArray<BoundStatement> initializerStatements)
+    {
+        if (type == null || (initializers.IsEmpty && initializerStatements.IsDefaultOrEmpty))
+        {
+            return;
+        }
+
+        var threadId = Environment.CurrentManagedThreadId;
+        ExceptionDispatchInfo priorFailure = null;
+        lock (globalsLock)
+        {
+            while (initializingStaticTypes.TryGetValue(type, out var ownerThread) &&
+                   ownerThread != threadId)
+            {
+                Monitor.Wait(globalsLock);
+            }
+
+            if (!failedStaticTypes.TryGetValue(type, out priorFailure))
+            {
+                if (initializedStaticTypes.Contains(type) ||
+                    (initializingStaticTypes.TryGetValue(type, out var reentrantOwner) &&
+                     reentrantOwner == threadId))
+                {
+                    return;
+                }
+
+                initializingStaticTypes[type] = threadId;
+            }
+        }
+
+        if (priorFailure != null)
+        {
+            priorFailure.Throw();
+            return;
+        }
+
+        var succeeded = false;
+        ExceptionDispatchInfo failure = null;
+        try
+        {
+            var frame = new ConcurrentDictionary<Symbols.VariableSymbol, object>();
+            using (PushFrame(frame))
+            {
+                foreach (var field in fields)
+                {
+                    if (initializers.TryGetValue(field, out var initializer))
+                    {
+                        var value = EvaluateExpression(initializer);
+                        if (type is Symbols.StructSymbol structType)
+                        {
+                            SetStaticField(structType, field, value);
+                        }
+                        else
+                        {
+                            SetInterfaceStaticField((Symbols.InterfaceSymbol)type, field, value);
+                        }
+                    }
+                }
+
+                if (!initializerStatements.IsDefaultOrEmpty)
+                {
+                    EvaluateStatement(new BoundBlockStatement(null, initializerStatements));
+                }
+            }
+
+            succeeded = true;
+        }
+        catch (Exception ex)
+        {
+            failure = ExceptionDispatchInfo.Capture(ex);
+            throw;
+        }
+        finally
+        {
+            lock (globalsLock)
+            {
+                initializingStaticTypes.Remove(type);
+                if (succeeded)
+                {
+                    initializedStaticTypes.Add(type);
+                }
+                else if (failure != null)
+                {
+                    failedStaticTypes[type] = failure;
+                }
+
+                Monitor.PulseAll(globalsLock);
+            }
         }
     }
 

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -357,8 +357,11 @@ public sealed partial class Evaluator
         }
         catch (Exception ex)
         {
-            failure = ExceptionDispatchInfo.Capture(ex);
-            throw;
+            var wrapped = new TypeInitializationException(
+                type.ClrType?.FullName ?? type.Name,
+                UnwrapRuntimeException(ex));
+            failure = ExceptionDispatchInfo.Capture(wrapped);
+            throw wrapped;
         }
         finally
         {

--- a/src/Core/CodeAnalysis/Syntax/CollectionElementSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/CollectionElementSyntax.cs
@@ -8,7 +8,7 @@ namespace GSharp.Core.CodeAnalysis.Syntax;
 /// Issue #479 / ADR-0117: the base class for a single element of a
 /// <see cref="CollectionInitializerExpressionSyntax"/>. The three concrete
 /// shapes are <see cref="ExpressionCollectionElementSyntax"/> (a bare element
-/// <c>expr</c>), <see cref="KeyedCollectionElementSyntax"/> (a key/value entry
+/// <c>expr</c>, including <c>...source</c>), <see cref="KeyedCollectionElementSyntax"/> (a key/value entry
 /// <c>key: value</c>), and <see cref="IndexedCollectionElementSyntax"/> (an
 /// indexed entry <c>[key] = value</c>).
 /// </summary>

--- a/src/Core/CodeAnalysis/Syntax/CollectionInitializerExpressionSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/CollectionInitializerExpressionSyntax.cs
@@ -9,14 +9,17 @@ namespace GSharp.Core.CodeAnalysis.Syntax;
 /// collection construction. Examples:
 /// <c>List[int32]{1, 2, 3}</c>, <c>HashSet[int32](){1, 2}</c>,
 /// <c>Dictionary[string, int32]{"a": 1}</c>, and
-/// <c>Dictionary[K, V](comparer){ ["k"] = v }</c>.
+/// <c>Dictionary[K, V](comparer){ ["k"] = v }</c>, and
+/// <c>List[T](){ ...items }</c>.
 /// <para>
 /// The <see cref="Target"/> is the constructor call expression (a
 /// <see cref="CallExpressionSyntax"/> carrying the type-argument list and any
 /// explicit constructor arguments). For the no-parentheses spelling
 /// (<c>List[int32]{…}</c>) the parser synthesizes an empty-argument
 /// constructor call as the target. Each element in <see cref="Elements"/> is
-/// one of the three <see cref="CollectionElementSyntax"/> shapes. The binder
+/// one of the three <see cref="CollectionElementSyntax"/> shapes; a spread is
+/// an <see cref="ExpressionCollectionElementSyntax"/> containing a
+/// <see cref="SpreadElementExpressionSyntax"/>. The binder
 /// lowers this to a <see cref="GSharp.Core.CodeAnalysis.Binding.BoundBlockExpression"/>
 /// that constructs into a synthetic local, calls <c>Add(...)</c> / sets the
 /// indexer for each element, and yields the local.

--- a/src/Core/CodeAnalysis/Syntax/ExpressionCollectionElementSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/ExpressionCollectionElementSyntax.cs
@@ -7,7 +7,9 @@ namespace GSharp.Core.CodeAnalysis.Syntax;
 /// <summary>
 /// Issue #479 / ADR-0117: a bare element of a sequence/set collection
 /// initializer, e.g. the <c>1</c> in <c>List[int32]{1, 2, 3}</c>. Lowers to a
-/// <c>Add(expr)</c> call on the constructed collection.
+/// <c>Add(expr)</c> call on the constructed collection. When
+/// <see cref="Expression"/> is a <see cref="SpreadElementExpressionSyntax"/>,
+/// each source element is added in order.
 /// </summary>
 public sealed class ExpressionCollectionElementSyntax : CollectionElementSyntax
 {

--- a/src/Core/CodeAnalysis/Syntax/Parser.Expressions.Creation.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.Expressions.Creation.cs
@@ -315,7 +315,8 @@ public partial class Parser
             || Peek(1).Kind == SyntaxKind.DotToken)
         {
             var nestedElementType = ParseTypeClause();
-            var (nestedOpenBrace, nestedElements, nestedCloseBrace, nestedHasElements) = ParseOptionalArrayInitializer();
+            var (nestedOpenBrace, nestedElements, nestedCloseBrace, nestedHasElements) =
+                ParseOptionalArrayInitializer(allowSpread: lengthExpression == null && lengthToken == null);
 
             // Issue #1272: the no-initializer (or empty-initializer) form with a
             // length yields the runtime/zero-initialised allocation `[n][]T`.
@@ -354,7 +355,8 @@ public partial class Parser
         {
             var questionToken = MatchToken(SyntaxKind.QuestionToken);
             var elementClause = new TypeClauseSyntax(syntaxTree, openBracketToken: null, lengthToken: null, closeBracketToken: null, elementType, questionToken);
-            var (nElemOpenBrace, nElemElements, nElemCloseBrace, nElemHasElements) = ParseOptionalArrayInitializer();
+            var (nElemOpenBrace, nElemElements, nElemCloseBrace, nElemHasElements) =
+                ParseOptionalArrayInitializer(allowSpread: lengthExpression == null && lengthToken == null);
 
             if (!nElemHasElements && (lengthExpression != null || lengthToken != null))
             {
@@ -380,7 +382,8 @@ public partial class Parser
                 nElemCloseBrace ?? MatchToken(SyntaxKind.CloseBraceToken));
         }
 
-        var (openBrace, elements, closeBrace, hasElements) = ParseOptionalArrayInitializer();
+        var (openBrace, elements, closeBrace, hasElements) =
+            ParseOptionalArrayInitializer(allowSpread: lengthExpression == null && lengthToken == null);
 
         // Issue #1272: `[n]T` (no initializer) or `[n]T{}` (empty initializer)
         // with a runtime length is the zero-initialised allocation form. A lone
@@ -414,7 +417,7 @@ public partial class Parser
     // when no `{` is present (the issue #1272 no-initializer form), and reports
     // whether any element expressions were supplied (an empty `{}` counts as the
     // zero-initialised allocation form, not a literal).
-    private (SyntaxToken OpenBrace, SeparatedSyntaxList<ExpressionSyntax> Elements, SyntaxToken CloseBrace, bool HasElements) ParseOptionalArrayInitializer()
+    private (SyntaxToken OpenBrace, SeparatedSyntaxList<ExpressionSyntax> Elements, SyntaxToken CloseBrace, bool HasElements) ParseOptionalArrayInitializer(bool allowSpread)
     {
         if (Current.Kind != SyntaxKind.OpenBraceToken)
         {
@@ -422,7 +425,7 @@ public partial class Parser
         }
 
         var openBrace = MatchToken(SyntaxKind.OpenBraceToken);
-        var elements = ParseArrayInitializerElements();
+        var elements = ParseArrayInitializerElements(allowSpread);
         var closeBrace = MatchToken(SyntaxKind.CloseBraceToken);
         return (openBrace, elements, closeBrace, elements.Count > 0);
     }
@@ -471,7 +474,7 @@ public partial class Parser
         if (Current.Kind == SyntaxKind.OpenBraceToken)
         {
             openBrace = MatchToken(SyntaxKind.OpenBraceToken);
-            elements = ParseArrayInitializerElements();
+            elements = ParseArrayInitializerElements(allowSpread: false);
             closeBrace = MatchToken(SyntaxKind.CloseBraceToken);
         }
 
@@ -526,7 +529,7 @@ public partial class Parser
             body);
     }
 
-    private SeparatedSyntaxList<ExpressionSyntax> ParseArrayInitializerElements()
+    private SeparatedSyntaxList<ExpressionSyntax> ParseArrayInitializerElements(bool allowSpread)
     {
         var nodesAndSeparators = ImmutableArray.CreateBuilder<SyntaxNode>();
         var parseNext = Current.Kind != SyntaxKind.CloseBraceToken;
@@ -534,7 +537,16 @@ public partial class Parser
                Current.Kind != SyntaxKind.CloseBraceToken &&
                Current.Kind != SyntaxKind.EndOfFileToken)
         {
-            nodesAndSeparators.Add(ParseExpression());
+            if (allowSpread && Current.Kind == SyntaxKind.EllipsisToken)
+            {
+                var ellipsis = MatchToken(SyntaxKind.EllipsisToken);
+                nodesAndSeparators.Add(new SpreadElementExpressionSyntax(syntaxTree, ellipsis, ParseExpression()));
+            }
+            else
+            {
+                nodesAndSeparators.Add(ParseExpression());
+            }
+
             if (Current.Kind == SyntaxKind.CommaToken)
             {
                 nodesAndSeparators.Add(MatchToken(SyntaxKind.CommaToken));
@@ -1262,6 +1274,14 @@ public partial class Parser
         suppressStructLiteral = 0;
         try
         {
+            // Native spread element `...source`.
+            if (Current.Kind == SyntaxKind.EllipsisToken)
+            {
+                var ellipsis = MatchToken(SyntaxKind.EllipsisToken);
+                var spread = new SpreadElementExpressionSyntax(syntaxTree, ellipsis, ParseExpression());
+                return new ExpressionCollectionElementSyntax(syntaxTree, spread);
+            }
+
             // Indexed entry `[key] = value`.
             if (Current.Kind == SyntaxKind.OpenSquareBracketToken && LooksLikeIndexedCollectionElement())
             {

--- a/src/Core/CodeAnalysis/Syntax/SpreadElementExpressionSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/SpreadElementExpressionSyntax.cs
@@ -1,0 +1,37 @@
+// <copyright file="SpreadElementExpressionSyntax.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Represents an ellipsis spread inside an array or collection initializer,
+/// e.g. <c>...items</c> in <c>[]int32{ 0, ...items, 9 }</c>.
+/// </summary>
+public sealed class SpreadElementExpressionSyntax : ExpressionSyntax
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SpreadElementExpressionSyntax"/> class.
+    /// </summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="ellipsisToken">The leading <c>...</c> token.</param>
+    /// <param name="expression">The enumerable source expression.</param>
+    public SpreadElementExpressionSyntax(
+        SyntaxTree syntaxTree,
+        SyntaxToken ellipsisToken,
+        ExpressionSyntax expression)
+        : base(syntaxTree)
+    {
+        EllipsisToken = ellipsisToken;
+        Expression = expression;
+    }
+
+    /// <inheritdoc/>
+    public override SyntaxKind Kind => SyntaxKind.SpreadElementExpression;
+
+    /// <summary>Gets the leading <c>...</c> token.</summary>
+    public SyntaxToken EllipsisToken { get; }
+
+    /// <summary>Gets the enumerable source expression.</summary>
+    public ExpressionSyntax Expression { get; }
+}

--- a/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -412,6 +412,9 @@ public enum SyntaxKind
     // A bare element of a sequence/set collection initializer (`expr`).
     ExpressionCollectionElement,
 
+    // An ellipsis spread used as an array/collection initializer element (`...expr`).
+    SpreadElementExpression,
+
     // A key/value element of a dictionary collection initializer (`key: value`).
     KeyedCollectionElement,
 

--- a/test/Compiler.Tests/Emit/Issue3096CollectionSpreadEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3096CollectionSpreadEmitTests.cs
@@ -1,0 +1,180 @@
+// <copyright file="Issue3096CollectionSpreadEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>Runtime and ILVerify coverage for native initializer-safe spreads.</summary>
+public sealed class Issue3096CollectionSpreadEmitTests
+{
+    [Fact]
+    public void FieldPropertyAndCollectionSpreads_RunAndVerify()
+    {
+        const string Source = """
+            package Issue3096
+
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            data class Item(Value string) {}
+
+            func Copy[T any](source []T) []T {
+                return []T{ ...source }
+            }
+
+            func CountWithPrefix(prefix int32, values []int32) int32 {
+                return prefix + values.Length
+            }
+
+            func CopySpan(source Span[int32]) []int32 {
+                return []int32{ ...source }
+            }
+
+            interface IStaticValues {
+                shared {
+                    var Count int32 = []int32{ 6, ...[]int32{ 7 } }.Length
+                }
+            }
+
+            class Holder {
+                public let Instance []string = []string{ "instance-head", ...[]string{}, "instance-tail" }
+                public let Collection List[string] = List[string](){ "collection-head", ...[]string{ "collection-middle" }, "collection-tail" }
+                public prop Property []string { get; init; }
+
+                init() {
+                    Property = []string{ "property-head", ...[]string{}, "property-tail" }
+                }
+
+                shared {
+                    public var Calls int32 = 0
+                    public var Trace string = ""
+                    public let All []string = []string{ "a", "b", "skip" }
+                    public let Filtered []string = []string{ ...All.Where((x string) -> x != "skip") }
+                    public let Ordered []string = []string{ Mark("head", "A"), ...Source(), Mark("tail", "C") }
+                    public let Empty []string = []string{ ...[]string{} }
+                    public let Mixed []string = []string{ "before", ...Filtered, ...Empty, "after" }
+
+                    func Mark(value string, marker string) string {
+                        Trace = Trace + marker
+                        return value
+                    }
+
+                    func Source() []string {
+                        Calls++
+                        Trace = Trace + "B"
+                        return []string{ "middle-1", "middle-2" }
+                    }
+                }
+            }
+
+            let holder = Holder()
+            let list = List[string](){ "list-head", ...Holder.Filtered, "list-tail" }
+            let copied = Copy([]Item{ Item("user") })
+            let spanCopy = CopySpan([]int32{ 8, 9 })
+            let pairs = []KeyValuePair[string, int32]{ KeyValuePair[string, int32]("key", 42) }
+            let dictionary = Dictionary[string, int32](){ ...pairs }
+
+            Console.WriteLine(Holder.Filtered.Length)
+            Console.WriteLine(Holder.Filtered[0])
+            Console.WriteLine(Holder.Filtered[1])
+            Console.WriteLine(Holder.Ordered.Length)
+            Console.WriteLine(Holder.Ordered[0])
+            Console.WriteLine(Holder.Ordered[1])
+            Console.WriteLine(Holder.Ordered[2])
+            Console.WriteLine(Holder.Ordered[3])
+            Console.WriteLine(Holder.Trace)
+            Console.WriteLine(Holder.Calls)
+            Console.WriteLine(Holder.Empty.Length)
+            Console.WriteLine(Holder.Mixed.Length)
+            Console.WriteLine(holder.Instance.Length)
+            Console.WriteLine(holder.Collection.Count)
+            Console.WriteLine(holder.Property.Length)
+            Console.WriteLine(list.Count)
+            Console.WriteLine(copied[0].Value)
+            Console.WriteLine(CountWithPrefix(10, []int32{ ...[]int32{ 1, 2 } }))
+            Console.WriteLine(spanCopy[1])
+            Console.WriteLine(IStaticValues.Count)
+            Console.WriteLine(dictionary["key"])
+            """;
+
+        Assert.Equal(
+            "2\na\nb\n4\nhead\nmiddle-1\nmiddle-2\ntail\nABC\n1\n0\n4\n2\n3\n2\n4\nuser\n12\n9\n2\n42\n",
+            CompileVerifyAndRun(Source));
+    }
+
+    private static string CompileVerifyAndRun(string source)
+    {
+        var directory = Directory.CreateTempSubdirectory("gs_issue3096_").FullName;
+        try
+        {
+            var sourcePath = Path.Combine(directory, "test.gs");
+            var outputPath = Path.Combine(directory, "test.dll");
+            File.WriteAllText(sourcePath, source);
+
+            using var stdout = new StringWriter();
+            using var stderr = new StringWriter();
+            var previousOut = Console.Out;
+            var previousError = Console.Error;
+            Console.SetOut(stdout);
+            Console.SetError(stderr);
+            int exitCode;
+            try
+            {
+                exitCode = Program.Main(new[]
+                {
+                    "/out:" + outputPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    "/nowarn:GS9100",
+                    sourcePath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+                Console.SetError(previousError);
+            }
+
+            Assert.True(exitCode == 0, $"gsc failed:{Environment.NewLine}{stdout}{stderr}");
+            IlVerifier.Verify(outputPath);
+
+            using var process = Process.Start(new ProcessStartInfo("dotnet")
+            {
+                ArgumentList =
+                {
+                    "exec",
+                    "--runtimeconfig",
+                    Path.ChangeExtension(outputPath, ".runtimeconfig.json"),
+                    outputPath,
+                },
+                WorkingDirectory = directory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            }) ?? throw new InvalidOperationException("Failed to start dotnet exec.");
+            var output = process.StandardOutput.ReadToEnd();
+            var error = process.StandardError.ReadToEnd();
+            Assert.True(process.WaitForExit(30_000), "dotnet exec timed out.");
+            Assert.True(
+                process.ExitCode == 0,
+                $"exited {process.ExitCode}:{Environment.NewLine}{error}");
+            return output.Replace("\r\n", "\n", StringComparison.Ordinal);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue3096CollectionSpreadEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3096CollectionSpreadEmitTests.cs
@@ -108,6 +108,43 @@ public sealed class Issue3096CollectionSpreadEmitTests
             CompileVerifyAndRun(Source));
     }
 
+    [Fact]
+    public void FaultedStaticSpreadInitializer_ThrowsTypeInitializationExceptionOnce()
+    {
+        const string Source = """
+            package Issue3096.Fault
+
+            import System
+
+            var Attempts = 0
+
+            class Broken {
+                shared {
+                    let Values []int32 = []int32{ ...Fail() }
+
+                    func Fail() []int32 {
+                        Attempts++
+                        throw InvalidOperationException("boom")
+                    }
+                }
+            }
+
+            func Read() {
+                try {
+                    let ignored = Broken.Values
+                } catch (ex TypeInitializationException) {
+                    Console.WriteLine(ex.InnerException is InvalidOperationException)
+                }
+            }
+
+            Read()
+            Read()
+            Console.WriteLine(Attempts)
+            """;
+
+        Assert.Equal("True\nTrue\n1\n", CompileVerifyAndRun(Source));
+    }
+
     private static string CompileVerifyAndRun(string source)
     {
         var directory = Directory.CreateTempSubdirectory("gs_issue3096_").FullName;

--- a/test/Compiler.Tests/Emit/Issue3096CollectionSpreadEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3096CollectionSpreadEmitTests.cs
@@ -145,6 +145,43 @@ public sealed class Issue3096CollectionSpreadEmitTests
         Assert.Equal("True\nTrue\n1\n", CompileVerifyAndRun(Source));
     }
 
+    [Fact]
+    public void UserDefinedSpreadConversions_ArrayAndCollection_RunAndVerify()
+    {
+        const string Source = """
+            package Issue3096.Conversions
+
+            import System
+            import System.Collections.Generic
+
+            struct Celsius {
+                var Degrees float64
+            }
+
+            func operator implicit(value Celsius) float64 {
+                return value.Degrees
+            }
+
+            let source = []Celsius{
+                Celsius{ Degrees: 2.5 },
+                Celsius{ Degrees: 3.5 },
+            }
+            let array = []float64{ 1.0, ...source, 9.0 }
+            let list = List[float64](){ ...source }
+
+            Console.WriteLine(array.Length)
+            Console.WriteLine(array[1])
+            Console.WriteLine(array[2])
+            Console.WriteLine(list.Count)
+            Console.WriteLine(list[0])
+            Console.WriteLine(list[1])
+            """;
+
+        Assert.Equal(
+            "4\n2.5\n3.5\n2\n2.5\n3.5\n",
+            CompileVerifyAndRun(Source));
+    }
+
     private static string CompileVerifyAndRun(string source)
     {
         var directory = Directory.CreateTempSubdirectory("gs_issue3096_").FullName;

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3096CollectionSpreadBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3096CollectionSpreadBindingTests.cs
@@ -1,0 +1,115 @@
+// <copyright file="Issue3096CollectionSpreadBindingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>Binder coverage for native array/collection spread lowering.</summary>
+public sealed class Issue3096CollectionSpreadBindingTests
+{
+    [Fact]
+    public void ArraySpread_AppliesElementConversions()
+    {
+        var diagnostics = Bind("""
+            let source = []int32{ 2, 3 }
+            let values []int64 = []int64{ int64(1), ...source, int64(4) }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void CollectionSpread_UsesTargetAddContract()
+    {
+        var diagnostics = Bind("""
+            import System.Collections.Generic
+
+            let first = []int32{ 1, 2 }
+            let second = []int32{}
+            let values = HashSet[int32](){ 0, ...first, ...second, 3 }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void SpreadSource_MustBeEnumerable()
+    {
+        var diagnostics = Bind("let values = []int32{ ...42 }");
+
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Id == "GS0116");
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.Id == "GS9998");
+    }
+
+    [Fact]
+    public void DictionarySpread_UsesKeyValuePairAddContract()
+    {
+        var diagnostics = Bind("""
+            import System.Collections.Generic
+
+            let pairs = List[KeyValuePair[string, int32]]()
+            let values = Dictionary[string, int32](){ ...pairs }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void SpreadTarget_WithOnlyMultiArgumentAdd_IsRejected()
+    {
+        var diagnostics = Bind("""
+            class PairBag {
+                func Add(key string, value int32) {
+                }
+            }
+
+            let pairs = [](string, int32){ ("key", 1) }
+            let values = PairBag(){ ...pairs }
+            """);
+
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Id == "GS0369");
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.Id == "GS9998");
+    }
+
+    [Fact]
+    public void StaticAndInstanceFieldInitializers_Bind()
+    {
+        var diagnostics = Bind("""
+            class Holder {
+                let Instance []int32 = []int32{ 0, ...[]int32{}, 1 }
+
+                shared {
+                    let Source []string = []string{ "a", "b" }
+                    let Values []string = []string{ "head", ...Source, "tail" }
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    private static ImmutableArray<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        if (tree.Diagnostics.Any())
+        {
+            return tree.Diagnostics;
+        }
+
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+        if (globalScope.Diagnostics.Any())
+        {
+            return globalScope.Diagnostics;
+        }
+
+        return Binder.BindProgram(globalScope).Diagnostics.ToImmutableArray();
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3096CollectionSpreadBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3096CollectionSpreadBindingTests.cs
@@ -27,6 +27,38 @@ public sealed class Issue3096CollectionSpreadBindingTests
     }
 
     [Fact]
+    public void Spread_UserDefinedImplicitConversion_BindsBeforeAdd()
+    {
+        var program = BindProgram("""
+            import System.Collections.Generic
+
+            class Celsius {
+                prop Degrees float64 { get; init; }
+
+                init(degrees float64) {
+                    Degrees = degrees
+                }
+            }
+
+            func operator implicit(value Celsius) float64 {
+                return value.Degrees
+            }
+
+            let source = []Celsius{
+                Celsius(2.5),
+                Celsius(3.5),
+            }
+            let array = []float64{ 1.0, ...source, 9.0 }
+            let list = List[float64](){ ...source }
+            """);
+
+        Assert.Empty(program.Diagnostics);
+        var conversions = new UserDefinedConversionCollector();
+        conversions.Visit(program.Statement);
+        Assert.Equal(2, conversions.Count);
+    }
+
+    [Fact]
     public void CollectionSpread_UsesTargetAddContract()
     {
         var diagnostics = Bind("""
@@ -111,5 +143,38 @@ public sealed class Issue3096CollectionSpreadBindingTests
         }
 
         return Binder.BindProgram(globalScope).Diagnostics.ToImmutableArray();
+    }
+
+    private static BoundProgram BindProgram(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+        return Binder.BindProgram(globalScope);
+    }
+
+    private sealed class UserDefinedConversionCollector : BoundTreeWalker
+    {
+        public int Count { get; private set; }
+
+        public override void VisitExpression(BoundExpression node)
+        {
+            if (node is BoundFunctionLiteralExpression literal)
+            {
+                VisitStatement(literal.Body);
+                return;
+            }
+
+            base.VisitExpression(node);
+        }
+
+        protected override void VisitCallExpression(BoundCallExpression node)
+        {
+            if (node.Function.Name == "op_Implicit")
+            {
+                Count++;
+            }
+
+            base.VisitCallExpression(node);
+        }
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue1675SyntaxNodeChildEnumerationTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue1675SyntaxNodeChildEnumerationTests.cs
@@ -49,6 +49,9 @@ public class Issue1675SyntaxNodeChildEnumerationTests
         // from-end index and ranges
         "package p\nfunc F(a []int32) {\n  let b = a[^1]\n  let c = a[1..^1]\n  let d = a[..2]\n}\n",
 
+        // issue #3096: native array spread element
+        "package p\nfunc F(a []int32) {\n  let b = []int32{0, ...a, 9}\n}\n",
+
         // generic static receiver
         "package p\nstruct Box[T] { shared { func Make(x int32) int32 { return x } } }\nclass C { func F() int32 { return Box[int32?].Make(5) } }\n",
 

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue3096CollectionSpreadParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue3096CollectionSpreadParserTests.cs
@@ -1,0 +1,83 @@
+// <copyright file="Issue3096CollectionSpreadParserTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+/// <summary>Parser coverage for native array/collection ellipsis spreads.</summary>
+public sealed class Issue3096CollectionSpreadParserTests
+{
+    [Fact]
+    public void ArrayLiteral_ParsesFixedAndMultipleSpreadElements()
+    {
+        var expression = ParseInitializer("[]int32{ 0, ...first, ...second, 9 }");
+        var array = Assert.IsType<ArrayCreationExpressionSyntax>(expression);
+
+        Assert.Equal(4, array.Elements.Count);
+        Assert.IsType<LiteralExpressionSyntax>(array.Elements[0]);
+        Assert.Equal(
+            "first",
+            Assert.IsType<NameExpressionSyntax>(
+                Assert.IsType<SpreadElementExpressionSyntax>(array.Elements[1]).Expression)
+                .IdentifierToken.Text);
+        Assert.Equal(
+            "second",
+            Assert.IsType<NameExpressionSyntax>(
+                Assert.IsType<SpreadElementExpressionSyntax>(array.Elements[2]).Expression)
+                .IdentifierToken.Text);
+        Assert.IsType<LiteralExpressionSyntax>(array.Elements[3]);
+    }
+
+    [Fact]
+    public void CollectionInitializer_ExplicitCtorParsesSpread()
+    {
+        var expression = ParseInitializer("List[int32](){ 0, ...items, 9 }");
+        var collection = Assert.IsType<CollectionInitializerExpressionSyntax>(expression);
+        var spreadElement = Assert.IsType<ExpressionCollectionElementSyntax>(collection.Elements[1]);
+        var spread = Assert.IsType<SpreadElementExpressionSyntax>(spreadElement.Expression);
+
+        Assert.Equal("...", spread.EllipsisToken.Text);
+        Assert.Equal("items", Assert.IsType<NameExpressionSyntax>(spread.Expression).IdentifierToken.Text);
+    }
+
+    [Fact]
+    public void GenericStructLiteral_LeadingEllipsisRemainsStructuralSpread()
+    {
+        var expression = ParseInitializer("Box[int32]{ ...source }");
+        var literal = Assert.IsType<StructLiteralExpressionSyntax>(expression);
+
+        Assert.NotNull(literal.SpreadToken);
+        Assert.Equal("source", Assert.IsType<NameExpressionSyntax>(literal.SpreadExpression).IdentifierToken.Text);
+    }
+
+    [Fact]
+    public void DotDotRangeElement_RemainsRangeExpression()
+    {
+        var expression = ParseInitializer("List[Range](){ ..3 }");
+        var collection = Assert.IsType<CollectionInitializerExpressionSyntax>(expression);
+        var element = Assert.IsType<ExpressionCollectionElementSyntax>(Assert.Single(collection.Elements));
+
+        Assert.IsType<RangeExpressionSyntax>(element.Expression);
+    }
+
+    private static ExpressionSyntax ParseInitializer(string initializer)
+    {
+        var tree = SyntaxTree.Parse($"""
+            import System
+            import System.Collections.Generic
+            let value = {initializer}
+            """);
+        Assert.Empty(tree.Diagnostics);
+
+        return tree.Root.Members
+            .OfType<GlobalStatementSyntax>()
+            .Select(member => member.Statement)
+            .OfType<VariableDeclarationSyntax>()
+            .Single()
+            .Initializer;
+    }
+}

--- a/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
+++ b/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
@@ -228,6 +228,7 @@ SizeOfExpression
 SlashEqualsToken
 SlashToken
 SlicePattern
+SpreadElementExpression
 StackAllocExpression
 StarEqualsToken
 StarToken

--- a/test/Interpreter.Tests/Issue3096CollectionSpreadInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue3096CollectionSpreadInterpreterTests.cs
@@ -1,0 +1,202 @@
+// <copyright file="Issue3096CollectionSpreadInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>Interpreter coverage for native array/collection spreads.</summary>
+public sealed class Issue3096CollectionSpreadInterpreterTests
+{
+    [Fact]
+    public void ArraySpread_EvaluatesOnceInLexicalOrderAndConvertsElements()
+    {
+        const string Source = """
+            import System
+
+            var calls = 0
+            var trace = ""
+
+            func Mark(value int32, marker string) int32 {
+                trace = trace + marker
+                return value
+            }
+
+            func Source() []int32 {
+                calls++
+                trace = trace + "B"
+                return []int32{ 2, 3 }
+            }
+
+            let values = []int64{
+                int64(Mark(1, "A")),
+                ...Source(),
+                ...[]int32{},
+                int64(Mark(4, "C")),
+            }
+
+            Console.WriteLine(trace)
+            Console.WriteLine(calls)
+            Console.WriteLine(values.Length)
+            Console.WriteLine(values[0])
+            Console.WriteLine(values[1])
+            Console.WriteLine(values[2])
+            Console.WriteLine(values[3])
+            """;
+
+        Assert.Equal("ABC\n1\n4\n1\n2\n3\n4\n", Evaluate(Source));
+    }
+
+    [Fact]
+    public void CollectionAndFieldInitializerSpreads_PreserveContents()
+    {
+        const string Source = """
+            import System
+            import System.Collections.Generic
+
+            interface IStaticValues {
+                shared {
+                    var Count int32 = []int32{ 6, ...[]int32{ 7 } }.Length
+                }
+            }
+
+            class Holder {
+                let Values []int32 = []int32{ 5, ...[]int32{}, 6 }
+
+                shared {
+                    public var StaticCalls int32 = 0
+                    public var StaticTrace int32 = 0
+                    public let StaticValues []int32 = []int32{ 4, ...MakeStaticValues() }
+
+                    func MakeStaticValues() []int32 {
+                        StaticCalls++
+                        return []int32{ 5 }
+                    }
+
+                    init {
+                        StaticTrace = StaticCalls + 10
+                    }
+                }
+            }
+
+            let list = List[int32](){ 0, ...[]int32{ 1, 2 }, 3 }
+            let widened = List[int64](){ ...[]int32{ 7 } }
+            let set = HashSet[int32](){ ...[]int32{ 1, 1, 2 } }
+            let holder = Holder()
+
+            Console.WriteLine(list.Count)
+            Console.WriteLine(list[0])
+            Console.WriteLine(list[3])
+            Console.WriteLine(widened[0])
+            Console.WriteLine(set.Count)
+            Console.WriteLine(IStaticValues.Count)
+            Console.WriteLine(Holder.StaticValues[1])
+            Console.WriteLine(Holder.StaticCalls)
+            Console.WriteLine(Holder.StaticTrace)
+            Console.WriteLine(holder.Values.Length)
+            Console.WriteLine(holder.Values[1])
+            """;
+
+        Assert.Equal("4\n0\n3\n7\n2\n2\n5\n1\n11\n2\n6\n", Evaluate(Source));
+    }
+
+    [Fact]
+    public void FaultedStaticSpreadInitializer_IsNotRetried()
+    {
+        const string Source = """
+            import System
+
+            var attempts = 0
+
+            class Broken {
+                shared {
+                    let Value int32 = Fail()
+
+                    func Fail() int32 {
+                        attempts++
+                        throw InvalidOperationException("boom")
+                    }
+                }
+            }
+
+            func Read() {
+                try {
+                    let ignored = Broken.Value
+                } catch (ex InvalidOperationException) {
+                }
+            }
+
+            Read()
+            Read()
+            Console.WriteLine(attempts)
+            """;
+
+        Assert.Equal("1\n", Evaluate(Source));
+    }
+
+    [Fact]
+    public void StaticInitialization_RunsAfterCallArguments()
+    {
+        const string Source = """
+            import System
+
+            var trace = ""
+
+            func Argument() int32 {
+                trace = trace + "A"
+                return 1
+            }
+
+            class Ordered {
+                shared {
+                    let Initialized int32 = Initialize()
+
+                    func Initialize() int32 {
+                        trace = trace + "I"
+                        return 0
+                    }
+
+                    func Use(value int32) {
+                        trace = trace + "M"
+                    }
+                }
+            }
+
+            Ordered.Use(Argument())
+            Console.WriteLine(trace)
+            """;
+
+        Assert.Equal("AIM\n", Evaluate(Source));
+    }
+
+    private static string Evaluate(string source)
+    {
+        var compilation = new Compilation(SyntaxTree.Parse(source));
+
+        using var output = new StringWriter();
+        var previous = Console.Out;
+        Console.SetOut(output);
+        try
+        {
+            var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+            var errors = result.Diagnostics.Where(diagnostic => diagnostic.IsError).ToArray();
+            Assert.True(
+                errors.Length == 0,
+                "evaluation failed:\n" + string.Join("\n", errors.Select(diagnostic => diagnostic.ToString())));
+        }
+        finally
+        {
+            Console.SetOut(previous);
+        }
+
+        return output.ToString().Replace("\r\n", "\n", StringComparison.Ordinal);
+    }
+}

--- a/test/Interpreter.Tests/Issue3096CollectionSpreadInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue3096CollectionSpreadInterpreterTests.cs
@@ -118,9 +118,9 @@ public sealed class Issue3096CollectionSpreadInterpreterTests
 
             class Broken {
                 shared {
-                    let Value int32 = Fail()
+                    let Values []int32 = []int32{ ...Fail() }
 
-                    func Fail() int32 {
+                    func Fail() []int32 {
                         attempts++
                         throw InvalidOperationException("boom")
                     }
@@ -129,8 +129,9 @@ public sealed class Issue3096CollectionSpreadInterpreterTests
 
             func Read() {
                 try {
-                    let ignored = Broken.Value
-                } catch (ex InvalidOperationException) {
+                    let ignored = Broken.Values
+                } catch (ex TypeInitializationException) {
+                    Console.WriteLine(ex.InnerException is InvalidOperationException)
                 }
             }
 
@@ -139,7 +140,7 @@ public sealed class Issue3096CollectionSpreadInterpreterTests
             Console.WriteLine(attempts)
             """;
 
-        Assert.Equal("1\n", Evaluate(Source));
+        Assert.Equal("True\nTrue\n1\n", Evaluate(Source));
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GExpression.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GExpression.cs
@@ -383,7 +383,8 @@ public sealed class AnonymousClassLiteralExpression : GExpression
 /// <summary>
 /// A single element of a <see cref="CollectionInitializerExpression"/>:
 /// a bare element, a <c>key: value</c> pair, or an <c>[key] = value</c>
-/// indexer entry (ADR-0117).
+/// indexer entry (ADR-0117). A native spread is represented as a bare
+/// <see cref="SpreadElementExpression"/> value.
 /// </summary>
 public sealed class CollectionInitializerElement : GNode
 {
@@ -475,6 +476,25 @@ public sealed class CollectionInitializerExpression : GExpression
 
     /// <summary>Gets the collection elements.</summary>
     public IReadOnlyList<CollectionInitializerElement> Elements { get; }
+}
+
+/// <summary>
+/// An ellipsis spread element <c>...source</c> inside an array or collection
+/// initializer.
+/// </summary>
+public sealed class SpreadElementExpression : GExpression
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SpreadElementExpression"/> class.
+    /// </summary>
+    /// <param name="source">The enumerable source expression.</param>
+    public SpreadElementExpression(GExpression source)
+    {
+        Source = source;
+    }
+
+    /// <summary>Gets the enumerable source expression.</summary>
+    public GExpression Source { get; }
 }
 
 /// <summary>

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -504,6 +504,9 @@ public static class GSharpPrinter
                 var rangeEnd = range.End != null ? RenderExpression(range.End, indent) : string.Empty;
                 return $"{rangeStart}..{rangeEnd}";
 
+            case SpreadElementExpression spread:
+                return $"...{RenderExpression(spread.Source, indent)}";
+
             case CompositeLiteralExpression composite:
                 var inits = string.Join(", ", composite.FieldInitializers.Select(f => $"{f.Name}: {RenderExpression(f.Value, indent)}"));
                 return $"{RenderType(composite.Type)}{{{inits}}}";
@@ -756,7 +759,8 @@ public static class GSharpPrinter
         }
         else if (collection.Target is InvocationExpression invocation
             && invocation.Arguments.Count == 0
-            && invocation.TypeArguments.Count > 0)
+            && invocation.TypeArguments.Count > 0
+            && !collection.Elements.Any(element => element.Value is SpreadElementExpression))
         {
             var typeArgs = $"[{string.Join(", ", invocation.TypeArguments.Select(RenderType))}]";
             target = $"{RenderExpression(invocation.Target, indent)}{typeArgs}";

--- a/tools/cs2gs/Cs2Gs.Tests/Coverage/GNodeSamples.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Coverage/GNodeSamples.cs
@@ -80,6 +80,9 @@ public static class GNodeSamples
                 List(new AnonymousClassMemberInitializer("Bar", Type("int32"), Int("2"))))),
             [typeof(CollectionInitializerElement)] = CollectionInitializerSample,
             [typeof(CollectionInitializerExpression)] = CollectionInitializerSample,
+            [typeof(SpreadElementExpression)] = () => Expr(new ArrayLiteralExpression(
+                Type("int32"),
+                List<GExpression>(new SpreadElementExpression(Id("items"))))),
             [typeof(ArrayLiteralExpression)] = () => Expr(new ArrayLiteralExpression(Type("int32"), List<GExpression>(Int("1"), Int("2")))),
             [typeof(ArrayAllocationExpression)] = () => Expr(new ArrayAllocationExpression(Type("int32"), Int("3"))),
             [typeof(ConversionExpression)] = () => Expr(new ConversionExpression(Type("int32"), Id("y"))),

--- a/tools/cs2gs/Cs2Gs.Tests/Coverage/code-model-surface.golden.txt
+++ b/tools/cs2gs/Cs2Gs.Tests/Coverage/code-model-surface.golden.txt
@@ -32,6 +32,7 @@ ObjectCreationInitializerExpression
 OutArgumentExpression
 ParenthesizedExpression
 RangeIndexExpression
+SpreadElementExpression
 StackAllocExpression
 SwitchExpression
 ThisExpression

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1897CollectionExpressionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1897CollectionExpressionTranslationTests.cs
@@ -16,11 +16,8 @@ namespace Cs2Gs.Tests;
 /// grid corpus, each fixed independently:
 /// <list type="bullet">
 /// <item>a collection-expression spread element (<c>[0, ..rest, 9]</c>) —
-/// was CS2GS-GAP "SpreadElement ... has no canonical G# composite-literal
-/// form yet"; lowers to a build-and-append <c>List[T]</c> temporary
-/// (<c>Add</c>/<c>AddRange</c> calls hoisted into the enclosing statement's
-/// prologue), converted back via <c>.ToArray()</c> for an array/span
-/// target.</item>
+/// maps to native G# ellipsis spread syntax
+/// (<c>[]T{0, ...rest, 9}</c>).</item>
 /// <item>a <c>List&lt;T&gt;</c>-targeted collection expression
 /// (<c>List&lt;int&gt; l = [10, 20];</c>) — previously mistranslated to a
 /// G# array literal (<c>[]int32{10, 20}</c>) that does not convert to
@@ -39,7 +36,7 @@ namespace Cs2Gs.Tests;
 public class Issue1897CollectionExpressionTranslationTests
 {
     [Fact]
-    public void SpreadElement_LowersToBuildAndAppendTemporary()
+    public void SpreadElement_UsesNativeArrayLiteralSyntax()
     {
         string rendered = Render(@"
 namespace Corpus.Issue1897
@@ -55,20 +52,17 @@ namespace Corpus.Issue1897
 }
 ");
 
-        Assert.Contains("List[int32]()", rendered, StringComparison.Ordinal);
-        Assert.Contains(".Add(0)", rendered, StringComparison.Ordinal);
-        Assert.Contains(".AddRange(rest)", rendered, StringComparison.Ordinal);
-        Assert.Contains(".Add(9)", rendered, StringComparison.Ordinal);
-        Assert.Contains(".ToArray()", rendered, StringComparison.Ordinal);
+        Assert.Contains("[]int32{0, ...rest, 9}", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("__spread", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain(".AddRange(", rendered, StringComparison.Ordinal);
         AssertRoundTripParses(rendered);
     }
 
     [Fact]
-    public void SpreadElement_CoercesMismatchedElementTypeBeforeAddRange()
+    public void SpreadElement_CoercesMismatchedElementTypeNatively()
     {
-        // Issue #1985: spreading `int[]` into a `long[]` target must project
-        // through the implicit `int -> long` conversion before `AddRange`,
-        // since `List[int64].AddRange(IEnumerable[int32])` does not bind in gsc.
+        // Issue #1985 / #3096: gsc's native spread binder applies the ordinary
+        // implicit element conversion while adding each source element.
         string rendered = Render(@"
 namespace Corpus.Issue1985
 {
@@ -83,12 +77,13 @@ namespace Corpus.Issue1985
 }
 ");
 
-        Assert.Contains(".AddRange(rest.Select((__x int32) -> int64(__x)))", rendered, StringComparison.Ordinal);
+        Assert.Contains("[]int64{...rest}", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain(".Select(", rendered, StringComparison.Ordinal);
         AssertRoundTripParses(rendered);
     }
 
     [Fact]
-    public void SpreadElement_SpanTarget_LowersViaToArray()
+    public void SpreadElement_SpanTarget_UsesNativeArrayLiteral()
     {
         string rendered = Render(@"
 using System;
@@ -106,14 +101,12 @@ namespace Corpus.Issue1985
 }
 ");
 
-        Assert.Contains("List[int32]()", rendered, StringComparison.Ordinal);
-        Assert.Contains(".AddRange(rest)", rendered, StringComparison.Ordinal);
-        Assert.Contains(".ToArray()", rendered, StringComparison.Ordinal);
+        Assert.Contains("[]int32{0, ...rest, 9}", rendered, StringComparison.Ordinal);
         AssertRoundTripParses(rendered);
     }
 
     [Fact]
-    public void SpreadElement_EmptySpread_LowersToEmptyListThenToArray()
+    public void SpreadElement_EmptySpread_UsesNativeArrayLiteral()
     {
         string rendered = Render(@"
 namespace Corpus.Issue1985
@@ -129,14 +122,12 @@ namespace Corpus.Issue1985
 }
 ");
 
-        Assert.Contains("List[int32]()", rendered, StringComparison.Ordinal);
-        Assert.Contains(".AddRange(empty)", rendered, StringComparison.Ordinal);
-        Assert.Contains(".ToArray()", rendered, StringComparison.Ordinal);
+        Assert.Contains("[]int32{...empty}", rendered, StringComparison.Ordinal);
         AssertRoundTripParses(rendered);
     }
 
     [Fact]
-    public void SpreadElement_NestedSpreads_LowerToSequentialAddRangeCalls()
+    public void SpreadElement_NestedSpreads_StayInLexicalOrder()
     {
         string rendered = Render(@"
 namespace Corpus.Issue1985
@@ -152,9 +143,30 @@ namespace Corpus.Issue1985
 }
 ");
 
-        Assert.Contains(".AddRange(a)", rendered, StringComparison.Ordinal);
-        Assert.Contains(".AddRange(b)", rendered, StringComparison.Ordinal);
-        Assert.Contains(".ToArray()", rendered, StringComparison.Ordinal);
+        Assert.Contains("[]int32{...a, ...b}", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void SpreadElement_ListTarget_UsesExplicitCtorCollectionInitializer()
+    {
+        string rendered = Render(@"
+using System.Collections.Generic;
+
+namespace Corpus.Issue3096
+{
+    public class Holder
+    {
+        public List<int> Combine(int[] rest)
+        {
+            List<int> values = [0, .. rest, 9];
+            return values;
+        }
+    }
+}
+");
+
+        Assert.Contains("List[int32](){ 0, ...rest, 9 }", rendered, StringComparison.Ordinal);
         AssertRoundTripParses(rendered);
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3096CollectionSpreadInitializerTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3096CollectionSpreadInitializerTranslationTests.cs
@@ -1,0 +1,75 @@
+// <copyright file="Issue3096CollectionSpreadInitializerTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>Translation coverage for initializer-safe native collection spreads.</summary>
+public sealed class Issue3096CollectionSpreadInitializerTranslationTests
+{
+    [Fact]
+    public void FieldAndPropertyInitializers_UseNativeSpreadSyntaxWithoutSpills()
+    {
+        string rendered = Render("""
+            using System;
+            using System.Linq;
+
+            namespace Issue3096;
+
+            public sealed class Holder
+            {
+                private static readonly string[] All = ["a", "b", "skip"];
+                public static readonly string[] Filtered = [.. All.Where(x => x != "skip")];
+                public static readonly string[] Mixed = ["before", .. Filtered, "after"];
+                public static readonly string[] Empty = [.. Array.Empty<string>()];
+
+                public string[] Property { get; } =
+                    ["property-head", .. All.Where(x => x != "skip"), "property-tail"];
+
+                public Holder()
+                {
+                }
+            }
+            """);
+
+        Assert.Contains("All.Where(", rendered, StringComparison.Ordinal);
+        Assert.Contains("...", rendered, StringComparison.Ordinal);
+        Assert.Contains("\"before\", ...", rendered, StringComparison.Ordinal);
+        Assert.Contains("Filtered, \"after\"}", rendered, StringComparison.Ordinal);
+        Assert.Contains("Array.Empty[string]()", rendered, StringComparison.Ordinal);
+        Assert.Contains("Property = []string{\"property-head\", ...", rendered, StringComparison.Ordinal);
+        Assert.Contains("\"property-tail\"}", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("__spread", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain(".AddRange(", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("CS2GS-GAP", rendered, StringComparison.Ordinal);
+
+        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        Assert.True(
+            result.Success,
+            string.Join(Environment.NewLine, result.Errors) + Environment.NewLine + rendered);
+    }
+
+    private static string Render(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        string rendered = GSharpPrinter.Print(
+            new CSharpToGSharpTranslator().TranslateDocument(document, context));
+
+        Assert.Empty(context.Diagnostics);
+        return rendered;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3096CollectionSpreadPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3096CollectionSpreadPipelineTests.cs
@@ -1,0 +1,212 @@
+// <copyright file="Issue3096CollectionSpreadPipelineTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>Translator-to-runtime parity and ILVerify coverage for issue #3096.</summary>
+[Collection(IlVerifyPipelineCollection.Name)]
+public sealed class Issue3096CollectionSpreadPipelineTests
+{
+    [Fact]
+    public async Task InitializerSpreads_TranslateCompileVerifyAndPreserveRuntimeOrder()
+    {
+        string compiler = FindCompiler();
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null
+            || repoRoot is null
+            || GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot, "Debug") is null
+            || !IlVerifyToolAvailable())
+        {
+            return;
+        }
+
+        string sourceRoot = NewDirectory("scratch-projects");
+        File.WriteAllText(Path.Combine(sourceRoot, "Directory.Build.props"), "<Project></Project>");
+        string projectDirectory = Path.Combine(sourceRoot, "Issue3096");
+        Directory.CreateDirectory(projectDirectory);
+        string projectPath = Path.Combine(projectDirectory, "Issue3096.csproj");
+        File.WriteAllText(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <OutputType>Exe</OutputType>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(projectDirectory, "Program.cs"), """
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+
+            public sealed class Holder
+            {
+                public static int Calls;
+                public static string Trace = "";
+                private static readonly string[] All = ["a", "b", "skip"];
+
+                public static readonly string[] Filtered = [.. All.Where(x => x != "skip")];
+                public static readonly string[] Ordered =
+                    [Mark("head", "A"), .. Source(), .. Array.Empty<string>(), Mark("tail", "C")];
+                public static readonly string[] Empty = [.. Array.Empty<string>()];
+                public static readonly string[] Mixed = ["before", .. Filtered, .. Empty, "after"];
+                public static readonly List<string> ListTarget = ["list-head", .. Filtered, "list-tail"];
+
+                public string[] Property { get; } =
+                    ["property-head", .. All.Where(x => x != "skip"), "property-tail"];
+
+                public Holder()
+                {
+                }
+
+                private static string Mark(string value, string marker)
+                {
+                    Trace += marker;
+                    return value;
+                }
+
+                private static string[] Source()
+                {
+                    Calls++;
+                    Trace += "B";
+                    return ["middle-1", "middle-2"];
+                }
+
+            }
+
+            public static class Program
+            {
+                public static void Main()
+                {
+                    var holder = new Holder();
+                    Console.WriteLine(Holder.Filtered.Length);
+                    Console.WriteLine(Holder.Filtered[0]);
+                    Console.WriteLine(Holder.Filtered[1]);
+                    Console.WriteLine(Holder.Ordered.Length);
+                    Console.WriteLine(Holder.Ordered[0]);
+                    Console.WriteLine(Holder.Ordered[1]);
+                    Console.WriteLine(Holder.Ordered[2]);
+                    Console.WriteLine(Holder.Ordered[3]);
+                    Console.WriteLine(Holder.Trace);
+                    Console.WriteLine(Holder.Calls);
+                    Console.WriteLine(Holder.Empty.Length);
+                    Console.WriteLine(Holder.Mixed.Length);
+                    Console.WriteLine(Holder.ListTarget.Count);
+                    Console.WriteLine(Holder.ListTarget[2]);
+                    Console.WriteLine(holder.Property.Length);
+                    Console.WriteLine(holder.Property[0]);
+                    Console.WriteLine(holder.Property[3]);
+                }
+            }
+            """);
+        string goldenPath = Path.Combine(projectDirectory, "baseline.stdout.golden");
+        File.WriteAllText(
+            goldenPath,
+            "2\na\nb\n4\nhead\nmiddle-1\nmiddle-2\ntail\nABC\n1\n0\n4\n4\nb\n4\nproperty-head\nproperty-tail\n");
+
+        string outputRoot = NewDirectory("pipeline-tests");
+        var app = new CorpusApp(
+            "test/Issue3096",
+            projectPath,
+            TargetKind.Exe,
+            stdoutGolden: goldenPath);
+        var pipeline = new MigrationPipeline(
+            new PipelineOptions
+            {
+                GscPath = compiler,
+                OutputRoot = outputRoot,
+                SourceRoot = sourceRoot,
+                Config = "Debug",
+            },
+            new IMigrationStage[]
+            {
+                new TranslateStage(),
+                new CompileStage(),
+                new IlVerifyStage(),
+                new TestParityStage(),
+            });
+
+        RunResult result = await pipeline.RunAsync(new[] { app });
+        AppResult appResult = Assert.Single(result.Apps);
+        string appDirectory = Path.Combine(
+            outputRoot,
+            result.RunId,
+            MigrationPipeline.SanitizeAppId(app.Id));
+        string translated = string.Join(
+            Environment.NewLine,
+            Directory.GetFiles(appDirectory, "*.gs", SearchOption.AllDirectories)
+                .Select(File.ReadAllText));
+
+        Assert.Contains("All.Where(", translated, StringComparison.Ordinal);
+        Assert.Contains("\"before\", ...", translated, StringComparison.Ordinal);
+        Assert.Contains("Filtered, ...", translated, StringComparison.Ordinal);
+        Assert.Contains("Empty, \"after\"}", translated, StringComparison.Ordinal);
+        Assert.Contains("List[string](){", translated, StringComparison.Ordinal);
+        Assert.Contains("Property = []string{\"property-head\", ...", translated, StringComparison.Ordinal);
+        Assert.DoesNotContain("__spread", translated, StringComparison.Ordinal);
+        Assert.DoesNotContain(".AddRange(", translated, StringComparison.Ordinal);
+        Assert.True(
+            appResult.Succeeded,
+            string.Join("; ", appResult.Stages.Select(stage => stage.Stage + "=" + stage.Status)));
+        Assert.Equal(
+            new[] { "passed", "passed", "passed", "passed" },
+            appResult.Stages.Select(stage => stage.Status).ToArray());
+    }
+
+    private static bool IlVerifyToolAvailable()
+    {
+        try
+        {
+            return !IlVerifyRunner.IsEnabled || new IlVerifyRunner().EnsureToolAvailable();
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static string NewDirectory(string category)
+    {
+        string root = Path.Combine(
+            AppContext.BaseDirectory,
+            category,
+            "issue3096",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindCompiler()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            foreach (string configuration in new[] { "Debug", "Release" })
+            {
+                string candidate = Path.Combine(
+                    directory.FullName,
+                    "out",
+                    "bin",
+                    configuration,
+                    "Compiler",
+                    "gsc.dll");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3096CollectionSpreadPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3096CollectionSpreadPipelineTests.cs
@@ -47,6 +47,18 @@ public sealed class Issue3096CollectionSpreadPipelineTests
             using System.Collections.Generic;
             using System.Linq;
 
+            public sealed class Celsius
+            {
+                public Celsius(double degrees)
+                {
+                    Degrees = degrees;
+                }
+
+                public double Degrees { get; }
+
+                public static implicit operator double(Celsius value) => value.Degrees;
+            }
+
             public sealed class Holder
             {
                 public static int Calls;
@@ -59,6 +71,12 @@ public sealed class Issue3096CollectionSpreadPipelineTests
                 public static readonly string[] Empty = [.. Array.Empty<string>()];
                 public static readonly string[] Mixed = ["before", .. Filtered, .. Empty, "after"];
                 public static readonly List<string> ListTarget = ["list-head", .. Filtered, "list-tail"];
+                private static readonly Celsius[] Temperatures =
+                    [new Celsius(2.5), new Celsius(3.5)];
+                public static readonly double[] Converted =
+                    [1.0, .. Temperatures, 9.0];
+                public static readonly List<double> ConvertedList =
+                    [.. Temperatures];
 
                 public string[] Property { get; } =
                     ["property-head", .. All.Where(x => x != "skip"), "property-tail"];
@@ -104,13 +122,19 @@ public sealed class Issue3096CollectionSpreadPipelineTests
                     Console.WriteLine(holder.Property.Length);
                     Console.WriteLine(holder.Property[0]);
                     Console.WriteLine(holder.Property[3]);
+                    Console.WriteLine(Holder.Converted.Length);
+                    Console.WriteLine(Holder.Converted[1]);
+                    Console.WriteLine(Holder.Converted[2]);
+                    Console.WriteLine(Holder.ConvertedList.Count);
+                    Console.WriteLine(Holder.ConvertedList[0]);
+                    Console.WriteLine(Holder.ConvertedList[1]);
                 }
             }
             """);
         string goldenPath = Path.Combine(projectDirectory, "baseline.stdout.golden");
         File.WriteAllText(
             goldenPath,
-            "2\na\nb\n4\nhead\nmiddle-1\nmiddle-2\ntail\nABC\n1\n0\n4\n4\nb\n4\nproperty-head\nproperty-tail\n");
+            "2\na\nb\n4\nhead\nmiddle-1\nmiddle-2\ntail\nABC\n1\n0\n4\n4\nb\n4\nproperty-head\nproperty-tail\n4\n2.5\n3.5\n2\n2.5\n3.5\n");
 
         string outputRoot = NewDirectory("pipeline-tests");
         var app = new CorpusApp(
@@ -150,6 +174,9 @@ public sealed class Issue3096CollectionSpreadPipelineTests
         Assert.Contains("Filtered, ...", translated, StringComparison.Ordinal);
         Assert.Contains("Empty, \"after\"}", translated, StringComparison.Ordinal);
         Assert.Contains("List[string](){", translated, StringComparison.Ordinal);
+        Assert.Contains("[]float64{1", translated, StringComparison.Ordinal);
+        Assert.Contains("List[float64](){", translated, StringComparison.Ordinal);
+        Assert.Contains("...Holder.Temperatures", translated, StringComparison.Ordinal);
         Assert.Contains("Property = []string{\"property-head\", ...", translated, StringComparison.Ordinal);
         Assert.DoesNotContain("__spread", translated, StringComparison.Ordinal);
         Assert.DoesNotContain(".AddRange(", translated, StringComparison.Ordinal);

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -1802,30 +1802,27 @@ public sealed partial class CSharpToGSharpTranslator
 
             GTypeReference elementType = this.GetCollectionElementType(collection);
 
-            // A spread element (`[a, ..rest, b]`) has no G# composite-literal
-            // form (gsc's own collection-initializer grammar only has bare,
-            // keyed, and indexed elements — no spread). It lowers to a
-            // build-and-append temporary: a `List[T]` populated via `Add`/
-            // `AddRange` calls hoisted into the enclosing statement's prologue
-            // (issue #1897), then — for an array/span target — converted back
-            // via `.ToArray()`.
-            if (collection.Elements.Any(e => e is SpreadElementSyntax))
-            {
-                return this.TranslateSpreadCollectionExpression(collection, elementType, isConstructibleClassTarget);
-            }
-
             // A `List<T>`/`HashSet<T>`/... collection-expression target maps to
             // the canonical G# collection-initializer form (`List[int32]{...}`,
             // ADR-0117) — NOT the array/slice literal `[]T{...}`, which does not
-            // convert to a constructed collection class (issue #1897).
+            // convert to a constructed collection class (issue #1897). Issue
+            // #3096: native `...source` elements keep this form initializer-safe.
             if (isConstructibleClassTarget)
             {
                 var initElements = new List<CollectionInitializerElement>();
                 foreach (CollectionElementSyntax element in collection.Elements)
                 {
-                    var expressionElement = (ExpressionElementSyntax)element;
-                    initElements.Add(new CollectionInitializerElement(
-                        this.CoerceCollectionElement(expressionElement.Expression, elementType)));
+                    if (element is SpreadElementSyntax spread)
+                    {
+                        initElements.Add(new CollectionInitializerElement(
+                            new SpreadElementExpression(this.TranslateExpression(spread.Expression))));
+                    }
+                    else
+                    {
+                        var expressionElement = (ExpressionElementSyntax)element;
+                        initElements.Add(new CollectionInitializerElement(
+                            this.CoerceCollectionElement(expressionElement.Expression, elementType)));
+                    }
                 }
 
                 return new CollectionInitializerExpression(
@@ -1834,107 +1831,24 @@ public sealed partial class CSharpToGSharpTranslator
 
             // C# 12 collection expression `[a, b, c]` targeting an array/span.
             // The target type supplies the element type, so it maps to the
-            // canonical G# slice literal `[]T{ … }` (ADR-0115 §B).
+            // canonical G# slice literal `[]T{ … }` (ADR-0115 §B). Spreads map
+            // directly to native G# ellipsis elements, with no statement-hosted
+            // build/append temporary (issue #3096).
             var elements = new List<GExpression>();
-            foreach (CollectionElementSyntax element in collection.Elements)
-            {
-                var expressionElement = (ExpressionElementSyntax)element;
-                elements.Add(this.CoerceCollectionElement(expressionElement.Expression, elementType));
-            }
-
-            return new ArrayLiteralExpression(elementType, elements);
-        }
-
-        private GExpression TranslateSpreadCollectionExpression(
-            CollectionExpressionSyntax collection, GTypeReference elementType, bool isConstructibleClassTarget)
-        {
-            if (this.state.PendingSpillPrologue == null)
-            {
-                string message =
-                    "a collection-expression spread element here has no enclosing statement to host the " +
-                    "build-and-append lowering it needs (e.g. a field/property initializer); emitted an " +
-                    "identifier placeholder (ADR-0115 §B).";
-                this.context.ReportUnsupported(collection, message);
-                return new IdentifierExpression("nil");
-            }
-
-            string temp = $"__spread{this.state.SpreadCounter++}";
-            this.state.PendingSpillPrologue.Add(new LocalDeclarationStatement(
-                BindingKind.Let,
-                temp,
-                type: null,
-                initializer: new InvocationExpression(
-                    new IdentifierExpression("List"),
-                    new List<GExpression>(),
-                    new List<GTypeReference> { elementType })));
-
-            ITypeSymbol targetElementSymbol = GetEnumerableElementType(
-                this.context.GetTypeInfo(collection).ConvertedType ?? this.context.GetTypeInfo(collection).Type);
-
             foreach (CollectionElementSyntax element in collection.Elements)
             {
                 if (element is SpreadElementSyntax spread)
                 {
-                    GExpression source = this.CoerceSpreadSource(
-                        spread.Expression, this.TranslateExpression(spread.Expression), targetElementSymbol, elementType);
-                    this.state.PendingSpillPrologue.Add(new ExpressionStatement(new InvocationExpression(
-                        new MemberAccessExpression(new IdentifierExpression(temp), "AddRange"),
-                        new List<GExpression> { source })));
+                    elements.Add(new SpreadElementExpression(this.TranslateExpression(spread.Expression)));
                 }
                 else
                 {
                     var expressionElement = (ExpressionElementSyntax)element;
-                    this.state.PendingSpillPrologue.Add(new ExpressionStatement(new InvocationExpression(
-                        new MemberAccessExpression(new IdentifierExpression(temp), "Add"),
-                        new List<GExpression> { this.CoerceCollectionElement(expressionElement.Expression, elementType) })));
+                    elements.Add(this.CoerceCollectionElement(expressionElement.Expression, elementType));
                 }
             }
 
-            if (isConstructibleClassTarget)
-            {
-                return new IdentifierExpression(temp);
-            }
-
-            // `List[T].ToArray()` is the real (non-generic) BCL instance
-            // method — no bracket type argument (unlike the LINQ
-            // `Enumerable.ToArray[T]()` extension method).
-            return new InvocationExpression(
-                new MemberAccessExpression(new IdentifierExpression(temp), "ToArray"));
-        }
-
-        // A spread source (`..src` in `[..src]`) whose element type `U` differs
-        // from the target collection's element type `T` (an implicit conversion
-        // exists, e.g. `int[]` spread into a `long[]` target) needs a projection
-        // before `AddRange`, since `List[T].AddRange(IEnumerable[U])` does not
-        // bind in gsc (issue #1985). Wraps the source in `.Select(x => (T)x)`.
-        private GExpression CoerceSpreadSource(
-            ExpressionSyntax sourceExpression, GExpression translatedSource, ITypeSymbol targetElementSymbol, GTypeReference targetElementType)
-        {
-            if (targetElementSymbol == null)
-            {
-                return translatedSource;
-            }
-
-            ITypeSymbol sourceType = this.context.GetTypeInfo(sourceExpression).Type;
-            ITypeSymbol sourceElementSymbol = GetEnumerableElementType(sourceType);
-            if (sourceElementSymbol == null ||
-                SymbolEqualityComparer.Default.Equals(sourceElementSymbol, targetElementSymbol))
-            {
-                return translatedSource;
-            }
-
-            Conversion conversion = this.context.Compilation.ClassifyConversion(sourceElementSymbol, targetElementSymbol);
-            if (!conversion.Exists || conversion.IsIdentity)
-            {
-                return translatedSource;
-            }
-
-            GTypeReference sourceElementType = this.typeMapper.Map(sourceElementSymbol, this.context, sourceExpression.GetLocation());
-            var lambda = new LambdaExpression(
-                new List<Parameter> { new Parameter("__x", sourceElementType) },
-                expressionBody: new ConversionExpression(targetElementType, new IdentifierExpression("__x")));
-            return new InvocationExpression(
-                new MemberAccessExpression(translatedSource, "Select"), new List<GExpression> { lambda });
+            return new ArrayLiteralExpression(elementType, elements);
         }
 
         private GExpression CoerceCollectionElement(ExpressionSyntax element, GTypeReference elementType)

--- a/tools/cs2gs/Cs2Gs.Translator/DocumentTranslationState.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/DocumentTranslationState.cs
@@ -211,11 +211,6 @@ internal sealed class DocumentTranslationState
     // `BuildScopeParameter`.
     public QueryExpressionSyntax CurrentQueryNode { get; set; }
 
-    // Issue #1897: numbers the `__spreadN` temporary built to lower a
-    // collection-expression spread element (see
-    // <see cref="TranslateSpreadCollectionExpression"/>).
-    public int SpreadCounter { get; set; }
-
     // Issue #1849: when non-null, `SpillOperand` is inside a "null-seam"
     // expression context — a field/property initializer or a
     // base(...)/this(...) constructor argument (issue #1731 N1) — that has

--- a/tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/CollectionExpression.cs
+++ b/tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/CollectionExpression.cs
@@ -23,13 +23,11 @@ namespace Corpus.Grid05
             List<int> list = [10, 20];
             Console.WriteLine($"CollectionExpression: list={string.Join(",", list)} count={list.Count}");
 
-            // SpreadElement (issue #1897): lowers to a build-and-append
-            // temporary List populated via Add/AddRange, converted back with
-            // ToArray() for the array target.
+            // SpreadElement (issues #1897/#3096): maps to native G#
+            // ellipsis-spread syntax inside the array literal.
             int[] rest = [2, 3];
             int[] spread = [1, .. rest, 9];
             Console.WriteLine($"CollectionExpression: spread={string.Join(",", spread)}");
         }
     }
 }
-

--- a/tools/cs2gs/coverage/csharp-construct-inventory.json
+++ b/tools/cs2gs/coverage/csharp-construct-inventory.json
@@ -2051,9 +2051,12 @@
   {
     "kind": "SpreadElement",
     "nodeType": "SpreadElementSyntax",
-    "status": "Gap",
+    "status": "Translated",
+    "rule": "ADR-0117 / ADR-0115 \u00A7B.36",
     "rationale": "None",
-    "issue": "https://github.com/DavidObando/gsharp/issues/1897"
+    "fixture": "tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/CollectionExpression.cs",
+    "issue": "https://github.com/DavidObando/gsharp/issues/1897, https://github.com/DavidObando/gsharp/issues/3096",
+    "notes": "Maps to native G# \u0060...source\u0060 inside array/collection initializers; valid in field/property initializers with no translator spill."
   },
   {
     "kind": "StackAllocArrayCreationExpression",


### PR DESCRIPTION
## Summary

- add canonical native G# spread elements: `[]T{ before, ...source, after }` and `Collection[T](){ ...source }`
- map C# collection-expression spreads directly to native syntax, removing cs2gs statement-prologue `List`/`AddRange` spills and the field/property initializer gap
- bind spreads through ordinary `Add` overload resolution, preserving element conversions, single source evaluation, lexical order, empty/multiple spreads, arrays, collection targets, dictionaries, and ref-like sources
- keep generic `Type[T]{ ...source }` structural projection unambiguous; collection spreads use explicit `()`
- align interpreter static initialization with emitted `.cctor` behavior, including interface owners, ordering, once-only execution, and cached failures
- update ADRs, coverage inventories/goldens, corpus notes, parser/code-model surfaces

## Root cause and design

cs2gs previously lowered every spread into statements appended to an enclosing statement prologue. Field and property initializers have no such statement seam, so translation emitted CS2GS-GAP. gsc also lacked a native collection-element syntax node, forcing the translator to own construction mechanics.

This change moves the feature to the language root: parser recognizes `...source`; binder builds arrays/collections using existing collection-init, for-range, conversion, function-literal, and call nodes; emitter and evaluator consume those shared bound forms. Normal expression contexts use a non-capturing helper call so loops never leave operands on the IL stack across backward branches. Interface `.cctor` initializers use the stack-empty direct loop path.

## Verification

- `dotnet build GSharp.sln --no-restore --nologo`
- `dotnet build GSharp.sln -c Release --no-restore --nologo`
- Core.Tests: 7,126 passed, 1 skipped
- Interpreter.Tests: 1,218 passed
- Compiler.Tests: 4,233 passed, including runtime + ILVerify spread coverage
- Cs2Gs.Tests: 1,907 passed
- pipeline coverage: translate, compile, ILVerify, and C#/G# stdout parity all passed

Coverage includes static readonly array spread, fixed elements before/after, property initializer, empty/multiple spreads, ordering/counts, one-time evaluation, numeric conversion, List/HashSet/Dictionary targets, generic/user elements, Span source, static/instance/interface initialization, parser ambiguity, and invalid Add contracts.

No deferred work or blockers.

Fixes #3096