### PR TITLE
Reify the Emit cache-key generic-remap-scope invariant (GSA0004)

### DIFF
--- a/src/Analyzers/InternalAnalyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Analyzers/InternalAnalyzers/AnalyzerReleases.Unshipped.md
@@ -5,3 +5,4 @@ Rule ID | Category | Severity | Notes
 GSA0001 | GSharp.InternalAnalyzers | Warning | Resolve emitted field tokens through ResolveFieldToken
 GSA0002 | GSharp.InternalAnalyzers | Warning | Compare CLR Type identities with ClrTypeUtilities
 GSA0003 | GSharp.InternalAnalyzers | Warning | Use weak storage for static reflection identity caches
+GSA0004 | GSharp.InternalAnalyzers | Warning | Emit caches keyed on symbols producing metadata references must include RemapScope

--- a/src/Analyzers/InternalAnalyzers/DiagnosticDescriptors.cs
+++ b/src/Analyzers/InternalAnalyzers/DiagnosticDescriptors.cs
@@ -46,4 +46,17 @@ public static class DiagnosticDescriptors
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: "Strong static caches keyed by reflection Type, Assembly, or Module can pin MetadataLoadContexts.");
+
+    /// <summary>
+    /// Reports Emit-layer symbol-keyed metadata-reference caches whose key
+    /// omits the generic-remap scope.
+    /// </summary>
+    public static readonly DiagnosticDescriptor EmitCacheKeyMissingRemapScope = new(
+        "GSA0004",
+        "Include RemapScope in Emit-layer symbol-keyed metadata caches",
+        "Emit cache '{0}' maps symbols to scope-sensitive metadata rows but its key does not include RemapScope",
+        "GSharp.InternalAnalyzers",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "The same symbol encodes to different VAR/MVAR ordinals under different active generic remaps, so a TypeSpec/MemberRef/MethodSpec cache keyed on symbols without the RemapScope reuses rows across scopes and emits an invalid assembly (issues #2930, #3057, #3065; invariant #3163).");
 }

--- a/src/Analyzers/InternalAnalyzers/EmitCacheKeyRemapScopeAnalyzer.cs
+++ b/src/Analyzers/InternalAnalyzers/EmitCacheKeyRemapScopeAnalyzer.cs
@@ -1,0 +1,205 @@
+// <copyright file="EmitCacheKeyRemapScopeAnalyzer.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace GSharp.InternalAnalyzers;
+
+/// <summary>
+/// GSA0004 (issue #3163): enforces the Emit cache-key invariant — every
+/// dictionary in <c>GSharp.Core.CodeAnalysis.Emit</c> that maps symbols to
+/// scope-sensitive metadata rows (TypeSpec / MemberRef / MethodSpec /
+/// EntityHandle) must include the generic-remap scope (<c>RemapScope</c>)
+/// in its key.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The same symbol encodes to different <c>VAR</c>/<c>MVAR</c> ordinals
+/// depending on the remaps active on <c>GenericRemapState</c>, so a cache
+/// key that omits the scope reuses a row whose signature blob encodes the
+/// other scope's ordinals — an invalid assembly discovered only at runtime
+/// (<c>BadImageFormatException</c>). This bug class shipped as #2930/#3057
+/// (constructor MemberRefs) and again as #3065 (MethodSpecs); this rule
+/// makes a third recurrence a build break instead of a runtime defect.
+/// </para>
+/// <para>
+/// Definition-handle caches (<c>TypeDefinitionHandle</c>,
+/// <c>MethodDefinitionHandle</c>, <c>FieldDefinitionHandle</c>, ...) are
+/// scope-invariant by construction — a symbol has exactly one definition row
+/// — and are deliberately not flagged. Caches keyed purely on CLR
+/// reflection objects (<c>Type</c>, <c>MethodInfo</c>, ...) carry no
+/// symbolic type parameters and are likewise exempt.
+/// </para>
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class EmitCacheKeyRemapScopeAnalyzer : DiagnosticAnalyzer
+{
+    private const string EmitNamespace = "GSharp.Core.CodeAnalysis.Emit";
+    private const string SymbolsNamespace = "GSharp.Core.CodeAnalysis.Symbols";
+    private const string RemapScopeTypeName = "RemapScope";
+    private const int MaxDepth = 6;
+
+    private static readonly ImmutableHashSet<string> SensitiveHandleTypes = ImmutableHashSet.Create(
+        "global::System.Reflection.Metadata.EntityHandle",
+        "global::System.Reflection.Metadata.MemberReferenceHandle",
+        "global::System.Reflection.Metadata.TypeSpecificationHandle",
+        "global::System.Reflection.Metadata.MethodSpecificationHandle");
+
+    /// <inheritdoc />
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }
+        = ImmutableArray.Create(DiagnosticDescriptors.EmitCacheKeyMissingRemapScope);
+
+    /// <inheritdoc />
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSymbolAction(AnalyzeField, SymbolKind.Field);
+        context.RegisterSymbolAction(AnalyzeProperty, SymbolKind.Property);
+    }
+
+    private static void AnalyzeField(SymbolAnalysisContext context)
+    {
+        var field = (IFieldSymbol)context.Symbol;
+        if (field.IsImplicitlyDeclared)
+        {
+            return;
+        }
+
+        AnalyzeCacheMember(context, field, field.Type, field.Name);
+    }
+
+    private static void AnalyzeProperty(SymbolAnalysisContext context)
+    {
+        var property = (IPropertySymbol)context.Symbol;
+        AnalyzeCacheMember(context, property, property.Type, property.Name);
+    }
+
+    private static void AnalyzeCacheMember(SymbolAnalysisContext context, ISymbol member, ITypeSymbol memberType, string memberName)
+    {
+        if (!IsEmitNamespace(member.ContainingNamespace))
+        {
+            return;
+        }
+
+        if (memberType is not INamedTypeSymbol namedType
+            || namedType.TypeArguments.Length != 2
+            || !IsDictionary(namedType))
+        {
+            return;
+        }
+
+        var keyType = namedType.TypeArguments[0];
+        var valueType = namedType.TypeArguments[1];
+        if (!Mentions(valueType, IsSensitiveHandle) || !Mentions(keyType, IsGSharpSymbolType))
+        {
+            return;
+        }
+
+        if (Mentions(keyType, IsRemapScope))
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            DiagnosticDescriptors.EmitCacheKeyMissingRemapScope,
+            member.Locations.Length > 0 ? member.Locations[0] : null,
+            memberName));
+    }
+
+    private static bool IsEmitNamespace(INamespaceSymbol namespaceSymbol)
+    {
+        var name = namespaceSymbol?.ToDisplayString();
+        return name == EmitNamespace || (name != null && name.StartsWith(EmitNamespace + ".", System.StringComparison.Ordinal));
+    }
+
+    private static bool IsDictionary(INamedTypeSymbol type)
+    {
+        var metadataName = type.ConstructedFrom.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+        return metadataName == "global::System.Collections.Generic.Dictionary<TKey, TValue>"
+            || metadataName == "global::System.Collections.Concurrent.ConcurrentDictionary<TKey, TValue>";
+    }
+
+    private static bool IsSensitiveHandle(ITypeSymbol type)
+        => SensitiveHandleTypes.Contains(type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
+
+    private static bool IsGSharpSymbolType(ITypeSymbol type)
+        => type.ContainingNamespace?.ToDisplayString() == SymbolsNamespace;
+
+    private static bool IsRemapScope(ITypeSymbol type)
+        => type.Name == RemapScopeTypeName && IsEmitNamespace(type.ContainingNamespace);
+
+    /// <summary>
+    /// Walks the structure of <paramref name="type"/> — tuple elements,
+    /// generic type arguments, and the instance fields of user-defined key
+    /// structs declared in the Emit namespace — looking for any component
+    /// matching <paramref name="predicate"/>.
+    /// </summary>
+    private static bool Mentions(ITypeSymbol type, System.Func<ITypeSymbol, bool> predicate)
+        => Mentions(type, predicate, new HashSet<ITypeSymbol>(SymbolEqualityComparer.Default), depth: 0);
+
+    private static bool Mentions(ITypeSymbol type, System.Func<ITypeSymbol, bool> predicate, HashSet<ITypeSymbol> visited, int depth)
+    {
+        if (type == null || depth > MaxDepth || !visited.Add(type))
+        {
+            return false;
+        }
+
+        if (predicate(type))
+        {
+            return true;
+        }
+
+        if (type is IArrayTypeSymbol arrayType)
+        {
+            return Mentions(arrayType.ElementType, predicate, visited, depth + 1);
+        }
+
+        if (type is not INamedTypeSymbol namedType)
+        {
+            return false;
+        }
+
+        if (namedType.IsTupleType)
+        {
+            foreach (var element in namedType.TupleElements)
+            {
+                if (Mentions(element.Type, predicate, visited, depth + 1))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        foreach (var typeArgument in namedType.TypeArguments)
+        {
+            if (Mentions(typeArgument, predicate, visited, depth + 1))
+            {
+                return true;
+            }
+        }
+
+        // A user-defined composite key struct (e.g. MethodSpecSymbolKey)
+        // declared in the Emit namespace: inspect its instance fields so both
+        // the symbol mention and the RemapScope requirement see through it.
+        if (namedType.IsValueType && IsEmitNamespace(namedType.ContainingNamespace))
+        {
+            foreach (var fieldMember in namedType.GetMembers())
+            {
+                if (fieldMember is IFieldSymbol { IsStatic: false } instanceField
+                    && Mentions(instanceField.Type, predicate, visited, depth + 1))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Core/CodeAnalysis/Emit/GenericRemapState.cs
+++ b/src/Core/CodeAnalysis/Emit/GenericRemapState.cs
@@ -136,6 +136,15 @@ internal sealed class GenericRemapState
     internal Dictionary<TypeParameterSymbol, int> ActiveLambdaMethodTypeParamRemap => this.activeLambdaMethodTypeParamRemap;
 
     /// <summary>
+    /// Gets the current generic-remap scope identity (issue #3163): both
+    /// active remap channels captured as a single equatable value for use in
+    /// Emit-layer cache keys. Capture at the point of key construction —
+    /// never across a push/pop boundary.
+    /// </summary>
+    internal RemapScope CurrentScope
+        => new RemapScope(this.activeIteratorStateMachineRemap, this.activeLambdaMethodTypeParamRemap);
+
+    /// <summary>
     /// Issue #810: push the SM remap for <paramref name="smClass"/> so that
     /// every <see cref="SignatureEncoder.EncodeTypeSymbol"/> call made
     /// before the returned disposable is disposed translates outer-method

--- a/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
+++ b/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
@@ -877,8 +877,7 @@ internal sealed class ImportedMemberRefFactory
             var symbolKey = new MetadataTokenCache.MethodSpecSymbolKey(
                 method,
                 typeArgSymbols,
-                this.remaps.ActiveIteratorStateMachineRemap,
-                this.remaps.ActiveLambdaMethodTypeParamRemap);
+                this.remaps.CurrentScope);
             if (this.cache.MethodSpecsWithSymbolArgs.TryGetValue(symbolKey, out var existingSym))
             {
                 return existingSym;
@@ -921,8 +920,7 @@ internal sealed class ImportedMemberRefFactory
                 new MetadataTokenCache.MethodSpecSymbolKey(
                     method,
                     typeArgSymbols,
-                    this.remaps.ActiveIteratorStateMachineRemap,
-                    this.remaps.ActiveLambdaMethodTypeParamRemap)] = spec;
+                    this.remaps.CurrentScope)] = spec;
         }
 
         return spec;
@@ -1357,8 +1355,7 @@ internal sealed class ImportedMemberRefFactory
         var cacheKey = new MetadataTokenCache.CtorRefSymbolKey(
             ctor,
             imported.TypeArguments,
-            this.remaps.ActiveIteratorStateMachineRemap,
-            this.remaps.ActiveLambdaMethodTypeParamRemap);
+            this.remaps.CurrentScope);
         if (this.cache.CtorRefsWithSymbolArgs.TryGetValue(cacheKey, out var cached))
         {
             handle = cached;
@@ -1446,7 +1443,8 @@ internal sealed class ImportedMemberRefFactory
                 "GetNullableCtorMemberRefForOpenTypeParameter requires Nullable<TypeParameter>.");
         }
 
