### PR TITLE
Harden GetMethodSafe preconditions

### DIFF
--- a/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
+++ b/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
@@ -37,11 +37,13 @@ public static class ClrTypeUtilities
     /// <summary>
     /// Resolves a named method without asking a constructed
     /// <see cref="TypeBuilder"/> generic instantiation to resolve members
-    /// directly.
+    /// directly. The name must be unambiguous; use the parameter-type overload
+    /// for overloaded methods.
     /// </summary>
     /// <param name="type">The type that declares or inherits the method.</param>
     /// <param name="name">The method name to resolve.</param>
     /// <returns>The resolved method, or <see langword="null"/> when no matching method exists.</returns>
+    /// <exception cref="AmbiguousMatchException"><paramref name="name"/> identifies multiple methods.</exception>
     public static MethodInfo GetMethodSafe(this Type type, string name)
     {
         if (type is null || name is null)
@@ -92,7 +94,15 @@ public static class ClrTypeUtilities
                 return null;
             }
 
-            var openMethod = type.GetGenericTypeDefinition().GetMethod(name, types);
+            var openType = type.GetGenericTypeDefinition();
+            var typeArguments = type.GetGenericArguments();
+            var openTypeArguments = openType.GetGenericArguments();
+            var openParameterTypes = types.Select(parameterType =>
+            {
+                var index = Array.IndexOf(typeArguments, parameterType);
+                return index >= 0 ? openTypeArguments[index] : parameterType;
+            }).ToArray();
+            var openMethod = openType.GetMethod(name, openParameterTypes);
             return openMethod != null ? TypeBuilder.GetMethod(type, openMethod) : null;
         }
     }

--- a/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
+++ b/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
@@ -63,7 +63,7 @@ public static class ClrTypeUtilities
             }
 
             var openMethod = type.GetGenericTypeDefinition().GetMethod(name);
-            return openMethod != null ? TypeBuilder.GetMethod(type, openMethod) : null;
+            return openMethod != null ? GetConstructedGenericMethod(type, openMethod) : null;
         }
     }
 
@@ -105,7 +105,7 @@ public static class ClrTypeUtilities
                 types,
                 openTypeArguments,
                 typeArguments);
-            return openMethod != null ? TypeBuilder.GetMethod(type, openMethod) : null;
+            return openMethod != null ? GetConstructedGenericMethod(type, openMethod) : null;
         }
     }
 
@@ -1135,6 +1135,71 @@ public static class ClrTypeUtilities
         return type != null
             && type.IsConstructedGenericType
             && ContainsTypeBuilderGenericArgument(type);
