### PR TITLE
Fix website driver execution documentation

### DIFF
--- a/website/docs/bridges/gsharp-for-csharp-developers.md
+++ b/website/docs/bridges/gsharp-for-csharp-developers.md
@@ -139,7 +139,7 @@ let evens = nums.Where(x -> x % 2 == 0)   // canonical: inferred, bare single pa
 let twice = func (x int32) int32 { return x * 2 }   // explicit alternative
 ```
 
-Passing G# lambdas to imported CLR methods is supported when you build through the SDK or `gsc /out`. The interpreter path does not support that conversion.
+Passing G# lambdas to imported CLR methods works in every file mode: bare `gsc`, `gsc /out`, and `gsi file.gs`. `/out` is not required for the conversion.
 
 ## Low-level interop syntax is G#-shaped
 

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -45,7 +45,8 @@ G# combines a structured concurrency surface with .NET primitives. `go f` starts
 
 ## How does `async` work?
 
-`async func` and `await` exist for direct .NET interop with `Task`, `Task[T]`, and compatible awaitable shapes. In emitted code, G# lowers async functions and lambdas to .NET state machines; in the interpreter, awaits block on the awaiter for simple test and REPL behavior. 
+`async func` and `await` exist for direct .NET interop with `Task`, `Task[T]`, and compatible awaitable shapes. Emitted code lowers async functions and lambdas to .NET state machines; the deprecated evaluator instead blocks on the awaiter.
+
 ## How do optional parameters, named arguments, and overloading work in G# functions?
 
 User-defined G# functions support all three:
@@ -68,9 +69,9 @@ A `struct` is value-like, while a `class` is reference-like and can participate 
 
 Import the relevant CLR namespace or reference the assembly through the compiler or SDK project, then call the .NET type members from G#. Imported constructors, overloads, properties, fields, events, delegates, extension methods, operators, conversions, generics, and optional CLR arguments are part of the interop surface. See the [CLR interop reference](/docs/ref/clr-interop).
 
-## What is the difference between the `gsc` interpreter path and emit path?
+## What is the difference between the direct `gsc` modes?
 
-`gsc` shares lexing, parsing, binding, and lowering between both paths. If you invoke it without `/out:`, it interprets the program in-process; if you provide `/out:`, it emits a managed executable or library, with optional PDBs and reference assemblies. The interpreter is useful for REPL-style execution and tests, while emit is the production compilation path. See the [`gsc` reference](/docs/tooling/gsc).
+Every driver uses the emitter by default, including bare `gsc`, file-mode `gsi`, and the interactive REPL. Without `/out:`, `gsc` runs the emitted program immediately and prints `Success.` afterward; with `/out:`, it saves the assembly for later use. `gsi --engine evaluator` or `GSI_ENGINE=evaluator` selects the deprecated interactive evaluator, which is scheduled for removal. See the [`gsc` reference](/docs/tooling/gsc).
 
 ## Does G# have a Playground?
 

--- a/website/docs/getting-started/install.md
+++ b/website/docs/getting-started/install.md
@@ -86,7 +86,7 @@ cd gsharp
 dotnet build GSharp.sln
 ```
 
-After the build, run the compiler DLL with `dotnet`. In direct `gsc` mode, passing `/out:path` emits an assembly; omitting `/out` runs the interpreter compatibility path.
+After the build, run the compiler DLL with `dotnet`. Both direct `gsc` modes use the emitter: passing `/out:path` saves an assembly, while omitting `/out` runs the emitted program immediately.
 
 ```bash
 dotnet src/Compiler/bin/Debug/net10.0/gsc.dll samples/HelloWorld.gs

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -46,7 +46,7 @@ The SDK path is the everyday workflow. `Gsharp.NET.Sdk` wires `.gs` files into M
 
 ## Run it with `gsc` directly
 
-When you pass source files to `gsc` without `/out`, the compiler uses interpreter compatibility mode:
+When you pass source files to `gsc` without `/out`, the compiler emits the program and runs it immediately:
 
 ```bash
 dotnet path/to/gsc.dll samples/HelloWorld.gs
