### PR TITLE
Anchor driver-level GS9998 diagnostics

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -1200,7 +1200,11 @@ run as real CLR finalizers on every driver.
 
 ## Internal compiler error details (GS9998)
 
-`GS9998` is the *silent emit failure* diagnostic. It is always anchored at the user's source file at the location of the expression or statement that triggered the failure. If you ever see `GS9998` anchored at `(1,1,1,1)` against `gsc.dll` instead of your source file, that itself is a bug — please file an issue.
+`GS9998` is the *silent emit failure* diagnostic. When the compiler can recover
+the responsible expression or statement, it reports that source file and span.
+When no trustworthy source anchor exists, it reports `error GS9998: ...`
+without a file or coordinates. A `GS9998` anchored at `(1,1,1,1)` against
+`gsc.dll` or an arbitrary source file is itself a bug — please file an issue.
 
 The message format is `<ExceptionType>: <description>`, for example `InvalidOperationException: Variable 'x' has no local slot`. This tells you what the compiler was trying to do when it failed, even though the underlying bug may not be your fault.
 

--- a/src/Compiler/Program.cs
+++ b/src/Compiler/Program.cs
@@ -192,11 +192,9 @@ public class Program
         catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
         {
             // 6.2 SilentEmitFailure invariant (outer ring): any exception
-            // that escapes Compilation.Emit or the compilation setup is
-            // formatted as a canonical GS9998 diagnostic line on stdout so
-            // the SDK BuildTask regex matches it and the IDE error pane
-            // navigates to the source file.
-            return ReportUnhandledException(ex, parsed);
+            // that escapes Compilation.Emit or compilation setup becomes a
+            // GS9998 on stdout, using a carried source anchor when available.
+            return ReportUnhandledException(ex);
         }
     }
 
@@ -261,6 +259,17 @@ public class Program
         return tokens;
     }
 
+    internal static int ReportUnhandledException(Exception ex)
+    {
+        Console.Out.WriteDiagnostics(new[] { Compilation.CreateInternalErrorDiagnostic(ex) });
+        if (System.Environment.GetEnvironmentVariable("GS_DEBUG_STACK") != null)
+        {
+            Console.Out.WriteLine(ex.ToString());
+        }
+
+        return Error;
+    }
+
     private static int ReportFatalIOError(Exception ex)
     {
         // Emit in the csc-compatible "gsc: error GS9997: <message>" form so
@@ -268,27 +277,6 @@ public class Program
         // MSBuild error rather than an opaque process crash.
         var descriptor = DiagnosticDescriptors.FatalCompilerIOError;
         Console.Error.WriteLine($"gsc: error {descriptor.Id}: {string.Format(descriptor.MessageFormat, ex.Message)}");
-        return Error;
-    }
-
-    private static int ReportUnhandledException(Exception ex, CommandLineArgs parsed)
-    {
-        // 6.2 SilentEmitFailure invariant (outer ring): format the exception
-        // as a canonical diagnostic line so the SDK BuildTask regex matches.
-        // Anchor at the first source file when available.
-        var file = parsed?.SourceFiles?.Count > 0
-            ? Path.GetFullPath(parsed.SourceFiles[0])
-            : "gsc";
-
-        var typeName = ex.GetType().Name;
-        var message = $"{typeName}: {ex.Message}";
-
-        Console.Out.WriteLine($"{file}(1,1,1,1): error GS9998: {message}");
-        if (System.Environment.GetEnvironmentVariable("GS_DEBUG_STACK") != null)
-        {
-            Console.Out.WriteLine(ex.ToString());
-        }
-
         return Error;
     }
 

--- a/src/Core/CodeAnalysis/Compilation/Compilation.cs
+++ b/src/Core/CodeAnalysis/Compilation/Compilation.cs
@@ -398,7 +398,7 @@ public class Compilation
         }
         catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
         {
-            var diagnostic = BuildEmitFailureDiagnostic(ex);
+            var diagnostic = CreateInternalErrorDiagnostic(ex);
             var combined = allWarnings.Add(diagnostic);
             return new EmitResult(success: false, combined);
         }
@@ -547,7 +547,7 @@ public class Compilation
             // type) produces a structured GS9998 diagnostic anchored at the
             // offending source construct. Previously this only caught
             // NotSupportedException and InvalidOperationException (#519).
-            var diagnostic = BuildEmitFailureDiagnostic(ex);
+            var diagnostic = CreateInternalErrorDiagnostic(ex);
             var combined = allWarnings.Add(diagnostic);
             return new EmitResult(success: false, combined);
         }
@@ -567,37 +567,25 @@ public class Compilation
     public EmitResult Emit(Stream peStream, Stream refStream) =>
         Emit(peStream, pdbStream: null, refStream, docStream: null, assemblyName: null);
 
