### PR TITLE
Fix evaluator ref write-back for remaining call shapes

### DIFF
--- a/src/Core/CodeAnalysis/Evaluator.Calls.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Calls.cs
@@ -394,18 +394,17 @@ public sealed partial class Evaluator
         };
 
         var parameterOffset = method.ExplicitReceiverParameter == null ? 0 : 1;
-        for (int i = 0; i < node.Arguments.Length; i++)
-        {
-            var parameter = method.Parameters[i + parameterOffset];
-            var value = EvaluateExpression(node.Arguments[i]);
-            frame[parameter] = value;
-        }
+        var args = PopulateUserCallFrame(node.Arguments, method, parameterOffset, frame, out var refSlots);
 
+        object result;
         using (PushFrame(frame))
         {
             var statement = program.Functions[method];
-            return EvaluateUserMethodBody(method, statement);
+            result = EvaluateUserMethodBody(method, statement);
         }
+
+        WriteBackUserCallFrame(refSlots, args, method, parameterOffset, frame);
+        return result;
     }
 
     /// <summary>
@@ -486,12 +485,10 @@ public sealed partial class Evaluator
     /// </summary>
     private object EvaluateConstrainedStaticCallExpression(BoundConstrainedStaticCallExpression node)
     {
-        // Evaluate arguments left-to-right (matches IL evaluation order).
+        // BuildRefSlots evaluates arguments left-to-right while retaining caller lvalues for write-back.
         var evaluatedArgs = new object[node.Arguments.Length];
-        for (var i = 0; i < node.Arguments.Length; i++)
-        {
-            evaluatedArgs[i] = EvaluateExpression(node.Arguments[i]);
-        }
+        var refKinds = node.InterfaceMethod.Parameters.Select(parameter => parameter.RefKind).ToImmutableArray();
+        var refSlots = BuildRefSlots(node.Arguments, refKinds, evaluatedArgs, method: null);
 
         var slotIface = node.InterfaceMethod.StaticOwnerType as InterfaceSymbol;
         StructSymbol resolvedImpl = null;
@@ -619,10 +616,14 @@ public sealed partial class Evaluator
             frame2[target.Parameters[i]] = evaluatedArgs[i];
         }
 
+        object result;
         using (PushFrame(frame2))
         {
-            return EvaluateUserMethodBody(target, statement);
+            result = EvaluateUserMethodBody(target, statement);
         }
+
+        WriteBackUserCallFrame(refSlots, evaluatedArgs, target, parameterOffset: 0, frame2);
+        return result;
     }
 
     private object EvaluateConversionExpression(BoundConversionExpression node)
@@ -1579,6 +1580,12 @@ public sealed partial class Evaluator
                     break;
                 case BoundIndexExpression idx:
                     WriteBackIndex(idx, value);
+                    break;
+                case BoundDereferenceExpression deref:
+                    var target = deref.Operand is BoundAddressOfExpression addressOf
+                        ? addressOf.Operand
+                        : deref.Operand;
+                    WriteBackToOperand(target, value);
                     break;
             }
         }

--- a/src/Core/CodeAnalysis/Evaluator.Calls.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Calls.cs
@@ -1582,10 +1582,7 @@ public sealed partial class Evaluator
                     WriteBackIndex(idx, value);
                     break;
                 case BoundDereferenceExpression deref:
-                    var target = deref.Operand is BoundAddressOfExpression addressOf
-                        ? addressOf.Operand
-                        : deref.Operand;
-                    WriteBackToOperand(target, value);
+                    WriteBackToOperand(deref, value);
                     break;
             }
         }
@@ -1702,7 +1699,7 @@ public sealed partial class Evaluator
 
     /// <summary>
     /// Issue #491 (ADR-0060 follow-up): writes <paramref name="value"/> through a
