### PR TITLE
Begin incremental nullable adoption: ADR-0155 and the Text/Diagnostic/IO slice

### DIFF
--- a/docs/adr/0155-incremental-nullable-adoption.md
+++ b/docs/adr/0155-incremental-nullable-adoption.md
@@ -1,0 +1,64 @@
+# ADR-0155: Incremental nullable reference type adoption
+
+- **Status**: Accepted
+- **Date**: 2026-08-03
+- **Phase**: Repository maintainability
+- **Related**: #1364, #3163; ADR-0150 (decomposition conventions)
+
+## Context
+
+Nullable reference types are globally disabled via `<Nullable>disable</Nullable>` in `build/gsharp.build.props`; only `src/vs-gsharp` opts in at the project level. That means the compiler performs no null-state analysis over ~160K lines of production C#, and no API in `src/Core` carries a nullability contract — consumers (LanguageServer, Repl, tests, future SDK users) cannot tell which parameters and returns may be null. Latent null-dereference bugs have already surfaced where the implicit contracts were guessed wrong (issue #2144: a `default(TextLocation)` with a null `Text` NRE'd diagnostic rendering and masked the whole batch).
+
+Two constraints bound the migration. First, `TreatWarningsAsErrors=true` is global, so any file placed in a nullable context must be warning-clean immediately — a big-bang flip of the central switch is not buildable. Second, `src/Core` is a single project, so "enable per subsystem" cannot be expressed as a per-project MSBuild property; the enablement boundary must be finer-grained than the project.
+
+Two files (`Diagnostic/FileLogger.cs`, `Diagnostic/ILogger.cs`) already use per-file `#nullable enable` directives, establishing the in-repo precedent for sub-project opt-in.
+
+## Decision
+
+### Mechanism: per-file `#nullable enable`, directory-at-a-time
+
+- The central `<Nullable>disable</Nullable>` in `build/gsharp.build.props` stays until the migration completes.
+- A directory is migrated by adding `#nullable enable` to every `.cs` file in it and annotating until the solution builds clean under warnings-as-errors. The directive goes after the copyright header, separated by blank lines, before the `using` block (the `FileLogger.cs` layout).
+- The unit of migration is the directory (subsystem), not the file: a directory is either fully enabled or fully untouched. No half-enabled directories.
+- New files created in an enabled directory must carry `#nullable enable`. Reviewers treat a missing directive there as a defect.
+- Once a file is enabled it stays enabled: no `#nullable disable` re-additions, and no `#nullable disable`/`#nullable restore` region escapes inside enabled files.
+
+### Rollout order
+
+Leaf, low-churn subsystems first; high-churn, high-fan-in coordinators last, so annotation work never collides with in-flight feature branches:
+
+1. Leaf utilities: `src/Core/CodeAnalysis/Text/`, `src/Core/CodeAnalysis/Diagnostic/`, `src/Core/IO/` (this ADR's first slice)
+2. `src/Core/CodeAnalysis/Syntax/` (nodes first, then parser)
+3. `src/Core/CodeAnalysis/Symbols/`
+4. `src/Core/CodeAnalysis/Lowering/`, `src/Core/CodeAnalysis/Emit/`
+5. `src/Core/CodeAnalysis/Binding/` last (largest, highest churn)
+6. Remaining production projects (`Compiler`, `Repl`, `LanguageServer`, `Sdk`, `Analyzers`), then test projects
+
+Within a slice, dependencies must point outward only: an enabled directory may reference nullable-oblivious code (the compiler treats oblivious APIs leniently), but enabling a directory never requires editing files outside the slice.
+
+### Annotation rules
+
+- **Annotate the real contract, don't launder warnings.** A member is declared `T?` only when null is a genuine, intended state that callers must handle (e.g. `SourceText.RawBytes` is null for non-file sources). If null was only ever an accident of construction, tighten the construction path and keep the non-null declaration.
+- **`!` requires a justifying comment** adjacent to the use, stating the invariant that makes it safe. Uncommented `!` is a review defect.
+- **Structs**: `default(T)` zero-fills reference fields regardless of annotations. When a default instance is a legitimate domain state (e.g. `default(TextLocation)` for location-less diagnostics), annotate the reference members `?` honestly and let members that are only meaningful on non-default instances document that precondition — do not pretend the field is non-null.
+- **Oblivious boundaries**: values flowing in from not-yet-enabled code are trusted as declared. Do not add defensive null checks against oblivious callees; the check materializes when that directory is migrated.
+- Prefer flow-friendly restructuring (pattern matching, early returns, locals) over `!` or redundant checks.
+
+### Completion and tracking
+
+- Issue #1364 carries the checklist of enabled directories; every slice PR updates it and states which directories it enabled.
+- When every production source file is enabled, a final PR flips `build/gsharp.build.props` to `<Nullable>enable</Nullable>` and deletes all per-file directives in the same change. Test projects follow as a separate phase.
+
+## Consequences
+
+- Null-state analysis and explicit nullability contracts arrive incrementally without ever breaking the warnings-as-errors build, and without a long-lived migration branch.
+- The leaf-first order means the highest-value contracts (widely consumed utility types) harden earliest, while `Binding/` — where in-flight feature work concentrates — is disturbed last.
+- Per-file directives are visible noise in every enabled file until the final flip; the flip PR removes them wholesale.
+- Enabled code referencing oblivious code gets lenient treatment at the boundary, so some null bugs remain invisible until the callee's directory migrates. This is the accepted cost of incrementality.
+- Annotation may surface latent bugs (as #2144 did); fixing them is in scope for a slice when local, but behavior-visible fixes get their own commit and test.
+
+## Alternatives considered
+
+- **Issue #1364's original Phase 1** — flip the central switch to `enable` and stamp `#nullable disable` into every file. Rejected: it touches every file up front for zero analysis gain, inverts the reviewer signal (the marker would flag *unmigrated* files, so a new file missing a directive would silently join the migrated set unannotated), and mass-adds the exact directive this migration exists to remove.
+- **MSBuild-conditional enablement** (e.g. an `ItemGroup` stamping `#nullable` via generated attributes, or splitting `Core` into per-subsystem projects). Rejected: C# offers no per-directory compiler switch short of project splits, and splitting `Core` is a far larger structural change than this migration warrants; per-file directives are the standard incremental path and already have in-repo precedent.
+- **Big-bang annotation of `src/Core`**. Rejected: ~160K lines under warnings-as-errors cannot be made clean in one reviewable change, and it would conflict with every in-flight branch simultaneously.

--- a/src/Core/CodeAnalysis/Diagnostic/DiagnosticLogPaths.cs
+++ b/src/Core/CodeAnalysis/Diagnostic/DiagnosticLogPaths.cs
@@ -2,6 +2,8 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+#nullable enable
+
 namespace GSharp.Core.CodeAnalysis.Diagnostics;
 
 /// <summary>

--- a/src/Core/CodeAnalysis/Text/SourceText.cs
+++ b/src/Core/CodeAnalysis/Text/SourceText.cs
@@ -2,6 +2,8 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+#nullable enable
+
 using System.Collections.Immutable;
 
 namespace GSharp.Core.CodeAnalysis.Text;
@@ -13,7 +15,7 @@ public sealed class SourceText
 {
     private readonly string text;
 
-    private SourceText(string text, string fileName, byte[] rawBytes)
+    private SourceText(string text, string fileName, byte[]? rawBytes)
     {
         this.text = text;
         FileName = fileName;
@@ -28,7 +30,7 @@ public sealed class SourceText
     /// document hash must be derived from them — not from a re-encoded copy of
     /// the decoded text — for on-disk source resolution to succeed.
     /// </summary>
-    public byte[] RawBytes { get; }
+    public byte[]? RawBytes { get; }
 
     /// <summary>
     /// Gets the set of lines contained by this document.
@@ -63,7 +65,7 @@ public sealed class SourceText
     /// bytes a debugger hashes.
     /// </param>
     /// <returns>A hydrated source text instance.</returns>
-    public static SourceText From(string text, string fileName = "", byte[] rawBytes = null)
+    public static SourceText From(string text, string fileName = "", byte[]? rawBytes = null)
     {
         return new SourceText(text, fileName, rawBytes);
     }

--- a/src/Core/CodeAnalysis/Text/TextLine.cs
+++ b/src/Core/CodeAnalysis/Text/TextLine.cs
@@ -2,6 +2,8 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+#nullable enable
+
 namespace GSharp.Core.CodeAnalysis.Text;
 
 /// <summary>

--- a/src/Core/CodeAnalysis/Text/TextLocation.cs
+++ b/src/Core/CodeAnalysis/Text/TextLocation.cs
@@ -2,6 +2,8 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+#nullable enable
+
 using System;
 
 namespace GSharp.Core.CodeAnalysis.Text;
@@ -23,39 +25,53 @@ public struct TextLocation : IComparable<TextLocation>
     }
 
     /// <summary>
-    /// Gets the source text.
+    /// Gets the source text. Null for a location-less entry
+    /// (<c>default(TextLocation)</c>, e.g. a synthesized or assembly-level
+    /// diagnostic with no source location).
     /// </summary>
-    public SourceText Text { get; }
+    public SourceText? Text { get; }
 
     /// <summary>
     /// Gets the text span within the source text.
     /// </summary>
     public TextSpan Span { get; }
 
+    // The four positional accessors below use `Text!`: line/character
+    // coordinates are only defined for located entries (constructed via the
+    // constructor, whose `text` parameter is non-nullable). On a
+    // location-less `default(TextLocation)` they throw, exactly as before
+    // nullable annotations; callers that may hold a location-less entry must
+    // check `Text` first (see TextWriterExtensions.WriteDiagnostics).
+
     /// <summary>
     /// Gets the zero-based start line in the source text as indicated by the text span.
+    /// Only defined for located entries (non-null <see cref="Text"/>).
     /// </summary>
-    public int StartLine => Text.GetLineIndex(Span.Start);
+    public int StartLine => Text!.GetLineIndex(Span.Start);
 
     /// <summary>
     /// Gets the zero-based start line character as indicated by the text span.
+    /// Only defined for located entries (non-null <see cref="Text"/>).
     /// </summary>
-    public int StartCharacter => Span.Start - Text.Lines[StartLine].Start;
+    public int StartCharacter => Span.Start - Text!.Lines[StartLine].Start;
 
     /// <summary>
     /// Gets the zero-based end line in the source text as indicated by the text span.
+    /// Only defined for located entries (non-null <see cref="Text"/>).
     /// </summary>
-    public int EndLine => Text.GetLineIndex(Span.End);
+    public int EndLine => Text!.GetLineIndex(Span.End);
 
     /// <summary>
     /// Gets the zero-based end line character as indicated by the text span.
+    /// Only defined for located entries (non-null <see cref="Text"/>).
     /// </summary>
-    public int EndCharacter => Span.End - Text.Lines[EndLine].Start;
+    public int EndCharacter => Span.End - Text!.Lines[EndLine].Start;
 
     /// <summary>
-    /// Gets the file name.
+    /// Gets the file name. Null for a location-less entry; empty for source
+    /// texts created without a file name.
     /// </summary>
-    public string FileName => Text?.FileName;
+    public string? FileName => Text?.FileName;
 
     /// <summary>
     /// Compares two text locations, useful for sorting sets of text locations.
@@ -72,8 +88,8 @@ public struct TextLocation : IComparable<TextLocation>
         // `OrderBy`/`Array.Sort` throw `InvalidOperationException: Failed to
         // compare two elements in the array`, which the compiler surfaces as
         // GS9998 and which masks every other diagnostic in the batch.
-        string thisFile = Text?.FileName;
-        string otherFile = other.Text?.FileName;
+        string? thisFile = Text?.FileName;
+        string? otherFile = other.Text?.FileName;
 
         int cmp = string.CompareOrdinal(thisFile, otherFile);
         if (cmp == 0)

--- a/src/Core/CodeAnalysis/Text/TextSpan.cs
+++ b/src/Core/CodeAnalysis/Text/TextSpan.cs
@@ -2,6 +2,8 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+#nullable enable
+
 using System;
 
 namespace GSharp.Core.CodeAnalysis.Text;

--- a/src/Core/IO/TextWriterExtensions.cs
+++ b/src/Core/IO/TextWriterExtensions.cs
@@ -2,6 +2,8 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
@@ -136,7 +138,7 @@ public static class TextWriterExtensions
             // diagnostic) has no file/position/snippet to render. Emit just
             // the severity/id/message so a single such diagnostic no longer
             // NREs and masks the whole batch.
-            if (diagnostic.Location.Text is null)
+            if (diagnostic.Location.Text is not SourceText sourceText)
             {
                 writer.SetForeground(severityColor);
                 writer.Write($"{severityLabel} {diagnostic.Id}: ");
@@ -155,7 +157,7 @@ public static class TextWriterExtensions
             // diagnostic span. When the span crosses line boundaries the span end can
             // be far past the end of the start line, so clamp every boundary to the
             // start line to keep all computed lengths non-negative.
-            var startLine = diagnostic.Location.Text.Lines[diagnostic.Location.StartLine];
+            var startLine = sourceText.Lines[diagnostic.Location.StartLine];
 
             var spanStart = Math.Clamp(diagnostic.Location.Span.Start, startLine.Start, startLine.End);
             var spanEnd = Math.Clamp(diagnostic.Location.Span.End, spanStart, startLine.End);
@@ -164,9 +166,9 @@ public static class TextWriterExtensions
             var errorSpan = TextSpan.FromBounds(spanStart, spanEnd);
             var suffixSpan = TextSpan.FromBounds(spanEnd, startLine.End);
 
-            var prefix = diagnostic.Location.Text.ToString(prefixSpan);
-            var error = diagnostic.Location.Text.ToString(errorSpan);
-            var suffix = diagnostic.Location.Text.ToString(suffixSpan);
+            var prefix = sourceText.ToString(prefixSpan);
+            var error = sourceText.ToString(errorSpan);
+            var suffix = sourceText.ToString(suffixSpan);
 
             writer.Write("    ");
             writer.Write(prefix);


### PR DESCRIPTION
Begins the nullable-reference-types rollout tracked by #1364, per the code-health report (#3163, P1 item 6). Two commits: the conventions ADR, then the first enabled slice.

## ADR-0155 (`docs/adr/0155-incremental-nullable-adoption.md`)

Defines the rollout conventions: per-file `#nullable enable` directives, directory-at-a-time (the central `<Nullable>disable</Nullable>` in `build/gsharp.build.props` stays until completion, then flips in a single PR that also deletes the per-file directives); leaf-first rollout order ending with `Binding/`; honest-annotation rules (`?` only for genuine null states, `!` requires a justifying comment, no `#nullable disable` re-additions, new files in enabled directories must opt in); tracking via a directory checklist on #1364. It also records why #1364's original Phase 1 (central enable + `#nullable disable` everywhere) was rejected.

## First slice: directories enabled

- `src/Core/CodeAnalysis/Text/` (4 files)
- `src/Core/CodeAnalysis/Diagnostic/` (1 file newly enabled; `FileLogger.cs` and `ILogger.cs` already carried the directive)
- `src/Core/IO/` (1 file)

All are leaves: `Text/` and `Diagnostic/` depend on nothing else in Core; `IO/` consumes only oblivious `Syntax`/`CodeAnalysis` types. No conflict-zone files (`Binding/`, `Symbols/`, `Emit/`, `Analyzers/`) are touched.

## Annotation decisions of note

- **`SourceText.RawBytes` and the `rawBytes` parameters → `byte[]?`** — the documented contract already said null for non-file sources. The only external consumer (`Emit/PortablePdbEmitter.cs`) already null-guards and sits in an oblivious context, so no ripple.
- **`TextLocation.Text` → `SourceText?`** — null is a real domain state (`default(TextLocation)` for synthesized/assembly-level diagnostics; see issue #2144), so the honest annotation is nullable rather than pretending the struct default can't exist. `FileName` becomes `string?` accordingly, and `CompareTo`'s locals follow.
- **`!` uses (the only four in the slice)**: the positional accessors `TextLocation.StartLine/StartCharacter/EndLine/EndCharacter` use `Text!`, justified by an adjacent comment: coordinates are only defined for located entries (the constructor takes a non-nullable `SourceText`), and the throw-on-`default` behavior is exactly the pre-annotation behavior. Callers that may hold location-less entries must check `Text` first, which the one such caller does.
- **`TextWriterExtensions.WriteDiagnostics`** re-binds the guarded text via `is not SourceText sourceText` so flow analysis proves the snippet-rendering path null-safe with no suppressions (and no behavior change).

No StyleCop/analyzer ruleset changes were needed; the directive placement follows the existing `FileLogger.cs` layout.

## Verification

- `dotnet build GSharp.sln -c Release`: **0 warnings, 0 errors** (warnings-as-errors is global, so every enabled file is warning-clean).
- `dotnet test test/Core.Tests -c Release`: **7128 passed, 0 failed, 1 skipped** (`RegenerateBaseline`, standard opt-in skip), 4m13s.
- NOT RUN (delegated to CI required checks per verification policy): Compiler.Tests matrix, Interpreter.Tests, cs2gs suites.

## Tracking (#1364 checklist)

- [x] `src/Core/CodeAnalysis/Text/` (this PR)
- [x] `src/Core/CodeAnalysis/Diagnostic/` (this PR)
- [x] `src/Core/IO/` (this PR)
- [ ] `src/Core/CodeAnalysis/Syntax/`
- [ ] `src/Core/CodeAnalysis/Symbols/`
- [ ] `src/Core/CodeAnalysis/Lowering/`, `src/Core/CodeAnalysis/Emit/`
- [ ] `src/Core/CodeAnalysis/Binding/`
- [ ] Remaining production projects, then tests, then the central flip

Part of #3163, part of #1364 (first slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)