-    // Issue #519 + 6.2 SilentEmitFailure invariant: anchor the synthetic
-    // GS9998 at the best available source location. Preference order:
-    // 1. EmitDiagnosticException.Anchor (precise node that triggered the failure)
-    // 2. First syntax tree root (file-level fallback)
-    // 3. File-named empty SourceText (guarantees the SDK regex matches)
-    // The message includes the exception type name so the user can distinguish
-    // different ICE flavors without needing a stack trace.
-    private Diagnostic BuildEmitFailureDiagnostic(Exception ex)
+    /// <summary>
+    /// Creates a GS9998 diagnostic for an unexpected compiler exception.
+    /// </summary>
+    /// <param name="ex">The exception that escaped the compiler pipeline.</param>
+    /// <returns>
+    /// A diagnostic anchored at an <see cref="EmitDiagnosticException"/> source
+    /// node when available; otherwise a location-less diagnostic.
+    /// </returns>
+    internal static Diagnostic CreateInternalErrorDiagnostic(Exception ex)
     {
-        // Unwrap EmitDiagnosticException to get the original exception type
-        // name in the message and the precise anchor.
-        var anchor = (ex as Emit.EmitDiagnosticException)?.Anchor
-            ?? (ex.InnerException as Emit.EmitDiagnosticException)?.Anchor;
+        ArgumentNullException.ThrowIfNull(ex);
 
-        TextLocation location;
-        if (anchor != null)
-        {
-            location = new TextLocation(anchor.SyntaxTree.Text, anchor.Span);
-        }
-        else
-        {
-            var firstTree = SyntaxTrees.FirstOrDefault();
-            var sourceText = firstTree?.Text
-                ?? SourceText.From(string.Empty, fileName: "gsc");
-            location = new TextLocation(sourceText, new TextSpan(0, 0));
-        }
-
-        // Build the message: include the root-cause exception type and message.
-        var rootEx = ex is Emit.EmitDiagnosticException ede && ede.InnerException != null
-            ? ede.InnerException
-            : ex;
+        var emitException = ex as Emit.EmitDiagnosticException
+            ?? ex.InnerException as Emit.EmitDiagnosticException;
+        var anchor = emitException?.Anchor;
+        var location = anchor is null
+            ? default
+            : new TextLocation(anchor.SyntaxTree.Text, anchor.Span);
+        var rootEx = emitException?.InnerException ?? ex;
         var typeName = rootEx.GetType().Name;
         var message = $"{typeName}: {rootEx.Message}";
 

--- a/src/Core/CodeAnalysis/Compilation/Compilation.cs
+++ b/src/Core/CodeAnalysis/Compilation/Compilation.cs
@@ -579,13 +579,21 @@ public class Compilation
     {
         ArgumentNullException.ThrowIfNull(ex);
 
-        var emitException = ex as Emit.EmitDiagnosticException
-            ?? ex.InnerException as Emit.EmitDiagnosticException;
-        var anchor = emitException?.Anchor;
+        Emit.EmitDiagnosticException anchoredException = null;
+        var rootEx = ex;
+        for (var current = ex; current is not null; current = current.InnerException)
+        {
+            rootEx = current;
+            if (current is Emit.EmitDiagnosticException { Anchor: not null } emitException)
+            {
+                anchoredException = emitException;
+            }
+        }
+
+        var anchor = anchoredException?.Anchor;
         var location = anchor is null
             ? default
             : new TextLocation(anchor.SyntaxTree.Text, anchor.Span);
-        var rootEx = emitException?.InnerException ?? ex;
         var typeName = rootEx.GetType().Name;
         var message = $"{typeName}: {rootEx.Message}";
 

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -18,6 +18,7 @@
     <InternalsVisibleTo Include="GSharp.Interpreter.Tests" />
     <InternalsVisibleTo Include="GSharp.LanguageServer" />
     <InternalsVisibleTo Include="gsc" />
+    <InternalsVisibleTo Include="gsi" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Repl/Program.cs
+++ b/src/Repl/Program.cs
@@ -173,13 +173,7 @@ public static class Program
         }
         catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
         {
-            // 6.2 SilentEmitFailure invariant, gsi edition: a compiler
-            // exception that escapes the emit pipeline (e.g. #3183) must
-            // surface as gsc's canonical GS9998 line rather than a raw
-            // driver crash. User-code exceptions never reach here — the
-            // host reports those via UnhandledException below.
-            Console.Error.WriteLine($"{scriptPath}(1,1,1,1): error GS9998: {ex.GetType().Name}: {ex.Message}");
-            return 1;
+            return ReportUnhandledException(ex);
         }
         if (result.Diagnostics.Any())
         {
@@ -200,6 +194,12 @@ public static class Program
         }
 
         return result.ExitCode;
+    }
+
+    internal static int ReportUnhandledException(Exception ex)
+    {
+        Console.Error.WriteDiagnostics(new[] { Compilation.CreateInternalErrorDiagnostic(ex) });
+        return 1;
     }
 
     /// <summary>

--- a/src/Sdk/Gsharp.NET.Sdk/BuildTask.cs
+++ b/src/Sdk/Gsharp.NET.Sdk/BuildTask.cs
@@ -29,7 +29,7 @@ public class BuildTask : Microsoft.Build.Utilities.Task, ICancelableTask
     /// </summary>
     private static readonly System.Text.RegularExpressions.Regex DiagnosticLine =
         new(
-            @"^(?:(?<file>[^(]+)\((?<l1>\d+),(?<c1>\d+)(?:,(?<l2>\d+),(?<c2>\d+))?\):\s*)?(?<sev>error|warning|info)\s+(?<code>[^:]+):\s*(?<msg>.*)$",
+            @"^(?:(?<file>[^(]+)\((?<l1>\d+),(?<c1>\d+)(?:,(?<l2>\d+),(?<c2>\d+))?\):\s*)?(?<sev>error|warning|info)\s+(?<code>[^:\s]+):\s*(?<msg>.*)$",
             System.Text.RegularExpressions.RegexOptions.Compiled);
 
     /// <summary>Gets or sets the full path to gsc.dll.</summary>

