### PR TITLE
Fix prior-cell function values and member writes through prior-cell globals in the emitted REPL

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundClrPropertyAccessExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundClrPropertyAccessExpression.cs
@@ -27,7 +27,9 @@ public sealed class BoundClrPropertyAccessExpression : BoundExpression
         TypeSymbol resultType,
         TypeSymbol staticContainerType = null,
         TypeParameterSymbol constrainedReceiverTypeParameter = null,
-        TypeSymbol constrainedInterfaceType = null)
+        TypeSymbol constrainedInterfaceType = null,
+        bool isAddressableStaticField = false,
+        bool isReadOnlySubmissionGlobal = false)
         : base(syntax)
     {
         Receiver = receiver;
@@ -36,11 +38,36 @@ public sealed class BoundClrPropertyAccessExpression : BoundExpression
         StaticContainerType = staticContainerType;
         ConstrainedReceiverTypeParameter = constrainedReceiverTypeParameter;
         ConstrainedInterfaceType = constrainedInterfaceType;
+        IsAddressableStaticField = isAddressableStaticField;
+        IsReadOnlySubmissionGlobal = isReadOnlySubmissionGlobal;
     }
 
     public BoundExpression Receiver { get; }
 
     public MemberInfo Member { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether this is a static <see cref="FieldInfo"/>
+    /// read whose storage the emitter may address in place (<c>ldsflda</c>) —
+    /// ADR-0156 Phase 2 (issue #3185): a top-level global of a prior interactive
+    /// submission, surfaced as a public static field on that submission's
+    /// <c>&lt;Program&gt;</c> container. Member writes and mutating method calls
+    /// through such a receiver mutate the stored global rather than a spilled
+    /// copy, matching the same-cell global (<c>ldsflda</c>) semantics. Only ever
+    /// set by the submission-import binding fallbacks, so non-REPL compilation
+    /// paths are unaffected.
+    /// </summary>
+    public bool IsAddressableStaticField { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the submission global behind
+    /// <see cref="IsAddressableStaticField"/> was declared read-only
+    /// (<c>let</c>/<c>const</c>) in its source cell. The emitted field
+    /// intentionally omits <c>InitOnly</c>, so the source-side flag is carried
+    /// here for the binder's member-write rejection (mirroring issue #1132's
+    /// read-only value-receiver rule for locals).
+    /// </summary>
+    public bool IsReadOnlySubmissionGlobal { get; }
 
     /// <summary>
     /// Gets, for a static member read on a generic type constructed over
@@ -66,4 +93,37 @@ public sealed class BoundClrPropertyAccessExpression : BoundExpression
     public override TypeSymbol Type { get; }
 
     public override BoundNodeKind Kind => BoundNodeKind.ClrPropertyAccessExpression;
+
+    /// <summary>
+    /// ADR-0156 Phase 2 (issue #3185): whether <paramref name="expression"/>
+    /// is a pure, re-evaluable CLR field chain rooted at an addressable
+    /// submission global — the root's static-field read plus zero or more
+    /// <see cref="FieldInfo"/> links. Such a receiver must NOT be spilled to
+    /// a temp by duplicating-context lowering: writes through it must reach
+    /// the stored global's address, and re-reading a static field / field
+    /// chain has no observable side effect. Never true outside the
+    /// interactive submission gate (only the submission binder fallbacks set
+    /// <see cref="IsAddressableStaticField"/>).
+    /// </summary>
+    /// <param name="expression">The candidate receiver expression.</param>
+    /// <returns><see langword="true"/> for an addressable submission field chain.</returns>
+    public static bool IsAddressableSubmissionFieldChain(BoundExpression expression)
+    {
+        while (expression is BoundClrPropertyAccessExpression access)
+        {
+            if (access.Receiver == null)
+            {
+                return access.IsAddressableStaticField;
+            }
+
+            if (access.Member is not FieldInfo)
+            {
+                return false;
+            }
+
+            expression = access.Receiver;
+        }
+
+        return false;
+    }
 }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
@@ -2899,6 +2899,25 @@ internal sealed partial class ExpressionBinder
         var classSymbol = new ImportedClassSymbol(programType, syntax, references: scope.References);
         result = BindAccessorStep(receiver: null, classSymbol, syntax);
 
+        // Issue #3185: a prior-cell GLOBAL surfaces as a static-field read.
+        // Mark it addressable (and carry the source-side read-only flag) so
+        // member writes and mutating method calls through this receiver load
+        // the field's address (`ldsflda`) and mutate the stored global in
+        // place — never a silently-dropped struct copy — mirroring how a
+        // same-cell global (a static field of the current <Program>) behaves.
+        if (result is BoundClrPropertyAccessExpression { Receiver: null, Member: System.Reflection.FieldInfo } fieldRead
+            && submissionImports.TryFindGlobalVariable(scope.References, name, out _, out var declaredGlobal))
+        {
+            result = new BoundClrPropertyAccessExpression(
+                fieldRead.Syntax,
+                receiver: null,
+                fieldRead.Member,
+                fieldRead.Type,
+                fieldRead.StaticContainerType,
+                isAddressableStaticField: true,
+                isReadOnlySubmissionGlobal: declaredGlobal?.IsReadOnly == true);
+        }
+
         // Issue #3184: a prior-cell top-level FUNCTION referenced as a value
         // (`let g = addOne`) surfaces as an imported CLR method group on the
         // prior submission's <Program> container. Mirror the same-cell

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
@@ -2898,6 +2898,23 @@ internal sealed partial class ExpressionBinder
 
         var classSymbol = new ImportedClassSymbol(programType, syntax, references: scope.References);
         result = BindAccessorStep(receiver: null, classSymbol, syntax);
+
+        // Issue #3184: a prior-cell top-level FUNCTION referenced as a value
+        // (`let g = addOne`) surfaces as an imported CLR method group on the
+        // prior submission's <Program> container. Mirror the same-cell
+        // method-group rule (TryBindSingleMethodGroup binds a single
+        // non-generic candidate eagerly with its natural function type):
+        // resolve a single-candidate group to a delegate of its natural
+        // `FunctionTypeSymbol` so an untyped `let` infers a callable type.
+        // Overloaded/generic groups stay unresolved for target-typed
+        // conversion, exactly like their same-cell counterparts.
+        if (result is BoundClrMethodGroupExpression { ResolvedMethod: null } submissionGroup
+            && submissionGroup.Candidates.Length == 1
+            && TryGetNaturalClrMethodGroupType(submissionGroup, out var naturalFunctionType))
+        {
+            result = conversions.BindConversion(syntax.Location, submissionGroup, naturalFunctionType);
+        }
+
         return true;
     }
 

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -374,11 +374,42 @@ internal sealed partial class ExpressionBinder
             && !ReceiverTypeIsReference(bve.Variable.Type);
     }
 
