### PR TITLE
Reject inherited calls that box ref structs

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -660,8 +660,7 @@ internal sealed class ConversionClassifier
         // the same ref struct) already returned above.
         if (TypeSymbol.IsByRefLike(expression.Type)
             && type != TypeSymbol.String
-            && type?.ClrType != null
-            && !type.ClrType.IsValueType
+            && Conversion.IsReferenceLikeTarget(type)
             && expression.Type != TypeSymbol.Error)
         {
             Diagnostics.ReportByRefLikeEscape(diagnosticLocation, expression.Type, $"be boxed or converted to the reference type '{type}'");

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -413,6 +413,24 @@ internal sealed class ConversionClassifier
             return new BoundDefaultExpression(barePlaceholder, type);
         }
 
+        var methodGroupReceiver = expression switch
+        {
+            BoundMethodGroupExpression userGroup => userGroup.Receiver,
+            BoundClrMethodGroupExpression clrGroup => clrGroup.Receiver,
+            _ => null,
+        };
+        var methodGroupReceiverType = methodGroupReceiver?.Type is ByRefTypeSymbol byRefReceiver
+            ? byRefReceiver.PointeeType
+            : methodGroupReceiver?.Type;
+        if (methodGroupReceiverType != null && TypeSymbol.IsByRefLike(methodGroupReceiverType))
+        {
+            Diagnostics.ReportByRefLikeEscape(
+                diagnosticLocation,
+                methodGroupReceiverType,
+                "be captured as a delegate target because that requires boxing the receiver");
+            return new BoundErrorExpression(null);
+        }
+
         // Issue #337: a CLR member method group has no fixed type until the
         // target delegate signature drives overload selection. Resolve it here,
         // where the expected type is known, before classifying conversions.

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
@@ -1124,7 +1124,14 @@ internal sealed partial class ExpressionBinder
                 var inheritedArguments = OverloadResolver.BuildOrderedCallArguments(inheritedConvertedArgs, inheritedDownstreamMapping, inheritedParameters);
                 var refKinds = ComputeArgumentRefKinds(inheritedParameters);
                 overloads.ValidateRefArguments(inheritedArguments, refKinds, methodName, ce.Location);
