### PR TITLE
Migrate Core.Tests Issue1016-Issue2023 files to the EmittedOracle (Phase 3b.1, slice 2/3)

### DIFF
--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1016RangeSliceBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1016RangeSliceBindingTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -75,11 +76,9 @@ public class Issue1016RangeSliceBindingTests
         Assert.Contains(diagnostics, d => d.Id == "GS0392");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 
     private static ImmutableArray<Diagnostic> Bind(string source)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1019StaticInterfacePropertyTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1019StaticInterfacePropertyTests.cs
@@ -11,6 +11,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -231,11 +232,9 @@ sealed interface IData {
         Assert.Empty(result.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 
     private static void AssertEmitsAndLoads(string source)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1022FromEndIndexBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1022FromEndIndexBindingTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -99,10 +100,8 @@ public class Issue1022FromEndIndexBindingTests
         Assert.Equal(5, result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1030InterfaceStaticMembersTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1030InterfaceStaticMembersTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -144,10 +145,8 @@ func Bump() int32 {
         Assert.Empty(result.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1038StandaloneRangeBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1038StandaloneRangeBindingTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -102,11 +103,9 @@ public class Issue1038StandaloneRangeBindingTests
         Assert.Contains(diagnostics, d => d.Id == "GS0410");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 
     private static IEnumerable<Diagnostic> GetDiagnostics(string source)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1052UserInterfaceConstraintTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1052UserInterfaceConstraintTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -157,10 +158,8 @@ Bigger(Num{V: 7}, Num{V: 3})
         Assert.Equal(4, result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1056ClassConstraintTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1056ClassConstraintTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -96,10 +97,8 @@ open class Box2[T Box2[T]] {}
         Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0113");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1060BaseInitChainingBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1060BaseInitChainingBinderTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -103,10 +104,8 @@ class B : A {
         Assert.Contains(result.Diagnostics, d => d.Id == "GS0214");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1070FieldInitializerStaticTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1070FieldInitializerStaticTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -133,9 +134,7 @@ public class Issue1070FieldInitializerStaticTests
 
     private static IEnumerable<Diagnostic> GetDiagnostics(string source)
     {
-        var tree = SyntaxTree.Parse(source);
-        var compilation = new Compilation(tree);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(source);
         return result.Diagnostics.ToList();
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1100GenericMethodUserTypeArgTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1100GenericMethodUserTypeArgTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -103,10 +104,8 @@ class C {
         Assert.Empty(result.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1103ExtensionInstanceCallTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1103ExtensionInstanceCallTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -136,10 +137,8 @@ run(5)
         Assert.DoesNotContain(result.Diagnostics, d => d.Message.Contains("Cannot find function"));
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1104BasePropertyAccessBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1104BasePropertyAccessBinderTests.cs
@@ -184,7 +184,9 @@ open class Deriv() : Mid {
 var d = Deriv()
 d.RenderSize
 ";
-        var result = Evaluate(source);
+        // ADR-0156 Phase 3b (#3176): stays on Compilation.Evaluate —
+        // #3223 tracks the unloadable MethodImpl emitted for base[Base].Prop.
+        var result = EvaluateWithEvaluator(source);
         Assert.Empty(result.Diagnostics);
         Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0157");
 
@@ -300,5 +302,15 @@ open class Deriv() : Base {
     private static EmittedOracleResult Evaluate(string source)
     {
         return EmittedOracle.Evaluate(source);
+    }
+
+    // Evaluator-pinned twin of Evaluate for the #3223 test above; delete
+    // with the evaluator (ADR-0156 Phase 3c) or when #3223 aligns the
+    // engines.
+    private static EvaluationResult EvaluateWithEvaluator(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1104BasePropertyAccessBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1104BasePropertyAccessBinderTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -296,10 +297,8 @@ open class Deriv() : Base {
         Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0157");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1113TransitiveConstraintTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1113TransitiveConstraintTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -90,10 +91,8 @@ Use[NotABox](NotABox())
         Assert.Contains(result.Diagnostics, d => d.Id == "GS0152");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1121NonNullableToNullableBaseConversionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1121NonNullableToNullableBaseConversionTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -139,10 +140,8 @@ var b IBox? = Unrelated{}
         Assert.Contains(result.Diagnostics, d => d.Message.Contains("Cannot convert type"));
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1123AssignmentSmartCastBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1123AssignmentSmartCastBinderTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -178,10 +179,8 @@ class C {
         Assert.Contains(result.Diagnostics, d => d.Message.Contains("M", System.StringComparison.Ordinal));
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1124GenericUninferableOverloadTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1124GenericUninferableOverloadTests.cs
@@ -10,6 +10,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -134,9 +135,7 @@ class C {
     }
 }
 ";
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(source);
         Assert.Contains(result.Diagnostics, d => d.Id == "GS0266");
     }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1129StringIndexerBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1129StringIndexerBinderTests.cs
@@ -10,6 +10,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -117,11 +118,9 @@ public class Issue1129StringIndexerBinderTests
         Assert.Equal(20, result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 
     private static string[] GetDiagnostics(string source)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1136ObjectMemberBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1136ObjectMemberBinderTests.cs
@@ -185,7 +185,7 @@ class D {
         AssertNoErrors(Evaluate(source));
     }
 
-    private static void AssertNoErrors(EvaluationResult result)
+    private static void AssertNoErrors(EmittedOracleResult result)
     {
         Assert.Empty(result.Diagnostics.Where(d => d.IsError));
     }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1136ObjectMemberBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1136ObjectMemberBinderTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -189,10 +190,8 @@ class D {
         Assert.Empty(result.Diagnostics.Where(d => d.IsError));
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1154NullableWideningOverloadTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1154NullableWideningOverloadTests.cs
@@ -10,6 +10,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -41,6 +42,9 @@ class C {
     func F(a []?uint8) { var n = 1 }
 }
 ";
+        // Phase 3b (issue #3176): stays on Compilation.Evaluate — the test
+        // inspects this Compilation's bound state afterwards (FindCall), which
+        // the EmittedOracle does not expose; disposition in 3b.2.
         var compilation = Compile(source);
         var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
         Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
@@ -64,6 +68,9 @@ class C {
     func F(a []uint8) { var n = 1 }
 }
 ";
+        // Phase 3b (issue #3176): stays on Compilation.Evaluate — the test
+        // inspects this Compilation's bound state afterwards (FindCall), which
+        // the EmittedOracle does not expose; disposition in 3b.2.
         var compilation = Compile(source);
         var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
         Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
@@ -86,6 +93,9 @@ class C {
     func F(a []?uint8) { F(C.Make()) }
 }
 ";
+        // Phase 3b (issue #3176): stays on Compilation.Evaluate — the test
+        // inspects this Compilation's bound state afterwards (FindCall), which
+        // the EmittedOracle does not expose; disposition in 3b.2.
         var compilation = Compile(source);
         var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
         Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
@@ -109,6 +119,9 @@ class C {
     func F(a []?uint8) { var n = 1 }
 }
 ";
+        // Phase 3b (issue #3176): stays on Compilation.Evaluate — the test
+        // inspects this Compilation's bound state afterwards (FindCall), which
+        // the EmittedOracle does not expose; disposition in 3b.2.
         var compilation = Compile(source);
         var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
         Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
@@ -142,9 +155,7 @@ class C {
     }
 }
 ";
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(source);
         Assert.Contains(result.Diagnostics, d => d.Id == "GS0266");
     }
 
@@ -160,6 +171,9 @@ class C {
     func F(a string) { F(C.Make()) }
 }
 ";
+        // Phase 3b (issue #3176): stays on Compilation.Evaluate — IsLibrary is a
+        // Compilation-level knob the EmittedOracle does not expose; disposition
+        // in 3b.2.
         var tree = SyntaxTree.Parse(SourceText.From(source));
         var compilation = new Compilation(tree) { IsLibrary = true };
         var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1159LambdaEnclosingInstanceMemberBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1159LambdaEnclosingInstanceMemberBinderTests.cs
@@ -203,7 +203,7 @@ class C {
         AssertNoErrors(Evaluate(source));
     }
 
-    private static void AssertNoErrors(EvaluationResult result)
+    private static void AssertNoErrors(EmittedOracleResult result)
     {
         Assert.Empty(result.Diagnostics.Where(d => d.IsError));
     }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1159LambdaEnclosingInstanceMemberBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1159LambdaEnclosingInstanceMemberBinderTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -207,10 +208,8 @@ class C {
         Assert.Empty(result.Diagnostics.Where(d => d.IsError));
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1172ArrowLambdaParityBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1172ArrowLambdaParityBinderTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -179,11 +180,9 @@ let x = if true { 1 }
         Assert.Contains(result.Diagnostics, d => d.Id == "GS0276");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
         var prelude = "import System\nimport System.Threading.Tasks\n";
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(prelude + source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(prelude + source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1180SmartCastMembersBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1180SmartCastMembersBinderTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -289,10 +290,8 @@ Run(Box{Builder: System.Text.StringBuilder()})
         Assert.NotNull(result);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1182ValueTypeDefaultOptionalParameterTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1182ValueTypeDefaultOptionalParameterTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -153,10 +154,8 @@ func F(x int32 = 1 + 2) int32 { return x }
         Assert.Contains(diagnostics, d => d.Id == id);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1194FieldAndCtorInitializerScopeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1194FieldAndCtorInitializerScopeTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -94,9 +95,7 @@ public class Issue1194FieldAndCtorInitializerScopeTests
 
     private static IEnumerable<Diagnostic> GetDiagnostics(string source)
     {
-        var tree = SyntaxTree.Parse(source);
-        var compilation = new Compilation(tree);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(source);
         return result.Diagnostics.ToList();
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1196TypeParameterToInterfaceConversionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1196TypeParameterToInterfaceConversionTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -87,9 +88,7 @@ public class Issue1196TypeParameterToInterfaceConversionTests
 
     private static IEnumerable<Diagnostic> GetDiagnostics(string source)
     {
-        var tree = SyntaxTree.Parse(source);
-        var compilation = new Compilation(tree);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(source);
         return result.Diagnostics.ToList();
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1199ImportedCompositeLiteralBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1199ImportedCompositeLiteralBinderTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -87,10 +88,8 @@ sb.Capacity
         Assert.NotEmpty(result.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1209GenericTypeExprTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1209GenericTypeExprTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -154,10 +155,8 @@ func F() int32 {
         Assert.NotEmpty(result.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1211CompositeLiteralPropBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1211CompositeLiteralPropBinderTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -111,10 +112,8 @@ c.Name
         Assert.Contains(result.Diagnostics, d => d.Message.Contains("Cannot find member"));
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1214GenericExplicitInitCtorTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1214GenericExplicitInitCtorTests.cs
@@ -11,6 +11,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -203,9 +204,7 @@ public class Issue1214GenericExplicitInitCtorTests
         // construction expression inside a function body is actually bound and
         // any diagnostic surfaces. BindGlobalScope alone only binds signatures
         // and declaration-level constructs (e.g. `: base(...)`), not bodies.
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(source);
         return result.Diagnostics;
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1235TypeParameterClassMemberTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1235TypeParameterClassMemberTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -115,10 +116,8 @@ func Bad[T Base](t T) int32 { return t.Missing }
         Assert.Contains(result.Diagnostics, d => d.Id == "GS0158");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1235TypeParameterMemberWriteTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1235TypeParameterMemberWriteTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -159,18 +160,14 @@ func Bad[T Base]() T { return T{P: 1} }
         Assert.Contains(diagnostics, d => d.Id == "GS0389");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 
     private static IReadOnlyList<Diagnostic> Bind(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(source);
         return result.Diagnostics.ToList();
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1240ParameterShadowsFieldTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1240ParameterShadowsFieldTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -153,15 +154,11 @@ var r = c.M(42)
 
     private static System.Collections.Immutable.ImmutableArray<Diagnostic> Bind(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>()).Diagnostics;
+        return EmittedOracle.Evaluate(source).Diagnostics;
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1244GenericAbstractOverrideBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1244GenericAbstractOverrideBinderTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -130,10 +131,8 @@ class Leaf : Der[int32] {
         Assert.Contains(result.Diagnostics, d => d.Id == "GS0387");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1248GenericUpcastBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1248GenericUpcastBinderTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -211,10 +212,8 @@ class C {
         Assert.Empty(result.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1250GenericMemberSubstitutionBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1250GenericMemberSubstitutionBinderTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -260,10 +261,8 @@ class C {
         Assert.Contains(result.Diagnostics, d => d.Id == "GS0155");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1255NullableToNullableRefUpcastConversionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1255NullableToNullableRefUpcastConversionTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -146,10 +147,8 @@ func F(x Unrelated?) {
         Assert.Contains(result.Diagnostics, d => d.Message.Contains("Cannot convert"));
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1256ElementWiseTupleConversionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1256ElementWiseTupleConversionTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -183,10 +184,8 @@ func F(a A, d Derived) { Take((a, d, a)) }
             d => d.Message.Contains("Cannot convert") || d.Message.Contains("requires a value of type"));
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1260BaseBclCallBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1260BaseBclCallBinderTests.cs
@@ -115,7 +115,7 @@ class MyMem : MemoryStream {
         Assert.Contains(result.Diagnostics, d => d.Id == "GS0384");
     }
 
-    private static void AssertNoErrors(EvaluationResult result)
+    private static void AssertNoErrors(EmittedOracleResult result)
     {
         Assert.Empty(result.Diagnostics.Where(d => d.IsError));
     }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1260BaseBclCallBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1260BaseBclCallBinderTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -119,10 +120,8 @@ class MyMem : MemoryStream {
         Assert.Empty(result.Diagnostics.Where(d => d.IsError));
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1262DiscardParameterBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1262DiscardParameterBinderTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -80,11 +81,9 @@ public class Issue1262DiscardParameterBinderTests
         Assert.Contains(result.Diagnostics, d => d.Id == "GS0125");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
         var prelude = "import System\n";
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(prelude + source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(prelude + source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1268StaticVirtualGenericInterfaceTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1268StaticVirtualGenericInterfaceTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -121,10 +122,8 @@ func Use[T IData[int32]]() int32 { return T.Missing }
         Assert.Contains(result.Diagnostics, d => d.Id == "GS0333");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1272ArrayAllocationBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1272ArrayAllocationBindingTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -68,11 +69,9 @@ public class Issue1272ArrayAllocationBindingTests
         Assert.Contains(diagnostics, d => d.Id == "GS0115");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 
     private static ImmutableArray<Diagnostic> Bind(string source)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1278ArrowExpressionMemberTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1278ArrowExpressionMemberTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -105,10 +106,8 @@ var r = bad(1)
         Assert.NotEmpty(result.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1307BaseInitNarrowingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1307BaseInitNarrowingTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -101,10 +102,8 @@ class D : B {
         Assert.NotEmpty(result.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1319OptionalDefaultCallSiteTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1319OptionalDefaultCallSiteTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -215,10 +216,8 @@ c.Tag()
         Assert.Fail($"Expected diagnostic '{id}' was not reported.");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1335LambdaProtectedAccessBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1335LambdaProtectedAccessBinderTests.cs
@@ -134,7 +134,7 @@ class C {
         Assert.Contains(diagnostics, d => d.Id == "GS0379");
     }
 
-    private static void AssertNoGS0379(EvaluationResult result)
+    private static void AssertNoGS0379(EmittedOracleResult result)
     {
         Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0379");
     }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1335LambdaProtectedAccessBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1335LambdaProtectedAccessBinderTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -138,10 +139,8 @@ class C {
         Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0379");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1347BaseAutoPropertyReadBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1347BaseAutoPropertyReadBinderTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -144,10 +145,8 @@ open class DashFile : BaseFile {
         Assert.Contains(result.Diagnostics, d => d.Id == "GS0127");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1537GenericNestedInGenericBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1537GenericNestedInGenericBinderTests.cs
@@ -11,6 +11,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -213,9 +214,7 @@ public class Issue1537GenericNestedInGenericBinderTests
 
     private static IReadOnlyList<Diagnostic> GetDiagnostics(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(source);
         return result.Diagnostics;
     }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1620FunctionTypeCacheNestedTypeParamTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1620FunctionTypeCacheNestedTypeParamTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -161,9 +162,7 @@ public class Issue1620FunctionTypeCacheNestedTypeParamTests
 
     private static IReadOnlyList<Diagnostic> GetDiagnostics(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(source);
         return result.Diagnostics;
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1628NamedArgumentPermutationOverloadTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1628NamedArgumentPermutationOverloadTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -52,10 +53,8 @@ x
         Assert.Equal(100, result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1629GenericCtorInferenceDoubleBindTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1629GenericCtorInferenceDoubleBindTests.cs
@@ -10,6 +10,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -124,9 +125,7 @@ public class Issue1629GenericCtorInferenceDoubleBindTests
 
     private static ImmutableArray<Diagnostic> Diagnose(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(source);
         return result.Diagnostics;
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1636TypeTestNarrowingSubtypeGateTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1636TypeTestNarrowingSubtypeGateTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -174,10 +175,8 @@ Run(Circle{Radius: 3})
         Assert.Empty(result.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1639NarrowingInvalidationFastPathTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1639NarrowingInvalidationFastPathTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -176,10 +177,8 @@ class C {
         Assert.Empty(result.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1641FieldInitializerShadowingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1641FieldInitializerShadowingTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -487,9 +488,7 @@ public class Issue1641FieldInitializerShadowingTests
 
     private static IEnumerable<Diagnostic> GetDiagnostics(string source)
     {
-        var tree = SyntaxTree.Parse(source);
-        var compilation = new Compilation(tree);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(source);
         return result.Diagnostics.ToList();
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1880UnsignedRightShiftInterpreterTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1880UnsignedRightShiftInterpreterTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -39,10 +40,8 @@ public class Issue1880UnsignedRightShiftInterpreterTests
         Assert.Equal((short)-1, result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1881CheckedUncheckedInterpreterTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1881CheckedUncheckedInterpreterTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -217,10 +218,8 @@ public class Issue1881CheckedUncheckedInterpreterTests
         Assert.Equal(double.PositiveInfinity, result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1885LockStatementTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1885LockStatementTests.cs
@@ -10,6 +10,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -114,11 +115,9 @@ lock n {
         Assert.Contains(diagnostics, d => d.Message.Contains("reference type"));
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 
     private static ImmutableArray<Diagnostic> Bind(string source)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1887TuplePositionalPatternTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1887TuplePositionalPatternTests.cs
@@ -7,6 +7,7 @@ using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -69,11 +70,9 @@ x
 ", "hit");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(source);
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 
     private static void AssertEvaluates(string source, object expected)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1912ExplicitEnumMemberValueTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1912ExplicitEnumMemberValueTests.cs
@@ -11,6 +11,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -167,10 +168,8 @@ StatusCode.DefaultError == StatusCode.ServerError
         return globalScope.Diagnostics;
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1915OpenGenericTypeOfBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1915OpenGenericTypeOfBindingTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -81,10 +82,8 @@ class C {
         Assert.Contains(result.Diagnostics, d => d.Id == "GS0113");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1922TupleForInStatementTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1922TupleForInStatementTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -150,10 +151,8 @@ class C { func F(xs [](int32, int32)) { for (a, b) in xs { } } }
         Assert.Empty(tree.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1923PatternMatchingSeamsTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1923PatternMatchingSeamsTests.cs
@@ -53,7 +53,10 @@ public class Issue1923PatternMatchingSeamsTests
 let answer object = 42
 answer == 42
 ";
-        var result = Evaluate(source);
+        // ADR-0156 Phase 3b (#3176): stays on Compilation.Evaluate —
+        // #3224 tracks the boxed-constant equality seam (emitted compares
+        // box references and yields false).
+        var result = EvaluateWithEvaluator(source);
         Assert.Empty(result.Diagnostics);
         Assert.Equal(true, result.Value);
     }
@@ -187,5 +190,15 @@ check(Person{Name: ""x""})
     private static EmittedOracleResult Evaluate(string source)
     {
         return EmittedOracle.Evaluate(source);
+    }
+
+    // Evaluator-pinned twin of Evaluate for the #3224 test above; delete
+    // with the evaluator (ADR-0156 Phase 3c) or when #3224 aligns the
+    // engines.
+    private static EvaluationResult EvaluateWithEvaluator(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1923PatternMatchingSeamsTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1923PatternMatchingSeamsTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -183,10 +184,8 @@ check(Person{Name: ""x""})
         Assert.Equal(1, result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1927VarianceConversionAndStringConcatTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1927VarianceConversionAndStringConcatTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -226,10 +227,8 @@ s1 + s2", "ab")]
         Assert.Equal(expected, result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1931GenericAbstractOverrideTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1931GenericAbstractOverrideTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -124,10 +125,8 @@ class BrokenShower() : MaybeShower {
         Assert.Contains(result.Diagnostics, d => d.Id == "GS0185");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1932GenericMethodInferenceOverUserTypeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1932GenericMethodInferenceOverUserTypeTests.cs
@@ -90,7 +90,10 @@ func Describe[T](h IHolder[T]) T {
 
 Describe(StringBox{Value: ""hi""})
 ";
-        var result = Evaluate(source);
+        // ADR-0156 Phase 3b (#3176): stays on Compilation.Evaluate —
+        // #3222 tracks the invalid IL for the implementing-struct call
+        // through the constructed generic interface parameter.
+        var result = EvaluateWithEvaluator(source);
         Assert.Empty(result.Diagnostics);
         Assert.Equal("hi", result.Value);
     }
@@ -120,5 +123,15 @@ swapped.First
     private static EmittedOracleResult Evaluate(string source)
     {
         return EmittedOracle.Evaluate(source);
+    }
+
+    // Evaluator-pinned twin of Evaluate for the #3222 test above; delete
+    // with the evaluator (ADR-0156 Phase 3c) or when #3222 aligns the
+    // engines.
+    private static EvaluationResult EvaluateWithEvaluator(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1932GenericMethodInferenceOverUserTypeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1932GenericMethodInferenceOverUserTypeTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -116,10 +117,8 @@ swapped.First
         Assert.Equal("b", result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1951ListPatternMetadataArrayTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1951ListPatternMetadataArrayTests.cs
@@ -7,6 +7,7 @@ using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -64,9 +65,7 @@ x
 
     private static void AssertEvaluates(string source, object expected)
     {
-        var tree = SyntaxTree.Parse(source);
-        var compilation = new Compilation(tree);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(source);
         Assert.Empty(result.Diagnostics);
         Assert.Equal(expected, result.Value);
     }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1988NarrowedStructFieldAssignmentBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1988NarrowedStructFieldAssignmentBinderTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -46,10 +47,8 @@ if oa is Money {
         Assert.Contains(result.Diagnostics, d => d.Id == "GS0158");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1989MultiArityOpenGenericTypeOfBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1989MultiArityOpenGenericTypeOfBindingTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -148,10 +149,8 @@ class C {
         Assert.Empty(result.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2023CheckedUnaryNegationInterpreterTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2023CheckedUnaryNegationInterpreterTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -164,10 +165,8 @@ public class Issue2023CheckedUnaryNegationInterpreterTests
         Assert.Equal(-5.5m, result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }


### PR DESCRIPTION
Part of #3176 (Phase 3b.1, slice 2/3), part of #3163.

## Summary

Second of three disjoint slices of the Core.Tests bulk migration from the `Compilation.Evaluate` oracle to `test/Shared/EmittedOracle` (PR #3206): the first **68 Issue-numbered files** (Issue1016…Issue2023 by filename order). Slice 1/3 (#3221) carried the feature-named files and the migration-script generalization this slice's rewrite was produced with (the script itself is unchanged on this branch — file sets stay disjoint); slice 3/3 carries the remaining Issue files.

- **Scripted rewrite**: 68 files, 70 transform applications (T2x58, T6x12) + 57 helper retypes, assertions unchanged.
- **Hand-fixes**: four `EvaluationResult`-typed local assertion helpers (`AssertNoErrors` x3, `AssertNoGS0379`) retyped to `EmittedOracleResult` to follow their retyped `Evaluate` helpers (Issue1136, Issue1159, Issue1260, Issue1335); Issue1154's five binder-inspection/`IsLibrary` sites annotated and left on `Compilation.Evaluate` (3b.2 disposition).

## Slice stats

| Category | Count |
|---|---|
| Files migrated (script) | 68 |
| Script transform sites | 70 (T2x58, T6x12) + 57 helper retypes |
| Hand-fixed follow-on retypes | 4 assertion helpers |
| Annotated residue sites left for 3b.2 | 5 (Issue1154: binder-inspection x4, IsLibrary x1) |
| Divergences — newly discovered, filed | 3 issues, 3 tests evaluator-pinned |
| Divergences — matching already-pinned categories | 0 |

## Divergence table

| Issue | Category | Pinned test |
|---|---|---|
| #3222 | Implementing-struct argument through a constructed generic-interface parameter emits invalid IL (`InvalidProgramException`) | Issue1932GenericMethodInferenceOverUserTypeTests.GenericInterfaceParameter_InfersTypeArgument_FromImplementingArgument |
| #3223 | `base[Base].Prop` emits an unloadable `MethodImpl` (`TypeLoadException`: "cannot be a final method") | Issue1104BasePropertyAccessBinderTests.BracketedBaseProperty_Read_ReachesSpecificAncestor |
| #3224 | Boxed-constant equality: emitted compares box references and yields `false`; evaluator compares by value (`true`) | Issue1923PatternMatchingSeamsTests.BoxedConstantEquality_BindsAgainstObjectTypedVariable |

Pinned tests keep their original expected values on `Compilation.Evaluate` via an `EvaluateWithEvaluator` twin helper (the #3206 pilot's convention), each annotated with its issue; they retire or realign with the issues' resolutions (ADR-0156 Phase 3c at the latest).

## Verification

- `dotnet build test/Core.Tests/Core.Tests.csproj -c Release`: 0 warnings, 0 errors.
- `test/Core.Tests` full suite (Release): **7135/7136 passed**, 1 skipped (standing `RegenerateBaseline` skip). Migrated tests green with unchanged assertions.
- Nothing outside `test/` touched (zero `src/` changes; the script change ships in slice 1).
- Witness (ADR-0154): migrated tests keep their original expected values against the real emitted semantics; the three filed divergences are this slice's discrimination evidence.
- NOT RUN: `Interpreter.Tests`, `Compiler.Tests`, `Extensions.Tests`, `LanguageServer.Tests`, `Sdk.Tests` (no product change — test-side only; `test/Shared` sources unchanged), `Cs2Gs.Tests` (pre-existing flaky host crash; GoldenTests-filter policy). CI required checks are the backstop.

## Checklist

- [x] Behavioral tests carry a witness of discrimination (ADR-0154): assertions unchanged; each migrated test still fails on its original broken world, now against emitted semantics.
- [x] Self-review verdict recorded when one was run (MERGEABLE / BLOCKER / SHOULD-FIX / NIT), with residuals filed as issues rather than dropped.

Self-review verdict: **MERGEABLE** — test-side only; every non-migrated site is annotated with its reason and reference; discovered divergences are filed (#3222–#3224) rather than papered over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)