-        if (this.cache.NullableOpenCtorMemberRefs.TryGetValue(tp, out var cached))
+        var tpKey = (tp, this.remaps.CurrentScope);
+        if (this.cache.NullableOpenCtorMemberRefs.TryGetValue(tpKey, out var cached))
         {
             return cached;
         }
@@ -1471,7 +1469,7 @@ internal sealed class ImportedMemberRefFactory
             parent: parent,
             name: this.emitCtx.Metadata.GetOrAddString(".ctor"),
             signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
-        this.cache.NullableOpenCtorMemberRefs[tp] = handle;
+        this.cache.NullableOpenCtorMemberRefs[tpKey] = handle;
         return handle;
     }
 
@@ -1494,7 +1492,8 @@ internal sealed class ImportedMemberRefFactory
                 "GetNullableCtorMemberRefForUserEnum requires Nullable<EnumSymbol>.");
         }
 
-        if (this.cache.NullableUserEnumCtorMemberRefs.TryGetValue(enumSym, out var cached))
+        var enumKey = (enumSym, this.remaps.CurrentScope);
+        if (this.cache.NullableUserEnumCtorMemberRefs.TryGetValue(enumKey, out var cached))
         {
             return cached;
         }
@@ -1517,7 +1516,7 @@ internal sealed class ImportedMemberRefFactory
             parent: parent,
             name: this.emitCtx.Metadata.GetOrAddString(".ctor"),
             signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
-        this.cache.NullableUserEnumCtorMemberRefs[enumSym] = handle;
+        this.cache.NullableUserEnumCtorMemberRefs[enumKey] = handle;
         return handle;
     }
 
@@ -1549,7 +1548,8 @@ internal sealed class ImportedMemberRefFactory
         }
 
         var underlying = nullableOfUserVt.UnderlyingType;
-        if (this.cache.NullableUserStructCtorMemberRefs.TryGetValue(underlying, out var cached))
+        var underlyingKey = (underlying, this.remaps.CurrentScope);
+        if (this.cache.NullableUserStructCtorMemberRefs.TryGetValue(underlyingKey, out var cached))
         {
             return cached;
         }