+    /// <summary>
+    /// ADR-0156 Phase 2 (issue #3185): classification of a member-write
+    /// receiver whose chain bottoms out at a prior interactive submission's
+    /// top-level global (an addressable static field on that submission's
+    /// <c>&lt;Program&gt;</c> container). <c>None</c> for every other shape,
+    /// so non-REPL binding behavior is unchanged.
+    /// </summary>
+    private enum SubmissionWriteReceiverKind
+    {
+        /// <summary>Not a submission-global-rooted value-type receiver.</summary>
+        None,
+
+        /// <summary>An addressable field chain — the write mutates the stored global in place.</summary>
+        Addressable,
+
+        /// <summary>The chain roots at a read-only (<c>let</c>) value-typed global — the write must be rejected.</summary>
+        ReadOnlyRoot,
+
+        /// <summary>The chain crosses a computed (property) link — an in-place write is impossible.</summary>
+        NotAddressable,
+    }
+
     private bool IsWritableStructFieldReceiver(BoundExpression receiver)
     {
         if (receiver is BoundVariableExpression)
         {
             return !ReceiverBlocksValueTypeMemberWrite(receiver);
+        }
+
+        // Issue #3185: a prior-cell submission global (or a value-type CLR
+        // field chain rooted at one) is writable storage exactly when the
+        // chain is addressable and its root is not a read-only global.
+        if (receiver is BoundClrPropertyAccessExpression submissionReceiver)
+        {
+            return ClassifySubmissionGlobalWriteReceiver(submissionReceiver)
+                == SubmissionWriteReceiverKind.Addressable;
         }
 
         if (receiver is BoundDereferenceExpression dereference)
@@ -650,6 +681,16 @@ internal sealed partial class ExpressionBinder
 
             Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, fieldName);
             return new BoundErrorExpression(null);
+        }
+
+        // ADR-0156 Phase 2 (issue #3185): `name.Member = value` where `name`
+        // is a top-level global declared by a prior interactive submission.
+        // Consulted before the imported-class probe so a prior cell's global
+        // shadows a same-named imported type, mirroring the read fallback's
+        // ordering in BindAccessorExpression.
+        if (TryBindSubmissionGlobalMemberAssignment(syntax, out var submissionMemberWrite))
+        {
+            return submissionMemberWrite;
         }
 
         // Stream B: imported class name on LHS → static field/property write.
@@ -1586,6 +1627,15 @@ internal sealed partial class ExpressionBinder
             return new BoundErrorExpression(null);
         }
 
+        // ADR-0156 Phase 2 (issue #3185): a compound write through a
+        // prior-cell submission global (`p.X += v`, `a.B.C *= v`) enforces
+        // the read-only root and addressable-chain rules; non-submission
+        // receivers are untouched.
+        if (ReportSubmissionGlobalMemberWriteBlocked(boundReceiver, memberName, syntax.OperatorToken.Location))
+        {
+            return new BoundErrorExpression(syntax);
+        }
+
         var boundRhs = BindExpression(syntax.Value);
         var leftRead = new BoundClrPropertyAccessExpression(null, boundReceiver, instanceMember, targetSymbol);
         var binary = TryBindCompoundBinaryOperation(baseOpSyntaxKind, leftRead, boundRhs, syntax.Value.Location);
@@ -2262,6 +2312,16 @@ internal sealed partial class ExpressionBinder
 
             _ = instWritable;
             _ = instTargetType;
+
+            // ADR-0156 Phase 2 (issue #3185): a chained write through a
+            // prior-cell submission global (`a.B.C = v`) enforces the
+            // read-only root and addressable-chain rules; non-submission
+            // receivers are untouched.
+            if (ReportSubmissionGlobalMemberWriteBlocked(receiver, fieldName, syntax.EqualsToken.Location))
+            {
+                return new BoundErrorExpression(syntax);
+            }
+
             var instConverted = conversions.BindConversion(syntax.Value.Location, BindValue(instTargetSymbol), instTargetSymbol);
             return new BoundClrPropertyAssignmentExpression(null, receiver, instanceMember, instConverted, instTargetSymbol, staticContainerType: null);
         }
@@ -2504,5 +2564,211 @@ internal sealed partial class ExpressionBinder
         var converted = conversions.BindConversion(syntax.Value.Location, binaryResult, targetSymbol);
         result = new BoundClrPropertyAssignmentExpression(null, receiver: null, member, converted, targetSymbol, staticContainerType: null);
         return true;
