### PR TITLE
Fix the constructed-generics emit cluster: T? receiver lift, struct-to-constructed-interface box, private struct initializer ctor

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
@@ -1706,7 +1706,8 @@ internal sealed partial class OverloadResolver
             else if (argument.Type != expectedType
                 && !(substitution != null && parameter.Type is TypeParameterSymbol)
                 && (!(substitution != null && TypeSymbol.ContainsTypeParameter(parameter.Type))
-                    || Conversion.Classify(argument.Type, expectedType).IsImplicit))
+                    || (Conversion.Classify(argument.Type, expectedType).IsImplicit
+                        && structuralArgumentType is not FunctionTypeSymbol)))
             {
                 // Issue #2335 (audit follow-up): every OTHER implicit
                 // conversion reaches this point already classified
@@ -1743,7 +1744,14 @@ internal sealed partial class OverloadResolver
                 // InvalidProgramException at the call site. Substituted
                 // non-bare slots whose conversion is NOT implicit keep the
                 // historical skip (status quo) rather than surfacing new
-                // diagnostics from this branch.
+                // diagnostics from this branch. A FUNCTION-shaped argument
+                // (lambda/method group into a substituted delegate slot like
+                // `Func[A, T]`) also keeps the historical skip: the emitter's
+                // delegate-materialization path already builds the accurate
+                // nullable-preserving `Func<…,Nullable<T>>` shape (#1518), and
+                // re-materializing it here rebuilt the delegate from the
+                // collapsed structural shape (`Func<int32,int32>`), tripping
+                // ilverify's DelegateCtor check.
                 var argLoc = i < parameterSyntax.Length ? parameterSyntax[i].Location : syntax.Identifier.Location;
                 boundArguments[i] = conversions.BindConversion(argLoc, argument, expectedType);
             }

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
@@ -1704,7 +1704,9 @@ internal sealed partial class OverloadResolver
                 boundArguments[i] = conversions.BindConversion(argLoc, argument, expectedType);
             }
             else if (argument.Type != expectedType
-                && !(substitution != null && TypeSymbol.ContainsTypeParameter(parameter.Type)))
+                && !(substitution != null && parameter.Type is TypeParameterSymbol)
+                && (!(substitution != null && TypeSymbol.ContainsTypeParameter(parameter.Type))
+                    || Conversion.Classify(argument.Type, expectedType).IsImplicit))
             {
                 // Issue #2335 (audit follow-up): every OTHER implicit
                 // conversion reaches this point already classified
@@ -1726,14 +1728,22 @@ internal sealed partial class OverloadResolver
                 // (`StackUnexpected: found Int32, expected ref 'object'`).
                 // The same gap silently dropped numeric widening
                 // (`int32 → int64`) and other representation-changing
-                // implicit conversions. `parameter.Type` (the UNSUBSTITUTED
-                // declared type) is checked — not `expectedType` — so an
-                // open erased slot in a generic callee (paramType containing
-                // a type parameter of THIS call's own substitution) is still
-                // skipped and left for the emitter's type-erasure boxing at
-                // the call boundary, exactly mirroring the equivalent guard
-                // in `BindUserInstanceCall`'s per-argument loop
+                // implicit conversions.
+                //
+                // Issue #3222: only a BARE erased slot (`parameter.Type is
+                // TypeParameterSymbol`, the `!!T` MVAR the emitter erases at
+                // the call boundary) is skipped — mirroring the equivalent
+                // guard in `BindUserInstanceCall`'s per-argument loop
                 // (`if (paramType is TypeParameterSymbol) { …; continue; }`).
+                // A parameter that merely CONTAINS a type parameter (e.g. a
+                // constructed generic interface `IHolder[T]`) emits as a real
+                // constructed slot (`IHolder<!!T>`), so a value-type argument
+                // still needs its materialized conversion (`box StringBox` →
+                // `IHolder<string>`); skipping it produced
+                // InvalidProgramException at the call site. Substituted
+                // non-bare slots whose conversion is NOT implicit keep the
+                // historical skip (status quo) rather than surfacing new
+                // diagnostics from this branch.
                 var argLoc = i < parameterSyntax.Length ? parameterSyntax[i].Location : syntax.Identifier.Location;
                 boundArguments[i] = conversions.BindConversion(argLoc, argument, expectedType);
             }

--- a/src/Core/CodeAnalysis/Emit/ConstructorBodyEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ConstructorBodyEmitter.cs
@@ -325,6 +325,108 @@ internal sealed class ConstructorBodyEmitter
         => !classSym.InstanceFieldInitializers.IsEmpty;
 
     /// <summary>
