### PR TITLE
Fix the 3b.1 metadata/signature emit cluster: byref top-level vars, nullable projection targets, override-accessor Final flags

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -560,10 +560,21 @@ public sealed class Conversion
             // so numeric nullable lifting (e.g. int32 → int64?) is unaffected.
             if (IsReferenceLikeTarget(toNullable.UnderlyingType))
             {
-                var underlyingConversion = Classify(from, toNullable.UnderlyingType);
+                // Issue #3218: honor the caller's structural-projection
+                // eligibility and PRESERVE the projection classification when
+                // the underlying `T → U` conversion is one. Returning a plain
+                // Implicit here erased the IsStructuralProjection flag, so
+                // BindConversion skipped the ADR-0148 bind-time lowering and
+                // emitted a raw BoundConversionExpression the emitter has no
+                // arm for (NotSupportedException at emit for e.g.
+                // `Source → System.Uri?`). ClassifyNonStructural callers now
+                // also stop classifying a projection-only pair as implicit.
+                var underlyingConversion = ClassifyCore(from, toNullable.UnderlyingType, allowStructuralProjection);
                 if (underlyingConversion.Exists && underlyingConversion.IsImplicit)
                 {
-                    return Conversion.Implicit;
+                    return underlyingConversion.IsStructuralProjection
+                        ? Conversion.StructuralProjection
+                        : Conversion.Implicit;
                 }
             }
         }

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -630,13 +630,27 @@ internal sealed class ConversionClassifier
                 return new BoundClrConversionCallExpression(null, expression, projectionConvMethod, type);
             }
 
-            return BindStructuralProjectionCore(
+            // Issue #3218: a nullable annotation over a reference-like target
+            // (e.g. an imported method's `System.Uri?` parameter) is
+            // metadata-only — the projection constructs the bare underlying
+            // type, and the `T → T?` widening is a representation-preserving
+            // no-op both engines already lower. The planner itself only
+            // understands concrete targets, so unwrap before planning and
+            // re-wrap the projected value to keep the bound tree's type honest.
+            var projectionTargetType = type is NullableTypeSymbol projectionNullableTarget
+                && Conversion.IsReferenceLikeTarget(projectionNullableTarget.UnderlyingType)
+                ? projectionNullableTarget.UnderlyingType
+                : type;
+            var projected = BindStructuralProjectionCore(
                 diagnosticLocation,
                 expression,
-                type,
+                projectionTargetType,
                 strict: true,
                 explicitValues: null,
                 explicitOrder: default);
+            return ReferenceEquals(projectionTargetType, type) || projected is BoundErrorExpression
+                ? projected
+                : new BoundConversionExpression(null, type, projected);
         }
 
         // Issue #367: a by-ref-like (`ref struct`) value boxes when converted to

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
@@ -1652,6 +1652,18 @@ internal sealed partial class DeclarationBinder
 
                     if (hasGetter && getAccessor?.Body != null)
                     {
+                        // Issue #3223: a property override is itself overridable —
+                        // the override-validation rule above accepts a base
+                        // property that is `IsVirtual || IsOverride` — so the
+                        // accessor symbol must be open whenever the property is
+                        // `open` OR `override`. Leaving an override accessor
+                        // closed made FunctionEmitter stamp it `Final`, and a
+                        // grandchild override of that slot produced an
+                        // unloadable type (TypeLoadException: "Declaration
+                        // referenced in a method implementation cannot be a
+                        // final method"). Mirrors the auto-property fallback
+                        // path in MemberDefEmitter, which never adds Final to
+                        // an override accessor.
                         var getterSymbol = new FunctionSymbol(
                             $"get_{propName}",
                             isIndexer ? indexerParameters : ImmutableArray<ParameterSymbol>.Empty,
@@ -1660,7 +1672,7 @@ internal sealed partial class DeclarationBinder
                             package,
                             getterAccessibility,
                             receiverType: structSymbol,
-                            isOpen: isVirtual,
+                            isOpen: isVirtual || isOverride,
                             isOverride: isOverride);
 
                         // ADR-0118: indexer accessors are emitted as SpecialName
@@ -1677,6 +1689,10 @@ internal sealed partial class DeclarationBinder
                         var setterParameters = isIndexer
                             ? indexerParameters.Add(setterParam)
                             : ImmutableArray.Create(setterParam);
+
+                        // Issue #3223: see the matching comment on the getter —
+                        // an override property's accessor stays open so a
+                        // further override can reuse its (non-Final) slot.
                         var setterSymbol = new FunctionSymbol(
                             $"set_{propName}",
                             setterParameters,
@@ -1685,7 +1701,7 @@ internal sealed partial class DeclarationBinder
                             package,
                             setterAccessibility,
                             receiverType: structSymbol,
-                            isOpen: isVirtual,
+                            isOpen: isVirtual || isOverride,
                             isOverride: isOverride);
                         setterSymbol.IsSpecialName = isIndexer;
                         setterSymbol.IsInitOnlySetter = isInitOnly;
@@ -1872,7 +1888,14 @@ internal sealed partial class DeclarationBinder
                     }
                 }
 
