### PR TITLE
Restore permission-boundary tense in superseded ADR

### DIFF
--- a/docs/adr/0153-interpreter-compiled-only-storage-boundary.md
+++ b/docs/adr/0153-interpreter-compiled-only-storage-boundary.md
@@ -46,7 +46,7 @@ natively. Phase 3c deleted the evaluator path and its boundary diagnostics.
 This ADR governed only the evaluator's storage-model boundary. It did not
 redefine unsafe/native language validity or CIL emission.
 
-The `unsafe` context itself remained supported. It was a permission boundary, not
+The `unsafe` context itself remained supported. It is a permission boundary, not
 a storage operation; an `unsafe` block containing only otherwise-supported
 value operations continued to evaluate normally.
 


### PR DESCRIPTION
## Summary

- restore present tense for `unsafe` as a current permission boundary in ADR-0153
- retain past tense for ADR-0152 driver behavior inside its closed “During ADR-0156 Phases 1–3b” frame

## Verification

- reread the full ADR-0152 paragraph: both semicolon-joined behavioral clauses use past tense and agree with the closed-window frame
- `git diff origin/main...HEAD --stat`: one file, one insertion, one deletion
- website search found no ADR-0152 or ADR-0153 mirror
- documentation-only change; no tests run

Fixes #3256
