### PR TITLE
Fix evaluator object reference equality

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
@@ -672,8 +672,20 @@ public sealed record BoundBinaryOperator
         list.Add(new BoundBinaryOperator(SyntaxKind.BangEqualsToken, BoundBinaryOperatorKind.NotEquals, TypeSymbol.String, TypeSymbol.Bool));
 
         // ADR-0045: `object` reference equality.
-        list.Add(new BoundBinaryOperator(SyntaxKind.EqualsEqualsToken, BoundBinaryOperatorKind.Equals, TypeSymbol.Object, TypeSymbol.Bool));
-        list.Add(new BoundBinaryOperator(SyntaxKind.BangEqualsToken, BoundBinaryOperatorKind.NotEquals, TypeSymbol.Object, TypeSymbol.Bool));
+        list.Add(new BoundBinaryOperator(
+            SyntaxKind.EqualsEqualsToken,
+            BoundBinaryOperatorKind.Equals,
+            TypeSymbol.Object,
+            TypeSymbol.Object,
+            TypeSymbol.Bool,
+            isReferenceEquality: true));
+        list.Add(new BoundBinaryOperator(
+            SyntaxKind.BangEqualsToken,
+            BoundBinaryOperatorKind.NotEquals,
+            TypeSymbol.Object,
+            TypeSymbol.Object,
+            TypeSymbol.Bool,
+            isReferenceEquality: true));
 
         return list.ToArray();
     }

--- a/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
@@ -45,8 +45,7 @@ public sealed record BoundBinaryOperator
         TypeSymbol leftType,
         TypeSymbol rightType,
         TypeSymbol resultType,
-        bool isReferenceEquality = false,
-        bool isBoxedValueEquality = false)
+        bool isReferenceEquality = false)
     {
         SyntaxKind = syntaxKind;
         Kind = kind;
@@ -54,7 +53,6 @@ public sealed record BoundBinaryOperator
         RightType = rightType;
         Type = resultType;
         IsReferenceEquality = isReferenceEquality;
-        IsBoxedValueEquality = isBoxedValueEquality;
     }
 
     /// <summary>
@@ -84,17 +82,6 @@ public sealed record BoundBinaryOperator
 
     /// <summary>Gets a value indicating whether equality compares reference identity.</summary>
     internal bool IsReferenceEquality { get; }
-
-    /// <summary>
-    /// Gets a value indicating whether equality compares boxed values by VALUE
-    /// (dispatching through <c>Object.Equals(object, object)</c>) rather than by
-    /// box reference identity. Set only by the Issue #1923 boxed-constant
-    /// equality seam (<c>answer == 42</c> where <c>answer</c> is typed
-    /// <c>object</c> and the other operand boxes in): the bound semantics
-    /// compare the boxed value, so the emitter must not fall through to the
-    /// reference-identity <c>ceq</c> tail (issue #3224).
-    /// </summary>
-    internal bool IsBoxedValueEquality { get; }
 
     /// <summary>
     /// Binds a syntax kind and a type symbol to the corresponding bound binary operator, or
@@ -391,26 +378,6 @@ public sealed record BoundBinaryOperator
             ? BoundBinaryOperatorKind.Equals
             : BoundBinaryOperatorKind.NotEquals;
         return new BoundBinaryOperator(syntaxKind, kind, leftType, rightType, TypeSymbol.Bool, isReferenceEquality: true);