+    /// Issue #3219: a value-kind struct whose declared field initializers
+    /// include a NON-public field cannot be materialized by the historical
+    /// call-site lowering (initobj + raw <c>stfld</c> per initializer) —
+    /// the private-field store executes outside the type and the runtime
+    /// rejects it with <see cref="FieldAccessException"/>. Such a struct
+    /// gets a synthesized public parameterless <c>.ctor</c> that runs ALL
+    /// declared instance field initializers in-type (mirroring the class
+    /// default-ctor path), and struct-literal sites construct through it.
+    /// Structs whose initializers are all public keep the historical inline
+    /// emission byte-for-byte. A user-declared parameterless ctor (which
+    /// would collide) and inline structs (fixed synthesized-member layout)
+    /// are excluded.
+    /// </summary>
+    /// <param name="structSym">The struct definition to probe.</param>
+    /// <returns><see langword="true"/> when the synthesized parameterless ctor is required.</returns>
+    internal static bool NeedsSynthesizedValueStructDefaultCtor(StructSymbol structSym)
+    {
+        if (structSym.IsClass || structSym.IsInline || structSym.InstanceFieldInitializers.IsEmpty)
+        {
+            return false;
+        }
+
+        if (!structSym.ExplicitConstructors.IsDefaultOrEmpty)
+        {
+            foreach (var ctor in structSym.ExplicitConstructors)
+            {
+                if (ctor.Parameters.Length == 0)
+                {
+                    return false;
+                }
+            }
+        }
+
+        foreach (var initializer in structSym.InstanceFieldInitializers)
+        {
+            if (initializer.Key.Accessibility != Accessibility.Public)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Issue #3219: builds the IL body for the synthesized parameterless
+    /// value-struct constructor — zero-initializes <c>this</c> (the caller's
+    /// storage may be a reused local) and then evaluates the declared
+    /// instance field initializers in declaration order, in-type, so
+    /// non-public initialized fields never need a call-site store.
+    /// Returns the resulting body offset.
+    /// </summary>
+    /// <param name="structSym">The struct whose ctor body is being emitted.</param>
+    /// <returns>The method-body stream offset.</returns>
+    internal int EmitValueStructDefaultConstructorBodyBytes(StructSymbol structSym)
+    {
+        // Synthesize a `this` parameter for the field-initializer receiver.
+        var thisParam = new ParameterSymbol("this", structSym);
+
+        // Synthesize field-initializer assignment statements.
+        var statements = BuildInstanceFieldInitializerStatements(structSym, thisParam);
+        var body = new BoundBlockStatement(null, statements);
+
+        var il = new InstructionEncoder(new BlobBuilder(), new ControlFlowBuilder());
+        var session = new ReflectionMetadataEmitter.MethodBodyEmitSession(this.outer, il);
+        session.Plan(body);
+
+        var parameters = new Dictionary<ParameterSymbol, int>
+        {
+            [thisParam] = 0,
+        };
+
+        var localsSignature = session.BuildLocalsSignature();
+
+        // arg0 of a value-type instance ctor is already a managed pointer;
+        // structThisParameter makes the receiver loads use ldarg.0 (the
+        // address) rather than ldarga (a pointer-to-pointer).
+        var emitter = session.CreateEmitter(parameters, structThisParameter: thisParam);
+
+        // `this` is a byref to caller storage (possibly a reused local):
+        // zero the whole value before the initializers store into it. For a
+        // generic struct the token is the self-instantiation TypeSpec
+        // (`Box`1<!0>`), the same in-type reference the field stores use.
+        il.LoadArgument(0);
+        il.OpCode(ILOpCode.Initobj);
+        il.Token(this.outer.userTokens.ResolveUserTypeToken(structSym));
+
+        // Instance field initializers
+        try
+        {
+            emitter.EmitBlock(body);
+        }
+        catch (Exception ex) when (ex is not EmitDiagnosticException and not OutOfMemoryException and not StackOverflowException)
+        {
+            var anchor = emitter.CurrentAnchor ?? structSym.Declaration;
+            EmitDiagnosticException.Wrap(anchor, ex);
+        }
+
+        return this.AddCompletedMethodBody(il, emitter, localsSignature);
+    }
+
+    /// <summary>
     /// Issue #640: builds the bound assignment statements for all instance
     /// field initializers in declaration order. Used by the default, primary,
     /// forwarding, and explicit constructor body emitters.

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Calls.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Calls.cs
@@ -767,4 +767,230 @@ internal sealed partial class MethodBodyEmitter
         this.il.OpCode(ILOpCode.Call);
         this.il.Token(methodToken);
     }
+
+    /// <summary>
+    /// Issue #3226: the per-call plan for lifting an unconstrained generic
+    /// instantiation to <c>Nullable&lt;X&gt;</c>. A user generic function with
+    /// an UNCONSTRAINED type parameter <c>T</c> and a parameter declared
+    /// <c>T?</c> (e.g. the receiver of <c>func (self T?) MyOrElse[T](fb T) T</c>)
+    /// encodes every <c>T</c>/<c>T?</c> slot as the bare MVAR <c>!!T</c>
+    /// (<see cref="SignatureEncoder"/> models unconstrained <c>T?</c> as a
+    /// metadata-only reference annotation). That erasure is only sound for
+    /// reference instantiations: a value-type call site would push a live
+    /// <c>Nullable&lt;X&gt;</c> into an <c>X</c>-typed slot (invalid IL for
+    /// primitives, silent nil-loss for user structs). The lift instead
+    /// instantiates the MethodSpec at <c>Nullable&lt;X&gt;</c> — so the
+    /// <c>T?</c> slot really holds a nullable, and the body's box-probe
+    /// <c>nil</c> checks work because boxing a <c>Nullable&lt;X&gt;</c> yields
+    /// a null reference for the empty value — wrapping bare-<c>X</c> arguments
+    /// (<c>newobj Nullable&lt;X&gt;::.ctor</c>) and unwrapping a bare-<c>T</c>
+    /// return (<c>box</c> + <c>unbox.any</c>, loud on the impossible nil).
+    /// </summary>
+    private sealed class UnconstrainedNullableLiftPlan
+    {
+        /// <summary>Gets or sets the full (lifted) MethodSpec type-argument vector.</summary>
+        public TypeSymbol[] TypeArguments { get; set; }
+
+        /// <summary>Gets or sets, per argument index, the Nullable&lt;X&gt; to wrap the emitted argument into (null = pass through).</summary>
+        public NullableTypeSymbol[] ArgumentWraps { get; set; }
+
+        /// <summary>Gets or sets the Nullable&lt;X&gt; the call leaves on the stack when the declared return is the bare lifted T (null = no unwrap).</summary>
+        public NullableTypeSymbol ReturnUnwrap { get; set; }
+    }
+
+    // Issue #3226: decide whether (and how) the generic call must be
+    // instantiated at Nullable<X> instead of X. Returns null when the call
+    // needs no lift (no unconstrained T? slot, reference instantiation, or a
+    // shape the lift cannot represent — see the occurrence scan below).
+    private UnconstrainedNullableLiftPlan TryPlanUnconstrainedNullableLift(BoundCallExpression call)
+    {
+        var fn = call.Function;
+        var tps = fn.TypeParameters;
+        if (tps.IsDefaultOrEmpty
+            || call.MethodTypeArguments.IsDefaultOrEmpty
+            || call.MethodTypeArguments.Length != tps.Length
+            || fn.Parameters.Length != call.Arguments.Length
+            || fn.IsAsync
+            || call.StaticGenericOwnerType != null
+            || call.StaticGenericInterfaceOwnerType != null)
+        {
+            // Async bodies return through the Task<T> state-machine wrapper —
+            // a nested T occurrence the lift cannot represent — and statics on
+            // constructed generic owners resolve through TypeSpec-parented
+            // MemberRefs, not the MethodSpec path the lift rewrites.
+            return null;
+        }
+
+        TypeSymbol[] liftedArgs = null;
+        var liftedTps = new bool[tps.Length];
+        for (int k = 0; k < tps.Length; k++)
+        {
+            var tp = tps[k];
+            var x = call.MethodTypeArguments[k];
+
+            // A struct-constrained T? already emits as Nullable<!!T>
+            // (Issue #814); only the unconstrained erasure needs the lift.
+            // The instantiation must be a closed value type: an open X (the
+            // caller is itself generic) keeps the erased contract, and an
+            // already-nullable X has no valid Nullable<Nullable<..>> form.
+            if (tp.HasValueTypeConstraint
+                || x is NullableTypeSymbol
+                || x is TypeParameterSymbol
+                || !ReflectionMetadataEmitter.IsValueTypeSymbol(x))
+            {
+                continue;
+            }
+
+            bool hasNullableSlot = false;
+            bool representable = true;
+            for (int i = 0; i < fn.Parameters.Length && representable; i++)
+            {
+                var pt = fn.Parameters[i].Type;
+                if (pt is NullableTypeSymbol pn && ReferenceEquals(pn.UnderlyingType, tp))
+                {
+                    // A byref T?/T slot would need write-back through the
+                    // lifted representation; keep the status quo there.
+                    hasNullableSlot |= fn.Parameters[i].RefKind == RefKind.None;
+                    representable &= fn.Parameters[i].RefKind == RefKind.None;
+                }
+                else if (ReferenceEquals(pt, tp))
+                {
+                    representable &= fn.Parameters[i].RefKind == RefKind.None;
+                }
+                else if (TypeSymbol.AnyTypeParameter(pt, cand => ReferenceEquals(cand, tp)))
+                {
+                    // T occurs NESTED (e.g. []T, Box[T]): the instantiated
+                    // slot shape ([]X) diverges from the lifted vector
+                    // (Nullable<X>) — the lift cannot represent this call.
+                    representable = false;
+                }
+            }
+
+            if (!hasNullableSlot || !representable)
+            {
+                continue;
+            }
+
+            var rt = fn.Type;
+            if (ReferenceEquals(rt, tp)
+                || (rt is NullableTypeSymbol rn && ReferenceEquals(rn.UnderlyingType, tp)))
+            {
+                // Bare-T return unwraps after the call; T? return already
+                // matches the lifted Nullable<X>.
+            }
+            else if (TypeSymbol.AnyTypeParameter(rt, cand => ReferenceEquals(cand, tp)))
+            {
+                // Nested occurrence in the return (Task[T], []T, ...): not
+                // representable by the lift.
+                continue;
+            }
+
+            liftedArgs ??= call.MethodTypeArguments.ToArray();
+            liftedArgs[k] = NullableTypeSymbol.Get(x);
+            liftedTps[k] = true;
+        }
+
+        if (liftedArgs == null)
+        {
+            return null;
+        }
+
+        var plan = new UnconstrainedNullableLiftPlan { TypeArguments = liftedArgs };
+        var wraps = new NullableTypeSymbol[call.Arguments.Length];
+        for (int i = 0; i < fn.Parameters.Length; i++)
+        {
+            var pt = fn.Parameters[i].Type;
+            var tpIndex = IndexOfLiftedTypeParameter(tps, liftedTps, pt);
+            if (tpIndex < 0)
+            {
+                continue;
+            }
+
+            // The slot's instantiated shape is Nullable<X>. Wrap any argument
+            // the binder materialized as bare X (a `fb T` argument, or a
+            // receiver that bound without the X → X? lift); an argument
+            // already typed X? matches the slot as-is.
+            if (call.Arguments[i].Type is not NullableTypeSymbol)
+            {
+                wraps[i] = (NullableTypeSymbol)plan.TypeArguments[tpIndex];
+            }
+        }
+
+        plan.ArgumentWraps = wraps;
+        var retIndex = IndexOfLiftedTypeParameter(tps, liftedTps, fn.Type);
+        if (retIndex >= 0 && fn.Type is TypeParameterSymbol)
+        {
+            plan.ReturnUnwrap = (NullableTypeSymbol)plan.TypeArguments[retIndex];
+        }
+
+        return plan;
+    }
+
+    // Issue #3226: maps a declared T or T? slot type onto the index of the
+    // LIFTED type parameter it names; -1 for every other shape.
+    private static int IndexOfLiftedTypeParameter(
+        ImmutableArray<TypeParameterSymbol> tps,
+        bool[] liftedTps,
+        TypeSymbol declaredType)
+    {
+        var tp = declaredType as TypeParameterSymbol
+            ?? (declaredType is NullableTypeSymbol n ? n.UnderlyingType as TypeParameterSymbol : null);
+        if (tp == null)
+        {
+            return -1;
+        }
+
+        for (int k = 0; k < tps.Length; k++)
+        {
+            if (liftedTps[k] && ReferenceEquals(tps[k], tp))
+            {
+                return k;
+            }
+        }
+
+        return -1;
+    }
+
+    // Issue #3226: X → Nullable<X> wrap for a lifted argument slot. Mirrors
+    // the Issue #504/#1298 lifts in EmitConversion: a symbolic underlying
+    // (user struct/enum/tuple) routes through the TypeSpec-parented ctor
+    // MemberRef; a CLR-backed underlying closes System.Nullable`1 through the
+    // ReferenceResolver (Issue #571) and refs its single-arg ctor.
+    private void EmitUnconstrainedNullableLiftWrap(NullableTypeSymbol lifted)
+    {
+        this.il.OpCode(ILOpCode.Newobj);
+        if (NullableLifting.RequiresSymbolicNullableGetValue(lifted))
+        {
+            this.il.Token(this.outer.memberRefs.GetNullableCtorMemberRefForUserValueType(lifted));
+            return;
+        }
+
+        var innerClr = lifted.UnderlyingType.ClrType
+            ?? throw new InvalidOperationException(
+                $"Nullable<{lifted.UnderlyingType.Name}> lift has no CLR underlying type.");
+        if (!NullableLifting.TryConstructNullable(this.outer.emitCtx.References, innerClr, out var nullableClr))
+        {
+            throw new InvalidOperationException(
+                $"Cannot construct Nullable<{innerClr.FullName}>: System.Nullable`1 is not resolvable in the reference set.");
+        }
+
+        var nullableInnerArg = nullableClr.GetGenericArguments()[0];
+        var ctor = nullableClr.GetConstructor(new[] { nullableInnerArg })
+            ?? throw new InvalidOperationException(
+                $"Nullable<{nullableInnerArg.FullName}> has no single-arg constructor.");
+        this.il.Token(this.outer.memberRefs.GetCtorReference(ctor));
+    }
+
+    // Issue #3226: Nullable<X> → X unwrap for a lifted bare-T return.
+    // `box Nullable<X>` collapses to a boxed X (never null here — a T-typed
+    // value cannot be nil in the source type system), and `unbox.any X`
+    // reloads the value; an impossible nil would surface loudly as an NRE
+    // rather than a silent default(X).
+    private void EmitUnconstrainedNullableLiftUnwrap(NullableTypeSymbol lifted)
+    {
+        this.il.OpCode(ILOpCode.Box);
+        this.il.Token(this.outer.memberRefs.GetElementTypeToken(lifted));
+        this.il.OpCode(ILOpCode.Unbox_any);
+        this.il.Token(this.outer.memberRefs.GetElementTypeToken(lifted.UnderlyingType));
+    }
 }

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
@@ -1241,14 +1241,60 @@ internal sealed partial class MethodBodyEmitter
                 + "Check StructLiteralCollector and its ancestor walker.");
         }
 
