### PR TITLE
Consult the submission fallback for bare indexed writes to prior-cell globals

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -1970,6 +1970,17 @@ internal sealed partial class ExpressionBinder
         var name = syntax.TargetIdentifier.Text;
         if (scope.TryLookupSymbol(name) is not VariableSymbol variable)
         {
+            // ADR-0156 Phase 2 (issue #3251): a bare indexed write
+            // (`name[i] = v`) whose target is a top-level global declared by
+            // a prior interactive submission. Every sibling lvalue shape
+            // (read, whole-variable write, compound `name[i] op= v` via the
+            // chain path) already consults the submission fallback; without
+            // this the shape reports a spurious GS0125.
+            if (TryBindSubmissionGlobalIndexAssignment(syntax, out var submissionIndexWrite))
+            {
+                return submissionIndexWrite;
+            }
+
             Diagnostics.ReportUndefinedVariable(syntax.TargetIdentifier.Location, name);
             return new BoundErrorExpression(null);
         }
@@ -2563,6 +2574,66 @@ internal sealed partial class ExpressionBinder
 
         var converted = conversions.BindConversion(syntax.Value.Location, binaryResult, targetSymbol);
         result = new BoundClrPropertyAssignmentExpression(null, receiver: null, member, converted, targetSymbol, staticContainerType: null);
+        return true;
+    }
+
+    /// <summary>
+    /// ADR-0156 Phase 2 (issue #3251): binds a bare indexed write
+    /// (<c>name[i] = v</c>) whose target is a top-level global declared by a
+    /// prior interactive submission. The receiver is bound through the shared
+    /// bare-identifier read fallback (<see cref="TryBindSubmissionStaticMember"/>,
+    /// which applies the issue #3185 addressable-static-field marking) into a
+    /// synthesized temp local, then the ordinary indexed write targets the
+    /// temp — for a map / array / slice global the temp holds the reference,
+    /// so the store mutates the stored global. This is the same
+    /// temp-receiver shape the compound chain path
+    /// (<c>BindIndexedWriteThroughChain</c>) and the same-cell static-field
+    /// path (<see cref="ImplicitStaticFieldVariableSymbol"/>) already use, so
+    /// simple and compound indexed writes stay in lockstep.
+    /// </summary>
+    /// <param name="syntax">The <c>name[index] = value</c> assignment syntax.</param>
+    /// <param name="result">The bound assignment when the target named a prior submission's global.</param>
+    /// <returns><c>true</c> when a prior submission declared the global (and the current cell does not shadow it).</returns>
+    private bool TryBindSubmissionGlobalIndexAssignment(IndexAssignmentExpressionSyntax syntax, out BoundExpression result)
+    {
+        result = null;
+        var submissionImports = scope.SubmissionImports;
+        var name = syntax.TargetIdentifier.Text;
+        if (submissionImports is null
+            || !submissionImports.TryFindGlobalVariable(scope.References, name, out _, out _))
+        {
+            return false;
+        }
+
+        // The current cell's own declarations shadow prior cells (newest
+        // declaration wins regardless of kind): when the name resolves to any
+        // same-cell symbol, keep the regular path's diagnostics.
+        if (scope.TryLookupSymbol(name) is not null)
+        {
+            return false;
+        }
+
+        var nameSyntax = new NameExpressionSyntax(syntax.SyntaxTree, syntax.TargetIdentifier);
+        if (!TryBindSubmissionStaticMember(nameSyntax, out var receiver)
+            || receiver is BoundErrorExpression
+            || receiver.Type == TypeSymbol.Error)
+        {
+            return false;
+        }
+
+        var tempName = $"<idxAsn{System.Threading.Interlocked.Increment(ref binderCtx.SyntheticLocalCounter)}>";
+        var tempVar = new LocalVariableSymbol(tempName, isReadOnly: true, receiver.Type);
+        scope.TryDeclareVariable(tempVar);
+        var declaration = new BoundVariableDeclaration(syntax, tempVar, receiver);
+
+        var assignment = BindIndexedAssignmentToVariable(tempVar, syntax.Index, syntax.Value, syntax.TargetIdentifier.Location);
+        if (assignment is BoundErrorExpression)
+        {
+            result = assignment;
+            return true;
+        }
+
+        result = new BoundBlockExpression(syntax, ImmutableArray.Create<BoundStatement>(declaration), assignment);
         return true;
     }
 

