### PR TITLE
Emit top-level statement-level awaits and branching trailing-value capture

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -2743,6 +2743,18 @@ public sealed class Binder
             // belong to the entry point — fall through to recurse.
         }
 
+        if (node is AwaitForRangeStatementSyntax or AwaitUsingStatementSyntax)
+        {
+            // Issue #3214: the statement-level await forms (`await for … { }`
+            // and `await using …`) carry their `await` as a keyword token on
+            // the statement syntax — there is no AwaitExpressionSyntax child
+            // to find. They make the synthesized entry point async exactly
+            // like an expression-level `await`; the async state-machine
+            // lowering handles the rest. Fall through to recurse: their
+            // bodies may contain returns/awaits of their own.
+            awaitFound = true;
+        }
+
         if (node is ReturnStatementSyntax ret)
         {
             if (ret.Expression == null)

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -1247,6 +1247,24 @@ public sealed class Binder
                         resultVariable,
                         new BoundVariableExpression(trailing.Syntax, trailingDeclaration.Variable)));
                 }
+                else if (TryInferTrailingCaptureType(trailing, out var trailingBranchType))
+                {
+                    // Issue #3227: the trailing statement is a value-producing
+                    // branching form — a trailing `if`/`if let` statement whose
+                    // arms all end in a value, a bare block, or an exhaustive
+                    // switch statement. The evaluator's LastValue echoed the
+                    // taken arm's tail value; capture statically by rewriting
+                    // every tail into an assignment of the synthesized
+                    // `<Result>$` global (the static field exists purely by
+                    // virtue of the GlobalVariableSymbol declaration — every
+                    // arm assigns it, so no separate initializer is needed).
+                    resultVariable = new GlobalVariableSymbol(
+                        SubmissionImports.ResultFieldName,
+                        isReadOnly: false,
+                        trailingBranchType,
+                        Accessibility.Public);
+                    statements[statements.Count - 1] = RewriteTrailingCapture(trailing, resultVariable);
+                }
 
                 if (resultVariable != null)
                 {
@@ -1374,6 +1392,131 @@ public sealed class Binder
             && type != TypeSymbol.Void
             && type != TypeSymbol.Error
             && !TypeSymbol.IsByRefLike(type);
+
+    /// <summary>
+    /// Issue #3227: determines whether a trailing branching statement — a
+    /// value-producing <c>if</c>/<c>if let</c> statement, a bare block, or an
+    /// exhaustive <c>switch</c> statement — has a statically capturable tail
+    /// value on every path, mirroring the shapes for which the retired
+    /// evaluator's LastValue produced the taken arm's tail value. Succeeds
+    /// only when every leaf tail is an expression statement (or variable
+    /// declaration) of one identical, capturable type: an <c>if</c> without
+    /// an <c>else</c>, an empty block, mixed arm types, or a non-value tail
+    /// on any path all decline the capture (no echo), exactly like the
+    /// historical single-statement shapes declined non-capturable values.
+    /// </summary>
+    private static bool TryInferTrailingCaptureType(BoundStatement statement, out TypeSymbol type)
+    {
+        switch (statement)
+        {
+            case BoundExpressionStatement expressionStatement:
+                type = expressionStatement.Expression.Type;
+                return IsCapturableEchoType(type);
+
+            case BoundVariableDeclaration declaration
+                when declaration.Initializer is not BoundAddressOfExpression:
+                type = declaration.Variable.Type;
+                return IsCapturableEchoType(type);
+
+            case BoundBlockStatement block when block.Statements.Length > 0:
+                return TryInferTrailingCaptureType(block.Statements[block.Statements.Length - 1], out type);
+
+            case BoundIfStatement ifStatement when ifStatement.ElseStatement != null:
+                if (TryInferTrailingCaptureType(ifStatement.ThenStatement, out var thenType)
+                    && TryInferTrailingCaptureType(ifStatement.ElseStatement, out var elseType)
+                    && thenType == elseType)
+                {
+                    type = thenType;
+                    return true;
+                }
+
+                type = null;
+                return false;
+
+            case BoundPatternSwitchStatement switchStatement
+                when switchStatement.Arms.Length > 0
+                    && (switchStatement.IsExhaustive || switchStatement.Arms.Any(a => a.IsDefault && a.Guard == null)):
+                TypeSymbol common = null;
+                foreach (var arm in switchStatement.Arms)
+                {
+                    if (!TryInferTrailingCaptureType(arm.Body, out var armType)
+                        || (common != null && armType != common))
+                    {
+                        type = null;
+                        return false;
+                    }
+
+                    common = armType;
+                }
+
+                type = common;
+                return type != null;
+
+            default:
+                type = null;
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// Issue #3227: rewrites the tails accepted by
+    /// <see cref="TryInferTrailingCaptureType"/> so every leaf tail stores
+    /// its value into the synthesized <c>&lt;Result&gt;$</c> global. Leaf
+    /// expression statements become assignments to the global; leaf variable
+    /// declarations keep the declaration and append the echo assignment
+    /// (matching the historical trailing-declaration echo).
+    /// </summary>
+    private static BoundStatement RewriteTrailingCapture(BoundStatement statement, GlobalVariableSymbol resultVariable)
+    {
+        switch (statement)
+        {
+            case BoundExpressionStatement expressionStatement:
+                return new BoundExpressionStatement(
+                    statement.Syntax,
+                    new BoundAssignmentExpression(statement.Syntax, resultVariable, expressionStatement.Expression));
+
+            case BoundVariableDeclaration declaration:
+                return new BoundBlockStatement(
+                    statement.Syntax,
+                    ImmutableArray.Create<BoundStatement>(
+                        declaration,
+                        new BoundExpressionStatement(
+                            statement.Syntax,
+                            new BoundAssignmentExpression(
+                                statement.Syntax,
+                                resultVariable,
+                                new BoundVariableExpression(statement.Syntax, declaration.Variable)))));
+
+            case BoundBlockStatement block:
+                return new BoundBlockStatement(
+                    block.Syntax,
+                    block.Statements.SetItem(
+                        block.Statements.Length - 1,
+                        RewriteTrailingCapture(block.Statements[block.Statements.Length - 1], resultVariable)));
+
+            case BoundIfStatement ifStatement:
+                return new BoundIfStatement(
+                    ifStatement.Syntax,
+                    ifStatement.Condition,
+                    RewriteTrailingCapture(ifStatement.ThenStatement, resultVariable),
+                    RewriteTrailingCapture(ifStatement.ElseStatement, resultVariable));
+
+            case BoundPatternSwitchStatement switchStatement:
+                return new BoundPatternSwitchStatement(
+                    switchStatement.Syntax,
+                    switchStatement.Discriminant,
+                    switchStatement.Arms.Select(a => new BoundPatternSwitchArm(
+                        a.Syntax,
+                        a.Pattern,
+                        a.Guard,
+                        RewriteTrailingCapture(a.Body, resultVariable))).ToImmutableArray(),
+                    switchStatement.IsExhaustive);
+
+            default:
+                throw new InvalidOperationException(
+                    $"Unexpected trailing-capture statement kind '{statement.Kind}'.");
+        }
+    }
 
     /// <summary>
     /// Produces a bound program from the specified global scope.

--- a/test/Compiler.Tests/Emit/Issue3214TopLevelAwaitForEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3214TopLevelAwaitForEmitTests.cs
@@ -1,0 +1,204 @@
+// <copyright file="Issue3214TopLevelAwaitForEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #3214 — a statement-level top-level await (<c>await for … { }</c>,
+/// <c>await using …</c>) carries its <c>await</c> as a keyword on the
+/// statement syntax, so the ADR-0066 D3 pre-scan that flags the synthesized
+/// <c>&lt;Main&gt;$</c> as async never saw it: the entry point stayed
+/// synchronous and emit failed with GS9998 ("AwaitExpression is not yet
+/// supported by the emitter") once the await-for lowering introduced its
+/// <c>MoveNextAsync</c> awaits. The pre-scan now recognizes the statement
+/// forms, and the existing #1904 async-entry machinery (state-machine
+/// lowering plus the synchronous kickoff drive) does the rest. These facts
+/// run the real <c>gsc</c>-compiled process — the file-mode surface.
+/// Each fact uses a UNIQUE package name because the in-process
+/// <c>FunctionTypeSymbol</c> cache is name-keyed (see Issue1502 emit tests).
+/// </summary>
+public class Issue3214TopLevelAwaitForEmitTests
+{
+    [Fact]
+    public void TopLevelAwaitFor_DrainsAsyncEnumerable_AndExitsZero()
+    {
+        const string source = """
+            package i3214awaitfor
+            import System
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            async func Counts() IAsyncEnumerable[int32] {
+                yield 1
+                await Task.Yield()
+                yield 2
+                await Task.Yield()
+                yield 3
+            }
+
+            var total = 0
+            await for v in Counts() {
+                total = total + v
+            }
+            Console.WriteLine(total)
+            """;
+
+        var output = CompileAndRun(source, expectedExitCode: 0);
+        Assert.Equal("6\n", output);
+    }
+
+    [Fact]
+    public void TopLevelAwaitFor_ReturnValue_BecomesProcessExitCode()
+    {
+        const string source = """
+            package i3214awaitforexit
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            async func Counts() IAsyncEnumerable[int32] {
+                yield 20
+                await Task.Yield()
+                yield 22
+            }
+
+            var total = 0
+            await for v in Counts() {
+                total = total + v
+            }
+            return total
+            """;
+
+        CompileAndRun(source, expectedExitCode: 42);
+    }
+
+    [Fact]
+    public void TopLevelAwaitUsing_DisposesAsynchronously()
+    {
+        const string source = """
+            package i3214awaitusing
+            import System
+            import System.Threading.Tasks
+
+            class Resource : IAsyncDisposable {
+                func DisposeAsync() ValueTask {
+                    Console.WriteLine("disposed")
+                    return ValueTask.CompletedTask
+                }
+            }
+
+            {
+                await using let r = Resource{}
+                Console.WriteLine("body")
+            }
+            Console.WriteLine("after")
+            """;
+
+        var output = CompileAndRun(source, expectedExitCode: 0);
+        Assert.Equal("body\ndisposed\nafter\n", output);
+    }
+
+    /// <summary>
+    /// Copied verbatim from <c>Issue1904AsyncEntryPointEmitTests.CompileAndRun</c>
+    /// (test/Compiler.Tests/Emit/Issue1904AsyncEntryPointEmitTests.cs): compiles
+    /// with the real gsc driver, ilverifies, and runs the produced executable
+    /// out-of-process so the CLR's entry-point signature validation is part of
+    /// the assertion surface.
+    /// </summary>
+    private static string CompileAndRun(string source, int expectedExitCode)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_3214_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == expectedExitCode,
+                $"expected exit {expectedExitCode}, got {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/AwaitForRangeStatementTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/AwaitForRangeStatementTests.cs
@@ -33,9 +33,7 @@ await for v in AsyncStreamFixture.Counts() {
 }
 total
 ";
-        // ADR-0156 Phase 3b (#3176): stays on Compilation.Evaluate —
-        // #3214 tracks top-level 'await' support in the emitter.
-        var result = EvaluateWithEvaluator(source);
+        var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
         Assert.Equal(1 + 2 + 3, result.Value);
     }
@@ -59,9 +57,7 @@ await for v in AsyncStreamFixture.Counts().ConfigureAwait(false) {
 }
 total
 ";
-        // ADR-0156 Phase 3b (#3176): stays on Compilation.Evaluate —
-        // #3214 tracks top-level 'await' support in the emitter.
-        var result = EvaluateWithEvaluator(source);
+        var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
         Assert.Equal(1 + 2 + 3, result.Value);
     }
@@ -90,9 +86,7 @@ import GSharp.Core.Tests.CodeAnalysis.Binding
 await for v in AsyncStreamFixture.Empty() {
 }
 ";
-        // ADR-0156 Phase 3b (#3176): stays on Compilation.Evaluate —
-        // #3214 tracks top-level 'await' support in the emitter.
-        var result = EvaluateWithEvaluator(source);
+        var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
     }
 
@@ -113,9 +107,7 @@ await for v in AsyncStreamFixture.Counts() {
 }
 evens
 ";
-        // ADR-0156 Phase 3b (#3176): stays on Compilation.Evaluate —
-        // #3214 tracks top-level 'await' support in the emitter.
-        var result = EvaluateWithEvaluator(source);
+        var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
         Assert.Equal(1, result.Value);
     }