-        // ldloca slot; initobj typedef — zero-initializes the value type.
+        // Issue #3219: a value struct with a NON-public declared field
+        // initializer cannot be materialized by initobj + raw stfld — the
+        // private-field store executes outside the type (FieldAccessException).
+        // Such a struct carries a synthesized parameterless .ctor (see
+        // ConstructorBodyEmitter.NeedsSynthesizedValueStructDefaultCtor) that
+        // zero-initializes and runs ALL declared initializers in-type;
+        // construct through it and skip the literal's injected
+        // declared-initializer entries (identified below by reference to the
+        // symbol's InstanceFieldInitializers expressions — the binder injects
+        // exactly those instances), so initializer side effects run once.
+        var structDefinition = literal.StructType.Definition ?? literal.StructType;
+        HashSet<BoundExpression> declaredInitializerValues = null;
+        if (this.outer.cache.ClassCtorHandles.ContainsKey(structDefinition)
+            && ConstructorBodyEmitter.NeedsSynthesizedValueStructDefaultCtor(structDefinition))
+        {
+            declaredInitializerValues = new HashSet<BoundExpression>(ReferenceEqualityComparer.Instance);
+            foreach (var declared in literal.StructType.InstanceFieldInitializers)
+            {
+                declaredInitializerValues.Add(declared.Value);
+            }
+
+            foreach (var declared in structDefinition.InstanceFieldInitializers)
+            {
+                declaredInitializerValues.Add(declared.Value);
+            }
+        }
+
+        // ldloca slot; initobj typedef — zero-initializes the value type —
+        // or, for a #3219 struct, ldloca slot; call .ctor() (which zeroes and
+        // runs the declared initializers in-type).
         this.il.LoadLocalAddress(slot);
-        this.il.OpCode(ILOpCode.Initobj);
-        this.il.Token(typeDef);
+        if (declaredInitializerValues != null)
+        {
+            this.il.OpCode(ILOpCode.Call);
+            this.il.Token(this.outer.userTokens.ResolveUserCtorTokenForDefault(literal.StructType));
+        }
+        else
+        {
+            this.il.OpCode(ILOpCode.Initobj);
+            this.il.Token(typeDef);
+        }
 
         // For each initializer: ldloca slot; <emit value>; stfld fieldHandle.
         foreach (var init in literal.Initializers)
         {
+            // Issue #3219: the synthesized ctor already ran this declared
+            // initializer in-type.
+            if (declaredInitializerValues != null
+                && init.Field != null
+                && declaredInitializerValues.Contains(init.Value))
+            {
+                continue;
+            }
+
             // Issue #1211: a `prop` member on a value type is set through its
             // setter/init accessor (`ldloca slot; <value>; call set_X`). The
             // managed-pointer receiver means a non-virtual `call`.

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
@@ -127,10 +127,20 @@ internal sealed partial class MethodBodyEmitter
                     break;
                 }
 
+                // Issue #3226: an unconstrained `T?` slot (e.g. the receiver of
+                // `func (self T?) MyOrElse[T](fb T) T`) erases to the bare MVAR
+                // `!!T`, so a value-type instantiation must be lifted to
+                // `Nullable<X>` — see TryPlanUnconstrainedNullableLift.
+                var nullableLift = this.TryPlanUnconstrainedNullableLift(call);
+
                 for (int i = 0; i < call.Arguments.Length; i++)
                 {
                     var arg = call.Arguments[i];
                     this.EmitExpression(arg);
+                    if (nullableLift?.ArgumentWraps[i] is { } liftWrap)
+                    {
+                        this.EmitUnconstrainedNullableLiftWrap(liftWrap);
+                    }
                 }
 
                 // Issue #1433: a `shared` (static) method called on a
