### PR TITLE
Migrate the feature-named Core.Tests files to the EmittedOracle (Phase 3b.1, slice 1/3)

### DIFF
--- a/build/migrate-emitted-oracle.py
+++ b/build/migrate-emitted-oracle.py
@@ -34,6 +34,21 @@ Handled shapes (everything else is left untouched and reported as residue):
            lines (dedented out of the deleted try) + `return
            result.Output.Replace(...)` on the oracle's captured stream.
 
+  T6  guarded statement form (Phase 3b.1 extension):
+        var <t> = SyntaxTree.Parse(<src>);
+        var <c> = new Compilation(<t>);
+        var <r> = <c>.Evaluate(new Dictionary<VariableSymbol, object>());
+        -> var <r> = EmittedOracle.Evaluate(<src>);
+      applied ONLY when neither <t> nor <c> is referenced again before the
+      enclosing block closes (binder-inspection tests that keep using the
+      Compilation object are left as residue on purpose).
+
+  Phase 3b.1 generalizations (Core.Tests bulk): the tree/compilation local
+  names are arbitrary identifiers, the empty-dictionary argument may be
+  namespace-qualified, T2 accepts a trailing member tail (e.g. `.Diagnostics`)
+  and the two-line `return new Compilation(<t>).Evaluate(...)` /
+  `var <c> = new Compilation(SyntaxTree.Parse(...));` folds.
+
 Usage:
   build/migrate-emitted-oracle.py [--dry-run] FILE [FILE ...]
 
@@ -51,18 +66,45 @@ import sys
 IDENT = r"[A-Za-z_][A-Za-z0-9_]*"
 
 # SyntaxTree.Parse(x) / SyntaxTree.Parse(SourceText.From(x)) where x is an
-# identifier or a simple string-concatenation expression without parens.
-PARSE_ARG = rf"(?:SourceText\.From\((?P<arg1>[^()]+)\)|(?P<arg2>{IDENT}))"
+# identifier or a simple comma-free expression (string concatenation) without
+# parens; a comma would smuggle a second SourceText.From argument into the
+# rewritten EmittedOracle.Evaluate call, so it is excluded.
+PARSE_ARG = rf"(?:SourceText\.From\((?P<arg1>[^(),]+)\)|(?P<arg2>{IDENT}))"
+
+# The empty variables dictionary, optionally namespace-qualified on either the
+# collection type or the VariableSymbol type argument.
+EMPTY_DICT = (
+    r"new (?:System\.Collections\.Generic\.)?"
+    r"Dictionary<(?:[A-Za-z0-9_.]+\.)?VariableSymbol, object>\(\)"
+)
 
 T1_INLINE = re.compile(
     rf"new Compilation\(SyntaxTree\.Parse\({PARSE_ARG}\)\)\s*\n?\s*"
-    r"\.Evaluate\(new Dictionary<VariableSymbol, object>\(\)\)",
+    rf"\.Evaluate\({EMPTY_DICT}\)",
 )
 
 T2_BLOCK = re.compile(
-    rf"var tree = SyntaxTree\.Parse\({PARSE_ARG}\);\s*\n"
-    r"(?P<indent>[ \t]*)var compilation = new Compilation\(tree\);\s*\n"
-    r"[ \t]*return compilation\.Evaluate\(new Dictionary<VariableSymbol, object>\(\)\);",
+    rf"var (?P<tv>{IDENT}) = SyntaxTree\.Parse\({PARSE_ARG}\);\s*\n"
+    rf"[ \t]*var (?P<cv>{IDENT}) = new Compilation\((?P=tv)\);\s*\n"
+    rf"[ \t]*return (?P=cv)\.Evaluate\({EMPTY_DICT}\)(?P<tail>[^;\n]*);",
+)
+
+# Two-line fold: the Compilation is constructed inside the return statement.
+T2_FOLD_RETURN = re.compile(
+    rf"var (?P<tv>{IDENT}) = SyntaxTree\.Parse\({PARSE_ARG}\);\s*\n"
+    rf"[ \t]*return new Compilation\((?P=tv)\)\.Evaluate\({EMPTY_DICT}\)(?P<tail>[^;\n]*);",
+)
+
+# Two-line fold: the parse happens inside the Compilation constructor call.
+T2_FOLD_PARSE = re.compile(
+    rf"var (?P<cv>{IDENT}) = new Compilation\(SyntaxTree\.Parse\({PARSE_ARG}\)\);\s*\n"
+    rf"[ \t]*return (?P=cv)\.Evaluate\({EMPTY_DICT}\)(?P<tail>[^;\n]*);",
+)
+
+T6_STATEMENT = re.compile(
+    rf"(?P<ind>[ \t]*)var (?P<tv>{IDENT}) = SyntaxTree\.Parse\({PARSE_ARG}\);\s*\n"
+    rf"[ \t]*var (?P<cv>{IDENT}) = new Compilation\((?P=tv)\);\s*\n"
+    rf"[ \t]*var (?P<rv>{IDENT}) = (?P=cv)\.Evaluate\({EMPTY_DICT}\);",
 )
 
 T3_RETYPE = re.compile(
@@ -88,13 +130,13 @@ T5_CONSOLE_HELPER = re.compile(
     r"(?P<cmp>, StringComparison\.Ordinal)?\);",
 )
 
-RESIDUE = re.compile(r"\.Evaluate\((?:new Dictionary<VariableSymbol, object>\(\)|variables)")
+RESIDUE = re.compile(rf"\.Evaluate\((?:{EMPTY_DICT}|variables\b|vars\b)")
 
 USING_LINE = re.compile(r"^using (?P<ns>[A-Za-z0-9_.]+);\s*$", re.MULTILINE)
 
 
 def rewrite(text: str) -> tuple[str, dict[str, int]]:
-    counts = {"T1": 0, "T2": 0, "T3": 0, "T4": 0, "T5": 0}
+    counts = {"T1": 0, "T2": 0, "T3": 0, "T4": 0, "T5": 0, "T6": 0}
 
     def t1(match: re.Match) -> str:
         counts["T1"] += 1
@@ -102,7 +144,8 @@ def rewrite(text: str) -> tuple[str, dict[str, int]]:
 
     def t2(match: re.Match) -> str:
         counts["T2"] += 1
-        return f"return EmittedOracle.Evaluate({match.group('arg1') or match.group('arg2')});"
+        source = match.group("arg1") or match.group("arg2")
+        return f"return EmittedOracle.Evaluate({source}){match.group('tail')};"
 
     def t3(match: re.Match) -> str:
         counts["T3"] += 1
@@ -128,6 +171,9 @@ def rewrite(text: str) -> tuple[str, dict[str, int]]:
     text = T5_CONSOLE_HELPER.sub(t5, text)
     text = T1_INLINE.sub(t1, text)
     text = T2_BLOCK.sub(t2, text)
+    text = T2_FOLD_RETURN.sub(t2, text)
+    text = T2_FOLD_PARSE.sub(t2, text)
+    text = apply_t6(text, counts)
     text = T3_RETYPE.sub(t3, text)
 
     if "EmittedOracle" in text and "using GSharp.Tests;" not in text and "namespace GSharp.Tests" not in text:
@@ -135,6 +181,37 @@ def rewrite(text: str) -> tuple[str, dict[str, int]]:
         counts["T4"] += 1
 
     return text, counts
+
+
+def apply_t6(text: str, counts: dict[str, int]) -> str:
+    """Rewrite guarded `var <r> = <c>.Evaluate(...)` statement triples.
+
+    Each candidate is applied only when neither the tree nor the compilation
+    local is referenced again before the enclosing block closes, so
+    binder-inspection tests that keep using the Compilation object are left
+    untouched (reported as residue).
+    """
+    pieces = []
+    pos = 0
+    for match in T6_STATEMENT.finditer(text):
+        if match.start() < pos:
+            continue
+
+        indent = match.group("ind")
+        outer = indent[:-4] if len(indent) >= 4 else ""
+        close = text.find("\n" + outer + "}", match.end())
+        span = text[match.end(): close if close != -1 else len(text)]
+        if re.search(rf"\b(?:{match.group('tv')}|{match.group('cv')})\b", span):
+            continue
+
+        source = match.group("arg1") or match.group("arg2")
+        pieces.append(text[pos: match.start()])
+        pieces.append(f"{indent}var {match.group('rv')} = EmittedOracle.Evaluate({source});")
+        pos = match.end()
+        counts["T6"] += 1
+
+    pieces.append(text[pos:])
+    return "".join(pieces)
 
 
 def insert_using(text: str, namespace: str) -> str:

--- a/test/Core.Tests/CodeAnalysis/Binding/AnonymousClassExpressionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/AnonymousClassExpressionTests.cs
@@ -13,6 +13,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -364,11 +365,9 @@ let x = v.Secret
         return result.Diagnostics;
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 
     private static string CompileAndRun(string source)

--- a/test/Core.Tests/CodeAnalysis/Binding/AnonymousClassExpressionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/AnonymousClassExpressionTests.cs
@@ -100,6 +100,9 @@ let a = object { let Id int32 = 1; let Alias string = ""x"" }
 let b = object { let Id int32 = 2; let Alias string = ""y"" }
 1
 ";
+        // Phase 3b (issue #3176): stays on Compilation.Evaluate — the test
+        // inspects this Compilation's bound state afterwards, which the
+        // EmittedOracle does not expose; disposition in 3b.2.
         var tree = SyntaxTree.Parse(SourceText.From(source));
         var compilation = new Compilation(tree);
         var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
@@ -115,6 +118,9 @@ let a = object { let Id int32 = 1 }
 let b = object { let Id int32 = 1; let Alias string = ""x"" }
 1
 ";
+        // Phase 3b (issue #3176): stays on Compilation.Evaluate — the test
+        // inspects this Compilation's bound state afterwards, which the
+        // EmittedOracle does not expose; disposition in 3b.2.
         var tree = SyntaxTree.Parse(SourceText.From(source));
         var compilation = new Compilation(tree);
         var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());

