### PR TITLE
Correct execution engine documentation

### DIFF
--- a/docs/adr/0022-go-chan-select-lowering.md
+++ b/docs/adr/0022-go-chan-select-lowering.md
@@ -11,7 +11,8 @@ Per ADR-0002 (D2) GSharp adopts a **synthesis** concurrency model: a Go-shaped s
 
 At the time of this decision, the interpreter was the project's semantic
 oracle. ADR-0156 later moved production file drivers and the conformance oracle
-to emitted execution. This ADR still documents both backends:
+to emitted execution. The evaluator backend is deprecated and scheduled for
+removal in ADR-0156 Phase 3c. This ADR still documents both backends:
 
 1. The Go-shaped surface the user sees.
 2. The .NET surface the interpreter (and, later, the emitter) lowers to.

--- a/docs/adr/0022-go-chan-select-lowering.md
+++ b/docs/adr/0022-go-chan-select-lowering.md
@@ -9,7 +9,9 @@
 
 Per ADR-0002 (D2) GSharp adopts a **synthesis** concurrency model: a Go-shaped surface (`go`, `chan T`, `<-`, `select`) lowered onto .NET primitives, plus first-class `async`/`await` for direct BCL interop. This ADR fixes the lowering targets and the visible semantics that fall out of those choices, so item-by-item work in 5.3 – 5.7 has a single agreed contract.
 
-The interpreter is the source of truth (per the cross-cutting "authoritative-semantics rule"). This ADR therefore documents both:
+At the time of this decision, the interpreter was the project's semantic
+oracle. ADR-0156 later moved production file drivers and the conformance oracle
+to emitted execution. This ADR still documents both backends:
 
 1. The Go-shaped surface the user sees.
 2. The .NET surface the interpreter (and, later, the emitter) lowers to.