--- a/test/Interpreter.Tests/Issue3251IndexAssignmentSubmissionGlobalTests.cs
+++ b/test/Interpreter.Tests/Issue3251IndexAssignmentSubmissionGlobalTests.cs
@@ -1,0 +1,157 @@
+// <copyright file="Issue3251IndexAssignmentSubmissionGlobalTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Repl.Engine;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #3251 (ADR-0156 Phase 2 seam, part of #3176/#3163): a bare indexed
+/// assignment (<c>name[i] = v</c>) whose target is a prior interactive
+/// submission's global bound through a raw scope lookup and reported GS0125,
+/// even though reads, whole-variable assignment, compound indexed assignment
+/// (<c>name[i] += v</c>), and indexed increment (<c>name[i]++</c>) through
+/// the same global all consulted the <c>SubmissionImports</c> fallback. The
+/// gap is path-specific (the <c>IndexAssignmentExpressionSyntax</c> binder),
+/// not scope-specific: top-level and loop-body forms failed identically.
+/// These tests pin the user's exact repro plus the sibling lvalue-shape
+/// matrix around it.
+/// </summary>
+public sealed class Issue3251IndexAssignmentSubmissionGlobalTests
+{
+    /// <summary>
+    /// The user's exact session: a map global declared in one cell, assigned
+    /// in the next, then populated element-by-element inside a
+    /// <c>for</c>-statement body in a later cell.
+    /// </summary>
+    [Fact]
+    public void ForBodyIndexedAssignmentToPriorCellMapGlobal()
+    {
+        using var engine = new EmittedSessionEngine();
+        AssertOk(engine, "var num = 42");
+        AssertOk(engine, "func Fib(i int) long -> if i <= 0 { 0 } else if i == 1 { 1 } else { Fib(i-1)+Fib(i-2) }");
+        AssertOk(engine, "var numbers map[int, long]");
+        AssertOk(engine, "numbers = map[int, long]{}");
+        AssertOk(engine, "for var i = 1; i <= 20; i++ {   numbers[i] = Fib(i) }");
+
+        var read = engine.Evaluate("numbers[20]");
+        Assert.False(read.HasError, string.Join("; ", read.Diagnostics));
+        Assert.Equal(6765L, read.Value);
+    }
+
+    /// <summary>
+    /// The same shape at top level (no enclosing statement): proves the gap
+    /// was the binder path, not nested-statement scoping, and pins the fix
+    /// for both.
+    /// </summary>
+    [Fact]
+    public void TopLevelIndexedAssignmentToPriorCellMapGlobal()
+    {
+        using var engine = new EmittedSessionEngine();
+        AssertOk(engine, "var m = map[int, long]{1: 10}");
+        AssertOk(engine, "m[2] = 20");
+
+        var read = engine.Evaluate("m[2]");
+        Assert.False(read.HasError, string.Join("; ", read.Diagnostics));
+        Assert.Equal(20L, read.Value);
+    }
+
+    /// <summary>
+    /// Array flavor of the same path: element store through a prior-cell
+    /// array global mutates the stored array (the receiver is a reference).
+    /// </summary>
+    [Fact]
+    public void IndexedAssignmentToPriorCellArrayGlobal()
+    {
+        using var engine = new EmittedSessionEngine();
+        AssertOk(engine, "var arr = [3]int{1, 2, 3}");
+        AssertOk(engine, "arr[0] = 9");
+
+        var read = engine.Evaluate("arr[0]");
+        Assert.False(read.HasError, string.Join("; ", read.Diagnostics));
+        Assert.Equal(9, read.Value);
+    }
+
+    /// <summary>
+    /// A <c>let</c> map global stays element-writable across cells, matching
+    /// the same-cell rule (the write goes through the stored reference, not
+    /// the read-only binding).
+    /// </summary>
+    [Fact]
+    public void IndexedAssignmentToPriorCellLetMapGlobal()
+    {
+        using var engine = new EmittedSessionEngine();
+        AssertOk(engine, "let lm = map[int, int]{1: 1}");
+        AssertOk(engine, "lm[2] = 9");
+
+        var read = engine.Evaluate("lm[2]");
+        Assert.False(read.HasError, string.Join("; ", read.Diagnostics));
+        Assert.Equal(9, read.Value);
+    }
+
+    /// <summary>
+    /// A current-cell declaration shadows the prior-cell global for the
+    /// indexed write, mirroring the read-side newest-wins rule.
+    /// </summary>
+    [Fact]
+    public void CurrentCellDeclarationShadowsPriorCellGlobal()
+    {
+        using var engine = new EmittedSessionEngine();
+        AssertOk(engine, "var m = map[int, int]{1: 1}");
+
+        var shadowed = engine.Evaluate("var m = map[int, int]{1: 100}\nm[1] = 7\nm[1]");
+        Assert.False(shadowed.HasError, string.Join("; ", shadowed.Diagnostics));
+        Assert.Equal(7, shadowed.Value);
+    }
+
+    /// <summary>
+    /// Sibling lvalue shapes that already consulted the fallback on main,
+    /// pinned so the seam stays whole: compound indexed assignment, indexed
+    /// increment, and a <c>ref</c> argument through an indexed element of a
+    /// prior-cell global.
+    /// </summary>
+    [Fact]
+    public void SiblingIndexedLvalueShapesThroughPriorCellGlobals()
+    {
+        using var engine = new EmittedSessionEngine();
+        AssertOk(engine, "var m = map[int, long]{1: 10}");
+
+        var compound = engine.Evaluate("m[1] += 1");
+        Assert.False(compound.HasError, string.Join("; ", compound.Diagnostics));
+        Assert.Equal(11L, compound.Value);
+
+        AssertOk(engine, "m[1]++");
+        var read = engine.Evaluate("m[1]");
+        Assert.False(read.HasError, string.Join("; ", read.Diagnostics));
+        Assert.Equal(12L, read.Value);
+
+        AssertOk(engine, "var arr = [3]int{1, 2, 3}");
+        AssertOk(engine, "func bump(ref n int) {\n    n = n + 1\n}");
+        var refArg = engine.Evaluate("bump(ref arr[1])\narr[1]");
+        Assert.False(refArg.HasError, string.Join("; ", refArg.Diagnostics));
+        Assert.Equal(3, refArg.Value);
+    }
+
+    /// <summary>
+    /// An undefined bare indexed-assignment target still reports GS0125:
+    /// the fallback only fires for names a prior submission declared.
+    /// </summary>
+    [Fact]
+    public void UndefinedIndexedAssignmentTargetStillReportsGs0125()
+    {
+        using var engine = new EmittedSessionEngine();
+        AssertOk(engine, "var m = map[int, int]{1: 1}");
+
+        var missing = engine.Evaluate("nope[1] = 2");
+        Assert.True(missing.HasError);
+        Assert.Contains(missing.Diagnostics, d => d.ToString().Contains("'nope' doesn't exist", System.StringComparison.Ordinal));
+    }
+
+    private static void AssertOk(EmittedSessionEngine engine, string cell)
+    {
+        var result = engine.Evaluate(cell);
+        Assert.False(result.HasError, $"cell '{cell}': {string.Join("; ", result.Diagnostics)}");
+    }
+}