+    }
+
+    private static MethodInfo GetConstructedGenericMethod(Type type, MethodInfo openMethod)
+    {
+        var declaringType = openMethod.DeclaringType;
+        if (!declaringType.IsGenericType)
+        {
+            return openMethod;
+        }
+
+        var declaringDefinition = declaringType.GetGenericTypeDefinition();
+        var methodDefinition = declaringType.IsGenericTypeDefinition
+            ? openMethod
+            : declaringDefinition.GetMethods()
+                .Single(method => method.Module == openMethod.Module
+                    && method.MetadataToken == openMethod.MetadataToken);
+        var openType = type.GetGenericTypeDefinition();
+        var constructedDeclaringType = SubstituteGenericTypeArguments(
+            declaringType,
+            openType.GetGenericArguments(),
+            type.GetGenericArguments());
+        return TypeBuilder.GetMethod(constructedDeclaringType, methodDefinition);
+    }
+
+    private static Type SubstituteGenericTypeArguments(
+        Type type,
+        Type[] openTypeArguments,
+        Type[] typeArguments)
+    {
+        if (type.IsGenericParameter)
+        {
+            var position = Array.IndexOf(openTypeArguments, type);
+            return position >= 0 ? typeArguments[position] : type;
+        }
+
+        if (type.HasElementType)
+        {
+            var elementType = SubstituteGenericTypeArguments(
+                type.GetElementType(),
+                openTypeArguments,
+                typeArguments);
+            if (type.IsByRef)
+            {
+                return elementType.MakeByRefType();
+            }
+
+            if (type.IsPointer)
+            {
+                return elementType.MakePointerType();
+            }
+
+            return type.IsSZArray
+                ? elementType.MakeArrayType()
+                : elementType.MakeArrayType(type.GetArrayRank());
+        }
+
+        return type.IsGenericType
+            ? type.GetGenericTypeDefinition().MakeGenericType(
+                type.GetGenericArguments()
+                    .Select(argument => SubstituteGenericTypeArguments(
+                        argument,
+                        openTypeArguments,
+                        typeArguments))
+                    .ToArray())
+            : type;
     }
 
     private static MethodInfo FindOpenGenericMethod(

--- a/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
+++ b/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
@@ -76,6 +76,8 @@ public static class ClrTypeUtilities
     /// <param name="name">The method name to resolve.</param>
     /// <param name="types">The method's parameter types.</param>
     /// <returns>The resolved method, or <see langword="null"/> when no matching method exists.</returns>
+    /// <exception cref="AmbiguousMatchException">More than one method matches the supplied signature.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="types"/> contains a <see langword="null"/> element.</exception>
     public static MethodInfo GetMethodSafe(this Type type, string name, Type[] types)
     {
         if (type is null || name is null || types is null)
@@ -97,12 +99,12 @@ public static class ClrTypeUtilities
             var openType = type.GetGenericTypeDefinition();
             var typeArguments = type.GetGenericArguments();
             var openTypeArguments = openType.GetGenericArguments();
-            var openParameterTypes = types.Select(parameterType =>
-            {
-                var index = Array.IndexOf(typeArguments, parameterType);
-                return index >= 0 ? openTypeArguments[index] : parameterType;
-            }).ToArray();
-            var openMethod = openType.GetMethod(name, openParameterTypes);
+            var openMethod = FindOpenGenericMethod(
+                openType,
+                name,
+                types,
+                openTypeArguments,
+                typeArguments);
             return openMethod != null ? TypeBuilder.GetMethod(type, openMethod) : null;
         }
     }
@@ -1133,6 +1135,109 @@ public static class ClrTypeUtilities
         return type != null
             && type.IsConstructedGenericType
             && ContainsTypeBuilderGenericArgument(type);
+    }
+
+    private static MethodInfo FindOpenGenericMethod(
+        Type openType,
+        string name,
+        Type[] parameterTypes,
+        Type[] openTypeArguments,
+        Type[] typeArguments)
+    {
+        var matches = openType.GetMethods()
+            .Where(method => string.Equals(method.Name, name, StringComparison.Ordinal))
+            .Where(method =>
+            {
+                var parameters = method.GetParameters();
+                return parameters.Length == parameterTypes.Length
+                    && parameters.Select(parameter => parameter.ParameterType)
+                    .Zip(parameterTypes, (open, constructed) =>
+                        MatchesConstructedParameterType(
+                            open,
+                            constructed,
+                            openTypeArguments,
+                            typeArguments))
+                    .All(matches => matches);
+            })
+            .Take(2)
+            .ToArray();
+
+        return matches.Length switch
+        {
+            0 => null,
+            1 => matches[0],
+            _ => throw new AmbiguousMatchException(),
+        };
+    }
+
+    private static bool MatchesConstructedParameterType(
+        Type open,
+        Type constructed,
+        Type[] openTypeArguments,
+        Type[] typeArguments)
+    {
+        if (open.IsGenericParameter)
+        {
+            var position = Array.IndexOf(openTypeArguments, open);
+            if (position >= 0)
+            {
+                return constructed == typeArguments[position];
+            }
+        }
+
+        if (open.IsByRef || constructed.IsByRef)
+        {
+            return open.IsByRef
+                && constructed.IsByRef
+                && MatchesConstructedParameterType(
+                    open.GetElementType(),
+                    constructed.GetElementType(),
+                    openTypeArguments,
+                    typeArguments);
+        }
+
+        if (open.IsPointer || constructed.IsPointer)
+        {
+            return open.IsPointer
+                && constructed.IsPointer
+                && MatchesConstructedParameterType(
+                    open.GetElementType(),
+                    constructed.GetElementType(),
+                    openTypeArguments,
+                    typeArguments);
+        }
+
+        if (open.IsArray || constructed.IsArray)
+        {
+            return open.IsArray
+                && constructed.IsArray
+                && open.IsSZArray == constructed.IsSZArray
+                && open.GetArrayRank() == constructed.GetArrayRank()
+                && MatchesConstructedParameterType(
+                    open.GetElementType(),
+                    constructed.GetElementType(),
+                    openTypeArguments,
+                    typeArguments);
+        }
+
+        if (open.IsConstructedGenericType || constructed.IsConstructedGenericType)
+        {
+            return open.IsConstructedGenericType
+                && constructed.IsConstructedGenericType
+                && open.GetGenericTypeDefinition() == constructed.GetGenericTypeDefinition()
+                && open.GetGenericArguments()
+                    .Zip(
+                        constructed.GetGenericArguments(),
+                        (openArgument, constructedArgument) =>
+                            MatchesConstructedParameterType(
+                                openArgument,
+                                constructedArgument,
+                                openTypeArguments,
+                                typeArguments))
+                    .All(matches => matches);
+        }
+
+        return open == constructed;
     }
 
     private static bool ContainsTypeBuilderGenericArgument(Type type)