@@ -59,9 +59,9 @@ Hello, world!
 Success.
 ```
 
-The `Success.` line is printed by `gsc` after interpreter execution completes.
+The `Success.` line is printed by `gsc` after the emitted program completes.
 
-To emit an assembly, add `/out`. For an executable, keep `/target:exe`; `/tfm` selects the target framework runtime config.
+To save the emitted assembly, add `/out`. For an executable, keep `/target:exe`; `/tfm` selects the target framework runtime config.
 
 ```bash
 dotnet path/to/gsc.dll samples/HelloWorld.gs /out:artifacts/HelloWorld.dll /target:exe /tfm:net10.0
@@ -74,6 +74,6 @@ Output:
 Hello, world!
 ```
 
-Use the emit path for application builds and for CLR interop scenarios that need real delegates, metadata, Portable PDBs, or runtime config files. The interpreter is convenient for quick checks, but it does not model every emitted CLR behavior.
+Both direct commands use the compiler emitter. Omit `/out` for immediate execution; add it when you need a reusable assembly.
 
 Next: [A Tour of G#](/docs/tour).

--- a/website/docs/guide/effective-gsharp.md
+++ b/website/docs/guide/effective-gsharp.md
@@ -123,4 +123,4 @@ Import CLR namespaces directly, pass function values to delegates, and rely on i
 
 ## Document implementation differences
 
-The interpreter is useful for REPL-style execution and quick feedback, but the emit path is the production path. If a feature depends on metadata emission, async or iterator state machines, Portable PDBs, or byref/pointer interop, verify it with `gsc /out:` or the SDK build path before presenting it as production behavior.
+Every driver emits CIL by default, including the interactive REPL. `gsi --engine evaluator` and `GSI_ENGINE=evaluator` are deprecated escape hatches scheduled for removal. Add `gsc /out:` when you need to inspect the saved assembly, metadata, or Portable PDB rather than run it immediately.

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -20,18 +20,19 @@ or TypeScript, much of the syntax will already feel familiar.
 
 ## How G# runs
 
-G# currently has two execution paths:
+G# currently has two execution engines:
 
-- The production compiler, `gsc`, parses, binds, lowers, and emits
-  managed PE assemblies directly. SDK projects use this path through
-  MSBuild, so `dotnet build` and `dotnet run` work for `.gsproj`
-  projects.
-- The interpreter path executes the same parsed and bound program
-  in-process. `gsc` uses this compatibility mode when you pass source
-  files but do not pass `/out`. It is useful for quick experiments,
-  but some CLR interop features are emit-only. In particular, the
-  interpreter cannot marshal G# function literals into CLR delegates
-  in every place the emitted assembly can.
+- Every driver parses, binds, lowers, and emits CIL. SDK projects use
+  the emitter through MSBuild. Direct `gsc` uses it both with and
+  without `/out`; without `/out`, `gsc` runs the emitted program
+  immediately. File-mode `gsi` and the interactive REPL also use the
+  emitter. G# function literals can be passed to CLR
+  delegate parameters on these file paths, including bare `gsc`.
+- The deprecated evaluator runs interactive submissions in-process
+  when `gsi --engine evaluator` or `GSI_ENGINE=evaluator` is selected.
+  It is scheduled for removal. The two engines can differ at runtime
+  boundaries: the evaluator reports `GS0510` and skips class
+  deinitializers, while the emitted engine runs them.
 
 The default emitted target framework is `net10.0`; the compiler also
 recognizes `net8.0` and `net9.0` target framework mappings.
@@ -45,8 +46,8 @@ modern, Kotlin-/Swift-shaped syntax but still need CLR interop,
 MSBuild projects, Portable PDBs, and the broader .NET ecosystem.
 
 The language is still growing. The documentation highlights what
-works today and calls out differences between the compiler and
-interpreter where they matter.
+works today and calls out differences between the emitter and
+interactive evaluator where they matter.
 
 The 0.3 line fills in more of the CLR-facing surface: collection
 initializers, index/range ergonomics, expression-bodied members,

--- a/website/docs/playground.md
+++ b/website/docs/playground.md
@@ -5,7 +5,7 @@ draft: false
 
 # Playground (status)
 
-A live browser Playground is intentionally deferred for this release. The current documentation site is static and hosted on GitHub Pages, while running G# code requires `gsc` to parse, bind, and either interpret code in a .NET process or compile it to a managed assembly.
+A live browser Playground is intentionally deferred for this release. The current documentation site is static and hosted on GitHub Pages, while running G# code requires `gsc` to parse, bind, emit, and execute the program in a .NET process.
 
 ## Why it is deferred
 
@@ -34,7 +34,7 @@ One practical shape would be:
 
 1. A static React or Docusaurus frontend embedded in the docs site.
 2. A separately hosted API, for example on Azure Container Apps, Fly.io, or another container platform.
-3. Per-request workers that invoke `gsc` in interpreter mode or emit mode inside a locked-down container.
+3. Per-request workers that invoke `gsc` for immediate emitted execution inside a locked-down container.
 4. Strict resource budgets and no ambient network or filesystem access from the user program.
 5. Optional snippet sharing through encoded URLs or a small persistent store.
 

--- a/website/docs/ref/clr-interop.md
+++ b/website/docs/ref/clr-interop.md
@@ -92,7 +92,7 @@ var handler = func(sender object, e EventArgs) {
 }
 ```
 