-    /// bound lvalue expression (variable, field, property, or indexer access).
+    /// bound lvalue expression (variable, field, property, indexer access, or dereference).
     /// Shared between ref-aliasing local writes and the existing ref/out parameter
     /// write-back path.
     /// </summary>
@@ -1724,7 +1721,10 @@ public sealed partial class Evaluator
                 break;
             case BoundDereferenceExpression deref:
                 // *p = v under interpreter: re-route through the inner operand.
-                WriteBackToOperand(deref.Operand, value);
+                var target = deref.Operand is BoundAddressOfExpression addressOf
+                    ? addressOf.Operand
+                    : deref.Operand;
+                WriteBackToOperand(target, value);
                 break;
         }
     }

--- a/test/Interpreter.Tests/Issue3140OutParameterWriteBackParityTests.cs
+++ b/test/Interpreter.Tests/Issue3140OutParameterWriteBackParityTests.cs
@@ -10,6 +10,10 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Repl.Engine;
 using Xunit;
 
 namespace GSharp.Interpreter.Tests;
@@ -33,34 +37,28 @@ public class Issue3140OutParameterWriteBackParityTests
 
     [Theory]
     [MemberData(nameof(ReceiverShapeMatrix))]
-    public async Task OutParameterWriteBack_GscEvaluateAndGsiMatchEmit(
+    public async Task OutParameterWriteBack_EvaluatorAndSessionEngineMatchEmit(
         ReceiverKind receiver,
         ArgumentShape shape)
     {
-        var source = BuildSource(receiver, shape);
-        var root = CreateEmptyDirectory(receiver + "-" + shape);
-        try
-        {
-            var emitted = await RunEmittedAsync(source, CreateEmptyDirectory(root, "emit"));
-            var evaluated = RunSourceDriver(
-                source,
-                CreateEmptyDirectory(root, "evaluate"),
-                GSharp.Compiler.Program.Main,
-                stripCompilerSuccess: true);
-            var interpreted = RunSourceDriver(
-                source,
-                CreateEmptyDirectory(root, "gsi"),
-                GSharp.Repl.Program.Main,
-                stripCompilerSuccess: false);
+        await AssertDriverParityAsync(BuildSource(receiver, shape), receiver + "-" + shape);
+    }
 
-            Assert.NotEmpty(emitted);
-            Assert.Equal(emitted, evaluated);
-            Assert.Equal(emitted, interpreted);
-        }
-        finally
+    /// <summary>Gets write-back operand-kind rows.</summary>
+    /// <returns>Operand-kind rows.</returns>
+    public static IEnumerable<object[]> WriteBackOperandKinds()
+    {
+        foreach (var operand in Enum.GetValues<OperandKind>())
         {
-            DeleteDirectory(root);
+            yield return new object[] { operand };
         }
+    }
+
+    [Theory]
+    [MemberData(nameof(WriteBackOperandKinds))]
+    public async Task OutParameterWriteBack_OperandKindsMatchEmit(OperandKind operand)
+    {
+        await AssertDriverParityAsync(BuildOperandSource(operand), "Operand-" + operand);
     }
 
     /// <summary>Call receiver shape.</summary>
@@ -89,6 +87,12 @@ public class Issue3140OutParameterWriteBackParityTests
 
         /// <summary>Generic class instance method.</summary>
         GenericMethod,
+
+        /// <summary>Interface default method called through <c>base[IFiller]</c>.</summary>
+        BaseInterface,
+
+        /// <summary>Static interface method called through a constrained type parameter.</summary>
+        ConstrainedStatic,
     }
 
     /// <summary>Argument shape.</summary>
@@ -108,6 +112,22 @@ public class Issue3140OutParameterWriteBackParityTests
 
         /// <summary>Distinct assignments in conditional branches.</summary>
         ConditionalOut,