--- a/test/Core.Tests/CodeAnalysis/Symbols/ClrTypeUtilitiesTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/ClrTypeUtilitiesTests.cs
@@ -266,6 +266,26 @@ public class ClrTypeUtilitiesTests
             [argument]));
     }
 
+    [Fact]
+    public void GetMethodSafe_TypeBuilderConstructedGeneric_ResolvesInheritedParameterType()
+    {
+        var assembly = AssemblyBuilder.DefineDynamicAssembly(
+            new AssemblyName("GetMethodSafeInheritedTypeBuilder"),
+            AssemblyBuilderAccess.Run);
+        var module = assembly.DefineDynamicModule("GetMethodSafeInheritedTypeBuilder");
+        var argument = module.DefineType("Argument", TypeAttributes.Public);
+        var constructed = typeof(TypeBuilderDerivedMethodFixture<>).MakeGenericType(argument);
+
+        Assert.Throws<NotSupportedException>(() => constructed.GetMethod(
+            nameof(TypeBuilderBaseMethodFixture<object>.Accept),
+            [argument]));
+        Assert.NotNull(constructed.GetMethodSafe(
+            nameof(TypeBuilderBaseMethodFixture<object>.Accept)));
+        Assert.NotNull(constructed.GetMethodSafe(
+            nameof(TypeBuilderBaseMethodFixture<object>.Accept),
+            [argument]));
+    }
+
     /// <summary>
     /// Loads <see cref="Fixture338"/> through a MetadataLoadContext whose
     /// reference set intentionally omits <c>System.Text.RegularExpressions</c>,
@@ -382,4 +402,13 @@ file sealed class TypeBuilderAmbiguousMethodFixture<TFirst, TSecond>
     public void Accept(TFirst value) => _ = value;
 
     public void Accept(TSecond value) => _ = value;
+}
+
+file class TypeBuilderBaseMethodFixture<T>
+{
+    public void Accept(T value) => _ = value;
+}
+
+file sealed class TypeBuilderDerivedMethodFixture<T> : TypeBuilderBaseMethodFixture<T>
+{
 }

--- a/test/Core.Tests/CodeAnalysis/Symbols/ClrTypeUtilitiesTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/ClrTypeUtilitiesTests.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -174,6 +175,97 @@ public class ClrTypeUtilitiesTests
         Assert.Equal(nameof(TypeBuilderMethodFixture<object>.Accept), method.Name);
     }
 