+    }
+
+    /// <summary>
+    /// ADR-0156 Phase 2 (issue #3185): binds a member write
+    /// (<c>name.Member = value</c>) where <c>name</c> is a top-level global
+    /// declared by a prior interactive submission. The receiver is the
+    /// submission's static field marked addressable, so the emitter stores
+    /// through the field's address (<c>ldsflda</c>) for a struct-typed global
+    /// (mutating the stored global in place, mirroring the same-cell
+    /// global-variable write) and through the object reference for a
+    /// class-typed global. A read-only (<c>let</c>) value-typed global
+    /// rejects the write with the same diagnostic the local-variable rule
+    /// (issue #1132) produces.
+    /// </summary>
+    /// <param name="syntax">The <c>name.field = value</c> assignment syntax.</param>
+    /// <param name="result">The bound assignment when the receiver named a prior submission's global.</param>
+    /// <returns><c>true</c> when a prior submission declared the global (and the current cell does not shadow it).</returns>
+    private bool TryBindSubmissionGlobalMemberAssignment(FieldAssignmentExpressionSyntax syntax, out BoundExpression result)
+    {
+        result = null;
+        var submissionImports = scope.SubmissionImports;
+        var name = syntax.Receiver.Text;
+        if (submissionImports is null
+            || !submissionImports.TryFindGlobalVariable(scope.References, name, out var programType, out var declared))
+        {
+            return false;
+        }
+
+        // The current cell's own declarations shadow prior cells: when the
+        // receiver name resolves as a variable in this compilation, the
+        // regular variable path below must bind it.
+        if (BindVariableReference(name, syntax.Receiver.Location, suppressNotAVariable: true, suppressUndefinedVariable: true) != null)
+        {
+            return false;
+        }
+
+        var container = new ImportedClassSymbol(programType, declaration: null, references: scope.References);
+        if (!container.TryLookupMember(name, ne: null, out var globalMember) || globalMember is not FieldInfo globalField)
+        {
+            return false;
+        }
+
+        var globalType = ClrNullability.GetFieldTypeSymbol(globalField);
+        if (globalType?.ClrType == null)
+        {
+            return false;
+        }
+
+        var receiver = new BoundClrPropertyAccessExpression(
+            null,
+            receiver: null,
+            globalField,
+            globalType,
+            isAddressableStaticField: true,
+            isReadOnlySubmissionGlobal: declared?.IsReadOnly == true);
+
+        var clrReceiverType = globalType.ClrType;
+        var memberName = syntax.FieldIdentifier.Text;
+        MemberInfo instanceMember = ClrTypeUtilities.SafeGetPropertyIncludingInterfaces(clrReceiverType, memberName, BindingFlags.Public | BindingFlags.Instance);
+        if (instanceMember is PropertyInfo indexedProperty && indexedProperty.GetIndexParameters().Length != 0)
+        {
+            instanceMember = null;
+        }
+
+        instanceMember ??= ClrTypeUtilities.SafeGetFieldIncludingInterfaces(clrReceiverType, memberName, BindingFlags.Public | BindingFlags.Instance);
+        if (instanceMember == null)
+        {
+            Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, memberName);
+            result = new BoundErrorExpression(null);
+            return true;
+        }
+
+        if (!TryGetWritableClrMember(instanceMember, out _, out var targetSymbol, out _))
+        {
+            Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, memberName);
+            result = new BoundErrorExpression(null);
+            return true;
+        }
+
+        // Issue #1132's read-only rule, mirrored for a prior-cell global: a
+        // member write through a `let` VALUE-typed global would mutate the
+        // value stored in the read-only binding — reject it. A class-typed
+        // `let` global mutates the heap object and stays writable.
+        if (declared?.IsReadOnly == true && !ReceiverTypeIsReference(globalType))
+        {
+            Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, name);
+        }
+
+        var value = BindAssignmentRhs(syntax.Value, targetSymbol);
+        var converted = conversions.BindConversion(syntax.Value.Location, value, targetSymbol);
+        result = new BoundClrPropertyAssignmentExpression(null, receiver, instanceMember, converted, targetSymbol, staticContainerType: null);
+        return true;
+    }
+
+    /// <summary>
+    /// Issue #3185: classifies a member-write receiver against the
+    /// submission-global chain rules. Walks CLR member-access links from the
+    /// receiver down to the chain root; only a chain that bottoms out at an
+    /// addressable submission static field classifies as anything but
+    /// <see cref="SubmissionWriteReceiverKind.None"/>. Crossing a
+    /// reference-typed link makes the remaining chain heap-rooted (writable
+    /// regardless of the root's read-only flag); crossing a computed
+    /// (property) link makes an in-place write impossible.
+    /// </summary>
+    /// <param name="receiver">The bound member-write receiver.</param>
+    /// <returns>The chain classification.</returns>
+    private static SubmissionWriteReceiverKind ClassifySubmissionGlobalWriteReceiver(BoundExpression receiver)
+    {
+        if (receiver is not BoundClrPropertyAccessExpression access || ReceiverTypeIsReference(access.Type))
+        {
+            return SubmissionWriteReceiverKind.None;
+        }
+
+        var sawComputedLink = false;
+        while (true)
+        {
+            if (access.Receiver == null)
+            {
+                if (!access.IsAddressableStaticField)
+                {
+                    return SubmissionWriteReceiverKind.None;
+                }
+
+                if (access.IsReadOnlySubmissionGlobal)
+                {
+                    return SubmissionWriteReceiverKind.ReadOnlyRoot;
+                }
+
+                return sawComputedLink
+                    ? SubmissionWriteReceiverKind.NotAddressable
+                    : SubmissionWriteReceiverKind.Addressable;
+            }
+
+            if (access.Member is not FieldInfo)
+            {
+                sawComputedLink = true;
+            }
+
+            if (ReceiverTypeIsReference(access.Receiver.Type))
+            {
+                // Heap-rooted from here on: the write mutates the referenced
+                // object, so the root's read-only flag no longer applies —
+                // but the value-typed links walked so far must all have been
+                // real fields for the address chain to reach the storage.
+                if (access.Receiver is BoundClrPropertyAccessExpression referenceLink
+                    && ChainHasSubmissionGlobalRoot(referenceLink))
+                {
+                    return sawComputedLink
+                        ? SubmissionWriteReceiverKind.NotAddressable
+                        : SubmissionWriteReceiverKind.Addressable;
+                }
+
+                return SubmissionWriteReceiverKind.None;
+            }
+
+            if (access.Receiver is not BoundClrPropertyAccessExpression inner)
+            {
+                return SubmissionWriteReceiverKind.None;
+            }
+
+            access = inner;
+        }
+    }
+
+    /// <summary>
+    /// Issue #3185: whether a CLR member-access chain bottoms out at a prior
+    /// submission's addressable global static field.
+    /// </summary>
+    /// <param name="access">The chain's innermost inspected link.</param>
+    /// <returns><c>true</c> when the chain root is a flagged submission global.</returns>
+    private static bool ChainHasSubmissionGlobalRoot(BoundClrPropertyAccessExpression access)
+    {
+        while (access.Receiver is BoundClrPropertyAccessExpression inner)
+        {
+            access = inner;
+        }
+
+        return access.Receiver == null && access.IsAddressableStaticField;
+    }
+
+    /// <summary>
+    /// Issue #3185: applies the gated submission-global diagnostics to a
+    /// CLR member write (simple or compound) through a possibly
+    /// submission-rooted receiver chain. Reports the read-only rejection
+    /// (report-and-continue, mirroring issue #1132's handling) or the
+    /// struct-temporary rejection (blocking — emitting it would silently
+    /// write a copy, the exact wrong-value class ADR-0156 exists to kill).
+    /// A non-submission receiver never produces a diagnostic here.
+    /// </summary>
+    /// <param name="receiver">The bound member-write receiver.</param>
+    /// <param name="memberName">The written member's name (for diagnostics).</param>
+    /// <param name="location">The assignment operator's location.</param>
+    /// <returns><c>true</c> when the write must be blocked (caller returns an error expression).</returns>
+    private bool ReportSubmissionGlobalMemberWriteBlocked(BoundExpression receiver, string memberName, TextLocation location)
+    {
+        switch (ClassifySubmissionGlobalWriteReceiver(receiver))
+        {
+            case SubmissionWriteReceiverKind.ReadOnlyRoot:
+                Diagnostics.ReportCannotAssign(location, memberName);
+                return false;
+            case SubmissionWriteReceiverKind.NotAddressable:
+                Diagnostics.ReportFieldAssignmentThroughStructTemporary(location, memberName, receiver.Type);
+                return true;
+            default:
+                return false;
+        }
     }
 }

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
@@ -1441,10 +1441,26 @@ internal sealed partial class MethodBodyEmitter
             // value on the evaluation stack produces invalid IL
             // (InvalidProgramException at JIT time).
             if (receiver is BoundFieldAccessExpression fa
-                && this.outer.cache.StructFieldDefs.ContainsKey(fa.Field)
+                && (this.outer.cache.StructFieldDefs.ContainsKey(fa.Field)
+                    || IsSubmissionRootedFieldChain(fa))
                 && this.IsAddressableFieldAccess(fa))
             {
                 this.EmitFieldAddress(fa);
+                return;
+            }
+
+            // ADR-0156 Phase 2 (issue #3185): a prior-cell submission global
+            // (a public static field on that submission's <Program>
+            // container), or a value-type CLR field chain rooted at one, is
+            // real addressable storage. Load its address (`ldsflda` [+
+            // `ldflda`…]) so member writes and mutating instance calls hit
+            // the stored global in place instead of a spilled copy — the
+            // silent-wrong-value class ADR-0156 exists to kill. The flag is
+            // only ever set by the submission-import binder fallbacks, so
+            // non-REPL receiver spilling is unchanged.
+            if (receiver is BoundClrPropertyAccessExpression clrChain
+                && this.TryEmitAddressableClrFieldAddress(clrChain))
+            {
                 return;
             }
 
