### PR TITLE
Pin interpreted char span slice offsets

### DIFF
--- a/test/Interpreter.Tests/Issue3114ReadOnlySpanInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue3114ReadOnlySpanInterpreterTests.cs
@@ -99,9 +99,10 @@ public class Issue3114ReadOnlySpanInterpreterTests
                 writable[1] = 44
                 var tail = readOnly.Slice(1)
                 var window = tail.Slice(0, 2)
-                var letters = []char{'a', 'b', 'c'}
+                var letters = []char{'a', 'b', 'c', 'd', 'e'}
                 var writableChars Span[char] = letters
                 var readOnlyChars ReadOnlySpan[char] = writableChars
+                var charWindow = readOnlyChars.Slice(1, 3)
                 Console.WriteLine(readOnly.Length)
                 Console.WriteLine(readOnly[1])
                 Console.WriteLine(window[1])
@@ -110,6 +111,7 @@ public class Issue3114ReadOnlySpanInterpreterTests
                 Console.WriteLine(window.ToString())
                 Console.WriteLine(writableChars.ToString())
                 Console.WriteLine(readOnlyChars.ToString())
+                Console.WriteLine(charWindow.ToString())
             }
             """;
 
@@ -121,11 +123,21 @@ public class Issue3114ReadOnlySpanInterpreterTests
 
         try
         {
+            var emitted = CompileAndRun(root, "span-operations.gs", sourcePath);
+            Assert.Equal(
+                "3\n44\n33\nSystem.Span<Int32>[3]\nSystem.ReadOnlySpan<Int32>[3]\nSystem.ReadOnlySpan<Int32>[2]\nabcde\nabcde\nbcd\n",
+                emitted.StandardOutput);
+
+            var evaluated = new GSharp.Repl.Engine.SessionEngine { CaptureConsole = true, RunEntryPoint = true }
+                .Evaluate(Source);
+            Assert.False(evaluated.HasError);
+            Assert.Equal(emitted.StandardOutput, evaluated.Output);
+
             var result = driver switch
             {
                 Driver.CompilerEvaluation => CaptureConsole(
                     () => GSharp.Compiler.Program.Main([sourcePath])),
-                Driver.CompilerEmission => CompileAndRun(root, "span-operations.gs", sourcePath),
+                Driver.CompilerEmission => emitted,
                 Driver.Interpreter => CaptureConsole(
                     () => GSharp.Repl.Program.Main([sourcePath])),
                 _ => throw new InvalidOperationException($"Unexpected driver {driver}."),
@@ -134,8 +146,8 @@ public class Issue3114ReadOnlySpanInterpreterTests
             Assert.Equal(0, result.ExitCode);
             Assert.Equal(
                 driver == Driver.CompilerEvaluation
-                    ? "3\n44\n33\nSystem.Span<Int32>[3]\nSystem.ReadOnlySpan<Int32>[3]\nSystem.ReadOnlySpan<Int32>[2]\nabc\nabc\nSuccess.\n"
-                    : "3\n44\n33\nSystem.Span<Int32>[3]\nSystem.ReadOnlySpan<Int32>[3]\nSystem.ReadOnlySpan<Int32>[2]\nabc\nabc\n",
+                    ? emitted.StandardOutput + "Success.\n"
+                    : emitted.StandardOutput,
                 result.StandardOutput);
             Assert.Equal(string.Empty, result.StandardError);
         }
@@ -143,6 +155,26 @@ public class Issue3114ReadOnlySpanInterpreterTests
         {
             Directory.Delete(root, recursive: true);
         }
+    }
+
+    [Fact]
+    public void ClrProducedSpan_RemainsLoudlyRefusedInteractively()
+    {
+        const string Source = """
+            import System
+
+            func Main() {
+                var text = "hello"
+                var span = text.AsSpan()
+            }
+            """;
+
+        var cell = new GSharp.Repl.Engine.SessionEngine { RunEntryPoint = true }.Evaluate(Source);
+
+        var diagnostic = Assert.Single(cell.Diagnostics);
+        Assert.True(cell.HasError);
+        Assert.Equal("GS0511", diagnostic.Id);
+        Assert.DoesNotContain("GS9999", diagnostic.Message);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

- add a `ReadOnlySpan[char].Slice(1, 3)` value assertion over `abcde`, with emitted `bcd` as oracle
- compare remaining tree-walk evaluator directly against that oracle, so `InterpretedSpanValue.ToString()` stays covered after ADR-0156 moved file drivers to emission
- preserve CLR-produced-span `GS0511` boundary on remaining interactive evaluator path
- test-only change; no product code changed

Fixes #3179

## Current trigger correction

PR #3182 merged while this work was running. Bare `gsc` and `gsi <file>` now execute emitted code, so they no longer reach `Evaluator.Reflection.cs`:

| Shape | bare `gsc` | `gsc /out:` + run | `gsi` |
|---|---|---|---|
| sliced char span | rc0, `bcd` + `Success.` | rc0, `bcd` | rc0, `bcd` |
| `string.AsSpan()` inside `Main` | rc0 | rc0 | rc0 |

Therefore brief's file-driver `GS0511` control became stale on current `main`. Live refusal remains interactive `SessionEngine` evaluator: new control reaches it through `Main`, asserts exactly one `GS0511`, and rejects `GS9999`. Same variables at top level are rejected earlier with `GS0219`, so `Main` is required to measure evaluator boundary.

Three file-driver rows still assert printed `bcd` value with emit as oracle. Direct `SessionEngine` comparison in same test pins product branch issue #3179 targets.

## Product mutation proof

Measured on final head `9f8e2c6b` over `main` `81e6deab`. Both mutants applied exactly once (`pre original=1/mutant=0`, `post original=0/mutant=1`), produced changed md5, built with `BUILD_RC=0`, and restored to exact pristine md5 `ea53ed84bf4f459c78cf4a3ab5d05730`.

| Mutant | Current main tests | This head |
|---|---:|---:|
| `new string(chars, this.start, Length)` → `new string(chars, 0, Length)` | survives 15/15 | killed: 3 failures / 16, all `SpanConversionMutationAndSlicing_AgreeAcrossDrivers` rows; `bcd` became `abc` |
| `[{Length}]` → `[{this.array.Length}]` | survives 15/15 | killed: 3 failures / 16, same rows; sliced non-char display `[2]` became `[3]` |

Second row differs from issue text: before #3182 it was killed by two file-evaluator rows; after file drivers switched to emission, it became a live survivor too. This patch closes both reopened evaluator axes.

## Validation

Nine-project denominator comes from `dotnet sln GSharp.sln list`, matching `build/generate-ci-test-matrix.py:26`.

Unfiltered run on commit `b66a584b` (same patch, before final rebase):

| Project | Passed | Skipped | Failed |
|---|---:|---:|---:|
| InternalAnalyzers.Tests | 9 | 0 | 0 |
| GSharp.GeneratorHost.Tests | 31 | 0 | 0 |
| Core.Tests | 7,128 | 1 | 0 |
| Compiler.Tests | 4,245 | 0 | 0 |
| Interpreter.Tests | 1,341 | 0 | 0 |
| LanguageServer.Tests | 462 | 0 | 0 |
| Sdk.Tests | 59 | 0 | 0 |
| Extensions.Tests | 104 | 0 | 0 |
| Cs2Gs.Tests | 1,907 | 0 | 0 |
| **Total** | **15,286** | **1** | **0** |

Final rebased head `9f8e2c6b` over live `main` `81e6deab`:

- solution build: `BUILD_RC=0`, 0 warnings, 0 errors
- `GSharp.Core.dll` freshness: mtime after build start
- targeted issue tests: 16 passed, 0 failed
- merge-tree output: `f9812c0947a0e5b449156b7392b1be47fae8a924`, equal to head tree
- final two-sided mutations: results above

Not rerun after final rebase: all nine unfiltered projects. Final rebase added three already-merged main commits; solution build, targeted tests, and both product mutations were rerun. Local e2e, Oahu corpus, and standalone ILVerify were not run; required CI gates remain authoritative.