### PR DESCRIPTION
Fixes #3251. Part of #3176, part of #3163 (ADR-0156 post-Phase-3c hardening; the v1-gap family of #3184/#3185, PRs #3186/#3187).

## Summary

User-reported in interactive gsi (default emitted engine): populating a prior-cell map global inside a `for` body — `numbers[i] = Fib(i)` — reported **GS0125 Variable 'numbers' doesn't exist**, even though the sidebar listed `numbers`, plain reads worked, and whole-variable assignment (`numbers = map[int, long]{}`) worked.

## Root cause — path-specific, not scope-specific

Bare `name[index] = value` parses to `IndexAssignmentExpressionSyntax`, and `ExpressionBinder.BindIndexAssignmentExpression` resolved its target with a raw `scope.TryLookupSymbol(name)` and reported GS0125 without consulting the `SubmissionImports` fallback. The top-level form (`numbers[1] = Fib(1)`) failed identically to the for-body form — same binder path, so nested statement scope was never the variable. Every sibling lvalue shape already consulted the fallback: reads (`TryBindSubmissionStaticMember`), whole-variable writes (`TryBindSubmissionStaticFieldWrite`), and compound `name[i] op= v` / `name[i]++` (the chain path `BindIndexedWriteThroughChain` binds its receiver via `BindExpression`, inheriting the read fallback) — which is why cell 4 worked and cell 5 didn't.

