### PR TITLE
Correct stale interpreter test intent

### DIFF
--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1881CheckedUncheckedEmittedOracleTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1881CheckedUncheckedEmittedOracleTests.cs
@@ -1,29 +1,21 @@
-// <copyright file="Issue1881CheckedUncheckedInterpreterTests.cs" company="GSharp">
+// <copyright file="Issue1881CheckedUncheckedEmittedOracleTests.cs" company="GSharp">
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
-using System.Collections.Generic;
-using GSharp.Core.CodeAnalysis;
-using GSharp.Core.CodeAnalysis.Compilation;
-using GSharp.Core.CodeAnalysis.Symbols;
-using GSharp.Core.CodeAnalysis.Syntax;
-using GSharp.Core.CodeAnalysis.Text;
 using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 
 /// <summary>
-/// Issue #1881: interpreter counterpart of
-/// <see cref="GSharp.Core.Tests.CodeAnalysis.Emit.Issue1881CheckedUncheckedEmitTests"/>.
-/// Asserts the tree-walking evaluator agrees with the compiled/emitted IL for
-/// <c>checked</c>/<c>unchecked</c> expressions and blocks: overflow throws
+/// Issue #1881: emitted-oracle coverage for <c>checked</c>/<c>unchecked</c>
+/// expressions and blocks. Pins that overflow throws
 /// <see cref="System.OverflowException"/> (caught here via a G#-level
 /// try/catch, mirroring real usage) in a checked context, and wraps silently
 /// in an unchecked context (the C# project default), across signed/unsigned
 /// integer widths and narrowing conversions.
 /// </summary>
