### PR TITLE
Flip interactive gsi default to the emitted session engine (ADR-0156 Phase 3a)

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -1168,10 +1168,11 @@ GS0264, even though iterator specialization synthesizes equivalent variants.
 This is an intentional interpreter capability boundary, not an internal
 compiler error. It applies even when the declaration is not called because
 the interpreter cannot create a valid callable value for direct or indirect
-use. Since [ADR-0156](adr/0156-gsi-emit-to-memory-execution.md) Phase 1 only
-the interactive REPL interprets: `gsi <file>` and bare `gsc` execute emitted
-code, so P/Invoke runs natively there and this diagnostic no longer fires on
-those drivers.
+use. Since [ADR-0156](adr/0156-gsi-emit-to-memory-execution.md) Phase 3a no
+driver interprets by default: `gsi <file>`, bare `gsc`, and the interactive
+REPL all execute emitted code, where P/Invoke runs natively. This diagnostic
+now fires only under gsi's deprecated `--engine evaluator` escape hatch and
+retires with the evaluator in Phase 3c.
 
 ## Explicit-layout reference storage (GS0518)
 
@@ -1189,8 +1190,11 @@ Interpreter values use boxed storage, which cannot hold stack-only CLR values
 or preserve their interior references. The interpreter emulates spans created
 from arrays; CLR methods and properties returning stack-only values remain
 unsupported. Since [ADR-0156](adr/0156-gsi-emit-to-memory-execution.md)
-Phase 1 only the interactive REPL interprets: `gsi <file>` and bare `gsc`
-execute emitted code, where ByRefLike values work natively.
+Phase 3a no driver interprets by default: `gsi <file>`, bare `gsc`, and the
+interactive REPL all execute emitted code, where ByRefLike values work
+natively. This diagnostic now fires only under gsi's deprecated
+`--engine evaluator` escape hatch and retires with the evaluator in
+Phase 3c.
 
 ## Interpreter deinitializer boundary (GS0510)
 
@@ -1200,10 +1204,12 @@ execute emitted code, where ByRefLike values work natively.
 
 The interpreter has no emitted class with a CLR `Finalize` override and does
 not invent deterministic scope-exit cleanup. Since
-[ADR-0156](adr/0156-gsi-emit-to-memory-execution.md) Phase 1 only the
-interactive REPL interprets: `gsi <file>` and bare `gsc` execute emitted code,
-whose deinitializers run as real CLR finalizers, so this warning no longer
-fires on those drivers.
+[ADR-0156](adr/0156-gsi-emit-to-memory-execution.md) Phase 3a no driver
+interprets by default: `gsi <file>`, bare `gsc`, and the interactive REPL all
+execute emitted code, whose deinitializers run as real CLR finalizers, so
+this warning no longer appears in a default `gsi` session. It now fires only
+under gsi's deprecated `--engine evaluator` escape hatch and retires with the
+evaluator in Phase 3c.
 
 ## Internal compiler error details (GS9998)
 

--- a/docs/emit-pipeline.md
+++ b/docs/emit-pipeline.md
@@ -1,6 +1,6 @@
 # Emit pipeline
 