**Fix:** a new `TryBindSubmissionGlobalIndexAssignment` fallback in `BindIndexAssignmentExpression`, gated on `SubmissionImports != null`. It binds the receiver through the shared bare-identifier read fallback (which applies #3185's addressable-static-field marking) into a synthesized temp local and routes the ordinary indexed write at the temp — the same temp-receiver shape the compound chain path and the same-cell static-field path (`ImplicitStaticFieldVariableSymbol`) already use. Current-cell declarations shadow (newest wins, regardless of kind). `gsc`, `gsi <file>`, `Compilation.Evaluate`, and the LSP are untouched.

## Shape matrix (cross-cell lvalues through a prior-cell global)

| Shape | Before | After |
| --- | --- | --- |
| `numbers[i] = v` in a `for` body (user's repro) | GS0125 | works; `numbers[20]` echoes 6765 |
| `m[2] = 20` top-level (map) | GS0125 | works |
| `arr[0] = 9` (array) | GS0125 | works |
| `lm[2] = 9` (`let` map — same-cell-legal reference write) | GS0125 | works |
| `m[1] += 1` (compound index) | worked (chain path) | pinned |
| `m[1]++` (indexed increment) | worked (chain path) | pinned |
| `bump(ref arr[1])` (ref arg through indexed element) | worked | pinned |
| current-cell redeclaration shadows the prior-cell global | worked | pinned |
| `nope[1] = 2` (genuinely undefined) | GS0125 | GS0125 (pinned negative) |
| `ps[0].X = v` (struct-field write through indexed element) | silently drops the write (same-cell reports GS0499) | unchanged — filed as #3252, needs the writable-storage classification, beyond this fix's seam |

## Verification

- `dotnet build GSharp.sln -c Release`: 0 warnings, 0 errors.
- New witness tests (`Issue3251IndexAssignmentSubmissionGlobalTests`, 7 tests): RED on main (the four bare indexed-write shapes failed with GS0125; the three pins passed) → GREEN with the fix (ADR-0154 witness discipline).
- `test/Interpreter.Tests` full suite (Release): **1345/1345 passed** (0 failed, 3 skipped — standing skips), including the 7 new witness/matrix tests.
- `test/Core.Tests` full suite (Release): **7178/7179 passed**, 0 failed, 1 skipped (the standing `RegenerateBaseline` skip).
- `test/Compiler.Tests` LanguageConformance filter (Release): **126/126 passed** — file-mode drivers unchanged.
- NOT RUN: full `Compiler.Tests` beyond the LanguageConformance filter, `Cs2Gs.Tests` (pre-existing flaky host crash; GoldenTests-filter policy), `Extensions.Tests`, `LanguageServer.Tests`, manual TUI drive (gsi requires a TTY; the engine-level repro is exact). CI required checks are the backstop.

## Checklist

- [x] Behavioral tests carry a witness of discrimination (ADR-0154): the four fixed shapes fail on main with the exact user-visible GS0125 and pass with the fix.
- [x] Self-review verdict recorded.

Self-review verdict: **MERGEABLE** — 71-line binder change entirely behind the `SubmissionImports != null` gate, reusing the established fallback + temp-receiver machinery; the one adjacent residual (silent copy-drop on `ps[0].X = v`, pre-existing) is filed as #3252 rather than scope-crept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