--- a/test/Core.Tests/CodeAnalysis/Binding/ArrayTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ArrayTests.cs
@@ -11,6 +11,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -92,11 +93,9 @@ public class ArrayTests
         Assert.Contains(diagnostics, d => d.Message.Contains("doesn't exist"));
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 
     private static ImmutableArray<Diagnostic> Bind(string source)

--- a/test/Core.Tests/CodeAnalysis/Binding/AsyncAwaitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/AsyncAwaitTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -139,10 +140,8 @@ class Probe {
         Assert.Empty(result.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/AwaitForRangeStatementTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/AwaitForRangeStatementTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -111,11 +112,9 @@ evens
         Assert.Equal(1, result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/AwaitForRangeStatementTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/AwaitForRangeStatementTests.cs
@@ -33,7 +33,9 @@ await for v in AsyncStreamFixture.Counts() {
 }
 total
 ";
-        var result = Evaluate(source);
+        // ADR-0156 Phase 3b (#3176): stays on Compilation.Evaluate —
+        // #3214 tracks top-level 'await' support in the emitter.
+        var result = EvaluateWithEvaluator(source);
         Assert.Empty(result.Diagnostics);
         Assert.Equal(1 + 2 + 3, result.Value);
     }
@@ -57,7 +59,9 @@ await for v in AsyncStreamFixture.Counts().ConfigureAwait(false) {
 }
 total
 ";
-        var result = Evaluate(source);
+        // ADR-0156 Phase 3b (#3176): stays on Compilation.Evaluate —
+        // #3214 tracks top-level 'await' support in the emitter.
+        var result = EvaluateWithEvaluator(source);
         Assert.Empty(result.Diagnostics);
         Assert.Equal(1 + 2 + 3, result.Value);
     }
@@ -86,7 +90,9 @@ import GSharp.Core.Tests.CodeAnalysis.Binding
 await for v in AsyncStreamFixture.Empty() {
 }
 ";
-        var result = Evaluate(source);
+        // ADR-0156 Phase 3b (#3176): stays on Compilation.Evaluate —
+        // #3214 tracks top-level 'await' support in the emitter.
+        var result = EvaluateWithEvaluator(source);
         Assert.Empty(result.Diagnostics);
     }
 
