### PR TITLE
Hand-migrate the non-canonical Compilation.Evaluate tail (Phase 3b.2)

### DIFF
--- a/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
+++ b/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
@@ -1223,7 +1223,16 @@ public sealed class ReferenceResolver : IDisposable
 
         foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
         {
-            if (asm.IsDynamic || AssemblyLoadContext.GetLoadContext(asm) is DriverReferenceLoadContext)
+            // Collectible load contexts hold execution artifacts — in-memory
+            // emitted programs and submissions (EmittedProgramHost,
+            // InteractiveSessionHost, the test oracle) awaiting unload — not
+            // references. Including them let a finished run's emitted types
+            // shadow same-named source packages in later compilations
+            // (issue #3235); driver reference contexts stay excluded as
+            // before.
+            if (asm.IsDynamic
+                || AssemblyLoadContext.GetLoadContext(asm) is DriverReferenceLoadContext
+                || (AssemblyLoadContext.GetLoadContext(asm)?.IsCollectible ?? false))
             {
                 continue;
             }

--- a/test/Core.Tests/CodeAnalysis/Binding/AnonymousClassExpressionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/AnonymousClassExpressionTests.cs
@@ -100,13 +100,12 @@ let a = object { let Id int32 = 1; let Alias string = ""x"" }
 let b = object { let Id int32 = 2; let Alias string = ""y"" }
 1
 ";
-        // Phase 3b (issue #3176): stays on Compilation.Evaluate — the test
-        // inspects this Compilation's bound state afterwards, which the
-        // EmittedOracle does not expose; disposition in 3b.2.
+        // Binder-inspection test (issue #3176 Phase 3b.2): bind via
+        // EmittedOracle.CompileDiagnostics and inspect this Compilation's
+        // bound state; nothing needs to run.
         var tree = SyntaxTree.Parse(SourceText.From(source));
         var compilation = new Compilation(tree);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.Empty(result.Diagnostics);
+        Assert.Empty(EmittedOracle.CompileDiagnostics(compilation));
         Assert.Single(compilation.GlobalScope.AnonymousTypes);
     }
 
@@ -118,13 +117,12 @@ let a = object { let Id int32 = 1 }
 let b = object { let Id int32 = 1; let Alias string = ""x"" }
 1
 ";
-        // Phase 3b (issue #3176): stays on Compilation.Evaluate — the test
-        // inspects this Compilation's bound state afterwards, which the
-        // EmittedOracle does not expose; disposition in 3b.2.
+        // Binder-inspection test (issue #3176 Phase 3b.2): bind via
+        // EmittedOracle.CompileDiagnostics and inspect this Compilation's
+        // bound state; nothing needs to run.
         var tree = SyntaxTree.Parse(SourceText.From(source));
         var compilation = new Compilation(tree);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.Empty(result.Diagnostics);
+        Assert.Empty(EmittedOracle.CompileDiagnostics(compilation));
         Assert.Equal(2, compilation.GlobalScope.AnonymousTypes.Length);
     }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/ByRefEvaluationTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ByRefEvaluationTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -48,12 +49,16 @@ var ok = Int32.TryParse(""notanumber"", &result)
     [Fact]
     public void Dereference_Returns_Original_Value()
     {
+        // ADR-0156 Phase 3b (#3176): pinned on Compilation.Evaluate — a
+        // pointer-typed top-level global trips the #3215 signature-encoding
+        // failure under emit ("Cannot encode '*int32' as a non-byref
+        // signature slot"); realigns with that issue's resolution.
         var source = @"
 var x = 100
 var p = &x
 var y = *p
 ";
-        var (eval, vars) = EvaluateWithVariables(source);
+        var (eval, vars) = EvaluateWithEvaluatorVariables(source);
         Assert.Empty(eval.Diagnostics);
         Assert.Equal(100, vars["y"]);
     }
@@ -61,17 +66,31 @@ var y = *p
     [Fact]
     public void AddressOf_Evaluates_To_Value_In_Interpreter()
     {
+        // ADR-0156 Phase 3b (#3176): pinned on Compilation.Evaluate — same
+        // #3215 pointer-global emit failure as above, and the asserted
+        // semantics ("&x evaluates to the value") are the interpreter's
+        // pointer model by design (ADR-0039); retires with the evaluator.
         var source = @"
 var x = 55
 var p = &x
 ";
-        var (eval, vars) = EvaluateWithVariables(source);
+        var (eval, vars) = EvaluateWithEvaluatorVariables(source);
         Assert.Empty(eval.Diagnostics);
         // In the interpreter, &x just evaluates to the value of x.
         Assert.Equal(55, vars["p"]);
     }
 
-    private static (EvaluationResult Result, Dictionary<string, object> Variables) EvaluateWithVariables(string source)
+    private static (EmittedOracleResult Result, IReadOnlyDictionary<string, object> Variables) EvaluateWithVariables(string source)
+    {
+        // Post-run globals read back through the oracle (issue #3176 Phase
+        // 3b.2): the emitted equivalent of the evaluator's variables
+        // dictionary.
+        var result = EmittedOracle.Evaluate(source);
+        return (result, result.ReadGlobals());
+    }
+
+    // ADR-0156 Phase 3b (#3176): evaluator twin for the #3215-pinned tests.
+    private static (EvaluationResult Result, Dictionary<string, object> Variables) EvaluateWithEvaluatorVariables(string source)
     {
         var tree = SyntaxTree.Parse(SourceText.From(source));
         var compilation = new Compilation(tree);

--- a/test/Core.Tests/CodeAnalysis/Binding/ClassTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ClassTests.cs
@@ -412,13 +412,12 @@ open class A {
     open func F() int32 { return 1 }
 }
 "));
-        // Phase 3b (issue #3176): stays on Compilation.Evaluate — multi-tree
-        // compilation; the EmittedOracle takes a single source. Disposition
-        // in 3b.2.
-        var result = new Compilation(derived, baseType)
-            .Evaluate(new Dictionary<VariableSymbol, object>());
+        // Tree-order binder regression (issue #3176 Phase 3b.2): bind the
+        // plain multi-tree compilation via EmittedOracle.CompileDiagnostics;
+        // the sources declare types only and nothing needs to run.
+        var compilation = new Compilation(derived, baseType);
 
-        Assert.Empty(result.Diagnostics);
+        Assert.Empty(EmittedOracle.CompileDiagnostics(compilation));
     }
 
     [Fact]

--- a/test/Core.Tests/CodeAnalysis/Binding/DataStructTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/DataStructTests.cs
@@ -249,13 +249,12 @@ data struct Point {
 }
 0
 ";
-        // Phase 3b (issue #3176): stays on Compilation.Evaluate — the test
-        // inspects this Compilation's bound state afterwards, which the
-        // EmittedOracle does not expose; disposition in 3b.2.
+        // Binder-inspection helper (issue #3176 Phase 3b.2): bind via
+        // EmittedOracle.CompileDiagnostics and inspect this Compilation's
+        // bound state; nothing needs to run.
         var tree = SyntaxTree.Parse(SourceText.From(source));
         compilation = new Compilation(tree);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.Empty(result.Diagnostics);
+        Assert.Empty(EmittedOracle.CompileDiagnostics(compilation));
         var sym = (StructSymbol)compilation.GlobalScope.Structs.Single(s => s.Name == "Point");
         Assert.NotNull(sym);
         Assert.True(sym.IsData);

--- a/test/Core.Tests/CodeAnalysis/Binding/ExtensionFunctionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ExtensionFunctionTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -22,14 +23,14 @@ public class ExtensionFunctionTests
     [Fact]
     public void Extension_OnCrossPackageUserStruct_Binds_And_Dispatches()
     {
-        var typeTree = SyntaxTree.Parse(SourceText.From(@"
+        var typeTree = @"
 package Geometry
 public struct Point {
     var X int32
     var Y int32
 }
-"));
-        var extensionTree = SyntaxTree.Parse(SourceText.From(@"
+";
+        var extensionTree = @"
 package GeometryExtensions
 func (p Point) SumXY() int32 {
     return p.X + p.Y
@@ -37,7 +38,7 @@ func (p Point) SumXY() int32 {
 
 var p = Point{X: 3, Y: 4}
 p.SumXY()
-"));
+";
         var result = Evaluate(typeTree, extensionTree);
         Assert.Empty(result.Diagnostics);
         Assert.Equal(7, result.Value);
@@ -314,15 +315,13 @@ a
         Assert.NotEmpty(result.Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        return Evaluate(syntaxTree);
+        return EmittedOracle.Evaluate(source);
     }
 
-    private static EvaluationResult Evaluate(params SyntaxTree[] syntaxTrees)
+    private static EmittedOracleResult Evaluate(params string[] sources)
     {
-        var compilation = new Compilation(syntaxTrees);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(sources);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/InterfaceTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/InterfaceTests.cs
@@ -221,24 +221,20 @@ sealed interface IGood {
     [Fact]
     public void SealedInterface_DifferentPackage_Implementor_Diagnoses()
     {
-        var t1 = SyntaxTree.Parse(SourceText.From(@"
+        var t1 = @"
 package GSharp.Tests.Sealed.A
 public sealed interface IResult {
     func Ok() bool;
 }
-"));
-        var t2 = SyntaxTree.Parse(SourceText.From(@"
+";
+        var t2 = @"
 package GSharp.Tests.Sealed.B
 import GSharp.Tests.Sealed.A
 class Success : IResult {
     func Ok() bool { return true }
 }
-"));
-        // Phase 3b (issue #3176): stays on Compilation.Evaluate — multi-tree
-        // compilation; the EmittedOracle takes a single source. Disposition
-        // in 3b.2.
-        var compilation = new Compilation(t1, t2);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+";
+        var result = EmittedOracle.Evaluate(new[] { t1, t2 });
         Assert.Contains(result.Diagnostics, d => d.Message.Contains("sealed interface"));
     }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/InterpolatedStringHandlerArgumentTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/InterpolatedStringHandlerArgumentTests.cs
@@ -15,6 +15,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -267,12 +268,11 @@ let msg = InterpolationHarness.Gated(false, ""y=${InterpolationHarness.BumpAndRe
 
     private static (ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> Diagnostics, object? Value) EvaluateNamed(string source, string variableName)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        var vars = new Dictionary<VariableSymbol, object>();
-        var result = compilation.Evaluate(vars);
-        var match = vars.FirstOrDefault(kv => kv.Key.Name == variableName);
-        return (result.Diagnostics, match.Key is null ? null : match.Value);
+        // Post-run global read back through the oracle (issue #3176 Phase
+        // 3b.2): the emitted equivalent of the evaluator's variables
+        // dictionary.
+        var result = EmittedOracle.Evaluate(source);
+        return (result.Diagnostics, result.ReadGlobal(variableName));
     }
 
     private static string CompileAndRun(string source, string contextName)

--- a/test/Core.Tests/CodeAnalysis/Binding/InterpolatedStringTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/InterpolatedStringTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -59,7 +60,7 @@ public class InterpolatedStringTests
         var source = "let name = \"world\"\nlet msg = \"hello $name\"\n";
         var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
-        var msg = result.Variables.Single(kv => kv.Key.Name == "msg");
+        var msg = result.Variables.Single(kv => kv.Key == "msg");
         Assert.Equal("hello world", msg.Value);
     }
 
@@ -69,7 +70,7 @@ public class InterpolatedStringTests
         var source = "let n = 42\nlet msg = \"answer=$n\"\n";
         var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
-        var msg = result.Variables.Single(kv => kv.Key.Name == "msg");
+        var msg = result.Variables.Single(kv => kv.Key == "msg");
         Assert.Equal("answer=42", msg.Value);
     }
 
@@ -79,7 +80,7 @@ public class InterpolatedStringTests
         var source = "let msg = \"sum=${1 + 2}\"\n";
         var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
-        var msg = result.Variables.Single(kv => kv.Key.Name == "msg");
+        var msg = result.Variables.Single(kv => kv.Key == "msg");
         Assert.Equal("sum=3", msg.Value);
     }
 
@@ -89,7 +90,7 @@ public class InterpolatedStringTests
         var source = "let a = 1\nlet b = 2\nlet msg = \"$a + $b = ${a + b}\"\n";
         var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
-        var msg = result.Variables.Single(kv => kv.Key.Name == "msg");
+        var msg = result.Variables.Single(kv => kv.Key == "msg");
         Assert.Equal("1 + 2 = 3", msg.Value);
     }
 
@@ -112,7 +113,7 @@ public class InterpolatedStringTests
         var source = "let n = 255\nlet msg = \"${n:X4}\"\n";
         var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
-        var msg = result.Variables.Single(kv => kv.Key.Name == "msg");
+        var msg = result.Variables.Single(kv => kv.Key == "msg");
         Assert.Equal("00FF", msg.Value);
     }
 
@@ -122,7 +123,7 @@ public class InterpolatedStringTests
         var source = "let s = \"hi\"\nlet msg = \"[${s,5}]\"\n";
         var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
-        var msg = result.Variables.Single(kv => kv.Key.Name == "msg");
+        var msg = result.Variables.Single(kv => kv.Key == "msg");
         Assert.Equal("[   hi]", msg.Value);
     }
 
@@ -132,7 +133,7 @@ public class InterpolatedStringTests
         var source = "let s = \"hi\"\nlet msg = \"[${s,-5}]\"\n";
         var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
-        var msg = result.Variables.Single(kv => kv.Key.Name == "msg");
+        var msg = result.Variables.Single(kv => kv.Key == "msg");
         Assert.Equal("[hi   ]", msg.Value);
     }
 
@@ -142,7 +143,7 @@ public class InterpolatedStringTests
         var source = "let n = 255\nlet msg = \"[${n,6:X2}]\"\n";
         var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
-        var msg = result.Variables.Single(kv => kv.Key.Name == "msg");
+        var msg = result.Variables.Single(kv => kv.Key == "msg");
         Assert.Equal("[    FF]", msg.Value);
     }
 
@@ -154,7 +155,7 @@ public class InterpolatedStringTests
         var source = "let n = 1\nlet msg = \"${n.GetType()}\"\n";
         var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
-        var msg = result.Variables.Single(kv => kv.Key.Name == "msg");
+        var msg = result.Variables.Single(kv => kv.Key == "msg");
         Assert.Equal("System.Int32", msg.Value);
     }
 
@@ -167,7 +168,7 @@ public class InterpolatedStringTests
         var source = "let total = 1234.5\nlet msg = \"amount: ${total:N2}\"\n";
         var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
-        var msg = result.Variables.Single(kv => kv.Key.Name == "msg");
+        var msg = result.Variables.Single(kv => kv.Key == "msg");
         Assert.Equal("amount: " + (1234.5).ToString("N2", System.Globalization.CultureInfo.CurrentCulture), msg.Value);
     }
 
@@ -177,7 +178,7 @@ public class InterpolatedStringTests
         var source = "let name = \"Acme\"\nlet msg = \"[${name,8}][${name,-8}]\"\n";
         var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
-        var msg = result.Variables.Single(kv => kv.Key.Name == "msg");
+        var msg = result.Variables.Single(kv => kv.Key == "msg");
         Assert.Equal("[    Acme][Acme    ]", msg.Value);
     }
 
@@ -190,7 +191,7 @@ public class InterpolatedStringTests
         var source = "let total = 1234.5\nlet fs FormattableString = \"amount: ${total:N2}\"\n";
         var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
-        var fs = result.Variables.Single(kv => kv.Key.Name == "fs").Value;
+        var fs = result.Variables.Single(kv => kv.Key == "fs").Value;
         Assert.IsAssignableFrom<System.FormattableString>(fs);
     }
 
@@ -202,7 +203,7 @@ public class InterpolatedStringTests
         var source = "let total = 1234.5\nlet fs FormattableString = \"amount: ${total:N2}\"\n";
         var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
-        var fs = (System.FormattableString)result.Variables.Single(kv => kv.Key.Name == "fs").Value;
+        var fs = (System.FormattableString)result.Variables.Single(kv => kv.Key == "fs").Value;
 
         Assert.Equal("amount: 1,234.50", fs.ToString(System.Globalization.CultureInfo.InvariantCulture));
         Assert.Equal("amount: 1.234,50", fs.ToString(System.Globalization.CultureInfo.GetCultureInfo("de-DE")));
@@ -216,7 +217,7 @@ public class InterpolatedStringTests
         var source = "let total = 1234.5\nlet qty = 7\nlet fs FormattableString = \"a ${total:N2} b ${qty,4} c\"\n";
         var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
-        var fs = (System.FormattableString)result.Variables.Single(kv => kv.Key.Name == "fs").Value;
+        var fs = (System.FormattableString)result.Variables.Single(kv => kv.Key == "fs").Value;
 
         Assert.Equal("a {0:N2} b {1,4} c", fs.Format);
         Assert.Equal(2, fs.ArgumentCount);
@@ -229,7 +230,7 @@ public class InterpolatedStringTests
         var source = "let n = 42\nlet f IFormattable = \"n=${n:D3}\"\n";
         var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
-        var f = result.Variables.Single(kv => kv.Key.Name == "f").Value;
+        var f = result.Variables.Single(kv => kv.Key == "f").Value;
         Assert.IsAssignableFrom<System.IFormattable>(f);
         Assert.Equal("n=042", ((System.IFormattable)f).ToString(null, System.Globalization.CultureInfo.InvariantCulture));
     }
@@ -250,7 +251,7 @@ public class InterpolatedStringTests
             "let msg = render(\"amount: ${total:N2}\")\n";
         var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
-        var msg = result.Variables.Single(kv => kv.Key.Name == "msg").Value;
+        var msg = result.Variables.Single(kv => kv.Key == "msg").Value;
         Assert.Equal("amount: 1.234,50", msg);
     }
 