--- a/src/Sdk/Gsharp.NET.Sdk/BuildTask.cs
+++ b/src/Sdk/Gsharp.NET.Sdk/BuildTask.cs
@@ -23,14 +23,13 @@ public class BuildTask : Microsoft.Build.Utilities.Task, ICancelableTask
     private readonly CancellationTokenSource cts = new();
 
     /// <summary>
-    /// Matches gsc's canonical diagnostic header line
-    /// <c>file(startLine,startCol,endLine,endCol): error|warning|info CODE: message</c>
-    /// so it can be re-emitted through the MSBuild logger with structured
-    /// location, code, and severity. End line/column are optional.
+    /// Matches gsc's canonical diagnostic header line, with or without source
+    /// coordinates, so every diagnostic can be re-emitted through the MSBuild
+    /// logger with structured code and severity. End line/column are optional.
     /// </summary>
     private static readonly System.Text.RegularExpressions.Regex DiagnosticLine =
         new(
-            @"^(?<file>[^(]+)\((?<l1>\d+),(?<c1>\d+)(?:,(?<l2>\d+),(?<c2>\d+))?\):\s*(?<sev>error|warning|info)\s+(?<code>[^:]+):\s*(?<msg>.*)$",
+            @"^(?:(?<file>[^(]+)\((?<l1>\d+),(?<c1>\d+)(?:,(?<l2>\d+),(?<c2>\d+))?\):\s*)?(?<sev>error|warning|info)\s+(?<code>[^:]+):\s*(?<msg>.*)$",
             System.Text.RegularExpressions.RegexOptions.Compiled);
 
     /// <summary>Gets or sets the full path to gsc.dll.</summary>
@@ -419,7 +418,7 @@ public class BuildTask : Microsoft.Build.Utilities.Task, ICancelableTask
     /// importance to keep default-verbosity output clean.
     /// </summary>
     /// <param name="line">A line written by gsc to standard output.</param>
-    private void LogCompilerLine(string line)
+    internal void LogCompilerLine(string line)
     {
         var match = DiagnosticLine.Match(line);
         if (!match.Success)
@@ -428,11 +427,11 @@ public class BuildTask : Microsoft.Build.Utilities.Task, ICancelableTask
             return;
         }
 
-        var file = match.Groups["file"].Value.Trim();
+        var file = match.Groups["file"].Success ? match.Groups["file"].Value.Trim() : null;
         var code = match.Groups["code"].Value.Trim();
         var message = match.Groups["msg"].Value;
-        var startLine = int.Parse(match.Groups["l1"].Value);
-        var startColumn = int.Parse(match.Groups["c1"].Value);
+        var startLine = match.Groups["l1"].Success ? int.Parse(match.Groups["l1"].Value) : 0;
+        var startColumn = match.Groups["c1"].Success ? int.Parse(match.Groups["c1"].Value) : 0;
         var endLine = match.Groups["l2"].Success ? int.Parse(match.Groups["l2"].Value) : 0;
         var endColumn = match.Groups["c2"].Success ? int.Parse(match.Groups["c2"].Value) : 0;
 

--- a/test/Compiler.Tests/ProgramSilentFailureTests.cs
+++ b/test/Compiler.Tests/ProgramSilentFailureTests.cs
@@ -49,19 +49,17 @@ public class ProgramSilentFailureTests
     }
 
     [Fact]
-    public void DiagnosticLineRegex_MatchesExpectedGS9998Format()
+    public void DiagnosticLineRegex_MatchesLocatedGS9998Format()
     {
-        // Verify the format that ReportUnhandledException produces
-        // matches the SDK BuildTask diagnostic regex.
-        var sampleLine = "/path/to/test.gs(1,1,1,1): error GS9998: InvalidOperationException: something broke";
+        var sampleLine = "/path/to/test.gs(9,5,9,16): error GS9998: InvalidOperationException: something broke";
         var match = DiagnosticLine.Match(sampleLine);
 
         Assert.True(match.Success, $"Regex should match: {sampleLine}");
         Assert.Equal("/path/to/test.gs", match.Groups["file"].Value);
-        Assert.Equal("1", match.Groups["l1"].Value);
-        Assert.Equal("1", match.Groups["c1"].Value);
-        Assert.Equal("1", match.Groups["l2"].Value);
-        Assert.Equal("1", match.Groups["c2"].Value);
+        Assert.Equal("9", match.Groups["l1"].Value);
+        Assert.Equal("5", match.Groups["c1"].Value);
+        Assert.Equal("9", match.Groups["l2"].Value);
+        Assert.Equal("16", match.Groups["c2"].Value);
         Assert.Equal("error", match.Groups["sev"].Value);
         Assert.Equal("GS9998", match.Groups["code"].Value.Trim());
         Assert.Contains("InvalidOperationException", match.Groups["msg"].Value);
@@ -135,4 +133,3 @@ public class ProgramSilentFailureTests
         }
     }
 }
-