+    }
+
+    /// <summary>Caller storage kind used by a ref/out argument.</summary>
+    public enum OperandKind
+    {
+        /// <summary>Local variable.</summary>
+        Variable,
+
+        /// <summary>Instance field.</summary>
+        Field,
+
+        /// <summary>Array element.</summary>
+        Index,
+
+        /// <summary>Dereferenced managed address.</summary>
+        Dereference,
     }
 
     private static string BuildSource(ReceiverKind receiver, ArgumentShape shape)
@@ -160,13 +180,30 @@ public class Issue3140OutParameterWriteBackParityTests
                 target = "target.Fill[string]";
                 callPrefix = "\"marker\", ";
                 break;
+            case ReceiverKind.BaseInterface:
+                declarations =
+                    $"interface Filler {{\n{Indent(method, 4)}\n}}\n"
+                    + $"class Target : Filler {{\n    func Fill({spec.Parameters}) {{\n"
+                    + $"        base[Filler].Fill({spec.ForwardArguments})\n    }}\n}}";
+                target = "target.Fill";
+                break;
+            case ReceiverKind.ConstrainedStatic:
+                declarations =
+                    $"interface Filler {{\n    shared {{\n        func Fill({spec.Parameters});\n    }}\n}}\n"
+                    + $"struct Target : Filler {{\n    shared {{\n{Indent(method, 8)}\n    }}\n}}\n"
+                    + $"func Invoke[T Filler](witness T, {spec.Parameters}) {{\n"
+                    + $"    T.Fill({spec.ForwardArguments})\n}}";
+                target = "Invoke";
+                callPrefix = "Target{}, ";
+                break;
             default:
                 throw new ArgumentOutOfRangeException(nameof(receiver), receiver, null);
         }
 
         var receiverLocal = receiver switch
         {
-            ReceiverKind.ClassInstance or ReceiverKind.BaseClass or ReceiverKind.GenericMethod =>
+            ReceiverKind.ClassInstance or ReceiverKind.BaseClass or ReceiverKind.GenericMethod
+                or ReceiverKind.BaseInterface =>
                 "var target = Target()",
             ReceiverKind.StructInstance => "var target = Target{}",
             ReceiverKind.Interface => "var target Filler = Target()",
@@ -186,6 +223,52 @@ public class Issue3140OutParameterWriteBackParityTests
             {receiverLocal}
             {spec.Locals}
             {calls}
+            """;
+    }
+
+    private static string BuildOperandSource(OperandKind operand)
+    {
+        var (declaration, locals, argument, output) = operand switch
+        {
+            OperandKind.Variable => (
+                string.Empty,
+                "var value = 101",
+                "&value",
+                "value"),
+            OperandKind.Field => (
+                "class Holder { var Value int32 }",
+                "let holder = Holder{}\nholder.Value = 102",
+                "&holder.Value",
+                "holder.Value"),
+            OperandKind.Index => (
+                string.Empty,
+                "var values = []int32{101, 104}",
+                "&values[1]",
+                "values[1]"),
+            OperandKind.Dereference => (
+                string.Empty,
+                "var value = 105",
+                "&*(&value)",
+                "value"),
+            _ => throw new ArgumentOutOfRangeException(nameof(operand), operand, null),
+        };
+
+        return $$"""
+            package Issue3140Operand{{operand}}
+            import System
+
+            class Target {
+                func Fill(out value int32) {
+                    value = 91
+                }
+            }
+
+            {{declaration}}
+
+            let target = Target()
+            {{locals}}
+            target.Fill({{argument}})
+            Console.WriteLine({{output}})
             """;
     }
 
@@ -227,21 +310,61 @@ public class Issue3140OutParameterWriteBackParityTests
         _ => throw new ArgumentOutOfRangeException(nameof(shape), shape, null),
     };
 
-    private static string RunSourceDriver(
-        string source,
-        string directory,
-        Func<string[], int> driver,
-        bool stripCompilerSuccess)
+    private static async Task AssertDriverParityAsync(string source, string name)
     {
-        var sourcePath = Path.Combine(directory, "probe.gs");
-        File.WriteAllText(sourcePath, source);
-        var result = CaptureConsole(() => driver([sourcePath]));
+        var root = CreateEmptyDirectory(name);
+        try
+        {
+            var emitted = await RunEmittedAsync(source, CreateEmptyDirectory(root, "emit"));
+            var evaluated = RunEvaluator(source);
+            var interpreted = RunSessionEngine(source);
 
-        Assert.True(
-            result.ExitCode == 0,
-            $"driver failed ({result.ExitCode})\nstdout:\n{result.Stdout}\nstderr:\n{result.Stderr}");
-        Assert.Equal(string.Empty, result.Stderr);
-        return Normalize(result.Stdout, stripCompilerSuccess);
+            Assert.NotEmpty(emitted);
+            Assert.Equal(emitted, evaluated);
+            Assert.Equal(emitted, interpreted);
+        }
+        finally
+        {
+            DeleteDirectory(root);
+        }
+    }
+
+    private static string RunEvaluator(string source)
+    {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            var result = new Compilation(SyntaxTree.Parse(source))
+                .Evaluate(new Dictionary<VariableSymbol, object>());
+            var errors = result.Diagnostics.Where(diagnostic => diagnostic.IsError).ToArray();
+            Assert.True(
+                errors.Length == 0,
+                "evaluation failed:\n" + string.Join("\n", errors.Select(error => error.ToString())));
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+
+        Assert.Equal(string.Empty, stderr.ToString());
+        return Normalize(stdout.ToString(), stripCompilerSuccess: false);
+    }
+
+    private static string RunSessionEngine(string source)
+    {
+        var engine = new SessionEngine { CaptureConsole = true };
+        var result = engine.Evaluate(source);
+
+        Assert.False(
+            result.HasError,
+            "session evaluation failed:\n" + string.Join("\n", result.Diagnostics));
+        return Normalize(result.Output, stripCompilerSuccess: false);
     }
 
     private static async Task<string> RunEmittedAsync(string source, string directory)

--- a/test/Interpreter.Tests/Issue3140OutParameterWriteBackParityTests.cs
+++ b/test/Interpreter.Tests/Issue3140OutParameterWriteBackParityTests.cs
@@ -41,24 +41,35 @@ public class Issue3140OutParameterWriteBackParityTests
         ReceiverKind receiver,
         ArgumentShape shape)
     {
-        await AssertDriverParityAsync(BuildSource(receiver, shape), receiver + "-" + shape);
+        await AssertDriverParityAsync(
+            BuildSource(receiver, shape),
+            GetExpectedOutput(shape),
+            receiver + "-" + shape);
     }
 
-    /// <summary>Gets write-back operand-kind rows.</summary>
-    /// <returns>Operand-kind rows.</returns>
-    public static IEnumerable<object[]> WriteBackOperandKinds()
+    /// <summary>Gets receiver and write-back operand-kind rows.</summary>
+    /// <returns>Receiver and operand-kind rows.</returns>
+    public static IEnumerable<object[]> WriteBackOperandMatrix()
     {
-        foreach (var operand in Enum.GetValues<OperandKind>())
+        foreach (var receiver in Enum.GetValues<ReceiverKind>())
         {
-            yield return new object[] { operand };
+            foreach (var operand in Enum.GetValues<OperandKind>())
+            {
+                yield return new object[] { receiver, operand };
+            }
         }
     }
 
     [Theory]
-    [MemberData(nameof(WriteBackOperandKinds))]
-    public async Task OutParameterWriteBack_OperandKindsMatchEmit(OperandKind operand)
+    [MemberData(nameof(WriteBackOperandMatrix))]
+    public async Task OutParameterWriteBack_ReceiverAndOperandKindsMatchEmit(
+        ReceiverKind receiver,
+        OperandKind operand)
     {
-        await AssertDriverParityAsync(BuildOperandSource(operand), "Operand-" + operand);
+        await AssertDriverParityAsync(
+            BuildOperandSource(receiver, operand),
+            "91",
+            receiver + "-" + operand);
     }
 
     /// <summary>Call receiver shape.</summary>
@@ -130,10 +141,19 @@ public class Issue3140OutParameterWriteBackParityTests
         Dereference,
     }
 
-    private static string BuildSource(ReceiverKind receiver, ArgumentShape shape)
+    private static string BuildSource(ReceiverKind receiver, ArgumentShape shape) =>
+        BuildSource(
+            receiver,
+            GetShape(shape),
+            $"Issue3140{receiver}{shape}",
+            string.Empty);
+
+    private static string BuildSource(
+        ReceiverKind receiver,
+        ShapeSpec spec,
+        string package,
+        string extraDeclaration)
     {
-        var spec = GetShape(shape);
-        var package = $"Issue3140{receiver}{shape}";
         var method = $"func Fill({spec.Parameters}) {{\n{Indent(spec.Body, 4)}\n}}";
         string declarations;
         string target;
@@ -220,13 +240,15 @@ public class Issue3140OutParameterWriteBackParityTests
 
             {declarations}
 
+            {extraDeclaration}
+
             {receiverLocal}
             {spec.Locals}
             {calls}
             """;
     }
 
