### PR TITLE
Align interpreter deinit test names

### DIFF
--- a/test/Interpreter.Tests/Issue2988DeinitInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2988DeinitInterpreterTests.cs
@@ -139,7 +139,7 @@ public class Issue2988DeinitInterpreterTests
     }
 
     [Fact]
-    public void EscapingInstanceIsNotFinalizedAtScopeExitOrWhileReachable()
+    public void ForcedCollectionSkipsDeinitializerAndWarnsOnce()
     {
         var source = """
             import System
@@ -190,7 +190,7 @@ public class Issue2988DeinitInterpreterTests
     }
 
     [Fact]
-    public void ScriptRunnerUsesRichRendererForBoundaryWarning()
+    public void ScriptRunnerWritesBoundaryWarningToStandardError()
     {
         var sourcePath = Path.Combine(AppContext.BaseDirectory, "issue2988-deinit.gs");
         File.WriteAllText(


### PR DESCRIPTION
## Summary

- rename the forced-collection interpreter test to the behavior its assertions observe
- rename the script-runner sibling to avoid claiming an untested renderer implementation

ADR-0068 specifies that interpreted deinitializers are skipped, so this is a naming/coverage correction, not an interpreter behavior change. The original reachability test was partial rather than vacuous: it still rejected scope-exit deinitializer execution.

## Resolution

Rename: interpreter has no reachability contract; existing assertions pin deinitializer skipping, one `GS0510`, preserved output, and stderr routing.

Fixes #3161