+    [Fact]
+    public void GetMethodSafe_TypeBuilderConstructedGeneric_ResolvesNestedParameterTypes()
+    {
+        var assembly = AssemblyBuilder.DefineDynamicAssembly(
+            new AssemblyName("GetMethodSafeNestedTypeBuilder"),
+            AssemblyBuilderAccess.Run);
+        var module = assembly.DefineDynamicModule("GetMethodSafeNestedTypeBuilder");
+        var argument = module.DefineType("Argument", TypeAttributes.Public);
+        var constructed = typeof(TypeBuilderMethodFixture<>).MakeGenericType(argument);
+        var cases = new[]
+        {
+            (nameof(TypeBuilderMethodFixture<object>.AcceptList), typeof(List<>).MakeGenericType(argument)),
+            (nameof(TypeBuilderMethodFixture<object>.AcceptArray), argument.MakeArrayType()),
+            (nameof(TypeBuilderMethodFixture<object>.AcceptFunc), typeof(Func<>).MakeGenericType(argument)),
+            (nameof(TypeBuilderMethodFixture<object>.AcceptByRef), argument.MakeByRefType()),
+        };
+
+        foreach (var (name, parameterType) in cases)
+        {
+            Assert.Throws<NotSupportedException>(() => constructed.GetMethod(name, [parameterType]));
+            Assert.NotNull(constructed.GetMethodSafe(name, [parameterType]));
+        }
+    }
+
+    [Fact]
+    public void GetMethodSafe_TypeBuilderConstructedGeneric_ResolvesPointerParameterType()
+    {
+        var assembly = AssemblyBuilder.DefineDynamicAssembly(
+            new AssemblyName("GetMethodSafePointerTypeBuilder"),
+            AssemblyBuilderAccess.Run);
+        var module = assembly.DefineDynamicModule("GetMethodSafePointerTypeBuilder");
+        var argument = module.DefineType(
+            "Argument",
+            TypeAttributes.Public | TypeAttributes.Sealed,
+            typeof(ValueType));
+        var constructed = typeof(TypeBuilderPointerMethodFixture<>).MakeGenericType(argument);
+        var parameterType = argument.MakePointerType();
+
+        Assert.Throws<NotSupportedException>(() => constructed.GetMethod(
+            nameof(TypeBuilderPointerMethodFixture<int>.AcceptPointer),
+            [parameterType]));
+        Assert.NotNull(constructed.GetMethodSafe(
+            nameof(TypeBuilderPointerMethodFixture<int>.AcceptPointer),
+            [parameterType]));
+    }
+
+    [Fact]
+    public void GetMethodSafe_TypeBuilderConstructedGeneric_MapsDuplicateArgumentsByPosition()
+    {
+        var assembly = AssemblyBuilder.DefineDynamicAssembly(
+            new AssemblyName("GetMethodSafeDuplicateTypeBuilder"),
+            AssemblyBuilderAccess.Run);
+        var module = assembly.DefineDynamicModule("GetMethodSafeDuplicateTypeBuilder");
+        var argument = module.DefineType("Argument", TypeAttributes.Public);
+        var constructed = typeof(TypeBuilderPairMethodFixture<,>).MakeGenericType(argument, argument);
+
+        Assert.Throws<NotSupportedException>(() => constructed.GetMethod(
+            nameof(TypeBuilderPairMethodFixture<object, object>.Second),
+            [argument]));
+        Assert.Throws<NotSupportedException>(() => constructed.GetMethod(
+            nameof(TypeBuilderPairMethodFixture<object, object>.Both),
+            [argument, argument]));
+
+        var first = constructed.GetMethodSafe(
+            nameof(TypeBuilderPairMethodFixture<object, object>.First),
+            [argument]);
+        var second = constructed.GetMethodSafe(
+            nameof(TypeBuilderPairMethodFixture<object, object>.Second),
+            [argument]);
+        var both = constructed.GetMethodSafe(
+            nameof(TypeBuilderPairMethodFixture<object, object>.Both),
+            [argument, argument]);
+
+        Assert.NotNull(first);
+        Assert.NotNull(second);
+        Assert.NotNull(both);
+        Assert.Equal(0, first.GetParameters()[0].ParameterType.GenericParameterPosition);
+        Assert.Equal(1, second.GetParameters()[0].ParameterType.GenericParameterPosition);
+        Assert.Equal(
+            [0, 1],
+            both.GetParameters()
+                .Select(parameter => parameter.ParameterType.GenericParameterPosition)
+                .ToArray());
+
+        var ambiguous = typeof(TypeBuilderAmbiguousMethodFixture<,>)
+            .MakeGenericType(argument, argument);
+        Assert.Throws<AmbiguousMatchException>(() => ambiguous.GetMethodSafe(
+            nameof(TypeBuilderAmbiguousMethodFixture<object, string>.Accept),
+            [argument]));
+    }
+
     /// <summary>
     /// Loads <see cref="Fixture338"/> through a MetadataLoadContext whose
     /// reference set intentionally omits <c>System.Text.RegularExpressions</c>,
