### PR TITLE
Reify ambient generic arguments in evaluator

### DIFF
--- a/src/Core/CodeAnalysis/Evaluator.Calls.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Calls.cs
@@ -1344,6 +1344,29 @@ public sealed partial class Evaluator
                 : NullableTypeSymbol.Get(underlying);
         }
 
+        if (type is StructSymbol structType)
+        {
+            var definition = structType.Definition ?? structType;
+            var ownArguments = ResolveRuntimeTypeArguments(structType.TypeArguments, out var ownChanged);
+            var enclosingArguments = ResolveRuntimeTypeArguments(
+                structType.EnclosingTypeArguments,
+                out var enclosingChanged);
+
+            if (!ownChanged && !enclosingChanged)
+            {
+                return type;
+            }
+
+            if (!enclosingArguments.IsDefaultOrEmpty)
+            {
+                return ownArguments.IsDefaultOrEmpty
+                    ? StructSymbol.ConstructNested(definition, enclosingArguments)
+                    : StructSymbol.ConstructNestedGeneric(definition, enclosingArguments, ownArguments);
+            }
+
+            return StructSymbol.Construct(definition, ownArguments);
+        }
+
         if (type is not ImportedTypeSymbol imported
             || imported.OpenDefinition == null
             || imported.TypeArguments.IsDefaultOrEmpty)
@@ -1351,18 +1374,33 @@ public sealed partial class Evaluator
             return type;
         }
 
-        var arguments = ImmutableArray.CreateBuilder<TypeSymbol>(imported.TypeArguments.Length);
-        var changed = false;
-        foreach (var argument in imported.TypeArguments)
+        var arguments = ResolveRuntimeTypeArguments(imported.TypeArguments, out var changed);
+
+        return changed
+            ? ImportedTypeSymbol.GetConstructed(imported.ClrType, imported.OpenDefinition, arguments)
+            : type;
+    }
+
+    private ImmutableArray<TypeSymbol> ResolveRuntimeTypeArguments(
+        ImmutableArray<TypeSymbol> arguments,
+        out bool changed)
+    {
+        if (arguments.IsDefaultOrEmpty)
+        {
+            changed = false;
+            return arguments;
+        }
+
+        var resolvedArguments = ImmutableArray.CreateBuilder<TypeSymbol>(arguments.Length);
+        changed = false;
+        foreach (var argument in arguments)
         {
             var resolved = ResolveRuntimeTypeSymbol(argument);
             changed |= !ReferenceEquals(resolved, argument);
-            arguments.Add(resolved);
+            resolvedArguments.Add(resolved);
         }
 
-        return changed
-            ? ImportedTypeSymbol.GetConstructed(imported.ClrType, imported.OpenDefinition, arguments.MoveToImmutable())
-            : type;
+        return resolvedArguments.MoveToImmutable();
     }
 
     private T ResolveMemberForRuntimeType<T>(T member, Type runtimeType)