@@ -1612,12 +1628,133 @@ internal sealed partial class MethodBodyEmitter
         }
 
         if (fa.Receiver is BoundFieldAccessExpression nested
-            && this.outer.cache.StructFieldDefs.ContainsKey(nested.Field))
+            && (this.outer.cache.StructFieldDefs.ContainsKey(nested.Field)
+                || IsSubmissionRootedFieldChain(nested)))
         {
             return this.IsAddressableFieldAccess(nested);
         }
 
+        // Issue #3185: a prior-cell submission global (or a value-type CLR
+        // field chain rooted at one) is addressable storage.
+        if (fa.Receiver is BoundClrPropertyAccessExpression clrReceiver)
+        {
+            return this.IsAddressableClrFieldChain(clrReceiver);
+        }
+
         return false;
+    }
+
+    /// <summary>
+    /// ADR-0156 Phase 2 (issue #3185): whether <paramref name="access"/> is a
+    /// CLR field chain whose address can be loaded in place — the chain must
+    /// consist of real <see cref="FieldInfo"/> links over value-type
+    /// receivers and bottom out either at a submission global static field
+    /// flagged addressable by the binder, or at a reference-typed link of a
+    /// submission-rooted chain (the object reference is then the storage
+    /// root). Never true outside the interactive submission gate, since only
+    /// the submission binder fallbacks set the flag.
+    /// </summary>
+    /// <param name="access">The candidate CLR member access.</param>
+    /// <returns><see langword="true"/> when the chain's address is loadable.</returns>
+    private bool IsAddressableClrFieldChain(BoundClrPropertyAccessExpression access)
+    {
+        if (access.Member is not FieldInfo)
+        {
+            return false;
+        }
+
+        if (access.Receiver == null)
+        {
+            return access.IsAddressableStaticField;
+        }
+
+        if (access.Receiver is not BoundClrPropertyAccessExpression inner)
+        {
+            return false;
+        }
+
+        if (!ReflectionMetadataEmitter.IsValueTypeSymbol(inner.Type))
+        {
+            return IsSubmissionRootedFieldChain(inner);
+        }
+
+        return this.IsAddressableClrFieldChain(inner);
+    }
+
+    /// <summary>
+    /// Issue #3185: emits the managed-pointer address of an addressable CLR
+    /// field chain (see <see cref="IsAddressableClrFieldChain"/>):
+    /// <c>ldsflda</c> for the submission-global root, <c>ldflda</c> per
+    /// value-type field link, and a plain object-reference load for a
+    /// reference-typed link. Returns <see langword="false"/> without emitting
+    /// when the chain is not addressable.
+    /// </summary>
+    /// <param name="access">The CLR member access whose address to load.</param>
+    /// <returns><see langword="true"/> once the address is on the stack.</returns>
+    private bool TryEmitAddressableClrFieldAddress(BoundClrPropertyAccessExpression access)
+    {
+        if (!this.IsAddressableClrFieldChain(access))
+        {
+            return false;
+        }
+
+        this.EmitClrFieldAddressCore(access);
+        return true;
+    }
+
+    private void EmitClrFieldAddressCore(BoundClrPropertyAccessExpression access)
+    {
+        var field = (FieldInfo)access.Member;
+        if (access.Receiver == null)
+        {
+            this.il.OpCode(ILOpCode.Ldsflda);
+            this.il.Token(this.outer.memberRefs.GetFieldReference(field));
+            return;
+        }
+
+        var inner = (BoundClrPropertyAccessExpression)access.Receiver;
+        if (!ReflectionMetadataEmitter.IsValueTypeSymbol(inner.Type))
+        {
+            // Reference-typed link: the loaded object reference is the
+            // storage root for the remaining `ldflda` chain.
+            this.EmitExpression(inner);
+        }
+        else
+        {
+            this.EmitClrFieldAddressCore(inner);
+        }
+
+        this.il.OpCode(ILOpCode.Ldflda);
+        this.il.Token(this.outer.memberRefs.GetFieldReference(field));
+    }
+
+    /// <summary>
+    /// Issue #3185: whether a member-access chain (mixed CLR reflection links
+    /// and imported-aggregate field links) bottoms out at a prior-cell
+    /// submission global flagged addressable by the binder. Used to gate the
+    /// imported-field addressing paths so shapes outside the interactive
+    /// submission gate keep their existing spill behavior.
+    /// </summary>
+    /// <param name="node">The chain's outermost link.</param>
+    /// <returns><see langword="true"/> when the chain root is a flagged submission global.</returns>
+    private static bool IsSubmissionRootedFieldChain(BoundExpression node)
+    {
+        while (true)
+        {
+            switch (node)
+            {
+                case BoundClrPropertyAccessExpression clr when clr.Receiver == null:
+                    return clr.IsAddressableStaticField;
+                case BoundClrPropertyAccessExpression clr:
+                    node = clr.Receiver;
+                    continue;
+                case BoundFieldAccessExpression fieldAccess when fieldAccess.Receiver != null:
+                    node = fieldAccess.Receiver;
+                    continue;
+                default:
+                    return false;
+            }
+        }
     }
 
     private bool CanLoadVariableAddress(VariableSymbol variable)