-    private static string BuildOperandSource(OperandKind operand)
+    private static string BuildOperandSource(ReceiverKind receiver, OperandKind operand)
     {
         var (declaration, locals, argument, output) = operand switch
         {
@@ -253,23 +275,17 @@ public class Issue3140OutParameterWriteBackParityTests
             _ => throw new ArgumentOutOfRangeException(nameof(operand), operand, null),
         };
 
-        return $$"""
-            package Issue3140Operand{{operand}}
-            import System
-
-            class Target {
-                func Fill(out value int32) {
-                    value = 91
-                }
-            }
-
-            {{declaration}}
-
-            let target = Target()
-            {{locals}}
-            target.Fill({{argument}})
-            Console.WriteLine({{output}})
-            """;
+        var spec = new ShapeSpec(
+            "out value int32",
+            "value = 91",
+            locals,
+            "&value",
+            [new(argument, $"Console.WriteLine({output})")]);
+        return BuildSource(
+            receiver,
+            spec,
+            $"Issue3140Operand{receiver}{operand}",
+            declaration);
     }
 
     private static ShapeSpec GetShape(ArgumentShape shape) => shape switch
@@ -310,7 +326,17 @@ public class Issue3140OutParameterWriteBackParityTests
         _ => throw new ArgumentOutOfRangeException(nameof(shape), shape, null),
     };
 