@@ -1572,7 +1572,7 @@ internal sealed class ImportedMemberRefFactory
             parent: parent,
             name: this.emitCtx.Metadata.GetOrAddString(".ctor"),
             signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
-        this.cache.NullableUserStructCtorMemberRefs[underlying] = handle;
+        this.cache.NullableUserStructCtorMemberRefs[underlyingKey] = handle;
         return handle;
     }
 
@@ -1601,7 +1601,8 @@ internal sealed class ImportedMemberRefFactory
         }
 
         var underlying = nullableOfUserVt.UnderlyingType;
-        if (this.cache.NullableUserValueTypeGetValueMemberRefs.TryGetValue(underlying, out var cached))
+        var underlyingKey = (underlying, this.remaps.CurrentScope);
+        if (this.cache.NullableUserValueTypeGetValueMemberRefs.TryGetValue(underlyingKey, out var cached))
         {
             return cached;
         }
@@ -1621,7 +1622,7 @@ internal sealed class ImportedMemberRefFactory
             parent: parent,
             name: this.emitCtx.Metadata.GetOrAddString("get_Value"),
             signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
-        this.cache.NullableUserValueTypeGetValueMemberRefs[underlying] = handle;
+        this.cache.NullableUserValueTypeGetValueMemberRefs[underlyingKey] = handle;
         return handle;
     }
 
@@ -1649,7 +1650,8 @@ internal sealed class ImportedMemberRefFactory
         }
 
         var underlying = nullableOfUserVt.UnderlyingType;
-        if (this.cache.NullableUserValueTypeGetHasValueMemberRefs.TryGetValue(underlying, out var cached))
+        var underlyingKey = (underlying, this.remaps.CurrentScope);
+        if (this.cache.NullableUserValueTypeGetHasValueMemberRefs.TryGetValue(underlyingKey, out var cached))
         {
             return cached;
         }
@@ -1669,7 +1671,7 @@ internal sealed class ImportedMemberRefFactory
             parent: parent,
             name: this.emitCtx.Metadata.GetOrAddString("get_HasValue"),
             signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
-        this.cache.NullableUserValueTypeGetHasValueMemberRefs[underlying] = handle;
+        this.cache.NullableUserValueTypeGetHasValueMemberRefs[underlyingKey] = handle;
         return handle;
     }
 
@@ -2043,20 +2045,20 @@ internal sealed class ImportedMemberRefFactory
     }
 
     // ADR-0087 §3 R6: cache reified delegate metadata by function shape and
-    // active generic-remap scopes. The same interned FunctionTypeSymbol can
-    // encode as VAR inside a synthesized generic class and MVAR at its outer
-    // generic-method use site.
-    private readonly Dictionary<(FunctionTypeSymbol Type, object ClassRemap, object MethodRemap), EntityHandle>
+    // the active generic-remap scope (issue #3163). The same interned
+    // FunctionTypeSymbol can encode as VAR inside a synthesized generic class
+    // and MVAR at its outer generic-method use site.
+    private readonly Dictionary<(FunctionTypeSymbol Type, RemapScope Scope), EntityHandle>
         functionDelegateTypeSpecCache = new();
 
-    private readonly Dictionary<(FunctionTypeSymbol Type, object ClassRemap, object MethodRemap), EntityHandle>
+    private readonly Dictionary<(FunctionTypeSymbol Type, RemapScope Scope), EntityHandle>
         functionDelegateCtorRefCache = new();
 
-    private readonly Dictionary<(FunctionTypeSymbol Type, object ClassRemap, object MethodRemap), EntityHandle>
+    private readonly Dictionary<(FunctionTypeSymbol Type, RemapScope Scope), EntityHandle>
         functionDelegateInvokeRefCache = new();
 
-    private (FunctionTypeSymbol Type, object ClassRemap, object MethodRemap) GetFunctionDelegateCacheKey(FunctionTypeSymbol fnType)
-        => (fnType, this.remaps.ActiveIteratorStateMachineRemap, this.remaps.ActiveLambdaMethodTypeParamRemap);
+    private (FunctionTypeSymbol Type, RemapScope Scope) GetFunctionDelegateCacheKey(FunctionTypeSymbol fnType)
+        => (fnType, this.remaps.CurrentScope);
 
     /// <summary>
     /// ADR-0087 §3 R6: returns a <c>TypeSpec</c> EntityHandle for the

--- a/src/Core/CodeAnalysis/Emit/MetadataTokenCache.cs
+++ b/src/Core/CodeAnalysis/Emit/MetadataTokenCache.cs
@@ -142,10 +142,13 @@ internal sealed class MetadataTokenCache
     /// <c>System.Nullable`1&lt;!!T&gt;::.ctor(!0)</c> (issue #814 / ADR-0084 §L5).
     /// The parent TypeSpec uses the same VAR/MVAR slot as the wrapping
     /// method's signature, so a single MemberRef per <c>T</c> serves every
-    /// instantiation of the enclosing generic method or type.
+    /// instantiation of the enclosing generic method or type. Issue #3163:
+    /// the parent TypeSpec is encoded through <c>EncodeTypeSymbol</c>, whose
+    /// VAR/MVAR ordinal depends on the active generic remaps, so the key
+    /// includes the <see cref="RemapScope"/>.
     /// </summary>
-    public Dictionary<TypeParameterSymbol, MemberReferenceHandle> NullableOpenCtorMemberRefs { get; }
-        = new Dictionary<TypeParameterSymbol, MemberReferenceHandle>();
+    public Dictionary<(TypeParameterSymbol Tp, RemapScope Scope), MemberReferenceHandle> NullableOpenCtorMemberRefs { get; }
+        = new Dictionary<(TypeParameterSymbol Tp, RemapScope Scope), MemberReferenceHandle>();
 
     /// <summary>
     /// Gets the cache mapping a user-defined <see cref="EnumSymbol"/> to the
@@ -153,19 +156,24 @@ internal sealed class MetadataTokenCache
     /// <c>System.Nullable`1&lt;E&gt;::.ctor(!0)</c> (issue #1298). The parent
     /// TypeSpec closes <c>Nullable&lt;&gt;</c> over the enum's emitted TypeDef,
     /// so one MemberRef per enum serves every <c>E -&gt; E?</c> lift site.
+    /// Issue #3163: a nested enum's parent TypeSpec can encode enclosing
+    /// type-parameter ordinals, so the key includes the
+    /// <see cref="RemapScope"/>.
     /// </summary>
-    public Dictionary<EnumSymbol, MemberReferenceHandle> NullableUserEnumCtorMemberRefs { get; }
-        = new Dictionary<EnumSymbol, MemberReferenceHandle>();
+    public Dictionary<(EnumSymbol Enum, RemapScope Scope), MemberReferenceHandle> NullableUserEnumCtorMemberRefs { get; }
+        = new Dictionary<(EnumSymbol Enum, RemapScope Scope), MemberReferenceHandle>();
 
     /// <summary>
     /// Gets the cache mapping a symbolic value-type underlying to the
     /// <see cref="MemberReferenceHandle"/> for
     /// <c>System.Nullable`1&lt;T&gt;::.ctor(!0)</c>. The parent TypeSpec closes
     /// <c>Nullable&lt;&gt;</c> over the encoded underlying, so one MemberRef
