### PR TITLE
Add ILVerify gate over emitted sample assemblies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -164,6 +164,30 @@ jobs:
       - name: Run end-to-end tests
         run: ./build/run-e2e-tests.sh
 
+  ilverify:
+    # Part of #3163: compile every golden sample under samples/ with gsc and
+    # run dotnet-ilverify over each emitted assembly, so unverifiable IL that
+    # happens to execute correctly still fails CI. Known verifier false
+    # positives are baselined in build/ilverify-known-failures.txt; any NEW
+    # finding fails the job.
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET SDK (main)
+        uses: actions/setup-dotnet@v5
+        with:
+          global-json-file: global.json
+
+      - name: Restore .NET local tools
+        run: dotnet tool restore
+
+      - name: Run ILVerify gate
+        run: ./build/run-ilverify.sh
+
   cs2gs-corpus:
     # ADR-0138: the C#→G# migration quality gate. Runs the full in-repo corpus
     # (L1–L5 + the conformance grid) through translate → compile → ilverify →
@@ -385,7 +409,7 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
-    needs: [build, tests, e2e, cs2gs-corpus, cs2gs-oahu, vsix, visual-studio-extension]
+    needs: [build, tests, e2e, ilverify, cs2gs-corpus, cs2gs-oahu, vsix, visual-studio-extension]
     if: startsWith(github.ref, 'refs/tags/v')
 
     permissions:

--- a/build/ilverify-known-failures.txt
+++ b/build/ilverify-known-failures.txt
@@ -1,0 +1,25 @@
+# Known ILVerify failure baseline for build/run-ilverify.sh (issue #3163).
+#
+# Format (whitespace-separated):
+#   <AssemblyBaseName> <comma-separated-ilverify-error-codes>
+#
+# Each listed code is passed to ilverify as an assembly-scoped `-g <code>`
+# ignore flag for that sample only. Any error NOT listed here fails the gate.
+# Every entry must cite the tracking issue explaining why it is suppressed;
+# remove entries as the underlying bugs (or upstream verifier gaps) are fixed.
+# The method-scoped versions of these suppressions live in
+# test/Compiler.Tests/IlVerifier.cs (GetKnownIssuesForSample) and run inside
+# the conformance suite.
+
+# ilverify 10.0.8 false positive: by-value returns of a user-declared ref
+# struct trip ReturnPtrToStack even though the value is in its only legal
+# "permanent home" (the caller's frame). csc-emitted IL for the same C#
+# fails identically. Upstream: dotnet/runtime#129030.
+UserRefStruct ReturnPtrToStack
+
+# ilverify 10.0.8 predates .NET 7 static-virtual interface dispatch: the
+# canonical `constrained. !!T call <iface>::<method>` pattern trips the
+# pre-C#-11 CallAbstract/Constrained rules; csc-emitted IL for the same
+# C# 11 pattern fails identically and the JIT accepts it.
+# ADR-0089 / #755; upstream: dotnet/runtime#49558.
+StaticVirtualInterfaces CallAbstract,Constrained

