### PR TITLE
Honor gsi engine selection in script mode

### DIFF
--- a/docs/adr/0068-deinit-destructor-support.md
+++ b/docs/adr/0068-deinit-destructor-support.md
@@ -115,7 +115,7 @@ changed which invocations use that backend. Current routing is:
 | `gsc /out:program.dll file.gs`, then run the assembly | emit to file, then CLR host | real CLR finalizer; no GS0510 |
 | `gsi file.gs` | emit to memory, then `EmittedProgramHost.Run` | real CLR finalizer; no GS0510 |
 | interactive `gsi` (default) | `EmittedSessionEngine` | real CLR finalizer; no GS0510 |
-| interactive `gsi --engine evaluator` (deprecated; removed in Phase 3c) | `SessionEngine` → `Compilation.Evaluate` | skips the body; GS0510 once per declaring class |
+| `gsi --engine evaluator` (script or interactive; deprecated; removed in Phase 3c) | `SessionEngine` → `Compilation.Evaluate` | skips the body; GS0510 once per declaring class |
 
 The old two-column `gsc`/`gsi` table made object reachability appear to be the
 discriminating axis. It is not. Driving the legacy evaluator-backed

--- a/docs/adr/0152-interpreter-native-call-boundary.md
+++ b/docs/adr/0152-interpreter-native-call-boundary.md
@@ -33,10 +33,10 @@ fabricated results and delayed `GS9999` failures, and adds no native or
 reflection dispatch path.
 
 Since ADR-0156 Phases 1–3a, this boundary applies to `SessionEngine`,
-`Compilation.Evaluate`, and interactive `gsi --engine evaluator`, not to
-default drivers. Bare `gsc`, `gsi <file>`, and the default interactive REPL
-emit and run the native call; `gsc /out:` emits it to disk. The evaluator path
-is deprecated and scheduled for removal in Phase 3c.
+`Compilation.Evaluate`, and `gsi --engine evaluator` in script or interactive
+mode, not to default drivers. Bare `gsc`, `gsi <file>`, and the default
+interactive REPL emit and run the native call; `gsc /out:` emits it to disk.
+The evaluator path is deprecated and scheduled for removal in Phase 3c.
 
 ## Consequences
 

--- a/docs/adr/0153-interpreter-compiled-only-storage-boundary.md
+++ b/docs/adr/0153-interpreter-compiled-only-storage-boundary.md
@@ -38,11 +38,11 @@ cannot rely on surrounding rendering for meaning.
 Constructs whose interpreter behavior requires real address identity —
 including pinning, stack allocation, unmanaged-pointer storage or dereference,
 and function-pointer execution — are **compiled-only in the tree evaluator**.
-Interactive `gsi --engine evaluator` must report a self-contained boundary
-diagnostic instead of attempting a value-only approximation. Since ADR-0156
-Phases 1–3a, all default drivers use emitted execution and run these constructs
-natively. The evaluator path is deprecated and scheduled for removal in
-Phase 3c.
+`gsi --engine evaluator` in script or interactive mode must report a
+self-contained boundary diagnostic instead of attempting a value-only
+approximation. Since ADR-0156 Phases 1–3a, all default drivers use emitted
+execution and run these constructs natively. The evaluator path is deprecated
+and scheduled for removal in Phase 3c.
 
 This ADR governs only the evaluator's storage-model boundary. It does not
 redefine unsafe/native language validity or CIL emission.

--- a/docs/adr/0156-gsi-emit-to-memory-execution.md
+++ b/docs/adr/0156-gsi-emit-to-memory-execution.md
@@ -109,15 +109,17 @@ direct `Compilation.Evaluate` consumers until Phase 3c.
 | bare `gsc file.gs` | `EmittedProgramHost.Run` |
 | `gsc /out:program.dll file.gs` | emit PE to disk; the CLR runs it separately |
 | `gsi file.gs` | `EmittedProgramHost.Run` |
+| `gsi --engine evaluator file.gs` | `SessionEngine` → `Compilation.Evaluate` |
 | interactive `gsi` | `EmittedSessionEngine` (default) |
 | interactive `gsi --engine evaluator` | `SessionEngine` → `Compilation.Evaluate` |
 
 Therefore the former "three-driver" model no longer identifies three
 execution semantics: every default driver compiles through the emitter. The