@@ -268,7 +269,7 @@ public class InterpolatedStringTests
             "let msg = render(\"n=${n:D3}\")\n";
         var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
-        var msg = result.Variables.Single(kv => kv.Key.Name == "msg").Value;
+        var msg = result.Variables.Single(kv => kv.Key == "msg").Value;
         Assert.IsAssignableFrom<System.IFormattable>(msg);
         Assert.Equal("n=042", ((System.IFormattable)msg).ToString(null, System.Globalization.CultureInfo.InvariantCulture));
     }
@@ -287,7 +288,7 @@ public class InterpolatedStringTests
             "let msg = echo(\"amount: ${total:N2}\")\n";
         var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
-        var msg = result.Variables.Single(kv => kv.Key.Name == "msg").Value;
+        var msg = result.Variables.Single(kv => kv.Key == "msg").Value;
         Assert.IsType<string>(msg);
         Assert.Equal("amount: " + (1234.5).ToString("N2", System.Globalization.CultureInfo.CurrentCulture), msg);
     }
@@ -308,7 +309,7 @@ public class InterpolatedStringTests
             "}\n";
         var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
-        var msg = result.Variables.Single(kv => kv.Key.Name == "msg").Value;
+        var msg = result.Variables.Single(kv => kv.Key == "msg").Value;
         Assert.IsType<string>(msg);
         Assert.Equal("x", msg);
     }
@@ -326,7 +327,7 @@ public class InterpolatedStringTests
             "let msg = FormattableString.Invariant(\"amount: ${total:N2}\")\n";
         var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
-        var msg = result.Variables.Single(kv => kv.Key.Name == "msg").Value;
+        var msg = result.Variables.Single(kv => kv.Key == "msg").Value;
         Assert.Equal("amount: 1,234.50", msg);
     }
 
@@ -345,7 +346,7 @@ public class InterpolatedStringTests
         var source = "let msg = \"x=${\"inner\"}\"\n";
         var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
-        var msg = result.Variables.Single(kv => kv.Key.Name == "msg");
+        var msg = result.Variables.Single(kv => kv.Key == "msg");
         Assert.Equal("x=inner", msg.Value);
     }
 
@@ -357,7 +358,7 @@ public class InterpolatedStringTests
         var source = "let msg = \"${\"a,b:c\".Length}\"\n";
         var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
-        var msg = result.Variables.Single(kv => kv.Key.Name == "msg");
+        var msg = result.Variables.Single(kv => kv.Key == "msg");
         Assert.Equal("5", msg.Value);
     }
 
@@ -368,7 +369,7 @@ public class InterpolatedStringTests
         var source = "let msg = \"sum=${1 +\n2}\"\n";
         var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
-        var msg = result.Variables.Single(kv => kv.Key.Name == "msg");
+        var msg = result.Variables.Single(kv => kv.Key == "msg");
         Assert.Equal("sum=3", msg.Value);
     }
 
@@ -415,10 +416,7 @@ public class InterpolatedStringTests
         // point at the expression's true offset in the outer file, not at the
         // whole string token (or offset 0).
         var source = "let x = 1\nlet msg = \"val=${undefinedThing}\"\n";
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        var vars = new System.Collections.Generic.Dictionary<VariableSymbol, object>();
-        var result = compilation.Evaluate(vars);
+        var result = EmittedOracle.Evaluate(source);
 
         var expectedStart = source.IndexOf("undefinedThing", System.StringComparison.Ordinal);
         var diagnostic = Assert.Single(result.Diagnostics, d => d.Location.Span.Start == expectedStart);
@@ -433,10 +431,7 @@ public class InterpolatedStringTests
         // right for a hole many lines into the file.
         var source = string.Concat(System.Linq.Enumerable.Repeat("let a = 1\n", 20))
             + "let msg = \"val=${undefinedThing}\"\n";
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        var vars = new System.Collections.Generic.Dictionary<VariableSymbol, object>();
-        var result = compilation.Evaluate(vars);
+        var result = EmittedOracle.Evaluate(source);
 
         var expectedStart = source.IndexOf("undefinedThing", System.StringComparison.Ordinal);
         var diagnostic = Assert.Single(result.Diagnostics, d => d.Location.Span.Start == expectedStart);
@@ -501,12 +496,12 @@ public class InterpolatedStringTests
         Assert.True(large < small * 50, $"expected near-linear scaling, got small={small} large={large} ratio={(double)large / small}");
     }
 
-    private static (ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> Diagnostics, System.Collections.Generic.Dictionary<VariableSymbol, object> Variables) Evaluate(string source)
+    private static (ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> Diagnostics, System.Collections.Generic.IReadOnlyDictionary<string, object> Variables) Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        var vars = new System.Collections.Generic.Dictionary<VariableSymbol, object>();
-        var result = compilation.Evaluate(vars);
-        return (result.Diagnostics, vars);
+        // Post-run globals read back through the oracle (issue #3176 Phase
+        // 3b.2): the emitted equivalent of the evaluator's variables
+        // dictionary.
+        var result = EmittedOracle.Evaluate(source);
+        return (result.Diagnostics, result.ReadGlobals());
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1154NullableWideningOverloadTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1154NullableWideningOverloadTests.cs
@@ -42,13 +42,13 @@ class C {
     func F(a []?uint8) { var n = 1 }
 }
 ";
-        // Phase 3b (issue #3176): stays on Compilation.Evaluate — the test
-        // inspects this Compilation's bound state afterwards (FindCall), which
-        // the EmittedOracle does not expose; disposition in 3b.2.
+        // Binder-inspection test (issue #3176 Phase 3b.2): bind via
+        // EmittedOracle.CompileDiagnostics and inspect this Compilation's
+        // bound state (FindCall); nothing needs to run.
         var compilation = Compile(source);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
-        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+        var diagnostics = EmittedOracle.CompileDiagnostics(compilation);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(diagnostics, d => d.IsError);
 
         var selected = FindCall(compilation, "F", "F");
         Assert.NotNull(selected);
@@ -68,13 +68,13 @@ class C {
     func F(a []uint8) { var n = 1 }
 }
 ";
-        // Phase 3b (issue #3176): stays on Compilation.Evaluate — the test
-        // inspects this Compilation's bound state afterwards (FindCall), which
-        // the EmittedOracle does not expose; disposition in 3b.2.
+        // Binder-inspection test (issue #3176 Phase 3b.2): bind via
+        // EmittedOracle.CompileDiagnostics and inspect this Compilation's
+        // bound state (FindCall); nothing needs to run.
         var compilation = Compile(source);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
-        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+        var diagnostics = EmittedOracle.CompileDiagnostics(compilation);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(diagnostics, d => d.IsError);
 
         var selected = FindCall(compilation, "F", "F");
         Assert.NotNull(selected);
@@ -93,13 +93,13 @@ class C {
     func F(a []?uint8) { F(C.Make()) }
 }
 ";
-        // Phase 3b (issue #3176): stays on Compilation.Evaluate — the test
-        // inspects this Compilation's bound state afterwards (FindCall), which
-        // the EmittedOracle does not expose; disposition in 3b.2.
+        // Binder-inspection test (issue #3176 Phase 3b.2): bind via
+        // EmittedOracle.CompileDiagnostics and inspect this Compilation's
+        // bound state (FindCall); nothing needs to run.
         var compilation = Compile(source);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
-        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+        var diagnostics = EmittedOracle.CompileDiagnostics(compilation);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(diagnostics, d => d.IsError);
 
         var selected = FindCall(compilation, "F", "F");
         Assert.NotNull(selected);
@@ -119,13 +119,13 @@ class C {
     func F(a []?uint8) { var n = 1 }
 }
 ";
-        // Phase 3b (issue #3176): stays on Compilation.Evaluate — the test
-        // inspects this Compilation's bound state afterwards (FindCall), which
-        // the EmittedOracle does not expose; disposition in 3b.2.
+        // Binder-inspection test (issue #3176 Phase 3b.2): bind via
+        // EmittedOracle.CompileDiagnostics and inspect this Compilation's
+        // bound state (FindCall); nothing needs to run.
         var compilation = Compile(source);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
-        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+        var diagnostics = EmittedOracle.CompileDiagnostics(compilation);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(diagnostics, d => d.IsError);
 
         var selected = FindCall(compilation, "F", "F");
         Assert.NotNull(selected);
@@ -171,14 +171,13 @@ class C {
     func F(a string) { F(C.Make()) }
 }
 ";
-        // Phase 3b (issue #3176): stays on Compilation.Evaluate — IsLibrary is a
-        // Compilation-level knob the EmittedOracle does not expose; disposition
-        // in 3b.2.
+        // Binder-diagnostics test over a library compilation (issue #3176
+        // Phase 3b.2): bind via EmittedOracle.CompileDiagnostics.
         var tree = SyntaxTree.Parse(SourceText.From(source));
         var compilation = new Compilation(tree) { IsLibrary = true };
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.NotEmpty(result.Diagnostics);
-        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
+        var diagnostics = EmittedOracle.CompileDiagnostics(compilation);
+        Assert.NotEmpty(diagnostics);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0266");
     }
 
     private static Compilation Compile(string source)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1246CompoundAssignWideningEvaluatorTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1246CompoundAssignWideningEvaluatorTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -59,19 +60,12 @@ x += 1
         Assert.Equal(4000000001L, vars["x"]);
     }
 
-    private static (EvaluationResult Result, Dictionary<string, object> Variables) EvaluateWithVariables(string source)
+    private static (EmittedOracleResult Result, IReadOnlyDictionary<string, object> Variables) EvaluateWithVariables(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        var variables = new Dictionary<VariableSymbol, object>();
-        var result = compilation.Evaluate(variables);
-
-        var namedVars = new Dictionary<string, object>();
-        foreach (var kvp in variables)
-        {
-            namedVars[kvp.Key.Name] = kvp.Value;
-        }
-
-        return (result, namedVars);
+        // Post-run globals read back through the oracle (issue #3176 Phase
+        // 3b.2): the emitted equivalent of the evaluator's variables
+        // dictionary.
+        var result = EmittedOracle.Evaluate(source);
+        return (result, result.ReadGlobals());
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1323GenericStaticReceiverBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1323GenericStaticReceiverBinderTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -81,9 +82,7 @@ class C { func F() int32 { return Box[int32].Make(5) } }
 
     private static IReadOnlyList<Diagnostic> GetDiagnostics(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree) { IsLibrary = true };
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(new[] { source }, new EmittedOracleOptions { IsLibrary = true });
         return result.Diagnostics;
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1379GenericStaticReturnSubstitutionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1379GenericStaticReturnSubstitutionTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -74,9 +75,7 @@ class C { func F() int32 { return Box[int32].Make() } }
 
     private static IReadOnlyList<Diagnostic> GetDiagnostics(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree) { IsLibrary = true };
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(new[] { source }, new EmittedOracleOptions { IsLibrary = true });
         return result.Diagnostics;
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1395ArityCollisionStaticReceiverTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1395ArityCollisionStaticReceiverTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -95,9 +96,7 @@ class C { func F() Box { return Box.Make() } }
 
     private static IReadOnlyList<Diagnostic> GetDiagnostics(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree) { IsLibrary = true };
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(new[] { source }, new EmittedOracleOptions { IsLibrary = true });
         return result.Diagnostics;
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1552NullableArgOverloadTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1552NullableArgOverloadTests.cs
@@ -10,6 +10,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -52,9 +53,9 @@ func Issue1552AF(caller Type) int32 -> 2
 func Issue1552AUseNull(t Type?) int32 -> Issue1552AF(t)
 ";
         var compilation = Compile(source);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
-        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+        var diagnostics = EmittedOracle.CompileDiagnostics(compilation);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(diagnostics, d => d.IsError);
 
         var selected = FindCall(compilation, "Issue1552AF");
         Assert.NotNull(selected);
@@ -74,8 +75,8 @@ func Issue1552NnF(caller Type) int32 -> 2
 func Issue1552NnUse(t Type) int32 -> Issue1552NnF(t)
 ";
         var compilation = Compile(source);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+        var diagnostics = EmittedOracle.CompileDiagnostics(compilation);
+        Assert.DoesNotContain(diagnostics, d => d.IsError);
 
         var selected = FindCall(compilation, "Issue1552NnF");
         Assert.NotNull(selected);
@@ -99,9 +100,9 @@ func Issue1552CG(d Issue1552CDog) int32 -> 2
 func Issue1552CUse(d Issue1552CDog?) int32 -> Issue1552CG(d)
 ";
         var compilation = Compile(source);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
-        var gs0154 = Assert.Single(result.Diagnostics, d => d.Id == "GS0154");
+        var diagnostics = EmittedOracle.CompileDiagnostics(compilation);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0266");
+        var gs0154 = Assert.Single(diagnostics, d => d.Id == "GS0154");
         Assert.Contains("Issue1552CAnimal", gs0154.Message);
         Assert.Contains("Issue1552CDog?", gs0154.Message);
     }
@@ -119,9 +120,9 @@ func Issue1552SSink(a Issue1552SAnimal) int32 -> 1
 func Issue1552SUse(d Issue1552SDog?) int32 -> Issue1552SSink(d)
 ";
         var compilation = Compile(source);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
-        Assert.Contains(result.Diagnostics, d => d.Id == "GS0154");
+        var diagnostics = EmittedOracle.CompileDiagnostics(compilation);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0266");
+        Assert.Contains(diagnostics, d => d.Id == "GS0154");
     }
 
     [Fact]
