### PR TITLE
Fix enclosing generic field reification

### DIFF
--- a/src/Core/CodeAnalysis/Evaluator.Expressions.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Expressions.cs
@@ -1295,7 +1295,9 @@ public sealed partial class Evaluator
     {
         var module = CreateClrBackingModule();
         var definition = structType.Definition ?? structType;
-        var arity = definition.TypeParameters.Length;
+
+        // Issue #3180: CLR nested types redeclare the flattened enclosing and own generic parameters.
+        var reifiedParameters = GetClrReifiedTypeParameters(definition);
         var reifiedTypeParameters = new Dictionary<TypeParameterSymbol, Type>();
         var enclosingTypes = new Stack<StructSymbol>();
         for (var containing = definition.ContainingType as StructSymbol;
@@ -1343,13 +1345,13 @@ public sealed partial class Evaluator
                 metadataName,
                 (attributes & ~TypeAttributes.VisibilityMask) | TypeAttributes.NestedPublic,
                 clrBase);
-        if (arity > 0)
+        if (!reifiedParameters.IsDefaultOrEmpty)
         {
             var parameters = typeBuilder.DefineGenericParameters(
-                definition.TypeParameters.Select(static parameter => parameter.Name).ToArray());
+                reifiedParameters.Select(static parameter => parameter.Name).ToArray());
             for (var i = 0; i < parameters.Length; i++)
             {
-                reifiedTypeParameters[definition.TypeParameters[i]] = parameters[i];
+                reifiedTypeParameters[reifiedParameters[i]] = parameters[i];
             }
         }
 
@@ -1416,18 +1418,35 @@ public sealed partial class Evaluator
             enclosingBuilders[i].CreateType();
         }
 
-        if (arity == 0)
+        if (reifiedParameters.IsDefaultOrEmpty)
         {
             return backingType;
         }
 
-        var typeArguments = new Type[structType.TypeArguments.Length];
-        for (var i = 0; i < typeArguments.Length; i++)
+        var definitionEnclosingParameters = StructSymbol.CollectEnclosingTypeParameters(definition);
+        var typeArguments = new Type[reifiedParameters.Length];
+        for (var i = 0; i < definitionEnclosingParameters.Length; i++)
         {
-            typeArguments[i] = ResolveClrBackingTypeArgument(structType.TypeArguments[i]);
+            var argument = i < structType.EnclosingTypeArguments.Length
+                ? structType.EnclosingTypeArguments[i]
+                : definitionEnclosingParameters[i];
+            typeArguments[i] = ResolveClrBackingTypeArgument(argument);
+        }
+
+        for (var i = 0; i < definition.TypeParameters.Length; i++)
+        {
+            var argument = i < structType.TypeArguments.Length
+                ? structType.TypeArguments[i]
+                : definition.TypeParameters[i];
+            typeArguments[definitionEnclosingParameters.Length + i] = ResolveClrBackingTypeArgument(argument);
         }
 
         return backingType.MakeGenericType(typeArguments);