--- a/build/run-ilverify.sh
+++ b/build/run-ilverify.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# ILVerify gate over gsc-emitted sample assemblies (issue #3163).
+#
+# Compiles every golden sample under samples/ with gsc (the same corpus and
+# compile flags the SampleConformanceTests harness uses) and runs the
+# repo-pinned dotnet-ilverify local tool (.config/dotnet-tools.json) over each
+# emitted assembly. Any IL verification error that is not listed in
+# build/ilverify-known-failures.txt fails the gate, turning
+# silent-invalid-IL emitter bugs into loud CI failures without waiting on the
+# 45-minute test matrix.
+#
+# Corpus (mirrors test/Compiler.Tests/LanguageConformance/SampleConformanceData.cs):
+#   - single-file: samples/*.gs that have a sibling *.golden
+#   - multi-file:  samples/<dir>/ (except aspirational/) containing *.gs and
+#                  <dir>/<dir>.golden
+# Samples without a golden are not part of the conformance corpus and are
+# skipped; every golden sample is expected to compile with exit code 0, so a
+# gsc failure here is also a gate failure.
+#
+# Known-failure baseline (build/ilverify-known-failures.txt): each line is
+#   <AssemblyBaseName> <comma-separated-ilverify-error-codes>
+# The listed codes are passed to ilverify as `-g <code>` ignore flags for that
+# assembly only, so existing documented debt stays green while any NEW error
+# (either a new code on a listed assembly or any error on an unlisted
+# assembly) breaks the gate. The stricter method-scoped version of these
+# suppressions still runs inside the conformance suite
+# (test/Compiler.Tests/IlVerifier.cs, GetKnownIssuesForSample).
+#
+# Usage:
+#   ./build/run-ilverify.sh              # full gate
+#   ./build/run-ilverify.sh Arithmetic   # only samples whose base name matches
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+CONFIG=Release
+GSC_DLL="$ROOT/out/bin/$CONFIG/Compiler/gsc.dll"
+EXTENSIONS_DLL="$ROOT/out/bin/$CONFIG/Gsharp.Extensions/Gsharp.Extensions.dll"
+SAMPLES_DIR="$ROOT/samples"
+BASELINE_FILE="$ROOT/build/ilverify-known-failures.txt"
+TMP_BASE="${TMPDIR:-/tmp}"
+OUT_DIR="${GSHARP_ILVERIFY_OUT:-$(mktemp -d "${TMP_BASE%/}/gsharp-ilverify.XXXXXX")}"
+FILTER="${1:-}"
+
+cleanup() {
+    if [[ -z "${GSHARP_ILVERIFY_OUT:-}" ]]; then
+        rm -rf "$OUT_DIR"
+    fi
+}
+trap cleanup EXIT
+
+echo "==> Building gsc and Gsharp.Extensions ($CONFIG)"
+# Gsharp.Extensions -> Gsharp.NET.Sdk packs gsgen via a raw <MSBuild> task, so
+# its restore does not flow transitively; restore the solution like CI does.
+dotnet restore GSharp.sln --nologo -v:q
+dotnet build src/Compiler/Compiler.csproj -c "$CONFIG" --no-restore --nologo -v:q
+dotnet build src/Sdk/Gsharp.Extensions/Gsharp.Extensions.csproj -c "$CONFIG" --no-restore --nologo -v:q
+[[ -f "$GSC_DLL" ]] || { echo "ERROR: gsc not found at $GSC_DLL"; exit 1; }
+[[ -f "$EXTENSIONS_DLL" ]] || { echo "ERROR: Gsharp.Extensions not found at $EXTENSIONS_DLL"; exit 1; }
+
+echo "==> Restoring repo-local dotnet tools (dotnet-ilverify)"
+if ! dotnet tool run ilverify --version >/dev/null 2>&1; then
+    dotnet tool restore
+fi
+echo "    ilverify $(dotnet tool run ilverify --version)"
+
+# Reference set: the newest host Microsoft.NETCore.App 10.x BCL, filtered the
+# same way as test/Compiler.Tests/IlVerifier.cs (System.*, mscorlib,
+# netstandard, plus the few Microsoft.* facades). This matches the implicit
+# references gsc resolves for /targetframework:net10.0.
+RUNTIME_DIR="$(dotnet --list-runtimes \
+    | awk '$1 == "Microsoft.NETCore.App" && $2 ~ /^10\./ { path = $3; ver = $2 }
+           END { if (ver != "") { gsub(/[\[\]]/, "", path); print path "/" ver } }')"
+[[ -n "$RUNTIME_DIR" && -d "$RUNTIME_DIR" ]] || {
+    echo "ERROR: could not locate a Microsoft.NETCore.App 10.x runtime via 'dotnet --list-runtimes'"
+    exit 1
+}
+echo "==> BCL reference dir: $RUNTIME_DIR"
+
+REF_ARGS=()
+for dll in "$RUNTIME_DIR"/System.*.dll \
+           "$RUNTIME_DIR"/mscorlib.dll \
+           "$RUNTIME_DIR"/netstandard.dll \
+           "$RUNTIME_DIR"/Microsoft.CSharp.dll \
+           "$RUNTIME_DIR"/Microsoft.VisualBasic.Core.dll \
+           "$RUNTIME_DIR"/Microsoft.Win32.Primitives.dll \
+           "$RUNTIME_DIR"/Microsoft.Win32.Registry.dll; do
+    [[ -f "$dll" ]] && REF_ARGS+=(-r "$dll")
+done
+
+# Baseline: map assembly base name -> comma-separated ignored error codes.
+baseline_codes() {
+    local name="$1"
+    [[ -f "$BASELINE_FILE" ]] || return 0
+    # Strip comments/blank lines; first field is the name, second the codes.
+    awk -v name="$name" '
+        /^[[:space:]]*(#|$)/ { next }
+        $1 == name { print $2; exit }
+    ' "$BASELINE_FILE"
+}
+
+PASSED=0
+SUPPRESSED=0
+FAILED=0
+COMPILE_FAILED=0
+FAILURES=()
+
+verify_sample() {
+    local name="$1"; shift
+    local uses_extensions="$1"; shift
+    local sources=("$@")
+
+    if [[ -n "$FILTER" && "$name" != *"$FILTER"* ]]; then
+        return 0
+    fi
+
+    local sample_out="$OUT_DIR/$name"
+    mkdir -p "$sample_out"
+    local dll="$sample_out/$name.dll"
+
+    # Mirror SampleConformanceTests.RunEmittedAsync's gsc invocation.
+    local gsc_args=("/out:$dll" "/target:exe" "/targetframework:net10.0" "/nowarn:GS9100")
+    if [[ "$uses_extensions" == "yes" ]]; then
+        gsc_args+=("/r:$EXTENSIONS_DLL")
+    fi
+    gsc_args+=("${sources[@]}")
+
+    local compile_output
+    if ! compile_output="$(dotnet "$GSC_DLL" "${gsc_args[@]}" 2>&1)"; then
+        echo "FAIL(compile) $name"
+        echo "$compile_output" | sed 's/^/    /'
+        COMPILE_FAILED=$((COMPILE_FAILED + 1))
+        FAILURES+=("$name (gsc compile failed)")
+        return 0
+    fi
+
+    local ignore_args=()
+    local codes
+    codes="$(baseline_codes "$name")"
+    if [[ -n "$codes" ]]; then
+        local code
+        while IFS= read -r code; do
+            [[ -n "$code" ]] && ignore_args+=(-g "$code")
+        done < <(tr ',' '\n' <<< "$codes")
+    fi
+
+    local extra_refs=()
+    if [[ "$uses_extensions" == "yes" ]]; then
+        extra_refs=(-r "$EXTENSIONS_DLL")
+    fi
+
+    local verify_output rc=0
+    verify_output="$(dotnet tool run ilverify "$dll" -s System.Private.CoreLib \
+        "${REF_ARGS[@]}" ${extra_refs[@]+"${extra_refs[@]}"} \
+        ${ignore_args[@]+"${ignore_args[@]}"} 2>&1)" || rc=$?
+
+    # Match on the file name, not the full path: ilverify echoes a normalized
+    # path that may differ from $dll (e.g. collapsed double slashes).
+    if [[ $rc -eq 0 && "$verify_output" == *"All Classes and Methods in "*"/$name.dll Verified."* ]]; then
+        if [[ -n "$codes" ]]; then
+            echo "PASS(suppressed: $codes) $name"
+            SUPPRESSED=$((SUPPRESSED + 1))
+        else
+            echo "PASS $name"
+        fi
+        PASSED=$((PASSED + 1))
+    else
+        echo "FAIL(ilverify rc=$rc) $name"
+        echo "$verify_output" | sed 's/^/    /'
+        FAILED=$((FAILED + 1))
+        FAILURES+=("$name (ilverify rc=$rc)")
+    fi
+}
+
+echo "==> Compiling and verifying golden samples from $SAMPLES_DIR"
+
+# Single-file samples: samples/*.gs with a sibling .golden.
+for source in "$SAMPLES_DIR"/*.gs; do
+    [[ -f "${source%.gs}.golden" ]] || continue
+    name="$(basename "$source" .gs)"
+    uses_extensions=no
+    grep -q "Gsharp.Extensions" "$source" && uses_extensions=yes
+    verify_sample "$name" "$uses_extensions" "$source"
+done
+
+# Multi-file samples: samples/<dir>/ with <dir>.golden and *.gs inside.
+for dir in "$SAMPLES_DIR"/*/; do
+    dir="${dir%/}"
+    name="$(basename "$dir")"
+    [[ "$name" == "aspirational" ]] && continue
+    [[ -f "$dir/$name.golden" ]] || continue
+    sources=()
+    while IFS= read -r file; do
+        sources+=("$file")
+    done < <(find "$dir" -maxdepth 1 -name '*.gs' | sort)
+    [[ ${#sources[@]} -gt 0 ]] || continue
+    uses_extensions=no
+    grep -q "Gsharp.Extensions" "${sources[@]}" && uses_extensions=yes
+    verify_sample "$name" "$uses_extensions" "${sources[@]}"
+done
+
+TOTAL=$((PASSED + FAILED + COMPILE_FAILED))
+echo ""
+echo "========================================"
+echo " ILVerify gate: $PASSED/$TOTAL verified" \
+     "($SUPPRESSED with documented suppressions," \
+     "$FAILED verification failures, $COMPILE_FAILED compile failures)"
+echo "========================================"
+
+if [[ $TOTAL -eq 0 ]]; then
+    echo "ERROR: no samples matched — the corpus discovery is broken (or the filter '$FILTER' matched nothing)."
+    exit 1
+fi
+
+if [[ ${#FAILURES[@]} -gt 0 ]]; then
+    echo ""
+    echo "Failed assemblies:"
+    for f in "${FAILURES[@]}"; do
+        echo "  - $f"
+    done
+    echo ""
+    echo "New ilverify findings indicate gsc emitted unverifiable IL. If a finding"
+    echo "is a documented ilverify false positive or tracked compiler bug, add it to"
+    echo "build/ilverify-known-failures.txt with an issue reference; otherwise fix the emitter."
+    exit 1
+fi


### PR DESCRIPTION
Part of #3163 — implements the P0 code-health recommendation: run ILVerify over every gsc-emitted assembly in CI, turning the "unverifiable but happens to run" class of IL bugs (the `gap:ilverify` class, e.g. #3094) into loud gate failures.

## What the gate covers

New `build/run-ilverify.sh` + a new `ilverify` CI job (parallel to `e2e`, added to `publish`'s `needs`):

- **Corpus** — the same golden-sample corpus `SampleConformanceTests` uses (mirrors `SampleConformanceData`): the 122 single-file `samples/*.gs` with a sibling `.golden`, plus multi-file sample directories (`MultiPackage/`); `samples/aspirational/` is excluded. **123 assemblies total.**
- **Compile** — each sample is compiled with the freshly built Release `gsc` using the conformance harness's exact flags (`/out`, `/target:exe`, `/targetframework:net10.0`, `/nowarn:GS9100`, plus `/r:Gsharp.Extensions.dll` when the sample references it). Every golden sample is expected to compile with rc 0, so a gsc failure is itself a gate failure.
- **Verify** — the repo-pinned `dotnet-ilverify` **10.0.8** local tool (already in `.config/dotnet-tools.json`; no new tool version introduced) runs per assembly with `-s System.Private.CoreLib` and the host `Microsoft.NETCore.App` 10.x BCL reference set, filtered exactly like the existing `test/Compiler.Tests/IlVerifier.cs` wrapper. Success requires both exit 0 and ilverify's "All Classes and Methods … Verified." marker, so abnormal tool exits can't pass silently.

## Known-failures baseline

`build/ilverify-known-failures.txt` maps an assembly base name to the ilverify error codes suppressed for that assembly only (passed as `-g` flags). Any **new** code on a listed assembly, or **any** error on an unlisted assembly, fails the job. Both current entries are documented **upstream ilverify false positives** (not gsc emitter bugs — csc emits identical IL for the equivalent C#), carried over from the suppressions the conformance suite already applies method-scoped in `IlVerifier.GetKnownIssuesForSample`:

| Assembly | Suppressed codes | Why |
|---|---|---|
| `UserRefStruct` | `ReturnPtrToStack` | ilverify rejects by-value returns of user `ref struct`s even in their permanent home — dotnet/runtime#129030 |
| `StaticVirtualInterfaces` | `CallAbstract`, `Constrained` | ilverify's pre-C#-11 rules reject the .NET 7 static-virtual `constrained. !!T call` dispatch pattern — ADR-0089 / #755, dotnet/runtime#49558 |

No genuine emitter failures needed baselining: with only those two suppressions the corpus verifies clean.

## Relationship to existing coverage

`SampleConformanceTests` already IL-verifies samples, but only inside the 45-minute test matrix and via the in-process compiler API. This job exercises the `gsc` CLI end-to-end and gives the same signal standalone in ~5 minutes of CI (checkout + restore + build gsc/Extensions + verify; the verify loop itself is ~90 s).

## Local run

```
$ ./build/run-ilverify.sh
==> Building gsc and Gsharp.Extensions (Release)
==> Restoring repo-local dotnet tools (dotnet-ilverify)
    ilverify 10.0.8-servicing.26229.119+…
==> BCL reference dir: /usr/local/share/dotnet/shared/Microsoft.NETCore.App/10.0.9
==> Compiling and verifying golden samples from …/samples
PASS AddressBook
…
PASS(suppressed: CallAbstract,Constrained) StaticVirtualInterfaces
PASS(suppressed: ReturnPtrToStack) UserRefStruct
…
PASS MultiPackage

========================================
 ILVerify gate: 123/123 verified (2 with documented suppressions, 0 verification failures, 0 compile failures)
========================================
```

Negative test verified: removing the baseline makes `UserRefStruct` fail with rc 2 and the script exits 1 listing the assembly and full ilverify output. `./build/run-ilverify.sh <filter>` runs a subset for local debugging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)