@@ -107,7 +113,9 @@ await for v in AsyncStreamFixture.Counts() {
 }
 evens
 ";
-        var result = Evaluate(source);
+        // ADR-0156 Phase 3b (#3176): stays on Compilation.Evaluate —
+        // #3214 tracks top-level 'await' support in the emitter.
+        var result = EvaluateWithEvaluator(source);
         Assert.Empty(result.Diagnostics);
         Assert.Equal(1, result.Value);
     }
@@ -115,6 +123,16 @@ evens
     private static EmittedOracleResult Evaluate(string source)
     {
         return EmittedOracle.Evaluate(source);
+    }
+
+    // Evaluator-pinned twin of Evaluate for the #3214 tests above; delete
+    // with the evaluator (ADR-0156 Phase 3c) or when #3214 aligns the
+    // engines.
+    private static EvaluationResult EvaluateWithEvaluator(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
     }
 }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/BareVariableDeclarationTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/BareVariableDeclarationTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -103,10 +104,8 @@ var x
         Assert.NotEmpty(result.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/ByRefPointerTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ByRefPointerTests.cs
@@ -27,7 +27,9 @@ public class ByRefPointerTests
 var x = 42
 var p = &x
 ";
-        var result = Evaluate(source);
+        // ADR-0156 Phase 3b (#3176): stays on Compilation.Evaluate —
+        // #3215 tracks address-of/pointer signature encoding in the emitter.
+        var result = EvaluateWithEvaluator(source);
         Assert.Empty(result.Diagnostics);
     }
 
@@ -83,7 +85,9 @@ var x = 42
 var p = &x
 var y = *p
 ";
-        var result = Evaluate(source);
+        // ADR-0156 Phase 3b (#3176): stays on Compilation.Evaluate —
+        // #3215 tracks address-of/pointer signature encoding in the emitter.
+        var result = EvaluateWithEvaluator(source);
         Assert.Empty(result.Diagnostics);
     }
 
@@ -168,7 +172,9 @@ var ok = Int32.TryParse(""123"", &result)
 var x = 10
 var p = &x
 ";
-        var result = Evaluate(source);
+        // ADR-0156 Phase 3b (#3176): stays on Compilation.Evaluate —
+        // #3215 tracks address-of/pointer signature encoding in the emitter.
+        var result = EvaluateWithEvaluator(source);
         Assert.Empty(result.Diagnostics);
     }
 
