### PR TITLE
Fix boxing for reified generic call arguments

### DIFF
--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Calls.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Calls.cs
@@ -121,6 +121,61 @@ internal sealed partial class MethodBodyEmitter
         this.il.Token(ctorHandle);
     }
 
+    private void EmitReifiedUserCallArgument(
+        BoundExpression argument,
+        ParameterSymbol parameter,
+        ImmutableArray<TypeParameterSymbol> methodTypeParameters,
+        ImmutableArray<TypeSymbol> methodTypeArguments,
+        StructSymbol constructedOwner)
+    {
+        if (parameter.RefKind != RefKind.None)
+        {
+            this.EmitExpression(argument);
+            return;
+        }
+
+        var targetType = constructedOwner?.SubstituteMemberType(parameter.Type) ?? parameter.Type;
+        if (targetType is TypeParameterSymbol targetParameter
+            && !methodTypeArguments.IsDefault
+            && !methodTypeParameters.IsDefault
+            && methodTypeArguments.Length == methodTypeParameters.Length)
+        {
+            for (var i = 0; i < methodTypeParameters.Length; i++)
+            {
+                if (ReferenceEquals(targetParameter, methodTypeParameters[i]))
+                {
+                    targetType = methodTypeArguments[i];
+                    break;
+                }
+            }
+        }
+
+        var sourceType = argument.Type;
+        var sourceNeedsBox = ReflectionMetadataEmitter.IsValueTypeSymbol(sourceType)
+            || sourceType is TypeParameterSymbol
+            || sourceType is NullableTypeSymbol { UnderlyingType: TypeParameterSymbol };
+        var unwrappedTarget = targetType is NullableTypeSymbol nullableTarget
+            && !ReflectionMetadataEmitter.IsValueTypeNullable(nullableTarget)
+                ? nullableTarget.UnderlyingType
+                : targetType;
+        var targetClr = unwrappedTarget?.ClrType;
+        var targetAcceptsBox = targetClr?.IsSameAs(typeof(object)) == true
+            || IsInterfaceTargetType(targetType)
+            || targetClr?.IsSameAs(typeof(ValueType)) == true
+            || targetClr?.IsSameAs(typeof(Enum)) == true;
+
+        if (sourceNeedsBox && targetAcceptsBox)
+        {
+            // Match the already-working shared-method path: materialize the
+            // same conversion node so canonical conversion emission supplies
+            // the required box opcode.
+            this.EmitExpression(new BoundConversionExpression(null, targetType, argument));
+            return;
+        }
+
+        this.EmitExpression(argument);
+    }
+
     private void EmitUserInstanceCall(BoundUserInstanceCallExpression call)
     {
         // Issue #1052: a call dispatched through a type parameter's
@@ -228,10 +283,24 @@ internal sealed partial class MethodBodyEmitter
 
         this.EmitInstanceReceiver(call.Receiver);
         var calleeParameterOffset = call.Method.ExplicitReceiverParameter == null ? 0 : 1;
+        var constructedOwner = inheritedGenericBase ?? receiverType;
+        var hasReifiedParameters = call.Method.IsGeneric || constructedOwner?.Definition != null;
         for (var i = 0; i < call.Arguments.Length; i++)
         {
             var arg = call.Arguments[i];
-            this.EmitExpression(arg);
+            if (hasReifiedParameters)
+            {
+                this.EmitReifiedUserCallArgument(
+                    arg,
+                    call.Method.Parameters[i + calleeParameterOffset],
+                    call.Method.TypeParameters,
+                    call.MethodTypeArguments,
+                    constructedOwner);
+            }
+            else
+            {
+                this.EmitExpression(arg);
+            }
         }
 
         var receiverIsValueType = call.Method.ReceiverType is StructSymbol receiverStruct && !receiverStruct.IsClass;

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
@@ -132,11 +132,25 @@ internal sealed partial class MethodBodyEmitter
                 // `!!T`, so a value-type instantiation must be lifted to
                 // `Nullable<X>` — see TryPlanUnconstrainedNullableLift.
                 var nullableLift = this.TryPlanUnconstrainedNullableLift(call);
+                var hasReifiedParameters = call.Function.IsGeneric || call.StaticGenericOwnerType != null;
 
                 for (int i = 0; i < call.Arguments.Length; i++)
                 {
                     var arg = call.Arguments[i];
-                    this.EmitExpression(arg);
+                    if (hasReifiedParameters)
+                    {
+                        this.EmitReifiedUserCallArgument(
+                            arg,
+                            call.Function.Parameters[i],
+                            call.Function.TypeParameters,
+                            call.MethodTypeArguments,
+                            call.StaticGenericOwnerType);
+                    }
+                    else
+                    {
+                        this.EmitExpression(arg);
+                    }
+
                     if (nullableLift?.ArgumentWraps[i] is { } liftWrap)
                     {
                         this.EmitUnconstrainedNullableLiftWrap(liftWrap);

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue3271ReifiedGenericArgumentBoxingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue3271ReifiedGenericArgumentBoxingTests.cs
@@ -1,0 +1,343 @@
+// <copyright file="Issue3271ReifiedGenericArgumentBoxingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #3271: value-type arguments passed through a reified generic slot
+/// whose call-site type argument is a reference type must be boxed before the
+/// call. The shared-method binder path already materialized that conversion;
+/// free, extension, and instance calls emitted the raw value instead.
+/// </summary>
+public class Issue3271ReifiedGenericArgumentBoxingTests
+{
+    [Fact]
+    public void TopLevel_ValueTypes_BoxToObject()
+    {
+        AssertRuns(
+            """
+            package Issue3271TopObject
+            import System
+
+            struct Token { var Value int32 }
+
+            func Show[T](value T, label string) {
+                Console.WriteLine(label)
+                Console.WriteLine([]T{value}.GetType())
+                Console.WriteLine(value.GetType())
+            }
+
+            Show[object](11, "int")
+            Show[object](true, "bool")
+            Show[object](Token{Value: 7}, "struct")
+            """,
+            "int",
+            "System.Object[]",
+            "System.Int32",
+            "bool",
+            "System.Object[]",
+            "System.Boolean",
+            "struct",
+            "System.Object[]",
+            "Issue3271TopObject.Token");
+    }
+
+    [Fact]
+    public void TopLevel_ValueTypes_BoxToInterfacesAndValueType()
+    {
+        AssertRuns(
+            """
+            package Issue3271TopReferences
+            import System
+
+            interface IMark { func Code() int32; }
+            struct Mark : IMark {
+                var Value int32
+                func Code() int32 { return Value }
+            }
+
+            func Show[T](value T, label string) {
+                Console.WriteLine(label)
+                Console.WriteLine([]T{value}.GetType())
+                Console.WriteLine(value.GetType())
+            }
+
+            Show[IComparable](21, "imported-interface")
+            Show[IMark](Mark{Value: 22}, "user-interface")
+            Show[ValueType](23, "value-type-base")
+            """,
+            "imported-interface",
+            "System.IComparable[]",
+            "System.Int32",
+            "user-interface",
+            "Issue3271TopReferences.IMark[]",
+            "Issue3271TopReferences.Mark",
+            "value-type-base",
+            "System.ValueType[]",
+            "System.Int32");
+    }
+
+    [Fact]
+    public void GenericInstanceMethod_BoxesReferenceTargets()
+    {
+        AssertRuns(
+            """
+            package Issue3271Instance
+            import System
+
+            class Runner {
+                init() {}
+
+                func Show[T](value T, label string) {
+                    Console.WriteLine(label)
+                    Console.WriteLine([]T{value}.GetType())
+                    Console.WriteLine(value.GetType())
+                }
+            }
+
+            let runner = Runner()
+            runner.Show[object](31, "object")
+            runner.Show[IComparable](32, "interface")
+            runner.Show[ValueType](33, "value-type-base")
+            """,
+            "object",
+            "System.Object[]",
+            "System.Int32",
+            "interface",
+            "System.IComparable[]",
+            "System.Int32",
+            "value-type-base",
+            "System.ValueType[]",
+            "System.Int32");
+    }
+
+    [Fact]
+    public void GenericExtensionMethod_BoxesReferenceTargets()
+    {
+        AssertRuns(
+            """
+            package Issue3271Extension
+            import System
+
+            func (self string) Show[T](value T, label string) {
+                Console.WriteLine(self + ":" + label)
+                Console.WriteLine([]T{value}.GetType())
+                Console.WriteLine(value.GetType())
+            }
+
+            "extension".Show[object](41, "object")
+            "extension".Show[IComparable](42, "interface")
+            "extension".Show[ValueType](43, "value-type-base")
+            """,
+            "extension:object",
+            "System.Object[]",
+            "System.Int32",
+            "extension:interface",
+            "System.IComparable[]",
+            "System.Int32",
+            "extension:value-type-base",
+            "System.ValueType[]",
+            "System.Int32");
+    }
+
+    [Fact]
+    public void ConstructedGenericOwner_InstanceMethods_BoxReferenceTargets()
+    {
+        AssertRuns(
+            """
+            package Issue3271Owner
+            import System
+
+            class Box[T](_seed T) {
+                func Show(value T, label string) {
+                    Console.WriteLine(label)
+                    Console.WriteLine([]T{value}.GetType())
+                    Console.WriteLine(value.GetType())
+                }
+            }
+
+            open class Base[T] {
+                init() {}
+                func Show(value T, label string) {
+                    Console.WriteLine(label)
+                    Console.WriteLine([]T{value}.GetType())
+                    Console.WriteLine(value.GetType())
+                }
+            }
+
+            class Derived : Base[object] {
+                init() : base() {}
+            }
+
+            struct Outer[T] {
+                struct Middle {
+                    func Show(value T, label string) {
+                        Console.WriteLine(label)
+                        Console.WriteLine([]T{value}.GetType())
+                        Console.WriteLine(value.GetType())
+                    }
+                }
+            }
+
+            Box[object]("seed").Show(51, "direct")
+            Derived().Show(52, "inherited")
+            let middle = default(Outer[object].Middle)
+            middle.Show(53, "nested")
+            """,
+            "direct",
+            "System.Object[]",
+            "System.Int32",
+            "inherited",
+            "System.Object[]",
+            "System.Int32",
+            "nested",
+            "System.Object[]",
+            "System.Int32");
+    }
+
+    [Fact]
+    public void NullableReferenceTypeArgument_StillBoxesValue()
+    {
+        AssertRuns(
+            """
+            package Issue3271NullableReference
+            import System
+
+            func Show[T](value T) {
+                Console.WriteLine([]T{value}.GetType())
+                Console.WriteLine(value.GetType())
+            }
+
+            Show[object?](61)
+            """,
+            "System.Object[]",
+            "System.Int32");
+    }
+
+    [Fact]
+    public void ReifiedTypeArgumentOrder_IsNotErasedOrTransposed()
+    {
+        AssertRuns(
+            """
+            package Issue3271Order
+            import System
+
+            func Pair[A, B](a A, b B) {
+                Console.WriteLine([]A{a}.GetType())
+                Console.WriteLine([]B{b}.GetType())
+                Console.WriteLine(a.GetType())
+                Console.WriteLine(b.GetType())
+            }
+
+            Pair[object, string](71, "right")
+            Pair[string, object]("left", 72)
+            """,
+            "System.Object[]",
+            "System.String[]",
+            "System.Int32",
+            "System.String",
+            "System.String[]",
+            "System.Object[]",
+            "System.String",
+            "System.Int32");
+    }
+
+    [Fact]
+    public void ValueTypeTargets_StayUnboxed()
+    {
+        AssertRuns(
+            """
+            package Issue3271ValueTargets
+            import System
+
+            func Unconstrained[T](value T) {
+                Console.WriteLine([]T{value}.GetType())
+            }
+
+            func Constrained[T struct](value T) {
+                Console.WriteLine([]T{value}.GetType())
+            }
+
+            func NullableArgument[T](value T) {
+                Console.WriteLine([]T{value}.GetType())
+            }
+
+            func NullableParameter[T struct](value T?) {
+                Console.WriteLine([]T?{value}.GetType())
+                Console.WriteLine(value!!)
+            }
+
+            Unconstrained[int32](81)
+            Constrained[int32](82)
+            var nullable int32? = 83
+            NullableArgument[int32?](nullable)
+            NullableParameter[int32](nullable)
+            """,
+            "System.Int32[]",
+            "System.Int32[]",
+            "System.Nullable`1[System.Int32][]",
+            "System.Nullable`1[System.Int32][]",
+            "83");
+    }
+
+    [Fact]
+    public void ExistingSharedAndReferencePaths_StayCorrect()
+    {
+        AssertRuns(
+            """
+            package Issue3271Controls
+            import System
+
+            interface IMark { func Code() int32; }
+            class Mark : IMark {
+                init() {}
+                func Code() int32 { return 91 }
+            }
+
+            class Runner {
+                shared {
+                    func Show[T](value T) {
+                        Console.WriteLine([]T{value}.GetType())
+                        Console.WriteLine(value.GetType())
+                    }
+                }
+            }
+
+            func Show[T](value T) {
+                Console.WriteLine([]T{value}.GetType())
+                Console.WriteLine(value.GetType())
+            }
+
+            Runner.Show[object](91)
+            Runner.Show[IComparable](92)
+            Show[object]("right")
+            Show[IMark](Mark())
+            """,
+            "System.Object[]",
+            "System.Int32",
+            "System.IComparable[]",
+            "System.Int32",
+            "System.Object[]",
+            "System.String",
+            "Issue3271Controls.IMark[]",
+            "Issue3271Controls.Mark");
+    }
+
+    private static void AssertRuns(string source, params string[] expectedLines)
+    {
+        var result = EmittedOracle.Evaluate(source);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(0, result.ExitCode);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(string.Empty, result.ErrorOutput);
+        Assert.Equal(
+            string.Join(Environment.NewLine, expectedLines) + Environment.NewLine,
+            result.Output);
+    }
+}


### PR DESCRIPTION
## Summary
- resolve bare generic parameter slots to their call-site method or constructed-owner type arguments
- route value-type-to-reference targets through the canonical conversion emitter, matching the already-correct shared-method path
- add runtime coverage for top-level, instance, extension, constructed/inherited/nested owners, nullable targets, interfaces, `ValueType`, controls, and type-argument transposition

## Root cause
Shared methods already bind `int32 -> object` as a `BoundConversionExpression`, whose canonical emission supplies `box`. Top-level, extension, and instance generic paths deliberately left bare type-parameter arguments unconverted, expecting call-boundary boxing that no longer existed. Their shared emitter helper now resolves the reified target and materializes that same conversion only for object, interface, `ValueType`, or `Enum` reference targets.

## Validation
- exact repro: compile rc 0; `dotnet exec` rc 0; stdout `42`
- regression pins: 9/9 green; unfixed product: 7 failed with `InvalidProgramException`
- three condition-inversion product mutants killed; `GSharp.Core.dll` moved and restored exactly for each
- `dotnet build GSharp.sln`: 0 warnings, 0 errors
- all 9 test projects: 15,378 passed, 4 skipped
- ILVerify gate: 123/123 verified; 2 documented suppressions; 0 failures

## Separate observed defect
`Runner.Run[ValueType](42)` on the shared-method binder path still reports GS0155. CLR boxing from `int32` to `System.ValueType` is legal; this pre-existing binder inconsistency is unchanged by this emitter fix.

Fixes #3271