-                BoundExpression inheritedCall = new BoundImportedInstanceCallExpression(null, inheritedUpdatedReceiver ?? receiver, resolution.Best, returnType, inheritedArguments, refKinds, inheritedTypeArgSymbolsForCall, isNonVirtualBaseCall: nonVirtualBaseCall);
+                var inheritedCallReceiver = inheritedUpdatedReceiver ?? receiver;
+                if (TryReportByRefLikeInheritedCall(inheritedCallReceiver, resolution.Best, ce.Location))
+                {
+                    result = new BoundErrorExpression(null);
+                    return true;
+                }
+
+                BoundExpression inheritedCall = new BoundImportedInstanceCallExpression(null, inheritedCallReceiver, resolution.Best, returnType, inheritedArguments, refKinds, inheritedTypeArgSymbolsForCall, isNonVirtualBaseCall: nonVirtualBaseCall);
                 result = WrapWithHandlerPrelude(inheritedCall, inheritedHandlerPrelude, ce);
                 return true;
             case ClrOverloadResolution.ResolutionOutcome.Ambiguous:

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -26,6 +26,27 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 
 internal sealed partial class ExpressionBinder
 {
+    private bool TryReportByRefLikeInheritedCall(
+        BoundExpression receiver,
+        MethodInfo method,
+        TextLocation location)
+    {
+        var receiverType = receiver.Type is ByRefTypeSymbol byRef
+            ? byRef.PointeeType
+            : receiver.Type;
+        if (!TypeSymbol.IsByRefLike(receiverType)
+            || !ReflectionMetadataEmitter.ImportedInstanceReceiverRequiresBoxing(receiverType, method))
+        {
+            return false;
+        }
+
+        Diagnostics.ReportByRefLikeEscape(
+            location,
+            receiverType,
+            $"invoke inherited method '{method.Name}' because dispatch requires boxing the receiver");
+        return true;
+    }
+
     /// <summary>
     /// Issue #311: resolves the explicit <c>[T1, T2]</c> type-argument list on a
     /// generic-method call site into CLR types projected onto the reference load
@@ -3039,7 +3060,13 @@ internal sealed partial class ExpressionBinder
                         var instArguments = OverloadResolver.BuildOrderedCallArguments(instConvertedArgs, instDownstreamMapping, instParameters);
                         var instRefKinds = ComputeArgumentRefKinds(instParameters);
                         overloads.ValidateRefArguments(instArguments, instRefKinds, methodName, ce.Location);
-                        BoundExpression instCall = ConversionClassifier.AutoDereferenceRefReturn(new BoundImportedInstanceCallExpression(null, instUpdatedReceiver ?? receiver, resolution.Best, returnType, instArguments, instRefKinds, instTypeArgSymbolsForCall));
+                        var callReceiver = instUpdatedReceiver ?? receiver;
+                        if (TryReportByRefLikeInheritedCall(callReceiver, resolution.Best, ce.Location))
+                        {
+                            return new BoundErrorExpression(null);
+                        }
+
+                        BoundExpression instCall = ConversionClassifier.AutoDereferenceRefReturn(new BoundImportedInstanceCallExpression(null, callReceiver, resolution.Best, returnType, instArguments, instRefKinds, instTypeArgSymbolsForCall));
                         return WrapWithHandlerPrelude(instCall, instHandlerPrelude, ce);
                     case ClrOverloadResolution.ResolutionOutcome.Ambiguous:
                         Diagnostics.ReportAmbiguousOverload(ce.Location, methodName, resolution.Ambiguous.Length, resolution.Ambiguous.Select(ClrOverloadResolution.FormatMethodSignature));

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
@@ -1353,6 +1353,11 @@ internal sealed partial class OverloadResolver
             var constraintLocation = syntax.TypeArgumentList != null
                 ? syntax.TypeArgumentList.Location
                 : syntax.Identifier.Location;
+            if (TryReportByRefLikeTypeArgument(function.TypeParameters, substitution, constraintLocation))
+            {
+                return new BoundErrorExpression(null);
+            }
+
             foreach (var tp in function.TypeParameters)
             {
                 var typeArg = substitution[tp];

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Invocations.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Invocations.cs
@@ -1129,6 +1129,11 @@ internal sealed partial class OverloadResolver
             var constraintLocation = ce.TypeArgumentList != null
                 ? ce.TypeArgumentList.Location
                 : ce.Identifier.Location;
+            if (TryReportByRefLikeTypeArgument(extension.TypeParameters, substitution, constraintLocation))
+            {
+                return new BoundErrorExpression(null);
+            }
+
             foreach (var tp in extension.TypeParameters)
             {
                 var typeArg = substitution[tp];
@@ -1439,6 +1444,11 @@ internal sealed partial class OverloadResolver
             var constraintLocation = ce.TypeArgumentList != null
                 ? ce.TypeArgumentList.Location
                 : ce.Identifier.Location;
+            if (TryReportByRefLikeTypeArgument(method.TypeParameters, substitution, constraintLocation))
+            {
+                return new BoundErrorExpression(null);
+            }
+
             foreach (var tp in method.TypeParameters)
             {
                 var typeArg = substitution[tp];

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.cs
@@ -63,6 +63,26 @@ namespace GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
 /// </remarks>
 internal sealed partial class OverloadResolver
 {
+    private bool TryReportByRefLikeTypeArgument(
+        ImmutableArray<TypeParameterSymbol> typeParameters,
+        Dictionary<TypeParameterSymbol, TypeSymbol> substitution,
+        TextLocation location)
+    {
+        foreach (var typeParameter in typeParameters)
+        {
+            var typeArgument = substitution[typeParameter];
+            if (!TypeSymbol.IsByRefLike(typeArgument))
+            {
+                continue;
+            }
+
+            Diagnostics.ReportByRefLikeEscape(location, typeArgument, "be used as a generic type argument");
+            return true;
+        }
+
+        return false;
+    }
+
     /// <summary>
     /// Custom delegate type for the <c>TryBindClrConstructorCall</c>
     /// callback, required because <see cref="Func{T1, T2, TResult}"/>

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
@@ -288,10 +288,9 @@ internal sealed partial class MethodBodyEmitter
                     // pointer to the value; without the box the raw value bits
                     // are reinterpreted as a reference, producing an
                     // AccessViolationException (or silent corruption) at runtime.
-                    var declaringType = instCall.Method.DeclaringType;
-                    var receiverNeedsBox = receiverIsValueType
-                        && declaringType != null
-                        && !declaringType.IsValueType;
+                    var receiverNeedsBox = ReflectionMetadataEmitter.ImportedInstanceReceiverRequiresBoxing(
+                        receiverType,
+                        instCall.Method);
 
                     // A value type calling a method it declares itself receives a
                     // managed pointer (`this` is `ref TStruct`) and uses `call`;

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -5111,6 +5111,17 @@ internal sealed class ReflectionMetadataEmitter
         return false;
     }
 
+    internal static bool ImportedInstanceReceiverRequiresBoxing(TypeSymbol receiverType, MethodInfo method)
+    {
+        if (receiverType is ByRefTypeSymbol byRef)
+        {
+            receiverType = byRef.PointeeType;
+        }
+
+        return IsValueTypeSymbol(receiverType)
+            && method?.DeclaringType is { IsValueType: false };
+    }
+
     // Issue #671 (construction-call follow-up): a generic type-argument
     // position carries a "user-defined" symbol when it is itself a
     // user-declared type (Struct/Class/Interface/Enum/Delegate) — its

--- a/test/Compiler.Tests/Emit/Issue3240RefStructInheritedVirtualBoxingTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3240RefStructInheritedVirtualBoxingTests.cs
@@ -186,6 +186,90 @@ public sealed class Issue3240RefStructInheritedVirtualBoxingTests
     }
 
     [Fact]
+    public void InheritedMethodGroup_OnRefStruct_ReportsBoxing()
+    {
+        const string Source = """
+            ref struct Bare {
+                var id int32
+            }
+
+            func Run() {
+                var b = Bare{id: 42}
+                let f () -> string = b.ToString
+            }
+            Run()
+            """;
+
+        AssertRejectedWithoutAssembly(
+            Source,
+            "b.ToString",
+            "be captured as a delegate target because that requires boxing the receiver");
+    }
+
+    [Fact]
+    public void DeclaredMethodGroup_OnRefStruct_ReportsBoxing()
+    {
+        const string Source = """
+            ref struct Bare {
+                var id int32
+                func Get() int32 -> id
+            }
+
+            func Run() {
+                var b = Bare{id: 42}
+                let f () -> int32 = b.Get
+            }
+            Run()
+            """;
+
+        AssertRejectedWithoutAssembly(
+            Source,
+            "b.Get",
+            "be captured as a delegate target because that requires boxing the receiver");
+    }
+
+    [Fact]
+    public void UserExtensionMethodGroup_OnImportedRefStruct_ReportsBoxing()
+    {
+        const string Source = """
+            import System
+
+            func (span ReadOnlySpan[int32]) Ext() int32 -> span.Length
+
+            func Run() {
+                var values []int32 = []int32{11, 22}
+                var span ReadOnlySpan[int32] = values
+                let f () -> int32 = span.Ext
+            }
+            Run()
+            """;
+
+        AssertRejectedWithoutAssembly(
+            Source,
+            "span.Ext",
+            "be captured as a delegate target because that requires boxing the receiver");
+    }
+
+    [Fact]
+    public void ImportedExtensionMethodGroup_OnImportedRefStruct_ReportsBoxing()
+    {
+        const string Source = """
+            import System
+
+            func Run() {
+                var span ReadOnlySpan[char] = " "
+                let f () -> bool = span.IsWhiteSpace
+            }
+            Run()
+            """;
+
+        AssertRejectedWithoutAssembly(
+            Source,
+            "span.IsWhiteSpace",
+            "be captured as a delegate target because that requires boxing the receiver");
+    }
+
+    [Fact]
     public void DeclaredObjectMethods_OnRefStruct_RemainDirectCalls()
     {
         const string Source = """

--- a/test/Compiler.Tests/Emit/Issue3240RefStructInheritedVirtualBoxingTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3240RefStructInheritedVirtualBoxingTests.cs
@@ -1,0 +1,394 @@
+// <copyright file="Issue3240RefStructInheritedVirtualBoxingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #3240: inherited CLR instance methods on a by-ref-like receiver require
+/// illegal boxing and must be rejected before an assembly is emitted.
+/// </summary>
+public sealed class Issue3240RefStructInheritedVirtualBoxingTests
+{
+    public static TheoryData<string> InheritedCalls => new()
+    {
+        "b.ToString()",
+        "b.GetHashCode()",
+        "b.Equals(nil)",
+        "b.GetType()",
+    };
+
+    [Theory]
+    [MemberData(nameof(InheritedCalls))]
+    public void InheritedObjectMethod_OnRefStruct_ReportsBoxingAtCallAndDoesNotEmit(string call)
+    {
+        var source = $$"""
+            ref struct Bare {
+                var id int32
+            }
+
+            func Run() {
+                var b = Bare{id: 42}
+                var result = {{call}}
+            }
+            Run()
+            """;
+
+        AssertRejectedWithoutAssembly(
+            source,
+            call[(call.IndexOf('.', StringComparison.Ordinal) + 1)..],
+            $"invoke inherited method '{MethodName(call)}' because dispatch requires boxing the receiver");
+    }
+
+    [Fact]
+    public void InheritedObjectMethod_OnConstructedGenericRefStruct_ReportsBoxing()
+    {
+        const string Source = """
+            ref struct Bare[T any] {
+                var value T
+            }
+
+            func Run() {
+                var b = Bare[int32]{value: 42}
+                var result = b.ToString()
+            }
+            Run()
+            """;
+
+        AssertRejectedWithoutAssembly(
+            Source,
+            "ToString()",
+            "invoke inherited method 'ToString' because dispatch requires boxing the receiver");
+    }
+
+    [Fact]
+    public void InheritedObjectMethod_OnImportedRefStruct_ReportsBoxing()
+    {
+        const string Source = """
+            import System
+
+            func Run() {
+                var values []int32 = []int32{11, 22}
+                var span ReadOnlySpan[int32] = values
+                var result = span.GetType()
+            }
+            Run()
+            """;
+
+        AssertRejectedWithoutAssembly(
+            Source,
+            "GetType()",
+            "invoke inherited method 'GetType' because dispatch requires boxing the receiver");
+    }
+
+    [Fact]
+    public void RefStructConversionToUserInterface_ReportsExistingBoxingDiagnostic()
+    {
+        const string Source = """
+            interface Marker {
+                func Mark() string;
+            }
+
+            ref struct Bare : Marker {
+                var id int32
+                func Mark() string -> "marker-55"
+            }
+
+            func Run() {
+                var b = Bare{id: 42}
+                var marker Marker = b
+            }
+            Run()
+            """;
+
+        AssertRejectedWithoutAssembly(
+            Source,
+            "b",
+            "be boxed or converted to the reference type 'Marker'");
+    }
+
+    [Fact]
+    public void InferredRefStructGenericArgument_ReportsExistingGenericArgumentDiagnostic()
+    {
+        const string Source = """
+            ref struct Bare {
+                var id int32
+            }
+
+            func Use[T any](value T) {
+                var text = value.ToString()
+            }
+
+            func Run() {
+                var b = Bare{id: 42}
+                Use(b)
+            }
+            Run()
+            """;
+
+        AssertRejectedWithoutAssembly(Source, "Use", "be used as a generic type argument");
+    }
+
+    [Fact]
+    public void InferredRefStructGenericInstanceMethodArgument_ReportsExistingGenericArgumentDiagnostic()
+    {
+        const string Source = """
+            ref struct Bare {
+                var id int32
+            }
+
+            class Host {
+                func Use[T any](value T) {
+                    var text = value.ToString()
+                }
+            }
+
+            func Run() {
+                var b = Bare{id: 42}
+                var host = Host()
+                host.Use(b)
+            }
+            Run()
+            """;
+
+        AssertRejectedWithoutAssembly(Source, "Use", "be used as a generic type argument");
+    }
+
+    [Fact]
+    public void InferredRefStructGenericExtensionArgument_ReportsExistingGenericArgumentDiagnostic()
+    {
+        const string Source = """
+            ref struct Bare {
+                var id int32
+            }
+
+            func (host string) Use[T any](value T) {
+                var text = value.ToString()
+            }
+
+            func Run() {
+                var b = Bare{id: 42}
+                "host".Use(b)
+            }
+            Run()
+            """;
+
+        AssertRejectedWithoutAssembly(Source, "Use", "be used as a generic type argument");
+    }
+
+    [Fact]
+    public void DeclaredObjectMethods_OnRefStruct_RemainDirectCalls()
+    {
+        const string Source = """
+            import System
+
+            ref struct Bare {
+                var id int32
+                override func ToString() string -> "declared-11"
+                override func GetHashCode() int32 -> 22
+                override func Equals(value object) bool -> true
+                func GetType() string -> "declared-44"
+            }
+
+            func Run() {
+                var b = Bare{id: 42}
+                var other object = "other"
+                Console.WriteLine(b.ToString())
+                Console.WriteLine(b.GetHashCode())
+                Console.WriteLine(b.Equals(other))
+                Console.WriteLine(b.GetType())
+                Console.WriteLine("implicit=${b}")
+            }
+            Run()
+            """;
+
+        Assert.Equal(
+            string.Join(Environment.NewLine, "declared-11", "22", "True", "declared-44", "implicit=declared-11", string.Empty),
+            CompileAndRun(Source).StandardOutput);
+    }
+
+    [Fact]
+    public void InheritedObjectMethods_OnPlainStruct_RemainCallable()
+    {
+        const string Source = """
+            import System
+
+            struct Plain {
+                var id int32
+            }
+
+            func Run() {
+                var value = Plain{id: 42}
+                Console.WriteLine(value.ToString())
+                Console.WriteLine(value.GetHashCode())
+                Console.WriteLine(value.Equals(nil))
+                Console.WriteLine(value.GetType().FullName)
+            }
+            Run()
+            """;
+
+        var lines = CompileAndRun(Source).StandardOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal(4, lines.Length);
+        Assert.Equal("Default.Plain", lines[0]);
+        Assert.True(int.TryParse(lines[1], out _), $"Expected integer hash code, got '{lines[1]}'.");
+        Assert.Equal("False", lines[2]);
+        Assert.Equal("Default.Plain", lines[3]);
+    }
+
+    [Fact]
+    public void ImportedRefStructDeclaredMethod_AndUserInterfaceMethod_RemainDirectCalls()
+    {
+        const string Source = """
+            import System
+
+            interface Marker {
+                func Mark() string;
+            }
+
+            ref struct Bare : Marker {
+                var id int32
+                func Mark() string -> "marker-55"
+            }
+
+            func Run() {
+                var values []int32 = []int32{11, 22}
+                var span ReadOnlySpan[int32] = values
+                var bare = Bare{id: 42}
+                Console.WriteLine(span.ToString())
+                Console.WriteLine(bare.Mark())
+            }
+            Run()
+            """;
+
+        Assert.Equal(
+            string.Join(Environment.NewLine, "System.ReadOnlySpan<Int32>[2]", "marker-55", string.Empty),
+            CompileAndRun(Source).StandardOutput);
+    }
+
+    private static void AssertRejectedWithoutAssembly(
+        string source,
+        string expectedSpan,
+        string expectedReason)
+    {
+        var root = Path.Combine(Environment.CurrentDirectory, $".issue3240-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        var sourcePath = Path.Combine(root, "probe.gs");
+        var assemblyPath = Path.Combine(root, "probe.dll");
+        File.WriteAllText(sourcePath, source);
+
+        try
+        {
+            var compile = CaptureConsole(
+                () => GSharp.Compiler.Program.Main(
+                    ["/out:" + assemblyPath, "/target:exe", "/targetframework:net10.0", sourcePath]));
+            var runtime = compile.ExitCode == 0 && File.Exists(assemblyPath)
+                ? RunAssembly(assemblyPath)
+                : default;
+
+            Assert.True(
+                compile.ExitCode != 0,
+                $"Expected compile rejection, got compile rc=0; run rc={runtime.ExitCode}; stdout=[{runtime.StandardOutput}]; stderr=[{runtime.StandardError}].");
+            Assert.Contains("error GS0219:", compile.StandardOutput, StringComparison.Ordinal);
+            Assert.Equal($"Failed.{Environment.NewLine}", compile.StandardError);
+            Assert.False(File.Exists(assemblyPath), "Compiler must not write an assembly after GS0219.");
+
+            var tree = SyntaxTree.Parse(SourceText.From(source, "issue3240.gs"));
+            var compilation = new Compilation(tree);
+            using var peStream = new MemoryStream();
+            var emit = compilation.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "Issue3240");
+            var diagnostic = Assert.Single(emit.Diagnostics.Where(candidate => candidate.IsError));
+
+            Assert.False(emit.Success);
+            Assert.Equal("GS0219", diagnostic.Id);
+            Assert.Contains(expectedReason, diagnostic.Message, StringComparison.Ordinal);
+            Assert.Equal(expectedSpan, diagnostic.Location.Text.ToString(diagnostic.Location.Span));
+            Assert.Equal(0, peStream.Length);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static (int ExitCode, string StandardOutput, string StandardError) CompileAndRun(string source)
+    {
+        var root = Path.Combine(Environment.CurrentDirectory, $".issue3240-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        var sourcePath = Path.Combine(root, "control.gs");
+        var assemblyPath = Path.Combine(root, "control.dll");
+        File.WriteAllText(sourcePath, source);
+
+        try
+        {
+            var compile = CaptureConsole(
+                () => GSharp.Compiler.Program.Main(
+                    ["/out:" + assemblyPath, "/target:exe", "/targetframework:net10.0", sourcePath]));
+            Assert.Equal(0, compile.ExitCode);
+            Assert.Equal(string.Empty, compile.StandardError);
+            Assert.True(File.Exists(assemblyPath), "Expected control assembly.");
+
+            var runtime = RunAssembly(assemblyPath);
+            Assert.Equal(0, runtime.ExitCode);
+            Assert.Equal(string.Empty, runtime.StandardError);
+            return runtime;
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static (int ExitCode, string StandardOutput, string StandardError) RunAssembly(string assemblyPath)
+    {
+        using var process = Process.Start(new ProcessStartInfo("dotnet")
+        {
+            ArgumentList = { "exec", assemblyPath },
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        });
+        Assert.NotNull(process);
+        var standardOutput = process.StandardOutput.ReadToEndAsync();
+        var standardError = process.StandardError.ReadToEndAsync();
+        Assert.True(process.WaitForExit(30_000), "Timed out running emitted assembly.");
+        return (
+            process.ExitCode,
+            standardOutput.GetAwaiter().GetResult(),
+            standardError.GetAwaiter().GetResult());
+    }
+
+    private static (int ExitCode, string StandardOutput, string StandardError) CaptureConsole(Func<int> action)
+    {
+        using var standardOutput = new StringWriter();
+        using var standardError = new StringWriter();
+        var previousOutput = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(standardOutput);
+        Console.SetError(standardError);
+        try
+        {
+            return (action(), standardOutput.ToString(), standardError.ToString());
+        }
+        finally
+        {
+            Console.SetOut(previousOutput);
+            Console.SetError(previousError);
+        }
+    }
+
+    private static string MethodName(string call)
+    {
+        var dot = call.IndexOf('.', StringComparison.Ordinal);
+        var open = call.IndexOf('(', dot + 1);
+        return call[(dot + 1)..open];
+    }
+}


### PR DESCRIPTION
Fixes #3240.

## Summary
- centralize the emitter's imported value-receiver boxing decision and reuse it while binding inherited CLR calls
- report existing GS0219 before inherited dispatch, interface conversion, inferred generic use, or method-group capture can box a by-ref-like value
- preserve declared ref-struct direct calls, plain structs, imported declared methods, and direct interface/extension calls
- add 17 compile/no-assembly/runtime regression cases with diagnostic ID and source-span assertions, including all four method-group shapes from review

## Validation
- Issue #3240 regression tests: 17 passed
- method-group regression tests: 50 passed
- Release warnings-as-errors solution build: 0 warnings, 0 errors
- GitHub checks: running on 4d970c0fb
