### PR TITLE
Retire-gate the tree-walking evaluator: sweep, [Obsolete] census, NBGV CI fix (Phase 3b.3 finale)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,18 @@ on:
     branches:
       - main
 
+env:
+  # Nerdbank.GitVersioning's GitHub Actions integration appends
+  # GitBuildVersion* lines to $GITHUB_ENV from every MSBuild node; with
+  # parallel builds (-graph, dotnet test) concurrent appends interleave and
+  # corrupt the file, failing shards with "Unable to process file command
+  # 'env': Invalid format". No step in any workflow consumes those variables
+  # (version stamping goes through the nbgv CLI instead), so disable the
+  # emission workflow-wide. The gate property in Nerdbank.GitVersioning
+  # 3.11's targets is NBGV_SetCloudBuildVersionVars; the cloud build-number
+  # path is already a no-op on GitHub Actions.
+  NBGV_SetCloudBuildVersionVars: false
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/cs2gs-nightly.yml
+++ b/.github/workflows/cs2gs-nightly.yml
@@ -16,6 +16,12 @@ permissions:
   issues: write
   pull-requests: write
 
+env:
+  # Parallel MSBuild nodes corrupt $GITHUB_ENV via Nerdbank.GitVersioning's
+  # GitBuildVersion* emission; nothing consumes those variables, so disable
+  # it (see build.yml for the full rationale).
+  NBGV_SetCloudBuildVersionVars: false
+
 jobs:
   nightly:
     runs-on: ubuntu-latest

--- a/.github/workflows/windows-nightly.yml
+++ b/.github/workflows/windows-nightly.yml
@@ -32,6 +32,12 @@ on:
     - cron: '23 9 * * *'
   workflow_dispatch:
 
+env:
+  # Parallel MSBuild nodes corrupt $GITHUB_ENV via Nerdbank.GitVersioning's
+  # GitBuildVersion* emission; nothing consumes those variables, so disable
+  # it (see build.yml for the full rationale).
+  NBGV_SetCloudBuildVersionVars: false
+
 jobs:
   windows:
     runs-on: windows-latest

--- a/src/Core/CodeAnalysis/Compilation/Compilation.cs
+++ b/src/Core/CodeAnalysis/Compilation/Compilation.cs
@@ -308,6 +308,7 @@ public class Compilation
     /// </summary>
     /// <param name="variables">The symbol table with actual values.</param>
     /// <returns>An evaluation result.</returns>
+    [Obsolete("The tree-walking evaluator retires in ADR-0156 Phase 3c. New callers are forbidden; see #3176.", error: false)]
     public EvaluationResult Evaluate(Dictionary<VariableSymbol, object> variables) =>
         Evaluate(variables, evaluateEntryPoint: true, useEntryPointReturnType: false);
 
@@ -317,6 +318,7 @@ public class Compilation
     /// <param name="variables">The symbol table with actual values.</param>
     /// <param name="evaluateEntryPoint">Whether to invoke an explicit program entry point.</param>
     /// <returns>An evaluation result.</returns>
+    [Obsolete("The tree-walking evaluator retires in ADR-0156 Phase 3c. New callers are forbidden; see #3176.", error: false)]
     public EvaluationResult Evaluate(Dictionary<VariableSymbol, object> variables, bool evaluateEntryPoint) =>
         Evaluate(variables, evaluateEntryPoint, useEntryPointReturnType: evaluateEntryPoint);
 
@@ -327,6 +329,7 @@ public class Compilation
     /// <param name="evaluateEntryPoint">Whether to invoke an explicit program entry point.</param>
     /// <param name="useEntryPointReturnType">Whether the declared entry-point return type controls the result.</param>
     /// <returns>An evaluation result.</returns>