-                // Create add/remove method symbols
+                // Create add/remove method symbols.
+                // Issue #3223: like a property override, an event override is
+                // itself overridable (the override-validation rule above
+                // accepts a base event that is `IsVirtual || IsOverride`), so
+                // accessor symbols must be open whenever the event is `open`
+                // OR `override` — otherwise FunctionEmitter stamps the
+                // computed accessor `Final` and a grandchild override produces
+                // an unloadable type.
                 var handlerParam = new ParameterSymbol("value", handlerType);
                 eventSymbol.AddMethodSymbol = new FunctionSymbol(
                     $"add_{eventName}",
@@ -1882,7 +1905,7 @@ internal sealed partial class DeclarationBinder
                     package,
                     eventAccessibility,
                     receiverType: structSymbol,
-                    isOpen: isVirtual,
+                    isOpen: isVirtual || isOverride,
                     isOverride: isOverride)
                 {
                     IsSpecialName = true,
@@ -1896,7 +1919,7 @@ internal sealed partial class DeclarationBinder
                     package,
                     eventAccessibility,
                     receiverType: structSymbol,
-                    isOpen: isVirtual,
+                    isOpen: isVirtual || isOverride,
                     isOverride: isOverride)
                 {
                     IsSpecialName = true,
@@ -1926,7 +1949,7 @@ internal sealed partial class DeclarationBinder
                         package,
                         eventAccessibility,
                         receiverType: structSymbol,
-                        isOpen: isVirtual,
+                        isOpen: isVirtual || isOverride,
                         isOverride: isOverride)
                     {
                         IsSpecialName = true,

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -1268,6 +1268,23 @@ internal sealed partial class ExpressionBinder
                     return null;
                 }
 
+                // Issue #3215: a top-level `var p = &x` holds a managed pointer
+                // (`*T`). ECMA-335 forbids a byref field signature, so such a
+                // variable can never be hoisted to a static field — it lives
+                // only as a local slot of the synthesized entry point (see the
+                // matching PlanFieldRows carve-out). A declared function or
+                // method body therefore has no storage to reach it through;
+                // reject the reference with the byref-escape diagnostic instead
+                // of failing deep inside emit.
+                if (variable is GlobalVariableSymbol && variable.Type is ByRefTypeSymbol
+                    && this.function is { IsTopLevelEntryPoint: false })
+                {
+                    Diagnostics.ReportByRefCannotEscape(
+                        location,
+                        $"the top-level pointer variable '{name}' cannot be referenced from a function body; a managed pointer (*T) cannot be stored in a global field");
+                    return null;
+                }
+
                 reportObsoleteUseIfApplicable(location, variable, variable.Name);
                 return variable;
 

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -1738,6 +1738,20 @@ internal sealed class ReflectionMetadataEmitter
         // after these globals so SM field rows remain strictly greater than
         // <Program>'s fieldList pointer.
         var globals = this.emitCtx.Program.Globals;