@@ -1791,10 +1928,18 @@ internal sealed partial class MethodBodyEmitter
         }
         else if (!receiverIsClass
             && fa.Receiver is BoundFieldAccessExpression nested
-            && this.outer.cache.StructFieldDefs.ContainsKey(nested.Field)
+            && (this.outer.cache.StructFieldDefs.ContainsKey(nested.Field)
+                || IsSubmissionRootedFieldChain(nested))
             && this.IsAddressableFieldAccess(nested))
         {
             this.EmitFieldAddress(nested);
+        }
+        else if (!receiverIsClass
+            && fa.Receiver is BoundClrPropertyAccessExpression clrChainReceiver
+            && this.TryEmitAddressableClrFieldAddress(clrChainReceiver))
+        {
+            // Issue #3185: the receiver is a prior-cell submission global (or
+            // a CLR field chain rooted at one); its address is on the stack.
         }
         else
         {

--- a/src/Core/CodeAnalysis/Lowering/SideEffectSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/SideEffectSpiller.cs
@@ -203,7 +203,12 @@ internal sealed class SideEffectSpiller : NestedFunctionBodyRewriter
     {
         var rewritten = (BoundPropertyAssignmentExpression)base.RewritePropertyAssignmentExpression(node);
 
-        var spillReceiver = SideEffectAnalyzer.HasObservableSideEffect(rewritten.Receiver);
+        // ADR-0156 Phase 2 (issue #3185): a prior-cell submission global (or
+        // a field chain rooted at one) is pure, re-evaluable, addressable
+        // storage — spilling it to a temp would silently redirect the write
+        // into the copy.
+        var spillReceiver = SideEffectAnalyzer.HasObservableSideEffect(rewritten.Receiver)
+            && !BoundClrPropertyAccessExpression.IsAddressableSubmissionFieldChain(rewritten.Receiver);
         var value = rewritten.Value;
         var statements = ImmutableArray.CreateBuilder<BoundStatement>();
 
@@ -247,8 +252,11 @@ internal sealed class SideEffectSpiller : NestedFunctionBodyRewriter
     {
         var rewritten = (BoundClrPropertyAssignmentExpression)base.RewriteClrPropertyAssignmentExpression(node);
 
+        // ADR-0156 Phase 2 (issue #3185): see RewritePropertyAssignmentExpression —
+        // an addressable submission-global receiver chain must not be spilled.
         var spillReceiver = rewritten.Receiver != null
-            && SideEffectAnalyzer.HasObservableSideEffect(rewritten.Receiver);
+            && SideEffectAnalyzer.HasObservableSideEffect(rewritten.Receiver)
+            && !BoundClrPropertyAccessExpression.IsAddressableSubmissionFieldChain(rewritten.Receiver);
         var value = rewritten.Value;
         var statements = ImmutableArray.CreateBuilder<BoundStatement>();
 

--- a/test/Interpreter.Tests/EmittedSessionEngineParityTests.cs
+++ b/test/Interpreter.Tests/EmittedSessionEngineParityTests.cs
@@ -95,6 +95,18 @@ public sealed class EmittedSessionEngineParityTests
                 "m[\"a\"]",
             }
         },
+        {
+            // Issue #3184: a prior cell's top-level function used as a value —
+            // untyped `let`, direct invocation, and delegate-argument passing.
+            "prior-cell-function-as-value",
+            new[]
+            {
+                "func addOne(n int) int {\n    return n + 1\n}",
+                "let g = addOne\ng(41)",
+                "func apply(f func(int) int, v int) int {\n    return f(v)\n}",
+                "apply(addOne, 1) + g(0)",
+            }
+        },
     };
 
     [Theory]

--- a/test/Interpreter.Tests/EmittedSessionEngineParityTests.cs
+++ b/test/Interpreter.Tests/EmittedSessionEngineParityTests.cs
@@ -107,6 +107,59 @@ public sealed class EmittedSessionEngineParityTests
                 "apply(addOne, 1) + g(0)",
             }
         },
+        {
+            // Issue #3185 (part 1): cross-cell interface conversion for a
+            // nominally conforming struct — declaration-typed global, reuse
+            // from a later cell, and reassignment through the conversion.
+            "cross-cell-interface-conversion",
+            new[]
+            {
+                "interface Shape {\n    func Area() int;\n}\nstruct Sq : Shape {\n    var S int\n    func Area() int {\n        return S * S\n    }\n}",
+                "var sh Shape = Sq{S: 3}\nsh.Area()",
+                "sh.Area() * 2",
+                "sh = Sq{S: 5}\nsh.Area()",
+            }
+        },
+        {
+            // Issue #3185 (part 1, negative): G# interface conformance is
+            // nominal — without the base clause BOTH engines report GS0155.
+            "cross-cell-interface-nominal-required",
+            new[]
+            {
+                "interface Shape {\n    func Area() int;\n}\nstruct Sq {\n    var S int\n    func Area() int {\n        return S * S\n    }\n}",
+                "var sh Shape = Sq{S: 3}",
+            }
+        },
+        {
+            // Issue #3185 (part 2): member writes through prior-cell globals —
+            // struct simple/compound, nested struct chains, and class-typed
+            // globals (simple and compound).
+            "member-writes-through-prior-cell-globals",
+            new[]
+            {
+                "struct P {\n    var X int\n}\nvar p = P{X: 1}\np.X",
+                "p.X = 5",
+                "p.X",
+                "p.X += 2\np.X",
+                "struct Inner {\n    var C int\n}\nstruct Outer {\n    var B Inner\n}\nvar a = Outer{B: Inner{C: 1}}\na.B.C",
+                "a.B.C = 7\na.B.C",
+                "class Counter {\n    var N int\n}\nvar c = Counter{N: 1}\nc.N",
+                "c.N = 41\nc.N",
+                "c.N += 1\nc.N",
+            }
+        },
+        {
+            // Issue #3185 (part 2): a `let` struct global rejects member
+            // writes on both engines (issue #1132's read-only rule).
+            "let-global-member-writes-rejected",
+            new[]
+            {
+                "struct P {\n    var X int\n}\nlet p = P{X: 1}\np.X",
+                "p.X = 5",
+                "p.X += 1",
+                "p.X",
+            }
+        },
     };
 
     [Theory]