-    }
-
-    /// <summary>
-    /// Issue #3224: builds the boxed-value equality (<c>==</c> / <c>!=</c>)
-    /// operator the Issue #1923 boxed-constant seam binds when exactly one
-    /// operand is statically <c>object</c> and the other side boxes in via an
-    /// implicit conversion (<c>answer == 42</c> where <c>answer</c> is typed
-    /// <c>object</c>). Both operands are <c>object</c>-typed after the boxing
-    /// conversion and compare by VALUE — the evaluator's historical semantics —
-    /// so the emitter dispatches through <c>Object.Equals(object, object)</c>
-    /// instead of the reference-identity <c>ceq</c> tail.
-    /// </summary>
-    /// <param name="syntaxKind">The <c>==</c> or <c>!=</c> token.</param>
-    /// <returns>The boxed-value equality operator over <c>object</c> operands.</returns>
-    internal static BoundBinaryOperator MakeBoxedValueEquality(SyntaxKind syntaxKind)
-    {
-        var kind = syntaxKind == SyntaxKind.EqualsEqualsToken
-            ? BoundBinaryOperatorKind.Equals
-            : BoundBinaryOperatorKind.NotEquals;
-        return new BoundBinaryOperator(syntaxKind, kind, TypeSymbol.Object, TypeSymbol.Object, TypeSymbol.Bool, isReferenceEquality: false, isBoxedValueEquality: true);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -2044,11 +2044,7 @@ internal sealed partial class ExpressionBinder
         // 'int32'" even though C# boxes the value-type operand and compares
         // by reference identity. When exactly one side is `object` and the
         // OTHER side has an implicit (boxing) conversion to `object`, box it
-        // and bind the boxed-VALUE equality operator: the bound semantics
-        // compare the boxed value (the evaluator's historical behavior), so
-        // the emitter must dispatch through `Object.Equals(object, object)`
-        // rather than compare two distinct box references with `ceq`, which
-        // silently yielded `false` for equal values (issue #3224).
+        // and rebind the homogeneous `object == object` operator.
         if (boundOperator == null && (operatorKind == SyntaxKind.EqualsEqualsToken || operatorKind == SyntaxKind.BangEqualsToken))
         {
             if (boundLeft.Type == TypeSymbol.Object
@@ -2056,14 +2052,14 @@ internal sealed partial class ExpressionBinder
                 && Conversion.Classify(boundRight.Type, TypeSymbol.Object).IsImplicit)
             {
                 boundRight = conversions.BindConversion(rightLocation, boundRight, TypeSymbol.Object);
-                boundOperator = BoundBinaryOperator.MakeBoxedValueEquality(operatorKind);
+                boundOperator = BoundBinaryOperator.Bind(operatorKind, boundLeft.Type, boundRight.Type);
             }
             else if (boundRight.Type == TypeSymbol.Object
                 && boundLeft.Type != TypeSymbol.Object
                 && Conversion.Classify(boundLeft.Type, TypeSymbol.Object).IsImplicit)
             {
                 boundLeft = conversions.BindConversion(leftLocation, boundLeft, TypeSymbol.Object);
-                boundOperator = BoundBinaryOperator.MakeBoxedValueEquality(operatorKind);
+                boundOperator = BoundBinaryOperator.Bind(operatorKind, boundLeft.Type, boundRight.Type);
             }
         }
 

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
@@ -709,30 +709,6 @@ internal sealed partial class MethodBodyEmitter
             return;
         }
 
-        // Issue #3224: the Issue #1923 boxed-constant equality seam
-        // (`answer == 42` where `answer` is typed `object` and the other
-        // operand boxes in). The bound semantics compare the boxed VALUE —
-        // the binder marks the operator with IsBoxedValueEquality — so
-        // dispatch through static `Object.Equals(object, object)` (which
-        // routes to the boxed value's Equals override and handles nil on
-        // either side). Falling through to the bottom-of-method `ceq` tail
-        // compared two distinct box references and silently yielded `false`
-        // for equal values. Both operands are already `object`-typed after
-        // the seam's boxing conversion, so no `box` is needed here.
-        if (b.Op.IsBoxedValueEquality)
-        {
-            this.EmitExpression(b.Left);
-            this.EmitExpression(b.Right);
-            this.il.Call(this.outer.wellKnown.GetObjectStaticEqualsReference());
-            if (b.Op.Kind == BoundBinaryOperatorKind.NotEquals)
-            {
-                this.il.LoadConstantI4(0);
-                this.il.OpCode(ILOpCode.Ceq);
-            }
-
-            return;
-        }
-
         // String concatenation / equality go through BCL helpers. Issue #1927:
         // `+` also accepts `string?` mixed with `string` on either/both sides
         // (the operator table binds that combination too); at runtime a