-tree evaluator remains reachable only through its deprecated interactive
-escape hatch and direct API/test consumers. This partially supersedes
-ADR-0068's original `deinit` interpreter boundary (and ADR-0152/ADR-0153) for
-default drivers, while leaving those boundaries in force for evaluator residue.
+tree evaluator remains reachable only through its deprecated script or
+interactive escape hatch and direct API/test consumers. This partially
+supersedes ADR-0068's original `deinit` interpreter boundary (and
+ADR-0152/ADR-0153) for default drivers, while leaving those boundaries in
+force for evaluator residue.
 
 ### Phased migration plan
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -324,9 +324,10 @@ self-contained boundary messages through legacy `GS9999`; issue
 [#3199](https://github.com/DavidObando/gsharp/issues/3199) tracks moving those
 deliberate failures out of the internal-error category. Since
 [ADR-0156](adr/0156-gsi-emit-to-memory-execution.md) Phase 3a the boundary
-applies only to direct tree evaluation and `gsi --engine evaluator`; all
-default drivers execute emitted code, where these constructs run natively.
-The evaluator path is deprecated and scheduled for removal in Phase 3c.
+applies only to direct tree evaluation and `gsi --engine evaluator` in script
+or interactive mode; all default drivers execute emitted code, where these
+constructs run natively. The evaluator path is deprecated and scheduled for
+removal in Phase 3c.
 
 ## Documentation diagnostics (GS0227–GS0231)
 

--- a/docs/emit-pipeline.md
+++ b/docs/emit-pipeline.md
@@ -1,6 +1,6 @@
 # Emit pipeline
 
-GSharp has two execution backends. The emit pipeline produces managed PEs — written to disk by `dotnet build`/`gsc /out:`, or loaded straight from memory by the in-process drivers ([ADR-0156](adr/0156-gsi-emit-to-memory-execution.md)) — and since ADR-0156 Phase 3a it is the execution path for every driver by default, including the interactive REPL. The interpreter (`Evaluator`) walks the bound tree in-process; it survives only behind gsi's deprecated `--engine evaluator` escape hatch and as the `Compilation.Evaluate` oracle in many language tests, and it retires in ADR-0156 Phase 3c. This document describes the emit pipeline only.
+GSharp has two execution backends. The emit pipeline produces managed PEs — written to disk by `dotnet build`/`gsc /out:`, or loaded straight from memory by the in-process drivers ([ADR-0156](adr/0156-gsi-emit-to-memory-execution.md)) — and since ADR-0156 Phase 3a it is the execution path for every driver by default, including the interactive REPL. The interpreter (`Evaluator`) walks the bound tree in-process; it survives only behind gsi's deprecated `--engine evaluator` escape hatch in script or interactive mode and as the `Compilation.Evaluate` oracle in many language tests, and it retires in ADR-0156 Phase 3c. This document describes the emit pipeline only.
 
 ```
 .gs source ──► Lexer ──► Parser ──► Syntax tree
@@ -157,7 +157,7 @@ The emit path does **not** depend on Roslyn — `ReflectionMetadataEmitter` writ
 
 ## Interpreter vs. emit
 
-Since [ADR-0156](adr/0156-gsi-emit-to-memory-execution.md) the emitted pipeline is the execution backend for every driver by default — `gsc`, `gsi <file>` (Phase 1), and the interactive REPL (Phases 2–3a). The in-process `Evaluator` remains reachable only via gsi's deprecated `--engine evaluator` escape hatch and as the `Compilation.Evaluate` oracle in existing language tests; where the two disagree, the emitted semantics are authoritative (evaluator/emit divergence is the bug class ADR-0156 retires), and the evaluator is deleted in Phase 3c. Both paths share the `Binder`, `BoundProgram`, and lowering stages — only the final code-generation step differs.
+Since [ADR-0156](adr/0156-gsi-emit-to-memory-execution.md) the emitted pipeline is the execution backend for every driver by default — `gsc`, `gsi <file>` (Phase 1), and the interactive REPL (Phases 2–3a). The in-process `Evaluator` remains reachable only via gsi's deprecated `--engine evaluator` escape hatch in script or interactive mode and as the `Compilation.Evaluate` oracle in existing language tests; where the two disagree, the emitted semantics are authoritative (evaluator/emit divergence is the bug class ADR-0156 retires), and the evaluator is deleted in Phase 3c. Both paths share the `Binder`, `BoundProgram`, and lowering stages — only the final code-generation step differs.
 
 ## File map
 

--- a/src/Repl/Program.cs
+++ b/src/Repl/Program.cs
@@ -35,10 +35,10 @@ public static class Program
                 Console.WriteLine("  file.gs                Run the given G# script and exit.");
                 Console.WriteLine("  /r:<file>              Reference an assembly (repeatable).");
                 Console.WriteLine("  /reference:<file>      Alias for /r: (also -r: and --reference:).");
-                Console.WriteLine("  --engine <name>        Interactive engine: 'emit' (default) or 'evaluator'");
-                Console.WriteLine("                         (also via GSI_ENGINE). 'evaluator' selects the legacy");
-                Console.WriteLine("                         tree-walking engine; it is deprecated and will be");
-                Console.WriteLine("                         removed in ADR-0156 Phase 3c.");
+                Console.WriteLine("  --engine <name>        Script and interactive engine: 'emit' (default)");
+                Console.WriteLine("                         or 'evaluator' (also via GSI_ENGINE).");
+                Console.WriteLine("                         'evaluator' selects the legacy tree-walking engine;");
+                Console.WriteLine("                         it is deprecated and will be removed in Phase 3c.");
                 Console.WriteLine("  --help, -h             Show this help and exit.");
                 Console.WriteLine("  --version              Show the gsi version and exit.");
                 Console.WriteLine("  (no args)              Start the interactive REPL.");
@@ -106,13 +106,12 @@ public static class Program
             return 1;
         }
 
-        return RunScript(scriptPath, references);
+        return RunScript(scriptPath, references, engineChoice);
     }
 
     /// <summary>
-    /// Decides whether an interactive engine choice selects the legacy
-    /// tree-walking evaluator. ADR-0156 Phase 3a: the emitted
-    /// submission-chaining engine is the interactive default, so only an
+    /// Decides whether an engine choice selects the legacy tree-walking
+    /// evaluator. ADR-0156 Phase 3a: emitted execution is the default, so only an
     /// explicit <c>--engine evaluator</c> (or <c>GSI_ENGINE=evaluator</c>)
     /// selects the evaluator — a deprecated escape hatch that retires with
     /// the evaluator in Phase 3c.
@@ -152,17 +151,39 @@ public static class Program
     }
 
     /// <summary>
-    /// ADR-0156 Phase 1: script execution compiles with the real emitter into
-    /// memory and runs in-process via <see cref="EmittedProgramHost"/> instead
-    /// of the tree-walking evaluator. The driver protocol is unchanged:
-    /// diagnostics render to standard error, the program's output streams
-    /// straight through, and its integer result is the exit code.
+    /// Runs a script through emitted execution by default, or through the
+    /// legacy tree-walking evaluator when explicitly requested. The driver
+    /// protocol is unchanged: diagnostics render to standard error, the
+    /// program's output streams straight through, and its integer result is
+    /// the exit code.
     /// </summary>
-    private static int RunScript(string scriptPath, List<string> references)
+    private static int RunScript(string scriptPath, List<string> references, string? engineChoice)
     {
-        var tree = SyntaxTree.Parse(SourceText.From(File.ReadAllText(scriptPath), scriptPath));
+        var source = File.ReadAllText(scriptPath);
         var effectiveReferences = ReferenceResolver.ResolveDriverReferencePaths(references);
         using var resolver = ReferenceResolver.WithRuntimeReferences(effectiveReferences);
+        if (UsesEvaluatorEngine(engineChoice))
+        {
+            var cell = new Engine.SessionEngine(resolver) { RunEntryPoint = true }.Evaluate(source, scriptPath);
+            if (cell.Diagnostics.Length > 0)
+            {
+                Console.Error.WriteDiagnostics(cell.Diagnostics);
+            }
+
+            if (cell.HasError)
+            {
+                return 1;
+            }
+
+            return cell.Value switch
+            {
+                int exitCode => exitCode,
+                uint unsignedExitCode => unchecked((int)unsignedExitCode),
+                _ => 0,
+            };
+        }
+
+        var tree = SyntaxTree.Parse(SourceText.From(source, scriptPath));
         var compilation = new Compilation(resolver, tree);
         EmittedProgramResult result;
         try

--- a/test/Interpreter.Tests/Issue3230ScriptEngineOptionTests.cs
+++ b/test/Interpreter.Tests/Issue3230ScriptEngineOptionTests.cs
@@ -1,0 +1,83 @@
+// <copyright file="Issue3230ScriptEngineOptionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #3230: script mode must honor an explicit engine choice.
+/// </summary>
+[Collection("ConsoleIo")]
+public sealed class Issue3230ScriptEngineOptionTests
+{
+    [Fact]
+    public void EvaluatorEngineOptionRunsScriptWithTreeWalkingEvaluator()
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            nameof(Issue3230ScriptEngineOptionTests),
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        var scriptPath = Path.Combine(directory, "boundary.gs");
+        File.WriteAllText(
+            scriptPath,
+            """
+            import System
+            import System.Runtime.InteropServices
+
+            @DllImport("libc", EntryPoint: "strlen", CharSet: CharSet.Ansi)
+            func NativeStrLen(text string) nint;
+
+            Console.WriteLine("emitted-only-11")
+            """);
+
+        try
+        {
+            var result = Capture(() => GSharp.Repl.Program.Main(["--engine", "evaluator", scriptPath]));
+
+            Assert.Equal(1, result.ExitCode);
+            Assert.Equal(string.Empty, result.StandardOutput);
+            Assert.Contains("error GS0514:", result.StandardError, StringComparison.Ordinal);
+            Assert.Contains("NativeStrLen", result.StandardError, StringComparison.Ordinal);
+            Assert.DoesNotContain("emitted-only-11", result.StandardError, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void HelpStatesEngineOptionAppliesToScriptsAndInteractiveSessions()
+    {
+        var result = Capture(() => GSharp.Repl.Program.Main(["--help"]));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("Script and interactive engine", result.StandardOutput, StringComparison.Ordinal);
+        Assert.Equal(string.Empty, result.StandardError);
+    }
+
+    private static (int ExitCode, string StandardOutput, string StandardError) Capture(Func<int> action)
+    {
+        using var stdout = new StringWriter { NewLine = "\n" };
+        using var stderr = new StringWriter { NewLine = "\n" };
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        try
+        {
+            Console.SetOut(stdout);
+            Console.SetError(stderr);
+            var exitCode = action();
+            return (exitCode, stdout.ToString(), stderr.ToString());
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+    }
+}

--- a/website/docs/ref/diagnostics.md
+++ b/website/docs/ref/diagnostics.md
@@ -317,9 +317,9 @@ carry self-contained boundary messages through legacy `GS9999`; issue
 deliberate failures out of the internal-error category. Since
 [ADR-0156](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0156-gsi-emit-to-memory-execution.md)
 Phase 3a the boundary applies only to direct tree evaluation and
-`gsi --engine evaluator`; all default drivers execute emitted code, where
-these constructs run natively. The evaluator path is deprecated and scheduled
-for removal in Phase 3c.
+`gsi --engine evaluator` in script or interactive mode; all default drivers
+execute emitted code, where these constructs run natively. The evaluator path
+is deprecated and scheduled for removal in Phase 3c.
 
 ## Documentation diagnostics (GS0227–GS0231)
 


### PR DESCRIPTION
## Summary

- pass the validated engine choice into script execution
- use existing `Program.UsesEvaluatorEngine` predicate for both script and interactive routing
- run evaluator-requested scripts through the existing `SessionEngine` whole-program path
- clarify `--help`, ADRs, diagnostics docs, and website mirror: `--engine` / `GSI_ENGINE` apply to scripts and interactive sessions

## Design

**Honor the option.** Script mode already retained the legacy `SessionEngine` whole-program machinery (`RunEntryPoint`) and reference resolver needed for evaluator execution. Threading `engineChoice` to that existing path is smaller and matches the documented escape hatch until Phase 3c; refusing it would create an unnecessary mode-specific restriction.

One decision surface remains: `Program.UsesEvaluatorEngine`.

## RED proof

Test pin alone on unfixed `20fbbec41`:

```text
TEST_RC=1
Failed: 1, Passed: 0, Total: 1
Expected: 1 (emitted path returned 0)
```

Tree restored to porcelain-0 before applying production fix. Inverted product condition mutant:

```text
MUTANT_TEST_RC=1
Failed: 1, Passed: 1, Total: 2
```

Restored production condition: 2/2 green.

## Measured routing

```text
default script:             rc 0, stdout emitted-only-11, no GS0514
--engine emit script:       rc 0, stdout emitted-only-11, no GS0514
--engine evaluator script:  rc 1, empty stdout, GS0514
GSI_ENGINE=evaluator script: rc 1, empty stdout, GS0514
```

Rebuilt help:

```text
--engine <name>        Script and interactive engine: 'emit' (default)
                       or 'evaluator' (also via GSI_ENGINE).
                       'evaluator' selects the legacy tree-walking engine;
                       it is deprecated and will be removed in Phase 3c.
```

## Validation

Final tree rebased onto `5cd0d766a60f`:

- `dotnet build GSharp.sln -c Release`: 0 warnings, 0 errors
- full 9-project Release suite: 15,533 passed, 5 skipped, 0 failed
- issue tests: 2/2 passed
- ILVerify: 123/123 verified; 2 documented suppressions, 0 failures
- worktree clean

Addresses #3230
