### PR TITLE
Cache evaluator BCL override dispatch

### DIFF
--- a/src/Core/CodeAnalysis/Evaluator.Calls.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Calls.cs
@@ -30,6 +30,7 @@ public sealed partial class Evaluator
 {
     private readonly System.Runtime.CompilerServices.ConditionalWeakTable<ConcurrentDictionary<VariableSymbol, object>, Dictionary<TypeParameterSymbol, TypeSymbol>> runtimeTypeArguments = new();
     private readonly ConcurrentDictionary<(System.Reflection.MemberInfo Member, Type RuntimeType), System.Reflection.MemberInfo> runtimeMembers = new();
+    private readonly ConcurrentDictionary<StructSymbol, IReadOnlyDictionary<MethodInfo, FunctionSymbol>> externalOverrides = new();
 
     private object EvaluateCallExpression(BoundCallExpression node)
     {
@@ -1058,8 +1059,11 @@ public sealed partial class Evaluator
         return result;
     }
 
-    private StructValue CreateStructValue(StructSymbol structType) =>
-        new(structType, TryEvaluateExternalOverride);
+    private StructValue CreateStructValue(StructSymbol structType)
+    {
+        var overrides = GetExternalOverrides(structType);
+        return new(structType, overrides.Count == 0 ? null : TryEvaluateExternalOverride);
+    }
 
     private bool TryEvaluateExternalOverride(
         StructValue receiver,
@@ -1101,16 +1105,32 @@ public sealed partial class Evaluator
         }
     }
 
-    private static FunctionSymbol FindExternalOverride(StructSymbol type, MethodInfo externalMethod)
+    private FunctionSymbol FindExternalOverride(StructSymbol type, MethodInfo externalMethod)
     {
-        FunctionSymbol externalOverride = null;
-        for (; type != null && externalOverride == null; type = type.BaseClass)
+        var overrides = GetExternalOverrides(type);
+        return overrides.TryGetValue(externalMethod, out var externalOverride)
+            ? externalOverride
+            : null;
+    }
+
+    private IReadOnlyDictionary<MethodInfo, FunctionSymbol> GetExternalOverrides(StructSymbol type) =>
+        externalOverrides.GetOrAdd(type, static key => BuildExternalOverrides(key));
+
+    private static IReadOnlyDictionary<MethodInfo, FunctionSymbol> BuildExternalOverrides(StructSymbol type)
+    {
+        var overrides = new Dictionary<MethodInfo, FunctionSymbol>();
+        for (; type != null; type = type.BaseClass)
         {
-            externalOverride = type.Methods.FirstOrDefault(method =>
-                method.IsOverride && FindExternalOverrideRoot(method)?.Equals(externalMethod) == true);
+            foreach (var method in type.Methods)
+            {
+                if (method.IsOverride && FindExternalOverrideRoot(method) is MethodInfo root)
+                {
+                    overrides.TryAdd(root, method);
+                }
+            }
         }
 
-        return externalOverride;
+        return overrides;
     }
 
     private static MethodInfo FindExternalOverrideRoot(FunctionSymbol method)

--- a/test/Interpreter.Tests/Issue2896StructObjectOverrideTests.cs
+++ b/test/Interpreter.Tests/Issue2896StructObjectOverrideTests.cs
@@ -154,6 +154,87 @@ public class Issue2896StructObjectOverrideTests
     }
 
     [Fact]
