### PR TITLE
Validate explicit generic calls and reified boxing

### DIFF
--- a/docs/adr/0099-lsp-nil-quick-fixes.md
+++ b/docs/adr/0099-lsp-nil-quick-fixes.md
@@ -19,7 +19,7 @@ operators through correctly:
 | ---- | ----------- | ------- |
 | `GS0154` | `DiagnosticBag.ReportWrongArgumentType` | An argument of type `T?` was passed to a parameter declared `T`. |
 | `GS0155` | `DiagnosticBag.ReportCannotConvert` | An expression of type `T?` was used where `T` was required (assignment, return value, conditional arm, …). |
-| `GS0156` | `DiagnosticBag.ReportCannotConvertImplicitly` | Same as GS0155 but an explicit conversion exists (typically the implicit-only nullable→non-nullable). |
+| `GS0156` | `DiagnosticBag.ReportCannotConvertImplicitly` | Same as GS0155 but reported from an implicit-conversion context (typically nullable→non-nullable). |
 | `GS0158` | `DiagnosticBag.ReportUnableToFindMember` | A member access `a.b` did not find `b`; when the receiver is `T?` the binder reports this rather than a dedicated "deref of nullable" message — the `Nullable<T>` projection for value types and the NRT receiver path both flow here. |
 | `GS0274` | `DiagnosticBag.ReportNilNotAssignableToNonNullableParameter` | A literal `nil` was passed to a non-nullable parameter. |
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -118,7 +118,7 @@ IDs may be given as `GS0001`, `0001`, or the bare integer `1`; all three forms a
 | GS0153 | Error | Constraint is neither an interface nor a class. | A generic type-parameter constraint must be an interface (any interface — sealed or not, generic or not;) or a base class; a value type such as a struct or enum is rejected. |
 | GS0154 | Error | Wrong argument type. | A positional argument's type does not match the parameter type. |
 | GS0155 | Error | Cannot convert type. | An explicit cast between incompatible types. |
-| GS0156 | Error | Cannot convert implicitly; explicit conversion exists. | `int x = 3.14` — an explicit cast is available but was not written. |
+| GS0156 | Error | Cannot convert implicitly. | The source value is not implicitly compatible with the required target type; provide a value of the target type instead. |
 | GS0157 | Error | Cannot find type (possibly missing import). | A package-qualified type name that resolves to nothing. |
 | GS0158 | Error | Cannot find member. | A field or property access that does not resolve. |
 | GS0159 | Error | Cannot resolve function call. | A function name does not resolve, or its nullable receiver lacks valid non-null narrowing. |

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
@@ -1704,7 +1704,9 @@ internal sealed partial class OverloadResolver
                 boundArguments[i] = conversions.BindConversion(argLoc, argument, expectedType);
             }
             else if (argument.Type != expectedType
-                && !(substitution != null && parameter.Type is TypeParameterSymbol)
+                && !(substitution != null
+                    && parameter.Type is TypeParameterSymbol
+                    && TypeSymbol.ContainsTypeParameter(expectedType))
                 && (!(substitution != null && TypeSymbol.ContainsTypeParameter(parameter.Type))
                     || (Conversion.Classify(argument.Type, expectedType).IsImplicit
                         && structuralArgumentType is not FunctionTypeSymbol)))
@@ -1731,9 +1733,10 @@ internal sealed partial class OverloadResolver
                 // (`int32 → int64`) and other representation-changing
                 // implicit conversions.
                 //
-                // Issue #3222: only a BARE erased slot (`parameter.Type is
-                // TypeParameterSymbol`, the `!!T` MVAR the emitter erases at
-                // the call boundary) is skipped.
+                // Issue #3222: only a BARE erased slot whose substituted target
+                // remains open is skipped. Once explicit substitution closes
+                // the slot, this branch must materialize conversions such as
+                // value-type boxing, matching the instance and extension paths.
                 // A parameter that merely CONTAINS a type parameter (e.g. a
                 // constructed generic interface `IHolder[T]`) emits as a real
                 // constructed slot (`IHolder<!!T>`), so a value-type argument

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
@@ -1704,9 +1704,7 @@ internal sealed partial class OverloadResolver
                 boundArguments[i] = conversions.BindConversion(argLoc, argument, expectedType);
             }
             else if (argument.Type != expectedType
-                && !(substitution != null
-                    && parameter.Type is TypeParameterSymbol
-                    && TypeSymbol.ContainsTypeParameter(expectedType))
+                && !(substitution != null && parameter.Type is TypeParameterSymbol)
                 && (!(substitution != null && TypeSymbol.ContainsTypeParameter(parameter.Type))
                     || (Conversion.Classify(argument.Type, expectedType).IsImplicit
                         && structuralArgumentType is not FunctionTypeSymbol)))
