### PR TITLE
Fix enclosing generic closure emission

### DIFF
--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Statements.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Statements.cs
@@ -410,13 +410,27 @@ internal sealed partial class MethodBodyEmitter
                 $"Go display invoke method '{closure.InvokeMethod.Name}' has no emitted MethodDef.");
         }
 
+        var constructedClosure = closure.ConstructedClassSym;
+        var closureIsGeneric = ReflectionMetadataEmitter.IsUserGenericTypeReference(constructedClosure);
+
         this.il.OpCode(ILOpCode.Newobj);
-        this.il.Token(ctorHandle);
+        this.il.Token(closureIsGeneric
+            ? this.outer.userTokens.ResolveUserCtorTokenForDefault(constructedClosure)
+            : ctorHandle);
 
         foreach (var captured in closure.CaptureFields.Keys)
         {
             var field = closure.CaptureFields[captured];
-            if (!this.outer.cache.StructFieldDefs.TryGetValue(field, out var fieldHandle))
+            EntityHandle fieldToken;
+            if (closureIsGeneric)
+            {
+                fieldToken = this.outer.userTokens.ResolveFieldToken(constructedClosure, field);
+            }
+            else if (this.outer.cache.StructFieldDefs.TryGetValue(field, out var fieldHandle))
+            {
+                fieldToken = fieldHandle;
+            }
+            else
             {
                 throw new InvalidOperationException(
                     $"Go display field '{field.Name}' has no emitted FieldDef.");
@@ -425,16 +439,19 @@ internal sealed partial class MethodBodyEmitter
             this.il.OpCode(ILOpCode.Dup);
             this.EmitExpression(new BoundVariableExpression(null, captured));
             this.il.OpCode(ILOpCode.Stfld);
-            this.il.Token(fieldHandle);
+            this.il.Token(fieldToken);
         }
 
         var isAsync = ClosureEmitter.IsTaskClrType(closure.InvokeMethod.Type?.ClrType);
+        var invokeToken = closureIsGeneric
+            ? this.outer.userTokens.ResolveClosureInvokeFtnToken(constructedClosure, closure.ClassSym, closure.InvokeMethod)
+            : invokeHandle;
 
         if (isAsync)
         {
             var funcTaskCtor = typeof(Func<System.Threading.Tasks.Task>).GetConstructor(new[] { typeof(object), typeof(nint) });
             this.il.OpCode(ILOpCode.Ldftn);
-            this.il.Token(invokeHandle);
+            this.il.Token(invokeToken);
             this.il.OpCode(ILOpCode.Newobj);
             this.il.Token(this.outer.memberRefs.GetCtorReference(funcTaskCtor));
         }
@@ -442,7 +459,7 @@ internal sealed partial class MethodBodyEmitter
         {
             var actionCtor = typeof(Action).GetConstructor(new[] { typeof(object), typeof(nint) });
             this.il.OpCode(ILOpCode.Ldftn);
-            this.il.Token(invokeHandle);
+            this.il.Token(invokeToken);
             this.il.OpCode(ILOpCode.Newobj);
             this.il.Token(this.outer.memberRefs.GetCtorReference(actionCtor));
         }

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -1501,14 +1501,15 @@ public sealed class StructSymbol : TypeSymbol
         Dictionary<TypeParameterSymbol, TypeSymbol> running = null;
         for (var c = this; c != null; c = c.BaseClass)
         {
-            // Issue #1521: a constructed reference to a type nested inside a
-            // generic enclosing type (`Box[int32].Tag`) already carries the
-            // enclosing arguments on EnclosingTypeArguments and declares no own
-            // type arguments to compose. When such a receiver directly declares
-            // the sought member, return it verbatim so the field/method
-            // reference is parented at its own `Box`1+Tag`1<int32>` TypeSpec
-            // rather than a rebuilt open self-instantiation.
-            if (c.IsConstructedNestedType && declaringDefinitionPredicate(c.Definition ?? c))
+            // A constructed nested receiver already carries the argument shape
+            // needed by its TypeSpec. Keep it verbatim: rebuilding a generic
+            // nested type whose open enclosing arguments are implicit would
+            // mistake its own arguments for the flattened enclosing slots.
+            var isConstructedNested = c.IsConstructedNestedType
+                || (c.Definition != null
+                    && !c.TypeArguments.IsDefaultOrEmpty
+                    && !CollectEnclosingTypeParameters(c).IsDefaultOrEmpty);
+            if (isConstructedNested && declaringDefinitionPredicate(c.Definition ?? c))
             {
                 return c;
             }
@@ -1748,7 +1749,7 @@ public sealed class StructSymbol : TypeSymbol
 
     private static TypeSymbol EnclosingTypeOf(TypeSymbol type) => type switch
     {
-        StructSymbol s => s.ContainingType,
+        StructSymbol s => (s.Definition ?? s).ContainingType,
         InterfaceSymbol i => i.ContainingType,
         EnumSymbol e => e.ContainingType,
         _ => null,

--- a/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
@@ -555,41 +555,33 @@ public class TypeSymbol : Symbol
                 }
 
                 return;
-            case StructSymbol ssNested when !ssNested.EnclosingTypeArguments.IsDefaultOrEmpty:
-                foreach (var arg in ssNested.EnclosingTypeArguments)
+            case StructSymbol ss:
+                if (!ss.EnclosingTypeArguments.IsDefaultOrEmpty)
                 {
-                    CollectReferencedTypeParameters(arg, sink);
+                    foreach (var arg in ss.EnclosingTypeArguments)
+                    {
+                        CollectReferencedTypeParameters(arg, sink);
+                    }
                 }
-
-                foreach (var arg in ssNested.TypeArguments)
+                else
                 {
-                    CollectReferencedTypeParameters(arg, sink);
-                }
-
-                if (ssNested.TypeArguments.IsDefaultOrEmpty)
-                {
-                    foreach (var tp in ssNested.TypeParameters)
+                    foreach (var tp in StructSymbol.CollectEnclosingTypeParameters(ss))
                     {
                         CollectReferencedTypeParameters(tp, sink);
                     }
                 }
 
-                return;
-            case StructSymbol ss when !ss.TypeArguments.IsDefaultOrEmpty:
                 foreach (var arg in ss.TypeArguments)
                 {
                     CollectReferencedTypeParameters(arg, sink);
                 }
 
-                return;
-            case StructSymbol ssOpen when !ssOpen.TypeParameters.IsDefaultOrEmpty:
-                // Issue #1477: a captured `this` of a generic type `G[T]` is the
-                // OPEN definition (TypeParameters set, no TypeArguments) — its
-                // own parameters ARE the enclosing parameters the capture field
-                // references (`G`1<!0>`), so collect them.
-                foreach (var tp in ssOpen.TypeParameters)
+                if (ss.TypeArguments.IsDefaultOrEmpty)
                 {
-                    CollectReferencedTypeParameters(tp, sink);
+                    foreach (var tp in ss.TypeParameters)
+                    {
+                        CollectReferencedTypeParameters(tp, sink);
+                    }
                 }
 
                 return;

--- a/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
@@ -555,6 +555,26 @@ public class TypeSymbol : Symbol
                 }
 
                 return;
+            case StructSymbol ssNested when !ssNested.EnclosingTypeArguments.IsDefaultOrEmpty:
+                foreach (var arg in ssNested.EnclosingTypeArguments)
+                {
+                    CollectReferencedTypeParameters(arg, sink);
+                }
+
+                foreach (var arg in ssNested.TypeArguments)
+                {
+                    CollectReferencedTypeParameters(arg, sink);
+                }
+
+                if (ssNested.TypeArguments.IsDefaultOrEmpty)
+                {
+                    foreach (var tp in ssNested.TypeParameters)
+                    {
+                        CollectReferencedTypeParameters(tp, sink);
+                    }
+                }
+
+                return;
             case StructSymbol ss when !ss.TypeArguments.IsDefaultOrEmpty:
                 foreach (var arg in ss.TypeArguments)
                 {

--- a/test/Compiler.Tests/Emit/Issue3254EnclosingGenericClosureEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3254EnclosingGenericClosureEmitTests.cs
@@ -1,0 +1,179 @@
+// <copyright file="Issue3254EnclosingGenericClosureEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #3254: synthesized lambda and <c>go</c> closure types must preserve
+/// enclosing generic type parameters at their definitions and use sites.
+/// </summary>
+public class Issue3254EnclosingGenericClosureEmitTests
+{
+    [Fact]
+    public void LambdaCapturingNestedTypeWithEnclosingTypeParameterRuns()
+    {
+        const string Source = """
+            package Issue3254.Lambda
+            import System
+
+            class Owner[T] {
+                struct Payload[U] {
+                    var First T
+                    var Second U
+                }
+            }
+
+            func Run[T](value Owner[T].Payload[string]) T {
+                let read = () -> value
+                return read().First
+            }
+
+            func Main() {
+                Console.WriteLine(Run[int32](Owner[int32].Payload[string]{ First: 42, Second: "int" }))
+                Console.WriteLine(Run[string](Owner[string].Payload[string]{ First: "right", Second: "string" }))
+            }
+            """;
+
+        AssertCompilesAndRuns(Source, "42\nright\n", nameof(LambdaCapturingNestedTypeWithEnclosingTypeParameterRuns));
+    }
+
+    [Fact]
+    public void GoInsideGenericFunctionPreservesCapturedTypeParameter()
+    {
+        const string Source = """
+            package Issue3254.Go
+            import System
+            import Gsharp.Extensions.Go
+
+            func Show[T](value T) int32 {
+                Console.WriteLine(value)
+                return 0
+            }
+
+            func Run[T](value T) {
+                scope {
+                    go Show[T](value)
+                }
+            }
+
+            func Main() {
+                Run[int32](42)
+                Run[string]("right")
+            }
+            """;
+
+        AssertCompilesAndRuns(Source, "42\nright\n", nameof(GoInsideGenericFunctionPreservesCapturedTypeParameter));
+    }
+
+    [Fact]
+    public void AsyncGoInsideGenericFunctionPreservesCapturedTypeParameter()
+    {
+        const string Source = """
+            package Issue3254.AsyncGo
+            import System
+            import System.Threading.Tasks
+            import Gsharp.Extensions.Go
+
+            async func Show[T](value T) {
+                await Task.Delay(1)
+                Console.WriteLine(value)
+            }
+
+            func Run[T](value T) {
+                scope {
+                    go Show[T](value)
+                }
+            }
+
+            func Main() {
+                Run[int32](42)
+                Run[string]("right")
+            }
+            """;
+
+        AssertCompilesAndRuns(Source, "42\nright\n", nameof(AsyncGoInsideGenericFunctionPreservesCapturedTypeParameter));
+    }
+
+    private static void AssertCompilesAndRuns(string source, string expectedOutput, string testName)
+    {
+        var directory = Directory.CreateDirectory(
+            Path.Combine(AppContext.BaseDirectory, "issue3254", testName + "-" + Guid.NewGuid().ToString("N"))).FullName;
+        try
+        {
+            var sourcePath = Path.Combine(directory, "Probe.gs");
+            var assemblyPath = Path.Combine(directory, "Probe.dll");
+            File.WriteAllText(sourcePath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var previousOut = Console.Out;
+            var previousError = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(
+                [
+                    "/out:" + assemblyPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    sourcePath,
+                ]);
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+                Console.SetError(previousError);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc exited {compileExit}\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            using var process = Process.Start(new ProcessStartInfo("dotnet")
+            {
+                ArgumentList =
+                {
+                    "exec",
+                    "--runtimeconfig",
+                    Path.ChangeExtension(assemblyPath, ".runtimeconfig.json"),
+                    assemblyPath,
+                },
+                WorkingDirectory = directory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            }) ?? throw new InvalidOperationException("Failed to start dotnet exec.");
+
+            var stdoutTask = process.StandardOutput.ReadToEndAsync();
+            var stderrTask = process.StandardError.ReadToEndAsync();
+            Assert.True(process.WaitForExit(30_000), "dotnet exec timed out.");
+            var stdout = stdoutTask.GetAwaiter().GetResult().Replace("\r\n", "\n", StringComparison.Ordinal);
+            var stderr = stderrTask.GetAwaiter().GetResult();
+            Assert.True(
+                process.ExitCode == 0,
+                $"dotnet exited {process.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+            Assert.Equal(expectedOutput, stdout);
+
+            IlVerifier.Verify(assemblyPath);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue3254EnclosingGenericClosureEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3254EnclosingGenericClosureEmitTests.cs
@@ -23,6 +23,9 @@ public class Issue3254EnclosingGenericClosureEmitTests
             package Issue3254.Lambda
             import System
 
+            class Thing {
+            }
+
             class Owner[T] {
                 struct Payload[U] {
                     var First T
@@ -30,18 +33,65 @@ public class Issue3254EnclosingGenericClosureEmitTests
                 }
             }
 
-            func Run[T](value Owner[T].Payload[string]) T {
+            func Run[T, U](value Owner[T].Payload[U]) {
                 let read = () -> value
-                return read().First
+                Console.WriteLine([]T{ read().First }.GetType())
+                Console.WriteLine(read().First)
+                Console.WriteLine([]U{ read().Second }.GetType())
+                Console.WriteLine(read().Second)
+            }
+
+            func ShowTypes[T, U](value Owner[T].Payload[U]) {
+                let read = () -> value
+                Console.WriteLine([]T{ read().First }.GetType())
+                Console.WriteLine([]U{ read().Second }.GetType())
             }
 
             func Main() {
-                Console.WriteLine(Run[int32](Owner[int32].Payload[string]{ First: 42, Second: "int" }))
-                Console.WriteLine(Run[string](Owner[string].Payload[string]{ First: "right", Second: "string" }))
+                Run[int32, string](Owner[int32].Payload[string]{ First: 42, Second: "right" })
+                Run[string, int32](Owner[string].Payload[int32]{ First: "left", Second: 7 })
+                ShowTypes[string, Thing](Owner[string].Payload[Thing]{ First: "ref", Second: Thing{} })
             }
             """;
 
-        AssertCompilesAndRuns(Source, "42\nright\n", nameof(LambdaCapturingNestedTypeWithEnclosingTypeParameterRuns));
+        AssertCompilesAndRuns(
+            Source,
+            "System.Int32[]\n42\nSystem.String[]\nright\n"
+                + "System.String[]\nleft\nSystem.Int32[]\n7\n"
+                + "System.String[]\nIssue3254.Lambda.Thing[]\n",
+            nameof(LambdaCapturingNestedTypeWithEnclosingTypeParameterRuns));
+    }
+
+    [Fact]
+    public void LambdaCapturingUnqualifiedNestedTypeInsideGenericClassRuns()
+    {
+        const string Source = """
+            package Issue3254.UnqualifiedLambda
+            import System
+
+            class Owner[T] {
+                struct Payload[U] {
+                    var First T
+                    var Second U
+                }
+
+                func Show(value Payload[string]) {
+                    let read = () -> value
+                    Console.WriteLine([]T{ read().First }.GetType())
+                    Console.WriteLine(read().First)
+                }
+            }
+
+            func Main() {
+                Owner[int32]{}.Show(Owner[int32].Payload[string]{ First: 42, Second: "int" })
+                Owner[string]{}.Show(Owner[string].Payload[string]{ First: "right", Second: "string" })
+            }
+            """;
+
+        AssertCompilesAndRuns(
+            Source,
+            "System.Int32[]\n42\nSystem.String[]\nright\n",
+            nameof(LambdaCapturingUnqualifiedNestedTypeInsideGenericClassRuns));
     }
 
     [Fact]
@@ -53,6 +103,7 @@ public class Issue3254EnclosingGenericClosureEmitTests
             import Gsharp.Extensions.Go
 
             func Show[T](value T) int32 {
+                Console.WriteLine([]T{ value }.GetType())
                 Console.WriteLine(value)
                 return 0
             }
@@ -63,13 +114,27 @@ public class Issue3254EnclosingGenericClosureEmitTests
                 }
             }
 
+            class Runner[T] {
+                func Run(value T) {
+                    scope {
+                        go Show[T](value)
+                    }
+                }
+            }
+
             func Main() {
                 Run[int32](42)
                 Run[string]("right")
+                Runner[int32]{}.Run(7)
+                Runner[string]{}.Run("class")
             }
             """;
 
-        AssertCompilesAndRuns(Source, "42\nright\n", nameof(GoInsideGenericFunctionPreservesCapturedTypeParameter));
+        AssertCompilesAndRuns(
+            Source,
+            "System.Int32[]\n42\nSystem.String[]\nright\n"
+                + "System.Int32[]\n7\nSystem.String[]\nclass\n",
+            nameof(GoInsideGenericFunctionPreservesCapturedTypeParameter));
     }
 
     [Fact]
@@ -83,6 +148,7 @@ public class Issue3254EnclosingGenericClosureEmitTests
 
             async func Show[T](value T) {
                 await Task.Delay(1)
+                Console.WriteLine([]T{ value }.GetType())
                 Console.WriteLine(value)
             }
 
@@ -98,7 +164,10 @@ public class Issue3254EnclosingGenericClosureEmitTests
             }
             """;
 
-        AssertCompilesAndRuns(Source, "42\nright\n", nameof(AsyncGoInsideGenericFunctionPreservesCapturedTypeParameter));
+        AssertCompilesAndRuns(
+            Source,
+            "System.Int32[]\n42\nSystem.String[]\nright\n",
+            nameof(AsyncGoInsideGenericFunctionPreservesCapturedTypeParameter));
     }
 
     private static void AssertCompilesAndRuns(string source, string expectedOutput, string testName)


### PR DESCRIPTION
## Summary

The two failures had distinct root causes:

- Nested user struct captures only scanned the struct's own type arguments. They now also collect `EnclosingTypeArguments`, so lambda display classes reify enclosing generic parameters.
- `go` display classes were synthesized as generic but their constructor, capture fields, and invoke method were referenced through bare definition handles. They now use member tokens parented by the constructed closure TypeSpec, matching ordinary lambda emission.

## Regression coverage

Added emitted-executable tests for:

- a lambda capturing `Owner[T].Payload[string]`
- synchronous generic `go`
- asynchronous generic `go` (`Func<Task>` path)

Each runs both `T = int32` and `T = string` and asserts exact output `42\nright\n`, process exit 0, and ILVerify.

Tests-only on the unfixed tree reproduced the real runtime failures:

- `BadImageFormatException: An attempt was made to load a program with an incorrect format.`
- `TypeLoadException: Could not load type 'Issue3254.Go.<go_1>\`1'`
- the async shape produced the corresponding `Issue3254.AsyncGo.<go_1>\`1` TypeLoadException

Targeted branch inversions and a bare async invoke-token mutant each made their intended runtime test fail while control rows stayed green.

## Validation

- Release nine-project suite: 15,372 passed, 4 skipped
- ILVerify gate: 123/123
- `dotnet build -c Release`: 0 warnings, 0 errors

Fixes #3254
