### PR TITLE
Fix boxing conversions to ValueType and Enum

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -850,17 +850,13 @@ public sealed class Conversion
             return Conversion.Implicit;
         }
 
-        // Issue #1218: an enum value boxes implicitly to its CLR reference base
-        // types — System.Object, System.ValueType, and System.Enum. An
-        // EnumSymbol carries no ClrType during binding (the enum is still being
-        // compiled), so the general object-boxing rule above cannot fire. This
-        // makes inherited Enum/ValueType/Object members callable on enum values
-        // (e.g. passing an enum to System.Enum.HasFlag(System.Enum)); the
-        // emitter lowers the conversion to a single `box <Enum>`.
-        if (from is EnumSymbol && to?.ClrType is System.Type enumBoxTarget
-            && (enumBoxTarget.IsSameAs(typeof(object))
-                || enumBoxTarget.IsSameAs(typeof(System.ValueType))
-                || enumBoxTarget.IsSameAs(typeof(System.Enum))))
+        // Issues #1218/#3280: value types box implicitly to System.ValueType,
+        // while enum values additionally box to System.Enum. A same-compilation
+        // EnumSymbol has no ClrType yet, so retain its object-boxing path too.
+        if (to?.ClrType is System.Type valueTypeBaseTarget
+            && ((IsValueTypeLikeFrom(from) && valueTypeBaseTarget.IsSameAs(typeof(System.ValueType)))
+                || (IsEnumLikeType(from) && valueTypeBaseTarget.IsSameAs(typeof(System.Enum)))
+                || (from is EnumSymbol && valueTypeBaseTarget.IsSameAs(typeof(object)))))
         {
             return Conversion.Implicit;
         }
@@ -2719,6 +2715,11 @@ public sealed class Conversion
 
     private static bool IsValueTypeLikeFrom(TypeSymbol type)
     {
+        if (type is TypeParameterSymbol { HasValueTypeConstraint: true })
+        {
+            return true;
+        }
+
         if (type is NullableTypeSymbol nullable
             && NullableLifting.IsAnyValueTypeNullable(nullable))
         {

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue3271ReifiedGenericArgumentBoxingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue3271ReifiedGenericArgumentBoxingTests.cs
@@ -76,17 +76,21 @@ public class Issue3271ReifiedGenericArgumentBoxingTests
             "Issue3271TopReferences.IMark[]",
             "Issue3271TopReferences.Mark");
 
-        // Issue #3280: value-type → System.ValueType is not classified yet.
-        AssertValueTypeTargetDiagnostic(
+        AssertRuns(
             """
             package Issue3271TopValueType
             import System
 
-            func Show[T](value T) { }
+            func Show[T](value T) {
+                Console.WriteLine([]T{value}.GetType())
+                Console.WriteLine(value.GetType())
+                Console.WriteLine(value)
+            }
 
             Show[ValueType](23)
             """,
-            "GS0154",
+            "System.ValueType[]",
+            "System.Int32",
             "23");
     }
 
@@ -119,20 +123,24 @@ public class Issue3271ReifiedGenericArgumentBoxingTests
             "System.IComparable[]",
             "System.Int32");
 
-        // Issue #3280: value-type → System.ValueType is not classified yet.
-        AssertValueTypeTargetDiagnostic(
+        AssertRuns(
             """
             package Issue3271InstanceValueType
             import System
 
             class Runner {
                 init() {}
-                func Show[T](value T) { }
+                func Show[T](value T) {
+                    Console.WriteLine([]T{value}.GetType())
+                    Console.WriteLine(value.GetType())
+                    Console.WriteLine(value)
+                }
             }
 
             Runner().Show[ValueType](33)
             """,
-            "GS0155",
+            "System.ValueType[]",
+            "System.Int32",
             "33");
     }
 
@@ -160,17 +168,21 @@ public class Issue3271ReifiedGenericArgumentBoxingTests
             "System.IComparable[]",
             "System.Int32");
 
-        // Issue #3280: value-type → System.ValueType is not classified yet.
-        AssertValueTypeTargetDiagnostic(
+        AssertRuns(
             """
             package Issue3271ExtensionValueType
             import System
 
-            func (self string) Show[T](value T) { }
+            func (self string) Show[T](value T) {
+                Console.WriteLine([]T{value}.GetType())
+                Console.WriteLine(value.GetType())
+                Console.WriteLine(value)
+            }
 
             "extension".Show[ValueType](43)
             """,
-            "GS0155",
+            "System.ValueType[]",
+            "System.Int32",
             "43");
     }
 
@@ -370,14 +382,4 @@ public class Issue3271ReifiedGenericArgumentBoxingTests
             result.Output);
     }
 