-Interpreter limitation: function-literal-to-delegate marshalling for some imported delegate scenarios is an emit-path feature. The evaluator supports G# closure values and many reflection calls, but delegate materialization is not identical to emitted IL in every case.
+Deprecated evaluator limitation: function-literal-to-delegate marshalling for some imported delegate scenarios is an emit-path feature. Every driver emits by default, so this does not apply unless `gsi --engine evaluator` or `GSI_ENGINE=evaluator` is selected. The evaluator supports G# closure values and many reflection calls, but delegate materialization is not identical to emitted IL in every case.
 
 ## Events
 

--- a/website/docs/ref/feature-matrix.md
+++ b/website/docs/ref/feature-matrix.md
@@ -6,7 +6,7 @@ draft: false
 
 # Feature matrix
 
-This matrix summarizes feature support in the compiler emit path (`gsc`) and the interpreter/REPL path. Legend: **Supported** means implemented on that path; **Mostly supported** means ordinary cases work with known edge limitations; **Partial** means syntax or binding exists but execution or emit is incomplete; **Not supported** means rejected or intentionally absent; **N/A** means the feature belongs to tooling rather than one execution path.
+This matrix summarizes feature support in the emitter and interactive evaluator. Every driver uses the emitter by default, including the interactive `gsi` REPL. `gsi --engine evaluator` or `GSI_ENGINE=evaluator` selects the deprecated evaluator, which is scheduled for removal. Legend: **Supported** means implemented on that path; **Mostly supported** means ordinary cases work with known edge limitations; **Partial** means syntax or binding exists but execution or emit is incomplete; **Not supported** means rejected or intentionally absent; **N/A** means the feature belongs to tooling rather than one execution path.
 
 ## Lexical and source structure
 
@@ -154,6 +154,6 @@ This matrix summarizes feature support in the compiler emit path (`gsc`) and the
 | Portable PDB, Source Link, embedded sources, deterministic IDs | Supported | N/A | Emit-only debug information. |
 | Reference assemblies | Supported | N/A | SDK can produce reference assemblies. |
 | SDK `.gsproj` build/run/pack | Supported | N/A | `Gsharp.NET.Sdk` integrates with MSBuild and `dotnet`. |
-| REPL | N/A | Supported | Interpreter executable starts a REPL with no file argument. |
+| REPL | Supported (default) | Deprecated (`--engine evaluator`) | `gsi` starts the interactive REPL when no file is supplied. |
 | Language server and VS Code extension | N/A | N/A | Pull-based diagnostics, semantic tokens, hover for CLR XML docs, CodeLens reference counts on members of types/structs/interfaces/enums, signature help, inlay hints, completion, go-to-definition, references, rename, formatting, debug + test integration. |
 | VS Code color themes | N/A | N/A | Six bundled themes (Ember, Magma, Synthwave — Dark + Light each). |

