### PR TITLE
Execute gsi scripts and bare gsc through emit-to-memory (ADR-0156 Phase 1)

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -321,7 +321,9 @@ storage-dependent unsafe constructs as compiled-only. The clean boundary sites
 for `fixed`, `stackalloc`, unmanaged `sizeof`, and function pointers currently
 surface through `GS0513` with a self-contained message naming the construct and
 the required CIL emit path. Evaluator `GS9999` diagnostics still indicate a
-defect.
+defect. Since [ADR-0156](adr/0156-gsi-emit-to-memory-execution.md) Phase 1 the
+boundary applies only to the interactive REPL — `gsi <file>` and bare `gsc`
+execute emitted code, where these constructs run natively.
 
 ## Documentation diagnostics (GS0227–GS0231)
 
@@ -1165,7 +1167,11 @@ GS0264, even though iterator specialization synthesizes equivalent variants.
 
 This is an intentional interpreter capability boundary, not an internal
 compiler error. It applies even when the declaration is not called because
-`gsi` cannot create a valid callable value for direct or indirect use.
+the interpreter cannot create a valid callable value for direct or indirect
+use. Since [ADR-0156](adr/0156-gsi-emit-to-memory-execution.md) Phase 1 only
+the interactive REPL interprets: `gsi <file>` and bare `gsc` execute emitted
+code, so P/Invoke runs natively there and this diagnostic no longer fires on
+those drivers.
 
 ## Explicit-layout reference storage (GS0518)
 
@@ -1182,7 +1188,9 @@ compiler error. It applies even when the declaration is not called because
 Interpreter values use boxed storage, which cannot hold stack-only CLR values
 or preserve their interior references. The interpreter emulates spans created
 from arrays; CLR methods and properties returning stack-only values remain
-unsupported. Compile the program with `gsc /out:<file>` to use those values.
+unsupported. Since [ADR-0156](adr/0156-gsi-emit-to-memory-execution.md)
+Phase 1 only the interactive REPL interprets: `gsi <file>` and bare `gsc`
+execute emitted code, where ByRefLike values work natively.
 
 ## Interpreter deinitializer boundary (GS0510)
 
@@ -1191,8 +1199,11 @@ unsupported. Compile the program with `gsc /out:<file>` to use those values.
 | GS0510 | Warning | A class declares a CLR GC finalizer with `deinit`, which does not run under interpreted execution. |
 
 The interpreter has no emitted class with a CLR `Finalize` override and does
-not invent deterministic scope-exit cleanup. Compile with `gsc` when program
-behavior depends on GC finalization.
+not invent deterministic scope-exit cleanup. Since
+[ADR-0156](adr/0156-gsi-emit-to-memory-execution.md) Phase 1 only the
+interactive REPL interprets: `gsi <file>` and bare `gsc` execute emitted code,
+whose deinitializers run as real CLR finalizers, so this warning no longer
+fires on those drivers.
 
 ## Internal compiler error details (GS9998)
 

--- a/src/Compiler/Program.cs
+++ b/src/Compiler/Program.cs
@@ -13,6 +13,7 @@ using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Diagnostics;
 using GSharp.Core.CodeAnalysis.Emit;
+using GSharp.Core.CodeAnalysis.Execution;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.IO;
@@ -153,8 +154,10 @@ public class Program
 
                 if (parsed.OutputPath is null)
                 {
-                    // Legacy / no-output mode: interpret the program (back-compat).
-                    return Interpret(compilation, parsed);
+                    // Legacy / no-output mode (ADR-0156 Phase 1): compile with
+                    // the real emitter into memory and execute in-process,
+                    // preserving the historical evaluate-mode driver protocol.
+                    return ExecuteInMemory(compilation, parsed);
                 }
 
                 return Emit(compilation, parsed);
@@ -308,9 +311,14 @@ public class Program
             "Members that reference these assemblies will be skipped. Ensure the full transitive closure of references is passed (e.g. add the missing package or project reference).");
     }
 
-    private static int Interpret(Compilation compilation, CommandLineArgs args)
+    // ADR-0156 Phase 1: bare gsc no longer interprets. The program is emitted
+    // to memory and executed in-process by the shared host, keeping the
+    // driver protocol: diagnostics to stdout, "Success."/"Failed." trailer,
+    // exit code 0 on success (the program's own return value is discarded,
+    // as evaluate mode always did — use /out: for a real executable).
+    private static int ExecuteInMemory(Compilation compilation, CommandLineArgs args)
     {
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedProgramHost.Run(compilation, args.References);
         if (result.Diagnostics.Any())
         {
             var effective = ApplySuppressPromote(result.Diagnostics, args);
@@ -320,6 +328,14 @@ public class Program
                 Console.Error.WriteLine("Failed.");
                 return Error;
             }
+        }
+
+        if (result.UnhandledException is not null)
+        {
+            // Mirror the CLR host's unhandled-exception protocol so the
+            // in-memory driver and `dotnet exec` render crashes identically.
+            Console.Error.WriteLine(EmittedProgramHost.FormatUnhandledException(result.UnhandledException));
+            return EmittedProgramHost.UnhandledExceptionExitCode;
         }
 
         Console.WriteLine("Success.");

--- a/src/Core/CodeAnalysis/Execution/EmittedProgramHost.cs
+++ b/src/Core/CodeAnalysis/Execution/EmittedProgramHost.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.Loader;
 using System.Threading;
+using GSharp.Core.CodeAnalysis.Symbols;
 
 namespace GSharp.Core.CodeAnalysis.Execution;
 
@@ -137,10 +138,12 @@ public static class EmittedProgramHost
             // The CLR host validates the managed entry point's signature
             // before running a single user statement; mirror its check (and
             // its exact crash text) so an invalid Main crashes identically
