### PR TITLE
Resolve bundled extensions in loose IDE files

### DIFF
--- a/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
+++ b/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
@@ -374,6 +374,18 @@ public sealed class ReferenceResolver : IDisposable
     /// <returns>A default resolver.</returns>
     public static ReferenceResolver Default()
     {
+        foreach (var path in ResolveDriverReferencePaths(Array.Empty<string>()))
+        {
+            try
+            {
+                _ = AssemblyLoadContext.Default.LoadFromAssemblyPath(path);
+            }
+            catch (FileLoadException)
+            {
+                // Already loaded into the default context.
+            }
+        }
+
         return new ReferenceResolver(BuildHostAssemblies(), metadataContext: null);
     }
 

--- a/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
+++ b/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
@@ -378,11 +378,12 @@ public sealed class ReferenceResolver : IDisposable
         {
             try
             {
+                // Deliberately load here: BuildHostAssemblies excludes DriverReferenceLoadContext assemblies.
                 _ = AssemblyLoadContext.Default.LoadFromAssemblyPath(path);
             }
-            catch (FileLoadException)
+            catch (Exception ex) when (ex is FileLoadException or BadImageFormatException)
             {
-                // Already loaded into the default context.
+                // Already loaded or corrupt; leave it unavailable to the resolver.
             }
         }
 

--- a/test/LanguageServer.Tests/Issue3198LooseFileExtensionDiagnosticsTests.cs
+++ b/test/LanguageServer.Tests/Issue3198LooseFileExtensionDiagnosticsTests.cs
@@ -1,0 +1,119 @@
+// <copyright file="Issue3198LooseFileExtensionDiagnosticsTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GSharp.LanguageServer.Protocol;
+using GSharp.LanguageServer.Server;
+using Xunit;
+
+namespace GSharp.LanguageServer.Tests;
+
+/// <summary>Issue #3198: loose files resolve bundled extension references.</summary>
+public sealed class Issue3198LooseFileExtensionDiagnosticsTests
+{
+    [Fact]
+    public async Task LooseFileWithoutExtensions_PublishesNoDiagnostics()
+    {
+        var diagnostics = await GetPublishedDiagnosticsAsync(
+            "AddressBook",
+            File.ReadAllText(Path.Combine(LocateSamplesDirectory(), "AddressBook.gs")));
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Theory]
+    [InlineData("GsharpExtensionsOptional")]
+    [InlineData("GsharpExtensionsMixed")]
+    [InlineData("GsharpExtensionsSequences")]
+    public async Task LooseExtensionSample_PublishesNoDiagnostics(string sample)
+    {
+        var diagnostics = await GetPublishedDiagnosticsAsync(
+            sample,
+            File.ReadAllText(Path.Combine(LocateSamplesDirectory(), sample + ".gs")));
+
+        Assert.True(
+            diagnostics.Count == 0,
+            string.Join(Environment.NewLine, diagnostics.Select(d => $"{d.Code.Value}: {d.Message}")));
+    }
+
+    [Fact]
+    public async Task LooseFileWithPlainExtensionImport_PublishesNoDiagnostics()
+    {
+        var diagnostics = await GetPublishedDiagnosticsAsync(
+            "PlainExtensionImport",
+            """
+            package Issue3198.Plain
+            import System
+            import Gsharp.Extensions.Sequences
+
+            let values = Sequences.Of(7, 8, 9)
+            Console.WriteLine(values[0])
+            """);
+
+        Assert.True(
+            diagnostics.Count == 0,
+            string.Join(Environment.NewLine, diagnostics.Select(d => $"{d.Code.Value}: {d.Message}")));
+    }
+
+    private static async Task<IReadOnlyList<Diagnostic>> GetPublishedDiagnosticsAsync(string name, string source)
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            nameof(Issue3198LooseFileExtensionDiagnosticsTests),
+            name + "-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        Assert.Empty(Directory.GetFileSystemEntries(directory));
+
+        try
+        {
+            var sourcePath = Path.Combine(directory, name + ".gs");
+            File.WriteAllText(sourcePath, source);
+            var server = new LspServer(new DocumentContentService(), new WorkspaceState());
+            var published = new TaskCompletionSource<IReadOnlyList<Diagnostic>>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var bindCompleted = 0;
+            server.TestOnBindResult = (_, _) => Interlocked.Exchange(ref bindCompleted, 1);
+            server.TestOnPublish = (_, diagnostics) =>
+            {
+                if (Volatile.Read(ref bindCompleted) == 1)
+                {
+                    published.TrySetResult(diagnostics);
+                }
+            };
+
+            await server.DidOpenAsync(new DidOpenTextDocumentParams
+            {
+                TextDocument = new TextDocumentItem
+                {
+                    Uri = DocumentUri.FromFileSystemPath(sourcePath),
+                    Text = source,
+                },
+            });
+
+            return await published.Task.WaitAsync(TimeSpan.FromSeconds(30));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static string LocateSamplesDirectory()
+    {
+        for (var directory = new DirectoryInfo(AppContext.BaseDirectory); directory != null; directory = directory.Parent)
+        {
+            var candidate = Path.Combine(directory.FullName, "samples");
+            if (Directory.Exists(candidate) && File.Exists(Path.Combine(directory.FullName, "GSharp.sln")))
+            {
+                return candidate;
+            }
+        }
+
+        throw new DirectoryNotFoundException("Unable to locate samples directory");
+    }
+}

--- a/test/LanguageServer.Tests/Issue3198LooseFileExtensionDiagnosticsTests.cs
+++ b/test/LanguageServer.Tests/Issue3198LooseFileExtensionDiagnosticsTests.cs
@@ -15,6 +15,7 @@ using Xunit;
 namespace GSharp.LanguageServer.Tests;
 
 /// <summary>Issue #3198: loose files resolve bundled extension references.</summary>
+[Collection("Issue3198AppContext")]
 public sealed class Issue3198LooseFileExtensionDiagnosticsTests
 {
     [Fact]
@@ -59,6 +60,39 @@ public sealed class Issue3198LooseFileExtensionDiagnosticsTests
         Assert.True(
             diagnostics.Count == 0,
             string.Join(Environment.NewLine, diagnostics.Select(d => $"{d.Code.Value}: {d.Message}")));
+    }
+
+    [Fact]
+    public void CorruptBundledExtension_PublishesDiagnosticInsteadOfThrowing()
+    {
+        var originalBaseDirectory = AppContext.GetData("APP_CONTEXT_BASE_DIRECTORY");
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            nameof(Issue3198LooseFileExtensionDiagnosticsTests),
+            "corrupt-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        Assert.Empty(Directory.GetFileSystemEntries(directory));
+
+        try
+        {
+            File.WriteAllText(Path.Combine(directory, "Gsharp.Extensions.dll"), "not a managed assembly");
+            AppContext.SetData("APP_CONTEXT_BASE_DIRECTORY", directory);
+
+            var syntaxTree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree.Parse(
+                "package Issue3198.Corrupt\nlet broken TotallyUndefinedType = nil");
+            var compilation = new GSharp.Core.CodeAnalysis.Compilation.Compilation(syntaxTree);
+            var diagnostics = compilation.GlobalScope.Diagnostics
+                .Concat(compilation.BoundProgram.Diagnostics);
+
+            Assert.Contains(
+                diagnostics,
+                diagnostic => diagnostic.Message.Contains("TotallyUndefinedType", StringComparison.Ordinal));
+        }
+        finally
+        {
+            AppContext.SetData("APP_CONTEXT_BASE_DIRECTORY", originalBaseDirectory);
+            Directory.Delete(directory, recursive: true);
+        }
     }
 
     private static async Task<IReadOnlyList<Diagnostic>> GetPublishedDiagnosticsAsync(string name, string source)
@@ -116,4 +150,9 @@ public sealed class Issue3198LooseFileExtensionDiagnosticsTests
 
         throw new DirectoryNotFoundException("Unable to locate samples directory");
     }
