### PR TITLE
Migrate the ContinueWith-chain tests onto the emitted session engine (Phase 3b.3, chain migration)

### DIFF
--- a/test/Core.Tests/CodeAnalysis/Emit/DebugInformationOptionsTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/DebugInformationOptionsTests.cs
@@ -63,6 +63,14 @@ public class DebugInformationOptionsTests
         Assert.True(compilation.DebugInformation.Deterministic);
     }
 
+    /// <summary>
+    /// CHAIN-MACHINERY PIN (ADR-0156 Phase 3b.3, #3176): pins the
+    /// <see cref="Compilation.ContinueWith"/> options-cloning contract, not
+    /// the evaluator oracle (nothing here evaluates). The API's only product
+    /// consumer is the tree-walking REPL <c>SessionEngine</c>, so Phase 3c
+    /// must revisit this test alongside any decision to delete
+    /// <c>ContinueWith</c> with that engine.
+    /// </summary>
     [Fact]
     public void DebugInformation_IsClonedThroughContinueWith()
     {

--- a/test/Interpreter.Tests/SessionEngineChainedPerfTests.cs
+++ b/test/Interpreter.Tests/SessionEngineChainedPerfTests.cs
@@ -13,14 +13,25 @@ namespace GSharp.Interpreter.Tests;
 /// <c>Compilation.ContinueWith(tree).Evaluate(variables)</c> got dramatically
 /// slower as the number of prior submissions grew — the per-submission cost
 /// doubled roughly every additional cell (~O(2^n)), turning a 30-cell session
-/// into a multi-minute CI hang. This is a functional regression guard with a
-/// generous timeout, not a tight perf assertion (those are flaky in CI): it
+/// into a multi-minute CI hang. These are functional regression guards with
+/// generous timeouts, not tight perf assertions (those are flaky in CI): each
 /// only asserts that 50 trivial submissions complete well within a budget
-/// that the old exponential behavior could never hit (it took ~80s for a
-/// single submission around N=31 before the fix).
+/// that exponential per-cell behavior could never hit (it took ~80s for a
+/// single submission around N=31 before the #2101 fix).
 /// </summary>
 public class SessionEngineChainedPerfTests
 {
+    /// <summary>
+    /// EVALUATOR-MACHINERY PIN (ADR-0156 Phase 3b.3; retire with the
+    /// evaluator engine in Phase 3c, #3176): only the tree-walking
+    /// <see cref="SessionEngine"/> drives the
+    /// <c>ContinueWith</c> → <c>Previous</c> bound-scope chain whose binding
+    /// cost #2101 fixed — the emitted engine builds an independent
+    /// compilation per submission via <c>SubmissionImports</c> and never
+    /// touches that path. This guard pins the deprecated
+    /// <c>--engine evaluator</c> escape hatch's chain scaling until 3c
+    /// deletes the engine (and this test with it).
+    /// </summary>
     [Fact]
     public void Evaluate_FiftyChainedSubmissions_CompletesQuickly()
     {
@@ -43,5 +54,44 @@ public class SessionEngineChainedPerfTests
         Assert.True(
             sw.Elapsed.TotalSeconds < 10,
             $"50 chained submissions took {sw.Elapsed.TotalSeconds:F1}s — expected linear-ish scaling, not the pre-fix O(2^n) blowup.");
+    }
+
+    /// <summary>
+    /// The emitted counterpart (ADR-0156 Phase 3b.3): the interactive-default
+    /// <see cref="EmittedSessionEngine"/> has a different per-submission cost
+    /// channel — a full in-memory emit, an ALC assembly load, and an import
+    /// surface that grows with every prior submission — so it needs its own
+    /// chain-scaling canary; the evaluator guard above cannot cover it (the
+    /// engines share no chain machinery). Survives Phase 3c. Also asserts the
+    /// chain actually carries state end to end (first and last variables
+    /// readable from cell 51 — the REPL model the chain exists for).
+    /// </summary>
+    [Fact]
+    public void Evaluate_FiftyChainedSubmissions_EmittedEngine_CompletesQuickly()
+    {
+        using var engine = new EmittedSessionEngine();
+        var sw = Stopwatch.StartNew();
+
+        for (var i = 0; i < 50; i++)
+        {
+            var cell = engine.Evaluate($"var x{i} = {i}");
+            Assert.False(cell.HasError, $"submission {i} unexpectedly failed: {string.Join(", ", cell.Diagnostics)}");
+        }
+
+        sw.Stop();
+
+        // The chain must still be live: a 51st cell reads globals declared by
+        // the 1st and 50th submissions across their submission assemblies.
+        var sum = engine.Evaluate("x0 + x49");
+        Assert.False(sum.HasError, $"state-carry submission unexpectedly failed: {string.Join(", ", sum.Diagnostics)}");
+        Assert.Equal(49, sum.Value);
+
+        // Generous sanity ceiling for 50 emit+load cycles: linear-ish
+        // per-cell cost lands well under this on any CI runner, while any
+        // reintroduced super-linear growth (binding against the accumulated
+        // import surface is the risk spot) blows past it long before cell 50.
+        Assert.True(
+            sw.Elapsed.TotalSeconds < 30,
+            $"50 chained emitted submissions took {sw.Elapsed.TotalSeconds:F1}s — expected linear-ish scaling in the emitted submission chain.");
     }
 }


### PR DESCRIPTION
Part of #3176 (Phase 3b.3, chain migration), part of #3163. First half of 3b.3 only: the `[Obsolete]` + grep-gate finale lands separately once 3b.2 (`feat/3176-phase3b2-oracle-tail`, in flight) merges; this branch touches none of that branch's files (verified by diffing its file list against this one — zero overlap).

## Chain-oracle design decision

**Option (b) — drive the session engines directly, parity-suite style. No `EmittedOracle` session mode.** The precise inventory (below) collapses the 3b.0 plan estimate ("~7 ContinueWith chain files") to **one** genuine evaluator-chain test, and it already drives the product `SessionEngine` — a test-side session oracle in `test/Shared` would have zero consumers. Extending `EmittedOracle` for that would be capability theater; the smaller, honest diff is to point the chain coverage at `EmittedSessionEngine` directly, exactly as `EmittedSessionEngineParityTests` already does for multi-cell scripts.

## Precise inventory (`grep -rl "ContinueWith" test/` → 8 files, classified)

| File | Actual usage | Disposition |
|---|---|---|
| `test/Interpreter.Tests/SessionEngineChainedPerfTests.cs` | Genuine chain guard (#2101 O(2^n) fix) via evaluator `SessionEngine` | **Evaluator-machinery pin, annotated for 3c** + emitted counterpart added (see below) |
| `test/Core.Tests/CodeAnalysis/Emit/DebugInformationOptionsTests.cs` | Real `Compilation.ContinueWith`, but never evaluates — options-cloning contract | **Chain-machinery pin, annotated**: `ContinueWith`'s only product caller is the evaluator `SessionEngine` (verified: 1 src site), so 3c must revisit this pin with any `ContinueWith` deletion |
| `test/Core.Tests/.../Issue2365ExpressionTreeGenericSubstitutionTests.cs` | `Task.ContinueWith` in GSharp fixture source | False positive (3b.2 file — untouched here) |
| `test/Core.Tests/.../Issue2498NullableLambdaGenericInferenceTests.cs` | `Task.ContinueWith` in fixture | False positive (3b.2 file — untouched here) |
| `test/Core.Tests/.../Issue707WhileDoLabeledBindingTests.cs` | `ContinueWithUnknownLabel` = labeled-`continue` test name | False positive |
| `test/Core.Tests/.../Issue707WhileDoLabeledParserTests.cs` | `Parses_ContinueWithLabel` test name | False positive |
| `test/Compiler.Tests/Emit/Issue1512GenericClosureInferenceEmitTests.cs` | `Task.ContinueWith` in fixture | False positive |
| `test/Compiler.Tests/IlVerifier.cs` | `Task.ContinueWith` on harness process streams | False positive |

The 3b.0 count was a raw grep; **no test anywhere chains `Compilation.ContinueWith(...).Evaluate(...)` directly** — the REPL chain model lives behind the engines, and the ~172 `ISessionEngine.Evaluate` cell calls were already scoped out of 3b by the plan measurement.

## Summary

- Annotate `Evaluate_FiftyChainedSubmissions_CompletesQuickly` as an **evaluator-machinery pin** (retire with 3c): the #2101 fix lives in the `ContinueWith` → `Previous` bound-scope chain that only the tree-walking engine drives; `EmittedSessionEngine` builds an independent compilation per submission via `SubmissionImports` and never touches that path — the guard cannot be "migrated" without guarding nothing.
- Add `Evaluate_FiftyChainedSubmissions_EmittedEngine_CompletesQuickly`: the same 50-cell chain shape through the interactive-default `EmittedSessionEngine`, whose distinct per-cell cost channel (full in-memory emit + ALC load + growing import surface) had no scaling canary, plus an end-to-end state-carry assertion (cell 51 evaluates `x0 + x49` = 49 across submission assemblies — the REPL model the chain exists for). Survives 3c.
- Annotate `DebugInformation_IsClonedThroughContinueWith` as a chain-machinery (not oracle) pin for the 3c `ContinueWith`-deletion decision.

## Divergence table

| Divergence | Disposition |
|---|---|
| — | None encountered: no assertion-bearing chain file changed oracles (the one migratable intent got a new emitted-side test with its own assertions; the evaluator original is byte-identical in assertions). Nothing aligned against the pinned list (redefinition newest-wins, struct-method mutation, deinit, echo, #3209 map concurrency); nothing new to file. |

## Remaining for the finale (`[Obsolete]` + grep-gate PR, after 3b.2 merges)

Projected `Compilation.Evaluate` callers in `test/` after this PR ∖ 3b.2's file list (26 files):

- **Compiler.Tests dual-oracle files (8)**: Issue1714, Issue2853, Issue2854, Issue2906, Issue2907, Issue2914, Issue2927, Issue2928 — the plan's "emit-host vs emit-file parity or single-oracle" conversion; not chains, not in 3b.2's diff.
- **Core.Tests (7)**: Issue1654EvaluateNoCfgDumpTests (evaluator-machinery pin), StructuralProjectionTests, AsyncInterpVsEmitParityTests (parity harness), Issue2544LiftedUnaryOperatorTests, LanguageConformance ×3 (AddressBookSample, AspirationalSamples, CountWordsSample).
- **Interpreter.Tests (10)**: the 3b.0 pilot's kept files (Adr0156 spike + parity harnesses Issue2896/2921/3058; machinery pins Issue2938/2984/2991/2953; Issue1799 pinned on #3205/#3209) + Issue3140OutParameterWriteBackParityTests (post-pilot parity file).
- **Product-side suppressions the `[Obsolete]` PR must handle**: `src/Repl/Engine/SessionEngine.cs:234` (the `evaluateEntryPoint` site — the plan's category 5) and `test/Shared/EmittedOracle.cs`'s doc references; grep gate then enforces zero non-obsolete callers outside `src/Core`.
- **3c retirement list started here**: `SessionEngineChainedPerfTests.Evaluate_FiftyChainedSubmissions_CompletesQuickly`, `DebugInformationOptionsTests.DebugInformation_IsClonedThroughContinueWith`.

## Verification

- `dotnet build GSharp.sln -c Release`: 0 warnings, 0 errors.
- `test/Interpreter.Tests` full (Release): **1489/1493 passed, 4 skipped** (standing skips incl. the #3210 map-concurrency disables pending #3209). New emitted chain canary passes with wide margin (both perf tests together: 9s wall).
- `test/Core.Tests` full (Release): **7179/7180 passed, 1 skipped** (standing `RegenerateBaseline` skip) — run although this PR only adds a doc comment there.
- NOT RUN: `Compiler.Tests`, `Cs2Gs.Tests` (pre-existing flaky host-crash; GoldenTests-filter policy), `Extensions.Tests`, `LanguageServer.Tests`, `Sdk.Tests` — zero `src/` changes; CI required checks are the backstop.
- Witness note (ADR-0154): the evaluator guard's assertions are unchanged (its witness is #2101's historical pre-fix world). The new emitted test is a scaling canary with no historical broken world to replay — its discrimination is the state-carry assertion (fails if the chain stops carrying globals across submission assemblies; verified it fails under a deliberately broken expectation) plus the budget ceiling; the emitted engine never had the #2101 path, so no pre-fix RED exists by construction.

## Checklist

- [x] Behavioral tests carry a witness of discrimination (ADR-0154): each new/changed test fails on the pre-change code (pre-fix commit, reverted hunk, or an applied product mutant) and passes with it. *(Qualified above: the emitted canary is a guard-shaped addition; the evaluator pin keeps its original #2101 witness.)*
- [x] Self-review verdict recorded when one was run (MERGEABLE / BLOCKER / SHOULD-FIX / NIT), with residuals filed as issues rather than dropped.

Self-review verdict: **MERGEABLE** — test-side only (zero `src/` changes), zero overlap with the in-flight 3b.2 branch, both touched suites fully green, and the corrected inventory is measured (grep-classified table) rather than asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)