@@ -256,4 +348,38 @@ file sealed class TypeBuilderMethodFixture<T>
     public void Accept(T value) => _ = value;
 
     public void Accept(int value) => _ = value;
+
+    public void AcceptList(List<T> value) => _ = value;
+
+    public void AcceptArray(T[] value) => _ = value;
+
+    public void AcceptFunc(Func<T> value) => _ = value;
+
+    public void AcceptByRef(ref T value) => _ = value;
+}
+
+file sealed class TypeBuilderPairMethodFixture<TFirst, TSecond>
+{
+    public void First(TFirst value) => _ = value;
+
+    public void Second(TSecond value) => _ = value;
+
+    public void Both(TFirst first, TSecond second)
+    {
+        _ = first;
+        _ = second;
+    }
+}
+
+file unsafe sealed class TypeBuilderPointerMethodFixture<T>
+    where T : unmanaged
+{
+    public void AcceptPointer(T* value) => _ = value;
+}
+
+file sealed class TypeBuilderAmbiguousMethodFixture<TFirst, TSecond>
+{
+    public void Accept(TFirst value) => _ = value;
+
+    public void Accept(TSecond value) => _ = value;
 }

--- a/test/Core.Tests/CodeAnalysis/Symbols/ClrTypeUtilitiesTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/ClrTypeUtilitiesTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Reflection.Emit;
 using System.Text.RegularExpressions;
 using GSharp.Core.CodeAnalysis.Symbols;
 using Xunit;
@@ -150,6 +151,29 @@ public class ClrTypeUtilitiesTests
         Assert.Null(ClrTypeUtilities.SafeGetEvent(fixture, nameof(Fixture338.BadEvent), InstanceFlags));
     }
 
+    [Fact]
+    public void GetMethodSafe_TypeBuilderConstructedGeneric_ResolvesParameterType()
+    {
+        var assembly = AssemblyBuilder.DefineDynamicAssembly(
+            new AssemblyName("GetMethodSafeTypeBuilder"),
+            AssemblyBuilderAccess.Run);
+        var module = assembly.DefineDynamicModule("GetMethodSafeTypeBuilder");
+        var argument = module.DefineType("Argument", TypeAttributes.Public);
+        var constructed = typeof(TypeBuilderMethodFixture<>).MakeGenericType(argument);
+
+        Assert.Equal("TypeBuilderInstantiation", constructed.GetType().Name);
+        Assert.Throws<NotSupportedException>(() => constructed.GetMethod(
+            nameof(TypeBuilderMethodFixture<object>.Accept),
+            [argument]));
+
+        var method = constructed.GetMethodSafe(
+            nameof(TypeBuilderMethodFixture<object>.Accept),
+            [argument]);
+
+        Assert.NotNull(method);
+        Assert.Equal(nameof(TypeBuilderMethodFixture<object>.Accept), method.Name);
+    }
+
     /// <summary>
     /// Loads <see cref="Fixture338"/> through a MetadataLoadContext whose
     /// reference set intentionally omits <c>System.Text.RegularExpressions</c>,
@@ -226,3 +250,10 @@ file sealed class Fixture338
 }
 #pragma warning restore CS0067
 #pragma warning restore CS0649
+
+file sealed class TypeBuilderMethodFixture<T>
+{
+    public void Accept(T value) => _ = value;
+
+    public void Accept(int value) => _ = value;
+}


### PR DESCRIPTION
Fixes #3278.

## Summary

- Document that the name-only `GetMethodSafe` overload requires an unambiguous method name and propagates `AmbiguousMatchException` otherwise.
- Match constructed parameter shapes recursively before the TypeBuilder-safe typed lookup fallback, including nested generics, arrays, by-ref and pointer types, and duplicate generic arguments by position.
- Map inherited generic methods through their constructed declaring type instead of assuming every resolved method is declared directly on the receiver.
- Add focused regression coverage using in-flight `TypeBuilder` arguments.

## Rationale

Keeping `AmbiguousMatchException` visible distinguishes caller misuse from a missing method. The typed fallback is hardened because returning null for a resolvable method would silently mislead future callers. Inherited methods need separate declaring-type mapping because `TypeBuilder.GetMethod` only accepts the generic type that actually declares the method.