### PR TITLE
Extract overload resolution into a dedicated sub-namespace

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -112,7 +112,7 @@ public sealed class Binder
     // supporting machinery (named-argument reordering, default-value
     // fill, params lowering, generic type-argument inference, candidate
     // selection, and diagnostic emission). Wraps the pure reflection-level
-    // resolver in OverloadResolution.cs (which is unchanged). Composed
+    // resolver in ClrOverloadResolution.cs (which is unchanged). Composed
     // via Func / custom-delegate callbacks; never back-references Binder.
     private readonly OverloadResolver overloads;
 
@@ -184,7 +184,7 @@ public sealed class Binder
         // Stream E: let overload-resolution see user-defined op_Implicit when
         // built-in conversions don't apply. Implicit-only here — explicit
         // conversions never participate in overload tie-breaking.
-        OverloadResolution.UserDefinedImplicitConversionLookup ??= (source, target) =>
+        ClrOverloadResolution.UserDefinedImplicitConversionLookup ??= (source, target) =>
             ClrOperatorResolution.TryResolveConversion(source, target, allowExplicit: false, out _, out _);
     }
 
@@ -4523,7 +4523,7 @@ public sealed class Binder
             // #611 intentional asymmetry: a fixed-array `[N]T` does NOT unify
             // against a slice parameter `[]T` (or vice versa). In Go, explicit
             // slicing is required to produce a slice from a fixed-length array.
-            // The CLR-level inference path (OverloadResolution.UnifyForInference)
+            // The CLR-level inference path (ClrOverloadResolution.UnifyForInference)
             // handles this differently because both map to CLR T[], but at the
             // GSharp semantic level they are distinct types.
         }

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -8,6 +8,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
 using GSharp.Core.CodeAnalysis.Documentation;
 using GSharp.Core.CodeAnalysis.Lowering;
 using GSharp.Core.CodeAnalysis.Lowering.Async;

--- a/src/Core/CodeAnalysis/Binding/ClrOperatorResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/ClrOperatorResolution.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Reflection;
+using GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 

--- a/src/Core/CodeAnalysis/Binding/ClrOperatorResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/ClrOperatorResolution.cs
@@ -16,7 +16,7 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// values to CLR operator method names (<c>op_Addition</c>, <c>op_Equality</c>,
 /// <c>op_UnaryNegation</c>, ...) and performs the actual public-static lookup
 /// across the two operand types. The "better function member" tie-break is
-/// delegated to <see cref="OverloadResolution.Resolve{T}"/> so user-defined
+/// delegated to <see cref="ClrOverloadResolution.Resolve{T}"/> so user-defined
 /// operators participate in the same conversion ranking as method calls and
 /// constructors (Stream A).
 /// </summary>
@@ -116,14 +116,14 @@ internal static class ClrOperatorResolution
         // only operand types, not the bound operand expressions needed to prove
         // an integer value is a compile-time constant and in range.
         var argTypes = new[] { leftType?.ClrType, rightType?.ClrType };
-        var outcome = OverloadResolution.Resolve(candidates, argTypes);
-        if (outcome.Outcome == OverloadResolution.ResolutionOutcome.Resolved)
+        var outcome = ClrOverloadResolution.Resolve(candidates, argTypes);
+        if (outcome.Outcome == ClrOverloadResolution.ResolutionOutcome.Resolved)
         {
             method = outcome.Best;
             return true;
         }
 
-        if (outcome.Outcome == OverloadResolution.ResolutionOutcome.Ambiguous)
+        if (outcome.Outcome == ClrOverloadResolution.ResolutionOutcome.Ambiguous)
         {
             isAmbiguous = true;
         }
@@ -160,14 +160,14 @@ internal static class ClrOperatorResolution
         // Constant-narrowing is also unavailable for the same reason: the
         // literal value is not present in this type-only helper.
         var argTypes = new[] { operandType.ClrType };
-        var outcome = OverloadResolution.Resolve(candidates, argTypes);
-        if (outcome.Outcome == OverloadResolution.ResolutionOutcome.Resolved)
+        var outcome = ClrOverloadResolution.Resolve(candidates, argTypes);
+        if (outcome.Outcome == ClrOverloadResolution.ResolutionOutcome.Resolved)
         {
             method = outcome.Best;
             return true;
         }
 
-        if (outcome.Outcome == OverloadResolution.ResolutionOutcome.Ambiguous)
+        if (outcome.Outcome == ClrOverloadResolution.ResolutionOutcome.Ambiguous)
         {
             isAmbiguous = true;
         }

--- a/src/Core/CodeAnalysis/Binding/ClrOverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/ClrOverloadResolution.cs
@@ -1,4 +1,4 @@
-// <copyright file="OverloadResolution.cs" company="GSharp">
+// <copyright file="ClrOverloadResolution.cs" company="GSharp">
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
@@ -26,7 +26,7 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// <see cref="UserDefinedImplicitConversionLookup"/> callback so this file can
 /// land before the conversion work.
 /// </remarks>
-internal static class OverloadResolution
+internal static class ClrOverloadResolution
 {
     // C# §7.5.3.4 "Better conversion target" — signed integral T1 beats unsigned
     // integral T2 in this map. Used only as a secondary signed/unsigned tie-break

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -795,7 +795,7 @@ internal sealed class ConversionClassifier
                     }
                 }
                 else if (!parameterType.IsByRef
-                    && (argument.Type != TypeSymbol.Error || OverloadResolution.IsUnresolvedMethodGroupArgument(argument)))
+                    && (argument.Type != TypeSymbol.Error || ClrOverloadResolution.IsUnresolvedMethodGroupArgument(argument)))
                 {
                     // ADR-0087 §3 R5 / issue #765: when the call dispatches
                     // through a constructed CLR generic whose type arguments
@@ -825,7 +825,7 @@ internal sealed class ConversionClassifier
                     // so non-lambda argument coercion is unaffected.
                     // Issue #2347: an unresolved method group (deferred through
                     // overload resolution the same way a lambda is deferred, see
-                    // OverloadResolution.IsUnresolvedMethodGroupArgument) needs
+                    // ClrOverloadResolution.IsUnresolvedMethodGroupArgument) needs
                     // the identical symbolic-target recovery — its resolved
                     // MethodInfo is picked below against whichever delegate
                     // target is recovered here, so a generic method whose
@@ -833,7 +833,7 @@ internal sealed class ConversionClassifier
                     // open) type argument must see the symbolic shape too.
                     if (substituted == null
                         && (argument.Type is FunctionTypeSymbol
-                            || OverloadResolution.IsUnresolvedMethodGroupArgument(argument)))
+                            || ClrOverloadResolution.IsUnresolvedMethodGroupArgument(argument)))
                     {
                         substituted = TrySubstituteParameterTypeFromMethodTypeArgs(method, paramIndex, symbolicMethodTypeArgs);
                     }
@@ -948,7 +948,7 @@ internal sealed class ConversionClassifier
 
                     // Issue #2347: an unresolved method group's natural type is
                     // the Error sentinel (see
-                    // OverloadResolution.IsUnresolvedMethodGroupArgument), so
+                    // ClrOverloadResolution.IsUnresolvedMethodGroupArgument), so
                     // Conversion.Classify below — which deliberately treats
                     // Error as convertible to nothing, to avoid cascading
                     // diagnostics — never reports it as convertible to the
@@ -959,7 +959,7 @@ internal sealed class ConversionClassifier
                     // MethodInfo/function overload matching targetType's
                     // Invoke signature, the same way it already does for a
                     // user-defined generic function's method-group argument.