@@ -171,11 +181,24 @@ internal sealed partial class MethodBodyEmitter
                 }
                 else if (call.Function.IsGeneric && !call.Function.TypeParameters.IsDefaultOrEmpty)
                 {
-                    callTokenToEmit = this.outer.userTokens.BuildMethodSpecForGenericCall(fnHandle, call);
+                    // Issue #3226: a lifted call instantiates the MethodSpec at
+                    // Nullable<X> so the erased `!!T` slots really carry the
+                    // nullable representation the T? contract promises.
+                    callTokenToEmit = nullableLift != null
+                        ? this.outer.userTokens.BuildMethodSpecForLiftedGenericCall(fnHandle, nullableLift.TypeArguments)
+                        : this.outer.userTokens.BuildMethodSpecForGenericCall(fnHandle, call);
                 }
 
                 this.il.OpCode(ILOpCode.Call);
                 this.il.Token(callTokenToEmit);
+
+                // Issue #3226: a lifted call whose declared return is the bare
+                // lifted T leaves Nullable<X> on the stack; unwrap it back to
+                // the X the bound tree types the call as.
+                if (nullableLift?.ReturnUnwrap is { } liftUnwrap)
+                {
+                    this.EmitUnconstrainedNullableLiftUnwrap(liftUnwrap);
+                }
 
                 // ADR-0087 §3 R3+R4: after R2/R3, every G# call (MethodSpec'd
                 // or plain MethodDef) returns the method's reified signature.

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -1132,6 +1132,7 @@ internal sealed class ReflectionMetadataEmitter
             (ctor, containingType) => this.memberRefs.GetCtorReference(ctor, containingType),
             this.ctorBodies.EmitStaticConstructorBodyBytes,
             this.ctorBodies.EmitClassDefaultConstructorBodyBytes,
+            this.ctorBodies.EmitValueStructDefaultConstructorBodyBytes,
             this.ctorBodies.EmitClassPrimaryConstructorBodyBytes,
             this.ctorBodies.EmitClassConstructorWithBaseInitializerBodyBytes,
             this.ctorBodies.EmitClassConstructorWithBodyBodyBytes,
@@ -2110,7 +2111,13 @@ internal sealed class ReflectionMetadataEmitter
         var structFirstMethodRows = new Dictionary<StructSymbol, int>();
         void PlanStructMethods(StructSymbol s)
         {
-            if (s.Methods.IsDefaultOrEmpty && s.ExplicitConstructors.IsDefaultOrEmpty && !s.IsInline && !s.IsData && s.Properties.IsDefaultOrEmpty && s.Events.IsDefaultOrEmpty && s.StaticMethods.IsDefaultOrEmpty && s.StaticProperties.IsDefaultOrEmpty && s.StaticEvents.IsDefaultOrEmpty && s.StaticFieldInitializers.IsEmpty && !s.HasStaticInitializerBlock)
+            // Issue #3219: a value struct with a non-public declared field
+            // initializer gets a synthesized parameterless .ctor (planned as
+            // the struct's LAST row, below, so the explicit-ctor /
+            // inline-struct first-row offsets pre-registered later in this
+            // pass stay valid).
+            var needsSynthesizedDefaultCtor = ConstructorBodyEmitter.NeedsSynthesizedValueStructDefaultCtor(s);
+            if (s.Methods.IsDefaultOrEmpty && s.ExplicitConstructors.IsDefaultOrEmpty && !s.IsInline && !s.IsData && s.Properties.IsDefaultOrEmpty && s.Events.IsDefaultOrEmpty && s.StaticMethods.IsDefaultOrEmpty && s.StaticProperties.IsDefaultOrEmpty && s.StaticEvents.IsDefaultOrEmpty && s.StaticFieldInitializers.IsEmpty && !s.HasStaticInitializerBlock && !needsSynthesizedDefaultCtor)
             {
                 return;
             }
@@ -2237,6 +2244,16 @@ internal sealed class ReflectionMetadataEmitter
             if (!s.StaticFieldInitializers.IsEmpty || s.HasStaticInitializerBlock)
             {
                 this.cache.CctorHandles[s] = MetadataTokens.MethodDefinitionHandle(methodRow++);
+            }
+
+            // Issue #3219: plan (and pre-register, so bodies emitted before
+            // EmitStructMethodBodies can construct through it) the synthesized
+            // parameterless .ctor as the struct's last row. ClassCtorHandles
+            // doubles as the default-ctor registry ResolveUserCtorTokenForDefault
+            // consults for constructed-generic MemberRef parenting.
+            if (needsSynthesizedDefaultCtor)
+            {
+                this.cache.ClassCtorHandles[s] = MetadataTokens.MethodDefinitionHandle(methodRow++);
             }
         }
 
@@ -3564,8 +3581,18 @@ internal sealed class ReflectionMetadataEmitter
                 this.dataStructSynth.EmitDataStructSynthesizedMembers(s);
             }
 
+            // Issue #3219: the synthesized value-struct default ctor is the
+            // struct's LAST planned row — emitted at the tail of this method,
+            // so the early-out below must not skip a struct whose only row is
+            // that ctor.
+            var emitsSynthesizedDefaultCtor = ConstructorBodyEmitter.NeedsSynthesizedValueStructDefaultCtor(s);
             if (s.Methods.IsDefaultOrEmpty && s.ExplicitConstructors.IsDefaultOrEmpty && s.Properties.IsDefaultOrEmpty && s.Events.IsDefaultOrEmpty && s.StaticMethods.IsDefaultOrEmpty && s.StaticProperties.IsDefaultOrEmpty && s.StaticEvents.IsDefaultOrEmpty && s.StaticFieldInitializers.IsEmpty && !s.HasStaticInitializerBlock)
             {
+                if (emitsSynthesizedDefaultCtor)
+                {
+                    this.typeDefEmitter.EmitValueStructDefaultConstructor(s);
+                }
+
                 return;
             }
 
@@ -3639,6 +3666,13 @@ internal sealed class ReflectionMetadataEmitter
             // ADR-0149: emit MethodImpl rows for explicit-interface-clause
             // event implementations (add/remove/raise accessors).
             this.interfaceImpls.EmitExplicitInterfaceEventMethodImpls(s);
+
+            // Issue #3219: emit the synthesized value-struct default ctor at
+            // the tail so its MethodDef lands on the last planned row.
+            if (emitsSynthesizedDefaultCtor)
+            {
+                this.typeDefEmitter.EmitValueStructDefaultConstructor(s);
+            }
 
             // Issues #2718/#2742: see the class path above.
             this.interfaceImpls.EmitImplicitEventMethodImpls(s);

--- a/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
@@ -106,6 +106,7 @@ internal sealed class TypeDefEmitter
     private readonly Func<ConstructorInfo, TypeSymbol, MemberReferenceHandle> getCtorReferenceForType;
     private readonly Func<StructSymbol, int> emitStaticConstructorBodyBytes;
     private readonly Func<StructSymbol, EntityHandle, int> emitClassDefaultConstructorBodyBytes;
+    private readonly Func<StructSymbol, int> emitValueStructDefaultConstructorBodyBytes;
     private readonly Func<StructSymbol, EntityHandle, int> emitClassPrimaryConstructorBodyBytes;
     private readonly Func<StructSymbol, ImmutableArray<ParameterSymbol>, BaseConstructorInitializer, EntityHandle, int> emitClassConstructorWithBaseInitializerBodyBytes;
     private readonly Func<StructSymbol, ConstructorSymbol, BaseConstructorInitializer, EntityHandle, int> emitClassConstructorWithBodyBodyBytes;