+    public async Task Issue3135_OverrideCacheSeparatesTypesMethodsAndInheritedSlots()
+    {
+        var suffix = Guid.NewGuid().ToString("N");
+        var source = $$"""
+            package Issue3135{{suffix}}
+            import System
+            import System.Collections.Generic
+
+            struct Plain{{suffix}} {
+                var Number int32
+            }
+
+            struct Direct{{suffix}} {
+                var Number int32
+                override func Equals(value object) bool -> true
+                override func GetHashCode() int32 -> 313511
+                override func ToString() string -> "DIRECT-11"
+            }
+
+            open class Base{{suffix}} {
+                open override func Equals(value object) bool -> true
+                open override func GetHashCode() int32 -> 313533
+                open override func ToString() string -> "BASE-33"
+            }
+
+            class Inherited{{suffix}} : Base{{suffix}} {
+            }
+
+            class MostDerived{{suffix}} : Base{{suffix}} {
+                override func Equals(value object) bool -> false
+                override func GetHashCode() int32 -> 313544
+                override func ToString() string -> "DERIVED-44"
+            }
+
+            let plainA = Plain{{suffix}}{Number: 11}
+            let plainB = Plain{{suffix}}{Number: 22}
+            let plainValues = Dictionary[Plain{{suffix}}, int32]()
+            plainValues[plainA] = 11
+            plainValues[plainB] = 22
+            Console.WriteLine(String.Format("PLAIN-22-{0}-{1}", plainValues.Count, plainA.Equals(plainB)))
+
+            let directA = Direct{{suffix}}{Number: 11}
+            let directB = Direct{{suffix}}{Number: 22}
+            let directValues = Dictionary[Direct{{suffix}}, int32]()
+            directValues[directA] = 11
+            directValues[directB] = 22
+            Console.WriteLine(String.Format("DIRECT-11-{0}-{1}-{2}", directValues.Count, directA.Equals(directB), directA))
+
+            let inheritedA = Inherited{{suffix}}()
+            let inheritedB = Inherited{{suffix}}()
+            let inheritedValues = Dictionary[Inherited{{suffix}}, int32]()
+            inheritedValues[inheritedA] = 11
+            inheritedValues[inheritedB] = 33
+            Console.WriteLine(String.Format("INHERITED-33-{0}-{1}-{2}", inheritedValues.Count, inheritedA.Equals(inheritedB), inheritedA))
+
+            let derivedA = MostDerived{{suffix}}()
+            let derivedB = MostDerived{{suffix}}()
+            let derivedValues = Dictionary[MostDerived{{suffix}}, int32]()
+            derivedValues[derivedA] = 11
+            derivedValues[derivedB] = 44
+            Console.WriteLine(String.Format("DERIVED-44-{0}-{1}-{2}", derivedValues.Count, derivedA.Equals(derivedB), derivedA))
+
+            Console.WriteLine(String.Format("PLAIN-22-AGAIN-{0}", plainA.Equals(plainB)))
+            """;
+
+        var emitted = await RunDriverAsync(source, suffix + "Emit", "gsc-emit");
+        Assert.Equal(
+            """
+            PLAIN-22-2-False
+            DIRECT-11-1-True-DIRECT-11
+            INHERITED-33-1-True-BASE-33
+            DERIVED-44-2-False-DERIVED-44
+            PLAIN-22-AGAIN-False
+            """.Replace("\r\n", "\n", StringComparison.Ordinal) + "\n",
+            emitted);
+        Assert.Equal(emitted, Evaluate(source));
+        Assert.Equal(emitted, await RunDriverAsync(source, suffix + "Evaluate", "gsc-evaluate"));
+        Assert.Equal(emitted, await RunDriverAsync(source, suffix + "Gsi", "gsi"));
+    }
+
+    [Fact]
     public void GenericInterfaceOperatorNestedAndSharedShapes_DispatchOverrides()
     {
         const string Source = """


### PR DESCRIPTION
## Summary

- Build and cache one BCL override map per exact source `StructSymbol` for each evaluator.
- Omit the `StructValue` override dispatcher entirely when the map is empty.
- Add a direct-evaluator correctness pin plus the bare `gsc`, emitted `gsc /out:`, and `gsi` driver matrix for no override, direct override, inherited override, and most-derived replacement cases.

Fixes #3135

## Cache identity and lifetime

The outer key is the exact `StructSymbol` object. Symbols use reference identity, so constructed generic types do not share entries with their definition or another construction. Imported CLR objects do not enter the `StructValue` path. The cache belongs to one evaluator and therefore cannot outlive or cross bound programs. The inner key is the external root `MethodInfo` used by the existing dispatcher. Derived-to-base traversal with `TryAdd` preserves the most-derived override.

## Measurement

Current `gsi file.gs` executes through the emitter after #3182, so it no longer measures this evaluator path. I used a minimal process-isolated evaluator harness against exact trees `81e6deab` (base) and `4279f6fc` (cache production change), with 200,000 inserts and 200,000 lookups. Ten alternating rounds were measured after two warmups; every process ran in a newly asserted-empty directory and printed `200000`.

| tree | median startup | median total | median work |
|---|---:|---:|---:|
| base | 126.413 ms | 1186.651 ms | 1058.538 ms |
| cache | 127.717 ms | 1183.060 ms | 1047.737 ms |

Ratio of median work: **1.010×**. Median paired ratio: **1.006×**. Thus the reported 1.8× premise is substantially overstated on current main; the cache produces a small measured improvement.

## Correctness

All paths produce:

```text
PLAIN-22-2-False
DIRECT-11-1-True-DIRECT-11
INHERITED-33-1-True-BASE-33
DERIVED-44-2-False-DERIVED-44
PLAIN-22-AGAIN-False
```

Checked through direct evaluator, bare `gsc`, `gsc /out:` plus loaded/executed assembly, and `gsi`.

Product mutations against `Issue3135_OverrideCacheSeparatesTypesMethodsAndInheritedSlots`:

- Replacing derived-first `TryAdd` with assignment failed: expected `DERIVED-44-2-False-DERIVED-44`, got `DERIVED-44-1-False-BASE-33` (`rc=1`).
- Inverting the empty-map fast path failed: direct overrides stopped dispatching (`rc=1`).
- Main production code with the new test retained passed (`rc=0`).

## Validation

`GSharp.sln` enumerates nine test projects, the same source used by `build/generate-ci-test-matrix.py`. All nine ran unfiltered; counts below are executed tests, not `--list-tests` output:

- Compiler.Tests: 4260 passed
- Core.Tests: 7128 passed, 1 skipped
- Extensions.Tests: 104 passed
- InternalAnalyzers.Tests: 9 passed
- Interpreter.Tests: 1395 passed
- LanguageServer.Tests: 462 passed
- Sdk.Tests: 59 passed
- Cs2Gs.Tests: 1907 passed
- GSharp.GeneratorHost.Tests: 31 passed

Total: **15,355 passed, 1 skipped, 0 failed**.

**Correction addendum:** the earlier PR body incorrectly marked Sdk.Tests as out of bounds based on a documentation comment. Structural inspection shows its relevant test calls `Program.Main` in-process and does not spawn `dotnet build` or write the shared SDK package cache. The unfiltered project run passed 59/59.

Rebased onto live main `917677ec934a48147efbb03327bc89269e8b577a`. The merge-tree result exactly matched the branch tree (`5e14f02603faca3eef1e42d8917aac36e9bd3230`). `dotnet build GSharp.sln -c Release -m:1`: `BUILD_RC=0`, 0 warnings, 0 errors. Core copies under Core, Compiler, and Repl were nonzero, byte-identical, and had equal epoch-second mtimes.

`StructValue.Equals` and `StructValue.GetHashCode` were not modified.