--- a/website/docs/ref/spec.md
+++ b/website/docs/ref/spec.md
@@ -16,7 +16,7 @@ The grammar fragments use EBNF. Terminals are quoted. `identifier`, `number`, `s
 
 Source files are Unicode text. The compiler consumes source through .NET strings; in normal use files are UTF-8. Line terminators are LF, CR, or CRLF. Outside strings, whitespace is insignificant except where it separates tokens. Comments and whitespace are skipped before parsing.
 
-A compilation unit consists of an optional package declaration, zero or more imports, and declarations or top-level statements. The production compiler path is `gsc` with an `/out:` option, which emits managed assemblies and optional Portable PDBs. Without `/out:`, `gsc` uses the interpreter path. Both paths share parsing and binding, but features involving metadata emission, state machines, and byref/pointer interop are most complete in the emit path.
+A compilation unit consists of an optional package declaration, zero or more imports, and declarations or top-level statements. Every driver executes emitted code by default: `gsc` runs the emitted program immediately without `/out:`, saves an assembly with `/out:`, and `gsi file.gs` emits and runs the script. The interactive `gsi` REPL also uses the emitter. `gsi --engine evaluator` or `GSI_ENGINE=evaluator` selects its deprecated evaluator, which is scheduled for removal.
 
 ## Lexical elements
 

--- a/website/docs/release-notes.md
+++ b/website/docs/release-notes.md
@@ -124,7 +124,7 @@ The `0.1` version base identifies the first pre-1.0 line. This is not a dated st
 
 ### Tooling
 
-- `gsc` compiler driver with an interpreter path when no `/out:` is supplied and an emit path for managed executables or libraries.
+- `gsc` compiler driver with immediate execution when no `/out:` is supplied and saved managed executables or libraries with `/out:`.
 - Managed PE and metadata emission without Roslyn, optional reference assemblies, target-framework-aware reference resolution, runtime configuration output, and Portable PDB support.
 - MSBuild SDK support through `Gsharp.NET.Sdk`, `.gsproj` projects, `dotnet build`, `dotnet run`, templates, and SDK-side response-file invocation.
 - VS Code extension and language server support for diagnostics, hover, definitions, references, symbols, formatting, completions, signature help, rename, code actions, CodeLens, semantic tokens, inlay hints, and debugging integration.

--- a/website/docs/tooling/compiler-architecture.md
+++ b/website/docs/tooling/compiler-architecture.md
@@ -6,7 +6,7 @@ draft: false
 
 # Compiler architecture
 
-G# has a shared front end and two execution backends: an interpreter used by no-output `gsc` runs and the REPL, and an emit pipeline used by `dotnet build`, libraries, packages, and debugging.
+G# has a shared front end and two execution backends: an emit pipeline used by every command-line driver by default, including the interactive REPL, and a deprecated evaluator exposed through opt-in REPL settings and the `Compilation.Evaluate` embedding API.
 
 ## End-to-end pipeline
 
@@ -34,9 +34,9 @@ G# stays on the bespoke emitter and does not use Roslyn to write assemblies at r
 
 Roslyn is used only by sibling tooling. `cs2gs` uses Roslyn to read C# projects for migration, and `gsgen` hosts Roslyn source generators out of process, projects G# declarations to C# stubs, translates generator output back to G#, and then hands generated `.g.gs` files to `gsc`. The compiler process itself remains Roslyn-free.
 
-## Interpreter backend
+## Interactive evaluator backend
 
-When `gsc` is called without `/out:<path>`, it evaluates the program in-process. The interpreter shares the same syntax, binding, and lowering stages, then walks bound nodes with `Evaluator` instead of emitting IL. This path is also used by the REPL and many language tests. It is useful for quick execution and semantic validation, while emitted assemblies are the production path.
+Every command-line driver uses the emitter by default, including the interactive `gsi` REPL. Passing `--engine evaluator` or setting `GSI_ENGINE=evaluator` selects the deprecated evaluator, which walks bound nodes in-process and is scheduled for removal. The `Compilation.Evaluate` embedding API also invokes this evaluator directly. `/out:<path>` controls whether `gsc` saves the assembly or runs the emitted program immediately.
 
 ## Lowering and generated code
 
@@ -74,7 +74,7 @@ Constraints (`any`, `comparable`, sealed-interface bounds) round-trip as `Generi
 | Lexer/parser/syntax | `src/Core/CodeAnalysis/Syntax/` |
 | Binding and symbols | `src/Core/CodeAnalysis/Binding/`, `src/Core/CodeAnalysis/Symbols/` |
 | Lowering | `src/Core/CodeAnalysis/Lowering/` |