-    /// serves every matching nullable lift site.
+    /// serves every matching nullable lift site. Issue #3163: the symbolic
+    /// underlying can encode type-parameter ordinals, so the key includes
+    /// the <see cref="RemapScope"/>.
     /// </summary>
-    public Dictionary<TypeSymbol, MemberReferenceHandle> NullableUserStructCtorMemberRefs { get; }
-        = new Dictionary<TypeSymbol, MemberReferenceHandle>();
+    public Dictionary<(TypeSymbol Underlying, RemapScope Scope), MemberReferenceHandle> NullableUserStructCtorMemberRefs { get; }
+        = new Dictionary<(TypeSymbol Underlying, RemapScope Scope), MemberReferenceHandle>();
 
     /// <summary>
     /// Gets the cache mapping a user-defined value-type underlying
@@ -174,10 +182,13 @@ internal sealed class MetadataTokenCache
     /// <c>System.Nullable`1&lt;T&gt;::get_Value()</c> (issue #1572). The parent
     /// TypeSpec closes <c>Nullable&lt;&gt;</c> over the type's emitted
     /// TypeDef/TypeSpec, so one MemberRef per underlying serves every
-    /// <c>(v!!)</c> unwrap and narrowing-read site.
+    /// <c>(v!!)</c> unwrap and narrowing-read site. Issue #3163: the
+    /// underlying can be (or contain) a type parameter whose VAR/MVAR
+    /// ordinal depends on the active remaps, so the key includes the
+    /// <see cref="RemapScope"/>.
     /// </summary>
-    public Dictionary<TypeSymbol, MemberReferenceHandle> NullableUserValueTypeGetValueMemberRefs { get; }
-        = new Dictionary<TypeSymbol, MemberReferenceHandle>();
+    public Dictionary<(TypeSymbol Underlying, RemapScope Scope), MemberReferenceHandle> NullableUserValueTypeGetValueMemberRefs { get; }
+        = new Dictionary<(TypeSymbol Underlying, RemapScope Scope), MemberReferenceHandle>();
 
     /// <summary>
     /// Gets the cache mapping a user-defined value-type underlying
@@ -189,9 +200,11 @@ internal sealed class MetadataTokenCache
     /// over a same-compilation struct, where no real CLR
     /// <see cref="System.Type"/> exists to drive the reflection-based
     /// <see cref="WellKnownReferences.GetNullableGetHasValueReference"/>.
+    /// Issue #3163: keyed with the <see cref="RemapScope"/>, mirroring
+    /// <see cref="NullableUserValueTypeGetValueMemberRefs"/>.
     /// </summary>
-    public Dictionary<TypeSymbol, MemberReferenceHandle> NullableUserValueTypeGetHasValueMemberRefs { get; }
-        = new Dictionary<TypeSymbol, MemberReferenceHandle>();
+    public Dictionary<(TypeSymbol Underlying, RemapScope Scope), MemberReferenceHandle> NullableUserValueTypeGetHasValueMemberRefs { get; }
+        = new Dictionary<(TypeSymbol Underlying, RemapScope Scope), MemberReferenceHandle>();
 
     /// <summary>
     /// Gets the cache mapping a <see cref="FieldInfo"/> to its
@@ -400,27 +413,25 @@ internal sealed class MetadataTokenCache
 
     /// <summary>
     /// Issue #420 / #3065: structural cache key for MethodSpec rows whose
-    /// generic arguments include user-defined type symbols. Includes both
-    /// active generic-remap scopes because the same symbols can encode to
-    /// different VAR/MVAR ordinals. Uses reference equality throughout.
+    /// generic arguments include user-defined type symbols. Requires the
+    /// full <see cref="RemapScope"/> (issue #3163) because the same symbols
+    /// can encode to different VAR/MVAR ordinals under different active
+    /// remaps. Uses reference equality throughout.
     /// </summary>
     internal readonly struct MethodSpecSymbolKey : IEquatable<MethodSpecSymbolKey>
     {
         private readonly MethodInfo method;
         private readonly ImmutableArray<TypeSymbol> typeArgs;
-        private readonly object classRemap;
-        private readonly object methodRemap;
+        private readonly RemapScope scope;
 
         public MethodSpecSymbolKey(
             MethodInfo method,
             ImmutableArray<TypeSymbol> typeArgs,
-            object classRemap,
-            object methodRemap)
+            RemapScope scope)
         {
             this.method = method;
             this.typeArgs = typeArgs.IsDefault ? ImmutableArray<TypeSymbol>.Empty : typeArgs;
-            this.classRemap = classRemap;
-            this.methodRemap = methodRemap;
+            this.scope = scope;
         }
 
         public bool Equals(MethodSpecSymbolKey other)
@@ -430,8 +441,7 @@ internal sealed class MetadataTokenCache
                 return false;
             }
 