+}
+
+[CollectionDefinition("Issue3198AppContext", DisableParallelization = true)]
+public sealed class Issue3198AppContextCollection
+{
 }


### PR DESCRIPTION
## Summary

- load bundled `Gsharp.Extensions` through existing `ResolveDriverReferencePaths` before constructing default in-process resolvers
- tolerate corrupt bundled assemblies instead of escaping from every resolver-less compilation
- cover real published IDE diagnostics, including clean, extension, undefined-type, and corrupt-assembly cases

## Measurement

| probe | drivers | IDE before | IDE after |
|---|---|---|---|
| AddressBook control | clean | empty | empty |
| Optional / Mixed / Sequences / plain import | clean | unresolved extension diagnostics | empty |
| corrupt bundled assembly + undefined type | n/a | `BadImageFormatException` escaped | undefined-type diagnostic published |

## Mutation / RED proof

- exact original fix-hunk revert: RED, 4 failed / 1 passed
- bundled-reference condition inversion control: RED, 4 failed / 1 passed
- corrupt-assembly pin alone against narrow `FileLoadException` catch: RED with `BadImageFormatException`, 1 matched test
- restored/fixed pin: GREEN, 1/1

## Validation

- Release solution build: 0 warnings, 0 errors
- `LanguageServer.Tests`: 468/468
- 9 of 9 test projects enumerated from `GSharp.sln`: 15,460 passed, 5 skipped, 0 failed
- ILVerify: 123/123, 2 documented suppressions, 0 verification or compile failures
- CI: green

Fixes #3198