### PR TITLE
Reduce evaluator override dispatch allocations

### DIFF
--- a/src/Core/CodeAnalysis/Evaluator.Calls.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Calls.cs
@@ -1060,7 +1060,7 @@ public sealed partial class Evaluator
     }
 
     private StructValue CreateStructValue(StructSymbol structType) =>
-        new(structType, TryEvaluateExternalOverride);
+        new(structType, objectOverrideDispatcher);
 
     private bool TryEvaluateExternalOverride(
         StructValue receiver,
@@ -1104,14 +1104,18 @@ public sealed partial class Evaluator
 
     private static FunctionSymbol FindExternalOverride(StructSymbol type, MethodInfo externalMethod)
     {
-        FunctionSymbol externalOverride = null;
-        for (; type != null && externalOverride == null; type = type.BaseClass)
+        for (; type != null; type = type.BaseClass)
         {
-            externalOverride = type.Methods.FirstOrDefault(method =>
-                method.IsOverride && FindExternalOverrideRoot(method)?.Equals(externalMethod) == true);
+            foreach (var method in type.Methods)
+            {
+                if (method.IsOverride && FindExternalOverrideRoot(method)?.Equals(externalMethod) == true)
+                {
+                    return method;
+                }
+            }
         }
 
-        return externalOverride;
+        return null;
     }
 
     private static MethodInfo FindExternalOverrideRoot(FunctionSymbol method)

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -40,6 +40,7 @@ public sealed partial class Evaluator
     private readonly Dictionary<VariableSymbol, object> globals;
     private readonly bool evaluateEntryPoint;
     private readonly bool useEntryPointReturnType;
+    private readonly StructValue.ObjectOverrideDispatcher objectOverrideDispatcher;
 
     // Issue #1651: everything below this point used to be an ordinary
     // instance field. That is correct only because the interpreter was
@@ -127,6 +128,7 @@ public sealed partial class Evaluator
         globals = variables;
         this.evaluateEntryPoint = evaluateEntryPoint;
         this.useEntryPointReturnType = useEntryPointReturnType;
+        objectOverrideDispatcher = TryEvaluateExternalOverride;
         Locals.Push(new ConcurrentDictionary<VariableSymbol, object>());
     }
 

--- a/test/Interpreter.Tests/Issue2896StructObjectOverrideTests.cs
+++ b/test/Interpreter.Tests/Issue2896StructObjectOverrideTests.cs
@@ -9,9 +9,11 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Repl.Engine;
 using GSharp.Tests;
 using Xunit;
 using CompilerProgram = GSharp.Compiler.Program;
@@ -135,6 +137,51 @@ public class Issue2896StructObjectOverrideTests
         AssertIssue3134EmittedSemantics(surface, emitted);
         Assert.Equal(emitted, await RunDriverAsync(source, suffix + "Evaluate", "gsc-evaluate"));
         Assert.Equal(emitted, await RunDriverAsync(source, suffix + "Gsi", "gsi"));
+    }
+
+    [Fact]
+    public void Issue3135_NoOverrideDispatchReusesDelegateWithoutPerCallClosure()
+    {
+        const string Source = """
+            package Issue3135
+            import System
+
+            struct Empty {
+            }
+
+            let first = Empty{}
+            let second = Empty{}
+            Console.WriteLine(first.Equals(second))
+            """;
+
+        var engine = new SessionEngine { CaptureConsole = true };
+        var cell = engine.Evaluate(Source);
+
+        Assert.False(cell.HasError, string.Join(Environment.NewLine, cell.Diagnostics));
+        Assert.Equal("True\n", cell.Output);
+
+        var values = engine.Variables.Values.OfType<StructValue>().ToArray();
+        Assert.Equal(2, values.Length);
+
+        var dispatcherField = typeof(StructValue).GetField(
+            "objectOverrideDispatcher",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(dispatcherField);
+        var dispatcher = dispatcherField.GetValue(values[0]);
+        Assert.NotNull(dispatcher);
+        Assert.Same(dispatcher, dispatcherField.GetValue(values[1]));
+
+        _ = values[0].GetHashCode();
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var i = 0; i < 100_000; i++)
+        {
+            _ = values[0].GetHashCode();
+        }
+
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        Assert.True(
+            allocated < 14_000_000,
+            $"100,000 no-override hash calls allocated {allocated:N0} bytes; expected no per-call LINQ closure.");
     }
 
     [Theory]


### PR DESCRIPTION
## Summary