-| Interpreter | `src/Core/CodeAnalysis/Evaluator.cs`, `src/Repl/` (gsi REPL host) |
+| Interactive evaluator | `src/Core/CodeAnalysis/Evaluator.cs`, `src/Repl/` (gsi REPL host) |
 | PE emit | `src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs` |
 | Portable PDB emit | `src/Core/CodeAnalysis/Emit/PortablePdbEmitter.cs` |
 | SDK integration | `src/Sdk/Gsharp.NET.Sdk/` |

--- a/website/docs/tooling/gsc.md
+++ b/website/docs/tooling/gsc.md
@@ -6,7 +6,7 @@ draft: false
 
 # The gsc compiler
 
-`gsc` is the command-line compiler driver for G#. It accepts one or more `.gs` source files, parses and binds them with the shared compiler front end, and then either runs the program in-process or emits a managed .NET assembly.
+`gsc` is the command-line compiler driver for G#. It accepts one or more `.gs` source files, parses and binds them with the shared compiler front end, emits the program, and either runs it immediately or saves a managed .NET assembly.
 
 ## Basic usage
 
@@ -14,7 +14,7 @@ draft: false
 gsc Program.gs
 ```
 
-With no `/out:<path>` option, `gsc` uses interpreter mode. The program is evaluated in the current process. If diagnostics contain errors, they are printed and the process exits with failure; otherwise `gsc` prints `Success.`.
+With no `/out:<path>` option, `gsc` runs the emitted program immediately. If diagnostics contain errors, they are printed and the process exits with failure; otherwise `gsc` prints `Success.`.
 
 ```bash
 gsc Program.gs /out:bin/Hello.dll
@@ -54,7 +54,7 @@ This option list was checked against `dotnet out\bin\Release\Compiler\gsc.dll --
 
 | Option | Accepted values and behavior |
 | --- | --- |
-| `/out:<file>` | Emit a PE assembly to `<file>`. Its presence selects emit mode; absence selects interpreter mode. |
+| `/out:<file>` | Save the emitted PE assembly to `<file>`. Without this option, `gsc` runs the emitted program immediately. |
 | `/refout:<file>` | Emit a metadata-only reference assembly to `<file>` in the same compiler invocation. |
 | `/assemblyname:<name>` | Override the emitted assembly name. |
 | `/version:<string>` | Set the informational version stamped on the output assembly. |
@@ -132,8 +132,6 @@ XML documentation output is selected independently with `/doc:<file>` and is use
 
 Use `/embed+` when you intentionally want all primary source bytes embedded in the PDB. This is useful for self-contained debugging artifacts but is opt-in because it ships source text inside symbols.
 
-## Interpreter mode versus emit mode
+## Immediate execution versus saved output
 
-Interpreter mode is useful for quick checks and compatibility with the REPL path. It shares parsing, binding, and lowering with the compiler but executes bound nodes in-process through `Evaluator`.
-
-Emit mode is the production path for `dotnet build`, NuGet packaging, and debugging. It writes standard managed PE metadata through `ReflectionMetadataEmitter`; for executables it also writes `.runtimeconfig.json`, so the result can be launched with `dotnet`. If `/analyzer` is supplied, the driver first runs the sibling `gsgen` tool and adds its generated `.g.gs` files to the same compilation.
+Both `gsc` modes use the emitter. Without `/out`, `gsc` runs the result immediately; with `/out`, it saves standard managed PE metadata and, for executables, a `.runtimeconfig.json` that can be launched with `dotnet`. If `/analyzer` is supplied, the driver first runs the sibling `gsgen` tool and adds its generated `.g.gs` files to the same compilation.

--- a/website/docs/tooling/repl.md
+++ b/website/docs/tooling/repl.md
@@ -33,13 +33,17 @@ dotnet tool uninstall --global Gsharp.Repl
 ## Command-line usage
 
 ```text