-            if (!ReferenceEquals(this.classRemap, other.classRemap)
-                || !ReferenceEquals(this.methodRemap, other.methodRemap)
+            if (!this.scope.Equals(other.scope)
                 || this.typeArgs.Length != other.typeArgs.Length)
             {
                 return false;
@@ -453,8 +463,7 @@ internal sealed class MetadataTokenCache
         public override int GetHashCode()
         {
             var hash = RuntimeHelpers.GetHashCode(this.method);
-            hash = unchecked((hash * 31) + RuntimeHelpers.GetHashCode(this.classRemap));
-            hash = unchecked((hash * 31) + RuntimeHelpers.GetHashCode(this.methodRemap));
+            hash = unchecked((hash * 31) + this.scope.GetHashCode());
             for (var i = 0; i < this.typeArgs.Length; i++)
             {
                 hash = unchecked((hash * 31) + RuntimeHelpers.GetHashCode(this.typeArgs[i]));
@@ -467,27 +476,26 @@ internal sealed class MetadataTokenCache
     /// <summary>
     /// Issues #671 and #2930: structural cache key for ctor MemberRef rows
     /// whose parent TypeSpec carries G# user-defined symbolic type arguments.
-    /// Includes both active generic-remap scopes because the same symbols can
-    /// encode to different VAR/MVAR ordinals. Issue #3065 tracks equivalent
-    /// remap discrimination for <see cref="MethodSpecSymbolKey"/>.
+    /// Requires the full <see cref="RemapScope"/> (issue #3163) because the
+    /// same symbols can encode to different VAR/MVAR ordinals under
+    /// different active remaps. Counterpart to
+    /// <see cref="MethodSpecSymbolKey"/>, which is keyed the same way
+    /// since #3065.
     /// </summary>
     internal readonly struct CtorRefSymbolKey : IEquatable<CtorRefSymbolKey>
     {
         private readonly ConstructorInfo ctor;
         private readonly ImmutableArray<TypeSymbol> typeArgs;
-        private readonly object classRemap;
-        private readonly object methodRemap;
+        private readonly RemapScope scope;
 
         public CtorRefSymbolKey(
             ConstructorInfo ctor,
             ImmutableArray<TypeSymbol> typeArgs,
-            object classRemap,
-            object methodRemap)
+            RemapScope scope)
         {
             this.ctor = ctor;
             this.typeArgs = typeArgs.IsDefault ? ImmutableArray<TypeSymbol>.Empty : typeArgs;
-            this.classRemap = classRemap;
-            this.methodRemap = methodRemap;
+            this.scope = scope;
         }
 
         public bool Equals(CtorRefSymbolKey other)
@@ -497,8 +505,7 @@ internal sealed class MetadataTokenCache
                 return false;
             }
 
-            if (!ReferenceEquals(this.classRemap, other.classRemap)
-                || !ReferenceEquals(this.methodRemap, other.methodRemap)
+            if (!this.scope.Equals(other.scope)
                 || this.typeArgs.Length != other.typeArgs.Length)
             {
                 return false;
@@ -520,8 +527,7 @@ internal sealed class MetadataTokenCache
         public override int GetHashCode()
         {
             var hash = RuntimeHelpers.GetHashCode(this.ctor);
-            hash = unchecked((hash * 31) + RuntimeHelpers.GetHashCode(this.classRemap));
-            hash = unchecked((hash * 31) + RuntimeHelpers.GetHashCode(this.methodRemap));
+            hash = unchecked((hash * 31) + this.scope.GetHashCode());
             for (var i = 0; i < this.typeArgs.Length; i++)
             {
                 hash = unchecked((hash * 31) + RuntimeHelpers.GetHashCode(this.typeArgs[i]));

--- a/src/Core/CodeAnalysis/Emit/RemapScope.cs
+++ b/src/Core/CodeAnalysis/Emit/RemapScope.cs
@@ -1,0 +1,79 @@
+// <copyright file="RemapScope.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace GSharp.Core.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #3163: the reified generic-remap scope identity that every Emit-layer
+/// cache keyed on symbols and producing scope-sensitive metadata rows
+/// (TypeSpec / MemberRef / MethodSpec) must carry in its key.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The same <see cref="GSharp.Core.CodeAnalysis.Symbols.TypeParameterSymbol"/>
+/// (or a symbol constructed over one) encodes to different
+/// <c>ELEMENT_TYPE_VAR</c> / <c>ELEMENT_TYPE_MVAR</c> ordinals depending on
+/// which remaps are active on <see cref="GenericRemapState"/> — the
+/// state-machine/nested/closure class remap (VAR) and the generic-promoted
+/// lambda method remap (MVAR). A cache key that omits either scope reuses a
+/// row whose signature blob encodes the <em>other</em> scope's ordinals,
+/// producing an invalid assembly (<c>BadImageFormatException</c>): this shipped
+/// as #2930/#3057 (constructor MemberRefs) and again as #3065 (MethodSpecs).
+/// </para>
+/// <para>
+/// Discrimination is <see cref="object.ReferenceEquals(object, object)"/> on
+/// the remap dictionary objects: <see cref="GenericRemapState.PushSmRemap"/> /
+/// <see cref="GenericRemapState.PushLambdaMethodRemap"/> install a distinct
+/// dictionary object per reified class and per promoted lambda rather than
+/// mutating a shared buffer, so object identity is the intended discriminator
+/// (a stale identity fails safe: cache miss, recompute). Obtain the current
+/// scope via <see cref="GenericRemapState.CurrentScope"/> at the point of
+/// key construction — never cache a <see cref="RemapScope"/> across a
+/// push/pop boundary.
+/// </para>
+/// <para>
+/// The internal analyzer rule GSA0004
+/// (<c>EmitCacheKeyRemapScopeAnalyzer</c>, ADR-0147) enforces the invariant:
+/// any <c>Dictionary</c>/<c>ConcurrentDictionary</c> field or property in
+/// this namespace whose key mentions a symbol type and whose value is a
+/// scope-sensitive handle must include a <see cref="RemapScope"/> in its key.
+/// </para>
+/// </remarks>
+internal readonly struct RemapScope : IEquatable<RemapScope>
+{
+    private readonly object classRemap;
+    private readonly object methodRemap;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RemapScope"/> struct.
+    /// Prefer <see cref="GenericRemapState.CurrentScope"/>; this constructor
+    /// exists for that property and for tests.
+    /// </summary>
+    /// <param name="classRemap">The active state-machine/nested/closure class remap (VAR channel), or <see langword="null"/>.</param>
+    /// <param name="methodRemap">The active generic-promoted lambda method remap (MVAR channel), or <see langword="null"/>.</param>
+    internal RemapScope(object classRemap, object methodRemap)
+    {
+        this.classRemap = classRemap;
+        this.methodRemap = methodRemap;
+    }
+
+    /// <inheritdoc />
+    public bool Equals(RemapScope other)
+        => ReferenceEquals(this.classRemap, other.classRemap)
+        && ReferenceEquals(this.methodRemap, other.methodRemap);
+
+    /// <inheritdoc />
+    public override bool Equals(object obj) => obj is RemapScope other && this.Equals(other);
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        var hash = this.classRemap == null ? 0 : RuntimeHelpers.GetHashCode(this.classRemap);
+        var methodHash = this.methodRemap == null ? 0 : RuntimeHelpers.GetHashCode(this.methodRemap);
+        return unchecked((hash * 31) + methodHash);
+    }
+}

--- a/src/Core/CodeAnalysis/Emit/UserTokenResolver.cs
+++ b/src/Core/CodeAnalysis/Emit/UserTokenResolver.cs
@@ -86,17 +86,18 @@ internal sealed class UserTokenResolver
     // on the class remap let a lambda-scope TypeSpec/MemberRef leak into the
     // enclosing scope (and vice versa), producing an out-of-range MVAR index
     // (ilverify get_GenericParameters IndexOutOfRange / runtime
-    // BadImageFormatException). Both channels are part of every key.
-    private readonly Dictionary<(StructSymbol Sym, object ClassRemap, object MethodRemap), EntityHandle> userStructTypeSpecCache = new();
-    private readonly Dictionary<(EnumSymbol Sym, object ClassRemap, object MethodRemap), EntityHandle> userEnumTypeSpecCache = new();
-    private readonly Dictionary<(StructSymbol Containing, FieldSymbol DefField, object ClassRemap, object MethodRemap), EntityHandle> userStructFieldRefCache = new();
-    private readonly Dictionary<(StructSymbol Containing, EntityHandle OpenMember, object ClassRemap, object MethodRemap), EntityHandle> userStructMethodRefCache = new();
-    private readonly Dictionary<(InterfaceSymbol Sym, object ClassRemap, object MethodRemap), EntityHandle> userInterfaceTypeSpecCache = new();
-    private readonly Dictionary<(InterfaceSymbol Containing, EntityHandle OpenMember, object ClassRemap, object MethodRemap), EntityHandle> userInterfaceMethodRefCache = new();
-    private readonly Dictionary<(InterfaceSymbol Containing, FieldSymbol DefField, object ClassRemap, object MethodRemap), EntityHandle> userInterfaceFieldRefCache = new();
-    private readonly Dictionary<(DelegateTypeSymbol Sym, object ClassRemap, object MethodRemap), EntityHandle> userDelegateTypeSpecCache = new();
-    private readonly Dictionary<(DelegateTypeSymbol Sym, object ClassRemap, object MethodRemap), EntityHandle> userDelegateCtorRefCache = new();
-    private readonly Dictionary<(DelegateTypeSymbol Sym, object ClassRemap, object MethodRemap), EntityHandle> userDelegateInvokeRefCache = new();
+    // BadImageFormatException). Both channels are part of every key,
+    // reified as a single RemapScope value (issue #3163).
+    private readonly Dictionary<(StructSymbol Sym, RemapScope Scope), EntityHandle> userStructTypeSpecCache = new();
+    private readonly Dictionary<(EnumSymbol Sym, RemapScope Scope), EntityHandle> userEnumTypeSpecCache = new();
+    private readonly Dictionary<(StructSymbol Containing, FieldSymbol DefField, RemapScope Scope), EntityHandle> userStructFieldRefCache = new();
+    private readonly Dictionary<(StructSymbol Containing, EntityHandle OpenMember, RemapScope Scope), EntityHandle> userStructMethodRefCache = new();
+    private readonly Dictionary<(InterfaceSymbol Sym, RemapScope Scope), EntityHandle> userInterfaceTypeSpecCache = new();
+    private readonly Dictionary<(InterfaceSymbol Containing, EntityHandle OpenMember, RemapScope Scope), EntityHandle> userInterfaceMethodRefCache = new();
+    private readonly Dictionary<(InterfaceSymbol Containing, FieldSymbol DefField, RemapScope Scope), EntityHandle> userInterfaceFieldRefCache = new();
+    private readonly Dictionary<(DelegateTypeSymbol Sym, RemapScope Scope), EntityHandle> userDelegateTypeSpecCache = new();
+    private readonly Dictionary<(DelegateTypeSymbol Sym, RemapScope Scope), EntityHandle> userDelegateCtorRefCache = new();
+    private readonly Dictionary<(DelegateTypeSymbol Sym, RemapScope Scope), EntityHandle> userDelegateInvokeRefCache = new();
 
     // Issue #2118: per-lambda-function ordered ORIGINAL enclosing type
     // parameters used as the MethodSpec type arguments when the lambda is
@@ -809,8 +810,8 @@ internal sealed class UserTokenResolver
     /// encoded under different scopes so a lambda-scope encoding is never
     /// reused at an enclosing-method use site.
     /// </summary>
-    private (StructSymbol Sym, object ClassRemap, object MethodRemap) GetUserStructRemapKey(StructSymbol structSym)
-        => (structSym, this.remaps.ActiveIteratorStateMachineRemap, this.remaps.ActiveLambdaMethodTypeParamRemap);
+    private (StructSymbol Sym, RemapScope Scope) GetUserStructRemapKey(StructSymbol structSym)
+        => (structSym, this.remaps.CurrentScope);
 
     /// <summary>
     /// Issue #2793: user-interface variant of <see cref="GetUserStructRemapKey"/>.
@@ -819,11 +820,11 @@ internal sealed class UserTokenResolver
     /// arguments (directly for the TypeSpec, transitively via the parent
     /// TypeSpec for its member refs).
     /// </summary>
-    private (InterfaceSymbol Sym, object ClassRemap, object MethodRemap) GetUserInterfaceRemapKey(InterfaceSymbol ifaceSym)
-        => (ifaceSym, this.remaps.ActiveIteratorStateMachineRemap, this.remaps.ActiveLambdaMethodTypeParamRemap);
+    private (InterfaceSymbol Sym, RemapScope Scope) GetUserInterfaceRemapKey(InterfaceSymbol ifaceSym)
+        => (ifaceSym, this.remaps.CurrentScope);
 
-    private (EnumSymbol Sym, object ClassRemap, object MethodRemap) GetUserEnumRemapKey(EnumSymbol enumSym)
-        => (enumSym, this.remaps.ActiveIteratorStateMachineRemap, this.remaps.ActiveLambdaMethodTypeParamRemap);
+    private (EnumSymbol Sym, RemapScope Scope) GetUserEnumRemapKey(EnumSymbol enumSym)
+        => (enumSym, this.remaps.CurrentScope);
 
     /// <summary>
     /// Issue #2793: user-delegate variant of <see cref="GetUserStructRemapKey"/>.
@@ -832,8 +833,8 @@ internal sealed class UserTokenResolver
     /// through the encoded type arguments of the (possibly shared) parent
     /// TypeSpec.
     /// </summary>
-    private (DelegateTypeSymbol Sym, object ClassRemap, object MethodRemap) GetUserDelegateRemapKey(DelegateTypeSymbol delegateSym)
-        => (delegateSym, this.remaps.ActiveIteratorStateMachineRemap, this.remaps.ActiveLambdaMethodTypeParamRemap);
+    private (DelegateTypeSymbol Sym, RemapScope Scope) GetUserDelegateRemapKey(DelegateTypeSymbol delegateSym)
+        => (delegateSym, this.remaps.CurrentScope);
 
     /// <summary>
     /// ADR-0087 §3 R3: returns a <c>TypeSpec</c> EntityHandle for a
@@ -1245,7 +1246,7 @@ internal sealed class UserTokenResolver
             defField = fieldOnContaining;
         }
 
-        var key = (containingType, defField, (object)this.remaps.ActiveIteratorStateMachineRemap, (object)this.remaps.ActiveLambdaMethodTypeParamRemap);
+        var key = (containingType, defField, this.remaps.CurrentScope);
         if (this.userStructFieldRefCache.TryGetValue(key, out var cached))
         {
             return cached;
@@ -1332,7 +1333,7 @@ internal sealed class UserTokenResolver
         var def = containingInterface.Definition ?? containingInterface;
         var defField = def.GetStaticField(fieldOnContaining.Name) ?? fieldOnContaining;
 
-        var key = (containingInterface, defField, (object)this.remaps.ActiveIteratorStateMachineRemap, (object)this.remaps.ActiveLambdaMethodTypeParamRemap);
+        var key = (containingInterface, defField, this.remaps.CurrentScope);
         if (this.userInterfaceFieldRefCache.TryGetValue(key, out var cached))
         {
             return cached;
@@ -1366,7 +1367,7 @@ internal sealed class UserTokenResolver
         // A caller may encode the signature under containingType's registered
         // remap, then restore the ambient remap used here. containingType
         // determines that signature remap and is already part of the key.
-        var key = (containingType, openMethodDef, (object)this.remaps.ActiveIteratorStateMachineRemap, (object)this.remaps.ActiveLambdaMethodTypeParamRemap);
+        var key = (containingType, openMethodDef, this.remaps.CurrentScope);
         if (this.userStructMethodRefCache.TryGetValue(key, out var cached))
         {
             return cached;
@@ -1660,7 +1661,7 @@ internal sealed class UserTokenResolver
         string methodName,
         BlobBuilder signature)
     {
-        var key = (containingInterface, openMethodDef, (object)this.remaps.ActiveIteratorStateMachineRemap, (object)this.remaps.ActiveLambdaMethodTypeParamRemap);
+        var key = (containingInterface, openMethodDef, this.remaps.CurrentScope);
         if (this.userInterfaceMethodRefCache.TryGetValue(key, out var cached))
         {
             return cached;
@@ -1880,7 +1881,7 @@ internal sealed class UserTokenResolver
             return openDef;
         }
 
-        var key = (containingInterface, openDef, (object)this.remaps.ActiveIteratorStateMachineRemap, (object)this.remaps.ActiveLambdaMethodTypeParamRemap);
+        var key = (containingInterface, openDef, this.remaps.CurrentScope);
         if (this.userInterfaceMethodRefCache.TryGetValue(key, out var cached))
         {
             return cached;

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue3065MethodSpecRemapKeyTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue3065MethodSpecRemapKeyTests.cs
@@ -70,23 +70,19 @@ public class Issue3065MethodSpecRemapKeyTests
         var key = new MetadataTokenCache.MethodSpecSymbolKey(
             method,
             typeArguments,
-            classRemap,
-            methodRemap);
+            new RemapScope(classRemap, methodRemap));
         var sameScopes = new MetadataTokenCache.MethodSpecSymbolKey(
             method,
             typeArguments,
-            classRemap,
-            methodRemap);
+            new RemapScope(classRemap, methodRemap));
         var differentClassScope = new MetadataTokenCache.MethodSpecSymbolKey(
             method,
             typeArguments,
-            new Dictionary<TypeParameterSymbol, int>(),
-            methodRemap);
+            new RemapScope(new Dictionary<TypeParameterSymbol, int>(), methodRemap));
         var differentMethodScope = new MetadataTokenCache.MethodSpecSymbolKey(
             method,
             typeArguments,
-            classRemap,
-            new Dictionary<TypeParameterSymbol, int>());
+            new RemapScope(classRemap, new Dictionary<TypeParameterSymbol, int>()));
 
         Assert.Equal(key, sameScopes);
         Assert.NotEqual(key, differentClassScope);

--- a/test/Core.Tests/CodeAnalysis/Emit/MetadataTokenCacheTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/MetadataTokenCacheTests.cs
@@ -21,17 +21,29 @@ public class MetadataTokenCacheTests
         var typeArgs = ImmutableArray<TypeSymbol>.Empty;
         var classRemap = new Dictionary<TypeParameterSymbol, int>();
         var methodRemap = new Dictionary<TypeParameterSymbol, int>();
-        var key = new MetadataTokenCache.CtorRefSymbolKey(ctor, typeArgs, classRemap, methodRemap);
+        var key = new MetadataTokenCache.CtorRefSymbolKey(ctor, typeArgs, new RemapScope(classRemap, methodRemap));
 
         Assert.False(key.Equals(new MetadataTokenCache.CtorRefSymbolKey(
             ctor,
             typeArgs,
-            new Dictionary<TypeParameterSymbol, int>(),
-            methodRemap)));
+            new RemapScope(new Dictionary<TypeParameterSymbol, int>(), methodRemap))));
         Assert.False(key.Equals(new MetadataTokenCache.CtorRefSymbolKey(
             ctor,
             typeArgs,
-            classRemap,
-            new Dictionary<TypeParameterSymbol, int>())));
+            new RemapScope(classRemap, new Dictionary<TypeParameterSymbol, int>()))));
+    }
+
+    [Fact]
+    public void RemapScope_EqualityIsReferenceIdentityPerChannel()
+    {
+        var classRemap = new Dictionary<TypeParameterSymbol, int>();
+        var methodRemap = new Dictionary<TypeParameterSymbol, int>();
+        var scope = new RemapScope(classRemap, methodRemap);
+
+        Assert.True(scope.Equals(new RemapScope(classRemap, methodRemap)));
+        Assert.Equal(scope.GetHashCode(), new RemapScope(classRemap, methodRemap).GetHashCode());
+        Assert.False(scope.Equals(new RemapScope(new Dictionary<TypeParameterSymbol, int>(), methodRemap)));
+        Assert.False(scope.Equals(new RemapScope(classRemap, new Dictionary<TypeParameterSymbol, int>())));
+        Assert.True(default(RemapScope).Equals(new RemapScope(null, null)));
     }
 }