+
+        // Issue #3215: a top-level `var p = &x` binds `p` as a global whose
+        // type is a managed pointer (`*T`, ByRefTypeSymbol). ECMA-335 §II.14.4.2
+        // forbids ELEMENT_TYPE_BYREF in a field signature, so such a variable
+        // cannot be hoisted to a static FieldDef at all — the signature
+        // encoder (correctly) refuses to encode it and the whole emit died
+        // with an ICE. Keep byref-typed globals out of the hoist plan instead:
+        // every consumer (SlotPlanner, MethodBodyPlanner, the member-access
+        // emit paths) already falls back to an ordinary method-local slot when
+        // a GlobalVariableSymbol has no registered FieldDef, and a byref LOCAL
+        // slot is legal IL (EncodeLocalVariableType emits `T&`). The variable
+        // keeps evaluator-identical single-run semantics; it simply is not
+        // observable as a CLR static field (which no legal PE could express).
+        globals = globals.RemoveAll(g => g.Type is ByRefTypeSymbol);
         int programFirstFieldRow = nextFieldRow;
         var globalFieldRows = new Dictionary<GlobalVariableSymbol, int>();
         foreach (var g in globals)

--- a/test/Core.Tests/CodeAnalysis/Binding/ByRefPointerTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ByRefPointerTests.cs
@@ -2,12 +2,6 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
-using System.Collections.Generic;
-using System.Linq;
-using GSharp.Core.CodeAnalysis;
-using GSharp.Core.CodeAnalysis.Binding;
-using GSharp.Core.CodeAnalysis.Compilation;
-using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
 using GSharp.Tests;
@@ -27,9 +21,8 @@ public class ByRefPointerTests
 var x = 42
 var p = &x
 ";
-        // ADR-0156 Phase 3b (#3176): stays on Compilation.Evaluate —
-        // #3215 tracks address-of/pointer signature encoding in the emitter.
-        var result = EvaluateWithEvaluator(source);
+        // #3215: emitted — the byref-typed top-level var stays a local slot.
+        var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
     }
 
@@ -84,11 +77,12 @@ var y = *x
 var x = 42
 var p = &x
 var y = *p
+y
 ";
-        // ADR-0156 Phase 3b (#3176): stays on Compilation.Evaluate —
-        // #3215 tracks address-of/pointer signature encoding in the emitter.
-        var result = EvaluateWithEvaluator(source);
+        // #3215: emitted — dereference through the byref local round-trips.
+        var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
     }
 
     [Fact]
@@ -172,9 +166,8 @@ var ok = Int32.TryParse(""123"", &result)
 var x = 10
 var p = &x
 ";
-        // ADR-0156 Phase 3b (#3176): stays on Compilation.Evaluate —
-        // #3215 tracks address-of/pointer signature encoding in the emitter.
-        var result = EvaluateWithEvaluator(source);
+        // #3215: emitted — same shape as AddressOf_Variable_Binds_Successfully.
+        var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
     }
 
