### PR TITLE
Pin the shared-initializer beforefieldinit contract and unpin the #3203 divergence test

### DIFF
--- a/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
@@ -569,6 +569,10 @@ internal sealed class TypeDefEmitter
         // when a static constructor is declared — it must NOT be
         // `beforefieldinit` (which would let the runtime run the type
         // initializer at an unspecified time before first field access).
+        // Issue #3203 confirmed this contract as the language semantics:
+        // explicit init blocks get C# static-constructor timing, while types
+        // with only shared FIELD initializers keep `beforefieldinit`, exactly
+        // like C# types with only static field initializers.
         if (structSym.HasStaticInitializerBlock)
         {
             typeAttrs &= ~TypeAttributes.BeforeFieldInit;

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue3203SharedInitializerCctorTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue3203SharedInitializerCctorTests.cs
@@ -1,0 +1,307 @@
+// <copyright file="Issue3203SharedInitializerCctorTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #3203 / ADR-0140 §4: the emitted <c>beforefieldinit</c> contract for
+/// shared (static) initialization, exactly aligned with C#.
+/// <para>The metadata contract is the primary witness (deterministic and
+/// JIT-independent): a type with an explicit <c>shared { init { … } }</c>
+/// block emits a real <c>.cctor</c> and does NOT carry
+/// <see cref="System.Reflection.TypeAttributes.BeforeFieldInit"/> — C#
+/// static-constructor timing. A type with only shared field initializers (no
+/// explicit block) also emits a <c>.cctor</c> but KEEPS
+/// <c>beforefieldinit</c>, so the runtime may run it at an unspecified point
+/// no later than the first static-field access — exactly like a C# type with
+/// only static field initializers.</para>
+/// <para>The behavioral tests are the secondary witness and assert only the
+/// C#-guaranteed direction — the initializer has executed by the time the
+/// first static member access completes. They use direct console writes (not
+/// a main-initialized global) so they stay correct even where the runtime
+/// legally runs a type initializer earlier than the precise trigger point
+/// (observed on CoreCLR for assemblies in collectible
+/// <see cref="AssemblyLoadContext"/>s).</para>
+/// </summary>
+public class Issue3203SharedInitializerCctorTests
+{
+    [Fact]
+    public void ClassWithInitBlock_EmitsCctor_AndClearsBeforeFieldInit()
+    {
+        var source = @"package InitBlockClass
+import System
+
+class Ordered {
+    shared {
+        var Count int32 = 1
+        init {
+            Count = 2
+        }
+    }
+}
+
+Console.WriteLine(Ordered.Count)
+";
+        var (attrs, hasCctor) = CompileAndInspectType(source, "Ordered");
+
+        Assert.True(hasCctor, "a class with a shared init block must emit a .cctor");
+        Assert.False(
+            (attrs & System.Reflection.TypeAttributes.BeforeFieldInit) != 0,
+            "a class with a shared init block must not be beforefieldinit");
+    }
+
+    [Fact]
+    public void StructWithInitBlock_EmitsCctor_AndClearsBeforeFieldInit()
+    {
+        var source = @"package InitBlockStruct
+import System
+
+struct Counter {
+    shared {
+        var Count int32 = 0
+        init {
+            Count = 7
+        }
+    }
+}
+
+Console.WriteLine(Counter.Count)
+";
+        var (attrs, hasCctor) = CompileAndInspectType(source, "Counter");
+
+        Assert.True(hasCctor, "a struct with a shared init block must emit a .cctor");
+        Assert.False(
+            (attrs & System.Reflection.TypeAttributes.BeforeFieldInit) != 0,
+            "a struct with a shared init block must not be beforefieldinit");
+    }
+
+    [Fact]
+    public void ClassWithOnlyFieldInitializers_KeepsBeforeFieldInit()
+    {
+        // The C#-aligned other half of the #3203 decision: shared FIELD
+        // initializers alone do not declare an explicit type-initializer body,
+        // so the type keeps beforefieldinit (initialization runs at an
+        // unspecified time no later than first static-field access — the CLR
+        // may even skip it entirely when no static field is ever touched).
+        var source = @"package FieldInitOnlyClass
+import System
+
+class Eager {
+    shared {
+        let Value int32 = 41 + 1
+    }
+}
+
+Console.WriteLine(Eager.Value)
+";
+        var (attrs, hasCctor) = CompileAndInspectType(source, "Eager");
+
+        Assert.True(hasCctor, "shared field initializers still emit a .cctor");
+        Assert.True(
+            (attrs & System.Reflection.TypeAttributes.BeforeFieldInit) != 0,
+            "a class with only shared field initializers keeps beforefieldinit, like C#");
+    }
+
+    [Fact]
+    public void StructWithOnlyFieldInitializers_KeepsBeforeFieldInit()
+    {
+        var source = @"package FieldInitOnlyStruct
+import System
+
+struct Lazy {
+    shared {
+        let Value int32 = 5 * 5
+    }
+}
+
+Console.WriteLine(Lazy.Value)
+";
+        var (attrs, hasCctor) = CompileAndInspectType(source, "Lazy");
+
+        Assert.True(hasCctor, "shared field initializers still emit a .cctor");
+        Assert.True(
+            (attrs & System.Reflection.TypeAttributes.BeforeFieldInit) != 0,
+            "a struct with only shared field initializers keeps beforefieldinit, like C#");
+    }
+
+    [Fact]
+    public void GenericClassWithInitBlock_ClearsBeforeFieldInit_AndRunsCctor()
+    {
+        // Phase 4 emit parity: generic definitions are emitted type-erased as
+        // a single CLR TypeDef, so the beforefieldinit contract lands on that
+        // TypeDef and its .cctor covers every constructed use.
+        var source = @"package InitBlockGeneric
+import System
+
+class Box[T] {
+    shared {
+        var Tag int32 = 1
+        init {
+            Tag = Tag + 10
+        }
+    }
+}
+
+Console.WriteLine(Box[int32].Tag)
+";
+        var (attrs, hasCctor) = CompileAndInspectType(source, "Box`1");
+        Assert.True(hasCctor, "a generic class with a shared init block must emit a .cctor");
+        Assert.False(
+            (attrs & System.Reflection.TypeAttributes.BeforeFieldInit) != 0,
+            "a generic class with a shared init block must not be beforefieldinit");
+
+        var output = CompileLoadInvokeCaptureStdout(source, "Issue3203-Generic");
+        Assert.Equal("11", output.Trim());
+    }
+
+    [Fact]
+    public void InitBlock_RunsAfterCallArguments_BeforeFirstStaticMethodAccess()
+    {
+        // The #3203 divergence repro, in the decided explicit-block form: the
+        // first static access is a method that touches NO static field, so
+        // only the cleared beforefieldinit flag makes the runtime run the
+        // .cctor at all. C#-guaranteed timing: call arguments evaluate first
+        // ("A"), the .cctor runs at the invocation of Use ("I"), then the
+        // method body ("M").
+        var source = @"package InitBlockTiming
+import System
+
+func Argument() int32 {
+    Console.Write(""A"")
+    return 1
+}
+
+class Ordered {
+    shared {
+        init {
+            Console.Write(""I"")
+        }
+
+        func Use(value int32) {
+            Console.Write(""M"")
+        }
+    }
+}
+
+Ordered.Use(Argument())
+";
+        var output = CompileLoadInvokeCaptureStdout(source, "Issue3203-Timing").Trim();
+
+        // The guaranteed direction: the init block has executed by the time
+        // the first static member access runs its body ("I" strictly before
+        // "M") — without the cleared flag the CLR never runs it here at all.
+        var initIndex = output.IndexOf('I', StringComparison.Ordinal);
+        var methodIndex = output.IndexOf('M', StringComparison.Ordinal);
+        Assert.True(initIndex >= 0, $"init block never ran; output was '{output}'");
+        Assert.True(initIndex < methodIndex, $"init block must run before the first static member body; output was '{output}'");
+        Assert.Equal("AIM", output);
+    }
+
+    [Fact]
+    public void BaseClassInitBlock_RunsBeforeFirstDerivedInstanceCreation()
+    {
+        // Creating a Derived instance invokes Base's instance constructor,
+        // which (Base being non-beforefieldinit) triggers Base's .cctor no
+        // later than that call — so "B" always precedes "D".
+        var source = @"package InitBlockInheritance
+import System
+
+open class Base {
+    shared {
+        init {
+            Console.Write(""B"")
+        }
+    }
+}
+
+class Derived : Base {
+}
+
+let d = Derived()
+Console.Write(""D"")
+";
+        var output = CompileLoadInvokeCaptureStdout(source, "Issue3203-Inheritance").Trim();
+
+        Assert.Equal("BD", output);
+    }
+
+    private static EmitResult Compile(string source, Stream peStream)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Emit(peStream);
+    }
+
+    private static (System.Reflection.TypeAttributes Attributes, bool HasCctor) CompileAndInspectType(string source, string typeName)
+    {
+        using var peStream = new MemoryStream();
+        var result = Compile(source, peStream);
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        using var peReader = new PEReader(peStream, PEStreamOptions.LeaveOpen);
+        var md = peReader.GetMetadataReader();
+        var typeDef = md.TypeDefinitions
+            .Select(md.GetTypeDefinition)
+            .Single(t => md.GetString(t.Name) == typeName);
+        var hasCctor = typeDef.GetMethods()
+            .Select(md.GetMethodDefinition)
+            .Any(m => md.GetString(m.Name) == ".cctor");
+        return (typeDef.Attributes, hasCctor);
+    }
+
+    private static string CompileLoadInvokeCaptureStdout(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var result = Compile(source, peStream);
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        try
+        {
+            var asm = loadContext.LoadFromStream(peStream);
+            var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+            Assert.NotNull(programType);
+            var entry = programType!.GetMethod(
+                "<Main>$",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(entry);
+
+            var stdout = Console.Out;
+            var captured = new StringWriter();
+            Console.SetOut(captured);
+            try
+            {
+                entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { System.Array.Empty<string>() });
+            }
+            finally
+            {
+                Console.SetOut(stdout);
+            }
+
+            return captured.ToString();
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+}

--- a/test/Interpreter.Tests/Issue3096CollectionSpreadInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue3096CollectionSpreadInterpreterTests.cs
@@ -3,12 +3,7 @@
 // </copyright>
 
 using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using GSharp.Core.CodeAnalysis.Compilation;
-using GSharp.Core.CodeAnalysis.Symbols;
-using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Tests;
 using Xunit;
 
@@ -150,38 +145,36 @@ public sealed class Issue3096CollectionSpreadInterpreterTests
         const string Source = """
             import System
 
-            var trace = ""
-
             func Argument() int32 {
-                trace = trace + "A"
+                Console.Write("A")
                 return 1
             }
 
             class Ordered {
                 shared {
-                    let Initialized int32 = Initialize()
-
-                    func Initialize() int32 {
-                        trace = trace + "I"
-                        return 0
+                    init {
+                        Console.Write("I")
                     }
 
                     func Use(value int32) {
-                        trace = trace + "M"
+                        Console.Write("M")
                     }
                 }
             }
 
             Ordered.Use(Argument())
-            Console.WriteLine(trace)
             """;
 
-        // ADR-0156 Phase 3b (#3176): stays on Compilation.Evaluate — issue
-        // #3203 pins the divergence this test exposed: the EVALUATOR runs
-        // shared initializers eagerly at first static use ("AIM"), while
-        // emitted execution is CLR-beforefieldinit lazy and never runs the
-        // initializer here ("AM"). Realigns with #3203's resolution.
-        Assert.Equal("AIM\n", EvaluateWithEvaluator(Source));
+        // Issue #3203 resolution (ADR-0140 §4): an explicit `shared { init }`
+        // block emits a real `.cctor` with C# static-constructor timing —
+        // `beforefieldinit` cleared — so the initializer is guaranteed to run
+        // at the first static access (the `Use` invocation), after its call
+        // arguments. The original field-initializer-only form of this repro
+        // keeps `beforefieldinit` (aligned with C#) and its timing is
+        // CLR-unspecified; that half of the contract is pinned by the
+        // Issue3203SharedInitializerCctorTests metadata tests in Core.Tests.
+        // Migrated off the evaluator pin per ADR-0156 Phase 3b (#3176).
+        Assert.Equal("AIM", Evaluate(Source));
     }
 
     private static string Evaluate(string source)
@@ -193,30 +186,5 @@ public sealed class Issue3096CollectionSpreadInterpreterTests
             "evaluation failed:\n" + string.Join("\n", errors.Select(diagnostic => diagnostic.ToString())));
 
         return result.Output.Replace("\r\n", "\n", StringComparison.Ordinal);