--- a/src/Core/CodeAnalysis/Evaluator.Calls.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Calls.cs
@@ -672,11 +672,11 @@ public sealed partial class Evaluator
             || (node.Type?.ClrType != null && !node.Type.ClrType.IsValueType))
         {
             // Reference upcast (class → implemented interface, derived class
-            // → base class, or any → object). Also covers issue #521: a CLR
-            // class or interface widening. The interpreter stores instances
-            // as boxed objects, so the upcast is a no-op at runtime — only
-            // the bind-time static type changes.
-            return value;
+            // → base class, or any → object). User value structs take one
+            // boxed snapshot; reference values keep their existing identity.
+            return value is StructValue { IsBoxed: false, StructType.IsClass: false } structValue
+                ? structValue.Box()
+                : value;
         }
         else if (node.Type?.ClrType != null && IsSupportedNumericClrType(node.Type.ClrType))
         {
@@ -1669,9 +1669,9 @@ public sealed partial class Evaluator
 
     private void Assign(VariableSymbol variable, object value)
     {
-        // Value-typed structs are copied on assignment (Go semantics).
-        // Class types (Phase 3.B.3) are reference types — share the instance.
-        if (value is StructValue sv && !sv.StructType.IsClass)
+        // Unboxed value structs copy on assignment (Go semantics). Boxes and
+        // class values are references — preserve the existing instance.
+        if (value is StructValue sv && !sv.StructType.IsClass && !sv.IsBoxed)
         {
             value = sv.Copy();
         }

--- a/src/Core/CodeAnalysis/Evaluator.Concurrency.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Concurrency.cs
@@ -369,6 +369,23 @@ public sealed partial class Evaluator
                 {
                     return true;
                 }
+
+                // A boxed G# value retains both user-declared and imported
+                // interface identities through is/as and pattern bindings.
+                if (targetType is InterfaceSymbol targetInterface
+                    && t.Interfaces.Any(iface => iface.SelfAndAllBaseInterfaces().Contains(targetInterface)))
+                {
+                    return true;
+                }
+
+                if (targetType.ClrType is { IsInterface: true } targetClrInterface
+                    && t.ImplementedClrInterfaces.Any(iface =>
+                        iface.ClrType != null
+                        && (ClrTypeUtilities.AreSame(iface.ClrType, targetClrInterface)
+                            || ClrTypeUtilities.ImplementsInterfaceByName(iface.ClrType, targetClrInterface))))
+                {
+                    return true;
+                }
             }
 
             // Issue #319: when a GSharp class carries a CLR backing (because it

--- a/src/Core/CodeAnalysis/Evaluator.Expressions.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Expressions.cs
@@ -117,6 +117,11 @@ public sealed partial class Evaluator
 
     private object EvaluateLiteralExpression(BoundLiteralExpression n)
     {
+        if (n.Type == TypeSymbol.String)
+        {
+            return string.Intern((string)n.Value);
+        }
+
         return n.Value;
     }
 

--- a/src/Core/CodeAnalysis/StructValue.cs
+++ b/src/Core/CodeAnalysis/StructValue.cs
@@ -113,6 +113,9 @@ public sealed class StructValue
     /// </summary>
     public object ClrBacking { get; set; }
 
+    /// <summary>Gets a value indicating whether this value represents a CLR box.</summary>
+    internal bool IsBoxed { get; private set; }
+
     /// <summary>Creates a shallow copy of this struct value (value-semantics).</summary>
     /// <returns>A new instance with the same fields.</returns>
     public StructValue Copy()
@@ -141,7 +144,9 @@ public sealed class StructValue
         var copy = new ConcurrentDictionary<string, object>();
         foreach (var kvp in Fields)
         {
-            copy[kvp.Key] = kvp.Value is StructValue inner ? inner.Copy() : kvp.Value;
+            copy[kvp.Key] = kvp.Value is StructValue { IsBoxed: false, StructType.IsClass: false } inner
+                ? inner.Copy()
+                : kvp.Value;
         }
 
         return new StructValue(StructType, copy, objectOverrideDispatcher)
@@ -240,6 +245,15 @@ public sealed class StructValue
 
         sb.Append(')');
         return sb.ToString();
+    }
+
+    /// <summary>Creates an identity-preserving boxed copy of this struct value.</summary>
+    /// <returns>A boxed copy.</returns>
+    internal StructValue Box()
+    {
+        var box = Copy();
+        box.IsBoxed = true;
+        return box;
     }
 
     internal static bool TryGetStorageSize(StructSymbol structType, out int size)

--- a/test/Compiler.Tests/Emit/Issue3224BoxedConstantEqualityEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3224BoxedConstantEqualityEmitTests.cs
@@ -12,18 +12,13 @@ namespace GSharp.Compiler.Tests.Emit;
 /// <summary>
 /// Issue #3224: equality between an <c>object</c>-typed operand and a value
 /// that boxes in (the Issue #1923 boxed-constant seam, <c>answer == 42</c>
