### PR TITLE
Lower nullable-lifted reference conversions in the emitter (covariant interface lift, constrained T? to nullable base)

### DIFF
--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
@@ -550,9 +550,28 @@ internal sealed partial class MethodBodyEmitter
         // to the constraint, one of its bases, or an implemented interface.
         // For a reference-type instantiation `box !T` is a runtime no-op, while
         // giving the verifier the constrained reference shape it requires.
-        if (from is TypeParameterSymbol classConstrainedParameter
+        //
+        // Issue #3236: the same widening reaches emit through reference-
+        // nullable wrappers on either side — `T? → Animal?`, `T → Animal?`
+        // under `[T Animal]`. A class-base-constrained T is provably a
+        // reference type, so its `T?` is a binder-level annotation over the
+        // bare `!!T` slot (never `Nullable<!!T>` — that shape is value-type-
+        // constrained and excluded by IsValueTypeNullable), and a nullable
+        // reference target likewise erases to its underlying representation.
+        // The lifted conversion therefore degenerates to the identical
+        // `box !!T`: a null reference boxes to null, so nil flows through
+        // unchanged, and a live reference is a runtime no-op box.
+        var classConstrainedBoxSource = from is NullableTypeSymbol fromRefLiftBox
+            && !ReflectionMetadataEmitter.IsValueTypeNullable(fromRefLiftBox)
+            ? fromRefLiftBox.UnderlyingType
+            : from;
+        var classConstrainedBoxTarget = to is NullableTypeSymbol toRefLiftBox
+            && !ReflectionMetadataEmitter.IsValueTypeNullable(toRefLiftBox)
+            ? toRefLiftBox.UnderlyingType
+            : to;
+        if (classConstrainedBoxSource is TypeParameterSymbol classConstrainedParameter
             && classConstrainedParameter.ClassConstraint is TypeSymbol classConstraint
-            && IsReferenceCompatible(classConstraint, to))
+            && IsReferenceCompatible(classConstraint, classConstrainedBoxTarget))
         {
             this.il.OpCode(ILOpCode.Box);
             this.il.Token(this.outer.memberRefs.GetElementTypeToken(classConstrainedParameter));

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
@@ -849,7 +849,21 @@ internal sealed partial class MethodBodyEmitter
             {
                 foreach (var iface in c.Interfaces)
                 {
-                    if (iface == targetIface)
+                    // Issue #3236: mirror the binder's #2535 rule —
+                    // declaration-site variance lifts through a class's
+                    // implemented interface (`Service : IService[object]` →
+                    // `IService[object?]`), exactly as the #1927 arm above
+                    // already recognises for an interface-typed SOURCE. At the
+                    // IL level this stays a plain reference load with no cast:
+                    // both constructed interfaces erase to the same open
+                    // generic definition (differing only by reference type
+                    // argument) and CLR generic-interface variance makes the
+                    // runtime reference directly assignment-compatible.
+                    // Without this, the emitter threw NotSupportedException
+                    // for the class-sourced lift the binder had accepted
+                    // (`Conversion from 'Service' to 'IService[object?]?'`).
+                    if (iface == targetIface
+                        || Conversion.IsVarianceCompatibleInterfaceConversion(iface, targetIface))
                     {
                         return true;
                     }

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue3236NullableLiftedReferenceConversionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue3236NullableLiftedReferenceConversionTests.cs
@@ -1,0 +1,184 @@
+// <copyright file="Issue3236NullableLiftedReferenceConversionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #3236: the emitter could not lower two nullable-lifted REFERENCE
+/// conversion shapes the binder accepts (both surfaced as real <c>gsc</c>
+/// library-build failures by the ADR-0156 Phase 3b.2 oracle-tail migration):
+/// <list type="bullet">
+///   <item><description><c>Service → IService[object?]?</c> — the covariant
+///     user-interface upcast (<c>#2535</c>) lifted through reference
+///     nullability. <c>MethodBodyEmitter.IsReferenceCompatible</c>'s
+///     class→interface arm matched implemented interfaces by reference
+///     equality only, missing the binder's #2535 declaration-site variance
+///     rule, so <c>EmitConversion</c> threw
+///     <c>NotSupportedException: Conversion from 'Service' to
+///     'IService[object?]?' is not yet supported</c>.</description></item>
+///   <item><description><c>T? → Animal?</c> under <c>[T Animal]</c> — the
+///     #2519 constrained-type-parameter box arm only fired for a BARE
+///     <c>T</c> source and a bare target, so the nullable-lifted form threw
+///     <c>NotSupportedException: Conversion from 'T?' to 'Animal?'</c>.
+///     </description></item>
+/// </list>
+/// For reference-type targets <c>X?</c> is representation-free (no
+/// <c>Nullable&lt;T&gt;</c> wrapper), so both lifts degenerate to the
+/// underlying reference conversion: a no-op reference load for the variance
+/// upcast, and the same <c>box !!T</c> the bare #2519 arm emits for the
+/// constrained type parameter (null boxes to null, so nil flows through).
+/// </summary>
+public class Issue3236NullableLiftedReferenceConversionTests
+{
+    [Fact]
+    public void CovariantInterfaceLift_LibraryShape_EmitsCleanly()
+    {
+        // The issue's first repro, on the exact channel that surfaced it:
+        // a library compilation (no entry point) through the emitted
+        // oracle's IsLibrary option — gsc building this source as a library
+        // died with the emit-stage NotSupportedException pre-fix.
+        var result = EmittedOracle.Evaluate(
+            new[]
+            {
+                """
+                interface IService[out T] {}
+                class Service : IService[object] {}
+
+                func Lift(value Service) IService[object?]? -> value
+                """,
+            },
+            new EmittedOracleOptions { IsLibrary = true });
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void CovariantInterfaceLift_FullPinnedFamily_LibraryEmitsCleanly()
+    {
+        // The complete #2535 family (the shapes pinned on
+        // Compilation.Evaluate by the Phase 3b.2 migration): the direct
+        // class lift, the nullable-source lift, the `!!`-asserted
+        // non-nullable-target lift, and the smart-cast flow lift must all
+        // emit alongside the already-working interface-typed control.
+        var result = EmittedOracle.Evaluate(
+            new[]
+            {
+                """
+                interface IService[out T] {}
+                class Service : IService[object] {}
+
+                func InterfaceControl(value IService[object]) IService[object?]? -> value
+                func Lift(value Service) IService[object?]? -> value
+                func NullableLift(value Service?) IService[object?]? -> value
+                func AssertedLift(value Service?) IService[object?] -> value!!
+                func FlowLift(value object?) IService[object?]? {
+                    if value is Service {
+                        return value
+                    }
+                    return nil
+                }
+                """,
+            },
+            new EmittedOracleOptions { IsLibrary = true });
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void ConstrainedNullableTypeParamToNullableBase_LibraryShape_EmitsCleanly()
+    {
+        // The issue's second repro (verbatim), also on the IsLibrary
+        // channel: a class-base-constrained T's `T?` converting to the
+        // nullable base.
+        var result = EmittedOracle.Evaluate(
+            new[]
+            {
+                """
+                package p
+                class Animal { init() {} }
+                func Sink[T Animal](x T?) Animal? -> x
+                """,
+            },
+            new EmittedOracleOptions { IsLibrary = true });
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void CovariantInterfaceLift_Executing_NilFlowsThroughAndNonNilConverts()
+    {
+        // End-to-end: a non-nil Service converts (the reference survives the
+        // variance lift), and a nil source flows through as nil — the
+        // conversion must not fabricate a value in either direction.
+        var result = EmittedOracle.Evaluate("""
+            interface IService[out T] {}
+            class Service : IService[object] {}
+
+            func Lift(value Service?) IService[object?]? -> value
+
+            let a = Lift(Service{})
+            let b = Lift(nil)
+            var r = ""
+            if a != nil { r = r + "A" }
+            if b == nil { r = r + "B" }
+            r
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal("AB", result.Value);
+    }
+
+    [Fact]
+    public void ConstrainedNullableTypeParam_Executing_NilFlowsThroughAndNonNilConverts()
+    {
+        // End-to-end for the `T? → Animal?` shape: `box !!T` on a null
+        // reference yields null (nil flows through), and a live Dog boxes to
+        // the same reference (a runtime no-op for the class instantiation).
+        var result = EmittedOracle.Evaluate("""
+            open class Animal {}
+            class Dog : Animal {}
+
+            func Sink[T Animal](x T?) Animal? -> x
+
+            let a = Sink[Dog](Dog{})
+            let b = Sink[Dog](nil)
+            var r = ""
+            if a != nil { r = r + "A" }
+            if b == nil { r = r + "B" }
+            r
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal("AB", result.Value);
+    }
+
+    [Fact]
+    public void UnconstrainedNullableTypeParam_ValueInstantiation_LiftStaysIntact()
+    {
+        // Guard for the #3226 unconstrained-`T?` lift (PR #3234): an
+        // UNCONSTRAINED T's `T?` slot instantiated at a value type routes
+        // through the Nullable<X> MethodSpec lift, which the #3236 arms
+        // (keyed on a class-base-constrained T) must leave untouched. A nil
+        // Nullable<int32> takes the fallback and a live one unwraps.
+        var result = EmittedOracle.Evaluate("""
+            func Pass[T](x T?, fb T) T {
+                if x != nil { return x!! }
+                return fb
+            }
+
+            var v1 int32? = nil
+            var v2 int32? = 7
+            Pass(v1, 99) * 100 + Pass(v2, 0)
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(9907, result.Value);
+    }
+}


### PR DESCRIPTION
Fixes #3236. Part of #3176 (pre-3c), part of #3163.

## Summary

Two nullable-lifted REFERENCE conversion shapes the binder accepts had no emit lowering (`NotSupportedException` from `EmitConversion`) — real `gsc` library-build failures surfaced by Phase 3b.2's IsLibrary oracle channel; the evaluator handled them dynamically. Both shapes fixed; none deferred.

| Shape | Root cause | Fix |
| --- | --- | --- |
| `Service → IService[object?]?` (covariant interface lift through reference nullability) | `MethodBodyEmitter.IsReferenceCompatible`'s class→interface arm matched implemented interfaces by reference equality only — the binder's #2535 declaration-site-variance rule had no emit mirror, so the nullable-target (#1121-arm) and nullable-source (#1255-arm) paths both fell through to the throw | Mirror the binder's #2535 rule in the class→interface arm (`Conversion.IsVarianceCompatibleInterfaceConversion`), exactly as the #1927 arm already does for an interface-typed SOURCE. The lift stays a no-op reference load: both constructed interfaces erase to the same open generic definition and CLR generic-interface variance makes the reference assignment-compatible |
| `T? → Animal?` under `[T Animal]` (constrained type parameter to its nullable base) | The #2519 constrained-type-parameter box arm fired only for a bare `T` source and a bare target; the nullable-lifted forms (`T? → Animal?`, `T → Animal?`) had no arm | A class-base-constrained `T` is provably a reference type, so `T?` erases to the bare `!!T` slot and `Animal?` to `Animal` (both wrappers representation-free). The arm now unwraps reference-nullable wrappers on both sides and emits the identical `box !!T` — null boxes to null, so nil flows through; a live reference is a runtime no-op box |

Relation to #3218 (PR #3233): the same unwrap-convert-rewrap principle — a nullable wrapper over a reference-like type is representation-free, so the lifted conversion degenerates to the underlying reference conversion. #3218 applied it at bind time to the structural-projection arm; this PR applies it at emit time to the general lifted reference-conversion family (variance no-op + constrained-type-parameter box). Value-type nullables stay excluded via `ReflectionMetadataEmitter.IsValueTypeNullable`, leaving the #3226 unconstrained-`T?` lift (PR #3234) untouched (guard test included).

Deliberately NOT in this PR: unpinning `Issue2535NullableReferenceConversionTests.CovariantImplementedInterfaceLiftsThroughReferenceNullability` and `Issue2188ReferenceConstrainedTypeParamObjectTests.BaseClassConstrainedNullableTypeParam_ToNullableBase_Compiles` off `Compilation.Evaluate` — a parallel PR is sweeping the existing test files; the unpinning is a small follow-up after both merge.

## Verification

- Release build (Core, Compiler, test projects): 0 warnings, 0 errors.
- **Witness (ADR-0154)**, new `Issue3236NullableLiftedReferenceConversionTests`: **5/6 RED on main** with the issue's exact `NotSupportedException` signatures ("Conversion from 'Service' to 'IService[object?]?'", "Conversion from 'T?' to 'Animal?'"); **6/6 green** post-fix. Covers: both repros on the `EmittedOracle` **IsLibrary** channel (the original failure channel), the full #2535 pinned family (direct/nullable-source/`!!`-asserted/smart-cast-flow lifts + interface control), executing end-to-end for both shapes (nil flows through, non-nil converts), and the #3226 unconstrained-`T?` value-instantiation guard (green pre- and post-fix).
- Real-surface run: `gsc /target:library` on both issue repros compiles (previously threw); a combined executing program compiled with `gsc /target:exe` prints the expected `ABCD` (non-nil converts / nil flows through for both shapes); contravariant (`in T`) direction also compiles. `dotnet-ilverify`: **"All Classes and Methods Verified"** for all four output assemblies; invariant control still rejected at bind time (GS0155).
- Area filters (Conversion|Projection|Nullable|Variance|Issue2535|Issue2188|Issue2519|Issue1927): **688/688**.
- Full `Core.Tests`: **7185 passed, 0 failed, 1 skipped** (pre-existing `RegenerateBaseline` skip).
- `Compiler.Tests` LanguageConformance filter: **126/126**.
- `Interpreter.Tests` full: **1499 passed, 0 failed, 4 skipped** (pre-existing skips).
- NOT RUN: remaining `Compiler.Tests` (non-conformance), `LanguageServer.Tests`, `Sdk.Tests`, `Cs2Gs.Tests` (pre-existing flaky host crash — see repo memory), other tool suites — outside the touched Emit surface; CI backstop.

## Checklist

- [x] Behavioral tests carry a witness of discrimination (ADR-0154): each new/changed test fails on the pre-change code (pre-fix commit, reverted hunk, or an applied product mutant) and passes with it.
- [x] Self-review verdict recorded when one was run (MERGEABLE / BLOCKER / SHOULD-FIX / NIT), with residuals filed as issues rather than dropped.

Self-review verdict: **MERGEABLE** — two narrow emit arms, each an exact mirror of an existing binder rule; no planner/slot changes; evaluator untouched. Residual: the two evaluator-pinned tests stay pinned until the post-merge unpinning follow-up noted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