@@ -1733,10 +1731,9 @@ internal sealed partial class OverloadResolver
                 // (`int32 → int64`) and other representation-changing
                 // implicit conversions.
                 //
-                // Issue #3222: only a BARE erased slot whose substituted target
-                // remains open is skipped. Once explicit substitution closes
-                // the slot, this branch must materialize conversions such as
-                // value-type boxing, matching the instance and extension paths.
+                // Issue #3222: only a BARE erased slot (`parameter.Type is
+                // TypeParameterSymbol`, the `!!T` MVAR the emitter erases at
+                // the call boundary) is skipped.
                 // A parameter that merely CONTAINS a type parameter (e.g. a
                 // constructed generic interface `IHolder[T]`) emits as a real
                 // constructed slot (`IHolder<!!T>`), so a value-type argument

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
@@ -1643,7 +1643,7 @@ internal sealed partial class OverloadResolver
             }
 
             if (argument.Type != expectedType
-                && !(substitution != null && TypeSymbol.ContainsTypeParameter(parameter.Type))
+                && !TypeSymbol.ContainsTypeParameter(expectedType)
                 && !Conversion.Classify(argument.Type, expectedType).IsImplicit)
             {
                 // Issue #889: arrow/func literal → void-returning delegate.

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
@@ -1704,7 +1704,9 @@ internal sealed partial class OverloadResolver
                 boundArguments[i] = conversions.BindConversion(argLoc, argument, expectedType);
             }
             else if (argument.Type != expectedType
-                && !(substitution != null && parameter.Type is TypeParameterSymbol)
+                && !(substitution != null
+                    && parameter.Type is TypeParameterSymbol
+                    && TypeSymbol.ContainsTypeParameter(expectedType))
                 && (!(substitution != null && TypeSymbol.ContainsTypeParameter(parameter.Type))
                     || (Conversion.Classify(argument.Type, expectedType).IsImplicit
                         && structuralArgumentType is not FunctionTypeSymbol)))
@@ -1731,11 +1733,10 @@ internal sealed partial class OverloadResolver
                 // (`int32 → int64`) and other representation-changing
                 // implicit conversions.
                 //
-                // Issue #3222: only a BARE erased slot (`parameter.Type is
-                // TypeParameterSymbol`, the `!!T` MVAR the emitter erases at
-                // the call boundary) is skipped — mirroring the equivalent
-                // guard in `BindUserInstanceCall`'s per-argument loop
-                // (`if (paramType is TypeParameterSymbol) { …; continue; }`).
+                // Issue #3222: only a BARE erased slot whose substituted target
+                // remains open is skipped. Once explicit substitution closes
+                // the slot, this branch must materialize conversions such as
+                // value-type boxing, matching the instance and extension paths.
                 // A parameter that merely CONTAINS a type parameter (e.g. a
                 // constructed generic interface `IHolder[T]`) emits as a real
                 // constructed slot (`IHolder<!!T>`), so a value-type argument

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Invocations.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Invocations.cs
@@ -1146,7 +1146,9 @@ internal sealed partial class OverloadResolver
         for (var i = 0; i < permutedArguments.Length; i++)
         {
             var paramType = extension.Parameters[i + 1].Type;
-            if (substitution != null && TypeSymbol.ContainsTypeParameter(paramType))
+            var expectedType = substitution != null ? substituteType(paramType, substitution) : paramType;
+            if (substitution != null
+                && TypeSymbol.ContainsTypeParameter(paramType))
             {
                 if (paramType is FunctionTypeSymbol openFunctionParameter
                     && tryGetFunctionLiteral(permutedArguments[i], out var functionLiteralArgument))
@@ -1160,17 +1162,18 @@ internal sealed partial class OverloadResolver
                     continue;
                 }
 
-                // A parameter typed as an open T is encoded as System.Object in
-                // the emitted signature; pass the argument unconverted so the
-                // emitter inserts box / unbox.any around the erased boundary.
-                convertedArgs.Add(permutedArguments[i]);
+                if (TypeSymbol.ContainsTypeParameter(expectedType))
+                {
+                    // A parameter typed as an open T is encoded as System.Object in
+                    // the emitted signature; pass the argument unconverted so the
+                    // emitter inserts box / unbox.any around the erased boundary.
+                    convertedArgs.Add(permutedArguments[i]);
+                    continue;
+                }
             }