+    }
+
+    private static ImmutableArray<TypeParameterSymbol> GetClrReifiedTypeParameters(StructSymbol type)
+    {
+        return StructSymbol.CollectEnclosingTypeParameters(type).AddRange(type.TypeParameters);
     }
 
     private static Type ResolveClrBackingTypeArgument(

--- a/test/Interpreter.Tests/Issue3099TypeArgumentReificationTests.cs
+++ b/test/Interpreter.Tests/Issue3099TypeArgumentReificationTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using GSharp.Compiler;
+using GSharp.Repl.Engine;
 using Xunit;
 
 namespace GSharp.Interpreter.Tests;
@@ -17,6 +18,8 @@ namespace GSharp.Interpreter.Tests;
 /// Issue #3099: interpreter-created generic backing types must preserve every
 /// G# type-argument kind instead of erasing value types to <see cref="object"/>.
 /// Issue #3137 extends the same emit-oracle matrix to reflected field shape.
+/// Issue #3180 covers enclosing generic parameters in the interactive evaluator;
+/// ADR-0156 file drivers remain compared against the emitted oracle.
 /// </summary>
 [Collection("ConsoleIo")]
 public class Issue3099TypeArgumentReificationTests
@@ -29,6 +32,11 @@ public class Issue3099TypeArgumentReificationTests
         yield return ["string", string.Empty, "string"];
         yield return ["nested-class", "class Owner {\n    class Payload {\n        let Eleven int32\n        var TwentyTwo string\n    }\n}", "Owner.Payload"];
         yield return ["nested-struct", "class Owner {\n    struct Payload {\n        let Eleven int32\n        var TwentyTwo string\n    }\n}", "Owner.Payload"];
+        yield return ["generic-owner-nested-class", "class Owner[T] {\n    class Payload {\n        let Eleven T\n        var TwentyTwo string\n    }\n}", "Owner[int32].Payload"];
+        yield return ["generic-owner-nested-struct", "class Owner[T] {\n    struct Payload {\n        let Eleven T\n        var TwentyTwo string\n    }\n}", "Owner[int32].Payload"];
+        yield return ["generic-owner-multi-arity-nested", "class Owner[TFirst, TSecond] {\n    class Payload {\n        let Eleven TFirst\n        var TwentyTwo TSecond\n    }\n}", "Owner[int32, string].Payload"];
+        yield return ["generic-owner-nested-generic", "class Owner[T] {\n    class Payload[U] {\n        let Eleven T\n        var TwentyTwo U\n    }\n}", "Owner[int32].Payload[string]"];
+        yield return ["generic-owner-deep-nested", "class Owner[T] {\n    class Middle[U] {\n        class Payload {\n            let Eleven T\n            var TwentyTwo U\n        }\n    }\n}", "Owner[int32].Middle[string].Payload"];
         yield return ["gsharp-generic", "struct Payload[T] {\n    let Value T\n    var Imported List[T]\n    var Slice []T\n    var Nullable T?\n    var Array [3]T\n    shared {\n        var Stat int32\n    }\n    const Kilo int32 = 1000\n}", "Payload[int32]"];
         yield return ["imported-generic", "struct Payload {\n    let Eleven int32\n    var TwentyTwo string\n}", "List[Payload]"];
         yield return ["nullable", "struct Payload {\n    let Eleven int32\n    var TwentyTwo string\n}", "Payload?"];
@@ -38,7 +46,7 @@ public class Issue3099TypeArgumentReificationTests
 
     [Theory]
     [MemberData(nameof(TypeArgumentCases))]
-    public void TypeArguments_AgreeAcrossEvaluationEmitAndInterpretation(
+    public void TypeArguments_AgreeAcrossInteractiveEvaluationEmitAndFileDrivers(
         string caseName,
         string declaration,
         string typeArgument)
@@ -52,17 +60,18 @@ public class Issue3099TypeArgumentReificationTests
 
         try
         {
-            var compilerEvaluation = RunSourceDriver(
+            var compilerFile = RunSourceDriver(
                 Path.Combine(root, "gsc-eval"),
                 source,
                 Program.Main);
-            Assert.EndsWith("Success.\n", compilerEvaluation);
-            compilerEvaluation = compilerEvaluation[..^"Success.\n".Length];
+            Assert.EndsWith("Success.\n", compilerFile);
+            compilerFile = compilerFile[..^"Success.\n".Length];
 
-            var interpreter = RunSourceDriver(
+            var gsiFile = RunSourceDriver(
                 Path.Combine(root, "gsi"),
                 source,
                 GSharp.Repl.Program.Main);
+            var interactive = RunInteractive(source);
 
             var emitDirectory = PrepareEmptyDirectory(Path.Combine(root, "gsc-emit"));
             var sourcePath = Path.Combine(emitDirectory, "Probe.gs");
@@ -90,15 +99,18 @@ public class Issue3099TypeArgumentReificationTests
             });
 
             var expected = NormalizeGenericTypeNames(emitted);
-            var evaluated = NormalizeGenericTypeNames(compilerEvaluation);
-            var interpreted = NormalizeGenericTypeNames(interpreter);
+            var evaluated = NormalizeGenericTypeNames(interactive);
+            var compiledFile = NormalizeGenericTypeNames(compilerFile);
+            var interpretedFile = NormalizeGenericTypeNames(gsiFile);
             const string ControlShape =
                 "44\n2|Eleven:System.Int32:True:False:False|TwentyTwo:System.String:False:False:False\n";
             Assert.Contains(ControlShape, expected, StringComparison.Ordinal);
             Assert.Contains(ControlShape, evaluated, StringComparison.Ordinal);
-            Assert.Contains(ControlShape, interpreted, StringComparison.Ordinal);
+            Assert.Contains(ControlShape, compiledFile, StringComparison.Ordinal);
+            Assert.Contains(ControlShape, interpretedFile, StringComparison.Ordinal);
             Assert.Equal(expected, evaluated);
-            Assert.Equal(expected, interpreted);
+            Assert.Equal(expected, compiledFile);
+            Assert.Equal(expected, interpretedFile);
             Assert.Contains("11\n", expected);
             Assert.Contains("22\n", expected);
             Assert.Contains("33\n", expected);
@@ -178,6 +190,13 @@ public class Issue3099TypeArgumentReificationTests
         var sourcePath = Path.Combine(probeDirectory, "Probe.gs");
         File.WriteAllText(sourcePath, source);
         return CaptureDriver(() => driver([sourcePath]));
+    }
+
+    private static string RunInteractive(string source)
+    {
+        var cell = new SessionEngine { CaptureConsole = true }.Evaluate(source);
+        Assert.False(cell.HasError, string.Join(Environment.NewLine, cell.Diagnostics));
+        return cell.Output.Replace("\r\n", "\n", StringComparison.Ordinal);
     }
 
     private static string PrepareEmptyDirectory(string directory)


### PR DESCRIPTION
## Summary

- reify evaluator-created nested CLR types over the flattened enclosing + own generic parameter list
- close those nested types with `EnclosingTypeArguments` followed by own `TypeArguments`
- extend the existing emitted-oracle matrix with class, struct, multi-arity, nested-generic, and deep-nesting specimens
- keep an explicit `SessionEngine` column after ADR-0156 moved bare `gsc` and `gsi <file>` from evaluation to emit-to-memory

Closes #3180.

## Main interaction

Issue assignment started on `aa453ac6`, where bare `gsc` and `gsi <file>` reproduced `V:System.Object`. Main then merged #3182/#3186: file-mode drivers now execute emitted assemblies, so on final base `81e6deab` all three file columns already print the emitted result. Default interactive `SessionEngine` still uses the evaluator and retained the bug. Coverage now names and measures that remaining evaluator path instead of passing vacuously through three emit paths.

## Measured behavior

Exact repro on final head:

| path | output |
|---|---|
| bare `gsc` | `2|V:System.Int32|W:System.Int32` + `Success.` |
| `gsc /out:` | `2|V:System.Int32|W:System.Int32` |
| `gsi <file>` | `2|V:System.Int32|W:System.Int32` |
| interactive evaluator | matches emitted oracle in the 16-case matrix |

Final test copied onto current main without the production change: **5 failed / 11 passed**. Failing set:

- `generic-owner-nested-class`
- `generic-owner-nested-struct`
- `generic-owner-multi-arity-nested`
- `generic-owner-nested-generic`
- `generic-owner-deep-nested`

Head: **16/16 passed**.

## Product mutations

Every mutant was asserted by `git diff` and md5, then restored to exact md5.

| mutant | result |
|---|---|
| target uses own parameters only, dropping flattened enclosing parameters | RED: 5 failed / 11 passed |
| invert concrete enclosing-argument selection | RED: 5 failed / 11 passed |
| invert target generic-definition condition (broad control) | RED: 16 failed / 0 passed |
| flatten parameters on intermediate enclosing builders | SURVIVED 16/16; hunk proved unnecessary and was deleted |

## Validation

- final base: `81e6deab4ad19f2f642182691c42146dd63ddb27`
- final head: `6944c1bcda4c40673d12727a2aaf5ba1dd04fd7b`
- Debug and Release solution builds: 0 warnings, 0 errors
- merge-tree output `3021468e5a31c1e1b6a50577199d9ae8ec714aae`, exactly equal to `HEAD^{tree}`
- full unfiltered 9-project run: **15,343 passed, 1 skipped, 0 failed**
  - Compiler 4,245
  - Core 7,128 + 1 skipped
  - Extensions 104
  - InternalAnalyzers 9
  - Interpreter 1,398
  - LanguageServer 462
  - SDK 59
  - Cs2Gs 1,907
  - GeneratorHost 31
- Cs2Gs first run lacked Release packages and failed its package-smoke prerequisite; after solution Release build, full rerun passed 1,907/1,907
- full 9-project run was on preceding base `0ffd90b1`; final main added only #2903 (`MemberLookup`, overload resolution, one Compiler test file), with no file overlap. After final rebase: solution build passed, issue matrix passed 16/16, and #2903's new interaction class passed 15/15.

Not run: local SDK e2e, because shared `~/.nuget/packages/gsharp.net.sdk/` is prohibited.
