### PR TITLE
Chain interactive gsi submissions through emitted in-memory assemblies (ADR-0156 Phase 2, opt-in)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -708,9 +708,40 @@ public sealed class Binder
     /// <param name="isLibrary">When <c>true</c>, the compilation produces a library and top-level statements are reported as <c>GS0285</c> at the first global statement.</param>
     /// <returns>The new chained bound global scope.</returns>
     public static BoundGlobalScope BindGlobalScope(BoundGlobalScope previous, ImmutableArray<SyntaxTree> syntaxTrees, ReferenceResolver references, bool implicitSystemImport, ImmutableHashSet<string> preprocessorSymbols, bool isLibrary)
+        => BindGlobalScope(previous, syntaxTrees, references, implicitSystemImport, preprocessorSymbols, isLibrary, submission: null);
+
+    /// <summary>
+    /// Binds a set of syntax trees to the previous global scope, with full
+    /// control over implicit-import seeding, the active preprocessor symbol
+    /// set, whether the compilation is a library, and — ADR-0156 Phase 2 —
+    /// optional interactive submission options that bind prior REPL
+    /// submissions as metadata-backed imports.
+    /// </summary>
+    /// <param name="previous">The previous global scope.</param>
+    /// <param name="syntaxTrees">The new syntax trees.</param>
+    /// <param name="references">The reference resolver; <c>null</c> selects <see cref="ReferenceResolver.Default"/>.</param>
+    /// <param name="implicitSystemImport">When <c>true</c>, an implicit <c>import System</c> is seeded before user imports are processed.</param>
+    /// <param name="preprocessorSymbols">The active preprocessor symbol set; <c>null</c> means the empty set.</param>
+    /// <param name="isLibrary">When <c>true</c>, the compilation produces a library and top-level statements are reported as <c>GS0285</c> at the first global statement.</param>
+    /// <param name="submission">Interactive submission options, or <c>null</c> for an ordinary compilation.</param>
+    /// <returns>The new chained bound global scope.</returns>
+    public static BoundGlobalScope BindGlobalScope(BoundGlobalScope previous, ImmutableArray<SyntaxTree> syntaxTrees, ReferenceResolver references, bool implicitSystemImport, ImmutableHashSet<string> preprocessorSymbols, bool isLibrary, SubmissionBindingOptions submission)
     {
-        var parentScope = CreateParentScope(previous, references, preprocessorSymbols, preserveLatestImportSyntaxTrees: false);
+        var parentScope = CreateParentScope(previous, references, preprocessorSymbols, preserveLatestImportSyntaxTrees: false, submissionImports: submission?.Imports);
         var binder = new Binder(parentScope, function: null);
+
+        // ADR-0156 Phase 2: replay the session's accumulated imports so an
+        // `import` evaluated in an earlier cell keeps its effect in this one
+        // (each submission is a fresh compilation with no source chaining).
+        // TryImport short-circuits on the first same-name import, so replayed
+        // duplicates and the implicit System seed below coexist harmlessly.
+        if (submission?.ReplayImports.IsDefaultOrEmpty == false)
+        {
+            foreach (var replayed in submission.ReplayImports)
+            {
+                binder.scope.TryImport(new ImportSymbol(replayed.Name, replayed.Target, declaration: null));
+            }
+        }
 
         if (implicitSystemImport && previous == null)
         {
@@ -729,12 +760,13 @@ public sealed class Binder
         var packagesByName = new Dictionary<string, PackageSymbol>(StringComparer.Ordinal);
         var packagesInOrder = ImmutableArray.CreateBuilder<PackageSymbol>();
         var packageByTree = new Dictionary<SyntaxTree, PackageSymbol>();
+        var defaultPackageName = submission?.DefaultPackageName ?? "Default";
         foreach (var tree in syntaxTrees)
         {
             var packageSyntax = tree.Root.Members.OfType<PackageSyntax>().FirstOrDefault();
             var packageName = packageSyntax != null
                 ? string.Concat(packageSyntax.IdentifiersWithDots.Select(t => t.Text))
-                : "Default";
+                : defaultPackageName;
             if (!packagesByName.TryGetValue(packageName, out var packageSymbol))
             {
                 packageSymbol = new PackageSymbol(packageName, packageSyntax);
@@ -1178,6 +1210,49 @@ public sealed class Binder
                     binder.scope.TryDeclareVariable(v);
                 }
             }
+
+            // ADR-0156 Phase 2: capture the submission's trailing value into
+            // the synthesized `<Result>$` global so the REPL echoes it. The
+            // evaluator's historical echo is its `LastValue` after the block;
+            // the two statically-capturable shapes are a trailing expression
+            // statement (its value) and a trailing variable declaration (its
+            // initialized value). ByRefLike values cannot live in a static
+            // field and are skipped (no echo), as are `void`/error results.
+            if (submission?.CaptureTrailingExpression == true && statements.Count > 0)
+            {
+                GlobalVariableSymbol resultVariable = null;
+                var trailing = statements[statements.Count - 1];
+                if (trailing is BoundExpressionStatement trailingExpression
+                    && IsCapturableEchoType(trailingExpression.Expression.Type))
+                {
+                    resultVariable = new GlobalVariableSymbol(
+                        SubmissionImports.ResultFieldName,
+                        isReadOnly: false,
+                        trailingExpression.Expression.Type,
+                        Accessibility.Public);
+                    statements[statements.Count - 1] = new BoundVariableDeclaration(
+                        trailing.Syntax, resultVariable, trailingExpression.Expression);
+                }
+                else if (trailing is BoundVariableDeclaration trailingDeclaration
+                    && trailingDeclaration.Initializer is not BoundAddressOfExpression
+                    && IsCapturableEchoType(trailingDeclaration.Variable.Type))
+                {
+                    resultVariable = new GlobalVariableSymbol(
+                        SubmissionImports.ResultFieldName,
+                        isReadOnly: false,
+                        trailingDeclaration.Variable.Type,
+                        Accessibility.Public);
+                    statements.Add(new BoundVariableDeclaration(
+                        trailing.Syntax,
+                        resultVariable,
+                        new BoundVariableExpression(trailing.Syntax, trailingDeclaration.Variable)));
+                }
+
+                if (resultVariable != null)
+                {
+                    binder.scope.TryDeclareVariable(resultVariable);
+                }
+            }
         }
 
         var imports = binder.scope.GetOwnDeclaredImports();
@@ -1284,8 +1359,21 @@ public sealed class Binder
             };
         }
 
+        // ADR-0156 Phase 2: carry the submission import set on the scope so
+        // BindProgram's freshly-derived scope chain (CreateParentScope) can
+        // rehydrate prior-submission metadata lookup for member bodies.
+        result.SubmissionImports = submission?.Imports;
+
         return result;
     }
+
+    // ADR-0156 Phase 2: whether a submission's trailing value can be stored
+    // in the synthesized `<Result>$` static field for the REPL echo.
+    private static bool IsCapturableEchoType(TypeSymbol type)
+        => type != null
+            && type != TypeSymbol.Void
+            && type != TypeSymbol.Error
+            && !TypeSymbol.IsByRefLike(type);
 
     /// <summary>
     /// Produces a bound program from the specified global scope.
@@ -2550,6 +2638,14 @@ public sealed class Binder
         ReferenceResolver references,
         ImmutableHashSet<string> preprocessorSymbols,
         bool preserveLatestImportSyntaxTrees)
+        => CreateParentScope(previous, references, preprocessorSymbols, preserveLatestImportSyntaxTrees, previous?.SubmissionImports);
+
+    private static BoundScope CreateParentScope(
+        BoundGlobalScope previous,
+        ReferenceResolver references,
+        ImmutableHashSet<string> preprocessorSymbols,
+        bool preserveLatestImportSyntaxTrees,
+        SubmissionImports submissionImports)
     {
         var stack = new Stack<BoundGlobalScope>();
         while (previous != null)
@@ -2559,6 +2655,7 @@ public sealed class Binder
         }
 
         var parent = CreateRootScope(references, preprocessorSymbols);
+        parent.SetSubmissionImports(submissionImports);
 
         while (stack.Count > 0)
         {
@@ -6064,6 +6161,22 @@ public sealed class Binder
             // possibly be what a colliding SOURCE type reference means — and
             // let the caller report the dedicated ambiguity diagnostic.
             return null;
+        }
+
+        // ADR-0156 Phase 2: a type declared by a prior interactive submission
+        // resolves as an imported CLR type over that submission's emitted
+        // assembly, newest submission first. Consulted after this
+        // compilation's own source types (the current cell shadows history)
+        // and before ordinary imports.
+        if (scope.SubmissionImports is { } submissionImports
+            && submissionImports.TryResolveType(scope.References, name, preferredArity, out var submissionClrType))
+        {
+            if (ImportedTypeSymbol.TryCreateSemanticAggregate(submissionClrType, scope.References, out var submissionAggregate))
+            {
+                return submissionAggregate;
+            }
+
+            return TypeSymbol.FromClrType(submissionClrType);
         }
 
         if (scope.TryLookupImportedClass(name, declaration: null, out var importedClass))

--- a/src/Core/CodeAnalysis/Binding/BoundGlobalScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundGlobalScope.cs
@@ -308,6 +308,15 @@ public sealed class BoundGlobalScope
     public ImmutableArray<BoundAttribute> ModuleAttributes { get; internal set; } = ImmutableArray<BoundAttribute>.Empty;
 
     /// <summary>
+    /// Gets the interactive submission import set this scope was bound with
+    /// (ADR-0156 Phase 2), or <see langword="null"/> for an ordinary
+    /// compilation. Carried on the scope so <c>BindProgram</c>'s
+    /// freshly-derived scope chain rehydrates prior-submission metadata
+    /// lookup when binding member bodies.
+    /// </summary>
+    public SubmissionImports SubmissionImports { get; internal set; }
+
+    /// <summary>
     /// Gets or sets every anonymous-class type (issue #2224) synthesized
     /// while binding this compilation's top-level statements and (once
     /// <c>Binder.BindProgram</c> runs) its function/method bodies.

--- a/src/Core/CodeAnalysis/Binding/BoundScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundScope.cs
@@ -23,6 +23,10 @@ public sealed class BoundScope
     private ImmutableArray<string>.Builder functionKeys;
     private ImmutableArray<ImportSymbol>.Builder imports;
     private ImmutableDictionary<string, TypeSymbol>.Builder typeAliases;
+
+    // ADR-0156 Phase 2: registered on the root scope of an interactive
+    // submission's scope chain; exposed via SubmissionImports.
+    private SubmissionImports submissionImports;
     private ImmutableArray<string>.Builder typeAliasKeys;
     private ImmutableArray<FunctionSymbol>.Builder extensionFunctions;
 
@@ -147,6 +151,13 @@ public sealed class BoundScope
     /// by the function's <c>[Conditional]</c> applications is in this set.
     /// </summary>
     public ImmutableHashSet<string> PreprocessorSymbols { get; }
+
+    /// <summary>
+    /// Gets the interactive submission import set (ADR-0156 Phase 2) visible
+    /// from this scope, walking the parent chain to the root scope it was
+    /// registered on; <see langword="null"/> for ordinary compilations.
+    /// </summary>
+    public SubmissionImports SubmissionImports => submissionImports ?? Parent?.SubmissionImports;
 
     /// <summary>
     /// Tries to add an import to this scope.
@@ -626,6 +637,16 @@ public sealed class BoundScope
             return false;
         }
 
