### PR TITLE
Migrate Core.Tests Issue2043-Issue3096 files to the EmittedOracle (Phase 3b.1, slice 3/3)

### DIFF
--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2043NullCoalesceStaticFieldTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2043NullCoalesceStaticFieldTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -120,10 +121,8 @@ c.Field
         Assert.Equal("default", result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2044PrivateAccessibilityTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2044PrivateAccessibilityTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -232,10 +233,8 @@ class Derived : Base {
         Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0125");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2058PrivateMethodCallAccessibilityTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2058PrivateMethodCallAccessibilityTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -171,10 +172,8 @@ class Other {
         Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0472");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2059LiteralAccessibilityTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2059LiteralAccessibilityTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -180,10 +181,8 @@ class Other {
         Assert.Contains(result.Diagnostics, d => d.Id == "GS0472");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2059StructLiteralAccessibilityTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2059StructLiteralAccessibilityTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -152,10 +153,8 @@ class Other {
         Assert.Contains(result.Diagnostics, d => d.Id == "GS0379");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2060BareNameInheritedPrivateFieldTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2060BareNameInheritedPrivateFieldTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -110,10 +111,8 @@ class Foo {
         Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0472");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2067PrivateConstructorAccessibilityTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2067PrivateConstructorAccessibilityTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -117,10 +118,8 @@ class Other {
         Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0379");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2071StaticMethodCallAccessibilityTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2071StaticMethodCallAccessibilityTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -145,10 +146,8 @@ class Other {
         Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0379");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2111FieldInitializerAccessibilityTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2111FieldInitializerAccessibilityTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -102,10 +103,8 @@ class Bar {
         Assert.Contains(result.Diagnostics, d => d.Id == "GS0472");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2159IfJoinNarrowingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2159IfJoinNarrowingTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -204,10 +205,8 @@ func f(s string?) string {
         Assert.Contains(result.Diagnostics, d => d.Message.Contains("Cannot convert", StringComparison.Ordinal));
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2165IsInterfaceNarrowingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2165IsInterfaceNarrowingTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -163,10 +164,8 @@ func Run(x IShape) void {
         Assert.Contains(result.Diagnostics, d => d.Message.Contains("Init"));
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2171NullableIsInterfaceNarrowingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2171NullableIsInterfaceNarrowingTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -135,10 +136,8 @@ func Run(x object?) void {
         Assert.Empty(result.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2193ExtensionOverloadShadowTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2193ExtensionOverloadShadowTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -132,10 +133,8 @@ class Wrap {
         Assert.Empty(result.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2209GenericFqnStaticAccessTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2209GenericFqnStaticAccessTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -31,9 +32,7 @@ public class Issue2209GenericFqnStaticAccessTests
 {
     private static ImmutableArray<Diagnostic> Bind(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(source);
         return result.Diagnostics;
     }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2226EnumZeroLiteralComparisonTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2226EnumZeroLiteralComparisonTests.cs
@@ -13,6 +13,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -235,10 +236,8 @@ Console.WriteLine(hasAlt(ConsoleModifiers.Shift | ConsoleModifiers.Control))
         }
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2229ElementWiseTupleBoxingConversionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2229ElementWiseTupleBoxingConversionTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -114,10 +115,8 @@ func F(n int32?) { Take((""count"", n)) }
             d => d.Message.Contains("Cannot convert") || d.Message.Contains("requires a value of type"));
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2258QualifiedClrLiteralTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2258QualifiedClrLiteralTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -130,10 +131,8 @@ o
         Assert.Empty(result.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2300InterfaceAndTypeParameterNilCompareTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2300InterfaceAndTypeParameterNilCompareTests.cs
@@ -10,6 +10,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -275,10 +276,8 @@ func IsNotNil[T](value T) bool {
             .ToImmutableArray();
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2349LambdaIfStatementBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2349LambdaIfStatementBinderTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -249,11 +250,9 @@ let f = () -> {
         Assert.Empty(result.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
         var prelude = "import System\nimport System.Threading.Tasks\n";
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(prelude + source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(prelude + source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2350AsyncRefStructLivenessTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2350AsyncRefStructLivenessTests.cs
@@ -10,6 +10,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -475,11 +476,9 @@ func gen(arr []int32) sequence[int32] {
         Assert.Contains(diagnostics, d => d.Id == "GS0219");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 
     // Binds declarations and function bodies and returns the resulting

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2360AsyncTryFinallyReturnLivenessTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2360AsyncTryFinallyReturnLivenessTests.cs
@@ -10,6 +10,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -313,10 +314,8 @@ async func PipelineProbeCheck(buffer []byte) Task[int32] {
         Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS9998");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2361DataToStringOverrideTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2361DataToStringOverrideTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -295,10 +296,8 @@ func (a Point) operator ==(b Point) bool {
         Assert.Contains(result.Diagnostics, d => d.Id == "GS0232");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2363EmptyDataTypesTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2363EmptyDataTypesTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -255,10 +256,8 @@ mfa.Kind + "" "" + cvf.Kind + "" "" + approval.Kind
         Assert.Equal("mfa cvf approval", result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2377OperatorMetadataShapeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2377OperatorMetadataShapeTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -285,10 +286,8 @@ var x = TimeSpan(0, 0, 5) + TimeSpan(0, 0, 3)
         return new Compilation(tree);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2388NullableCustomEqualityBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2388NullableCustomEqualityBinderTests.cs
@@ -183,7 +183,7 @@ func F(a MetersB, b MetersB) bool {
         AssertNoErrors(Evaluate(source));
     }
 
-    private static void AssertNoErrors(EvaluationResult result)
+    private static void AssertNoErrors(EmittedOracleResult result)
     {
         Assert.Empty(result.Diagnostics.Where(d => d.IsError));
     }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2388NullableCustomEqualityBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2388NullableCustomEqualityBinderTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -187,10 +188,8 @@ func F(a MetersB, b MetersB) bool {
         Assert.Empty(result.Diagnostics.Where(d => d.IsError));
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2400LiftedGenericOperatorTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2400LiftedGenericOperatorTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -135,10 +136,8 @@ public class Issue2400LiftedGenericOperatorTests
         Assert.Contains(result.Diagnostics, d => d.IsError);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2442ClosureCallableNarrowingBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2442ClosureCallableNarrowingBinderTests.cs
@@ -396,12 +396,12 @@ Run(Box{convertAction: nil}, []uint8{})
         Assert.Contains(result.Diagnostics, d => d.IsError);
     }
 
-    private static void AssertClean(EvaluationResult result)
+    private static void AssertClean(EmittedOracleResult result)
     {
         Assert.Empty(result.Diagnostics);
     }
 
-    private static void AssertContainsError(EvaluationResult result, string diagnosticId)
+    private static void AssertContainsError(EmittedOracleResult result, string diagnosticId)
     {
         Assert.Contains(result.Diagnostics, d => d.IsError && d.Id == diagnosticId);
     }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2442ClosureCallableNarrowingBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2442ClosureCallableNarrowingBinderTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -405,10 +406,8 @@ Run(Box{convertAction: nil}, []uint8{})
         Assert.Contains(result.Diagnostics, d => d.IsError && d.Id == diagnosticId);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2502InheritedStaticMemberTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2502InheritedStaticMemberTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -133,10 +134,8 @@ public class Issue2502InheritedStaticMemberTests
         Assert.NotEmpty(Evaluate(Source).Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2534BaseClassCallBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2534BaseClassCallBinderTests.cs
@@ -7,6 +7,7 @@ using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -79,9 +80,8 @@ public class Issue2534BaseClassCallBinderTests
         Assert.Equal(42, result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var compilation = new Compilation(SyntaxTree.Parse(source));
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2553RepeatedDiscardBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2553RepeatedDiscardBinderTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -47,9 +48,8 @@ public class Issue2553RepeatedDiscardBinderTests
         Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0125");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        return new Compilation(tree).Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2553RepeatedDiscardRuntimeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2553RepeatedDiscardRuntimeTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -35,9 +36,8 @@ public class Issue2553RepeatedDiscardRuntimeTests
         Assert.Equal(19, result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        return new Compilation(tree).Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2579NullableReferenceBoundaryTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2579NullableReferenceBoundaryTests.cs
@@ -19,7 +19,7 @@ public sealed class Issue2579NullableReferenceBoundaryTests
     [Fact]
     public void GuardsAndAssertions_EnableReferenceUsesAcrossAllBoundaries()
     {
-        EvaluationResult result = Evaluate("""
+        EmittedOracleResult result = Evaluate("""
             import System
             import System.Collections.Generic
 
@@ -60,7 +60,7 @@ public sealed class Issue2579NullableReferenceBoundaryTests
     [Fact]
     public void UnguardedNullableReferencesRemainHardErrors()
     {
-        EvaluationResult result = Evaluate("""
+        EmittedOracleResult result = Evaluate("""
             import System.Collections.Generic
 
             func Consume(value string) {}
@@ -85,7 +85,7 @@ public sealed class Issue2579NullableReferenceBoundaryTests
     [Fact]
     public void NullableValuesAndInvalidReferenceConversionsRemainHardErrors()
     {
-        EvaluationResult result = Evaluate("""
+        EmittedOracleResult result = Evaluate("""
             interface IService {}
             class Service : IService {}
             class Other {}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2579NullableReferenceBoundaryTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2579NullableReferenceBoundaryTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -105,10 +106,8 @@ public sealed class Issue2579NullableReferenceBoundaryTests
             Assert.Contains(diagnostic.Id, new[] { "GS0154", "GS0155", "GS0156" }));
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2621ImportedGenericConstructorTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2621ImportedGenericConstructorTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -66,8 +67,6 @@ public sealed class Issue2621ImportedGenericConstructorTests
 
     private static ImmutableArray<Diagnostic> Bind(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>()).Diagnostics;
+        return EmittedOracle.Evaluate(source).Diagnostics;
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2769PositionalDeconstructionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2769PositionalDeconstructionTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -42,10 +43,8 @@ public sealed class Issue2769PositionalDeconstructionTests
         Assert.Contains(result.Diagnostics, d => d.Id == "GS0164");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2818StructTemporaryFieldAssignmentTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2818StructTemporaryFieldAssignmentTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -218,10 +219,8 @@ public class Issue2818StructTemporaryFieldAssignmentTests
         Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0499");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2834CompoundAssignmentOperatorTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2834CompoundAssignmentOperatorTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -382,10 +383,8 @@ class Bag {
         return new Compilation(tree);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2924TupleElementDelegateCallTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2924TupleElementDelegateCallTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -327,11 +328,9 @@ public class Issue2924TupleElementDelegateCallTests
         Assert.Equal(10, result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 
     private static IEnumerable<SyntaxNode> Walk(SyntaxNode node)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3091PropertyPatternPropertyTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3091PropertyPatternPropertyTests.cs
@@ -11,6 +11,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -216,8 +217,7 @@ public sealed class Issue3091PropertyPatternPropertyTests
 
     private static void AssertEvaluates(string source, object expected)
     {
-        var result = new Compilation(SyntaxTree.Parse(SourceText.From(source)))
-            .Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(source);
         Assert.Empty(result.Diagnostics);
         Assert.Equal(expected, result.Value);
     }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3093SequenceInterfaceBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3093SequenceInterfaceBindingTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -141,10 +142,8 @@ public sealed class Issue3093SequenceInterfaceBindingTests
         Assert.Contains(Evaluate(Source).Diagnostics, diagnostic => diagnostic.Id == "GS0187");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue319ClrBaseInterpreterTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue319ClrBaseInterpreterTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -205,10 +206,8 @@ msg
         Assert.Equal("kaboom", result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue521ClassToInterfaceConversionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue521ClassToInterfaceConversionTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -252,10 +253,8 @@ r[1]
         Assert.Equal("second", result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue524DefaultCtorBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue524DefaultCtorBinderTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -173,10 +174,8 @@ var s = Stream()
         Assert.NotEmpty(result.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue671UserTypeAsClrGenericArgTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue671UserTypeAsClrGenericArgTests.cs
@@ -12,6 +12,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -34,9 +35,7 @@ public class Issue671UserTypeAsClrGenericArgTests
 {
     private static ImmutableArray<Diagnostic> Bind(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(source);
         return result.Diagnostics;
     }
 
@@ -45,6 +44,9 @@ public class Issue671UserTypeAsClrGenericArgTests
         var trees = sources
             .Select(s => SyntaxTree.Parse(SourceText.From(s)))
             .ToArray();
+        // Phase 3b (issue #3176): stays on Compilation.Evaluate — multi-tree
+        // compilation; the EmittedOracle takes a single source. Disposition
+        // in 3b.2.
         var compilation = new Compilation(trees);
         var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
         return result.Diagnostics;

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue693DictionaryConstructionBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue693DictionaryConstructionBindingTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -27,9 +28,7 @@ public class Issue693DictionaryConstructionBindingTests
 {
     private static ImmutableArray<Diagnostic> Bind(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(source);
         return result.Diagnostics;
     }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue700SmartCastBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue700SmartCastBinderTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -309,10 +310,8 @@ Run(""hi"")
         Assert.Empty(result.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue708IfLetGuardLetBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue708IfLetGuardLetBindingTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -324,10 +325,8 @@ Run()
         Assert.Single(result.Diagnostics, d => d.Id == "GS0297");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue711IfExpressionBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue711IfExpressionBindingTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -219,10 +220,8 @@ func Run(b bool) int32 {
         Assert.Empty(result.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue712FlowNarrowingExtensionsBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue712FlowNarrowingExtensionsBinderTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -430,10 +431,8 @@ switch a {
         Assert.Empty(result.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue714LambdaBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue714LambdaBinderTests.cs
@@ -11,6 +11,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -133,10 +134,8 @@ s
         Assert.Equal("one", result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue715ArrowFunctionTypeClauseBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue715ArrowFunctionTypeClauseBinderTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -136,9 +137,7 @@ f(0) + g(0) + h(0) + i(0)
         var source = @"
 let f (int32) -> int32 = ""not a function""
 ";
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        var diagnostics = compilation.Evaluate(new Dictionary<VariableSymbol, object>()).Diagnostics;
+        var diagnostics = EmittedOracle.Evaluate(source).Diagnostics;
 
         Assert.Contains(diagnostics, d => d.IsError && d.Message.Contains("(int32) -> int32"));
     }
@@ -221,10 +220,8 @@ let n ((int32) -> int32)? = nil
         Assert.Equal(1, result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue716LambdaBindingInferenceTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue716LambdaBindingInferenceTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -233,17 +234,13 @@ spelled(41)
         Assert.Equal(42, result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 
     private static System.Collections.Immutable.ImmutableArray<Diagnostic> GetDiagnostics(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>()).Diagnostics;
+        return EmittedOracle.Evaluate(source).Diagnostics;
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue721NullIdentifierDiagnosticTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue721NullIdentifierDiagnosticTests.cs
@@ -11,6 +11,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -179,15 +180,11 @@ public class Issue721NullIdentifierDiagnosticTests
 
     private static ImmutableArray<Diagnostic> Bind(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>()).Diagnostics;
+        return EmittedOracle.Evaluate(source).Diagnostics;
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue721NullIdentifierDiagnosticTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue721NullIdentifierDiagnosticTests.cs
@@ -169,7 +169,10 @@ public class Issue721NullIdentifierDiagnosticTests
     {
         // Sanity guard: the changes for #721 must not regress the
         // canonical `nil` spelling.
-        var result = Evaluate("""
+        // ADR-0156 Phase 3b (#3176): stays on Compilation.Evaluate —
+        // #3227 tracks trailing if-expression value capture in the emitted
+        // submission (<Result>$ stays null).
+        var result = EvaluateWithEvaluator("""
             let x string? = nil
             if x == nil { 1 } else { 0 }
             """);
@@ -186,5 +189,15 @@ public class Issue721NullIdentifierDiagnosticTests
     private static EmittedOracleResult Evaluate(string source)
     {
         return EmittedOracle.Evaluate(source);
+    }
+
+    // Evaluator-pinned twin of Evaluate for the #3227 tests above; delete
+    // with the evaluator (ADR-0156 Phase 3c) or when #3227 aligns the
+    // engines.
+    private static EvaluationResult EvaluateWithEvaluator(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue722GoExtensionsImportGateTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue722GoExtensionsImportGateTests.cs
@@ -10,6 +10,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -259,6 +260,9 @@ n
 func work() int32 { return 1 }
 go work()
 ";
+        // Phase 3b (issue #3176): stays on Compilation.Evaluate —
+        // ImplicitSystemImport is a Compilation-level knob the EmittedOracle
+        // does not expose; disposition in 3b.2.
         var tree = SyntaxTree.Parse(SourceText.From(source));
         var compilation = new Compilation(tree) { ImplicitSystemImport = false };
         var diags = compilation.Evaluate(new Dictionary<VariableSymbol, object>()).Diagnostics;
@@ -302,16 +306,12 @@ got
 
     private static ImmutableArray<Diagnostic> Bind(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>()).Diagnostics;
+        return EmittedOracle.Evaluate(source).Diagnostics;
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 
     private static void AssertNoGateDiagnostic(ImmutableArray<Diagnostic> diags)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue723GoBuiltinsImportGateTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue723GoBuiltinsImportGateTests.cs
@@ -10,6 +10,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -265,6 +266,9 @@ let n = len(42)
 let xs = []int32{1}
 let n = len(xs)
 ";
+        // Phase 3b (issue #3176): stays on Compilation.Evaluate —
+        // ImplicitSystemImport is a Compilation-level knob the EmittedOracle
+        // does not expose; disposition in 3b.2.
         var tree = SyntaxTree.Parse(SourceText.From(source));
         var compilation = new Compilation(tree) { ImplicitSystemImport = false };
         var diags = compilation.Evaluate(new Dictionary<VariableSymbol, object>()).Diagnostics;
@@ -356,16 +360,12 @@ n
 
     private static ImmutableArray<Diagnostic> Bind(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>()).Diagnostics;
+        return EmittedOracle.Evaluate(source).Diagnostics;
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 
     private static void AssertNoBuiltinGateDiagnostic(ImmutableArray<Diagnostic> diags)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue751RichReceiverBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue751RichReceiverBinderTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -123,10 +124,8 @@ m.CountKeys()
         Assert.True(errors.Count == 0, "Unexpected errors:\n" + string.Join("\n", errors.Select(d => d.ToString())));
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue751RichReceiverBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue751RichReceiverBinderTests.cs
@@ -118,7 +118,7 @@ m.CountKeys()
         Assert.Equal(3, result.Value);
     }
 
-    private static void AssertNoErrors(EvaluationResult result)
+    private static void AssertNoErrors(EmittedOracleResult result)
     {
         var errors = result.Diagnostics.Where(d => d.IsError).ToList();
         Assert.True(errors.Count == 0, "Unexpected errors:\n" + string.Join("\n", errors.Select(d => d.ToString())));

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue757BaseInterfaceCallBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue757BaseInterfaceCallBinderTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -203,10 +204,8 @@ class C : IFoo {
         Assert.NotEmpty(result.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue773GenericReceiverDispatchTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue773GenericReceiverDispatchTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -341,10 +342,8 @@ a.FirstOr(99)
         Assert.Equal(99, result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue773GenericReceiverDispatchTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue773GenericReceiverDispatchTests.cs
@@ -146,7 +146,10 @@ func (self T?) MyOrElse[T](fb T) T {
 var v int32? = nil
 v.MyOrElse(99)
 ";
-        var result = Evaluate(source);
+        // ADR-0156 Phase 3b (#3176): stays on Compilation.Evaluate —
+        // #3226 tracks the invalid IL for the T? extension receiver on
+        // Nullable<int32>.
+        var result = EvaluateWithEvaluator(source);
         Assert.Empty(result.Diagnostics);
         Assert.Equal(99, result.Value);
     }
@@ -173,7 +176,11 @@ var def = Point{X: 1, Y: 2}
 var r = pt.MyOrElse(def)
 r.X
 ";
-        var result = Evaluate(source);
+        // ADR-0156 Phase 3b (#3176): stays on Compilation.Evaluate —
+        // #3226 tracks the wrong-value dispatch for the T? extension
+        // receiver on a nil user-struct Nullable (default(Point) instead of
+        // the fallback).
+        var result = EvaluateWithEvaluator(source);
         Assert.Empty(result.Diagnostics);
         Assert.Equal(1, result.Value);
     }
@@ -345,5 +352,15 @@ a.FirstOr(99)
     private static EmittedOracleResult Evaluate(string source)
     {
         return EmittedOracle.Evaluate(source);
+    }
+
+    // Evaluator-pinned twin of Evaluate for the #3226 tests above; delete
+    // with the evaluator (ADR-0156 Phase 3c) or when #3226 aligns the
+    // engines.
+    private static EvaluationResult EvaluateWithEvaluator(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue775ClassStructConstraintTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue775ClassStructConstraintTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -260,10 +261,8 @@ a + b
         Assert.Equal("classstruct", result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue794GenericInstanceCallReturnTypeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue794GenericInstanceCallReturnTypeTests.cs
@@ -10,6 +10,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -223,9 +224,7 @@ func MakeKeys[K any, V any]() {
 
     private static IReadOnlyList<Diagnostic> GetDiagnostics(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(source);
         return result.Diagnostics;
     }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue814OrNilOverloadTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue814OrNilOverloadTests.cs
@@ -11,6 +11,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -209,11 +210,9 @@ head
         Assert.NotEmpty(diags);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 
     private static ImmutableArray<Diagnostic> GetErrorDiagnostics(string source)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue818AnonymousFunctionTypeVariadicTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue818AnonymousFunctionTypeVariadicTests.cs
@@ -11,6 +11,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -172,11 +173,9 @@ count(2, ""x"", ""y"", ""z"")
         Assert.Equal(5, result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From("import Gsharp.Extensions.Go\n" + source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate("import Gsharp.Extensions.Go\n" + source);
     }
 
     private static ImmutableArray<Diagnostic> Bind(string source)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue819PrimaryCtorVariadicTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue819PrimaryCtorVariadicTests.cs
@@ -10,6 +10,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -257,13 +258,11 @@ let t = Tags(name: ""a"", tags: ""b"")
         Assert.NotEmpty(result.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
         // Mirrors VariadicTests.Evaluate — `len(...)` lives behind the
         // Gsharp.Extensions.Go gate.
-        var syntaxTree = SyntaxTree.Parse(SourceText.From("import Gsharp.Extensions.Go\n" + source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate("import Gsharp.Extensions.Go\n" + source);
     }
 
     private static System.Collections.Immutable.ImmutableArray<Diagnostic> Bind(string source)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue833OpenTGenericMethodCallReturnTypeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue833OpenTGenericMethodCallReturnTypeTests.cs
@@ -10,6 +10,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -220,9 +221,7 @@ func MakeEmpty[T]() []T {
 
     private static IReadOnlyList<Diagnostic> GetDiagnostics(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(source);
         return result.Diagnostics;
     }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue948FieldInitializerBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue948FieldInitializerBindingTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -70,9 +71,7 @@ public class Issue948FieldInitializerBindingTests
 
     private static IEnumerable<Diagnostic> GetDiagnostics(string source)
     {
-        var tree = SyntaxTree.Parse(source);
-        var compilation = new Compilation(tree);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(source);
         return result.Diagnostics;
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue950ProtectedModifierTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue950ProtectedModifierTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -176,10 +177,8 @@ class Other {
         Assert.Contains(result.Diagnostics, d => d.Id == "GS0379");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue986BaseClassCallBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue986BaseClassCallBinderTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -169,10 +170,8 @@ class Circle() : Shape {
         Assert.Contains(result.Diagnostics, d => d.Id == "GS0385");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue987AbstractMethodBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue987AbstractMethodBinderTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -142,10 +143,8 @@ open class Shape {
         Assert.Contains(result.Diagnostics, d => d.Id == "GS0388");
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue988NewConstraintConstructionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue988NewConstraintConstructionTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -97,9 +98,7 @@ let f = Factory[int32]()
 
     private static IReadOnlyList<Diagnostic> Bind(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(source);
         return result.Diagnostics.ToList();
     }
 }


### PR DESCRIPTION
Part of #3176 (Phase 3b.1, slice 3/3), part of #3163.

## Summary

Last of three disjoint slices of the Core.Tests bulk migration from the `Compilation.Evaluate` oracle to `test/Shared/EmittedOracle` (PR #3206): the remaining **68 Issue-numbered files** (Issue2043…Issue3096 by filename order, plus the Issue6xx/7xx range that sorts after Issue2xxx). Slice 1/3 is #3221 (feature-named files + the migration-script generalization this rewrite was produced with — the script itself is unchanged on this branch, keeping file sets disjoint); slice 2/3 is #3225.

- **Scripted rewrite**: 68 files, 72 transform applications (T1x1, T2x64, T6x7) + 59 helper retypes, assertions unchanged.
- **Hand-fixes**: Issue715's `var diagnostics = compilation.Evaluate(...).Diagnostics;` tail statement hand-migrated; `EvaluationResult`-typed assertion helpers/locals retyped to `EmittedOracleResult` in Issue2388, Issue2442, Issue2579, Issue751; the multi-tree (Issue671) and `ImplicitSystemImport` (Issue722, Issue723) sites annotated and left on `Compilation.Evaluate` (3b.2 disposition).

## Slice stats

| Category | Count |
|---|---|
| Files migrated (script) | 68 |
| Script transform sites | 72 (T1x1, T2x64, T6x7) + 59 helper retypes |
| Hand-migrated sites | 1 (Issue715 tail statement) |
| Hand-fixed follow-on retypes | 4 files (helpers + explicit locals) |
| Annotated residue sites left for 3b.2 | 3 (multi-tree x1, ImplicitSystemImport x2) |
| Divergences — newly discovered, filed | 2 issues, 3 tests evaluator-pinned |
| Divergences — matching already-pinned categories | 0 |

## Divergence table

| Issue | Category | Pinned tests |
|---|---|---|
| #3226 | Generic extension on a `T?` receiver breaks for value types: invalid IL on `int32?`, silently wrong value (default struct instead of fallback) on a user-struct `T?` | Issue773GenericReceiverDispatchTests x2 |
| #3227 | Emitted submission does not capture a trailing if-expression's value (`<Result>$` stays null; evaluator returns the branch value per #669) | Issue721NullIdentifierDiagnosticTests.Existing_Nil_Program_Still_Compiles_And_Runs |

Pinned tests keep their original expected values on `Compilation.Evaluate` via an `EvaluateWithEvaluator` twin helper (the #3206 pilot's convention), each annotated with its issue; they retire or realign with the issues' resolutions (ADR-0156 Phase 3c at the latest).

## Verification

- `dotnet build test/Core.Tests/Core.Tests.csproj -c Release`: 0 warnings, 0 errors.
- `test/Core.Tests` full suite (Release): **7135/7136 passed**, 1 skipped (standing `RegenerateBaseline` skip). Migrated tests green with unchanged assertions.
- Nothing outside `test/` touched (zero `src/` changes; the script change ships in slice 1).
- Witness (ADR-0154): migrated tests keep their original expected values against the real emitted semantics; the two filed divergences are this slice's discrimination evidence — #3226's user-struct case is a silent wrong-value divergence only an oracle swap could catch.
- NOT RUN: `Interpreter.Tests`, `Compiler.Tests`, `Extensions.Tests`, `LanguageServer.Tests`, `Sdk.Tests` (no product change — test-side only; `test/Shared` sources unchanged), `Cs2Gs.Tests` (pre-existing flaky host crash; GoldenTests-filter policy). CI required checks are the backstop.

## Checklist

- [x] Behavioral tests carry a witness of discrimination (ADR-0154): assertions unchanged; each migrated test still fails on its original broken world, now against emitted semantics.
- [x] Self-review verdict recorded when one was run (MERGEABLE / BLOCKER / SHOULD-FIX / NIT), with residuals filed as issues rather than dropped.

Self-review verdict: **MERGEABLE** — test-side only; every non-migrated site is annotated with its reason and reference; discovered divergences are filed (#3226, #3227) rather than papered over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)