--- a/docs/adr/0040-sequence-type-and-yield.md
+++ b/docs/adr/0040-sequence-type-and-yield.md
@@ -112,7 +112,8 @@ This reuses architectural patterns from the async state-machine pipeline (`Synth
 3. **Interpreter parity**: the interpreter (`Evaluator.cs`) does not gain
    `yield` support in this slice. Iterator functions are emit-only. This is a
    known evaluator gap tracked as #138; ADR-0156 later made emitted execution
-   the production oracle and routed file-mode drivers through it.
+   the production oracle and routed every default driver through it. The
+   evaluator is deprecated and scheduled for removal in Phase 3c.
 
 ## Alternatives considered
 

--- a/docs/adr/0040-sequence-type-and-yield.md
+++ b/docs/adr/0040-sequence-type-and-yield.md
@@ -109,7 +109,10 @@ This reuses architectural patterns from the async state-machine pipeline (`Synth
 
 1. **Async iterator alias**: `IAsyncEnumerable[T]` support shipped in #128 but no `asyncSequence[T]` alias exists yet. ADR-0041 proposes overloading `sequence[T]` in `async` return-type position to mean `IAsyncEnumerable[T]`, in lieu of a separate keyword.
 2. **Try/finally in iterators**: this slice does not support `try`/`finally` within iterator bodies (would require `Dispose()` to resume into finally blocks). A diagnostic is emitted if detected.
-3. **Interpreter parity**: the interpreter (`Evaluator.cs`) does not gain `yield` support in this slice. Iterator functions are emit-only. This is a known gap tracked as #138 — the interpreter is authoritative per `docs/emit-pipeline.md` but iterator state machines are inherently an emit concern.
+3. **Interpreter parity**: the interpreter (`Evaluator.cs`) does not gain
+   `yield` support in this slice. Iterator functions are emit-only. This is a
+   known evaluator gap tracked as #138; ADR-0156 later made emitted execution
+   the production oracle and routed file-mode drivers through it.
 
 ## Alternatives considered
 

--- a/docs/adr/0047-attribute-syntax-and-declaration.md
+++ b/docs/adr/0047-attribute-syntax-and-declaration.md
@@ -165,7 +165,8 @@ The interpreter (`Evaluator`) gains a parallel "attribute table" keyed by GSharp
 This originally followed the project's interpreter-authority convention.
 ADR-0156 later made emitted execution the production oracle; evaluator parity
 remains relevant only while direct `Compilation.Evaluate` consumers and the
-deprecated `gsi --engine evaluator` compatibility path remain.
+deprecated `gsi --engine evaluator` compatibility path remain. Phase 3c
+removes the evaluator.
 
 ### 10. Grammar additions (summary)
 

--- a/docs/adr/0047-attribute-syntax-and-declaration.md
+++ b/docs/adr/0047-attribute-syntax-and-declaration.md
@@ -162,7 +162,10 @@ Extension functions (ADR-0019) lower to a static method on `<Extensions>` with t
 
 The interpreter (`Evaluator`) gains a parallel "attribute table" keyed by GSharp symbol. Each binding records the resolved attribute type, the constructor arguments (as runtime `object?[]`), and the named-arguments dictionary. The interpreter exposes them through the same reflection-shaped facade it already uses for `MethodInfo` / `Type` mirrors — `GetCustomAttributes(typeof(T))` on an interpreter symbol returns the same materialised list the emit path would surface to a runtime caller. Compiler-recognised attributes (§6) are honoured at interpretation time identically to the compiled path: `[Conditional("DEBUG")]` elision, `[Obsolete]` diagnostics, `[EnumeratorCancellation]` threading.
 
-This keeps the ADR-0023 rule that the interpreter is the authoritative semantics for everything the language exposes.
+This originally followed ADR-0023's interpreter-authority rule. ADR-0156 later
+made emitted execution the production oracle; evaluator parity remains relevant
+only while `Compilation.Evaluate` consumers and the default interactive engine
+remain.
 
 ### 10. Grammar additions (summary)
 

--- a/docs/adr/0047-attribute-syntax-and-declaration.md
+++ b/docs/adr/0047-attribute-syntax-and-declaration.md
@@ -162,10 +162,10 @@ Extension functions (ADR-0019) lower to a static method on `<Extensions>` with t
 
 The interpreter (`Evaluator`) gains a parallel "attribute table" keyed by GSharp symbol. Each binding records the resolved attribute type, the constructor arguments (as runtime `object?[]`), and the named-arguments dictionary. The interpreter exposes them through the same reflection-shaped facade it already uses for `MethodInfo` / `Type` mirrors — `GetCustomAttributes(typeof(T))` on an interpreter symbol returns the same materialised list the emit path would surface to a runtime caller. Compiler-recognised attributes (§6) are honoured at interpretation time identically to the compiled path: `[Conditional("DEBUG")]` elision, `[Obsolete]` diagnostics, `[EnumeratorCancellation]` threading.
 
-This originally followed ADR-0023's interpreter-authority rule. ADR-0156 later
-made emitted execution the production oracle; evaluator parity remains relevant
-only while `Compilation.Evaluate` consumers and the default interactive engine
-remain.
+This originally followed the project's interpreter-authority convention.
+ADR-0156 later made emitted execution the production oracle; evaluator parity
+remains relevant only while direct `Compilation.Evaluate` consumers and the
+deprecated `gsi --engine evaluator` compatibility path remain.
 
 ### 10. Grammar additions (summary)
 

--- a/docs/adr/0068-deinit-destructor-support.md
+++ b/docs/adr/0068-deinit-destructor-support.md
@@ -115,7 +115,7 @@ changed which invocations use that backend. Current routing is:
 | `gsc /out:program.dll file.gs`, then run the assembly | emit to file, then CLR host | real CLR finalizer; no GS0510 |
 | `gsi file.gs` | emit to memory, then `EmittedProgramHost.Run` | real CLR finalizer; no GS0510 |
 | interactive `gsi` (default) | `EmittedSessionEngine` | real CLR finalizer; no GS0510 |
-| interactive `gsi --engine evaluator` | `SessionEngine` → `Compilation.Evaluate` | skips the body; GS0510 once per declaring class |
+| interactive `gsi --engine evaluator` (deprecated; removed in Phase 3c) | `SessionEngine` → `Compilation.Evaluate` | skips the body; GS0510 once per declaring class |
 
 The old two-column `gsc`/`gsi` table made object reachability appear to be the
 discriminating axis. It is not. Driving the legacy evaluator-backed
@@ -173,4 +173,5 @@ Two new diagnostics are allocated:
 
 The `deinit` language and emission design remain accepted. ADR-0156 partially
 supersedes only this ADR's original driver-boundary model: all default drivers
-now emit, while the evaluator compatibility path retains GS0510.
+now emit, while the deprecated evaluator compatibility path retains GS0510
+until its Phase 3c removal.

--- a/docs/adr/0068-deinit-destructor-support.md
+++ b/docs/adr/0068-deinit-destructor-support.md
@@ -114,11 +114,11 @@ changed which invocations use that backend. Current routing is:
 | bare `gsc file.gs` | emit to memory, then `EmittedProgramHost.Run` | real CLR finalizer; no GS0510 |
 | `gsc /out:program.dll file.gs`, then run the assembly | emit to file, then CLR host | real CLR finalizer; no GS0510 |
 | `gsi file.gs` | emit to memory, then `EmittedProgramHost.Run` | real CLR finalizer; no GS0510 |
-| interactive `gsi` (default) | `SessionEngine` → `Compilation.Evaluate` | skips the body; GS0510 once per declaring class |
-| interactive `gsi --engine emit` | `EmittedSessionEngine` | real CLR finalizer; no GS0510 |
+| interactive `gsi` (default) | `EmittedSessionEngine` | real CLR finalizer; no GS0510 |
+| interactive `gsi --engine evaluator` | `SessionEngine` → `Compilation.Evaluate` | skips the body; GS0510 once per declaring class |
 
 The old two-column `gsc`/`gsi` table made object reachability appear to be the
-discriminating axis. It is not. Driving the default interactive
+discriminating axis. It is not. Driving the legacy evaluator-backed
 `SessionEngine` across the old rows produces the same boundary regardless of
 liveness:
 
@@ -133,6 +133,13 @@ lifetime to the CLR; the tree evaluator has no emitted `Finalize` override and
 does not invent scope-exit cleanup. GS0510 remains a warning on that evaluator
 surface because the program can complete while omitting a nondeterministic
 GC-scheduled side effect.
+
+Matching CLR behavior requires tying finalization to `StructValue` lifetime
+and re-entering `Evaluator` from a finalizer thread, risking shutdown deadlock
+and timing-dependent output that golden-sample comparison cannot pin. In
+contrast, unsafe storage and P/Invoke boundaries are errors because interpreted
+execution cannot proceed correctly without emitted storage or would fabricate a
+deterministic native return value.
 
 ## Considered alternatives
 
@@ -165,5 +172,5 @@ Two new diagnostics are allocated:
 ## Status
 
 The `deinit` language and emission design remain accepted. ADR-0156 partially
-supersedes only this ADR's original driver-boundary model: all file-mode
-drivers now emit, while the default interactive evaluator retains GS0510.
+supersedes only this ADR's original driver-boundary model: all default drivers
+now emit, while the evaluator compatibility path retains GS0510.

--- a/docs/adr/0068-deinit-destructor-support.md
+++ b/docs/adr/0068-deinit-destructor-support.md
@@ -1,9 +1,9 @@
 # ADR-0068: `deinit` destructor support for classes
 
-- **Status**: Accepted
+- **Status**: Partially superseded by [ADR-0156](0156-gsi-emit-to-memory-execution.md) (execution-engine boundary only; the `deinit` language and emission design remain accepted)
 - **Date**: 2026-06-11
 - **Phase**: Phase 9 — language depth / class destruction
-- **Related**: ADR-0003 (OO surface), ADR-0017 (method virtuality / `open`), ADR-0065 (class initializers and base invocation), ADR-0067 (fields require `var`/`let`), issue [#698](https://github.com/DavidObando/gsharp/issues/698)
+- **Related**: ADR-0003 (OO surface), ADR-0017 (method virtuality / `open`), ADR-0065 (class initializers and base invocation), ADR-0067 (fields require `var`/`let`), [ADR-0156](0156-gsi-emit-to-memory-execution.md) (execution-engine migration), issue [#698](https://github.com/DavidObando/gsharp/issues/698)
 
 ## Context
 
@@ -104,33 +104,35 @@ The compiler does **not** auto-generate either side of this pattern. It does not
 
 The `deinit` member is not a callable name. There is no `obj.deinit()`, no `this.deinit()`, and no `init(args)`-style delegation form. The synthesized `Finalize` method exists in metadata so the CLR runtime can invoke it, but the user-facing G# binder does not surface `deinit` as a member lookup name. Attempting `obj.deinit()` produces the standard "member not found" diagnostic.
 
-### Interpreter boundary
+### Execution-engine boundary (amended by ADR-0156)
 
-`deinit` requires CLR GC finalization and therefore runs only in emitted code.
-The interpreter has no emitted class with a `Finalize` override, and running
-the body at scope exit would incorrectly finalize objects that remain
-reachable. Interpreted execution reports warning **GS0510** once for each
-declaring class and skips its deinitializer. Compile with `gsc` when program
-behavior depends on finalization.
+`deinit` requires an emitted CLR type with a `Finalize` override. ADR-0156
+changed which invocations use that backend. Current routing is:
 
-Measurements against emitted CLR behavior establish the boundary:
-
-| Probe | `gsc` | `gsi` |
+| Invocation | Engine | Deinitializer behavior |
 |---|---|---|
-| Object dies in a function; collection forced | `made-22` / `deinit-11` / `body-33` | `made-22` / `body-33` |
-| Object dies in a function; no forced collection | `made-22` / `body-33` | `made-22` / `body-33` |
-| Object remains reachable at exit | no `deinit` | no `deinit` |
+| bare `gsc file.gs` | emit to memory, then `EmittedProgramHost.Run` | real CLR finalizer; no GS0510 |
+| `gsc /out:program.dll file.gs`, then run the assembly | emit to file, then CLR host | real CLR finalizer; no GS0510 |
+| `gsi file.gs` | emit to memory, then `EmittedProgramHost.Run` | real CLR finalizer; no GS0510 |
+| interactive `gsi` (default) | `SessionEngine` → `Compilation.Evaluate` | skips the body; GS0510 once per declaring class |
+| interactive `gsi --engine emit` | `EmittedSessionEngine` | real CLR finalizer; no GS0510 |
 
-Scope-exit and shutdown execution are therefore both wrong. Matching CLR
-behavior requires tying finalization to `StructValue` lifetime and re-entering
-`Evaluator` from a finalizer thread, risking shutdown deadlock and
-timing-dependent output that golden-sample comparison cannot pin.
+The old two-column `gsc`/`gsi` table made object reachability appear to be the
+discriminating axis. It is not. Driving the default interactive
+`SessionEngine` across the old rows produces the same boundary regardless of
+liveness:
 
-GS0510 is a warning because the CLR does not guarantee that a finalizer runs;
-the interpreted program can still complete with an omitted GC-scheduled side
-effect. In contrast, unsafe storage and P/Invoke boundaries are errors because
-interpreted execution cannot proceed correctly without emitted storage or
-would fabricate a deterministic native return value.
+| Evaluator probe | Output | GS0510 |
+|---|---|---:|
+| object dies in a function; collection forced | `made-22` / `body-33` | 1 |
+| object dies in a function; no forced collection | `made-22` / `body-33` | 1 |
+| object remains reachable; collection forced | `made-22` / `body-33` / `kept` | 1 |
+
+The discriminating axis is the execution engine. Emitted execution delegates
+lifetime to the CLR; the tree evaluator has no emitted `Finalize` override and
+does not invent scope-exit cleanup. GS0510 remains a warning on that evaluator
+surface because the program can complete while omitting a nondeterministic
+GC-scheduled side effect.
 
 ## Considered alternatives
 
@@ -162,4 +164,6 @@ Two new diagnostics are allocated:
 
 ## Status
 
-Accepted; implemented in the same PR as this ADR.
+The `deinit` language and emission design remain accepted. ADR-0156 partially
+supersedes only this ADR's original driver-boundary model: all file-mode
+drivers now emit, while the default interactive evaluator retains GS0510.

--- a/docs/adr/0069-smart-cast-flow-narrowing.md
+++ b/docs/adr/0069-smart-cast-flow-narrowing.md
@@ -327,8 +327,9 @@ Narrowing proved anew for each iteration remains valid. In particular,
 `while x != nil`, `while x is T`, and equivalent C-style loop conditions keep
 their condition-derived narrowing, while a guard or proven-non-null assignment
 inside the body may re-establish narrowing after an inherited narrowing is
-removed. This applies equally to function locals and top-level globals, so
-compiled top-level programs and `gsi` scripts use the same back-edge rules.
+removed. This applies equally to function locals and top-level globals. Since
+ADR-0156, all file-mode drivers use the compiled back-edge rules; the default
+interactive evaluator implements the same flow analysis.
 
 Assignment precision is limited to plain storage whose identity the flow pass
 tracks directly: ordinary locals (including captured locals and `if let`

--- a/docs/adr/0069-smart-cast-flow-narrowing.md
+++ b/docs/adr/0069-smart-cast-flow-narrowing.md
@@ -328,8 +328,9 @@ Narrowing proved anew for each iteration remains valid. In particular,
 their condition-derived narrowing, while a guard or proven-non-null assignment
 inside the body may re-establish narrowing after an inherited narrowing is
 removed. This applies equally to function locals and top-level globals. Since
-ADR-0156, all file-mode drivers use the compiled back-edge rules; the default
-interactive evaluator implements the same flow analysis.
+ADR-0156 Phase 3a, every default driver, including interactive `gsi`, uses the
+compiled back-edge rules. The `gsi --engine evaluator` escape hatch is
+deprecated and scheduled for removal in Phase 3c.
 
 Assignment precision is limited to plain storage whose identity the flow pass
 tracks directly: ordinary locals (including captured locals and `if let`

--- a/docs/adr/0084-gsharp-extensions-optional-sequences.md
+++ b/docs/adr/0084-gsharp-extensions-optional-sequences.md
@@ -386,7 +386,7 @@ of that migration, not left behind as dead code.
   / `IAsyncEnumerable[T]` / `async sequence[T]` — surfaced as
   `GS0136 Function 'yield' doesn't exist` (when reached through
   the compile path) or `GS9998 Unexpected statement: YieldStatement`
-  (when reached through the gsc no-output / interpreter path via
+  (when reached through the then-evaluator-backed bare-`gsc` path via
   `ControlFlowGraph.Create`). Root cause was two-fold and not
   actually shared-static-specific: (a) `StatementBinder.GetIteratorElementType`
   read only `function.Type.ClrType`, which is type-erased to

--- a/docs/adr/0084-gsharp-extensions-optional-sequences.md
+++ b/docs/adr/0084-gsharp-extensions-optional-sequences.md
@@ -387,7 +387,9 @@ of that migration, not left behind as dead code.
   `GS0136 Function 'yield' doesn't exist` (when reached through
   the compile path) or `GS9998 Unexpected statement: YieldStatement`
   (when reached through the then-evaluator-backed bare-`gsc` path via
-  `ControlFlowGraph.Create`). Root cause was two-fold and not
+  `ControlFlowGraph.Create`). ADR-0156 now routes every default driver through
+  emit and schedules the deprecated evaluator's removal for Phase 3c. Root
+  cause was two-fold and not
   actually shared-static-specific: (a) `StatementBinder.GetIteratorElementType`
   read only `function.Type.ClrType`, which is type-erased to
   `IEnumerable<object>` for an `ImportedTypeSymbol` constructed

--- a/docs/adr/0086-pinvoke-native-interop.md
+++ b/docs/adr/0086-pinvoke-native-interop.md
@@ -16,9 +16,11 @@ Issue #727 (under parent #706) requires that G# emit real CLR P/Invoke metadata 
 
 ### Interpreter boundary
 
-This decision specifies emitted CLR behavior. Per ADR-0152, `gsi` reports
-GS0514 (Error) at a P/Invoke declaration and does not load a native library.
-Programs that require native calls must use `gsc`.
+This decision specifies emitted CLR behavior. Per ADR-0152, the default
+interactive evaluator reports GS0514 (Error) at a P/Invoke declaration and
+does not load a native library. Since ADR-0156 Phase 1, bare `gsc` and
+`gsi <file>` use emitted execution and run P/Invoke natively; `gsc /out:`
+emits the same CLR metadata to disk.
 
 ### 1. Syntax — `@DllImport("libname") func Name(...) ReturnType;`
 

--- a/docs/adr/0086-pinvoke-native-interop.md
+++ b/docs/adr/0086-pinvoke-native-interop.md
@@ -16,11 +16,11 @@ Issue #727 (under parent #706) requires that G# emit real CLR P/Invoke metadata 
 
 ### Interpreter boundary
 
-This decision specifies emitted CLR behavior. Per ADR-0152, the default
-interactive evaluator reports GS0514 (Error) at a P/Invoke declaration and
-does not load a native library. Since ADR-0156 Phase 1, bare `gsc` and
-`gsi <file>` use emitted execution and run P/Invoke natively; `gsc /out:`
-emits the same CLR metadata to disk.
+This decision specifies emitted CLR behavior. Per ADR-0152, the deprecated
+`gsi --engine evaluator` path reports GS0514 (Error) at a P/Invoke declaration
+and does not load a native library; ADR-0156 Phase 3c removes that evaluator.
+Every default driver now uses emitted execution and runs P/Invoke natively;
+`gsc /out:` emits the same CLR metadata to disk.
 
 ### 1. Syntax — `@DllImport("libname") func Name(...) ReturnType;`
 

--- a/docs/adr/0092-libraryimport-pinvoke-source-generator.md
+++ b/docs/adr/0092-libraryimport-pinvoke-source-generator.md
@@ -137,7 +137,12 @@ A "real" Roslyn-style source generator would model `@LibraryImport` (and future 
 
 We therefore generate the wrapper inline in the emitter and revisit the source-generator infrastructure if and when (a) at least one additional consumer is identified, **and** (b) the wrapper logic grows complex enough that bound-tree rewriting becomes the simpler implementation. Neither trigger is met today.
 
-For the interpreter (which has no IL emit), `@LibraryImport` functions are treated identically to `@DllImport`: the binder reserves an empty body and the evaluator returns the default value for the declared return type. The interpreter is not a runtime for native interop; programs that actually need to transition to unmanaged code must be compiled with `gsc`.
+ADR-0152 supersedes the original evaluator behavior described here. A valid
+`@LibraryImport` declaration now reports GS0514 before tree evaluation instead
+of returning a fabricated default value. ADR-0156 Phase 1 moved bare `gsc` and
+`gsi <file>` to emitted execution, where the generated wrapper performs the
+real native transition. The boundary remains on the default interactive
+evaluator.
 
 ### 5. Diagnostics (new)
 
@@ -167,7 +172,7 @@ The inner P/Invoke is emitted before the outer body to keep the row order in syn
   - Parser: `Issue758LibraryImportParserTests` covers `;`-bodied `@LibraryImport` declarations with each attribute knob.
   - Binder: `Issue758LibraryImportBinderTests` covers GS0342 – GS0344 plus successful acceptance, including a `string` return that binds with an explicit `StringMarshalling` and still reports GS0344 without one (issue #1504).
   - Emit (CompileAndRun + ilverify): `Issue758LibraryImportEmitTests` covers `strlen` (Utf8 round-trip), `getpid` (no string), empty-string null-safe behaviour, and metadata-shape verification of the outer + hidden inner pair. `Issue1504LibraryImportStringReturnEmitTests` covers `string` returns: a `setenv`+`getenv` Utf8 round-trip, the null-pointer→`nil` path, and metadata/IL-shape checks (outer returns `string`, inner returns `IntPtr`, the `PtrToString*` materialization is emitted, and the return pointer is never freed) for Utf8/Utf16 and return-only/return-plus-param shapes.
-  - Interpreter: `Issue758LibraryImportInterpreterTests` confirms the bound program does not crash under the interpreter and that GS0344 fires for an under-specified declaration before evaluation.
+  - Interpreter: `Issue758LibraryImportInterpreterTests` confirms valid declarations report GS0514 and that GS0344 fires for an under-specified declaration before evaluation.
 - **Follow-ups (filed under parent #706, peers of #758):**
   - `out` / `ref` primitive parameter marshalling for `@LibraryImport` (issue #759).
   - `Span<T>` and `ReadOnlySpan<T>` parameter marshalling (issue #760).
@@ -178,7 +183,9 @@ The inner P/Invoke is emitted before the outer body to keep the row order in syn
 
 - Programs that need AOT-friendly native interop no longer have to wrap the call in a hand-written C# `[LibraryImport]` partial method. The same surface is available directly in G# source.
 - The emitter delta is modest: one new bound-tree flag (`PInvokeMetadata.IsLibraryImport`), one new emit dispatch, and an explicit IL-stub generator. There is no new bound-node kind, so the BoundTree exhaustiveness allowlist is unaffected.
-- The interpreter inherits the existing P/Invoke "return default" behaviour. We document the limitation rather than masking it as a feature; it is consistent with how the interpreter treats `@DllImport` today.
+- The default interactive evaluator reports ADR-0152's GS0514 boundary for
+  valid declarations; it does not fabricate a return value. File-mode drivers
+  execute the emitted wrapper under ADR-0156.
 - ADR-0086 §4 is now superseded; cross-links from the v1 P/Invoke ADR point to ADR-0092 for the modern attribute. The historical rationale for deferring the work is preserved in ADR-0086 for context.
 - A full source-generator infrastructure is **not** added in this ADR. The trigger conditions for revisiting that decision are recorded in §4.
 

--- a/docs/adr/0092-libraryimport-pinvoke-source-generator.md
+++ b/docs/adr/0092-libraryimport-pinvoke-source-generator.md
@@ -141,8 +141,8 @@ ADR-0152 supersedes the original evaluator behavior described here. A valid
 `@LibraryImport` declaration now reports GS0514 before tree evaluation instead
 of returning a fabricated default value. ADR-0156 Phase 1 moved bare `gsc` and
 `gsi <file>` to emitted execution, where the generated wrapper performs the
-real native transition. The boundary remains on the default interactive
-evaluator.
+real native transition. The boundary remains on direct tree evaluation and
+the deprecated `gsi --engine evaluator` compatibility path.
 
 ### 5. Diagnostics (new)
 
@@ -183,9 +183,9 @@ The inner P/Invoke is emitted before the outer body to keep the row order in syn
 
 - Programs that need AOT-friendly native interop no longer have to wrap the call in a hand-written C# `[LibraryImport]` partial method. The same surface is available directly in G# source.
 - The emitter delta is modest: one new bound-tree flag (`PInvokeMetadata.IsLibraryImport`), one new emit dispatch, and an explicit IL-stub generator. There is no new bound-node kind, so the BoundTree exhaustiveness allowlist is unaffected.
-- The default interactive evaluator reports ADR-0152's GS0514 boundary for
-  valid declarations; it does not fabricate a return value. File-mode drivers
-  execute the emitted wrapper under ADR-0156.
+- The tree evaluator reports ADR-0152's GS0514 boundary for valid declarations;
+  it does not fabricate a return value. Default drivers execute the emitted
+  wrapper under ADR-0156.
 - ADR-0086 §4 is now superseded; cross-links from the v1 P/Invoke ADR point to ADR-0092 for the modern attribute. The historical rationale for deferring the work is preserved in ADR-0086 for context.
 - A full source-generator infrastructure is **not** added in this ADR. The trigger conditions for revisiting that decision are recorded in §4.
 

--- a/docs/adr/0092-libraryimport-pinvoke-source-generator.md
+++ b/docs/adr/0092-libraryimport-pinvoke-source-generator.md
@@ -142,7 +142,8 @@ ADR-0152 supersedes the original evaluator behavior described here. A valid
 of returning a fabricated default value. ADR-0156 Phase 1 moved bare `gsc` and
 `gsi <file>` to emitted execution, where the generated wrapper performs the
 real native transition. The boundary remains on direct tree evaluation and
-the deprecated `gsi --engine evaluator` compatibility path.
+the deprecated `gsi --engine evaluator` compatibility path until ADR-0156
+Phase 3c removes the evaluator.
 
 ### 5. Diagnostics (new)
 

--- a/docs/adr/0093-pinvoke-struct-marshalling.md
+++ b/docs/adr/0093-pinvoke-struct-marshalling.md
@@ -155,7 +155,8 @@ valid P/Invoke declaration, ADR-0152 supersedes the original "return default"
 behavior: the tree evaluator reports GS0514 before evaluation. ADR-0156 default
 drivers emit and run the native transition. Interpreter tests cover managed
 layout behavior and confirm that diagnostics GS0346–GS0351 still fire before
-execution where applicable.
+execution where applicable. The evaluator is deprecated and scheduled for
+removal in ADR-0156 Phase 3c.
 
 ## Consequences
 

--- a/docs/adr/0093-pinvoke-struct-marshalling.md
+++ b/docs/adr/0093-pinvoke-struct-marshalling.md
@@ -149,7 +149,13 @@ The existing GS0323 (generic "type is not supported for marshalling") continues 
 
 ### 8. Interpreter behavior
 
-The interpreter does **not** perform actual native transitions (per ADR-0086 §7 / ADR-0092 §4 it returns the declared return type's default value for any P/Invoke call). Blittable / explicit-layout structs are bound and constructable identically to other G# structs — the layout annotations do not change interpreter evaluation. The interpreter test suite therefore covers (a) that struct / class layout annotations bind without diagnostics, (b) that a P/Invoke call returning a struct yields the value-type default, and (c) that diagnostics GS0346 – GS0351 fire under the interpreter as well as the compiler.
+Blittable / explicit-layout structs are bound and constructable identically to
+other G# structs — the layout annotations do not change tree evaluation. For a
+valid P/Invoke declaration, ADR-0152 supersedes the original "return default"
+behavior: the default interactive evaluator reports GS0514 before evaluation.
+ADR-0156 file-mode drivers emit and run the native transition. Interpreter
+tests cover managed layout behavior and confirm that diagnostics GS0346–GS0351
+still fire before execution where applicable.
 
 ## Consequences
 

--- a/docs/adr/0093-pinvoke-struct-marshalling.md
+++ b/docs/adr/0093-pinvoke-struct-marshalling.md
@@ -152,10 +152,10 @@ The existing GS0323 (generic "type is not supported for marshalling") continues 
 Blittable / explicit-layout structs are bound and constructable identically to
 other G# structs — the layout annotations do not change tree evaluation. For a
 valid P/Invoke declaration, ADR-0152 supersedes the original "return default"
-behavior: the default interactive evaluator reports GS0514 before evaluation.
-ADR-0156 file-mode drivers emit and run the native transition. Interpreter
-tests cover managed layout behavior and confirm that diagnostics GS0346–GS0351
-still fire before execution where applicable.
+behavior: the tree evaluator reports GS0514 before evaluation. ADR-0156 default
+drivers emit and run the native transition. Interpreter tests cover managed
+layout behavior and confirm that diagnostics GS0346–GS0351 still fire before
+execution where applicable.
 
 ## Consequences
 

--- a/docs/adr/0094-pinvoke-ref-out-in-parameters.md
+++ b/docs/adr/0094-pinvoke-ref-out-in-parameters.md
@@ -138,7 +138,7 @@ ref-kind P/Invoke declarations bind without GS0326/GS0352, then the tree
 evaluator reports GS0514 before evaluation; no call-site write-back or native
 transition occurs. Binder errors such as GS0352 still take precedence.
 ADR-0156 default drivers emit the byref signature and execute the real native
-transition.
+transition. The evaluator is deprecated and scheduled for removal in Phase 3c.
 
 The interpreter test suite covers valid `ref`/`out`/`in` declarations reaching
 GS0514 and invalid pointees reaching GS0352 before that boundary.

--- a/docs/adr/0094-pinvoke-ref-out-in-parameters.md
+++ b/docs/adr/0094-pinvoke-ref-out-in-parameters.md
@@ -133,9 +133,15 @@ The binder lowers `ref t` to a `BoundAddressOfExpression` wrapping a `BoundVaria
 
 ### 6. Interpreter behavior
 
-The interpreter does **not** perform actual native transitions — for any P/Invoke target it runs the empty body the binder reserves (`BoundBlockStatement` with zero statements) and returns the declared return type's default value (consistent with ADR-0086 §7 / ADR-0092 §4 / ADR-0093 §8). The ADR-0060 call-site write-back of ref-kind parameter slots still fires: the interpreter seeds `locals[parameter]` from the caller's lvalue before the call and writes the post-body slot value back to the lvalue after the call. For an empty body the post-body value equals the pre-body value, so the lvalue is unchanged. The interpreter therefore accepts ref-kind P/Invoke declarations and runs them without crashing, but the only way to actually observe native side-effects is the compiler (`gsc`) emit path.
+ADR-0152 supersedes the original empty-body/default-value behavior. Valid
+ref-kind P/Invoke declarations bind without GS0326/GS0352, then the default
+interactive evaluator reports GS0514 before evaluation; no call-site write-back
+or native transition occurs. Binder errors such as GS0352 still take
+precedence. ADR-0156 file-mode drivers emit the byref signature and execute the
+real native transition.
 
-The interpreter test suite covers (a) ref-kind P/Invoke declarations bind without GS0326 / GS0352 diagnostics, (b) `ref` / `out` / `in` parameters with a blittable pointee evaluate to the default return value, and (c) the GS0352 path is reachable from the REPL.
+The interpreter test suite covers valid `ref`/`out`/`in` declarations reaching
+GS0514 and invalid pointees reaching GS0352 before that boundary.
 
 ### 7. Interaction with ADR-0086, ADR-0092, ADR-0093
 
@@ -158,7 +164,9 @@ The interpreter test suite covers (a) ref-kind P/Invoke declarations bind withou
 - The bound tree gains **no new** `BoundNodeKind` (per the rule of engagement). The bound model already represented ref-kind parameters via `ParameterSymbol.RefKind` and ref-kind arguments via `BoundAddressOfExpression`; the only changes are the binder's narrowed validation (GS0326 → GS0349 / GS0352 routing) and a tighter `IsSupportedMarshallingType` byref pointee classifier.
 - The emit pipeline is unchanged. `EmitPInvokeFunction` and `EmitLibraryImportFunction` already encode `isByRef: p.RefKind != RefKind.None`; the resulting metadata signature carries `ELEMENT_TYPE_BYREF` before the pointee type. The runtime marshaller sees a `T*` and passes the caller's managed slot address straight to the unmanaged callee.
 - `ilverify` is clean on the emitted assemblies. The ADR-0094 emit tests gate verification through `IlVerifier.Verify` exactly as the ADR-0086 / ADR-0092 / ADR-0093 emit tests do.
-- The interpreter accepts ref-kind P/Invoke declarations without crashing and continues to return the declared return type's default value — there is no managed-IL emit pipeline under the interpreter, so the byref slot does not actually round-trip through a native call (consistent with how `@DllImport` / `@LibraryImport` behave today).
+- The default interactive evaluator accepts the ref-kind declaration shape,
+  then reports GS0514 before execution. File-mode drivers emit the signature
+  and round-trip the byref slot through the native call.
 - The remaining v1 P/Invoke gaps (issue #761 function pointers, #762 `@MarshalAs` custom marshallers, slices of structs, fixed-size buffers inside marshalled structs) are unchanged.
 
 ## Alternatives considered

--- a/docs/adr/0094-pinvoke-ref-out-in-parameters.md
+++ b/docs/adr/0094-pinvoke-ref-out-in-parameters.md
@@ -134,11 +134,11 @@ The binder lowers `ref t` to a `BoundAddressOfExpression` wrapping a `BoundVaria
 ### 6. Interpreter behavior
 
 ADR-0152 supersedes the original empty-body/default-value behavior. Valid
-ref-kind P/Invoke declarations bind without GS0326/GS0352, then the default
-interactive evaluator reports GS0514 before evaluation; no call-site write-back
-or native transition occurs. Binder errors such as GS0352 still take
-precedence. ADR-0156 file-mode drivers emit the byref signature and execute the
-real native transition.
+ref-kind P/Invoke declarations bind without GS0326/GS0352, then the tree
+evaluator reports GS0514 before evaluation; no call-site write-back or native
+transition occurs. Binder errors such as GS0352 still take precedence.
+ADR-0156 default drivers emit the byref signature and execute the real native
+transition.
 
 The interpreter test suite covers valid `ref`/`out`/`in` declarations reaching
 GS0514 and invalid pointees reaching GS0352 before that boundary.
@@ -164,9 +164,9 @@ GS0514 and invalid pointees reaching GS0352 before that boundary.
 - The bound tree gains **no new** `BoundNodeKind` (per the rule of engagement). The bound model already represented ref-kind parameters via `ParameterSymbol.RefKind` and ref-kind arguments via `BoundAddressOfExpression`; the only changes are the binder's narrowed validation (GS0326 → GS0349 / GS0352 routing) and a tighter `IsSupportedMarshallingType` byref pointee classifier.
 - The emit pipeline is unchanged. `EmitPInvokeFunction` and `EmitLibraryImportFunction` already encode `isByRef: p.RefKind != RefKind.None`; the resulting metadata signature carries `ELEMENT_TYPE_BYREF` before the pointee type. The runtime marshaller sees a `T*` and passes the caller's managed slot address straight to the unmanaged callee.
 - `ilverify` is clean on the emitted assemblies. The ADR-0094 emit tests gate verification through `IlVerifier.Verify` exactly as the ADR-0086 / ADR-0092 / ADR-0093 emit tests do.
-- The default interactive evaluator accepts the ref-kind declaration shape,
-  then reports GS0514 before execution. File-mode drivers emit the signature
-  and round-trip the byref slot through the native call.
+- The tree evaluator accepts the ref-kind declaration shape, then reports
+  GS0514 before execution. Default drivers emit the signature and round-trip
+  the byref slot through the native call.
 - The remaining v1 P/Invoke gaps (issue #761 function pointers, #762 `@MarshalAs` custom marshallers, slices of structs, fixed-size buffers inside marshalled structs) are unchanged.
 
 ## Alternatives considered

--- a/docs/adr/0095-pinvoke-function-pointer-marshalling.md
+++ b/docs/adr/0095-pinvoke-function-pointer-marshalling.md
@@ -195,10 +195,10 @@ The emitted FNPTR signature is bit-compatible with the C# / Roslyn `delegate*` e
 ### 9. Interpreter behavior
 
 ADR-0152 supersedes the original empty-body/default-value behavior. Valid
-Shape A and Shape B declarations bind, then the default interactive evaluator
-reports GS0514 before evaluation; it neither invokes the delegate nor
-fabricates `default(R)`. Binder diagnostics GS0353–GS0356 still take
-precedence. ADR-0156 file-mode drivers emit and run the native transition.
+Shape A and Shape B declarations bind, then the tree evaluator reports GS0514
+before evaluation; it neither invokes the delegate nor fabricates `default(R)`.
+Binder diagnostics GS0353–GS0356 still take precedence. ADR-0156 default
+drivers emit and run the native transition.
 
 The interpreter test suite covers valid Shape A/Shape B declarations reaching
 GS0514 and invalid shapes reaching their binder diagnostics first.
@@ -223,9 +223,9 @@ See §5. ADR-0086 §1 GS0323 continues to fire for every other unsupported funct
 - A single new `SyntaxKind` is added — `FunctionPointerType` — and surfaces in the CoverageMatrix golden snapshot.
 - The `EncodeTypeSymbol` emit-side fork adds one branch (FNPTR encoding via `SignatureTypeEncoder.FunctionPointer(...)`); every other emit path is unchanged.
 - `ilverify` is clean on the emitted assemblies. The ADR-0095 emit tests gate verification through `IlVerifier.Verify` exactly as the ADR-0086 / ADR-0092 / ADR-0093 / ADR-0094 emit tests do.
-- The default interactive evaluator accepts both declaration shapes, then
-  reports GS0514 before execution. File-mode drivers use emitted execution, so
-  callback invocation can flow through native code there.
+- The tree evaluator accepts both declaration shapes, then reports GS0514
+  before execution. Default drivers use emitted execution, so callback
+  invocation can flow through native code there.
 - The remaining v1 P/Invoke gaps (issue #762 `@MarshalAs` custom marshallers, slices of structs, fixed-size buffers, direct `calli` invocation of `FunctionPointerTypeSymbol` values without a `Marshal.GetDelegateForFunctionPointer` round-trip) are unchanged. The direct-invocation gap in particular is the only foreseeable follow-up that would require a new `BoundNodeKind` and is deliberately deferred to a future ADR.
 
 ## Alternatives considered

--- a/docs/adr/0095-pinvoke-function-pointer-marshalling.md
+++ b/docs/adr/0095-pinvoke-function-pointer-marshalling.md
@@ -194,9 +194,14 @@ The emitted FNPTR signature is bit-compatible with the C# / Roslyn `delegate*` e
 
 ### 9. Interpreter behavior
 
-The interpreter does **not** perform actual native transitions for P/Invoke targets — for every P/Invoke target it runs the empty body the binder reserves and returns the declared return type's default value (consistent with ADR-0086 §7 / ADR-0092 §4 / ADR-0093 §8 / ADR-0094 §6). For Shape A the binder accepts the delegate parameter and the interpreter returns `default(R)` from the empty body without ever invoking the delegate. For Shape B the binder accepts the `FunctionPointerTypeSymbol` parameter / return and the interpreter again returns `default(R)` (zero `nint` for a Shape-B return) from the empty body.
+ADR-0152 supersedes the original empty-body/default-value behavior. Valid
+Shape A and Shape B declarations bind, then the default interactive evaluator
+reports GS0514 before evaluation; it neither invokes the delegate nor
+fabricates `default(R)`. Binder diagnostics GS0353–GS0356 still take
+precedence. ADR-0156 file-mode drivers emit and run the native transition.
 
-The interpreter test suite covers (a) Shape-A P/Invoke declarations bind without GS0353 / GS0354 / GS0355 diagnostics, (b) Shape-A delegate parameters evaluate to the default return value without invoking the delegate, (c) Shape-B `unmanaged[CC] (T) -> R` parameters and returns parse and bind, and (d) the GS0353 / GS0356 paths are reachable from the REPL.
+The interpreter test suite covers valid Shape A/Shape B declarations reaching
+GS0514 and invalid shapes reaching their binder diagnostics first.
 
 ### 10. Interaction with ADR-0086, ADR-0092, ADR-0093, ADR-0094
 
@@ -218,7 +223,9 @@ See §5. ADR-0086 §1 GS0323 continues to fire for every other unsupported funct
 - A single new `SyntaxKind` is added — `FunctionPointerType` — and surfaces in the CoverageMatrix golden snapshot.
 - The `EncodeTypeSymbol` emit-side fork adds one branch (FNPTR encoding via `SignatureTypeEncoder.FunctionPointer(...)`); every other emit path is unchanged.
 - `ilverify` is clean on the emitted assemblies. The ADR-0095 emit tests gate verification through `IlVerifier.Verify` exactly as the ADR-0086 / ADR-0092 / ADR-0093 / ADR-0094 emit tests do.
-- The interpreter accepts both shapes without crashing and continues to return the declared return type's default value — there is no managed-IL emit pipeline under the interpreter, so callback invocation does not actually flow through native (consistent with how `@DllImport` / `@LibraryImport` behave today). The only way to observe the callback being called by native code is via the compiler (`gsc`) emit path.
+- The default interactive evaluator accepts both declaration shapes, then
+  reports GS0514 before execution. File-mode drivers use emitted execution, so
+  callback invocation can flow through native code there.
 - The remaining v1 P/Invoke gaps (issue #762 `@MarshalAs` custom marshallers, slices of structs, fixed-size buffers, direct `calli` invocation of `FunctionPointerTypeSymbol` values without a `Marshal.GetDelegateForFunctionPointer` round-trip) are unchanged. The direct-invocation gap in particular is the only foreseeable follow-up that would require a new `BoundNodeKind` and is deliberately deferred to a future ADR.
 
 ## Alternatives considered

--- a/docs/adr/0095-pinvoke-function-pointer-marshalling.md
+++ b/docs/adr/0095-pinvoke-function-pointer-marshalling.md
@@ -198,7 +198,8 @@ ADR-0152 supersedes the original empty-body/default-value behavior. Valid
 Shape A and Shape B declarations bind, then the tree evaluator reports GS0514
 before evaluation; it neither invokes the delegate nor fabricates `default(R)`.
 Binder diagnostics GS0353–GS0356 still take precedence. ADR-0156 default
-drivers emit and run the native transition.
+drivers emit and run the native transition. The evaluator is deprecated and
+scheduled for removal in Phase 3c.
 
 The interpreter test suite covers valid Shape A/Shape B declarations reaching
 GS0514 and invalid shapes reaching their binder diagnostics first.

--- a/docs/adr/0125-fixed-pinned-statement.md
+++ b/docs/adr/0125-fixed-pinned-statement.md
@@ -194,11 +194,11 @@ kind: it gets a real `case` in `MethodBodyEmitter.EmitStatement` and in
   a nested lambda remains legal because that lambda has its own function body;
   normal fixed-pointer escape rules still prevent capturing the pointer.
 - `fixed` is compiled-only under
-  [ADR-0153](0153-interpreter-compiled-only-storage-boundary.md). The default
-  interactive evaluator reports that pinning requires the CIL pinned-local
-  emit path; it does not attempt to emulate pinning without a storage and
-  address model. Since ADR-0156 Phase 1, bare `gsc` and `gsi <file>` execute
-  the emitted pinned-local path.
+  [ADR-0153](0153-interpreter-compiled-only-storage-boundary.md). The deprecated
+  `gsi --engine evaluator` path reports that pinning requires the CIL
+  pinned-local emit path; it does not attempt to emulate pinning without a
+  storage and address model. Every default driver executes the emitted
+  pinned-local path. ADR-0156 Phase 3c removes the evaluator.
 - Deferred: fixed-size buffers.
 
 ## Diagnostics

--- a/docs/adr/0125-fixed-pinned-statement.md
+++ b/docs/adr/0125-fixed-pinned-statement.md
@@ -194,9 +194,11 @@ kind: it gets a real `case` in `MethodBodyEmitter.EmitStatement` and in
   a nested lambda remains legal because that lambda has its own function body;
   normal fixed-pointer escape rules still prevent capturing the pointer.
 - `fixed` is compiled-only under
-  [ADR-0153](0153-interpreter-compiled-only-storage-boundary.md). `gsi` reports
-  that pinning requires the CIL pinned-local emit path; it does not attempt to
-  emulate pinning without a storage and address model.
+  [ADR-0153](0153-interpreter-compiled-only-storage-boundary.md). The default
+  interactive evaluator reports that pinning requires the CIL pinned-local
+  emit path; it does not attempt to emulate pinning without a storage and
+  address model. Since ADR-0156 Phase 1, bare `gsc` and `gsi <file>` execute
+  the emitted pinned-local path.
 - Deferred: fixed-size buffers.
 
 ## Diagnostics

--- a/docs/adr/0139-goto-and-general-labels.md
+++ b/docs/adr/0139-goto-and-general-labels.md
@@ -81,10 +81,11 @@ rejects transfers out of a `finally` with CS0157.
 Issue [#2953](https://github.com/DavidObando/gsharp/issues/2953) routes ordinary
 fallthrough around fixed and protected-region return epilogues to the
 compiler-generated non-void guard. Only an actual rewritten return reaches
-the epilogue's value slot. Protected-region lowering is also consumed by
-`gsi`, where reaching this guard reports GS0100 instead of the GS9999
-internal-error fallback. This is an intended interpreter behavior change:
-`gsi` now rejects the fallthrough instead of returning a default value.
+the epilogue's value slot. Protected-region lowering is also consumed by the
+tree evaluator. In the default interactive `SessionEngine`, reaching this guard reports GS0100
+instead of the GS9999 internal-error fallback. This evaluator behavior rejects
+the fallthrough instead of returning a default value. File-mode `gsi` uses
+emitted execution under ADR-0156.
 GS0506 (`FixedStatementCannotSuspend`, issue
 [#2917](https://github.com/DavidObando/gsharp/issues/2917)) is existing
 precedent that a deliberate `fixed`-boundary rejection uses a semantic

--- a/docs/adr/0139-goto-and-general-labels.md
+++ b/docs/adr/0139-goto-and-general-labels.md
@@ -82,10 +82,11 @@ Issue [#2953](https://github.com/DavidObando/gsharp/issues/2953) routes ordinary
 fallthrough around fixed and protected-region return epilogues to the
 compiler-generated non-void guard. Only an actual rewritten return reaches
 the epilogue's value slot. Protected-region lowering is also consumed by the
-tree evaluator. In the default interactive `SessionEngine`, reaching this guard reports GS0100
-instead of the GS9999 internal-error fallback. This evaluator behavior rejects
-the fallthrough instead of returning a default value. File-mode `gsi` uses
-emitted execution under ADR-0156.
+tree evaluator. In the evaluator-backed `SessionEngine` compatibility path,
+reaching this guard reports GS0100 instead of the GS9999 internal-error
+fallback. This evaluator behavior rejects the fallthrough instead of returning
+a default value. Default `gsi` execution uses the emitted engine under
+ADR-0156.
 GS0506 (`FixedStatementCannotSuspend`, issue
 [#2917](https://github.com/DavidObando/gsharp/issues/2917)) is existing
 precedent that a deliberate `fixed`-boundary rejection uses a semantic

--- a/docs/adr/0139-goto-and-general-labels.md
+++ b/docs/adr/0139-goto-and-general-labels.md
@@ -82,11 +82,11 @@ Issue [#2953](https://github.com/DavidObando/gsharp/issues/2953) routes ordinary
 fallthrough around fixed and protected-region return epilogues to the
 compiler-generated non-void guard. Only an actual rewritten return reaches
 the epilogue's value slot. Protected-region lowering is also consumed by the
-tree evaluator. In the evaluator-backed `SessionEngine` compatibility path,
-reaching this guard reports GS0100 instead of the GS9999 internal-error
+tree evaluator. In `SessionEngine`, the deprecated evaluator compatibility
+path, reaching this guard reports GS0100 instead of the GS9999 internal-error
 fallback. This evaluator behavior rejects the fallthrough instead of returning
-a default value. Default `gsi` execution uses the emitted engine under
-ADR-0156.
+a default value. Default `gsi` execution uses the emitted engine under ADR-0156;
+Phase 3c removes the evaluator.
 GS0506 (`FixedStatementCannotSuspend`, issue
 [#2917](https://github.com/DavidObando/gsharp/issues/2917)) is existing
 precedent that a deliberate `fixed`-boundary rejection uses a semantic

--- a/docs/adr/0152-interpreter-native-call-boundary.md
+++ b/docs/adr/0152-interpreter-native-call-boundary.md
@@ -1,6 +1,6 @@
 # ADR-0152: Interpreter native-call boundary
 
-- **Status**: Partially superseded by [ADR-0156](0156-gsi-emit-to-memory-execution.md) Phase 1; remains accepted for the default interactive evaluator
+- **Status**: Partially superseded by [ADR-0156](0156-gsi-emit-to-memory-execution.md) Phases 1–3a; remains accepted for direct tree evaluation and the deprecated evaluator compatibility path
 - **Date**: 2026-07-31
 - **Phase**: Interpreter conformance
 - **Related**: ADR-0086 (P/Invoke), ADR-0153 (interpreter compiled-only storage boundary), [ADR-0156](0156-gsi-emit-to-memory-execution.md) (execution-engine migration), issue [#2986](https://github.com/DavidObando/gsharp/issues/2986)
@@ -32,19 +32,17 @@ declaration at the shared evaluation boundary is deterministic, prevents both
 fabricated results and delayed `GS9999` failures, and adds no native or
 reflection dispatch path.
 
-Since ADR-0156 Phase 1, this boundary applies to `SessionEngine`,
-`Compilation.Evaluate`, and default interactive `gsi`, not to file drivers.
-Bare `gsc` and `gsi <file>` emit and run the native call; `gsc /out:` emits it
-to disk. Interactive `gsi --engine emit` also uses emitted execution.
+Since ADR-0156 Phases 1–3a, this boundary applies to `SessionEngine`,
+`Compilation.Evaluate`, and interactive `gsi --engine evaluator`, not to
+default drivers. Bare `gsc`, `gsi <file>`, and the default interactive REPL
+emit and run the native call; `gsc /out:` emits it to disk.
 
 ## Consequences
 
-- The default interactive evaluator never loads a native library for a
-  P/Invoke declaration.
+- The tree evaluator never loads a native library for a P/Invoke declaration.
 - P/Invoke cannot silently return zero, `nil`, or another fabricated default.
-- File-mode programs and the opt-in emitted interactive engine run P/Invoke
-  through the CLR; evaluator submissions report GS0514 even when a particular
-  execution would not call the declaration.
+- Default drivers run P/Invoke through the CLR; evaluator submissions report
+  GS0514 even when a particular execution would not call the declaration.
 - `GS9999` remains an unexpected evaluator-exception diagnostic, not a
   deliberate capability boundary.
 

--- a/docs/adr/0152-interpreter-native-call-boundary.md
+++ b/docs/adr/0152-interpreter-native-call-boundary.md
@@ -35,7 +35,8 @@ reflection dispatch path.
 Since ADR-0156 Phases 1–3a, this boundary applies to `SessionEngine`,
 `Compilation.Evaluate`, and interactive `gsi --engine evaluator`, not to
 default drivers. Bare `gsc`, `gsi <file>`, and the default interactive REPL
-emit and run the native call; `gsc /out:` emits it to disk.
+emit and run the native call; `gsc /out:` emits it to disk. The evaluator path
+is deprecated and scheduled for removal in Phase 3c.
 
 ## Consequences
 

--- a/docs/adr/0152-interpreter-native-call-boundary.md
+++ b/docs/adr/0152-interpreter-native-call-boundary.md
@@ -1,9 +1,9 @@
 # ADR-0152: Interpreter native-call boundary
 
-- **Status**: Accepted
+- **Status**: Partially superseded by [ADR-0156](0156-gsi-emit-to-memory-execution.md) Phase 1; remains accepted for the default interactive evaluator
 - **Date**: 2026-07-31
 - **Phase**: Interpreter conformance
-- **Related**: ADR-0086 (P/Invoke), ADR-0153 (interpreter compiled-only storage boundary), issue [#2986](https://github.com/DavidObando/gsharp/issues/2986)
+- **Related**: ADR-0086 (P/Invoke), ADR-0153 (interpreter compiled-only storage boundary), [ADR-0156](0156-gsi-emit-to-memory-execution.md) (execution-engine migration), issue [#2986](https://github.com/DavidObando/gsharp/issues/2986)
 
 ## Context
 
@@ -21,27 +21,30 @@ This ADR does not redefine that boundary.
 
 ## Decision
 
-A bound P/Invoke declaration reports **GS0514 (Error)** before evaluation,
-located at the function identifier. The message names P/Invoke and directs the
-user to compile with `gsc`.
+A bound P/Invoke declaration presented to the tree evaluator reports **GS0514
+(Error)** before evaluation, located at the function identifier. The message
+names P/Invoke and directs the user to compile with `gsc`.
 
-The error applies even when the declaration is not called. `gsi` cannot create
-a valid callable value for the declaration, and function references can escape
-the declaring expression before a later indirect call. Refusing the declaration
-at the shared evaluation boundary is deterministic, prevents both fabricated
-results and delayed `GS9999` failures, and adds no native or reflection dispatch
-path.
+The error applies even when the declaration is not called. The evaluator cannot
+create a valid callable value for the declaration, and function references can
+escape the declaring expression before a later indirect call. Refusing the
+declaration at the shared evaluation boundary is deterministic, prevents both
+fabricated results and delayed `GS9999` failures, and adds no native or
+reflection dispatch path.
 
-Batch `gsi` renders the diagnostic through the shared renderer, including the
-filename, location, severity, and source excerpt. Rendering is presentation,
-not part of the boundary's semantic contract.
+Since ADR-0156 Phase 1, this boundary applies to `SessionEngine`,
+`Compilation.Evaluate`, and default interactive `gsi`, not to file drivers.
+Bare `gsc` and `gsi <file>` emit and run the native call; `gsc /out:` emits it
+to disk. Interactive `gsi --engine emit` also uses emitted execution.
 
 ## Consequences
 
-- `gsi` never loads a native library for a P/Invoke declaration.
+- The default interactive evaluator never loads a native library for a
+  P/Invoke declaration.
 - P/Invoke cannot silently return zero, `nil`, or another fabricated default.
-- Programs containing P/Invoke declarations must use `gsc`, even when a
-  particular interpreter execution would not call them.
+- File-mode programs and the opt-in emitted interactive engine run P/Invoke
+  through the CLR; evaluator submissions report GS0514 even when a particular
+  execution would not call the declaration.
 - `GS9999` remains an unexpected evaluator-exception diagnostic, not a
   deliberate capability boundary.
 

--- a/docs/adr/0153-interpreter-compiled-only-storage-boundary.md
+++ b/docs/adr/0153-interpreter-compiled-only-storage-boundary.md
@@ -1,6 +1,6 @@
 # ADR-0153: Interpreter compiled-only storage boundary
 
-- **Status**: Partially superseded by [ADR-0156](0156-gsi-emit-to-memory-execution.md) Phase 1; remains accepted for the default interactive evaluator
+- **Status**: Partially superseded by [ADR-0156](0156-gsi-emit-to-memory-execution.md) Phases 1–3a; remains accepted for direct tree evaluation and the deprecated evaluator compatibility path
 - **Date**: 2026-08-01
 - **Phase**: Phase 9 — low-level / interop depth
 - **Related**: ADR-0039 (managed by-ref pointers), ADR-0122 (unsafe context and unmanaged pointers), ADR-0124 (`stackalloc`), ADR-0125 (`fixed`), [ADR-0156](0156-gsi-emit-to-memory-execution.md) (execution-engine migration), issues [#2956](https://github.com/DavidObando/gsharp/issues/2956), [#3004](https://github.com/DavidObando/gsharp/issues/3004), [#3022](https://github.com/DavidObando/gsharp/issues/3022), [#3028](https://github.com/DavidObando/gsharp/pull/3028), [#3032](https://github.com/DavidObando/gsharp/pull/3032), [#2939](https://github.com/DavidObando/gsharp/issues/2939), and [#3199](https://github.com/DavidObando/gsharp/issues/3199)
@@ -38,10 +38,10 @@ cannot rely on surrounding rendering for meaning.
 Constructs whose interpreter behavior requires real address identity —
 including pinning, stack allocation, unmanaged-pointer storage or dereference,
 and function-pointer execution — are **compiled-only in the tree evaluator**.
-Default interactive `gsi` must report a self-contained boundary diagnostic
-instead of attempting a value-only approximation. Since ADR-0156 Phase 1,
-bare `gsc` and `gsi <file>` use emitted execution and run these constructs
-natively; `gsc /out:` emits them to disk.
+Interactive `gsi --engine evaluator` must report a self-contained boundary
+diagnostic instead of attempting a value-only approximation. Since ADR-0156
+Phases 1–3a, all default drivers use emitted execution and run these constructs
+natively.
 
 This ADR governs only the evaluator's storage-model boundary. It does not
 redefine unsafe/native language validity or CIL emission.
@@ -52,7 +52,7 @@ value operations continues to evaluate normally.
 
 The current implementation status is:
 
-| Construct | Current default interactive-evaluator behavior | Contract status |
+| Construct | Current tree-evaluator behavior | Contract status |
 |---|---|---|
 | `unsafe { ... }` without a storage-only construct | Evaluates normally | Supported |
 | `fixed` over array/slice, string, or a pinnable-reference source | Self-contained legacy GS9999 boundary | Message meets contract; diagnostic category tracked by #3199 |
@@ -73,9 +73,8 @@ Outside those named legacy guards, `GS9999` remains a failure.
 
 ## Consequences
 
-- The default interactive evaluator does not promise parity for
-  storage-dependent unsafe constructs; file-mode drivers use emitted
-  execution.
+- The tree evaluator does not promise parity for storage-dependent unsafe
+  constructs; default drivers use emitted execution.
 - Existing ref/out argument write-back at call sites remains supported; this
   does not provide stable ref-local aliasing.
 - Boundary tests pin non-zero exit status, empty standard output, and the

--- a/docs/adr/0153-interpreter-compiled-only-storage-boundary.md
+++ b/docs/adr/0153-interpreter-compiled-only-storage-boundary.md
@@ -1,9 +1,9 @@
 # ADR-0153: Interpreter compiled-only storage boundary
 
-- **Status**: Accepted
+- **Status**: Partially superseded by [ADR-0156](0156-gsi-emit-to-memory-execution.md) Phase 1; remains accepted for the default interactive evaluator
 - **Date**: 2026-08-01
 - **Phase**: Phase 9 — low-level / interop depth
-- **Related**: ADR-0039 (managed by-ref pointers), ADR-0122 (unsafe context and unmanaged pointers), ADR-0124 (`stackalloc`), ADR-0125 (`fixed`), issues [#2956](https://github.com/DavidObando/gsharp/issues/2956), [#3004](https://github.com/DavidObando/gsharp/issues/3004), [#3022](https://github.com/DavidObando/gsharp/issues/3022), [#3028](https://github.com/DavidObando/gsharp/pull/3028), [#3032](https://github.com/DavidObando/gsharp/pull/3032), and [#2939](https://github.com/DavidObando/gsharp/issues/2939)
+- **Related**: ADR-0039 (managed by-ref pointers), ADR-0122 (unsafe context and unmanaged pointers), ADR-0124 (`stackalloc`), ADR-0125 (`fixed`), [ADR-0156](0156-gsi-emit-to-memory-execution.md) (execution-engine migration), issues [#2956](https://github.com/DavidObando/gsharp/issues/2956), [#3004](https://github.com/DavidObando/gsharp/issues/3004), [#3022](https://github.com/DavidObando/gsharp/issues/3022), [#3028](https://github.com/DavidObando/gsharp/pull/3028), [#3032](https://github.com/DavidObando/gsharp/pull/3032), [#2939](https://github.com/DavidObando/gsharp/issues/2939), and [#3199](https://github.com/DavidObando/gsharp/issues/3199)
 
 ## Context
 
@@ -21,24 +21,27 @@ that position, an address was previously reduced to a value copy. Issue #3004
 demonstrated the consequence; #3028 now rejects free-standing unmanaged pointer
 operations with `GS0513` and exit code 1.
 
-`fixed` is the cleanest existing boundary. The evaluator already rejects it
-with a self-contained message explaining that pinning requires the CIL
-pinned-local emit path. `stackalloc`, `sizeof` over unmanaged storage, method
-function pointers, and function-pointer invocation use the same pattern.
+`fixed` is the cleanest existing boundary message: the evaluator explains that
+pinning requires the CIL pinned-local emit path. `stackalloc`, `sizeof` over
+unmanaged storage, method function pointers, and function-pointer invocation
+use the same pattern. These older guards are still wrapped as legacy GS9999
+diagnostics; #3199 tracks moving deliberate boundary failures out of the
+internal-error category.
 
-Script-mode diagnostic rendering is not part of this boundary contract and may
-include a source location and caret. Boundary messages must still name the
-construct, state that the interpreter does not support it, and explain which
-compiled runtime facility it requires. They cannot rely on surrounding
-diagnostic rendering for meaning.
+Diagnostic presentation is not part of this boundary contract. Boundary
+messages must still name the construct, state that the evaluator does not
+support it, and explain which compiled runtime facility it requires. They
+cannot rely on surrounding rendering for meaning.
 
 ## Decision
 
 Constructs whose interpreter behavior requires real address identity —
 including pinning, stack allocation, unmanaged-pointer storage or dereference,
-and function-pointer execution — are **compiled-only**. `gsi` must report a
-self-contained boundary diagnostic instead of attempting a value-only
-approximation. Users who need these constructs must compile with `gsc`.
+and function-pointer execution — are **compiled-only in the tree evaluator**.
+Default interactive `gsi` must report a self-contained boundary diagnostic
+instead of attempting a value-only approximation. Since ADR-0156 Phase 1,
+bare `gsc` and `gsi <file>` use emitted execution and run these constructs
+natively; `gsc /out:` emits them to disk.
 
 This ADR governs only the evaluator's storage-model boundary. It does not
 redefine unsafe/native language validity or CIL emission.
@@ -49,29 +52,30 @@ value operations continues to evaluate normally.
 
 The current implementation status is:
 
-| Construct | Current `gsi` behavior | Contract status |
+| Construct | Current default interactive-evaluator behavior | Contract status |
 |---|---|---|
 | `unsafe { ... }` without a storage-only construct | Evaluates normally | Supported |
-| `fixed` over array/slice, string, or a pinnable-reference source | Self-contained boundary diagnostic | Meets contract |
-| `stackalloc` | Self-contained boundary diagnostic | Meets contract |
-| `sizeof` requiring the CIL unmanaged-storage path | Self-contained boundary diagnostic | Meets contract |
-| `&Method` function pointer | Self-contained boundary diagnostic | Meets contract |
-| Function-pointer invocation | Self-contained boundary diagnostic | Meets contract |
-| Ref local alias (`let ref r = arr[i]`) | Re-evaluates the initializer at read time; silently wrong | Must alias a captured storage location; fixed by #3032 |
+| `fixed` over array/slice, string, or a pinnable-reference source | Self-contained legacy GS9999 boundary | Message meets contract; diagnostic category tracked by #3199 |
+| `stackalloc` | Self-contained legacy GS9999 boundary | Message meets contract; diagnostic category tracked by #3199 |
+| `sizeof` requiring the CIL unmanaged-storage path | Self-contained legacy GS9999 boundary | Message meets contract; diagnostic category tracked by #3199 |
+| `&Method` function pointer | Self-contained legacy GS9999 boundary | Message meets contract; diagnostic category tracked by #3199 |
+| Function-pointer invocation | Self-contained legacy GS9999 boundary | Message meets contract; diagnostic category tracked by #3199 |
+| Ref local alias (`let ref r = arr[i]`) | Aliases the captured storage location | Meets contract after #3032 |
 | `*p = value` | `GS0513` compiled-only boundary | Meets contract |
 | `*(p + 1)` | `GS0513` fires before pointer arithmetic is evaluated | Meets contract |
 | Free-standing `&x` followed by `*p` | `GS0513` compiled-only boundary | Meets contract |
 | Pointer arithmetic or comparison over copied values | May return coincidentally plausible results | Must become a boundary |
 
-The evaluator reports compiled-only storage boundaries through `GS0513` with
-exact, construct-specific messages. The conformance work in #2939 must classify
-that code as `IntentionalBoundary` and assert that each listed boundary fires;
-`GS9999` remains a failure.
+The evaluator reports unmanaged `&`/`*` storage boundaries through `GS0513`.
+The older construct-specific guards listed above still use self-contained
+messages carried by GS9999; #3199 tracks that diagnostic-classification gap.
+Outside those named legacy guards, `GS9999` remains a failure.
 
 ## Consequences
 
-- `gsi` does not promise compiled/interpreted parity for storage-dependent
-  unsafe constructs.
+- The default interactive evaluator does not promise parity for
+  storage-dependent unsafe constructs; file-mode drivers use emitted
+  execution.
 - Existing ref/out argument write-back at call sites remains supported; this
   does not provide stable ref-local aliasing.
 - Boundary tests pin non-zero exit status, empty standard output, and the

--- a/docs/adr/0153-interpreter-compiled-only-storage-boundary.md
+++ b/docs/adr/0153-interpreter-compiled-only-storage-boundary.md
@@ -41,7 +41,8 @@ and function-pointer execution — are **compiled-only in the tree evaluator**.
 Interactive `gsi --engine evaluator` must report a self-contained boundary
 diagnostic instead of attempting a value-only approximation. Since ADR-0156
 Phases 1–3a, all default drivers use emitted execution and run these constructs
-natively.
+natively. The evaluator path is deprecated and scheduled for removal in
+Phase 3c.
 
 This ADR governs only the evaluator's storage-model boundary. It does not
 redefine unsafe/native language validity or CIL emission.

--- a/docs/adr/0154-test-oracle-strength.md
+++ b/docs/adr/0154-test-oracle-strength.md
@@ -23,7 +23,8 @@ and believes the property is covered.
 The concrete anti-patterns, each observed in this codebase:
 
 1. **Byte-identical fixture pair** (#3161). The positive and negative variants of the claimed
-   property produce identical output — escaping vs. non-escaping receivers under `gsi` were
+   property produce identical output — escaping vs. non-escaping receivers under the
+   then-evaluator-backed `gsi` were
    byte-identical in stdout and diagnostic count — so the assertion cannot distinguish them.
    The test name claimed reachability semantics; the only load-bearing assertion was a
    diagnostic count about something else.

--- a/docs/adr/0154-test-oracle-strength.md
+++ b/docs/adr/0154-test-oracle-strength.md
@@ -27,7 +27,8 @@ The concrete anti-patterns, each observed in this codebase:
    then-evaluator-backed `gsi` were
    byte-identical in stdout and diagnostic count — so the assertion cannot distinguish them.
    The test name claimed reachability semantics; the only load-bearing assertion was a
-   diagnostic count about something else.
+   diagnostic count about something else. ADR-0156 now deprecates that evaluator and
+   schedules its removal for Phase 3c.
 2. **Degenerate parity oracle** (#3150). A driver-parity test computed its oracle from an emit
    run in which the discriminating code (deinit bodies) never executed, so the "computed"
    oracle equaled a constant; deleting the deinit bodies left the test green. One row compared

--- a/docs/adr/0156-gsi-emit-to-memory-execution.md
+++ b/docs/adr/0156-gsi-emit-to-memory-execution.md
@@ -5,7 +5,8 @@
 - **Phase**: Interpreter conformance / execution architecture
 - **Related**: #3176 (tracking), #3163 (code-health P2 headline item), ADR-0152
   (interpreter native-call boundary), ADR-0153 (interpreter compiled-only
-  storage boundary), ADR-0154 (test oracle strength); divergence instances
+  storage boundary), ADR-0154 (test oracle strength), ADR-0068 (`deinit`
+  destructor support); divergence instances
   [#3140](https://github.com/DavidObando/gsharp/issues/3140),
   [#3134](https://github.com/DavidObando/gsharp/issues/3134),
   [#3116](https://github.com/DavidObando/gsharp/issues/3116),
@@ -24,9 +25,10 @@
 
 ## Context
 
-G# has three execution drivers and two execution engines. `gsc /out:` emits IL
+Before this decision, G# had three execution drivers and two execution engines.
+`gsc /out:` emitted IL
 through `ReflectionMetadataEmitter` and the program runs on the CLR. Bare `gsc`
-(no `/out:`) and `gsi` both call `Compilation.Evaluate`, which walks bound
+(no `/out:`) and `gsi` both called `Compilation.Evaluate`, which walks bound
 trees with the `Evaluator` — ~7,300 lines across seven partial files in
 `src/Core/CodeAnalysis/Evaluator*.cs`. The two engines do not even consume the
 same trees: the emit path runs `InterpolatedStringHandlerLowerer`,
@@ -78,10 +80,11 @@ applicable because the pieces already exist here:
 
 ## Decision
 
-**Bare `gsc` and `gsi` stop interpreting. They compile with the real emitter
-into memory, load the PE bytes into a collectible `AssemblyLoadContext` inside
-the driver process, invoke the entry point, and surface stdout/stderr and the
-exit code exactly as today.** The tree-walking evaluator is retired on a
+**Bare `gsc` and file-mode `gsi` stop interpreting. They compile with the real
+emitter into memory, load the PE bytes into a collectible
+`AssemblyLoadContext` inside the driver process, invoke the entry point, and
+surface stdout/stderr and the exit code exactly as today.** Interactive `gsi`
+follows the phased migration below. The tree-walking evaluator is retired on a
 phased schedule, ending with its deletion or a documented residue. One codegen
 pipeline executes everywhere; the divergence class dies by construction.
 
@@ -93,6 +96,27 @@ framework and `/r:` references from the default context / resolver paths,
 value to an exit code (`int`/`uint`/`void→0`, matching today's gsi protocol),
 and unwrap `TargetInvocationException` into the driver's unhandled-exception
 protocol.
+
+### Implementation status (2026-08-04)
+
+Phase 1 shipped in #3182. Phase 2's emitted submission engine shipped in #3186
+as an opt-in; the evaluator remains the interactive default. Phase 3 is not
+complete.
+
+| Invocation | Current execution path |
+|---|---|
+| bare `gsc file.gs` | `EmittedProgramHost.Run` |
+| `gsc /out:program.dll file.gs` | emit PE to disk; the CLR runs it separately |
+| `gsi file.gs` | `EmittedProgramHost.Run` |
+| interactive `gsi` | `SessionEngine` → `Compilation.Evaluate` (default) |
+| interactive `gsi --engine emit` | `EmittedSessionEngine` |
+
+Therefore the former "three-driver" model no longer identifies three
+execution semantics: all file-mode columns compile through the emitter. The
+default interactive REPL is the remaining shipped evaluator harness. This
+partially supersedes ADR-0068's original `deinit` interpreter boundary (and
+ADR-0152/ADR-0153) for migrated drivers, while leaving those boundaries in
+force for the evaluator residue.
 
 ### Phased migration plan
 
@@ -196,9 +220,9 @@ ALC lifetime). No changes to the language, the LSP, or `gsc /out:`.
   session that registers callbacks with default-ALC statics (timers, events)
   can pin the session ALC — accepted, same as any REPL.
 - **Deinit semantics**: emitted code runs real deinitializers, so the
-  GS0510 evaluator boundary disappears on migrated drivers and the recent
-  deinit driver-boundary observability work applies to all three drivers
-  uniformly.
+  GS0510 evaluator boundary in
+  [ADR-0068](0068-deinit-destructor-support.md) disappears on migrated drivers;
+  deinit behavior applies to all three file-mode columns uniformly.
 - **stdout / exit code**: the host process's `Console` is the program's
   `Console` (today's gsi behavior, spike-verified including async
   submissions); the TUI's `CaptureConsole` redirection keeps working because

--- a/docs/adr/0156-gsi-emit-to-memory-execution.md
+++ b/docs/adr/0156-gsi-emit-to-memory-execution.md
@@ -99,24 +99,25 @@ protocol.
 
 ### Implementation status (2026-08-04)
 
-Phase 1 shipped in #3182. Phase 2's emitted submission engine shipped in #3186
-as an opt-in; the evaluator remains the interactive default. Phase 3 is not
-complete.
+Phase 1 shipped in #3182. Phase 2's emitted submission engine shipped in #3186,
+and Phase 3a made it the interactive default in #3201. The evaluator remains
+available through the deprecated `--engine evaluator` compatibility path and
+direct `Compilation.Evaluate` consumers until Phase 3c.
 
 | Invocation | Current execution path |
 |---|---|
 | bare `gsc file.gs` | `EmittedProgramHost.Run` |
 | `gsc /out:program.dll file.gs` | emit PE to disk; the CLR runs it separately |
 | `gsi file.gs` | `EmittedProgramHost.Run` |
-| interactive `gsi` | `SessionEngine` → `Compilation.Evaluate` (default) |
-| interactive `gsi --engine emit` | `EmittedSessionEngine` |
+| interactive `gsi` | `EmittedSessionEngine` (default) |
+| interactive `gsi --engine evaluator` | `SessionEngine` → `Compilation.Evaluate` |
 
 Therefore the former "three-driver" model no longer identifies three
-execution semantics: all file-mode columns compile through the emitter. The
-default interactive REPL is the remaining shipped evaluator harness. This
-partially supersedes ADR-0068's original `deinit` interpreter boundary (and
-ADR-0152/ADR-0153) for migrated drivers, while leaving those boundaries in
-force for the evaluator residue.
+execution semantics: every default driver compiles through the emitter. The
+tree evaluator remains reachable only through its deprecated interactive
+escape hatch and direct API/test consumers. This partially supersedes
+ADR-0068's original `deinit` interpreter boundary (and ADR-0152/ADR-0153) for
+default drivers, while leaving those boundaries in force for evaluator residue.
 
 ### Phased migration plan
 
@@ -270,10 +271,10 @@ The gate's post-migration definition:
   resolution, `/r:` closure, Console/exit-code protocol, unhandled-exception
   shape, TFM/runtimeconfig differences between `dotnet exec` and in-proc
   loading;
-- while any interpreter surface remains reachable (between Phases 1 and 3,
-  the interactive REPL), the interpreter column stays in the gate for that
-  surface, with the `ExpectedDifferences` table shrinking monotonically —
-  entries are deleted with the boundary that caused them, never added.
+- while any interpreter surface remains reachable before Phase 3c, the
+  interpreter column stays in the gate for that surface, with the
+  `ExpectedDifferences` table shrinking monotonically — entries are deleted
+  with the boundary that caused them, never added.
 
 After Phase 3 the gate is a two-column host-parity gate plus the golden
 files, and the standing obligation to hand-maintain a table of known

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -323,9 +323,9 @@ Unmanaged `&`/`*` operations surface through `GS0513`. Older guards for
 self-contained boundary messages through legacy `GS9999`; issue
 [#3199](https://github.com/DavidObando/gsharp/issues/3199) tracks moving those
 deliberate failures out of the internal-error category. Since
-[ADR-0156](adr/0156-gsi-emit-to-memory-execution.md) Phase 1 the boundary
-applies only to the interactive REPL — `gsi <file>` and bare `gsc` execute
-emitted code, where these constructs run natively.
+[ADR-0156](adr/0156-gsi-emit-to-memory-execution.md) Phase 3a the boundary
+applies only to direct tree evaluation and `gsi --engine evaluator`; all
+default drivers execute emitted code, where these constructs run natively.
 
 ## Documentation diagnostics (GS0227–GS0231)
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -317,13 +317,15 @@ These diagnostics indicate a fatal compiler or evaluator failure. If you encount
 #### Interpreter compiled-only boundaries
 
 [ADR-0153](adr/0153-interpreter-compiled-only-storage-boundary.md) defines
-storage-dependent unsafe constructs as compiled-only. The clean boundary sites
-for `fixed`, `stackalloc`, unmanaged `sizeof`, and function pointers currently
-surface through `GS0513` with a self-contained message naming the construct and
-the required CIL emit path. Evaluator `GS9999` diagnostics still indicate a
-defect. Since [ADR-0156](adr/0156-gsi-emit-to-memory-execution.md) Phase 1 the
-boundary applies only to the interactive REPL — `gsi <file>` and bare `gsc`
-execute emitted code, where these constructs run natively.
+storage-dependent unsafe constructs as compiled-only in the tree evaluator.
+Unmanaged `&`/`*` operations surface through `GS0513`. Older guards for
+`fixed`, `stackalloc`, unmanaged `sizeof`, and function pointers still carry
+self-contained boundary messages through legacy `GS9999`; issue
+[#3199](https://github.com/DavidObando/gsharp/issues/3199) tracks moving those
+deliberate failures out of the internal-error category. Since
+[ADR-0156](adr/0156-gsi-emit-to-memory-execution.md) Phase 1 the boundary
+applies only to the interactive REPL — `gsi <file>` and bare `gsc` execute
+emitted code, where these constructs run natively.
 
 ## Documentation diagnostics (GS0227–GS0231)
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -326,6 +326,7 @@ deliberate failures out of the internal-error category. Since
 [ADR-0156](adr/0156-gsi-emit-to-memory-execution.md) Phase 3a the boundary
 applies only to direct tree evaluation and `gsi --engine evaluator`; all
 default drivers execute emitted code, where these constructs run natively.
+The evaluator path is deprecated and scheduled for removal in Phase 3c.
 
 ## Documentation diagnostics (GS0227–GS0231)
 

--- a/website/docs/ref/diagnostics.md
+++ b/website/docs/ref/diagnostics.md
@@ -308,11 +308,17 @@ These diagnostics indicate a fatal compiler or evaluator failure. If you encount
 
 #### Interpreter compiled-only boundaries
 
-Storage-dependent unsafe constructs are compiled-only. The clean boundary
-sites for `fixed`, `stackalloc`, unmanaged `sizeof`, and function pointers
-currently surface through `GS0513` with a self-contained message naming the
-construct and the required CIL emit path. Evaluator `GS9999` diagnostics still
-indicate a defect.
+[ADR-0153](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0153-interpreter-compiled-only-storage-boundary.md)
+defines storage-dependent unsafe constructs as compiled-only in the tree
+evaluator. Unmanaged `&`/`*` operations surface through `GS0513`. Older guards
+for `fixed`, `stackalloc`, unmanaged `sizeof`, and function pointers still
+carry self-contained boundary messages through legacy `GS9999`; issue
+[#3199](https://github.com/DavidObando/gsharp/issues/3199) tracks moving those
+deliberate failures out of the internal-error category. Since
+[ADR-0156](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0156-gsi-emit-to-memory-execution.md)
+Phase 3a the boundary applies only to direct tree evaluation and
+`gsi --engine evaluator`; all default drivers execute emitted code, where
+these constructs run natively.
 
 ## Documentation diagnostics (GS0227–GS0231)
 

--- a/website/docs/ref/diagnostics.md
+++ b/website/docs/ref/diagnostics.md
@@ -318,7 +318,8 @@ deliberate failures out of the internal-error category. Since
 [ADR-0156](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0156-gsi-emit-to-memory-execution.md)
 Phase 3a the boundary applies only to direct tree evaluation and
 `gsi --engine evaluator`; all default drivers execute emitted code, where
-these constructs run natively.
+these constructs run natively. The evaluator path is deprecated and scheduled
+for removal in Phase 3c.
 
 ## Documentation diagnostics (GS0227–GS0231)
 
@@ -1777,7 +1778,12 @@ GS0264, even though iterator specialization synthesizes equivalent variants.
 
 This is an intentional interpreter capability boundary, not an internal
 compiler error. It applies even when the declaration is not called because
-`gsi` cannot create a valid callable value for direct or indirect use.
+the interpreter cannot create a valid callable value for direct or indirect
+use. Since [ADR-0156](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0156-gsi-emit-to-memory-execution.md)
+Phase 3a no driver interprets by default: `gsi <file>`, bare `gsc`, and the
+interactive REPL all execute emitted code, where P/Invoke runs natively. This
+diagnostic now fires only under gsi's deprecated `--engine evaluator` escape
+hatch and retires with the evaluator in Phase 3c.
 
 ## Interpreter deinitializer boundary (GS0510)
 
@@ -1786,8 +1792,13 @@ compiler error. It applies even when the declaration is not called because
 | GS0510 | Warning | A class declares a CLR GC finalizer with `deinit`, which does not run under interpreted execution. |
 
 The interpreter has no emitted class with a CLR `Finalize` override and does
-not invent deterministic scope-exit cleanup. Compile with `gsc` when program
-behavior depends on GC finalization.
+not invent deterministic scope-exit cleanup. Since
+[ADR-0156](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0156-gsi-emit-to-memory-execution.md)
+Phase 3a no driver interprets by default: `gsi <file>`, bare `gsc`, and the
+interactive REPL all execute emitted code, whose deinitializers run as real CLR
+finalizers, so this warning no longer appears in a default `gsi` session. It
+now fires only under gsi's deprecated `--engine evaluator` escape hatch and
+retires with the evaluator in Phase 3c.
 
 ## Explicit-layout reference storage (GS0518)
 


### PR DESCRIPTION
## Summary

- amend ADR-0068's stale `gsc`/`gsi` liveness table with the current execution-engine boundary
- mark ADR-0068 partially superseded and add the missing ADR-0156 cross-reference in both directions
- record ADR-0156 Phase 3a: interactive `gsi` now uses emitted execution by default
- mark the explicit evaluator path deprecated and scheduled for removal in Phase 3c
- remove ADR-0047's unsupported ADR-0023 interpreter-authority citation
- correct stale evaluator-boundary claims across the affected ADRs and diagnostic catalogues
- synchronize `website/docs/ref/diagnostics.md` with the authoritative diagnostics catalogue
- preserve ADR-0068's finalizer-thread risk and diagnostic-severity rationale

Closes #3196.

## Status decision

ADR-0068 is **partially superseded by ADR-0156**, not wholly superseded. Its `deinit` syntax, CLR finalizer shape, diagnostics, and emission decision remain accepted; only its original execution-driver boundary is obsolete. This follows existing scoped-supersession precedent (ADR-0017 and ADR-0033) rather than inventing a new status. ADR-0156 names the ADR-0068 boundary it supersedes.

## Final remeasurement

Final base: `0484b00f139fe216b7910a23bb08415d571e2a28`. Head: `24ced1162b6aa37cf266cbdb206b26af85477192`.

Rebuilt Release `gsi --help` returned rc 0 and reports:

```text
--engine <name>        Interactive engine: 'emit' (default) or 'evaluator'
                       (also via GSI_ENGINE). 'evaluator' selects the legacy
                       tree-walking engine; it is deprecated and will be
                       removed in ADR-0156 Phase 3c.
```

Targeted engine/deinitializer tests passed **13/13** on the final rebased tree. They cover:

- unset interactive choice -> emitted engine
- explicit `emit` -> emitted engine
- `--engine evaluator` and `GSI_ENGINE=evaluator` -> evaluator escape hatch
- bare `gsc`, `gsc /out:`, and file-mode `gsi` running emitted deinitializers without GS0510
- `EmittedSessionEngine` running a real CLR finalizer
- explicit `SessionEngine` omitting the deinitializer and reporting GS0510 regardless of reachability

This establishes execution engine, not object liveness, as the boundary. Every default driver emits; only explicit evaluator selection and direct `Compilation.Evaluate` consumers retain the deprecated evaluator behavior.

## Measured versus inferred

Measured on the final rebased tree: rebuilt CLI help text and rc, engine selection, deinitializer output and diagnostics through the 13 targeted tests, documentation build, link resolution, residue greps, diff scope, and PR mergeability.

Documentation-policy decision: ADR-0068 remains accepted except for the execution-engine boundary, which is partially superseded by ADR-0156.

## Validation

- Release `src/Repl/Repl.csproj` build with warnings as errors: **0 warnings, 0 errors**.
- Targeted `Interpreter.Tests`: **13/13 passed**.
- Local Docusaurus production build: passed.
- Current-head Docs site CI `Build docs`: passed.
- Relative link check: **27 real relative links across 19 changed Markdown files, 0 broken**. The post-rebase count is smaller because current `main` already contains several formerly changed documentation files.
- Stale default-model, old three-driver-model, and phantom-rule residue greps: 0 hits.
- `git diff --check`: clean.
- No mutation testing: no executable code changed.
- Full test suites not rerun for this docs-only round; targeted tests cover every behavioral claim retained in the changed text.

## Scope

```text
$ git diff --name-only $(git merge-base origin/main HEAD)...HEAD | grep -E '^(src|test|e2etests|build|samples)/'

$ git diff --name-only -- src/

```

Both outputs are empty. Product code unchanged.