-    private static async Task AssertDriverParityAsync(string source, string name)
+    private static string GetExpectedOutput(ArgumentShape shape) => shape switch
+    {
+        ArgumentShape.SingleOut => "11",
+        ArgumentShape.MultipleOut => "21\n22",
+        ArgumentShape.OutAndRef => "31\n37",
+        ArgumentShape.OutAndNormal => "44",
+        ArgumentShape.ConditionalOut => "51\n52",
+        _ => throw new ArgumentOutOfRangeException(nameof(shape), shape, null),
+    };
+
+    private static async Task AssertDriverParityAsync(string source, string expected, string name)
     {
         var root = CreateEmptyDirectory(name);
         try
@@ -319,6 +345,7 @@ public class Issue3140OutParameterWriteBackParityTests
             var evaluated = RunEvaluator(source);
             var interpreted = RunSessionEngine(source);
 
+            Assert.Equal(expected, emitted);
             Assert.NotEmpty(emitted);
             Assert.Equal(emitted, evaluated);
             Assert.Equal(emitted, interpreted);


### PR DESCRIPTION
## Summary
- route `base[IFiller].M(...)` through existing user-call ref-slot population and write-back
- retain caller lvalues during constrained-static dispatch, then write callee `out`/`ref` values back after frame restoration
- unwrap managed-address dereferences once in shared `WriteBackToOperand`; `WriteBackRefSlots` delegates to that path
- cross all 10 receiver kinds with all 4 reachable operand kinds
- anchor every parity row on a distinctive literal post-call value before comparing evaluator paths

## Impact
Post-ADR-0156, all file-based drivers emit. This defect is therefore observable through the embedding API and interactive REPL evaluator, not file-mode `gsc`/`gsi`. Tests intentionally use direct `Compilation.Evaluate` and evaluator-backed `SessionEngine`; emitted execution remains the oracle.

## Measurement
Measured evidence:

- original test rows alone on unfixed `main`: **11 failed / 43 passed**
  - `BaseInterface`: all 5 argument shapes
  - `ConstrainedStatic`: all 5 argument shapes
  - instance `Dereference`: 1 operand row
- round-two matrix alone on the prior PR product: **4 failed / 86 passed**
  - `Free-Dereference`
  - `ClassShared-Dereference`
  - `StructShared-Dereference`
  - `ConstrainedStatic-Dereference`
- fixed targeted matrix: **90/90 passed**
  - receiver shapes: 10 receivers × 5 argument shapes
  - operand shapes: 10 receivers × 4 operands (`Variable`, `Field`, `Index`, `Dereference`)
- focused reviewer-size probe: **47/47 passed**
  - all 40 receiver × operand rows
  - 7 `SingleOut` controls spanning free/shared/instance/base-interface/constrained dispatch
- original six fixed-vs-unfixed emit probes stayed byte-identical: base-interface `61`, constrained-static `81`, and four operand kinds `91`
- property address-taking was measured and rejected with `GS9001`; it is not a reachable source lvalue

Root cause is inferred from source flow: static/free calls wrote through `WriteBackToOperand`, while instance/base calls wrote through `WriteBackRefSlots`; only the latter had address-of unwrapping.

## Mutation testing
Six product mutants, zero survivors across both rounds. Round two:

- invert address-shape selection at `WriteBackRefSlots` delegation: **6 failed / 84 passed**
- invert address-shape selection in shared `WriteBackToOperand`: **10 failed / 80 passed**

Both changed `Evaluator.Calls.cs` and `out/bin/Debug/Core/GSharp.Core.dll` MD5 within this worktree. Each restore returned source and DLL hashes exactly to baseline and rebuilt green.

Literal-value assertion proof: changing generated callee output uniformly from `91` to `105` made emitted, evaluated, and interpreted paths agree on the wrong value; the new expected-value assertion killed **40/40** rows (`Expected: "91"`, `Actual: "105"`). This was a test-fixture mutant, not scored as a product mutant.

## Validation
Final base: `origin/main` `57256713`. Test denominator: 9 projects from `dotnet sln GSharp.sln list`, matching `build/generate-ci-test-matrix.py:26`.

- Core: 7,128 passed, 1 skipped
- Extensions: 104 passed
- InternalAnalyzers: 9 passed
- Interpreter: 1,460 passed
- LanguageServer: 462 passed
- Sdk: 59 passed
- GeneratorHost: 31 passed
- Compiler: 4,260 passed
- Cs2Gs: 1,907 passed
- total: **15,420 passed, 1 skipped, 0 failed**
- Debug and Release solution builds: 0 warnings, 0 errors
- ILVerify: **123/123 verified**, 2 documented suppressions, 0 failures
- `git merge-tree --write-tree origin/main HEAD` output equals `HEAD^{tree}`: `fdb593b4e28a2824eaf09f5c1cb330e28bc965a7`
- merged-tree `BUILD_RC=0`

Local e2e/Oahu gates were not run; local e2e is prohibited for this worktree and both are outside this evaluator change.

Fixes #3162