--- a/test/InternalAnalyzers.Tests/EmitCacheKeyRemapScopeAnalyzerTests.cs
+++ b/test/InternalAnalyzers.Tests/EmitCacheKeyRemapScopeAnalyzerTests.cs
@@ -1,0 +1,132 @@
+// <copyright file="EmitCacheKeyRemapScopeAnalyzerTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace GSharp.InternalAnalyzers.Tests;
+
+public sealed class EmitCacheKeyRemapScopeAnalyzerTests
+{
+    private const string Prelude = """
+using System.Collections.Generic;
+
+namespace System.Reflection.Metadata
+{
+    public struct EntityHandle { }
+    public struct MemberReferenceHandle { }
+    public struct TypeSpecificationHandle { }
+    public struct MethodSpecificationHandle { }
+    public struct TypeDefinitionHandle { }
+    public struct MethodDefinitionHandle { }
+    public struct FieldDefinitionHandle { }
+}
+
+namespace GSharp.Core.CodeAnalysis.Symbols
+{
+    public class TypeSymbol { }
+    public class StructSymbol { }
+    public class TypeParameterSymbol { }
+    public class FunctionSymbol { }
+}
+
+""";
+
+    [Fact]
+    public Task ReportsSymbolKeyedReferenceCachesWithoutRemapScope()
+    {
+        const string Source = Prelude + """
+namespace GSharp.Core.CodeAnalysis.Emit
+{
+    using System.Reflection.Metadata;
+    using GSharp.Core.CodeAnalysis.Symbols;
+
+    internal readonly struct RemapScope { }
+
+    internal readonly struct BadCompositeKey
+    {
+        private readonly TypeSymbol[] typeArgs;
+
+        public BadCompositeKey(TypeSymbol[] typeArgs) => this.typeArgs = typeArgs;
+    }
+
+    internal sealed class Caches
+    {
+        private readonly Dictionary<StructSymbol, MemberReferenceHandle> [|plainSymbolCache|] = new();
+        private readonly Dictionary<(StructSymbol Sym, object ClassRemap, object MethodRemap), EntityHandle> [|objectTupleCache|] = new();
+        private readonly Dictionary<BadCompositeKey, MethodSpecificationHandle> [|compositeKeyCache|] = new();
+
+        public Dictionary<TypeParameterSymbol, MemberReferenceHandle> [|NullableCtorRefs|] { get; } = new();
+    }
+}
+""";
+
+        return AnalyzerTestHelper.AssertDiagnosticsAsync(
+            new EmitCacheKeyRemapScopeAnalyzer(),
+            Source,
+            "GSA0004",
+            "GSA0004",
+            "GSA0004",
+            "GSA0004");
+    }
+
+    [Fact]
+    public Task IgnoresScopedKeysDefinitionHandlesAndNonSymbolKeys()
+    {
+        const string Source = Prelude + """
+namespace GSharp.Core.CodeAnalysis.Emit
+{
+    using System.Reflection.Metadata;
+    using GSharp.Core.CodeAnalysis.Symbols;
+
+    internal readonly struct RemapScope { }
+
+    internal readonly struct ScopedCompositeKey
+    {
+        private readonly TypeSymbol[] typeArgs;
+        private readonly RemapScope scope;
+
+        public ScopedCompositeKey(TypeSymbol[] typeArgs, RemapScope scope)
+        {
+            this.typeArgs = typeArgs;
+            this.scope = scope;
+        }
+    }
+
+    internal sealed class Caches
+    {
+        // Key carries the remap scope: the invariant is satisfied.
+        private readonly Dictionary<(StructSymbol Sym, RemapScope Scope), EntityHandle> scopedTupleCache = new();
+        private readonly Dictionary<ScopedCompositeKey, MethodSpecificationHandle> scopedCompositeCache = new();
+
+        // Definition rows are scope-invariant: one row per symbol.
+        private readonly Dictionary<StructSymbol, TypeDefinitionHandle> typeDefCache = new();
+        private readonly Dictionary<FunctionSymbol, MethodDefinitionHandle> methodDefCache = new();
+
+        // Non-symbol keys carry no symbolic type parameters.
+        private readonly Dictionary<string, MemberReferenceHandle> stringKeyedCache = new();
+
+        // Non-handle values are not metadata rows.
+        private readonly Dictionary<FunctionSymbol, TypeParameterSymbol[]> symbolToSymbolsCache = new();
+
+        public Dictionary<(TypeParameterSymbol Tp, RemapScope Scope), MemberReferenceHandle> ScopedProperty { get; } = new();
+    }
+}
+
+namespace GSharp.Core.CodeAnalysis.Binding
+{
+    using System.Reflection.Metadata;
+    using GSharp.Core.CodeAnalysis.Symbols;
+
+    // Outside the Emit namespace: not this rule's concern.
+    internal sealed class OtherLayer
+    {
+        private readonly Dictionary<StructSymbol, MemberReferenceHandle> notEmit = new();
+    }
+}
+""";
+
+        return AnalyzerTestHelper.AssertDiagnosticsAsync(new EmitCacheKeyRemapScopeAnalyzer(), Source);
+    }
+}