@@ -123,16 +115,6 @@ evens
     private static EmittedOracleResult Evaluate(string source)
     {
         return EmittedOracle.Evaluate(source);
-    }
-
-    // Evaluator-pinned twin of Evaluate for the #3214 tests above; delete
-    // with the evaluator (ADR-0156 Phase 3c) or when #3214 aligns the
-    // engines.
-    private static EvaluationResult EvaluateWithEvaluator(string source)
-    {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
     }
 }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/ForInStatementTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ForInStatementTests.cs
@@ -157,9 +157,7 @@ await for v in AsyncStreamFixture.Counts() {
 }
 total
 ";
-        // ADR-0156 Phase 3b (#3176): stays on Compilation.Evaluate —
-        // #3214 tracks top-level 'await' support in the emitter.
-        var result = EvaluateWithEvaluator(source);
+        var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
         Assert.Equal(6, result.Value);
     }
@@ -192,9 +190,7 @@ await for v in AsyncStreamFixture.Counts() {
 }
 total
 ";
-        // ADR-0156 Phase 3b (#3176): stays on Compilation.Evaluate —
-        // #3214 tracks top-level 'await' support in the emitter.
-        var result = EvaluateWithEvaluator(source);
+        var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
         Assert.Equal(6, result.Value);
     }
