### PR TITLE
Correct emitted oracle test intent

### DIFF
--- a/test/Compiler.Tests/Emit/Issue2928TupleFunctionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2928TupleFunctionEmitTests.cs
@@ -1,4 +1,4 @@
-// <copyright file="Issue2928TupleFunctionParityTests.cs" company="GSharp">
+// <copyright file="Issue2928TupleFunctionEmitTests.cs" company="GSharp">
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
@@ -14,29 +14,18 @@ namespace GSharp.Compiler.Tests.Emit;
 
 /// <summary>
 /// Issue #2928: tuple-contained function values execute correctly through the
-/// compiled backend. The interpreter parity arm was retired with the
-/// evaluator in ADR-0156 Phase 3c (#3176); its cross-checked output is pinned
-/// as the golden value.
+/// compiled backend, pinned to an explicit output value.
 /// </summary>
-public class Issue2928TupleFunctionParityTests
+public class Issue2928TupleFunctionEmitTests
 {
     private const string Source = """
-        package TupleFunctionInterpreter
+        package TupleFunctionEmit
         import System
 
         let handler (int32) -> int32 = (value int32) -> value + 1
         let t = (handler, 0)
         Console.WriteLine(t.Item1(41))
         """;
-
-    [Fact]
-    public void TupleFunction_EmittedOutputMatchesPinnedParityValue()
-    {
-        // "42\n" is the cross-checked interpreter/emit parity value, pinned
-        // as a literal golden when the evaluator retired in ADR-0156
-        // Phase 3c (#3176): t.Item1 invokes handler, which returns 41 + 1.
-        Assert.Equal("42\n", CompileAndRun(Source));
-    }
 
     [Fact]
     public void TupleFunction_CompiledBackendExecutes()

--- a/test/Core.Tests/CodeAnalysis/Emit/AsyncEmitGoldenTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/AsyncEmitGoldenTests.cs
@@ -1,4 +1,4 @@
-// <copyright file="AsyncInterpVsEmitParityTests.cs" company="GSharp">
+// <copyright file="AsyncEmitGoldenTests.cs" company="GSharp">
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
@@ -22,12 +22,12 @@ namespace GSharp.Core.Tests.CodeAnalysis.Emit;
 /// the tree-walking evaluator in ADR-0156 Phase 3c (#3176) — the goldens were
 /// the cross-checked parity values and are preserved verbatim.
 /// </summary>
-public class AsyncInterpVsEmitParityTests
+public class AsyncEmitGoldenTests
 {
     [Fact]
-    public void Parity_PureAsyncSequence_TaskFromResult()
+    public void Emit_PureAsyncSequence_TaskFromResult()
     {
-        const string Source = @"package ParityPure
+        const string Source = @"package AsyncEmitPure
 import System
 import System.Threading.Tasks
 
@@ -44,13 +44,13 @@ t2.Wait()
 Console.WriteLine(t2.Result)
 ";
         const string Expected = "6\n15\n";
-        AssertParity(Source, Expected, nameof(Parity_PureAsyncSequence_TaskFromResult));
+        AssertEmitOutput(Source, Expected, nameof(Emit_PureAsyncSequence_TaskFromResult));
     }
 
     [Fact]
-    public void Parity_RealSuspension_TaskDelay()
+    public void Emit_RealSuspension_TaskDelay()
     {
-        const string Source = @"package ParityDelay
+        const string Source = @"package AsyncEmitDelay
 import System
 import System.Threading.Tasks
 
@@ -65,13 +65,13 @@ async func run() {
 run().Wait()
 ";
         const string Expected = "A\nB\nC\n";
-        AssertParity(Source, Expected, nameof(Parity_RealSuspension_TaskDelay));
+        AssertEmitOutput(Source, Expected, nameof(Emit_RealSuspension_TaskDelay));
     }
 
     [Fact]
-    public void Parity_AsyncWithMultipleAwaitsInTry()
+    public void Emit_AsyncWithMultipleAwaitsInTry()
     {
-        const string Source = @"package ParityMultiAwaitTry
+        const string Source = @"package AsyncEmitMultiAwaitTry
 import System
 import System.Threading.Tasks
 
@@ -95,13 +95,13 @@ t.Wait()
 Console.WriteLine(t.Result)
 ";
         const string Expected = "7\n";
-        AssertParity(Source, Expected, nameof(Parity_AsyncWithMultipleAwaitsInTry));
+        AssertEmitOutput(Source, Expected, nameof(Emit_AsyncWithMultipleAwaitsInTry));
     }
 
     [Fact]
-    public void Parity_AsyncWithNestedTryAroundAwait()
+    public void Emit_AsyncWithNestedTryAroundAwait()
     {
-        const string Source = @"package ParityNestedTry
+        const string Source = @"package AsyncEmitNestedTry
 import System
 import System.Threading.Tasks
 
@@ -127,16 +127,16 @@ t.Wait()
 Console.WriteLine(t.Result)
 ";
         const string Expected = "11\n";
-        AssertParity(Source, Expected, nameof(Parity_AsyncWithNestedTryAroundAwait));
+        AssertEmitOutput(Source, Expected, nameof(Emit_AsyncWithNestedTryAroundAwait));
     }
 
     [Fact]
-    public void Parity_AsyncTryFinally_RunsOnceOnNormalCompletion()
+    public void Emit_AsyncTryFinally_RunsOnceOnNormalCompletion()
     {
         // Regression for #137: with the IL `leave` fix, the finally must run
         // exactly once (after the try body completes), not on every async
         // suspension.
-        const string Source = @"package ParityFinallyOnce
+        const string Source = @"package AsyncEmitFinallyOnce
 import System
 import System.Threading.Tasks
 
@@ -157,13 +157,13 @@ t.Wait()
 Console.WriteLine(t.Result)
 ";
         const string Expected = "1\n";
-        AssertParity(Source, Expected, nameof(Parity_AsyncTryFinally_RunsOnceOnNormalCompletion));
+        AssertEmitOutput(Source, Expected, nameof(Emit_AsyncTryFinally_RunsOnceOnNormalCompletion));
     }
 
     [Fact]
-    public void Parity_AsyncWithTryCatch_AroundAwait()
+    public void Emit_AsyncWithTryCatch_AroundAwait()
     {
-        const string Source = @"package ParityTryCatch
+        const string Source = @"package AsyncEmitTryCatch
 import System
 import System.Threading.Tasks
 
@@ -183,13 +183,13 @@ t.Wait()
 Console.WriteLine(t.Result)
 ";
         const string Expected = "42\n";
-        AssertParity(Source, Expected, nameof(Parity_AsyncWithTryCatch_AroundAwait));
+        AssertEmitOutput(Source, Expected, nameof(Emit_AsyncWithTryCatch_AroundAwait));
     }
 
     [Fact]
-    public void Parity_AsyncWithTryFinally_AroundAwait()
+    public void Emit_AsyncWithTryFinally_AroundAwait()
     {
-        const string Source = @"package ParityTryFinally
+        const string Source = @"package AsyncEmitTryFinally
 import System
 import System.Threading.Tasks
 
@@ -209,13 +209,13 @@ t.Wait()
 Console.WriteLine(t.Result)
 ";
         const string Expected = "11\n";
-        AssertParity(Source, Expected, nameof(Parity_AsyncWithTryFinally_AroundAwait));
+        AssertEmitOutput(Source, Expected, nameof(Emit_AsyncWithTryFinally_AroundAwait));
     }
 
     [Fact]
-    public void Parity_AsyncAccumulator_MultipleAwaits()
+    public void Emit_AsyncAccumulator_MultipleAwaits()
     {
-        const string Source = @"package ParityAccum
+        const string Source = @"package AsyncEmitAccum
 import System
 import System.Threading.Tasks
 
@@ -233,13 +233,13 @@ t.Wait()
 Console.WriteLine(t.Result)
 ";
         const string Expected = "30\n";
-        AssertParity(Source, Expected, nameof(Parity_AsyncAccumulator_MultipleAwaits));
+        AssertEmitOutput(Source, Expected, nameof(Emit_AsyncAccumulator_MultipleAwaits));
     }
 
     [Fact]
-    public void Parity_SyncIterator_Sequence()
+    public void Emit_SyncIterator_Sequence()
     {
-        const string Source = @"package ParitySyncIter
+        const string Source = @"package AsyncEmitSyncIter
 import System
 import System.Collections.Generic
 
@@ -254,13 +254,13 @@ for x in nums() {
 }
 ";
         const string Expected = "1\n2\n3\n";
-        AssertParity(Source, Expected, nameof(Parity_SyncIterator_Sequence));
+        AssertEmitOutput(Source, Expected, nameof(Emit_SyncIterator_Sequence));
     }
 
     [Fact]
-    public void Parity_AsyncIterator_YieldWithAwait()
+    public void Emit_AsyncIterator_YieldWithAwait()
     {
-        const string Source = @"package ParityAsyncIter
+        const string Source = @"package AsyncEmitAsyncIter
 import System
 import System.Collections.Generic
 import System.Threading.Tasks
@@ -282,7 +282,7 @@ async func consume() {
 consume().Wait()
 ";
         const string Expected = "10\n20\n30\n";
-        AssertParity(Source, Expected, nameof(Parity_AsyncIterator_YieldWithAwait));
+        AssertEmitOutput(Source, Expected, nameof(Emit_AsyncIterator_YieldWithAwait));
     }
 
     [Fact]
@@ -315,10 +315,10 @@ await for x in gen() {
     }
 
     [Fact]
-    public void Parity_GoScope_AsyncTarget()
+    public void Emit_GoScope_AsyncTarget()
     {
         // Exercises the go+scope emit fix (Func<Task> path).
-        const string Source = @"package ParityGoScope
+        const string Source = @"package AsyncEmitGoScope
 import System
 import System.Threading.Tasks
 import Gsharp.Extensions.Go
@@ -334,10 +334,10 @@ scope {
 Console.WriteLine(""end"")
 ";
         const string Expected = "hello\nend\n";
-        AssertParity(Source, Expected, nameof(Parity_GoScope_AsyncTarget));
+        AssertEmitOutput(Source, Expected, nameof(Emit_GoScope_AsyncTarget));
     }
 
-    private static void AssertParity(string source, string expected, string contextName)
+    private static void AssertEmitOutput(string source, string expected, string contextName)
     {
         var emitOutput = RunEmitter(source, contextName);
 

--- a/test/Core.Tests/CodeAnalysis/Emit/AsyncIteratorEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/AsyncIteratorEmitTests.cs
@@ -20,7 +20,7 @@ namespace GSharp.Core.Tests.CodeAnalysis.Emit;
 /// <summary>
 /// End-to-end emit tests for async iterator functions (IAsyncEnumerable/IAsyncEnumerator with yield + await).
 /// Tests consume the produced stream via C# reflection; the consumer-side `await for` lowering is exercised
-/// by <see cref="AsyncInterpVsEmitParityTests"/>.
+/// by <see cref="AsyncEmitGoldenTests"/>.
 /// </summary>
 public class AsyncIteratorEmitTests
 {

--- a/test/Interpreter.Tests/Issue2896StructObjectOverrideTests.cs
+++ b/test/Interpreter.Tests/Issue2896StructObjectOverrideTests.cs
@@ -76,7 +76,7 @@ public class Issue2896StructObjectOverrideTests
     {
         Assert.Equal(
             "OVERRIDDEN-11\nOVERRIDDEN-11\nFalse\nFalse\n289611\n289611\n",
-            Evaluate(source));
+            RunEmittedOracle(source));
     }
 
     [Theory]
@@ -124,7 +124,7 @@ public class Issue2896StructObjectOverrideTests
     [InlineData("operatorEquals")]
     [InlineData("equals")]
     [InlineData("getHashCode")]
-    public async Task Issue3134_ClassIdentityAndStructValueEqualityMatchEmitter(string surface)
+    public async Task Issue3134_ClassIdentityAndStructValueEqualityAgreeAcrossEmittedDrivers(string surface)
     {
         var suffix = Guid.NewGuid().ToString("N");
         var source = BuildIssue3134Source(surface, suffix);
@@ -149,7 +149,7 @@ public class Issue2896StructObjectOverrideTests
     [InlineData("dataClass", "DataClass|True|True|False|False|False|True")]
     [InlineData("version", "Version|True|True|False|False|False|True")]
     [InlineData("typedStrings", "TypedStrings|True|True|False|False|False|True")]
-    public async Task Issue3173_ObjectReferenceEqualityMatchesEmitter(string specimen, string expected)
+    public async Task Issue3173_ObjectReferenceEqualityAgreesAcrossEmittedDrivers(string specimen, string expected)
     {
         var suffix = Guid.NewGuid().ToString("N");
         var source = BuildIssue3173Source(specimen, suffix);
@@ -289,7 +289,7 @@ public class Issue2896StructObjectOverrideTests
             SHARED-OVERRIDDEN-43
             SHARED-OVERRIDDEN-43
             """.Replace("\r\n", "\n", StringComparison.Ordinal) + "\n",
-            Evaluate(Source));
+            RunEmittedOracle(Source));
     }
 
     [Fact]
@@ -327,10 +327,10 @@ public class Issue2896StructObjectOverrideTests
         Assert.Equal(
             "DataValue(Number=7)\nDataValue(Number=7)\n"
                 + "Issue2896.Controls.DefaultValue\nIssue2896.Controls.DefaultValue\n",
-            Evaluate(Source));
+            RunEmittedOracle(Source));
     }
 
-    private static string Evaluate(string source)
+    private static string RunEmittedOracle(string source)
     {
         var result = EmittedOracle.Evaluate(source);
         var errors = result.Diagnostics.Where(diagnostic => diagnostic.IsError).ToArray();
@@ -884,9 +884,9 @@ public class Issue2896StructObjectOverrideTests
 
             return driver switch
             {
-                "gsc-script" => RunCompilerEvaluation(sourcePath),
+                "gsc-script" => RunGscScript(sourcePath),
                 "gsc-emit" => await RunEmittedBinaryAsync(directory, sourcePath, suffix),
-                "gsi" => RunInterpreter(sourcePath),
+                "gsi" => RunGsiScript(sourcePath),
                 _ => throw new ArgumentOutOfRangeException(nameof(driver), driver, null),
             };
         }
@@ -902,18 +902,18 @@ public class Issue2896StructObjectOverrideTests
         }
     }
 
-    private static string RunCompilerEvaluation(string sourcePath)
+    private static string RunGscScript(string sourcePath)
     {
         var result = CaptureConsole(() => CompilerProgram.Main(new[] { sourcePath }));
         Assert.True(
             result.ExitCode == 0,
-            $"gsc evaluation failed ({result.ExitCode})\nstdout:\n{result.StandardOutput}\nstderr:\n{result.StandardError}");
+            $"gsc script failed ({result.ExitCode})\nstdout:\n{result.StandardOutput}\nstderr:\n{result.StandardError}");
         Assert.Equal(string.Empty, result.StandardError);
         Assert.EndsWith("Success.\n", result.StandardOutput, StringComparison.Ordinal);
         return result.StandardOutput[..^"Success.\n".Length];
     }
 
-    private static string RunInterpreter(string sourcePath)
+    private static string RunGsiScript(string sourcePath)
     {
         var result = CaptureConsole(() => GSharp.Repl.Program.Main(new[] { sourcePath }));
         Assert.True(

--- a/test/Interpreter.Tests/Issue3015ImportedBaseIdentityTests.cs
+++ b/test/Interpreter.Tests/Issue3015ImportedBaseIdentityTests.cs
@@ -190,10 +190,10 @@ public class Issue3015ImportedBaseIdentityTests
     }
 
     [Fact]
-    public void CompilerAndInterpreter_AgreeOnDerivedRuntimeType()
+    public void ExplicitEmitAndOracle_AgreeOnDerivedRuntimeType()
     {
         const string Source = """
-            package Issue3015.CompilerParity
+            package Issue3015.CompilerDriver
             import System
 
             class Sentinel : EventArgs {
@@ -203,7 +203,7 @@ public class Issue3015ImportedBaseIdentityTests
             Console.WriteLine(value.GetType().FullName)
             """;
 
-        var interpreterTypeName = Evaluate(Source).Trim();
+        var oracleTypeName = Evaluate(Source).Trim();
         var artifactDirectory = Path.Combine(
             GetRepositoryRoot(),
             "out",
@@ -228,8 +228,8 @@ public class Issue3015ImportedBaseIdentityTests
             var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
             var emittedType = Assert.Single(
                 assembly.GetTypes(),
-                static type => type.FullName == "Issue3015.CompilerParity.Sentinel");
-            Assert.Equal(emittedType.FullName, interpreterTypeName);
+                static type => type.FullName == "Issue3015.CompilerDriver.Sentinel");
+            Assert.Equal(emittedType.FullName, oracleTypeName);
         }
         finally
         {
@@ -263,10 +263,10 @@ public class Issue3015ImportedBaseIdentityTests
     }
 
     [Fact]
-    public void GenericTypeArguments_AgreeAcrossCompilerEmitAndInterpreter()
+    public void GenericTypeArguments_AgreeAcrossEmittedDrivers()
     {
         const string Source = """
-            package Issue3015.GenericParity
+            package Issue3015.GenericDrivers
             import System
 
             class Payload {
@@ -280,9 +280,9 @@ public class Issue3015ImportedBaseIdentityTests
             Console.WriteLine(Box[Box[Payload]]().GetType().FullName)
             """;
         const string Expected = """
-            Issue3015.GenericParity.Box`1[[Issue3015.GenericParity.Payload]]
-            Issue3015.GenericParity.Box`1[[System.String]]
-            Issue3015.GenericParity.Box`1[[Issue3015.GenericParity.Box`1[[Issue3015.GenericParity.Payload]]]]
+            Issue3015.GenericDrivers.Box`1[[Issue3015.GenericDrivers.Payload]]
+            Issue3015.GenericDrivers.Box`1[[System.String]]
+            Issue3015.GenericDrivers.Box`1[[Issue3015.GenericDrivers.Box`1[[Issue3015.GenericDrivers.Payload]]]]
 
             """;
 
@@ -290,18 +290,18 @@ public class Issue3015ImportedBaseIdentityTests
             GetRepositoryRoot(),
             "out",
             "test-artifacts",
-            $"issue3015-generic-parity-{Guid.NewGuid():N}");
+            $"issue3015-generic-drivers-{Guid.NewGuid():N}");
 
         try
         {
-            var compilerEvaluation = RunSourceDriver(Path.Combine(root, "gsc-eval"), Source, Program.Main);
-            Assert.EndsWith("Success.\n", compilerEvaluation);
-            compilerEvaluation = compilerEvaluation[..^"Success.\n".Length];
-            var interpreter = RunSourceDriver(Path.Combine(root, "gsi"), Source, GSharp.Repl.Program.Main);
+            var gscScript = RunSourceDriver(Path.Combine(root, "gsc-script"), Source, Program.Main);
+            Assert.EndsWith("Success.\n", gscScript);
+            gscScript = gscScript[..^"Success.\n".Length];
+            var gsiScript = RunSourceDriver(Path.Combine(root, "gsi"), Source, GSharp.Repl.Program.Main);
             var emitDirectory = Path.Combine(root, "gsc-emit");
             Directory.CreateDirectory(emitDirectory);
-            var emitSourcePath = Path.Combine(emitDirectory, "GenericParity.gs");
-            var assemblyPath = Path.Combine(emitDirectory, $"GenericParity-{Guid.NewGuid():N}.dll");
+            var emitSourcePath = Path.Combine(emitDirectory, "GenericDrivers.gs");
+            var assemblyPath = Path.Combine(emitDirectory, $"GenericDrivers-{Guid.NewGuid():N}.dll");
             File.WriteAllText(emitSourcePath, Source);
             _ = CaptureDriver(() => Program.Main(new[]
             {
@@ -314,7 +314,7 @@ public class Issue3015ImportedBaseIdentityTests
             Assert.NotEmpty(assembly.GetTypes());
             var entryPoint = assembly.EntryPoint
                 ?? throw new InvalidOperationException("Emitted assembly has no entry point.");
-            var emitted = CaptureDriver(() =>
+            var explicitEmit = CaptureDriver(() =>
             {
                 entryPoint.Invoke(
                     null,
@@ -322,9 +322,9 @@ public class Issue3015ImportedBaseIdentityTests
                 return 0;
             });
 
-            Assert.Equal(Expected, NormalizeGenericTypeNames(compilerEvaluation));
-            Assert.Equal(Expected, NormalizeGenericTypeNames(emitted));
-            Assert.Equal(Expected, NormalizeGenericTypeNames(interpreter));
+            Assert.Equal(Expected, NormalizeGenericTypeNames(gscScript));
+            Assert.Equal(Expected, NormalizeGenericTypeNames(explicitEmit));
+            Assert.Equal(Expected, NormalizeGenericTypeNames(gsiScript));
         }
         finally
         {

--- a/test/Interpreter.Tests/Issue3099TypeArgumentReificationTests.cs
+++ b/test/Interpreter.Tests/Issue3099TypeArgumentReificationTests.cs
@@ -15,11 +15,12 @@ using Xunit;
 namespace GSharp.Interpreter.Tests;
 
 /// <summary>
-/// Issue #3099: interpreter-created generic backing types must preserve every
+/// Issue #3099: emitted generic backing types must preserve every
 /// G# type-argument kind instead of erasing value types to <see cref="object"/>.
 /// Issue #3137 extends the same emit-oracle matrix to reflected field shape.
-/// Issue #3180 covers enclosing generic parameters in the interactive evaluator;
-/// ADR-0156 file drivers remain compared against the emitted oracle.
+/// Issue #3180 covers enclosing generic parameters in the interactive emitted
+/// engine; ADR-0156 file drivers remain compared against explicit and interactive
+/// emitted hosts.
 /// </summary>
 [Collection("ConsoleIo")]
 public class Issue3099TypeArgumentReificationTests
@@ -46,7 +47,7 @@ public class Issue3099TypeArgumentReificationTests
 
     [Theory]
     [MemberData(nameof(TypeArgumentCases))]
-    public void TypeArguments_AgreeAcrossInteractiveEvaluationEmitAndFileDrivers(
+    public void TypeArguments_AgreeAcrossEmittedHostsAndFileDrivers(
         string caseName,
         string declaration,
         string typeArgument)
@@ -60,18 +61,18 @@ public class Issue3099TypeArgumentReificationTests
 
         try
         {
-            var compilerFile = RunSourceDriver(
-                Path.Combine(root, "gsc-eval"),
+            var gscScript = RunSourceDriver(
+                Path.Combine(root, "gsc-script"),
                 source,
                 Program.Main);
-            Assert.EndsWith("Success.\n", compilerFile);
-            compilerFile = compilerFile[..^"Success.\n".Length];
+            Assert.EndsWith("Success.\n", gscScript);
+            gscScript = gscScript[..^"Success.\n".Length];
 
-            var gsiFile = RunSourceDriver(
+            var gsiScript = RunSourceDriver(
                 Path.Combine(root, "gsi"),
                 source,
                 GSharp.Repl.Program.Main);
-            var interactive = RunInteractive(source);
+            var interactiveEmit = RunInteractiveEmit(source);
 
             var emitDirectory = PrepareEmptyDirectory(Path.Combine(root, "gsc-emit"));
             var sourcePath = Path.Combine(emitDirectory, "Probe.gs");
@@ -90,7 +91,7 @@ public class Issue3099TypeArgumentReificationTests
             Assert.Contains(assembly.GetTypes(), type => type.FullName?.EndsWith(".Pair`2", StringComparison.Ordinal) == true);
             var entryPoint = assembly.EntryPoint
                 ?? throw new InvalidOperationException("Emitted assembly has no entry point.");
-            var emitted = CaptureDriver(() =>
+            var explicitEmit = CaptureDriver(() =>
             {
                 entryPoint.Invoke(
                     null,
@@ -98,19 +99,19 @@ public class Issue3099TypeArgumentReificationTests
                 return 0;
             });
 
-            var expected = NormalizeGenericTypeNames(emitted);
-            var evaluated = NormalizeGenericTypeNames(interactive);
-            var compiledFile = NormalizeGenericTypeNames(compilerFile);
-            var interpretedFile = NormalizeGenericTypeNames(gsiFile);
+            var expected = NormalizeGenericTypeNames(explicitEmit);
+            var interactiveOutput = NormalizeGenericTypeNames(interactiveEmit);
+            var gscOutput = NormalizeGenericTypeNames(gscScript);
+            var gsiOutput = NormalizeGenericTypeNames(gsiScript);
             const string ControlShape =
                 "44\n2|Eleven:System.Int32:True:False:False|TwentyTwo:System.String:False:False:False\n";
             Assert.Contains(ControlShape, expected, StringComparison.Ordinal);
-            Assert.Contains(ControlShape, evaluated, StringComparison.Ordinal);
-            Assert.Contains(ControlShape, compiledFile, StringComparison.Ordinal);
-            Assert.Contains(ControlShape, interpretedFile, StringComparison.Ordinal);
-            Assert.Equal(expected, evaluated);
-            Assert.Equal(expected, compiledFile);
-            Assert.Equal(expected, interpretedFile);
+            Assert.Contains(ControlShape, interactiveOutput, StringComparison.Ordinal);
+            Assert.Contains(ControlShape, gscOutput, StringComparison.Ordinal);
+            Assert.Contains(ControlShape, gsiOutput, StringComparison.Ordinal);
+            Assert.Equal(expected, interactiveOutput);
+            Assert.Equal(expected, gscOutput);
+            Assert.Equal(expected, gsiOutput);
             Assert.Contains("11\n", expected);
             Assert.Contains("22\n", expected);
             Assert.Contains("33\n", expected);
@@ -192,7 +193,7 @@ public class Issue3099TypeArgumentReificationTests
         return CaptureDriver(() => driver([sourcePath]));
     }
 
-    private static string RunInteractive(string source)
+    private static string RunInteractiveEmit(string source)
     {
         // ADR-0156 Phase 3c (#3176): the interactive column runs on the
         // emitted submission-chaining engine.

--- a/test/Interpreter.Tests/Issue3100FieldOffsetDriverTests.cs
+++ b/test/Interpreter.Tests/Issue3100FieldOffsetDriverTests.cs
@@ -1,4 +1,4 @@
-// <copyright file="Issue3100FieldOffsetParityTests.cs" company="GSharp">
+// <copyright file="Issue3100FieldOffsetDriverTests.cs" company="GSharp">
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
@@ -13,9 +13,12 @@ using Xunit;
 
 namespace GSharp.Interpreter.Tests;
 
-/// <summary>Issues #3100 and #3115: explicit field layout must match the CLR.</summary>
+/// <summary>
+/// Issues #3100 and #3115: explicit field layout must match the CLR across
+/// bare <c>gsc</c>, explicit-output <c>gsc</c>, and <c>gsi</c> emitted drivers.
+/// </summary>
 [Collection("ConsoleIo")]
-public class Issue3100FieldOffsetParityTests
+public class Issue3100FieldOffsetDriverTests
 {
     public static TheoryData<string> LayoutCases => new()
     {
@@ -28,7 +31,7 @@ public class Issue3100FieldOffsetParityTests
 
     [Theory]
     [MemberData(nameof(LayoutCases))]
-    public void FieldLayout_EmitEvaluateAndGsiAgree(string layoutCase)
+    public void FieldLayout_AgreesAcrossEmittedDrivers(string layoutCase)
     {
         var source = SourceFor(layoutCase);
         var root = CreateEmptyDirectory(layoutCase);
@@ -36,14 +39,14 @@ public class Issue3100FieldOffsetParityTests
         {
             var bare = RunBareGsc(source, CreateEmptyDirectory(root, "bare"));
             var emitted = RunEmitted(source, layoutCase, CreateEmptyDirectory(root, "emit"));
-            var interpreted = RunGsi(source, CreateEmptyDirectory(root, "gsi"));
+            var gsi = RunGsi(source, CreateEmptyDirectory(root, "gsi"));
 
             var expected = layoutCase is "FullOverlap" or "PartialOverlap"
                 ? "2\n11\n22\n33\n44\n44"
                 : "1\n11\n22\n33\n33\n44";
             Assert.Equal(expected, emitted);
             Assert.Equal(emitted, bare);
-            Assert.Equal(emitted, interpreted);
+            Assert.Equal(emitted, gsi);
         }
         finally
         {
@@ -54,7 +57,7 @@ public class Issue3100FieldOffsetParityTests
     [Theory]
     [InlineData(0, "int64")]
     [InlineData(4, "int32")]
-    public void ReferenceAndPrimitiveOverlapReportsGs0518AcrossDrivers(
+    public void ReferenceAndPrimitiveOverlapReportsGs0518AcrossEmittedDrivers(
         int primitiveOffset,
         string primitiveType)
     {
@@ -72,11 +75,11 @@ public class Issue3100FieldOffsetParityTests
             var value = Bad{Text: "x", Bits: 0}
             Console.WriteLine(value.Bits)
             """;
-        AssertGs0518AcrossDrivers(source, "ReferencePrimitiveOverlap");
+        AssertGs0518AcrossEmittedDrivers(source, "ReferencePrimitiveOverlap");
     }
 
     [Fact]
-    public void ForwardDeclaredValueTypeOverlapReportsGs0518AcrossDrivers()
+    public void ForwardDeclaredValueTypeOverlapReportsGs0518AcrossEmittedDrivers()
     {
         const string Source = """
             package Issue3115ForwardOverlap
@@ -94,11 +97,11 @@ public class Issue3100FieldOffsetParityTests
             Console.WriteLine(value.Bits.Value)
             """;
 
-        AssertGs0518AcrossDrivers(Source, "ForwardValueOverlap");
+        AssertGs0518AcrossEmittedDrivers(Source, "ForwardValueOverlap");
     }
 
     [Fact]
-    public void NestedStructOverlapReportsGs0518AcrossDrivers()
+    public void NestedStructOverlapReportsGs0518AcrossEmittedDrivers()
     {
         const string Source = """
             package Issue3115NestedOverlap
@@ -115,13 +118,13 @@ public class Issue3100FieldOffsetParityTests
             Console.WriteLine(value)
             """;
 
-        AssertGs0518AcrossDrivers(Source, "NestedOverlap", 8, 29, 33);
+        AssertGs0518AcrossEmittedDrivers(Source, "NestedOverlap", 8, 29, 33);
     }
 
     [Theory]
     [InlineData(0, 6)]
     [InlineData(24, 30)]
-    public void MisalignedReferenceReportsGs0518WithRealLocationAcrossDrivers(
+    public void MisalignedReferenceReportsGs0518WithRealLocationAcrossEmittedDrivers(
         int paddingLines,
         int expectedLine)
     {
@@ -145,7 +148,7 @@ public class Issue3100FieldOffsetParityTests
                 "Console.WriteLine(value.Bits)",
             ]));
 
-        AssertGs0518AcrossDrivers(
+        AssertGs0518AcrossEmittedDrivers(
             source,
             $"MisalignedReference{paddingLines}",
             expectedLine,
@@ -155,7 +158,7 @@ public class Issue3100FieldOffsetParityTests
     }
 
     [Fact]
-    public void WorkingReferenceLayoutsRemainValidAcrossDrivers()
+    public void WorkingReferenceLayoutsRemainValidAcrossEmittedDrivers()
     {
         var source = ReferenceLayoutCorpusSource();
         var root = CreateEmptyDirectory("ReferenceLayoutCorpus");
@@ -163,11 +166,11 @@ public class Issue3100FieldOffsetParityTests
         {
             var bare = RunBareGsc(source, CreateEmptyDirectory(root, "bare"));
             var emitted = RunEmitted(source, CreateEmptyDirectory(root, "emit"));
-            var interpreted = RunGsi(source, CreateEmptyDirectory(root, "gsi"));
+            var gsi = RunGsi(source, CreateEmptyDirectory(root, "gsi"));
 
             Assert.Equal("A\n11\nC\nD\n22\n44\nE\n55", emitted);
             Assert.Equal(emitted, bare);
-            Assert.Equal(emitted, interpreted);
+            Assert.Equal(emitted, gsi);
         }
         finally
         {
@@ -262,7 +265,7 @@ public class Issue3100FieldOffsetParityTests
         return (sourcePath, stdout + stderr);
     }
 
-    private static void AssertGs0518AcrossDrivers(
+    private static void AssertGs0518AcrossEmittedDrivers(
         string source,
         string name,
         int line = 8,
@@ -282,14 +285,14 @@ public class Issue3100FieldOffsetParityTests
                 CreateEmptyDirectory(root, "emit"),
                 path => GSharp.Compiler.Program.Main(
                     ["/out:" + Path.Combine(root, "emit", "probe.dll"), path]));
-            var interpreted = RunDiagnostic(
+            var gsi = RunDiagnostic(
                 source,
                 CreateEmptyDirectory(root, "gsi"),
                 path => GSharp.Repl.Program.Main([path]));
 
             AssertGs0518(bare.SourcePath, bare.Output, line, startColumn, endColumn, reason);
             AssertGs0518(emitted.SourcePath, emitted.Output, line, startColumn, endColumn, reason);
-            AssertGs0518(interpreted.SourcePath, interpreted.Output, line, startColumn, endColumn, reason);
+            AssertGs0518(gsi.SourcePath, gsi.Output, line, startColumn, endColumn, reason);
         }
         finally
         {

--- a/test/Interpreter.Tests/Issue3140OutParameterWriteBackDriverTests.cs
+++ b/test/Interpreter.Tests/Issue3140OutParameterWriteBackDriverTests.cs
@@ -1,4 +1,4 @@
-// <copyright file="Issue3140OutParameterWriteBackParityTests.cs" company="GSharp">
+// <copyright file="Issue3140OutParameterWriteBackDriverTests.cs" company="GSharp">
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
@@ -22,7 +22,7 @@ namespace GSharp.Interpreter.Tests;
 /// SessionEngine columns retired in ADR-0156 Phase 3c (#3176).
 /// </summary>
 [Collection("ConsoleIo")]
-public class Issue3140OutParameterWriteBackParityTests
+public class Issue3140OutParameterWriteBackDriverTests
 {
     /// <summary>Gets receiver and argument-shape matrix rows.</summary>
     /// <returns>Matrix rows.</returns>
@@ -39,11 +39,11 @@ public class Issue3140OutParameterWriteBackParityTests
 
     [Theory]
     [MemberData(nameof(ReceiverShapeMatrix))]
-    public async Task OutParameterWriteBack_InProcessHostMatchesEmit(
+    public async Task OutParameterWriteBack_AgreesAcrossEmittedDrivers(
         ReceiverKind receiver,
         ArgumentShape shape)
     {
-        await AssertDriverParityAsync(
+        await AssertEmittedDriverAgreementAsync(
             BuildSource(receiver, shape),
             GetExpectedOutput(shape),
             receiver + "-" + shape);
@@ -64,11 +64,11 @@ public class Issue3140OutParameterWriteBackParityTests
 
     [Theory]
     [MemberData(nameof(WriteBackOperandMatrix))]
-    public async Task OutParameterWriteBack_ReceiverAndOperandKindsMatchEmit(
+    public async Task OutParameterWriteBack_ReceiverAndOperandKindsAgreeAcrossEmittedDrivers(
         ReceiverKind receiver,
         OperandKind operand)
     {
-        await AssertDriverParityAsync(
+        await AssertEmittedDriverAgreementAsync(
             BuildOperandSource(receiver, operand),
             "91",
             receiver + "-" + operand);
@@ -338,7 +338,7 @@ public class Issue3140OutParameterWriteBackParityTests
         _ => throw new ArgumentOutOfRangeException(nameof(shape), shape, null),
     };
 
-    private static async Task AssertDriverParityAsync(string source, string expected, string name)
+    private static async Task AssertEmittedDriverAgreementAsync(string source, string expected, string name)
     {
         var root = CreateEmptyDirectory(name);
         try
@@ -446,7 +446,7 @@ public class Issue3140OutParameterWriteBackParityTests
 
     private static string CreateEmptyDirectory(string name)
     {
-        var parent = Path.Combine(AppContext.BaseDirectory, nameof(Issue3140OutParameterWriteBackParityTests));
+        var parent = Path.Combine(AppContext.BaseDirectory, nameof(Issue3140OutParameterWriteBackDriverTests));
         return CreateEmptyDirectory(parent, name + "-" + Guid.NewGuid().ToString("N"));
     }
 


### PR DESCRIPTION
## Summary

- rename former interpreter-vs-emit tests to describe emitted goldens or emitted driver comparisons
- remove one literally duplicated Issue #2928 emit assertion
- preserve distinct gsc, gsi, explicit-output, oracle, and interactive emitted driver coverage

Refs #3257

## Validation

- targeted affected tests: 204 passed
- nine-project matrix: 15,368 passed, 4 skipped
- ILVerify: 123/123 verified, 2 documented suppressions
- solution build: 0 warnings, 0 errors