-            else
-            {
-                var expectedType = substitution != null ? substituteType(paramType, substitution) : paramType;
-                var argLoc = i < permutedSyntax.Length ? permutedSyntax[i].Location : ce.Location;
-                convertedArgs.Add(conversions.BindCallArgumentWithRefKind(argLoc, permutedArguments[i], expectedType, extension.Parameters[i + 1]));
-            }
+
+            var argLoc = i < permutedSyntax.Length ? permutedSyntax[i].Location : ce.Location;
+            convertedArgs.Add(conversions.BindCallArgumentWithRefKind(argLoc, permutedArguments[i], expectedType, extension.Parameters[i + 1]));
         }
 
         // Issue #1931: stash the extension function's own (explicit or
@@ -1509,6 +1512,7 @@ internal sealed partial class OverloadResolver
         {
             var parameter = method.Parameters[i + parameterOffset];
             var paramType = parameter.Type;
+            var expectedType = substitution != null ? substituteType(paramType, substitution) : paramType;
 
             // ADR-0060 / issue #1133: an inline-decl `out var n` / `out let n` /
             // `out _` was bound with TypeSymbol.Error in the first pass (from
@@ -1537,13 +1541,11 @@ internal sealed partial class OverloadResolver
             // An argument bound to an open type parameter is left untouched —
             // the emitter boxes value types at the call boundary (the parameter
             // is encoded as System.Object under the type-erased model).
-            if (paramType is TypeParameterSymbol)
+            if (paramType is TypeParameterSymbol && TypeSymbol.ContainsTypeParameter(expectedType))
             {
                 convertedArgs.Add(permutedArguments[i]);
                 continue;
             }
-
-            var expectedType = substitution != null ? substituteType(paramType, substitution) : paramType;
 
             if (substitution != null
                 && tryGetFunctionLiteral(permutedArguments[i], out var functionLiteralArgument))

--- a/src/Core/CodeAnalysis/DiagnosticDescriptors.cs
+++ b/src/Core/CodeAnalysis/DiagnosticDescriptors.cs
@@ -72,7 +72,7 @@ internal static class DiagnosticDescriptors
     internal static readonly DiagnosticDescriptor ConstraintNotInterface = new("GS0153", DiagnosticSeverity.Error, "Type '{0}' cannot be used as a type-parameter constraint because it is neither an interface nor a class.");
     internal static readonly DiagnosticDescriptor WrongArgumentType = new("GS0154", DiagnosticSeverity.Error, "Parameter '{0}' requires a value of type '{1}' but was given a value of type '{2}'.");
     internal static readonly DiagnosticDescriptor CannotConvert = new("GS0155", DiagnosticSeverity.Error, "Cannot convert type '{0}' to '{1}'.");
-    internal static readonly DiagnosticDescriptor CannotConvertImplicitly = new("GS0156", DiagnosticSeverity.Error, "Cannot convert type '{0}' to '{1}'. An explicit conversion exists (are you missing a cast?)");
+    internal static readonly DiagnosticDescriptor CannotConvertImplicitly = new("GS0156", DiagnosticSeverity.Error, "Cannot convert type '{0}' to '{1}'. Provide a value of type '{1}' instead.");
     internal static readonly DiagnosticDescriptor UnableToFindType = new("GS0157", DiagnosticSeverity.Error, "Cannot find type {0}. Are you missing an import?");
     internal static readonly DiagnosticDescriptor UnableToFindMember = new("GS0158", DiagnosticSeverity.Error, "Cannot find member {0}.");
     internal static readonly DiagnosticDescriptor UnableToFindFunction = new("GS0159", DiagnosticSeverity.Error, "{0}");

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2851GenericDiagnosticDisplayTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2851GenericDiagnosticDisplayTests.cs
@@ -213,10 +213,10 @@ public class Issue2851GenericDiagnosticDisplayTests
         Assert.Collection(
             bag,
             diagnostic => Assert.Equal(
-                "Cannot convert type 'Box[int32]' to 'Box[int32]?'. An explicit conversion exists (are you missing a cast?)",
+                "Cannot convert type 'Box[int32]' to 'Box[int32]?'. Provide a value of type 'Box[int32]?' instead.",
                 diagnostic.Message),
             diagnostic => Assert.Equal(
-                "Cannot convert type 'Conv[int32]?' to 'Conv[int32]'. An explicit conversion exists (are you missing a cast?)",
+                "Cannot convert type 'Conv[int32]?' to 'Conv[int32]'. Provide a value of type 'Conv[int32]' instead.",
                 diagnostic.Message));
     }
 