@@ -189,5 +195,15 @@ var y = &x + 1
     private static EmittedOracleResult Evaluate(string source)
     {
         return EmittedOracle.Evaluate(source);
+    }
+
+    // Evaluator-pinned twin of Evaluate for the #3215 tests above; delete
+    // with the evaluator (ADR-0156 Phase 3c) or when #3215 aligns the
+    // engines.
+    private static EvaluationResult EvaluateWithEvaluator(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/ByRefPointerTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ByRefPointerTests.cs
@@ -10,6 +10,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -185,10 +186,8 @@ var y = &x + 1
         Assert.NotEmpty(result.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/ChannelTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ChannelTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -97,7 +98,7 @@ close(x)
         Assert.Contains(result.Diagnostics, d => d.Message.Contains("channel"));
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
         // ADR-0082 / issue #722: every Go-flavored concurrency form is
         // gated behind `import Gsharp.Extensions.Go`. These tests focus on
@@ -105,8 +106,6 @@ close(x)
         // import once for the whole class. The dedicated
         // Issue722GoExtensionsImportGateTests cover the gate explicitly.
         var fullSource = "import Gsharp.Extensions.Go\n" + source;
-        var tree = SyntaxTree.Parse(SourceText.From(fullSource));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(fullSource);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/ClassTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ClassTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -906,10 +907,8 @@ class Dog : Animal(""rex"") {
         Assert.Contains(result.Diagnostics, d => d.Message.Contains("may not declare ': base"));
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/ClassTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ClassTests.cs
@@ -412,6 +412,9 @@ open class A {
     open func F() int32 { return 1 }
 }
 "));
+        // Phase 3b (issue #3176): stays on Compilation.Evaluate — multi-tree
+        // compilation; the EmittedOracle takes a single source. Disposition
+        // in 3b.2.
         var result = new Compilation(derived, baseType)
             .Evaluate(new Dictionary<VariableSymbol, object>());
 

--- a/test/Core.Tests/CodeAnalysis/Binding/ClrConstructorCallTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ClrConstructorCallTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -80,10 +81,8 @@ var sb = StringBuilder(""x"", ""y"", ""z"")
         Assert.NotEmpty(result.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/ClrConversionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ClrConversionTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -50,10 +51,8 @@ var x BigInteger = 12345
         Assert.Equal(System.Numerics.BigInteger.Parse("12345"), result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/ClrGenericMethodInferenceTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ClrGenericMethodInferenceTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -96,10 +97,8 @@ let found = Enumerable.Contains(s, 2)
         Assert.Empty(result.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/ClrMemberAccessTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ClrMemberAccessTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -320,10 +321,8 @@ Console.CancelKeyPress -= h
         Assert.Empty(result.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/ClrMethodGroupConversionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ClrMethodGroupConversionTests.cs
@@ -10,6 +10,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -80,10 +81,8 @@ var x int32 = Console.WriteLine
         Assert.Contains(result.Diagnostics, d => d.Id == "GS0218");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/ClrNestedTypeAccessTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ClrNestedTypeAccessTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -124,10 +125,8 @@ var sf = Environment.SpecialFolder.CommonApplicationData
         Assert.Empty(result.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/ClrOperatorTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ClrOperatorTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -98,10 +99,8 @@ var earlier = dt - span
         Assert.Equal(new DateTime(2025, 1, 1), result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/ConversionOperatorTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ConversionOperatorTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -307,10 +308,8 @@ let target Target = n
         Assert.Contains(result.Diagnostics, d => d.Id == "GS0155");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/DataStructErgonomicsTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/DataStructErgonomicsTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -205,10 +206,8 @@ data struct Point {
 }
 ";
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/DataStructTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/DataStructTests.cs
@@ -249,6 +249,9 @@ data struct Point {
 }
 0
 ";
+        // Phase 3b (issue #3176): stays on Compilation.Evaluate — the test
+        // inspects this Compilation's bound state afterwards, which the
+        // EmittedOracle does not expose; disposition in 3b.2.
         var tree = SyntaxTree.Parse(SourceText.From(source));
         compilation = new Compilation(tree);
         var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());

--- a/test/Core.Tests/CodeAnalysis/Binding/DataStructTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/DataStructTests.cs
@@ -10,6 +10,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -258,10 +259,8 @@ data struct Point {
         return sym;
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/DeferStatementTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/DeferStatementTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -255,11 +256,9 @@ DeferFixture.Snapshot()
         Assert.Equal("body,using-2,defer-2,using-1,defer-1", result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/EnumDeclarationTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/EnumDeclarationTests.cs
@@ -11,6 +11,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -188,10 +189,8 @@ same && different
         return Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/ExceptionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ExceptionTests.cs
@@ -10,6 +10,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -227,11 +228,9 @@ n
         Assert.NotEmpty(result.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 
     private static ImmutableArray<Diagnostic> Bind(string source)

--- a/test/Core.Tests/CodeAnalysis/Binding/ForInStatementTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ForInStatementTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -217,11 +218,9 @@ in + 2
         Assert.Equal(3, result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/ForInStatementTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ForInStatementTests.cs
@@ -157,7 +157,9 @@ await for v in AsyncStreamFixture.Counts() {
 }
 total
 ";
-        var result = Evaluate(source);
+        // ADR-0156 Phase 3b (#3176): stays on Compilation.Evaluate —
+        // #3214 tracks top-level 'await' support in the emitter.
+        var result = EvaluateWithEvaluator(source);
         Assert.Empty(result.Diagnostics);
         Assert.Equal(6, result.Value);
     }
@@ -190,7 +192,9 @@ await for v in AsyncStreamFixture.Counts() {
 }
 total
 ";
-        var result = Evaluate(source);
+        // ADR-0156 Phase 3b (#3176): stays on Compilation.Evaluate —
+        // #3214 tracks top-level 'await' support in the emitter.
+        var result = EvaluateWithEvaluator(source);
         Assert.Empty(result.Diagnostics);
         Assert.Equal(6, result.Value);
     }
@@ -221,6 +225,16 @@ in + 2
     private static EmittedOracleResult Evaluate(string source)
     {
         return EmittedOracle.Evaluate(source);
+    }
+
+    // Evaluator-pinned twin of Evaluate for the #3214 tests above; delete
+    // with the evaluator (ADR-0156 Phase 3c) or when #3214 aligns the
+    // engines.
+    private static EvaluationResult EvaluateWithEvaluator(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
     }
 }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/ForRangeStatementTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ForRangeStatementTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -137,10 +138,8 @@ for v in x {
         Assert.NotEmpty(result.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/GenericBclConsumptionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/GenericBclConsumptionTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -128,10 +129,8 @@ func FirstValue[T](rows List[Dictionary[string, T]]) T {
         Assert.Empty(result.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/GenericFunctionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/GenericFunctionTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -239,10 +240,8 @@ func F[T Base](x T) int32 { return 0 }
         Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0153");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/GenericInterfaceTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/GenericInterfaceTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -123,10 +124,8 @@ sealed interface Result[T any] {
         Assert.Empty(result.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/GenericMethodDelegateTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/GenericMethodDelegateTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -119,10 +120,8 @@ Apply(7, func(x int32) int32 { return x * 2 })
         Assert.Equal(14, result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/GenericMethodOnTypeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/GenericMethodOnTypeTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -189,10 +190,8 @@ c.Echo(9)
         Assert.Equal(9, result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/GenericTypeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/GenericTypeTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -125,10 +126,8 @@ h.Get()
         Assert.Equal(42, result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/GoStatementTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/GoStatementTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -56,15 +57,13 @@ go x
         Assert.Contains(result.Diagnostics, d => d.Message.Contains("'go'"));
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
         // ADR-0082 / issue #722: gate test fixtures auto-prepend the
         // Go-extensions import so existing `go` tests continue to exercise
         // bind/lower/emit rather than the gate. Issue722-specific gate
         // behaviour is covered by Issue722GoExtensionsImportGateTests.
         var fullSource = "import Gsharp.Extensions.Go\n" + source;
-        var tree = SyntaxTree.Parse(SourceText.From(fullSource));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(fullSource);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/ImportedExtensionMethodTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ImportedExtensionMethodTests.cs
@@ -15,6 +15,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -52,8 +53,7 @@ for (key, value) in values {
 total
 ";
             AssertCompilesWithoutErrors(source);
-        var result = new Compilation(SyntaxTree.Parse(SourceText.From(source)))
-            .Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(source);
 
         Assert.Empty(result.Diagnostics);
         Assert.Equal(3, result.Value);

--- a/test/Core.Tests/CodeAnalysis/Binding/InheritedFieldResolutionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/InheritedFieldResolutionTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -52,10 +53,8 @@ a
         Assert.Equal(9, result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/InlineStructTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/InlineStructTests.cs
@@ -12,6 +12,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -149,11 +150,9 @@ let id = UserId(""u-1"")
         return false;
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 
     private static EmitResult Compile(string source, Stream peStream)

--- a/test/Core.Tests/CodeAnalysis/Binding/InterfaceTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/InterfaceTests.cs
@@ -234,6 +234,9 @@ class Success : IResult {
     func Ok() bool { return true }
 }
 "));
+        // Phase 3b (issue #3176): stays on Compilation.Evaluate — multi-tree
+        // compilation; the EmittedOracle takes a single source. Disposition
+        // in 3b.2.
         var compilation = new Compilation(t1, t2);
         var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
         Assert.Contains(result.Diagnostics, d => d.Message.Contains("sealed interface"));

--- a/test/Core.Tests/CodeAnalysis/Binding/InterfaceTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/InterfaceTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -573,10 +574,8 @@ t.Public()
         Assert.Equal(1, result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/IsAsExpressionBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/IsAsExpressionBinderTests.cs
@@ -10,6 +10,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -62,10 +63,8 @@ public class IsAsExpressionBinderTests
             $"Expected GS0270, got: {string.Join(", ", result.Diagnostics.Select(d => $"{d.Id}: {d.Message}"))}");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/KotlinStyleDeclarationGrammarTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/KotlinStyleDeclarationGrammarTests.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -40,9 +41,7 @@ public class KotlinStyleDeclarationGrammarTests
             src += " { }";
         }
 
-        var tree = SyntaxTree.Parse(SourceText.From(src + "\n0\n"));
-        var compilation = new Compilation(tree);
-        var result = compilation.Evaluate(new System.Collections.Generic.Dictionary<GSharp.Core.CodeAnalysis.Symbols.VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(src + "\n0\n");
 
         // The matrix row must parse and bind. Some rows (e.g. a class with
         // an unused param) emit warnings; only assert no parser-level
@@ -59,18 +58,14 @@ public class KotlinStyleDeclarationGrammarTests
     [InlineData("type Foo interface { }", "GS0306")]
     public void LegacyTypeKindHead_Rejected(string src, string expected)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(src + "\n0\n"));
-        var compilation = new Compilation(tree);
-        var result = compilation.Evaluate(new System.Collections.Generic.Dictionary<GSharp.Core.CodeAnalysis.Symbols.VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(src + "\n0\n");
         Assert.Contains(result.Diagnostics, d => d.Id == expected);
     }
 
     [Fact]
     public void LegacyRecordKeyword_Rejected()
     {
-        var tree = SyntaxTree.Parse(SourceText.From("record Foo { var X int32 }\n0\n"));
-        var compilation = new Compilation(tree);
-        var result = compilation.Evaluate(new System.Collections.Generic.Dictionary<GSharp.Core.CodeAnalysis.Symbols.VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate("record Foo { var X int32 }\n0\n");
         Assert.Contains(result.Diagnostics, d => d.Id == "GS0307");
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/LambdaTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/LambdaTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -118,10 +119,8 @@ apply(twice, 21)
         Assert.Equal(42, result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/LetFieldBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/LetFieldBindingTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -36,9 +37,7 @@ public class LetFieldBindingTests
 
     private static System.Collections.Generic.IEnumerable<Diagnostic> GetDiagnostics(string source)
     {
-        var tree = SyntaxTree.Parse(source);
-        var compilation = new Compilation(tree);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(source);
         return result.Diagnostics;
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/MapTypeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/MapTypeTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -141,13 +142,11 @@ len(m)
         Assert.Equal(1, result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
         // ADR-0083 / issue #723: prepend the Go extensions import so tests
         // that exercise map `len` and `delete` keep binding/lowering rather
         // than tripping the GS0317 gate.
-        var syntaxTree = SyntaxTree.Parse(SourceText.From("import Gsharp.Extensions.Go\n" + source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate("import Gsharp.Extensions.Go\n" + source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/MethodWithReceiverTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/MethodWithReceiverTests.cs
@@ -10,6 +10,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -182,10 +183,8 @@ c.Inc()
         }
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/NamedArgumentTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/NamedArgumentTests.cs
@@ -11,6 +11,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -381,11 +382,9 @@ receiver.Apply(
         Assert.Contains(diagnostics, d => d.Id == id);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/NullSafeOperatorTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/NullSafeOperatorTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -215,10 +216,8 @@ dir.Parent!!.Name
     private static string EscapeForGSharpString(string s) =>
         s.Replace("\\", "\\\\").Replace("\"", "\\\"");
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/NullSafeOperatorTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/NullSafeOperatorTests.cs
@@ -63,7 +63,10 @@ x!!
 var x int32? = nil
 x!!
 ";
-        var result = Evaluate(source);
+        // ADR-0156 Phase 3b (#3176): stays on Compilation.Evaluate —
+        // #3216 tracks the '!!'-on-nil failure contract (evaluator panics
+        // with 'nil value !!'; emitted throws the raw CLR exception).
+        var result = EvaluateWithEvaluator(source);
         Assert.NotEmpty(result.Diagnostics);
         Assert.Contains(result.Diagnostics, d => d.Message.Contains("nil value"));
     }
@@ -141,7 +144,10 @@ import System
 var s string? = nil
 s!!.Length
 ";
-        var result = Evaluate(source);
+        // ADR-0156 Phase 3b (#3176): stays on Compilation.Evaluate —
+        // #3216 tracks the '!!'-on-nil failure contract (evaluator panics
+        // with 'nil value !!'; emitted throws the raw CLR exception).
+        var result = EvaluateWithEvaluator(source);
         Assert.NotEmpty(result.Diagnostics);
         Assert.Contains(result.Diagnostics, d => d.Message.Contains("nil value"));
     }
@@ -208,7 +214,10 @@ import System.IO
 let dir = DirectoryInfo(""{literal}"")
 dir.Parent!!.Name
 ";
-        var result = Evaluate(source);
+        // ADR-0156 Phase 3b (#3176): stays on Compilation.Evaluate —
+        // #3216 tracks the '!!'-on-nil failure contract (evaluator panics
+        // with 'nil value !!'; emitted throws the raw CLR exception).
+        var result = EvaluateWithEvaluator(source);
         Assert.NotEmpty(result.Diagnostics);
         Assert.Contains(result.Diagnostics, d => d.Message.Contains("nil value"));
     }
@@ -219,5 +228,15 @@ dir.Parent!!.Name
     private static EmittedOracleResult Evaluate(string source)
     {
         return EmittedOracle.Evaluate(source);
+    }
+
+    // Evaluator-pinned twin of Evaluate for the #3216 tests above; delete
+    // with the evaluator (ADR-0156 Phase 3c) or when #3216 aligns the
+    // engines.
+    private static EvaluationResult EvaluateWithEvaluator(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/NullableFlowAnalysisTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/NullableFlowAnalysisTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -580,10 +581,8 @@ p.Run()
         Assert.Equal(10, result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/NullableInstanceMemberBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/NullableInstanceMemberBindingTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -253,10 +254,8 @@ a.GetValueOrDefault(99)
         Assert.Equal(7, result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/NullableTypeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/NullableTypeTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -81,10 +82,8 @@ var x int32 = nil
         Assert.NotEmpty(result.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/ObjectInitializerBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ObjectInitializerBinderTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -123,10 +124,8 @@ var b = Box() { Width = 1 }
         Assert.NotEmpty(result.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/OverloadAndOptionalParameterTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/OverloadAndOptionalParameterTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -249,10 +250,8 @@ f(10)
         Assert.Contains(diagnostics, d => d.Id == id);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/OwnedReceiverWarningTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/OwnedReceiverWarningTests.cs
@@ -10,6 +10,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -236,10 +237,8 @@ func (m MyClass) Do() int32 { return 1 }
         Assert.Equal("MyClass", text);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/PatternEvaluationTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/PatternEvaluationTests.cs
@@ -7,6 +7,7 @@ using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -174,10 +175,8 @@ x
         Assert.Equal(expected, result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(source);
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/RecordAliasTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/RecordAliasTests.cs
@@ -150,6 +150,9 @@ type Foo class {
 
     private static StructSymbol BuildStruct(string source)
     {
+        // Phase 3b (issue #3176): stays on Compilation.Evaluate — the test
+        // inspects this Compilation's bound state afterwards, which the
+        // EmittedOracle does not expose; disposition in 3b.2.
         var tree = SyntaxTree.Parse(SourceText.From(source));
         var compilation = new Compilation(tree);
         var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());

--- a/test/Core.Tests/CodeAnalysis/Binding/RecordAliasTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/RecordAliasTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -156,10 +157,8 @@ type Foo class {
         return (StructSymbol)compilation.GlobalScope.Structs.Single(s => s.Name == "Point");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/RefKindDefiniteAssignmentTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/RefKindDefiniteAssignmentTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -21,11 +22,9 @@ namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 /// </summary>
 public class RefKindDefiniteAssignmentTests
 {
-    private static EvaluationResult Compile(string source)
+    private static EmittedOracleResult Compile(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 
     [Fact]

--- a/test/Core.Tests/CodeAnalysis/Binding/RefKindInParameterDiagnosticTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/RefKindInParameterDiagnosticTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -20,11 +21,9 @@ namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 /// </summary>
 public class RefKindInParameterDiagnosticTests
 {
-    private static EvaluationResult Compile(string source)
+    private static EmittedOracleResult Compile(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 
     [Fact]

--- a/test/Core.Tests/CodeAnalysis/Binding/RefKindParameterSitesTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/RefKindParameterSitesTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -316,10 +317,8 @@ class MyParser : IParser {
         Assert.Empty(result.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/RefLocalAliasingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/RefLocalAliasingTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -192,10 +193,8 @@ tweak()
         Assert.Empty(result.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/RefReturnDiagnosticTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/RefReturnDiagnosticTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -22,11 +23,9 @@ namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 /// </summary>
 public class RefReturnDiagnosticTests
 {
-    private static EvaluationResult Compile(string source)
+    private static EmittedOracleResult Compile(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 
     [Fact]

--- a/test/Core.Tests/CodeAnalysis/Binding/RefStructTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/RefStructTests.cs
@@ -11,6 +11,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -434,11 +435,9 @@ func set(arr []int32) {
         Assert.Contains(diagnostics, d => d.Id == "GS0226");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 
     // Binds declarations and function bodies and returns the resulting

--- a/test/Core.Tests/CodeAnalysis/Binding/ScopeStatementTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ScopeStatementTests.cs
@@ -131,25 +131,13 @@ scope {
         // the failure surfaces from the runtime, which is what this test
         // actually exercises.
         source = "import Gsharp.Extensions.Go\n" + source;
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        EvaluationResult result = null;
-        Exception thrown = null;
-        try
-        {
-            result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        }
-        catch (Exception ex)
-        {
-            thrown = ex;
-        }
+        var result = EmittedOracle.Evaluate(source);
 
-        // The failure may surface either as a raw exception escaping
-        // the evaluator or as an evaluator-reported diagnostic — both
-        // are acceptable, what matters is that the failure was not
-        // silently swallowed.
+        // The failure may surface either as an unhandled runtime exception
+        // or as a reported diagnostic — both are acceptable, what matters
+        // is that the failure was not silently swallowed.
         Assert.True(
-            thrown != null || (result != null && !result.Diagnostics.IsEmpty),
+            result.UnhandledException != null || !result.Diagnostics.IsEmpty,
             "Scope did not surface the failure from the scoped goroutine.");
     }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/ScopeStatementTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ScopeStatementTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -152,14 +153,12 @@ scope {
             "Scope did not surface the failure from the scoped goroutine.");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
         // ADR-0082 / issue #722: prepend the Go-extensions import so
         // existing scope-with-go tests continue to exercise scope
         // semantics rather than the import gate.
         var fullSource = "import Gsharp.Extensions.Go\n" + source;
-        var tree = SyntaxTree.Parse(SourceText.From(fullSource));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(fullSource);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/ScopedRefKindCompositionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ScopedRefKindCompositionTests.cs
@@ -10,6 +10,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -24,11 +25,9 @@ namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 /// </summary>
 public class ScopedRefKindCompositionTests
 {
-    private static EvaluationResult Compile(string source)
+    private static EmittedOracleResult Compile(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 
     private static FunctionSymbol GetFunction(string source, string name)

--- a/test/Core.Tests/CodeAnalysis/Binding/SelectTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/SelectTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -161,15 +162,13 @@ case x <- 1 { let a = 0 }
         Assert.Contains(result.Diagnostics, d => d.Message.Contains("channel"));
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
         // ADR-0082 / issue #722: gate test fixtures auto-prepend the
         // Go-extensions import so existing concurrency tests continue to
         // exercise bind/lower/emit rather than the gate. Issue722-specific
         // gate behaviour is covered by Issue722GoExtensionsImportGateTests.
         var fullSource = "import Gsharp.Extensions.Go\n" + source;
-        var tree = SyntaxTree.Parse(SourceText.From(fullSource));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(fullSource);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/SliceTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/SliceTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -114,16 +115,14 @@ public class SliceTests
         Assert.Equal("b", result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
         // ADR-0083 / issue #723: every gated built-in (len / cap / append /
         // delete) used in the test sources is intentional, so prepend the
         // gate import here rather than duplicating it across every literal
         // string. This mirrors the helper-level mitigation #722 applied for
         // the channel-cluster tests.
-        var tree = SyntaxTree.Parse(SourceText.From("import Gsharp.Extensions.Go\n" + source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate("import Gsharp.Extensions.Go\n" + source);
     }
 
     private static ImmutableArray<Diagnostic> Bind(string source)

--- a/test/Core.Tests/CodeAnalysis/Binding/SmartCastTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/SmartCastTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -119,10 +120,8 @@ y
         Assert.Equal(5, result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/SmartCastTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/SmartCastTests.cs
@@ -64,7 +64,9 @@ if nil != x {
 }
 y
 ";
-        var result = Evaluate(source);
+        // ADR-0156 Phase 3b (#3176): stays on Compilation.Evaluate —
+        // #3217 tracks the nil-on-left smart-cast invalid IL.
+        var result = EvaluateWithEvaluator(source);
         Assert.Empty(result.Diagnostics);
         Assert.Equal(7, result.Value);
     }
@@ -123,5 +125,15 @@ y
     private static EmittedOracleResult Evaluate(string source)
     {
         return EmittedOracle.Evaluate(source);
+    }
+
+    // Evaluator-pinned twin of Evaluate for the #3217 tests above; delete
+    // with the evaluator (ADR-0156 Phase 3c) or when #3217 aligns the
+    // engines.
+    private static EvaluationResult EvaluateWithEvaluator(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/StaticVirtualInterfaceTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/StaticVirtualInterfaceTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -210,10 +211,8 @@ interface IBad {
         Assert.Contains(result.Diagnostics, d => d.Id == "GS0330");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/StructTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/StructTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -152,10 +153,8 @@ struct Point {
         Assert.NotEmpty(result.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/StructuralProjectionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/StructuralProjectionTests.cs
@@ -10,6 +10,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -551,10 +552,8 @@ Touch(ref source)
         Assert.NotEmpty(result.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/StructuralProjectionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/StructuralProjectionTests.cs
@@ -27,6 +27,9 @@ class Target { var Name string var Age int64 }
 let source = Source{Name: ""Ada"", Age: 36, Extra: true}
 0
 ";
+        // Phase 3b (issue #3176): stays on Compilation.Evaluate — the test
+        // inspects this Compilation's bound state afterwards, which the
+        // EmittedOracle does not expose; disposition in 3b.2.
         var tree = SyntaxTree.Parse(SourceText.From(sourceText));
         var compilation = new Compilation(tree);
         _ = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
@@ -301,7 +304,9 @@ target.Number
     [Fact]
     public void ImportedMethodOverloadAcceptsStructuralProjection()
     {
-        var result = Evaluate(@"
+        // ADR-0156 Phase 3b (#3176): stays on Compilation.Evaluate —
+        // #3218 tracks the imported-nullable structural-projection emit gap.
+        var result = EvaluateWithEvaluator(@"
 import System.Net.Http
 class Source { var uriString string }
 func Probe(client HttpClient, source Source) {
@@ -439,7 +444,10 @@ let box Box[int32] = source
     [Fact]
     public void ConstructedGenericTargetsPreserveDeclaredFieldInitializers()
     {
-        var classResult = Evaluate(@"
+        // ADR-0156 Phase 3b (#3176): stays on Compilation.Evaluate —
+        // #3219 tracks projection's private-field materialization
+        // (FieldAccessException on the constructed generic target).
+        var classResult = EvaluateWithEvaluator(@"
 class Source { var Value int32 }
 class Box[T] {
     var Value T
@@ -453,7 +461,7 @@ box.ReadMarker()
         Assert.Empty(classResult.Diagnostics);
         Assert.Equal(9, classResult.Value);
 
-        var structResult = Evaluate(@"
+        var structResult = EvaluateWithEvaluator(@"
 struct Source { var Value int32 }
 struct Box[T] {
     var Value T
@@ -555,5 +563,15 @@ Touch(ref source)
     private static EmittedOracleResult Evaluate(string source)
     {
         return EmittedOracle.Evaluate(source);
+    }
+
+    // Evaluator-pinned twin of Evaluate for the #3218/#3219 tests above; delete
+    // with the evaluator (ADR-0156 Phase 3c) or when #3218/#3219 aligns the
+    // engines.
+    private static EvaluationResult EvaluateWithEvaluator(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/SwitchExpressionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/SwitchExpressionTests.cs
@@ -10,6 +10,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -398,10 +399,8 @@ let label = switch v { case > 0 and < 10: ""x"" case < 0 or > 100: ""y"" }
         return Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new System.Collections.Generic.Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/TrailingLambdaTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/TrailingLambdaTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -128,10 +129,8 @@ combine(10) async func(x int32) int32 { return await twice(x) }
         Assert.Empty(result.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/TupleTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/TupleTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -84,9 +85,7 @@ q.Item2
 let p = (1, ""x"")
 p.Item3
 ";
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(source);
         Assert.NotEmpty(result.Diagnostics);
     }
 
@@ -140,10 +139,8 @@ r
         Assert.Equal(1, result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/UserMethodGroupConversionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/UserMethodGroupConversionTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -178,10 +179,8 @@ Register(BuildCommand.Create)
         Assert.Equal("build", result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/UserOperatorTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/UserOperatorTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -118,10 +119,8 @@ var sum = p + q
         Assert.Equal(12, result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/VariadicTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/VariadicTests.cs
@@ -11,6 +11,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -442,15 +443,13 @@ bad()
         Assert.Contains(result.Diagnostics, d => d.Id == "GS0363");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
         // ADR-0083 / issue #723: prepend the Go extensions import so the
         // `len(...)` calls inside variadic-helper test sources keep
         // binding rather than tripping the GS0317 gate. The unused import
         // is silent when a test happens not to call any gated built-in.
-        var syntaxTree = SyntaxTree.Parse(SourceText.From("import Gsharp.Extensions.Go\n" + source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate("import Gsharp.Extensions.Go\n" + source);
     }
 
     private static ImmutableArray<Diagnostic> Bind(string source)

--- a/test/Core.Tests/CodeAnalysis/SharedBlockTests.cs
+++ b/test/Core.Tests/CodeAnalysis/SharedBlockTests.cs
@@ -16,6 +16,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis;
@@ -353,11 +354,9 @@ Console.WriteLine(Service.instanceCount)
     // Helpers
     // ─────────────────────────────────────────────────────────────────────────
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 
     private static EmitResult Compile(string source, Stream peStream)


### PR DESCRIPTION
Part of #3176 (Phase 3b.1, slice 1/3), part of #3163.

## Summary

First of three disjoint slices of the Core.Tests bulk migration from the `Compilation.Evaluate` oracle to `test/Shared/EmittedOracle` (PR #3206): the **71 feature-named files** (everything in `test/Core.Tests/CodeAnalysis` not `IssueNNN*`-prefixed that matches the canonical shapes). Slices 2/3 and 3/3 carry the Issue-numbered files.

- **Script generalization** (own commit, rides in this slice per the plan): `build/migrate-emitted-oracle.py` learns the Core.Tests canonical variants — arbitrary tree/compilation local names, namespace-qualified empty-dictionary arguments, trailing member tails (`.Diagnostics`), two-line return/parse folds, and a new **guarded T6 statement form** (`var result = compilation.Evaluate(...)` rewritten only when the tree/compilation locals are never referenced again before the enclosing block closes, so binder-inspection tests are left as reported residue). Dry-run coverage over the 255 Core.Tests oracle files: 134 → **207 transformed (195 residue-free)**.
- **Scripted rewrite**: 71 files, 74 transform applications (T1x1, T2x68, T6x5), assertions unchanged.
- **Hand-fixes**: ScopeStatementTests' try/catch failure-surface site moved onto the oracle's `UnhandledException`/diagnostic channel (assertion disjunction preserved); 6 binder-inspection/multi-tree sites annotated and left on `Compilation.Evaluate` (3b.2 disposition per the plan — the oracle does not expose the Compilation's bound state and takes a single source).

## Slice stats

| Category | Count |
|---|---|
| Files migrated (script) | 71 |
| Script transform sites | 74 (T1x1, T2x68, T6x5) + 68 helper retypes |
| Hand-migrated sites | 1 (ScopeStatementTests) |
| Annotated residue sites left for 3b.2 | 7 (binder-inspection x5, multi-tree x2) |
| Divergences — newly discovered, filed | 6 issues, 15 tests evaluator-pinned |
| Divergences — matching already-pinned categories | 0 |

## Divergence table

| Issue | Category | Pinned tests |
|---|---|---|
| #3214 | Emitter: top-level `await` unsupported (`AwaitExpression` GS9998) | AwaitForRangeStatementTests x4, ForInStatementTests x2 |
| #3215 | Emitter: address-of/pointer signature encoding ICE | ByRefPointerTests x3 |
| #3216 | `!!`-on-nil failure contract: evaluator panics `nil value !!`, emitted throws raw CLR exception | NullSafeOperatorTests x3 |
| #3217 | `nil != x` (nil-on-left) smart-cast emits invalid IL | SmartCastTests x1 |
| #3218 | Structural projection into imported nullable class param: emit `NotSupportedException` | StructuralProjectionTests x1 |
| #3219 | Projection onto constructed generic writes private field from call site (`FieldAccessException`) | StructuralProjectionTests x1 |

Pinned tests keep their original expected values on `Compilation.Evaluate` via an `EvaluateWithEvaluator` twin helper (the #3206 pilot's convention), each annotated with its issue; they retire or realign with the issues' resolutions (ADR-0156 Phase 3c at the latest).

## Verification

- `dotnet build test/Core.Tests/Core.Tests.csproj -c Release`: 0 warnings, 0 errors.
- `test/Core.Tests` full suite (Release): **7135/7136 passed**, 1 skipped (standing `RegenerateBaseline` skip). Migrated tests green with unchanged assertions.
- Nothing outside `test/` touched except `build/migrate-emitted-oracle.py` (the migration script itself; zero `src/` changes).
- Witness (ADR-0154): migrated tests keep their original expected values against the real emitted semantics; the six filed divergences are this slice's discrimination evidence — the oracle swap surfaced them immediately.
- NOT RUN: `Interpreter.Tests`, `Compiler.Tests`, `Extensions.Tests`, `LanguageServer.Tests`, `Sdk.Tests` (no product change — test-side only; `test/Shared` sources unchanged), `Cs2Gs.Tests` (pre-existing flaky host crash; GoldenTests-filter policy). CI required checks are the backstop.

## Checklist

- [x] Behavioral tests carry a witness of discrimination (ADR-0154): assertions unchanged; each migrated test still fails on its original broken world, now against emitted semantics.
- [x] Self-review verdict recorded when one was run (MERGEABLE / BLOCKER / SHOULD-FIX / NIT), with residuals filed as issues rather than dropped.

Self-review verdict: **MERGEABLE** — test-side plus migration-script only; every non-migrated site is annotated with its reason and reference; discovered divergences are filed (#3214–#3219) rather than papered over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)