-                    var isUnresolvedMethodGroupTarget = OverloadResolution.IsUnresolvedMethodGroupArgument(argument);
+                    var isUnresolvedMethodGroupTarget = ClrOverloadResolution.IsUnresolvedMethodGroupArgument(argument);
 
                     if (argument.Type != targetType
                         && (Conversion.Classify(argument.Type, targetType).Exists || isExpressionTreeLiteralTarget || isUnresolvedMethodGroupTarget)
@@ -1005,7 +1005,7 @@ internal sealed class ConversionClassifier
                         && argument.Type != targetType
                         && !IsNaturalStructuralDelegateTarget(argument.Type, targetType)
                         && (!(argument is BoundFunctionLiteralExpression
-                                || OverloadResolution.IsUnresolvedMethodGroupArgument(argument))
+                                || ClrOverloadResolution.IsUnresolvedMethodGroupArgument(argument))
                             || !MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(targetType, out _)))
                     {
                         // Issue #2391: overload resolution necessarily sees the
@@ -1458,8 +1458,8 @@ internal sealed class ConversionClassifier
             // interpolated-string literal in the first place.
             // The same applies to constant-narrowing: there are no bound call
             // arguments here, only the target delegate signature.
-            var resolution = OverloadResolution.Resolve(applicable, argTypes);
-            if (resolution.Outcome == OverloadResolution.ResolutionOutcome.Resolved)
+            var resolution = ClrOverloadResolution.Resolve(applicable, argTypes);
+            if (resolution.Outcome == ClrOverloadResolution.ResolutionOutcome.Resolved)
             {
                 var resolved = new BoundClrMethodGroupExpression(group.Syntax, group.Receiver, resolution.Best, targetType);
                 return targetType is FunctionTypeSymbol functionTarget
@@ -2361,7 +2361,7 @@ internal sealed class ConversionClassifier
         // narrowing for every imported-CLR-method guard compiled outside a
         // real-reflection host (i.e. every real `gsc` build). Use the
         // existing cross-ReferenceResolver identity helper (already relied
-        // on by `OverloadResolution.ClassifyImplicit`) instead of a raw
+        // on by `ClrOverloadResolution.ClassifyImplicit`) instead of a raw
         // reference comparison.
         return !ClrTypeUtilities.AreSame(from.ClrType, targetParameterType);
     }

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
+using GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
 using GSharp.Core.CodeAnalysis.Emit;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Constructors.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Constructors.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
+using GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Constructors.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Constructors.cs
@@ -192,7 +192,7 @@ internal sealed partial class DeclarationBinder
             // interpolated-string literals (base-ctor arguments are always
             // positional, never named).
             var interpolatedStringArgs = ComputeInterpolatedStringArgFlags(argSyntax, boundArguments.Count);
-            var resolution = OverloadResolution.Resolve(
+            var resolution = ClrOverloadResolution.Resolve(
                 ctors,
                 argTypes,
                 interpolatedStringArgs: interpolatedStringArgs,
@@ -201,12 +201,12 @@ internal sealed partial class DeclarationBinder
                 delegateRefKindArgumentCheck: ExpressionBinder.MakeDelegateRefKindArgumentCheck(boundArguments));
             switch (resolution.Outcome)
             {
-                case OverloadResolution.ResolutionOutcome.Resolved:
+                case ClrOverloadResolution.ResolutionOutcome.Resolved:
                     bestCtor = resolution.Best as ConstructorInfo;
                     isExpanded = resolution.IsExpanded;
                     break;
-                case OverloadResolution.ResolutionOutcome.Ambiguous:
-                    Diagnostics.ReportAmbiguousOverload(location, clrBase.Name, resolution.Ambiguous.Length, resolution.Ambiguous.Select(OverloadResolution.FormatMethodSignature));
+                case ClrOverloadResolution.ResolutionOutcome.Ambiguous:
+                    Diagnostics.ReportAmbiguousOverload(location, clrBase.Name, resolution.Ambiguous.Length, resolution.Ambiguous.Select(ClrOverloadResolution.FormatMethodSignature));
                     return null;
                 default:
                     break;
@@ -236,7 +236,7 @@ internal sealed partial class DeclarationBinder
             for (var i = 0; i < limit; i++)
             {
                 if (argSyntax(i) is InterpolatedStringExpressionSyntax interpolated
-                    && OverloadResolution.IsFormattableStringTarget(bestCtorParams[i].ParameterType))
+                    && ClrOverloadResolution.IsFormattableStringTarget(bestCtorParams[i].ParameterType))
                 {
                     boundArguments[i] = bindInterpolatedStringAsFormattable(interpolated, targetType: null);
                 }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
@@ -14,6 +14,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
 using GSharp.Core.CodeAnalysis.Lowering;
 using GSharp.Core.CodeAnalysis.Lowering.Async;
 using GSharp.Core.CodeAnalysis.Symbols;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -14,6 +14,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
 using GSharp.Core.CodeAnalysis.Lowering;
 using GSharp.Core.CodeAnalysis.Lowering.Async;
 using GSharp.Core.CodeAnalysis.Symbols;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
@@ -81,7 +81,7 @@ internal sealed partial class ExpressionBinder
     /// instance-method resolution: the extension is only preferred when (a) the
     /// resolved instance method's <em>worst</em> argument conversion is a
     /// delegate-reshaping conversion (rank ≥
-    /// <see cref="OverloadResolution.ImplicitConversionKind.LambdaToVoidDelegate"/>),
+    /// <see cref="ClrOverloadResolution.ImplicitConversionKind.LambdaToVoidDelegate"/>),
     /// and (b) some applicable user extension matches the same arguments with a
     /// strictly better worst-case conversion. An instance method that matches by
     /// identity / standard implicit conversion always wins, so a genuine member
@@ -121,7 +121,7 @@ internal sealed partial class ExpressionBinder
 
         // The extension must be a strictly better match than the instance method.
         var extWorst = ComputeBestApplicableExtensionWorstConversionRank(extCandidates, argTypes);
-        if (extWorst == OverloadResolution.ImplicitConversionKind.None
+        if (extWorst == ClrOverloadResolution.ImplicitConversionKind.None
             || (int)extWorst >= (int)clrWorst)
         {
             return false;
@@ -139,47 +139,47 @@ internal sealed partial class ExpressionBinder
 
     /// <summary>
     /// Issue #2193: a delegate-reshaping implicit conversion (rank ≥
-    /// <see cref="OverloadResolution.ImplicitConversionKind.LambdaToVoidDelegate"/>
+    /// <see cref="ClrOverloadResolution.ImplicitConversionKind.LambdaToVoidDelegate"/>
     /// and ≤
-    /// <see cref="OverloadResolution.ImplicitConversionKind.DelegateReturnNumericWidening"/>)
+    /// <see cref="ClrOverloadResolution.ImplicitConversionKind.DelegateReturnNumericWidening"/>)
     /// reshapes a G# function value to satisfy a differently-shaped or
     /// differently-named CLR delegate parameter (discarding a return value,
     /// widening/covarying a return type, or retargeting to a named delegate).
     /// These are the "worst"-ranked conversions and are the loose applicability
     /// that lets a same-named BCL instance method shadow an exact user extension.
     /// </summary>
-    private static bool IsDelegateReshapingConversion(OverloadResolution.ImplicitConversionKind kind)
+    private static bool IsDelegateReshapingConversion(ClrOverloadResolution.ImplicitConversionKind kind)
     {
-        return kind is OverloadResolution.ImplicitConversionKind.LambdaToVoidDelegate
-            or OverloadResolution.ImplicitConversionKind.DelegateReturnCovariance
-            or OverloadResolution.ImplicitConversionKind.DelegateStructuralMatch
-            or OverloadResolution.ImplicitConversionKind.DelegateReturnNumericWidening;
+        return kind is ClrOverloadResolution.ImplicitConversionKind.LambdaToVoidDelegate
+            or ClrOverloadResolution.ImplicitConversionKind.DelegateReturnCovariance
+            or ClrOverloadResolution.ImplicitConversionKind.DelegateStructuralMatch
+            or ClrOverloadResolution.ImplicitConversionKind.DelegateReturnNumericWidening;
     }
 
     /// <summary>
     /// Issue #2193: classifies each supplied argument against the corresponding
     /// parameter of a resolved CLR candidate and returns the <em>worst</em>
     /// (highest-ordinal) implicit-conversion rank across all arguments. Returns
-    /// <see cref="OverloadResolution.ImplicitConversionKind.None"/> when the
+    /// <see cref="ClrOverloadResolution.ImplicitConversionKind.None"/> when the
     /// arities do not line up positionally (the candidate matched in an expanded
     /// / named / defaulted form this cheap check cannot reason about, so the
     /// tie-break is skipped and the instance method keeps winning).
     /// </summary>
-    private static OverloadResolution.ImplicitConversionKind ComputeClrCandidateWorstConversionRank(MethodInfo candidate, Type[] argTypes)
+    private static ClrOverloadResolution.ImplicitConversionKind ComputeClrCandidateWorstConversionRank(MethodInfo candidate, Type[] argTypes)
     {
         var parameters = candidate.GetParameters();
         if (parameters.Length != argTypes.Length)
         {
-            return OverloadResolution.ImplicitConversionKind.None;
+            return ClrOverloadResolution.ImplicitConversionKind.None;
         }
 
-        var worst = OverloadResolution.ImplicitConversionKind.Identity;
+        var worst = ClrOverloadResolution.ImplicitConversionKind.Identity;
         for (var i = 0; i < argTypes.Length; i++)
         {
-            var kind = OverloadResolution.ClassifyImplicit(parameters[i].ParameterType, argTypes[i]);
-            if (kind == OverloadResolution.ImplicitConversionKind.None)
+            var kind = ClrOverloadResolution.ClassifyImplicit(parameters[i].ParameterType, argTypes[i]);
+            if (kind == ClrOverloadResolution.ImplicitConversionKind.None)
             {
-                return OverloadResolution.ImplicitConversionKind.None;
+                return ClrOverloadResolution.ImplicitConversionKind.None;
             }
 
             if ((int)kind > (int)worst)
@@ -198,14 +198,14 @@ internal sealed partial class ExpressionBinder
     /// <paramref name="argTypes"/>) and returns the <em>best</em> (lowest-ordinal)
     /// worst-rank. The extension's synthetic receiver slot lives in
     /// <c>Parameters[0]</c>, so user arguments align against <c>Parameters[1..]</c>.
-    /// Returns <see cref="OverloadResolution.ImplicitConversionKind.None"/> when
+    /// Returns <see cref="ClrOverloadResolution.ImplicitConversionKind.None"/> when
     /// no overload lines up positionally with the arguments.
     /// </summary>
-    private OverloadResolution.ImplicitConversionKind ComputeBestApplicableExtensionWorstConversionRank(
+    private ClrOverloadResolution.ImplicitConversionKind ComputeBestApplicableExtensionWorstConversionRank(
         ImmutableArray<FunctionSymbol> extCandidates,
         Type[] argTypes)
     {
-        var best = OverloadResolution.ImplicitConversionKind.None;
+        var best = ClrOverloadResolution.ImplicitConversionKind.None;
         foreach (var candidate in extCandidates)
         {
             if (candidate == null || candidate.Parameters.Length != argTypes.Length + 1)
@@ -213,13 +213,13 @@ internal sealed partial class ExpressionBinder
                 continue;
             }
 
-            var worst = OverloadResolution.ImplicitConversionKind.Identity;
+            var worst = ClrOverloadResolution.ImplicitConversionKind.Identity;
             var applicable = true;
             for (var i = 0; i < argTypes.Length; i++)
             {
                 var paramClr = GetEffectiveArgumentClrTypeForOverloadResolution(candidate.Parameters[i + 1].Type);
-                var kind = OverloadResolution.ClassifyImplicit(paramClr, argTypes[i]);
-                if (kind == OverloadResolution.ImplicitConversionKind.None)
+                var kind = ClrOverloadResolution.ClassifyImplicit(paramClr, argTypes[i]);
+                if (kind == ClrOverloadResolution.ImplicitConversionKind.None)
                 {
                     applicable = false;
                     break;
@@ -236,7 +236,7 @@ internal sealed partial class ExpressionBinder
                 continue;
             }
 
-            if (best == OverloadResolution.ImplicitConversionKind.None || (int)worst < (int)best)
+            if (best == ClrOverloadResolution.ImplicitConversionKind.None || (int)worst < (int)best)
             {
                 best = worst;
             }
@@ -997,7 +997,7 @@ internal sealed partial class ExpressionBinder
                 // TryBindImportedExtensionCall) instead of failing outright;
                 // BindClrParameterConversions resolves it once the candidate
                 // (and its parameter type) is known.
-                if (!OverloadResolution.IsUnresolvedMethodGroupArgument(arguments[i]))
+                if (!ClrOverloadResolution.IsUnresolvedMethodGroupArgument(arguments[i]))
                 {
                     return false;
                 }
@@ -1021,7 +1021,7 @@ internal sealed partial class ExpressionBinder
         var inheritedSymbolicArgs = MemberLookup.BuildSymbolicArgTypeVector(
             null,
             ImmutableArray.CreateRange(arguments.Select(a => a?.Type)));
-        var resolution = OverloadResolution.Resolve(
+        var resolution = ClrOverloadResolution.Resolve(
             candidates,
             argTypes,
             explicitTypeArgs,
@@ -1042,7 +1042,7 @@ internal sealed partial class ExpressionBinder
 
         switch (resolution.Outcome)
         {
-            case OverloadResolution.ResolutionOutcome.Resolved:
+            case ClrOverloadResolution.ResolutionOutcome.Resolved:
                 // Issue #1260: a `base.M(...)` into an abstract BCL member has no
                 // base implementation to delegate to (e.g. Stream.Read). Match C#
                 // (CS0205) with a clean diagnostic instead of emitting invalid IL.
@@ -1126,8 +1126,8 @@ internal sealed partial class ExpressionBinder
                 BoundExpression inheritedCall = new BoundImportedInstanceCallExpression(null, inheritedUpdatedReceiver ?? receiver, resolution.Best, returnType, inheritedArguments, refKinds, inheritedTypeArgSymbolsForCall, isNonVirtualBaseCall: nonVirtualBaseCall);
                 result = WrapWithHandlerPrelude(inheritedCall, inheritedHandlerPrelude, ce);
                 return true;
-            case OverloadResolution.ResolutionOutcome.Ambiguous:
-                Diagnostics.ReportAmbiguousOverload(ce.Location, methodName, resolution.Ambiguous.Length, resolution.Ambiguous.Select(OverloadResolution.FormatMethodSignature));
+            case ClrOverloadResolution.ResolutionOutcome.Ambiguous:
+                Diagnostics.ReportAmbiguousOverload(ce.Location, methodName, resolution.Ambiguous.Length, resolution.Ambiguous.Select(ClrOverloadResolution.FormatMethodSignature));
                 result = new BoundErrorExpression(null);
                 return true;
             default:
@@ -1273,7 +1273,7 @@ internal sealed partial class ExpressionBinder
                 // extension-call candidate. It is resolved against the
                 // winning candidate's (possibly generic-inferred) parameter
                 // type afterwards by BindClrParameterConversions.
-                if (!OverloadResolution.IsUnresolvedMethodGroupArgument(arguments[i]))
+                if (!ClrOverloadResolution.IsUnresolvedMethodGroupArgument(arguments[i]))
                 {
                     // Issue #833: argument may carry an open TP (e.g. `T`,
                     // `[]T`). Project to an erased shape so resolution can run.
@@ -1389,7 +1389,7 @@ internal sealed partial class ExpressionBinder
             }
         }
 
-        // OverloadResolution.Resolve infers type arguments for open generic
+        // ClrOverloadResolution.Resolve infers type arguments for open generic
         // method definitions (e.g. Where<TSource>(IEnumerable<TSource>,
         // Func<TSource,bool>)) from the receiver and argument types. Issue #311:
         // when the call site supplied explicit type arguments (e.g.
@@ -1417,7 +1417,7 @@ internal sealed partial class ExpressionBinder
         // consistently with the instance/inherited/static/ctor paths. Offset by
         // 1 (receiverArgCount) since slot 0 here is the receiver, not a
         // user-supplied argument.
-        var resolution = OverloadResolution.Resolve(
+        var resolution = ClrOverloadResolution.Resolve(
             candidates,
             argTypes,
             explicitTypeArgs,
@@ -1439,10 +1439,10 @@ internal sealed partial class ExpressionBinder
 
         switch (resolution.Outcome)
         {
-            case OverloadResolution.ResolutionOutcome.Resolved:
+            case ClrOverloadResolution.ResolutionOutcome.Resolved:
                 break;
-            case OverloadResolution.ResolutionOutcome.Ambiguous:
-                Diagnostics.ReportAmbiguousOverload(ce.Location, methodName, resolution.Ambiguous.Length, resolution.Ambiguous.Select(OverloadResolution.FormatMethodSignature));
+            case ClrOverloadResolution.ResolutionOutcome.Ambiguous:
+                Diagnostics.ReportAmbiguousOverload(ce.Location, methodName, resolution.Ambiguous.Length, resolution.Ambiguous.Select(ClrOverloadResolution.FormatMethodSignature));
                 result = new BoundErrorExpression(null);
                 return true;
             default:
@@ -1887,7 +1887,7 @@ internal sealed partial class ExpressionBinder
     /// by its surrogate CLR type in <paramref name="argTypes"/>) implements the
     /// specified CLR <paramref name="target"/> interface. Used as the
     /// <c>supplementaryInterfaceCheck</c> argument to
-    /// <see cref="OverloadResolution.Resolve{T}"/> during overload resolution for
+    /// <see cref="ClrOverloadResolution.Resolve{T}"/> during overload resolution for
     /// calls that include user-class arguments.
     /// </summary>
     private static bool IsUserClassAssignableToInterface(
@@ -2919,7 +2919,7 @@ internal sealed partial class ExpressionBinder
             {
                 // Issue #2347: defer an unresolved method-group argument (see
                 // TryBindImportedExtensionCall) instead of failing outright.
-                if (!OverloadResolution.IsUnresolvedMethodGroupArgument(arguments[i]))
+                if (!ClrOverloadResolution.IsUnresolvedMethodGroupArgument(arguments[i]))
                 {
                     return false;
                 }
@@ -2933,7 +2933,7 @@ internal sealed partial class ExpressionBinder
         // treats them as applicable to an IFormattable/FormattableString (or
         // handler) parameter, just like every other CLR-call Resolve site.
         var interpolatedStringArgs = ComputeInterpolatedStringArgFlags(ce.Arguments, arguments.Length);
-        var resolution = OverloadResolution.Resolve(
+        var resolution = ClrOverloadResolution.Resolve(
             candidates,
             argTypes,
             null,
@@ -2945,7 +2945,7 @@ internal sealed partial class ExpressionBinder
             delegateRefKindArgumentCheck: MakeDelegateRefKindArgumentCheck(arguments),
             methodGroupInference: MakeMethodGroupInference(arguments, GetEffectiveArgumentClrTypeForOverloadResolution),
             methodGroupArgumentCheck: MakeMethodGroupArgumentCheck(arguments));
-        if (resolution.Outcome != OverloadResolution.ResolutionOutcome.Resolved)
+        if (resolution.Outcome != ClrOverloadResolution.ResolutionOutcome.Resolved)
         {
             return false;
         }
@@ -3048,7 +3048,7 @@ internal sealed partial class ExpressionBinder
             {
                 // Issue #2347: defer an unresolved method-group argument (see
                 // TryBindImportedExtensionCall) instead of failing outright.
-                if (!OverloadResolution.IsUnresolvedMethodGroupArgument(arguments[i]))
+                if (!ClrOverloadResolution.IsUnresolvedMethodGroupArgument(arguments[i]))
                 {
                     return false;
                 }
@@ -3069,14 +3069,14 @@ internal sealed partial class ExpressionBinder
         // Constant-narrowing is intentionally omitted for the same reason:
         // object members expose only zero parameters or Equals(object), never a
         // narrower integer parameter.
-        var resolution = OverloadResolution.Resolve(
+        var resolution = ClrOverloadResolution.Resolve(
             candidates,
             argTypes,
             null,
             scope.References.MapClrTypeToReferences,
             null,
             argumentNames.IsDefault ? null : (IReadOnlyList<string>)argumentNames);
-        if (resolution.Outcome != OverloadResolution.ResolutionOutcome.Resolved)
+        if (resolution.Outcome != ClrOverloadResolution.ResolutionOutcome.Resolved)
         {
             return false;
         }
@@ -3167,7 +3167,7 @@ internal sealed partial class ExpressionBinder
             {
                 // Issue #2347: defer an unresolved method-group argument (see
                 // TryBindImportedExtensionCall) instead of failing outright.
-                if (!OverloadResolution.IsUnresolvedMethodGroupArgument(arguments[i]))
+                if (!ClrOverloadResolution.IsUnresolvedMethodGroupArgument(arguments[i]))
                 {
                     return false;
                 }
@@ -3179,14 +3179,14 @@ internal sealed partial class ExpressionBinder
         // Constant-narrowing is intentionally omitted: the only object member
         // with an argument is Equals(object), so there is no narrower integer
         // parameter for §10.2.11 to target.
-        var resolution = OverloadResolution.Resolve(
+        var resolution = ClrOverloadResolution.Resolve(
             candidates,
             argTypes,
             null,
             scope.References.MapClrTypeToReferences,
             null,
             argumentNames.IsDefault ? null : (IReadOnlyList<string>)argumentNames);
-        if (resolution.Outcome != OverloadResolution.ResolutionOutcome.Resolved)
+        if (resolution.Outcome != ClrOverloadResolution.ResolutionOutcome.Resolved)
         {
             return false;
         }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
@@ -14,6 +14,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
 using GSharp.Core.CodeAnalysis.Lowering;
 using GSharp.Core.CodeAnalysis.Lowering.Async;
 using GSharp.Core.CodeAnalysis.Symbols;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -139,7 +139,7 @@ internal sealed partial class ExpressionBinder
 
         foreach (var candidate in candidates)
         {
-            if (OverloadResolution.TryDescribeValueTypeBaseConstraintViolation(candidate, explicitTypeArgs, typeArgSymbols, out var typeParameterName, out var typeArgument, out var constraintDescription))
+            if (ClrOverloadResolution.TryDescribeValueTypeBaseConstraintViolation(candidate, explicitTypeArgs, typeArgSymbols, out var typeParameterName, out var typeArgument, out var constraintDescription))
             {
                 Diagnostics.ReportTypeArgumentDoesNotSatisfyConstraint(location, typeParameterName, typeArgument, constraintDescription);
                 return true;
@@ -164,7 +164,7 @@ internal sealed partial class ExpressionBinder
     private static TypeSymbol ResolveImportedGenericReturnType(System.Reflection.MethodInfo closed, ImmutableArray<TypeSymbol> typeArgSymbols)
     {
         if (!typeArgSymbols.IsDefaultOrEmpty
-            && OverloadResolution.TryGetGenericMethodParameterReturnPosition(closed, out var position)
+            && ClrOverloadResolution.TryGetGenericMethodParameterReturnPosition(closed, out var position)
             && position >= 0
             && position < typeArgSymbols.Length)
         {
@@ -1194,13 +1194,13 @@ internal sealed partial class ExpressionBinder
             // correctly overall.
             IReadOnlyList<string> deferredArgumentNames =
                 BuildDeferredArgumentNames(ce, offset);
-            var resolution = OverloadResolution.Resolve(
+            var resolution = ClrOverloadResolution.Resolve(
                 methods,
                 argTypes,
                 explicitTypeArgs,
                 scope.References.MapClrTypeToReferences,
                 argumentNames: deferredArgumentNames);
-            if (resolution.Outcome != OverloadResolution.ResolutionOutcome.Resolved)
+            if (resolution.Outcome != ClrOverloadResolution.ResolutionOutcome.Resolved)
             {
                 continue;
             }
@@ -1408,7 +1408,7 @@ internal sealed partial class ExpressionBinder
                 continue;
             }
 
-            if (!OverloadResolution.TryInferDeferredLambdaParameterTypes(method, argTypes, lambdaParamIndices, arities, out var closed))
+            if (!ClrOverloadResolution.TryInferDeferredLambdaParameterTypes(method, argTypes, lambdaParamIndices, arities, out var closed))
             {
                 continue;
             }
@@ -2106,7 +2106,7 @@ internal sealed partial class ExpressionBinder
         ImmutableArray<TypeSymbol> typeArgSymbols)
     {
         if (!typeArgSymbols.IsDefaultOrEmpty
-            && OverloadResolution.TryGetGenericMethodParameterPosition(resolvedMethod, parameterIndex, out var position)
+            && ClrOverloadResolution.TryGetGenericMethodParameterPosition(resolvedMethod, parameterIndex, out var position)
             && position >= 0
             && position < typeArgSymbols.Length)
         {
@@ -2431,7 +2431,7 @@ internal sealed partial class ExpressionBinder
                 // Issue #505: surface the competing candidate signatures so the
                 // caller can pick a disambiguation (typically an explicit
                 // type-argument list).
-                Diagnostics.ReportAmbiguousOverload(ce.Location, methodName, staticAmbiguousMethods.Length, staticAmbiguousMethods.Select(OverloadResolution.FormatMethodSignature));
+                Diagnostics.ReportAmbiguousOverload(ce.Location, methodName, staticAmbiguousMethods.Length, staticAmbiguousMethods.Select(ClrOverloadResolution.FormatMethodSignature));
                 return new BoundErrorExpression(null);
             }
 
@@ -2858,7 +2858,7 @@ internal sealed partial class ExpressionBinder
                 // the local's type is inferred from the chosen overload below.
                 if (TryGetInlineOutVarArgument(ce, i, out _))
                 {
-                    argTypes[i] = OverloadResolution.InlineOutVarArgumentType;
+                    argTypes[i] = ClrOverloadResolution.InlineOutVarArgumentType;
                     continue;
                 }
 
@@ -2880,7 +2880,7 @@ internal sealed partial class ExpressionBinder
                     // candidate set; it is resolved against the winning
                     // overload's parameter type afterwards by
                     // BindClrParameterConversions.
-                    if (!OverloadResolution.IsUnresolvedMethodGroupArgument(arguments[i]))
+                    if (!ClrOverloadResolution.IsUnresolvedMethodGroupArgument(arguments[i]))
                     {
                         argsAllTyped = false;
                         break;
@@ -2907,7 +2907,7 @@ internal sealed partial class ExpressionBinder
                 var preResolutionSymbolicArgs = MemberLookup.BuildSymbolicArgTypeVector(
                     null,
                     ImmutableArray.CreateRange(arguments.Select(a => a?.Type)));
-                var resolution = OverloadResolution.Resolve(
+                var resolution = ClrOverloadResolution.Resolve(
                     candidates,
                     argTypes,
                     explicitTypeArgs,
@@ -2927,7 +2927,7 @@ internal sealed partial class ExpressionBinder
                     methodGroupArgumentCheck: MakeMethodGroupArgumentCheck(arguments));
                 switch (resolution.Outcome)
                 {
-                    case OverloadResolution.ResolutionOutcome.Resolved:
+                    case ClrOverloadResolution.ResolutionOutcome.Resolved:
                         // Issue #2193: a CLR/imported instance method that shares a
                         // name with a user extension function must not automatically
                         // win overload resolution when it is only applicable through
@@ -3011,8 +3011,8 @@ internal sealed partial class ExpressionBinder
                         overloads.ValidateRefArguments(instArguments, instRefKinds, methodName, ce.Location);
                         BoundExpression instCall = ConversionClassifier.AutoDereferenceRefReturn(new BoundImportedInstanceCallExpression(null, instUpdatedReceiver ?? receiver, resolution.Best, returnType, instArguments, instRefKinds, instTypeArgSymbolsForCall));
                         return WrapWithHandlerPrelude(instCall, instHandlerPrelude, ce);
-                    case OverloadResolution.ResolutionOutcome.Ambiguous:
-                        Diagnostics.ReportAmbiguousOverload(ce.Location, methodName, resolution.Ambiguous.Length, resolution.Ambiguous.Select(OverloadResolution.FormatMethodSignature));
+                    case ClrOverloadResolution.ResolutionOutcome.Ambiguous:
+                        Diagnostics.ReportAmbiguousOverload(ce.Location, methodName, resolution.Ambiguous.Length, resolution.Ambiguous.Select(ClrOverloadResolution.FormatMethodSignature));
                         return new BoundErrorExpression(null);
                     default:
                         break;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -14,6 +14,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
 using GSharp.Core.CodeAnalysis.Emit;
 using GSharp.Core.CodeAnalysis.Lowering;
 using GSharp.Core.CodeAnalysis.Lowering.Async;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -14,6 +14,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
 using GSharp.Core.CodeAnalysis.Lowering;
 using GSharp.Core.CodeAnalysis.Lowering.Async;
 using GSharp.Core.CodeAnalysis.Symbols;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -1572,7 +1572,7 @@ internal sealed partial class ExpressionBinder
                 // the other arguments) instead of aborting resolution
                 // outright; it is resolved against the winning constructor's
                 // parameter type afterwards by BindClrParameterConversions.
-                if (!OverloadResolution.IsUnresolvedMethodGroupArgument(boundArguments[i]))
+                if (!ClrOverloadResolution.IsUnresolvedMethodGroupArgument(boundArguments[i]))
                 {
                     argsAllTyped = false;
                     break;
@@ -1602,7 +1602,7 @@ internal sealed partial class ExpressionBinder
                 ? (source, target) => IsUserClassAssignableToInterface(boundArguments, argTypes, source, target)
                 : null;
 
-            var resolution = OverloadResolution.Resolve(
+            var resolution = ClrOverloadResolution.Resolve(
                 ctors,
                 argTypes,
                 interpolatedStringArgs: ComputeInterpolatedStringArgFlags(syntax.Arguments, boundArguments.Count),
@@ -1613,13 +1613,13 @@ internal sealed partial class ExpressionBinder
                 delegateRefKindArgumentCheck: MakeDelegateRefKindArgumentCheck(boundArguments));
             switch (resolution.Outcome)
             {
-                case OverloadResolution.ResolutionOutcome.Resolved:
+                case ClrOverloadResolution.ResolutionOutcome.Resolved:
                     bestCtor = resolution.Best;
                     ctorMapping = resolution.ParameterMapping;
                     ctorIsExpanded = resolution.IsExpanded;
                     break;
-                case OverloadResolution.ResolutionOutcome.Ambiguous:
-                    Diagnostics.ReportAmbiguousOverload(syntax.Location, clrType.Name, resolution.Ambiguous.Length, resolution.Ambiguous.Select(OverloadResolution.FormatMethodSignature));
+                case ClrOverloadResolution.ResolutionOutcome.Ambiguous:
+                    Diagnostics.ReportAmbiguousOverload(syntax.Location, clrType.Name, resolution.Ambiguous.Length, resolution.Ambiguous.Select(ClrOverloadResolution.FormatMethodSignature));
                     return false;
                 default:
                     break;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -14,6 +14,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
 using GSharp.Core.CodeAnalysis.Lowering;
 using GSharp.Core.CodeAnalysis.Lowering.Async;
 using GSharp.Core.CodeAnalysis.Symbols;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -511,7 +511,7 @@ internal sealed partial class ExpressionBinder
         var receiverClr = closesReceiver
             ? NullableTypeSymbol.GetEffectiveClrType(group.Receiver.Type)
             : null;
-        var matches = new List<(MethodInfo Method, OverloadResolution.ImplicitConversionKind ReceiverConversion)>();
+        var matches = new List<(MethodInfo Method, ClrOverloadResolution.ImplicitConversionKind ReceiverConversion)>();
 
         foreach (var candidate in group.Candidates)
         {
@@ -528,9 +528,9 @@ internal sealed partial class ExpressionBinder
             }
 
             var receiverConversion = closesReceiver
-                ? OverloadResolution.ClassifyImplicit(parameters[0].ParameterType, receiverClr)
-                : OverloadResolution.ImplicitConversionKind.Identity;
-            if (receiverConversion != OverloadResolution.ImplicitConversionKind.None)
+                ? ClrOverloadResolution.ClassifyImplicit(parameters[0].ParameterType, receiverClr)
+                : ClrOverloadResolution.ImplicitConversionKind.Identity;
+            if (receiverConversion != ClrOverloadResolution.ImplicitConversionKind.None)
             {
                 matches.Add((candidate, receiverConversion));
             }
@@ -635,7 +635,7 @@ internal sealed partial class ExpressionBinder
 
     /// <summary>
     /// ADR-0055 Tier 4 (#369): builds the per-argument flags consumed by
-    /// <see cref="OverloadResolution.Resolve{T}"/>,
+    /// <see cref="ClrOverloadResolution.Resolve{T}"/>,
     /// marking each positional argument whose syntax is an interpolated-string
     /// literal. These arguments may convert to an
     /// <c>IFormattable</c>/<c>FormattableString</c> parameter in addition to
@@ -706,7 +706,7 @@ internal sealed partial class ExpressionBinder
 
             var argSyntax = OverloadResolver.UnwrapNamedArgumentValue(argumentSyntax[i - receiverArgCount]);
             if (argSyntax is InterpolatedStringExpressionSyntax interpolated
-                && OverloadResolution.IsFormattableStringTarget(parameters[paramIndex].ParameterType))
+                && ClrOverloadResolution.IsFormattableStringTarget(parameters[paramIndex].ParameterType))
             {
                 builder ??= arguments.ToBuilder();
                 builder[i] = BindInterpolatedStringAsFormattable(interpolated, targetType: null);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -2570,7 +2570,7 @@ internal sealed partial class ExpressionBinder
     }
 
     // Issue #1311: builds the per-call constant-narrowing applicability hook for
-    // imported/BCL overload resolution (OverloadResolution.Resolve). The hook
+    // imported/BCL overload resolution (ClrOverloadResolution.Resolve). The hook
     // receives the source-argument index (into argTypes) and the candidate's CLR
     // parameter type; it returns true when the corresponding bound argument is a
     // constant integer expression whose value fits that (possibly narrower /

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -14,6 +14,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
 using GSharp.Core.CodeAnalysis.Lowering;
 using GSharp.Core.CodeAnalysis.Lowering.Async;
 using GSharp.Core.CodeAnalysis.Symbols;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -1598,7 +1598,7 @@ internal sealed partial class ExpressionBinder
         Func<TypeSymbol, Type> projectType,
         int argumentOffset = 0)
     {
-        if (arguments == null || !arguments.Any(OverloadResolution.IsUnresolvedMethodGroupArgument))
+        if (arguments == null || !arguments.Any(ClrOverloadResolution.IsUnresolvedMethodGroupArgument))
         {
             return null;
         }
@@ -1619,7 +1619,7 @@ internal sealed partial class ExpressionBinder
         IReadOnlyList<BoundExpression> arguments,
         int argumentOffset = 0)
     {
-        if (arguments == null || !arguments.Any(OverloadResolution.IsUnresolvedMethodGroupArgument))
+        if (arguments == null || !arguments.Any(ClrOverloadResolution.IsUnresolvedMethodGroupArgument))
         {
             return null;
         }
@@ -1629,7 +1629,7 @@ internal sealed partial class ExpressionBinder
             var sourceIndex = argumentIndex - argumentOffset;
             return sourceIndex >= 0
                 && sourceIndex < arguments.Count
-                && OverloadResolution.IsUnresolvedMethodGroupArgument(arguments[sourceIndex]);
+                && ClrOverloadResolution.IsUnresolvedMethodGroupArgument(arguments[sourceIndex]);
         };
     }
 
@@ -1659,8 +1659,8 @@ internal sealed partial class ExpressionBinder
                 resolutionArguments[i + (closesExtensionReceiver ? 1 : 0)] = delegateParameterTypes[i];
             }
 
-            var resolution = OverloadResolution.Resolve(clrGroup.Candidates, resolutionArguments);
-            if (resolution.Outcome != OverloadResolution.ResolutionOutcome.Resolved)
+            var resolution = ClrOverloadResolution.Resolve(clrGroup.Candidates, resolutionArguments);
+            if (resolution.Outcome != ClrOverloadResolution.ResolutionOutcome.Resolved)
             {
                 return null;
             }
@@ -1682,7 +1682,7 @@ internal sealed partial class ExpressionBinder
             return null;
         }
 
-        var matches = new List<(Tuple<Type[], Type> Signature, OverloadResolution.ImplicitConversionKind[] Conversions)>();
+        var matches = new List<(Tuple<Type[], Type> Signature, ClrOverloadResolution.ImplicitConversionKind[] Conversions)>();
         foreach (var candidate in userGroup.Candidates)
         {
             var candidateOwner = userGroup.StaticOwnerType != null && candidate.StaticOwnerType is StructSymbol declaredOwner
@@ -1702,15 +1702,15 @@ internal sealed partial class ExpressionBinder
             }
 
             var parameterTypes = new Type[delegateParameterTypes.Count];
-            var conversions = new OverloadResolution.ImplicitConversionKind[delegateParameterTypes.Count];
+            var conversions = new ClrOverloadResolution.ImplicitConversionKind[delegateParameterTypes.Count];
             var compatible = true;
             for (var i = 0; i < parameterTypes.Length; i++)
             {
                 parameterTypes[i] = projectType(closedParameters[i]);
                 conversions[i] = parameterTypes[i] == null
-                    ? OverloadResolution.ImplicitConversionKind.None
-                    : OverloadResolution.ClassifyImplicit(parameterTypes[i], delegateParameterTypes[i]);
-                if (conversions[i] == OverloadResolution.ImplicitConversionKind.None)
+                    ? ClrOverloadResolution.ImplicitConversionKind.None
+                    : ClrOverloadResolution.ClassifyImplicit(parameterTypes[i], delegateParameterTypes[i]);
+                if (conversions[i] == ClrOverloadResolution.ImplicitConversionKind.None)
                 {
                     compatible = false;
                     break;
@@ -1804,8 +1804,8 @@ internal sealed partial class ExpressionBinder
     }
 
     private static bool IsBetterMethodGroupConversion(
-        IReadOnlyList<OverloadResolution.ImplicitConversionKind> candidate,
-        IReadOnlyList<OverloadResolution.ImplicitConversionKind> other)
+        IReadOnlyList<ClrOverloadResolution.ImplicitConversionKind> candidate,
+        IReadOnlyList<ClrOverloadResolution.ImplicitConversionKind> other)
     {
         var strictlyBetter = false;
         for (var i = 0; i < candidate.Count; i++)

--- a/src/Core/CodeAnalysis/Binding/InterpolatedStringHandlerInfo.cs
+++ b/src/Core/CodeAnalysis/Binding/InterpolatedStringHandlerInfo.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
+using GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
 using GSharp.Core.CodeAnalysis.Symbols;
 
 namespace GSharp.Core.CodeAnalysis.Binding;

--- a/src/Core/CodeAnalysis/Binding/InterpolatedStringHandlerInfo.cs
+++ b/src/Core/CodeAnalysis/Binding/InterpolatedStringHandlerInfo.cs
@@ -368,12 +368,12 @@ public sealed class InterpolatedStringHandlerInfo
                 argumentTypes[index] = stringType;
             }
 
-            var resolution = OverloadResolution.Resolve<MethodInfo>(candidates, argumentTypes);
-            if (resolution.Outcome == OverloadResolution.ResolutionOutcome.Resolved)
+            var resolution = ClrOverloadResolution.Resolve<MethodInfo>(candidates, argumentTypes);
+            if (resolution.Outcome == ClrOverloadResolution.ResolutionOutcome.Resolved)
             {
                 method = resolution.Best;
             }
-            else if (resolution.Outcome == OverloadResolution.ResolutionOutcome.Ambiguous)
+            else if (resolution.Outcome == ClrOverloadResolution.ResolutionOutcome.Ambiguous)
             {
                 foreach (var candidate in resolution.Ambiguous)
                 {
@@ -523,7 +523,7 @@ public sealed class InterpolatedStringHandlerInfo
 
                 var argType = forwardedArgs[i].Type?.ClrType;
                 if (argType != null
-                    && OverloadResolution.ClassifyImplicit(paramType, argType) == OverloadResolution.ImplicitConversionKind.None)
+                    && ClrOverloadResolution.ClassifyImplicit(paramType, argType) == ClrOverloadResolution.ImplicitConversionKind.None)
                 {
                     ok = false;
                     break;

--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
 using GSharp.Core.CodeAnalysis.Lowering;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -240,7 +240,7 @@ internal sealed class MemberLookup
     /// its base chain, and its transitive implemented interfaces with the given
     /// <paramref name="name"/>.
     /// The overload-resolution-facing variant, used by call sites that need to
-    /// pass a candidate set into <see cref="OverloadResolution.Resolve"/>.
+    /// pass a candidate set into <see cref="ClrOverloadResolution.Resolve"/>.
     /// Hides base-method-with-same-signature shadowing the same way C# does
     /// (via the existing <c>IsHiddenByExisting</c> helper in <see cref="ClrTypeUtilities"/>).
     /// </summary>
@@ -1254,7 +1254,7 @@ internal sealed class MemberLookup
         var argumentCount = symbolicArgTypes.IsDefault ? 0 : symbolicArgTypes.Length;
         if (isExpanded
             && openParams.Length > 0
-            && OverloadResolution.IsParamsArrayParameter(openParams[^1])
+            && ClrOverloadResolution.IsParamsArrayParameter(openParams[^1])
             && openParams[^1].ParameterType.GetElementType() is Type paramsElementType)
         {
             var paramsIndex = openParams.Length - 1;
@@ -1599,7 +1599,7 @@ internal sealed class MemberLookup
             }
 
             var hasParams = parameters.Length > 0
-                && OverloadResolution.IsParamsArrayParameter(parameters[parameters.Length - 1]);
+                && ClrOverloadResolution.IsParamsArrayParameter(parameters[parameters.Length - 1]);
             var nextPositionalParameter = 0;
             for (var i = 0; i < symbolicArgTypes.Length; i++)
             {
@@ -3189,8 +3189,8 @@ internal sealed class MemberLookup
             }
         }
 
-        var resolution = OverloadResolution.Resolve(properties.Select(static property => property.GetMethod).ToArray(), argTypes);
-        if (resolution.Outcome != OverloadResolution.ResolutionOutcome.Resolved)
+        var resolution = ClrOverloadResolution.Resolve(properties.Select(static property => property.GetMethod).ToArray(), argTypes);
+        if (resolution.Outcome != ClrOverloadResolution.ResolutionOutcome.Resolved)
         {
             return false;
         }

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
+using GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
 using GSharp.Core.CodeAnalysis.Symbols;
 
 namespace GSharp.Core.CodeAnalysis.Binding;

--- a/src/Core/CodeAnalysis/Binding/NumericWideningLattice.cs
+++ b/src/Core/CodeAnalysis/Binding/NumericWideningLattice.cs
@@ -17,7 +17,7 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// <para>
 /// Previously this lattice was hand-copied into three places — the conversion
 /// classifier (<see cref="Conversion"/>), the overload "better conversion"
-/// ranker (<see cref="OverloadResolution"/>), and the binary-operator binder.
+/// ranker (<see cref="ClrOverloadResolution"/>), and the binary-operator binder.
 /// The copies had already DIVERGED: the overload-resolution copy was missing
 /// every native-width integer (<c>nint</c>/<c>nuint</c> = <c>System.IntPtr</c>/
 /// <c>System.UIntPtr</c>) row, so <c>Conversion.Classify</c> and overload

--- a/src/Core/CodeAnalysis/Binding/NumericWideningLattice.cs
+++ b/src/Core/CodeAnalysis/Binding/NumericWideningLattice.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/ClrOverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/ClrOverloadResolution.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 
-namespace GSharp.Core.CodeAnalysis.Binding;
+namespace GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
 
 /// <summary>
 /// Shared C#-style "better function member" overload resolution used by the

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Arguments.cs
@@ -17,7 +17,7 @@ using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
 
-namespace GSharp.Core.CodeAnalysis.Binding;
+namespace GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
 
 internal sealed partial class OverloadResolver
 {

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
@@ -17,7 +17,7 @@ using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
 
-namespace GSharp.Core.CodeAnalysis.Binding;
+namespace GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
 
 internal sealed partial class OverloadResolver
 {

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Candidates.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Candidates.cs
@@ -17,7 +17,7 @@ using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
 
-namespace GSharp.Core.CodeAnalysis.Binding;
+namespace GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
 
 internal sealed partial class OverloadResolver
 {

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
@@ -17,7 +17,7 @@ using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
 
-namespace GSharp.Core.CodeAnalysis.Binding;
+namespace GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
 
 internal sealed partial class OverloadResolver
 {

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Invocations.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Invocations.cs
@@ -17,7 +17,7 @@ using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
 
-namespace GSharp.Core.CodeAnalysis.Binding;
+namespace GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
 
 internal sealed partial class OverloadResolver
 {

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.cs
@@ -17,7 +17,7 @@ using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
 
-namespace GSharp.Core.CodeAnalysis.Binding;
+namespace GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
 
 /// <summary>
 /// PR-B-4: the binder-side facade for call-site overload resolution. Owns

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.Candidates.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.Candidates.cs
@@ -385,9 +385,9 @@ internal sealed partial class OverloadResolver
 
         // Phase 2 (issue #1631): rank by C# §7.5.3.2 "better function member"
         // pairwise domination over per-argument conversion kind, reusing the
-        // SAME OverloadResolution.ImplicitConversionKind ranking (and numeric "better conversion
+        // SAME ClrOverloadResolution.ImplicitConversionKind ranking (and numeric "better conversion
         // target" tie-break) the CLR-reflection resolver
-        // (OverloadResolution.RankApplicable/CompareConversions) uses for
+        // (ClrOverloadResolution.RankApplicable/CompareConversions) uses for
         // imported-method overloads. This replaces the previous ad-hoc linear
         // score, under which any two candidates that both needed an implicit
         // conversion tied at score 0 (e.g. F(int64) / F(float64) called with an
@@ -426,7 +426,7 @@ internal sealed partial class OverloadResolver
             // parameters). Map each argument to its real slot before
             // classifying, so a named call still ranks against the correct
             // parameter type.
-            var kinds = new OverloadResolution.ImplicitConversionKind[boundArguments.Count];
+            var kinds = new ClrOverloadResolution.ImplicitConversionKind[boundArguments.Count];
             var paramTypes = new TypeSymbol[boundArguments.Count];
             var isTailSlot = new bool[boundArguments.Count];
             var elementType = isVariadic && cand.Parameters[cand.Parameters.Length - 1].Type is SliceTypeSymbol variadicSlice
@@ -439,7 +439,7 @@ internal sealed partial class OverloadResolver
                 {
                     // Unmapped (shouldn't happen for an applicable candidate) —
                     // neutral: contributes no per-argument preference.
-                    kinds[i] = OverloadResolution.ImplicitConversionKind.Identity;
+                    kinds[i] = ClrOverloadResolution.ImplicitConversionKind.Identity;
                     continue;
                 }
 
@@ -460,7 +460,7 @@ internal sealed partial class OverloadResolver
                     isTailSlot[i] = true;
                     var tailArgType = boundArguments[i]?.Type;
                     kinds[i] = elementType == null
-                        ? OverloadResolution.ImplicitConversionKind.Identity
+                        ? ClrOverloadResolution.ImplicitConversionKind.Identity
                         : ClassifyUserArgumentConversionKind(tailArgType, elementType);
                     continue;
                 }
@@ -483,7 +483,7 @@ internal sealed partial class OverloadResolver
                 // C#'s "better conversion from a method group" rule — instead
                 // of tying and reporting a spurious GS0266.
                 kinds[i] = IsValueReturnDiscardedToVoidDelegate(argType, paramType, candSubstitution)
-                    ? OverloadResolution.ImplicitConversionKind.LambdaToVoidDelegate
+                    ? ClrOverloadResolution.ImplicitConversionKind.LambdaToVoidDelegate
                     : ClassifyUserArgumentConversionKind(argType, paramType);
             }
 
@@ -576,7 +576,7 @@ internal sealed partial class OverloadResolver
         // so neither dominates on conversion kind and the earlier tie-breaks
         // cannot choose. Mirrors C#'s preference for the task-returning delegate
         // overload for an async/task-returning lambda argument, and the parallel
-        // rule in OverloadResolution.RankApplicable for imported (BCL) overloads.
+        // rule in ClrOverloadResolution.RankApplicable for imported (BCL) overloads.
         // Generalised: fires for ANY user overload set differing by `(...) -> X`
         // vs `(...) -> Task[X]` at a task-returning-lambda argument slot.
         if (pool.Count > 1)
@@ -698,7 +698,7 @@ internal sealed partial class OverloadResolver
     /// </summary>
     private readonly struct UserCandidateRankData
     {
-        public UserCandidateRankData(FunctionSymbol candidate, OverloadResolution.ImplicitConversionKind[] kinds, TypeSymbol[] paramTypes, bool[] isTailSlot, int defaultsUsed, bool isVariadic)
+        public UserCandidateRankData(FunctionSymbol candidate, ClrOverloadResolution.ImplicitConversionKind[] kinds, TypeSymbol[] paramTypes, bool[] isTailSlot, int defaultsUsed, bool isVariadic)
         {
             Candidate = candidate;
             Kinds = kinds;
@@ -710,7 +710,7 @@ internal sealed partial class OverloadResolver
 
         public FunctionSymbol Candidate { get; }
 
-        public OverloadResolution.ImplicitConversionKind[] Kinds { get; }
+        public ClrOverloadResolution.ImplicitConversionKind[] Kinds { get; }
 
         public TypeSymbol[] ParamTypes { get; }
 
@@ -728,7 +728,7 @@ internal sealed partial class OverloadResolver
 
     /// <summary>
     /// Issue #1631: C# §7.5.3.2 "better function member" pairwise comparison —
-    /// mirrors <c>OverloadResolution.IsAtLeastAsGoodAs</c> for user-symbolic
+    /// mirrors <c>ClrOverloadResolution.IsAtLeastAsGoodAs</c> for user-symbolic
     /// candidates. Returns <see langword="true"/> when <paramref name="a"/> is
     /// not worse than <paramref name="b"/> on any argument and strictly better
     /// on at least one.
@@ -755,15 +755,15 @@ internal sealed partial class OverloadResolver
 
     /// <summary>
     /// Issue #1631: compares two candidate conversions for the SAME argument,
-    /// mirroring <c>OverloadResolution.CompareConversions</c>. Different
-    /// <see cref="OverloadResolution.ImplicitConversionKind"/>s rank by their declared ordinal
+    /// mirroring <c>ClrOverloadResolution.CompareConversions</c>. Different
+    /// <see cref="ClrOverloadResolution.ImplicitConversionKind"/>s rank by their declared ordinal
     /// (lower is better); same-kind numeric widenings tie-break via the
-    /// shared <see cref="OverloadResolution.CompareNumericTargets"/> "better
+    /// shared <see cref="ClrOverloadResolution.CompareNumericTargets"/> "better
     /// conversion target" rule (C# §7.5.3.4), reusing the exact CLR-path
     /// helper rather than reimplementing the numeric/signed-vs-unsigned
     /// lattice a second time.
     /// </summary>
-    private static int CompareUserConversions(OverloadResolution.ImplicitConversionKind ka, TypeSymbol paramA, bool tailA, OverloadResolution.ImplicitConversionKind kb, TypeSymbol paramB, bool tailB, TypeSymbol source)
+    private static int CompareUserConversions(ClrOverloadResolution.ImplicitConversionKind ka, TypeSymbol paramA, bool tailA, ClrOverloadResolution.ImplicitConversionKind kb, TypeSymbol paramB, bool tailB, TypeSymbol source)
     {
         // Issue #1631 (B1'): per C# §7.5.3.2, "non-expanded form preferred
         // over expanded form" is a LATE tie-break applied only when per-arg
@@ -778,9 +778,9 @@ internal sealed partial class OverloadResolver
             return ((int)ka).CompareTo((int)kb);
         }
 
-        if (ka == OverloadResolution.ImplicitConversionKind.NumericWidening)
+        if (ka == ClrOverloadResolution.ImplicitConversionKind.NumericWidening)
         {
-            return OverloadResolution.CompareNumericTargets(paramA?.ClrType, paramB?.ClrType, source?.ClrType);
+            return ClrOverloadResolution.CompareNumericTargets(paramA?.ClrType, paramB?.ClrType, source?.ClrType);
         }
 
         // Issue #2146: reference "better conversion target" tie-break
@@ -795,7 +795,7 @@ internal sealed partial class OverloadResolver
         // more-derived reference parameter win (Animal over object; Type? over
         // object). If neither target converts to the other (genuinely unrelated
         // reference types), leave the tie (0) so real ambiguity is preserved.
-        if (ka == OverloadResolution.ImplicitConversionKind.Reference && paramA != null && paramB != null && !ReferenceEquals(paramA, paramB))
+        if (ka == ClrOverloadResolution.ImplicitConversionKind.Reference && paramA != null && paramB != null && !ReferenceEquals(paramA, paramB))
         {
             return CompareReferenceTargets(paramA, paramB);
         }
@@ -839,8 +839,8 @@ internal sealed partial class OverloadResolver
     /// <summary>
     /// Issue #1631: classifies the implicit conversion from a user-symbolic
     /// argument type to a user-symbolic parameter type using the SAME
-    /// <see cref="OverloadResolution.ImplicitConversionKind"/> ranking the CLR-reflection
-    /// resolver (<see cref="OverloadResolution.ClassifyImplicit"/>) uses for
+    /// <see cref="ClrOverloadResolution.ImplicitConversionKind"/> ranking the CLR-reflection
+    /// resolver (<see cref="ClrOverloadResolution.ClassifyImplicit"/>) uses for
     /// imported-method overloads, so both resolvers agree on which conversion
     /// is "better". Bounded to the conversion shapes the user-symbolic
     /// <see cref="Conversion"/> classifier actually distinguishes: identity,
@@ -848,28 +848,28 @@ internal sealed partial class OverloadResolver
     /// shared <see cref="NumericWideningLattice"/>). Every other implicit
     /// conversion (reference upcast, interface satisfaction, boxing,
     /// user-defined <c>op_Implicit</c>, …) folds into
-    /// <see cref="OverloadResolution.ImplicitConversionKind.Reference"/> — the user-symbolic type
+    /// <see cref="ClrOverloadResolution.ImplicitConversionKind.Reference"/> — the user-symbolic type
     /// model does not carry enough structure to rank those sub-kinds
     /// separately, but they still rank strictly better than the numeric/
     /// delegate special cases ranked worse below.
     /// </summary>
-    private OverloadResolution.ImplicitConversionKind ClassifyUserArgumentConversionKind(TypeSymbol argType, TypeSymbol paramType)
+    private ClrOverloadResolution.ImplicitConversionKind ClassifyUserArgumentConversionKind(TypeSymbol argType, TypeSymbol paramType)
     {
         if (argType == null || paramType == null)
         {
-            return OverloadResolution.ImplicitConversionKind.None;
+            return ClrOverloadResolution.ImplicitConversionKind.None;
         }
 
         if (argType == paramType)
         {
-            return OverloadResolution.ImplicitConversionKind.Identity;
+            return ClrOverloadResolution.ImplicitConversionKind.Identity;
         }
 
         if (Conversion.Classify(argType, paramType).IsStructuralProjection)
         {
             return conversions.HasUserDefinedImplicitConversion(argType, paramType)
-                ? OverloadResolution.ImplicitConversionKind.UserDefinedImplicit
-                : OverloadResolution.ImplicitConversionKind.StructuralProjection;
+                ? ClrOverloadResolution.ImplicitConversionKind.UserDefinedImplicit
+                : ClrOverloadResolution.ImplicitConversionKind.StructuralProjection;
         }
 
         if (paramType is NullableTypeSymbol nullableParam && argType == nullableParam.UnderlyingType)
@@ -885,10 +885,10 @@ internal sealed partial class OverloadResolver
             // target over `object`.
             if (NullableLifting.IsValueTypeNullable(nullableParam))
             {
-                return OverloadResolution.ImplicitConversionKind.NullableWrap;
+                return ClrOverloadResolution.ImplicitConversionKind.NullableWrap;
             }
 
-            return OverloadResolution.ImplicitConversionKind.Reference;
+            return ClrOverloadResolution.ImplicitConversionKind.Reference;
         }
 
         // ponytail: widening-then-wrap (e.g. int32 -> int64?) is not caught by
@@ -904,7 +904,7 @@ internal sealed partial class OverloadResolver
             && NumericWideningLattice.IsNumericPrimitive(paramClr.FullName)
             && NumericWideningLattice.IsWidening(argClr, paramClr))
         {
-            return OverloadResolution.ImplicitConversionKind.NumericWidening;
+            return ClrOverloadResolution.ImplicitConversionKind.NumericWidening;
         }
 
         // ponytail: object vs. an implemented interface (e.g. f(object) vs.
@@ -914,7 +914,7 @@ internal sealed partial class OverloadResolver
         // #1631 regression. Upgrade path: split Reference into sub-kinds
         // (exact-interface-satisfaction vs. base-class/object upcast) sharing
         // more of Conversion.Classify's structure, if this surfaces in practice.
-        return OverloadResolution.ImplicitConversionKind.Reference;
+        return ClrOverloadResolution.ImplicitConversionKind.Reference;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.Constructors.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.Constructors.cs
@@ -1569,7 +1569,7 @@ internal sealed partial class OverloadResolver
         TextLocation location,
         out BoundExpression converted)
     {
-        if (OverloadResolution.IsUnresolvedMethodGroupArgument(argument))
+        if (ClrOverloadResolution.IsUnresolvedMethodGroupArgument(argument))
         {
             converted = conversions.BindConversion(location, argument, targetType);
             return true;

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -26,7 +26,7 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// entry points, plus the supporting machinery — named-argument
 /// reordering, default-value fill, <c>params T[]</c> lowering, generic
 /// type-argument inference, candidate selection (delegating to the pure
-/// reflection-level resolver in <see cref="OverloadResolution"/>), and
+/// reflection-level resolver in <see cref="ClrOverloadResolution"/>), and
 /// the diagnostic emission used at all four call-site shapes.
 /// </summary>
 /// <remarks>
@@ -44,8 +44,8 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// established in PR-B-3.
 /// </para>
 /// <para>
-/// The pure value-shaped <see cref="OverloadResolution"/> static class
-/// in <c>OverloadResolution.cs</c> is unchanged and continues to expose
+/// The pure value-shaped <see cref="ClrOverloadResolution"/> static class
+/// in <c>ClrOverloadResolution.cs</c> is unchanged and continues to expose
 /// the reflection-level <c>Resolve&lt;T&gt;</c> /
 /// <c>TryInferTypeArguments</c> entry points. This class merely wraps
 /// that pure resolver with the diagnostic emission, syntax-aware

--- a/src/Core/CodeAnalysis/Binding/PatternBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/PatternBinder.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Immutable;
 using System.Numerics;
 using System.Reflection;
+using GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
@@ -1842,7 +1842,7 @@ internal sealed partial class StatementBinder
                         return method;
                     }
 
-                    if (!OverloadResolution.TryInferTypeArguments(method, inferenceTypes, out var typeArguments))
+                    if (!ClrOverloadResolution.TryInferTypeArguments(method, inferenceTypes, out var typeArguments))
                     {
                         return null;
                     }
@@ -1877,27 +1877,27 @@ internal sealed partial class StatementBinder
 
             Array.Fill(
                 argumentTypes,
-                OverloadResolution.InlineOutVarArgumentType,
+                ClrOverloadResolution.InlineOutVarArgumentType,
                 startIndex: receiverOffset,
                 count: identifiers.Count);
 
-            var resolution = OverloadResolution.Resolve(
+            var resolution = ClrOverloadResolution.Resolve(
                 candidates,
                 argumentTypes,
                 projectTypeArgument: scope.References.MapClrTypeToReferences);
-            if (resolution.Outcome == OverloadResolution.ResolutionOutcome.Ambiguous)
+            if (resolution.Outcome == ClrOverloadResolution.ResolutionOutcome.Ambiguous)
             {
                 Diagnostics.ReportAmbiguousOverload(
                     location,
                     "Deconstruct",
                     resolution.Ambiguous.Length,
-                    resolution.Ambiguous.Select(OverloadResolution.FormatMethodSignature));
+                    resolution.Ambiguous.Select(ClrOverloadResolution.FormatMethodSignature));
                 DeclareErrorTypedLocals(identifiers);
                 statements = ImmutableArray<BoundStatement>.Empty;
                 return true;
             }
 
-            if (resolution.Outcome != OverloadResolution.ResolutionOutcome.Resolved)
+            if (resolution.Outcome != ClrOverloadResolution.ResolutionOutcome.Resolved)
             {
                 continue;
             }

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
+using GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
 using GSharp.Core.CodeAnalysis.Lowering;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;

--- a/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
@@ -210,7 +210,7 @@ public sealed class ImportedClassSymbol : Symbol
             // BindClrParameterConversions against the resolved parameter type.
             if (arguments[i] is BoundDefaultExpression { Type: var defType } && defType == TypeSymbol.Error)
             {
-                argTypes[i] = OverloadResolution.DefaultLiteralArgumentType;
+                argTypes[i] = ClrOverloadResolution.DefaultLiteralArgumentType;
                 continue;
             }
 
@@ -226,7 +226,7 @@ public sealed class ImportedClassSymbol : Symbol
             // resolves instead of collapsing to GS0159 and poisoning the body.
             if (arguments[i] is BoundAddressOfExpression { Operand.Type: var outVarPointee } && outVarPointee == TypeSymbol.Error)
             {
-                argTypes[i] = OverloadResolution.InlineOutVarArgumentType;
+                argTypes[i] = ClrOverloadResolution.InlineOutVarArgumentType;
                 continue;
             }
 
@@ -249,7 +249,7 @@ public sealed class ImportedClassSymbol : Symbol
                     || byRefPointee is TypeParameterSymbol { HasValueTypeConstraint: true })
                 && byRefPointee.ClrType == null)
             {
-                argTypes[i] = OverloadResolution.InlineOutVarArgumentType;
+                argTypes[i] = ClrOverloadResolution.InlineOutVarArgumentType;
                 continue;
             }
 
@@ -262,7 +262,7 @@ public sealed class ImportedClassSymbol : Symbol
             var t = NullableTypeSymbol.GetEffectiveClrType(arguments[i].Type);
             if (t == null && arguments[i].Type != TypeSymbol.Null)
             {
-                if (OverloadResolution.IsUnresolvedMethodGroupArgument(arguments[i]))
+                if (ClrOverloadResolution.IsUnresolvedMethodGroupArgument(arguments[i]))
                 {
                     argTypes[i] = null;
                     continue;
@@ -337,7 +337,7 @@ public sealed class ImportedClassSymbol : Symbol
             symbolicArgVector,
             argumentNames,
             SymbolicReceiver).ToList();
-        var result = OverloadResolution.Resolve(
+        var result = ClrOverloadResolution.Resolve(
             nameMatches,
             argTypes,
             explicitTypeArgs,
@@ -356,14 +356,14 @@ public sealed class ImportedClassSymbol : Symbol
 
         switch (result.Outcome)
         {
-            case OverloadResolution.ResolutionOutcome.Resolved:
+            case ClrOverloadResolution.ResolutionOutcome.Resolved:
                 // Issue #320: when an imported generic method returns exactly one
                 // of its method type parameters and was closed over a user-defined
                 // type argument (placeholder CLR type), recover the real return
                 // type from the explicit type-argument symbol.
                 TypeSymbol returnOverride = null;
                 if (!typeArgSymbols.IsDefaultOrEmpty
-                    && OverloadResolution.TryGetGenericMethodParameterReturnPosition(result.Best, out var position)
+                    && ClrOverloadResolution.TryGetGenericMethodParameterReturnPosition(result.Best, out var position)
                     && position >= 0
                     && position < typeArgSymbols.Length)
                 {
@@ -389,7 +389,7 @@ public sealed class ImportedClassSymbol : Symbol
                 parameterMapping = result.ParameterMapping;
                 isExpanded = result.IsExpanded;
                 return true;
-            case OverloadResolution.ResolutionOutcome.Ambiguous:
+            case ClrOverloadResolution.ResolutionOutcome.Ambiguous:
                 isAmbiguous = true;
                 ambiguousMethods = result.Ambiguous;
                 return false;

--- a/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
@@ -8,6 +8,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
 using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
 using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Symbols;

--- a/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
+++ b/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
@@ -658,8 +658,8 @@ public sealed class ReferenceResolver : IDisposable
         // without being rebound. Fail with an actionable internal-compiler-error
         // that names the bug instead of the opaque MetadataLoadContext projection
         // failure it would otherwise cause.
-        if (ReferenceEquals(hostType, GSharp.Core.CodeAnalysis.Binding.OverloadResolution.InlineOutVarArgumentType)
-            || ReferenceEquals(hostType, GSharp.Core.CodeAnalysis.Binding.OverloadResolution.DefaultLiteralArgumentType))
+        if (ReferenceEquals(hostType, GSharp.Core.CodeAnalysis.Binding.ClrOverloadResolution.InlineOutVarArgumentType)
+            || ReferenceEquals(hostType, GSharp.Core.CodeAnalysis.Binding.ClrOverloadResolution.DefaultLiteralArgumentType))
         {
             throw new InvalidOperationException(
                 $"Internal compiler error: the overload-resolution sentinel '{hostType.FullName}' escaped the " +
@@ -1455,7 +1455,7 @@ public sealed class ReferenceResolver : IDisposable
 
             // Returning null lets MetadataLoadContext raise a load failure only
             // if a member actually depends on this assembly; the per-member
-            // tolerance in OverloadResolution then skips that member rather than
+            // tolerance in ClrOverloadResolution then skips that member rather than
             // aborting the whole lookup.
             return null;
         }

--- a/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
+++ b/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
@@ -15,6 +15,7 @@ using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Runtime.CompilerServices;
 using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
 
 namespace GSharp.Core.CodeAnalysis.Symbols;
 
@@ -658,8 +659,8 @@ public sealed class ReferenceResolver : IDisposable
         // without being rebound. Fail with an actionable internal-compiler-error
         // that names the bug instead of the opaque MetadataLoadContext projection
         // failure it would otherwise cause.
-        if (ReferenceEquals(hostType, GSharp.Core.CodeAnalysis.Binding.ClrOverloadResolution.InlineOutVarArgumentType)
-            || ReferenceEquals(hostType, GSharp.Core.CodeAnalysis.Binding.ClrOverloadResolution.DefaultLiteralArgumentType))
+        if (ReferenceEquals(hostType, ClrOverloadResolution.InlineOutVarArgumentType)
+            || ReferenceEquals(hostType, ClrOverloadResolution.DefaultLiteralArgumentType))
         {
             throw new InvalidOperationException(
                 $"Internal compiler error: the overload-resolution sentinel '{hostType.FullName}' escaped the " +

--- a/test/Compiler.Tests/Emit/Issue1833EnumConstraintViolationEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1833EnumConstraintViolationEmitTests.cs
@@ -16,7 +16,7 @@ namespace GSharp.Compiler.Tests.Emit;
 /// type parameter carries a real <c>System.Enum</c> base-class constraint
 /// (<c>Enum.IsDefined&lt;TEnum&gt;</c>) must be rejected by the compiler with a
 /// clear <c>GS0152</c> constraint-violation diagnostic at bind time. Before the
-/// fix, <c>OverloadResolution.SatisfiesGenericConstraints</c> unconditionally
+/// fix, <c>ClrOverloadResolution.SatisfiesGenericConstraints</c> unconditionally
 /// treated any <c>System.Enum</c>-named base constraint as satisfied once the
 /// argument was classified as a value-type-erased symbol, so the candidate
 /// bound through overload resolution and only failed later — at CLR

--- a/test/Compiler.Tests/Emit/Issue2338GenericNamedDelegateCallSiteEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2338GenericNamedDelegateCallSiteEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using GSharp.Compiler;
+using GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -19,7 +20,7 @@ namespace GSharp.Compiler.Tests.Emit;
 /// mismatch, independent of any closure/capture.
 /// <para>
 /// Root cause: <c>Binder.SubstituteType</c> — the substitution routine
-/// <see cref="GSharp.Core.CodeAnalysis.Binding.OverloadResolver"/> uses to
+/// <see cref="OverloadResolver"/> uses to
 /// compute a generic call's substituted parameter/return types (for source
 /// functions, methods, and extension methods alike, both instance and shared)
 /// — had no case for <c>DelegateTypeSymbol</c>, unlike its sibling

--- a/test/Compiler.Tests/Emit/Issue2403MethodCallVsImportedTypeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2403MethodCallVsImportedTypeEmitTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -12,7 +13,7 @@ namespace GSharp.Compiler.Tests.Emit;
 /// <summary>
 /// Issue #2403: compiled (gsc emit + IL verify + execute) coverage for the
 /// call-vs-imported-type precedence fix in
-/// <see cref="GSharp.Core.CodeAnalysis.Binding.OverloadResolver.BindCallExpression"/>.
+/// <see cref="OverloadResolver.BindCallExpression"/>.
 /// A user/same-compilation method (or implicit-<c>this</c> instance method)
 /// whose name collides with an imported CLR type (e.g.
 /// <c>System.Net.Http.HttpClient</c>) must be preferred over that type's

--- a/test/Compiler.Tests/Emit/Issue611SliceArrayParityTests.cs
+++ b/test/Compiler.Tests/Emit/Issue611SliceArrayParityTests.cs
@@ -27,7 +27,7 @@ public class Issue611SliceArrayParityTests
         // Validates that slice → CLR generic method inference works end-to-end.
         // System.Linq.Enumerable.Count<T>(IEnumerable<T>) must infer T from a
         // []string argument. This exercises the CLR-level inference path
-        // (OverloadResolution.UnifyForInference → FindClosedGeneric) which walks
+        // (ClrOverloadResolution.UnifyForInference → FindClosedGeneric) which walks
         // the array's interfaces to find IEnumerable<string>.
         var gsource = """
             package Probe.Tests

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1482NumericWideningLatticeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1482NumericWideningLatticeTests.cs
@@ -15,7 +15,7 @@ namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 /// <summary>
 /// Issue #1482: the implicit numeric-widening lattice (ADR-0044 / C# §6.1.2)
 /// used to be hand-copied into <see cref="Conversion"/> and
-/// <see cref="OverloadResolution"/>, and the two copies had DIVERGED — the
+/// <see cref="ClrOverloadResolution"/>, and the two copies had DIVERGED — the
 /// overload-resolution copy was missing every native-width integer
 /// (<c>nint</c>/<c>nuint</c> = <c>System.IntPtr</c>/<c>System.UIntPtr</c>) row.
 /// These tests pin the now-single source of truth
@@ -88,8 +88,8 @@ public class Issue1482NumericWideningLatticeTests
                 var latticeWidens = NumericWideningLattice.IsWidening(source.ClrName, target.ClrName);
                 var conversionImplicit = Conversion.Classify(source.Symbol, target.Symbol).IsImplicit;
                 var overloadWidens =
-                    OverloadResolution.ClassifyImplicit(target.ClrType, source.ClrType)
-                    == OverloadResolution.ImplicitConversionKind.NumericWidening;
+                    ClrOverloadResolution.ClassifyImplicit(target.ClrType, source.ClrType)
+                    == ClrOverloadResolution.ImplicitConversionKind.NumericWidening;
 
                 if (latticeWidens != conversionImplicit || latticeWidens != overloadWidens)
                 {
@@ -155,8 +155,8 @@ public class Issue1482NumericWideningLatticeTests
         Assert.Equal(expectedWidens, Conversion.Classify(source.Symbol, target.Symbol).IsImplicit);
 
         var overloadWidens =
-            OverloadResolution.ClassifyImplicit(target.ClrType, source.ClrType)
-            == OverloadResolution.ImplicitConversionKind.NumericWidening;
+            ClrOverloadResolution.ClassifyImplicit(target.ClrType, source.ClrType)
+            == ClrOverloadResolution.ImplicitConversionKind.NumericWidening;
         Assert.Equal(expectedWidens, overloadWidens);
     }
 
@@ -175,13 +175,13 @@ public class Issue1482NumericWideningLatticeTests
         Assert.False(Conversion.Classify(TypeSymbol.Float64, TypeSymbol.Int64).IsImplicit);
 
         // int64 is the better conversion target than double for a nint source.
-        Assert.True(OverloadResolution.CompareNumericTargets(typeof(long), typeof(double), typeof(nint)) < 0);
+        Assert.True(ClrOverloadResolution.CompareNumericTargets(typeof(long), typeof(double), typeof(nint)) < 0);
 
         var int64Overload = typeof(NIntFixture).GetMethod(nameof(NIntFixture.TakeInt64), BindingFlags.Public | BindingFlags.Static);
         var doubleOverload = typeof(NIntFixture).GetMethod(nameof(NIntFixture.TakeDouble), BindingFlags.Public | BindingFlags.Static);
-        var result = OverloadResolution.Resolve(new[] { int64Overload, doubleOverload }, new[] { typeof(nint) });
+        var result = ClrOverloadResolution.Resolve(new[] { int64Overload, doubleOverload }, new[] { typeof(nint) });
 
-        Assert.Equal(OverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
         Assert.Equal(nameof(NIntFixture.TakeInt64), result.Best.Name);
     }
 
@@ -191,13 +191,13 @@ public class Issue1482NumericWideningLatticeTests
         // Symmetric nuint case: nuint → uint64 → double, so uint64 wins.
         Assert.True(Conversion.Classify(TypeSymbol.NUInt, TypeSymbol.UInt64).IsImplicit);
         Assert.True(Conversion.Classify(TypeSymbol.NUInt, TypeSymbol.Float64).IsImplicit);
-        Assert.True(OverloadResolution.CompareNumericTargets(typeof(ulong), typeof(double), typeof(nuint)) < 0);
+        Assert.True(ClrOverloadResolution.CompareNumericTargets(typeof(ulong), typeof(double), typeof(nuint)) < 0);
 
         var uint64Overload = typeof(NIntFixture).GetMethod(nameof(NIntFixture.TakeUInt64), BindingFlags.Public | BindingFlags.Static);
         var doubleOverload = typeof(NIntFixture).GetMethod(nameof(NIntFixture.TakeDouble), BindingFlags.Public | BindingFlags.Static);
-        var result = OverloadResolution.Resolve(new[] { uint64Overload, doubleOverload }, new[] { typeof(nuint) });
+        var result = ClrOverloadResolution.Resolve(new[] { uint64Overload, doubleOverload }, new[] { typeof(nuint) });
 
-        Assert.Equal(OverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
         Assert.Equal(nameof(NIntFixture.TakeUInt64), result.Best.Name);
     }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1482NumericWideningLatticeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1482NumericWideningLatticeTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
 using GSharp.Core.CodeAnalysis.Symbols;
 using Xunit;
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1626InterfaceStaticSelfArityTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1626InterfaceStaticSelfArityTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1631UserOverloadBetterMemberTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1631UserOverloadBetterMemberTests.cs
@@ -18,7 +18,7 @@ namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 /// the C#-faithful "better function member" pairwise domination rules
 /// (§7.5.3.2), reusing the same <c>ImplicitConversionKind</c> ranking and
 /// numeric "better conversion target" tie-break the CLR-reflection resolver
-/// (<c>OverloadResolution</c>) applies to imported-method overloads — instead
+/// (<c>ClrOverloadResolution</c>) applies to imported-method overloads — instead
 /// of the previous ad-hoc linear score under which two candidates that both
 /// needed an implicit conversion tied at score 0 regardless of which
 /// conversion C# actually prefers.

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1812ClrCallResolveTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1812ClrCallResolveTests.cs
@@ -17,7 +17,7 @@ namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 /// <summary>
 /// Issue #1812 (follow-up to #1638 / PR #1811): the STATIC and EXTENSION
 /// CLR-call construction paths in <c>ExpressionBinder.Calls.cs</c> must pass
-/// <c>interpolatedStringArgs</c> to their <c>OverloadResolution.Resolve</c>
+/// <c>interpolatedStringArgs</c> to their <c>ClrOverloadResolution.Resolve</c>
 /// call — the same flag the ctor, instance, and inherited-instance paths
 /// already forward — so an interpolated-string argument bound to an
 /// <c>IFormattable</c>/<c>FormattableString</c> parameter resolves and

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1833EnumConstraintViolationTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1833EnumConstraintViolationTests.cs
@@ -23,7 +23,7 @@ namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 /// diagnostic instead of silently binding through overload resolution and
 /// only failing later at CLR verification.
 /// <para>
-/// Root cause: <c>OverloadResolution.SatisfiesGenericConstraints</c>'s
+/// Root cause: <c>ClrOverloadResolution.SatisfiesGenericConstraints</c>'s
 /// base-type-constraint loop treated <em>every</em> <c>System.ValueType</c>-
 /// or <c>System.Enum</c>-named constraint as satisfied once the argument was
 /// classified as a value-type-erased symbol (<c>IsValueTypeErasedSymbol</c>,

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1852ConstrainedInterfaceCallRebindTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1852ConstrainedInterfaceCallRebindTests.cs
@@ -26,7 +26,7 @@ namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 /// unset because the path skips the whole CLR parameter-conversion pipeline
 /// (the emitted MemberRef parameter is the interface type-variable
 /// <c>!0</c>, passed unconverted). This fix passes the flag to
-/// <c>OverloadResolution.Resolve</c> and, after the interface method is
+/// <c>ClrOverloadResolution.Resolve</c> and, after the interface method is
 /// selected, re-lowers any interpolated-string argument whose resolved
 /// parameter is IFormattable/FormattableString-shaped via
 /// <c>RebindFormattableInterpolationArguments</c> — mirroring the

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2058PrivateMethodCallAccessibilityTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2058PrivateMethodCallAccessibilityTests.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
@@ -13,7 +14,7 @@ using Xunit;
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 
 /// <summary>
-/// Issue #2058: <see cref="GSharp.Core.CodeAnalysis.Binding.OverloadResolver.BindUserInstanceCall"/>
+/// Issue #2058: <see cref="OverloadResolver.BindUserInstanceCall"/>
 /// previously only consulted <see cref="AccessibilityChecker.IsAccessible"/>
 /// when a called method's accessibility was exactly <c>protected</c>, so a
 /// <c>private</c> method called from outside its declaring type was never

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2126InlineOutVarMarkerLeakTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2126InlineOutVarMarkerLeakTests.cs
@@ -17,7 +17,7 @@ namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 
 /// <summary>
 /// Regression tests for issue #2126: the overload-resolution sentinel type
-/// <c>OverloadResolution+InlineOutVarArgumentMarker</c> must never escape the
+/// <c>ClrOverloadResolution+InlineOutVarArgumentMarker</c> must never escape the
 /// binder into type projection or emit.
 /// <para>
 /// When an inline <c>out var</c> (or a pre-declared <c>out</c> whose pointee is a

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2347MethodGroupExtensionInferenceTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2347MethodGroupExtensionInferenceTests.cs
@@ -24,12 +24,12 @@ namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 /// with no fixed <c>MethodInfo</c>/<c>FunctionType</c> yet) carries the
 /// <c>TypeSymbol.Error</c> sentinel as its natural type, and every CLR
 /// call-binding path that builds the argument-type vector for
-/// <c>OverloadResolution.Resolve</c>/<c>TryInferTypeArguments</c> (imported
+/// <c>ClrOverloadResolution.Resolve</c>/<c>TryInferTypeArguments</c> (imported
 /// extension calls, static/instance CLR calls, constructors, constrained
 /// interface/object-member calls) treated that as a hard "argument not typed"
 /// failure — aborting the whole candidate instead of deferring the method
 /// group the same way an untyped arrow lambda is deferred. The fix recognises
-/// this shape everywhere (<c>OverloadResolution.IsUnresolvedMethodGroupArgument</c>),
+/// this shape everywhere (<c>ClrOverloadResolution.IsUnresolvedMethodGroupArgument</c>),
 /// lets generic inference/applicability proceed using the other arguments (the
 /// receiver, in the LINQ case), and resolves the method group against the
 /// winning candidate's parameter type afterwards via the existing

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2348NotNullWhenMetadataLoadContextTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2348NotNullWhenMetadataLoadContextTests.cs
@@ -46,7 +46,7 @@ namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 /// <para>
 /// The fix reuses the codebase's existing cross-<see cref="ReferenceResolver"/>
 /// type-identity helper (<c>ClrTypeUtilities.AreSame</c>/<c>IsSameAs</c>, already
-/// relied on by <c>OverloadResolution.ClassifyImplicit</c> for issue #835) instead
+/// relied on by <c>ClrOverloadResolution.ClassifyImplicit</c> for issue #835) instead
 /// of the raw <see cref="System.Type"/> reference comparison.
 /// </para>
 /// </summary>

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2403MethodCallVsImportedTypeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2403MethodCallVsImportedTypeTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
 using Xunit;

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2516SliceCovarianceBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2516SliceCovarianceBindingTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
 using GSharp.Core.CodeAnalysis.Symbols;
 using Xunit;
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2516SliceCovarianceBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2516SliceCovarianceBindingTests.cs
@@ -63,20 +63,20 @@ public class Issue2516SliceCovarianceBindingTests
     public void ClrOverloadClassification_UsesDeclaredVarianceOnly()
     {
         Assert.Equal(
-            OverloadResolution.ImplicitConversionKind.Reference,
-            OverloadResolution.ClassifyImplicit(typeof(IEnumerable<object>), typeof(string[])));
+            ClrOverloadResolution.ImplicitConversionKind.Reference,
+            ClrOverloadResolution.ClassifyImplicit(typeof(IEnumerable<object>), typeof(string[])));
         Assert.Equal(
-            OverloadResolution.ImplicitConversionKind.None,
-            OverloadResolution.ClassifyImplicit(typeof(IList<object>), typeof(string[])));
+            ClrOverloadResolution.ImplicitConversionKind.None,
+            ClrOverloadResolution.ClassifyImplicit(typeof(IList<object>), typeof(string[])));
         Assert.Equal(
-            OverloadResolution.ImplicitConversionKind.None,
-            OverloadResolution.ClassifyImplicit(typeof(object[]), typeof(string[])));
+            ClrOverloadResolution.ImplicitConversionKind.None,
+            ClrOverloadResolution.ClassifyImplicit(typeof(object[]), typeof(string[])));
         Assert.Equal(
-            OverloadResolution.ImplicitConversionKind.None,
-            OverloadResolution.ClassifyImplicit(typeof(IEnumerable<object>), typeof(int[])));
+            ClrOverloadResolution.ImplicitConversionKind.None,
+            ClrOverloadResolution.ClassifyImplicit(typeof(IEnumerable<object>), typeof(int[])));
         Assert.Equal(
-            OverloadResolution.ImplicitConversionKind.None,
-            OverloadResolution.ClassifyImplicit(typeof(ICovariant<object>), typeof(string[])));
+            ClrOverloadResolution.ImplicitConversionKind.None,
+            ClrOverloadResolution.ClassifyImplicit(typeof(ICovariant<object>), typeof(string[])));
     }
 
     private interface ICovariant<out T>

--- a/test/Core.Tests/CodeAnalysis/Binding/OverloadResolutionGenerators.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/OverloadResolutionGenerators.cs
@@ -89,9 +89,9 @@ public static class OverloadResolutionGenerators
             .ToImmutableArray();
 
     internal static int CompareExpected(
-        OverloadResolution.ImplicitConversionKind firstClassification,
+        ClrOverloadResolution.ImplicitConversionKind firstClassification,
         Type firstTarget,
-        OverloadResolution.ImplicitConversionKind secondClassification,
+        ClrOverloadResolution.ImplicitConversionKind secondClassification,
         Type secondTarget,
         Type source)
     {
@@ -100,9 +100,9 @@ public static class OverloadResolutionGenerators
             return ((int)firstClassification).CompareTo((int)secondClassification);
         }
 
-        if (firstClassification == OverloadResolution.ImplicitConversionKind.NumericWidening)
+        if (firstClassification == ClrOverloadResolution.ImplicitConversionKind.NumericWidening)
         {
-            return OverloadResolution.CompareNumericTargets(firstTarget, secondTarget, source);
+            return ClrOverloadResolution.CompareNumericTargets(firstTarget, secondTarget, source);
         }
 
         return 0;

--- a/test/Core.Tests/CodeAnalysis/Binding/OverloadResolutionGenerators.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/OverloadResolutionGenerators.cs
@@ -10,6 +10,7 @@ using System.Reflection;
 using FsCheck;
 using FsCheck.Fluent;
 using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 

--- a/test/Core.Tests/CodeAnalysis/Binding/OverloadResolutionPropertyTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/OverloadResolutionPropertyTests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Reflection;
 using FsCheck.Xunit;
 using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 

--- a/test/Core.Tests/CodeAnalysis/Binding/OverloadResolutionPropertyTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/OverloadResolutionPropertyTests.cs
@@ -11,7 +11,7 @@ using GSharp.Core.CodeAnalysis.Binding;
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 
 /// <summary>
-/// Property-based tests for <see cref="OverloadResolution"/>.
+/// Property-based tests for <see cref="ClrOverloadResolution"/>.
 /// </summary>
 public class OverloadResolutionPropertyTests
 {
@@ -23,8 +23,8 @@ public class OverloadResolutionPropertyTests
     [Property(MaxTest = 300, Arbitrary = [typeof(OverloadResolutionGenerators)])]
     public bool Resolution_is_deterministic(MethodInfo[] candidates, Type[] argTypes)
     {
-        var first = OverloadResolution.Resolve(candidates, argTypes);
-        var second = OverloadResolution.Resolve(candidates, argTypes);
+        var first = ClrOverloadResolution.Resolve(candidates, argTypes);
+        var second = ClrOverloadResolution.Resolve(candidates, argTypes);
 
         return first.Outcome == second.Outcome
             && MethodIdentityComparer.Instance.Equals(first.Best, second.Best)
@@ -39,15 +39,15 @@ public class OverloadResolutionPropertyTests
     [Property(MaxTest = 300, Arbitrary = [typeof(OverloadResolutionGenerators)])]
     public bool Outcome_payloads_match_outcome(MethodInfo[] candidates, Type[] argTypes)
     {
-        var result = OverloadResolution.Resolve(candidates, argTypes);
+        var result = ClrOverloadResolution.Resolve(candidates, argTypes);
 
         return result.Outcome switch
         {
-            OverloadResolution.ResolutionOutcome.NoneApplicable =>
+            ClrOverloadResolution.ResolutionOutcome.NoneApplicable =>
                 result.Best is null && result.Ambiguous.IsEmpty,
-            OverloadResolution.ResolutionOutcome.Resolved =>
+            ClrOverloadResolution.ResolutionOutcome.Resolved =>
                 result.Best is not null && result.Ambiguous.IsEmpty,
-            OverloadResolution.ResolutionOutcome.Ambiguous =>
+            ClrOverloadResolution.ResolutionOutcome.Ambiguous =>
                 result.Best is null && result.Ambiguous.Length >= 2,
             _ => false,
         };
@@ -61,13 +61,13 @@ public class OverloadResolutionPropertyTests
     [Property(MaxTest = 300, Arbitrary = [typeof(OverloadResolutionGenerators)])]
     public bool Resolution_only_returns_input_candidates(MethodInfo[] candidates, Type[] argTypes)
     {
-        var result = OverloadResolution.Resolve(candidates, argTypes);
+        var result = ClrOverloadResolution.Resolve(candidates, argTypes);
 
         return result.Outcome switch
         {
-            OverloadResolution.ResolutionOutcome.Resolved =>
+            ClrOverloadResolution.ResolutionOutcome.Resolved =>
                 Contains(candidates, result.Best),
-            OverloadResolution.ResolutionOutcome.Ambiguous =>
+            ClrOverloadResolution.ResolutionOutcome.Ambiguous =>
                 result.Ambiguous.All(m => Contains(candidates, m)),
             _ => true,
         };
@@ -86,9 +86,9 @@ public class OverloadResolutionPropertyTests
             .Concat(distractors.Where(m => !MethodIdentityComparer.Instance.Equals(m, exact)))
             .Distinct(MethodIdentityComparer.Instance)
             .ToArray();
-        var result = OverloadResolution.Resolve(candidates, [argumentType]);
+        var result = ClrOverloadResolution.Resolve(candidates, [argumentType]);
 
-        return result.Outcome == OverloadResolution.ResolutionOutcome.Resolved
+        return result.Outcome == ClrOverloadResolution.ResolutionOutcome.Resolved
             && MethodIdentityComparer.Instance.Equals(exact, result.Best);
     }
 
@@ -118,10 +118,10 @@ public class OverloadResolutionPropertyTests
 
         var firstTarget = first.GetParameters()[0].ParameterType;
         var secondTarget = second.GetParameters()[0].ParameterType;
-        var firstClassification = OverloadResolution.ClassifyImplicit(firstTarget, source);
-        var secondClassification = OverloadResolution.ClassifyImplicit(secondTarget, source);
-        if (firstClassification == OverloadResolution.ImplicitConversionKind.None
-            || secondClassification == OverloadResolution.ImplicitConversionKind.None)
+        var firstClassification = ClrOverloadResolution.ClassifyImplicit(firstTarget, source);
+        var secondClassification = ClrOverloadResolution.ClassifyImplicit(secondTarget, source);
+        if (firstClassification == ClrOverloadResolution.ImplicitConversionKind.None
+            || secondClassification == ClrOverloadResolution.ImplicitConversionKind.None)
         {
             return true;
         }
@@ -138,15 +138,15 @@ public class OverloadResolutionPropertyTests
         }
 
         var expected = comparison < 0 ? first : second;
-        var forward = OverloadResolution.CompareNumericTargets(firstTarget, secondTarget, source);
-        var reverse = OverloadResolution.CompareNumericTargets(secondTarget, firstTarget, source);
+        var forward = ClrOverloadResolution.CompareNumericTargets(firstTarget, secondTarget, source);
+        var reverse = ClrOverloadResolution.CompareNumericTargets(secondTarget, firstTarget, source);
         if (forward != -reverse)
         {
             return false;
         }
 
-        var result = OverloadResolution.Resolve(new[] { first, second }, [source]);
-        return result.Outcome == OverloadResolution.ResolutionOutcome.Resolved
+        var result = ClrOverloadResolution.Resolve(new[] { first, second }, [source]);
+        return result.Outcome == ClrOverloadResolution.ResolutionOutcome.Resolved
             && MethodIdentityComparer.Instance.Equals(expected, result.Best);
     }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/OverloadResolutionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/OverloadResolutionTests.cs
@@ -12,7 +12,7 @@ using Xunit;
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 
 /// <summary>
-/// Stream F: pure unit tests for <see cref="OverloadResolution"/> focused on
+/// Stream F: pure unit tests for <see cref="ClrOverloadResolution"/> focused on
 /// numeric "better conversion target" tie-breaking (C# §7.5.3.4). Builds tiny
 /// fixture method sets via reflection so we can drive the resolver directly
 /// without going through the binder.
@@ -61,8 +61,8 @@ public class OverloadResolutionTests
         // so the two widenings tie and the resolver reports ambiguity.
         var first = typeof(Fixture).GetMethod(nameof(Fixture.F_Float), BindingFlags.Public | BindingFlags.Static);
         var second = typeof(Fixture).GetMethod(nameof(Fixture.F_Decimal), BindingFlags.Public | BindingFlags.Static);
-        var result = OverloadResolution.Resolve(new[] { first, second }, new[] { typeof(int) });
-        Assert.Equal(OverloadResolution.ResolutionOutcome.Ambiguous, result.Outcome);
+        var result = ClrOverloadResolution.Resolve(new[] { first, second }, new[] { typeof(int) });
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.Ambiguous, result.Outcome);
     }
 
     [Fact]
@@ -76,8 +76,8 @@ public class OverloadResolutionTests
         // as a spurious ambiguity.
         var method = typeof(Fixture).GetMethod(nameof(Fixture.F_Int), BindingFlags.Public | BindingFlags.Static);
         Assert.NotNull(method);
-        var result = OverloadResolution.Resolve(new[] { method, method }, new[] { typeof(int) });
-        Assert.Equal(OverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
+        var result = ClrOverloadResolution.Resolve(new[] { method, method }, new[] { typeof(int) });
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
         Assert.Equal(nameof(Fixture.F_Int), result.Best.Name);
     }
 
@@ -95,27 +95,27 @@ public class OverloadResolutionTests
     [Fact]
     public void CompareNumericTargets_LongBeatsFloatFromInt()
     {
-        Assert.True(OverloadResolution.CompareNumericTargets(typeof(long), typeof(float), typeof(int)) < 0);
-        Assert.True(OverloadResolution.CompareNumericTargets(typeof(float), typeof(long), typeof(int)) > 0);
+        Assert.True(ClrOverloadResolution.CompareNumericTargets(typeof(long), typeof(float), typeof(int)) < 0);
+        Assert.True(ClrOverloadResolution.CompareNumericTargets(typeof(float), typeof(long), typeof(int)) > 0);
     }
 
     [Fact]
     public void CompareNumericTargets_IntBeatsUIntFromShort()
     {
-        Assert.True(OverloadResolution.CompareNumericTargets(typeof(int), typeof(uint), typeof(short)) < 0);
+        Assert.True(ClrOverloadResolution.CompareNumericTargets(typeof(int), typeof(uint), typeof(short)) < 0);
     }
 
     [Fact]
     public void CompareNumericTargets_EqualTargetsCompareZero()
     {
-        Assert.Equal(0, OverloadResolution.CompareNumericTargets(typeof(int), typeof(int), typeof(short)));
+        Assert.Equal(0, ClrOverloadResolution.CompareNumericTargets(typeof(int), typeof(int), typeof(short)));
     }
 
     [Fact]
     public void InferTypeArguments_Identity_BindsTFromArgument()
     {
         var open = typeof(Fixture).GetMethod(nameof(Fixture.G_Identity), BindingFlags.Public | BindingFlags.Static);
-        var ok = OverloadResolution.TryInferTypeArguments(open, new[] { typeof(string) }, out var typeArgs);
+        var ok = ClrOverloadResolution.TryInferTypeArguments(open, new[] { typeof(string) }, out var typeArgs);
         Assert.True(ok);
         Assert.Equal(new[] { typeof(string) }, typeArgs);
     }
@@ -124,7 +124,7 @@ public class OverloadResolutionTests
     public void InferTypeArguments_PairWithConsistentBounds_Succeeds()
     {
         var open = typeof(Fixture).GetMethod(nameof(Fixture.G_Pair), BindingFlags.Public | BindingFlags.Static);
-        var ok = OverloadResolution.TryInferTypeArguments(open, new[] { typeof(int), typeof(int) }, out var typeArgs);
+        var ok = ClrOverloadResolution.TryInferTypeArguments(open, new[] { typeof(int), typeof(int) }, out var typeArgs);
         Assert.True(ok);
         Assert.Equal(new[] { typeof(int) }, typeArgs);
     }
@@ -133,7 +133,7 @@ public class OverloadResolutionTests
     public void InferTypeArguments_PairWithConflictingBounds_Fails()
     {
         var open = typeof(Fixture).GetMethod(nameof(Fixture.G_Pair), BindingFlags.Public | BindingFlags.Static);
-        var ok = OverloadResolution.TryInferTypeArguments(open, new[] { typeof(int), typeof(string) }, out var typeArgs);
+        var ok = ClrOverloadResolution.TryInferTypeArguments(open, new[] { typeof(int), typeof(string) }, out var typeArgs);
         Assert.False(ok);
         Assert.Null(typeArgs);
     }
@@ -142,7 +142,7 @@ public class OverloadResolutionTests
     public void InferTypeArguments_TwoParam_BindsBothIndependently()
     {
         var open = typeof(Fixture).GetMethod(nameof(Fixture.G_TwoParam), BindingFlags.Public | BindingFlags.Static);
-        var ok = OverloadResolution.TryInferTypeArguments(open, new[] { typeof(int), typeof(string) }, out var typeArgs);
+        var ok = ClrOverloadResolution.TryInferTypeArguments(open, new[] { typeof(int), typeof(string) }, out var typeArgs);
         Assert.True(ok);
         Assert.Equal(new[] { typeof(int), typeof(string) }, typeArgs);
     }
@@ -151,7 +151,7 @@ public class OverloadResolutionTests
     public void InferTypeArguments_Array_UnwrapsElementType()
     {
         var open = typeof(Fixture).GetMethod(nameof(Fixture.G_Array), BindingFlags.Public | BindingFlags.Static);
-        var ok = OverloadResolution.TryInferTypeArguments(open, new[] { typeof(int[]) }, out var typeArgs);
+        var ok = ClrOverloadResolution.TryInferTypeArguments(open, new[] { typeof(int[]) }, out var typeArgs);
         Assert.True(ok);
         Assert.Equal(new[] { typeof(int) }, typeArgs);
     }
@@ -160,7 +160,7 @@ public class OverloadResolutionTests
     public void InferTypeArguments_Enumerable_FromList_WalksInterface()
     {
         var open = typeof(Fixture).GetMethod(nameof(Fixture.G_Enumerable), BindingFlags.Public | BindingFlags.Static);
-        var ok = OverloadResolution.TryInferTypeArguments(open, new[] { typeof(System.Collections.Generic.List<int>) }, out var typeArgs);
+        var ok = ClrOverloadResolution.TryInferTypeArguments(open, new[] { typeof(System.Collections.Generic.List<int>) }, out var typeArgs);
         Assert.True(ok);
         Assert.Equal(new[] { typeof(int) }, typeArgs);
     }
@@ -171,7 +171,7 @@ public class OverloadResolutionTests
         // #611: an array `int[]` implements IEnumerable<int>; the inference
         // should walk interfaces and find T = int.
         var open = typeof(Fixture).GetMethod(nameof(Fixture.G_Enumerable), BindingFlags.Public | BindingFlags.Static);
-        var ok = OverloadResolution.TryInferTypeArguments(open, new[] { typeof(int[]) }, out var typeArgs);
+        var ok = ClrOverloadResolution.TryInferTypeArguments(open, new[] { typeof(int[]) }, out var typeArgs);
         Assert.True(ok);
         Assert.Equal(new[] { typeof(int) }, typeArgs);
     }
@@ -181,7 +181,7 @@ public class OverloadResolutionTests
     {
         // #611: string[] → IEnumerable<string> inference.
         var open = typeof(Fixture).GetMethod(nameof(Fixture.G_Enumerable), BindingFlags.Public | BindingFlags.Static);
-        var ok = OverloadResolution.TryInferTypeArguments(open, new[] { typeof(string[]) }, out var typeArgs);
+        var ok = ClrOverloadResolution.TryInferTypeArguments(open, new[] { typeof(string[]) }, out var typeArgs);
         Assert.True(ok);
         Assert.Equal(new[] { typeof(string) }, typeArgs);
     }
@@ -190,7 +190,7 @@ public class OverloadResolutionTests
     public void InferTypeArguments_Dictionary_BindsBothKeyAndValue()
     {
         var open = typeof(Fixture).GetMethod(nameof(Fixture.G_DictionaryFromValues), BindingFlags.Public | BindingFlags.Static);
-        var ok = OverloadResolution.TryInferTypeArguments(
+        var ok = ClrOverloadResolution.TryInferTypeArguments(
             open,
             new[] { typeof(System.Collections.Generic.Dictionary<string, int>) },
             out var typeArgs);
@@ -207,7 +207,7 @@ public class OverloadResolutionTests
     {
         // Issue #661: G_Pair<T>(T, T) with (Quality, Quality?) must infer T = Quality?
         var open = typeof(Fixture).GetMethod(nameof(Fixture.G_Pair), BindingFlags.Public | BindingFlags.Static);
-        var ok = OverloadResolution.TryInferTypeArguments(open, new[] { typeof(Quality), typeof(Quality?) }, out var typeArgs);
+        var ok = ClrOverloadResolution.TryInferTypeArguments(open, new[] { typeof(Quality), typeof(Quality?) }, out var typeArgs);
         Assert.True(ok);
         Assert.Equal(new[] { typeof(Quality?) }, typeArgs);
     }
@@ -217,7 +217,7 @@ public class OverloadResolutionTests
     {
         // Issue #661: symmetric — G_Pair<T>(T, T) with (Quality?, Quality) must infer T = Quality?
         var open = typeof(Fixture).GetMethod(nameof(Fixture.G_Pair), BindingFlags.Public | BindingFlags.Static);
-        var ok = OverloadResolution.TryInferTypeArguments(open, new[] { typeof(Quality?), typeof(Quality) }, out var typeArgs);
+        var ok = ClrOverloadResolution.TryInferTypeArguments(open, new[] { typeof(Quality?), typeof(Quality) }, out var typeArgs);
         Assert.True(ok);
         Assert.Equal(new[] { typeof(Quality?) }, typeArgs);
     }
@@ -227,7 +227,7 @@ public class OverloadResolutionTests
     {
         // Both operands nullable — should infer T = Quality? trivially.
         var open = typeof(Fixture).GetMethod(nameof(Fixture.G_Pair), BindingFlags.Public | BindingFlags.Static);
-        var ok = OverloadResolution.TryInferTypeArguments(open, new[] { typeof(Quality?), typeof(Quality?) }, out var typeArgs);
+        var ok = ClrOverloadResolution.TryInferTypeArguments(open, new[] { typeof(Quality?), typeof(Quality?) }, out var typeArgs);
         Assert.True(ok);
         Assert.Equal(new[] { typeof(Quality?) }, typeArgs);
     }
@@ -237,7 +237,7 @@ public class OverloadResolutionTests
     {
         // Both non-nullable — should infer T = Quality.
         var open = typeof(Fixture).GetMethod(nameof(Fixture.G_Pair), BindingFlags.Public | BindingFlags.Static);
-        var ok = OverloadResolution.TryInferTypeArguments(open, new[] { typeof(Quality), typeof(Quality) }, out var typeArgs);
+        var ok = ClrOverloadResolution.TryInferTypeArguments(open, new[] { typeof(Quality), typeof(Quality) }, out var typeArgs);
         Assert.True(ok);
         Assert.Equal(new[] { typeof(Quality) }, typeArgs);
     }
@@ -247,7 +247,7 @@ public class OverloadResolutionTests
     {
         // Regression guard: the int case must still work.
         var open = typeof(Fixture).GetMethod(nameof(Fixture.G_Pair), BindingFlags.Public | BindingFlags.Static);
-        var ok = OverloadResolution.TryInferTypeArguments(open, new[] { typeof(int), typeof(int?) }, out var typeArgs);
+        var ok = ClrOverloadResolution.TryInferTypeArguments(open, new[] { typeof(int), typeof(int?) }, out var typeArgs);
         Assert.True(ok);
         Assert.Equal(new[] { typeof(int?) }, typeArgs);
     }
@@ -259,8 +259,8 @@ public class OverloadResolutionTests
         var candidates = typeof(EqualLike)
             .GetMethods(BindingFlags.Public | BindingFlags.Static)
             .Where(m => m.Name == "Equal");
-        var result = OverloadResolution.Resolve(candidates, new[] { typeof(Quality), typeof(Quality?) });
-        Assert.Equal(OverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
+        var result = ClrOverloadResolution.Resolve(candidates, new[] { typeof(Quality), typeof(Quality?) });
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
         Assert.Equal(typeof(Quality?), result.Best.GetGenericArguments()[0]);
     }
 
@@ -271,8 +271,8 @@ public class OverloadResolutionTests
         var candidates = typeof(EqualLike)
             .GetMethods(BindingFlags.Public | BindingFlags.Static)
             .Where(m => m.Name == "Equal");
-        var result = OverloadResolution.Resolve(candidates, new[] { typeof(Quality?), typeof(Quality) });
-        Assert.Equal(OverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
+        var result = ClrOverloadResolution.Resolve(candidates, new[] { typeof(Quality?), typeof(Quality) });
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
         Assert.Equal(typeof(Quality?), result.Best.GetGenericArguments()[0]);
     }
 
@@ -285,8 +285,8 @@ public class OverloadResolutionTests
         var open = typeof(System.Linq.Enumerable)
             .GetMethods(BindingFlags.Public | BindingFlags.Static)
             .Single(m => m.Name == nameof(System.Linq.Enumerable.Repeat) && m.IsGenericMethodDefinition);
-        var result = OverloadResolution.Resolve(new[] { open }, new[] { typeof(int), typeof(int) });
-        Assert.Equal(OverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
+        var result = ClrOverloadResolution.Resolve(new[] { open }, new[] { typeof(int), typeof(int) });
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
         Assert.False(result.Best.IsGenericMethodDefinition);
         Assert.Equal(typeof(int), result.Best.GetGenericArguments()[0]);
         Assert.Equal(typeof(System.Collections.Generic.IEnumerable<int>), result.Best.ReturnType);
@@ -298,8 +298,8 @@ public class OverloadResolutionTests
         // G_Pair<T>(T, T) called with (int, string) cannot infer T — the
         // candidate must be dropped silently (NoneApplicable, not Ambiguous).
         var open = typeof(Fixture).GetMethod(nameof(Fixture.G_Pair), BindingFlags.Public | BindingFlags.Static);
-        var result = OverloadResolution.Resolve(new[] { open }, new[] { typeof(int), typeof(string) });
-        Assert.Equal(OverloadResolution.ResolutionOutcome.NoneApplicable, result.Outcome);
+        var result = ClrOverloadResolution.Resolve(new[] { open }, new[] { typeof(int), typeof(string) });
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.NoneApplicable, result.Outcome);
     }
 
     [Fact]
@@ -310,8 +310,8 @@ public class OverloadResolutionTests
         // argument must infer TValue = string and close the method even though
         // the declared arity is 2 with a trailing optional parameter.
         var open = typeof(Fixture).GetMethod(nameof(Fixture.G_SerializeLike), BindingFlags.Public | BindingFlags.Static);
-        var result = OverloadResolution.Resolve(new[] { open }, new[] { typeof(string) });
-        Assert.Equal(OverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
+        var result = ClrOverloadResolution.Resolve(new[] { open }, new[] { typeof(string) });
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
         Assert.False(result.Best.IsGenericMethodDefinition);
         Assert.Equal(typeof(string), result.Best.GetGenericArguments()[0]);
     }
@@ -331,8 +331,8 @@ public class OverloadResolutionTests
             return t;
         }
 
-        var result = OverloadResolution.Resolve(new[] { open }, new[] { typeof(string) }, explicitTypeArgs: null, projectTypeArgument: Project);
-        Assert.Equal(OverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
+        var result = ClrOverloadResolution.Resolve(new[] { open }, new[] { typeof(string) }, explicitTypeArgs: null, projectTypeArgument: Project);
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
         Assert.Equal(typeof(string), result.Best.GetGenericArguments()[0]);
         Assert.Contains(typeof(string), seen);
     }
@@ -344,8 +344,8 @@ public class OverloadResolutionTests
         // applicable when called with a single int argument; the optional
         // trailing parameter is omitted. Mirrors HttpResponse.WriteAsync(text).
         var method = typeof(Fixture).GetMethod(nameof(Fixture.O_OneOptional), BindingFlags.Public | BindingFlags.Static);
-        var result = OverloadResolution.Resolve(new[] { method }, new[] { typeof(int) });
-        Assert.Equal(OverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
+        var result = ClrOverloadResolution.Resolve(new[] { method }, new[] { typeof(int) });
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
         Assert.Equal(nameof(Fixture.O_OneOptional), result.Best.Name);
     }
 
@@ -355,8 +355,8 @@ public class OverloadResolutionTests
         // The same candidate is still applicable when the optional argument is
         // supplied explicitly.
         var method = typeof(Fixture).GetMethod(nameof(Fixture.O_OneOptional), BindingFlags.Public | BindingFlags.Static);
-        var result = OverloadResolution.Resolve(new[] { method }, new[] { typeof(int), typeof(System.Threading.CancellationToken) });
-        Assert.Equal(OverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
+        var result = ClrOverloadResolution.Resolve(new[] { method }, new[] { typeof(int), typeof(System.Threading.CancellationToken) });
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
     }
 
     [Fact]
@@ -365,8 +365,8 @@ public class OverloadResolutionTests
         // O_Required(int, int) has no optional parameters; calling with a single
         // argument leaves a non-optional parameter unfilled and is not applicable.
         var method = typeof(Fixture).GetMethod(nameof(Fixture.O_Required), BindingFlags.Public | BindingFlags.Static);
-        var result = OverloadResolution.Resolve(new[] { method }, new[] { typeof(int) });
-        Assert.Equal(OverloadResolution.ResolutionOutcome.NoneApplicable, result.Outcome);
+        var result = ClrOverloadResolution.Resolve(new[] { method }, new[] { typeof(int) });
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.NoneApplicable, result.Outcome);
     }
 
     [Fact]
@@ -378,8 +378,8 @@ public class OverloadResolutionTests
         // fewer omitted optionals wins (C# §7.5.3.2).
         var oneOpt = typeof(Fixture).GetMethod(nameof(Fixture.O_OneOptional), BindingFlags.Public | BindingFlags.Static);
         var twoOpt = typeof(Fixture).GetMethod(nameof(Fixture.O_TwoOptional), BindingFlags.Public | BindingFlags.Static);
-        var result = OverloadResolution.Resolve(new[] { oneOpt, twoOpt }, new[] { typeof(int) });
-        Assert.Equal(OverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
+        var result = ClrOverloadResolution.Resolve(new[] { oneOpt, twoOpt }, new[] { typeof(int) });
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
         Assert.Equal(nameof(Fixture.O_OneOptional), result.Best.Name);
     }
 
@@ -393,10 +393,10 @@ public class OverloadResolutionTests
         var open = typeof(System.Linq.Enumerable)
             .GetMethods(BindingFlags.Public | BindingFlags.Static)
             .Single(m => m.Name == nameof(System.Linq.Enumerable.CountBy) && m.IsGenericMethodDefinition);
-        var result = OverloadResolution.Resolve(
+        var result = ClrOverloadResolution.Resolve(
             new[] { open },
             new[] { typeof(System.Collections.Generic.IEnumerable<int>), typeof(Func<int, int>) });
-        Assert.Equal(OverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
         Assert.False(result.Best.IsGenericMethodDefinition);
     }
 
@@ -406,8 +406,8 @@ public class OverloadResolutionTests
         var second = typeof(Fixture).GetMethod(b, BindingFlags.Public | BindingFlags.Static);
         Assert.NotNull(first);
         Assert.NotNull(second);
-        var result = OverloadResolution.Resolve(new[] { first, second }, argTypes);
-        Assert.Equal(OverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
+        var result = ClrOverloadResolution.Resolve(new[] { first, second }, argTypes);
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
         return result.Best;
     }
 
@@ -427,12 +427,12 @@ public class OverloadResolutionTests
 
         // Candidate order must not matter — both orderings resolve to the
         // Func<Task<TResult>> overload without ambiguity.
-        var forward = OverloadResolution.Resolve(new[] { funcTResult, funcTaskTResult }, new[] { argType });
-        Assert.Equal(OverloadResolution.ResolutionOutcome.Resolved, forward.Outcome);
+        var forward = ClrOverloadResolution.Resolve(new[] { funcTResult, funcTaskTResult }, new[] { argType });
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.Resolved, forward.Outcome);
         Assert.Equal(nameof(Fixture.Run_FuncTaskTResult), forward.Best.Name);
 
-        var reverse = OverloadResolution.Resolve(new[] { funcTaskTResult, funcTResult }, new[] { argType });
-        Assert.Equal(OverloadResolution.ResolutionOutcome.Resolved, reverse.Outcome);
+        var reverse = ClrOverloadResolution.Resolve(new[] { funcTaskTResult, funcTResult }, new[] { argType });
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.Resolved, reverse.Outcome);
         Assert.Equal(nameof(Fixture.Run_FuncTaskTResult), reverse.Best.Name);
 
         // The winning overload closes over TResult = object, so its return type
@@ -454,8 +454,8 @@ public class OverloadResolutionTests
         var funcTaskTResult = typeof(Fixture).GetMethod(nameof(Fixture.Run_FuncTaskTResult), BindingFlags.Public | BindingFlags.Static);
         var argType = typeof(System.Func<object>);
 
-        var result = OverloadResolution.Resolve(new[] { funcTResult, funcTaskTResult }, new[] { argType });
-        Assert.Equal(OverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
+        var result = ClrOverloadResolution.Resolve(new[] { funcTResult, funcTaskTResult }, new[] { argType });
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
         Assert.Equal(nameof(Fixture.Run_FuncTResult), result.Best.Name);
     }
 
@@ -467,11 +467,11 @@ public class OverloadResolutionTests
         // identity conversion) beats the `FormattableString` overload.
         var stringOverload = typeof(Fixture).GetMethod(nameof(Fixture.F_String), BindingFlags.Public | BindingFlags.Static);
         var formattableOverload = typeof(Fixture).GetMethod(nameof(Fixture.F_FormattableString), BindingFlags.Public | BindingFlags.Static);
-        var result = OverloadResolution.Resolve(
+        var result = ClrOverloadResolution.Resolve(
             new[] { stringOverload, formattableOverload },
             new[] { typeof(string) },
             interpolatedStringArgs: new[] { true });
-        Assert.Equal(OverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
         Assert.Equal(nameof(Fixture.F_String), result.Best.Name);
     }
 
@@ -481,11 +481,11 @@ public class OverloadResolutionTests
         // With only a FormattableString overload, the flagged interpolated-string
         // argument is applicable thanks to the Tier 4 relaxation.
         var formattableOverload = typeof(Fixture).GetMethod(nameof(Fixture.F_FormattableString), BindingFlags.Public | BindingFlags.Static);
-        var result = OverloadResolution.Resolve(
+        var result = ClrOverloadResolution.Resolve(
             new[] { formattableOverload },
             new[] { typeof(string) },
             interpolatedStringArgs: new[] { true });
-        Assert.Equal(OverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
         Assert.Equal(nameof(Fixture.F_FormattableString), result.Best.Name);
     }
 
@@ -496,10 +496,10 @@ public class OverloadResolutionTests
         // argument must NOT convert to FormattableString, so the overload is not
         // applicable. This keeps ordinary string arguments unaffected.
         var formattableOverload = typeof(Fixture).GetMethod(nameof(Fixture.F_FormattableString), BindingFlags.Public | BindingFlags.Static);
-        var result = OverloadResolution.Resolve(
+        var result = ClrOverloadResolution.Resolve(
             new[] { formattableOverload },
             new[] { typeof(string) });
-        Assert.Equal(OverloadResolution.ResolutionOutcome.NoneApplicable, result.Outcome);
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.NoneApplicable, result.Outcome);
     }
 
     [Fact]
@@ -509,22 +509,22 @@ public class OverloadResolutionTests
         // (better) target when both overloads apply to an interpolated string.
         var formattableOverload = typeof(Fixture).GetMethod(nameof(Fixture.F_FormattableString), BindingFlags.Public | BindingFlags.Static);
         var iformattableOverload = typeof(Fixture).GetMethod(nameof(Fixture.F_IFormattable), BindingFlags.Public | BindingFlags.Static);
-        var result = OverloadResolution.Resolve(
+        var result = ClrOverloadResolution.Resolve(
             new[] { iformattableOverload, formattableOverload },
             new[] { typeof(string) },
             interpolatedStringArgs: new[] { true });
-        Assert.Equal(OverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
         Assert.Equal(nameof(Fixture.F_FormattableString), result.Best.Name);
     }
 
     [Fact]
     public void IsFormattableStringTarget_RecognizesFormattableTargets()
     {
-        Assert.True(OverloadResolution.IsFormattableStringTarget(typeof(System.FormattableString)));
-        Assert.True(OverloadResolution.IsFormattableStringTarget(typeof(System.IFormattable)));
-        Assert.False(OverloadResolution.IsFormattableStringTarget(typeof(string)));
-        Assert.False(OverloadResolution.IsFormattableStringTarget(typeof(object)));
-        Assert.False(OverloadResolution.IsFormattableStringTarget(null));
+        Assert.True(ClrOverloadResolution.IsFormattableStringTarget(typeof(System.FormattableString)));
+        Assert.True(ClrOverloadResolution.IsFormattableStringTarget(typeof(System.IFormattable)));
+        Assert.False(ClrOverloadResolution.IsFormattableStringTarget(typeof(string)));
+        Assert.False(ClrOverloadResolution.IsFormattableStringTarget(typeof(object)));
+        Assert.False(ClrOverloadResolution.IsFormattableStringTarget(null));
     }
 
     [Fact]
@@ -536,10 +536,10 @@ public class OverloadResolutionTests
         // preferred. Without this tie-break, users had to write `Equal[string]`.
         var nonGeneric = typeof(EqualLike).GetMethod(nameof(EqualLike.Equal_StringString), BindingFlags.Public | BindingFlags.Static);
         var generic = typeof(EqualLike).GetMethod(nameof(EqualLike.Equal_TT), BindingFlags.Public | BindingFlags.Static);
-        var result = OverloadResolution.Resolve(
+        var result = ClrOverloadResolution.Resolve(
             new[] { generic, nonGeneric },
             new[] { typeof(string), typeof(string) });
-        Assert.Equal(OverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
         Assert.Equal(nameof(EqualLike.Equal_StringString), result.Best.Name);
         Assert.False(result.Best.IsGenericMethod);
     }
@@ -564,8 +564,8 @@ public class OverloadResolutionTests
         // Pass them in via the synthesized `Equal` name on a real CLR Equal
         // probe class so this exercises the same EvaluateCandidate path.
         var nameMatches = candidates.Where(m => m.Name == "Equal").ToList();
-        var result = OverloadResolution.Resolve(nameMatches, new[] { typeof(string), typeof(string) });
-        Assert.Equal(OverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
+        var result = ClrOverloadResolution.Resolve(nameMatches, new[] { typeof(string), typeof(string) });
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
         Assert.False(result.Best.IsGenericMethod);
         var parameters = result.Best.GetParameters();
         Assert.Equal(2, parameters.Length);
@@ -582,11 +582,11 @@ public class OverloadResolutionTests
         // broken by the new non-generic-preference tie-breaker.
         var generic = typeof(EqualLike).GetMethod(nameof(EqualLike.Equal_TT), BindingFlags.Public | BindingFlags.Static);
         var nonGeneric = typeof(EqualLike).GetMethod(nameof(EqualLike.Equal_StringString), BindingFlags.Public | BindingFlags.Static);
-        var result = OverloadResolution.Resolve(
+        var result = ClrOverloadResolution.Resolve(
             new[] { generic, nonGeneric },
             new[] { typeof(string), typeof(string) },
             explicitTypeArgs: new[] { typeof(string) });
-        Assert.Equal(OverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
         Assert.True(result.Best.IsGenericMethod);
         Assert.Equal(typeof(string), result.Best.GetGenericArguments()[0]);
     }
@@ -603,8 +603,8 @@ public class OverloadResolutionTests
             .GetMethods(BindingFlags.Public | BindingFlags.Static)
             .Where(m => m.Name == "Equal")
             .ToList();
-        var result = OverloadResolution.Resolve(candidates, new[] { typeof(int), typeof(int) });
-        Assert.Equal(OverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
+        var result = ClrOverloadResolution.Resolve(candidates, new[] { typeof(int), typeof(int) });
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
         Assert.True(result.Best.IsGenericMethod);
         Assert.Equal(typeof(int), result.Best.GetGenericArguments()[0]);
     }
@@ -618,8 +618,8 @@ public class OverloadResolutionTests
             .GetMethods(BindingFlags.Public | BindingFlags.Static)
             .Where(m => m.Name == "NotEqual")
             .ToList();
-        var result = OverloadResolution.Resolve(candidates, new[] { typeof(string), typeof(string) });
-        Assert.Equal(OverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
+        var result = ClrOverloadResolution.Resolve(candidates, new[] { typeof(string), typeof(string) });
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
         Assert.False(result.Best.IsGenericMethod);
         var parameters = result.Best.GetParameters();
         Assert.Equal(typeof(string), parameters[0].ParameterType);
@@ -636,10 +636,10 @@ public class OverloadResolutionTests
         // caller can format them into the GS0160 diagnostic.
         var first = typeof(EqualLike).GetMethod(nameof(EqualLike.Take_IA), BindingFlags.Public | BindingFlags.Static);
         var second = typeof(EqualLike).GetMethod(nameof(EqualLike.Take_IB), BindingFlags.Public | BindingFlags.Static);
-        var result = OverloadResolution.Resolve(new[] { first, second }, new[] { typeof(EqualLike.BothAB) });
-        Assert.Equal(OverloadResolution.ResolutionOutcome.Ambiguous, result.Outcome);
+        var result = ClrOverloadResolution.Resolve(new[] { first, second }, new[] { typeof(EqualLike.BothAB) });
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.Ambiguous, result.Outcome);
         Assert.Equal(2, result.Ambiguous.Length);
-        var signatures = result.Ambiguous.Select(OverloadResolution.FormatMethodSignature).ToArray();
+        var signatures = result.Ambiguous.Select(ClrOverloadResolution.FormatMethodSignature).ToArray();
         Assert.Contains(signatures, s => s.Contains("IA"));
         Assert.Contains(signatures, s => s.Contains("IB"));
     }
@@ -651,7 +651,7 @@ public class OverloadResolutionTests
         // including the closed generic type arguments.
         var open = typeof(Fixture).GetMethod(nameof(Fixture.G_Identity), BindingFlags.Public | BindingFlags.Static);
         var closed = open.MakeGenericMethod(typeof(string));
-        var formatted = OverloadResolution.FormatMethodSignature(closed);
+        var formatted = ClrOverloadResolution.FormatMethodSignature(closed);
         Assert.Equal("G_Identity[String](String)", formatted);
     }
 
@@ -659,7 +659,7 @@ public class OverloadResolutionTests
     public void FormatMethodSignature_FormatsNonGenericMethod_PlainParens()
     {
         var method = typeof(Fixture).GetMethod(nameof(Fixture.F_Int), BindingFlags.Public | BindingFlags.Static);
-        var formatted = OverloadResolution.FormatMethodSignature(method);
+        var formatted = ClrOverloadResolution.FormatMethodSignature(method);
         Assert.Equal("F_Int(Int32)", formatted);
     }
 
@@ -670,7 +670,7 @@ public class OverloadResolutionTests
         // bracketed arguments rather than mangled (`IEnumerable`1`) names.
         var method = typeof(Fixture).GetMethod(nameof(Fixture.G_Enumerable), BindingFlags.Public | BindingFlags.Static);
         var closed = method.MakeGenericMethod(typeof(int));
-        var formatted = OverloadResolution.FormatMethodSignature(closed);
+        var formatted = ClrOverloadResolution.FormatMethodSignature(closed);
         Assert.Equal("G_Enumerable[Int32](IEnumerable[Int32])", formatted);
     }
 
@@ -684,16 +684,16 @@ public class OverloadResolutionTests
         // throw from MakeGenericMethod, so the explicit constraint check has
         // to drop the candidate.
         var open = typeof(ConstraintFixture).GetMethod(nameof(ConstraintFixture.OnlyClass), BindingFlags.Public | BindingFlags.Static);
-        var result = OverloadResolution.Resolve(new[] { open }, new[] { typeof(int) });
-        Assert.Equal(OverloadResolution.ResolutionOutcome.NoneApplicable, result.Outcome);
+        var result = ClrOverloadResolution.Resolve(new[] { open }, new[] { typeof(int) });
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.NoneApplicable, result.Outcome);
     }
 
     [Fact]
     public void Resolve_DropsCandidate_WhenStructConstraintViolatedByReferenceType()
     {
         var open = typeof(ConstraintFixture).GetMethod(nameof(ConstraintFixture.OnlyStruct), BindingFlags.Public | BindingFlags.Static);
-        var result = OverloadResolution.Resolve(new[] { open }, new[] { typeof(string) });
-        Assert.Equal(OverloadResolution.ResolutionOutcome.NoneApplicable, result.Outcome);
+        var result = ClrOverloadResolution.Resolve(new[] { open }, new[] { typeof(string) });
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.NoneApplicable, result.Outcome);
     }
 
     [Fact]
@@ -702,8 +702,8 @@ public class OverloadResolutionTests
         // `where T : struct` rejects Nullable<T> — int? is not a "non-nullable
         // value type" per ECMA-335.
         var open = typeof(ConstraintFixture).GetMethod(nameof(ConstraintFixture.OnlyStruct), BindingFlags.Public | BindingFlags.Static);
-        var result = OverloadResolution.Resolve(new[] { open }, new[] { typeof(int?) });
-        Assert.Equal(OverloadResolution.ResolutionOutcome.NoneApplicable, result.Outcome);
+        var result = ClrOverloadResolution.Resolve(new[] { open }, new[] { typeof(int?) });
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.NoneApplicable, result.Outcome);
     }
 
     [Fact]
@@ -712,8 +712,8 @@ public class OverloadResolutionTests
         // ConstraintFixture.OnlyNew<T>() where T : new() — string has no
         // public parameterless ctor.
         var open = typeof(ConstraintFixture).GetMethod(nameof(ConstraintFixture.OnlyNew), BindingFlags.Public | BindingFlags.Static);
-        var result = OverloadResolution.Resolve(new[] { open }, new[] { typeof(string) });
-        Assert.Equal(OverloadResolution.ResolutionOutcome.NoneApplicable, result.Outcome);
+        var result = ClrOverloadResolution.Resolve(new[] { open }, new[] { typeof(string) });
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.NoneApplicable, result.Outcome);
     }
 
     [Fact]
@@ -725,8 +725,8 @@ public class OverloadResolutionTests
         var both = typeof(MapLike)
             .GetMethods(BindingFlags.Public | BindingFlags.Static)
             .Where(m => m.Name == nameof(MapLike.Map));
-        var result = OverloadResolution.Resolve(both, new[] { typeof(string), typeof(Func<string, string>) });
-        Assert.Equal(OverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
+        var result = ClrOverloadResolution.Resolve(both, new[] { typeof(string), typeof(Func<string, string>) });
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
         // Class overload's T resolves to string; struct overload couldn't infer
         // T at all from a string receiver.
         Assert.Equal(typeof(string), result.Best.GetGenericArguments()[0]);
@@ -739,8 +739,8 @@ public class OverloadResolutionTests
         var both = typeof(MapLike)
             .GetMethods(BindingFlags.Public | BindingFlags.Static)
             .Where(m => m.Name == nameof(MapLike.Map));
-        var result = OverloadResolution.Resolve(both, new[] { typeof(int?), typeof(Func<int, int>) });
-        Assert.Equal(OverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
+        var result = ClrOverloadResolution.Resolve(both, new[] { typeof(int?), typeof(Func<int, int>) });
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
         // Struct overload binds T = int.
         Assert.Equal(typeof(int), result.Best.GetGenericArguments()[0]);
     }
@@ -752,8 +752,8 @@ public class OverloadResolutionTests
         // non-nullable value type the struct overload wins; the unconstrained
         // overload is dominated by constraint-specificity per ADR-0088.
         var all = ThreeWayCandidates();
-        var result = OverloadResolution.Resolve(all, new[] { typeof(int) });
-        Assert.Equal(OverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
+        var result = ClrOverloadResolution.Resolve(all, new[] { typeof(int) });
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
         Assert.Equal(typeof(ThreeWayStruct), result.Best.DeclaringType);
     }
 
@@ -761,8 +761,8 @@ public class OverloadResolutionTests
     public void Resolve_ThreeWayConstraints_PrefersClassOverNone_ForReferenceArgument()
     {
         var all = ThreeWayCandidates();
-        var result = OverloadResolution.Resolve(all, new[] { typeof(string) });
-        Assert.Equal(OverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
+        var result = ClrOverloadResolution.Resolve(all, new[] { typeof(string) });
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
         Assert.Equal(typeof(ThreeWayClass), result.Best.DeclaringType);
     }
 
@@ -773,8 +773,8 @@ public class OverloadResolutionTests
         // value type) nor struct (because the struct constraint excludes
         // Nullable<T>) applies. The unconstrained overload survives and wins.
         var all = ThreeWayCandidates();
-        var result = OverloadResolution.Resolve(all, new[] { typeof(int?) });
-        Assert.Equal(OverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
+        var result = ClrOverloadResolution.Resolve(all, new[] { typeof(int?) });
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
         Assert.Equal(typeof(ThreeWayNone), result.Best.DeclaringType);
     }
 
@@ -789,8 +789,8 @@ public class OverloadResolutionTests
             typeof(AmbiguousSameShapeA).GetMethod(nameof(AmbiguousSameShapeA.Take), BindingFlags.Public | BindingFlags.Static),
             typeof(AmbiguousSameShapeB).GetMethod(nameof(AmbiguousSameShapeB.Take), BindingFlags.Public | BindingFlags.Static),
         };
-        var result = OverloadResolution.Resolve(all, new[] { typeof(string) });
-        Assert.Equal(OverloadResolution.ResolutionOutcome.Ambiguous, result.Outcome);
+        var result = ClrOverloadResolution.Resolve(all, new[] { typeof(string) });
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.Ambiguous, result.Outcome);
     }
 
     // ----- Issue #1634: supplementaryInterfaceCheck / constantNarrowingArgumentCheck
@@ -818,11 +818,11 @@ public class OverloadResolutionTests
             {
                 try
                 {
-                    var result = OverloadResolution.Resolve(
+                    var result = ClrOverloadResolution.Resolve(
                         candidates,
                         new[] { typeof(object) },
                         supplementaryInterfaceCheck: (source, target) => target == wantInterface);
-                    if (result.Outcome != OverloadResolution.ResolutionOutcome.Resolved
+                    if (result.Outcome != ClrOverloadResolution.ResolutionOutcome.Resolved
                         || result.Best.Name != expectedName)
                     {
                         lock (errors)
@@ -864,7 +864,7 @@ public class OverloadResolutionTests
         var candidates = new[] { takeIA, takeIB };
 
         var nestedCallCount = 0;
-        var outerResult = OverloadResolution.Resolve(
+        var outerResult = ClrOverloadResolution.Resolve(
             candidates,
             new[] { typeof(object) },
             supplementaryInterfaceCheck: (source, target) =>
@@ -879,11 +879,11 @@ public class OverloadResolutionTests
                     // ClassifyImplicit probe of the outer call would silently
                     // stop recognising IA.
                     nestedCallCount++;
-                    var nested = OverloadResolution.Resolve(
+                    var nested = ClrOverloadResolution.Resolve(
                         candidates,
                         new[] { typeof(object) },
                         supplementaryInterfaceCheck: (nestedSource, nestedTarget) => nestedTarget == typeof(EqualLike.IB));
-                    Assert.Equal(OverloadResolution.ResolutionOutcome.Resolved, nested.Outcome);
+                    Assert.Equal(ClrOverloadResolution.ResolutionOutcome.Resolved, nested.Outcome);
                     Assert.Equal(nameof(EqualLike.Take_IB), nested.Best.Name);
                     return true;
                 }
@@ -892,7 +892,7 @@ public class OverloadResolutionTests
             });
 
         Assert.True(nestedCallCount > 0);
-        Assert.Equal(OverloadResolution.ResolutionOutcome.Resolved, outerResult.Outcome);
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.Resolved, outerResult.Outcome);
         Assert.Equal(nameof(EqualLike.Take_IA), outerResult.Best.Name);
     }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/OverloadResolutionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/OverloadResolutionTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Linq;
 using System.Reflection;
 using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
 using GSharp.Core.CodeAnalysis.Symbols;
 using Xunit;
 

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue1919AsyncLambdaMlcEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue1919AsyncLambdaMlcEmitTests.cs
@@ -37,7 +37,7 @@ namespace GSharp.Core.Tests.CodeAnalysis.Emit;
 /// <see cref="System.Reflection.Emit.TypeBuilderInstantiation"/> — an
 /// intentionally-tolerated, only-partially-real <see cref="Type"/> that this
 /// codebase already special-cases in several places (see
-/// <c>Binding/Conversion.cs</c>, <c>Binding/OverloadResolution.cs</c>).
+/// <c>Binding/Conversion.cs</c>, <c>Binding/ClrOverloadResolution.cs</c>).
 /// <see cref="Lowering.Async.AsyncCaptureWalker"/> (and the sibling
 /// <c>IteratorRewriter</c> / <c>AsyncIteratorRewriter</c> hoist walkers) read
 /// <c>local.Type.ClrType.IsByRefLike</c> directly to skip stack-only locals

--- a/test/Core.Tests/CodeAnalysis/Symbols/ReferenceResolverTransitiveClosureTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/ReferenceResolverTransitiveClosureTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
 using GSharp.Core.CodeAnalysis.Symbols;
 using Xunit;
 

--- a/test/Core.Tests/CodeAnalysis/Symbols/ReferenceResolverTransitiveClosureTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/ReferenceResolverTransitiveClosureTests.cs
@@ -89,8 +89,8 @@ public class ReferenceResolverTransitiveClosureTests : IDisposable
         var candidate = widget.GetMethod("M", BindingFlags.Public | BindingFlags.Static);
         Assert.NotNull(candidate);
 
-        var result = OverloadResolution.Resolve(new[] { candidate }, Array.Empty<Type>());
-        Assert.Equal(OverloadResolution.ResolutionOutcome.NoneApplicable, result.Outcome);
+        var result = ClrOverloadResolution.Resolve(new[] { candidate }, Array.Empty<Type>());
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.NoneApplicable, result.Outcome);
     }
 
     /// <summary>


### PR DESCRIPTION
Pilot extraction for real modularization of the Binding subsystem (P1 item 6 of the code-health report, #3163): overload resolution now lives in a dedicated sub-namespace, `GSharp.Core.CodeAnalysis.Binding.OverloadResolution`, following the existing `Lowering.Async` / `Lowering.Iterators` directory-per-namespace convention and the ADR-0150 decomposition rules.

## Cluster map

**Moved to `src/Core/CodeAnalysis/Binding/OverloadResolution/`** (each file changes only its `namespace` line):

| File | Lines | Role |
| --- | --- | --- |
| `OverloadResolver.cs` + `.Arguments` / `.CallBinding` / `.Candidates` / `.Constructors` / `.Invocations` partials | ~8,300 | Binder collaborator: user-function, extension, constructor, method-group, and invocation candidate resolution |
| `ClrOverloadResolution.cs` (was `OverloadResolution.cs`) | ~5,170 | Pure CLR `MethodBase`-candidate resolution (scoped §7.5.3 subset) + argument sentinels (`InlineOutVarArgumentType`, `DefaultLiteralArgumentType`) |

**Stayed in `Binding` — and why:**

- `Conversion.cs` (public type) and `ConversionClassifier.cs`: conversion classification is general binding infrastructure — consumed by pattern binding, statement narrowing, lambda binding, structural projections, and `Emit/ConversionEmitter`. Not overload-resolution internals. Natural candidate for a follow-up `Binding.Conversions` slice.
- `ClrOperatorResolution.cs`, `EnumOperatorTable.cs`, `OperatorNames.cs`: operator resolution, consumed by `ExpressionBinder.Operators` and `Emit/MethodBodyEmitter.*` — a separate follow-up cluster.

The coupling analysis (every consumer of every cluster type, repo-wide) showed this is the smallest scope that makes the boundary real; nothing outside the moved set reaches into resolver internals, so no forwarders or visibility widenings were needed.

## The rename (commit 1)

The static class `OverloadResolution` had to be renamed to `ClrOverloadResolution`: a type sharing its sibling namespace's name is shadowed by that namespace in every consumer inside `GSharp.Core.CodeAnalysis.Binding` (enclosing-namespace member lookup wins before using directives, and an in-namespace alias is a CS0576 conflict). The new name is also more accurate — it is the CLR `MethodBase`-candidate algorithm, mirroring the sibling `ClrOperatorResolution` — and it frees the name issue #1365 asked for. Pure textual rename of an internal type; no public API impact.

## Seam description

What the sub-namespace exposes to the rest of the compiler (all `internal`; consumers add one `using GSharp.Core.CodeAnalysis.Binding.OverloadResolution;`):

- `OverloadResolver` — the binder collaborator; entry points used by `Binder`, `ExpressionBinder.*`, `MemberLookup`, `ConversionClassifier`, `DeclarationBinder`, `LambdaBinder`, `PatternBinder` (call binding, argument shaping, betterness, constructor/invocation resolution).
- `ClrOverloadResolution` — `Resolve`/`Resolve<T>`, `ResolutionOutcome`, `ImplicitConversionKind`, signature formatting, and the inline-`out var`/`default` argument sentinels. Consumed inside Binding plus two spots in `Symbols` (`ImportedClassSymbol` CLR candidate resolution, `ReferenceResolver` sentinel-leak guard).

The reverse dependency (cluster → Binding) is unchanged: the moved files reach Binding types (`BinderContext`, bound nodes, `Conversion`) via enclosing-namespace lookup and needed zero new usings. Per the pilot's scope, no interface abstraction or dependency inversion was attempted — the namespace boundary, file layout, and this seam description are the deliverable.

## Verification

- `dotnet build GSharp.sln -c Release`: clean, 0 warnings (warnings-as-errors), after each commit.
- ADR-0150 pure-move protocol: `diff` of each moved file against its pre-move blob shows only the `namespace` line changed.
- `dotnet test test/Core.Tests` filtered `Overload|Conversion|CommonType|Operator`: **658 passed, 0 failed**.
- `dotnet test test/Compiler.Tests` (same filter): **380 passed, 0 failed**.
- Full `dotnet test test/Core.Tests`: **7127 passed, 0 failed, 1 skipped** (the manual `RegenerateBaseline` entry point) — includes `RefactoringBaselineTests`, the IL byte-identity gate over the `samples/` corpus, the strongest available no-behavior-change witness (ADR-0150 verification protocol). No baseline regeneration needed: compiler-internal namespaces cannot affect emitted IL.
- **NOT RUN**: full Compiler.Tests matrix, Interpreter.Tests, cs2gs suites — CI's required status checks on this PR are the backstop for those, per direction to keep local verification to the binder-focused scope.

No new behavioral tests: structural refactor with intentionally zero behavior change; the witness is the unchanged suite plus the byte-identical-IL baseline gate.

Part of #3163. Closes #1365.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