+    [Obsolete("The tree-walking evaluator retires in ADR-0156 Phase 3c. New callers are forbidden; see #3176.", error: false)]
     public EvaluationResult Evaluate(
         Dictionary<VariableSymbol, object> variables,
         bool evaluateEntryPoint,

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -108,6 +108,7 @@ public sealed partial class Evaluator
     /// </summary>
     /// <param name="program">The program.</param>
     /// <param name="variables">The variables.</param>
+    [Obsolete("The tree-walking evaluator retires in ADR-0156 Phase 3c. New callers are forbidden; see #3176.", error: false)]
     public Evaluator(BoundProgram program, Dictionary<VariableSymbol, object> variables)
         : this(
             program,
@@ -117,6 +118,7 @@ public sealed partial class Evaluator
     {
     }
 
+    [Obsolete("The tree-walking evaluator retires in ADR-0156 Phase 3c. New callers are forbidden; see #3176.", error: false)]
     internal Evaluator(
         BoundProgram program,
         Dictionary<VariableSymbol, object> variables,

--- a/src/Repl/Engine/SessionEngine.cs
+++ b/src/Repl/Engine/SessionEngine.cs
@@ -231,7 +231,11 @@ public sealed class SessionEngine : ISessionEngine
                 var compilation = previous == null
                     ? references is null ? new Compilation(tree) : new Compilation(references, tree)
                     : previous.ContinueWith(tree);
+                // The tree-walking SessionEngine is the evaluator's product host; it
+                // retires with the evaluator in ADR-0156 Phase 3c (#3176).
+#pragma warning disable CS0618
                 var result = compilation.Evaluate(variables, evaluateEntryPoint: RunEntryPoint);
+#pragma warning restore CS0618
 
                 var hasError = result.Diagnostics.Any(d => d.IsError);
 

--- a/test/Compiler.Tests/Emit/Issue1714StringZeroValueEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1714StringZeroValueEmitTests.cs
@@ -17,6 +17,10 @@ using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
 using Xunit;
 
+// Dual-oracle emit-vs-interp parity harness; the evaluator oracle retires
+// with the evaluator in ADR-0156 Phase 3c (#3176).
+#pragma warning disable CS0618 // Compilation.Evaluate / Evaluator are retiring (ADR-0156 Phase 3c, #3176)
+
 namespace GSharp.Compiler.Tests.Emit;
 
 /// <summary>

--- a/test/Compiler.Tests/Emit/Issue2853EllipsisLoopCaptureTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2853EllipsisLoopCaptureTests.cs
@@ -13,6 +13,10 @@ using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using Xunit;
 
+// Dual-oracle emit-vs-interp parity harness; the evaluator oracle retires
+// with the evaluator in ADR-0156 Phase 3c (#3176).
+#pragma warning disable CS0618 // Compilation.Evaluate / Evaluator are retiring (ADR-0156 Phase 3c, #3176)
+
 namespace GSharp.Compiler.Tests.Emit;
 
 /// <summary>

--- a/test/Compiler.Tests/Emit/Issue2854TopLevelEllipsisLoopCaptureTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2854TopLevelEllipsisLoopCaptureTests.cs
@@ -13,6 +13,10 @@ using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using Xunit;
 
+// Dual-oracle emit-vs-interp parity harness; the evaluator oracle retires
+// with the evaluator in ADR-0156 Phase 3c (#3176).
+#pragma warning disable CS0618 // Compilation.Evaluate / Evaluator are retiring (ADR-0156 Phase 3c, #3176)
+
 namespace GSharp.Compiler.Tests.Emit;
 
 /// <summary>

--- a/test/Compiler.Tests/Emit/Issue2906ExhaustiveSwitchReturnEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2906ExhaustiveSwitchReturnEmitTests.cs
@@ -15,6 +15,10 @@ using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
 using Xunit;
 
+// Dual-oracle emit-vs-interp parity harness; the evaluator oracle retires
+// with the evaluator in ADR-0156 Phase 3c (#3176).
+#pragma warning disable CS0618 // Compilation.Evaluate / Evaluator are retiring (ADR-0156 Phase 3c, #3176)
+
 namespace GSharp.Compiler.Tests.Emit;
 
 /// <summary>

--- a/test/Compiler.Tests/Emit/Issue2907IteratorLoopCaptureTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2907IteratorLoopCaptureTests.cs
@@ -15,6 +15,10 @@ using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using Xunit;
 
+// Dual-oracle emit-vs-interp parity harness; the evaluator oracle retires
+// with the evaluator in ADR-0156 Phase 3c (#3176).
+#pragma warning disable CS0618 // Compilation.Evaluate / Evaluator are retiring (ADR-0156 Phase 3c, #3176)
+
 namespace GSharp.Compiler.Tests.Emit;
 
 /// <summary>

--- a/test/Compiler.Tests/Emit/Issue2914ConstantPatternSwitchLoweringTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2914ConstantPatternSwitchLoweringTests.cs
@@ -15,6 +15,10 @@ using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
 using Xunit;
 
+// Dual-oracle emit-vs-interp parity harness; the evaluator oracle retires
+// with the evaluator in ADR-0156 Phase 3c (#3176).
+#pragma warning disable CS0618 // Compilation.Evaluate / Evaluator are retiring (ADR-0156 Phase 3c, #3176)
+
 namespace GSharp.Compiler.Tests.Emit;
 
 /// <summary>Issue #2914: constant pattern switches fold during lowering.</summary>

--- a/test/Compiler.Tests/Emit/Issue2927NullableSequenceElementTypeTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2927NullableSequenceElementTypeTests.cs
@@ -15,6 +15,10 @@ using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using Xunit;
 
+// Dual-oracle emit-vs-interp parity harness; the evaluator oracle retires
+// with the evaluator in ADR-0156 Phase 3c (#3176).
+#pragma warning disable CS0618 // Compilation.Evaluate / Evaluator are retiring (ADR-0156 Phase 3c, #3176)
+
 namespace GSharp.Compiler.Tests.Emit;
 
 /// <summary>

--- a/test/Compiler.Tests/Emit/Issue2928TupleFunctionParityTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2928TupleFunctionParityTests.cs
@@ -12,6 +12,10 @@ using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using Xunit;
 
+// Dual-oracle emit-vs-interp parity harness; the evaluator oracle retires
+// with the evaluator in ADR-0156 Phase 3c (#3176).
+#pragma warning disable CS0618 // Compilation.Evaluate / Evaluator are retiring (ADR-0156 Phase 3c, #3176)
+
 namespace GSharp.Compiler.Tests.Emit;
 
 /// <summary>

--- a/test/Core.Tests/CodeAnalysis/Binding/ByRefEvaluationTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ByRefEvaluationTests.cs
@@ -49,16 +49,15 @@ var ok = Int32.TryParse(""notanumber"", &result)
     [Fact]
     public void Dereference_Returns_Original_Value()
     {
-        // ADR-0156 Phase 3b (#3176): pinned on Compilation.Evaluate — a
-        // pointer-typed top-level global trips the #3215 signature-encoding
-        // failure under emit ("Cannot encode '*int32' as a non-byref
-        // signature slot"); realigns with that issue's resolution.
+        // #3215 (fixed): the byref-typed `p` stays an entry-point local under
+        // emit while `x` and `y` still hoist, so the dereference round-trip
+        // is observable through the emitted globals.
         var source = @"
 var x = 100
 var p = &x
 var y = *p
 ";
-        var (eval, vars) = EvaluateWithEvaluatorVariables(source);
+        var (eval, vars) = EvaluateWithVariables(source);
         Assert.Empty(eval.Diagnostics);
         Assert.Equal(100, vars["y"]);
     }
@@ -66,10 +65,11 @@ var y = *p
     [Fact]
     public void AddressOf_Evaluates_To_Value_In_Interpreter()
     {
-        // ADR-0156 Phase 3b (#3176): pinned on Compilation.Evaluate — same
-        // #3215 pointer-global emit failure as above, and the asserted
-        // semantics ("&x evaluates to the value") are the interpreter's
-        // pointer model by design (ADR-0039); retires with the evaluator.
+        // ADR-0156 Phase 3b (#3176): pinned on Compilation.Evaluate — the
+        // asserted semantics ("&x evaluates to the value") are the
+        // interpreter's pointer model by design (ADR-0039), and under the
+        // #3215 fix the byref-typed `p` is an entry-point local, not a
+        // readable global; retires with the evaluator (Phase 3c).
         var source = @"
 var x = 55
 var p = &x
@@ -89,7 +89,8 @@ var p = &x
         return (result, result.ReadGlobals());
     }
 
-    // ADR-0156 Phase 3b (#3176): evaluator twin for the #3215-pinned tests.
+    // ADR-0156 Phase 3b (#3176): evaluator twin for the ADR-0039-pinned
+    // pointer-model test above; delete with the evaluator (Phase 3c).
     private static (EvaluationResult Result, Dictionary<string, object> Variables) EvaluateWithEvaluatorVariables(string source)
     {
         var tree = SyntaxTree.Parse(SourceText.From(source));

--- a/test/Core.Tests/CodeAnalysis/Binding/ByRefEvaluationTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ByRefEvaluationTests.cs
@@ -11,6 +11,10 @@ using GSharp.Core.CodeAnalysis.Text;
 using GSharp.Tests;
 using Xunit;
 
+// Pinned: the AddressOf test asserts the interpreter's by-design ADR-0039
+// pointer model; retires with the evaluator in ADR-0156 Phase 3c (#3176).
+#pragma warning disable CS0618 // Compilation.Evaluate / Evaluator are retiring (ADR-0156 Phase 3c, #3176)
+
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 
 /// <summary>

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1654EvaluateNoCfgDumpTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1654EvaluateNoCfgDumpTests.cs
@@ -11,6 +11,10 @@ using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
 using Xunit;
 
+// Evaluator-machinery pin: tests Compilation.Evaluate's own no-CFG-dump
+// contract; retires with the evaluator in ADR-0156 Phase 3c (#3176).
+#pragma warning disable CS0618 // Compilation.Evaluate / Evaluator are retiring (ADR-0156 Phase 3c, #3176)
+
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 
 /// <summary>

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2188ReferenceConstrainedTypeParamObjectTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2188ReferenceConstrainedTypeParamObjectTests.cs
@@ -12,6 +12,11 @@ using GSharp.Core.CodeAnalysis.Text;
 using GSharp.Tests;
 using Xunit;
 
+// Pinned on the evaluator pending the #3236 emitter fix (nullable-lifted
+// reference conversions); unpins onto the emitted oracle when #3236 lands
+// (ADR-0156, #3176).
+#pragma warning disable CS0618 // Compilation.Evaluate / Evaluator are retiring (ADR-0156 Phase 3c, #3176)
+
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 
 /// <summary>

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2535NullableReferenceConversionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2535NullableReferenceConversionTests.cs
@@ -12,6 +12,11 @@ using GSharp.Core.CodeAnalysis.Text;
 using GSharp.Tests;
 using Xunit;
 
+// Pinned on the evaluator pending the #3236 emitter fix (nullable-lifted
+// reference conversions); unpins onto the emitted oracle when #3236 lands
+// (ADR-0156, #3176).
+#pragma warning disable CS0618 // Compilation.Evaluate / Evaluator are retiring (ADR-0156 Phase 3c, #3176)
+
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 
 /// <summary>

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue698DeinitBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue698DeinitBinderTests.cs
@@ -11,6 +11,11 @@ using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
 using Xunit;
 
+// Evaluator-machinery pin: asserts the interpreter-boundary GS0510 deinit
+// diagnostic only Compilation.Evaluate synthesizes; retires with the
+// evaluator in ADR-0156 Phase 3c (#3176).
+#pragma warning disable CS0618 // Compilation.Evaluate / Evaluator are retiring (ADR-0156 Phase 3c, #3176)
+
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 
 /// <summary>

--- a/test/Core.Tests/CodeAnalysis/Binding/StructuralProjectionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/StructuralProjectionTests.cs
@@ -2,12 +2,9 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
-using System.Collections.Generic;
 using System.Linq;
-using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Binding;
 using GSharp.Core.CodeAnalysis.Compilation;
-using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
 using GSharp.Tests;
@@ -27,12 +24,11 @@ class Target { var Name string var Age int64 }
 let source = Source{Name: ""Ada"", Age: 36, Extra: true}
 0
 ";
-        // Phase 3b (issue #3176): stays on Compilation.Evaluate — the test
-        // inspects this Compilation's bound state afterwards, which the
-        // EmittedOracle does not expose; disposition in 3b.2.
+        // Binder inspection only (issue #3176 Phase 3b.3): a full bind of
+        // this compilation populates GlobalScope; nothing needs to execute.
         var tree = SyntaxTree.Parse(SourceText.From(sourceText));
         var compilation = new Compilation(tree);
-        _ = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        _ = EmittedOracle.CompileDiagnostics(compilation);
         var sourceType = compilation.GlobalScope.Variables.Single(v => v.Name == "source").Type;
         var targetType = compilation.GlobalScope.Structs.Single(s => s.Name == "Target");
 
@@ -563,15 +559,5 @@ Touch(ref source)
     private static EmittedOracleResult Evaluate(string source)
     {
         return EmittedOracle.Evaluate(source);
-    }
-
-    // Evaluator-pinned twin of Evaluate for the #3219 tests above; delete
-    // with the evaluator (ADR-0156 Phase 3c) or when #3219 aligns the
-    // engines.
-    private static EvaluationResult EvaluateWithEvaluator(string source)
-    {
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Emit/AsyncInterpVsEmitParityTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/AsyncInterpVsEmitParityTests.cs
@@ -16,6 +16,10 @@ using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
 using Xunit;
 
+// Interp-vs-emit parity harness: the evaluator side retires with the
+// evaluator in ADR-0156 Phase 3c (#3176).
+#pragma warning disable CS0618 // Compilation.Evaluate / Evaluator are retiring (ADR-0156 Phase 3c, #3176)
+
 namespace GSharp.Core.Tests.CodeAnalysis.Emit;
 
 /// <summary>

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue2544LiftedUnaryOperatorTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue2544LiftedUnaryOperatorTests.cs
@@ -14,6 +14,10 @@ using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
 using Xunit;
 
+// Interpreter twin of this file's emit tests; retires with the evaluator in
+// ADR-0156 Phase 3c (#3176).
+#pragma warning disable CS0618 // Compilation.Evaluate / Evaluator are retiring (ADR-0156 Phase 3c, #3176)
+
 namespace GSharp.Core.Tests.CodeAnalysis.Emit;
 
 public class Issue2544LiftedUnaryOperatorTests

--- a/test/Core.Tests/CodeAnalysis/EvaluatorRetirementGateTests.cs
+++ b/test/Core.Tests/CodeAnalysis/EvaluatorRetirementGateTests.cs
@@ -1,0 +1,141 @@
+// <copyright file="EvaluatorRetirementGateTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis;
+
+/// <summary>
+/// ADR-0156 Phase 3b.3 (#3176): the tree-walking evaluator's entry surface
+/// (<c>Compilation.Evaluate</c> and the <c>Evaluator</c> constructors) is
+/// <c>[Obsolete]</c>, and — because warnings-as-errors is global — every
+/// remaining legitimate caller carries an explicit
+/// <c>#pragma warning disable CS0618</c> with a justification comment. That
+/// suppression list IS the authoritative Phase 3c retirement inventory, so
+/// this gate pins it: any NEW suppression (a new evaluator caller) fails
+/// here and must instead use the emitted oracle
+/// (<c>test/Shared/EmittedOracle.cs</c>) — see issue #3176.
+/// </summary>
+public class EvaluatorRetirementGateTests
+{
+    /// <summary>
+    /// The pinned CS0618 suppression census (repo-relative paths, '/'
+    /// separators, sorted ordinally). Every entry is one of: the evaluator's
+    /// product host (SessionEngine), an interp-vs-emit parity harness, an
+    /// evaluator-machinery pin, or an issue-pinned divergence (#3236).
+    /// Phase 3c retires the evaluator by burning this list down to empty;
+    /// entries may be REMOVED as callers migrate, never added.
+    /// </summary>
+    private static readonly IReadOnlyList<string> AllowedSuppressionFiles = new[]
+    {
+        // Not an evaluator caller: pre-existing suppression for the BCL's
+        // obsolete OperandType.InlinePhi. The gate pins ALL CS0618
+        // suppressions so no evaluator caller can hide behind a new one.
+        "src/Core/CodeAnalysis/Emit/MaxStackTracker.cs",
+        "src/Repl/Engine/SessionEngine.cs",
+        "test/Compiler.Tests/Emit/Issue1714StringZeroValueEmitTests.cs",
+        "test/Compiler.Tests/Emit/Issue2853EllipsisLoopCaptureTests.cs",
+        "test/Compiler.Tests/Emit/Issue2854TopLevelEllipsisLoopCaptureTests.cs",
+        "test/Compiler.Tests/Emit/Issue2906ExhaustiveSwitchReturnEmitTests.cs",
+        "test/Compiler.Tests/Emit/Issue2907IteratorLoopCaptureTests.cs",
+        "test/Compiler.Tests/Emit/Issue2914ConstantPatternSwitchLoweringTests.cs",
+        "test/Compiler.Tests/Emit/Issue2927NullableSequenceElementTypeTests.cs",
+        "test/Compiler.Tests/Emit/Issue2928TupleFunctionParityTests.cs",
+        "test/Core.Tests/CodeAnalysis/Binding/ByRefEvaluationTests.cs",
+        "test/Core.Tests/CodeAnalysis/Binding/Issue1654EvaluateNoCfgDumpTests.cs",
+        "test/Core.Tests/CodeAnalysis/Binding/Issue2188ReferenceConstrainedTypeParamObjectTests.cs",
+        "test/Core.Tests/CodeAnalysis/Binding/Issue2535NullableReferenceConversionTests.cs",
+        "test/Core.Tests/CodeAnalysis/Binding/Issue698DeinitBinderTests.cs",
+        "test/Core.Tests/CodeAnalysis/Emit/AsyncInterpVsEmitParityTests.cs",
+        "test/Core.Tests/CodeAnalysis/Emit/Issue2544LiftedUnaryOperatorTests.cs",
+        "test/Core.Tests/LanguageConformance/AddressBookSampleTests.cs",
+        "test/Core.Tests/LanguageConformance/AspirationalSamplesTests.cs",
+        "test/Core.Tests/LanguageConformance/CountWordsSampleTests.cs",
+        "test/Interpreter.Tests/Adr0156EmitToMemorySpikeTests.cs",
+        "test/Interpreter.Tests/Issue1799MapAndInterfaceSlotConcurrencyInterpreterTests.cs",
+        "test/Interpreter.Tests/Issue2896StructObjectOverrideTests.cs",
+        "test/Interpreter.Tests/Issue2921LambdaBodyDefiniteReturnInterpreterTests.cs",
+        "test/Interpreter.Tests/Issue2938DelegateExceptionDiagnosticTests.cs",
+        "test/Interpreter.Tests/Issue2953ProtectedReturnFallthroughInterpreterTests.cs",
+        "test/Interpreter.Tests/Issue2984MainEntryPointInterpreterTests.cs",
+        "test/Interpreter.Tests/Issue2990ClrDelegateBoundaryTests.cs",
+        "test/Interpreter.Tests/Issue2991LambdaMethodIdentityTests.cs",
+        "test/Interpreter.Tests/Issue3058OutParameterMemberDefiniteAssignmentTests.cs",
+        "test/Interpreter.Tests/Issue3140OutParameterWriteBackParityTests.cs",
+        "tools/cs2gs/Cs2Gs.Tests/Issue1721PrinterPrecedenceTests.cs",
+    };
+
+    private static readonly Regex SuppressionLine = new(
+        @"^\s*#pragma\s+warning\s+disable\b[^\r\n]*\bCS0618\b",
+        RegexOptions.Multiline | RegexOptions.Compiled);
+
+    [Fact]
+    public void Cs0618_Suppressions_Match_The_Pinned_Evaluator_Retirement_Inventory()
+    {
+        var repoRoot = FindRepoRoot();
+        var found = new SortedSet<string>(StringComparer.Ordinal);
+
+        foreach (var topDir in new[] { "src", "test", "tools" })
+        {
+            var root = Path.Combine(repoRoot, topDir);
+            if (!Directory.Exists(root))
+            {
+                continue;
+            }
+
+            foreach (var file in Directory.EnumerateFiles(root, "*.cs", SearchOption.AllDirectories))
+            {
+                var relative = Path.GetRelativePath(repoRoot, file).Replace('\\', '/');
+                if (relative.Split('/').Any(segment => segment is "obj" or "bin" or "out"))
+                {
+                    continue;
+                }
+
+                if (SuppressionLine.IsMatch(File.ReadAllText(file)))
+                {
+                    found.Add(relative);
+                }
+            }
+        }
+
+        var expected = new SortedSet<string>(AllowedSuppressionFiles, StringComparer.Ordinal);
+        var added = found.Except(expected).ToList();
+        var removed = expected.Except(found).ToList();
+
+        Assert.True(
+            added.Count == 0 && removed.Count == 0,
+            "The CS0618 (Compilation.Evaluate / Evaluator obsolescence) suppression census changed."
+            + (added.Count > 0
+                ? "\nNEW suppressions (new tree-walking-evaluator callers are forbidden — use the"
+                  + " emitted oracle in test/Shared/EmittedOracle.cs instead; see issue #3176):\n  "
+                  + string.Join("\n  ", added)
+                : string.Empty)
+            + (removed.Count > 0
+                ? "\nRemoved suppressions (great — a caller migrated; delete its entry from"
+                  + " EvaluatorRetirementGateTests.AllowedSuppressionFiles to re-pin the census):\n  "
+                  + string.Join("\n  ", removed)
+                : string.Empty));
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(Path.GetDirectoryName(typeof(EvaluatorRetirementGateTests).Assembly.Location)!);
+        while (dir != null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "GSharp.sln")))
+            {
+                return dir.FullName;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException("GSharp.sln not found above the test assembly.");
+    }
+}

--- a/test/Core.Tests/LanguageConformance/AddressBookSampleTests.cs
+++ b/test/Core.Tests/LanguageConformance/AddressBookSampleTests.cs
@@ -12,6 +12,11 @@ using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
 using Xunit;
 
+// Interpreter-side conformance golden (emit side lives in Compiler.Tests
+// SampleConformanceTests); retires with the evaluator in ADR-0156 Phase 3c
+// (#3176).
+#pragma warning disable CS0618 // Compilation.Evaluate / Evaluator are retiring (ADR-0156 Phase 3c, #3176)
+
 namespace GSharp.Core.Tests.LanguageConformance;
 
 /// <summary>

--- a/test/Core.Tests/LanguageConformance/AspirationalSamplesTests.cs
+++ b/test/Core.Tests/LanguageConformance/AspirationalSamplesTests.cs
@@ -13,6 +13,11 @@ using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
 using Xunit;
 
+// Interpreter-side conformance golden (emit side lives in Compiler.Tests
+// SampleConformanceTests); retires with the evaluator in ADR-0156 Phase 3c
+// (#3176).
+#pragma warning disable CS0618 // Compilation.Evaluate / Evaluator are retiring (ADR-0156 Phase 3c, #3176)
+
 namespace GSharp.Core.Tests.LanguageConformance;
 
 /// <summary>

--- a/test/Core.Tests/LanguageConformance/CountWordsSampleTests.cs
+++ b/test/Core.Tests/LanguageConformance/CountWordsSampleTests.cs
@@ -12,6 +12,11 @@ using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
 using Xunit;
 
+// Interpreter-side conformance golden (emit side lives in Compiler.Tests
+// SampleConformanceTests); retires with the evaluator in ADR-0156 Phase 3c
+// (#3176).
+#pragma warning disable CS0618 // Compilation.Evaluate / Evaluator are retiring (ADR-0156 Phase 3c, #3176)
+
 namespace GSharp.Core.Tests.LanguageConformance;
 
 /// <summary>

--- a/test/Interpreter.Tests/Adr0156EmitToMemorySpikeTests.cs
+++ b/test/Interpreter.Tests/Adr0156EmitToMemorySpikeTests.cs
@@ -16,6 +16,10 @@ using GSharp.Core.CodeAnalysis.Syntax;
 using Xunit;
 using Xunit.Abstractions;
 
+// ADR-0156 spike parity harness comparing the evaluator and the emit path;
+// retires with the evaluator in Phase 3c (#3176).
+#pragma warning disable CS0618 // Compilation.Evaluate / Evaluator are retiring (ADR-0156 Phase 3c, #3176)
+
 namespace GSharp.Interpreter.Tests;
 
 /// <summary>

--- a/test/Interpreter.Tests/Issue1799MapAndInterfaceSlotConcurrencyInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue1799MapAndInterfaceSlotConcurrencyInterpreterTests.cs
@@ -10,6 +10,11 @@ using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
 using Xunit;
 
+// Evaluator-machinery pin on the interpreter's map/interface-slot
+// concurrency model (#3205/#3209); retires with the evaluator in ADR-0156
+// Phase 3c (#3176).
+#pragma warning disable CS0618 // Compilation.Evaluate / Evaluator are retiring (ADR-0156 Phase 3c, #3176)
+
 namespace GSharp.Interpreter.Tests;
 
 /// <summary>

--- a/test/Interpreter.Tests/Issue2896StructObjectOverrideTests.cs
+++ b/test/Interpreter.Tests/Issue2896StructObjectOverrideTests.cs
@@ -16,6 +16,10 @@ using GSharp.Tests;
 using Xunit;
 using CompilerProgram = GSharp.Compiler.Program;
 
+// Interp-vs-emit parity harness; the evaluator side retires with the
+// evaluator in ADR-0156 Phase 3c (#3176).
+#pragma warning disable CS0618 // Compilation.Evaluate / Evaluator are retiring (ADR-0156 Phase 3c, #3176)
+
 namespace GSharp.Interpreter.Tests;
 
 /// <summary>

--- a/test/Interpreter.Tests/Issue2921LambdaBodyDefiniteReturnInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2921LambdaBodyDefiniteReturnInterpreterTests.cs
@@ -10,6 +10,10 @@ using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using Xunit;
 
+// Interp-vs-emit parity harness; the evaluator side retires with the
+// evaluator in ADR-0156 Phase 3c (#3176).
+#pragma warning disable CS0618 // Compilation.Evaluate / Evaluator are retiring (ADR-0156 Phase 3c, #3176)
+
 namespace GSharp.Interpreter.Tests;
 
 /// <summary>

--- a/test/Interpreter.Tests/Issue2938DelegateExceptionDiagnosticTests.cs
+++ b/test/Interpreter.Tests/Issue2938DelegateExceptionDiagnosticTests.cs
@@ -12,6 +12,11 @@ using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using Xunit;
 
+// Evaluator-machinery pin: asserts the interpreter's delegate-exception
+// diagnostic surface; retires with the evaluator in ADR-0156 Phase 3c
+// (#3176).
+#pragma warning disable CS0618 // Compilation.Evaluate / Evaluator are retiring (ADR-0156 Phase 3c, #3176)
+
 namespace GSharp.Interpreter.Tests;
 
 /// <summary>

--- a/test/Interpreter.Tests/Issue2953ProtectedReturnFallthroughInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2953ProtectedReturnFallthroughInterpreterTests.cs
@@ -9,6 +9,11 @@ using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using Xunit;
 
+// Evaluator-machinery pin: asserts the interpreter's protected-return
+// fallthrough behavior; retires with the evaluator in ADR-0156 Phase 3c
+// (#3176).
+#pragma warning disable CS0618 // Compilation.Evaluate / Evaluator are retiring (ADR-0156 Phase 3c, #3176)
+
 namespace GSharp.Interpreter.Tests;
 
 /// <summary>

--- a/test/Interpreter.Tests/Issue2984MainEntryPointInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2984MainEntryPointInterpreterTests.cs
@@ -11,6 +11,11 @@ using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using Xunit;
 
+// Evaluator-machinery pin: exercises the evaluateEntryPoint overload surface
+// and Evaluator entry-point selection; retires with the evaluator in
+// ADR-0156 Phase 3c (#3176).
+#pragma warning disable CS0618 // Compilation.Evaluate / Evaluator are retiring (ADR-0156 Phase 3c, #3176)
+
 namespace GSharp.Interpreter.Tests;
 
 /// <summary>

--- a/test/Interpreter.Tests/Issue2990ClrDelegateBoundaryTests.cs
+++ b/test/Interpreter.Tests/Issue2990ClrDelegateBoundaryTests.cs
@@ -15,6 +15,10 @@ using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Tests;
 using Xunit;
 
+// Evaluator-machinery pin: drives the Evaluator's CLR-delegate boundary
+// directly; retires with the evaluator in ADR-0156 Phase 3c (#3176).
+#pragma warning disable CS0618 // Compilation.Evaluate / Evaluator are retiring (ADR-0156 Phase 3c, #3176)
+
 namespace GSharp.Interpreter.Tests;
 
 /// <summary>

--- a/test/Interpreter.Tests/Issue2991LambdaMethodIdentityTests.cs
+++ b/test/Interpreter.Tests/Issue2991LambdaMethodIdentityTests.cs
@@ -12,6 +12,10 @@ using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using Xunit;
 
+// Evaluator-machinery pin: asserts the interpreter's lambda method-identity
+// semantics; retires with the evaluator in ADR-0156 Phase 3c (#3176).
+#pragma warning disable CS0618 // Compilation.Evaluate / Evaluator are retiring (ADR-0156 Phase 3c, #3176)
+
 namespace GSharp.Interpreter.Tests;
 
 /// <summary>

--- a/test/Interpreter.Tests/Issue3058OutParameterMemberDefiniteAssignmentTests.cs
+++ b/test/Interpreter.Tests/Issue3058OutParameterMemberDefiniteAssignmentTests.cs
@@ -13,6 +13,10 @@ using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Repl.Engine;
 using Xunit;
 
+// Interp-vs-emit parity harness; the evaluator side retires with the
+// evaluator in ADR-0156 Phase 3c (#3176).
+#pragma warning disable CS0618 // Compilation.Evaluate / Evaluator are retiring (ADR-0156 Phase 3c, #3176)
+
 namespace GSharp.Interpreter.Tests;
 
 /// <summary>

--- a/test/Interpreter.Tests/Issue3140OutParameterWriteBackParityTests.cs
+++ b/test/Interpreter.Tests/Issue3140OutParameterWriteBackParityTests.cs
@@ -16,6 +16,10 @@ using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Repl.Engine;
 using Xunit;
 
+// Interp-vs-emit parity harness; the evaluator side retires with the
+// evaluator in ADR-0156 Phase 3c (#3176).
+#pragma warning disable CS0618 // Compilation.Evaluate / Evaluator are retiring (ADR-0156 Phase 3c, #3176)
+
 namespace GSharp.Interpreter.Tests;
 
 /// <summary>Issue #3140: evaluated user-method ref/out writes must match emitted execution.</summary>

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1721PrinterPrecedenceTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1721PrinterPrecedenceTests.cs
@@ -16,6 +16,11 @@ using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using Xunit;
 
+// Semantic round-trip check runs translated G# on the evaluator (Cs2Gs.Tests
+// has no emitted-oracle reference); migrate or retire with the evaluator in
+// ADR-0156 Phase 3c (#3176).
+#pragma warning disable CS0618 // Compilation.Evaluate / Evaluator are retiring (ADR-0156 Phase 3c, #3176)
+
 namespace Cs2Gs.Tests;
 
 /// <summary>


### PR DESCRIPTION
Part of #3176 (Phase 3b.3 finale), part of #3163.

## Summary

The Phase 3b finale: sweep the last conflict-deferred `Compilation.Evaluate` sites, mark the tree-walking evaluator's entry surface `[Obsolete]`, pin the resulting suppression census with a gate test (the census IS the Phase 3c retirement worklist), and structurally fix the recurring NBGV `$GITHUB_ENV` CI flake.

## 1. Sweep (bucket b, the conflict-deferred files)

The merged burn-down PRs (#3231–#3234) had already unpinned four of the five deferred files (ByRefPointerTests, Issue1104, Issue1932, Issue773) onto the `EmittedOracle` — verified by fresh grep against main. This PR sweeps what they left:

| File | Change |
|---|---|
| `StructuralProjectionTests` | Annotated binder-inspection residue site → `EmittedOracle.CompileDiagnostics` (the test reads `GlobalScope`; nothing executes); deleted the orphaned `EvaluateWithEvaluator` twin the #3219 unpin left with zero callers |
| `ByRefEvaluationTests` | `Dereference_Returns_Original_Value` unpinned onto the oracle — the #3215 fix covers its exact shape (witnessed by `Issue3215ByRefGlobalEmitTests.AddressOfTopLevelVariable_EmitsAndRoundTripsThroughDereference`); assertions unchanged |
| `ByRefEvaluationTests` | `AddressOf_Evaluates_To_Value_In_Interpreter` stays pinned, honestly: it asserts the interpreter's by-design ADR-0039 pointer model (`&x` evaluates to the value), and under the #3215 fix the byref-typed global is an entry-point local, not a readable global — it retires with the evaluator |

**Sweep tally: 2 sites migrated, 1 unpinned, 1 kept pinned (ADR-0039 by-design), 1 dead twin deleted.** After this PR, `grep -rn "compilation\.Evaluate(" test/` returns exactly the suppression census below.

## 2. `[Obsolete]` + suppression census + gate

`Compilation.Evaluate` (all three overloads) and both `Evaluator` constructors are now:

```csharp
[Obsolete("The tree-walking evaluator retires in ADR-0156 Phase 3c. New callers are forbidden; see #3176.", error: false)]
```

`EvaluationResult` stays non-obsolete deliberately: it is only obtainable through the obsolete surface, and obsoleting it would drag type-only references into the census without gating anything new. The `evaluateEntryPoint` path is covered by the overload + `Evaluator` ctor attributes (Issue2984's direct ctor use is in the census).

Because warnings-as-errors is global, every remaining caller carries an explicit `#pragma warning disable CS0618` with a justification comment. **This suppression list is the authoritative Phase 3c retirement inventory (31 files):**

| # | File | Category / justification |
|---|---|---|
| 1 | `src/Core/CodeAnalysis/Emit/MaxStackTracker.cs` | NOT an evaluator caller — pre-existing suppression for the BCL's obsolete `OperandType.InlinePhi`; allowlisted so the gate can pin ALL CS0618 suppressions |
| 2 | `src/Repl/Engine/SessionEngine.cs` | The evaluator's product host (narrow site-scoped pragma); retires with the evaluator |
| 3–10 | `Compiler.Tests/Emit`: Issue1714, Issue2853, Issue2854, Issue2906, Issue2907, Issue2914, Issue2927, Issue2928 | Dual-oracle emit-vs-interp parity harnesses |
| 11 | `Core.Tests` ByRefEvaluationTests | ADR-0039 pointer-model pin (see sweep) |
| 12 | `Core.Tests` Issue1654EvaluateNoCfgDumpTests | Evaluator-machinery: tests `Evaluate`'s own no-CFG-dump contract |
| 13 | `Core.Tests` Issue698DeinitBinderTests | GS0510 interpreter-boundary deinit diagnostic only `Compilation.Evaluate` synthesizes |
| 14–15 | `Core.Tests` Issue2188, Issue2535 | Pinned on the #3236 emitter fix (nullable-lifted reference conversions); unpin in a follow-up once that fix merges |
| 16 | `Core.Tests` AsyncInterpVsEmitParityTests | Interp-vs-emit parity harness |
| 17 | `Core.Tests` Issue2544LiftedUnaryOperatorTests | Interpreter twin of its own emit tests |
| 18–20 | `Core.Tests/LanguageConformance`: AddressBookSample, AspirationalSamples, CountWordsSample | Interpreter-side conformance goldens (emit side lives in Compiler.Tests `SampleConformanceTests`) |
| 21 | `Interpreter.Tests` Adr0156EmitToMemorySpikeTests | ADR-0156 spike parity harness |
| 22 | `Interpreter.Tests` Issue1799MapAndInterfaceSlotConcurrency | Evaluator-machinery pin (#3205/#3209) |
| 23–26 | `Interpreter.Tests` Issue2896, Issue2921, Issue3058, Issue3140 | Interp-vs-emit parity harnesses |
| 27–30 | `Interpreter.Tests` Issue2938, Issue2953, Issue2984, Issue2991 + Issue2990 | Evaluator-machinery pins (delegate-exception surface, protected-return fallthrough, `evaluateEntryPoint`/entry-point selection incl. direct `Evaluator` ctor use, lambda method identity, CLR-delegate boundary) |
| 31 | `tools/cs2gs` Issue1721PrinterPrecedenceTests | Semantic round-trip check runs translated G# on the evaluator (Cs2Gs.Tests has no emitted-oracle reference); migrate or retire in 3c |

(That's 31 rows counting Issue2990 separately — it calls the `Evaluator` ctor directly, a caller the plain `Compilation.Evaluate` grep missed and the `[Obsolete]` attribute caught.)

**Gate**: `test/Core.Tests/CodeAnalysis/EvaluatorRetirementGateTests` scans `src/`, `test/`, and `tools/` for `#pragma warning disable … CS0618` lines and asserts the file set equals the pinned census. Any NEW suppression (the only way to add an evaluator caller under global warnings-as-errors) fails with a message pointing at the emitted oracle and #3176; a removal (a caller migrated) asks for the census entry to be deleted, so the list can only burn down. Red-green witnessed: a temporary file with an unsanctioned `#pragma warning disable CS0618` made exactly this test fail with the intended message; removed, green again.

## 3. NBGV CI fix (recurring `$GITHUB_ENV` flake)

Nerdbank.GitVersioning's GitHub Actions integration appends `GitBuildVersion*` lines to `$GITHUB_ENV` from **every MSBuild node**; parallel nodes (`-graph` builds, `dotnet test`) interleave concurrent appends into a corrupt line and the shard dies with `Unable to process file command 'env': Invalid format` (most recently on #3238's extensions shard).

- **Verified consumption first**: no step in any workflow or `build/` script consumes `GitBuildVersion*` — both version-stamping sites (build job's step summary, vsix job's Marketplace stamp) go through the `nbgv` CLI, which is unaffected. So the disable is **workflow-level** (simplest correct scope) in `build.yml`, `cs2gs-nightly.yml`, and `windows-nightly.yml`, not per-shard.
- **Exact switch verified against the shipped targets** (Nerdbank.GitVersioning 3.11.13-beta, the locked version): the gating property is `NBGV_SetCloudBuildVersionVars` (target `SetCloudBuildVersionVars`, condition `'$(NBGV_SetCloudBuildVersionVars)' != 'false'`) — not the folklore `NBGV_SetCloudBuildVariables`, which does not exist in the targets. The cloud build-number path needs no switch: `GitHubActions.SetCloudBuildNumber` is a no-op (returns an empty dictionary), so `SetCloudBuildVersionVars` is the only `$GITHUB_ENV` writer.

## Divergence table

| Divergence | Disposition |
|---|---|
| — | None encountered: the one unpinned test kept its original assertions against emitted semantics; the kept pin (ADR-0039 pointer model) and the #3236 pins are recorded in the census, not aligned away. |

## Verification

- `dotnet build GSharp.sln -c Release`: **0 warnings, 0 errors** (the `[Obsolete]` attributes + 31-file suppression set compile clean under global warnings-as-errors).
- `test/Core.Tests` full (Release): **7180/7181 passed**, 1 skipped (standing `RegenerateBaseline` skip).
- `test/Interpreter.Tests` full (Release): **1499/1503 passed**, 4 skipped (standing #3205/#3210 map-concurrency skips).
- `Compiler.Tests` LanguageConformance filter (Release): **126/126 passed** — run because the three interpreter-golden conformance files gained suppressions.
- Gate red-green witness: temp unsanctioned suppression → gate fails with the #3176 message; removed → green (see above).
- Workflow YAML: all three files parse clean (`yaml.safe_load`), `env: {NBGV_SetCloudBuildVersionVars: false}` confirmed at workflow scope.
- NOT RUN: the rest of `Compiler.Tests`, `Extensions.Tests`, `LanguageServer.Tests`, `Sdk.Tests` (product change is attribute-only; the census suppressions in Compiler.Tests are compile-time and covered by the clean Release build), `Cs2Gs.Tests` (pre-existing flaky host crash; GoldenTests-filter policy — its one census file is compile-time-verified by the build). CI required checks are the backstop, and this PR's own CI run doubles as the NBGV fix's live witness.

## Checklist

- [x] Behavioral tests carry a witness of discrimination (ADR-0154): the unpinned ByRef test keeps its original assertions against emitted semantics (its broken world is #3215's pre-fix ICE); the gate test's witness is the red-green run above.
- [x] Self-review verdict recorded when one was run (MERGEABLE / BLOCKER / SHOULD-FIX / NIT), with residuals filed as issues rather than dropped.

Self-review verdict: **MERGEABLE** — the product diff is attribute-only plus a scoped pragma in SessionEngine; every remaining evaluator caller is enumerated, justified in-file, and pinned by a gate that can only burn down; the CI fix is verified against the shipped NBGV targets rather than assumed. Overlap guard respected: no Emit/Binding conversion code touched; the #3236 pins stay suppressed pending the parallel fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