+        // ADR-0156 Phase 2: a generic type declared by a prior interactive
+        // submission resolves over that submission's emitted assembly,
+        // newest submission first (see TryLookupImportedClass).
+        if (SubmissionImports is { } submissionImports
+            && submissionImports.TryResolveType(References, name, arity, out var submissionType))
+        {
+            type = submissionType;
+            return true;
+        }
+
         var mangled = name + "`" + arity;
         foreach (var import in EnumerateImports())
         {
@@ -650,6 +671,19 @@ public sealed class BoundScope
     public bool TryLookupImportedClass(string name, ExpressionSyntax declaration, out ImportedClassSymbol importedClass)
     {
         importedClass = null;
+
+        // ADR-0156 Phase 2: a type declared by a prior interactive submission
+        // resolves as an imported class over that submission's emitted
+        // assembly, newest submission first. Consulted before ordinary
+        // imports so a session-defined type shadows a same-named imported
+        // type, mirroring the evaluator scope chain (source lookups have
+        // already had their chance before any caller reaches this method).
+        if (SubmissionImports is { } submissionImports
+            && submissionImports.TryResolveType(References, name, preferredArity: 0, out var submissionType))
+        {
+            importedClass = new ImportedClassSymbol(submissionType, declaration, references: References);
+            return true;
+        }
 
         foreach (var import in EnumerateImports())
         {
@@ -771,7 +805,7 @@ public sealed class BoundScope
     /// submission's own imports (issue #2101): that field is later re-seeded,
     /// one historical <see cref="BoundGlobalScope"/> per chained REPL
     /// submission, into a fresh per-level <see cref="BoundScope"/> by
-    /// <see cref="Binder.CreateParentScope"/>. Using the walking/cumulative
+    /// <see cref="Binder.CreateParentScope(BoundGlobalScope, ReferenceResolver, ImmutableHashSet{string}, bool)"/>. Using the walking/cumulative
     /// <see cref="GetDeclaredImports"/> there previously made every submission
     /// re-import the ENTIRE flattened history of every prior submission into
     /// its own scope layer, which was then itself re-flattened on the next
@@ -1321,6 +1355,13 @@ public sealed class BoundScope
     /// <returns>The named delegate types in declaration order.</returns>
     public ImmutableArray<DelegateTypeSymbol> GetDeclaredDelegates()
         => GetDeclaredTypeSymbols<DelegateTypeSymbol>();
+
+    /// <summary>
+    /// Registers the interactive submission import set (ADR-0156 Phase 2) on
+    /// this (root) scope; exposed to child scopes via <see cref="SubmissionImports"/>.
+    /// </summary>
+    /// <param name="imports">The submission import set; may be <see langword="null"/>.</param>
+    internal void SetSubmissionImports(SubmissionImports imports) => submissionImports = imports;
 
     /// <summary>
     /// Gets the per-compile-pass anonymous-class-literal type cache (issue

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
@@ -394,6 +394,16 @@ internal sealed partial class ExpressionBinder
                     return BindAccessorStep(inheritedClrHead, null, rightPart);
                 }
             }
+            else if (TryBindSubmissionStaticMember(leftName, out var submissionHead)
+                && submissionHead is not BoundErrorExpression)
+            {
+                // ADR-0156 Phase 2: an accessor chain whose head names a
+                // top-level global (or function) of a prior interactive
+                // submission — e.g. `p.Sum()` where `p` was declared in an
+                // earlier cell — binds the head as the submission's static
+                // field read and continues the chain on that value.
+                return BindAccessorStep(submissionHead, null, rightPart);
+            }
             else if (scope.TryLookupImport(name, out var matchedImport)
                 && TryBindImportAccessor(matchedImport, ref rightPart, out var typeFromImport))
             {
@@ -2857,6 +2867,38 @@ internal sealed partial class ExpressionBinder
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// ADR-0156 Phase 2: attempts to resolve an unqualified identifier
+    /// against the static members of a prior interactive submission's
+    /// <c>&lt;Program&gt;</c> container — a top-level global (static field)
+    /// or function (static method group). Submissions are consulted newest
+    /// first, so a redefinition in a later cell shadows earlier cells; the
+    /// first submission declaring the name wins outright (no ambiguity
+    /// diagnostics, mirroring the evaluator's scope-chain shadowing).
+    /// </summary>
+    /// <param name="syntax">The identifier syntax naming the prospective submission member.</param>
+    /// <param name="result">The bound submission-member access, when one is produced.</param>
+    /// <returns><c>true</c> when a prior submission declared the member.</returns>
+    private bool TryBindSubmissionStaticMember(NameExpressionSyntax syntax, out BoundExpression result)
+    {
+        result = null;
+        var submissionImports = scope.SubmissionImports;
+        if (submissionImports is null)
+        {
+            return false;
+        }
+
+        var name = syntax.IdentifierToken.Text;
+        if (!submissionImports.TryFindMemberContainer(scope.References, name, out var programType))
+        {
+            return false;
+        }
+
+        var classSymbol = new ImportedClassSymbol(programType, syntax, references: scope.References);
+        result = BindAccessorStep(receiver: null, classSymbol, syntax);
+        return true;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -48,6 +48,14 @@ internal sealed partial class ExpressionBinder
                 return inheritedWrite;
             }
 
+            // ADR-0156 Phase 2: a bare write to a top-level global declared by
+            // a prior interactive submission stores to the static field on
+            // that submission's <Program> container (newest submission first).
+            if (TryBindSubmissionStaticFieldWrite(name, syntax.Expression, syntax.EqualsToken.Location, out var submissionWrite))
+            {
+                return submissionWrite;
+            }
+
             // Surface the diagnostic suppressed above (GS0125) only when the
             // name is genuinely unresolved; a non-variable symbol already
             // reported its own diagnostic.
@@ -1123,6 +1131,15 @@ internal sealed partial class ExpressionBinder
                 {
                     return inheritedCompound;
                 }
+            }
+
+            // ADR-0156 Phase 2: a bare compound write (`counter += 1`) to a
+            // top-level global declared by a prior interactive submission
+            // reads and stores the static field on that submission's
+            // <Program> container (newest submission first).
+            if (TryBindSubmissionStaticFieldCompound(name, bareName, syntax, out var submissionCompound))
+            {
+                return submissionCompound;
             }
 
             // Surface the diagnostic suppressed above (GS0125) only when the
@@ -2378,5 +2395,114 @@ internal sealed partial class ExpressionBinder
             compoundRhsSyntax: syntax.Value,
             diagnosticLocation: syntax.OperatorToken.Location,
             outerSyntax: syntax);
+    }
+
+    /// <summary>
+    /// ADR-0156 Phase 2: binds a bare simple write (<c>name = value</c>) to a
+    /// top-level global declared by a prior interactive submission as a store
+    /// to the static field on that submission's <c>&lt;Program&gt;</c>
+    /// container, newest submission first. Read-only (<c>let</c>) globals —
+    /// known from the submission's source-side scope, since the emitted field
+    /// intentionally omits <c>InitOnly</c> — report GS0203.
+    /// </summary>
+    /// <param name="name">The bare identifier being assigned.</param>
+    /// <param name="valueSyntax">The right-hand-side expression syntax.</param>
+    /// <param name="operatorLocation">The assignment operator's location for diagnostics.</param>
+    /// <param name="result">The bound assignment, when the name matched a prior submission's global.</param>
+    /// <returns><c>true</c> when a prior submission declared the global.</returns>
+    private bool TryBindSubmissionStaticFieldWrite(string name, ExpressionSyntax valueSyntax, TextLocation operatorLocation, out BoundExpression result)
+    {
+        result = null;
+        var submissionImports = scope.SubmissionImports;
+        if (submissionImports is null
+            || !submissionImports.TryFindGlobalVariable(scope.References, name, out var programType, out var declared))
+        {
+            return false;
+        }
+
+        var classSymbol = new ImportedClassSymbol(programType, declaration: null, references: scope.References);
+        if (!classSymbol.TryLookupMember(name, ne: null, out var member)
+            || !TryGetWritableClrMember(member, out _, out var targetSymbol, out _))
+        {
+            Diagnostics.ReportCannotAssign(operatorLocation, name);
+            result = new BoundErrorExpression(null);
+            return true;
+        }
+
+        if (declared.IsReadOnly)
+        {
+            Diagnostics.ReportCannotAssign(operatorLocation, name);
+        }
+
+        var value = BindAssignmentRhs(valueSyntax, targetSymbol);
+        var converted = conversions.BindConversion(valueSyntax.Location, value, targetSymbol);
+        result = new BoundClrPropertyAssignmentExpression(null, receiver: null, member, converted, targetSymbol, staticContainerType: null);
+        return true;
+    }
+
+    /// <summary>
+    /// ADR-0156 Phase 2: binds a bare compound write (<c>name op= value</c>)
+    /// to a top-level global declared by a prior interactive submission as a
+    /// read-modify-store of the static field on that submission's
+    /// <c>&lt;Program&gt;</c> container, newest submission first.
+    /// </summary>
+    /// <param name="name">The bare identifier being assigned.</param>
+    /// <param name="bareName">The identifier's name-expression syntax (for the read half).</param>
+    /// <param name="syntax">The compound assignment syntax.</param>
+    /// <param name="result">The bound assignment, when the name matched a prior submission's global.</param>
+    /// <returns><c>true</c> when a prior submission declared the global.</returns>
+    private bool TryBindSubmissionStaticFieldCompound(string name, NameExpressionSyntax bareName, EventSubscriptionExpressionSyntax syntax, out BoundExpression result)
+    {
+        result = null;
+        var submissionImports = scope.SubmissionImports;
+        if (submissionImports is null
+            || !submissionImports.TryFindGlobalVariable(scope.References, name, out var programType, out var declared))
+        {
+            return false;
+        }
+
+        var classSymbol = new ImportedClassSymbol(programType, declaration: null, references: scope.References);
+        if (!classSymbol.TryLookupMember(name, ne: null, out var member)
+            || !TryGetWritableClrMember(member, out _, out var targetSymbol, out _))
+        {
+            Diagnostics.ReportCannotAssign(syntax.OperatorToken.Location, name);
+            result = new BoundErrorExpression(null);
+            return true;
+        }
+
+        if (declared.IsReadOnly)
+        {
+            Diagnostics.ReportCannotAssign(syntax.OperatorToken.Location, name);
+        }
+
+        // Read half: bind the same bare name through the submission member
+        // read fallback so the leftExpr is the field load.
+        if (!TryBindSubmissionStaticMember(bareName, out var leftExpr))
+        {
+            return false;
+        }
+
+        var boundRhs = BindExpression(syntax.Value);
+        SyntaxFacts.TryGetCompoundAssignmentBaseOperator(syntax.OperatorToken.Kind, out var baseOpSyntaxKind);
+
+        var userCompound = TryBindUserCompoundAssignmentOperator(
+            syntax.OperatorToken.Kind, leftExpr, boundRhs, syntax.Value.Location);
+        if (userCompound != null)
+        {
+            result = userCompound;
+            return true;
+        }
+
+        var binaryResult = TryBindCompoundBinaryOperation(baseOpSyntaxKind, leftExpr, boundRhs, syntax.Value.Location);
+        if (binaryResult == null)
+        {
+            Diagnostics.ReportUndefinedBinaryOperator(syntax.OperatorToken.Location, syntax.OperatorToken.Text, leftExpr.Type, boundRhs.Type);
+            result = new BoundErrorExpression(null);
+            return true;
+        }
+
+        var converted = conversions.BindConversion(syntax.Value.Location, binaryResult, targetSymbol);
+        result = new BoundClrPropertyAssignmentExpression(null, receiver: null, member, converted, targetSymbol, staticContainerType: null);
+        return true;
     }
 }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -511,6 +511,17 @@ internal sealed partial class ExpressionBinder
                 return methodGroup;
             }
 
+            // ADR-0156 Phase 2: a bare identifier may name a top-level global
+            // (static field) or function (static method group) of a prior
+            // interactive submission's <Program> container, newest submission
+            // first. Runs before the static-import fallbacks so prior cells'
+            // declarations shadow static-import members, mirroring the
+            // evaluator scope chain.
+            if (TryBindSubmissionStaticMember(syntax, out var submissionMember))
+            {
+                return submissionMember;
+            }
+
             // Issue #1201 (C# `using static`): an unqualified identifier may
             // name a `shared` (static) field, property, or method group of a
             // type brought into scope by a type import (`import Ns.Type`). This

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
@@ -819,6 +819,30 @@ internal sealed partial class OverloadResolver
                     }
                 }
 