@@ -225,16 +221,6 @@ in + 2
     private static EmittedOracleResult Evaluate(string source)
     {
         return EmittedOracle.Evaluate(source);
-    }
-
-    // Evaluator-pinned twin of Evaluate for the #3214 tests above; delete
-    // with the evaluator (ADR-0156 Phase 3c) or when #3214 aligns the
-    // engines.
-    private static EvaluationResult EvaluateWithEvaluator(string source)
-    {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
     }
 }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3214TopLevelAwaitCaptureTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3214TopLevelAwaitCaptureTests.cs
@@ -1,0 +1,90 @@
+// <copyright file="Issue3214TopLevelAwaitCaptureTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #3214 — statement-level awaits (<c>await for</c>, <c>await using</c>)
+/// in top-level statements must make the synthesized entry point async just
+/// like an expression-level <c>await</c> (ADR-0066 D3), so the emitted
+/// submission runs them through the async state-machine lowering instead of
+/// failing with GS9998. Also pins the ADR-0156 Phase 2 <c>&lt;Result&gt;$</c>
+/// capture of an awaited trailing value.
+/// </summary>
+public class Issue3214TopLevelAwaitCaptureTests
+{
+    [Fact]
+    public void TrailingAwaitExpression_ValueCaptured()
+    {
+        var result = EmittedOracle.Evaluate("""
+            import System.Threading.Tasks
+
+            await Task.FromResult(42)
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void AwaitedDeclarationThenTrailingVariable_ValueCaptured()
+    {
+        var result = EmittedOracle.Evaluate("""
+            import System.Threading.Tasks
+
+            let half = await Task.FromResult(21)
+            half * 2
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void TopLevelAwaitUsing_RunsAndDisposesAsynchronously()
+    {
+        var result = EmittedOracle.Evaluate("""
+            import System
+            import System.Threading.Tasks
+
+            class Resource : IAsyncDisposable {
+                func DisposeAsync() ValueTask {
+                    Console.WriteLine("disposed")
+                    return ValueTask.CompletedTask
+                }
+            }
+
+            {
+                await using let r = Resource{}
+                Console.WriteLine("body")
+            }
+            Console.WriteLine("after")
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("body\ndisposed\nafter\n", result.Output.Replace("\r\n", "\n"));
+    }
+
+    [Fact]
+    public void TopLevelAwaitFor_TrailingIf_CapturesBranchValue()
+    {
+        // #3214 x #3227: an async entry point still routes the trailing
+        // branching capture through the state machine.
+        var result = EmittedOracle.Evaluate("""
+            import GSharp.Core.Tests.CodeAnalysis.Binding
+
+            var total = 0
+            await for v in AsyncStreamFixture.Counts() {
+                total = total + v
+            }
+            if total == 6 { "drained" } else { "partial" }
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("drained", result.Value);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3227TrailingCaptureTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3227TrailingCaptureTests.cs
@@ -1,0 +1,200 @@
+// <copyright file="Issue3227TrailingCaptureTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #3227 — the emitted submission's trailing-expression capture must
+/// recognize every statically capturable value-producing trailing form, not
+/// just a plain trailing expression statement or variable declaration. The
+/// retired evaluator's <c>LastValue</c> echoed the taken arm's tail value for
+/// trailing <c>if</c>/<c>if let</c> statements, bare blocks, and switch
+/// statements; the ADR-0156 Phase 2 <c>&lt;Result&gt;$</c> capture now
+/// mirrors those shapes by storing every arm's tail value into the
+/// synthesized global. Forms with no value on some path (an <c>if</c>
+/// without <c>else</c>) or without a single static type across arms decline
+/// the capture and echo nothing, exactly like other non-capturable values.
+/// </summary>
+public class Issue3227TrailingCaptureTests
+{
+    [Fact]
+    public void TrailingIf_ThenBranchTaken_CapturesValue()
+    {
+        // The exact #3227 repro: with `if` a value-producing expression since
+        // #669, the trailing if yields its taken branch's value.
+        var result = EmittedOracle.Evaluate("""
+            let x string? = nil
+            if x == nil { 1 } else { 0 }
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(1, result.Value);
+    }
+
+    [Fact]
+    public void TrailingIf_ElseBranchTaken_CapturesValue()
+    {
+        var result = EmittedOracle.Evaluate("""
+            let x string? = "set"
+            if x == nil { 1 } else { 0 }
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(0, result.Value);
+    }
+
+    [Fact]
+    public void TrailingIfElseIfChain_CapturesTakenArmValue()
+    {
+        var result = EmittedOracle.Evaluate("""
+            let n = 2
+            if n == 1 { 10 } else if n == 2 { 20 } else { 30 }
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(20, result.Value);
+    }
+
+    [Fact]
+    public void TrailingNestedIf_CapturesInnerArmValue()
+    {
+        var result = EmittedOracle.Evaluate("""
+            let a = true
+            let b = false
+            if a { if b { 1 } else { 2 } } else { 3 }
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(2, result.Value);
+    }
+
+    [Fact]
+    public void TrailingIf_ArmsEndingInDeclarations_CapturesDeclaredValue()
+    {
+        // The evaluator's LastValue treated a variable declaration's
+        // initialized value as the statement's value; arm tails do the same.
+        var result = EmittedOracle.Evaluate("""
+            let flag = true
+            if flag { let y = 41 + 1 } else { let z = 0 }
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void TrailingIf_StringArms_CapturesReferenceTypedValue()
+    {
+        var result = EmittedOracle.Evaluate("""
+            let n = 7
+            if n > 5 { "big" } else { "small" }
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("big", result.Value);
+    }
+
+    [Fact]
+    public void TrailingBareBlock_CapturesTailValue()
+    {
+        var result = EmittedOracle.Evaluate("""
+            let n = 40
+            {
+                n + 2
+            }
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void TrailingSwitchStatement_WithDefault_CapturesTakenArmValue()
+    {
+        var result = EmittedOracle.Evaluate("""
+            let n = 2
+            switch n {
+            case 1 { 10 }
+            case 2 { 20 }
+            default { 30 }
+            }
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(20, result.Value);
+    }
+
+    [Fact]
+    public void TrailingSwitchStatement_DefaultArmTaken_CapturesValue()
+    {
+        var result = EmittedOracle.Evaluate("""
+            let n = 9
+            switch n {
+            case 1 { 10 }
+            default { 30 }
+            }
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(30, result.Value);
+    }
+
+    [Fact]
+    public void TrailingIfLetStatement_WithElse_CapturesTakenArmValue()
+    {
+        // ADR-0071 statement `if let` binds to a synthesized block ending in
+        // the guard if — the capture recurses through the composition.
+        var result = EmittedOracle.Evaluate("""
+            let x int32? = 21
+            if let y = x { y * 2 } else { 0 }
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void TrailingIfLetStatement_ElseTaken_CapturesElseValue()
+    {
+        var result = EmittedOracle.Evaluate("""
+            let x int32? = nil
+            if let y = x { y * 2 } else { -1 }
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(-1, result.Value);
+    }
+
+    [Fact]
+    public void TrailingIf_WithoutElse_DeclinesCapture()
+    {
+        // No value on the false path — not statically capturable; the
+        // submission echoes nothing (Value null), like other non-capturable
+        // trailing statements.
+        var result = EmittedOracle.Evaluate("""
+            let flag = true
+            if flag { 1 }
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.Value);
+    }
+
+    [Fact]
+    public void TrailingIf_MixedArmTypes_DeclinesCapture()
+    {
+        // A statement if does not unify arm types; without one static type
+        // there is no `<Result>$` field type, so the capture declines.
+        var result = EmittedOracle.Evaluate("""
+            let flag = true
+            if flag { 1 } else { "other" }
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.Value);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue721NullIdentifierDiagnosticTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue721NullIdentifierDiagnosticTests.cs
@@ -169,10 +169,7 @@ public class Issue721NullIdentifierDiagnosticTests
     {
         // Sanity guard: the changes for #721 must not regress the
         // canonical `nil` spelling.
-        // ADR-0156 Phase 3b (#3176): stays on Compilation.Evaluate —
-        // #3227 tracks trailing if-expression value capture in the emitted
-        // submission (<Result>$ stays null).
-        var result = EvaluateWithEvaluator("""
+        var result = Evaluate("""
             let x string? = nil
             if x == nil { 1 } else { 0 }
             """);
@@ -189,15 +186,5 @@ public class Issue721NullIdentifierDiagnosticTests
     private static EmittedOracleResult Evaluate(string source)
     {
         return EmittedOracle.Evaluate(source);
-    }
-
-    // Evaluator-pinned twin of Evaluate for the #3227 tests above; delete
-    // with the evaluator (ADR-0156 Phase 3c) or when #3227 aligns the
-    // engines.
-    private static EvaluationResult EvaluateWithEvaluator(string source)
-    {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
     }
 }

--- a/test/Interpreter.Tests/EmittedProgramHostTests.cs
+++ b/test/Interpreter.Tests/EmittedProgramHostTests.cs
@@ -59,6 +59,40 @@ public class EmittedProgramHostTests
     }
 
     [Fact]
+    public void TopLevelAwaitFor_DrainsAsyncEnumerable_TotalBecomesExitCode()
+    {
+        // Issue #3214: the statement-level `await for` form makes the
+        // synthesized entry point async (ADR-0066 D3); the #1904 kickoff
+        // drive keeps the CLR entry signature synchronous, so the gsi
+        // file-mode host runs it like any other program.
+        var (result, stdout, _) = Run("""
+            import System
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            async func Counts() IAsyncEnumerable[int32] {
+                yield 1
+                await Task.Yield()
+                yield 2
+                await Task.Yield()
+                yield 3
+            }
+
+            var total = 0
+            await for v in Counts() {
+                total = total + v
+            }
+            Console.WriteLine(total)
+            return total
+            """);
+
+        Assert.True(result.Success);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(6, result.ExitCode);
+        Assert.Equal("6\n", stdout);
+    }
+
+    [Fact]
     public void VoidProgram_ExitsZero()
     {
         var (result, stdout, _) = Run("""

--- a/test/Interpreter.Tests/EmittedSessionEngineTests.cs
+++ b/test/Interpreter.Tests/EmittedSessionEngineTests.cs
@@ -742,4 +742,16 @@ public sealed class EmittedSessionEngineTests : IDisposable
         Assert.Contains(state.Types, t => t.Display.Contains("Point", StringComparison.Ordinal));
         Assert.DoesNotContain(state.Variables, v => v.Display.Contains("<Result>$", StringComparison.Ordinal));
     }
+
+    [Fact]
+    public void TrailingIfCell_EchoesTakenBranchValue()
+    {
+        // Issue #3227: a trailing value-producing `if` statement in a cell
+        // echoes the taken branch's value through `<Result>$`.
+        Assert.False(engine.Evaluate("let x string? = nil").HasError);
+
+        var cell = engine.Evaluate("if x == nil { 1 } else { 0 }");
+        Assert.False(cell.HasError);
+        Assert.Equal(1, cell.Value);
+    }
 }

--- a/test/Interpreter.Tests/EmittedSessionEngineTests.cs
+++ b/test/Interpreter.Tests/EmittedSessionEngineTests.cs
@@ -744,6 +744,51 @@ public sealed class EmittedSessionEngineTests : IDisposable
     }
 
     [Fact]
+    public void TopLevelAwaitCell_EchoesAwaitedValue()
+    {
+        // Issue #3214: a top-level `await` in an interactive cell makes the
+        // cell's synthesized entry point async; the awaited trailing value
+        // still lands in `<Result>$` for the echo.
+        var cell = engine.Evaluate("""
+            import System.Threading.Tasks
+            await Task.FromResult(42)
+            """);
+
+        Assert.False(cell.HasError);
+        Assert.Equal(42, cell.Value);
+    }
+
+    [Fact]
+    public void AwaitForCell_DrainsAsyncIteratorFromEarlierCell()
+    {
+        // Issue #3214: the statement-level `await for` form in a cell, over
+        // an async iterator declared in a PRIOR cell.
+        Assert.False(engine.Evaluate("""
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            async func Counts() IAsyncEnumerable[int32] {
+                yield 1
+                await Task.Yield()
+                yield 2
+                await Task.Yield()
+                yield 3
+            }
+            """).HasError);
+
+        var cell = engine.Evaluate("""
+            var total = 0
+            await for v in Counts() {
+                total = total + v
+            }
+            total
+            """);
+
+        Assert.False(cell.HasError);
+        Assert.Equal(6, cell.Value);
+    }
+
+    [Fact]
     public void TrailingIfCell_EchoesTakenBranchValue()
     {
         // Issue #3227: a trailing value-producing `if` statement in a cell


### PR DESCRIPTION
Fixes #3214. Fixes #3227. Part of #3176 (pre-3c burn-down), part of #3163.

## Summary

- **#3214** — the ADR-0066 D3 pre-scan (`Binder.CollectTopLevelReturnsAndAwaits`) that flags the synthesized `<Main>$` as async only matched `AwaitExpressionSyntax`; `await for` / `await using` carry their `await` as a keyword token on the statement syntax, so the entry point stayed synchronous and emit died with GS9998 once the await-for lowering introduced its `MoveNextAsync` awaits. The pre-scan now recognizes the two statement forms. **No new synthesis was needed**: `FunctionSymbol.IsAsync` already routes the entry body through the ADR-0023 state-machine rewriter, and the #1904 kickoff drives the task synchronously when the kickoff is the CLR entry point, keeping the void/int32 signature. Since gsc file mode, gsi file mode (`EmittedProgramHost`), and interactive cells (`EmittedSessionEngine`/`InteractiveSessionHost`) all run the same synthesized entry via `assembly.EntryPoint`, one binder change covers **all three surfaces** — each has dedicated new coverage, including `<Result>$` capture of an awaited trailing value.
- **#3227** — the ADR-0156 Phase 2 trailing-value capture only recognized a trailing expression statement / variable declaration. New `TryInferTrailingCaptureType` + `RewriteTrailingCapture` (Binder.cs) recurse through block / `if`-with-`else` / exhaustive-or-defaulted switch compositions (statement `if let` arrives as such a composition), require one identical capturable type on every tail, and rewrite each tail into a store of the synthesized `<Result>$` global (the static field exists from the symbol declaration; every arm assigns it). Shapes without a value on some path (`if` without `else`, mixed arm types) decline the capture — no echo, matching the historical non-capturable protocol.
- Unpins all 7 Phase 3b.1 pinned witnesses (6× #3214 in `AwaitForRangeStatementTests`/`ForInStatementTests`, 1× #3227 in `Issue721NullIdentifierDiagnosticTests`) to the EmittedOracle and deletes the `EvaluateWithEvaluator` twins. Evaluator untouched.

## Verification

- Release builds: Core, Core.Tests, Compiler.Tests, Interpreter.Tests — 0 warnings / 0 errors.
- ADR-0154 witness: with the two Binder hunks reverted to origin/main, the new+unpinned tests fail 17/22 (GS9998 for the #3214 set, null `<Result>$` for the #3227 matrix); with the fix, 22/22 pass.
- Core.Tests full: 7152 passed, 1 skipped (pre-existing `RegenerateBaseline` skip), 0 failed.
- Interpreter.Tests full (interactive cells + parity suites): 1488 passed, 4 skipped (pre-existing), 0 failed.
- Compiler.Tests `Async|EntryPoint` filter: 268 passed. New `Issue3214TopLevelAwaitForEmitTests` (real gsc → ilverify → out-of-proc run): 3 passed.
- Compiler.Tests LanguageConformance: **126/126**. No aspirational/gated sample exists for top-level await (`samples/aspirational/` holds only a README), so nothing to un-gate; a new sample would grow the suite past 126 and was left for a follow-up.
- NOT RUN: full Compiler.Tests outside the filters above (async/entry/conformance surfaces covered; suite is long), LanguageServer.Tests, Sdk.Tests, Extensions.Tests, InternalAnalyzers.Tests, Cs2Gs.Tests (pre-existing non-deterministic host crash; no cs2gs surface touched) — no code in those surfaces changed.

## Checklist

- [x] Behavioral tests carry a witness of discrimination (ADR-0154): reverted-hunk run above (17 RED pre-change, all green post-change).
- [x] Self-review verdict recorded: **MERGEABLE** — no residuals; the declined-capture shapes (elseless `if`, mixed arm types, multi-binding `if let` flag composition) are deliberate no-echo semantics, not gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)