-/// where <c>answer</c> is typed <c>object</c>) compares the boxed VALUE.
-/// The emitted comparison previously fell through to the reference-identity
-/// <c>ceq</c> tail and compared two distinct box references — silently
-/// yielding <c>false</c> where the bound semantics (and the evaluator) said
-/// <c>true</c>. The binder now marks the seam's operator as boxed-value
-/// equality and the emitter dispatches through
-/// <c>Object.Equals(object, object)</c>.
+/// where <c>answer</c> is typed <c>object</c>) uses ADR-0045 reference
+/// equality. Each value operand boxes independently before the comparison.
 /// </summary>
 public sealed class Issue3224BoxedConstantEqualityEmitTests
 {
     [Fact]
-    public void BoxedConstantEquality_RunsAndVerifies()
+    public void BoxedConstantReferenceEquality_RunsAndVerifies()
     {
         const string Source = """
             package Issue3224
@@ -48,7 +43,7 @@ public sealed class Issue3224BoxedConstantEqualityEmitTests
             """;
 
         Assert.Equal(
-            "True\nFalse\nFalse\nTrue\nTrue\nTrue\nbranch\n",
+            "False\nTrue\nFalse\nTrue\nFalse\nTrue\n",
             CompileVerifyAndRun(Source));
     }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1923PatternMatchingSeamsTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1923PatternMatchingSeamsTests.cs
@@ -17,7 +17,9 @@ namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 /// <see cref="GSharp.Core.CodeAnalysis.Binding.BoundBinaryOperator"/> only
 /// registers the homogeneous <c>object == object</c> arm; there was no
 /// boxing-conversion adaptation for a non-<c>object</c> operand, unlike the
-/// existing integer-literal / numeric-widening adaptations.</description></item>
+/// existing integer-literal / numeric-widening adaptations. The comparison
+/// uses object reference identity, so separately boxed equal values are not
+/// equal.</description></item>
 /// <item><description>A property pattern (<c>{ City: "x" }</c>) against a
 /// nullable CLASS-typed subject (<c>Address?</c>) previously reported GS0172
 /// because <c>PatternBinder.BindPropertyPattern</c> required the discriminant
@@ -41,7 +43,7 @@ namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 public class Issue1923PatternMatchingSeamsTests
 {
     [Fact]
-    public void BoxedConstantEquality_BindsAgainstObjectTypedVariable()
+    public void BoxedConstantEquality_UsesObjectReferenceIdentity()
     {
         var source = @"
 let answer object = 42
@@ -52,7 +54,7 @@ answer == 42
         // previously compared two distinct box references and yielded false.
         var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
-        Assert.Equal(true, result.Value);
+        Assert.Equal(false, result.Value);
     }
 
     [Fact]

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1923PatternMatchingSeamsTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1923PatternMatchingSeamsTests.cs
@@ -49,9 +49,8 @@ public class Issue1923PatternMatchingSeamsTests
 let answer object = 42
 answer == 42
 ";
-        // Issue #3224: the emitted comparison dispatches through
-        // Object.Equals (value semantics), matching the evaluator; it
-        // previously compared two distinct box references and yielded false.
+        // ADR-0045: the literal boxes into a new object, so reference
+        // equality against the existing box is false.
         var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
         Assert.Equal(false, result.Value);

--- a/test/Interpreter.Tests/Issue2896StructObjectOverrideTests.cs
+++ b/test/Interpreter.Tests/Issue2896StructObjectOverrideTests.cs
@@ -87,10 +87,10 @@ public class Issue2896StructObjectOverrideTests
     }
 
     [Theory]
-    [InlineData(false, "gsc-evaluate")]
+    [InlineData(false, "gsc-script")]
     [InlineData(false, "gsc-emit")]
     [InlineData(false, "gsi")]
-    [InlineData(true, "gsc-evaluate")]
+    [InlineData(true, "gsc-script")]
     [InlineData(true, "gsc-emit")]
     [InlineData(true, "gsi")]
     public async Task ClassObjectOverrideChain_UsesMostDerivedOverrideAcrossDrivers(
@@ -138,14 +138,21 @@ public class Issue2896StructObjectOverrideTests
         var emitted = await RunDriverAsync(source, suffix + "Emit", "gsc-emit");
 
         AssertIssue3134EmittedSemantics(surface, emitted);
-        Assert.Equal(emitted, await RunDriverAsync(source, suffix + "Evaluate", "gsc-evaluate"));
+        Assert.Equal(emitted, await RunDriverAsync(source, suffix + "Evaluate", "gsc-script"));
         Assert.Equal(emitted, await RunDriverAsync(source, suffix + "Gsi", "gsi"));
     }
 
     [Theory]
+    [InlineData("objectStringLiterals", "ObjectStringLiterals|True|True|False|False|False|True")]
+    [InlineData("objectLiteralAndComputedString", "ObjectLiteralAndComputedString|False|True|False|True|False|True")]
     [InlineData("objectStrings", "ObjectStrings|False|True|False|True|False|True")]
     [InlineData("objectClass", "ObjectClass|False|True|False|True|False|True")]
     [InlineData("objectBoxedInts", "ObjectBoxedInts|False|True|False|True|False|True")]
+    [InlineData("objectBoxedStruct", "ObjectBoxedStruct|False|True|False|True|False|True")]
+    [InlineData("objectBoxedStructClrInterfaceAlias", "ObjectBoxedStructClrInterfaceAlias|False|True|False|True|False|True")]
+    [InlineData("objectBoxedStructInterfaceAlias", "ObjectBoxedStructInterfaceAlias|False|True|False|True|False|True")]
+    [InlineData("objectBoxedStructInCopiedValue", "ObjectBoxedStructInCopiedValue|False|True|False|True|False|True")]
+    [InlineData("objectBoxedEnum", "ObjectBoxedEnum|False|True|False|True|False|True")]
     [InlineData("dataClass", "DataClass|True|True|False|False|False|True")]
     [InlineData("version", "Version|True|True|False|False|False|True")]
     [InlineData("typedStrings", "TypedStrings|True|True|False|False|False|True")]
@@ -159,19 +166,19 @@ public class Issue2896StructObjectOverrideTests
         Assert.All(
             new[]
             {
-                await RunDriverAsync(source, suffix + "Evaluate", "gsc-evaluate"),
+                await RunDriverAsync(source, suffix + "Evaluate", "gsc-script"),
                 await RunDriverAsync(source, suffix + "Gsi", "gsi"),
-                Evaluate(source),
+                EvaluateWithEvaluator(source),
                 EvaluateWithSessionEngine(source),
             },
             output => Assert.Equal(emitted, output));
     }
 
     [Theory]
