### PR TITLE
Rename reachable deinit interpreter test

### DIFF
--- a/test/Interpreter.Tests/EmittedSessionEngineTests.cs
+++ b/test/Interpreter.Tests/EmittedSessionEngineTests.cs
@@ -331,7 +331,7 @@ public sealed class EmittedSessionEngineTests : IDisposable
     /// run real emitted code, so a class deinitializer executes as a genuine
     /// CLR finalizer when a collection is forced — and the GS0510 interpreter
     /// boundary warning (pinned for the evaluator engine by
-    /// <c>Issue2988DeinitInterpreterTests.ForcedCollectionSkipsDeinitializerAndWarnsOnce</c>)
+    /// <c>Issue2988DeinitInterpreterTests.ReachableInstanceReportsGS0510WithoutRunningDeinitializer</c>)
     /// no longer fires, matching Phase 1's script-mode behavior.
     /// </summary>
     [Fact]

--- a/test/Interpreter.Tests/Issue2988DeinitInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2988DeinitInterpreterTests.cs
@@ -125,7 +125,7 @@ public class Issue2988DeinitInterpreterTests
     }
 
     [Fact]
-    public void ForcedCollectionSkipsDeinitializerAndWarnsOnce()
+    public void ReachableInstanceReportsGS0510WithoutRunningDeinitializer()
     {
         var source = """
             import System


### PR DESCRIPTION
Closes #3181.

## Summary

- rename `ForcedCollectionSkipsDeinitializerAndWarnsOnce` to `ReachableInstanceReportsGS0510WithoutRunningDeinitializer`
- update the cross-reference added by ADR-0156 Phase 2
- preserve the forced collection fixture and every assertion
- make no product or documentation change

The new name foregrounds the properties this one-class evaluator test pins: the instance remains reachable, no deinitializer output occurs, and exactly one GS0510 is reported. It no longer claims forced collection caused the skip or that this cell proves the once-per-declaring-class guard.

## Coverage preservation

- target file: 240 lines on both sides
- 4 `[Fact]`, 1 `[Theory]`, and 22 `Assert.` calls on both sides
- after stripping only the renamed signature, base/head MD5: `5b8d2c7c3a3b74d0390ea2baaa48df10`
- repo-wide old-name search: zero hits
- `git diff --name-only origin/main...HEAD -- src/ docs/`: empty

## Product mutations

| Mutant | Result |
|---|---|
| `Compilation.cs`: replace declaring-function identity guard with `deinitializer is not null` | RED: `DeinitializersWarnOncePerDeclaringClassWithoutRunning` failed; renamed test survived, confirming it should not claim once-per-class |
| `Compilation.cs`: invert `!allErrors.Any()` | RED: 3/7 failed, including `ReachableInstanceReportsGS0510WithoutRunningDeinitializer` at its `Assert.Single` |

Both mutants were asserted by diff and source MD5, produced changed `GSharp.Core.dll` bytes, then restored to source MD5 `b3ca864d484665dd522394f9c5bee7d5` and DLL MD5 `dd5c1dd46d0631d5172cd96efadd192b` after rebuild. The former `Program.cs` stderr mutant from #3172 is no longer applicable: #3182 removed the script-mode GS0510 path and replaced that test with an emitted-finalizer assertion.

## Verification

- final merged-tree Release warnings-as-errors build: rc 0, 0 warnings, 0 errors
- focused evaluator/deinit tests: 7/7
- all 9 solution test projects (denominator from `dotnet sln GSharp.sln list`): 15,338 passed, 1 skipped on the immediately preceding main; after the final one-commit main refresh, the focused 7/7 and incoming commit's 15/15 tests passed
- merge-tree output: `03706aea8be2b72f9c2597f9bec4751dc0c18329`

## Current driver measurement

Main changed during the work: #3182 now runs bare `gsc` and script-mode `gsi` through emitted code. For the dying-object probe, all three drivers return rc 0 and print `made-22 / deinit-11: kept / after-collect-33` (bare `gsc` also prints `Success.`). The old expected script-driver divergence is therefore no longer true on current main. This PR does not alter that behavior; the renamed test directly exercises the evaluator `SessionEngine`, where GS0510 remains the boundary.