@@ -133,6 +134,7 @@ internal sealed class TypeDefEmitter
         Func<ConstructorInfo, TypeSymbol, MemberReferenceHandle> getCtorReferenceForType,
         Func<StructSymbol, int> emitStaticConstructorBodyBytes,
         Func<StructSymbol, EntityHandle, int> emitClassDefaultConstructorBodyBytes,
+        Func<StructSymbol, int> emitValueStructDefaultConstructorBodyBytes,
         Func<StructSymbol, EntityHandle, int> emitClassPrimaryConstructorBodyBytes,
         Func<StructSymbol, ImmutableArray<ParameterSymbol>, BaseConstructorInitializer, EntityHandle, int> emitClassConstructorWithBaseInitializerBodyBytes,
         Func<StructSymbol, ConstructorSymbol, BaseConstructorInitializer, EntityHandle, int> emitClassConstructorWithBodyBodyBytes,
@@ -159,6 +161,7 @@ internal sealed class TypeDefEmitter
         this.getCtorReferenceForType = getCtorReferenceForType ?? throw new ArgumentNullException(nameof(getCtorReferenceForType));
         this.emitStaticConstructorBodyBytes = emitStaticConstructorBodyBytes ?? throw new ArgumentNullException(nameof(emitStaticConstructorBodyBytes));
         this.emitClassDefaultConstructorBodyBytes = emitClassDefaultConstructorBodyBytes ?? throw new ArgumentNullException(nameof(emitClassDefaultConstructorBodyBytes));
+        this.emitValueStructDefaultConstructorBodyBytes = emitValueStructDefaultConstructorBodyBytes ?? throw new ArgumentNullException(nameof(emitValueStructDefaultConstructorBodyBytes));
         this.emitClassPrimaryConstructorBodyBytes = emitClassPrimaryConstructorBodyBytes ?? throw new ArgumentNullException(nameof(emitClassPrimaryConstructorBodyBytes));
         this.emitClassConstructorWithBaseInitializerBodyBytes = emitClassConstructorWithBaseInitializerBodyBytes ?? throw new ArgumentNullException(nameof(emitClassConstructorWithBaseInitializerBodyBytes));
         this.emitClassConstructorWithBodyBodyBytes = emitClassConstructorWithBodyBodyBytes ?? throw new ArgumentNullException(nameof(emitClassConstructorWithBodyBodyBytes));
@@ -1401,6 +1404,39 @@ internal sealed class TypeDefEmitter
                 il.OpCode(ILOpCode.Ret);
                 bodyOffset = this.emitCtx.MethodBodyStream.AddMethodBody(il, maxStack: MaxStackTracker.ComputeMaxStack(il));
             }