### PR DESCRIPTION
## Summary

P1 item 5 of the code-health report (#3163): the same bug shipped twice — #2930/#3057 (`CtorRefSymbolKey`) and #3065 (`MethodSpecSymbolKey`) — a symbol-keyed Emit cache that omitted the active generic-remap scope, reusing a metadata row whose signature blob encodes another scope's VAR/MVAR ordinals (`BadImageFormatException` at runtime, compiler reports success). This PR makes the invariant *"every symbol-keyed cache producing scope-sensitive metadata rows must include the full remap scope"* structural rather than conventional.

## Enforcement mechanism

Two mutually reinforcing pieces, chosen over a big-bang rewrite:

1. **`RemapScope`** (new, `src/Core/CodeAnalysis/Emit/RemapScope.cs`): a single equatable value capturing both active remap channels (`ActiveIteratorStateMachineRemap` VAR + `ActiveLambdaMethodTypeParamRemap` MVAR) by object identity, obtained via `GenericRemapState.CurrentScope`. `MethodSpecSymbolKey`/`CtorRefSymbolKey` constructors now *require* it, and the 13 tuple-keyed caches replace their two loose `object` components with it. A caller can no longer supply one channel and forget the other.
2. **GSA0004** (`EmitCacheKeyRemapScopeAnalyzer`, ADR-0147 infrastructure): any `Dictionary`/`ConcurrentDictionary` field or property in `GSharp.Core.CodeAnalysis.Emit` whose key mentions a symbol type and whose value is a scope-sensitive handle (`EntityHandle`, `MemberReferenceHandle`, `TypeSpecificationHandle`, `MethodSpecificationHandle`) must carry `RemapScope` in its key (as tuple element or composite-key field, seen through recursively). Core builds with warnings-as-errors, so the third recurrence is now a **build break**. Verified by negative control: adding an unscoped `Dictionary<StructSymbol, MemberReferenceHandle>` to Emit fails the Core build with `error GSA0004`.

Definition-handle caches are exempt by construction (one def row per symbol, no VAR/MVAR in the key's encoding), as are caches keyed purely on CLR reflection objects.

## Audit

| Cache | Key shape (before) | Scope-dependent? | Action |
|---|---|---|---|
| `MetadataTokenCache.MethodSpecsWithSymbolArgs` | `MethodSpecSymbolKey` (had both remaps since #3068) | Yes | Key now requires `RemapScope` |
| `MetadataTokenCache.CtorRefsWithSymbolArgs` | `CtorRefSymbolKey` (had both remaps since #2912/#3057) | Yes | Key now requires `RemapScope` |
| `UserTokenResolver` ×10 (`userStructTypeSpecCache`, `userEnumTypeSpecCache`, `userStructFieldRefCache`, `userStructMethodRefCache`, `userInterfaceTypeSpecCache`, `userInterfaceMethodRefCache`, `userInterfaceFieldRefCache`, `userDelegateTypeSpecCache`, `userDelegateCtorRefCache`, `userDelegateInvokeRefCache`) | `(Sym…, object ClassRemap, object MethodRemap)` | Yes (since #2793) | Two loose `object`s → `RemapScope` |
| `ImportedMemberRefFactory` ×3 (`functionDelegateTypeSpecCache`, `functionDelegateCtorRefCache`, `functionDelegateInvokeRefCache`) | `(FunctionTypeSymbol, object, object)` | Yes (ADR-0087 §3 R6) | Two loose `object`s → `RemapScope` |
| `MetadataTokenCache.NullableOpenCtorMemberRefs` | `TypeParameterSymbol` only | **Yes — latent bug class**: parent TypeSpec encodes the TP via `EncodeTypeSymbol`, whose VAR/MVAR ordinal consults the active remaps | Key → `(Tp, RemapScope)` |
| `NullableUserEnumCtorMemberRefs`, `NullableUserStructCtorMemberRefs`, `NullableUserValueTypeGetValueMemberRefs`, `NullableUserValueTypeGetHasValueMemberRefs` | symbol only | Yes (same `EncodeTypeSymbol` path; nested enums / symbolic underlyings can encode enclosing TP ordinals) | Key → `(symbol, RemapScope)` |
| `TypeRefs`, `TypeSpecs`, `MethodRefs`, `MethodSpecs`, `CtorRefs`, `FieldRefs`, `AssemblyRefs`, `PInvokeModuleRefs` | CLR reflection object / string | No — fully CLR-closed shapes, no symbolic VAR/MVAR | None (exempt: non-symbol key) |
| All `*Defs`/`*Handles` definition caches (`StructTypeDefs`, `FunctionHandles`, `MethodHandles`, `EnumTypeDefs`, `DelegateTypeDefs`, `ExplicitCtorHandles`, `PropertyAccessorHandles`, `EventAccessorHandles`, `DataStructSynthesizer` ×2, `PortablePdbEmitter.documentsByTree`, …) | symbol → definition handle | No — one definition row per symbol by construction | None (exempt: definition handles) |

The GSA0004 build over all of `src/Core/CodeAnalysis/Emit/` (44 files) is the machine-checked version of this table: zero diagnostics after the changes above.

## Test evidence

- `dotnet build src/Core/Core.csproj` — clean, 0 warnings; with a deliberately unscoped cache injected: `error GSA0004` (negative control, removed).
- `dotnet test test/InternalAnalyzers.Tests` — 9/9 (2 new GSA0004 tests: flags plain/tuple/composite/property shapes; ignores scoped keys, def handles, non-symbol keys, non-Emit namespaces).
- `dotnet test test/Core.Tests --filter "Issue3065|MetadataTokenCacheTests|GenericRemapPrecedence|Issue2325ArrayPointerByRefRemap"` — 16/16 (includes the #3065 runnable-assembly and cached-row tests, new `RemapScope` equality test).
- `dotnet test test/Compiler.Tests --filter "Issue2930|Issue2898NestedEnum|Issue2793UserGenericLambdaCache|Issue671|Issue693Dictionary"` — 40/40 (both remap channels of the #2930 fix, closure-class VAR half included).
- `dotnet test test/Compiler.Tests --filter "Nullable"` — 569/569 (covers the five re-keyed Nullable caches end-to-end).

Part of #3163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)