+                // ADR-0156 Phase 2: an unqualified call may resolve to a
+                // top-level function of a prior interactive submission — a
+                // static method on that submission's <Program> container.
+                // Submissions are consulted newest first and the first one
+                // declaring the name wins outright (scope-chain shadowing,
+                // not using-static ambiguity).
+                if (Scope.SubmissionImports is { } submissionImports)
+                {
+                    if (bindImportedClrStaticCall != null
+                        && submissionImports.TryFindFunctionContainer(Scope.References, syntax.Identifier.Text, out var submissionProgramType))
+                    {
+                        return bindImportedClrStaticCall(submissionProgramType, syntax);
+                    }
+
+                    // A function-typed global from a prior submission (e.g. a
+                    // closure stored with `let inc = func() { ... }`) invokes
+                    // through the indirect-call path: load the static field,
+                    // then dispatch its Func/Action shape.
+                    if (TryBindSubmissionDelegateGlobalCall(syntax, submissionImports, out var submissionDelegateCall))
+                    {
+                        return submissionDelegateCall;
+                    }
+                }
+
                 Diagnostics.ReportUndefinedFunction(syntax.Identifier.Location, syntax.Identifier.Text);
                 return new BoundErrorExpression(null);
             }
@@ -1860,5 +1884,81 @@ internal sealed partial class OverloadResolver
         }
 
         return new BoundCallExpression(null, function, arguments, returnType) { MethodTypeArguments = methodTypeArguments };
+    }
+
+    /// <summary>
+    /// ADR-0156 Phase 2: binds an unqualified call whose name matches a
+    /// function-typed global (a <c>System.Func</c>/<c>System.Action</c>-shaped
+    /// static field) declared by a prior interactive submission. The field is
+    /// loaded from the submission's <c>&lt;Program&gt;</c> container and the
+    /// invocation dispatches through the ordinary indirect-call path.
+    /// </summary>
+    /// <param name="syntax">The call syntax.</param>
+    /// <param name="submissionImports">The active submission import set.</param>
+    /// <param name="result">The bound invocation, when the name matched an invocable global.</param>
+    /// <returns><c>true</c> when the call was bound (or errored) against a submission global.</returns>
+    private bool TryBindSubmissionDelegateGlobalCall(CallExpressionSyntax syntax, SubmissionImports submissionImports, out BoundExpression result)
+    {
+        result = null;
+        var name = syntax.Identifier.Text;
+        if (!submissionImports.TryFindGlobalVariable(Scope.References, name, out var programType, out _))
+        {
+            return false;
+        }
+
+        var field = programType.GetField(name, BindingFlags.Public | BindingFlags.Static);
+        if (field is null || !TryMapClrDelegateToFunctionType(field.FieldType, out var functionType))
+        {
+            return false;
+        }
+
+        var calleeLoad = new BoundClrPropertyAccessExpression(syntax, receiver: null, field, functionType);
+        result = BindIndirectCallExpression(syntax, calleeLoad, name, syntax.Identifier.Location, nullSafeInvocation: null);
+        return true;
+    }
+
+    // Maps a System.Func`N / System.Action`N CLR delegate shape back to the
+    // equivalent G# function type so the indirect-call binder (and the
+    // emitter's Invoke dispatch) can consume it. Other delegate shapes (named
+    // G# delegates, custom CLR delegates) are not mapped here.
+    private static bool TryMapClrDelegateToFunctionType(Type clrType, out FunctionTypeSymbol functionType)
+    {
+        functionType = null;
+        if (clrType is null || !ClrTypeUtilities.IsDelegateType(clrType))
+        {
+            return false;
+        }
+
+        var fullName = clrType.IsGenericType ? clrType.GetGenericTypeDefinition().FullName : clrType.FullName;
+        var isAction = string.Equals(fullName, "System.Action", StringComparison.Ordinal)
+            || (fullName?.StartsWith("System.Action`", StringComparison.Ordinal) ?? false);
+        var isFunc = fullName?.StartsWith("System.Func`", StringComparison.Ordinal) ?? false;
+        if (!isAction && !isFunc)
+        {
+            return false;
+        }
+
+        var args = clrType.IsGenericType ? clrType.GetGenericArguments() : Type.EmptyTypes;
+        var parameterCount = isFunc ? args.Length - 1 : args.Length;
+        var parameterTypes = ImmutableArray.CreateBuilder<TypeSymbol>(parameterCount);
+        for (var i = 0; i < parameterCount; i++)
+        {
+            var mapped = TypeSymbol.FromClrType(args[i]);
+            if (mapped is null || mapped == TypeSymbol.Error)
+            {
+                return false;
+            }
+
+            parameterTypes.Add(mapped);
+        }
+
+        var returnType = isFunc ? TypeSymbol.FromClrType(args[^1]) : TypeSymbol.Void;
+        if (returnType is null || returnType == TypeSymbol.Error)
+        {
+            return false;
+        }
+
+        functionType = FunctionTypeSymbol.Get(parameterTypes.MoveToImmutable(), returnType);
+        return true;
     }
 }