- Confirms the post-#3127 slowdown still reproduces on reachable tree-walking evaluator surfaces: `Compilation.Evaluate` and the evaluator `SessionEngine` escape hatch.
- Removes the capturing LINQ predicate allocated by every override lookup.
- Reuses one evaluator-bound override dispatcher instead of allocating one delegate per `StructValue`.
- Deliberately does **not** resurrect #3194's override-result cache; that cache measured 5.2% slower despite a 99.99975% hit rate.

Refs #3135.

## Why this lever

Profiling placed `FindExternalOverride` scanning at only 0.14% exclusive CPU. Allocation measurement found the real regression: post-#3127 added about 8 MB per issue workload, and the capturing predicate alone allocated exactly 88 bytes per hash lookup (17.6 MB versus 8.8 MB over 100,000 calls). The fix removes those allocations without adding a dictionary or cache lookup.

File-mode and default interactive `gsi` now emit after ADR-0156, so they do not enter this path. The embedding API remains reachable; `SessionEngine` remains reachable through the documented evaluator escape hatch.

## Paired benchmarks

Release binaries were prebuilt and remained static. Each process warmed twice and reported the median of five workload executions. Each table contains 40 pairs in alternating A/B order. Load was captured before every process; threshold was 30 and observed ranges were 8.18–20.68, so no sample was discarded.

Exact workload: 20,000 dictionary inserts plus 20,000 lookups of a struct with no overrides.

### Does the regression reproduce?

Parent is #3127's parent (`4469e323`); main is `d5d25e4c`, whose evaluator sources are byte-identical through the final base `d6e7c4c39`.

| Surface | Parent median (min–max, σ), ms | Main median (min–max, σ), ms | Paired parent/main median (min–max, σ) | Parent faster |
|---|---:|---:|---:|---:|
| `Compilation.Evaluate` | 126.263 (113.536–143.795, 8.642) | 135.810 (122.925–149.834, 7.050) | 0.933× (0.796–1.101, 0.072) | 33/40 |
| evaluator `SessionEngine` | 125.915 (114.090–177.552, 10.338) | 135.761 (124.369–155.345, 8.622) | 0.933× (0.789–1.180, 0.075) | 35/40 |

Yes: current main is about 7.2% slower on both reachable evaluator surfaces.

### Before/after fix

| Surface | Main median (min–max, σ), ms | Fix median (min–max, σ), ms | Paired main/fix median (min–max, σ) | Fix faster |
|---|---:|---:|---:|---:|
| `Compilation.Evaluate` | 129.719 (119.058–294.777, 35.521) | 124.295 (114.043–188.610, 16.482) | 1.061× (0.675–1.750, 0.165) | 31/40 |
| evaluator `SessionEngine` | 121.830 (113.066–150.995, 9.088) | 114.461 (108.477–127.557, 4.710) | 1.062× (0.937–1.269, 0.075) | 37/40 |

### Positive control

The known #3134 class-identity difference was detected through both surfaces:

| Surface | #3127 parent | current main | fix |
|---|---|---|---|
| `Compilation.Evaluate` | `True` | `False` | `False` |
| evaluator `SessionEngine` | `True` | `False` | `False` |

## Mutation table

All applied mutants had a non-empty product diff and changed `GSharp.Core.dll`; killed mutants restored to the exact pre-mutant md5 before continuing.

| Mutant | Result | Signal |
|---|---|---|
| Per-value method-group allocation restored | RED | shared-dispatcher identity assertion failed |
| Capturing `FirstOrDefault` restored | RED | 100,000 hash calls allocated 17,600,000 bytes, above the 14 MB guard |
| Evaluator dispatcher initialized to `null` | RED | non-null dispatcher assertion failed |
| Base-chain loop condition inverted (`type == null`) | RED | printed dictionary count changed from expected `2` to `1` |
| `IsOverride` condition inverted | SURVIVED existing targeted corpus | Not scored; direct and implicit-override suites stayed green |
| Root-method match condition inverted | SURVIVED existing targeted corpus | Not scored; a follow-up probe threw before producing asserted output, so it was retargeted to the loop mutant above |

Main-without-PR control: the relevant existing `Issue2896StructObjectOverrideTests` corpus passed 46/46. Mutant restoration controls were GREEN with exact md5 round-trips.

## Validation

The denominator is 9 projects from `dotnet sln GSharp.sln list`.

- 9/9 unfiltered: **15,481 passed, 5 skipped, 0 failed**
- Final solution build: 0 warnings, 0 errors
- ILVerify: **123/123**, 2 documented suppressions, 0 verification failures
- Final `GSharp.Core.dll`: 20/20 top-level Release consumers non-zero and md5-identical