-public class Issue1881CheckedUncheckedInterpreterTests
+public class Issue1881CheckedUncheckedEmittedOracleTests
 {
     [Fact]
     public void CheckedAddition_Int32_Overflow_ThrowsOverflowException()

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2023CheckedUnaryNegationEmittedOracleTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2023CheckedUnaryNegationEmittedOracleTests.cs
@@ -1,29 +1,21 @@
-// <copyright file="Issue2023CheckedUnaryNegationInterpreterTests.cs" company="GSharp">
+// <copyright file="Issue2023CheckedUnaryNegationEmittedOracleTests.cs" company="GSharp">
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
-using System.Collections.Generic;
-using GSharp.Core.CodeAnalysis;
-using GSharp.Core.CodeAnalysis.Compilation;
-using GSharp.Core.CodeAnalysis.Symbols;
-using GSharp.Core.CodeAnalysis.Syntax;
-using GSharp.Core.CodeAnalysis.Text;
 using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 
 /// <summary>
-/// Issue #2023: interpreter counterpart of
-/// <see cref="GSharp.Core.Tests.CodeAnalysis.Emit.Issue2023CheckedUnaryNegationEmitTests"/>.
-/// Asserts the tree-walking evaluator agrees with the compiled/emitted IL for
-/// unary negation of the each width's <c>MinValue</c> inside a
+/// Issue #2023: emitted-oracle coverage for unary negation of each width's
+/// <c>MinValue</c> inside a
 /// <c>checked</c>/<c>unchecked</c> context: overflow throws
 /// <see cref="System.OverflowException"/> in a checked context and wraps
 /// silently in an unchecked context (the project default per #1881), while
 /// floating-point negation never traps regardless of context.
 /// </summary>
-public class Issue2023CheckedUnaryNegationInterpreterTests
+public class Issue2023CheckedUnaryNegationEmittedOracleTests
 {
     [Fact]
     public void CheckedNegation_Int32MinValue_ThrowsOverflowException()

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue1881CheckedUncheckedEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue1881CheckedUncheckedEmitTests.cs
@@ -19,10 +19,10 @@ namespace GSharp.Core.Tests.CodeAnalysis.Emit;
 /// <c>checked { }</c> statement translated (by cs2gs) to a plain block,
 /// silently erasing overflow-trap semantics, and <c>checked(...)</c>/
 /// <c>unchecked(...)</c> expressions had no G# equivalent whatsoever. This
-/// adds the language feature to gsc itself (syntax, binding, emission,
-/// interpreter) so cs2gs can translate faithfully. These tests exercise the
-/// compiled (emit) backend; <see cref="GSharp.Core.Tests.CodeAnalysis.Binding.Issue1881CheckedUncheckedInterpreterTests"/>
-/// exercises the interpreter and asserts the two backends agree.
+/// adds the language feature to gsc itself (syntax, binding, and emission) so
+/// cs2gs can translate faithfully. These tests execute compiled programs;
+/// <see cref="GSharp.Core.Tests.CodeAnalysis.Binding.Issue1881CheckedUncheckedEmittedOracleTests"/>
+/// pins expression and block forms through the emitted submission oracle.
 /// </summary>
 public class Issue1881CheckedUncheckedEmitTests
 {

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue2023CheckedUnaryNegationEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue2023CheckedUnaryNegationEmitTests.cs
@@ -20,8 +20,8 @@ namespace GSharp.Core.Tests.CodeAnalysis.Emit;
 /// <c>neg</c> opcode (2's-complement negation, which silently wraps
 /// <c>MinValue</c> back to itself) regardless of context. These tests
 /// exercise the compiled (emit) backend; <see
-/// cref="GSharp.Core.Tests.CodeAnalysis.Binding.Issue2023CheckedUnaryNegationInterpreterTests"/>
-/// exercises the interpreter and asserts the two backends agree.
+/// cref="GSharp.Core.Tests.CodeAnalysis.Binding.Issue2023CheckedUnaryNegationEmittedOracleTests"/>
+/// pins additional forms through the emitted submission oracle.
 /// </summary>
 public class Issue2023CheckedUnaryNegationEmitTests
 {

--- a/test/Interpreter.Tests/ParenthesizedReceiverEmittedSessionTests.cs
+++ b/test/Interpreter.Tests/ParenthesizedReceiverEmittedSessionTests.cs
@@ -1,4 +1,4 @@
-// <copyright file="ParenthesizedReceiverInterpreterTests.cs" company="GSharp">
+// <copyright file="ParenthesizedReceiverEmittedSessionTests.cs" company="GSharp">
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
@@ -10,21 +10,20 @@ namespace GSharp.Interpreter.Tests;
 
 /// <summary>
 /// ADR-0054: postfix member/index access on primary expressions. Verifies that
-/// the interpreter (a separate execution path from the emitter) evaluates
-/// member access, method calls, and indexing through a parenthesized receiver
-/// with the same results the compiled program produces.
+/// the emitted REPL session evaluates member access, method calls, and indexing
+/// through a parenthesized receiver to the exact expected value.
 /// </summary>
-public class ParenthesizedReceiverInterpreterTests
+public class ParenthesizedReceiverEmittedSessionTests
 {
     [Theory]
     [InlineData("(10 + 32).GetType()", "System.Int32")]
     [InlineData("(10 + 32).ToString()", "42")]
     [InlineData("(\"hello\").Length", "5")]
     [InlineData("([3]int32{10, 20, 30})[1]", "20")]
-    public void Interpreter_ParenthesizedReceiver_MatchesEmitter(string expr, string expectedContains)
+    public void EmittedSession_ParenthesizedReceiver_PrintsExpectedValue(string expr, string expected)
     {
         var output = RunSubmission(expr);
-        Assert.Contains(expectedContains, output);
+        Assert.Equal(expected + Environment.NewLine, output);
     }
 
     private static string RunSubmission(string text)

--- a/test/Interpreter.Tests/PrimitiveEmittedSessionTests.cs
+++ b/test/Interpreter.Tests/PrimitiveEmittedSessionTests.cs
@@ -1,4 +1,4 @@
-// <copyright file="PrimitiveInterpreterTests.cs" company="GSharp">
+// <copyright file="PrimitiveEmittedSessionTests.cs" company="GSharp">
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
@@ -9,12 +9,11 @@ using Xunit;
 namespace GSharp.Interpreter.Tests;
 
 /// <summary>
-/// Phase 5 of #142: interpreter parity for the expanded numeric
-/// primitive set. Each test feeds a snippet through the REPL and
-/// asserts that the printed value matches what the emitter produces
-/// in the equivalent compiled program.
+/// Phase 5 of #142: emitted-session coverage for the expanded numeric
+/// primitive set. Each test feeds a snippet through the REPL and pins
+/// its exact printed value.
 /// </summary>
-public class PrimitiveInterpreterTests
+public class PrimitiveEmittedSessionTests
 {
     [Theory]
     [InlineData("100L + 50L", "150")]
@@ -52,14 +51,14 @@ public class PrimitiveInterpreterTests
     [InlineData("int32(9999999999L)", "1410065407")]
 
     // Issue #1183 (C# §6.4.5.3): un-suffixed literals that exceed int32 infer
-    // a wider type and evaluate to the correct value in the tree interpreter.
+    // a wider type and evaluate to the correct value in the emitted session.
     [InlineData("4294967295", "4294967295")]
     [InlineData("5000000000", "5000000000")]
     [InlineData("18446744073709551615", "18446744073709551615")]
-    public void Interpreter_PrimitiveArithmetic_MatchesEmitter(string expr, string expectedContains)
+    public void EmittedSession_PrimitiveExpression_PrintsExpectedValue(string expr, string expected)
     {
         var output = RunSubmission(expr);
-        Assert.Contains(expectedContains, output);
+        Assert.Equal(expected + Environment.NewLine, output);
     }
 
     private static string RunSubmission(string text)


### PR DESCRIPTION
## Summary

- rename four stale interpreter-named suites to their real emitted-session or emitted-oracle paths
- strengthen 35 REPL specimens from substring checks to exact output pins
- preserve all 60 affected cases and update sibling XML documentation

Refs #3265

## Per-file verdict

- `PrimitiveInterpreterTests.cs` → `PrimitiveEmittedSessionTests.cs`: **rename, re-document, strengthen**. All 31 rows still run through `GSharpRepl`/`EmittedSessionEngine`; `Assert.Equal(expected + Environment.NewLine, output)` replaces weak `Assert.Contains`.
- `ParenthesizedReceiverInterpreterTests.cs` → `ParenthesizedReceiverEmittedSessionTests.cs`: **rename, re-document, strengthen**. All 4 rows now pin exact emitted-session output.
- `Issue1881CheckedUncheckedInterpreterTests.cs` → `Issue1881CheckedUncheckedEmittedOracleTests.cs`: **convert to explicit single-engine pin**. All 13 facts and assertions remain; only stale evaluator framing and unused evaluator-era imports are removed.
- `Issue2023CheckedUnaryNegationInterpreterTests.cs` → `Issue2023CheckedUnaryNegationEmittedOracleTests.cs`: **convert to explicit single-engine pin**. All 12 facts and assertions remain.

No test, helper, specimen, or assertion was removed. Nothing that was previously observable becomes undetected.

## RED proof

Temporarily appended `unexpected\n` to the primitive submission helper output. This mutation would survive the old substring assertion; the exact pin rejected every row:

```text
MUTANT_RC=1
Expected: "5000000000\n"
Actual:   "5000000000\nunexpected\n"
Failed: 31, Passed: 0, Total: 31
```

Restored source hash exactly, then affected tests passed 60/60. No surviving mutant is reported, so no survival positive control applies.

## Validation

- affected tests: 60 passed
- full nine-project suite: 15,368 passed, 4 skipped, 0 failed
- post-rebase affected tests: 60 passed
- stale-claim residue grep: 0 hits
- changed files outside `test/`: 0