### PR TITLE
Disable evaluator-era map-concurrency tests pending #3209

### DIFF
--- a/test/Interpreter.Tests/Issue1799MapAndInterfaceSlotConcurrencyInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue1799MapAndInterfaceSlotConcurrencyInterpreterTests.cs
@@ -56,7 +56,7 @@ namespace GSharp.Interpreter.Tests;
 /// </summary>
 public class Issue1799MapAndInterfaceSlotConcurrencyInterpreterTests
 {
-    [Fact]
+    [Fact(Skip = "Implicit map synchronization retired with the evaluator (ADR-0156 Phase 3, #3205); re-enable when #3209 lands.")]
     public void ManyGoroutines_WriteDistinctKeysOnSharedMap_AllWritesSurvive()
     {
         // A single map literal is captured by N goroutines, each writing a
@@ -108,7 +108,7 @@ public class Issue1799MapAndInterfaceSlotConcurrencyInterpreterTests
         Assert.Equal(expectedSum, result.Value);
     }
 
-    [Fact]
+    [Fact(Skip = "Implicit map synchronization retired with the evaluator (ADR-0156 Phase 3, #3205); re-enable when #3209 lands.")]
     public void ManyConcurrentRuns_GoroutinesWritingSharedMap_NeverCorruptsOrCrashes()
     {
         // Same stress shape as
@@ -173,7 +173,7 @@ public class Issue1799MapAndInterfaceSlotConcurrencyInterpreterTests
         Assert.Empty(outOfRangeResults);
     }
 
-    [Fact]
+    [Fact(Skip = "Implicit map synchronization retired with the evaluator (ADR-0156 Phase 3, #3205); re-enable when #3209 lands.")]
     public void ManyConcurrentRuns_OneGoroutineRangesWhileOthersWrite_NeverThrowsCollectionModified()
     {
         // Opus review follow-up (blocking gap B1): the language sugar
@@ -248,7 +248,7 @@ public class Issue1799MapAndInterfaceSlotConcurrencyInterpreterTests
         Assert.Empty(exceptions);
     }
 
-    [Fact]
+    [Fact(Skip = "Implicit map synchronization retired with the evaluator (ADR-0156 Phase 3, #3205); re-enable when #3209 lands.")]
     public void ManyConcurrentRuns_LenAndContainsKeyAndKeysReadWhileWriting_NeverThrows()
     {
         // Same gap as above (B1) but for the other reflection-dispatched


### PR DESCRIPTION
Part of #3205 / #3209, part of #3176

## Summary

- Skip (do not delete) the four evaluator-era map-concurrency tests whose passing depends on the evaluator's implicit per-instance map lock, per the decision on #3205: maps stay `Dictionary<K,V>`-backed with no implicit synchronization, and the ergonomic synchronization story is designed separately in #3209.
- Skip reason on each: `Implicit map synchronization retired with the evaluator (ADR-0156 Phase 3, #3205); re-enable when #3209 lands.` Test bodies are intact.

Disabled tests (all in `test/Interpreter.Tests/Issue1799MapAndInterfaceSlotConcurrencyInterpreterTests.cs`):

| Test | Why it depends on the implicit map lock |
| --- | --- |
| `ManyGoroutines_WriteDistinctKeysOnSharedMap_AllWritesSurvive` | asserts concurrent distinct-key goroutine writes all survive |
| `ManyConcurrentRuns_GoroutinesWritingSharedMap_NeverCorruptsOrCrashes` | asserts racy shared-map writes never corrupt/throw |
| `ManyConcurrentRuns_OneGoroutineRangesWhileOthersWrite_NeverThrowsCollectionModified` | asserts enumeration during concurrent writes never throws |
| `ManyConcurrentRuns_LenAndContainsKeyAndKeysReadWhileWriting_NeverThrows` | asserts `len`/`ContainsKey`/`Keys` reads during writes never throw |

Left enabled in the same file: `InterfaceSlotResolution_TwoInScopeImplementers_PicksSameOneEveryRun` — pins locals-scan determinism, not map synchronization.

Scope checks: no map-concurrency rows exist in the EmittedOracle/parity suite; the other concurrency suites (Issue1718 frame concurrency, Issue1651 goroutine isolation) do not touch maps — untouched. No docs or product code changed (interim non-guarantee doc note is assigned to the Phase 3d pass).

## Verification

- Release solution build: 0 warnings, 0 errors.
- Interpreter.Tests (Release, full): Failed: 0, Passed: 1477, Skipped: 4, Total: 1481 — the 4 skips are exactly the tests above (xUnit `[SKIP]` lines confirm each by name); no other test outcome changed.
- NOT RUN: Core.Tests, Compiler.Tests, Extensions.Tests, LanguageServer.Tests, Sdk.Tests, InternalAnalyzers.Tests — no files in those projects touched (single test-attribute-only diff in Interpreter.Tests).
- ADR-0154 witness: n/a — attribute-only change disabling tests; no behavioral test added or changed.

## Checklist

- [x] Behavioral tests carry a witness of discrimination (ADR-0154): n/a — no new/changed behavioral tests, attribute-only skips.
- [x] Self-review verdict recorded when one was run (MERGEABLE / BLOCKER / SHOULD-FIX / NIT): MERGEABLE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)