@@ -232,7 +232,7 @@ public class Issue2851GenericDiagnosticDisplayTests
 
         var diagnostic = Assert.Single(bag);
         Assert.Equal(
-            "Cannot convert type 'System.Collections.Generic.List[int32]' to 'string'. An explicit conversion exists (are you missing a cast?)",
+            "Cannot convert type 'System.Collections.Generic.List[int32]' to 'string'. Provide a value of type 'string' instead.",
             diagnostic.Message);
     }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2947ImportedNestedGenericTypeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2947ImportedNestedGenericTypeTests.cs
@@ -51,7 +51,7 @@ public class Issue2947ImportedNestedGenericTypeTests
                 var error = Assert.Single(errors);
                 Assert.Equal("GS0156", error.Id);
                 Assert.Equal(
-                    "Cannot convert type 'glib.Outer[T].Color' to 'int32'. An explicit conversion exists (are you missing a cast?)",
+                    "Cannot convert type 'glib.Outer[T].Color' to 'int32'. Provide a value of type 'int32' instead.",
                     error.Message);
 
                 var function = compilation.BoundProgram.Functions.Keys.Single(symbol => symbol.Name == "Take");
@@ -82,7 +82,7 @@ public class Issue2947ImportedNestedGenericTypeTests
             Assert.Equal(
                 new[]
                 {
-                    "Cannot convert type 'glib.Outer[T].Color' to 'int32'. An explicit conversion exists (are you missing a cast?)",
+                    "Cannot convert type 'glib.Outer[T].Color' to 'int32'. Provide a value of type 'int32' instead.",
                 },
                 runtimeErrors.Select(diagnostic => diagnostic.Message));
         }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3267ExplicitGenericArgumentValidationTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3267ExplicitGenericArgumentValidationTests.cs