+        }
+
+        var ctorSig = new BlobBuilder();
+        new BlobEncoder(ctorSig).MethodSignature(isInstanceMethod: true)
+            .Parameters(0, r => r.Void(), _ => { });
+
+        return this.emitCtx.Metadata.AddMethodDefinition(
+            attributes: MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.SpecialName
+                | MethodAttributes.RTSpecialName,
+            implAttributes: MethodImplAttributes.IL | MethodImplAttributes.Managed,
+            name: this.emitCtx.Metadata.GetOrAddString(".ctor"),
+            signature: this.emitCtx.Metadata.GetOrAddBlob(ctorSig),
+            bodyOffset: bodyOffset,
+            parameterList: this.nextParameterHandle());
+    }
+
+    /// <summary>
+    /// Issue #3219: emits the synthesized public parameterless <c>.ctor</c>
+    /// for a value-kind struct whose declared field initializers include a
+    /// non-public field (see
+    /// <see cref="ConstructorBodyEmitter.NeedsSynthesizedValueStructDefaultCtor"/>).
+    /// The body zero-initializes <c>this</c> and runs the declared instance
+    /// field initializers in-type, so struct-literal sites can construct
+    /// through it instead of storing private fields from the call site.
+    /// </summary>
+    /// <param name="structSym">The struct whose synthesized default constructor is being emitted.</param>
+    /// <returns>The emitted constructor's MethodDef handle.</returns>
+    public MethodDefinitionHandle EmitValueStructDefaultConstructor(StructSymbol structSym)
+    {
+        int bodyOffset = -1;
+        if (!this.emitCtx.MetadataOnly)
+        {
+            bodyOffset = this.emitValueStructDefaultConstructorBodyBytes(structSym);
         }
 
         var ctorSig = new BlobBuilder();

--- a/src/Core/CodeAnalysis/Emit/UserTokenResolver.cs
+++ b/src/Core/CodeAnalysis/Emit/UserTokenResolver.cs
@@ -244,6 +244,21 @@ internal sealed class UserTokenResolver
         => this.BuildMethodSpec(openMethod, methodGroup.MethodTypeArguments.ToArray());
 
     /// <summary>
+    /// Issue #3226: builds a MethodSpec for a generic G# user function call
+    /// whose instantiation was LIFTED at the call site — an unconstrained
+    /// <c>T?</c> parameter slot instantiated at a value type substitutes
+    /// <c>Nullable&lt;X&gt;</c> for the bind-time <c>X</c> so the erased
+    /// <c>!!T</c> slots carry the nullable representation. The caller
+    /// (<see cref="MethodBodyEmitter"/>'s lift planner) supplies the already
+    /// lifted type-argument vector.
+    /// </summary>
+    /// <param name="openMethod">The open generic MethodDef handle.</param>
+    /// <param name="liftedTypeArguments">The lifted instantiation vector.</param>
+    /// <returns>The MethodSpec handle.</returns>
+    internal EntityHandle BuildMethodSpecForLiftedGenericCall(EntityHandle openMethod, TypeSymbol[] liftedTypeArguments)
+        => this.BuildMethodSpec(openMethod, liftedTypeArguments);
+
+    /// <summary>
     /// ADR-0087 §3 R3+R4: builds a MethodSpec for a generic G# user
     /// instance method call (`h.Box[int32](42)`). Same inference rules
     /// as <see cref="BuildMethodSpecForGenericCall"/>.

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1932GenericMethodInferenceOverUserTypeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1932GenericMethodInferenceOverUserTypeTests.cs
@@ -2,12 +2,6 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
-using System.Collections.Generic;
-using GSharp.Core.CodeAnalysis;
-using GSharp.Core.CodeAnalysis.Compilation;
-using GSharp.Core.CodeAnalysis.Symbols;
-using GSharp.Core.CodeAnalysis.Syntax;
-using GSharp.Core.CodeAnalysis.Text;
 using GSharp.Tests;
 using Xunit;
 
@@ -90,10 +84,10 @@ func Describe[T](h IHolder[T]) T {
 
 Describe(StringBox{Value: ""hi""})
 ";
-        // ADR-0156 Phase 3b (#3176): stays on Compilation.Evaluate —
-        // #3222 tracks the invalid IL for the implementing-struct call
-        // through the constructed generic interface parameter.
-        var result = EvaluateWithEvaluator(source);
+        // #3222: the implementing-struct argument now materializes its
+        // `box StringBox → IHolder<string>` conversion at the plain-call
+        // argument site, so the emitted oracle matches the evaluator.
+        var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
         Assert.Equal("hi", result.Value);
     }
@@ -123,15 +117,5 @@ swapped.First
     private static EmittedOracleResult Evaluate(string source)
     {
         return EmittedOracle.Evaluate(source);
-    }
-
-    // Evaluator-pinned twin of Evaluate for the #3222 test above; delete
-    // with the evaluator (ADR-0156 Phase 3c) or when #3222 aligns the
-    // engines.
-    private static EvaluationResult EvaluateWithEvaluator(string source)
-    {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue773GenericReceiverDispatchTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue773GenericReceiverDispatchTests.cs
@@ -2,12 +2,6 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
-using System.Collections.Generic;
-using GSharp.Core.CodeAnalysis;
-using GSharp.Core.CodeAnalysis.Compilation;
-using GSharp.Core.CodeAnalysis.Symbols;
-using GSharp.Core.CodeAnalysis.Syntax;
-using GSharp.Core.CodeAnalysis.Text;
 using GSharp.Tests;
 using Xunit;
 
@@ -146,10 +140,10 @@ func (self T?) MyOrElse[T](fb T) T {
 var v int32? = nil
 v.MyOrElse(99)
 ";
-        // ADR-0156 Phase 3b (#3176): stays on Compilation.Evaluate —
-        // #3226 tracks the invalid IL for the T? extension receiver on
-        // Nullable<int32>.
-        var result = EvaluateWithEvaluator(source);
+        // #3226: the T? extension receiver on Nullable<int32> emits via the
+        // unconstrained-nullable lift (MethodSpec at Nullable<int32>), so the
+        // emitted oracle now matches the evaluator.
+        var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
         Assert.Equal(99, result.Value);
     }
@@ -176,11 +170,10 @@ var def = Point{X: 1, Y: 2}
 var r = pt.MyOrElse(def)
 r.X
 ";
-        // ADR-0156 Phase 3b (#3176): stays on Compilation.Evaluate —
-        // #3226 tracks the wrong-value dispatch for the T? extension
-        // receiver on a nil user-struct Nullable (default(Point) instead of
-        // the fallback).
-        var result = EvaluateWithEvaluator(source);
+        // #3226: the nil user-struct Nullable receiver now dispatches to the
+        // fallback on the emitted path too (the lift boxes Nullable<Point> for
+        // the nil probe instead of reinterpreting it as a bare Point).
+        var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
         Assert.Equal(1, result.Value);
     }
@@ -352,15 +345,5 @@ a.FirstOr(99)
     private static EmittedOracleResult Evaluate(string source)
     {
         return EmittedOracle.Evaluate(source);
-    }
-
-    // Evaluator-pinned twin of Evaluate for the #3226 tests above; delete
-    // with the evaluator (ADR-0156 Phase 3c) or when #3226 aligns the
-    // engines.
-    private static EvaluationResult EvaluateWithEvaluator(string source)
-    {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/StructuralProjectionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/StructuralProjectionTests.cs
@@ -444,10 +444,10 @@ let box Box[int32] = source
     [Fact]
     public void ConstructedGenericTargetsPreserveDeclaredFieldInitializers()
     {
-        // ADR-0156 Phase 3b (#3176): stays on Compilation.Evaluate —
-        // #3219 tracks projection's private-field materialization
-        // (FieldAccessException on the constructed generic target).
-        var classResult = EvaluateWithEvaluator(@"
+        // #3219: the struct target's private declared initializer now runs
+        // through the synthesized parameterless ctor (in-type) instead of a
+        // call-site stfld, so the emitted oracle matches the evaluator.
+        var classResult = Evaluate(@"
 class Source { var Value int32 }
 class Box[T] {
     var Value T
@@ -461,7 +461,7 @@ box.ReadMarker()
         Assert.Empty(classResult.Diagnostics);
         Assert.Equal(9, classResult.Value);
 
-        var structResult = EvaluateWithEvaluator(@"
+        var structResult = Evaluate(@"
 struct Source { var Value int32 }
 struct Box[T] {
     var Value T

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue3219StructPrivateInitializerEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue3219StructPrivateInitializerEmitTests.cs
@@ -1,0 +1,199 @@
+// <copyright file="Issue3219StructPrivateInitializerEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #3219: a value-kind struct literal (including the struct-target
+/// structural projection) materialized declared field initializers as raw
+/// <c>stfld</c>s at the construction site — including PRIVATE fields, which
+/// the runtime rejects from outside the type with
+/// <see cref="System.FieldAccessException"/>. The fix synthesizes a public
+/// parameterless <c>.ctor</c> for value structs whose declared initializers
+/// include a non-public field (running ALL declared initializers in-type),
+/// and routes literal construction through it, skipping the injected
+/// declared-initializer entries so initializer side effects run exactly once.
+/// Structs whose initializers are all public keep the historical inline
+/// emission (no synthesized ctor).
+/// </summary>
+public class Issue3219StructPrivateInitializerEmitTests
+{
+    [Fact]
+    public void StructLiteral_PrivateDeclaredInitializer_RunsInType()
+    {
+        // Pre-fix: FieldAccessException — `stfld Box::Marker` executed in
+        // <Main>$, outside the type.
+        var result = EmittedOracle.Evaluate(@"
+struct Box {
+    var Value int32
+    private var Marker int32 = 11
+    func ReadMarker() int32 { return Marker }
+}
+let box = Box{Value: 7}
+box.ReadMarker()
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(11, result.Value);
+    }
+
+    [Fact]
+    public void ConstructedGenericStructProjection_PreservesPrivateInitializer()
+    {
+        // The issue's projection repro at a constructed generic target:
+        // pre-fix FieldAccessException on `Box`1<System.Int32>.Marker`.
+        var result = EmittedOracle.Evaluate(@"
+struct Source { var Value int32 }
+struct Box[T] {
+    var Value T
+    private var Marker int32 = 11
+    func ReadMarker() int32 { return Marker }
+}
+let source = Source{Value: 7}
+let box Box[int32] = source
+box.ReadMarker()
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(11, result.Value);
+    }
+
+    [Fact]
+    public void ConstructedGenericStructProjection_CopiesPublicSlot()
+    {
+        // The projection's mapped public slot must still be written after the
+        // synthesized ctor ran — discriminates against a ctor-only lowering
+        // that drops the explicit member stores.
+        var result = EmittedOracle.Evaluate(@"
+struct Source { var Value int32 }
+struct Box[T] {
+    var Value T
+    private var Marker int32 = 11
+}
+let source = Source{Value: 7}
+let box Box[int32] = source
+box.Value
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(7, result.Value);
+    }
+
+    [Fact]
+    public void PrivateInitializerSideEffect_RunsExactlyOnce()
+    {
+        // The literal's injected declared-initializer entries are skipped at
+        // the call site when construction routes through the synthesized
+        // ctor; a double-run would print the marker twice.
+        var result = EmittedOracle.Evaluate(@"
+import System
+
+func Mark() int32 {
+    Counter.Hits = Counter.Hits + 1
+    return 11
+}
+
+class Counter {
+    shared {
+        var Hits int32 = 0
+    }
+}
+
+struct Box {
+    var Value int32
+    private var Marker int32 = Mark()
+    func ReadMarker() int32 { return Marker }
+}
+
+let box = Box{Value: 7}
+box.ReadMarker() * 100 + Counter.Hits
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(1101, result.Value);
+    }
+
+    [Fact]
+    public void ClassTarget_Control_StillRoutesThroughDefaultCtor()
+    {
+        // The issue's class-shaped repro: the class path already constructed
+        // through the synthesized default ctor; pins it against regression.
+        var result = EmittedOracle.Evaluate(@"
+class Source { var Value int32 }
+class Box[T] {
+    var Value T
+    private var Marker int32 = 9
+    func ReadMarker() int32 { return Marker }
+}
+let source = Source{Value: 7}
+let box Box[int32] = source
+box.ReadMarker()
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(9, result.Value);
+    }
+
+    [Fact]
+    public void SynthesizedCtor_OnlyForNonPublicInitializerStructs()
+    {
+        // Scope containment: the struct with a private initialized field
+        // carries exactly one parameterless .ctor; the all-public-initializer
+        // struct keeps the historical ctor-less shape (inline emission).
+        const string source = @"
+struct Hidden {
+    var Value int32
+    private var Marker int32 = 11
+    func ReadMarker() int32 { return Marker }
+}
+struct Open {
+    var Value int32
+    var Marker int32 = 11
+}
+let h = Hidden{Value: 1}
+let o = Open{Value: 2}
+h.ReadMarker() + o.Marker
+";
+        using var peStream = new MemoryStream();
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(source)));
+        var emitResult = compilation.Emit(peStream);
+        Assert.True(
+            emitResult.Success,
+            "compilation should succeed: " +
+            string.Join("; ", emitResult.Diagnostics.Select(diagnostic => diagnostic.Message)));
+
+        peStream.Position = 0;
+        using var peReader = new PEReader(peStream);
+        var metadata = peReader.GetMetadataReader();
+        int hiddenCtors = 0, openCtors = 0;
+        foreach (var typeHandle in metadata.TypeDefinitions)
+        {
+            var typeDef = metadata.GetTypeDefinition(typeHandle);
+            var typeName = metadata.GetString(typeDef.Name);
+            if (typeName != "Hidden" && typeName != "Open")
+            {
+                continue;
+            }
+
+            var ctorCount = typeDef.GetMethods()
+                .Count(m => metadata.GetString(metadata.GetMethodDefinition(m).Name) == ".ctor");
+            if (typeName == "Hidden")
+            {
+                hiddenCtors = ctorCount;
+            }
+            else
+            {
+                openCtors = ctorCount;
+            }
+        }
+
+        Assert.Equal(1, hiddenCtors);
+        Assert.Equal(0, openCtors);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue3222StructToConstructedInterfaceArgumentEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue3222StructToConstructedInterfaceArgumentEmitTests.cs
@@ -1,0 +1,116 @@
+// <copyright file="Issue3222StructToConstructedInterfaceArgumentEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #3222: a plain generic function call whose parameter is a
+/// constructed user generic interface (<c>func Describe[T](h IHolder[T])</c>)
+/// skipped the argument's materialized conversion whenever the declared
+/// parameter type CONTAINED a type parameter — but only a BARE <c>!!T</c>
+/// slot is emitter-erased; <c>IHolder&lt;!!T&gt;</c> is a real constructed
+/// reference slot, so a value-type argument needs its <c>box</c>. The raw
+/// struct on the stack where an interface reference was expected produced
+/// <c>InvalidProgramException</c>. The fix narrows the skip in
+/// <c>OverloadResolver.CallBinding</c> to bare type-parameter slots,
+/// mirroring <c>BindUserInstanceCall</c>'s per-argument guard.
+/// </summary>
+public class Issue3222StructToConstructedInterfaceArgumentEmitTests
+{
+    [Fact]
+    public void ImplementingStructArgument_Boxes_ToConstructedInterface()
+    {
+        // Pre-fix: InvalidProgramException (StringBox on the stack where
+        // IHolder<string> was expected — no box emitted).
+        var result = EmittedOracle.Evaluate(@"
+interface IHolder[T] {
+    func Get() T;
+}
+
+struct StringBox : IHolder[string] {
+    var Value string
+    func Get() string { return Value }
+}
+
+func Describe[T](h IHolder[T]) T {
+    return h.Get()
+}
+
+Describe(StringBox{Value: ""hi""})
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("hi", result.Value);
+    }
+
+    [Fact]
+    public void ImplementingStructArgument_ValueTypeArgument_Boxes()
+    {
+        // Same shape at a value-type interface instantiation: the boxed
+        // struct must dispatch Get() to the implementation, not to a zeroed
+        // copy — pins both the box and the interface dispatch.
+        var result = EmittedOracle.Evaluate(@"
+interface IHolder[T] {
+    func Get() T;
+}
+
+struct IntBox : IHolder[int32] {
+    var Value int32
+    func Get() int32 { return Value }
+}
+
+func Describe[T](h IHolder[T]) T {
+    return h.Get()
+}
+
+Describe(IntBox{Value: 42})
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void ImplementingClassArgument_Control_StillWorks()
+    {
+        // The reference-typed implementor never needed the box; guards the
+        // narrowed skip against regressing the previously-working path.
+        var result = EmittedOracle.Evaluate(@"
+interface IHolder[T] {
+    func Get() T;
+}
+
+class StringCell : IHolder[string] {
+    var Value string
+    func Get() string { return Value }
+}
+
+func Describe[T](h IHolder[T]) T {
+    return h.Get()
+}
+
+Describe(StringCell{Value: ""hi""})
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("hi", result.Value);
+    }
+
+    [Fact]
+    public void BareTypeParameterSlot_Control_KeepsErasedBoxing()
+    {
+        // A bare `x T` slot stays on the emitter's type-erasure boxing (the
+        // skip the fix deliberately preserves): a value-type argument through
+        // `!!T` must still work.
+        var result = EmittedOracle.Evaluate(@"
+func Identity[T](x T) T {
+    return x
+}
+
+Identity(41) + 1
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue3226NullableReceiverLiftEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue3226NullableReceiverLiftEmitTests.cs
@@ -1,0 +1,128 @@
+// <copyright file="Issue3226NullableReceiverLiftEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #3226: a generic extension (or plain generic function) whose
+/// parameter is declared <c>T?</c> over an UNCONSTRAINED <c>T</c> encodes the
+/// slot as the bare MVAR <c>!!T</c>. A value-type call site therefore pushed a
+/// live <c>Nullable&lt;X&gt;</c> into an <c>X</c>-typed slot — invalid IL for
+/// primitives (<c>InvalidProgramException</c> at <c>int32?</c>), and a SILENT
+/// WRONG VALUE for user structs (the nil <c>Nullable&lt;Point&gt;</c>
+/// reinterpreted as a zeroed <c>Point</c>, so the nil receiver dispatched to
+/// <c>self!!</c> instead of the fallback). The fix lifts the MethodSpec
+/// instantiation to <c>Nullable&lt;X&gt;</c>, wrapping bare-<c>T</c> arguments
+/// and unwrapping a bare-<c>T</c> return at the call boundary
+/// (<c>MethodBodyEmitter.TryPlanUnconstrainedNullableLift</c>).
+/// </summary>
+public class Issue3226NullableReceiverLiftEmitTests
+{
+    private const string OrElseExtension = @"
+func (self T?) MyOrElse[T](fb T) T {
+    if self != nil { return self!! }
+    return fb
+}
+";
+
+    [Fact]
+    public void Int32NullableReceiver_Nil_DispatchesToFallback()
+    {
+        // Pre-fix: InvalidProgramException (Nullable<int32> pushed into the
+        // int32-instantiated !!T slot).
+        var result = EmittedOracle.Evaluate(OrElseExtension + @"
+var v int32? = nil
+v.MyOrElse(99)
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(99, result.Value);
+    }
+
+    [Fact]
+    public void Int32NullableReceiver_Value_DispatchesToSelf()
+    {
+        // Discriminates against an always-fallback (or always-default)
+        // mis-lowering: a non-nil receiver must return its own value through
+        // the `self!!` arm and the return unwrap.
+        var result = EmittedOracle.Evaluate(OrElseExtension + @"
+var v int32? = 5
+v.MyOrElse(99)
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(5, result.Value);
+    }
+
+    [Fact]
+    public void UserStructNullableReceiver_Nil_DispatchesToFallback()
+    {
+        // Pre-fix SILENT WRONG VALUE: ran to completion and returned
+        // default(Point).X == 0 — the nil Nullable<Point> receiver was
+        // reinterpreted as a zeroed Point, so `self != nil` held.
+        var result = EmittedOracle.Evaluate(@"
+struct Point {
+    var X int32
+    var Y int32
+}
+" + OrElseExtension + @"
+var pt Point? = nil
+var def = Point{X: 1, Y: 2}
+var r = pt.MyOrElse(def)
+r.X
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(1, result.Value);
+    }
+
+    [Fact]
+    public void UserStructNullableReceiver_Value_DispatchesToSelf()
+    {
+        var result = EmittedOracle.Evaluate(@"
+struct Point {
+    var X int32
+    var Y int32
+}
+" + OrElseExtension + @"
+var pt Point? = Point{X: 7, Y: 8}
+var def = Point{X: 1, Y: 2}
+var r = pt.MyOrElse(def)
+r.X
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(7, result.Value);
+    }
+
+    [Fact]
+    public void PlainGenericFunction_TQuestionParameter_ValueTypeInstantiation()
+    {
+        // The same erased-slot defect reproduced without an extension
+        // receiver: the lift keys off the declared T? parameter shape, not
+        // extension-ness.
+        var result = EmittedOracle.Evaluate(@"
+func MyOrElse[T](self T?, fb T) T {
+    if self != nil { return self!! }
+    return fb
+}
+var v int32? = nil
+MyOrElse(v, 99)
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(99, result.Value);
+    }
+
+    [Fact]
+    public void StringNullableReceiver_Control_StaysOnReferencePath()
+    {
+        // Reference instantiations keep the historical (working) bare-!!T
+        // erasure — no lift, no behavioral change.
+        var result = EmittedOracle.Evaluate(OrElseExtension + @"
+var s string? = nil
+s.MyOrElse(""def"")
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("def", result.Value);
+    }
+}


### PR DESCRIPTION
Fixes #3226. Fixes #3222. Fixes #3219. Part of #3176 (pre-3c burn-down), part of #3163.

## Summary

Three constructed-generics emit-path bugs found by the Phase 3b.1 oracle migration, one commit each:

- **#3226** — lift unconstrained `T?` generic calls to `Nullable<X>` at value-type call sites (`MethodBodyEmitter.TryPlanUnconstrainedNullableLift` + `BuildMethodSpecForLiftedGenericCall`): wrap bare-`T` args via `newobj Nullable<X>::.ctor`, unwrap a bare-`T` return via `box`+`unbox.any`.
- **#3222** — narrow the plain-call argument-conversion skip in `OverloadResolver.CallBinding` from "parameter CONTAINS a type parameter" to "parameter IS a bare type parameter", so a struct argument to a constructed-interface slot (`IHolder[T]`) materializes its `box`.
- **#3219** — synthesize a public parameterless `.ctor` for value structs whose declared field initializers include a non-public field (runs ALL initializers in-type); struct-literal/projection sites construct through it and skip the injected initializer entries (side effects run once). All-public-initializer structs keep the historical inline emission byte-for-byte.

## Root causes

| Issue | Symptom | Root cause | Fix layer |
|---|---|---|---|
| #3226 | `InvalidProgramException` at `int32?`; **silent wrong value** (default `Point` instead of fallback) at `Point?` | Unconstrained `T?` encodes as bare MVAR `!!T` (SignatureEncoder's reference-nullable model), but the call site pushes a live `Nullable<X>` into the `X`-instantiated slot — no unwrap/box anywhere; the two symptoms are the JIT's two reactions to the same layout mismatch | Emit (call-site MethodSpec lift; definition IL unchanged) |
| #3222 | `InvalidProgramException` passing an implementing struct as `IHolder[T]` | `OverloadResolver.CallBinding`'s per-argument guard skipped `BindConversion` for ANY parameter containing a type parameter; only a bare `!!T` slot is emitter-erased — `IHolder<!!T>` is a real reference slot needing the `box` | Binding (guard narrowed to `parameter.Type is TypeParameterSymbol`, mirroring `BindUserInstanceCall`) |
| #3219 | `FieldAccessException` writing `Box`1<int32>.Marker` from the call site | Value-struct literals (incl. struct-target structural projection) inline ALL declared field initializers as raw `stfld`s at the construction site; `GetUserStructFieldRef` has no visibility gate, and the CLR rejects the out-of-type private store (class targets already routed through the synthesized default ctor) | Emit (synthesized in-type parameterless ctor; planner + literal emission) |

Scope notes:
- #3226's lift generalizes to any *method* type parameter with a declared `T?` slot (the plain `func F[T](x T?)` shape was equally broken); struct-constrained `T?` (#814), reference instantiations, async bodies, byref slots, and nested-`T` shapes keep the status quo. No new emit caches (the lift reuses `BuildMethodSpec`; GSA0004 untouched).
- #3219's class-shaped repro from the issue already passed at current main (the class path constructs through its default ctor); the live defect was the struct-target path — both shapes are pinned. The projection's synthesized `""`-fill for a *private uninitialized* string field remains a known gap (pre-existing, unhit by the pinned tests).
- Unpins the three 3b.1 evaluator-pinned tests (#3221/#3225/#3228 twins deleted where orphaned); `StructuralProjectionTests` keeps its `EvaluateWithEvaluator` twin for the unrelated #3218 pin.

## Verification

- `dotnet build GSharp.sln -c Release`: 0 warnings, 0 errors.
- Witness (ADR-0154), two-sided: with the three product commits stashed (tests kept), **16 tests RED** — all 14 new emit-level tests' non-control cases + the 3 unpinned tests (`InvalidProgramException` / `FieldAccessException` / wrong values), controls green; with the fixes restored, **63/63 GREEN** across the six touched test classes.
- ILVerify (the CI gate, run locally via the repo tool): all repro assemblies verify clean post-fix — `int32?`/`Point?` receiver lift, plain `T?` param, struct→`IHolder[string]` box, struct/class projection, private-initializer literal (pre-fix: `StackUnexpected` ×3 shapes).
- Targeted filters (`~Generic|~Extension|~Projection|~Nullable|~StructLiteral`, Core.Tests Release): **1402/1402**.
- Full `Core.Tests` (Release): **7151/7152 passed**, 1 skipped (standing `RegenerateBaseline` skip), 0 failed (4 m 26 s).
- `Compiler.Tests` LanguageConformance filter: **126/126 passed** (2 m 12 s).
- Full `Interpreter.Tests` (evaluator untouched; parity backstop): **1484/1488 passed**, 4 skipped (standing skips, incl. the #3210-disabled map-concurrency tests), 0 failed (1 m 46 s).
- **CI-caught regression + fix** (`fc1dfb83`): the tests (compiler-issue1-remainder) shard flagged `Issue1518NullableDelegateInferenceEmitTests.EndToEnd_NullableReturn_IntoUserGenericMethod_Runs` (ILVerify `DelegateCtor`/`StackUnexpected`) — the #3222 guard narrowing had pulled lambda arguments into `BindConversion`, rebuilding the delegate from the collapsed structural shape (`Func<int32,int32>`) instead of the emitter's #1518 nullable-preserving shape. Fixed by keeping function-shaped arguments on the historical skip (`structuralArgumentType is not FunctionTypeSymbol`). Post-fix: `Issue1518` filter **5/5** (was 4/5), Compiler.Tests `~Delegate` sweep **328/328**, witness filter **63/63**, full Core.Tests re-run **7151/7152** (1 standing skip), 0 failed.
- NOT RUN: `Extensions.Tests`, `LanguageServer.Tests`, `Sdk.Tests`, `GeneratorHost.Tests` (no surface touched beyond Binding/Emit; CI required checks are the backstop), `Cs2Gs.Tests` (pre-existing flaky host crash; GoldenTests-filter policy), full `Compiler.Tests` beyond the conformance gate (time; conformance is the language-behavior gate for this cluster).

## Checklist

- [x] Behavioral tests carry a witness of discrimination (ADR-0154): each new/changed test fails on the pre-change code (pre-fix commit, reverted hunk, or an applied product mutant) and passes with it.
- [x] Self-review verdict recorded when one was run (MERGEABLE / BLOCKER / SHOULD-FIX / NIT), with residuals filed as issues rather than dropped.

Self-review verdict: **MERGEABLE** — three orthogonal, minimally-scoped fixes; every deliberately-out-of-scope shape (nested-`T` lift, imported-struct private initializers, explicit-parameterless-ctor structs) degrades to today's behavior rather than a new one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
