### PR TITLE
Handle jagged delegate arrays in explicit generic closure

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/ClrOverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/ClrOverloadResolution.cs
@@ -2324,9 +2324,7 @@ internal static class ClrOverloadResolution
                         if (gmi.GetParameters().Any(static p =>
                                 p.ParameterType.ContainsGenericParameters
                                 && ClrTypeUtilities.IsDelegateType(
-                                    p.ParameterType.IsArray
-                                        ? p.ParameterType.GetElementType()
-                                        : p.ParameterType)))
+                                    UnwrapArrayElement(p.ParameterType))))
                         {
                             var recoveredSymbols = recoverTypeArgSymbols?.Invoke(gmi, false) ?? default;
                             if (TryCloseOverUserReferenceTypePlaceholders(
@@ -4440,6 +4438,16 @@ internal static class ClrOverloadResolution
         {
             return false;
         }
+    }
+
+    private static Type UnwrapArrayElement(Type type)
+    {
+        while (type is not null && type.IsArray)
+        {
+            type = type.GetElementType();
+        }
+
+        return type;
     }
 
     private static Type FindReferenceTypeConstraintPlaceholder(Type importedBase, Type genericParameter)

--- a/test/Compiler.Tests/Emit/Issue2857ExplicitGenericLambdaProjectReferenceEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2857ExplicitGenericLambdaProjectReferenceEmitTests.cs
@@ -118,6 +118,56 @@ public sealed class Issue2857ExplicitGenericLambdaProjectReferenceEmitTests
     }
 
     [Theory]
+    [InlineData("i3178jagged2", 2, 7)]
+    [InlineData("i3178jagged3", 3, 8)]
+    public void ExplicitGenericTypeArgument_WithJaggedDelegateArrayAcrossReference_Runs(
+        string packageName,
+        int arrayDepth,
+        int expected)
+    {
+        var libraryArrayType = string.Concat(Enumerable.Repeat("[]", arrayDepth)) + "((T) -> void)";
+        var consumerDelegateType = "((Derived) -> void)";
+        var consumerArrayType = string.Concat(Enumerable.Repeat("[]", arrayDepth)) + consumerDelegateType;
+        var callback = $"(item Derived) -> {{ item.Value = {expected} }}";
+        for (var depth = 1; depth < arrayDepth; depth++)
+        {
+            var nestedType = string.Concat(Enumerable.Repeat("[]", depth)) + consumerDelegateType;
+            callback = $"{nestedType}{{ {callback} }}";
+        }
+
+        var indices = string.Concat(Enumerable.Repeat("[0]", arrayDepth));
+        var library = $$"""
+            package {{packageName}}
+
+            open class Base {
+                var Value int32
+
+                shared {
+                    func Make[T Base init()](configure {{libraryArrayType}}) T {
+                        let value = T()
+                        configure{{indices}}(value)
+                        return value
+                    }
+                }
+            }
+            """;
+        var consumer = $$"""
+            package {{packageName}}use
+            import System
+
+            class Derived : {{packageName}}.Base {}
+
+            func Main() {
+                let value = {{packageName}}.Base.Make[Derived](
+                    {{consumerArrayType}}{ {{callback}} })
+                Console.WriteLine(value.Value)
+            }
+            """;
+
+        Assert.Equal($"{expected}\n", CompileAndRun(library, consumer, packageName));
+    }
+
+    [Theory]
     [InlineData("i2857arity0", 0, 22)]
     [InlineData("i2857arity1", 1, 11)]
     [InlineData("i2857arity2", 2, 33)]
@@ -297,6 +347,46 @@ public sealed class Issue2857ExplicitGenericLambdaProjectReferenceEmitTests
             """;
 
         var output = CompileExpectingFailure(library, consumer, packageName);
+        var diagnosticIds = Regex.Matches(output, @"\berror (GS\d{4}):")
+            .Select(match => match.Groups[1].Value)
+            .ToArray();
+        Assert.Equal(new[] { "GS0159" }, diagnosticIds);
+    }
+
+    [Fact]
+    public void ExplicitGenericTypeArgument_WithDelegateInConstructedGenericAcrossReference_IsRejected()
+    {
+        const string PackageName = "i3178constructedgeneric";
+        var library = $$"""
+            package {{PackageName}}
+            import System.Collections.Generic
+
+            open class Base {
+                var Value int32
+
+                shared {
+                    func Make[T Base init()](configure List[((T) -> void)]) T {
+                        let value = T()
+                        configure[0](value)
+                        return value
+                    }
+                }
+            }
+            """;
+        var consumer = $$"""
+            package {{PackageName}}use
+            import System.Collections.Generic
+
+            class Derived : {{PackageName}}.Base {}
+
+            func Main() {
+                let configure = List[((Derived) -> void)]()
+                configure.Add((item Derived) -> { item.Value = 9 })
+                {{PackageName}}.Base.Make[Derived](configure)
+            }
+            """;
+
+        var output = CompileExpectingFailure(library, consumer, PackageName);
         var diagnosticIds = Regex.Matches(output, @"\berror (GS\d{4}):")
             .Select(match => match.Groups[1].Value)
             .ToArray();


### PR DESCRIPTION
## Summary

- recursively unwrap jagged-array element types before delegate-dependent explicit generic re-closure
- retain constructed-generic boundary: `List[((T) -> void)]` still reports `GS0159`
- add value-based depth-2 (`7`) and depth-3 (`8`) regressions plus boundary coverage

Closes #3178.

## Live-main integration

#2903 squash-merged after this branch was created. Rebase dropped its obsolete original commits and replayed only #3178's issue commit. #3174's relocation remains intact: product change lives in `Binding/OverloadResolution/ClrOverloadResolution.cs` under dedicated overload-resolution namespace.

- base: `57256713f5131e46a8ca81759ae3c0eb5b2519b8`
- head: `8a3d953462099ab8c9f87340706f100dc8869a43`
- effective diff: 2 files, `+101/-3`
- `git merge-tree --write-tree --messages origin/main HEAD`: tree `5ff596ce85d3a118634151395bb6f02002526e16`, no conflict messages, rc 0

## Driver verification

Current file-mode bare `gsc` and `gsi` both use emitted execution; interactive REPL retains evaluator selection. Cross-assembly results on final head:

| Shape | `gsc /out:` | bare `gsc` | file `gsi` |
|---|---:|---:|---:|
| original #2857 | `5` | `5` | `5` |
| jagged #3178 | `7` | `7` | `7` |
| constructed generic | `GS0159` | `GS0159` | `GS0159` |

## Mutation verification

Clean focused control: 18/18.

| Mutant | Build | Result |
|---|---|---|
| restore one-level call-site unwrap | 0 warnings/errors | RED exactly 2/18: depth-2 and depth-3 jagged rows |
| invert helper loop condition | 0 warnings/errors | RED 12/18, including both jagged rows |

Applied through `git diff` plus source/Core DLL md5 movement. Exact restoration: source `4256019b...`, `GSharp.Core.dll` `dbe9c927...`.

## Validation

Release warnings-as-errors: 0 warnings, 0 errors. Fresh Core/Compiler/Repl `GSharp.Core.dll` epoch: `1785843381`.

All 9 projects ran unfiltered with `dotnet test GSharp.sln -c Release`:

| Project | Passed | Failed | Skipped |
|---|---:|---:|---:|
| Compiler.Tests | 4,263 | 0 | 0 |
| Core.Tests | 7,128 | 0 | 1 |
| Extensions.Tests | 104 | 0 | 0 |
| InternalAnalyzers.Tests | 9 | 0 | 0 |
| Interpreter.Tests | 1,410 | 0 | 0 |
| LanguageServer.Tests | 462 | 0 | 0 |
| Sdk.Tests | 59 | 0 | 0 |
| Cs2Gs.Tests | 1,907 | 0 | 0 |
| GSharp.GeneratorHost.Tests | 31 | 0 | 0 |
| **Total** | **15,373** | **0** | **1** |

Final-head CI: 32/32 checks successful, including `build`, `e2e`, `ilverify`, `cs2gs-corpus`, and `cs2gs-oahu`.

Not run locally: e2e workflow; CI e2e passed.
