### PR TITLE
Add the EmittedOracle test utility and pilot-migrate Interpreter.Tests (ADR-0156 Phase 3b.0)

### DIFF
--- a/build/migrate-emitted-oracle.py
+++ b/build/migrate-emitted-oracle.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Rewrite Compilation.Evaluate test-oracle call sites to EmittedOracle.
+
+ADR-0156 Phase 3b (issue #3176): mechanical migration of the canonical
+Compilation.Evaluate oracle shapes onto the shared emitted oracle in
+test/Shared/EmittedOracle.cs. Phase 3b.0 pilots it on Interpreter.Tests;
+Phase 3b.1 reuses it for the ~195 canonical per-file helpers in Core.Tests.
+
+Handled shapes (everything else is left untouched and reported as residue):
+
+  T1  inline chain, single- or multi-line:
+        new Compilation(SyntaxTree.Parse(<id>))
+            .Evaluate(new Dictionary<VariableSymbol, object>())
+      (also with SourceText.From(<id>) inside Parse)
+        -> EmittedOracle.Evaluate(<id>)
+
+  T2  canonical block helper body:
+        var tree = SyntaxTree.Parse(<id>);            # or SourceText.From(<id>)
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        -> return EmittedOracle.Evaluate(<id>);
+
+  T3  helper return-type retype: a `private static EvaluationResult
+      <Name>(string source)` helper whose (rewritten) body is now a direct
+      EmittedOracle.Evaluate call -> EmittedOracleResult.
+
+  T4  add `using GSharp.Tests;` (sorted) when the rewrite introduced
+      EmittedOracle into a file outside that namespace.
+
+  T5  canonical console-capture helper body (parse/compile, StringWriter +
+      Console.SetOut/restore around Evaluate(variables), error-guard lines,
+      return of the normalized captured text):
+        -> `var result = EmittedOracle.Evaluate(<id>);` + the error-guard
+           lines (dedented out of the deleted try) + `return
+           result.Output.Replace(...)` on the oracle's captured stream.
+
+Usage:
+  build/migrate-emitted-oracle.py [--dry-run] FILE [FILE ...]
+
+Exits 0; prints a per-file transform summary plus a residue report of files
+that still reference Compilation-based .Evaluate( call shapes and need a
+hand-fix (console-capture helpers, dual-oracle comparisons, ...).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+
+IDENT = r"[A-Za-z_][A-Za-z0-9_]*"
+
+# SyntaxTree.Parse(x) / SyntaxTree.Parse(SourceText.From(x)) where x is an
+# identifier or a simple string-concatenation expression without parens.
+PARSE_ARG = rf"(?:SourceText\.From\((?P<arg1>[^()]+)\)|(?P<arg2>{IDENT}))"
+
+T1_INLINE = re.compile(
+    rf"new Compilation\(SyntaxTree\.Parse\({PARSE_ARG}\)\)\s*\n?\s*"
+    r"\.Evaluate\(new Dictionary<VariableSymbol, object>\(\)\)",
+)
+
+T2_BLOCK = re.compile(
+    rf"var tree = SyntaxTree\.Parse\({PARSE_ARG}\);\s*\n"
+    r"(?P<indent>[ \t]*)var compilation = new Compilation\(tree\);\s*\n"
+    r"[ \t]*return compilation\.Evaluate\(new Dictionary<VariableSymbol, object>\(\)\);",
+)
+
+T3_RETYPE = re.compile(
+    r"private static EvaluationResult (?P<name>\w+)\(string (?P<param>\w+)\)"
+    r"(?P<body>\s*(?:=>\s*EmittedOracle\.Evaluate|\{[^{}]*?EmittedOracle\.Evaluate))",
+)
+
+T5_CONSOLE_HELPER = re.compile(
+    rf"(?P<ind>[ \t]*)var tree = SyntaxTree\.Parse\((?P<src>{IDENT})\);\n"
+    r"[ \t]*var compilation = new Compilation\(tree\);\n\n"
+    r"[ \t]*using var (?P<w>\w+) = new StringWriter\(\);\n"
+    r"[ \t]*var (?P<p>\w+) = Console\.Out;\n"
+    r"[ \t]*Console\.SetOut\((?P=w)\);\n"
+    r"[ \t]*try\n[ \t]*\{\n"
+    r"[ \t]*var variables = new Dictionary<VariableSymbol, object>\(\);\n"
+    r"[ \t]*var result = compilation\.Evaluate\(variables\);\n"
+    r"(?P<mid>(?:[^\n]*\n)*?)"
+    r"[ \t]*\}\n"
+    r"[ \t]*finally\n[ \t]*\{\n"
+    r"[ \t]*Console\.SetOut\((?P=p)\);\n"
+    r"[ \t]*\}\n\n"
+    r"[ \t]*return (?P=w)\.ToString\(\)\.Replace\(\"\\r\\n\", \"\\n\""
+    r"(?P<cmp>, StringComparison\.Ordinal)?\);",
+)
+
+RESIDUE = re.compile(r"\.Evaluate\((?:new Dictionary<VariableSymbol, object>\(\)|variables)")
+
+USING_LINE = re.compile(r"^using (?P<ns>[A-Za-z0-9_.]+);\s*$", re.MULTILINE)
+
+
+def rewrite(text: str) -> tuple[str, dict[str, int]]:
+    counts = {"T1": 0, "T2": 0, "T3": 0, "T4": 0, "T5": 0}
+
+    def t1(match: re.Match) -> str:
+        counts["T1"] += 1
+        return f"EmittedOracle.Evaluate({match.group('arg1') or match.group('arg2')})"
+
+    def t2(match: re.Match) -> str:
+        counts["T2"] += 1
+        return f"return EmittedOracle.Evaluate({match.group('arg1') or match.group('arg2')});"
+
+    def t3(match: re.Match) -> str:
+        counts["T3"] += 1
+        return (
+            f"private static EmittedOracleResult {match.group('name')}"
+            f"(string {match.group('param')}){match.group('body')}"
+        )
+
+    def t5(match: re.Match) -> str:
+        counts["T5"] += 1
+        indent = match.group("ind")
+        dedented = "".join(
+            line[4:] if line.startswith("    ") else line
+            for line in match.group("mid").splitlines(keepends=True)
+        )
+        comparison = match.group("cmp") or ""
+        return (
+            f"{indent}var result = EmittedOracle.Evaluate({match.group('src')});\n"
+            f"{dedented}"
+            f'{indent}return result.Output.Replace("\\r\\n", "\\n"{comparison});'
+        )
+
+    text = T5_CONSOLE_HELPER.sub(t5, text)
+    text = T1_INLINE.sub(t1, text)
+    text = T2_BLOCK.sub(t2, text)
+    text = T3_RETYPE.sub(t3, text)
+
+    if "EmittedOracle" in text and "using GSharp.Tests;" not in text and "namespace GSharp.Tests" not in text:
+        text = insert_using(text, "GSharp.Tests")
+        counts["T4"] += 1
+
+    return text, counts
+
+
+def insert_using(text: str, namespace: str) -> str:
+    """Insert `using <namespace>;` keeping System-first alphabetical order."""
+    usings = list(USING_LINE.finditer(text))
+    if not usings:
+        return text
+
+    def key(ns: str) -> tuple[int, str]:
+        return (0 if ns == "System" or ns.startswith("System.") else 1, ns)
+
+    line = f"using {namespace};"
+    for match in usings:
+        if key(match.group("ns")) > key(namespace):
+            return text[: match.start()] + line + "\n" + text[match.start():]
+
+    last = usings[-1]
+    return text[: last.end()] + "\n" + line + text[last.end():]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("files", nargs="+")
+    parser.add_argument("--dry-run", action="store_true", help="report without writing")
+    args = parser.parse_args()
+
+    residue_files = []
+    for path in args.files:
+        with open(path, encoding="utf-8") as handle:
+            original = handle.read()
+
+        text, counts = rewrite(original)
+        applied = {k: v for k, v in counts.items() if v}
+        if text != original and not args.dry_run:
+            with open(path, "w", encoding="utf-8") as handle:
+                handle.write(text)
+
+        residues = len(RESIDUE.findall(text))
+        if residues:
+            residue_files.append((path, residues))
+
+        summary = ", ".join(f"{k}x{v}" for k, v in applied.items()) or "no-op"
+        print(f"{path}: {summary}" + (f", residue={residues}" if residues else ""))
+
+    if residue_files:
+        print("\nResidue needing hand-fix (Compilation-based .Evaluate call sites):", file=sys.stderr)
+        for path, residues in residue_files:
+            print(f"  {path}: {residues}", file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/Core.Tests/Core.Tests.csproj
+++ b/test/Core.Tests/Core.Tests.csproj
@@ -21,4 +21,9 @@
     <ProjectReference Include="@(GsharpCore)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\Shared\EmittedOracle.cs" Link="EmittedOracle.cs" />
+    <Compile Include="..\Shared\EmittedOracleResult.cs" Link="EmittedOracleResult.cs" />
+  </ItemGroup>
+
 </Project>

--- a/test/Interpreter.Tests/EmittedOracleTests.cs
+++ b/test/Interpreter.Tests/EmittedOracleTests.cs
@@ -222,6 +222,24 @@ public class EmittedOracleTests
     }
 
     [Fact]
+    public void ReadGlobal_ReadsTopLevelVariablesPostRun()
+    {
+        // The emitted stand-in for reading the evaluator's variables
+        // dictionary after Compilation.Evaluate: top-level globals are
+        // static fields on the submission's <Program> container.
+        var result = EmittedOracle.Evaluate("""
+            var counter = 40
+            counter += 2
+            let label = "tag-44"
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.ReadGlobal("counter"));
+        Assert.Equal("tag-44", result.ReadGlobal("label"));
+        Assert.Null(result.ReadGlobal("missing"));
+    }
+
+    [Fact]
     public void Value_RemainsUsableAfterUnloadInitiated()
     {
         var result = EmittedOracle.Evaluate("""

--- a/test/Interpreter.Tests/EmittedOracleTests.cs
+++ b/test/Interpreter.Tests/EmittedOracleTests.cs
@@ -1,0 +1,291 @@
+// <copyright file="EmittedOracleTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using GSharp.Core.CodeAnalysis.Execution;
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// ADR-0156 Phase 3b.0 — the emitted test oracle's own witness suite. Pins
+/// the <see cref="EmittedOracle"/> assertion surface that the
+/// <c>Compilation.Evaluate</c> migration relies on: trailing-expression value
+/// capture, compile-failure short-circuit, the GS9999 runtime-failure
+/// protocol, console capture, ALC lifetime, and the known, pinned
+/// evaluator-vs-emit divergences (deinit boundary GS0510 and struct
+/// <c>Equals</c>/<c>GetHashCode</c> dispatch, #3116) that migrated tests may
+/// reference.
+/// </summary>
+[Collection("ConsoleIo")]
+public class EmittedOracleTests
+{
+    [Fact]
+    public void TrailingExpression_PrimitiveValue()
+    {
+        var result = EmittedOracle.Evaluate("1 + 2");
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(3, result.Value);
+        Assert.Equal(0, result.ExitCode);
+        Assert.Null(result.UnhandledException);
+    }
+
+    [Fact]
+    public void TrailingExpression_FlowsThroughVariablesAndFunctions()
+    {
+        var result = EmittedOracle.Evaluate("""
+            func Double(n int32) int32 -> n * 2
+            var seed = 21
+            Double(seed)
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void TrailingExpression_StringAndBoolUnifyWithTestTypes()
+    {
+        Assert.Equal("ab", EmittedOracle.Evaluate("""
+            let a = "a"
+            a + "b"
+            """).Value);
+        Assert.Equal(true, EmittedOracle.Evaluate("2 > 1").Value);
+    }
+
+    [Fact]
+    public void TrailingDeclaration_ValueIsCaptured()
+    {
+        var result = EmittedOracle.Evaluate("var answer = 40 + 2");
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void ConsoleOutput_IsCaptured()
+    {
+        var result = EmittedOracle.Evaluate("""
+            import System
+            Console.WriteLine("first-11")
+            Console.WriteLine("second-22")
+            "done"
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("done", result.Value);
+        Assert.Equal("first-11" + Environment.NewLine + "second-22" + Environment.NewLine, result.Output);
+        Assert.Equal(string.Empty, result.ErrorOutput);
+    }
+
+    [Fact]
+    public void CompileError_ShortCircuitsWithoutExecuting()
+    {
+        var result = EmittedOracle.Evaluate("""
+            import System
+            Console.WriteLine("must-not-run")
+            undefinedIdentifier
+            """);
+
+        Assert.Contains(result.Diagnostics, d => d.IsError);
+        Assert.Null(result.Value);
+        Assert.Equal(string.Empty, result.Output);
+        Assert.Equal(1, result.ExitCode);
+        Assert.Null(result.UnhandledException);
+    }
+
+    [Fact]
+    public void RuntimeException_SurfacesAsGs9999DiagnosticAndException()
+    {
+        var result = EmittedOracle.Evaluate("""
+            import System
+            Console.WriteLine("before-33")
+            throw InvalidOperationException("boom-42")
+            """);
+
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal("GS9999", diagnostic.Id);
+        Assert.Equal("boom-42", diagnostic.Message);
+        Assert.IsType<InvalidOperationException>(result.UnhandledException);
+        Assert.Equal("boom-42", result.UnhandledException.Message);
+        Assert.Null(result.Value);
+        Assert.Equal(EmittedProgramHost.UnhandledExceptionExitCode, result.ExitCode);
+        Assert.Equal("before-33" + Environment.NewLine, result.Output);
+    }
+
+    [Fact]
+    public void CaughtException_DoesNotSurface()
+    {
+        var result = EmittedOracle.Evaluate("""
+            import System
+            var caught = false
+            try {
+                var n = Int32.Parse("not a number")
+            } catch (e FormatException) {
+                caught = true
+            }
+            caught
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(true, result.Value);
+    }
+
+    [Fact]
+    public void SubmissionDeclaredType_ValueTextRendersAcrossTheAlcBoundary()
+    {
+        var result = EmittedOracle.Evaluate("""
+            struct Point {
+                var X int32
+                var Y int32
+                override func ToString() string -> "P(3,4)-55"
+            }
+            Point{X: 3, Y: 4}
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.NotNull(result.Value);
+
+        // The value's type lives in the run's own collectible ALC: reflection
+        // and rendering work; `is`-checks against test-side types cannot.
+        Assert.Equal("P(3,4)-55", result.ValueText);
+        Assert.Equal("Point", result.Value.GetType().Name);
+    }
+
+    [Fact]
+    public void ExplicitEntryPoint_ReturnValueIsTheValueAndExitCode()
+    {
+        var result = EmittedOracle.Evaluate("""
+            import System
+            func Main() int32 {
+                Console.WriteLine("main-ran-66")
+                return 7
+            }
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(7, result.Value);
+        Assert.Equal(7, result.ExitCode);
+        Assert.Equal("main-ran-66" + Environment.NewLine, result.Output);
+    }
+
+    // Pinned divergence (ADR-0156 / #3186): under emitted execution `deinit`
+    // is a real CLR finalizer, so the GS0510 evaluator-boundary warning that
+    // Compilation.Evaluate reported never appears. Mirrors
+    // EmittedSessionEngineTests.InteractiveDeinitializerRunsWithoutBoundaryWarning.
+    [Fact]
+    public void Deinit_CompilesAndRunsWithoutGs0510()
+    {
+        var result = EmittedOracle.Evaluate("""
+            import System
+            class Holder {
+                deinit {
+                }
+            }
+            var h = Holder()
+            GC.KeepAlive(h)
+            "alive-77"
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0510");
+        Assert.Equal("alive-77", result.Value);
+    }
+
+    // Pinned divergence (#3116): overridden struct Equals/GetHashCode
+    // dispatch for real under emitted execution, including through boxing —
+    // the tree-walking evaluator historically bypassed the overrides when the
+    // BCL invoked them.
+    [Fact]
+    public void StructObjectOverrides_DispatchThroughBoxing()
+    {
+        var result = EmittedOracle.Evaluate("""
+            struct Value {
+                var Number int32
+                override func ToString() string -> "OVERRIDDEN-88"
+                override func Equals(value object) bool -> false
+                override func GetHashCode() int32 -> 289611
+            }
+            let direct = Value{Number: 7}
+            let peer object = Value{Number: 7}
+            let boxed object = direct
+            boxed.Equals(peer)
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(false, result.Value);
+    }
+
+    [Fact]
+    public void Value_RemainsUsableAfterUnloadInitiated()
+    {
+        var result = EmittedOracle.Evaluate("""
+            class Named {
+                var Tag string
+                override func ToString() string -> Tag
+            }
+            Named{Tag: "still-here-99"}
+            """);
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        // Unload was initiated inside the oracle, but the held Value keeps
+        // the collectible context alive — assertions stay safe.
+        Assert.Equal("still-here-99", result.ValueText);
+        Assert.Equal("still-here-99", result.Value.ToString());
+    }
+
+    [Fact]
+    public void LoadContext_IsReclaimedOnceTheResultIsDropped()
+    {
+        var weakContext = RunAndDiscard();
+
+        for (var i = 0; i < 10 && weakContext.IsAlive; i++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+        }
+
+        Assert.False(weakContext.IsAlive);
+    }
+
+    [Fact]
+    public async Task ConcurrentEvaluations_DoNotInterleaveCapturedOutput()
+    {
+        var tasks = new Task<EmittedOracleResult>[4];
+        for (var i = 0; i < tasks.Length; i++)
+        {
+            var marker = "marker-" + i;
+            tasks[i] = Task.Run(() => EmittedOracle.Evaluate($"""
+                import System
+                Console.WriteLine("{marker}")
+                Console.WriteLine("{marker}")
+                "{marker}"
+                """));
+        }
+
+        var results = await Task.WhenAll(tasks);
+        for (var i = 0; i < results.Length; i++)
+        {
+            var marker = "marker-" + i;
+            Assert.Empty(results[i].Diagnostics);
+            Assert.Equal(marker, results[i].Value);
+            Assert.Equal(marker + Environment.NewLine + marker + Environment.NewLine, results[i].Output);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference RunAndDiscard()
+    {
+        var result = EmittedOracle.Evaluate("20 + 22");
+        Assert.Equal(42, result.Value);
+        return result.LoadContext;
+    }
+}

--- a/test/Interpreter.Tests/Interpreter.Tests.csproj
+++ b/test/Interpreter.Tests/Interpreter.Tests.csproj
@@ -11,6 +11,8 @@
     <ProjectReference Include="@(GsharpRepl)" />
     <ProjectReference Include="..\..\src\Sdk\Gsharp.Extensions\Gsharp.Extensions.csproj" />
     <Compile Include="..\Shared\Issue3081CompositeLiteralCases.cs" Link="Issue3081CompositeLiteralCases.cs" />
+    <Compile Include="..\Shared\EmittedOracle.cs" Link="EmittedOracle.cs" />
+    <Compile Include="..\Shared\EmittedOracleResult.cs" Link="EmittedOracleResult.cs" />
     <ProjectReference Include="..\..\test-assets\Issue3119.CrossConstants\Issue3119.CrossConstants.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
 

--- a/test/Interpreter.Tests/Issue1019StaticInterfacePropertyInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue1019StaticInterfacePropertyInterpreterTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Interpreter.Tests;
@@ -52,27 +53,12 @@ public class Issue1019StaticInterfacePropertyInterpreterTests
 
     private static string Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(source);
-        var compilation = new Compilation(tree);
+        var result = EmittedOracle.Evaluate(source);
 
-        using var outWriter = new StringWriter();
-        var prevOut = Console.Out;
-        Console.SetOut(outWriter);
-        try
-        {
-            var variables = new Dictionary<VariableSymbol, object>();
-            var result = compilation.Evaluate(variables);
-
-            var errors = result.Diagnostics.Where(d => d.IsError).ToList();
-            Assert.True(
-                errors.Count == 0,
-                "evaluation failed:\n" + string.Join("\n", errors.Select(d => d.ToString())));
-        }
-        finally
-        {
-            Console.SetOut(prevOut);
-        }
-
-        return outWriter.ToString().Replace("\r\n", "\n");
+        var errors = result.Diagnostics.Where(d => d.IsError).ToList();
+        Assert.True(
+            errors.Count == 0,
+            "evaluation failed:\n" + string.Join("\n", errors.Select(d => d.ToString())));
+        return result.Output.Replace("\r\n", "\n");
     }
 }

--- a/test/Interpreter.Tests/Issue1030InterfaceStaticMembersInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue1030InterfaceStaticMembersInterpreterTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Interpreter.Tests;
@@ -177,27 +178,12 @@ public class Issue1030InterfaceStaticMembersInterpreterTests
 
     private static string Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(source);
-        var compilation = new Compilation(tree);
+        var result = EmittedOracle.Evaluate(source);
 
-        using var outWriter = new StringWriter();
-        var prevOut = Console.Out;
-        Console.SetOut(outWriter);
-        try
-        {
-            var variables = new Dictionary<VariableSymbol, object>();
-            var result = compilation.Evaluate(variables);
-
-            var errors = result.Diagnostics.Where(d => d.IsError).ToList();
-            Assert.True(
-                errors.Count == 0,
-                "evaluation failed:\n" + string.Join("\n", errors.Select(d => d.ToString())));
-        }
-        finally
-        {
-            Console.SetOut(prevOut);
-        }
-
-        return outWriter.ToString().Replace("\r\n", "\n");
+        var errors = result.Diagnostics.Where(d => d.IsError).ToList();
+        Assert.True(
+            errors.Count == 0,
+            "evaluation failed:\n" + string.Join("\n", errors.Select(d => d.ToString())));
+        return result.Output.Replace("\r\n", "\n");
     }
 }

--- a/test/Interpreter.Tests/Issue1651GoroutineIsolationInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue1651GoroutineIsolationInterpreterTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Interpreter.Tests;
@@ -172,13 +173,11 @@ public class Issue1651GoroutineIsolationInterpreterTests
 
             run()
             """;
-        var tree = SyntaxTree.Parse(SourceText.From("import Gsharp.Extensions.Go\n" + source));
-        var compilation = new Compilation(tree);
-        EvaluationResult result = null;
+        EmittedOracleResult result = null;
         System.Exception thrown = null;
         try
         {
-            result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+            result = EmittedOracle.Evaluate("import Gsharp.Extensions.Go\n" + source);
         }
         catch (System.Exception ex)
         {
@@ -268,13 +267,11 @@ public class Issue1651GoroutineIsolationInterpreterTests
         Assert.Empty(exceptions);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
         // ADR-0082 / issue #722: `go` is gated behind this import.
         var fullSource = "import Gsharp.Extensions.Go\n" + source;
-        var tree = SyntaxTree.Parse(SourceText.From(fullSource));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(fullSource);
     }
 
     /// <summary>
@@ -285,7 +282,7 @@ public class Issue1651GoroutineIsolationInterpreterTests
     /// <c>ScopeStatementTests.Scope_WithSendInsideGo_Binds</c> does so
     /// these tests exercise goroutine isolation, not the layout warning.
     /// </summary>
-    private static void AssertNoRealDiagnostics(EvaluationResult result)
+    private static void AssertNoRealDiagnostics(EmittedOracleResult result)
     {
         Assert.DoesNotContain(result.Diagnostics, d => d.Id != "GS0286");
     }

--- a/test/Interpreter.Tests/Issue1718FrameConcurrencyInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue1718FrameConcurrencyInterpreterTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Interpreter.Tests;
@@ -192,13 +193,11 @@ public class Issue1718FrameConcurrencyInterpreterTests
         Assert.Empty(outOfRangeResults);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
         // ADR-0082 / issue #722: `go` is gated behind this import.
         var fullSource = "import Gsharp.Extensions.Go\n" + source;
-        var tree = SyntaxTree.Parse(SourceText.From(fullSource));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(fullSource);
     }
 
     /// <summary>
@@ -207,7 +206,7 @@ public class Issue1718FrameConcurrencyInterpreterTests
     /// that use it for readability, which GS0286 (ADR-0066 D5) flags as a
     /// warning, not an error.
     /// </summary>
-    private static void AssertNoRealDiagnostics(EvaluationResult result)
+    private static void AssertNoRealDiagnostics(EmittedOracleResult result)
     {
         Assert.DoesNotContain(result.Diagnostics, d => d.Id != "GS0286");
     }

--- a/test/Interpreter.Tests/Issue1799MapAndInterfaceSlotConcurrencyInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue1799MapAndInterfaceSlotConcurrencyInterpreterTests.cs
@@ -45,6 +45,14 @@ namespace GSharp.Interpreter.Tests;
 /// differ from run to run. The fix sorts each frame's candidates by variable
 /// name (ordinal) before scanning, giving a stable, always-reproducible
 /// pick.
+///
+/// ADR-0156 Phase 3b (#3176): this file stays on <c>Compilation.Evaluate</c>
+/// deliberately — it pins the EVALUATOR's per-instance map lock and locals-scan
+/// determinism, guarantees the emitted engines do not provide (plain
+/// <c>Dictionary&lt;,&gt;</c> IL loses concurrent writes and can corrupt; the
+/// emitted binder picks a different — also deterministic — interface-slot
+/// implementer). See issue #3205 for the language-level decision these tests
+/// await; they retire or are redefined with the evaluator in Phase 3c.
 /// </summary>
 public class Issue1799MapAndInterfaceSlotConcurrencyInterpreterTests
 {

--- a/test/Interpreter.Tests/Issue2616CharNumericPromotionInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2616CharNumericPromotionInterpreterTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Interpreter.Tests;
@@ -30,8 +31,7 @@ public class Issue2616CharNumericPromotionInterpreterTests
             lifted -= 'A'
             """;
 
-        var variables = new Dictionary<VariableSymbol, object>();
-        var result = new Compilation(SyntaxTree.Parse(SourceText.From(Source))).Evaluate(variables);
+        var result = EmittedOracle.Evaluate(Source);
 
         Assert.Empty(result.Diagnostics);
         Assert.Equal(4, Value("difference"));
@@ -39,7 +39,7 @@ public class Issue2616CharNumericPromotionInterpreterTests
         Assert.Equal('C', Value("value"));
         Assert.Equal((char)2, Value("lifted"));
 
-        object Value(string name) => variables.Single(pair => pair.Key.Name == name).Value;
+        object Value(string name) => result.ReadGlobal(name);
     }
 
     [Fact]
@@ -69,14 +69,12 @@ public class Issue2616CharNumericPromotionInterpreterTests
             }
             """;
 
-        var variables = new Dictionary<VariableSymbol, object>();
-        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(Source)));
-        var result = compilation.Evaluate(variables);
+        var result = EmittedOracle.Evaluate(Source);
         Assert.Empty(result.Diagnostics);
         Assert.Equal("yes", Value("narrowingCaught"));
         Assert.Equal("yes", Value("operatorCaught"));
         Assert.Equal("yes", Value("decimalCaught"));
 
-        object Value(string name) => variables.Single(pair => pair.Key.Name == name).Value;
+        object Value(string name) => result.ReadGlobal(name);
     }
 }

--- a/test/Interpreter.Tests/Issue2853EllipsisLoopCaptureInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2853EllipsisLoopCaptureInterpreterTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Interpreter.Tests;
@@ -179,16 +180,14 @@ public class Issue2853EllipsisLoopCaptureInterpreterTests
             mutate()
             """;
 
-        var result = new Compilation(SyntaxTree.Parse(Source))
-            .Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(Source);
 
         Assert.Contains(result.Diagnostics, d => d.Id == "GS9999");
     }
 
     private static void AssertEvaluates(string source, int expected)
     {
-        var result = new Compilation(SyntaxTree.Parse(source))
-            .Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(source);
 
         Assert.Empty(result.Diagnostics);
         Assert.Equal(expected, result.Value);

--- a/test/Interpreter.Tests/Issue2854TopLevelEllipsisLoopCaptureInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2854TopLevelEllipsisLoopCaptureInterpreterTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Interpreter.Tests;
@@ -52,8 +53,7 @@ public class Issue2854TopLevelEllipsisLoopCaptureInterpreterTests
 
     private static void AssertEvaluates(string source, int expected)
     {
-        var result = new Compilation(SyntaxTree.Parse(source))
-            .Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(source);
 
         Assert.Empty(result.Diagnostics);
         Assert.Equal(expected, result.Value);

--- a/test/Interpreter.Tests/Issue2885NullableDelegateReceiverInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2885NullableDelegateReceiverInterpreterTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Interpreter.Tests;
@@ -52,8 +53,7 @@ public class Issue2885NullableDelegateReceiverInterpreterTests
 
     private static void AssertEvaluates(string source, int expected)
     {
-        var evaluation = new Compilation(SyntaxTree.Parse(source))
-            .Evaluate(new Dictionary<VariableSymbol, object>());
+        var evaluation = EmittedOracle.Evaluate(source);
 
         Assert.Empty(evaluation.Diagnostics);
         Assert.Equal(expected, evaluation.Value);

--- a/test/Interpreter.Tests/Issue2894LambdaBodyGenericClosureInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2894LambdaBodyGenericClosureInterpreterTests.cs
@@ -8,6 +8,7 @@ using System.IO;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Interpreter.Tests;
@@ -75,20 +76,8 @@ public class Issue2894LambdaBodyGenericClosureInterpreterTests
 
     private static string Evaluate(string source)
     {
-        using var output = new StringWriter();
-        var previous = Console.Out;
-        Console.SetOut(output);
-        try
-        {
-            var result = new Compilation(SyntaxTree.Parse(source))
-                .Evaluate(new Dictionary<VariableSymbol, object>());
-            Assert.Empty(result.Diagnostics);
-        }
-        finally
-        {
-            Console.SetOut(previous);
-        }
-
-        return output.ToString().Replace("\r\n", "\n");
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        return result.Output.Replace("\r\n", "\n");
     }
 }

--- a/test/Interpreter.Tests/Issue2896StructObjectOverrideTests.cs
+++ b/test/Interpreter.Tests/Issue2896StructObjectOverrideTests.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Tests;
 using Xunit;
 using CompilerProgram = GSharp.Compiler.Program;
 
@@ -283,13 +284,31 @@ public class Issue2896StructObjectOverrideTests
             Console.WriteLine(boxedDefault.ToString())
             """;
 
+        // ADR-0156 Phase 3b (#3176): stays on Compilation.Evaluate — issue
+        // #3204 pins the divergence this control exposed: the EVALUATOR gives
+        // a plain struct without a ToString override the record-style
+        // rendering, while emitted execution falls to ValueType.ToString (the
+        // CLR type name). Retires or realigns with #3204's resolution.
         Assert.Equal(
             "DataValue(Number=7)\nDataValue(Number=7)\n"
                 + "DefaultValue(Number=7)\nDefaultValue(Number=7)\n",
-            Evaluate(Source));
+            EvaluateWithEvaluator(Source));
     }
 
     private static string Evaluate(string source)
+    {
+        var result = EmittedOracle.Evaluate(source);
+        var errors = result.Diagnostics.Where(diagnostic => diagnostic.IsError).ToArray();
+        Assert.True(
+            errors.Length == 0,
+            "evaluation failed:\n" + string.Join("\n", errors.Select(diagnostic => diagnostic.ToString())));
+
+        return result.Output.Replace("\r\n", "\n", StringComparison.Ordinal);
+    }
+
+    // Evaluator-pinned twin of Evaluate for the #3204 control above; delete
+    // with the evaluator (Phase 3c) or when #3204 aligns the engines.
+    private static string EvaluateWithEvaluator(string source)
     {
         var compilation = new Compilation(SyntaxTree.Parse(source));
 

--- a/test/Interpreter.Tests/Issue2906ExhaustiveSwitchStatementInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2906ExhaustiveSwitchStatementInterpreterTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Interpreter.Tests;
@@ -31,8 +32,7 @@ public class Issue2906ExhaustiveSwitchStatementInterpreterTests
             F(nil)
             """;
 
-        var result = new Compilation(SyntaxTree.Parse(Source))
-            .Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(Source);
         Assert.Empty(result.Diagnostics);
         Assert.Equal(0, result.Value);
     }

--- a/test/Interpreter.Tests/Issue2918InlineLambdaErasedReceiverInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2918InlineLambdaErasedReceiverInterpreterTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Interpreter.Tests;
@@ -272,27 +273,12 @@ public class Issue2918InlineLambdaErasedReceiverInterpreterTests
 
     private static string Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(source);
-        var compilation = new Compilation(tree);
-
-        using var output = new StringWriter();
-        var previousOut = Console.Out;
-        Console.SetOut(output);
-        try
-        {
-            var variables = new Dictionary<VariableSymbol, object>();
-            var result = compilation.Evaluate(variables);
-            var errors = result.Diagnostics.Where(diagnostic => diagnostic.IsError).ToList();
-            Assert.True(
-                errors.Count == 0,
-                "evaluation failed:\n" + string.Join("\n", errors.Select(diagnostic => diagnostic.ToString())));
-        }
-        finally
-        {
-            Console.SetOut(previousOut);
-        }
-
-        return output.ToString().Replace("\r\n", "\n", StringComparison.Ordinal);
+        var result = EmittedOracle.Evaluate(source);
+        var errors = result.Diagnostics.Where(diagnostic => diagnostic.IsError).ToList();
+        Assert.True(
+            errors.Count == 0,
+            "evaluation failed:\n" + string.Join("\n", errors.Select(diagnostic => diagnostic.ToString())));
+        return result.Output.Replace("\r\n", "\n", StringComparison.Ordinal);
     }
 
     private static string RunSubmission(string source)

--- a/test/Interpreter.Tests/Issue2928CallableMaterializationTests.cs
+++ b/test/Interpreter.Tests/Issue2928CallableMaterializationTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Interpreter.Tests;
@@ -214,8 +215,7 @@ public class Issue2928CallableMaterializationTests
             handler()
             """;
 
-        var result = new Compilation(SyntaxTree.Parse(Source))
-            .Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(Source);
 
         var diagnostic = Assert.Single(result.Diagnostics);
         Assert.Contains("boom", diagnostic.Message);
@@ -224,8 +224,7 @@ public class Issue2928CallableMaterializationTests
 
     private static object Evaluate(string source)
     {
-        var result = new Compilation(SyntaxTree.Parse(source))
-            .Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(source);
 
         Assert.Empty(result.Diagnostics);
         return result.Value;

--- a/test/Interpreter.Tests/Issue2933AsyncSelectArmBindingInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2933AsyncSelectArmBindingInterpreterTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Interpreter.Tests;
@@ -34,8 +35,7 @@ public class Issue2933AsyncSelectArmBindingInterpreterTests
             Run().GetAwaiter().GetResult()
             """;
 
-        var result = new Compilation(SyntaxTree.Parse(Source))
-            .Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(Source);
 
         Assert.Empty(result.Diagnostics);
         Assert.Equal(10, result.Value);

--- a/test/Interpreter.Tests/Issue2943LoopBackEdgeNarrowingInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2943LoopBackEdgeNarrowingInterpreterTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Interpreter.Tests;
@@ -46,8 +47,7 @@ public class Issue2943LoopBackEdgeNarrowingInterpreterTests
             run()
             """;
 
-        var result = new Compilation(SyntaxTree.Parse(source))
-            .Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(source);
 
         Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0159");
     }
@@ -104,8 +104,7 @@ public class Issue2943LoopBackEdgeNarrowingInterpreterTests
                 run()
                 """;
 
-        var result = new Compilation(SyntaxTree.Parse(source))
-            .Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(source);
 
         Assert.True(
             result.Diagnostics.IsEmpty,
@@ -135,8 +134,7 @@ public class Issue2943LoopBackEdgeNarrowingInterpreterTests
             run()
             """;
 
-        var result = new Compilation(SyntaxTree.Parse(Source))
-            .Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(Source);
 
         Assert.Empty(result.Diagnostics);
         Assert.Equal(1, result.Value);

--- a/test/Interpreter.Tests/Issue2953ProtectedReturnFallthroughInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2953ProtectedReturnFallthroughInterpreterTests.cs
@@ -14,6 +14,14 @@ namespace GSharp.Interpreter.Tests;
 /// <summary>
 /// Issue #2953: protected-region return funnels must not manufacture a default
 /// return value when an exhaustive enum switch misses an unnamed runtime value.
+///
+/// ADR-0156 Phase 3b (#3176): stays on <c>Compilation.Evaluate</c> deliberately
+/// — it pins the EVALUATOR's runtime-diagnostic protocol for the fallthrough
+/// guard (a GS0100 diagnostic with <c>NonVoidFallthroughGuardMessage</c>).
+/// Under emitted execution the same guard fires as the compiler-generated
+/// <c>InvalidOperationException</c> (surfacing as GS9999 through the emitted
+/// oracle; see #3006 for the compiled shape) — behavior agrees, only the
+/// reporting channel differs. Retires with the evaluator in Phase 3c.
 /// </summary>
 public class Issue2953ProtectedReturnFallthroughInterpreterTests
 {

--- a/test/Interpreter.Tests/Issue2962ConstrainedStaticPropertyChainInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2962ConstrainedStaticPropertyChainInterpreterTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Interpreter.Tests;
@@ -73,27 +74,12 @@ public class Issue2962ConstrainedStaticPropertyChainInterpreterTests
 
     private static string Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(source);
-        var compilation = new Compilation(tree);
-
-        using var output = new StringWriter();
-        var previousOut = Console.Out;
-        Console.SetOut(output);
-        try
-        {
-            var variables = new Dictionary<VariableSymbol, object>();
-            var result = compilation.Evaluate(variables);
-            var errors = result.Diagnostics.Where(diagnostic => diagnostic.IsError).ToList();
-            Assert.True(
-                errors.Count == 0,
-                "evaluation failed:\n" + string.Join("\n", errors.Select(diagnostic => diagnostic.ToString())));
-        }
-        finally
-        {
-            Console.SetOut(previousOut);
-        }
-
-        return output.ToString().Replace("\r\n", "\n", StringComparison.Ordinal);
+        var result = EmittedOracle.Evaluate(source);
+        var errors = result.Diagnostics.Where(diagnostic => diagnostic.IsError).ToList();
+        Assert.True(
+            errors.Count == 0,
+            "evaluation failed:\n" + string.Join("\n", errors.Select(diagnostic => diagnostic.ToString())));
+        return result.Output.Replace("\r\n", "\n", StringComparison.Ordinal);
     }
 
     private static string RunSubmission(string source)

--- a/test/Interpreter.Tests/Issue2985NamedDelegateConversionTests.cs
+++ b/test/Interpreter.Tests/Issue2985NamedDelegateConversionTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Interpreter.Tests;
@@ -159,8 +160,7 @@ public class Issue2985NamedDelegateConversionTests
             var beta Beta = alpha
             """;
 
-        var result = new Compilation(SyntaxTree.Parse(Source))
-            .Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(Source);
 
         var diagnostic = Assert.Single(result.Diagnostics);
         Assert.Equal("GS0155", diagnostic.Id);
@@ -168,8 +168,7 @@ public class Issue2985NamedDelegateConversionTests
 
     private static object Evaluate(string source)
     {
-        var result = new Compilation(SyntaxTree.Parse(source))
-            .Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(source);
 
         Assert.Empty(result.Diagnostics);
         return result.Value;

--- a/test/Interpreter.Tests/Issue2990ClrDelegateBoundaryTests.cs
+++ b/test/Interpreter.Tests/Issue2990ClrDelegateBoundaryTests.cs
@@ -12,6 +12,7 @@ using GSharp.Core.CodeAnalysis.Binding;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Interpreter.Tests;
@@ -191,22 +192,11 @@ public class Issue2990ClrDelegateBoundaryTests
 
     private static string Evaluate(string source)
     {
-        using var outWriter = new StringWriter();
-        var previousOut = Console.Out;
-        Console.SetOut(outWriter);
-        try
-        {
-            var result = new Compilation(SyntaxTree.Parse(source))
-                .Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(source);
 
-            Assert.Empty(result.Diagnostics);
-        }
-        finally
-        {
-            Console.SetOut(previousOut);
-        }
+        Assert.Empty(result.Diagnostics);
 
-        return outWriter.ToString().Replace("\r\n", "\n", StringComparison.Ordinal);
+        return result.Output.Replace("\r\n", "\n", StringComparison.Ordinal);
     }
 
     public class ConstructorProbe

--- a/test/Interpreter.Tests/Issue2993StructLiteralConstructionTests.cs
+++ b/test/Interpreter.Tests/Issue2993StructLiteralConstructionTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Interpreter.Tests;
@@ -105,24 +106,12 @@ public class Issue2993StructLiteralConstructionTests
 
     private static string Evaluate(string source)
     {
-        var compilation = new Compilation(SyntaxTree.Parse(source));
+        var result = EmittedOracle.Evaluate(source);
+        var errors = result.Diagnostics.Where(d => d.IsError).ToArray();
+        Assert.True(
+            errors.Length == 0,
+            "evaluation failed:\n" + string.Join("\n", errors.Select(d => d.ToString())));
 
-        using var outWriter = new StringWriter();
-        var previousOut = Console.Out;
-        Console.SetOut(outWriter);
-        try
-        {
-            var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-            var errors = result.Diagnostics.Where(d => d.IsError).ToArray();
-            Assert.True(
-                errors.Length == 0,
-                "evaluation failed:\n" + string.Join("\n", errors.Select(d => d.ToString())));
-        }
-        finally
-        {
-            Console.SetOut(previousOut);
-        }
-
-        return outWriter.ToString().Replace("\r\n", "\n");
+        return result.Output.Replace("\r\n", "\n");
     }
 }

--- a/test/Interpreter.Tests/Issue2999TargetInvocationExceptionInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2999TargetInvocationExceptionInterpreterTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Interpreter.Tests;
@@ -88,9 +89,8 @@ public class Issue2999TargetInvocationExceptionInterpreterTests
         Assert.Empty(result.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
-        => new Compilation(SyntaxTree.Parse(source))
-            .Evaluate(new Dictionary<VariableSymbol, object>());
+    private static EmittedOracleResult Evaluate(string source)
+        => EmittedOracle.Evaluate(source);
 }
 
 /// <summary>

--- a/test/Interpreter.Tests/Issue3003LambdaBodyLoweringTests.cs
+++ b/test/Interpreter.Tests/Issue3003LambdaBodyLoweringTests.cs
@@ -8,6 +8,7 @@ using System.IO;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Interpreter.Tests;
@@ -107,21 +108,10 @@ public class Issue3003LambdaBodyLoweringTests
 
     private static string Evaluate(string source)
     {
-        using var outWriter = new StringWriter();
-        var previousOut = Console.Out;
-        Console.SetOut(outWriter);
-        try
-        {
-            var result = new Compilation(SyntaxTree.Parse(source))
-                .Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(source);
 
-            Assert.Empty(result.Diagnostics);
-        }
-        finally
-        {
-            Console.SetOut(previousOut);
-        }
+        Assert.Empty(result.Diagnostics);
 
-        return outWriter.ToString().Replace("\r\n", "\n");
+        return result.Output.Replace("\r\n", "\n");
     }
 }

--- a/test/Interpreter.Tests/Issue3015ImportedBaseIdentityTests.cs
+++ b/test/Interpreter.Tests/Issue3015ImportedBaseIdentityTests.cs
@@ -12,6 +12,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Compiler;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Interpreter.Tests;
@@ -357,25 +358,13 @@ public class Issue3015ImportedBaseIdentityTests
 
     private static string Evaluate(string source)
     {
-        var compilation = new Compilation(SyntaxTree.Parse(source));
+        var result = EmittedOracle.Evaluate(source);
+        var errors = result.Diagnostics.Where(d => d.IsError).ToArray();
+        Assert.True(
+            errors.Length == 0,
+            "evaluation failed:\n" + string.Join("\n", errors.Select(d => d.ToString())));
 
-        using var outWriter = new StringWriter();
-        var previousOut = Console.Out;
-        Console.SetOut(outWriter);
-        try
-        {
-            var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-            var errors = result.Diagnostics.Where(d => d.IsError).ToArray();
-            Assert.True(
-                errors.Length == 0,
-                "evaluation failed:\n" + string.Join("\n", errors.Select(d => d.ToString())));
-        }
-        finally
-        {
-            Console.SetOut(previousOut);
-        }
-
-        return outWriter.ToString().Replace("\r\n", "\n");
+        return result.Output.Replace("\r\n", "\n");
     }
 
     private static string RunSourceDriver(string directory, string source, Func<string[], int> driver)

--- a/test/Interpreter.Tests/Issue3030LocalFunctionDeclarationInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue3030LocalFunctionDeclarationInterpreterTests.cs
@@ -8,6 +8,7 @@ using System.IO;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Interpreter.Tests;
@@ -67,22 +68,11 @@ public class Issue3030LocalFunctionDeclarationInterpreterTests
     [MemberData(nameof(Cases))]
     public void GenericLocalFunctionDeclaration_EvaluatesCalls(string source, string expectedOutput)
     {
-        using var writer = new StringWriter();
-        var previousOut = Console.Out;
-        Console.SetOut(writer);
-        try
-        {
-            var result = new Compilation(SyntaxTree.Parse(source))
-                .Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(source);
 
-            Assert.Empty(result.Diagnostics);
-        }
-        finally
-        {
-            Console.SetOut(previousOut);
-        }
+        Assert.Empty(result.Diagnostics);
 
-        Assert.Equal(expectedOutput, writer.ToString().Replace("\r\n", "\n", StringComparison.Ordinal));
+        Assert.Equal(expectedOutput, result.Output.Replace("\r\n", "\n", StringComparison.Ordinal));
     }
 
     private static object[] Case(string source, string expectedOutput)

--- a/test/Interpreter.Tests/Issue3034NullableNarrowingDiagnosticInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue3034NullableNarrowingDiagnosticInterpreterTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Interpreter.Tests;
@@ -47,8 +48,7 @@ public class Issue3034NullableNarrowingDiagnosticInterpreterTests
                 }
                 """;
 
-        var evaluation = new Compilation(SyntaxTree.Parse(source))
-            .Evaluate(new Dictionary<VariableSymbol, object>());
+        var evaluation = EmittedOracle.Evaluate(source);
         var diagnostic = Assert.Single(evaluation.Diagnostics.Where(diagnostic => diagnostic.Id == "GS0159"));
 
         Assert.Equal(expectedMessage, diagnostic.Message);

--- a/test/Interpreter.Tests/Issue3096CollectionSpreadInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue3096CollectionSpreadInterpreterTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Interpreter.Tests;
@@ -175,10 +176,28 @@ public sealed class Issue3096CollectionSpreadInterpreterTests
             Console.WriteLine(trace)
             """;
 
-        Assert.Equal("AIM\n", Evaluate(Source));
+        // ADR-0156 Phase 3b (#3176): stays on Compilation.Evaluate — issue
+        // #3203 pins the divergence this test exposed: the EVALUATOR runs
+        // shared initializers eagerly at first static use ("AIM"), while
+        // emitted execution is CLR-beforefieldinit lazy and never runs the
+        // initializer here ("AM"). Realigns with #3203's resolution.
+        Assert.Equal("AIM\n", EvaluateWithEvaluator(Source));
     }
 
     private static string Evaluate(string source)
+    {
+        var result = EmittedOracle.Evaluate(source);
+        var errors = result.Diagnostics.Where(diagnostic => diagnostic.IsError).ToArray();
+        Assert.True(
+            errors.Length == 0,
+            "evaluation failed:\n" + string.Join("\n", errors.Select(diagnostic => diagnostic.ToString())));
+
+        return result.Output.Replace("\r\n", "\n", StringComparison.Ordinal);
+    }
+
+    // Evaluator-pinned twin of Evaluate for the #3203 test above; delete with
+    // the evaluator (Phase 3c) or when #3203 aligns the engines.
+    private static string EvaluateWithEvaluator(string source)
     {
         var compilation = new Compilation(SyntaxTree.Parse(source));
 

--- a/test/Interpreter.Tests/Issue750ConstraintOverloadInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue750ConstraintOverloadInterpreterTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Interpreter.Tests;
@@ -143,28 +144,13 @@ public class Issue750ConstraintOverloadInterpreterTests
             try { System.Reflection.Assembly.LoadFrom(extPath); } catch { }
         }
 
-        var tree = SyntaxTree.Parse(source);
-        var compilation = new Compilation(tree);
+        var result = EmittedOracle.Evaluate(source);
 
-        using var outWriter = new StringWriter();
-        var prevOut = Console.Out;
-        Console.SetOut(outWriter);
-        try
-        {
-            var variables = new Dictionary<VariableSymbol, object>();
-            var result = compilation.Evaluate(variables);
-
-            var errors = result.Diagnostics.Where(d => d.IsError).ToList();
-            Assert.True(
-                errors.Count == 0,
-                "evaluation failed:\n" + string.Join("\n", errors.Select(d => d.ToString())));
-        }
-        finally
-        {
-            Console.SetOut(prevOut);
-        }
-
-        return outWriter.ToString().Replace("\r\n", "\n");
+        var errors = result.Diagnostics.Where(d => d.IsError).ToList();
+        Assert.True(
+            errors.Count == 0,
+            "evaluation failed:\n" + string.Join("\n", errors.Select(d => d.ToString())));
+        return result.Output.Replace("\r\n", "\n");
     }
 
     private static string LocateGsharpExtensionsAssembly()

--- a/test/Interpreter.Tests/Issue799VariadicInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue799VariadicInterpreterTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Interpreter.Tests;
@@ -134,27 +135,12 @@ public class Issue799VariadicInterpreterTests
 
     private static string Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(source);
-        var compilation = new Compilation(tree);
+        var result = EmittedOracle.Evaluate(source);
 
-        using var outWriter = new StringWriter();
-        var prevOut = Console.Out;
-        Console.SetOut(outWriter);
-        try
-        {
-            var variables = new Dictionary<VariableSymbol, object>();
-            var result = compilation.Evaluate(variables);
-
-            var errors = result.Diagnostics.Where(d => d.IsError).ToList();
-            Assert.True(
-                errors.Count == 0,
-                "evaluation failed:\n" + string.Join("\n", errors.Select(d => d.ToString())));
-        }
-        finally
-        {
-            Console.SetOut(prevOut);
-        }
-
-        return outWriter.ToString().Replace("\r\n", "\n");
+        var errors = result.Diagnostics.Where(d => d.IsError).ToList();
+        Assert.True(
+            errors.Count == 0,
+            "evaluation failed:\n" + string.Join("\n", errors.Select(d => d.ToString())));
+        return result.Output.Replace("\r\n", "\n");
     }
 }

--- a/test/Interpreter.Tests/Issue818AnonymousFunctionTypeVariadicInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue818AnonymousFunctionTypeVariadicInterpreterTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Interpreter.Tests;
@@ -81,27 +82,12 @@ public class Issue818AnonymousFunctionTypeVariadicInterpreterTests
 
     private static string Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(source);
-        var compilation = new Compilation(tree);
+        var result = EmittedOracle.Evaluate(source);
 
-        using var outWriter = new StringWriter();
-        var prevOut = Console.Out;
-        Console.SetOut(outWriter);
-        try
-        {
-            var variables = new Dictionary<VariableSymbol, object>();
-            var result = compilation.Evaluate(variables);
-
-            var errors = result.Diagnostics.Where(d => d.IsError).ToList();
-            Assert.True(
-                errors.Count == 0,
-                "evaluation failed:\n" + string.Join("\n", errors.Select(d => d.ToString())));
-        }
-        finally
-        {
-            Console.SetOut(prevOut);
-        }
-
-        return outWriter.ToString().Replace("\r\n", "\n");
+        var errors = result.Diagnostics.Where(d => d.IsError).ToList();
+        Assert.True(
+            errors.Count == 0,
+            "evaluation failed:\n" + string.Join("\n", errors.Select(d => d.ToString())));
+        return result.Output.Replace("\r\n", "\n");
     }
 }

--- a/test/Interpreter.Tests/StaticVirtualInterfaceInterpreterTests.cs
+++ b/test/Interpreter.Tests/StaticVirtualInterfaceInterpreterTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Interpreter.Tests;
@@ -140,27 +141,12 @@ public class StaticVirtualInterfaceInterpreterTests
 
     private static string Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(source);
-        var compilation = new Compilation(tree);
+        var result = EmittedOracle.Evaluate(source);
 
-        using var outWriter = new StringWriter();
-        var prevOut = Console.Out;
-        Console.SetOut(outWriter);
-        try
-        {
-            var variables = new Dictionary<VariableSymbol, object>();
-            var result = compilation.Evaluate(variables);
-
-            var errors = result.Diagnostics.Where(d => d.IsError).ToList();
-            Assert.True(
-                errors.Count == 0,
-                "evaluation failed:\n" + string.Join("\n", errors.Select(d => d.ToString())));
-        }
-        finally
-        {
-            Console.SetOut(prevOut);
-        }
-
-        return outWriter.ToString().Replace("\r\n", "\n");
+        var errors = result.Diagnostics.Where(d => d.IsError).ToList();
+        Assert.True(
+            errors.Count == 0,
+            "evaluation failed:\n" + string.Join("\n", errors.Select(d => d.ToString())));
+        return result.Output.Replace("\r\n", "\n");
     }
 }

--- a/test/Shared/EmittedOracle.cs
+++ b/test/Shared/EmittedOracle.cs
@@ -199,7 +199,8 @@ public static class EmittedOracle
                     stderr.ToString(),
                     EmittedProgramHost.UnhandledExceptionExitCode,
                     unhandledException,
-                    weakContext);
+                    weakContext,
+                    assembly);
             }
 
             // Prefer the synthesized trailing-expression capture; fall back to
@@ -221,7 +222,8 @@ public static class EmittedOracle
                 stderr.ToString(),
                 exitCode,
                 unhandledException: null,
-                weakContext);
+                weakContext,
+                assembly);
         }
         finally
         {

--- a/test/Shared/EmittedOracle.cs
+++ b/test/Shared/EmittedOracle.cs
@@ -1,0 +1,304 @@
+// <copyright file="EmittedOracle.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Threading;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Execution;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+
+namespace GSharp.Tests;
+
+/// <summary>
+/// The ADR-0156 Phase 3b emitted test oracle: the drop-in replacement for the
+/// historical <c>Compilation.Evaluate</c> semantic-oracle pattern
+/// (<c>new Compilation(SyntaxTree.Parse(source)).Evaluate(new Dictionary&lt;VariableSymbol, object&gt;())</c>).
+/// The source compiles as a one-shot REPL submission — which is what makes the
+/// trailing-expression value observable, via the synthesized
+/// <c>&lt;Result&gt;$</c> global the Phase 2 submission machinery emits — with
+/// the real emitter into an in-memory PE, loads into a fresh one-shot
+/// collectible <see cref="AssemblyLoadContext"/>, runs its entry point
+/// in-process with both console streams captured, and returns the
+/// <see cref="EmittedOracleResult"/> assertion surface.
+/// </summary>
+/// <remarks>
+/// <para><b>Diagnostics short-circuit.</b> Compile-time errors return
+/// immediately with the same warnings-then-errors diagnostic shape
+/// <c>Compilation.Evaluate</c> produced, and the program never runs — tests
+/// that assert diagnostics without execution keep their expectations
+/// verbatim.</para>
+/// <para><b>Runtime failures.</b> An exception the program does not catch is
+/// unwrapped from the reflection boundary and surfaces both as
+/// <see cref="EmittedOracleResult.UnhandledException"/> and as a synthesized
+/// <c>GS9999</c> error diagnostic carrying the exception's
+/// <see cref="Exception.Message"/> — the historical evaluator's
+/// uncaught-exception protocol, minus the interpreter-only source-node
+/// location (the synthesized diagnostic carries a default location; tests
+/// asserting runtime-error <em>locations</em> are evaluator-specific and stay
+/// on the old oracle until Phase 3c retires them).</para>
+/// <para><b>ALC lifetime.</b> Each call gets its own collectible context and
+/// unload is initiated before the result is returned. Collectible unload is
+/// cooperative: the context, its assembly, and any returned
+/// <see cref="EmittedOracleResult.Value"/> of a submission-declared type stay
+/// fully usable for as long as the test holds them — assertions after return
+/// are safe by construction, and the context is reclaimed when the last
+/// reference dies.</para>
+/// <para><b>Concurrency.</b> The oracle keeps no per-call shared state (no
+/// temp files — the PE never touches disk) and compiles concurrently; only the
+/// execute window is serialized by a process-wide gate, because console
+/// capture rides the process-global <see cref="Console.SetOut(TextWriter)"/>.
+/// Suites additionally keep their existing <c>ConsoleIo</c> collection
+/// discipline for tests that redirect the console themselves.</para>
+/// </remarks>
+public static class EmittedOracle
+{
+    private static readonly object ConsoleGate = new();
+    private static int submissionCounter;
+
+    /// <summary>
+    /// Compiles <paramref name="source"/> as a one-shot submission, runs it
+    /// emitted and in-process, and returns the full assertion surface.
+    /// </summary>
+    /// <param name="source">The G# source text.</param>
+    /// <returns>The oracle result.</returns>
+    public static EmittedOracleResult Evaluate(string source)
+        => Evaluate(source, references: null);
+
+    /// <summary>
+    /// Compiles <paramref name="source"/> as a one-shot submission against
+    /// the given reference assemblies, runs it emitted and in-process, and
+    /// returns the full assertion surface.
+    /// </summary>
+    /// <param name="source">The G# source text.</param>
+    /// <param name="references">Reference assembly paths resolvable at compile and run time (the <c>/r:</c> channel); may be <see langword="null"/>.</param>
+    /// <returns>The oracle result.</returns>
+    public static EmittedOracleResult Evaluate(string source, IReadOnlyList<string> references)
+    {
+        if (source is null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        var referencePaths = references?.Where(r => !string.IsNullOrWhiteSpace(r)).ToArray() ?? Array.Empty<string>();
+        var n = Interlocked.Increment(ref submissionCounter);
+        var assemblyName = "oracle$" + n;
+        var packageName = "oracle" + n;
+
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var resolver = referencePaths.Length > 0
+            ? ReferenceResolver.WithReferences(referencePaths)
+            : ReferenceResolver.Default();
+
+        var compilation = new Compilation(resolver, tree)
+        {
+            Submission = new SubmissionBindingOptions
+            {
+                Imports = SubmissionImports.Create(ImmutableArray<SubmissionReference>.Empty),
+                DefaultPackageName = packageName,
+            },
+        };
+
+        using var peStream = new MemoryStream();
+        var emitResult = compilation.Emit(peStream, pdbStream: null, refStream: null, assemblyName: assemblyName);
+
+        // Mirror Compilation.Evaluate's compile-failure shape: warnings first,
+        // then errors, value null, nothing executed.
+        var warnings = emitResult.Diagnostics.Where(d => !d.IsError).ToImmutableArray();
+        var errors = emitResult.Diagnostics.Where(d => d.IsError).ToImmutableArray();
+        if (!emitResult.Success || errors.Length > 0)
+        {
+            return new EmittedOracleResult(
+                warnings.Concat(errors).ToImmutableArray(),
+                value: null,
+                output: string.Empty,
+                errorOutput: string.Empty,
+                exitCode: 1,
+                unhandledException: null,
+                loadContext: null);
+        }
+
+        return Execute(peStream, referencePaths, warnings);
+    }
+
+    private static EmittedOracleResult Execute(
+        MemoryStream peStream,
+        IReadOnlyList<string> referencePaths,
+        ImmutableArray<Diagnostic> warnings)
+    {
+        var loadContext = new AssemblyLoadContext("gsharp-oracle-" + Guid.NewGuid().ToString("N"), isCollectible: true);
+        var weakContext = new WeakReference(loadContext);
+        loadContext.Resolving += (context, name) => ResolveDependency(context, name, referencePaths);
+
+        var stdout = new StringWriter();
+        var stderr = new StringWriter();
+
+        try
+        {
+            peStream.Position = 0;
+            var assembly = loadContext.LoadFromStream(peStream);
+            var entryPoint = assembly.EntryPoint;
+
+            object returnValue = null;
+            Exception unhandledException = null;
+            if (entryPoint is not null)
+            {
+                var arguments = entryPoint.GetParameters().Length == 0
+                    ? null
+                    : new object[] { Array.Empty<string>() };
+
+                // Serialize the redirected-console window across concurrent
+                // oracle calls; compilation and emit stay parallel.
+                lock (ConsoleGate)
+                {
+                    var originalOut = Console.Out;
+                    var originalError = Console.Error;
+                    Console.SetOut(stdout);
+                    Console.SetError(stderr);
+                    try
+                    {
+                        returnValue = entryPoint.Invoke(null, arguments);
+                    }
+                    catch (TargetInvocationException ex) when (ex.InnerException is not null)
+                    {
+                        unhandledException = ex.InnerException;
+                    }
+                    catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+                    {
+                        unhandledException = ex;
+                    }
+                    finally
+                    {
+                        Console.SetOut(originalOut);
+                        Console.SetError(originalError);
+                    }
+                }
+            }
+
+            if (unhandledException is not null)
+            {
+                // The historical evaluator surfaced an uncaught exception as a
+                // GS9999 error diagnostic with the exception's message; keep
+                // that assertion surface (location is default — runtime code
+                // has no bound-node context) and expose the exception itself.
+                var runtimeDiagnostic = new Diagnostic(default, "GS9999", DiagnosticSeverity.Error, unhandledException.Message);
+                return new EmittedOracleResult(
+                    warnings.Add(runtimeDiagnostic),
+                    value: null,
+                    stdout.ToString(),
+                    stderr.ToString(),
+                    EmittedProgramHost.UnhandledExceptionExitCode,
+                    unhandledException,
+                    weakContext);
+            }
+
+            // Prefer the synthesized trailing-expression capture; fall back to
+            // the entry point's return value (an explicit int/uint `main`),
+            // mirroring EmittedSessionEngine's echo protocol.
+            TryReadResultField(assembly, out var captured);
+            var value = captured ?? returnValue;
+            var exitCode = returnValue switch
+            {
+                int intValue => intValue,
+                uint uintValue => unchecked((int)uintValue),
+                _ => 0,
+            };
+
+            return new EmittedOracleResult(
+                warnings,
+                value,
+                stdout.ToString(),
+                stderr.ToString(),
+                exitCode,
+                unhandledException: null,
+                weakContext);
+        }
+        finally
+        {
+            // Initiate unload; reclamation waits for the last reference (the
+            // returned result's Value included) to die, so returned values
+            // remain safe to assert on.
+            loadContext.Unload();
+        }
+    }
+
+    private static bool TryReadResultField(Assembly assembly, out object value)
+    {
+        value = null;
+        Type[] types;
+        try
+        {
+            types = assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            types = ex.Types.Where(t => t is not null).ToArray();
+        }
+
+        foreach (var type in types)
+        {
+            if (!string.Equals(type.Name, SubmissionImports.ProgramTypeName, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var field = type.GetField(SubmissionImports.ResultFieldName, BindingFlags.Public | BindingFlags.Static);
+            if (field is not null)
+            {
+                value = field.GetValue(null);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static Assembly ResolveDependency(
+        AssemblyLoadContext context,
+        AssemblyName assemblyName,
+        IReadOnlyList<string> referencePaths)
+    {
+        // User-supplied references win over any same-named host assembly so
+        // the program binds against exactly what it was compiled against —
+        // mirrors EmittedProgramHost's script-mode resolution.
+        if (assemblyName.Name is not null)
+        {
+            var match = referencePaths.FirstOrDefault(path =>
+                string.Equals(Path.GetFileNameWithoutExtension(path), assemblyName.Name, StringComparison.OrdinalIgnoreCase)
+                && File.Exists(path));
+            if (match is not null)
+            {
+                return context.LoadFromAssemblyPath(Path.GetFullPath(match));
+            }
+        }
+
+        // Framework, test-assembly, and transitive dependencies fall back to
+        // the default context.
+        try
+        {
+            return Assembly.Load(assemblyName);
+        }
+        catch (FileNotFoundException)
+        {
+            return null;
+        }
+        catch (FileLoadException)
+        {
+            return null;
+        }
+        catch (BadImageFormatException)
+        {
+            return null;
+        }
+    }
+}

--- a/test/Shared/EmittedOracleResult.cs
+++ b/test/Shared/EmittedOracleResult.cs
@@ -1,0 +1,118 @@
+// <copyright file="EmittedOracleResult.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis;
+
+namespace GSharp.Tests;
+
+/// <summary>
+/// The observable outcome of one <see cref="EmittedOracle.Evaluate(string)"/>
+/// run: the same assertion surface tests historically consumed from
+/// <c>Compilation.Evaluate</c>'s <see cref="EvaluationResult"/>
+/// (<see cref="Diagnostics"/> + <see cref="Value"/>), plus the captured
+/// console streams and the emitted program's exit protocol.
+/// </summary>
+public sealed class EmittedOracleResult
+{
+    internal EmittedOracleResult(
+        ImmutableArray<Diagnostic> diagnostics,
+        object value,
+        string output,
+        string errorOutput,
+        int exitCode,
+        Exception unhandledException,
+        WeakReference loadContext)
+    {
+        Diagnostics = diagnostics;
+        Value = value;
+        Output = output;
+        ErrorOutput = errorOutput;
+        ExitCode = exitCode;
+        UnhandledException = unhandledException;
+        LoadContext = loadContext;
+    }
+
+    /// <summary>
+    /// Gets the diagnostics, shaped exactly like <c>Compilation.Evaluate</c>'s:
+    /// on compile failure, all warnings followed by all errors (the program
+    /// never ran); on a runtime failure, the compile warnings plus one
+    /// synthesized <c>GS9999</c> error carrying the unhandled exception's
+    /// message (the historical evaluator's uncaught-exception protocol);
+    /// warnings only otherwise. The interpreter-boundary diagnostics
+    /// (GS0510/GS0511/GS0513/GS0514) never appear — those constructs simply
+    /// work under emitted execution (ADR-0156).
+    /// </summary>
+    public ImmutableArray<Diagnostic> Diagnostics { get; }
+
+    /// <summary>
+    /// Gets the program's result value — the trailing expression (or trailing
+    /// variable declaration) value captured into the synthesized
+    /// <c>&lt;Result&gt;$</c> submission global, falling back to the entry
+    /// point's declared <c>int</c>/<c>uint</c> return value, otherwise
+    /// <see langword="null"/>. Equivalent to <see cref="EvaluationResult.Value"/>
+    /// for the canonical trailing-expression test shape.
+    /// <para>Identity caveat: a value whose type is <em>declared by the
+    /// evaluated source</em> is an instance of a type living in the run's own
+    /// collectible <see cref="System.Runtime.Loader.AssemblyLoadContext"/> —
+    /// <c>is</c>/cast checks against test-side types will not match (only
+    /// framework-typed values, e.g. <c>int</c>/<c>string</c>/<c>bool</c>, unify
+    /// with the test's type identities). Reflect on it, or assert on
+    /// <see cref="ValueText"/> / <see cref="Output"/> instead.</para>
+    /// <para>Lifetime: the load context's unload is <em>initiated</em> before
+    /// the result is returned, but a collectible context is only reclaimed once
+    /// nothing references it — holding this value keeps it (and its type) fully
+    /// usable for assertions; there is no use-after-unload hazard.</para>
+    /// </summary>
+    public object Value { get; }
+
+    /// <summary>
+    /// Gets <see cref="Value"/> rendered via <see cref="object.ToString"/>
+    /// (invariant rendering for the null case: <see langword="null"/> stays
+    /// <see langword="null"/>). The assertion-friendly channel for values of
+    /// submission-declared types, whose CLR identity lives in the run's own
+    /// load context.
+    /// </summary>
+    public string ValueText => Value?.ToString();
+
+    /// <summary>
+    /// Gets everything the program wrote to standard output, captured for the
+    /// duration of the run. Empty when the program never ran (compile failure)
+    /// or wrote nothing. Newlines are the platform's
+    /// (<see cref="Environment.NewLine"/>), matching a test-owned
+    /// <see cref="System.IO.StringWriter"/> capture around
+    /// <c>Compilation.Evaluate</c>.
+    /// </summary>
+    public string Output { get; }
+
+    /// <summary>
+    /// Gets everything the program wrote to standard error, captured for the
+    /// duration of the run.
+    /// </summary>
+    public string ErrorOutput { get; }
+
+    /// <summary>
+    /// Gets the emitted program's exit code: the entry point's <c>int</c>/<c>uint</c>
+    /// return value (otherwise 0), 1 on compile failure, or
+    /// <see cref="GSharp.Core.CodeAnalysis.Execution.EmittedProgramHost.UnhandledExceptionExitCode"/>
+    /// when the program threw.
+    /// </summary>
+    public int ExitCode { get; }
+
+    /// <summary>
+    /// Gets the unhandled exception the program threw, unwrapped from the
+    /// reflection invocation boundary, or <see langword="null"/>. Richer than
+    /// the synthesized GS9999 diagnostic when a test wants the exception type
+    /// or full text.
+    /// </summary>
+    public Exception UnhandledException { get; }
+
+    /// <summary>
+    /// Gets a weak reference to the run's collectible load context (unload
+    /// already initiated). Oracle-test seam for asserting reclaimability;
+    /// product tests should not consume this.
+    /// </summary>
+    internal WeakReference LoadContext { get; }
+}

--- a/test/Shared/EmittedOracleResult.cs
+++ b/test/Shared/EmittedOracleResult.cs
@@ -4,7 +4,9 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Reflection;
 using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
 
 namespace GSharp.Tests;
 
@@ -24,7 +26,8 @@ public sealed class EmittedOracleResult
         string errorOutput,
         int exitCode,
         Exception unhandledException,
-        WeakReference loadContext)
+        WeakReference loadContext,
+        Assembly assembly = null)
     {
         Diagnostics = diagnostics;
         Value = value;
@@ -33,6 +36,7 @@ public sealed class EmittedOracleResult
         ExitCode = exitCode;
         UnhandledException = unhandledException;
         LoadContext = loadContext;
+        Assembly = assembly;
     }
 
     /// <summary>
@@ -115,4 +119,56 @@ public sealed class EmittedOracleResult
     /// product tests should not consume this.
     /// </summary>
     internal WeakReference LoadContext { get; }
+
+    /// <summary>
+    /// Gets the executed submission assembly (<see langword="null"/> when the
+    /// program never ran). Holding the result keeps it loaded; see the
+    /// lifetime note on <see cref="Value"/>.
+    /// </summary>
+    internal Assembly Assembly { get; }
+
+    /// <summary>
+    /// Reads a top-level global's post-run value by name — the emitted
+    /// equivalent of reading the historical evaluator's variables dictionary
+    /// after <c>Compilation.Evaluate</c>: top-level <c>var</c>/<c>let</c>
+    /// emit as static fields on the submission's <c>&lt;Program&gt;</c>
+    /// container. Returns <see langword="null"/> when the program never ran
+    /// or no such global exists. The <see cref="Value"/> identity caveat
+    /// applies to values of submission-declared types.
+    /// </summary>
+    /// <param name="name">The top-level variable's source name.</param>
+    /// <returns>The global's current value, or <see langword="null"/>.</returns>
+    public object ReadGlobal(string name)
+    {
+        if (Assembly is null || string.IsNullOrEmpty(name))
+        {
+            return null;
+        }
+
+        Type[] types;
+        try
+        {
+            types = Assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            types = ex.Types;
+        }
+
+        foreach (var type in types)
+        {
+            if (type is null || !string.Equals(type.Name, SubmissionImports.ProgramTypeName, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var field = type.GetField(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+            if (field is not null)
+            {
+                return field.GetValue(null);
+            }
+        }
+
+        return null;
+    }
 }


### PR DESCRIPTION
Part of #3176 (Phase 3b.0), part of #3163; executes the Phase 3b plan's first slice (the oracle + a bounded pilot) ahead of the Core.Tests bulk rewrite (3b.1).

## Summary

- Add `test/Shared/EmittedOracle` (+ `EmittedOracleResult`), compiled into Core.Tests and Interpreter.Tests via the existing `test/Shared` linked-source convention: compile the test source as a **one-shot submission** (riding Phase 2's synthesized `<Result>$` trailing-expression capture), emit to memory, run in a **one-shot collectible ALC**, and return `{ Diagnostics, Value, ValueText, Output, ErrorOutput, ExitCode, UnhandledException }` — the `Compilation.Evaluate` assertion surface plus console capture.
- Design decisions:
  - **Compile short-circuit**: errors return warnings-then-errors (Evaluate's exact shape), value null, nothing executed.
  - **Runtime failures**: unwrapped at the reflection boundary; surfaced both as `UnhandledException` and as the evaluator's historical `GS9999` error diagnostic carrying the exception message (default location — runtime code has no node context; location-asserting tests stay evaluator-pinned until 3c).
  - **ALC lifetime**: unload is *initiated* before return; collectible unload is cooperative, so a held `Value` (including submission-declared types) stays fully usable for assertions — no use-after-unload hazard — and the context is reclaimed when the result is dropped (witnessed by `WeakReference`).
  - **Value identity**: framework-typed values unify with test-side types; submission-declared types live in the run's ALC — `ValueText` (rendered) plus raw `Value` for reflection. `ReadGlobal(name)` reads post-run top-level globals (the emitted stand-in for the evaluator's variables dictionary, which the 3b plan measured as unread — the pilot found 1 file / 2 sites reading it).
  - **Concurrency**: no temp files (PE never touches disk), per-call ALC, unique assembly/package names via an atomic counter; only the redirected-console invoke window is serialized by a process-wide gate.
- Add `build/migrate-emitted-oracle.py` — the mechanical rewriter (inline chains, canonical block helper, console-capture helper, retyping, sorted `using` insertion, residue report) that **3b.1 reuses** for Core.Tests' ~195 canonical per-file helpers.
- Pilot: **Interpreter.Tests' genuine `Compilation.Evaluate` users** (chosen per the plan's 3b measurement — a bounded, runtime-behavior-heavy set with an affordable full-suite cycle): **29 files / 36 call sites migrated with assertions unchanged** (21 transforms script-applied, residue hand-fixed).

## Pilot stats

| Category | Count |
|---|---|
| Files migrated (assertions unchanged) | 29 (36 sites) |
| Kept on `Compilation.Evaluate`: dual/tri-oracle parity harnesses (spike, Issue2921, Issue3058, Issue2896 driver theories) | 3 files + partial |
| Kept: evaluator-machinery pins (Issue2938 runtime-error node locations, Issue2984 entry-point selection, Issue2991 interpreter delegate identity, Issue2953 GS0100 runtime-guard protocol, Issue1799 map-lock/scan determinism) | 5 files |
| Divergences — aligned with documented protocol (runtime-failure GS9999 channel, per the 3b plan's mapping; behavior identical) | 1 (Issue2953, annotated) |
| Divergences — **newly discovered, filed**: #3203 (shared initializers: evaluator eager-at-first-use vs CLR `beforefieldinit` — silent side-effect drop), #3204 (plain-struct `ToString`: evaluator record-style vs CLR type name), #3205 (map goroutine-safety: evaluator per-instance lock vs unsynchronized emitted IL; + interface-slot pick) | 3 issues; affected tests evaluator-pinned with references |

Escape-hatch categories confirmed for 3b.2: live evaluator-side object identity (Issue2991), runtime-error source locations (Issue2938), dual-oracle files (convert to emit-host vs emit-file parity, not oracle swaps).

## Verification

- `dotnet build GSharp.sln -c Release`: 0 warnings, 0 errors.
- `test/Interpreter.Tests` full suite (Release): **1431/1431 passed** (includes the 16-test oracle witness suite; migrated tests green with unchanged assertions).
- `test/Core.Tests` full suite (Release): **7128/7129 passed**, 1 skipped (standing `RegenerateBaseline` skip) — the project newly compiles the linked oracle sources.
- Witness (ADR-0154): the oracle suite targets `EmittedOracle`, which does not exist pre-change (fails to compile on main); migrated tests keep their original expected values, so each still fails on its original broken world — now against the real emitted semantics. The three filed divergences are the pilot's discrimination evidence: the oracle swap surfaced them immediately.
- NOT RUN: `Compiler.Tests` (no product change — the oracle is test-side only; the LanguageConformance gate is unaffected), `Cs2Gs.Tests` (pre-existing flaky host crash; GoldenTests-filter policy), `Extensions.Tests`, `LanguageServer.Tests`, `Sdk.Tests`. CI required checks are the backstop.

## Checklist

- [x] Behavioral tests carry a witness of discrimination (ADR-0154): each new/changed test fails on the pre-change code (pre-fix commit, reverted hunk, or an applied product mutant) and passes with it.
- [x] Self-review verdict recorded when one was run (MERGEABLE / BLOCKER / SHOULD-FIX / NIT), with residuals filed as issues rather than dropped.

Self-review verdict: **MERGEABLE** — test-side only (zero `src/` changes); every non-migrated file is annotated with its reason and reference; discovered divergences are filed (#3203, #3204, #3205) rather than papered over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)