@@ -138,8 +139,8 @@ func Issue1552BG(d Issue1552BDog) int32 -> 2
 func Issue1552BUse(d Issue1552BDog?) int32 -> Issue1552BG(d!!)
 ";
         var compilation = Compile(source);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+        var diagnostics = EmittedOracle.CompileDiagnostics(compilation);
+        Assert.DoesNotContain(diagnostics, d => d.IsError);
 
         var selected = FindCall(compilation, "Issue1552BG");
         Assert.NotNull(selected);
@@ -159,8 +160,8 @@ func Issue1552NG(d Issue1552NDog) int32 -> 2
 func Issue1552NUse() int32 -> Issue1552NG(Issue1552NDog{})
 ";
         var compilation = Compile(source);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+        var diagnostics = EmittedOracle.CompileDiagnostics(compilation);
+        Assert.DoesNotContain(diagnostics, d => d.IsError);
 
         var selected = FindCall(compilation, "Issue1552NG");
         Assert.NotNull(selected);
@@ -181,9 +182,9 @@ func Issue1552PG(s string) int32 -> 2
 func Issue1552PUse(d Issue1552PDog?) int32 -> Issue1552PG(d)
 ";
         var compilation = Compile(source);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
-        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+        var diagnostics = EmittedOracle.CompileDiagnostics(compilation);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(diagnostics, d => d.IsError);
 
         var selected = FindCall(compilation, "Issue1552PG");
         Assert.NotNull(selected);
@@ -203,10 +204,10 @@ func Issue1552VG(a string) int32 -> 2
 func Issue1552VUse(n int32?) int32 -> Issue1552VG(n)
 ";
         var compilation = Compile(source);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
-        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0154");
-        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+        var diagnostics = EmittedOracle.CompileDiagnostics(compilation);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0154");
+        Assert.DoesNotContain(diagnostics, d => d.IsError);
 
         var selected = FindCall(compilation, "Issue1552VG");
         Assert.NotNull(selected);
@@ -231,8 +232,8 @@ func Issue1552AmbTake(x Issue1552IB) int32 -> 2
 func Issue1552AmbUse(b Issue1552Both) int32 -> Issue1552AmbTake(b)
 ";
         var compilation = Compile(source);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.Contains(result.Diagnostics, d => d.Id == "GS0266");
+        var diagnostics = EmittedOracle.CompileDiagnostics(compilation);
+        Assert.Contains(diagnostics, d => d.Id == "GS0266");
     }
 
     [Fact]
@@ -250,9 +251,9 @@ func Issue1552DG(b Issue1552DBase) int32 -> 2
 func Issue1552DUse(d Issue1552DDerived?) int32 -> Issue1552DG(d)
 ";
         var compilation = Compile(source);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
-        var gs0154 = Assert.Single(result.Diagnostics, d => d.Id == "GS0154");
+        var diagnostics = EmittedOracle.CompileDiagnostics(compilation);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0266");
+        var gs0154 = Assert.Single(diagnostics, d => d.Id == "GS0154");
         Assert.Contains("Issue1552DDerived?", gs0154.Message);
     }
 
@@ -272,9 +273,9 @@ func Issue1552OG(b Exception) int32 -> 2
 func Issue1552OUse(d ArgumentException?) int32 -> Issue1552OG(d)
 ";
         var compilation = Compile(source);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
-        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+        var diagnostics = EmittedOracle.CompileDiagnostics(compilation);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(diagnostics, d => d.IsError);
 
         var selected = FindCall(compilation, "Issue1552OG");
         Assert.NotNull(selected);

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1627ImportedNullableRefSourceGateTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1627ImportedNullableRefSourceGateTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -125,10 +126,8 @@ func Issue1627GUse(e ArgumentException?) int32 -> Issue1627GSink(e!!)
         Assert.Empty(Evaluate(source).Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree) { IsLibrary = true };
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(new[] { source }, new EmittedOracleOptions { IsLibrary = true });
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1631UserOverloadBetterMemberTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1631UserOverloadBetterMemberTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -41,9 +42,9 @@ func Issue1631NwF(x float64) int32 -> 2
 func Issue1631NwUse() int32 -> Issue1631NwF(5)
 ";
         var compilation = Compile(source);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
-        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+        var diagnostics = EmittedOracle.CompileDiagnostics(compilation);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(diagnostics, d => d.IsError);
 
         var selected = FindCall(compilation, "Issue1631NwF");
         Assert.NotNull(selected);
@@ -63,9 +64,9 @@ func Issue1631ChF(x float64) int32 -> 2
 func Issue1631ChUse(n int16) int32 -> Issue1631ChF(n)
 ";
         var compilation = Compile(source);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
-        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+        var diagnostics = EmittedOracle.CompileDiagnostics(compilation);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(diagnostics, d => d.IsError);
 
         var selected = FindCall(compilation, "Issue1631ChF");
         Assert.NotNull(selected);
@@ -86,8 +87,8 @@ func Issue1631AmbF(x decimal) int32 -> 2
 func Issue1631AmbUse(n int32) int32 -> Issue1631AmbF(n)
 ";
         var compilation = Compile(source);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.Contains(result.Diagnostics, d => d.Id == "GS0266");
+        var diagnostics = EmittedOracle.CompileDiagnostics(compilation);
+        Assert.Contains(diagnostics, d => d.Id == "GS0266");
     }
 
     [Fact]
@@ -103,9 +104,9 @@ func Issue1631GenF(x string) int32 -> 2
 func Issue1631GenUse(s string) int32 -> Issue1631GenF(s)
 ";
         var compilation = Compile(source);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
-        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+        var diagnostics = EmittedOracle.CompileDiagnostics(compilation);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(diagnostics, d => d.IsError);
 
         var selected = FindCall(compilation, "Issue1631GenF");
         Assert.NotNull(selected);
@@ -125,9 +126,9 @@ func Issue1631VarF(x int32, rest ...int32) int32 -> 2
 func Issue1631VarUse() int32 -> Issue1631VarF(1, 2)
 ";
         var compilation = Compile(source);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
-        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+        var diagnostics = EmittedOracle.CompileDiagnostics(compilation);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(diagnostics, d => d.IsError);
 
         var selected = FindCall(compilation, "Issue1631VarF");
         Assert.NotNull(selected);
@@ -153,9 +154,9 @@ func Issue1631VarWF(x int32, rest ...int32) int32 -> 2
 func Issue1631VarWUse() int32 -> Issue1631VarWF(1, 2)
 ";
         var compilation = Compile(source);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
-        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+        var diagnostics = EmittedOracle.CompileDiagnostics(compilation);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(diagnostics, d => d.IsError);
 
         var selected = FindCall(compilation, "Issue1631VarWF");
         Assert.NotNull(selected);
@@ -177,9 +178,9 @@ func Issue1631VarTieF(x int32, rest ...int32) int32 -> 2
 func Issue1631VarTieUse() int32 -> Issue1631VarTieF(1, 2)
 ";
         var compilation = Compile(source);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
-        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+        var diagnostics = EmittedOracle.CompileDiagnostics(compilation);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(diagnostics, d => d.IsError);
 
         var selected = FindCall(compilation, "Issue1631VarTieF");
         Assert.NotNull(selected);
@@ -200,9 +201,9 @@ func Issue1631VarSoleF(x int32, rest ...int32) int32 -> 2
 func Issue1631VarSoleUse() int32 -> Issue1631VarSoleF(1, 2, 3)
 ";
         var compilation = Compile(source);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
-        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+        var diagnostics = EmittedOracle.CompileDiagnostics(compilation);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(diagnostics, d => d.IsError);
 
         var selected = FindCall(compilation, "Issue1631VarSoleF");
         Assert.NotNull(selected);
@@ -221,9 +222,9 @@ func Issue1631VarVsVarF(x int32, rest ...int64) int32 -> 2
 func Issue1631VarVsVarUse() int32 -> Issue1631VarVsVarF(1, 2)
 ";
         var compilation = Compile(source);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
-        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+        var diagnostics = EmittedOracle.CompileDiagnostics(compilation);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(diagnostics, d => d.IsError);
 
         var selected = FindCall(compilation, "Issue1631VarVsVarF");
         Assert.NotNull(selected);
@@ -248,9 +249,9 @@ func Issue1631NamedF(a int32, b int64) int32 -> 2
 func Issue1631NamedUse() int32 -> Issue1631NamedF(b: 2, a: 1)
 ";
         var compilation = Compile(source);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
-        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+        var diagnostics = EmittedOracle.CompileDiagnostics(compilation);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(diagnostics, d => d.IsError);
 
         var selected = FindCall(compilation, "Issue1631NamedF");
         Assert.NotNull(selected);
@@ -270,8 +271,8 @@ func Issue1631PairF(a int64, b int32) int32 -> 2
 func Issue1631PairUse(x int32, y int32) int32 -> Issue1631PairF(x, y)
 ";
         var compilation = Compile(source);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.Contains(result.Diagnostics, d => d.Id == "GS0266");
+        var diagnostics = EmittedOracle.CompileDiagnostics(compilation);
+        Assert.Contains(diagnostics, d => d.Id == "GS0266");
     }
 
     [Fact]
@@ -286,8 +287,8 @@ func Issue1631IdF(x int64) int32 -> 2
 func Issue1631IdUse(n int32) int32 -> Issue1631IdF(n)
 ";
         var compilation = Compile(source);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+        var diagnostics = EmittedOracle.CompileDiagnostics(compilation);
+        Assert.DoesNotContain(diagnostics, d => d.IsError);
 
         var selected = FindCall(compilation, "Issue1631IdF");
         Assert.NotNull(selected);

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1680ExtensionResolutionIndexTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1680ExtensionResolutionIndexTests.cs
@@ -10,6 +10,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -39,12 +40,12 @@ public class Issue1680ExtensionResolutionIndexTests
         // types the extension's own package doesn't own (ADR-0079), so the
         // types and the extension live in separate packages, like the
         // pre-existing cross-package extension tests.