-    private static void AssertValueTypeTargetDiagnostic(string source, string expectedId, string expectedText)
-    {
-        var result = EmittedOracle.Evaluate(source);
-        var diagnostic = Assert.Single(result.Diagnostics);
-
-        Assert.Equal(expectedId, diagnostic.Id);
-        Assert.Equal(expectedText, diagnostic.Location.Text.ToString(diagnostic.Location.Span));
-        Assert.Equal(1, result.ExitCode);
-        Assert.Equal(string.Empty, result.Output);
-    }
 }

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue3280ValueTypeBaseBoxingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue3280ValueTypeBaseBoxingTests.cs
@@ -1,0 +1,276 @@
+// <copyright file="Issue3280ValueTypeBaseBoxingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #3280: CLR value types box implicitly to <see cref="ValueType"/>,
+/// and enum values box implicitly to <see cref="Enum"/>, in every call shape.
+/// </summary>
+public sealed class Issue3280ValueTypeBaseBoxingTests
+{
+    [Theory]
+    [InlineData("top-level")]
+    [InlineData("instance")]
+    [InlineData("extension")]
+    [InlineData("shared")]
+    public void ValueTypeReferenceBases_BoxAndRun_InEveryCallShape(string shape)
+    {
+        AssertRuns(
+            MatrixSource(shape),
+            "System.ValueType[]",
+            "System.Int32",
+            "5",
+            "System.Enum[]",
+            "System.DayOfWeek",
+            "Sunday",
+            "System.Object[]",
+            "System.Int32",
+            "11",
+            "System.ValueType[]",
+            "System.Int32",
+            "22",
+            "System.Enum[]",
+            "System.DayOfWeek",
+            "Monday",
+            "System.DayOfWeek[]",
+            "System.DayOfWeek",
+            "Tuesday");
+    }
+
+    [Fact]
+    public void AlreadyBoxedValueTypeArgument_PreservesTargetTypeAndValue()
+    {
+        AssertRuns(
+            """
+            package Issue3280AlreadyBoxed
+            import System
+
+            func Show[T](value T) {
+                Console.WriteLine([]T{value}.GetType())
+                Console.WriteLine(value.GetType())
+                Console.WriteLine(value)
+            }
+
+            let boxed ValueType = 31
+            Show[ValueType](boxed)
+            """,
+            "System.ValueType[]",
+            "System.Int32",
+            "31");
+    }
+
+    [Fact]
+    public void ReferenceTypeArgument_RemainsReferenceTyped()
+    {
+        Assert.False(
+            Conversion.Classify(
+                TypeSymbol.String,
+                TypeSymbol.FromClrType(typeof(ValueType))).Exists);
+        Assert.False(
+            Conversion.Classify(
+                TypeSymbol.Int32,
+                TypeSymbol.FromClrType(typeof(Enum))).Exists);
+
+        AssertRuns(
+            """
+            package Issue3280ReferenceControl
+            import System
+
+            func Show[T](value T) {
+                Console.WriteLine([]T{value}.GetType())
+                Console.WriteLine(value.GetType())
+                Console.WriteLine(value)
+            }
+
+            Show[object]("right")
+            """,
+            "System.Object[]",
+            "System.String",
+            "right");
+    }
+
+    [Fact]
+    public void ReifiedValueTypeParameter_RemainsUnboxed()
+    {
+        AssertRuns(
+            """
+            package Issue3280ReifiedValueControl
+            import System
+
+            func Show[T](value T) {
+                Console.WriteLine([]T{value}.GetType())
+                Console.WriteLine(value.GetType())
+                Console.WriteLine(value)
+            }
+
+            func Forward[T](value T) {
+                Show[T](value)
+            }
+
+            Forward[int32](41)
+            """,
+            "System.Int32[]",
+            "System.Int32",
+            "41");
+    }
+
+    [Fact]
+    public void StructConstrainedTypeParameter_BoxesToValueType()
+    {
+        AssertRuns(
+            """
+            package Issue3280StructConstraint
+            import System
+
+            func Take(value ValueType) {
+                Console.WriteLine(value.GetType())
+                Console.WriteLine(value)
+            }
+
+            func Forward[T struct](value T) {
+                Take(value)
+            }
+
+            Forward[int32](42)
+            """,
+            "System.Int32",
+            "42");
+    }
+
+    [Fact]
+    public void NullableValueTypeParameter_RemainsUnboxed()
+    {
+        AssertRuns(
+            """
+            package Issue3280NullableValueControl
+            import System
+
+            func Show[T](value T) {
+                Console.WriteLine([]T{value}.GetType())
+                Console.WriteLine(value.GetType())
+                Console.WriteLine(value)
+            }
+
+            var value int32? = 51
+            Show[int32?](value)
+            """,
+            "System.Nullable`1[System.Int32][]",
+            "System.Int32",
+            "51");
+    }
+
+    [Fact]
+    public void ConstrainedMutableStruct_RemainsMutable()
+    {
+        AssertRuns(
+            """
+            package Issue3280MutableStructControl
+            import System
+
+            interface IMutable {
+                func Bump();
+                func Read() int32;
+            }
+
+            struct Counter : IMutable {
+                var Value int32
+                func Bump() { Value = Value + 1 }
+                func Read() int32 { return Value }
+            }
+
+            func Mutate[T IMutable](value T) T {
+                value.Bump()
+                return value
+            }
+
+            let result = Mutate[Counter](Counter{Value: 60})
+            Console.WriteLine(result.Read())
+            """,
+            "61");
+    }
+
+    private static string MatrixSource(string shape)
+    {
+        const string genericMethodBody = """
+            {
+                Console.WriteLine([]T{value}.GetType())
+                Console.WriteLine(value.GetType())
+                Console.WriteLine(value)
+            }
+            """;
+        const string valueTypeMethodBody = """
+            {
+                Console.WriteLine([]ValueType{value}.GetType())
+                Console.WriteLine(value.GetType())
+                Console.WriteLine(value)
+            }
+            """;
+        const string enumMethodBody = """
+            {
+                Console.WriteLine([]Enum{value}.GetType())
+                Console.WriteLine(value.GetType())
+                Console.WriteLine(value)
+            }
+            """;
+
+        var declaration = shape switch
+        {
+            "top-level" => "func TakeValueType(value ValueType) " + valueTypeMethodBody
+                + " func TakeEnum(value Enum) " + enumMethodBody
+                + " func Show[T](value T) " + genericMethodBody,
+            "instance" => "class Runner { init() {} func TakeValueType(value ValueType) " + valueTypeMethodBody
+                + " func TakeEnum(value Enum) " + enumMethodBody
+                + " func Show[T](value T) " + genericMethodBody + " }",
+            "extension" => "func (self string) TakeValueType(value ValueType) " + valueTypeMethodBody
+                + " func (self string) TakeEnum(value Enum) " + enumMethodBody
+                + " func (self string) Show[T](value T) " + genericMethodBody,
+            "shared" => "class Runner { shared { func TakeValueType(value ValueType) " + valueTypeMethodBody
+                + " func TakeEnum(value Enum) " + enumMethodBody
+                + " func Show[T](value T) " + genericMethodBody + " } }",
+            _ => throw new ArgumentOutOfRangeException(nameof(shape)),
+        };
+        var target = shape switch
+        {
+            "top-level" => string.Empty,
+            "instance" => "Runner().",
+            "extension" => "\"receiver\".",
+            "shared" => "Runner.",
+            _ => throw new ArgumentOutOfRangeException(nameof(shape)),
+        };
+
+        return $$"""
+            package Issue3280{{shape.Replace("-", string.Empty, StringComparison.Ordinal)}}
+            import System
+
+            {{declaration}}
+
+            {{target}}TakeValueType(5)
+            {{target}}TakeEnum(DayOfWeek.Sunday)
+            {{target}}Show[object](11)
+            {{target}}Show[ValueType](22)
+            {{target}}Show[Enum](DayOfWeek.Monday)
+            {{target}}Show[DayOfWeek](DayOfWeek.Tuesday)
+            """;
+    }
+
+    private static void AssertRuns(string source, params string[] expectedLines)
+    {
+        var result = EmittedOracle.Evaluate(source);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(0, result.ExitCode);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(string.Empty, result.ErrorOutput);
+        Assert.Equal(
+            string.Join(Environment.NewLine, expectedLines) + Environment.NewLine,
+            result.Output);
+    }
+}