-    }
-
-    // Evaluator-pinned twin of Evaluate for the #3203 test above; delete with
-    // the evaluator (Phase 3c) or when #3203 aligns the engines.
-    private static string EvaluateWithEvaluator(string source)
-    {
-        var compilation = new Compilation(SyntaxTree.Parse(source));
-
-        using var output = new StringWriter();
-        var previous = Console.Out;
-        Console.SetOut(output);
-        try
-        {
-            var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-            var errors = result.Diagnostics.Where(diagnostic => diagnostic.IsError).ToArray();
-            Assert.True(
-                errors.Length == 0,
-                "evaluation failed:\n" + string.Join("\n", errors.Select(diagnostic => diagnostic.ToString())));
-        }
-        finally
-        {
-            Console.SetOut(previous);
-        }
-
-        return output.ToString().Replace("\r\n", "\n", StringComparison.Ordinal);
     }
 }


### PR DESCRIPTION
Fixes #3203. Part of #3176, part of #3163.

## Summary

- **Investigation finding: no emit change was needed.** The decided contract is already what the emitter produces (since #2133 / ADR-0140 §4). Verified in emitted metadata and by execution: an explicit `shared { init { … } }` block emits a real `.cctor` (`TypeDefEmitter.SuppressBeforeFieldInitForStruct` clears `beforefieldinit`; `ConstructorBodyEmitter.EmitStaticConstructorBodyBytes` appends the block after field initializers), and a type with only shared field initializers keeps `beforefieldinit` — exactly C#. The #3203 divergence was evaluator-only eagerness on a field-initializer-only type; the evaluator is untouched (retires in 3c) and its eager-at-first-use timing is conforming under `beforefieldinit`.
- **The metadata contract, stated plainly:** explicit `shared { init }` block ⇒ `.cctor` emitted AND `TypeAttributes.BeforeFieldInit` absent (C# static-constructor timing: initialization runs exactly at first static access). Shared field initializers only ⇒ `.cctor` emitted AND `BeforeFieldInit` present (timing unspecified, no later than first static-field access; may never run if no static field is touched).
- Pin that contract in `Issue3203SharedInitializerCctorTests` (Core.Tests): metadata as the primary, JIT-independent witness — class, struct, generic (type-erased TypeDef), and the keeps-BFI half for field-initializer-only class/struct — plus behavioral witnesses: the #3203 repro in explicit-block form (`AIM`: init runs after call arguments, before the first static member body, where that member touches no static field) and base-class init on first derived instance creation (`BD`).
- Migrate `StaticInitialization_RunsAfterCallArguments` (the only 3b.0 pilot test that could not migrate) off its evaluator pin onto `EmittedOracle`, in the decided explicit-block form; delete the evaluator-pinned twin helper. Unpinned test count: **1** (it was the only test pinned on #3203).
- Document the confirmed decision at the emit site (comment only).
- Behavioral tests use direct console writes rather than a main-initialized global: CoreCLR runs precise-init `.cctor`s eagerly at JIT time for assemblies in **collectible ALCs** (reproduced with a Roslyn-compiled assembly, so not a G# emit issue), which would clobber-race a global trace. Submission containers (`gsi$N` `<Program>`) are untouched: their `BeforeFieldInit` is composed on a separate hard-coded path (`ReflectionMetadataEmitter.cs:3108/3132`) keyed off `PackageSymbol`, not `StructSymbol.HasStaticInitializerBlock`; the EmittedOracle tests exercise that path green.

## Verification

- Release solution build: 0 warnings, 0 errors.
- Core.Tests full: 7135 passed, 0 failed, 1 skipped (pre-existing `RegenerateBaseline`).
- Compiler.Tests `LanguageConformance` filter: 126/126 passed — no golden-sample output changes.
- Interpreter.Tests full: 1481 passed, 0 failed (includes the migrated oracle test).
- Targeted filters: `Issue3203SharedInitializerCctorTests` 7/7, `Issue2131StaticInitializerBlockTests` 7/7, `Issue3096CollectionSpreadInterpreterTests` 4/4.
- ADR-0154 witness (product mutant, since the product already implements the decision): with `SuppressBeforeFieldInitForStruct`'s flag-clearing disabled, `Issue3203SharedInitializerCctorTests` goes 5 RED / 2 green (the 2 green are the keeps-BFI tests pinning the unchanged half) and the migrated `StaticInitialization_RunsAfterCallArguments` goes RED. Mutant reverted.
- NOT RUN: Compiler.Tests full (beyond LanguageConformance), Cs2Gs.Tests (pre-existing flaky host crash — verify via GoldenTests filter per project note), Extensions/LanguageServer/Sdk/InternalAnalyzers test suites — no product code changed; CI backstop.

## Checklist

- [x] Behavioral tests carry a witness of discrimination (ADR-0154): each new/changed test fails on the applied product mutant (beforefieldinit clearing disabled) and passes with it.
- [x] Self-review verdict recorded when one was run (MERGEABLE / BLOCKER / SHOULD-FIX / NIT), with residuals filed as issues rather than dropped.

Self-review verdict: **MERGEABLE** — no product behavior change; tests-plus-comment change pinning already-correct emit semantics and retiring the last evaluator pin from the 3b.0 pilot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)