@@ -173,5 +226,35 @@ public sealed class EmittedSessionEngineParityTests
         var emittedCall = emitted.Evaluate("g()");
         Assert.False(emittedCall.HasError);
         Assert.Equal(2, emittedCall.Value);
+    }
+
+    /// <summary>
+    /// Issue #3185 follow-on, pinned on both engines: a mutating method call
+    /// on a struct-typed global. The tree-walking evaluator invokes struct
+    /// methods against a COPY of the receiver, so the mutation is lost — even
+    /// within a single cell — while the emitted engine passes the global's
+    /// real address (`ldsflda`) as the receiver, so the mutation persists,
+    /// matching what the same program compiled by `gsc` does. When the
+    /// emitted engine becomes the default, the evaluator half of this test
+    /// retires with it.
+    /// </summary>
+    [Fact]
+    public void StructMethodReceiverMutationDivergesByDesign()
+    {
+        const string declare = "struct P {\n    var X int\n    func Bump() {\n        X = X + 1\n    }\n}\nvar p = P{X: 41}";
+
+        var evaluator = new SessionEngine();
+        Assert.False(evaluator.Evaluate(declare).HasError);
+        Assert.False(evaluator.Evaluate("p.Bump()").HasError);
+        var evaluatorRead = evaluator.Evaluate("p.X");
+        Assert.False(evaluatorRead.HasError);
+        Assert.Equal(41, evaluatorRead.Value);
+
+        using var emitted = new EmittedSessionEngine();
+        Assert.False(emitted.Evaluate(declare).HasError);
+        Assert.False(emitted.Evaluate("p.Bump()").HasError);
+        var emittedRead = emitted.Evaluate("p.X");
+        Assert.False(emittedRead.HasError);
+        Assert.Equal(42, emittedRead.Value);
     }
 }

--- a/test/Interpreter.Tests/EmittedSessionEngineTests.cs
+++ b/test/Interpreter.Tests/EmittedSessionEngineTests.cs
@@ -387,6 +387,56 @@ public sealed class EmittedSessionEngineTests : IDisposable
         Assert.Equal(2, cell.Value);
     }
 
+    /// <summary>
+    /// Issue #3184: a prior cell's top-level function referenced as a value
+    /// (`let g = addOne`) binds to a delegate over the emitted static method,
+    /// exactly like the same-cell method-group-to-function-value conversion.
+    /// </summary>
+    [Fact]
+    public void PriorCellFunctionAsValueBindsAndInvokes()
+    {
+        Assert.False(engine.Evaluate("func addOne(n int) int {\n    return n + 1\n}").HasError);
+
+        var let = engine.Evaluate("let g = addOne");
+        Assert.False(let.HasError);
+
+        var call = engine.Evaluate("g(41)");
+        Assert.False(call.HasError);
+        Assert.Equal(42, call.Value);
+    }
+
+    /// <summary>
+    /// Issue #3184 (typed form): a prior cell's function converts to an
+    /// explicitly typed function-value slot.
+    /// </summary>
+    [Fact]
+    public void PriorCellFunctionAsValueWithExplicitFunctionType()
+    {
+        Assert.False(engine.Evaluate("func double(n int) int {\n    return n * 2\n}").HasError);
+
+        var let = engine.Evaluate("let g func(int) int = double");
+        Assert.False(let.HasError);
+
+        var call = engine.Evaluate("g(21)");
+        Assert.False(call.HasError);
+        Assert.Equal(42, call.Value);
+    }
+
+    /// <summary>
+    /// Issue #3184: a prior cell's function passed directly as a delegate
+    /// argument (a value context other than a declaration initializer).
+    /// </summary>
+    [Fact]
+    public void PriorCellFunctionAsArgumentToHigherOrderFunction()
+    {
+        Assert.False(engine.Evaluate("func addOne(n int) int {\n    return n + 1\n}").HasError);
+        Assert.False(engine.Evaluate("func apply(f func(int) int, v int) int {\n    return f(v)\n}").HasError);
+
+        var call = engine.Evaluate("apply(addOne, 41)");
+        Assert.False(call.HasError);
+        Assert.Equal(42, call.Value);
+    }
+
     [Fact]
     public void SnapshotListsAccumulatedSymbolsWithValues()
     {

--- a/test/Interpreter.Tests/EmittedSessionEngineTests.cs
+++ b/test/Interpreter.Tests/EmittedSessionEngineTests.cs
@@ -437,6 +437,293 @@ public sealed class EmittedSessionEngineTests : IDisposable
         Assert.Equal(42, call.Value);
     }
 