-Usage: gsi [options] [file.gs]
-  file.gs                       Run the given G# script and exit.
-  /r:<file>, /reference:<file>  Reference an assembly (repeatable).
-  -r:<file>, --reference:<file> Reference an assembly (repeatable).
-  --help, -h                    Show this help and exit.
-  --version                     Show the gsi version and exit.
-  (no file)                     Start the interactive REPL.
+Usage: gsi [file.gs] [/r:<assembly> ...] [--engine <name>] [--help] [--version]
+  file.gs                Run the given G# script and exit.
+  /r:<file>              Reference an assembly (repeatable).
+  /reference:<file>      Alias for /r: (also -r: and --reference:).
+  --engine <name>        Interactive engine: 'emit' (default) or 'evaluator'
+                         (also via GSI_ENGINE). 'evaluator' selects the legacy
+                         tree-walking engine; it is deprecated and will be
+                         removed in ADR-0156 Phase 3c.
+  --help, -h             Show this help and exit.
+  --version              Show the gsi version and exit.
+  (no args)              Start the interactive REPL.
 ```
 
 ### Interactive REPL
@@ -78,7 +82,7 @@ with a message instead of starting the UI.
 
 ### Run a script and exit
 
-Pass a `.gs` file to evaluate it in-process and print the final value.
+Pass a `.gs` file to emit and run it.
 This is handy for quick experiments and shell one-offs — no `.gsproj`
 required:
 
@@ -115,11 +119,10 @@ without adding an explicit reference.
 
 ## How it relates to `gsc`
 
-`gsi` and the compiler share lexing, parsing, binding, and lowering. The
-REPL always runs on the **interpreter** path (the same in-process
-evaluation `gsc` uses when you omit `/out:`), which is ideal for
-exploration and tests. When you are ready to produce a managed assembly,
-switch to a `.gsproj` project or invoke `gsc` with `/out:`. Some CLR
-interop features are emit-only; see the [`gsc` reference](./gsc.md) and
-the [introduction](../intro.md) for the differences between the
-interpreter and emit paths.
+Every driver uses the emitter by default, including `gsi file.gs` and
+the interactive REPL. Pass `--engine evaluator` or set
+`GSI_ENGINE=evaluator` to select the deprecated in-process evaluator,
+which is scheduled for removal. `--engine emit` explicitly selects the
+default. Both direct `gsc` modes use the emitter, with `/out:` only
+controlling whether the assembly is saved. See the
+[`gsc` reference](./gsc.md) and [introduction](../intro.md) for details.

--- a/website/docs/tour/dotnet-interop.md
+++ b/website/docs/tour/dotnet-interop.md
@@ -174,7 +174,7 @@ The SDK bundles a `Gsharp.Extensions` assembly with opt-in helper namespaces. Im
 
 `Optional` adds `Map` / `FlatMap` / `OrElse` / `OrCompute` / `OrThrow` / `IfPresent` / `Filter` over `T?`. `Sequences` adds builders and transformers. See the [standard-library reference](/docs/ref/standard-library) for the full surface.
 
-Use emitted builds for delegate-heavy interop. The interpreter can evaluate many imported members by reflection, but it cannot marshal every G# function literal into a CLR delegate the same way an emitted assembly can.
+File execution uses emitted code, including bare `gsc`, so G# function literals can be passed to imported CLR delegate parameters without `/out`.
 
 ## Unsafe pointers
 

--- a/website/docs/tutorials/dotnet-interop.md
+++ b/website/docs/tutorials/dotnet-interop.md
@@ -9,7 +9,7 @@ draft: false
 In this tutorial, you will import CLR namespaces, call constructors and methods, subscribe to events, pass delegates, use extension functions, and rely on operator overloads.
 
 :::note
-Passing G# lambdas to imported CLR methods works on the compiler emit path, such as SDK builds or `gsc /out`. It does not work in the interpreter path used when `gsc` runs without `/out`.
+Passing G# lambdas to imported CLR methods works in every file mode: bare `gsc`, `gsc /out`, and `gsi file.gs`. `/out` is only needed when you want to save the assembly.
 :::
 
 ## Prerequisites
@@ -626,5 +626,4 @@ Expected output:
 
 - Imports bind both G# packages and CLR namespaces.
 - Constructors, inheritance, properties, events, operators, and extension methods are available from CLR metadata.
-- G# lambdas, function values, and method groups can become delegates on the emit path.
-- Interpreter-only runs do not support passing G# lambdas to imported CLR methods; use SDK builds or `gsc /out` for that scenario.
+- G# lambdas, function values, and method groups can become delegates on every file path, including bare `gsc`.

--- a/website/docs/tutorials/getting-started.md
+++ b/website/docs/tutorials/getting-started.md
@@ -90,7 +90,7 @@ $ dotnet path/to/gsc.dll Program.gs /out:bin/hello.dll /target:exe /tfm:net10.0
 $ dotnet bin/hello.dll
 ```
 