### PR DESCRIPTION
Refs #3280

## Summary
- classify concrete CLR value types and `struct`-constrained type parameters as implicitly boxable to `System.ValueType`
- classify concrete enum values as implicitly boxable to `System.Enum`
- execute non-generic and explicitly closed generic object, ValueType, Enum, and concrete-enum calls across free, instance, extension, and shared methods
- replace #3272's temporary ValueType diagnostic pins with runtime boxing assertions
- pin reference, nullable, reified value-type, and mutable-struct controls against over-boxing

## Scope
This addresses the missing valid boxing conversions described in #3280. The separate GS0154/GS0155 disagreement for rejected arguments remains reproducible and is tracked by #3312, and #3280 remains open./

## Coordination
#3272 is merged. This branch is rebased onto current `main`; its duplicate generic-call mirror commit dropped as already upstream. The resulting PR diff is limited to the conversion classifier and boxing regression tests. `merge-tree` is clean against current `main` and nearby ref-struct boxing PR #3283.

## Validation
- issue #3271/#3280 boxing tests: 19 passed, 0 failed
- issue #3267 generic-call regression tests: 18 passed, 0 failed
- issue #1218 enum regression tests: 4 passed, 0 failed
- Release solution build with `ContinuousIntegrationBuild=true`: 0 warnings, 0 errors