--- a/test/Core.Tests/CodeAnalysis/Emit/SilentEmitFailureInvariantTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/SilentEmitFailureInvariantTests.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Emit;
@@ -67,12 +66,11 @@ public class SilentEmitFailureInvariantTests
     }
 
     [Fact]
-    public void BuildEmitFailureDiagnostic_WithAnchor_ProducesGS9998AtAnchorLocation()
+    public void CreateInternalErrorDiagnostic_WithAnchor_ProducesGS9998AtAnchorLocation()
     {
         var source = "package Test\n\nvar x = 1\n";
         var sourceText = SourceText.From(source, "anchor_test.gs");
         var tree = SyntaxTree.Parse(sourceText);
-        var compilation = new Compilation(tree);
 
         // The "var x = 1" statement is on line 2 (0-based).
         // Use the first statement's syntax node as anchor.
@@ -83,48 +81,31 @@ public class SilentEmitFailureInvariantTests
             anchor,
             new InvalidOperationException("unsupported node"));
 
-        // Call the private BuildEmitFailureDiagnostic via reflection
-        var method = typeof(Compilation).GetMethod(
-            "BuildEmitFailureDiagnostic",
-            BindingFlags.Instance | BindingFlags.NonPublic);
-        Assert.NotNull(method);
-
-        var diagnostic = (Diagnostic)method.Invoke(compilation, new object[] { emitEx });
+        var diagnostic = Compilation.CreateInternalErrorDiagnostic(
+            new Exception("outer wrapper", emitEx));
 
         Assert.Equal("GS9998", diagnostic.Id);
         Assert.True(diagnostic.IsError);
         Assert.Equal("anchor_test.gs", diagnostic.Location.FileName);
+        Assert.Equal(2, diagnostic.Location.StartLine);
+        Assert.Equal(0, diagnostic.Location.StartCharacter);
+        Assert.Equal(2, diagnostic.Location.EndLine);
+        Assert.Equal(9, diagnostic.Location.EndCharacter);
+        Assert.Equal("var x = 1", diagnostic.Location.Text.ToString(diagnostic.Location.Span));
         Assert.Contains("InvalidOperationException", diagnostic.Message);
         Assert.Contains("unsupported node", diagnostic.Message);
-
-        // The anchor is on line 2 (0-based), not at origin (0,0)
-        Assert.True(
-            diagnostic.Location.StartLine >= 2,
-            $"Expected line >= 2, got {diagnostic.Location.StartLine}");
     }
 
     [Fact]
-    public void BuildEmitFailureDiagnostic_WithoutAnchor_FallsBackToFirstTree()
+    public void CreateInternalErrorDiagnostic_WithoutAnchor_HasNoLocation()
     {
-        var source = "package Test\nvar x = 1\n";
-        var sourceText = SourceText.From(source, "fallback_test.gs");
-        var tree = SyntaxTree.Parse(sourceText);
-        var compilation = new Compilation(tree);
-
-        // A plain exception (not EmitDiagnosticException) should still produce GS9998
         var plainEx = new InvalidOperationException("unexpected failure");
-
-        var method = typeof(Compilation).GetMethod(
-            "BuildEmitFailureDiagnostic",
-            BindingFlags.Instance | BindingFlags.NonPublic);
-        Assert.NotNull(method);
-
-        var diagnostic = (Diagnostic)method.Invoke(compilation, new object[] { plainEx });
+        var diagnostic = Compilation.CreateInternalErrorDiagnostic(plainEx);
 
         Assert.Equal("GS9998", diagnostic.Id);
         Assert.True(diagnostic.IsError);
-        // Falls back to first tree's file name
-        Assert.Equal("fallback_test.gs", diagnostic.Location.FileName);
+        Assert.Null(diagnostic.Location.Text);
+        Assert.Null(diagnostic.Location.FileName);
         Assert.Contains("InvalidOperationException", diagnostic.Message);
     }
 
@@ -152,4 +133,3 @@ public class SilentEmitFailureInvariantTests
         Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS9998");
     }
 }
-

--- a/test/Core.Tests/CodeAnalysis/Emit/SilentEmitFailureInvariantTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/SilentEmitFailureInvariantTests.cs
@@ -97,6 +97,25 @@ public class SilentEmitFailureInvariantTests
     }
 
     [Fact]