-            // under `dotnet exec` and the in-memory drivers.
-            if (entryPoint.ReturnType != typeof(void)
-                && entryPoint.ReturnType != typeof(int)
-                && entryPoint.ReturnType != typeof(uint))
+            // under `dotnet exec` and the in-memory drivers. IsSameAs keeps
+            // the issue-#835 typeof-identity guard clean even though these
+            // are runtime-loaded (never MetadataLoadContext) types.
+            if (!entryPoint.ReturnType.IsSameAs(typeof(void))
+                && !entryPoint.ReturnType.IsSameAs(typeof(int))
+                && !entryPoint.ReturnType.IsSameAs(typeof(uint)))
             {
                 var invalidEntryPoint = new MethodAccessException(
                     "Entry point must have a return type of void, integer, or unsigned integer.");

--- a/src/Core/CodeAnalysis/Execution/EmittedProgramHost.cs
+++ b/src/Core/CodeAnalysis/Execution/EmittedProgramHost.cs
@@ -1,0 +1,226 @@
+// <copyright file="EmittedProgramHost.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Threading;
+
+namespace GSharp.Core.CodeAnalysis.Execution;
+
+/// <summary>
+/// Shared execution host for the evaluating drivers (ADR-0156 Phase 1):
+/// compiles a <see cref="Compilation.Compilation"/> with the real emitter into
+/// a <see cref="MemoryStream"/>, loads the PE bytes into a collectible
+/// <see cref="AssemblyLoadContext"/>, invokes the entry point in-process, and
+/// maps the outcome onto the drivers' exit-code protocol. Framework
+/// dependencies resolve through the default load context; user-supplied
+/// reference assemblies (<c>/r:</c>) resolve from their explicit paths.
+/// </summary>
+/// <remarks>
+/// <para>The program's console is the host process's console — output and
+/// input stream straight through, exactly as under <c>dotnet exec</c>, and
+/// callers that need capture use the process-global <see cref="Console.SetOut(TextWriter)"/>
+/// as they always have.</para>
+/// <para>Cancellation is best-effort and matches the historical evaluator
+/// drivers: the token is only observed before the entry point is invoked, so
+/// an already-running program cannot be interrupted, and Ctrl+C keeps its
+/// process-default behavior in the CLI drivers.</para>
+/// <para>In-process execution inherits the same hazards the tree-walking
+/// evaluator had: <see cref="Environment.Exit(int)"/> in user code terminates
+/// the driver, and threads the program spawned may outlive its entry point.</para>
+/// </remarks>
+public static class EmittedProgramHost
+{
+    /// <summary>
+    /// Gets the exit code a driver reports when the program threw an
+    /// unhandled exception, matching the CLR host's crash exit code
+    /// (SIGABRT's 134 on Unix, the CLR exception COMPLUS code on Windows).
+    /// </summary>
+    public static int UnhandledExceptionExitCode { get; } =
+        OperatingSystem.IsWindows() ? unchecked((int)0xE0434352) : 134;
+
+    /// <summary>
+    /// Renders an unhandled program exception the way the CLR host does for
+    /// an emitted executable: <c>Unhandled exception. </c> followed by the
+    /// exception text, with the reflection-invoker frames the in-process
+    /// invocation appends below the program's own frames trimmed away so the
+    /// text matches <c>dotnet exec</c> byte-for-byte.
+    /// </summary>
+    /// <param name="unhandledException">The unhandled exception from <see cref="EmittedProgramResult.UnhandledException"/>.</param>
+    /// <returns>The single- or multi-line crash text, without a trailing newline.</returns>
+    public static string FormatUnhandledException(Exception unhandledException)
+    {
+        if (unhandledException is null)
+        {
+            throw new ArgumentNullException(nameof(unhandledException));
+        }
+
+        var lines = unhandledException.ToString()
+            .Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Split('\n')
+            .ToList();
+        while (lines.Count > 0 && IsReflectionInvokerFrame(lines[^1]))
+        {
+            lines.RemoveAt(lines.Count - 1);
+        }
+
+        return "Unhandled exception. " + string.Join(Environment.NewLine, lines);
+    }
+
+    /// <summary>
+    /// Compiles <paramref name="compilation"/> to memory and, when emit
+    /// succeeds, executes its entry point in a collectible
+    /// <see cref="AssemblyLoadContext"/> which is unloaded before returning.
+    /// </summary>
+    /// <param name="compilation">The compilation to emit and run.</param>
+    /// <param name="referencePaths">User-supplied reference assembly paths (<c>/r:</c>) made resolvable at runtime; may be <see langword="null"/>.</param>
+    /// <param name="cancellationToken">Best-effort cancellation, observed only before the entry point is invoked.</param>
+    /// <returns>The emit diagnostics plus the program's exit code or unhandled exception.</returns>
+    /// <exception cref="OperationCanceledException">The token was cancelled before the program was invoked.</exception>
+    public static EmittedProgramResult Run(
+        Compilation.Compilation compilation,
+        IReadOnlyList<string> referencePaths = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (compilation is null)
+        {
+            throw new ArgumentNullException(nameof(compilation));
+        }
+
+        using var peStream = new MemoryStream();
+        var emitResult = compilation.Emit(peStream);
+        if (!emitResult.Success)
+        {
+            return EmittedProgramResult.FromFailedEmit(emitResult.Diagnostics);
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var (exitCode, unhandledException, loadContext) = LoadAndInvoke(peStream, referencePaths);
+        return EmittedProgramResult.FromExecution(emitResult.Diagnostics, exitCode, unhandledException, loadContext);
+    }
+
+    private static bool IsReflectionInvokerFrame(string line)
+    {
+        var trimmed = line.TrimStart();
+        return trimmed.StartsWith("at System.Reflection.MethodBaseInvoker.", StringComparison.Ordinal)
+            || trimmed.StartsWith("at System.Reflection.RuntimeMethodInfo.Invoke(", StringComparison.Ordinal)
+            || trimmed.StartsWith("at System.Reflection.MethodBase.Invoke(", StringComparison.Ordinal)
+            || trimmed.StartsWith("at System.RuntimeMethodHandle.InvokeMethod(", StringComparison.Ordinal);
+    }
+
+    private static (int ExitCode, Exception UnhandledException, WeakReference LoadContext) LoadAndInvoke(
+        MemoryStream peStream,
+        IReadOnlyList<string> referencePaths)
+    {
+        var loadContext = new AssemblyLoadContext($"gsharp-emitted-{Guid.NewGuid():N}", isCollectible: true);
+        var weakReference = new WeakReference(loadContext);
+        loadContext.Resolving += (context, assemblyName) => ResolveDependency(context, assemblyName, referencePaths);
+
+        try
+        {
+            peStream.Position = 0;
+            var assembly = loadContext.LoadFromStream(peStream);
+            var entryPoint = assembly.EntryPoint;
+            if (entryPoint is null)
+            {
+                // A declaration-only script emits no runnable statements; the
+                // historical drivers report success with exit code 0.
+                return (0, null, weakReference);
+            }
+
+            // The CLR host validates the managed entry point's signature
+            // before running a single user statement; mirror its check (and
+            // its exact crash text) so an invalid Main crashes identically
+            // under `dotnet exec` and the in-memory drivers.
+            if (entryPoint.ReturnType != typeof(void)
+                && entryPoint.ReturnType != typeof(int)
+                && entryPoint.ReturnType != typeof(uint))
+            {
+                var invalidEntryPoint = new MethodAccessException(
+                    "Entry point must have a return type of void, integer, or unsigned integer.");
+                return (UnhandledExceptionExitCode, invalidEntryPoint, weakReference);
+            }
+
+            var arguments = entryPoint.GetParameters().Length == 0
+                ? null
+                : new object[] { Array.Empty<string>() };
+
+            object returnValue;
+            try
+            {
+                returnValue = entryPoint.Invoke(null, arguments);
+            }
+            catch (TargetInvocationException ex) when (ex.InnerException is not null)
+            {
+                // The inner exception's stack trace was frozen at the
+                // reflection boundary, so it ends at the program's own frames —
+                // rendering it reproduces exactly what the CLR host prints
+                // for an emitted executable, with no host frames appended.
+                return (UnhandledExceptionExitCode, ex.InnerException, weakReference);
+            }
+            catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+            {
+                return (UnhandledExceptionExitCode, ex, weakReference);
+            }
+
+            var exitCode = returnValue switch
+            {
+                int value => value,
+                uint value => unchecked((int)value),
+                _ => 0,
+            };
+
+            return (exitCode, null, weakReference);
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+
+    private static Assembly ResolveDependency(
+        AssemblyLoadContext context,
+        AssemblyName assemblyName,
+        IReadOnlyList<string> referencePaths)
+    {
+        // User-supplied references win over any same-named host assembly so
+        // the program binds against exactly what it was compiled against.
+        if (referencePaths is not null && assemblyName.Name is not null)
+        {
+            var match = referencePaths.FirstOrDefault(path =>
+                !string.IsNullOrWhiteSpace(path)
+                && string.Equals(Path.GetFileNameWithoutExtension(path), assemblyName.Name, StringComparison.OrdinalIgnoreCase)
+                && File.Exists(path));
+            if (match is not null)
+            {
+                return context.LoadFromAssemblyPath(Path.GetFullPath(match));
+            }
+        }
+
+        // Framework and transitive dependencies fall back to the default
+        // context, mirroring how the emitted program would bind under the
+        // shared-framework host.
+        try
+        {
+            return Assembly.Load(assemblyName);
+        }
+        catch (FileNotFoundException)
+        {
+            return null;
+        }
+        catch (FileLoadException)
+        {
+            return null;
+        }
+        catch (BadImageFormatException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/Core/CodeAnalysis/Execution/EmittedProgramResult.cs
+++ b/src/Core/CodeAnalysis/Execution/EmittedProgramResult.cs
@@ -1,0 +1,96 @@
+// <copyright file="EmittedProgramResult.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+
+namespace GSharp.Core.CodeAnalysis.Execution;
+
+/// <summary>
+/// The observable outcome of compiling a program to memory and executing it
+/// in-process via <see cref="EmittedProgramHost"/> (ADR-0156): the emit
+/// diagnostics, the entry point's exit code, and any unhandled exception the
+/// program surfaced. Standard output and error are not captured here — the
+/// program writes to the process console exactly as an emitted executable
+/// would, so drivers stream them through unchanged.
+/// </summary>
+public sealed class EmittedProgramResult
+{
+    private EmittedProgramResult(
+        bool success,
+        ImmutableArray<Diagnostic> diagnostics,
+        int exitCode,
+        Exception unhandledException,
+        WeakReference loadContext)
+    {
+        Success = success;
+        Diagnostics = diagnostics;
+        ExitCode = exitCode;
+        UnhandledException = unhandledException;
+        LoadContext = loadContext;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether emit succeeded and the program was
+    /// executed. When <see langword="false"/>, <see cref="Diagnostics"/>
+    /// contains at least one error and the program never ran. Note that a
+    /// program which ran but threw (<see cref="UnhandledException"/>) or
+    /// returned a non-zero <see cref="ExitCode"/> still reports
+    /// <see langword="true"/> here — success describes the compile-and-launch
+    /// pipeline, not the program's own outcome.
+    /// </summary>
+    public bool Success { get; }
+
+    /// <summary>
+    /// Gets the emit-time diagnostics: parse, bind, lowering, and emitter
+    /// diagnostics, including warnings when emit succeeded.
+    /// </summary>
+    public ImmutableArray<Diagnostic> Diagnostics { get; }
+
+    /// <summary>
+    /// Gets the exit code produced by the program's entry point:
+    /// its <see cref="int"/> or <see cref="uint"/> return value, otherwise 0.
+    /// Meaningless when <see cref="Success"/> is <see langword="false"/> or
+    /// <see cref="UnhandledException"/> is non-null.
+    /// </summary>
+    public int ExitCode { get; }
+
+    /// <summary>
+    /// Gets the unhandled exception the program threw, if any, unwrapped from
+    /// the reflection invocation boundary. Drivers surface it on standard
+    /// error and exit with <see cref="EmittedProgramHost.UnhandledExceptionExitCode"/>,
+    /// mirroring the CLR host's crash protocol.
+    /// </summary>
+    public Exception UnhandledException { get; }
+
+    /// <summary>
+    /// Gets a weak reference to the collectible <see cref="System.Runtime.Loader.AssemblyLoadContext"/>
+    /// the program ran in, already unloaded by the time the result is
+    /// returned. Test-only seam for asserting the context is reclaimable.
+    /// </summary>
+    internal WeakReference LoadContext { get; }
+
+    /// <summary>
+    /// Creates a result for a compilation whose emit failed; the program never ran.
+    /// </summary>
+    /// <param name="diagnostics">The emit diagnostics, containing at least one error.</param>
+    /// <returns>The failed result.</returns>
+    internal static EmittedProgramResult FromFailedEmit(ImmutableArray<Diagnostic> diagnostics)
+        => new(success: false, diagnostics, exitCode: 1, unhandledException: null, loadContext: null);
+
+    /// <summary>
+    /// Creates a result for a program that was emitted and executed.
+    /// </summary>
+    /// <param name="diagnostics">The emit diagnostics (warnings only, since emit succeeded).</param>
+    /// <param name="exitCode">The entry point's mapped exit code.</param>
+    /// <param name="unhandledException">The unhandled exception the program threw, if any.</param>
+    /// <param name="loadContext">Weak reference to the unloaded, collectible load context.</param>
+    /// <returns>The executed result.</returns>
+    internal static EmittedProgramResult FromExecution(
+        ImmutableArray<Diagnostic> diagnostics,
+        int exitCode,
+        Exception unhandledException,
+        WeakReference loadContext)
+        => new(success: true, diagnostics, exitCode, unhandledException, loadContext);
+}

--- a/src/Repl/Program.cs
+++ b/src/Repl/Program.cs
@@ -98,7 +98,21 @@ public static class Program
         try
         {
             var compilation = new Compilation(resolver, tree);
-            var result = EmittedProgramHost.Run(compilation, references);
+            EmittedProgramResult result;
+            try
+            {
+                result = EmittedProgramHost.Run(compilation, references);
+            }
+            catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+            {
+                // 6.2 SilentEmitFailure invariant, gsi edition: a compiler
+                // exception that escapes the emit pipeline (e.g. #3183) must
+                // surface as gsc's canonical GS9998 line rather than a raw
+                // driver crash. User-code exceptions never reach here — the
+                // host reports those via UnhandledException below.
+                Console.Error.WriteLine($"{scriptPath}(1,1,1,1): error GS9998: {ex.GetType().Name}: {ex.Message}");
+                return 1;
+            }
             if (result.Diagnostics.Any())
             {
                 Console.Error.WriteDiagnostics(result.Diagnostics);

--- a/src/Repl/Program.cs
+++ b/src/Repl/Program.cs
@@ -3,9 +3,16 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Execution;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
 using GSharp.Core.IO;
-using GSharp.Repl.Engine;
 
 namespace GSharp.Repl;
 
@@ -25,57 +32,126 @@ public static class Program
             return ReplHost.Run();
         }
 
-        var arg = args[0];
-        switch (arg)
+        switch (args[0])
         {
             case "--help":
             case "-h":
             case "/?":
-                Console.WriteLine("Usage: gsi [file.gs] [--help] [--version]");
-                Console.WriteLine("  file.gs      Run the given G# script and exit.");
-                Console.WriteLine("  --help, -h   Show this help and exit.");
-                Console.WriteLine("  --version    Show the gsi version and exit.");
-                Console.WriteLine("  (no args)    Start the interactive REPL.");
+                Console.WriteLine("Usage: gsi [file.gs] [/r:<assembly> ...] [--help] [--version]");
+                Console.WriteLine("  file.gs                Run the given G# script and exit.");
+                Console.WriteLine("  /r:<file>              Reference an assembly in script mode (alias: /reference:<file>; repeatable).");
+                Console.WriteLine("  --help, -h             Show this help and exit.");
+                Console.WriteLine("  --version              Show the gsi version and exit.");
+                Console.WriteLine("  (no args)              Start the interactive REPL.");
                 return 0;
             case "--version":
                 Console.WriteLine(ReplHost.GetVersion());
                 return 0;
         }
 
-        if (!arg.EndsWith(".gs", StringComparison.OrdinalIgnoreCase))
+        var references = new List<string>();
+        string? scriptPath = null;
+        foreach (var arg in args)
         {
+            if (TryParseReferenceSwitch(arg, out var referencePath))
+            {
+                references.Add(referencePath);
+                continue;
+            }
+
+            if (scriptPath is null && arg.EndsWith(".gs", StringComparison.OrdinalIgnoreCase))
+            {
+                scriptPath = arg;
+                continue;
+            }
+
             Console.Error.WriteLine($"Unrecognized argument: {arg}");
             return 1;
         }
 
-        if (!File.Exists(arg))
+        if (scriptPath is null)
         {
-            Console.Error.WriteLine($"File not found: {arg}");
+            Console.Error.WriteLine("Must specify a .gs script file.");
             return 1;
         }
 
-        var engine = new SessionEngine { RunEntryPoint = true };
-        var cell = engine.Evaluate(File.ReadAllText(arg), arg);
-        if (cell.Diagnostics.Length > 0)
+        if (!File.Exists(scriptPath))
         {
-            Console.Error.WriteDiagnostics(cell.Diagnostics);
-        }
-
-        if (cell.HasError)
-        {
+            Console.Error.WriteLine($"File not found: {scriptPath}");
             return 1;
         }
 
-        if (cell.Value is int exitCode)
+        return RunScript(scriptPath, references);
+    }
+
+    /// <summary>
+    /// ADR-0156 Phase 1: script execution compiles with the real emitter into
+    /// memory and runs in-process via <see cref="EmittedProgramHost"/> instead
+    /// of the tree-walking evaluator. The driver protocol is unchanged:
+    /// diagnostics render to standard error, the program's output streams
+    /// straight through, and its integer result is the exit code.
+    /// </summary>
+    private static int RunScript(string scriptPath, List<string> references)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(File.ReadAllText(scriptPath), scriptPath));
+        var resolver = references.Count > 0 ? ReferenceResolver.WithReferences(references) : null;
+        try
         {
-            return exitCode;
+            var compilation = new Compilation(resolver, tree);
+            var result = EmittedProgramHost.Run(compilation, references);
+            if (result.Diagnostics.Any())
+            {
+                Console.Error.WriteDiagnostics(result.Diagnostics);
+            }
+
+            if (!result.Success)
+            {
+                return 1;
+            }
+
+            if (result.UnhandledException is not null)
+            {
+                // Mirror the CLR host's unhandled-exception protocol so gsi
+                // and `dotnet exec` render crashes identically.
+                Console.Error.WriteLine(EmittedProgramHost.FormatUnhandledException(result.UnhandledException));
+                return EmittedProgramHost.UnhandledExceptionExitCode;
+            }
+
+            return result.ExitCode;
+        }
+        finally
+        {
+            resolver?.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Parses gsc-style reference switches: <c>/r:&lt;file&gt;</c> or
+    /// <c>/reference:&lt;file&gt;</c> (also accepted with a leading dash).
+    /// </summary>
+    private static bool TryParseReferenceSwitch(string arg, [NotNullWhen(true)] out string? referencePath)
+    {
+        referencePath = null;
+        if (arg.Length < 2 || (arg[0] != '/' && arg[0] != '-'))
+        {
+            return false;
         }
 
-        if (cell.Value is uint unsignedExitCode)
+        var body = arg.Substring(1);
+        var separator = body.IndexOfAny(new[] { ':', '=' });
+        if (separator <= 0)
         {
-            return unchecked((int)unsignedExitCode);
+            return false;
         }
 
-        return 0;
+        var name = body.Substring(0, separator);
+        if (!name.Equals("r", StringComparison.OrdinalIgnoreCase)
+            && !name.Equals("reference", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        referencePath = body.Substring(separator + 1);
+        return true;
     }
 }

--- a/test/Compiler.Tests/LanguageConformance/SampleConformanceTests.cs
+++ b/test/Compiler.Tests/LanguageConformance/SampleConformanceTests.cs
@@ -17,7 +17,12 @@ namespace GSharp.Compiler.Tests.LanguageConformance;
 
 /// <summary>
 /// Runs every golden sample through the emitted runtime and every single-file
-/// sample through both evaluator front ends.
+/// sample through the in-process emit-to-memory drivers (bare <c>gsc</c> and
+/// <c>gsi</c>, ADR-0156 Phase 1), comparing all three byte-wise. Since Phase 1
+/// there are no expected per-driver differences: the historical
+/// <c>ExpectedDifferences</c> table (interpreter boundaries GS0510/GS0511/GS0514
+/// and the missing gsi reference channel, #3130) was deleted with the
+/// boundaries that caused it, and per the ADR no new entries may be added.
 /// </summary>
 public class SampleConformanceTests
 {
@@ -37,37 +42,6 @@ public class SampleConformanceTests
         "PInvokeRefOutIn.gs",
         "PInvokeMarshalAs.gs",
     };
-
-    private static readonly IReadOnlyDictionary<string, ExpectedDifference> ExpectedDifferences =
-        new Dictionary<string, ExpectedDifference>(StringComparer.Ordinal)
-        {
-            ["Deinit.gs"] = SameDifference(
-                Expected(0, "Allocated: db/users\ndone\n", "GS0510"),
-                "docs/diagnostics.md GS0510 / #2988",
-                "the evaluators do not run deinitializers"),
-            ["GsharpExtensionsMixed.gs"] = SameDifference(
-                Expected(1, string.Empty, "GS0157", "GS0159"),
-                "#3130",
-                "the evaluator drivers do not load the separately built Gsharp.Extensions assembly"),
-            ["GsharpExtensionsOptional.gs"] = SameDifference(
-                Expected(1, string.Empty, "GS0159"),
-                "#3130",
-                "the evaluator drivers do not load the separately built Gsharp.Extensions assembly"),
-            ["GsharpExtensionsSequences.gs"] = SameDifference(
-                Expected(1, string.Empty, "GS0157", "GS0158", "GS0159"),
-                "#3130",
-                "the evaluator drivers do not load the separately built Gsharp.Extensions assembly"),
-            ["PInvoke.gs"] = NativeCallDifference(),
-            ["PInvokeFunctionPointer.gs"] = NativeCallDifference(),
-            ["PInvokeLibraryImport.gs"] = NativeCallDifference(),
-            ["PInvokeLibraryImportStringReturn.gs"] = NativeCallDifference(),
-            ["PInvokeMarshalAs.gs"] = NativeCallDifference(),
-            ["PInvokeRefOutIn.gs"] = NativeCallDifference(),
-            ["RefStructSpan.gs"] = SameDifference(
-                Expected(1, string.Empty, "GS0511"),
-                "docs/diagnostics.md GS0511 / #3114",
-                "reflection cannot invoke ByRefLike signatures"),
-        };
 
     private static readonly Regex DiagnosticIdPattern =
         new(@"\b(?:GS\d{4}|GSI\d{3})\b", RegexOptions.CultureInvariant);
@@ -112,26 +86,27 @@ public class SampleConformanceTests
         var sourcePath = Path.Combine(samplesDirectory, sampleName);
         var goldenPath = Path.ChangeExtension(sourcePath, ".golden");
 
-        Assembly.Load("Gsharp.Extensions");
+        var extensionsAssembly = Assembly.Load("Gsharp.Extensions");
+
+        // Samples that consume the separately built Gsharp.Extensions assembly
+        // need it on every driver's reference channel (#3130): gsc and gsi get
+        // the same /r: path the emitted column compiles against, and gsc also
+        // mirrors the emitted column's GS9100 suppression so the compile-time
+        // console output stays identical.
+        var usesExtensions = File.ReadAllText(sourcePath).Contains("Gsharp.Extensions", StringComparison.Ordinal);
+        var extensionsReference = usesExtensions
+            ? "/r:" + extensionsAssembly.Location
+            : null;
+        var compilerArguments = usesExtensions
+            ? new[] { extensionsReference, "/nowarn:GS9100", sourcePath }
+            : new[] { sourcePath };
+        var interpreterArguments = usesExtensions
+            ? new[] { extensionsReference, sourcePath }
+            : new[] { sourcePath };
 
         var emitted = await RunEmittedAsync(new[] { sourcePath }, goldenPath, Path.GetFileNameWithoutExtension(sampleName));
-        var evaluatingCompiler = await RunDriverProcessAsync("Compiler", "gsc", sourcePath, compilerProtocol: true);
-        var interpreter = await RunDriverProcessAsync("Repl", "gsi", sourcePath, compilerProtocol: false);
-
-        if (ExpectedDifferences.TryGetValue(sampleName, out var difference))
-        {
-            var expectedCompiler = difference.EvaluatingCompiler;
-            var expectedInterpreter = difference.Interpreter;
-            Assert.False(
-                Equivalent(emitted, expectedCompiler)
-                && Equivalent(emitted, expectedInterpreter),
-                $"{sampleName} has a redundant expected-difference entry ({difference.Reference}: {difference.Reason}).");
-            AssertResults(
-                sampleName,
-                ("gsc", expectedCompiler, evaluatingCompiler),
-                ("gsi", expectedInterpreter, interpreter));
-            return;
-        }
+        var evaluatingCompiler = await RunDriverProcessAsync("Compiler", "gsc", sourcePath, compilerProtocol: true, compilerArguments);
+        var interpreter = await RunDriverProcessAsync("Repl", "gsi", sourcePath, compilerProtocol: false, interpreterArguments);
 
         AssertResults(
             sampleName,
@@ -165,7 +140,6 @@ public class SampleConformanceTests
         Assert.True(
             samples.Count >= MinimumSingleFileSampleCount,
             $"Expected at least {MinimumSingleFileSampleCount} single-file golden samples, found {samples.Count}.");
-        Assert.Empty(ExpectedDifferences.Keys.Except(samples, StringComparer.Ordinal));
     }
 
     [Fact]
@@ -184,6 +158,8 @@ public class SampleConformanceTests
         Assert.Equal(MainOnlySamples, actual);
         foreach (var sample in actual)
         {
+            // A Main-only sample with empty golden output would pass every
+            // driver vacuously; require the entry point to produce evidence.
             var golden = SampleConformanceData.ReadNormalizedFile(
                 Path.Combine(samplesDirectory, Path.ChangeExtension(sample, ".golden")));
             Assert.False(string.IsNullOrEmpty(golden), $"{sample} must have non-empty golden output.");
@@ -294,7 +270,8 @@ public class SampleConformanceTests
         string projectDirectory,
         string executableName,
         string sourcePath,
-        bool compilerProtocol)
+        bool compilerProtocol,
+        string[] arguments)
     {
         var testDirectory = Path.GetDirectoryName(typeof(SampleConformanceTests).Assembly.Location);
         Assert.NotNull(testDirectory);
@@ -308,7 +285,7 @@ public class SampleConformanceTests
         var process = await RunProcessAsync(
             executable,
             Path.GetDirectoryName(sourcePath),
-            sourcePath);
+            arguments);
         return CreateCliResult(
             process.ExitCode,
             process.StandardOutput,
@@ -383,21 +360,6 @@ public class SampleConformanceTests
             await stderrTask);
     }
 
-    private static ExpectedDifference NativeCallDifference()
-        => SameDifference(
-            Expected(1, string.Empty, "GS0514"),
-            "ADR-0152 / #2986",
-            "GS0514 requires native calls to use emitted gsc output");
-
-    private static ExpectedDifference SameDifference(
-        DriverResult result,
-        string reference,
-        string reason)
-        => new(result, result, reference, reason);
-
-    private static DriverResult Expected(int exitCode, string output, params string[] diagnosticIds)
-        => new(exitCode, output, diagnosticIds, string.Empty);
-
     private static bool Equivalent(DriverResult left, DriverResult right)
         => left.ExitCode == right.ExitCode
             && string.Equals(left.Output, right.Output, StringComparison.Ordinal)
@@ -433,12 +395,6 @@ public class SampleConformanceTests
         string Output,
         string[] DiagnosticIds,
         string StandardError);
-
-    private sealed record ExpectedDifference(
-        DriverResult EvaluatingCompiler,
-        DriverResult Interpreter,
-        string Reference,
-        string Reason);
 
     private sealed record ProcessResult(
         int ExitCode,

--- a/test/Interpreter.Tests/EmittedProgramHostTests.cs
+++ b/test/Interpreter.Tests/EmittedProgramHostTests.cs
@@ -1,0 +1,243 @@
+// <copyright file="EmittedProgramHostTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Reflection;
+using System.Threading;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Execution;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// ADR-0156 Phase 1: unit coverage for <see cref="EmittedProgramHost"/> — the
+/// shared emit-to-memory execution host behind bare <c>gsc</c> and
+/// <c>gsi &lt;file&gt;</c>. Pins the exit-code mapping, the unhandled-exception
+/// protocol (including the CLR-host crash rendering), emit-failure reporting,
+/// best-effort cancellation, reference-assembly resolution, and reclamation of
+/// the collectible <see cref="System.Runtime.Loader.AssemblyLoadContext"/>.
+/// </summary>
+[Collection("ConsoleIo")]
+public class EmittedProgramHostTests
+{
+    [Fact]
+    public void TopLevelIntegerReturn_BecomesExitCode()
+    {
+        var (result, stdout, _) = Run("""
+            import System
+
+            Console.WriteLine("tls-11")
+            return 7
+            """);
+
+        Assert.True(result.Success);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(7, result.ExitCode);
+        Assert.Equal("tls-11\n", stdout);
+    }
+
+    [Fact]
+    public void UnsignedMainReturn_BecomesExitCode()
+    {
+        var (result, stdout, _) = Run("""
+            import System
+
+            func Main() uint32 {
+                Console.WriteLine("unsigned-22")
+                return 9
+            }
+            """);
+
+        Assert.True(result.Success);
+        Assert.Equal(9, result.ExitCode);
+        Assert.Equal("unsigned-22\n", stdout);
+    }
+
+    [Fact]
+    public void VoidProgram_ExitsZero()
+    {
+        var (result, stdout, _) = Run("""
+            import System
+
+            Console.WriteLine("void-33")
+            """);
+
+        Assert.True(result.Success);
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("void-33\n", stdout);
+    }
+
+    [Fact]
+    public void UnhandledException_IsSurfacedUnwrappedWithClrHostRendering()
+    {
+        var (result, stdout, _) = Run("""
+            import System
+
+            Console.WriteLine("before-44")
+            throw InvalidOperationException("boom-44")
+            """);
+
+        Assert.True(result.Success);
+        Assert.Equal("before-44\n", stdout);
+        var exception = Assert.IsType<InvalidOperationException>(result.UnhandledException);
+        Assert.Equal("boom-44", exception.Message);
+
+        // The driver-facing rendering matches `dotnet exec` byte-for-byte:
+        // the CLR prefix, the program's own frames, and no reflection-invoker
+        // or host frames below them.
+        var rendered = EmittedProgramHost.FormatUnhandledException(exception);
+        Assert.StartsWith("Unhandled exception. System.InvalidOperationException: boom-44", rendered, StringComparison.Ordinal);
+        Assert.Contains("<Main>$", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("MethodBaseInvoker", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("EmittedProgramHost", rendered, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void InvalidEntryPointReturnType_CrashesLikeClrHostWithoutRunning()
+    {
+        var (result, stdout, _) = Run("""
+            import System
+
+            func Main() string {
+                Console.WriteLine("must-not-run")
+                return "invalid"
+            }
+            """);
+
+        Assert.True(result.Success);
+        Assert.Equal(string.Empty, stdout);
+        var exception = Assert.IsType<MethodAccessException>(result.UnhandledException);
+        Assert.Equal(
+            "Entry point must have a return type of void, integer, or unsigned integer.",
+            exception.Message);
+    }
+
+    [Fact]
+    public void EmitFailure_ReportsDiagnosticsWithoutRunning()
+    {
+        var (result, stdout, stderr) = Run("""
+            import System
+
+            Console.WriteLine(undefinedSymbol)
+            """);
+
+        Assert.False(result.Success);
+        Assert.Contains(result.Diagnostics, d => d.IsError);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(string.Empty, stdout);
+        Assert.Equal(string.Empty, stderr);
+    }
+
+    [Fact]
+    public void PreCancelledToken_ThrowsBeforeTheProgramRuns()
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        var compilation = Compile("""
+            import System
+
+            Console.WriteLine("must-not-run")
+            """);
+
+        var (stdout, _) = CaptureConsole(() =>
+        {
+            Assert.ThrowsAny<OperationCanceledException>(
+                () => EmittedProgramHost.Run(compilation, referencePaths: null, cancellation.Token));
+            return 0;
+        });
+        Assert.Equal(string.Empty, stdout);
+    }
+
+    [Fact]
+    public void CollectibleLoadContext_IsReclaimedAfterRun()
+    {
+        var (result, stdout, _) = Run("""
+            import System
+
+            Console.WriteLine("collect-55")
+            """);
+
+        Assert.True(result.Success);
+        Assert.Equal("collect-55\n", stdout);
+        Assert.NotNull(result.LoadContext);
+        for (var i = 0; result.LoadContext.IsAlive && i < 10; i++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+        }
+
+        Assert.False(result.LoadContext.IsAlive, "Collectible AssemblyLoadContext was not reclaimed after the run.");
+    }
+
+    [Fact]
+    public void UserReferenceAssembly_ResolvesAtCompileTimeAndRuntime()
+    {
+        const string Source = """
+            import System
+            import Gsharp.Extensions.Optional
+
+            let name string? = "ada"
+            let upper = name.Map(func(s string) string { return s.ToUpper() })
+            Console.WriteLine(upper ?? "<absent>")
+            """;
+        var extensionsPath = Assembly.Load("Gsharp.Extensions").Location;
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { extensionsPath });
+        var compilation = new Compilation(resolver, SyntaxTree.Parse(Source));
+        EmittedProgramResult result = null;
+        var (stdout, _) = CaptureConsole(() =>
+        {
+            result = EmittedProgramHost.Run(compilation, new[] { extensionsPath });
+            return 0;
+        });
+
+        Assert.True(result.Success, string.Join("\n", result.Diagnostics));
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("ADA\n", stdout);
+    }
+
+    private static Compilation Compile(string source)
+        => new(SyntaxTree.Parse(source));
+
+    private static (EmittedProgramResult Result, string Stdout, string Stderr) Run(string source)
+    {
+        var compilation = Compile(source);
+        EmittedProgramResult result = null;
+        var (stdout, stderr) = CaptureConsole(() =>
+        {
+            result = EmittedProgramHost.Run(compilation);
+            return 0;
+        });
+        return (result, stdout, stderr);
+    }
+
+    private static (string Stdout, string Stderr) CaptureConsole(Func<int> action)
+    {
+        using var stdout = new StringWriter { NewLine = "\n" };
+        using var stderr = new StringWriter { NewLine = "\n" };
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            action();
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+
+        return (
+            stdout.ToString().Replace("\r\n", "\n", StringComparison.Ordinal),
+            stderr.ToString().Replace("\r\n", "\n", StringComparison.Ordinal));
+    }
+}

--- a/test/Interpreter.Tests/Issue2956InterpreterBoundaryTests.cs
+++ b/test/Interpreter.Tests/Issue2956InterpreterBoundaryTests.cs
@@ -9,17 +9,23 @@ using Xunit;
 namespace GSharp.Interpreter.Tests;
 
 /// <summary>
-/// Issue #2956 / ADR-0153: script-mode <c>gsi</c> reports self-contained
-/// diagnostics for constructs that require the compiled storage model.
+/// Issue #2956 / ADR-0153 / ADR-0156 Phase 1: script-mode <c>gsi</c> executes
+/// the compiled storage model natively. The constructs the interpreting driver
+/// used to reject with self-contained boundary diagnostics (<c>fixed</c>,
+/// <c>stackalloc</c>, <c>sizeof</c> on user structs, function pointers) now
+/// compile through the real emitter and run in-process, so each case asserts
+/// the construct's observable result instead of a refusal. The ADR-0153
+/// boundary remains in force for the interactive REPL, which still evaluates
+/// (see <c>Issue3004PointerBoundaryInterpreterTests</c>).
 /// </summary>
 [Collection("ConsoleIo")]
 public class Issue2956InterpreterBoundaryTests
 {
     [Fact]
-    public void FixedArrayReportsCompiledOnlyBoundary()
+    public void FixedArrayPinsAndExecutes()
     {
-        AssertBoundary(
-            nameof(FixedArrayReportsCompiledOnlyBoundary),
+        var result = RunGsi(
+            nameof(FixedArrayPinsAndExecutes),
             """
             import System
 
@@ -29,15 +35,16 @@ public class Issue2956InterpreterBoundaryTests
                     Console.WriteLine(values.Length)
                 }
             }
-            """,
-            "'fixed' (pinning) statements are not supported in the interpreter; they require the CIL pinned-local emit path.");
+            """);
+
+        AssertRan(result, "2\n");
     }
 
     [Fact]
-    public void FixedStringReportsCompiledOnlyBoundary()
+    public void FixedStringPinsAndDereferences()
     {
-        AssertBoundary(
-            nameof(FixedStringReportsCompiledOnlyBoundary),
+        var result = RunGsi(
+            nameof(FixedStringPinsAndDereferences),
             """
             import System
 
@@ -46,90 +53,111 @@ public class Issue2956InterpreterBoundaryTests
                     Console.WriteLine(*p)
                 }
             }
-            """,
-            "'fixed' (pinning) statements are not supported in the interpreter; they require the CIL pinned-local emit path.");
+            """);
+
+        AssertRan(result, "65\n");
     }
 
     [Fact]
-    public void FixedPinnableSpanReportsCompiledOnlyBoundary()
+    public void FixedEmptySpanPinsNil()
     {
-        AssertBoundary(
-            nameof(FixedPinnableSpanReportsCompiledOnlyBoundary),
+        var result = RunGsi(
+            nameof(FixedEmptySpanPinsNil),
             """
             import System
 
             unsafe {
                 fixed p *int32 = Span[int32].Empty {
-                    Console.WriteLine(*p)
+                    if p == nil {
+                        Console.WriteLine("empty-span-pins-nil")
+                    }
                 }
             }
-            """,
-            "'fixed' (pinning) statements are not supported in the interpreter; they require the CIL pinned-local emit path.");
+            """);
+
+        AssertRan(result, "empty-span-pins-nil\n");
     }
 
     [Fact]
-    public void StackAllocReportsCompiledOnlyBoundary()
+    public void StackAllocExecutes()
     {
-        AssertBoundary(
-            nameof(StackAllocReportsCompiledOnlyBoundary),
+        var result = RunGsi(
+            nameof(StackAllocExecutes),
             """
+            import System
+
             func run() int32 {
                 let values = stackalloc [2]int32
                 return values.Length
             }
 
-            run()
-            """,
-            "stackalloc is not supported in the interpreter; it requires the CIL localloc emit path.");
+            Console.WriteLine(run())
+            """);
+
+        AssertRan(result, "2\n");
     }
 
     [Fact]
-    public void SizeOfUserStructReportsCompiledOnlyBoundary()
+    public void SizeOfUserStructExecutes()
     {
-        AssertBoundary(
-            nameof(SizeOfUserStructReportsCompiledOnlyBoundary),
+        var result = RunGsi(
+            nameof(SizeOfUserStructExecutes),
             """
+            import System
+
             struct Pair {
                 var Left int32
                 var Right int32
             }
 
             unsafe {
-                sizeof(Pair)
+                Console.WriteLine(sizeof(Pair))
             }
-            """,
-            "sizeof on an unmanaged-pointer struct pointee is not supported in the interpreter; it requires the CIL sizeof emit path.");
+            """);
+
+        AssertRan(result, "8\n");
     }
 
     [Fact]
-    public void FunctionPointerAddressReportsCompiledOnlyBoundary()
+    public void FunctionPointerAddressExecutes()
     {
-        AssertBoundary(
-            nameof(FunctionPointerAddressReportsCompiledOnlyBoundary),
+        var result = RunGsi(
+            nameof(FunctionPointerAddressExecutes),
             """
+            import System
+
             unsafe func identity(value int32) int32 {
                 return value
             }
 
             unsafe {
                 let pointer *func(int32) int32 = &identity
+                Console.WriteLine("took-address")
             }
-            """,
-            "'&Method' function pointers are not supported in the interpreter; they require the CIL ldftn/calli emit path (ADR-0122 §9).");
+            """);
+
+        AssertRan(result, "took-address\n");
     }
 
     [Fact]
-    public void FunctionPointerInvocationReportsCompiledOnlyBoundary()
+    public void FunctionPointerInvocationExecutes()
     {
-        AssertBoundary(
-            nameof(FunctionPointerInvocationReportsCompiledOnlyBoundary),
+        var result = RunGsi(
+            nameof(FunctionPointerInvocationExecutes),
             """
-            unsafe {
-                let pointer *func(int32) int32 = nil
-                pointer(1)
+            import System
+
+            unsafe func identity(value int32) int32 {
+                return value
             }
-            """,
-            "function-pointer invocation ('fp(args)') is not supported in the interpreter; it requires the CIL calli emit path (ADR-0122 §9).");
+
+            unsafe {
+                let pointer *func(int32) int32 = &identity
+                Console.WriteLine(pointer(41) + 1)
+            }
+            """);
+
+        AssertRan(result, "42\n");
     }
 
     [Fact]
@@ -145,18 +173,16 @@ public class Issue2956InterpreterBoundaryTests
             }
             """);
 
-        Assert.Equal(0, result.ExitCode);
-        Assert.Equal("42\n", result.StandardOutput);
-        Assert.Equal(string.Empty, result.StandardError);
+        AssertRan(result, "42\n");
     }
 
-    private static void AssertBoundary(string name, string source, string message)
+    private static void AssertRan(
+        (int ExitCode, string StandardOutput, string StandardError) result,
+        string expectedOutput)
     {
-        var result = RunGsi(name, source);
-
-        Assert.Equal(1, result.ExitCode);
-        Assert.Equal(string.Empty, result.StandardOutput);
-        Assert.Contains(message, result.StandardError);
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(expectedOutput, result.StandardOutput);
+        Assert.Equal(string.Empty, result.StandardError);
     }
 
     private static (int ExitCode, string StandardOutput, string StandardError) RunGsi(

--- a/test/Interpreter.Tests/Issue2986InterpreterBoundaryTests.cs
+++ b/test/Interpreter.Tests/Issue2986InterpreterBoundaryTests.cs
@@ -62,15 +62,27 @@ public class Issue2986InterpreterBoundaryTests
         Assert.DoesNotContain("IConvertible", diagnostic.Message);
     }
 
+    /// <summary>
+    /// ADR-0156 Phase 1: script-mode <c>gsi</c> executes emitted code, so the
+    /// ADR-0152 native-call boundary (GS0514) no longer applies to file mode —
+    /// the P/Invoke sample calls straight into libc and prints its golden
+    /// output. GS0514 remains an interactive-REPL boundary (tests above).
+    /// </summary>
     [Fact]
-    public void BatchFileRunner_RendersPInvokeLocationAndUsesErrorExitCode()
+    public void BatchFileRunner_ExecutesPInvokeNatively()
     {
+        if (OperatingSystem.IsWindows())
+        {
+            // The sample targets POSIX libc; the conformance gate skips it on
+            // Windows for the same reason (WindowsSkippedSamples).
+            return;
+        }
+
         var pInvokePath = LocateSample("PInvoke.gs");
         var pInvoke = RunBatchFile(pInvokePath);
-        Assert.Equal(1, pInvoke.ExitCode);
-        Assert.Contains($"{pInvokePath}(20,6,20,18): error GS0514:", pInvoke.StandardError);
-        Assert.Contains("func NativeStrLen(text string) nint;", pInvoke.StandardError);
-        Assert.Equal(string.Empty, pInvoke.StandardOutput);
+        Assert.Equal(0, pInvoke.ExitCode);
+        Assert.Equal("13\n", pInvoke.StandardOutput.Replace("\r\n", "\n", StringComparison.Ordinal));
+        Assert.Equal(string.Empty, pInvoke.StandardError);
     }
 
     private static (int ExitCode, string StandardOutput, string StandardError) RunBatchFile(string path)

--- a/test/Interpreter.Tests/Issue2988DeinitInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2988DeinitInterpreterTests.cs
@@ -64,11 +64,19 @@ public class Issue2988DeinitInterpreterTests
         Assert.DoesNotContain(next.Diagnostics, diagnostic => diagnostic.Id == "GS0510");
     }
 
+    /// <summary>
+    /// ADR-0156 Phase 1: bare <c>gsc</c> and script-mode <c>gsi</c> execute
+    /// emitted code, so deinitializers run as real CLR finalizers on every
+    /// driver — derived-then-base, per declaring class — and the GS0510
+    /// boundary warning no longer fires on any of them. The warning remains
+    /// an interactive-REPL concern (see the SessionEngine tests above).
+    /// </summary>
+    /// <param name="driver">The driver under test.</param>
     [Theory]
     [InlineData(Issue3010EntryPointDriverMatrixTests.Driver.CompilerEvaluation)]
     [InlineData(Issue3010EntryPointDriverMatrixTests.Driver.CompilerEmission)]
     [InlineData(Issue3010EntryPointDriverMatrixTests.Driver.Interpreter)]
-    public void InheritedDeinitializersExposeDriverBoundaryPerDeclaringClass(
+    public void InheritedDeinitializersRunOnEveryDriver(
         Issue3010EntryPointDriverMatrixTests.Driver driver)
     {
         const string Source = """
@@ -100,7 +108,6 @@ public class Issue2988DeinitInterpreterTests
             GC.WaitForPendingFinalizers()
             Console.WriteLine("end-55")
             """;
-        const string InterpretedOutput = "body-44\nend-55\n";
         const string EmittedOutput = "body-44\nderived-deinit-22\nbase-deinit-11\nend-55\n";
 
         var result = Issue3010EntryPointDriverMatrixTests.Run(
@@ -109,33 +116,12 @@ public class Issue2988DeinitInterpreterTests
             driver);
         Assert.Equal(0, result.ExitCode);
 
-        string warningOutput;
-        switch (driver)
-        {
-            case Issue3010EntryPointDriverMatrixTests.Driver.CompilerEvaluation:
-                Assert.StartsWith(InterpretedOutput + "\n", result.StandardOutput, StringComparison.Ordinal);
-                Assert.EndsWith("Success.\n", result.StandardOutput, StringComparison.Ordinal);
-                Assert.Equal(string.Empty, result.StandardError);
-                warningOutput = result.StandardOutput[InterpretedOutput.Length..];
-                break;
-            case Issue3010EntryPointDriverMatrixTests.Driver.CompilerEmission:
-                Assert.Equal(EmittedOutput, result.StandardOutput);
-                Assert.Equal(string.Empty, result.StandardError);
-                return;
-            case Issue3010EntryPointDriverMatrixTests.Driver.Interpreter:
-                Assert.Equal(InterpretedOutput, result.StandardOutput);
-                warningOutput = result.StandardError;
-                break;
-            default:
-                throw new InvalidOperationException($"Unexpected driver {driver}.");
-        }
-
-        Assert.Equal(
-            2,
-            warningOutput.Split('\n')
-                .Count(line => line.Contains("warning GS0510", StringComparison.Ordinal)));
-        Assert.Contains("class 'CachedResource'", warningOutput, StringComparison.Ordinal);
-        Assert.Contains("class 'Resource'", warningOutput, StringComparison.Ordinal);
+        var expectedOutput = driver == Issue3010EntryPointDriverMatrixTests.Driver.CompilerEvaluation
+            ? EmittedOutput + "Success.\n"
+            : EmittedOutput;
+        Assert.Equal(expectedOutput, result.StandardOutput);
+        Assert.Equal(string.Empty, result.StandardError);
+        Assert.DoesNotContain("GS0510", result.StandardOutput + result.StandardError, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -189,18 +175,35 @@ public class Issue2988DeinitInterpreterTests
         Assert.DoesNotContain(cell.Diagnostics, diagnostic => diagnostic.Id == "GS0510");
     }
 
+    /// <summary>
+    /// ADR-0156 Phase 1: script-mode <c>gsi</c> runs emitted code, so a class
+    /// deinitializer executes as a real CLR finalizer — asserted positively by
+    /// forcing a collection — and the GS0510 boundary warning that used to
+    /// accompany file mode no longer fires there.
+    /// </summary>
     [Fact]
-    public void ScriptRunnerWritesBoundaryWarningToStandardError()
+    public void ScriptRunnerRunsDeinitializersWithoutBoundaryWarning()
     {
         var sourcePath = Path.Combine(AppContext.BaseDirectory, "issue2988-deinit.gs");
         File.WriteAllText(
             sourcePath,
             """
+            import System
+
             class Resource {
                 deinit {
+                    Console.WriteLine("deinit-ran-22")
                 }
             }
 
+            func Allocate() {
+                var resource = Resource()
+                GC.KeepAlive(resource)
+            }
+
+            Allocate()
+            GC.Collect()
+            GC.WaitForPendingFinalizers()
             Console.WriteLine("body-33")
             """);
 
@@ -214,11 +217,9 @@ public class Issue2988DeinitInterpreterTests
         {
             var exitCode = GSharp.Repl.Program.Main([sourcePath]);
 
-            // Unlike GS0513, GS0510 skips only a GC-scheduled side effect after evaluation completes.
             Assert.Equal(0, exitCode);
-            Assert.Equal("body-33\n", output.ToString());
-            Assert.Contains("warning GS0510", error.ToString(), StringComparison.Ordinal);
-            Assert.Contains("deinit", error.ToString(), StringComparison.Ordinal);
+            Assert.Equal("deinit-ran-22\nbody-33\n", output.ToString());
+            Assert.Equal(string.Empty, error.ToString());
         }
         finally
         {

--- a/test/Interpreter.Tests/Issue3006FallthroughGuardDriverTests.cs
+++ b/test/Interpreter.Tests/Issue3006FallthroughGuardDriverTests.cs
@@ -238,6 +238,9 @@ public class Issue3006FallthroughGuardDriverTests
     [MemberData(nameof(FallthroughCases))]
     public async Task UnmatchedExhaustiveSwitch_AllDriversSurfaceGuard(string name, string source)
     {
+        // ADR-0156 Phase 1: every driver executes emitted code, so all three
+        // surface the guard identically — the InvalidOperationException crash
+        // protocol of the CLR host, not an interpreter diagnostic.
         var root = CreateEmptyProbeRoot(name);
         try
         {
@@ -245,19 +248,17 @@ public class Issue3006FallthroughGuardDriverTests
                 CreateEmptyDirectory(root, "gsc-eval"),
                 source,
                 Program.Main);
-            Assert.Equal(1, compilerEvaluation.ExitCode);
-            Assert.Contains("GS0100", compilerEvaluation.StandardOutput);
-            Assert.Contains(GuardMessage, compilerEvaluation.StandardOutput);
-            Assert.Equal($"Failed.{Environment.NewLine}", compilerEvaluation.StandardError);
+            Assert.Equal(ExpectedUnhandledExceptionExitCode, compilerEvaluation.ExitCode);
+            Assert.Equal(string.Empty, compilerEvaluation.StandardOutput);
+            Assert.Contains($"Unhandled exception. System.InvalidOperationException: {GuardMessage}", compilerEvaluation.StandardError);
 
             var interpreter = RunSourceDriver(
                 CreateEmptyDirectory(root, "gsi"),
                 source,
                 GSharp.Repl.Program.Main);
-            Assert.Equal(1, interpreter.ExitCode);
+            Assert.Equal(ExpectedUnhandledExceptionExitCode, interpreter.ExitCode);
             Assert.Equal(string.Empty, interpreter.StandardOutput);
-            Assert.Contains("GS0100", interpreter.StandardError);
-            Assert.Contains(GuardMessage, interpreter.StandardError);
+            Assert.Contains($"Unhandled exception. System.InvalidOperationException: {GuardMessage}", interpreter.StandardError);
 
             var emitted = await CompileAndRunAsync(
                 CreateEmptyDirectory(root, "gsc-emit"),
@@ -433,13 +434,18 @@ public class Issue3006FallthroughGuardDriverTests
         }
     }
 
-    [Theory]
-    [InlineData(0, 3)]
-    [InlineData(9, 12)]
-    public void FallthroughGuard_ReportsFunctionDeclarationLocation(int paddingLines, int functionLine)
+    /// <summary>
+    /// ADR-0156 Phase 1: the guard is a runtime exception on every driver, so
+    /// the evaluator's GS0100 diagnostic (which carried the function's
+    /// declaration location) is gone. What remains observable — and what this
+    /// pins so a silently swallowed guard cannot pass — is the crash protocol:
+    /// the CLR-host "Unhandled exception." prefix, the exception type and
+    /// guard message, and a stack trace rooted in the program's own frames.
+    /// </summary>
+    [Fact]
+    public void FallthroughGuard_RendersClrHostCrashProtocol()
     {
         var source = "import System\n\n"
-            + new string('\n', paddingLines)
             + """
             func F(x DateTimeKind) int32 {
                 switch x {
@@ -451,33 +457,38 @@ public class Issue3006FallthroughGuardDriverTests
 
             F(DateTimeKind(99))
             """;
-        var root = CreateEmptyProbeRoot($"Location-{functionLine}");
+        var root = CreateEmptyProbeRoot("CrashProtocol");
 
         try
         {
-            var compilerDirectory = CreateEmptyDirectory(root, "gsc-eval");
-            var compilerEvaluation = RunSourceDriver(compilerDirectory, source, Program.Main);
-            var sourcePath = Path.Combine(compilerDirectory, "Probe.gs");
-            Assert.Equal(1, compilerEvaluation.ExitCode);
-            Assert.Contains(
-                $"{sourcePath}({functionLine},6,{functionLine},7): error GS0100",
-                compilerEvaluation.StandardOutput);
-            Assert.Contains("func F(x DateTimeKind) int32 {", compilerEvaluation.StandardOutput);
+            var compilerEvaluation = RunSourceDriver(
+                CreateEmptyDirectory(root, "gsc-eval"),
+                source,
+                Program.Main);
+            Assert.Equal(ExpectedUnhandledExceptionExitCode, compilerEvaluation.ExitCode);
+            AssertCrashProtocol(compilerEvaluation.StandardError);
 
             var interpreter = RunSourceDriver(
                 CreateEmptyDirectory(root, "gsi"),
                 source,
                 GSharp.Repl.Program.Main);
-            Assert.Equal(1, interpreter.ExitCode);
-            Assert.Contains(
-                $"({functionLine},6,{functionLine},7): error GS0100",
-                interpreter.StandardError);
-            Assert.Contains("func F(x DateTimeKind) int32 {", interpreter.StandardError);
+            Assert.Equal(ExpectedUnhandledExceptionExitCode, interpreter.ExitCode);
+            AssertCrashProtocol(interpreter.StandardError);
         }
         finally
         {
             Directory.Delete(root, recursive: true);
         }
+    }
+
+    private static void AssertCrashProtocol(string standardError)
+    {
+        Assert.StartsWith(
+            $"Unhandled exception. System.InvalidOperationException: {GuardMessage}",
+            standardError,
+            StringComparison.Ordinal);
+        Assert.Contains("   at Default.<Program>.<Main>$(String[] args)", standardError, StringComparison.Ordinal);
+        Assert.DoesNotContain("MethodBaseInvoker", standardError, StringComparison.Ordinal);
     }
 
     private static int ExpectedUnhandledExceptionExitCode

--- a/test/Interpreter.Tests/Issue3010EntryPointExitCodeTests.cs
+++ b/test/Interpreter.Tests/Issue3010EntryPointExitCodeTests.cs
@@ -210,10 +210,13 @@ public class Issue3010EntryPointExitCodeTests
 
         var result = RunScript(Source);
 
-        Assert.Equal(1, result.ExitCode);
+        // ADR-0156 Phase 1: the emitted driver mirrors the CLR host, which
+        // rejects an invalid entry-point signature with MethodAccessException
+        // before running a single statement.
+        Assert.Equal(GSharp.Core.CodeAnalysis.Execution.EmittedProgramHost.UnhandledExceptionExitCode, result.ExitCode);
         Assert.Equal(string.Empty, result.StandardOutput);
         Assert.Contains(
-            "error GSI001: Evaluation error: Entry point must have a return type of void, int32, or uint32.",
+            "Unhandled exception. System.MethodAccessException: Entry point must have a return type of void, integer, or unsigned integer.",
             result.StandardError);
     }
 
@@ -235,10 +238,11 @@ public class Issue3010EntryPointExitCodeTests
 
         var result = RunScript(Source);
 
-        Assert.Equal(1, result.ExitCode);
+        // ADR-0156 Phase 1: same CLR-host rejection shape as the string case.
+        Assert.Equal(GSharp.Core.CodeAnalysis.Execution.EmittedProgramHost.UnhandledExceptionExitCode, result.ExitCode);
         Assert.Equal(string.Empty, result.StandardOutput);
         Assert.Contains(
-            "error GSI001: Evaluation error: Entry point must have a return type of void, int32, or uint32.",
+            "Unhandled exception. System.MethodAccessException: Entry point must have a return type of void, integer, or unsigned integer.",
             result.StandardError);
     }
 

--- a/test/Interpreter.Tests/Issue3114ReadOnlySpanInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue3114ReadOnlySpanInterpreterTests.cs
@@ -145,9 +145,16 @@ public class Issue3114ReadOnlySpanInterpreterTests
         }
     }
 
-    [Theory]
-    [MemberData(nameof(InterpretingDrivers))]
-    public void SpanInterpolation_UsesPublicSpanName(Driver driver)
+    /// <summary>
+    /// The evaluator's public-name span interpolation (#3128) now lives only
+    /// where the evaluator still runs — the interactive REPL. ADR-0156
+    /// Phase 1 moved <c>gsi &lt;file&gt;</c> and bare <c>gsc</c> to emitted
+    /// execution, and the emit path cannot lower a span interpolation hole
+    /// (#3183), so the driver-level variant of this coverage is
+    /// <see cref="SpanInterpolation_ReportsEmitIceOnFileDrivers"/>.
+    /// </summary>
+    [Fact]
+    public void SpanInterpolation_UsesPublicSpanNameInteractively()
     {
         const string Source = """
             import System
@@ -158,6 +165,41 @@ public class Issue3114ReadOnlySpanInterpreterTests
                 var readOnly ReadOnlySpan[int32] = writable
                 Console.WriteLine("writable=${writable}")
                 Console.WriteLine("readonly=${readOnly}")
+            }
+            """;
+
+        // ByRefLike values cannot be top-level session variables (GS0219), so
+        // the interpolation runs inside an entry point, exactly as the file
+        // drivers used to evaluate it.
+        var cell = new GSharp.Repl.Engine.SessionEngine { CaptureConsole = true, RunEntryPoint = true }.Evaluate(Source);
+
+        Assert.False(cell.HasError);
+        Assert.Equal(
+            "writable=System.Span<Int32>[3]\nreadonly=System.ReadOnlySpan<Int32>[3]\n",
+            cell.Output);
+    }
+
+    /// <summary>
+    /// #3183: the emit path ICEs on span interpolation holes
+    /// (<c>DefaultInterpolatedStringHandler.AppendFormatted[T]</c> rejects
+    /// ByRefLike type arguments), which the evaluator masked on the file
+    /// drivers until ADR-0156 Phase 1. Until #3183 is fixed, both emitted
+    /// file drivers must surface the canonical GS9998 line with exit code 1
+    /// instead of crashing; when it is fixed, flip this to assert the
+    /// evaluator's golden rendering.
+    /// </summary>
+    /// <param name="driver">The driver under test.</param>
+    [Theory]
+    [MemberData(nameof(InterpretingDrivers))]
+    public void SpanInterpolation_ReportsEmitIceOnFileDrivers(Driver driver)
+    {
+        const string Source = """
+            import System
+
+            func Main() {
+                var values = []int32{11, 22, 33}
+                var writable Span[int32] = values
+                Console.WriteLine("writable=${writable}")
             }
             """;
 
@@ -178,13 +220,12 @@ public class Issue3114ReadOnlySpanInterpreterTests
                 _ => throw new InvalidOperationException($"Unexpected driver {driver}."),
             };
 
-            Assert.Equal(0, result.ExitCode);
-            Assert.Equal(
-                driver == Driver.CompilerEvaluation
-                    ? "writable=System.Span<Int32>[3]\nreadonly=System.ReadOnlySpan<Int32>[3]\nSuccess.\n"
-                    : "writable=System.Span<Int32>[3]\nreadonly=System.ReadOnlySpan<Int32>[3]\n",
-                result.StandardOutput);
-            Assert.Equal(string.Empty, result.StandardError);
+            Assert.Equal(1, result.ExitCode);
+            var diagnosticStream = driver == Driver.CompilerEvaluation
+                ? result.StandardOutput
+                : result.StandardError;
+            Assert.Contains("error GS9998: ArgumentException", diagnosticStream, StringComparison.Ordinal);
+            Assert.Contains("AppendFormatted", diagnosticStream, StringComparison.Ordinal);
         }
         finally
         {

--- a/test/Interpreter.Tests/Issue3130GsiReferenceOptionTests.cs
+++ b/test/Interpreter.Tests/Issue3130GsiReferenceOptionTests.cs
@@ -1,0 +1,152 @@
+// <copyright file="Issue3130GsiReferenceOptionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #3130 / ADR-0156 Phase 1: <c>gsi</c> gains gsc's <c>/r:</c> reference
+/// channel in script mode, and the referenced assembly resolves both at
+/// compile time (the import binds) and at runtime (the emitted program's load
+/// context loads it from the supplied path). The library is compiled by gsc
+/// into a scratch directory so it is invisible to the test host's own probing
+/// paths — the negative case below proves the reference channel is the only
+/// thing making the positive cases pass.
+/// </summary>
+[Collection("ConsoleIo")]
+public class Issue3130GsiReferenceOptionTests
+{
+    // Each test uses its own package name: an assembly loaded (even into an
+    // unloaded, collectible context) by one test must not be able to satisfy
+    // another test's import through the in-process resolver's view of loaded
+    // assemblies.
+    private const string LibrarySourceTemplate = """
+        package {0}
+
+        import System
+
+        class Doubler(Factor int32) {{
+            func Apply(value int32) int32 {{
+                return value * Factor
+            }}
+        }}
+        """;
+
+    private const string ScriptSourceTemplate = """
+        import System
+        import {0}
+
+        Console.WriteLine(Doubler(2).Apply(21))
+        """;
+
+    [Fact]
+    public void ReferenceOption_LoadsAssemblyForCompileAndRun()
+    {
+        const string PackageName = "Widgets3130A";
+        var directory = CreateTestDirectory(nameof(ReferenceOption_LoadsAssemblyForCompileAndRun));
+        var libraryPath = CompileLibrary(directory, PackageName);
+
+        var result = RunGsi(directory, PackageName, "/r:" + libraryPath);
+
+        Assert.Equal(string.Empty, result.StandardError);
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("42\n", result.StandardOutput);
+    }
+
+    [Fact]
+    public void ReferenceKeywordAlias_IsAccepted()
+    {
+        const string PackageName = "Widgets3130B";
+        var directory = CreateTestDirectory(nameof(ReferenceKeywordAlias_IsAccepted));
+        var libraryPath = CompileLibrary(directory, PackageName);
+
+        var result = RunGsi(directory, PackageName, "/reference:" + libraryPath);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("42\n", result.StandardOutput);
+    }
+
+    [Fact]
+    public void WithoutReference_TheImportFailsToBind()
+    {
+        // Discriminating witness for the reference channel: the identical
+        // script must fail without /r:, so the passing cases above cannot be
+        // passing for a reason other than the supplied reference.
+        const string PackageName = "Widgets3130C";
+        var directory = CreateTestDirectory(nameof(WithoutReference_TheImportFailsToBind));
+        CompileLibrary(directory, PackageName);
+
+        var result = RunGsi(directory, PackageName);
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Equal(string.Empty, result.StandardOutput);
+        Assert.Contains("error GS0130: Function 'Doubler' doesn't exist.", result.StandardError, StringComparison.Ordinal);
+    }
+
+    private static string CreateTestDirectory(string name)
+    {
+        var directory = Path.Combine(AppContext.BaseDirectory, nameof(Issue3130GsiReferenceOptionTests), name);
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
+    private static string CompileLibrary(string directory, string packageName)
+    {
+        var librarySourcePath = Path.Combine(directory, "widgets.gs");
+        var libraryPath = Path.Combine(directory, packageName + ".dll");
+        File.WriteAllText(librarySourcePath, string.Format(LibrarySourceTemplate, packageName));
+
+        var (exitCode, stdout, stderr) = Capture(() => GSharp.Compiler.Program.Main(new[]
+        {
+            "/target:library",
+            "/out:" + libraryPath,
+            librarySourcePath,
+        }));
+        Assert.True(exitCode == 0, $"library compile failed: {stdout}{stderr}");
+        Assert.True(File.Exists(libraryPath));
+        return libraryPath;
+    }
+
+    private static (int ExitCode, string StandardOutput, string StandardError) RunGsi(
+        string directory,
+        string packageName,
+        params string[] additionalArguments)
+    {
+        var sourcePath = Path.Combine(directory, "script.gs");
+        File.WriteAllText(sourcePath, string.Format(ScriptSourceTemplate, packageName));
+
+        var arguments = new string[additionalArguments.Length + 1];
+        additionalArguments.CopyTo(arguments, 0);
+        arguments[^1] = sourcePath;
+        return Capture(() => GSharp.Repl.Program.Main(arguments));
+    }
+
+    private static (int ExitCode, string StandardOutput, string StandardError) Capture(Func<int> action)
+    {
+        using var stdout = new StringWriter { NewLine = "\n" };
+        using var stderr = new StringWriter { NewLine = "\n" };
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        int exitCode;
+        try
+        {
+            Console.SetOut(stdout);
+            Console.SetError(stderr);
+            exitCode = action();
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+
+        return (
+            exitCode,
+            stdout.ToString().Replace("\r\n", "\n", StringComparison.Ordinal),
+            stderr.ToString().Replace("\r\n", "\n", StringComparison.Ordinal));
+    }
+}


### PR DESCRIPTION
Part of #3176, part of #3163; implements ADR-0156 (#3177, approved/merging). Closes #3130.

## Summary

- Add `GSharp.Core.CodeAnalysis.Execution.EmittedProgramHost`: emit a `Compilation` to a `MemoryStream`, load into a collectible `AssemblyLoadContext` (default-context fallback for framework refs, explicit-path resolution for `/r:` assemblies), invoke the entry point in-process, map `int`/`uint`/`void` returns to exit codes, unwrap unhandled exceptions, unload the ALC. Crash rendering (`FormatUnhandledException`) reproduces `dotnet exec`'s text byte-for-byte (verified by diff against a real `dotnet exec` run), including the CLR host's entry-point signature rejection (`MethodAccessException`) and crash exit code (134 / `0xE0434352`).
- Switch bare `gsc` (no `/out:`) from `Compilation.Evaluate` to the host. Protocol preserved byte-wise: diagnostics to stdout, `Success.`/`Failed.` trailer, exit 0 on success with the program's return value discarded. `/r:` references now also resolve at runtime.
- Switch `gsi <file>` from SessionEngine/evaluator to the host; interactive REPL stays on the evaluator (Phase 2). Protocol preserved: diagnostics to stderr via the rich renderer, entry-point `int`/`uint` result is the exit code. `gsi` gains `/r:` / `/reference:` (#3130), wired into both binding (`ReferenceResolver.WithReferences`) and the host's runtime resolution.
- Delete the entire `ExpectedDifferences` table from `SampleConformanceTests` (all 14 rows) and its machinery; all three drivers are now compared byte-wise on every single-file sample. Un-gated and passing: `Deinit.gs` (GS0510), `RefStructGenericField.gs`/`RefStructSpan.gs`/`SpanComprehensive.gs`/`SpanIndexing.gs` (GS0511, #3114), 6 `PInvoke*.gs` (GS0514, ADR-0152), 3 `GsharpExtensions*.gs` (#3130 — harness now feeds all drivers the same `/r:` path the emitted column uses). GS0513 had no sample row; nothing to delete.
- Deinit: GS0510 no longer fires on file-mode drivers (it lives inside `Compilation.Evaluate`, which they no longer call); deinitializers run as real CLR finalizers there, asserted positively. Interactive-mode warning untouched.
- Docs: note in `docs/diagnostics.md` that the GS0510/0511/0513/0514 boundaries now apply only to the interactive REPL (links to the ADR file resolve once #3177 merges).
- Evaluator and `Compilation.Evaluate` fully intact; no test that consumes them directly was touched.

## Behavior changes (intentional, per ADR)

- Unhandled program exceptions under bare `gsc`/`gsi <file>` now use the CLR host protocol (exception text on stderr, exit 134/`0xE0434352`) instead of evaluator diagnostics (GSI001/GS0100-at-runtime, exit 1).
- `func Main() string`-style invalid entry points crash with the CLR host's `MethodAccessException` before running (previously the evaluator's GSI001 text).
- `gsi` now rejects unexpected extra arguments (previously silently ignored args past the first).

## #3177 interaction

- No files overlap with the ADR branch (it adds `docs/adr/0156-...md` and the spike test; this PR adds neither). The spike file's mechanics are superseded by the host but remain valid standalone evidence against this branch's Core surface. No conflict expected in either merge order.

## Verification

| Step | Result |
|---|---|
| `dotnet build GSharp.sln -c Release` | clean (0 warnings, 0 errors) |
| `test/Interpreter.Tests` (full) | 1319/1319 passed |
| `test/Compiler.Tests` filter `LanguageConformance` (all-driver gate) | 126/126 passed — every formerly-gated sample now byte-identical across emitted / bare gsc / gsi |
| `test/Compiler.Tests` filter `ProgramTests\|Issue2215\|Issue3067\|Issue2673\|Issue3081\|Issue2601\|ProgramSilentFailure\|ResourceLeak` (bare-gsc consumers) | 78/78 passed |
| `test/Core.Tests` (full, src/Core touched) | 7128 passed / 1 skipped (`RegenerateBaseline`, standing skip) |
| Manual byte-parity | `gsi` crash stderr diffed byte-identical against `dotnet exec` of the same program |

NOT RUN (CI required checks cover): full `Compiler.Tests` outside the filters above, `LanguageServer.Tests`, `Sdk.Tests`, `Extensions.Tests`, `InternalAnalyzers.Tests`, cs2gs suites (known flaky host crash noted in repo memory), Windows matrix (the new `BatchFileRunner_ExecutesPInvokeNatively` self-skips on Windows, mirroring `WindowsSkippedSamples`).

## Checklist

- [x] Behavioral tests carry a witness of discrimination (ADR-0154): every updated driver test asserts the new emitted behavior positively (deinit output present, storage constructs produce results, PInvoke prints golden output, crash protocol text + exit code) and each fails on the pre-change drivers by construction — the old drivers refused these constructs with GS05xx diagnostics and different exit codes. The gsi `/r:` suite includes a negative witness (`WithoutReference_TheImportFailsToBind`, against a scratch-compiled library invisible to the test host) proving the reference channel is what makes the positive cases pass.
- [x] Self-review verdict: **MERGEABLE**. Residuals deliberately deferred to later phases per the ADR: interactive REPL still evaluates (Phase 2, #3176), evaluator retirement and the two-host gate redefinition (Phase 3); `SessionEngine.RunEntryPoint` is now production-dead but kept for interactive-contract tests until Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Rebase onto main (post-#3177/#3128/#3172/#3153)

- `SampleConformanceTests`: #3128 had already deleted 3 of the 4 ByRefLike rows and the explicit-Main `ExpectedDifferences` requirement; resolution keeps this PR's end state (no table at all — the remaining `RefStructSpan.gs` row and the PInvoke/Deinit/Extensions rows go too). Gate re-run post-rebase: 126/126, all drivers byte-identical.
- `Issue2988DeinitInterpreterTests`: kept #3172's renames for the interactive (SessionEngine) tests; the file-mode test that #3172 renamed to `ScriptRunnerWritesBoundaryWarningToStandardError` is superseded by this PR's stronger witness `ScriptRunnerRunsDeinitializersWithoutBoundaryWarning` (deinit output asserted positively instead of the warning's rendering). No duplicate coverage.
- `docs/diagnostics.md` GS0511: merged #3128's span-emulation wording with the ADR-0156 driver-scope note.
- #3177's spike file (`Adr0156EmitToMemorySpikeTests.cs`) kept untouched; all 4 spike tests pass on the rebased tree.
- **New issue found by the rebase**: #3128's `SpanInterpolation_UsesPublicSpanName` exposed a pre-existing emit-path ICE the evaluator had masked on file drivers — span interpolation holes crash `InterpolatedStringHandlerLowerer` (`AppendFormatted[T]` rejects ByRefLike). Filed as **#3183** per the no-emit-fixes policy; `gsc /out:` already reports it as GS9998 today. This PR (a) makes gsi surface pipeline-escaping compiler exceptions as the canonical GS9998 line + exit 1 instead of a raw driver crash, (b) re-pins the evaluator's span-interpolation rendering interactively via SessionEngine, and (c) pins the GS9998 protocol on both file drivers with a #3183 reference to flip when fixed.

Post-rebase verification (sequential): solution Release build clean; Interpreter.Tests **1337/1337** (incl. spike); LanguageConformance **126/126**; bare-gsc filter **78/78**. Core.Tests full run NOT repeated — the rebase brought main-side src/Core changes already validated by main's CI, and conflict resolution touched no src/Core file beyond this branch's own.