-        var typeTree = SyntaxTree.Parse(SourceText.From(@"
+        var typeTree = @"
 package Zoo
 open class Animal { var Name string }
 class Dog : Animal { }
-"));
-        var extensionTree = SyntaxTree.Parse(SourceText.From(@"
+";
+        var extensionTree = @"
 package ZooExtensions
 func (a Animal) Speak() string {
     return ""...""
@@ -52,7 +53,7 @@ func (a Animal) Speak() string {
 
 var d = Dog{Name: ""Rex""}
 d.Speak()
-"));
+";
         var result = Evaluate(typeTree, extensionTree);
         Assert.Empty(result.Diagnostics);
         Assert.Equal("...", result.Value);
@@ -63,7 +64,7 @@ d.Speak()
     {
         // An extension declared on an INTERFACE must be found for a call site
         // whose static receiver type is a class that implements it.
-        var typeTree = SyntaxTree.Parse(SourceText.From(@"
+        var typeTree = @"
 package Greeting
 interface IGreeter {
     func Hello() string;
@@ -71,8 +72,8 @@ interface IGreeter {
 class Person : IGreeter {
     func Hello() string -> ""hi""
 }
-"));
-        var extensionTree = SyntaxTree.Parse(SourceText.From(@"
+";
+        var extensionTree = @"
 package GreetingExtensions
 func (g IGreeter) Greet() string {
     return g.Hello()
@@ -80,7 +81,7 @@ func (g IGreeter) Greet() string {
 
 var p = Person{}
 p.Greet()
-"));
+";
         var result = Evaluate(typeTree, extensionTree);
         Assert.Empty(result.Diagnostics);
         Assert.Equal("hi", result.Value);
@@ -165,15 +166,13 @@ arr.MyFirst(99)
         return function;
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        return Evaluate(syntaxTree);
+        return EmittedOracle.Evaluate(source);
     }
 
-    private static EvaluationResult Evaluate(params SyntaxTree[] syntaxTrees)
+    private static EmittedOracleResult Evaluate(params string[] sources)
     {
-        var compilation = new Compilation(syntaxTrees);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(sources);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1701NullabilityConversionCracksTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1701NullabilityConversionCracksTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -123,10 +124,8 @@ func Issue1701FSink[T struct](x T?) object -> x
         Assert.Empty(Evaluate(source).Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree) { IsLibrary = true };
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(new[] { source }, new EmittedOracleOptions { IsLibrary = true });
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1884GotoLabelBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1884GotoLabelBindingTests.cs
@@ -11,6 +11,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -137,19 +138,12 @@ public class Issue1884GotoLabelBindingTests
         return globalScope.Diagnostics.ToList();
     }
 
-    private static (EvaluationResult Result, Dictionary<string, object> Variables) EvaluateWithVariables(string source)
+    private static (EmittedOracleResult Result, IReadOnlyDictionary<string, object> Variables) EvaluateWithVariables(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        var variables = new Dictionary<VariableSymbol, object>();
-        var result = compilation.Evaluate(variables);
-
-        var namedVars = new Dictionary<string, object>();
-        foreach (var kvp in variables)
-        {
-            namedVars[kvp.Key.Name] = kvp.Value;
-        }
-
-        return (result, namedVars);
+        // Post-run globals read back through the oracle (issue #3176 Phase
+        // 3b.2): the emitted equivalent of the evaluator's variables
+        // dictionary.
+        var result = EmittedOracle.Evaluate(source);
+        return (result, result.ReadGlobals());
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2027GotoLabelIsolationBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2027GotoLabelIsolationBinderTests.cs
@@ -11,6 +11,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -149,19 +150,12 @@ public class Issue2027GotoLabelIsolationBinderTests
         return globalScope.Diagnostics.ToList();
     }
 
-    private static (EvaluationResult Result, Dictionary<string, object> Variables) EvaluateWithVariables(string source)
+    private static (EmittedOracleResult Result, IReadOnlyDictionary<string, object> Variables) EvaluateWithVariables(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        var variables = new Dictionary<VariableSymbol, object>();
-        var result = compilation.Evaluate(variables);
-
-        var namedVars = new Dictionary<string, object>();
-        foreach (var kvp in variables)
-        {
-            namedVars[kvp.Key.Name] = kvp.Value;
-        }
-
-        return (result, namedVars);
+        // Post-run globals read back through the oracle (issue #3176 Phase
+        // 3b.2): the emitted equivalent of the evaluator's variables
+        // dictionary.
+        var result = EmittedOracle.Evaluate(source);
+        return (result, result.ReadGlobals());
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2146ReferenceBetternessTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2146ReferenceBetternessTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -41,9 +42,9 @@ func Issue2146U(x Issue2146Animal) int32 -> 2
 func Issue2146Use(d Issue2146Dog) int32 -> Issue2146U(d)
 ";
         var compilation = Compile(source);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
-        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+        var diagnostics = EmittedOracle.CompileDiagnostics(compilation);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(diagnostics, d => d.IsError);
 
         var selected = FindCall(compilation, "Issue2146U");
         Assert.NotNull(selected);
@@ -65,9 +66,9 @@ func Issue2146UId(x Issue2146AnimalId) int32 -> 2
 func Issue2146UseId(a Issue2146AnimalId) int32 -> Issue2146UId(a)
 ";
         var compilation = Compile(source);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
-        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+        var diagnostics = EmittedOracle.CompileDiagnostics(compilation);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(diagnostics, d => d.IsError);
 
         var selected = FindCall(compilation, "Issue2146UId");
         Assert.NotNull(selected);
@@ -89,9 +90,9 @@ func Issue2146H(x Issue2146Mid) int32 -> 2
 func Issue2146HUse(leaf Issue2146Leaf) int32 -> Issue2146H(leaf)
 ";
         var compilation = Compile(source);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
-        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+        var diagnostics = EmittedOracle.CompileDiagnostics(compilation);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(diagnostics, d => d.IsError);
 
         var selected = FindCall(compilation, "Issue2146H");
         Assert.NotNull(selected);
@@ -114,9 +115,9 @@ func Issue2146L(caller Type?) int32 -> 2
 func Issue2146LUse() int32 -> Issue2146L(typeof(Issue2146LogC))
 ";
         var compilation = Compile(source);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
-        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+        var diagnostics = EmittedOracle.CompileDiagnostics(compilation);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(diagnostics, d => d.IsError);
 
         var selected = FindCall(compilation, "Issue2146L");
         Assert.NotNull(selected);
@@ -139,8 +140,8 @@ func Issue2146A(x Issue2146IB) int32 -> 2
 func Issue2146AUse(b Issue2146Both) int32 -> Issue2146A(b)
 ";
         var compilation = Compile(source);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.Contains(result.Diagnostics, d => d.Id == "GS0266");
+        var diagnostics = EmittedOracle.CompileDiagnostics(compilation);
+        Assert.Contains(diagnostics, d => d.Id == "GS0266");
     }
 
     [Fact]
@@ -159,9 +160,9 @@ func Issue2146S(x Issue2146IShape) int32 -> 2
 func Issue2146SUse(sq Issue2146Square) int32 -> Issue2146S(sq)
 ";
         var compilation = Compile(source);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
-        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+        var diagnostics = EmittedOracle.CompileDiagnostics(compilation);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(diagnostics, d => d.IsError);
 
         var selected = FindCall(compilation, "Issue2146S");
         Assert.NotNull(selected);

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2188ReferenceConstrainedTypeParamObjectTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2188ReferenceConstrainedTypeParamObjectTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -118,12 +119,17 @@ func Sink[T Animal](x T?) object? -> x
     {
         // Not special-cased to `object`: the reference conversion also reaches
         // the base-class constraint target.
+        // ADR-0156 Phase 3b (#3176): pinned on Compilation.Evaluate — the
+        // emitter cannot lower the constrained nullable type parameter to
+        // its nullable base yet (issue #3236: NotSupportedException
+        // "Conversion from 'T?' to 'Animal?'"); realigns with that issue's
+        // resolution.
         var source = @"
 package p
 class Animal { init() {} }
 func Sink[T Animal](x T?) Animal? -> x
 ";
-        Assert.Empty(Evaluate(source).Diagnostics);
+        Assert.Empty(EvaluateWithEvaluator(source).Diagnostics);
     }
 
     [Fact]
@@ -197,7 +203,13 @@ class C {
         Assert.Empty(Evaluate(source).Diagnostics);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
+    {
+        return EmittedOracle.Evaluate(new[] { source }, new EmittedOracleOptions { IsLibrary = true });
+    }
+
+    // ADR-0156 Phase 3b (#3176): evaluator twin for the #3236-pinned test.
+    private static EvaluationResult EvaluateWithEvaluator(string source)
     {
         var tree = SyntaxTree.Parse(SourceText.From(source));
         var compilation = new Compilation(tree) { IsLibrary = true };

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2227CharBitwisePromotionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2227CharBitwisePromotionTests.cs
@@ -13,6 +13,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -135,20 +136,13 @@ while i < 4 {{
         Assert.Equal(expectedDiff, vars["diff"]);
     }
 
-    private static (EvaluationResult Result, Dictionary<string, object> Variables) EvaluateWithVariables(string source)
+    private static (EmittedOracleResult Result, IReadOnlyDictionary<string, object> Variables) EvaluateWithVariables(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        var variables = new Dictionary<VariableSymbol, object>();
-        var result = compilation.Evaluate(variables);
-
-        var namedVars = new Dictionary<string, object>();
-        foreach (var kvp in variables)
-        {
-            namedVars[kvp.Key.Name] = kvp.Value;
-        }
-
-        return (result, namedVars);
+        // Post-run globals read back through the oracle (issue #3176 Phase
+        // 3b.2): the emitted equivalent of the evaluator's variables
+        // dictionary.
+        var result = EmittedOracle.Evaluate(source);
+        return (result, result.ReadGlobals());
     }
 
     /// <summary>

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2273ImportTypeAliasTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2273ImportTypeAliasTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -25,7 +26,7 @@ public class Issue2273ImportTypeAliasTests
     [Fact]
     public void Alias_To_CrossPackage_Source_Type_Resolves_Static_Member_Access()
     {
-        var holderTree = SyntaxTree.Parse(SourceText.From(@"
+        var holderTree = @"
 package App.Nested
 
 class Holder {
@@ -33,14 +34,14 @@ class Holder {
         const Message string = ""hi""
     }
 }
-"));
-        var mainTree = SyntaxTree.Parse(SourceText.From(@"
+";
+        var mainTree = @"
 package App
 
 import R = App.Nested.Holder
 
 var result = R.Message
-"));
+";
         var result = Evaluate(holderTree, mainTree);
         Assert.Empty(result.Diagnostics);
         Assert.Equal("hi", result.Value);
@@ -61,7 +62,7 @@ var result = R.Sqrt(16.0)
     [Fact]
     public void Alias_To_CrossPackage_Source_Type_Resolves_In_TypeClause_Position()
     {
-        var holderTree = SyntaxTree.Parse(SourceText.From(@"
+        var holderTree = @"
 package App.Nested
 
 class Holder {
@@ -74,15 +75,15 @@ class Holder {
         }
     }
 }
-"));
-        var mainTree = SyntaxTree.Parse(SourceText.From(@"
+";
+        var mainTree = @"
 package App
 
 import R = App.Nested.Holder
 
 var h R = R.MakeOne()
 var result = h.Value
-"));
+";
         var result = Evaluate(holderTree, mainTree);
         Assert.Empty(result.Diagnostics);
         Assert.Equal(42, result.Value);
@@ -91,7 +92,7 @@ var result = h.Value
     [Fact]
     public void Alias_To_Outer_Type_Resolves_Nested_Type_Access()
     {
-        var outerTree = SyntaxTree.Parse(SourceText.From(@"
+        var outerTree = @"
 package App.Nested
 
 class Outer {
@@ -101,28 +102,26 @@ class Outer {
         }
     }
 }
-"));
-        var mainTree = SyntaxTree.Parse(SourceText.From(@"
+";
+        var mainTree = @"
 package App
 
 import R = App.Nested.Outer
 
 var result = R.Inner.Message
-"));
+";
         var result = Evaluate(outerTree, mainTree);
         Assert.Empty(result.Diagnostics);
         Assert.Equal("nested-hi", result.Value);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        return Evaluate(syntaxTree);
+        return EmittedOracle.Evaluate(source);
     }
 
-    private static EvaluationResult Evaluate(params SyntaxTree[] syntaxTrees)
+    private static EmittedOracleResult Evaluate(params string[] sources)
     {
-        var compilation = new Compilation(syntaxTrees);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(sources);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2364PrimaryConstructorConversionBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2364PrimaryConstructorConversionBindingTests.cs
@@ -2,7 +2,6 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
-using System.Collections.Generic;
 using System.Linq;
 using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Binding;
@@ -10,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -54,8 +54,7 @@ let w = Wide(22050, 32)
 ";
         var tree = SyntaxTree.Parse(SourceText.From(source));
         var compilation = new Compilation(tree);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.Empty(result.Diagnostics);
+        Assert.Empty(EmittedOracle.CompileDiagnostics(compilation));
 
         var call = FindConstructorCall(compilation, "Wide");
         Assert.NotNull(call);
@@ -91,8 +90,7 @@ let p = Plain(a, b)
 ";
         var tree = SyntaxTree.Parse(SourceText.From(source));
         var compilation = new Compilation(tree);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.Empty(result.Diagnostics);
+        Assert.Empty(EmittedOracle.CompileDiagnostics(compilation));
 
         var call = FindConstructorCall(compilation, "Plain");
         Assert.NotNull(call);
@@ -118,8 +116,7 @@ let h = Holder(5)
 ";
         var tree = SyntaxTree.Parse(SourceText.From(source));
         var compilation = new Compilation(tree);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.Empty(result.Diagnostics);
+        Assert.Empty(EmittedOracle.CompileDiagnostics(compilation));
 
         var call = FindConstructorCall(compilation, "Holder");
         Assert.NotNull(call);
@@ -177,8 +174,7 @@ Foo(5)
 ";
         var tree = SyntaxTree.Parse(SourceText.From(source));
         var compilation = new Compilation(tree);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.Empty(result.Diagnostics);
+        Assert.Empty(EmittedOracle.CompileDiagnostics(compilation));
 
         var call = compilation.GlobalScope.Statements
             .OfType<BoundExpressionStatement>()
@@ -194,8 +190,7 @@ Foo(5)
     {
         var tree = SyntaxTree.Parse(SourceText.From(source));
         var compilation = new Compilation(tree);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.Empty(result.Diagnostics);
+        Assert.Empty(EmittedOracle.CompileDiagnostics(compilation));
 
         var call = FindConstructorCall(compilation, typeName);
         Assert.NotNull(call);

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2377OperatorMetadataShapeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2377OperatorMetadataShapeTests.cs
@@ -25,8 +25,8 @@ namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 /// only as an ordinary first parameter — exactly like
 /// <c>BindConversionOperatorDeclaration</c>'s <c>op_Implicit</c>/
 /// <c>op_Explicit</c> shape. These tests exercise the symbol shape directly
-/// (via <see cref="Compilation.GlobalScope"/>) and the interpreter-level
-/// (<see cref="Compilation.Evaluate"/>) behavior across binary, unary,
+/// (via <see cref="Compilation.GlobalScope"/>) and the executed behavior
+/// (via the emitted <c>EmittedOracle</c>, ADR-0156 Phase 3b) across binary, unary,
 /// comparison, generic, nested, inherited, duplicate-signature, and
 /// undefined-operator (negative) scenarios. Emission-level (reflection
 /// metadata, C#-consumer, ClrOperatorResolution re-import fallback,

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2402GenericOperatorDeclarationTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2402GenericOperatorDeclarationTests.cs
@@ -2,13 +2,13 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
-using System.Collections.Generic;
 using System.Linq;
 using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -31,12 +31,15 @@ public class Issue2402GenericOperatorDeclarationTests
 
             42
             """;
-        var compilation = Compile(source);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = Evaluate(source);
 
         Assert.Empty(result.Diagnostics);
         Assert.Equal(42, result.Value);
 
+        // Binder inspection (issue #3176 Phase 3b.2): the bound-shape asserts
+        // read a locally bound Compilation; the run above came from the
+        // emitted oracle.
+        var compilation = Compile(source);
         var box = (StructSymbol)compilation.GlobalScope.Structs.Single(t => t.Name == "Box");
         var add = box.StaticMethods.Single(m => m.Name == "op_Addition");
         Assert.Same(box, add.StaticOwnerType);
@@ -87,12 +90,15 @@ public class Issue2402GenericOperatorDeclarationTests
 
             42
             """;
-        var compilation = Compile(source);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = Evaluate(source);
 
         Assert.Empty(result.Diagnostics);
         Assert.Equal(42, result.Value);
 
+        // Binder inspection (issue #3176 Phase 3b.2): the bound-shape asserts
+        // read a locally bound Compilation; the run above came from the
+        // emitted oracle.
+        var compilation = Compile(source);
         var box = (StructSymbol)compilation.GlobalScope.Structs.Single(t => t.Name == "Box");
         var conversion = box.StaticMethods.Single(m => m.Name == "op_Implicit");
         Assert.Same(box, conversion.StaticOwnerType);
@@ -166,8 +172,8 @@ public class Issue2402GenericOperatorDeclarationTests
         return new Compilation(tree);
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        return Compile(source).Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(source);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2492NullableBoxedConversionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2492NullableBoxedConversionTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -105,10 +106,8 @@ public sealed class Issue2492NullableBoxedConversionTests
         Assert.Equal(3, diagnostics.Count(d => d.Id == "GS0155"));
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree) { IsLibrary = true };
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return EmittedOracle.Evaluate(new[] { source }, new EmittedOracleOptions { IsLibrary = true });
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2514ImportedInterfaceConstraintMemberTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2514ImportedInterfaceConstraintMemberTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -79,10 +80,6 @@ public sealed class Issue2514ImportedInterfaceConstraintMemberTests
 
     private static IReadOnlyList<Diagnostic> Bind(string source)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(syntaxTree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>())
-            .Diagnostics
-            .ToList();
+        return EmittedOracle.Evaluate(source).Diagnostics.ToList();
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2517ConstructedBaseOrderingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2517ConstructedBaseOrderingTests.cs
@@ -2,11 +2,10 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
-using System.Collections.Generic;
 using GSharp.Core.CodeAnalysis.Compilation;
-using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -53,10 +52,12 @@ public sealed class Issue2517ConstructedBaseOrderingTests
             }
             """);
 
-        var result = new Compilation(early, derived, entry, middle, baseType)
-            .Evaluate(new Dictionary<VariableSymbol, object>());
+        // Tree-order binder regression (issue #3176 Phase 3b.2): bind the
+        // plain multi-tree compilation via EmittedOracle.CompileDiagnostics;
+        // the sources declare types only and nothing needs to run.
+        var compilation = new Compilation(early, derived, entry, middle, baseType);
 
-        Assert.Empty(result.Diagnostics);
+        Assert.Empty(EmittedOracle.CompileDiagnostics(compilation));
     }
 
     [Theory]
@@ -95,10 +96,9 @@ public sealed class Issue2517ConstructedBaseOrderingTests
         var trees = reverse
             ? new[] { layers, derived, early }
             : new[] { early, derived, layers };
-        var result = new Compilation(trees)
-            .Evaluate(new Dictionary<VariableSymbol, object>());
+        var compilation = new Compilation(trees);
 
-        Assert.Empty(result.Diagnostics);
+        Assert.Empty(EmittedOracle.CompileDiagnostics(compilation));
     }
 
     private static SyntaxTree Parse(string source)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2519SourceClassConstraintOrderingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2519SourceClassConstraintOrderingTests.cs
@@ -2,17 +2,22 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
-using System.Collections.Generic;
 using System.Linq;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 
-/// <summary>Binding regressions for issue #2519's source class-constraint ordering.</summary>
+/// <summary>Binding regressions for issue #2519's source class-constraint
+/// ordering. Tree-order binder regressions (issue #3176 Phase 3b.2): these
+/// bind the plain multi-tree compilation via
+/// <c>EmittedOracle.CompileDiagnostics</c> — the property under test is the
+/// PLAIN compilation's order independence, and the sources declare types
+/// only, so nothing needs to run.</summary>
 public sealed class Issue2519SourceClassConstraintOrderingTests
 {
     [Theory]
@@ -52,10 +57,9 @@ public sealed class Issue2519SourceClassConstraintOrderingTests
         var trees = reverse
             ? new[] { constraint, constrained }
             : new[] { constrained, constraint };
-        var result = new Compilation(trees)
-            .Evaluate(new Dictionary<VariableSymbol, object>());
+        var compilation = new Compilation(trees);
 
-        Assert.Empty(result.Diagnostics);
+        Assert.Empty(EmittedOracle.CompileDiagnostics(compilation));
     }
 
     [Theory]
@@ -107,12 +111,11 @@ public sealed class Issue2519SourceClassConstraintOrderingTests
         var trees = reverse
             ? new[] { genericBase, dependencies, multipart }
             : new[] { multipart, dependencies, genericBase };
-        var result = new Compilation(trees)
-            .Evaluate(new Dictionary<VariableSymbol, object>());
+        var compilation = new Compilation(trees);
 
-        Assert.Empty(result.Diagnostics);
+        Assert.Empty(EmittedOracle.CompileDiagnostics(compilation));
         Assert.DoesNotContain(
-            result.Diagnostics,
+            EmittedOracle.CompileDiagnostics(compilation),
             diagnostic => diagnostic.Message.Contains("FrameEntry2519")
                 || diagnostic.Message.Contains("Chunk")
                 || diagnostic.Message.Contains("SamplesInFrame"));
@@ -132,9 +135,8 @@ public sealed class Issue2519SourceClassConstraintOrderingTests
             }
             """);
         var compilation = new Compilation(tree);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
 
-        Assert.Empty(result.Diagnostics);
+        Assert.Empty(EmittedOracle.CompileDiagnostics(compilation));
         var holder = Assert.Single(compilation.GlobalScope.Structs.Where(s => s.Name == "Holder2519"));
         var constraint = Assert.IsType<StructSymbol>(Assert.Single(holder.TypeParameters).ClassConstraint);
         Assert.Equal("Entry2519", constraint.Name);
@@ -170,10 +172,9 @@ public sealed class Issue2519SourceClassConstraintOrderingTests
         var trees = reverse
             ? new[] { model, consumers }
             : new[] { consumers, model };
-        var result = new Compilation(trees)
-            .Evaluate(new Dictionary<VariableSymbol, object>());
+        var compilation = new Compilation(trees);
 
-        Assert.Empty(result.Diagnostics);
+        Assert.Empty(EmittedOracle.CompileDiagnostics(compilation));
     }
 
     private static SyntaxTree Parse(string source)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2535NullableReferenceConversionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2535NullableReferenceConversionTests.cs
@@ -9,6 +9,7 @@ using GsCompilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GsSyntaxTree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -22,7 +23,12 @@ public sealed class Issue2535NullableReferenceConversionTests
     [Fact]
     public void CovariantImplementedInterfaceLiftsThroughReferenceNullability()
     {
-        var result = Evaluate("""
+        // ADR-0156 Phase 3b (#3176): pinned on Compilation.Evaluate — the
+        // emitter cannot lower the covariant interface lift through
+        // reference nullability yet (issue #3236: NotSupportedException
+        // "Conversion from 'Service' to 'IService[object?]?'"); realigns
+        // with that issue's resolution.
+        var result = EvaluateWithEvaluator("""
             interface IService[out T] {}
             class Service : IService[object] {}
 
@@ -60,7 +66,13 @@ public sealed class Issue2535NullableReferenceConversionTests
         Assert.Equal(3, result.Diagnostics.Count());
     }
 
-    private static EvaluationResult Evaluate(string source)
+    private static EmittedOracleResult Evaluate(string source)
+    {
+        return EmittedOracle.Evaluate(new[] { source }, new EmittedOracleOptions { IsLibrary = true });
+    }
+
+    // ADR-0156 Phase 3b (#3176): evaluator twin for the #3236-pinned test.
+    private static EvaluationResult EvaluateWithEvaluator(string source)
     {
         var tree = GsSyntaxTree.Parse(SourceText.From(source));
         var compilation = new GsCompilation(tree) { IsLibrary = true };

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2644TransitiveGenericInterfaceTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2644TransitiveGenericInterfaceTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -115,6 +116,9 @@ public sealed class Issue2644TransitiveGenericInterfaceTests
     private static Compilation Compile(string source)
         => new(SyntaxTree.Parse(SourceText.From(source)));
 
+    // Binder-inspection helper (issue #3176 Phase 3b.2): bind via
+    // EmittedOracle.CompileDiagnostics and inspect this Compilation's bound
+    // state; nothing needs to run.
     private static IReadOnlyList<Diagnostic> GetDiagnostics(Compilation compilation)
-        => compilation.Evaluate(new Dictionary<VariableSymbol, object>()).Diagnostics;
+        => EmittedOracle.CompileDiagnostics(compilation);
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2856InterpolationTernaryTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2856InterpolationTernaryTests.cs
@@ -10,6 +10,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -190,16 +191,17 @@ public class Issue2856InterpolationTernaryTests
         Assert.Equal("[     3]", Value(result, "text"));
     }
 
-    private static (ImmutableArray<Diagnostic> Diagnostics, Dictionary<VariableSymbol, object> Variables) Evaluate(string source)
+    private static (ImmutableArray<Diagnostic> Diagnostics, IReadOnlyDictionary<string, object> Variables) Evaluate(string source)
     {
-        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(source)));
-        var variables = new Dictionary<VariableSymbol, object>();
-        var result = compilation.Evaluate(variables);
-        return (result.Diagnostics, variables);
+        // Post-run globals read back through the oracle (issue #3176 Phase
+        // 3b.2): the emitted equivalent of the evaluator's variables
+        // dictionary.
+        var result = EmittedOracle.Evaluate(source);
+        return (result.Diagnostics, result.ReadGlobals());
     }
 
     private static object Value(
-        (ImmutableArray<Diagnostic> Diagnostics, Dictionary<VariableSymbol, object> Variables) result,
+        (ImmutableArray<Diagnostic> Diagnostics, IReadOnlyDictionary<string, object> Variables) result,
         string name) =>
-        result.Variables.Single(pair => pair.Key.Name == name).Value;
+        result.Variables[name];
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3075DiagnosticTypeKindTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3075DiagnosticTypeKindTests.cs
@@ -2,13 +2,13 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
-using System.Collections.Generic;
 using System.Linq;
 using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -159,11 +159,7 @@ public class Issue3075DiagnosticTypeKindTests
 
     private static Diagnostic GetDiagnostic(string id, params string[] sources)
     {
-        var trees = sources
-            .Select((source, index) => SyntaxTree.Parse(SourceText.From(source, $"issue3075-{index}.gs")))
-            .ToArray();
-        var compilation = new Compilation(trees);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(sources);
         return Assert.Single(result.Diagnostics.Where(diagnostic => diagnostic.Id == id));
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue656InitAsPrimaryCtorBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue656InitAsPrimaryCtorBinderTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -34,8 +35,8 @@ class Counter {
 
 var c = Counter()
 ";
-        var (result, structs) = EvaluateAndGetStructs(source);
-        Assert.Empty(result.Diagnostics);
+        var (diagnostics, structs) = EvaluateAndGetStructs(source);
+        Assert.Empty(diagnostics);
 
         var counter = structs.Single(s => s.Name == "Counter");
         Assert.NotNull(counter.ExplicitConstructor);
@@ -56,8 +57,8 @@ class Counter {
 
 var c = Counter()
 ";
-        var (result, structs) = EvaluateAndGetStructs(source);
-        Assert.Empty(result.Diagnostics);
+        var (diagnostics, structs) = EvaluateAndGetStructs(source);
+        Assert.Empty(diagnostics);
 
         var counter = structs.Single(s => s.Name == "Counter");
         Assert.NotNull(counter.ExplicitConstructor);
@@ -77,8 +78,8 @@ class Greeting {
 
 var g = Greeting(""hi"")
 ";
-        var (result, structs) = EvaluateAndGetStructs(source);
-        Assert.Empty(result.Diagnostics);
+        var (diagnostics, structs) = EvaluateAndGetStructs(source);
+        Assert.Empty(diagnostics);
 
         var greeting = structs.Single(s => s.Name == "Greeting");
         Assert.NotNull(greeting.ExplicitConstructor);
@@ -108,8 +109,8 @@ class Color {
 
 var c = Color(1, 2, 3)
 ";
-        var (result, structs) = EvaluateAndGetStructs(source);
-        Assert.Empty(result.Diagnostics);
+        var (diagnostics, structs) = EvaluateAndGetStructs(source);
+        Assert.Empty(diagnostics);
 
         var color = structs.Single(s => s.Name == "Color");
         Assert.NotNull(color.ExplicitConstructor);
@@ -132,8 +133,8 @@ class Config {
 
 var cfg = Config()
 ";
-        var (result, structs) = EvaluateAndGetStructs(source);
-        Assert.Empty(result.Diagnostics);
+        var (diagnostics, structs) = EvaluateAndGetStructs(source);
+        Assert.Empty(diagnostics);
 
         var config = structs.Single(s => s.Name == "Config");
         Assert.NotNull(config.ExplicitConstructor);
@@ -155,8 +156,8 @@ class Dual(Name string) {
 
 var d = Dual(""x"")
 ";
-        var (result, structs) = EvaluateAndGetStructs(source);
-        Assert.Empty(result.Diagnostics);
+        var (diagnostics, structs) = EvaluateAndGetStructs(source);
+        Assert.Empty(diagnostics);
 
         var dual = structs.Single(s => s.Name == "Dual");
         Assert.True(dual.HasPrimaryConstructor);
@@ -175,8 +176,8 @@ class Plain {
 
 var p = Plain()
 ";
-        var (result, structs) = EvaluateAndGetStructs(source);
-        Assert.Empty(result.Diagnostics);
+        var (diagnostics, structs) = EvaluateAndGetStructs(source);
+        Assert.Empty(diagnostics);
 
         var plain = structs.Single(s => s.Name == "Plain");
         Assert.Null(plain.ExplicitConstructor);
@@ -191,20 +192,23 @@ class Box(Value int32) { }
 
 var b = Box(42)
 ";
-        var (result, structs) = EvaluateAndGetStructs(source);
-        Assert.Empty(result.Diagnostics);
+        var (diagnostics, structs) = EvaluateAndGetStructs(source);
+        Assert.Empty(diagnostics);
 
         var box = structs.Single(s => s.Name == "Box");
         Assert.Null(box.ExplicitConstructor);
         Assert.True(box.HasPrimaryConstructor);
     }
 
-    private static (EvaluationResult Result, IEnumerable<StructSymbol> Structs) EvaluateAndGetStructs(string source)
+    // Binder-inspection helper (issue #3176 Phase 3b.2): bind via
+    // EmittedOracle.CompileDiagnostics and inspect this Compilation's bound
+    // state; nothing needs to run.
+    private static (System.Collections.Immutable.ImmutableArray<Diagnostic> Diagnostics, IEnumerable<StructSymbol> Structs) EvaluateAndGetStructs(string source)
     {
         var tree = SyntaxTree.Parse(SourceText.From(source));
         var compilation = new Compilation(tree);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        var diagnostics = EmittedOracle.CompileDiagnostics(compilation);
         var structs = compilation.GlobalScope.Structs;
-        return (result, structs);
+        return (diagnostics, structs);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue671UserTypeAsClrGenericArgTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue671UserTypeAsClrGenericArgTests.cs
@@ -41,14 +41,7 @@ public class Issue671UserTypeAsClrGenericArgTests
 
     private static ImmutableArray<Diagnostic> BindMultiFile(params string[] sources)
     {
-        var trees = sources
-            .Select(s => SyntaxTree.Parse(SourceText.From(s)))
-            .ToArray();
-        // Phase 3b (issue #3176): stays on Compilation.Evaluate — multi-tree
-        // compilation; the EmittedOracle takes a single source. Disposition
-        // in 3b.2.
-        var compilation = new Compilation(trees);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        var result = EmittedOracle.Evaluate(sources);
         return result.Diagnostics;
     }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue698DeinitBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue698DeinitBinderTests.cs
@@ -133,6 +133,10 @@ class CachedResource : Resource {
         Assert.NotSame(resource.Deinitializer, cached.Deinitializer);
     }
 
+    // ADR-0156 Phase 3b (#3176): stays on Compilation.Evaluate — several
+    // tests here assert the interpreter-boundary deinit diagnostic GS0510,
+    // which only Compilation.Evaluate synthesizes (deinit simply works under
+    // emitted execution). Retires with the evaluator in Phase 3c.
     private static (EvaluationResult Result, IEnumerable<StructSymbol> Structs) EvaluateAndGetStructs(string source)
     {
         var tree = SyntaxTree.Parse(SourceText.From(source));

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue722GoExtensionsImportGateTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue722GoExtensionsImportGateTests.cs
@@ -260,12 +260,9 @@ n
 func work() int32 { return 1 }
 go work()
 ";
-        // Phase 3b (issue #3176): stays on Compilation.Evaluate —
-        // ImplicitSystemImport is a Compilation-level knob the EmittedOracle
-        // does not expose; disposition in 3b.2.
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree) { ImplicitSystemImport = false };
-        var diags = compilation.Evaluate(new Dictionary<VariableSymbol, object>()).Diagnostics;
+        var diags = EmittedOracle.Evaluate(
+            new[] { source },
+            new EmittedOracleOptions { ImplicitSystemImport = false }).Diagnostics;
 
         Assert.Contains(diags, d => d.Id == GateDiagnosticId);
     }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue723GoBuiltinsImportGateTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue723GoBuiltinsImportGateTests.cs
@@ -266,12 +266,9 @@ let n = len(42)
 let xs = []int32{1}
 let n = len(xs)
 ";
-        // Phase 3b (issue #3176): stays on Compilation.Evaluate —
-        // ImplicitSystemImport is a Compilation-level knob the EmittedOracle
-        // does not expose; disposition in 3b.2.
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree) { ImplicitSystemImport = false };
-        var diags = compilation.Evaluate(new Dictionary<VariableSymbol, object>()).Diagnostics;
+        var diags = EmittedOracle.Evaluate(
+            new[] { source },
+            new EmittedOracleOptions { ImplicitSystemImport = false }).Diagnostics;
 
         Assert.Contains(diags, d => d.Id == BuiltinDiagnosticId);
     }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue729FriendlyNumericAliasBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue729FriendlyNumericAliasBinderTests.cs
@@ -2,13 +2,13 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
-using System.Collections.Generic;
 using System.Linq;
 using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -212,18 +212,15 @@ type {alias} = string
         return null;
     }
 
-    private static (EvaluationResult Result, Compilation Compilation) EvaluateInternal(string source)
+    // Binder-inspection helper (issue #3176 Phase 3b.2): bind via
+    // EmittedOracle.CompileDiagnostics and inspect this Compilation's bound
+    // state; nothing needs to run.
+    private static EvaluationResultWithCompilation Evaluate(string source)
     {
         var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
         var compilation = new Compilation(syntaxTree);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        return (result, compilation);
-    }
-
-    private static EvaluationResultWithCompilation Evaluate(string source)
-    {
-        var (result, compilation) = EvaluateInternal(source);
-        return new EvaluationResultWithCompilation(result, compilation);
+        var diagnostics = EmittedOracle.CompileDiagnostics(compilation);
+        return new EvaluationResultWithCompilation(diagnostics, compilation);
     }
 
     /// <summary>
@@ -233,16 +230,14 @@ type {alias} = string
     /// </summary>
     private sealed class EvaluationResultWithCompilation
     {
-        public EvaluationResultWithCompilation(EvaluationResult inner, Compilation compilation)
+        public EvaluationResultWithCompilation(System.Collections.Immutable.ImmutableArray<Diagnostic> diagnostics, Compilation compilation)
         {
-            Inner = inner;
+            Diagnostics = diagnostics;
             Compilation = compilation;
         }
 
-        public EvaluationResult Inner { get; }
+        public System.Collections.Immutable.ImmutableArray<Diagnostic> Diagnostics { get; }
 
         public Compilation Compilation { get; }
-
-        public System.Collections.Immutable.ImmutableArray<Diagnostic> Diagnostics => Inner.Diagnostics;
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue774OpenReceiverIterationTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue774OpenReceiverIterationTests.cs
@@ -10,6 +10,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -256,10 +257,12 @@ func (self IEnumerable[T]) Walk[T]() {
     }
 }
 ";
+        // Binder-inspection test (issue #3176 Phase 3b.2): bind via
+        // EmittedOracle.CompileDiagnostics and inspect this Compilation's
+        // bound state; nothing needs to run.
         var tree = SyntaxTree.Parse(SourceText.From(source));
         var compilation = new Compilation(tree);
-        var diagnostics = compilation.Evaluate(new Dictionary<VariableSymbol, object>()).Diagnostics;
-        Assert.Empty(diagnostics);
+        Assert.Empty(EmittedOracle.CompileDiagnostics(compilation));
 
         var walkSymbol = compilation.GlobalScope.Functions.Single(f => f.Name == "Walk");
         Assert.Single(walkSymbol.TypeParameters);

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue795DefaultExpressionBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue795DefaultExpressionBinderTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -259,19 +260,12 @@ default: ""other""
         return new Compilation(tree);
     }
 
-    private static (EvaluationResult Result, Dictionary<string, object> Variables) EvaluateWithVariables(string source)
+    private static (EmittedOracleResult Result, IReadOnlyDictionary<string, object> Variables) EvaluateWithVariables(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        var variables = new Dictionary<VariableSymbol, object>();
-        var result = compilation.Evaluate(variables);
-
-        var namedVars = new Dictionary<string, object>();
-        foreach (var kvp in variables)
-        {
-            namedVars[kvp.Key.Name] = kvp.Value;
-        }
-
-        return (result, namedVars);
+        // Post-run globals read back through the oracle (issue #3176 Phase
+        // 3b.2): the emitted equivalent of the evaluator's variables
+        // dictionary.
+        var result = EmittedOracle.Evaluate(source);
+        return (result, result.ReadGlobals());
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue805MapTypeClauseSpellingBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue805MapTypeClauseSpellingBinderTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -24,11 +25,11 @@ public class Issue805MapTypeClauseSpellingBinderTests
     [Fact]
     public void CanonicalSpelling_BindsAsMapTypeSymbol_WithExpectedName()
     {
-        var (result, compilation) = Compile("""
+        var (diagnostics, compilation) = Compile("""
             var m map[string,int32] = map[string,int32]{"a": 1}
             """);
 
-        Assert.Empty(result.Diagnostics);
+        Assert.Empty(diagnostics);
 
         var variable = LookupGlobalVariable(compilation, "m");
         Assert.NotNull(variable);
@@ -44,20 +45,20 @@ public class Issue805MapTypeClauseSpellingBinderTests
         // The legacy shape still parses (with GS0366) and binds to the
         // exact same cached MapTypeSymbol instance — the comma is purely
         // a surface-syntax change.
-        var (legacyResult, legacy) = Compile("""
+        var (legacyDiagnostics, legacy) = Compile("""
             var m map[string]int32 = map[string,int32]{"a": 1}
             """);
 
         // GS0366 fires once per legacy occurrence; no cascade.
-        Assert.Contains(legacyResult.Diagnostics, d => d.Id == "GS0366");
+        Assert.Contains(legacyDiagnostics, d => d.Id == "GS0366");
         Assert.All(
-            legacyResult.Diagnostics,
+            legacyDiagnostics,
             d => Assert.Equal("GS0366", d.Id));
 
-        var (canonicalResult, canonical) = Compile("""
+        var (canonicalDiagnostics, canonical) = Compile("""
             var m map[string,int32] = map[string,int32]{"a": 1}
             """);
-        Assert.Empty(canonicalResult.Diagnostics);
+        Assert.Empty(canonicalDiagnostics);
 
         var legacyVar = LookupGlobalVariable(legacy, "m");
         var canonicalVar = LookupGlobalVariable(canonical, "m");
@@ -73,11 +74,11 @@ public class Issue805MapTypeClauseSpellingBinderTests
     [Fact]
     public void CanonicalSpelling_NullableMap_BindsAsNullableMapTypeSymbol()
     {
-        var (result, compilation) = Compile("""
+        var (diagnostics, compilation) = Compile("""
             var m map[string,int32]? = nil
             """);
 
-        Assert.Empty(result.Diagnostics);
+        Assert.Empty(diagnostics);
 
         var variable = LookupGlobalVariable(compilation, "m");
         Assert.NotNull(variable);
@@ -92,13 +93,13 @@ public class Issue805MapTypeClauseSpellingBinderTests
         // Use a function-parameter slot so we exercise the type clause
         // without having to invent a constructible expression of type
         // `sequence[map[K,V]]`.
-        var (result, compilation) = Compile("""
+        var (diagnostics, compilation) = Compile("""
             func receive(s sequence[map[string,int32]]) int32 {
                 return 0
             }
             """);
 
-        Assert.Empty(result.Diagnostics);
+        Assert.Empty(diagnostics);
 
         var function = compilation.GlobalScope.Functions.FirstOrDefault(f => f.Name == "receive");
         Assert.NotNull(function);
@@ -111,13 +112,16 @@ public class Issue805MapTypeClauseSpellingBinderTests
     private static VariableSymbol LookupGlobalVariable(Compilation compilation, string name)
         => compilation.GlobalScope.Variables.FirstOrDefault(v => v.Name == name);
 
-    private static (EvaluationResult Result, Compilation Compilation) Compile(string source)
+    // Binder-inspection helper (issue #3176 Phase 3b.2): bind via
+    // EmittedOracle.CompileDiagnostics and inspect this Compilation's bound
+    // state; nothing needs to run.
+    private static (System.Collections.Immutable.ImmutableArray<Diagnostic> Diagnostics, Compilation Compilation) Compile(string source)
     {
         // Prepend the Go-extensions import so map ops bind without
         // tripping ADR-0083's GS0317 import gate.
         var syntaxTree = SyntaxTree.Parse(SourceText.From("import Gsharp.Extensions.Go\n" + source));
         var compilation = new Compilation(syntaxTree);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        return (result, compilation);
+        var diagnostics = EmittedOracle.CompileDiagnostics(compilation);
+        return (diagnostics, compilation);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue836IteratorTryFinallyBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue836IteratorTryFinallyBinderTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -26,7 +27,7 @@ public class Issue836IteratorTryFinallyBinderTests
     [Fact]
     public void YieldInsideTryFinally_Accepted()
     {
-        var (result, _) = Compile("""
+        var (diagnostics, _) = Compile("""
             import System
             import System.Collections.Generic
             func gen() IEnumerable[int32] {
@@ -39,13 +40,13 @@ public class Issue836IteratorTryFinallyBinderTests
             }
             """);
 
-        Assert.Empty(result.Diagnostics);
+        Assert.Empty(diagnostics);
     }
 
     [Fact]
     public void YieldInsideTryWithCatch_RejectedWithGS0367()
     {
-        var (result, _) = Compile("""
+        var (diagnostics, _) = Compile("""
             import System
             import System.Collections.Generic
             func gen() IEnumerable[int32] {
@@ -57,13 +58,13 @@ public class Issue836IteratorTryFinallyBinderTests
             }
             """);
 
-        Assert.Contains(result.Diagnostics, d => d.Id == "GS0367");
+        Assert.Contains(diagnostics, d => d.Id == "GS0367");
     }
 
     [Fact]
     public void YieldInsideTryCatchFinally_RejectedWithGS0367()
     {
-        var (result, _) = Compile("""
+        var (diagnostics, _) = Compile("""
             import System
             import System.Collections.Generic
             func gen() IEnumerable[int32] {
@@ -77,13 +78,13 @@ public class Issue836IteratorTryFinallyBinderTests
             }
             """);
 
-        Assert.Contains(result.Diagnostics, d => d.Id == "GS0367");
+        Assert.Contains(diagnostics, d => d.Id == "GS0367");
     }
 
     [Fact]
     public void NestedTryFinally_BothLevelsContainYields_Accepted()
     {
-        var (result, _) = Compile("""
+        var (diagnostics, _) = Compile("""
             import System
             import System.Collections.Generic
             func gen() IEnumerable[int32] {
@@ -100,13 +101,13 @@ public class Issue836IteratorTryFinallyBinderTests
             }
             """);
 
-        Assert.Empty(result.Diagnostics);
+        Assert.Empty(diagnostics);
     }
 
     [Fact]
     public void NestedTryFinally_InnerHasCatchWithYield_InnerRejected()
     {
-        var (result, _) = Compile("""
+        var (diagnostics, _) = Compile("""
             import System
             import System.Collections.Generic
             func gen() IEnumerable[int32] {
@@ -122,14 +123,14 @@ public class Issue836IteratorTryFinallyBinderTests
             }
             """);
 
-        Assert.Contains(result.Diagnostics, d => d.Id == "GS0367");
+        Assert.Contains(diagnostics, d => d.Id == "GS0367");
     }
 
     [Fact]
     public void TryWithCatch_NoYield_StillBinds()
     {
         // Non-iterator try/catch is unaffected.
-        var (result, _) = Compile("""
+        var (diagnostics, _) = Compile("""
             import System
             func gen() int32 {
                 try {
@@ -140,7 +141,7 @@ public class Issue836IteratorTryFinallyBinderTests
             }
             """);
 
-        Assert.Empty(result.Diagnostics);
+        Assert.Empty(diagnostics);
     }
 
     [Fact]
@@ -150,7 +151,7 @@ public class Issue836IteratorTryFinallyBinderTests
         // count as belonging to the outer try/catch (different lexical
         // scope; the inner lambda would have its own iterator semantics
         // if it returned a sequence).
-        var (result, _) = Compile("""
+        var (diagnostics, _) = Compile("""
             import System
             import System.Collections.Generic
             func gen() IEnumerable[int32] {
@@ -170,14 +171,17 @@ public class Issue836IteratorTryFinallyBinderTests
 
         // The outer try has only a finally, not a catch — should be
         // accepted regardless of where the inner lambda's yield lives.
-        Assert.Empty(result.Diagnostics);
+        Assert.Empty(diagnostics);
     }
 
-    private static (EvaluationResult Result, Compilation Compilation) Compile(string source)
+    // Binder-inspection helper (issue #3176 Phase 3b.2): bind via
+    // EmittedOracle.CompileDiagnostics and inspect this Compilation's bound
+    // state; nothing needs to run.
+    private static (System.Collections.Immutable.ImmutableArray<Diagnostic> Diagnostics, Compilation Compilation) Compile(string source)
     {
         var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
         var compilation = new Compilation(syntaxTree);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        return (result, compilation);
+        var diagnostics = EmittedOracle.CompileDiagnostics(compilation);
+        return (diagnostics, compilation);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/RecordAliasTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/RecordAliasTests.cs
@@ -150,13 +150,12 @@ type Foo class {
 
     private static StructSymbol BuildStruct(string source)
     {
-        // Phase 3b (issue #3176): stays on Compilation.Evaluate — the test
-        // inspects this Compilation's bound state afterwards, which the
-        // EmittedOracle does not expose; disposition in 3b.2.
+        // Binder-inspection helper (issue #3176 Phase 3b.2): bind via
+        // EmittedOracle.CompileDiagnostics and inspect this Compilation's
+        // bound state; nothing needs to run.
         var tree = SyntaxTree.Parse(SourceText.From(source));
         var compilation = new Compilation(tree);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.Empty(result.Diagnostics);
+        Assert.Empty(EmittedOracle.CompileDiagnostics(compilation));
         return (StructSymbol)compilation.GlobalScope.Structs.Single(s => s.Name == "Point");
     }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/TypeOfNameOfTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/TypeOfNameOfTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -180,19 +181,12 @@ var n = nameof(List[List[int32]])
         throw new Xunit.Sdk.XunitException($"variable '{name}' not found");
     }
 
-    private static (EvaluationResult Result, Dictionary<string, object> Variables) EvaluateWithVariables(string source)
+    private static (EmittedOracleResult Result, IReadOnlyDictionary<string, object> Variables) EvaluateWithVariables(string source)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        var variables = new Dictionary<VariableSymbol, object>();
-        var result = compilation.Evaluate(variables);
-
-        var namedVars = new Dictionary<string, object>();
-        foreach (var kvp in variables)
-        {
-            namedVars[kvp.Key.Name] = kvp.Value;
-        }
-
-        return (result, namedVars);
+        // Post-run globals read back through the oracle (issue #3176 Phase
+        // 3b.2): the emitted equivalent of the evaluator's variables
+        // dictionary.
+        var result = EmittedOracle.Evaluate(source);
+        return (result, result.ReadGlobals());
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Symbols/Issue1621ConstructedGenericCacheKeyTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/Issue1621ConstructedGenericCacheKeyTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Symbols;
@@ -64,8 +65,7 @@ class Box[T] {
     {
         var tree = SyntaxTree.Parse(SourceText.From(Source));
         var compilation = new Compilation(tree);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.Empty(result.Diagnostics);
+        Assert.Empty(EmittedOracle.CompileDiagnostics(compilation));
         return (StructSymbol)compilation.GlobalScope.Structs.Single(s => s.Name == name);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Symbols/Issue1622ClearCacheOnDisposeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/Issue1622ClearCacheOnDisposeTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Symbols;
@@ -212,8 +213,7 @@ class Box[T] {
     {
         var tree = SyntaxTree.Parse(SourceText.From(StructSource));
         var compilation = new Compilation(tree);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.Empty(result.Diagnostics);
+        Assert.Empty(EmittedOracle.CompileDiagnostics(compilation));
         return (StructSymbol)compilation.GlobalScope.Structs.Single(s => s.Name == name);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Symbols/Issue989GenericPropertySubstitutionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/Issue989GenericPropertySubstitutionTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Symbols;
@@ -67,8 +68,7 @@ class Box[T] {
     {
         var tree = SyntaxTree.Parse(SourceText.From(Source));
         var compilation = new Compilation(tree);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.Empty(result.Diagnostics);
+        Assert.Empty(EmittedOracle.CompileDiagnostics(compilation));
         return (StructSymbol)compilation.GlobalScope.Structs.Single(s => s.Name == name);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Symbols/TypeMemberModelTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/TypeMemberModelTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Symbols;
@@ -299,8 +300,7 @@ enum Color {
     {
         var tree = SyntaxTree.Parse(SourceText.From(Source));
         var compilation = new Compilation(tree);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.Empty(result.Diagnostics);
+        Assert.Empty(EmittedOracle.CompileDiagnostics(compilation));
         return (StructSymbol)compilation.GlobalScope.Structs.Single(s => s.Name == name);
     }
 
@@ -308,8 +308,7 @@ enum Color {
     {
         var tree = SyntaxTree.Parse(SourceText.From(Source));
         var compilation = new Compilation(tree);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.Empty(result.Diagnostics);
+        Assert.Empty(EmittedOracle.CompileDiagnostics(compilation));
         return compilation.GlobalScope.Interfaces.Single(s => s.Name == name);
     }
 
@@ -317,8 +316,7 @@ enum Color {
     {
         var tree = SyntaxTree.Parse(SourceText.From(Source));
         var compilation = new Compilation(tree);
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        Assert.Empty(result.Diagnostics);
+        Assert.Empty(EmittedOracle.CompileDiagnostics(compilation));
         return compilation.GlobalScope.Enums.Single(s => s.Name == name);
     }
 }

--- a/test/Core.Tests/Core.Tests.csproj
+++ b/test/Core.Tests/Core.Tests.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup>
     <Compile Include="..\Shared\EmittedOracle.cs" Link="EmittedOracle.cs" />
+    <Compile Include="..\Shared\EmittedOracleOptions.cs" Link="EmittedOracleOptions.cs" />
     <Compile Include="..\Shared\EmittedOracleResult.cs" Link="EmittedOracleResult.cs" />
   </ItemGroup>
 

--- a/test/Interpreter.Tests/EmittedOracleTests.cs
+++ b/test/Interpreter.Tests/EmittedOracleTests.cs
@@ -341,6 +341,74 @@ public class EmittedOracleTests
     }
 
     [Fact]
+    public void MultiSource_CrossTreeImportAlias_ResolvesAndRuns()
+    {
+        var holder = """
+            package Oracle3b2.Nested
+
+            class Holder3b2 {
+                prop Value int32
+
+                shared {
+                    func MakeOne() Holder3b2 {
+                        var h Holder3b2 = Holder3b2{Value: 42}
+                        return h
+                    }
+                }
+            }
+            """;
+        var main = """
+            package Oracle3b2Main
+
+            import R = Oracle3b2.Nested.Holder3b2
+
+            var h R = R.MakeOne()
+            h.Value
+            """;
+
+        var result = EmittedOracle.Evaluate(new[] { holder, main });
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void OracleRuns_DoNotShadowLaterCompilationsOfTheSamePackage()
+    {
+        // Issue #3235: a finished oracle run's collectible assembly must not
+        // leak into later compilations' default reference scans — otherwise
+        // its emitted types shadow same-named source packages.
+        var first = EmittedOracle.Evaluate("""
+            package Oracle3b2.Shadow
+            class Probe3b2 {
+                shared {
+                    const Tag string = "first"
+                }
+            }
+            var t = Probe3b2.Tag
+            t
+            """);
+        Assert.Empty(first.Diagnostics);
+        Assert.Equal("first", first.Value);
+
+        // Same package, different shape: must bind against ITS OWN source,
+        // not the still-loaded assembly of the first run (kept alive by the
+        // held result above).
+        var second = EmittedOracle.Evaluate("""
+            package Oracle3b2.Shadow
+            class Probe3b2 {
+                shared {
+                    func Make() int32 -> 42
+                }
+            }
+            var r = Probe3b2.Make()
+            r
+            """);
+        Assert.Empty(second.Diagnostics);
+        Assert.Equal(42, second.Value);
+    }
+
+    [Fact]
     public void IsLibrary_EmitsWithoutExecuting()
     {
         var result = EmittedOracle.Evaluate(

--- a/test/Interpreter.Tests/EmittedOracleTests.cs
+++ b/test/Interpreter.Tests/EmittedOracleTests.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using GSharp.Core.CodeAnalysis.Execution;
@@ -297,6 +298,150 @@ public class EmittedOracleTests
             Assert.Equal(marker, results[i].Value);
             Assert.Equal(marker + Environment.NewLine + marker + Environment.NewLine, results[i].Output);
         }
+    }
+
+    // ─── Phase 3b.2 capability additions (issue #3176) ───────────────────
+
+    [Fact]
+    public void MultiSource_CompilesAllTreesAndRunsTrailingExpression()
+    {
+        // The multi-tree Compilation.Evaluate shape: declarations in one
+        // tree, consuming top-level statements in another, distinct packages.
+        var result = EmittedOracle.Evaluate(new[]
+        {
+            """
+            package Geometry
+            public struct Point {
+                var X int32
+                var Y int32
+            }
+            """,
+            """
+            package GeometryUse
+            var p = Point{X: 40, Y: 2}
+            p.X + p.Y
+            """,
+        });
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void MultiSource_DiagnosticsSurfaceFromEveryTree()
+    {
+        var result = EmittedOracle.Evaluate(new[]
+        {
+            "func Ok() int32 -> 1",
+            "let broken = undefinedName3b2",
+        });
+
+        Assert.Contains(result.Diagnostics, d => d.IsError);
+        Assert.Null(result.Value);
+    }
+
+    [Fact]
+    public void IsLibrary_EmitsWithoutExecuting()
+    {
+        var result = EmittedOracle.Evaluate(
+            new[]
+            {
+                """
+                package Lib3b2
+                public func Answer() int32 -> 42
+                """,
+            },
+            new EmittedOracleOptions { IsLibrary = true });
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.Value);
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(string.Empty, result.Output);
+    }
+
+    [Fact]
+    public void IsLibrary_TopLevelStatementsStayAnError()
+    {
+        // IsLibrary's contract (ADR-0066 D4): top-level statements are an
+        // error, exactly as they were under Compilation.Evaluate.
+        var result = EmittedOracle.Evaluate(
+            new[] { "var leaked = 1" },
+            new EmittedOracleOptions { IsLibrary = true });
+
+        Assert.Contains(result.Diagnostics, d => d.IsError);
+    }
+
+    [Fact]
+    public void ImplicitSystemImport_CanBeDisabled()
+    {
+        const string Source = """
+            package Gate3b2
+            let t = typeof(Console)
+            """;
+
+        Assert.Empty(EmittedOracle.Evaluate(new[] { Source }).Diagnostics);
+
+        var gated = EmittedOracle.Evaluate(
+            new[] { Source },
+            new EmittedOracleOptions { ImplicitSystemImport = false });
+        Assert.Contains(gated.Diagnostics, d => d.IsError);
+    }
+
+    [Fact]
+    public void ReadGlobals_ReturnsEverySourceGlobalAndNoSynthesizedFields()
+    {
+        var result = EmittedOracle.Evaluate("""
+            var counter = 40
+            counter += 2
+            let label = "tag-44"
+            label
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        var globals = result.ReadGlobals();
+        Assert.Equal(42, globals["counter"]);
+        Assert.Equal("tag-44", globals["label"]);
+        Assert.All(globals.Keys, name => Assert.DoesNotContain("<", name));
+    }
+
+    [Fact]
+    public void CompileDiagnostics_BindsWithoutRunningAndKeepsBoundStateInspectable()
+    {
+        // The binder-inspection companion: the caller's own Compilation stays
+        // inspectable (GlobalScope/BoundProgram), diagnostics come back in
+        // Evaluate's pre-execution shape, and nothing ever executes.
+        var tree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree.Parse(
+            GSharp.Core.CodeAnalysis.Text.SourceText.From("""
+                struct Pair {
+                    var A int32
+                    var B int32
+                }
+                let p = Pair{A: 1, B: 2}
+                """));
+        var compilation = new GSharp.Core.CodeAnalysis.Compilation.Compilation(tree);
+
+        var diagnostics = EmittedOracle.CompileDiagnostics(compilation);
+
+        Assert.Empty(diagnostics);
+        Assert.Contains(compilation.GlobalScope.Structs, s => s.Name == "Pair");
+    }
+
+    [Fact]
+    public void CompileDiagnostics_SurfacesBodyBindingErrorsWarningsFirst()
+    {
+        var tree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree.Parse(
+            GSharp.Core.CodeAnalysis.Text.SourceText.From("""
+                func Broken() int32 {
+                    return undefinedName3b2
+                }
+                """));
+        var compilation = new GSharp.Core.CodeAnalysis.Compilation.Compilation(tree);
+
+        var diagnostics = EmittedOracle.CompileDiagnostics(compilation);
+
+        Assert.Contains(diagnostics, d => d.IsError);
+        var firstError = diagnostics.TakeWhile(d => !d.IsError).Count();
+        Assert.All(diagnostics.Skip(firstError), d => Assert.True(d.IsError));
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/test/Interpreter.Tests/Interpreter.Tests.csproj
+++ b/test/Interpreter.Tests/Interpreter.Tests.csproj
@@ -12,6 +12,7 @@
     <ProjectReference Include="..\..\src\Sdk\Gsharp.Extensions\Gsharp.Extensions.csproj" />
     <Compile Include="..\Shared\Issue3081CompositeLiteralCases.cs" Link="Issue3081CompositeLiteralCases.cs" />
     <Compile Include="..\Shared\EmittedOracle.cs" Link="EmittedOracle.cs" />
+    <Compile Include="..\Shared\EmittedOracleOptions.cs" Link="EmittedOracleOptions.cs" />
     <Compile Include="..\Shared\EmittedOracleResult.cs" Link="EmittedOracleResult.cs" />
     <ProjectReference Include="..\..\test-assets\Issue3119.CrossConstants\Issue3119.CrossConstants.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>

--- a/test/Shared/EmittedOracle.cs
+++ b/test/Shared/EmittedOracle.cs
@@ -64,17 +64,6 @@ namespace GSharp.Tests;
 public static class EmittedOracle
 {
     private static readonly object ConsoleGate = new();
-
-    // One process-wide host-reference snapshot, taken on first oracle use.
-    // ReferenceResolver.Default() rescans AppDomain.CurrentDomain.GetAssemblies()
-    // on every call, so a fresh per-call resolver would see the still-loaded
-    // collectible assemblies of EARLIER oracle runs — and their emitted types
-    // would shadow same-named source packages in later compilations
-    // (issue #3235). Snapshotting once keeps every oracle compilation's
-    // reference surface identical and oracle-emission-free.
-    private static readonly Lazy<ReferenceResolver> SharedDefaultResolver =
-        new(() => ReferenceResolver.Default(), LazyThreadSafetyMode.ExecutionAndPublication);
-
     private static int submissionCounter;
 
     /// <summary>
@@ -137,9 +126,14 @@ public static class EmittedOracle
         var packageName = "oracle" + n;
 
         var trees = sources.Select(s => SyntaxTree.Parse(SourceText.From(s))).ToArray();
+
+        // A fresh default resolver per call is safe: ReferenceResolver
+        // excludes collectible-ALC assemblies from its host scan, so earlier
+        // oracle runs' still-loaded emitted assemblies can never shadow this
+        // compilation's source packages (issue #3235).
         var resolver = referencePaths.Length > 0
             ? ReferenceResolver.WithReferences(referencePaths)
-            : SharedDefaultResolver.Value;
+            : ReferenceResolver.Default();
 
         var compilation = new Compilation(resolver, trees);
         if (options.ImplicitSystemImport is bool implicitSystemImport)

--- a/test/Shared/EmittedOracle.cs
+++ b/test/Shared/EmittedOracle.cs
@@ -64,6 +64,17 @@ namespace GSharp.Tests;
 public static class EmittedOracle
 {
     private static readonly object ConsoleGate = new();
+
+    // One process-wide host-reference snapshot, taken on first oracle use.
+    // ReferenceResolver.Default() rescans AppDomain.CurrentDomain.GetAssemblies()
+    // on every call, so a fresh per-call resolver would see the still-loaded
+    // collectible assemblies of EARLIER oracle runs — and their emitted types
+    // would shadow same-named source packages in later compilations
+    // (issue #3235). Snapshotting once keeps every oracle compilation's
+    // reference surface identical and oracle-emission-free.
+    private static readonly Lazy<ReferenceResolver> SharedDefaultResolver =
+        new(() => ReferenceResolver.Default(), LazyThreadSafetyMode.ExecutionAndPublication);
+
     private static int submissionCounter;
 
     /// <summary>
@@ -128,7 +139,7 @@ public static class EmittedOracle
         var trees = sources.Select(s => SyntaxTree.Parse(SourceText.From(s))).ToArray();
         var resolver = referencePaths.Length > 0
             ? ReferenceResolver.WithReferences(referencePaths)
-            : ReferenceResolver.Default();
+            : SharedDefaultResolver.Value;
 
         var compilation = new Compilation(resolver, trees);
         if (options.ImplicitSystemImport is bool implicitSystemImport)

--- a/test/Shared/EmittedOracle.cs
+++ b/test/Shared/EmittedOracle.cs
@@ -90,24 +90,67 @@ public static class EmittedOracle
             throw new ArgumentNullException(nameof(source));
         }
 
-        var referencePaths = references?.Where(r => !string.IsNullOrWhiteSpace(r)).ToArray() ?? Array.Empty<string>();
+        return Evaluate(new[] { source }, new EmittedOracleOptions { References = references });
+    }
+
+    /// <summary>
+    /// Compiles all <paramref name="sources"/> as the syntax trees of one
+    /// compilation — the multi-tree equivalent of
+    /// <c>new Compilation(t1, t2, …).Evaluate(…)</c> — applying the given
+    /// compilation <paramref name="options"/>, and returns the full assertion
+    /// surface. Unless <see cref="EmittedOracleOptions.IsLibrary"/> is set the
+    /// sources compile as a one-shot submission and run emitted in-process;
+    /// a library compilation emits and returns diagnostics without executing
+    /// (there is no entry point to run — the historical evaluator likewise
+    /// had nothing to execute for a library).
+    /// </summary>
+    /// <param name="sources">The G# source texts, one per syntax tree, in compilation order.</param>
+    /// <param name="options">Compilation-level knobs; <see langword="null"/> for defaults.</param>
+    /// <returns>The oracle result.</returns>
+    public static EmittedOracleResult Evaluate(IReadOnlyList<string> sources, EmittedOracleOptions options = null)
+    {
+        if (sources is null)
+        {
+            throw new ArgumentNullException(nameof(sources));
+        }
+
+        if (sources.Count == 0 || sources.Any(s => s is null))
+        {
+            throw new ArgumentException("At least one non-null source is required.", nameof(sources));
+        }
+
+        options ??= new EmittedOracleOptions();
+        var referencePaths = options.References?.Where(r => !string.IsNullOrWhiteSpace(r)).ToArray() ?? Array.Empty<string>();
         var n = Interlocked.Increment(ref submissionCounter);
         var assemblyName = "oracle$" + n;
         var packageName = "oracle" + n;
 
-        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var trees = sources.Select(s => SyntaxTree.Parse(SourceText.From(s))).ToArray();
         var resolver = referencePaths.Length > 0
             ? ReferenceResolver.WithReferences(referencePaths)
             : ReferenceResolver.Default();
 
-        var compilation = new Compilation(resolver, tree)
+        var compilation = new Compilation(resolver, trees);
+        if (options.ImplicitSystemImport is bool implicitSystemImport)
         {
-            Submission = new SubmissionBindingOptions
+            compilation.ImplicitSystemImport = implicitSystemImport;
+        }
+
+        if (options.IsLibrary)
+        {
+            // A library has no entry point and forbids top-level statements,
+            // so there is nothing to wrap in a submission — and nothing to
+            // run afterwards.
+            compilation.IsLibrary = true;
+        }
+        else
+        {
+            compilation.Submission = new SubmissionBindingOptions
             {
                 Imports = SubmissionImports.Create(ImmutableArray<SubmissionReference>.Empty),
                 DefaultPackageName = packageName,
-            },
-        };
+            };
+        }
 
         using var peStream = new MemoryStream();
         var emitResult = compilation.Emit(peStream, pdbStream: null, refStream: null, assemblyName: assemblyName);
@@ -128,7 +171,49 @@ public static class EmittedOracle
                 loadContext: null);
         }
 
+        if (options.IsLibrary)
+        {
+            return new EmittedOracleResult(
+                warnings,
+                value: null,
+                output: string.Empty,
+                errorOutput: string.Empty,
+                exitCode: 0,
+                unhandledException: null,
+                loadContext: null);
+        }
+
         return Execute(peStream, referencePaths, warnings);
+    }
+
+    /// <summary>
+    /// Fully binds the caller's <paramref name="compilation"/> — global scope
+    /// plus every function/method body and top-level statement — and returns
+    /// its diagnostics in <c>Compilation.Evaluate</c>'s pre-execution shape
+    /// (parse, then global-scope, then body diagnostics; warnings before
+    /// errors), without ever executing. The binder-inspection companion for
+    /// Phase 3b.2 (issue #3176): tests that assert on the compilation's bound
+    /// state afterwards (<c>GlobalScope</c>, <c>BoundProgram</c>) keep their
+    /// own <c>Compilation</c> instance and stop running code they never
+    /// observe. The interpreter-only diagnostics <c>Compilation.Evaluate</c>
+    /// appended after this point (deinit GS0510, P/Invoke GS0514) never
+    /// appear — those constructs simply work under emitted execution
+    /// (ADR-0156); tests asserting them are evaluator-machinery pins.
+    /// </summary>
+    /// <param name="compilation">The compilation to bind.</param>
+    /// <returns>The full bind-time diagnostics, warnings first.</returns>
+    public static ImmutableArray<Diagnostic> CompileDiagnostics(Compilation compilation)
+    {
+        if (compilation is null)
+        {
+            throw new ArgumentNullException(nameof(compilation));
+        }
+
+        var all = compilation.SyntaxTrees.SelectMany(tree => tree.Diagnostics)
+            .Concat(compilation.GlobalScope.Diagnostics)
+            .Concat(compilation.BoundProgram.Diagnostics)
+            .ToImmutableArray();
+        return all.Where(d => !d.IsError).Concat(all.Where(d => d.IsError)).ToImmutableArray();
     }
 
     private static EmittedOracleResult Execute(

--- a/test/Shared/EmittedOracleOptions.cs
+++ b/test/Shared/EmittedOracleOptions.cs
@@ -1,0 +1,41 @@
+// <copyright file="EmittedOracleOptions.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+
+namespace GSharp.Tests;
+
+/// <summary>
+/// Compilation-level knobs for <see cref="EmittedOracle.Evaluate(IReadOnlyList{string}, EmittedOracleOptions)"/>,
+/// mirroring the <c>Compilation</c> properties the historical
+/// <c>Compilation.Evaluate</c> tests set on their hand-built compilations
+/// (Phase 3b.2, issue #3176). Defaults reproduce the plain
+/// <c>EmittedOracle.Evaluate(source)</c> behavior exactly.
+/// </summary>
+public sealed class EmittedOracleOptions
+{
+    /// <summary>
+    /// Gets reference assembly paths resolvable at compile and run time (the
+    /// <c>/r:</c> channel); may be <see langword="null"/>.
+    /// </summary>
+    public IReadOnlyList<string> References { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the sources compile as a library
+    /// (<c>Compilation.IsLibrary</c>): declarations only, no entry point, no
+    /// submission wrapping — the oracle emits and returns diagnostics but
+    /// never executes, exactly like the historical evaluator, which had
+    /// nothing to run for a library compilation (top-level statements are an
+    /// error under <c>IsLibrary</c>).
+    /// </summary>
+    public bool IsLibrary { get; init; }
+
+    /// <summary>
+    /// Gets the <c>Compilation.ImplicitSystemImport</c> override: whether an
+    /// implicit <c>import System</c> is seeded before user imports.
+    /// <see langword="null"/> keeps the compilation default
+    /// (<see langword="true"/>).
+    /// </summary>
+    public bool? ImplicitSystemImport { get; init; }
+}

--- a/test/Shared/EmittedOracleResult.cs
+++ b/test/Shared/EmittedOracleResult.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Reflection;
 using GSharp.Core.CodeAnalysis;
@@ -140,9 +141,54 @@ public sealed class EmittedOracleResult
     /// <returns>The global's current value, or <see langword="null"/>.</returns>
     public object ReadGlobal(string name)
     {
-        if (Assembly is null || string.IsNullOrEmpty(name))
+        if (string.IsNullOrEmpty(name))
         {
             return null;
+        }
+
+        foreach (var field in EnumerateGlobalFields())
+        {
+            if (string.Equals(field.Name, name, StringComparison.Ordinal))
+            {
+                return field.GetValue(null);
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Reads every top-level global's post-run value by name — the emitted
+    /// equivalent of the historical evaluator's whole variables dictionary
+    /// after <c>Compilation.Evaluate</c>. Synthesized submission fields
+    /// (<c>&lt;Result&gt;$</c> and friends) are excluded. Empty when the
+    /// program never ran. The <see cref="Value"/> identity caveat applies to
+    /// values of submission-declared types.
+    /// </summary>
+    /// <returns>A name-to-value map of the top-level globals.</returns>
+    public IReadOnlyDictionary<string, object> ReadGlobals()
+    {
+        var globals = new Dictionary<string, object>(StringComparer.Ordinal);
+        foreach (var field in EnumerateGlobalFields())
+        {
+            if (field.Name.IndexOf('<') >= 0)
+            {
+                // Compiler-synthesized (e.g. the <Result>$ capture) — not a
+                // source global.
+                continue;
+            }
+
+            globals[field.Name] = field.GetValue(null);
+        }
+
+        return globals;
+    }
+
+    private IEnumerable<FieldInfo> EnumerateGlobalFields()
+    {
+        if (Assembly is null)
+        {
+            yield break;
         }
 
         Type[] types;
@@ -162,13 +208,10 @@ public sealed class EmittedOracleResult
                 continue;
             }
 
-            var field = type.GetField(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
-            if (field is not null)
+            foreach (var field in type.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static))
             {
-                return field.GetValue(null);
+                yield return field;
             }
         }
-
-        return null;
     }
 }


### PR DESCRIPTION
Part of #3176 (Phase 3b.2), part of #3163. Resolves #3235.

## Summary

The hand-migration of the non-canonical `Compilation.Evaluate` tail the 3b.1 scripted bulk (#3221/#3225/#3228) left behind: **49 Core.Tests files migrated** (the 48 untouched files plus the 15 annotated residue sites inside 3b.1-migrated files, minus the conflict-deferred set), with the oracle capabilities the tail needed added to `test/Shared` first, each in its own commit.

- **Oracle capabilities** (own commit + witness tests in `EmittedOracleTests`, 26 green): multi-source `Evaluate(IReadOnlyList<string>, EmittedOracleOptions)`; `EmittedOracleOptions` with `IsLibrary` (emit-only, nothing runs — a library has no entry point, exactly like the evaluator) and `ImplicitSystemImport`; `EmittedOracleResult.ReadGlobals()` (the whole post-run variables dictionary by name); `EmittedOracle.CompileDiagnostics(Compilation)` (binder-inspection companion: full bind of the caller's own compilation, `Evaluate`'s pre-execution diagnostics shape, nothing executes).
- **Host-reference leak fix** (#3235, own commits — the one deliberate product touch): running the tail exposed that `ReferenceResolver.Default()`'s AppDomain rescan included the still-loaded collectible assemblies of earlier in-process emitted runs, whose types then shadowed same-named source packages in later compilations. A first, test-side-only attempt (freezing one resolver snapshot in the oracle) broke lazily-loaded BCL resolution in the full run (Issue2258/System.Text.Json), so the leak is fixed at its source instead: `BuildHostAssemblies` now skips collectible-ALC assemblies — execution artifacts (`EmittedProgramHost`, `InteractiveSessionHost`, the oracle) are not references. Emitted REPL chaining is unaffected (prior submissions flow in as explicit `WithReferences` paths). Resolves #3235; two oracle witness tests guard the behavior.
- **Migrations by category** (one commit each): binder-inspection → `CompileDiagnostics`; multi-tree → oracle multi-source (execution-observing) or `CompileDiagnostics` over the original plain compilation (tree-order binder regressions, whose guarded property is the plain gsc-path binder); compile knobs → `EmittedOracleOptions`; variables read-back → `ReadGlobals`/`ReadGlobal`; stragglers + the stale `Issue2377` doc-comment mention.

## Category tally

| Category | Files | Notes |
|---|---|---|
| Binder-inspection → `CompileDiagnostics` | 20 | AnonymousClassExpression, DataStruct, RecordAlias, Issue1154 (5 sites), Issue1552 (11), Issue1631 (12), Issue2146 (6), Issue2364 (5), Issue2402, Issue656, Issue729, Issue774, Issue805, Issue836, Issue2644, Symbols x4 (Issue1621/1622/989/TypeMemberModel), Issue2519's single-tree fact |
| Tree-order binder regressions → plain compilation + `CompileDiagnostics` | 3 | Issue2517 (2 sites), Issue2519 (3 sites), ClassTests' derived-before-base site |
| Multi-tree → oracle multi-source | 6 | ExtensionFunctionTests, Issue1680, Issue2273, InterfaceTests site, Issue671 `BindMultiFile`, Issue3075 |
| `IsLibrary` → options | 8 | Issue1323, Issue1379, Issue1395, Issue1627, Issue1701, Issue2188, Issue2492, Issue2535 |
| `ImplicitSystemImport` → options | 2 | Issue722, Issue723 |
| Variables read-back → `ReadGlobals`/`ReadGlobal` | 10 | ByRefEvaluation, Issue1246, Issue1884, Issue2027, Issue2227, Issue795, TypeOfNameOf, Issue2856, InterpolatedString, InterpolatedStringHandlerArgument |
| Canonical stragglers → oracle | 1 | Issue2514 |
| Doc-comment-only fix | 1 | Issue2377 |
| Console-capture variants | 0 | the only console-capture callers are the three LanguageConformance `RunsOnInterpreter` golden tests and `AsyncInterpVsEmitParityTests` — deliberate interpreter-side coverage that retires with the evaluator (list (a) below), not migrable without changing what they test |
| Newly annotated, not migrated | 1 | Issue698 (asserts the interpreter-boundary GS0510 deinit diagnostic only `Compilation.Evaluate` synthesizes) |

## Divergence table

Assertions never changed; pinned tests keep their original expected values on `Compilation.Evaluate` via `EvaluateWithEvaluator` twins annotated with their issue.

| Issue | Status | Category | Pinned tests |
|---|---|---|---|
| #3236 | new, filed | Emitter: nullable-lifted reference conversions (`Service → IService[object?]?`, `T? → Animal?`) fail with `NotSupportedException` — real `gsc` library-build failures the IsLibrary channel surfaced | Issue2535 `CovariantImplementedInterfaceLiftsThroughReferenceNullability`, Issue2188 `BaseClassConstrainedNullableTypeParam_ToNullableBase_Compiles` |
| #3215 | already filed (burn-down in flight) | pointer-typed top-level global fails signature encoding | ByRefEvaluationTests `Dereference_Returns_Original_Value`, `AddressOf_Evaluates_To_Value_In_Interpreter` (the latter also asserts the interpreter's by-design ADR-0039 pointer model) |
| #3235 | new, filed and **fixed here** (product finding, not a test pin) | in-process emitted assemblies leaked into later `ReferenceResolver.Default()` scans, shadowing same-named source packages | — (2 oracle witness tests added) |

## Remaining `Compilation.Evaluate` callers in test/ (the exact 3b.3 worklist)

**(a) Parity / evaluator-machinery / issue-pinned — retire or resolve with the evaluator (Phase 3c) or their issues:**

- Core.Tests, machinery/interpreter-coverage: `Issue1654EvaluateNoCfgDumpTests` (tests `Evaluate` itself), `Issue698DeinitBinderTests` (GS0510, now annotated), `Issue2544LiftedUnaryOperatorTests` (`Interpreter_…` twin of its own emit tests), `AsyncInterpVsEmitParityTests`, `AddressBookSampleTests`/`AspirationalSamplesTests`/`CountWordsSampleTests` (interpreter-vs-golden conformance; emit side lives in Compiler.Tests `SampleConformanceTests`)
- Core.Tests, issue-pinned this phase: `ByRefEvaluationTests` (#3215 x2), `Issue2188…` (#3236), `Issue2535…` (#3236)
- Interpreter.Tests (evaluator's own suite / parity, per the #3206 pilot classification): `Adr0156EmitToMemorySpikeTests`, `Issue1799MapAndInterfaceSlotConcurrencyInterpreterTests`, `Issue2896StructObjectOverrideTests`, `Issue2921LambdaBodyDefiniteReturnInterpreterTests`, `Issue2938DelegateExceptionDiagnosticTests`, `Issue2953ProtectedReturnFallthroughInterpreterTests`, `Issue2984MainEntryPointInterpreterTests` (the `evaluateEntryPoint` overload surface), `Issue2991LambdaMethodIdentityTests`, `Issue3058OutParameterMemberDefiniteAssignmentTests`, `Issue3140OutParameterWriteBackParityTests`
- Compiler.Tests (dual-oracle emit↔interp parity harnesses, `AssertEnginesAgree` shape): `Issue1714StringZeroValueEmitTests`, `Issue2853EllipsisLoopCaptureTests`, `Issue2854TopLevelEllipsisLoopCaptureTests`, `Issue2906ExhaustiveSwitchReturnEmitTests`, `Issue2907IteratorLoopCaptureTests`, `Issue2914ConstantPatternSwitchLoweringTests`, `Issue2927NullableSequenceElementTypeTests`, `Issue2928TupleFunctionParityTests`

**(b) Deferred-for-conflict** (touched by the in-flight burn-down branches `fix/3219-3222-3226-generics-emit` / `fix/3215-3218-3223-metadata-emit`; all five already carry `EvaluateWithEvaluator` pins from 3b.1, and StructuralProjectionTests additionally carries one annotated binder-inspection residue site for the follow-up pass):

- `ByRefPointerTests` (#3215 pins), `Issue1104BasePropertyAccessBinderTests` (#3223), `Issue1932GenericMethodInferenceOverUserTypeTests` (#3222), `Issue773GenericReceiverDispatchTests` (#3226), `StructuralProjectionTests` (#3218/#3219 + 1 residue site)

**(c) `ContinueWith`-chain / session machinery reserved for 3b.3** (the plan's "chains onto the session oracle + the `evaluateEntryPoint` site" row): no test file calls `Compilation.ContinueWith(...).Evaluate` directly — the chain callers are `SessionEngine` (src/Repl) and its suites (`SessionEngineChainedPerfTests`, `SessionEngineCancellationTests`, `SessionEngineConsoleIoTests`, `SessionEngineRedefineTests`, `GSharpReplTests`, `ReplLayoutTests`, `Adr0151IfLetExpressionInterpreterTests`, and the SessionEngine-driven `Issue*InterpreterTests`), which exercise `Compilation.Evaluate` through the engine. 3b.3 moves those onto the emitted session oracle and adds the `[Obsolete]`/grep gate.

After this PR merges, greps for `\.Evaluate(new Dictionary`/`compilation.Evaluate(` in `test/` return exactly lists (a) and (b).

## Verification

- `dotnet build GSharp.sln -c Release`: 0 warnings, 0 errors.
- `test/Core.Tests` full suite (Release): **7152/7153 passed**, 1 skipped (standing `RegenerateBaseline` skip).
- `test/Interpreter.Tests` full suite (Release, touched — oracle witness tests live here): **1498/1502 passed**, 4 skipped (pre-existing #3205 map-concurrency skips).
- Witness (ADR-0154): migrated tests keep their original expected values against the real emitted semantics; #3236's two library-build failures and #3235's shadowing leak are this phase's discrimination evidence.
- `LanguageConformance` filter (Release): `Compiler.Tests` `~Conformance` **126/126 passed** (the emit-host conformance gate; Core.Tests' LanguageConformance suite ran green inside the full run) — run because of the one-line `ReferenceResolver` product change.
- NOT RUN: the rest of `Compiler.Tests`, `Extensions.Tests`, `LanguageServer.Tests`, `Sdk.Tests` (the product change is a strict narrowing of the host-reference scan, exercised directly by the suites above), `Cs2Gs.Tests` (pre-existing flaky host crash; GoldenTests-filter policy). CI required checks are the backstop.

## Checklist

- [x] Behavioral tests carry a witness of discrimination (ADR-0154): assertions unchanged; each migrated test still fails on its original broken world, now against emitted (or bind-only, where the test never observed execution) semantics.
- [x] Self-review verdict recorded when one was run (MERGEABLE / BLOCKER / SHOULD-FIX / NIT), with residuals filed as issues rather than dropped.

Self-review verdict: **MERGEABLE** — test-side plus one surgical, witness-guarded product fix (#3235); every remaining `Compilation.Evaluate` caller in test/ is classified in the three lists above; discovered divergences and the resolver leak are filed (#3235, #3236) rather than papered over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