--- a/src/Core/CodeAnalysis/Binding/SubmissionImports.cs
+++ b/src/Core/CodeAnalysis/Binding/SubmissionImports.cs
@@ -1,0 +1,295 @@
+// <copyright file="SubmissionImports.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Symbols;
+
+namespace GSharp.Core.CodeAnalysis.Binding;
+
+/// <summary>
+/// ADR-0156 Phase 2: the ordered (newest-first) set of prior interactive
+/// submissions a REPL submission binds against. Each prior submission is a
+/// real emitted assembly reachable through the compilation's
+/// <see cref="ReferenceResolver"/>; its top-level functions and globals live
+/// as static members of its per-package <c>&lt;Program&gt;</c> container and
+/// its user types as ordinary CLR types under the submission's package
+/// namespace. Name lookup walks submissions newest-first so a redefinition in
+/// a later cell shadows earlier cells, matching the historical evaluator
+/// scope-chain semantics.
+/// </summary>
+public sealed class SubmissionImports
+{
+    /// <summary>
+    /// The reserved name of the synthesized public static field that receives
+    /// the value of a submission's trailing expression (or trailing variable
+    /// declaration) for the REPL's cell-value echo.
+    /// </summary>
+    public const string ResultFieldName = "<Result>$";
+
+    /// <summary>
+    /// The metadata type name of the per-package top-level container that
+    /// holds a submission's top-level functions (static methods) and globals
+    /// (static fields).
+    /// </summary>
+    public const string ProgramTypeName = "<Program>";
+
+    private SubmissionImports(ImmutableArray<SubmissionReference> newestFirst)
+    {
+        NewestFirst = newestFirst;
+    }
+
+    /// <summary>
+    /// Gets the prior submissions, newest first.
+    /// </summary>
+    public ImmutableArray<SubmissionReference> NewestFirst { get; }
+
+    /// <summary>
+    /// Creates a <see cref="SubmissionImports"/> over the given prior
+    /// submissions.
+    /// </summary>
+    /// <param name="newestFirst">The prior submissions, newest first.</param>
+    /// <returns>The import set.</returns>
+    public static SubmissionImports Create(ImmutableArray<SubmissionReference> newestFirst)
+        => new(newestFirst.IsDefault ? ImmutableArray<SubmissionReference>.Empty : newestFirst);
+
+    /// <summary>
+    /// Finds the newest prior submission that declares a top-level function
+    /// named <paramref name="name"/> and resolves its <c>&lt;Program&gt;</c>
+    /// container type through <paramref name="references"/>.
+    /// </summary>
+    /// <param name="references">The active reference resolver.</param>
+    /// <param name="name">The bare function name.</param>
+    /// <param name="programType">The container CLR type on success.</param>
+    /// <returns>Whether a prior submission declares the function.</returns>
+    public bool TryFindFunctionContainer(ReferenceResolver references, string name, out Type programType)
+    {
+        programType = null;
+        foreach (var submission in NewestFirst)
+        {
+            if (DeclaresFunction(submission, name))
+            {
+                return TryResolveProgramType(references, submission, out programType);
+            }
+
+            // A same-named global in a newer submission shadows an older
+            // submission's function, mirroring the evaluator scope chain
+            // where the newest declaration of a name wins regardless of kind.
+            if (DeclaresGlobal(submission, name))
+            {
+                return false;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Finds the newest prior submission that declares a top-level global
+    /// variable named <paramref name="name"/>, resolving its container type
+    /// and reporting the source-side declaration (for read-only checks).
+    /// </summary>
+    /// <param name="references">The active reference resolver.</param>
+    /// <param name="name">The bare variable name.</param>
+    /// <param name="programType">The container CLR type on success.</param>
+    /// <param name="declared">The submission's source-side variable symbol.</param>
+    /// <returns>Whether a prior submission declares the global.</returns>
+    public bool TryFindGlobalVariable(ReferenceResolver references, string name, out Type programType, out VariableSymbol declared)
+    {
+        programType = null;
+        declared = null;
+        foreach (var submission in NewestFirst)
+        {
+            var match = FindGlobal(submission, name);
+            if (match is not null)
+            {
+                declared = match;
+                return TryResolveProgramType(references, submission, out programType);
+            }
+
+            // A same-named function in a newer submission shadows an older
+            // submission's global (newest declaration wins regardless of kind).
+            if (DeclaresFunction(submission, name))
+            {
+                return false;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Finds the newest prior submission that declares a top-level function
+    /// or global variable named <paramref name="name"/> and resolves its
+    /// container type. Used by the bare-identifier read fallback, which
+    /// binds fields, and method groups through the same accessor machinery.
+    /// </summary>
+    /// <param name="references">The active reference resolver.</param>
+    /// <param name="name">The bare member name.</param>
+    /// <param name="programType">The container CLR type on success.</param>
+    /// <returns>Whether a prior submission declares the member.</returns>
+    public bool TryFindMemberContainer(ReferenceResolver references, string name, out Type programType)
+    {
+        programType = null;
+        foreach (var submission in NewestFirst)
+        {
+            if (DeclaresFunction(submission, name) || DeclaresGlobal(submission, name))
+            {
+                return TryResolveProgramType(references, submission, out programType);
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Finds the newest prior submission that declares a type (struct, class,
+    /// interface, enum, or delegate) named <paramref name="name"/> and
+    /// resolves its emitted CLR type through <paramref name="references"/>.
+    /// </summary>
+    /// <param name="references">The active reference resolver.</param>
+    /// <param name="name">The simple type name.</param>
+    /// <param name="preferredArity">The preferred generic arity, or -1/0 for a non-generic use site.</param>
+    /// <param name="clrType">The resolved CLR type on success.</param>
+    /// <returns>Whether a prior submission declares the type.</returns>
+    public bool TryResolveType(ReferenceResolver references, string name, int preferredArity, out Type clrType)
+    {
+        clrType = null;
+        foreach (var submission in NewestFirst)
+        {
+            var arity = FindDeclaredTypeArity(submission, name, preferredArity);
+            if (arity < 0)
+            {
+                continue;
+            }
+
+            var metadataName = arity == 0
+                ? name
+                : name + "`" + arity.ToString(CultureInfo.InvariantCulture);
+            return references.TryResolveType(submission.PackageName + "." + metadataName, out clrType);
+        }
+
+        return false;
+    }
+
+    private static bool DeclaresFunction(SubmissionReference submission, string name)
+        => submission.GlobalScope.Functions.Any(f =>
+            !f.IsSpecialName
+            && !f.IsTopLevelEntryPoint
+            && string.Equals(f.Name, name, StringComparison.Ordinal));
+
+    private static bool DeclaresGlobal(SubmissionReference submission, string name)
+        => FindGlobal(submission, name) is not null;
+
+    private static VariableSymbol FindGlobal(SubmissionReference submission, string name)
+        => string.Equals(name, ResultFieldName, StringComparison.Ordinal)
+            ? null
+            : submission.GlobalScope.Variables.FirstOrDefault(v =>
+                v is GlobalVariableSymbol && string.Equals(v.Name, name, StringComparison.Ordinal));
+
+    // Returns the declared generic arity of the newest matching type in this
+    // submission, or -1 when the submission does not declare the name. When
+    // the use site requests a specific arity (> 0), only a same-arity
+    // declaration matches; a bare use site (-1 or 0) matches a non-generic
+    // declaration first and otherwise any declared arity.
+    private static int FindDeclaredTypeArity(SubmissionReference submission, string name, int preferredArity)
+    {
+        var scope = submission.GlobalScope;
+        var arities = scope.Structs
+            .Where(s => string.Equals(s.Name, name, StringComparison.Ordinal))
+            .Select(s => s.TypeParameters.IsDefaultOrEmpty ? 0 : s.TypeParameters.Length)
+            .Concat(scope.Interfaces
+                .Where(i => string.Equals(i.Name, name, StringComparison.Ordinal))
+                .Select(i => i.TypeParameters.IsDefaultOrEmpty ? 0 : i.TypeParameters.Length))
+            .Concat(scope.Enums
+                .Where(e => string.Equals(e.Name, name, StringComparison.Ordinal))
+                .Select(_ => 0))
+            .Concat(scope.Delegates
+                .Where(d => string.Equals(d.Name, name, StringComparison.Ordinal))
+                .Select(d => d.TypeParameters.IsDefaultOrEmpty ? 0 : d.TypeParameters.Length))
+            .ToArray();
+
+        if (arities.Length == 0)
+        {
+            return -1;
+        }
+
+        if (preferredArity > 0)
+        {
+            return arities.Contains(preferredArity) ? preferredArity : -1;
+        }
+
+        return arities.Contains(0) ? 0 : arities[0];
+    }
+
+    private static bool TryResolveProgramType(ReferenceResolver references, SubmissionReference submission, out Type programType)
+        => references.TryResolveType(submission.PackageName + "." + ProgramTypeName, out programType);
+}
+
+/// <summary>
+/// One prior interactive submission: its emitted assembly identity, the
+/// package (namespace) its members were emitted under, and the source-side
+/// global scope recording what it declared (names, kinds, and read-only
+/// flags — used to steer metadata lookup without reflection scans).
+/// </summary>
+public sealed class SubmissionReference
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SubmissionReference"/> class.
+    /// </summary>
+    /// <param name="assemblyName">The emitted assembly's simple name (e.g. <c>gsi$3</c>).</param>
+    /// <param name="packageName">The package (metadata namespace) the submission's members were emitted under.</param>
+    /// <param name="globalScope">The submission's bound global scope.</param>
+    public SubmissionReference(string assemblyName, string packageName, BoundGlobalScope globalScope)
+    {
+        AssemblyName = assemblyName ?? throw new ArgumentNullException(nameof(assemblyName));
+        PackageName = packageName ?? throw new ArgumentNullException(nameof(packageName));
+        GlobalScope = globalScope ?? throw new ArgumentNullException(nameof(globalScope));
+    }
+
+    /// <summary>Gets the emitted assembly's simple name.</summary>
+    public string AssemblyName { get; }
+
+    /// <summary>Gets the package (metadata namespace) of the submission's members.</summary>
+    public string PackageName { get; }
+
+    /// <summary>Gets the submission's bound global scope.</summary>
+    public BoundGlobalScope GlobalScope { get; }
+}
+
+/// <summary>
+/// ADR-0156 Phase 2: options that put a compilation into interactive
+/// submission mode — prior-submission metadata binding, a per-submission
+/// default package, replayed session imports, and trailing-expression value
+/// capture for the REPL echo.
+/// </summary>
+public sealed class SubmissionBindingOptions
+{
+    /// <summary>Gets or sets the prior-submission import set (may be <see langword="null"/> for the first cell).</summary>
+    public SubmissionImports Imports { get; set; }
+
+    /// <summary>
+    /// Gets or sets the package name used for syntax trees without a
+    /// <c>package</c> declaration (each submission gets a distinct default
+    /// package so its emitted members have a unique namespace).
+    /// </summary>
+    public string DefaultPackageName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the imports accumulated by earlier submissions, replayed
+    /// into this submission's root scope so <c>import</c> statements keep
+    /// their session-wide effect.
+    /// </summary>
+    public ImmutableArray<ImportSymbol> ReplayImports { get; set; } = ImmutableArray<ImportSymbol>.Empty;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the trailing expression (or
+    /// trailing variable declaration) of the submission is captured into the
+    /// synthesized <see cref="SubmissionImports.ResultFieldName"/> global for
+    /// the REPL's cell-value echo. Defaults to <see langword="true"/>.
+    /// </summary>
+    public bool CaptureTrailingExpression { get; set; } = true;
+}

--- a/src/Core/CodeAnalysis/Compilation/Compilation.cs
+++ b/src/Core/CodeAnalysis/Compilation/Compilation.cs
@@ -225,6 +225,19 @@ public class Compilation
     }
 
     /// <summary>
+    /// Gets or sets the interactive submission options (ADR-0156 Phase 2).
+    /// When set, the compilation binds as one REPL submission: prior
+    /// submissions' functions, globals, and types resolve as metadata-backed
+    /// imports over their emitted assemblies, syntax trees without a
+    /// <c>package</c> declaration fall into the submission's own package,
+    /// session imports are replayed, and the trailing expression value is
+    /// captured into the synthesized
+    /// <see cref="SubmissionImports.ResultFieldName"/> global for the cell
+    /// echo. Defaults to <see langword="null"/> (ordinary compilation).
+    /// </summary>
+    public SubmissionBindingOptions Submission { get; set; }
+
+    /// <summary>
     /// Gets the global scope.
     /// </summary>
     public BoundGlobalScope GlobalScope
@@ -240,7 +253,7 @@ public class Compilation
                 // Emit.
                 PrepareReferencesForBinding(assemblyName);
                 var globalScope = ReusedGlobalScope
-                    ?? Binder.BindGlobalScope(Previous?.GlobalScope, SyntaxTrees, References, ImplicitSystemImport, PreprocessorSymbols, IsLibrary);
+                    ?? Binder.BindGlobalScope(Previous?.GlobalScope, SyntaxTrees, References, ImplicitSystemImport, PreprocessorSymbols, IsLibrary, Submission);
                 Interlocked.CompareExchange(ref this.globalScope, globalScope, null);
             }
 

--- a/src/Core/CodeAnalysis/Execution/InteractiveSessionHost.cs
+++ b/src/Core/CodeAnalysis/Execution/InteractiveSessionHost.cs
@@ -1,0 +1,238 @@
+// <copyright file="InteractiveSessionHost.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace GSharp.Core.CodeAnalysis.Execution;
+
+/// <summary>
+/// Execution host for the interactive REPL (ADR-0156 Phase 2). Owns one
+/// collectible <see cref="AssemblyLoadContext"/> for the whole session: each
+/// submission's emitted PE loads into it and stays loaded — submission
+/// <c>N+1</c> references <c>N</c>'s assembly and its live static state, so
+/// the unit of unload is the session, reclaimed by <see cref="Reset"/> or
+/// <see cref="Dispose"/>. Framework dependencies resolve through the default
+/// load context; sibling submissions resolve by name from the session's own
+/// loaded set; user-supplied reference assemblies (<c>/r:</c>) resolve from
+/// their explicit paths.
+/// </summary>
+public sealed class InteractiveSessionHost : IDisposable
+{
+    private readonly object gate = new();
+    private readonly IReadOnlyList<string> referencePaths;
+    private Dictionary<string, Assembly> loadedByName;
+    private AssemblyLoadContext loadContext;
+    private bool disposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InteractiveSessionHost"/> class.
+    /// </summary>
+    /// <param name="referencePaths">User-supplied reference assembly paths (<c>/r:</c>) made resolvable at runtime; may be <see langword="null"/>.</param>
+    public InteractiveSessionHost(IReadOnlyList<string> referencePaths = null)
+    {
+        this.referencePaths = referencePaths ?? Array.Empty<string>();
+        CreateLoadContext();
+    }
+
+    /// <summary>
+    /// Loads a submission's emitted PE bytes into the session context and
+    /// invokes its entry point (when one exists — a declarations-only
+    /// submission has none and simply loads). The assembly stays loaded for
+    /// the rest of the session either way; a submission whose entry point
+    /// threw keeps whatever side effects it already applied, exactly like the
+    /// historical evaluator's partial-state behavior.
+    /// </summary>
+    /// <param name="peImage">The emitted PE image.</param>
+    /// <param name="assemblyName">The submission assembly's simple name (used for sibling resolution).</param>
+    /// <returns>The loaded assembly plus the entry point's outcome.</returns>
+    public SubmissionRunResult RunSubmission(byte[] peImage, string assemblyName)
+    {
+        if (peImage is null)
+        {
+            throw new ArgumentNullException(nameof(peImage));
+        }
+
+        ObjectDisposedException.ThrowIf(disposed, this);
+
+        Assembly assembly;
+        lock (gate)
+        {
+            using var stream = new MemoryStream(peImage, writable: false);
+            assembly = loadContext.LoadFromStream(stream);
+            if (!string.IsNullOrEmpty(assemblyName))
+            {
+                loadedByName[assemblyName] = assembly;
+            }
+        }
+
+        var entryPoint = assembly.EntryPoint;
+        if (entryPoint is null)
+        {
+            return new SubmissionRunResult(assembly, returnValue: null, unhandledException: null);
+        }
+
+        var arguments = entryPoint.GetParameters().Length == 0
+            ? null
+            : new object[] { Array.Empty<string>() };
+
+        try
+        {
+            var returnValue = entryPoint.Invoke(null, arguments);
+            return new SubmissionRunResult(assembly, returnValue, unhandledException: null);
+        }
+        catch (TargetInvocationException ex) when (ex.InnerException is not null)
+        {
+            return new SubmissionRunResult(assembly, returnValue: null, unhandledException: ex.InnerException);
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+        {
+            return new SubmissionRunResult(assembly, returnValue: null, unhandledException: ex);
+        }
+    }
+
+    /// <summary>
+    /// Reads a public static field from a loaded submission assembly via
+    /// runtime reflection — the value channel for the REPL's cell echo
+    /// (the synthesized <c>&lt;Result&gt;$</c> field) and the state sidebar's
+    /// values column. Returns <see langword="null"/> when the type or field
+    /// does not exist.
+    /// </summary>
+    /// <param name="assembly">The loaded submission assembly.</param>
+    /// <param name="typeFullName">The declaring type's metadata full name (e.g. <c>gsi3.&lt;Program&gt;</c>).</param>
+    /// <param name="fieldName">The static field's name.</param>
+    /// <returns>The field's current value, or <see langword="null"/>.</returns>
+    public object ReadStaticField(Assembly assembly, string typeFullName, string fieldName)
+    {
+        if (assembly is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            var type = assembly.GetType(typeFullName, throwOnError: false);
+            var field = type?.GetField(fieldName, BindingFlags.Public | BindingFlags.Static);
+            return field?.GetValue(null);
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Unloads the session's load context (letting real deinitializers run
+    /// when the finalizer queue drains after collection) and starts a fresh
+    /// one, discarding every loaded submission.
+    /// </summary>
+    public void Reset()
+    {
+        lock (gate)
+        {
+            ObjectDisposedException.ThrowIf(disposed, this);
+            loadContext.Unload();
+            CreateLoadContext();
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        lock (gate)
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            disposed = true;
+            loadContext.Unload();
+            loadContext = null;
+            loadedByName = null;
+        }
+    }
+
+    private void CreateLoadContext()
+    {
+        loadedByName = new Dictionary<string, Assembly>(StringComparer.OrdinalIgnoreCase);
+        loadContext = new AssemblyLoadContext($"gsi-session-{Guid.NewGuid():N}", isCollectible: true);
+        loadContext.Resolving += ResolveDependency;
+    }
+
+    private Assembly ResolveDependency(AssemblyLoadContext context, AssemblyName assemblyName)
+    {
+        if (assemblyName.Name is null)
+        {
+            return null;
+        }
+
+        // Sibling submissions resolve from the session's own loaded set.
+        lock (gate)
+        {
+            if (loadedByName is not null && loadedByName.TryGetValue(assemblyName.Name, out var sibling))
+            {
+                return sibling;
+            }
+        }
+
+        // User-supplied references win over any same-named host assembly so
+        // the submission binds against exactly what it was compiled against.
+        var match = referencePaths.FirstOrDefault(path =>
+            !string.IsNullOrWhiteSpace(path)
+            && string.Equals(Path.GetFileNameWithoutExtension(path), assemblyName.Name, StringComparison.OrdinalIgnoreCase)
+            && File.Exists(path));
+        if (match is not null)
+        {
+            return context.LoadFromAssemblyPath(Path.GetFullPath(match));
+        }
+
+        // Framework and transitive dependencies fall back to the default
+        // context, mirroring EmittedProgramHost's script-mode resolution.
+        try
+        {
+            return Assembly.Load(assemblyName);
+        }
+        catch (FileNotFoundException)
+        {
+            return null;
+        }
+        catch (FileLoadException)
+        {
+            return null;
+        }
+        catch (BadImageFormatException)
+        {
+            return null;
+        }
+    }
+}
+
+/// <summary>
+/// The outcome of running one submission: the loaded assembly (always
+/// non-null — a submission that threw stays loaded), the entry point's
+/// return value, and the unhandled exception when the submission threw.
+/// </summary>
+public sealed class SubmissionRunResult
+{
+    internal SubmissionRunResult(Assembly assembly, object returnValue, Exception unhandledException)
+    {
+        Assembly = assembly;
+        ReturnValue = returnValue;
+        UnhandledException = unhandledException;
+    }
+
+    /// <summary>Gets the loaded submission assembly.</summary>
+    public Assembly Assembly { get; }
+
+    /// <summary>Gets the entry point's return value (<see langword="null"/> for void or on failure).</summary>
+    public object ReturnValue { get; }
+
+    /// <summary>Gets the exception the submission's entry point threw, or <see langword="null"/> on success.</summary>
+    public Exception UnhandledException { get; }
+}

--- a/src/Repl/Engine/EmittedSessionEngine.cs
+++ b/src/Repl/Engine/EmittedSessionEngine.cs
@@ -1,0 +1,385 @@
+// <copyright file="EmittedSessionEngine.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Execution;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Symbols.Display;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+
+namespace GSharp.Repl.Engine;
+
+/// <summary>
+/// The emitted submission-chaining REPL engine (ADR-0156 Phase 2): every
+/// submission compiles with the real emitter into an in-memory assembly
+/// (<c>gsi$N</c>) that binds against all prior submissions' assemblies, loads
+/// into one session-wide collectible <see cref="System.Runtime.Loader.AssemblyLoadContext"/>,
+/// and runs its entry point in-process. Top-level variables live as static
+/// fields on each submission's <c>&lt;Program&gt;</c> container so later
+/// submissions read and write them as ordinary cross-assembly members; the
+/// trailing expression value is captured into the synthesized
+/// <c>&lt;Result&gt;$</c> field for the cell echo. Failed submissions never
+/// advance the chain: diagnostics render, and the next submission binds
+/// against the last good chain.
+/// </summary>
+public sealed class EmittedSessionEngine : ISessionEngine, IDisposable
+{
+    private readonly List<Cell> cells = new();
+    private readonly List<SubmissionState> submissions = new(); // newest first
+    private readonly List<ImportSymbol> sessionImports = new();
+    private readonly IReadOnlyList<string> userReferences;
+    private readonly InteractiveSessionHost host;
+    private readonly string submissionsDirectory;
+    private int submissionCounter;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EmittedSessionEngine"/> class.
+    /// </summary>
+    /// <param name="references">User-supplied reference assembly paths (<c>/r:</c>); may be <see langword="null"/>.</param>
+    public EmittedSessionEngine(IReadOnlyList<string>? references = null)
+    {
+        userReferences = references?.Where(r => !string.IsNullOrWhiteSpace(r)).ToArray() ?? Array.Empty<string>();
+        host = new InteractiveSessionHost(userReferences);
+        submissionsDirectory = Path.Combine(Path.GetTempPath(), "gsi-session-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(submissionsDirectory);
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyList<Cell> Cells => cells;
+
+    /// <inheritdoc/>
+    public bool CaptureConsole { get; set; }
+
+    /// <inheritdoc/>
+    public Func<string?>? InputProvider { get; set; }
+
+    /// <inheritdoc/>
+    public Cell Evaluate(string text) => EvaluateCore(text, CancellationToken.None);
+
+    /// <inheritdoc/>
+    public Task<Cell> EvaluateAsync(string text, CancellationToken cancellationToken)
+        => Task.Run(() => EvaluateCore(text, cancellationToken));
+
+    /// <inheritdoc/>
+    public ReplState Snapshot()
+    {
+        if (submissions.Count == 0)
+        {
+            return ReplState.Empty;
+        }
+
+        try
+        {
+            var imports = new List<ReplSymbol>();
+            var functions = new List<ReplSymbol>();
+            var vars = new List<ReplSymbol>();
+            var types = new List<ReplSymbol>();
+            var seenImports = new HashSet<string>(StringComparer.Ordinal);
+            var seenFunctions = new HashSet<string>(StringComparer.Ordinal);
+            var seenVars = new HashSet<string>(StringComparer.Ordinal);
+            var seenTypes = new HashSet<string>(StringComparer.Ordinal);
+
+            // Walk submissions newest-to-oldest so redeclarations show their
+            // latest form, mirroring the evaluator engine's scope-chain walk.
+            foreach (var submission in submissions)
+            {
+                var scope = submission.GlobalScope;
+                foreach (var import in scope.Imports)
+                {
+                    if (seenImports.Add(import.Name))
+                    {
+                        imports.Add(new ReplSymbol(Display(import, submission)));
+                    }
+                }
+
+                foreach (var fn in scope.Functions)
+                {
+                    if (ReferenceEquals(fn, scope.EntryPoint) || fn.IsSpecialName || fn.IsTopLevelEntryPoint || !seenFunctions.Add(fn.Name))
+                    {
+                        continue;
+                    }
+
+                    functions.Add(new ReplSymbol(Display(fn, submission)));
+                }
+
+                foreach (var v in scope.Variables)
+                {
+                    if (v is not GlobalVariableSymbol
+                        || string.Equals(v.Name, SubmissionImports.ResultFieldName, StringComparison.Ordinal)
+                        || !seenVars.Add(v.Name))
+                    {
+                        continue;
+                    }
+
+                    var display = Display(v, submission);
+                    var value = host.ReadStaticField(
+                        submission.RuntimeAssembly,
+                        submission.PackageName + "." + SubmissionImports.ProgramTypeName,
+                        v.Name);
+                    if (value is not null)
+                    {
+                        display += $" = {Truncate(value.ToString(), 20)}";
+                    }
+
+                    vars.Add(new ReplSymbol(display));
+                }
+
+                foreach (var s in scope.Structs)
+                {
+                    if (seenTypes.Add(s.Name))
+                    {
+                        types.Add(new ReplSymbol(Display(s, submission)));
+                    }
+                }
+
+                foreach (var i in scope.Interfaces)
+                {
+                    if (seenTypes.Add(i.Name))
+                    {
+                        types.Add(new ReplSymbol(Display(i, submission)));
+                    }
+                }
+
+                foreach (var e in scope.Enums)
+                {
+                    if (seenTypes.Add(e.Name))
+                    {
+                        types.Add(new ReplSymbol(Display(e, submission)));
+                    }
+                }
+
+                foreach (var d in scope.Delegates)
+                {
+                    if (seenTypes.Add(d.Name))
+                    {
+                        types.Add(new ReplSymbol(Display(d, submission)));
+                    }
+                }
+            }
+
+            return new ReplState(imports, functions, vars, types);
+        }
+        catch
+        {
+            return ReplState.Empty;
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Reset()
+    {
+        host.Reset();
+        submissions.Clear();
+        sessionImports.Clear();
+        cells.Clear();
+        TryDeleteSubmissionFiles();
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        host.Dispose();
+        TryDeleteSubmissionFiles();
+        try
+        {
+            Directory.Delete(submissionsDirectory, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+
+    private static string Truncate(string? text, int max)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return string.Empty;
+        }
+
+        var oneLine = text.Replace("\r", " ").Replace("\n", " ");
+        return oneLine.Length <= max ? oneLine : oneLine[..(max - 1)] + "…";
+    }
+
+    private string Display(Symbol symbol, SubmissionState submission)
+        => SymbolDisplay.ToDisplayString(symbol, SymbolDisplayFormat.Signature, submission.Compilation);
+
+    private Cell EvaluateCore(string text, CancellationToken cancellationToken)
+    {
+        var index = cells.Count + 1;
+
+        var originalOut = Console.Out;
+        var originalError = Console.Error;
+        var originalIn = Console.In;
+        StringWriter? stdout = null;
+        StringWriter? stderr = null;
+
+        if (CaptureConsole)
+        {
+            stdout = new StringWriter { NewLine = "\n" };
+            stderr = new StringWriter { NewLine = "\n" };
+            Console.SetOut(stdout);
+            Console.SetError(stderr);
+        }
+
+        if (InputProvider is not null)
+        {
+            Console.SetIn(new CallbackTextReader(InputProvider));
+        }
+
+        Cell cell;
+        try
+        {
+            try
+            {
+                cell = CompileAndRun(text, index, cancellationToken, stdout, stderr);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                var diag = new Diagnostic(default, "GSI001", DiagnosticSeverity.Error, $"Evaluation error: {ex.Message}");
+                cell = new Cell(index, text, null, ImmutableArray.Create(diag), true, stdout?.ToString() ?? string.Empty, stderr?.ToString() ?? string.Empty);
+            }
+        }
+        finally
+        {
+            if (CaptureConsole)
+            {
+                Console.SetOut(originalOut);
+                Console.SetError(originalError);
+            }
+
+            if (InputProvider is not null)
+            {
+                Console.SetIn(originalIn);
+            }
+        }
+
+        cells.Add(cell);
+        return cell;
+    }
+
+    private Cell CompileAndRun(string text, int index, CancellationToken cancellationToken, StringWriter? stdout, StringWriter? stderr)
+    {
+        // Submission identities are monotonic and never reused: a submission
+        // that failed at runtime was already loaded into the session context,
+        // so its assembly name is burned even though its declarations are
+        // discarded from the chain.
+        var n = ++submissionCounter;
+        var assemblyName = "gsi$" + n;
+        var packageName = "gsi" + n;
+
+        var tree = SyntaxTree.Parse(SourceText.From(text, string.Empty));
+        var referencePaths = submissions.Select(s => s.DllPath).Concat(userReferences).ToArray();
+        var resolver = referencePaths.Length > 0
+            ? ReferenceResolver.WithReferences(referencePaths)
+            : ReferenceResolver.Default();
+
+        var compilation = new Compilation(resolver, tree)
+        {
+            Submission = new SubmissionBindingOptions
+            {
+                Imports = SubmissionImports.Create(
+                    submissions.Select(s => new SubmissionReference(s.AssemblyName, s.PackageName, s.GlobalScope)).ToImmutableArray()),
+                DefaultPackageName = packageName,
+                ReplayImports = sessionImports.ToImmutableArray(),
+            },
+        };
+
+        using var peStream = new MemoryStream();
+        var emitResult = compilation.Emit(peStream, pdbStream: null, refStream: null, assemblyName: assemblyName);
+        var hasError = emitResult.Diagnostics.Any(d => d.IsError) || !emitResult.Success;
+        if (hasError)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return new Cell(index, text, null, emitResult.Diagnostics, true, stdout?.ToString() ?? string.Empty, stderr?.ToString() ?? string.Empty);
+        }
+
+        // Flush the PE to the session directory before running: future
+        // submissions' reference resolvers read it from disk.
+        var peImage = peStream.ToArray();
+        var dllPath = Path.Combine(submissionsDirectory, assemblyName + ".dll");
+        File.WriteAllBytes(dllPath, peImage);
+
+        var runResult = host.RunSubmission(peImage, assemblyName);
+        if (runResult.UnhandledException is not null)
+        {
+            // Runtime failure: the submission's declarations are discarded
+            // (the chain stays at the last good submission), but side effects
+            // it already applied to earlier submissions' state persist —
+            // matching the evaluator engine's partial-state behavior.
+            TryDeleteFile(dllPath);
+            var ex = runResult.UnhandledException;
+            var diag = new Diagnostic(default, "GSI002", DiagnosticSeverity.Error, $"Unhandled exception. {ex.GetType().Name}: {ex.Message}");
+            cancellationToken.ThrowIfCancellationRequested();
+            return new Cell(index, text, null, emitResult.Diagnostics.Add(diag), true, stdout?.ToString() ?? string.Empty, stderr?.ToString() ?? string.Empty);
+        }
+
+        var value = host.ReadStaticField(
+            runResult.Assembly,
+            packageName + "." + SubmissionImports.ProgramTypeName,
+            SubmissionImports.ResultFieldName)
+            ?? runResult.ReturnValue;
+
+        // The only cancellation checkpoint: if the caller interrupted before
+        // this (possibly long-running) submission finished, discard the result
+        // instead of committing it to the transcript or the chain.
+        cancellationToken.ThrowIfCancellationRequested();
+
+        submissions.Insert(0, new SubmissionState(compilation, compilation.GlobalScope, assemblyName, packageName, dllPath, runResult.Assembly));
+        foreach (var import in compilation.GlobalScope.Imports)
+        {
+            if (!sessionImports.Any(i =>
+                string.Equals(i.Name, import.Name, StringComparison.Ordinal)
+                && string.Equals(i.Target, import.Target, StringComparison.Ordinal)))
+            {
+                sessionImports.Add(new ImportSymbol(import.Name, import.Target, declaration: null));
+            }
+        }
+
+        return new Cell(index, text, value, emitResult.Diagnostics, false, stdout?.ToString() ?? string.Empty, stderr?.ToString() ?? string.Empty);
+    }
+
+    private void TryDeleteSubmissionFiles()
+    {
+        foreach (var submission in submissions)
+        {
+            TryDeleteFile(submission.DllPath);
+        }
+    }
+
+    private static void TryDeleteFile(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+
+    private sealed record SubmissionState(
+        Compilation Compilation,
+        BoundGlobalScope GlobalScope,
+        string AssemblyName,
+        string PackageName,
+        string DllPath,
+        Assembly RuntimeAssembly);
+}

--- a/src/Repl/Engine/ISessionEngine.cs
+++ b/src/Repl/Engine/ISessionEngine.cs
@@ -1,0 +1,58 @@
+// <copyright file="ISessionEngine.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GSharp.Repl.Engine;
+
+/// <summary>
+/// The evaluation engine surface the interactive TUI drives (ADR-0156
+/// Phase 2): the historical tree-walking <see cref="SessionEngine"/> and the
+/// emitted submission-chaining <see cref="EmittedSessionEngine"/> both
+/// implement it, so the REPL screen is engine-agnostic.
+/// </summary>
+public interface ISessionEngine
+{
+    /// <summary>Gets the transcript of evaluated cells.</summary>
+    IReadOnlyList<Cell> Cells { get; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether standard output/error produced
+    /// while evaluating a cell are captured into the cell instead of leaking
+    /// to the raw terminal.
+    /// </summary>
+    bool CaptureConsole { get; set; }
+
+    /// <summary>
+    /// Gets or sets the optional provider that supplies a line of standard
+    /// input when evaluated code reads from <see cref="Console.In"/>.
+    /// </summary>
+    Func<string?>? InputProvider { get; set; }
+
+    /// <summary>Evaluates a submission, appends a cell, and returns it. Never throws.</summary>
+    /// <param name="text">The submission source.</param>
+    /// <returns>The evaluated cell.</returns>
+    Cell Evaluate(string text);
+
+    /// <summary>
+    /// Evaluates a submission on a background thread so the caller's render
+    /// loop stays responsive. Cancellation is best-effort: the token is only
+    /// observed at the single checkpoint before the result would be committed
+    /// to <see cref="Cells"/>/session state.
+    /// </summary>
+    /// <param name="text">The submission source.</param>
+    /// <param name="cancellationToken">Best-effort cancellation token.</param>
+    /// <returns>The evaluated cell.</returns>
+    Task<Cell> EvaluateAsync(string text, CancellationToken cancellationToken);
+
+    /// <summary>Builds a snapshot of the accumulated session state for the REPL sidebar.</summary>
+    /// <returns>The snapshot; <see cref="ReplState.Empty"/> when nothing has been evaluated.</returns>
+    ReplState Snapshot();
+
+    /// <summary>Discards all session state and starts a fresh submission chain.</summary>
+    void Reset();
+}

--- a/src/Repl/Engine/SessionEngine.cs
+++ b/src/Repl/Engine/SessionEngine.cs
@@ -22,7 +22,7 @@ namespace GSharp.Repl.Engine;
 /// Owns the incremental compilation state and the transcript of evaluated cells.
 /// Replaces the eval core of the old <c>GSharpRepl</c> without any console output.
 /// </summary>
-public sealed class SessionEngine
+public sealed class SessionEngine : ISessionEngine
 {
     private readonly Dictionary<VariableSymbol, object> variables = new();
     private readonly List<Cell> cells = new();

--- a/src/Repl/Program.cs
+++ b/src/Repl/Program.cs
@@ -23,13 +23,7 @@ public static class Program
     {
         if (args.Length == 0)
         {
-            if (Console.IsInputRedirected)
-            {
-                Console.Error.WriteLine("gsi requires an interactive terminal");
-                return 1;
-            }
-
-            return ReplHost.Run();
+            return RunInteractive(EngineChoiceFromEnvironment(), new List<string>());
         }
 
         switch (args[0])
@@ -37,9 +31,11 @@ public static class Program
             case "--help":
             case "-h":
             case "/?":
-                Console.WriteLine("Usage: gsi [file.gs] [/r:<assembly> ...] [--help] [--version]");
+                Console.WriteLine("Usage: gsi [file.gs] [/r:<assembly> ...] [--engine <name>] [--help] [--version]");
                 Console.WriteLine("  file.gs                Run the given G# script and exit.");
-                Console.WriteLine("  /r:<file>              Reference an assembly in script mode (alias: /reference:<file>; repeatable).");
+                Console.WriteLine("  /r:<file>              Reference an assembly (alias: /reference:<file>; repeatable).");
+                Console.WriteLine("  --engine <name>        Interactive engine: 'evaluator' (default) or 'emit'");
+                Console.WriteLine("                         (ADR-0156 Phase 2 opt-in; also via GSI_ENGINE).");
                 Console.WriteLine("  --help, -h             Show this help and exit.");
                 Console.WriteLine("  --version              Show the gsi version and exit.");
                 Console.WriteLine("  (no args)              Start the interactive REPL.");
@@ -51,11 +47,25 @@ public static class Program
 
         var references = new List<string>();
         string? scriptPath = null;
-        foreach (var arg in args)
+        string? engineChoice = null;
+        for (var i = 0; i < args.Length; i++)
         {
+            var arg = args[i];
             if (TryParseReferenceSwitch(arg, out var referencePath))
             {
                 references.Add(referencePath);
+                continue;
+            }
+
+            if (arg is "--engine" && i + 1 < args.Length)
+            {
+                engineChoice = args[++i];
+                continue;
+            }
+
+            if (arg.StartsWith("--engine=", StringComparison.Ordinal))
+            {
+                engineChoice = arg.Substring("--engine=".Length);
                 continue;
             }
 
@@ -69,10 +79,16 @@ public static class Program
             return 1;
         }
 
+        engineChoice ??= EngineChoiceFromEnvironment();
+        if (engineChoice is not null and not "evaluator" and not "emit")
+        {
+            Console.Error.WriteLine($"Unknown engine '{engineChoice}'. Expected 'evaluator' or 'emit'.");
+            return 1;
+        }
+
         if (scriptPath is null)
         {
-            Console.Error.WriteLine("Must specify a .gs script file.");
-            return 1;
+            return RunInteractive(engineChoice, references);
         }
 
         if (!File.Exists(scriptPath))
@@ -82,6 +98,36 @@ public static class Program
         }
 
         return RunScript(scriptPath, references);
+    }
+
+    private static string? EngineChoiceFromEnvironment()
+        => Environment.GetEnvironmentVariable("GSI_ENGINE") is { Length: > 0 } env ? env.ToLowerInvariant() : null;
+
+    /// <summary>
+    /// Starts the interactive TUI. ADR-0156 Phase 2: <c>--engine emit</c> (or
+    /// <c>GSI_ENGINE=emit</c>) selects the emitted submission-chaining engine;
+    /// the default remains the tree-walking evaluator until the flip lands.
+    /// </summary>
+    private static int RunInteractive(string? engineChoice, List<string> references)
+    {
+        if (Console.IsInputRedirected)
+        {
+            Console.Error.WriteLine("gsi requires an interactive terminal");
+            return 1;
+        }
+
+        if (engineChoice == "emit")
+        {
+            return ReplHost.Run(new Engine.EmittedSessionEngine(references));
+        }
+
+        if (references.Count > 0)
+        {
+            Console.Error.WriteLine("/r: references in interactive mode require --engine emit (ADR-0156 Phase 2).");
+            return 1;
+        }
+
+        return ReplHost.Run();
     }
 
     /// <summary>

--- a/src/Repl/ReplHost.cs
+++ b/src/Repl/ReplHost.cs
@@ -15,7 +15,16 @@ namespace GSharp.Repl;
 /// <summary>Owns the alt-screen lifecycle and the AppShell. Restores the terminal on exit.</summary>
 public static class ReplHost
 {
-    public static int Run()
+    public static int Run() => Run(new SessionEngine());
+
+    /// <summary>
+    /// Runs the interactive TUI over the given evaluation engine (ADR-0156
+    /// Phase 2: the tree-walking <see cref="SessionEngine"/> or the emitted
+    /// <see cref="EmittedSessionEngine"/>).
+    /// </summary>
+    /// <param name="engine">The evaluation engine driving the session.</param>
+    /// <returns>The process exit code.</returns>
+    public static int Run(ISessionEngine engine)
     {
         // The TUI renders Unicode glyphs (box-drawing rules, status dots, prompt
         // chevrons, ellipses). On Windows the console defaults to a legacy OEM code
@@ -29,7 +38,6 @@ public static class ReplHost
             // Output is redirected or the encoding can't be changed; ignore.
         }
 
-        var engine = new SessionEngine();
         var tabs = new List<ITabScreen>
         {
             new ReplScreen(engine),
@@ -64,6 +72,8 @@ public static class ReplHost
             {
                 // ignore
             }
+
+            (engine as IDisposable)?.Dispose();
         }
     }
 

--- a/src/Repl/Screens/ReplScreen.cs
+++ b/src/Repl/Screens/ReplScreen.cs
@@ -23,7 +23,7 @@ public sealed class ReplScreen : ITabScreen, IDisposable
 {
     private const int MaxPopup = 7;
 
-    private readonly SessionEngine engine;
+    private readonly ISessionEngine engine;
     private readonly MultilineEditor editor = new();
     private readonly ScrollState scroll = new();
     private IAppShellNavigator? navigator;
@@ -36,7 +36,7 @@ public sealed class ReplScreen : ITabScreen, IDisposable
     private int evalFrame;
     private bool cancelRequested;
 
-    public ReplScreen(SessionEngine engine)
+    public ReplScreen(ISessionEngine engine)
     {
         this.engine = engine;
         engine.CaptureConsole = true;

--- a/test/Interpreter.Tests/EmittedSessionEngineParityTests.cs
+++ b/test/Interpreter.Tests/EmittedSessionEngineParityTests.cs
@@ -1,0 +1,165 @@
+// <copyright file="EmittedSessionEngineParityTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using GSharp.Repl.Engine;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// ADR-0156 Phase 2 parity gate: drives the SAME submission script through
+/// the historical tree-walking <see cref="SessionEngine"/> and the emitted
+/// <see cref="EmittedSessionEngine"/> and compares each cell's error flag,
+/// echoed value rendering, and captured console output. Scripts here cover
+/// the surface whose observable semantics the migration must preserve;
+/// deliberate divergences (deinit, GS0510, interpreter boundaries) have their
+/// own dedicated tests instead of parity rows.
+/// </summary>
+public sealed class EmittedSessionEngineParityTests
+{
+    public static TheoryData<string, string[]> ParityScripts() => new()
+    {
+        {
+            "arithmetic-and-locals",
+            new[]
+            {
+                "var a = 6",
+                "var b = 7",
+                "a * b",
+                "a = a + 1",
+                "a",
+            }
+        },
+        {
+            "strings-and-interpolation",
+            new[]
+            {
+                "var name = \"world\"",
+                "\"hello \" + name",
+                "name.Length",
+            }
+        },
+        {
+            "functions-and-recursion",
+            new[]
+            {
+                "func fib(n int) int {\n    if n < 2 {\n        return n\n    }\n    return fib(n - 1) + fib(n - 2)\n}",
+                "fib(10)",
+            }
+        },
+        {
+            "structs-and-methods",
+            new[]
+            {
+                "struct Point {\n    var X int\n    var Y int\n    func Sum() int {\n        return X + Y\n    }\n}",
+                "var p = Point{X: 3, Y: 4}\np.Sum()",
+                "p.Sum() * 2",
+            }
+        },
+        {
+            "console-output",
+            new[]
+            {
+                "Console.WriteLine(\"line-1\")",
+                "for i in range 3 {\n    Console.WriteLine(i.ToString())\n}",
+            }
+        },
+        {
+            "redefinition-shadowing",
+            new[]
+            {
+                "var x = 1",
+                "var x = \"text\"",
+                "x",
+            }
+        },
+        {
+            "failed-submissions-recover",
+            new[]
+            {
+                "var ok = 41",
+                "nope + 1",
+                "ok + 1",
+            }
+        },
+        {
+            "collections",
+            new[]
+            {
+                "let arr = [3]int{10, 20, 30}",
+                "arr[1]",
+                "var m = map[string,int]{\"a\": 1}",
+                "m[\"a\"]",
+            }
+        },
+    };
+
+    [Theory]
+    [MemberData(nameof(ParityScripts))]
+    public void BothEnginesAgreeCellByCell(string label, string[] submissions)
+    {
+        _ = label;
+        var evaluator = new SessionEngine { CaptureConsole = true };
+        using var emitted = new EmittedSessionEngine { CaptureConsole = true };
+
+        var mismatches = new List<string>();
+        for (var i = 0; i < submissions.Length; i++)
+        {
+            var evaluatorCell = evaluator.Evaluate(submissions[i]);
+            var emittedCell = emitted.Evaluate(submissions[i]);
+
+            if (evaluatorCell.HasError != emittedCell.HasError)
+            {
+                mismatches.Add($"cell {i + 1}: HasError evaluator={evaluatorCell.HasError} emitted={emittedCell.HasError} (evaluator diags: {string.Join("; ", evaluatorCell.Diagnostics)}) (emitted diags: {string.Join("; ", emittedCell.Diagnostics)})");
+                continue;
+            }
+
+            if (!evaluatorCell.HasError)
+            {
+                var evaluatorValue = evaluatorCell.Value?.ToString();
+                var emittedValue = emittedCell.Value?.ToString();
+                if (!string.Equals(evaluatorValue, emittedValue, StringComparison.Ordinal))
+                {
+                    mismatches.Add($"cell {i + 1}: Value evaluator='{evaluatorValue}' emitted='{emittedValue}'");
+                }
+            }
+
+            if (!string.Equals(evaluatorCell.Output, emittedCell.Output, StringComparison.Ordinal))
+            {
+                mismatches.Add($"cell {i + 1}: Output evaluator='{evaluatorCell.Output}' emitted='{emittedCell.Output}'");
+            }
+        }
+
+        Assert.True(mismatches.Count == 0, string.Join(Environment.NewLine, mismatches));
+    }
+
+    /// <summary>
+    /// ADR-0156 Phase 2 deliberate semantic change, pinned on both engines:
+    /// redefining a same-signature function and calling it. The evaluator
+    /// engine's chained scopes surface BOTH declarations as overloads, so the
+    /// call reports an ambiguity and the redefined function is uncallable;
+    /// the emitted engine gives clean newest-wins shadowing (the Roslyn
+    /// interactive model). When the emitted engine becomes the default, the
+    /// evaluator half of this test retires with it.
+    /// </summary>
+    [Fact]
+    public void RedefinedFunctionCallDivergesByDesign()
+    {
+        var evaluator = new SessionEngine();
+        evaluator.Evaluate("func g() int {\n    return 1\n}");
+        evaluator.Evaluate("func g() int {\n    return 2\n}");
+        var evaluatorCall = evaluator.Evaluate("g()");
+        Assert.True(evaluatorCall.HasError);
+        Assert.Contains(evaluatorCall.Diagnostics, d => d.Message.Contains("ambiguous", StringComparison.OrdinalIgnoreCase));
+
+        using var emitted = new EmittedSessionEngine();
+        emitted.Evaluate("func g() int {\n    return 1\n}");
+        emitted.Evaluate("func g() int {\n    return 2\n}");
+        var emittedCall = emitted.Evaluate("g()");
+        Assert.False(emittedCall.HasError);
+        Assert.Equal(2, emittedCall.Value);
+    }
+}

--- a/test/Interpreter.Tests/EmittedSessionEngineTests.cs
+++ b/test/Interpreter.Tests/EmittedSessionEngineTests.cs
@@ -1,0 +1,408 @@
+// <copyright file="EmittedSessionEngineTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using GSharp.Repl.Engine;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// ADR-0156 Phase 2: the emitted submission-chaining REPL engine. Each test
+/// pins one of the interactive semantics the migration must preserve (or
+/// deliberately changes — see the deinit test, where real emitted code now
+/// runs deinitializers interactively and GS0510 no longer fires).
+/// </summary>
+public sealed class EmittedSessionEngineTests : IDisposable
+{
+    private readonly EmittedSessionEngine engine = new();
+
+    public void Dispose() => engine.Dispose();
+
+    [Fact]
+    public void CrossSubmissionVariableReadAndWrite()
+    {
+        Assert.False(engine.Evaluate("var counter = 10").HasError);
+
+        var read = engine.Evaluate("counter + 5");
+        Assert.False(read.HasError);
+        Assert.Equal(15, read.Value);
+
+        var write = engine.Evaluate("counter = 40");
+        Assert.False(write.HasError);
+
+        var compound = engine.Evaluate("counter += 2");
+        Assert.False(compound.HasError);
+
+        var readBack = engine.Evaluate("counter");
+        Assert.False(readBack.HasError);
+        Assert.Equal(42, readBack.Value);
+    }
+
+    [Fact]
+    public void CrossSubmissionFunctionCall()
+    {
+        Assert.False(engine.Evaluate("func addOne(n int) int {\n    return n + 1\n}").HasError);
+
+        var call = engine.Evaluate("addOne(41)");
+        Assert.False(call.HasError);
+        Assert.Equal(42, call.Value);
+    }
+
+    [Fact]
+    public void CrossSubmissionStructConstructionAndMethodCall()
+    {
+        Assert.False(engine.Evaluate("""
+            struct Point {
+                var X int
+                var Y int
+                func Sum() int {
+                    return X + Y
+                }
+            }
+            """).HasError);
+
+        var use = engine.Evaluate("var p = Point{X: 3, Y: 4}\np.Sum()");
+        Assert.False(use.HasError);
+        Assert.Equal(7, use.Value);
+
+        // Member access on the stored instance from yet another submission.
+        var later = engine.Evaluate("p.Sum()");
+        Assert.False(later.HasError);
+        Assert.Equal(7, later.Value);
+    }
+
+    [Fact]
+    public void CrossSubmissionClassInstanceMutation()
+    {
+        Assert.False(engine.Evaluate("""
+            class Counter {
+                var N int
+                func Bump() {
+                    N = N + 1
+                }
+            }
+            var c = Counter{N: 5}
+            """).HasError);
+
+        var first = engine.Evaluate("c.Bump()\nc.N");
+        Assert.False(first.HasError);
+        Assert.Equal(6, first.Value);
+
+        var second = engine.Evaluate("c.Bump()\nc.N");
+        Assert.False(second.HasError);
+        Assert.Equal(7, second.Value);
+    }
+
+    [Fact]
+    public void ClosureCapturingHoistedGlobalSharesTheCell()
+    {
+        Assert.False(engine.Evaluate("var total = 0").HasError);
+        Assert.False(engine.Evaluate("""
+            let bump = func() int {
+                total = total + 10
+                return total
+            }
+            """).HasError);
+
+        var first = engine.Evaluate("bump()");
+        Assert.False(first.HasError);
+        Assert.Equal(10, first.Value);
+
+        var second = engine.Evaluate("bump()");
+        Assert.False(second.HasError);
+        Assert.Equal(20, second.Value);
+
+        var direct = engine.Evaluate("total");
+        Assert.False(direct.HasError);
+        Assert.Equal(20, direct.Value);
+    }
+
+    [Fact]
+    public void RedefiningVariableNewestWinsEvenAcrossTypes()
+    {
+        Assert.False(engine.Evaluate("var x = 1").HasError);
+        Assert.False(engine.Evaluate("var x = \"text\"").HasError);
+
+        var read = engine.Evaluate("x");
+        Assert.False(read.HasError);
+        Assert.Equal("text", read.Value);
+    }
+
+    [Fact]
+    public void RedefiningFunctionNewestWins()
+    {
+        Assert.False(engine.Evaluate("func f() int {\n    return 1\n}").HasError);
+        Assert.False(engine.Evaluate("func f() int {\n    return 2\n}").HasError);
+
+        var call = engine.Evaluate("f()");
+        Assert.False(call.HasError);
+        Assert.Equal(2, call.Value);
+    }
+
+    [Fact]
+    public void RedefiningStructNewestWinsAndOldInstancesKeepOldType()
+    {
+        Assert.False(engine.Evaluate("""
+            struct S {
+                var V int
+                func Tag() int {
+                    return V
+                }
+            }
+            var old = S{V: 7}
+            """).HasError);
+        Assert.False(engine.Evaluate("""
+            struct S {
+                var V int
+                func Tag() int {
+                    return V * 100
+                }
+            }
+            """).HasError);
+
+        var fresh = engine.Evaluate("var neu = S{V: 2}\nneu.Tag()");
+        Assert.False(fresh.HasError);
+        Assert.Equal(200, fresh.Value);
+
+        // The instance created before the redefinition keeps its original
+        // type and behavior — exactly like Roslyn interactive.
+        var stale = engine.Evaluate("old.Tag()");
+        Assert.False(stale.HasError);
+        Assert.Equal(7, stale.Value);
+    }
+
+    [Fact]
+    public void LetGlobalIsReadOnlyAcrossSubmissions()
+    {
+        Assert.False(engine.Evaluate("let frozen = 5").HasError);
+
+        var write = engine.Evaluate("frozen = 6");
+        Assert.True(write.HasError);
+        Assert.Contains(write.Diagnostics, d => d.Id == "GS0127");
+
+        var read = engine.Evaluate("frozen");
+        Assert.False(read.HasError);
+        Assert.Equal(5, read.Value);
+    }
+
+    [Fact]
+    public void FailedCompilationDoesNotPoisonTheChain()
+    {
+        Assert.False(engine.Evaluate("var ok = 1").HasError);
+
+        var bad = engine.Evaluate("definitely_undefined + 1");
+        Assert.True(bad.HasError);
+
+        var next = engine.Evaluate("ok + 1");
+        Assert.False(next.HasError);
+        Assert.Equal(2, next.Value);
+    }
+
+    [Fact]
+    public void FailedSubmissionDeclarationsAreDiscarded()
+    {
+        var bad = engine.Evaluate("var kept = 1\nundefined_here");
+        Assert.True(bad.HasError);
+
+        var read = engine.Evaluate("kept");
+        Assert.True(read.HasError);
+    }
+
+    [Fact]
+    public void RuntimeExceptionKeepsChainAtLastGoodSubmissionButPartialEffectsPersist()
+    {
+        Assert.False(engine.Evaluate("var state = \"initial\"").HasError);
+
+        // The submission mutates earlier state, then throws: the mutation
+        // persists (it already executed) but the submission's own
+        // declarations are discarded — matching the evaluator engine.
+        var throwing = engine.Evaluate("""
+            state = "mutated"
+            var localOnly = 3
+            let arr = [2]int{1, 2}
+            arr[9]
+            """);
+        Assert.True(throwing.HasError);
+        Assert.Contains(throwing.Diagnostics, d => d.Id == "GSI002");
+
+        var state = engine.Evaluate("state");
+        Assert.False(state.HasError);
+        Assert.Equal("mutated", state.Value);
+
+        var dropped = engine.Evaluate("localOnly");
+        Assert.True(dropped.HasError);
+    }
+
+    [Fact]
+    public void TrailingExpressionValueIsEchoed()
+    {
+        var cell = engine.Evaluate("2 * 21");
+        Assert.False(cell.HasError);
+        Assert.Equal(42, cell.Value);
+    }
+
+    [Fact]
+    public void TrailingVariableDeclarationEchoesItsValue()
+    {
+        var cell = engine.Evaluate("var q = 5 * 5");
+        Assert.False(cell.HasError);
+        Assert.Equal(25, cell.Value);
+    }
+
+    [Fact]
+    public void VoidCallHasNoEcho()
+    {
+        var cell = new EmittedSessionEngine { CaptureConsole = true }.Evaluate("Console.WriteLine(\"hi\")");
+        Assert.False(cell.HasError);
+        Assert.Null(cell.Value);
+        Assert.Equal("hi\n", cell.Output);
+    }
+
+    [Fact]
+    public void DeclarationOnlySubmissionHasNoEchoAndNoError()
+    {
+        var cell = engine.Evaluate("func noop() {\n}");
+        Assert.False(cell.HasError);
+        Assert.Null(cell.Value);
+    }
+
+    [Fact]
+    public void ImportsPersistAcrossSubmissions()
+    {
+        Assert.False(engine.Evaluate("import System.Text").HasError);
+
+        var use = engine.Evaluate("""
+            var sb = StringBuilder()
+            sb.Append("ab")
+            sb.ToString()
+            """);
+        Assert.False(use.HasError);
+        Assert.Equal("ab", use.Value);
+    }
+
+    [Fact]
+    public void AsyncSubmissionAwaitsToCompletionAndEchoes()
+    {
+        Assert.False(engine.Evaluate("import System.Threading.Tasks").HasError);
+
+        var cell = engine.Evaluate("""
+            let t = Task.Run(func() int { return 40 + 2 })
+            await t
+            """);
+        Assert.False(cell.HasError);
+        Assert.Equal(42, cell.Value);
+    }
+
+    [Fact]
+    public void ConsoleOutputIsCapturedPerCell()
+    {
+        engine.CaptureConsole = true;
+        var cell = engine.Evaluate("Console.WriteLine(\"line-1\")\nConsole.WriteLine(\"line-2\")");
+        Assert.False(cell.HasError);
+        Assert.Equal("line-1\nline-2\n", cell.Output);
+    }
+
+    [Fact]
+    public void ResetStartsAFreshChain()
+    {
+        Assert.False(engine.Evaluate("var x = 1").HasError);
+        Assert.False(engine.Evaluate("func g() int {\n    return 3\n}").HasError);
+
+        engine.Reset();
+        Assert.Empty(engine.Cells);
+        Assert.True(engine.Snapshot().IsEmpty);
+
+        Assert.True(engine.Evaluate("x").HasError);
+        Assert.True(engine.Evaluate("g()").HasError);
+
+        // And the fresh chain accepts new definitions under the old names.
+        Assert.False(engine.Evaluate("var x = 9").HasError);
+        var read = engine.Evaluate("x");
+        Assert.False(read.HasError);
+        Assert.Equal(9, read.Value);
+    }
+
+    /// <summary>
+    /// ADR-0156 Phase 2 deliberate semantic change: interactive submissions
+    /// run real emitted code, so a class deinitializer executes as a genuine
+    /// CLR finalizer when a collection is forced — and the GS0510 interpreter
+    /// boundary warning (pinned for the evaluator engine by
+    /// <c>Issue2988DeinitInterpreterTests.ForcedCollectionSkipsDeinitializerAndWarnsOnce</c>)
+    /// no longer fires, matching Phase 1's script-mode behavior.
+    /// </summary>
+    [Fact]
+    public void InteractiveDeinitializerRunsWithoutBoundaryWarning()
+    {
+        engine.CaptureConsole = true;
+        var cell = engine.Evaluate("""
+            class Resource {
+                deinit {
+                    Console.WriteLine("deinit-ran-22")
+                }
+            }
+
+            func Allocate() {
+                var resource = Resource()
+                GC.KeepAlive(resource)
+            }
+
+            Allocate()
+            GC.Collect()
+            GC.WaitForPendingFinalizers()
+            Console.WriteLine("body-33")
+            """);
+
+        Assert.False(cell.HasError);
+        Assert.DoesNotContain(cell.Diagnostics, d => d.Id == "GS0510");
+        Assert.Contains("deinit-ran-22", cell.Output, StringComparison.Ordinal);
+        Assert.Contains("body-33", cell.Output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task EvaluateAsyncCancelledBeforeCommitDoesNotAppendCellOrMutateState()
+    {
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => engine.EvaluateAsync("let x = 1", cts.Token));
+
+        Assert.Empty(engine.Cells);
+
+        var next = engine.Evaluate("x");
+        Assert.True(next.HasError);
+    }
+
+    [Fact]
+    public async Task EvaluateAsyncNotCancelledCommitsCellNormally()
+    {
+        var cell = await engine.EvaluateAsync("1 + 1", CancellationToken.None);
+
+        Assert.Single(engine.Cells);
+        Assert.False(cell.HasError);
+        Assert.Equal(2, cell.Value);
+    }
+
+    [Fact]
+    public void SnapshotListsAccumulatedSymbolsWithValues()
+    {
+        Assert.False(engine.Evaluate("var counter = 10").HasError);
+        Assert.False(engine.Evaluate("func addOne(n int) int {\n    return n + 1\n}").HasError);
+        Assert.False(engine.Evaluate("""
+            struct Point {
+                var X int
+            }
+            """).HasError);
+        Assert.False(engine.Evaluate("counter = 42").HasError);
+
+        var state = engine.Snapshot();
+        Assert.Contains(state.Variables, v => v.Display.Contains("counter", StringComparison.Ordinal) && v.Display.Contains("42", StringComparison.Ordinal));
+        Assert.Contains(state.Functions, f => f.Display.Contains("addOne", StringComparison.Ordinal));
+        Assert.Contains(state.Types, t => t.Display.Contains("Point", StringComparison.Ordinal));
+        Assert.DoesNotContain(state.Variables, v => v.Display.Contains("<Result>$", StringComparison.Ordinal));
+    }
+}


### PR DESCRIPTION
Part of #3176, part of #3163; implements ADR-0156 Phase 2 (`docs/adr/0156-gsi-emit-to-memory-execution.md`).

## Summary

- Add submission-as-metadata binding to Core: a `Compilation` with `Submission` options binds one REPL cell against all prior submissions' **emitted assemblies** — top-level functions resolve as static-method calls on each submission's `<Program>` container, top-level globals as static-field reads/writes, and user types as imported CLR types (semantic aggregates) — all riding the existing CLR-import machinery (`ImportedClassSymbol`, `BoundClrPropertyAccess/Assignment`, `ImportedMemberRefFactory`), so the emitter needed **zero** new reference surface. Lookup walks submissions newest-first, reproducing the evaluator's scope-chain shadowing.
- Hoisting: top-level `var`/`let` already emit as static fields on `<Program>` (issue #191); Phase 2 adds the cross-submission binding to them plus capture of the trailing expression (or trailing declaration) value into a synthesized public static `<Result>$` global for the cell echo.
- Add `InteractiveSessionHost` (Core.Execution): one **collectible ALC per session** — submissions load and stay loaded (N+1 references N's live static state), `Reset()` unloads the ALC wholesale. Sibling submissions resolve by name from the session set, `/r:` from explicit paths, framework from the default context (mirrors Phase 1's `EmittedProgramHost`).
- Add `EmittedSessionEngine` (Repl) implementing a new `ISessionEngine` seam that `ReplScreen` now drives. Failed submissions never advance the chain; runtime exceptions surface as `GSI002` error cells with partial side effects preserved (evaluator parity); imports replay across cells; the sidebar snapshot reads live values via reflection over submission fields; cancellation keeps the single commit-checkpoint model.
- **Opt-in, not the default (sanctioned fallback from the Phase 2 plan):** `gsi --engine emit` or `GSI_ENGINE=emit` selects the emitted engine; the evaluator remains the interactive default until the flip lands in a follow-up. `/r:` in interactive mode lights up with the emitted engine (closing the interactive half of #3130). `gsc`, `gsi <file>` (Phase 1), and `Compilation.Evaluate` are untouched.

## Semantic changes (observable REPL behavior)

| Behavior | Evaluator engine (today) | Emitted engine | Why |
|---|---|---|---|
| Redefining a same-signature function, then calling it | GS0131-adjacent **ambiguity error** — the redefined function is uncallable (both chained declarations surface as overloads) | Clean **newest-wins** call | Metadata shadowing follows the Roslyn interactive model; pinned on both engines by `RedefinedFunctionCallDivergesByDesign` |
| Class `deinit` interactively | Never runs; **GS0510** warning per cell | **Runs as a real CLR finalizer**; no GS0510 | The point of the migration; matches Phase 1 script mode; pinned by `InteractiveDeinitializerRunsWithoutBoundaryWarning` |
| Echo of non-trailing values (e.g. a cell ending in `if`/loop whose last executed statement had a value) | Echoes the interpreter's incidental `LastValue` | Echoes only a trailing expression / trailing declaration value | ADR-0156 specifies trailing-expression capture; statically capturable shapes only |
| Cell ending in `return <expr>` | Echoes the value | Echoes the entry point's return value (same result for int) | Value now flows through the entry-point return protocol |
| ByRefLike (span) trailing value | interpreter boundary | No echo (cannot live in a static field); everything else about spans now works interactively | CLR constraint |

## Known v1 limitations of the opt-in engine (follow-ups filed)

- #3184 — assigning a prior-cell **function as a value** (`let g = addOne`) does not bind (works in the evaluator engine; workaround: wrap in a lambda). Calling a prior-cell **closure/Func-typed global** works.
- #3185 — converting a value to a **prior-cell interface type** (`var s Shape = Sq{...}` across cells) reports GS0155; and writing **through** a prior-cell global's member (`p.X = 5`) reports a clean unresolved-variable error instead of silently mutating a copy (reads and method calls work; mutation via methods persists, with reference semantics for class-typed globals).
- `internal`/`private` top-level declarations lose cross-cell visibility (cross-assembly now); top-level defaults are public per ADR-0014.
- Session memory grows monotonically until `Reset()` (per the ADR), and each submission builds a fresh `MetadataLoadContext` over the chain (O(n²) enumeration growth; small assemblies, acceptable interactively).

## ADR deviations

- Opt-in flag instead of direct swap — explicitly sanctioned; flip is the follow-up.
- Submission PEs are additionally flushed to a per-session temp directory because `ReferenceResolver.WithReferences` only ingests on-disk paths (MLC); execution still loads from the in-memory bytes.
- Value echo is a synthesized `<Result>$` static field read rather than a factory return value — equivalent observable protocol, no entry-point signature change.

## Verification

- `dotnet build GSharp.sln -c Release`: 0 warnings, 0 errors.
- `test/Interpreter.Tests` full suite (Release): **1370/1370 passed**, 0 failed — no existing SessionEngine expectation needed updating (the evaluator engine is untouched; the emitted engine is additive behind the flag).
- `test/Compiler.Tests` LanguageConformance filter (Release): **126/126 passed** — all-driver byte parity holds (the interactive engine is not in this gate; the new cross-engine parity suite below is the interactive-parity evidence).
- `test/Core.Tests` full suite (Release): **7128/7129 passed**, 0 failed, 1 skipped (the standing `RegenerateBaseline` skip).
- New: `EmittedSessionEngineTests` (witness set: cross-submission state, redefinition, chain isolation, echo, deinit, cancellation, reset, snapshot) + `EmittedSessionEngineParityTests` (same scripts through BOTH engines, cell-by-cell value/output/error comparison) — 33 tests green.
- NOT RUN: full `Compiler.Tests` beyond the LanguageConformance filter, `Cs2Gs.Tests` (pre-existing flaky host crash — verified via GoldenTests filter policy), `Extensions.Tests`, `LanguageServer.Tests`, manual TUI drive (`gsi` requires an interactive terminal; engine behavior covered by the suites above). CI required checks are the backstop.
- Witness (ADR-0154): every new test targets `EmittedSessionEngine`, which does not exist pre-change (fails to compile on main); the parity divergence test additionally pins the evaluator's current behavior on unmodified code paths.

## Checklist

- [x] Behavioral tests carry a witness of discrimination (ADR-0154): each new/changed test fails on the pre-change code (pre-fix commit, reverted hunk, or an applied product mutant) and passes with it.
- [x] Self-review verdict recorded when one was run (MERGEABLE / BLOCKER / SHOULD-FIX / NIT), with residuals filed as issues rather than dropped.

Self-review verdict: **MERGEABLE** — opt-in engine, default path untouched; residual gaps filed as follow-up issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