@@ -195,15 +188,5 @@ var y = &x + 1
     private static EmittedOracleResult Evaluate(string source)
     {
         return EmittedOracle.Evaluate(source);
-    }
-
-    // Evaluator-pinned twin of Evaluate for the #3215 tests above; delete
-    // with the evaluator (ADR-0156 Phase 3c) or when #3215 aligns the
-    // engines.
-    private static EvaluationResult EvaluateWithEvaluator(string source)
-    {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1104BasePropertyAccessBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1104BasePropertyAccessBinderTests.cs
@@ -2,12 +2,6 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
-using System.Collections.Generic;
-using GSharp.Core.CodeAnalysis;
-using GSharp.Core.CodeAnalysis.Compilation;
-using GSharp.Core.CodeAnalysis.Symbols;
-using GSharp.Core.CodeAnalysis.Syntax;
-using GSharp.Core.CodeAnalysis.Text;
 using GSharp.Tests;
 using Xunit;
 
@@ -184,9 +178,9 @@ open class Deriv() : Mid {
 var d = Deriv()
 d.RenderSize
 ";
-        // ADR-0156 Phase 3b (#3176): stays on Compilation.Evaluate —
-        // #3223 tracks the unloadable MethodImpl emitted for base[Base].Prop.
-        var result = EvaluateWithEvaluator(source);
+        // #3223: emitted — the override accessors reuse (non-Final) slots, so
+        // the three-level chain loads and `base[Base]` reaches the grandparent.
+        var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
         Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0157");
 
@@ -302,15 +296,5 @@ open class Deriv() : Base {
     private static EmittedOracleResult Evaluate(string source)
     {
         return EmittedOracle.Evaluate(source);
-    }
-
-    // Evaluator-pinned twin of Evaluate for the #3223 test above; delete
-    // with the evaluator (ADR-0156 Phase 3c) or when #3223 aligns the
-    // engines.
-    private static EvaluationResult EvaluateWithEvaluator(string source)
-    {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/StructuralProjectionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/StructuralProjectionTests.cs
@@ -304,9 +304,9 @@ target.Number
     [Fact]
     public void ImportedMethodOverloadAcceptsStructuralProjection()
     {
-        // ADR-0156 Phase 3b (#3176): stays on Compilation.Evaluate —
-        // #3218 tracks the imported-nullable structural-projection emit gap.
-        var result = EvaluateWithEvaluator(@"
+        // #3218: emitted — the projection into the imported `System.Uri?`
+        // parameter lowers at bind time and the nullable wrap is a no-op.
+        var result = Evaluate(@"
 import System.Net.Http
 class Source { var uriString string }
 func Probe(client HttpClient, source Source) {
@@ -565,8 +565,8 @@ Touch(ref source)
         return EmittedOracle.Evaluate(source);
     }
 
-    // Evaluator-pinned twin of Evaluate for the #3218/#3219 tests above; delete
-    // with the evaluator (ADR-0156 Phase 3c) or when #3218/#3219 aligns the
+    // Evaluator-pinned twin of Evaluate for the #3219 tests above; delete
+    // with the evaluator (ADR-0156 Phase 3c) or when #3219 aligns the
     // engines.
     private static EvaluationResult EvaluateWithEvaluator(string source)
     {

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue3215ByRefGlobalEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue3215ByRefGlobalEmitTests.cs
@@ -1,0 +1,126 @@
+// <copyright file="Issue3215ByRefGlobalEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #3215: taking the address of a top-level variable (`var p = &amp;x`)
+/// used to crash the emitter with an internal signature-encoding exception
+/// ("Cannot encode '*int32' as a non-byref signature slot"), because the
+/// submission machinery hoisted the byref-typed (`*T`) variable to a static
+/// FieldDef — a signature ECMA-335 §II.14.4.2 forbids. The fix keeps
+/// byref-typed top-level variables as entry-point local slots (byref LOCALS
+/// are legal IL) while every other top-level variable still hoists, and turns
+/// the genuinely unrepresentable shapes — referencing such a variable from a
+/// declared function or a lambda body, which would require the impossible
+/// static field — into the GS9004 byref-escape diagnostic instead of an ICE.
+/// </summary>
+public class Issue3215ByRefGlobalEmitTests
+{
+    [Fact]
+    public void AddressOfTopLevelVariable_EmitsAndRoundTripsThroughDereference()
+    {
+        // The issue's exact repro, executed emitted, with the dereferenced
+        // value observed so the pointer round-trip is the assertion.
+        var result = EmittedOracle.Evaluate(@"
+var x = 42
+var p = &x
+var y = *p
+y
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void WriteThroughTopLevelPointer_MutatesThePointeeVariable()
+    {
+        // The discriminating direction: `*p = 100` must write through the
+        // managed pointer into `x`'s storage (the hoisted static field the
+        // pointer was taken from), not a detached copy.
+        var result = EmittedOracle.Evaluate(@"
+var x = 42
+var p = &x
+*p = 100
+x
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(100, result.Value);
+    }
+
+    [Fact]
+    public void ByRefTypedTopLevelVariable_IsNotHoistedToAStaticField()
+    {
+        // The metadata contract behind the fix: `x` still hoists to a static
+        // FieldDef on <Program>, while the byref-typed `p` must not appear as
+        // a field at all — no legal field signature can carry
+        // ELEMENT_TYPE_BYREF.
+        var source = @"
+var x = 42
+var p = &x
+var y = *p
+y
+";
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var emitResult = compilation.Emit(peStream);
+        Assert.True(
+            emitResult.Success,
+            "compilation should succeed: " + string.Join("; ", emitResult.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        using var peReader = new PEReader(peStream, PEStreamOptions.LeaveOpen);
+        var md = peReader.GetMetadataReader();
+        var fieldNames = md.FieldDefinitions
+            .Select(md.GetFieldDefinition)
+            .Select(f => md.GetString(f.Name))
+            .ToList();
+
+        Assert.Contains("x", fieldNames);
+        Assert.DoesNotContain("p", fieldNames);
+    }
+
+    [Fact]
+    public void FunctionReferencingByRefTopLevelVariable_ReportsGS9004()
+    {
+        // A declared function body has no storage through which to reach the
+        // entry-point-local pointer (a static byref field cannot exist), so
+        // the reference is a compile-time byref-escape error — never an ICE.
+        var result = EmittedOracle.Evaluate(@"
+var x = 42
+var p = &x
+func f() int32 { return *p }
+f()
+");
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS9004");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS9998");
+    }
+
+    [Fact]
+    public void LambdaReferencingByRefTopLevelVariable_ReportsGS9004()
+    {
+        // Same contract for a function literal: globals are normally read
+        // live from their static fields (never captured), which is exactly
+        // what a byref-typed global cannot provide.
+        var result = EmittedOracle.Evaluate(@"
+var x = 42
+var p = &x
+let f = func() int32 { return *p }
+f()
+");
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS9004");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS9998");
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue3218NullableProjectionTargetEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue3218NullableProjectionTargetEmitTests.cs
@@ -1,0 +1,62 @@
+// <copyright file="Issue3218NullableProjectionTargetEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #3218 / ADR-0148: a structural projection whose target is an
+/// imported nullable class parameter (e.g. <c>System.Uri?</c>) classified as
+/// a plain implicit conversion — the <c>T → U?</c> nullable-wrapping arm of
+/// <c>Conversion.Classify</c> dropped the <c>IsStructuralProjection</c> flag —
+/// so <c>BindConversion</c> skipped the bind-time projection lowering and left
+/// a raw <c>BoundConversionExpression</c> in the tree. The evaluator absorbed
+/// that dynamically, but the emitter (correctly) has no arm for it and threw
+/// <c>NotSupportedException: Conversion from 'Source' to 'System.Uri?' is not
+/// yet supported</c>. The classification now preserves the projection flag and
+/// the lowering projects into the bare underlying reference type (the nullable
+/// wrap is representation-free), so both engines run the ADR-0148 §E lowering.
+/// </summary>
+public class Issue3218NullableProjectionTargetEmitTests
+{
+    [Fact]
+    public void ProjectionIntoImportedNullableCtorParameter_ConstructsTheProjectedValue()
+    {
+        // Executing witness: HttpRequestMessage(HttpMethod, Uri?) is side-
+        // effect-free, so the projected System.Uri (built from `uriString`
+        // through Uri's public ctor — the ADR-0148 construction path) is
+        // observable through the request it lands in. Pre-fix this failed at
+        // emit with the NotSupportedException above.
+        var result = EmittedOracle.Evaluate(@"
+import System
+import System.Net.Http
+class Source { var uriString string }
+let source = Source{uriString: ""https://example.test/probe""}
+let request = HttpRequestMessage(HttpMethod.Get, source)
+request.RequestUri!!.AbsoluteUri
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("https://example.test/probe", result.Value);
+    }
+
+    [Fact]
+    public void ProjectionIntoImportedNullableMethodParameter_BindsAndEmits()
+    {
+        // The issue's exact repro shape (never invoked — GetAsync would do
+        // I/O): overload resolution picks GetAsync(System.Uri?) via the
+        // structural projection and the emitted body must compile.
+        var result = EmittedOracle.Evaluate(@"
+import System.Net.Http
+class Source { var uriString string }
+func Probe(client HttpClient, source Source) {
+    let pending = client.GetAsync(source)
+}
+0
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(0, result.Value);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue3223OverridePropertyFinalFlagTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue3223OverridePropertyFinalFlagTests.cs
@@ -1,0 +1,185 @@
+// <copyright file="Issue3223OverridePropertyFinalFlagTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #3223: a three-level property override chain
+/// (<c>Base.open prop</c> → <c>Mid.override prop</c> → <c>Deriv.override prop</c>)
+/// emitted <c>Mid</c>'s computed accessor as <c>Final</c>, so the loader
+/// rejected <c>Deriv</c>'s implicit override of it
+/// (<c>TypeLoadException: "Declaration referenced in a method implementation
+/// cannot be a final method"</c>) — the type never loaded, regardless of any
+/// <c>base[Base]</c> qualifier in the body. The binder's override rule accepts
+/// a base property that is <c>IsVirtual || IsOverride</c> (property overrides
+/// are re-overridable), so the accessor symbols of an <c>override prop</c>
+/// (and <c>override event</c>) are now open and their MethodDefs carry
+/// <c>Virtual</c> without <c>Final</c>. The assembly-load-and-run tests are
+/// the sharp witness (they died with the TypeLoadException pre-fix); the
+/// metadata test pins the flag contract itself.
+/// </summary>
+public class Issue3223OverridePropertyFinalFlagTests
+{
+    private const string ThreeLevelPropertySource = @"
+open class Base {
+    open prop RenderSize int64 {
+        get { return 10L }
+    }
+}
+
+open class Mid() : Base {
+    override prop RenderSize int64 {
+        get { return 99L }
+    }
+}
+
+open class Deriv() : Mid {
+    override prop RenderSize int64 {
+        get { return base[Base].RenderSize + base.RenderSize }
+    }
+}
+
+var d = Deriv()
+d.RenderSize
+";
+
+    [Fact]
+    public void ThreeLevelOverrideChain_WithBracketedBase_LoadsAndReturns109()
+    {
+        // The issue's exact repro: the emitted assembly must LOAD (this line
+        // threw TypeLoadException pre-fix) and `base[Base].RenderSize` must
+        // reach the grandparent slot non-virtually: 10 + 99 = 109.
+        var result = EmittedOracle.Evaluate(ThreeLevelPropertySource);
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(109L, result.Value);
+    }
+
+    [Fact]
+    public void OverridePropertyAccessor_EmitsVirtualWithoutFinalOrNewSlot()
+    {
+        // The metadata contract: an override accessor reuses the base virtual
+        // slot — Virtual, no NewSlot (it is the same slot), and no Final (the
+        // binder lets any override property be overridden again).
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(ThreeLevelPropertySource));
+        var compilation = new Compilation(tree);
+        var emitResult = compilation.Emit(peStream);
+        Assert.True(
+            emitResult.Success,
+            "compilation should succeed: " + string.Join("; ", emitResult.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        using var peReader = new PEReader(peStream, PEStreamOptions.LeaveOpen);
+        var md = peReader.GetMetadataReader();
+
+        var midGetter = FindMethod(md, "Mid", "get_RenderSize");
+        Assert.True((midGetter & MethodAttributes.Virtual) != 0, "Mid.get_RenderSize must be Virtual");
+        Assert.True((midGetter & MethodAttributes.NewSlot) == 0, "Mid.get_RenderSize must reuse Base's slot (no NewSlot)");
+        Assert.True((midGetter & MethodAttributes.Final) == 0, "Mid.get_RenderSize must not be Final — Deriv overrides it");
+
+        var derivGetter = FindMethod(md, "Deriv", "get_RenderSize");
+        Assert.True((derivGetter & MethodAttributes.Virtual) != 0, "Deriv.get_RenderSize must be Virtual");
+        Assert.True((derivGetter & MethodAttributes.NewSlot) == 0, "Deriv.get_RenderSize must reuse the inherited slot (no NewSlot)");
+        Assert.True((derivGetter & MethodAttributes.Final) == 0, "Deriv.get_RenderSize must not be Final — override props stay overridable");
+    }
+
+    [Fact]
+    public void ThreeLevelOverrideChain_PlainBaseAccess_LoadsAndDispatches()
+    {
+        // Control without the bracketed qualifier — the pre-fix failure was
+        // independent of `base[Base]`; any further-overridden override
+        // accessor produced the unloadable Final declaration.
+        var result = EmittedOracle.Evaluate(@"
+open class Base {
+    open prop Tag int64 {
+        get { return 1L }
+    }
+}
+
+open class Mid() : Base {
+    override prop Tag int64 {
+        get { return 20L }
+    }
+}
+
+open class Deriv() : Mid {
+    override prop Tag int64 {
+        get { return base.Tag + 300L }
+    }
+}
+
+var d = Deriv()
+d.Tag
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.UnhandledException);
+
+        // base.Tag dispatches non-virtually to Mid (20) + 300.
+        Assert.Equal(320L, result.Value);
+    }
+
+    [Fact]
+    public void ThreeLevelOverrideEventChain_LoadsAndDispatchesToLeafAccessor()
+    {
+        // The event-accessor twin of the same root cause: computed accessors
+        // of an `override event` were stamped Final too, so a grandchild
+        // override produced the identical TypeLoadException.
+        var result = EmittedOracle.Evaluate(@"
+import System
+
+open class Base {
+    open event Changed () -> void {
+        add { Console.Write(""BA"") }
+        remove { }
+    }
+}
+
+open class Mid() : Base {
+    override event Changed () -> void {
+        add { Console.Write(""MA"") }
+        remove { }
+    }
+}
+
+open class Deriv() : Mid {
+    override event Changed () -> void {
+        add { Console.Write(""DA"") }
+        remove { }
+    }
+}
+
+var d = Deriv()
+d.Changed += func() {}
+0
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.UnhandledException);
+
+        // Virtual dispatch through the loaded chain lands on Deriv's add.
+        Assert.Equal("DA", result.Output);
+    }
+
+    private static MethodAttributes FindMethod(MetadataReader md, string typeName, string methodName)
+    {
+        var typeDef = md.TypeDefinitions
+            .Select(md.GetTypeDefinition)
+            .Single(t => md.GetString(t.Name) == typeName);
+        var method = typeDef.GetMethods()
+            .Select(md.GetMethodDefinition)
+            .Single(m => md.GetString(m.Name) == methodName);
+        return method.Attributes;
+    }
+}


### PR DESCRIPTION
Fixes #3215. Fixes #3218. Fixes #3223. Part of #3176 (pre-3c burn-down), part of #3163.

## Summary

Three metadata/signature emit bugs surfaced by the Phase 3b.1 oracle migration, one commit each:

| Issue | Root cause | Fix |
| --- | --- | --- |
| #3215 — address-of ICE ("Cannot encode '*int32' as a non-byref signature slot") | Issue #191 hoisting turned **every** top-level var into a static FieldDef; a `var p = &x` global is byref-typed (`*T`), and ECMA-335 §II.14.4.2 forbids ELEMENT_TYPE_BYREF in a field signature — the encoder correctly refused, the pipeline ICE'd | **Emits.** `PlanFieldRows` keeps byref-typed globals out of the hoist plan; they fall back to the (legal) entry-point byref **local slot** every consumer already supports. The unrepresentable shapes — a declared function or lambda referencing such a variable, which would need the impossible static field — now report **GS9004** at bind time instead of an ICE |
| #3218 — projection into imported nullable class parameter (`Source → System.Uri?` → runtime `NotSupportedException`) | The #1121 `T → U?` nullable-wrapping arm of `Conversion.Classify` recursed projection-eligible but collapsed the result to plain `Implicit`, **erasing `IsStructuralProjection`** — so `BindConversion` skipped the ADR-0148 bind-time lowering and left a raw `BoundConversionExpression` the emitter has no arm for (evaluator absorbed it dynamically) | **Emit path implemented by preserving the binder lowering** (per ADR-0148 §G: planner is the single source of truth, no projection-specific emitter path): the arm now propagates `Conversion.StructuralProjection`, and the projection branch unwraps a reference-like nullable target before planning — project to bare `Uri`, then the representation-free `T → T?` no-op wrap. `ClassifyNonStructural` also stops mis-reporting projection-only pairs as implicit |
| #3223 — `base[Base].Prop` chain → `TypeLoadException` "Declaration referenced in a method implementation cannot be a final method" | **Not a MethodImpl row at all** (none is emitted for this shape): computed accessors of an `override prop` were created `isOpen: isVirtual` only, so FunctionEmitter's ADR-0017 table stamped them `Virtual \| Final`; a grandchild override's implicit reuse of a Final slot is what the loader rejects. Independent of the bracketed qualifier; binder semantics (and the evaluator, and the auto-property emit fallback) treat property overrides as re-overridable (`IsVirtual \|\| IsOverride`) | Accessor symbols of `override prop` — and `override event` add/remove/raise, same rule, same reproduced failure — are created open (`isOpen: isVirtual \|\| isOverride`), so accessors emit `Virtual` without `NewSlot`/`Final`, matching the auto-property path and C#'s shape for un-sealed overrides. `base[Base].RenderSize` then lowers (as it already did) to a non-virtual `call` and returns 109 |

Unpinned per the 3b.1 slice convention (slices #3221/#3225/#3228 are on main): the three `ByRefPointerTests` #3215 pins, `Issue1104BasePropertyAccessBinderTests.BracketedBaseProperty_Read_ReachesSpecificAncestor`, and `StructuralProjectionTests.ImportedMethodOverloadAcceptsStructuralProjection` now run on the `EmittedOracle`; their `EvaluateWithEvaluator` twins are deleted where unused (the #3219 twin in `StructuralProjectionTests` stays pinned — separate issue).

Evaluator untouched. No new cache keys (GSA RemapScope/IsSameAs rules not implicated).

## Verification

- Release solution build: 0 warnings, 0 errors.
- **Witness (ADR-0154)**: with the three product hunks stashed (pre-fix tree) the 11 new emit-level tests + 5 unpinned tests fail **16/16**; with the fix, 16/16 pass. Repro `.dll`s for #3215/#3223 (property and event chains) additionally verified with the repo-local `ilverify`: all classes and methods verified.
- Targeted areas (Release, `--no-build`): pointer/byref/unsafe/fixed **266/266**; projection/spread/conversion **281/281**; explicit-interface/base-qualifier/override/event **175/175**.
- Full `Core.Tests`: **7146 passed, 0 failed, 1 skipped** (pre-existing `RegenerateBaseline` skip).
- `Compiler.Tests` LanguageConformance filter: **126/126**.
- `Interpreter.Tests` full: **1484 passed, 0 failed, 4 skipped** (pre-existing skips).
- NOT RUN: remaining `Compiler.Tests` (non-conformance), `LanguageServer.Tests`, `Sdk.Tests`, `Extensions.Tests`, `Cs2Gs.Tests` (pre-existing flaky host crash — see repo memory), `InternalAnalyzers.Tests`, `GeneratorHost.Tests` — outside the touched Binding/Emit surface; the changed code paths are covered by the suites above.

## Checklist

- [x] Behavioral tests carry a witness of discrimination (ADR-0154): each new/changed test fails on the pre-change code (pre-fix commit, reverted hunk, or an applied product mutant) and passes with it.
- [x] Self-review verdict recorded when one was run (MERGEABLE / BLOCKER / SHOULD-FIX / NIT), with residuals filed as issues rather than dropped.

Self-review verdict: **MERGEABLE** — no blockers; residual language-surface note (byref top-level vars are entry-point-local only, not cross-submission-persistable in emitted REPL sessions — inherent to the CLR field model) is documented in the #3215 commit and code comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