-When `/out` is omitted, `gsc` uses the interpreter path for compatibility. Prefer the SDK or `/out` when you want compiler-emitted behavior.
+When `/out` is omitted, `gsc` still emits the program and runs it immediately. Add `/out` when you want to save the assembly.
 
 ## Next steps
 


### PR DESCRIPTION
## Summary

- correct website prose: every command-line driver emits CIL by default, including interactive `gsi`
- document `--engine evaluator` / `GSI_ENGINE=evaluator` as deprecated evaluator escape hatches scheduled for Phase 3c removal
- keep `Compilation.Evaluate` identified as the evaluator-backed embedding API
- clarify that `/out` controls whether `gsc` saves the assembly, not which engine runs
- remove false lambda-to-CLR-delegate limitations from file-mode docs
- leave `website/docs/ref/diagnostics.md` untouched for #3200

## Rebuilt `gsi --help`

Measured after rebasing onto `main` `0484b00f139f` (contains `8b32fc36`):

```text
  --engine <name>        Interactive engine: 'emit' (default) or 'evaluator'
                         (also via GSI_ENGINE). 'evaluator' selects the legacy
                         tree-walking engine; it is deprecated and will be
                         removed in ADR-0156 Phase 3c.
```

## Measured routing

| invocation | rc | stdout / assertion | GS0510 | engine |
|---|---:|---|---:|---|
| bare `gsc samples/Deinit.gs` | 0 | golden + `Success.` | 0 | emit |
| `gsc /out:Deinit.dll` → `dotnet Deinit.dll` | 0 / 0 | golden | 0 | emit |
| `gsi samples/Deinit.gs` | 0 | golden | 0 | emit |
| interactive default / explicit `--engine emit` | — | engine-selection tests select emitted engine; deinit test prints `deinit-22`, `body-33` | 0 | emit |
| `--engine evaluator` / `GSI_ENGINE=evaluator` | — | engine-selection tests select evaluator | 1 in deinit test | evaluator |
| embedding `Compilation.Evaluate` | 0 | `body-33`; deinit skipped | 1 | evaluator |

Lambda-to-delegate probe (`nums.Where(func(n int32) bool { return n % 2 == 0 }).Count()`): bare `gsc` rc 0, stdout `2` + `Success.`.

## Residue sweep

```bash
PATTERN='gsc.*(uses?|used|runs?|called|invoke[sd]?|without|omitting|with|either|mode|path).*interpret|interpret.*(without|omitting|no).*\/out|interpreter compatibility|interpreter execution|absence selects interpreter|interpreter-only.*(lambda|delegate)|interpreter path does not support that conversion|REPL always runs on|interpreter cannot marshal G# function literals|interpreter.*cannot marshal every G# function literal|interpreter executable starts a REPL|interpreter is useful for REPL-style.*emit path.*production'
git grep -n -i -E "$PATTERN" -- website/docs ':(exclude)website/docs/ref/diagnostics.md'
```

Positive control on `0484b00f`: 19 hits. PR head: 0 hits.

## Validation

- `dotnet build GSharp.sln`: 0 warnings, 0 errors
- targeted interactive routing tests: 7/7 passed
- `cd website && npm run build`: pass; Docusaurus link validation passed
- product-path diff grep (`src|test|e2etests|build|samples`): 0 hits
- `website/docs/ref/diagnostics.md`: unchanged
- worktree clean

Fixes #3202