@@ -103,6 +103,13 @@ public class Issue3267ExplicitGenericArgumentValidationTests
         {
             """
             func Id[T](value T) T -> value
+            Id[object](41)
+            """,
+            41
+        },
+        {
+            """
+            func Id[T](value T) T -> value
             Id[int64](42)
             """,
             42L
@@ -166,6 +173,23 @@ public class Issue3267ExplicitGenericArgumentValidationTests
         Assert.Equal(expectedStart, diagnostic.Location.Span.Start);
         Assert.Equal(expectedSpan.Length, diagnostic.Location.Span.Length);
         Assert.Equal(expectedSpan, diagnostic.Location.Text.ToString(diagnostic.Location.Span));
+    }
+
+    [Fact]
+    public void ExplicitGenericArgumentMismatch_RecommendsCompatibleValue()
+    {
+        const string source = """
+            class Box {
+                func Id[T](value T) T -> value
+            }
+            Box().Id[int32]("wrong")
+            """;
+
+        var diagnostic = Assert.Single(GetErrors(source));
+
+        Assert.Equal(
+            "Cannot convert type 'string' to 'int32'. Provide a value of type 'int32' instead.",
+            diagnostic.Message);
     }
 
     [Theory]

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3267ExplicitGenericArgumentValidationTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3267ExplicitGenericArgumentValidationTests.cs
@@ -1,0 +1,190 @@
+// <copyright file="Issue3267ExplicitGenericArgumentValidationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #3267: explicitly substituted generic parameter types must be
+/// validated like their non-generic equivalents before invalid IL is emitted.
+/// </summary>
+public class Issue3267ExplicitGenericArgumentValidationTests
+{
+    public static TheoryData<string, string, string> InvalidCalls => new()
+    {
+        {
+            """
+            func Id[T](value T) T -> value
+            Id[int32]("wrong")
+            """,
+            "GS0154",
+            "\"wrong\""
+        },
+        {
+            """
+            class Box {
+                func Id[T](value T) T -> value
+            }
+            Box().Id[int32]("wrong")
+            """,
+            "GS0156",
+            "\"wrong\""
+        },
+        {
+            """
+            func (self string) IdExt[T](value T) T -> value
+            "receiver".IdExt[int32]("wrong")
+            """,
+            "GS0156",
+            "\"wrong\""
+        },
+        {
+            """
+            class Box[T](value T) {
+                prop Value T { get -> value }
+            }
+            Box[int32]("wrong").Value
+            """,
+            "GS0154",
+            "\"wrong\""
+        },
+        {
+            """
+            func First[T](first T, second T) T -> first
+            First[int32](1, "wrong")
+            """,
+            "GS0154",
+            "\"wrong\""
+        },
+        {
+            """
+            func Take[T](values []T) { }
+            Take[int32]([]string{"wrong"})
+            """,
+            "GS0154",
+            "[]string{\"wrong\"}"
+        },
+        {
+            """
+            func (self string) TakeExt[T](values []T) { }
+            "receiver".TakeExt[int32]([]string{"wrong"})
+            """,
+            "GS0155",
+            "[]string{\"wrong\"}"
+        },
+    };
+
+    public static TheoryData<string, object> ValidCalls => new()
+    {
+        {
+            """
+            func Id[T](value T) T -> value
+            Id[int32](41)
+            """,
+            41
+        },
+        {
+            """
+            func Id[T](value T) T -> value
+            Id[object]("explicit-object")
+            """,
+            "explicit-object"
+        },
+        {
+            """
+            func Id[T](value T) T -> value
+            Id[int64](42)
+            """,
+            42L
+        },
+        {
+            """
+            func Id[T](value T) T -> value
+            Id("inferred-string")
+            """,
+            "inferred-string"
+        },
+        {
+            """
+            func Keep[T class](value T) T -> value
+            Keep[string]("constrained")
+            """,
+            "constrained"
+        },
+        {
+            """
+            func First[T](first T, second T) T -> first
+            First[int64](43, 44)
+            """,
+            43L
+        },
+        {
+            """
+            class Box {
+                func Id[T](value T) T -> value
+            }
+            Box().Id[int64](45)
+            """,
+            45L
+        },
+        {
+            """
+            func (self string) IdExt[T](value T) T -> value
+            "receiver".IdExt[int64](46)
+            """,
+            46L
+        },
+        {
+            """
+            class Box[T](value T) {
+                prop Value T { get -> value }
+            }
+            Box[int64](47).Value
+            """,
+            47L
+        },
+    };
+
+    [Theory]
+    [MemberData(nameof(InvalidCalls))]
+    public void ExplicitGenericArgumentMismatch_ReportsAtArgument(string source, string expectedId, string expectedSpan)
+    {
+        var diagnostic = Assert.Single(GetErrors(source));
+        var expectedStart = source.IndexOf(expectedSpan, StringComparison.Ordinal);
+
+        Assert.Equal(expectedId, diagnostic.Id);
+        Assert.Equal(expectedStart, diagnostic.Location.Span.Start);
+        Assert.Equal(expectedSpan.Length, diagnostic.Location.Span.Length);
+        Assert.Equal(expectedSpan, diagnostic.Location.Text.ToString(diagnostic.Location.Span));
+    }
+
+    [Theory]
+    [MemberData(nameof(ValidCalls))]
+    public void CompatibleGenericArguments_CompileAndRun(string source, object expected)
+    {
+        var result = EmittedOracle.Evaluate(source);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(expected, result.Value);
+    }
+
+    private static IReadOnlyList<Diagnostic> GetErrors(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new GSharp.Core.CodeAnalysis.Compilation.Compilation(tree);
+        using var peStream = new MemoryStream();
+        return compilation.Emit(peStream).Diagnostics
+            .Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+            .ToArray();
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue3271ReifiedGenericArgumentBoxingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue3271ReifiedGenericArgumentBoxingTests.cs
@@ -1,0 +1,383 @@
+// <copyright file="Issue3271ReifiedGenericArgumentBoxingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #3271: value-type arguments passed through a reified generic slot
+/// whose call-site type argument is a reference type must be boxed before the
+/// call.
+/// </summary>
+public class Issue3271ReifiedGenericArgumentBoxingTests
+{
+    [Fact]
+    public void TopLevel_ValueTypes_BoxToObject()
+    {
+        AssertRuns(
+            """
+            package Issue3271TopObject
+            import System
+
+            struct Token { var Value int32 }
+
+            func Show[T](value T, label string) {
+                Console.WriteLine(label)
+                Console.WriteLine([]T{value}.GetType())
+                Console.WriteLine(value.GetType())
+            }
+
+            Show[object](11, "int")
+            Show[object](true, "bool")
+            Show[object](Token{Value: 7}, "struct")
+            """,
+            "int",
+            "System.Object[]",
+            "System.Int32",
+            "bool",
+            "System.Object[]",
+            "System.Boolean",
+            "struct",
+            "System.Object[]",
+            "Issue3271TopObject.Token");
+    }
+
+    [Fact]
+    public void TopLevel_ValueTypes_BoxToInterfacesAndValueType()
+    {
+        AssertRuns(
+            """
+            package Issue3271TopReferences
+            import System
+
+            interface IMark { func Code() int32; }
+            struct Mark : IMark {
+                var Value int32
+                func Code() int32 { return Value }
+            }
+
+            func Show[T](value T, label string) {
+                Console.WriteLine(label)
+                Console.WriteLine([]T{value}.GetType())
+                Console.WriteLine(value.GetType())
+            }
+
+            Show[IComparable](21, "imported-interface")
+            Show[IMark](Mark{Value: 22}, "user-interface")
+            """,
+            "imported-interface",
+            "System.IComparable[]",
+            "System.Int32",
+            "user-interface",
+            "Issue3271TopReferences.IMark[]",
+            "Issue3271TopReferences.Mark");
+
+        // Issue #3280: value-type → System.ValueType is not classified yet.
+        AssertValueTypeTargetDiagnostic(
+            """
+            package Issue3271TopValueType
+            import System
+
+            func Show[T](value T) { }
+
+            Show[ValueType](23)
+            """,
+            "GS0154",
+            "23");
+    }
+
+    [Fact]
+    public void GenericInstanceMethod_BoxesReferenceTargets()
+    {
+        AssertRuns(
+            """
+            package Issue3271Instance
+            import System
+
+            class Runner {
+                init() {}
+
+                func Show[T](value T, label string) {
+                    Console.WriteLine(label)
+                    Console.WriteLine([]T{value}.GetType())
+                    Console.WriteLine(value.GetType())
+                }
+            }
+
+            let runner = Runner()
+            runner.Show[object](31, "object")
+            runner.Show[IComparable](32, "interface")
+            """,
+            "object",
+            "System.Object[]",
+            "System.Int32",
+            "interface",
+            "System.IComparable[]",
+            "System.Int32");
+
+        // Issue #3280: value-type → System.ValueType is not classified yet.
+        AssertValueTypeTargetDiagnostic(
+            """
+            package Issue3271InstanceValueType
+            import System
+
+            class Runner {
+                init() {}
+                func Show[T](value T) { }
+            }
+
+            Runner().Show[ValueType](33)
+            """,
+            "GS0155",
+            "33");
+    }
+
+    [Fact]
+    public void GenericExtensionMethod_BoxesReferenceTargets()
+    {
+        AssertRuns(
+            """
+            package Issue3271Extension
+            import System
+
+            func (self string) Show[T](value T, label string) {
+                Console.WriteLine(self + ":" + label)
+                Console.WriteLine([]T{value}.GetType())
+                Console.WriteLine(value.GetType())
+            }
+
+            "extension".Show[object](41, "object")
+            "extension".Show[IComparable](42, "interface")
+            """,
+            "extension:object",
+            "System.Object[]",
+            "System.Int32",
+            "extension:interface",
+            "System.IComparable[]",
+            "System.Int32");
+
+        // Issue #3280: value-type → System.ValueType is not classified yet.
+        AssertValueTypeTargetDiagnostic(
+            """
+            package Issue3271ExtensionValueType
+            import System
+
+            func (self string) Show[T](value T) { }
+
+            "extension".Show[ValueType](43)
+            """,
+            "GS0155",
+            "43");
+    }
+
+    [Fact]
+    public void ConstructedGenericOwner_InstanceMethods_BoxReferenceTargets()
+    {
+        AssertRuns(
+            """
+            package Issue3271Owner
+            import System
+
+            class Box[T](_seed T) {
+                func Show(value T, label string) {
+                    Console.WriteLine(label)
+                    Console.WriteLine([]T{value}.GetType())
+                    Console.WriteLine(value.GetType())
+                }
+            }
+
+            open class Base[T] {
+                init() {}
+                func Show(value T, label string) {
+                    Console.WriteLine(label)
+                    Console.WriteLine([]T{value}.GetType())
+                    Console.WriteLine(value.GetType())
+                }
+            }
+
+            class Derived : Base[object] {
+                init() : base() {}
+            }
+
+            struct Outer[T] {
+                struct Middle {
+                    func Show(value T, label string) {
+                        Console.WriteLine(label)
+                        Console.WriteLine([]T{value}.GetType())
+                        Console.WriteLine(value.GetType())
+                    }
+                }
+            }
+
+            Box[object]("seed").Show(51, "direct")
+            Derived().Show(52, "inherited")
+            let middle = default(Outer[object].Middle)
+            middle.Show(53, "nested")
+            """,
+            "direct",
+            "System.Object[]",
+            "System.Int32",
+            "inherited",
+            "System.Object[]",
+            "System.Int32",
+            "nested",
+            "System.Object[]",
+            "System.Int32");
+    }
+
+    [Fact]
+    public void NullableReferenceTypeArgument_StillBoxesValue()
+    {
+        AssertRuns(
+            """
+            package Issue3271NullableReference
+            import System
+
+            func Show[T](value T) {
+                Console.WriteLine([]T{value}.GetType())
+                Console.WriteLine(value.GetType())
+            }
+
+            Show[object?](61)
+            """,
+            "System.Object[]",
+            "System.Int32");
+    }
+
+    [Fact]
+    public void ReifiedTypeArgumentOrder_IsNotErasedOrTransposed()
+    {
+        AssertRuns(
+            """
+            package Issue3271Order
+            import System
+
+            func Pair[A, B](a A, b B) {
+                Console.WriteLine([]A{a}.GetType())
+                Console.WriteLine([]B{b}.GetType())
+                Console.WriteLine(a.GetType())
+                Console.WriteLine(b.GetType())
+            }
+
+            Pair[object, string](71, "right")
+            Pair[string, object]("left", 72)
+            """,
+            "System.Object[]",
+            "System.String[]",
+            "System.Int32",
+            "System.String",
+            "System.String[]",
+            "System.Object[]",
+            "System.String",
+            "System.Int32");
+    }
+
+    [Fact]
+    public void ValueTypeTargets_StayUnboxed()
+    {
+        AssertRuns(
+            """
+            package Issue3271ValueTargets
+            import System
+
+            func Unconstrained[T](value T) {
+                Console.WriteLine([]T{value}.GetType())
+            }
+
+            func Constrained[T struct](value T) {
+                Console.WriteLine([]T{value}.GetType())
+            }
+
+            func NullableArgument[T](value T) {
+                Console.WriteLine([]T{value}.GetType())
+            }
+
+            func NullableParameter[T struct](value T?) {
+                Console.WriteLine([]T?{value}.GetType())
+                Console.WriteLine(value!!)
+            }
+
+            Unconstrained[int32](81)
+            Constrained[int32](82)
+            var nullable int32? = 83
+            NullableArgument[int32?](nullable)
+            NullableParameter[int32](nullable)
+            """,
+            "System.Int32[]",
+            "System.Int32[]",
+            "System.Nullable`1[System.Int32][]",
+            "System.Nullable`1[System.Int32][]",
+            "83");
+    }
+
+    [Fact]
+    public void ExistingSharedAndReferencePaths_StayCorrect()
+    {
+        AssertRuns(
+            """
+            package Issue3271Controls
+            import System
+
+            interface IMark { func Code() int32; }
+            class Mark : IMark {
+                init() {}
+                func Code() int32 { return 91 }
+            }
+
+            class Runner {
+                shared {
+                    func Show[T](value T) {
+                        Console.WriteLine([]T{value}.GetType())
+                        Console.WriteLine(value.GetType())
+                    }
+                }
+            }
+
+            func Show[T](value T) {
+                Console.WriteLine([]T{value}.GetType())
+                Console.WriteLine(value.GetType())
+            }
+
+            Runner.Show[object](91)
+            Runner.Show[IComparable](92)
+            Show[object]("right")
+            Show[IMark](Mark())
+            """,
+            "System.Object[]",
+            "System.Int32",
+            "System.IComparable[]",
+            "System.Int32",
+            "System.Object[]",
+            "System.String",
+            "Issue3271Controls.IMark[]",
+            "Issue3271Controls.Mark");
+    }
+
+    private static void AssertRuns(string source, params string[] expectedLines)
+    {
+        var result = EmittedOracle.Evaluate(source);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(0, result.ExitCode);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(string.Empty, result.ErrorOutput);
+        Assert.Equal(
+            string.Join(Environment.NewLine, expectedLines) + Environment.NewLine,
+            result.Output);
+    }
+
+    private static void AssertValueTypeTargetDiagnostic(string source, string expectedId, string expectedText)
+    {
+        var result = EmittedOracle.Evaluate(source);
+        var diagnostic = Assert.Single(result.Diagnostics);
+
+        Assert.Equal(expectedId, diagnostic.Id);
+        Assert.Equal(expectedText, diagnostic.Location.Text.ToString(diagnostic.Location.Span));
+        Assert.Equal(1, result.ExitCode);
+        Assert.Equal(string.Empty, result.Output);
+    }
+}

--- a/test/Interpreter.Tests/Issue2947ImportedNestedGenericDriverTests.cs
+++ b/test/Interpreter.Tests/Issue2947ImportedNestedGenericDriverTests.cs
@@ -77,8 +77,8 @@ public class Issue2947ImportedNestedGenericDriverTests
 
     private static readonly string[] ExpectedDiagnostics =
     {
-        "Cannot convert type 'glib.Outer[T].Color?' to 'glib.Outer[T].Color'. An explicit conversion exists (are you missing a cast?)",
-        "Cannot convert type 'glib.Outer[T].Color' to 'int32'. An explicit conversion exists (are you missing a cast?)",
+        "Cannot convert type 'glib.Outer[T].Color?' to 'glib.Outer[T].Color'. Provide a value of type 'glib.Outer[T].Color' instead.",
+        "Cannot convert type 'glib.Outer[T].Color' to 'int32'. Provide a value of type 'int32' instead.",
     };
 
     [Fact]

--- a/website/docs/ref/diagnostics.md
+++ b/website/docs/ref/diagnostics.md
@@ -118,7 +118,7 @@ IDs may be given as `GS0001`, `0001`, or the bare integer `1`; all three forms a
 | GS0153 | Error | Constraint is neither an interface nor a class. | A generic type-parameter constraint must be an interface (any interface — sealed or not, generic or not;) or a base class; a value type such as a struct or enum is rejected. |
 | GS0154 | Error | Wrong argument type. | A positional argument's type does not match the parameter type. |
 | GS0155 | Error | Cannot convert type. | An explicit cast between incompatible types. |
-| GS0156 | Error | Cannot convert implicitly; explicit conversion exists. | `int x = 3.14` — an explicit cast is available but was not written. |
+| GS0156 | Error | Cannot convert implicitly. | The source value is not implicitly compatible with the required target type; provide a value of the target type instead. |
 | GS0157 | Error | Cannot find type (possibly missing import). | A package-qualified type name that resolves to nothing. |
 | GS0158 | Error | Cannot find member. | A field or property access that does not resolve. |
 | GS0159 | Error | Cannot resolve function call. | A function name does not resolve, or its nullable receiver lacks valid non-null narrowing. |


### PR DESCRIPTION
## Summary

- validate closed substituted parameter types in free, instance, and extension generic calls
- materialize implicit conversions once an explicitly substituted bare generic slot is closed, including value-type boxing to `object`, interfaces, and nullable reference targets
- preserve genuinely open generic forwarding by skipping only bare slots whose substituted target still contains a type parameter
- replace misleading GS0156 cast advice and correct the stale free/instance mirror comment
- port nine runtime requirements from closed PR #3277

## Behavior

| shape | before | after |
|---|---|---|
| free `Id[int32]("wrong")` | compile rc 0; run rc 134 | `GS0154` at `"wrong"` |
| instance generic mismatch | compile rc 0; run rc 134 | `GS0156` at `"wrong"` |
| extension generic mismatch | compile rc 0; run rc 134 | `GS0156` at `"wrong"` |
| free `Show[object](42)` | compile rc 0; run rc 134 | run rc 0; runtime type `System.Int32`; value `42` |
| instance / extension / shared boxing | invalid program in affected paths | compile and run rc 0 |

Constructor and shared mismatch paths already used substitution-aware validation and remain unchanged.

## ValueType boundary

Issue #3280 tracks missing value-type → `System.ValueType` conversion classification. Ported rows retain that requirement as current diagnostic pins: `GS0154` for free calls and `GS0155` for instance/extension calls, including exact covered argument text. This PR does not change that conversion.

## GS0156 guidance

GS0156 now says `Provide a value of type 'int32' instead.` Following it with `Box().Id[int32](5)` compiles rc 0, runs rc 0, and prints:

```
System.Int32
5
```

The old suggested cast produced GS9998 and is no longer recommended.

## Mutation proof

Reverting only the closed-slot predicate moved `GSharp.Core.dll`:

```
5ca986f821cd20ff5da360490885c403
→ 8b354d3c5b430ac5dfde535d58514d93
→ 5ca986f821cd20ff5da360490885c403
```

Three free-function pins failed with `InvalidProgramException`. Standalone `object`, `IComparable`, and `object?` probes each compiled rc 0 with zero diagnostics, then ran rc 134. Restoring via `git checkout HEAD -- <path>` returned `git diff HEAD` rc 0 and all nine ported tests passed.

## Validation

- rebased onto `7341a6e688b6d4f1602dfaead0aca6fb1004e093`
- Release solution build: 0 warnings, 0 errors
- issue #3267 focused tests: 18/18 passed
- issue #3271 ported tests: 9/9 passed
- full nine-project suite: 15,416 passed, 4 skipped, 0 failed

Fixes #3267

Fixes #3271