--- a/src/Core/CodeAnalysis/Evaluator.Expressions.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Expressions.cs
@@ -1269,6 +1269,12 @@ public sealed partial class Evaluator
     {
         var clrBase = baseCtor.DeclaringType
             ?? throw new InvalidOperationException("Imported base constructor has no declaring type.");
+        var runtimeStructType = ResolveRuntimeTypeSymbol(structType);
+        if (!ReferenceEquals(runtimeStructType, structType))
+        {
+            structType = (StructSymbol)runtimeStructType;
+        }
+
         var backingType = ClrBackingTypes.GetValue(
             structType,
             _ => CreateClrBackingType(structType, clrBase));

--- a/test/Interpreter.Tests/Issue3099TypeArgumentReificationTests.cs
+++ b/test/Interpreter.Tests/Issue3099TypeArgumentReificationTests.cs
@@ -24,6 +24,83 @@ namespace GSharp.Interpreter.Tests;
 [Collection("ConsoleIo")]
 public class Issue3099TypeArgumentReificationTests
 {
+    [Fact]
+    public void OpenEnclosingFunctionTypeArgument_MatchesEmittedFieldTypes()
+    {
+        const string Source = """
+            package Issue3197
+            import System
+
+            class Owner[T] {
+                class Payload[U] {
+                    let A T
+                    let B U
+                }
+            }
+
+            class Box[T] : EventArgs {
+            }
+
+            func Reify[T]() {
+                var value = Box[Owner[T].Payload[string]]()
+                var payload = value.GetType().GenericTypeArguments[0]
+                Console.WriteLine("G:" + payload.GetGenericTypeDefinition().GetGenericArguments().Length.ToString())
+                for field in payload.GetFields() {
+                    Console.WriteLine(field.Name + ":" + field.FieldType.FullName)
+                }
+            }
+
+            Reify[int32]()
+            Reify[bool]()
+            """;
+
+        var root = Path.Combine(
+            GetRepositoryRoot(),
+            "out",
+            "test-artifacts",
+            $"issue3197-{Guid.NewGuid():N}");
+
+        try
+        {
+            var emitDirectory = PrepareEmptyDirectory(Path.Combine(root, "gsc-emit"));
+            var sourcePath = Path.Combine(emitDirectory, "Probe.gs");
+            var assemblyPath = Path.Combine(emitDirectory, "Probe.dll");
+            File.WriteAllText(sourcePath, Source);
+            _ = CaptureDriver(() => Program.Main(new[]
+            {
+                "/out:" + assemblyPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                sourcePath,
+            }));
+
+            var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+            Assert.NotEmpty(assembly.GetTypes());
+            var entryPoint = assembly.EntryPoint
+                ?? throw new InvalidOperationException("Emitted assembly has no entry point.");
+            var emitted = CaptureDriver(() =>
+            {
+                entryPoint.Invoke(
+                    null,
+                    entryPoint.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+                return 0;
+            });
+            var interactive = RunInteractive(Source);
+
+            Assert.Equal(
+                "G:2\nA:System.Int32\nB:System.String\nG:2\nA:System.Boolean\nB:System.String\n",
+                emitted);
+            Assert.Equal(emitted, interactive);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+
     public static IEnumerable<object[]> TypeArgumentCases()
     {
         yield return ["class", "class Payload {\n    let Eleven int32\n    var TwentyTwo string\n}", "Payload"];


### PR DESCRIPTION
## Summary

- resolve constructed G# struct symbols against evaluator ambient runtime type substitutions
- resolve before `ClrBackingTypes` cache lookup, so each concrete ambient instantiation gets correct backing type identity
- add emitted-oracle versus interactive `SessionEngine` regression using `Owner[T].Payload[string]` with `int32` and `bool` instantiations

This does not pass the builder substitution dictionary into the old fallback. That dictionary contains `GenericTypeParameterBuilder` values and lacks the enclosing function parameter. Instead, existing ambient runtime substitutions recursively reconstruct top-level, nested, and nested-generic struct symbols before CLR backing-type creation and caching.

Fixes #3197

## Printed-value proof

Validated from base `0484b00f`.

| Tree / driver | Printed field types |
|---|---|
| unfixed main, emitted oracle | `A:System.Int32`, `B:System.String` |
| unfixed main, interactive `SessionEngine` | `A:System.Object`, `B:System.String` |
| fixed, emitted oracle | `A:System.Int32`, `B:System.String`; then `A:System.Boolean`, `B:System.String` |
| fixed, interactive `SessionEngine` | byte-for-byte equal to fixed emitted oracle |

Both fixed instantiations print `G:2`, proving nested generated CLR type reifies enclosing plus own generic parameters. Emitted assembly executed successfully and `dotnet-ilverify` reported all classes and methods verified.

## Regression and mutation proof

- Regression test applied alone to unfixed main: RED (`System.Object` versus emitted `System.Int32`/`System.Boolean`). Restored to porcelain-clean production and rebuilt.
- Struct-resolution condition inversion: regression RED.
- runtime-argument-helper empty-condition inversion: regression RED.
- resolved cache-key condition inversion: regression RED.
- Each product mutant produced non-empty `git diff`, moved `GSharp.Core.dll` md5, and restoration round-tripped exact original md5.

Dying test for every hunk: `OpenEnclosingFunctionTypeArgument_MatchesEmittedFieldTypes`.

## Scope guard

#3151-pinned fallback branches are byte-identical to base:

- nullable: `857092da3f3f790eb06159032e84b8af`
- imported: `4f6128304ba2c728bbccca634eb7947e`
- slice: `e811588118b77a8aaec33d244571a6c2`
- array: `0952a3151d25f83064d6fc39752096ba`

## Validation

- Debug solution build: 0 warnings, 0 errors
- Release solution build: 0 warnings, 0 errors
- reification matrix: 17/17 passed
- all 9 solution test projects, unfiltered: 15,455 passed, 5 skipped, 0 failed
  - Compiler 4,263
  - Core 7,135 passed, 1 skipped
  - Interpreter 1,485 passed, 4 skipped
  - Extensions 104
  - InternalAnalyzers 9
  - LanguageServer 462
  - SDK 59
  - Cs2Gs 1,907
  - GeneratorHost 31
- final-base Core rerun: 7,135 passed, 1 skipped
- final-base Interpreter rerun: 1,485 passed, 4 skipped
- `git merge-tree`: no conflict markers