+    public void CreateInternalErrorDiagnostic_FindsAnchorAndRootCauseThroughMultipleWrappers()
+    {
+        var sourceText = SourceText.From("var x = 1\n", "wrapped.gs");
+        var tree = SyntaxTree.Parse(sourceText);
+        var anchor = tree.Root.Members[0];
+        var rootCause = new InvalidOperationException("deep failure");
+        var emitEx = new EmitDiagnosticException("emit failure", anchor, rootCause);
+        var exception = new Exception("outer one", new Exception("outer two", emitEx));
+
+        var diagnostic = Compilation.CreateInternalErrorDiagnostic(exception);
+
+        Assert.Equal("GS9998", diagnostic.Id);
+        Assert.Equal("wrapped.gs", diagnostic.Location.FileName);
+        Assert.Equal(anchor.Span, diagnostic.Location.Span);
+        Assert.Equal("var x = 1", diagnostic.Location.Text.ToString(diagnostic.Location.Span));
+        Assert.Equal("InvalidOperationException: deep failure", diagnostic.Message);
+    }
+
+    [Fact]
     public void CreateInternalErrorDiagnostic_WithoutAnchor_HasNoLocation()
     {
         var plainEx = new InvalidOperationException("unexpected failure");

--- a/test/Interpreter.Tests/Issue3266InternalErrorSpanTests.cs
+++ b/test/Interpreter.Tests/Issue3266InternalErrorSpanTests.cs
@@ -1,0 +1,175 @@
+// <copyright file="Issue3266InternalErrorSpanTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Emit;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+using CompilerProgram = GSharp.Compiler.Program;
+using ReplProgram = GSharp.Repl.Program;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #3266: driver-level GS9998 diagnostics use source anchors carried by
+/// compiler exceptions and remain location-less when no anchor exists.
+/// </summary>
+[Collection("ConsoleIo")]
+public class Issue3266InternalErrorSpanTests
+{
+    public static IEnumerable<object[]> AnchoredFailures()
+    {
+        yield return
+        [
+            "print(string(42))\n",
+            "print(string(42))",
+            0,
+            0,
+            0,
+            17,
+            "NotSupportedException",
+            "unsupported conversion",
+        ];
+        yield return
+        [
+            """
+            func probe() {
+                var original = []int32{10, 20, 30}
+                let ref r = original[^1]
+                Console.WriteLine(r)
+            }
+            probe()
+            """,
+            "original[^1]",
+            2,
+            16,
+            2,
+            28,
+            "InvalidOperationException",
+            "unsupported address",
+        ];
+    }
+
+    [Theory]
+    [MemberData(nameof(AnchoredFailures))]
+    public void Drivers_ReportAnchoredGS9998AtResponsibleConstruct(
+        string source,
+        string construct,
+        int startLine,
+        int startCharacter,
+        int endLine,
+        int endCharacter,
+        string exceptionType,
+        string message)
+    {
+        var sourceText = SourceText.From(source, "Issue3266.gs");
+        var tree = SyntaxTree.Parse(sourceText);
+        var anchor = DescendantsAndSelf(tree.Root)
+            .First(node => sourceText.ToString(node.Span) == construct);
+        Exception innerException = exceptionType switch
+        {
+            "NotSupportedException" => new NotSupportedException(message),
+            "InvalidOperationException" => new InvalidOperationException(message),
+            _ => throw new ArgumentOutOfRangeException(nameof(exceptionType)),
+        };
+        var exception = new EmitDiagnosticException(message, anchor, innerException);
+        var diagnostic = Compilation.CreateInternalErrorDiagnostic(exception);
+
+        Assert.Equal("GS9998", diagnostic.Id);
+        Assert.Equal(startLine, diagnostic.Location.StartLine);
+        Assert.Equal(startCharacter, diagnostic.Location.StartCharacter);
+        Assert.Equal(endLine, diagnostic.Location.EndLine);
+        Assert.Equal(endCharacter, diagnostic.Location.EndCharacter);
+        Assert.Equal(construct, diagnostic.Location.Text.ToString(diagnostic.Location.Span));
+
+        var expectedHeader =
+            $"Issue3266.gs({startLine + 1},{startCharacter + 1},{endLine + 1},{endCharacter + 1}): error GS9998: {exceptionType}: {message}";
+        var gsc = Capture(() => ReportCompilerUnhandledException(exception));
+        var gsi = Capture(() => ReplProgram.ReportUnhandledException(exception));
+
+        Assert.Equal(1, gsc.ExitCode);
+        Assert.Contains(expectedHeader, gsc.Stdout, StringComparison.Ordinal);
+        Assert.Contains(construct, gsc.Stdout, StringComparison.Ordinal);
+        Assert.Empty(gsc.Stderr);
+
+        Assert.Equal(1, gsi.ExitCode);
+        Assert.Empty(gsi.Stdout);
+        Assert.Contains(expectedHeader, gsi.Stderr, StringComparison.Ordinal);
+        Assert.Contains(construct, gsi.Stderr, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Drivers_ReportLocationlessGS9998WithoutInventingCoordinates()
+    {
+        var exception = new InvalidOperationException("no source location");
+        var diagnostic = Compilation.CreateInternalErrorDiagnostic(exception);
+        var gsc = Capture(() => ReportCompilerUnhandledException(exception));
+        var gsi = Capture(() => ReplProgram.ReportUnhandledException(exception));
+
+        Assert.Equal("GS9998", diagnostic.Id);
+        Assert.Null(diagnostic.Location.Text);
+        Assert.Null(diagnostic.Location.FileName);
+
+        Assert.Equal(1, gsc.ExitCode);
+        Assert.Contains("error GS9998: InvalidOperationException: no source location", gsc.Stdout, StringComparison.Ordinal);
+        Assert.DoesNotContain("(1,1,1,1)", gsc.Stdout, StringComparison.Ordinal);
+        Assert.Empty(gsc.Stderr);
+
+        Assert.Equal(1, gsi.ExitCode);
+        Assert.Empty(gsi.Stdout);
+        Assert.Contains("error GS9998: InvalidOperationException: no source location", gsi.Stderr, StringComparison.Ordinal);
+        Assert.DoesNotContain("(1,1,1,1)", gsi.Stderr, StringComparison.Ordinal);
+    }
+
+    private static IEnumerable<SyntaxNode> DescendantsAndSelf(SyntaxNode node)
+    {
+        yield return node;
+        foreach (var child in node.GetChildren())
+        {
+            foreach (var descendant in DescendantsAndSelf(child))
+            {
+                yield return descendant;
+            }
+        }
+    }
+
+    private static int ReportCompilerUnhandledException(Exception exception)
+    {
+        var method = typeof(CompilerProgram).GetMethod(
+            "ReportUnhandledException",
+            BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        var report = method.CreateDelegate<Func<Exception, int>>();
+        return report(exception);
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) Capture(Func<int> action)
+    {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            var exitCode = action();
+            return (
+                exitCode,
+                stdout.ToString().Replace("\r\n", "\n", StringComparison.Ordinal),
+                stderr.ToString().Replace("\r\n", "\n", StringComparison.Ordinal));
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+    }
+}

--- a/test/Sdk.Tests/BuildTaskSilentFailureTests.cs
+++ b/test/Sdk.Tests/BuildTaskSilentFailureTests.cs
@@ -2,55 +2,99 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
-using System.IO;
-using System.Text.RegularExpressions;
+using System.Collections.Generic;
+using Gsharp.NET.Sdk.Tools;
+using Microsoft.Build.Framework;
 using Xunit;
 
 namespace GSharp.Sdk.Tests;
 
 /// <summary>
-/// 6.2 SilentEmitFailure invariant (boundary ring): verifies that the BuildTask
-/// diagnostic parser accepts source-anchored GS9998 headers.
+/// 6.2 SilentEmitFailure invariant (boundary ring): verifies that the real
+/// BuildTask parser logs both source-anchored and location-less GS9998 output
+/// as structured MSBuild errors.
 ///
 /// <para>
-/// Location recovery and the honest location-less fallback are covered by the
-/// driver tests; this class pins the SDK-facing located header format.
+/// Located output carries the source file and span. Location-less output keeps
+/// the compiler's error code and root-cause message without inventing a file or
+/// coordinates, and still sets <see cref="Microsoft.Build.Utilities.TaskLoggingHelper.HasLoggedErrors"/>.
 /// </para>
 /// </summary>
 public class BuildTaskSilentFailureTests
 {
-    /// <summary>
-    /// The SDK BuildTask regex for diagnostic lines.
-    /// </summary>
-    private static readonly Regex DiagnosticLine = new(
-        @"^(?<file>[^(]+)\((?<l1>\d+),(?<c1>\d+)(?:,(?<l2>\d+),(?<c2>\d+))?\):\s*(?<sev>error|warning|info)\s+(?<code>[^:]+):\s*(?<msg>.*)$",
-        RegexOptions.Compiled);
-
     [Fact]
-    public void DiagnosticLine_Regex_MatchesGS9998_WithSourceFile()
+    public void LogCompilerLine_LocatedGS9998_LogsStructuredErrorWithSourceSpan()
     {
-        // Verify that the canonical GS9998 format emitted by Program.Main's
-        // outer-ring catch matches the BuildTask's DiagnosticLine regex and
-        // carries a source-file path (not "gsc.dll").
+        var (task, engine) = CreateTask();
         var line = "/path/to/test.gs(9,5,11,1): error GS9998: InvalidOperationException: test message";
-        var match = DiagnosticLine.Match(line);
 
-        Assert.True(match.Success, "Diagnostic line should match the regex");
-        Assert.Equal("/path/to/test.gs", match.Groups["file"].Value);
-        Assert.Equal("error", match.Groups["sev"].Value);
-        Assert.Equal("GS9998", match.Groups["code"].Value.Trim());
-        Assert.Contains("InvalidOperationException", match.Groups["msg"].Value);
+        task.LogCompilerLine(line);
+
+        var error = Assert.Single(engine.Errors);
+        Assert.True(task.Log.HasLoggedErrors);
+        Assert.Equal("GS9998", error.Code);
+        Assert.Equal("/path/to/test.gs", error.File);
+        Assert.Equal(9, error.LineNumber);
+        Assert.Equal(5, error.ColumnNumber);
+        Assert.Equal(11, error.EndLineNumber);
+        Assert.Equal(1, error.EndColumnNumber);
+        Assert.Equal("InvalidOperationException: test message", error.Message);
     }
 
     [Fact]
-    public void DiagnosticLine_Regex_MatchesOldFormat_ButNewCodeNeverEmitsGscDll()
+    public void LogCompilerLine_LocationlessGS9998_LogsStructuredErrorWithoutInventedSpan()
     {
-        // The old pattern "gsc.dll(0,0,0,0): error GS9998: ..." used to surface
-        // as MSB4181. Located diagnostics now carry the source anchor instead.
-        var goodLine = "/path/to/test.gs(9,5,11,1): error GS9998: something";
-        var goodMatch = DiagnosticLine.Match(goodLine);
-        Assert.True(goodMatch.Success);
-        Assert.DoesNotContain("gsc.dll", goodMatch.Groups["file"].Value);
-        Assert.Contains(".gs", goodMatch.Groups["file"].Value);
+        var (task, engine) = CreateTask();
+        var line = "error GS9998: InvalidOperationException: no source location";
+
+        task.LogCompilerLine(line);
+
+        var error = Assert.Single(engine.Errors);
+        Assert.True(task.Log.HasLoggedErrors);
+        Assert.Equal("GS9998", error.Code);
+        Assert.True(string.IsNullOrEmpty(error.File));
+        Assert.Equal(0, error.LineNumber);
+        Assert.Equal(0, error.ColumnNumber);
+        Assert.Equal("InvalidOperationException: no source location", error.Message);
+        Assert.DoesNotContain("(1,1,1,1)", error.ToString());
+    }
+
+    private static (BuildTask Task, RecordingBuildEngine Engine) CreateTask()
+    {
+        var engine = new RecordingBuildEngine();
+        return (new BuildTask { BuildEngine = engine }, engine);
+    }
+
+    private sealed class RecordingBuildEngine : IBuildEngine
+    {
+        public List<BuildErrorEventArgs> Errors { get; } = new();
+
+        public bool ContinueOnError => false;
+
+        public int LineNumberOfTaskNode => 0;
+
+        public int ColumnNumberOfTaskNode => 0;
+
+        public string ProjectFileOfTaskNode => string.Empty;
+
+        public bool BuildProjectFile(
+            string projectFileName,
+            string[] targetNames,
+            System.Collections.IDictionary globalProperties,
+            System.Collections.IDictionary targetOutputs) => true;
+
+        public void LogCustomEvent(CustomBuildEventArgs e)
+        {
+        }
+
+        public void LogErrorEvent(BuildErrorEventArgs e) => Errors.Add(e);
+
+        public void LogMessageEvent(BuildMessageEventArgs e)
+        {
+        }
+
+        public void LogWarningEvent(BuildWarningEventArgs e)
+        {
+        }
     }
 }

--- a/test/Sdk.Tests/BuildTaskSilentFailureTests.cs
+++ b/test/Sdk.Tests/BuildTaskSilentFailureTests.cs
@@ -59,6 +59,51 @@ public class BuildTaskSilentFailureTests
         Assert.DoesNotContain("(1,1,1,1)", error.ToString());
     }
 
+    [Theory]
+    [InlineData("error handling failed: retrying")]
+    [InlineData("warning signs detected: check config")]
+    [InlineData("info about the build: nothing to do")]
+    public void LogCompilerLine_ProseIsNotClassifiedAsDiagnostic(string line)
+    {
+        var (task, engine) = CreateTask();
+
+        task.LogCompilerLine(line);
+
+        Assert.Empty(engine.Errors);
+        Assert.Empty(engine.Warnings);
+        var message = Assert.Single(engine.Messages);
+        Assert.Equal(line, message.Message);
+        Assert.Equal(MessageImportance.Low, message.Importance);
+    }
+
+    [Fact]
+    public void LogCompilerLine_WarningIsNotPromotedToError()
+    {
+        var (task, engine) = CreateTask();
+
+        task.LogCompilerLine("warning GS0001: test warning");
+
+        Assert.Empty(engine.Errors);
+        var warning = Assert.Single(engine.Warnings);
+        Assert.Equal("GS0001", warning.Code);
+        Assert.Equal("test warning", warning.Message);
+    }
+
+    [Fact]
+    public void LogCompilerLine_GS9100RemainsLowImportanceMessage()
+    {
+        var (task, engine) = CreateTask();
+        var line = "warning GS9100: advisory warning";
+
+        task.LogCompilerLine(line);
+
+        Assert.Empty(engine.Errors);
+        Assert.Empty(engine.Warnings);
+        var message = Assert.Single(engine.Messages);
+        Assert.Equal(line, message.Message);
+        Assert.Equal(MessageImportance.Low, message.Importance);
+    }
+
     private static (BuildTask Task, RecordingBuildEngine Engine) CreateTask()
     {
         var engine = new RecordingBuildEngine();
@@ -68,6 +113,10 @@ public class BuildTaskSilentFailureTests
     private sealed class RecordingBuildEngine : IBuildEngine
     {
         public List<BuildErrorEventArgs> Errors { get; } = new();
+
+        public List<BuildWarningEventArgs> Warnings { get; } = new();
+
+        public List<BuildMessageEventArgs> Messages { get; } = new();
 
         public bool ContinueOnError => false;
 
@@ -89,12 +138,8 @@ public class BuildTaskSilentFailureTests
 
         public void LogErrorEvent(BuildErrorEventArgs e) => Errors.Add(e);
 
-        public void LogMessageEvent(BuildMessageEventArgs e)
-        {
-        }
+        public void LogMessageEvent(BuildMessageEventArgs e) => Messages.Add(e);
 
-        public void LogWarningEvent(BuildWarningEventArgs e)
-        {
-        }
+        public void LogWarningEvent(BuildWarningEventArgs e) => Warnings.Add(e);
     }
 }

--- a/test/Sdk.Tests/BuildTaskSilentFailureTests.cs
+++ b/test/Sdk.Tests/BuildTaskSilentFailureTests.cs
@@ -10,16 +10,11 @@ namespace GSharp.Sdk.Tests;
 
 /// <summary>
 /// 6.2 SilentEmitFailure invariant (boundary ring): verifies that the BuildTask
-/// safety-net logic anchors at the first Compile item rather than <c>gsc.dll</c>
-/// when gsc exits non-zero without logging a structured diagnostic.
+/// diagnostic parser accepts source-anchored GS9998 headers.
 ///
 /// <para>
-/// The BuildTask cannot be instantiated in isolation without MSBuild's
-/// <c>IBuildEngine</c>. These tests exercise the observable behavior by invoking
-/// <c>Program.Main</c> directly (which is what gsc.dll does) and verifying that
-/// the diagnostic line on stdout carries the source file name. The full
-/// end-to-end BuildTask path is covered by the existing acceptance tests that
-/// drive <c>dotnet build</c> on sample projects.
+/// Location recovery and the honest location-less fallback are covered by the
+/// driver tests; this class pins the SDK-facing located header format.
 /// </para>
 /// </summary>
 public class BuildTaskSilentFailureTests
@@ -51,10 +46,7 @@ public class BuildTaskSilentFailureTests
     public void DiagnosticLine_Regex_MatchesOldFormat_ButNewCodeNeverEmitsGscDll()
     {
         // The old pattern "gsc.dll(0,0,0,0): error GS9998: ..." used to surface
-        // as MSB4181. The regex would match it, but production code (Program.Main)
-        // now uses the first source file instead. This test documents the regex
-        // capability and serves as a guard that the new invariant format is
-        // distinguishable from the old one.
+        // as MSB4181. Located diagnostics now carry the source anchor instead.
         var goodLine = "/path/to/test.gs(9,5,11,1): error GS9998: something";
         var goodMatch = DiagnosticLine.Match(goodLine);
         Assert.True(goodMatch.Success);


### PR DESCRIPTION
Fixes #3266.

## Fix

Route compiler, REPL, and emit-pipeline internal failures through one shared `Compilation.CreateInternalErrorDiagnostic` path.

- `EmitDiagnosticException.Anchor` supplies the exact syntax span when available.
- Exception chains are traversed to the innermost anchor-bearing emit exception and root cause.
- Exceptions without source context produce an honest location-less `error GS9998: ...`; no synthetic `(1,1,1,1)`.
- `BuildTask` accepts both located and location-less diagnostic headers, preserving location-less `GS9998` as a structured MSBuild error instead of triggering its synthetic fallback.
- Top-level catches remain broad and keep their existing exit behavior.

## Driver evidence

Both `gsc` and file-driven `gsi` produced the same id/span:

| origin | id + rendered span | `Location.Text.ToString(Location.Span)` |
|---|---|---|
| builtin string conversion | `GS9998 (1,1,1,18)` | `print(string(42))` |
| index-from-end ref address | `GS9998 (3,17,3,29)` | `original[^1]` |

The one-based rendering uses inclusive start/exclusive end. No-anchor failures render as `error GS9998: <ExceptionType>: <message>`, without source coordinates.

## SDK/MSBuild evidence

A temporary compiler host deliberately called the real `gsc` `ReportUnhandledException` handler with `InvalidOperationException("no source location")`; the real `BuildTask` then consumed its output through `dotnet msbuild`:

```text
MSBUILD_RC=1
build.proj(5,5): error GS9998: InvalidOperationException: no source location
```

MSBuild supplies its task-node prefix because the structured error has no file; the recorded `BuildErrorEventArgs` has an empty file and zero coordinates. Root cause remains visible, `(1,1,1,1)` is absent, and the `without emitting a structured diagnostic` safety-net message is absent.

`Sdk.Tests` no longer copies the production regex into sample-string tests. It invokes the real `BuildTask.LogCompilerLine`, records MSBuild events, and asserts code, message, file, span, and `HasLoggedErrors`. Its class contract now documents both located and location-less output.

## Wrapper measurement

`Exception("outer one") -> Exception("outer two") -> EmitDiagnosticException(anchor) -> InvalidOperationException("deep failure")` now yields:

- id: `GS9998`
- file/text: `wrapped.gs` / `var x = 1`
- message: `InvalidOperationException: deep failure`

## RED proof

Final-tree product mutants built and changed the relevant product hash:

- location-less SDK header made location mandatory: `BuildTaskSilentFailureTests` RED, 1/2 failed; SDK md5 `9ca292dc...` -> `b23b3dee...`.
- depth-1 exception unwrap restored: `SilentEmitFailureInvariantTests` RED, 1/7 failed (`wrapped.gs` became null); Core md5 `f721921f...` -> `1832a6a6...`.
- Existing six driver/factory mutants remain pinned: fabricated fallback, inverted anchor selection, root-cause loss, wrapped-anchor loss, compiler hard-coded span, and REPL hard-coded span.

Both new mutants were restored and round-tripped GREEN: Core 7/7, SDK 2/2.

## Documentation

`docs/diagnostics.md` now documents both trustworthy anchored output and honest location-less output, and identifies fabricated `(1,1,1,1)` source anchors as bugs.

## Validation

Validated after rebasing onto `main` `6b8096197` (landed #3270 changed only ADR-0153), head `bd58f1be9`:

- Nine solution test projects: **15,373 passed, 0 failed, 4 skipped** (15,377 total).
- All tests used `-c Release -p:ContinuousIntegrationBuild=true` and built normally.
- `Core`, `Compiler`, and `Repl` copies of `GSharp.Core.dll`: md5 `f721921f80187a8c1debb14cc0e3aebd`.
- `Gsharp.NET.Sdk.dll`: md5 `9ca292dca714e20ade9e1e76a2b872d7`.
- `git merge-tree --write-tree origin/main HEAD`: clean (`3a9a2bd69a9374927b63798ce326e415334614ee`).