+    /// <summary>
+    /// Issue #3185 (part 1): a prior-cell struct converts to a prior-cell
+    /// interface it (nominally) implements, and dispatch through the
+    /// interface-typed global works from yet another cell.
+    /// </summary>
+    [Fact]
+    public void CrossCellInterfaceConversionAndDispatch()
+    {
+        Assert.False(engine.Evaluate("""
+            interface Shape {
+                func Area() int;
+            }
+            struct Sq : Shape {
+                var S int
+                func Area() int {
+                    return S * S
+                }
+            }
+            """).HasError);
+
+        var assign = engine.Evaluate("var sh Shape = Sq{S: 3}");
+        Assert.False(assign.HasError);
+
+        var call = engine.Evaluate("sh.Area()");
+        Assert.False(call.HasError);
+        Assert.Equal(9, call.Value);
+    }
+
+    /// <summary>
+    /// Issue #3185 (part 1): a struct declared in a LATER cell whose base
+    /// clause names an interface from an EARLIER cell converts and
+    /// dispatches across further cells.
+    /// </summary>
+    [Fact]
+    public void LaterCellStructImplementsEarlierCellInterface()
+    {
+        Assert.False(engine.Evaluate("""
+            interface Shape {
+                func Area() int;
+            }
+            """).HasError);
+        Assert.False(engine.Evaluate("""
+            struct Sq : Shape {
+                var S int
+                func Area() int {
+                    return S * S
+                }
+            }
+            """).HasError);
+
+        var assign = engine.Evaluate("var sh Shape = Sq{S: 4}");
+        Assert.False(assign.HasError);
+
+        var call = engine.Evaluate("sh.Area()");
+        Assert.False(call.HasError);
+        Assert.Equal(16, call.Value);
+    }
+
+    /// <summary>
+    /// Issue #3185 (part 1, both types from the same prior cell used in a
+    /// later assignment to an existing interface-typed global).
+    /// </summary>
+    [Fact]
+    public void CrossCellInterfaceConversionIntoExistingGlobal()
+    {
+        Assert.False(engine.Evaluate("""
+            interface Shape {
+                func Area() int;
+            }
+            struct Sq : Shape {
+                var S int
+                func Area() int {
+                    return S * S
+                }
+            }
+            var sh Shape = Sq{S: 2}
+            """).HasError);
+
+        var write = engine.Evaluate("sh = Sq{S: 5}");
+        Assert.False(write.HasError);
+
+        var call = engine.Evaluate("sh.Area()");
+        Assert.False(call.HasError);
+        Assert.Equal(25, call.Value);
+    }
+
+    /// <summary>
+    /// Issue #3185 (part 1, negative): a struct with NO base clause does not
+    /// satisfy an interface across cells — G# interface conformance is
+    /// nominal, and the emitted engine reports the same GS0155 the evaluator
+    /// engine (and a same-cell conversion) reports.
+    /// </summary>
+    [Fact]
+    public void CrossCellInterfaceConversionWithoutBaseClauseStillErrors()
+    {
+        Assert.False(engine.Evaluate("""
+            interface Shape {
+                func Area() int;
+            }
+            struct Sq {
+                var S int
+                func Area() int {
+                    return S * S
+                }
+            }
+            """).HasError);
+
+        var assign = engine.Evaluate("var sh Shape = Sq{S: 3}");
+        Assert.True(assign.HasError);
+        Assert.Contains(assign.Diagnostics, d => d.Id == "GS0155");
+    }
+
+    /// <summary>
+    /// Issue #3185 (part 2): member writes through a struct-typed prior-cell
+    /// global mutate the stored global in place (no silent struct-copy write).
+    /// </summary>
+    [Fact]
+    public void MemberWriteThroughPriorCellStructGlobalPersists()
+    {
+        Assert.False(engine.Evaluate("""
+            struct P {
+                var X int
+            }
+            var p = P{X: 1}
+            """).HasError);
+
+        var write = engine.Evaluate("p.X = 5");
+        Assert.False(write.HasError);
+
+        var read = engine.Evaluate("p.X");
+        Assert.False(read.HasError);
+        Assert.Equal(5, read.Value);
+    }
+
+    /// <summary>
+    /// Issue #3185 (part 2): compound member writes through a struct-typed
+    /// prior-cell global.
+    /// </summary>
+    [Fact]
+    public void CompoundMemberWriteThroughPriorCellStructGlobalPersists()
+    {
+        Assert.False(engine.Evaluate("""
+            struct P {
+                var X int
+            }
+            var p = P{X: 40}
+            """).HasError);
+
+        var write = engine.Evaluate("p.X += 2");
+        Assert.False(write.HasError);
+
+        var read = engine.Evaluate("p.X");
+        Assert.False(read.HasError);
+        Assert.Equal(42, read.Value);
+    }
+
+    /// <summary>
+    /// Issue #3185 (part 2): nested member writes (`a.B.C = x`) through a
+    /// struct-typed prior-cell global mutate the innermost field in place.
+    /// </summary>
+    [Fact]
+    public void NestedMemberWriteThroughPriorCellStructGlobalPersists()
+    {
+        Assert.False(engine.Evaluate("""
+            struct Inner {
+                var C int
+            }
+            struct Outer {
+                var B Inner
+            }
+            var a = Outer{B: Inner{C: 1}}
+            """).HasError);
+
+        var write = engine.Evaluate("a.B.C = 7");
+        Assert.False(write.HasError);
+
+        var read = engine.Evaluate("a.B.C");
+        Assert.False(read.HasError);
+        Assert.Equal(7, read.Value);
+    }
+
+    /// <summary>
+    /// Issue #3185 (part 2): a member write through a read-only (`let`)
+    /// struct-typed prior-cell global is rejected with the same read-only
+    /// diagnostic the same-cell rule (issue #1132) produces — never a
+    /// silent copy write.
+    /// </summary>
+    [Fact]
+    public void MemberWriteThroughPriorCellLetStructGlobalIsRejected()
+    {
+        Assert.False(engine.Evaluate("""
+            struct P {
+                var X int
+            }
+            let p = P{X: 1}
+            """).HasError);
+
+        var write = engine.Evaluate("p.X = 5");
+        Assert.True(write.HasError);
+        Assert.Contains(write.Diagnostics, d => d.Id == "GS0127");
+
+        var compound = engine.Evaluate("p.X += 1");
+        Assert.True(compound.HasError);
+        Assert.Contains(compound.Diagnostics, d => d.Id == "GS0127");
+
+        var read = engine.Evaluate("p.X");
+        Assert.False(read.HasError);
+        Assert.Equal(1, read.Value);
+    }
+
+    /// <summary>
+    /// Issue #3185 (part 2): a mutating method call on a struct-typed
+    /// prior-cell global mutates the stored global in place (the receiver is
+    /// the global's own address, mirroring the same-cell `ldsflda` shape).
+    /// </summary>
+    [Fact]
+    public void StructMethodMutationThroughPriorCellGlobalPersists()
+    {
+        Assert.False(engine.Evaluate("""
+            struct P {
+                var X int
+                func Bump() {
+                    X = X + 1
+                }
+            }
+            var p = P{X: 41}
+            """).HasError);
+
+        var call = engine.Evaluate("p.Bump()");
+        Assert.False(call.HasError);
+
+        var read = engine.Evaluate("p.X");
+        Assert.False(read.HasError);
+        Assert.Equal(42, read.Value);
+    }
+
+    /// <summary>
+    /// Issue #3185 (part 2): a write into a struct field of a class-typed
+    /// prior-cell global (`c.Inner.X = v`) mutates the struct stored inside
+    /// the heap object in place.
+    /// </summary>
+    [Fact]
+    public void StructFieldOfClassGlobalMemberWritePersists()
+    {
+        Assert.False(engine.Evaluate("""
+            struct Inner {
+                var X int
+            }
+            class Holder {
+                var Data Inner
+            }
+            var c = Holder{Data: Inner{X: 1}}
+            """).HasError);
+
+        var write = engine.Evaluate("c.Data.X = 5");
+        Assert.False(write.HasError);
+
+        var read = engine.Evaluate("c.Data.X");
+        Assert.False(read.HasError);
+        Assert.Equal(5, read.Value);
+    }
+
+    /// <summary>
+    /// Issue #3185 (part 2): member writes through a class-typed prior-cell
+    /// global write through the stored reference.
+    /// </summary>
+    [Fact]
+    public void MemberWriteThroughPriorCellClassGlobalPersists()
+    {
+        Assert.False(engine.Evaluate("""
+            class Counter {
+                var N int
+            }
+            var c = Counter{N: 1}
+            """).HasError);
+
+        var write = engine.Evaluate("c.N = 41");
+        Assert.False(write.HasError);
+
+        var compound = engine.Evaluate("c.N += 1");
+        Assert.False(compound.HasError);
+
+        var read = engine.Evaluate("c.N");
+        Assert.False(read.HasError);
+        Assert.Equal(42, read.Value);
+    }
+
     [Fact]
     public void SnapshotListsAccumulatedSymbolsWithValues()
     {


### PR DESCRIPTION
Fixes #3184. Fixes #3185. Part of #3176, part of #3163 (ADR-0156 Phase 2 hardening, ahead of the Phase 3 default-flip).

## Summary

- **#3184 — prior-cell function as a value.** `let g = addOne` bound the prior submission's function as an unresolved imported CLR method group whose `Error` type leaked into emit (`GS9998`). The submission bare-identifier fallback now mirrors the same-cell rule (`TryBindSingleMethodGroup`: a single non-generic candidate binds eagerly with its natural function type) by resolving a single-candidate group to a delegate of its natural `FunctionTypeSymbol` through the existing `TryGetNaturalClrMethodGroupType` / `BindClrMethodGroupConversion` machinery. Overloaded/generic groups stay unresolved for target-typed conversion, exactly like same-cell; typed slots (`let g func(int) int = double`) and delegate arguments (`apply(addOne, 41)`) already worked and are pinned.
- **#3185 part 2 — member writes through prior-cell globals.** The submission global's static-field read now carries `IsAddressableStaticField` (+ the source-side `let` bit), set **only** by the submission-import binder fallbacks. On that flag:
  - a new fallback in `BindFieldAssignmentExpression` binds `p.X = 5` (was a clean GS0125);
  - the emitter implements the ADR's `ldsflda` approach — static-field address for the root, `ldflda` per value-type field link, object-reference load at a reference-typed link — for member writes **and** mutating method receivers, so mutations hit the stored global in place, mirroring the same-cell global shape;
  - `SideEffectSpiller` exempts the pure, re-evaluable chain from receiver spilling — the spill was the mechanism behind main's **silent copy-writes**: on main, compound (`p.X += 2`) and nested (`a.B.C = 7`) member writes bound successfully and silently dropped the store (rc 0, wrong answer — the exact class ADR-0156 exists to kill). Both now write through.
  - Guard rails: `let` value-typed globals reject member writes with GS0127 (issue #1132's read-only rule, simple + compound); a chain crossing a computed (property) link reports a clean GS0499 struct-temporary error instead of a silent copy write; class-typed globals (including `let`) write through the stored reference; `c.Data.X = 5` (struct field inside a class global) mutates in place.
- **#3185 part 1 — cross-cell interface conversion: no product change needed.** With the required nominal base clause (`struct Sq : Shape`) every probed shape already works on main: declaration-typed global, implementer declared in a later cell than the interface, call-argument conversion, `as` / `is`, interface-typed returns and slices. The issue's GS0155 repro omits the base clause — G# interface conformance is nominal, and that shape errors **identically** in the evaluator engine and in a single cell, so the error is correct and parity holds. Pinned with positive witnesses, a negative GS0155 test on both engines, and parity scripts; #3185 is updated accordingly.

## Semantic notes

- All changes are behind the `SubmissionImports != null` gate: the flag is only ever set by submission-import binder fallbacks, and every new emitter/lowering path keys off that flag (or a chain rooted at it). `gsc`, `gsi <file>`, `Compilation.Evaluate`, LSP, and the evaluator are untouched.
- New pinned divergence (`StructMethodReceiverMutationDivergesByDesign`): a mutating struct method on a global (`p.Bump()`) mutates a **copy** under the tree-walking evaluator (even within one cell) but mutates the stored global under the emitted engine — which matches what the same program compiled by `gsc` does. This is the evaluator-divergence bug class #3176 retires; documented like the existing redefinition-shadowing divergence.
- Still blocked shape (clean error, documented in #3185): a member write whose chain crosses a **property** (computed) link on a value-typed prior-cell global reports GS0499 instead of writing in place — in-place semantics through a getter/setter pair are not expressible without emitter surgery beyond this PR's scope. No shape silently copy-writes anymore.

## Verification

- `dotnet build GSharp.sln -c Release`: 0 warnings, 0 errors.
- `test/Interpreter.Tests` full suite (Release): **1393/1393 passed** (includes the 14 new witness tests and 5 new parity scripts driven through BOTH engines; the evaluator engine passes the new parity rows unchanged).
- `test/Core.Tests` full suite (Release): **7128/7129 passed**, 0 failed, 1 skipped (the standing `RegenerateBaseline` skip).
- `test/Compiler.Tests` LanguageConformance filter (Release): **126/126 passed** — all-driver byte parity holds.
- Witness (ADR-0154): each fix's tests are RED on main — #3184 repro fails with GS9998/GS0130; `p.X = 5` / `c.N = 41` fail with GS0125; compound/nested writes read back stale values (silent drop) — all GREEN with the fix (transcript: 7 of the new tests failed on ed6ae55e before the product change).
- NOT RUN: full `Compiler.Tests` beyond the LanguageConformance filter, `Cs2Gs.Tests` (pre-existing flaky host crash; GoldenTests-filter policy), `Extensions.Tests`, `LanguageServer.Tests`, manual TUI drive. CI required checks are the backstop.

## Checklist

- [x] Behavioral tests carry a witness of discrimination (ADR-0154): each new/changed test fails on the pre-change code (pre-fix commit, reverted hunk, or an applied product mutant) and passes with it.
- [x] Self-review verdict recorded when one was run (MERGEABLE / BLOCKER / SHOULD-FIX / NIT), with residuals filed as issues rather than dropped.

Self-review verdict: **MERGEABLE** — gated to the opt-in emitted engine's submission path; the one residual limitation (property-link chains) keeps a clean error and is documented in #3185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