-GSharp has two execution backends. The interpreter (`Evaluator`) walks the bound tree in-process and is what powers the REPL and most language tests. The emit pipeline produces standalone managed PEs that load and run under any compatible .NET runtime. This document describes the emit pipeline only; the interpreter remains the canonical reference for language semantics, but compiling to disk is now the production path for `dotnet build`.
+GSharp has two execution backends. The emit pipeline produces managed PEs — written to disk by `dotnet build`/`gsc /out:`, or loaded straight from memory by the in-process drivers ([ADR-0156](adr/0156-gsi-emit-to-memory-execution.md)) — and since ADR-0156 Phase 3a it is the execution path for every driver by default, including the interactive REPL. The interpreter (`Evaluator`) walks the bound tree in-process; it survives only behind gsi's deprecated `--engine evaluator` escape hatch and as the `Compilation.Evaluate` oracle in many language tests, and it retires in ADR-0156 Phase 3c. This document describes the emit pipeline only.
 
 ```
 .gs source ──► Lexer ──► Parser ──► Syntax tree
@@ -157,7 +157,7 @@ The emit path does **not** depend on Roslyn — `ReflectionMetadataEmitter` writ
 
 ## Interpreter vs. emit
 
-The in-process `Evaluator` remains the canonical reference for language semantics and is still the default execution backend for the REPL and most language tests. The emit pipeline mirrors its lowering behavior for any construct it supports; if the two ever disagree, the interpreter is treated as authoritative. Both paths share the `Binder`, `BoundProgram`, and lowering stages — only the final code-generation step differs.
+Since [ADR-0156](adr/0156-gsi-emit-to-memory-execution.md) the emitted pipeline is the execution backend for every driver by default — `gsc`, `gsi <file>` (Phase 1), and the interactive REPL (Phases 2–3a). The in-process `Evaluator` remains reachable only via gsi's deprecated `--engine evaluator` escape hatch and as the `Compilation.Evaluate` oracle in existing language tests; where the two disagree, the emitted semantics are authoritative (evaluator/emit divergence is the bug class ADR-0156 retires), and the evaluator is deleted in Phase 3c. Both paths share the `Binder`, `BoundProgram`, and lowering stages — only the final code-generation step differs.
 
 ## File map
 

--- a/new-repl.md
+++ b/new-repl.md
@@ -1,5 +1,12 @@
 # Plan: a modern TUI REPL to replace `Interpreter.csproj`
 
+> **Historical note (2026-08):** this plan shipped as `src/Repl`. Its eval
+> core has since moved on: per [ADR-0156](docs/adr/0156-gsi-emit-to-memory-execution.md)
+> Phase 3a the interactive default engine is the emitted submission-chaining
+> `EmittedSessionEngine`, not the `Compilation.ContinueWith`/`Evaluate`
+> `SessionEngine` described below (which survives only behind the deprecated
+> `--engine evaluator` escape hatch until Phase 3c).
+
 ## 1. Goal
 
 Replace the current console REPL (`src/Interpreter`) with a brand-new, full-screen,

--- a/src/Repl/Engine/EmittedSessionEngine.cs
+++ b/src/Repl/Engine/EmittedSessionEngine.cs
@@ -22,7 +22,8 @@ using GSharp.Core.CodeAnalysis.Text;
 namespace GSharp.Repl.Engine;
 
 /// <summary>
-/// The emitted submission-chaining REPL engine (ADR-0156 Phase 2): every
+/// The emitted submission-chaining REPL engine (ADR-0156 Phase 2; the
+/// interactive default since Phase 3a): every
 /// submission compiles with the real emitter into an in-memory assembly
 /// (<c>gsi$N</c>) that binds against all prior submissions' assemblies, loads
 /// into one session-wide collectible <see cref="System.Runtime.Loader.AssemblyLoadContext"/>,

--- a/src/Repl/Engine/ISessionEngine.cs
+++ b/src/Repl/Engine/ISessionEngine.cs
@@ -10,9 +10,10 @@ using System.Threading.Tasks;
 namespace GSharp.Repl.Engine;
 
 /// <summary>
-/// The evaluation engine surface the interactive TUI drives (ADR-0156
-/// Phase 2): the historical tree-walking <see cref="SessionEngine"/> and the
-/// emitted submission-chaining <see cref="EmittedSessionEngine"/> both
+/// The evaluation engine surface the interactive TUI drives (ADR-0156): the
+/// emitted submission-chaining <see cref="EmittedSessionEngine"/> (the
+/// interactive default since Phase 3a) and the legacy tree-walking
+/// <see cref="SessionEngine"/> (deprecated escape hatch until Phase 3c) both
 /// implement it, so the REPL screen is engine-agnostic.
 /// </summary>
 public interface ISessionEngine

--- a/src/Repl/Engine/SessionEngine.cs
+++ b/src/Repl/Engine/SessionEngine.cs
@@ -21,6 +21,10 @@ namespace GSharp.Repl.Engine;
 /// <summary>
 /// Owns the incremental compilation state and the transcript of evaluated cells.
 /// Replaces the eval core of the old <c>GSharpRepl</c> without any console output.
+/// ADR-0156 Phase 3a: no longer the interactive default — the tree-walking
+/// evaluator behind this engine is reachable only via the deprecated
+/// <c>--engine evaluator</c> / <c>GSI_ENGINE=evaluator</c> escape hatch and
+/// retires with it in Phase 3c.
 /// </summary>
 public sealed class SessionEngine : ISessionEngine
 {

--- a/src/Repl/Program.cs
+++ b/src/Repl/Program.cs
@@ -35,8 +35,10 @@ public static class Program
                 Console.WriteLine("  file.gs                Run the given G# script and exit.");
                 Console.WriteLine("  /r:<file>              Reference an assembly (repeatable).");
                 Console.WriteLine("  /reference:<file>      Alias for /r: (also -r: and --reference:).");
-                Console.WriteLine("  --engine <name>        Interactive engine: 'evaluator' (default) or 'emit'");
-                Console.WriteLine("                         (ADR-0156 Phase 2 opt-in; also via GSI_ENGINE).");
+                Console.WriteLine("  --engine <name>        Interactive engine: 'emit' (default) or 'evaluator'");
+                Console.WriteLine("                         (also via GSI_ENGINE). 'evaluator' selects the legacy");
+                Console.WriteLine("                         tree-walking engine; it is deprecated and will be");
+                Console.WriteLine("                         removed in ADR-0156 Phase 3c.");
                 Console.WriteLine("  --help, -h             Show this help and exit.");
                 Console.WriteLine("  --version              Show the gsi version and exit.");
                 Console.WriteLine("  (no args)              Start the interactive REPL.");
@@ -83,7 +85,7 @@ public static class Program
         engineChoice ??= EngineChoiceFromEnvironment();
         if (engineChoice is not null and not "evaluator" and not "emit")
         {
-            Console.Error.WriteLine($"Unknown engine '{engineChoice}'. Expected 'evaluator' or 'emit'.");
+            Console.Error.WriteLine($"Unknown engine '{engineChoice}'. Expected 'emit' or 'evaluator'.");
             return 1;
         }
 
@@ -107,13 +109,29 @@ public static class Program
         return RunScript(scriptPath, references);
     }
 
-    private static string? EngineChoiceFromEnvironment()
+    /// <summary>
+    /// Decides whether an interactive engine choice selects the legacy
+    /// tree-walking evaluator. ADR-0156 Phase 3a: the emitted
+    /// submission-chaining engine is the interactive default, so only an
+    /// explicit <c>--engine evaluator</c> (or <c>GSI_ENGINE=evaluator</c>)
+    /// selects the evaluator — a deprecated escape hatch that retires with
+    /// the evaluator in Phase 3c.
+    /// </summary>
+    /// <param name="engineChoice">The normalized engine choice, or <see langword="null"/> for the default.</param>
+    /// <returns><see langword="true"/> when the evaluator engine was explicitly requested.</returns>
+    internal static bool UsesEvaluatorEngine(string? engineChoice) => engineChoice == "evaluator";
+
+    /// <summary>Reads the <c>GSI_ENGINE</c> environment variable as a normalized engine choice.</summary>
+    /// <returns>The lower-cased engine name, or <see langword="null"/> when unset or empty.</returns>
+    internal static string? EngineChoiceFromEnvironment()
         => Environment.GetEnvironmentVariable("GSI_ENGINE") is { Length: > 0 } env ? env.ToLowerInvariant() : null;
 
     /// <summary>
-    /// Starts the interactive TUI. ADR-0156 Phase 2: <c>--engine emit</c> (or
-    /// <c>GSI_ENGINE=emit</c>) selects the emitted submission-chaining engine;
-    /// the default remains the tree-walking evaluator until the flip lands.
+    /// Starts the interactive TUI. ADR-0156 Phase 3a: submissions execute
+    /// through the emitted <see cref="Engine.EmittedSessionEngine"/> by
+    /// default; <c>--engine evaluator</c> (or <c>GSI_ENGINE=evaluator</c>)
+    /// temporarily selects the legacy tree-walking engine until it is
+    /// removed in Phase 3c.
     /// </summary>
     private static int RunInteractive(string? engineChoice, List<string> references)
     {
@@ -124,13 +142,13 @@ public static class Program
         }
 
         var effectiveReferences = ReferenceResolver.ResolveDriverReferencePaths(references);
-        if (engineChoice == "emit")
+        if (UsesEvaluatorEngine(engineChoice))
         {
-            return ReplHost.Run(new Engine.EmittedSessionEngine(effectiveReferences));
+            using var resolver = ReferenceResolver.WithRuntimeReferences(effectiveReferences);
+            return ReplHost.Run(new Engine.SessionEngine(resolver));
         }
 
-        using var resolver = ReferenceResolver.WithRuntimeReferences(effectiveReferences);
-        return ReplHost.Run(new Engine.SessionEngine(resolver));
+        return ReplHost.Run(new Engine.EmittedSessionEngine(effectiveReferences));
     }
 
     /// <summary>

--- a/src/Repl/Repl.csproj
+++ b/src/Repl/Repl.csproj
@@ -44,7 +44,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="Interpreter.Tests" />
+    <!-- The test assembly is GSharp.Interpreter.Tests: gsharp.build.props
+         defaults AssemblyName to GSharp.$(MSBuildProjectName). -->
+    <InternalsVisibleTo Include="GSharp.Interpreter.Tests" />
   </ItemGroup>
 
 </Project>

--- a/src/Repl/ReplHost.cs
+++ b/src/Repl/ReplHost.cs
@@ -15,7 +15,13 @@ namespace GSharp.Repl;
 /// <summary>Owns the alt-screen lifecycle and the AppShell. Restores the terminal on exit.</summary>
 public static class ReplHost
 {
-    public static int Run() => Run(new SessionEngine());
+    /// <summary>
+    /// Runs the interactive TUI over the default engine — the emitted
+    /// submission-chaining <see cref="EmittedSessionEngine"/> (ADR-0156
+    /// Phase 3a).
+    /// </summary>
+    /// <returns>The process exit code.</returns>
+    public static int Run() => Run(new EmittedSessionEngine());
 
     /// <summary>
     /// Runs the interactive TUI over the given evaluation engine (ADR-0156

--- a/test/Interpreter.Tests/Adr0156DefaultEngineFlipTests.cs
+++ b/test/Interpreter.Tests/Adr0156DefaultEngineFlipTests.cs
@@ -1,0 +1,77 @@
+// <copyright file="Adr0156DefaultEngineFlipTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using ReplProgram = GSharp.Repl.Program;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// ADR-0156 Phase 3a: interactive <c>gsi</c> defaults to the emitted
+/// submission-chaining engine. Only an explicit <c>--engine evaluator</c> (or
+/// <c>GSI_ENGINE=evaluator</c>) selects the legacy tree-walking engine — a
+/// deprecated escape hatch that retires with the evaluator in Phase 3c.
+/// Witness (ADR-0154): <see cref="ReplProgram.UsesEvaluatorEngine"/> is the
+/// single interactive engine-selection predicate and does not exist before
+/// the flip; before this change the equivalent condition defaulted the
+/// unset/null choice to the evaluator, so
+/// <see cref="DefaultEngineChoiceSelectsEmittedEngine"/> pins the flipped
+/// behavior itself.
+/// </summary>
+public sealed class Adr0156DefaultEngineFlipTests
+{
+    [Fact]
+    public void DefaultEngineChoiceSelectsEmittedEngine()
+    {
+        // No --engine and no GSI_ENGINE: the emitted engine is the default.
+        Assert.False(ReplProgram.UsesEvaluatorEngine(null));
+    }
+
+    [Fact]
+    public void ExplicitEmitChoiceSelectsEmittedEngine()
+    {
+        Assert.False(ReplProgram.UsesEvaluatorEngine("emit"));
+    }
+
+    [Fact]
+    public void ExplicitEvaluatorChoiceSelectsEvaluatorEscapeHatch()
+    {
+        Assert.True(ReplProgram.UsesEvaluatorEngine("evaluator"));
+    }
+
+    [Fact]
+    public void EnvironmentVariableStillSelectsEvaluatorEscapeHatch()
+    {
+        var previous = Environment.GetEnvironmentVariable("GSI_ENGINE");
+        try
+        {
+            Environment.SetEnvironmentVariable("GSI_ENGINE", "EVALUATOR");
+            var choice = ReplProgram.EngineChoiceFromEnvironment();
+            Assert.Equal("evaluator", choice);
+            Assert.True(ReplProgram.UsesEvaluatorEngine(choice));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("GSI_ENGINE", previous);
+        }
+    }
+
+    [Fact]
+    public void UnsetEnvironmentVariableYieldsDefaultEmittedEngine()
+    {
+        var previous = Environment.GetEnvironmentVariable("GSI_ENGINE");
+        try
+        {
+            Environment.SetEnvironmentVariable("GSI_ENGINE", null);
+            var choice = ReplProgram.EngineChoiceFromEnvironment();
+            Assert.Null(choice);
+            Assert.False(ReplProgram.UsesEvaluatorEngine(choice));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("GSI_ENGINE", previous);
+        }
+    }
+}

--- a/test/Interpreter.Tests/EmittedSessionEngineParityTests.cs
+++ b/test/Interpreter.Tests/EmittedSessionEngineParityTests.cs
@@ -207,8 +207,10 @@ public sealed class EmittedSessionEngineParityTests
     /// engine's chained scopes surface BOTH declarations as overloads, so the
     /// call reports an ambiguity and the redefined function is uncallable;
     /// the emitted engine gives clean newest-wins shadowing (the Roslyn
-    /// interactive model). When the emitted engine becomes the default, the
-    /// evaluator half of this test retires with it.
+    /// interactive model). Phase 3a made the emitted engine the interactive
+    /// default; both halves keep selecting their engine EXPLICITLY while the
+    /// deprecated <c>--engine evaluator</c> escape hatch exists, and the
+    /// evaluator half retires with it in Phase 3c.
     /// </summary>
     [Fact]
     public void RedefinedFunctionCallDivergesByDesign()
@@ -234,9 +236,11 @@ public sealed class EmittedSessionEngineParityTests
     /// methods against a COPY of the receiver, so the mutation is lost — even
     /// within a single cell — while the emitted engine passes the global's
     /// real address (`ldsflda`) as the receiver, so the mutation persists,
-    /// matching what the same program compiled by `gsc` does. When the
-    /// emitted engine becomes the default, the evaluator half of this test
-    /// retires with it.
+    /// matching what the same program compiled by `gsc` does. Phase 3a made
+    /// the emitted engine the interactive default; both halves keep selecting
+    /// their engine EXPLICITLY while the deprecated <c>--engine evaluator</c>
+    /// escape hatch exists, and the evaluator half retires with it in
+    /// Phase 3c.
     /// </summary>
     [Fact]
     public void StructMethodReceiverMutationDivergesByDesign()

--- a/test/Interpreter.Tests/Issue2956InterpreterBoundaryTests.cs
+++ b/test/Interpreter.Tests/Issue2956InterpreterBoundaryTests.cs
@@ -14,8 +14,9 @@ namespace GSharp.Interpreter.Tests;
 /// used to reject with self-contained boundary diagnostics (<c>fixed</c>,
 /// <c>stackalloc</c>, <c>sizeof</c> on user structs, function pointers) now
 /// compile through the real emitter and run in-process, so each case asserts
-/// the construct's observable result instead of a refusal. The ADR-0153
-/// boundary remains in force for the interactive REPL, which still evaluates
+/// the construct's observable result instead of a refusal. Since Phase 3a the
+/// interactive REPL default is emitted too; the ADR-0153 boundary remains in
+/// force only under the deprecated <c>--engine evaluator</c> escape hatch
 /// (see <c>Issue3004PointerBoundaryInterpreterTests</c>).
 /// </summary>
 [Collection("ConsoleIo")]

--- a/test/Interpreter.Tests/Issue2986InterpreterBoundaryTests.cs
+++ b/test/Interpreter.Tests/Issue2986InterpreterBoundaryTests.cs
@@ -11,7 +11,14 @@ using Xunit;
 
 namespace GSharp.Interpreter.Tests;
 
-/// <summary>Issue #2986: explicit interpreter native-call boundary.</summary>
+/// <summary>
+/// Issue #2986: explicit interpreter native-call boundary (GS0514).
+/// ADR-0156 Phase 3a: the interactive cells here pin the LEGACY tree-walking
+/// evaluator engine, constructed explicitly as <see cref="SessionEngine"/> —
+/// never the interactive default, which is now the emitted engine where
+/// P/Invoke runs natively. These evaluator-pinned tests retire with the
+/// deprecated <c>--engine evaluator</c> escape hatch in Phase 3c.
+/// </summary>
 [Collection("ConsoleIo")]
 public class Issue2986InterpreterBoundaryTests
 {

--- a/test/Interpreter.Tests/Issue2987ByRefLikeBoundaryInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2987ByRefLikeBoundaryInterpreterTests.cs
@@ -14,7 +14,13 @@ namespace GSharp.Interpreter.Tests;
 
 /// <summary>
 /// Issue #2987: reflection cannot invoke members whose signatures contain
-/// stack-only CLR values, so the interpreter reports an explicit boundary.
+/// stack-only CLR values, so the interpreter reports an explicit boundary
+/// (GS0511). ADR-0156 Phase 3a: the interactive cells here pin the LEGACY
+/// tree-walking evaluator engine, constructed explicitly as
+/// <see cref="SessionEngine"/> — never the interactive default, which is now
+/// the emitted engine where ByRefLike values work natively. These
+/// evaluator-pinned tests retire with the deprecated
+/// <c>--engine evaluator</c> escape hatch in Phase 3c.
 /// </summary>
 public class Issue2987ByRefLikeBoundaryInterpreterTests
 {

--- a/test/Interpreter.Tests/Issue2988DeinitInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2988DeinitInterpreterTests.cs
@@ -13,6 +13,14 @@ namespace GSharp.Interpreter.Tests;
 
 /// <summary>
 /// Interpreter boundary coverage for CLR GC finalizers declared with <c>deinit</c>.
+/// ADR-0156 Phase 3a: the GS0510 tests here pin the LEGACY tree-walking
+/// evaluator engine, constructed explicitly as <see cref="SessionEngine"/> —
+/// never the interactive default, which is now the emitted engine that runs
+/// deinitializers for real without GS0510 (see
+/// <c>EmittedSessionEngineTests.InteractiveDeinitializerRunsWithoutBoundaryWarning</c>).
+/// The evaluator engine is reachable only via the deprecated
+/// <c>--engine evaluator</c> escape hatch; these evaluator-pinned tests
+/// retire with it in Phase 3c.
 /// </summary>
 [Collection("ConsoleIo")]
 public class Issue2988DeinitInterpreterTests
@@ -68,8 +76,10 @@ public class Issue2988DeinitInterpreterTests
     /// ADR-0156 Phase 1: bare <c>gsc</c> and script-mode <c>gsi</c> execute
     /// emitted code, so deinitializers run as real CLR finalizers on every
     /// driver — derived-then-base, per declaring class — and the GS0510
-    /// boundary warning no longer fires on any of them. The warning remains
-    /// an interactive-REPL concern (see the SessionEngine tests above).
+    /// boundary warning no longer fires on any of them. Since Phase 3a the
+    /// interactive default is emitted too, so the warning survives only under
+    /// the deprecated <c>--engine evaluator</c> escape hatch (see the
+    /// evaluator-pinned SessionEngine tests above).
     /// </summary>
     /// <param name="driver">The driver under test.</param>
     [Theory]

--- a/test/Interpreter.Tests/Issue3004PointerBoundaryInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue3004PointerBoundaryInterpreterTests.cs
@@ -9,7 +9,13 @@ namespace GSharp.Interpreter.Tests;
 
 /// <summary>
 /// Issue #3004: unmanaged pointer evaluation must fail loudly without breaking
-/// managed-byref auto-dereference used by ordinary CLR members.
+/// managed-byref auto-dereference used by ordinary CLR members (GS0513,
+/// ADR-0153). ADR-0156 Phase 3a: the interactive cells here pin the LEGACY
+/// tree-walking evaluator engine, constructed explicitly as
+/// <see cref="SessionEngine"/> — never the interactive default, which is now
+/// the emitted engine where the compiled storage model runs natively. These
+/// evaluator-pinned tests retire with the deprecated
+/// <c>--engine evaluator</c> escape hatch in Phase 3c.
 /// </summary>
 public class Issue3004PointerBoundaryInterpreterTests
 {


### PR DESCRIPTION
Part of #3176, part of #3163; ADR-0156 Phase 3a (`docs/adr/0156-gsi-emit-to-memory-execution.md`).

## Summary

- **Flip the interactive default**: `gsi` (no args, or with `/r:`) now drives the emitted submission-chaining `EmittedSessionEngine` (#3186, hardened by #3187) instead of the tree-walking evaluator. The selection collapses to a single internal predicate, `Program.UsesEvaluatorEngine` — only an explicit `--engine evaluator` or `GSI_ENGINE=evaluator` reaches the legacy engine, a **deprecated escape hatch** documented as such in `--help` and retired with the evaluator in Phase 3c. `ReplHost.Run()`'s parameterless overload flips with it. `--engine emit` stays accepted as an explicit no-op spelling of the default.
- **Test realignment (ADR-0154)**: new `Adr0156DefaultEngineFlipTests` pins the flipped selection (default/null → emitted; explicit `evaluator` flag or env var → evaluator; unset env → emitted). Audit of Interpreter.Tests found **zero** tests riding the default path — every interactive test constructs its engine explicitly — so no expectation changed; the evaluator-pinned boundary suites (GS0510 deinit, GS0511 ByRefLike, GS0513 pointers, GS0514 P/Invoke) are annotated as explicitly targeting the deprecated engine and retiring with it in 3c, and the divergence-by-design tests (`RedefinedFunctionCallDivergesByDesign`, `StructMethodReceiverMutationDivergesByDesign`) keep pinning BOTH engines explicitly while both exist. The dual-engine parity suite stays as-is — it is the safety net for the escape-hatch period.
- **IVT fix (required by the new tests)**: `Repl.csproj`'s `InternalsVisibleTo` named `Interpreter.Tests`, but `gsharp.build.props` prefixes test assembly names (`GSharp.Interpreter.Tests`), so the grant never matched anything; corrected.
- **Docs**: GS0510/GS0511/GS0514 entries, `docs/emit-pipeline.md`'s backend framing (the evaluator is no longer "what powers the REPL" nor authoritative on disagreement), and a historical note in `new-repl.md`. The `website/` diagnostics mirror already lagged Phase 1 and is scoped into the Phase 3d documentation sweep below.
- **Untouched by design**: `Compilation.Evaluate`, the Evaluator, `gsc` evaluate-mode internals, the LSP, and Phase 1 script mode.

## Default-behavior change: what a `gsi` user sees differently

| Behavior in a default interactive session | Before (evaluator default) | Now (emitted default) | Fixes / tracks |
|---|---|---|---|
| Class `deinit` | Never runs; GS0510 warning per cell | Runs as a real CLR finalizer; **no GS0510** | #2988 boundary; ADR-0156 goal |
| ByRefLike (`Span`) values | GS0511 error (beyond array-backed emulation) | Work natively (no echo for a span trailing value — CLR constraint) | #2987, #3114 |
| Unmanaged pointers, `fixed`, `stackalloc`, `sizeof` | GS0513 error (ADR-0153 boundary) | Run natively | #3004, #2956 |
| P/Invoke declarations | GS0514 error (ADR-0152 boundary) | Run natively | #2986 |
| `/r:<assembly>` references | Partially usable interactively | Fully usable (submissions bind + execute against them) | #3130 (interactive half) |
| Redefining a same-signature function, then calling it | Ambiguity error; redefined function uncallable | Clean newest-wins shadowing (Roslyn interactive model) | Pinned divergence (#3186) |
| Mutating struct method on a global (`p.Bump()`) | Mutates a copy — mutation silently lost | Mutates the stored global, matching compiled `gsc` | Pinned divergence (#3187) |
| Value echo of non-trailing values | Interpreter's incidental `LastValue` | Only a trailing expression / trailing declaration value | ADR-0156 echo protocol |
| Execution speed | Tree-walking | Emitted IL + JIT | #2190 |
| Session memory | Freed per cell | Grows until `Reset()` (one collectible ALC per session) | ADR-0156 accepted cost |

Known clean-error limitation carried from #3187: a member write crossing a computed (property) link on a value-typed prior-cell global reports GS0499 instead of writing in place (documented in #3185); no shape silently copy-writes.

Default-experience audit: sidebar snapshot values, themes/highlighting, completion, cancellation, Reset, and `/r:` are all engine-agnostic (`ReplScreen` drives `ISessionEngine`; the only engine gate in the product was the selection site in `Program.RunInteractive`) and are covered by #3186's `EmittedSessionEngineTests` witness set. No test or feature was gated on the opt-in flag (`GSI_ENGINE` is read in exactly one place). No new divergence surfaced beyond the suites #3186/#3187 already pin.

## Phase 3b plan — migrating the `Compilation.Evaluate` test oracle

Measured on this branch (grep `\.Evaluate(` over `test/`, `--include=*.cs`):

- **320 files / 555 call sites** match overall, but the true `Compilation.Evaluate`-oracle surface is **~301 files / ~383 sites**:
  - **Core.Tests: 255 files / 324 sites** — essentially all the canonical `compilation.Evaluate(new Dictionary<VariableSymbol, object>())` shape.
  - **Interpreter.Tests: 38 files / 49 sites** of genuine `Compilation.Evaluate` (the other ~172 matches are `ISessionEngine.Evaluate` REPL-cell calls, unaffected by 3b).
  - **Compiler.Tests: 8 files / 10 sites** — mostly `AssertEnginesAgree`-style dual-oracle helpers comparing evaluator vs emit.
- **Helper funneling: not centralized, but heavily patterned.** There is no shared helper today (`test/Shared` has none); instead **195 of the 255 Core.Tests files define a per-file local helper** (`private static EvaluationResult Evaluate(string source)` wrapping parse → `Compilation` → `Evaluate(empty dict)`), and the remaining ~60 call inline. So 3b is **not** a one-line helper swap, but the dominant per-file helper shares one canonical body, making the bulk migration scriptable (mechanical rewrite of the helper body to the new oracle, per-file signature preserved).
- **What `Evaluate` offers that `EmittedProgramHost` doesn't**, and how tests assert:
  1. **A value object** — tests assert `Assert.Equal(expected, result.Value)` on `EvaluationResult.Value` (last-expression value). `EmittedProgramResult` has diagnostics + exit code + unhandled exception only, and deliberately does not capture stdout. The Phase 2 submission machinery already solves value capture: the synthesized `<Result>$` static field. The 3b oracle reuses it — compile the test source as a single submission (or one-shot session), run in a collectible ALC, read `<Result>$` via reflection.
  2. **Console capture** — 83 Core.Tests files capture console output around `Evaluate`; the oracle must own `Console.SetOut/SetError` scoping (and the ConsoleIo collection discipline for xunit parallelism).
  3. **Variable seeding** — the `Dictionary<VariableSymbol, object>` parameter is always passed empty and never inspected afterwards (0 files read `variables[...]` post-eval); no migration surface.
  4. **`ContinueWith` chains** — 5 Core.Tests files (+1 Compiler.Tests, +1 perf test) chain compilations; these map onto submission chaining (`EmittedSessionEngine`/`InteractiveSessionHost`).
  5. **`evaluateEntryPoint` flag** — 1 site.
  6. **Runtime-failure surface** — evaluator-thrown errors vs `EmittedProgramResult.UnhandledException`; suites asserting runtime failures need a mapped assertion helper.
- **Witness discipline (ADR-0154, per the ADR's Phase 3 note)**: a migrated test must still fail on its original broken world — the migration PRs carry witness spot-checks (mutation or reverted-fix samples per suite), and any expectation that legitimately changes under the emitted oracle is a pinned divergence with a filed reference, exactly like #3186/#3187 handled.

Proposed slicing (sequential PRs, one full-suite run each per the repo's test-run policy):

| PR | Scope | Effort |
|---|---|---|
| **3b.0 — the oracle** | `test/Shared` `EmittedOracle.Evaluate(source, refs?) → { Value, Diagnostics, Output, ExitCode, UnhandledException }` on top of the submission compilation + collectible ALC + `<Result>$` read + console capture; witness suite proving it discriminates (drives the known divergence fixtures) | M (2–4 days) |
| **3b.1 — Core.Tests helper bulk** | Scripted rewrite of the 195 per-file helper bodies, split 2–3 PRs by directory (`Binding/`, `Evaluation/`+`Emit/`, `LanguageConformance/`+rest) to keep the 45-min full-run cycles reviewable; divergence tail pinned/filed per house policy | L total, mostly mechanical (1–2 days per slice + run time) |
| **3b.2 — inline long tail** | Remaining ~60 inline Core.Tests files, Interpreter.Tests' 38 files, Compiler.Tests' 8 (dual-oracle helpers become emit-host vs emit-file parity or single-oracle) | M (2–3 days) |
| **3b.3 — chains + closure** | `ContinueWith` chain files onto the session oracle; the lone `evaluateEntryPoint` site; mark `Compilation.Evaluate` `[Obsolete]`; grep gate: zero non-obsolete callers outside `src/Core` | S–M (1–2 days) |

Then **Phase 3c** deletes `Evaluator*.cs` (~7,300 lines), GS0510/0511/0513/0514 and their docs entries, the `--engine evaluator` escape hatch + `SessionEngine`, and the evaluator-pinned tests; ADR-0152/0153 get superseded-status updates; the conformance gate is redefined as emit-file vs emit-memory host parity.

Then **Phase 3d — documentation cleanup pass** (final stage, one PR, after 3c): a grep-driven sweep (`evaluator|interpreter|GS0510|GS0511|GS0513|GS0514|--engine`) of ALL documentation for stale interpreter/evaluator-era content once emit-everywhere is real, with a per-file disposition table (update / delete / keep-historical) produced before any edit. Scope: `docs/adr/` beyond the 0152/0153 supersession notes done in 3c (any ADR describing evaluator behavior as current); `docs/*.md` (diagnostics.md interpreter caveats, coverage matrices, lsp.md, emit-pipeline.md's evaluate-path mentions); `website/` Docusaurus content (`ref/spec.md`, `ref/diagnostics.md` — already known to lag Phase 1 — feature matrix, any REPL/gsi pages); repo-root docs (`README.md`, `new-repl.md`); `gsi`/`gsc` `--help` text; and template/sample READMEs that mention driver behavior. Rule: **ADRs are immutable decision records except status headers** — historical ADR bodies stay as written; only statuses and supersession links change.

## Verification

- `dotnet build GSharp.sln -c Release`: 0 warnings, 0 errors.
- `test/Interpreter.Tests` full suite (Release): **1415/1415 passed**, 0 failed (includes the 5 new default-flip tests; no existing expectation changed)
- `test/Compiler.Tests` LanguageConformance filter (Release): **126/126 passed** — all-driver byte parity holds
- NOT RUN: `test/Core.Tests` (src/Core untouched — this PR changes `src/Repl`, tests, and docs only), full `Compiler.Tests` beyond the LanguageConformance filter, `Cs2Gs.Tests` (pre-existing flaky host crash; GoldenTests-filter policy), `Extensions.Tests`, `LanguageServer.Tests`, `Sdk.Tests`, manual TUI drive (`gsi` requires an interactive terminal; engine behavior is covered by the suites above). CI required checks are the backstop.
- Witness (ADR-0154): `Program.UsesEvaluatorEngine` does not exist pre-change (the new tests fail to compile on main), and pre-flip the equivalent selection condition sent the null/unset choice to the evaluator, so `DefaultEngineChoiceSelectsEmittedEngine` discriminates the flip itself. No other test expectation changed (audit above).

## Checklist

- [x] Behavioral tests carry a witness of discrimination (ADR-0154): each new/changed test fails on the pre-change code (pre-fix commit, reverted hunk, or an applied product mutant) and passes with it.
- [x] Self-review verdict recorded when one was run (MERGEABLE / BLOCKER / SHOULD-FIX / NIT), with residuals filed as issues rather than dropped.

Self-review verdict: **MERGEABLE** — the flip is a two-site selection change behind an escape hatch; the engine itself shipped and hardened in #3186/#3187, no expectation in the existing suites moved, and the remaining evaluator surface is scoped by the Phase 3b/3c/3d plan above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