-    [InlineData(false, "gsc-evaluate")]
+    [InlineData(false, "gsc-script")]
     [InlineData(false, "gsc-emit")]
     [InlineData(false, "gsi")]
-    [InlineData(true, "gsc-evaluate")]
+    [InlineData(true, "gsc-script")]
     [InlineData(true, "gsc-emit")]
     [InlineData(true, "gsi")]
     public async Task ImplicitBclToString_DepthFourOverrideChain_UsesMostDerivedOverrideAcrossDrivers(
@@ -605,9 +612,42 @@ public class Issue2896StructObjectOverrideTests
 
             data class DataClass{{suffix}}(Number int32) {
             }
+
+            interface Marker{{suffix}} {
+            }
+
+            struct Value{{suffix}} : Marker{{suffix}}, IEquatable[Value{{suffix}}] {
+                var Number int32
+                func Equals(other Value{{suffix}}) bool -> Number == other.Number
+            }
+
+            struct Holder{{suffix}} {
+                var Item object
+            }
+
+            enum Shade{{suffix}} {
+                Light,
+                Dark
+            }
             """;
         var (label, setup) = specimen switch
         {
+            "objectStringLiterals" => (
+                "ObjectStringLiterals",
+                """
+                let a object = "hello"
+                let b object = "hello"
+                let c object = a
+                let other object = "world"
+                """),
+            "objectLiteralAndComputedString" => (
+                "ObjectLiteralAndComputedString",
+                """
+                let a object = "hello"
+                let b object = String.Concat("hel", "lo")
+                let c object = a
+                let other object = "world"
+                """),
             "objectStrings" => (
                 "ObjectStrings",
                 """
@@ -631,6 +671,48 @@ public class Issue2896StructObjectOverrideTests
                 let b object = 5
                 let c object = a
                 let other object = 6
+                """),
+            "objectBoxedStruct" => (
+                "ObjectBoxedStruct",
+                $$"""
+                let a object = Value{{suffix}}{Number: 5}
+                let b object = Value{{suffix}}{Number: 5}
+                let c object = a
+                let other object = Value{{suffix}}{Number: 6}
+                """),
+            "objectBoxedStructClrInterfaceAlias" => (
+                "ObjectBoxedStructClrInterfaceAlias",
+                $$"""
+                let a object = Value{{suffix}}{Number: 5}
+                let b object = Value{{suffix}}{Number: 5}
+                let c = a as IEquatable[Value{{suffix}}]
+                let other object = Value{{suffix}}{Number: 6}
+                """),
+            "objectBoxedStructInterfaceAlias" => (
+                "ObjectBoxedStructInterfaceAlias",
+                $$"""
+                let a object = Value{{suffix}}{Number: 5}
+                let b object = Value{{suffix}}{Number: 5}
+                let c = a as Marker{{suffix}}
+                let other object = Value{{suffix}}{Number: 6}
+                """),
+            "objectBoxedStructInCopiedValue" => (
+                "ObjectBoxedStructInCopiedValue",
+                $$"""
+                let a object = Value{{suffix}}{Number: 5}
+                let holder = Holder{{suffix}}{Item: a}
+                let copy = holder
+                let b object = Value{{suffix}}{Number: 5}
+                let c object = copy.Item
+                let other object = Value{{suffix}}{Number: 6}
+                """),
+            "objectBoxedEnum" => (
+                "ObjectBoxedEnum",
+                $$"""
+                let a object = Shade{{suffix}}.Dark
+                let b object = Shade{{suffix}}.Dark
+                let c object = a
+                let other object = Shade{{suffix}}.Light
                 """),
             "dataClass" => (
                 "DataClass",
@@ -717,7 +799,7 @@ public class Issue2896StructObjectOverrideTests
     public static IEnumerable<object[]> ImplicitBclOverrideCases()
     {
         var surfaces = new[] { "dictionary", "hashSet", "listContains", "format" };
-        var drivers = new[] { "gsc-evaluate", "gsc-emit", "gsi" };
+        var drivers = new[] { "gsc-script", "gsc-emit", "gsi" };
         foreach (var surface in surfaces)
         {
             foreach (var insideFunction in new[] { false, true })
@@ -827,7 +909,7 @@ public class Issue2896StructObjectOverrideTests
 
             return driver switch
             {
-                "gsc-evaluate" => RunCompilerEvaluation(sourcePath),
+                "gsc-script" => RunCompilerEvaluation(sourcePath),
                 "gsc-emit" => await RunEmittedBinaryAsync(directory, sourcePath, suffix),
                 "gsi" => RunInterpreter(sourcePath),
                 _ => throw new ArgumentOutOfRangeException(nameof(driver), driver, null),

--- a/test/Interpreter.Tests/Issue2896StructObjectOverrideTests.cs
+++ b/test/Interpreter.Tests/Issue2896StructObjectOverrideTests.cs
@@ -13,6 +13,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Tests;
+using GSharp.Repl.Engine;
 using Xunit;
 using CompilerProgram = GSharp.Compiler.Program;
 
@@ -139,6 +140,31 @@ public class Issue2896StructObjectOverrideTests
         AssertIssue3134EmittedSemantics(surface, emitted);
         Assert.Equal(emitted, await RunDriverAsync(source, suffix + "Evaluate", "gsc-evaluate"));
         Assert.Equal(emitted, await RunDriverAsync(source, suffix + "Gsi", "gsi"));
+    }
+
+    [Theory]
+    [InlineData("objectStrings", "ObjectStrings|False|True|False|True|False|True")]
+    [InlineData("objectClass", "ObjectClass|False|True|False|True|False|True")]
+    [InlineData("objectBoxedInts", "ObjectBoxedInts|False|True|False|True|False|True")]
+    [InlineData("dataClass", "DataClass|True|True|False|False|False|True")]
+    [InlineData("version", "Version|True|True|False|False|False|True")]
+    [InlineData("typedStrings", "TypedStrings|True|True|False|False|False|True")]
+    public async Task Issue3173_ObjectReferenceEqualityMatchesEmitter(string specimen, string expected)
+    {
+        var suffix = Guid.NewGuid().ToString("N");
+        var source = BuildIssue3173Source(specimen, suffix);
+        var emitted = await RunDriverAsync(source, suffix + "Emit", "gsc-emit");
+
+        Assert.Equal(expected + "\n", emitted);
+        Assert.All(
+            new[]
+            {
+                await RunDriverAsync(source, suffix + "Evaluate", "gsc-evaluate"),
+                await RunDriverAsync(source, suffix + "Gsi", "gsi"),
+                Evaluate(source),
+                EvaluateWithSessionEngine(source),
+            },
+            output => Assert.Equal(emitted, output));
     }
 
     [Theory]
@@ -564,6 +590,95 @@ public class Issue2896StructObjectOverrideTests
         };
 
         Assert.Equal(expected, output.Split('\n', StringSplitOptions.RemoveEmptyEntries));
+    }
+
+    private static string BuildIssue3173Source(string specimen, string suffix)
+    {
+        var declarations = $$"""
+            package Issue3173{{suffix}}
+            import System
+
+            class ClassWithOverrides{{suffix}} {
+                var Number int32
+                override func Equals(value object) bool -> true
+            }
+
+            data class DataClass{{suffix}}(Number int32) {
+            }
+            """;
+        var (label, setup) = specimen switch
+        {
+            "objectStrings" => (
+                "ObjectStrings",
+                """
+                let a object = String.Concat("he", "llo")
+                let b object = String.Concat("hel", "lo")
+                let c object = a
+                let other object = String.Concat("wor", "ld")
+                """),
+            "objectClass" => (
+                "ObjectClass",
+                $$"""
+                let a object = ClassWithOverrides{{suffix}}{Number: 5}
+                let b object = ClassWithOverrides{{suffix}}{Number: 5}
+                let c object = a
+                let other object = ClassWithOverrides{{suffix}}{Number: 6}
+                """),
+            "objectBoxedInts" => (
+                "ObjectBoxedInts",
+                """
+                let a object = 5
+                let b object = 5
+                let c object = a
+                let other object = 6
+                """),
+            "dataClass" => (
+                "DataClass",
+                $$"""
+                let a = DataClass{{suffix}}(5)
+                let b = DataClass{{suffix}}(5)
+                let c = a
+                let other = DataClass{{suffix}}(6)
+                """),
+            "version" => (
+                "Version",
+                """
+                let a = Version(1, 2, 3)
+                let b = Version(1, 2, 3)
+                let c = a
+                let other = Version(2, 0, 0)
+                """),
+            "typedStrings" => (
+                "TypedStrings",
+                """
+                let a = String.Concat("he", "llo")
+                let b = String.Concat("hel", "lo")
+                let c = a
+                let other = String.Concat("wor", "ld")
+                """),
+            _ => throw new ArgumentOutOfRangeException(nameof(specimen), specimen, null),
+        };
+
+        return declarations + "\n" + setup + "\n" + $$"""
+            Console.WriteLine(String.Format(
+                "{{label}}|{0}|{1}|{2}|{3}|{4}|{5}",
+                a == b,
+                a == c,
+                a == other,
+                a != b,
+                a != c,
+                a != other))
+            """;
+    }
+
+    private static string EvaluateWithSessionEngine(string source)
+    {
+        var cell = new SessionEngine { CaptureConsole = true }.Evaluate(source);
+        Assert.False(
+            cell.HasError,
+            "gsi evaluator failed:\n" + string.Join("\n", cell.Diagnostics.Select(diagnostic => diagnostic.ToString())));
+        Assert.Equal(string.Empty, cell.StandardError);
+        return cell.Output.Replace("\r\n", "\n", StringComparison.Ordinal);
     }
 
     private static string BuildClassOverrideChainSource(bool insideFunction, string suffix)


### PR DESCRIPTION
## Summary

- make evaluator `object == object` / `!=` use the ADR-0045 reference-equality contract
- preserve CLR-compatible identity for interned string literals and boxed user structs
- preserve boxed aliases through assignment, containing-struct copies, and user/CLR interface casts
- keep mixed `object`/value equality on ADR-0045 reference semantics after #3232 briefly introduced a boxed-value special path
- pin emitted output first, then require `Compilation.EvaluateWithEvaluator` and `SessionEngine` to match it

Closes #3173.

## Root cause

Round 1 correctly exposed reference equality, but the evaluator had not preserved the identities being compared. Equal literal occurrences were separate host strings instead of CLR-interned `ldstr` references, while `StructValue` represented both values and boxes and was copied/re-boxed during conversions and assignments. Interface aliases also failed because evaluator type matching ignored implemented interfaces.

The fix interns literal strings, marks boxed `StructValue` instances, creates one box snapshot on value-to-reference conversion, preserves that box by reference on assignment/copy, and recognizes user/imported interfaces in `MatchesType`.

During the latest-main rebase, #3232 introduced `IsBoxedValueEquality`/`Object.Equals` for `object == int`, contradicting ADR-0045:41-42 and turning the required `False` control back to `True`. This PR removes only that boxed-value special path; #3232's unrelated nil and `!!` fixes remain intact.

## Nine-cell conformance table

| cell | emit | evaluator / `SessionEngine` |
|---|---:|---:|
| `object == 42` | `False` | `False` |
| literal string vs `String.Concat` | `False` | `False` |
| distinct boxed structs `==` | `False` | `False` |
| distinct boxed structs `!=` | `True` | `True` |
| distinct boxed enums `==` | `False` | `False` |
| distinct boxed enums `!=` | `True` | `True` |
| boxed-int alias `a == c` | `True` | `True` |
| two `object` locals holding equal literals | `True` | `True` |
| boxed user-struct alias `a == c` | `True` | `True` |

The original seven corrected cells remain corrected; both round-2 regressions now match emit.

## RED proof

Final tests applied alone to unfixed round-1 head `f2699263`, after rebuilding: **5/13 RED**:

- `objectStringLiterals`
- `objectBoxedStruct`
- `objectBoxedStructInCopiedValue`
- `objectBoxedStructInterfaceAlias`
- `objectBoxedStructClrInterfaceAlias`

For the two reported regressions, emitted/file drivers remained green while both affected in-process surfaces (`Compilation.EvaluateWithEvaluator` and `SessionEngine`) failed. The tree was restored to porcelain-0 and rebuilt before continuing.

## Product mutation results

Each mutant was a condition inversion, applied per hunk, verified with `git diff HEAD` plus `GSharp.Core.dll` md5 movement, and restored by exact source/DLL hash round-trip.

| mutant | result |
|---|---:|
| literal interning condition | 9 RED |
| value-to-reference boxing condition | 3 RED |
| boxed assignment preservation | 1 RED |
| nested boxed-value copy preservation | 1 RED |
| user-interface matching | 1 RED |
| imported CLR-interface matching | 1 RED |
| reference-equality control | 8 RED |
| restore #3232 boxed-value special path | 1 Core RED + 1 emitted/ILVerify RED |

## Validation

Denominator **9**, from `dotnet sln GSharp.sln list` / CI matrix projects.

| project | passed | skipped |
|---|---:|---:|
| Compiler.Tests | 4263 | 0 |
| Core.Tests | 7135 | 1 |
| Extensions.Tests | 104 | 0 |
| InternalAnalyzers.Tests | 9 | 0 |
| Interpreter.Tests | 1490 | 4 |
| LanguageServer.Tests | 462 | 0 |
| Sdk.Tests | 59 | 0 |
| Cs2Gs.Tests | 1907 | 0 |
| GSharp.GeneratorHost.Tests | 31 | 0 |

Total: **15,460 passed, 5 skipped, 0 failed**. This nine-project local run predates later main rebases; current-head targeted validation is below and CI completed with **30 passed, 2 skipped**.

Current head `eb06ce81d` on `origin/main` `5cd0d766a` (#3242 evaluator retirement gate):

- Release solution build: 0 warnings, 0 errors
- issue #3173 matrix: 13/13
- evaluator coverage remains in-process (`Compilation.Evaluate` + `SessionEngine`); no script-mode `--engine evaluator` result used
- issue #1923 controls: 8/8
- issue #3224 emitted/ILVerify control: 1/1
- ILVerify gate: 123/123
- boxed-value product mutant: Core 1/8 RED; emitted control 1/1 RED; source and `GSharp.Core.dll` exact hash round-trip
- `git merge-tree --write-tree origin/main HEAD` exactly equals `HEAD^{tree}` (`2acab6102ef24d2f3e33dad6a9c7f47c17b86598`)





