### PR TITLE
Allow function pointer comparisons with nil

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -355,10 +355,9 @@ internal sealed partial class ExpressionBinder
     }
 
     /// <summary>
-    /// ADR-0122 / issue #1014: lowers a pointer arithmetic or comparison
-    /// binary expression where at least one operand is an unmanaged pointer
-    /// (<see cref="PointerTypeSymbol"/>). Returns <see langword="null"/> when
-    /// the operator/operand shape is not a supported pointer operation, so the
+    /// ADR-0122 / issues #1014 and #3286: lowers unmanaged-pointer arithmetic
+    /// and native pointer comparisons. Returns <see langword="null"/> when the
+    /// operator/operand shape is not a supported pointer operation, so the
     /// caller falls back to the normal (error-reporting) path.
     /// </summary>
     /// <param name="syntax">The binary expression syntax.</param>
@@ -584,7 +583,12 @@ internal sealed partial class ExpressionBinder
 
     private BoundExpression LowerPointerComparison(SyntaxKind operatorKind, BoundExpression left, BoundExpression right)
     {
-        var pointerType = (left.Type as PointerTypeSymbol) ?? (right.Type as PointerTypeSymbol);
+        if (!CanLowerPointerComparisonOperand(left.Type) || !CanLowerPointerComparisonOperand(right.Type))
+        {
+            return null;
+        }
+
+        var pointerType = left.Type == TypeSymbol.Null ? right.Type : left.Type;
         var leftNint = ToNativeIntForPointerComparison(left, pointerType);
         var rightNint = ToNativeIntForPointerComparison(right, pointerType);
         var op = BoundBinaryOperator.Bind(operatorKind, TypeSymbol.NInt, TypeSymbol.NInt);
@@ -596,7 +600,10 @@ internal sealed partial class ExpressionBinder
         return new BoundBinaryExpression(null, leftNint, op, rightNint);
     }
 
-    private BoundExpression ToNativeIntForPointerComparison(BoundExpression operand, PointerTypeSymbol pointerType)
+    private static bool CanLowerPointerComparisonOperand(TypeSymbol type) =>
+        type == TypeSymbol.Null || Conversion.Classify(type, TypeSymbol.NInt).Exists;
+
+    private BoundExpression ToNativeIntForPointerComparison(BoundExpression operand, TypeSymbol pointerType)
     {
         if (operand.Type == TypeSymbol.NInt)
         {
@@ -604,7 +611,7 @@ internal sealed partial class ExpressionBinder
         }
 
         // `nil` becomes a null pointer (zero native int) before the comparison.
-        if (operand.Type == TypeSymbol.Null && pointerType != null)
+        if (operand.Type == TypeSymbol.Null)
         {
             var nullPointer = new BoundConversionExpression(null, pointerType, operand);
             return new BoundConversionExpression(null, TypeSymbol.NInt, nullPointer);
@@ -1458,7 +1465,8 @@ internal sealed partial class ExpressionBinder
         // and pointer comparison (`==`, `!=`, `<`, …) inside an unsafe context.
         // Lowered to native-int (`nint`) arithmetic/comparison plus pointer
         // reinterpret conversions — no dedicated bound node is required.
-        if (boundLeft.Type is PointerTypeSymbol || boundRight.Type is PointerTypeSymbol)
+        if (boundLeft.Type is PointerTypeSymbol or FunctionPointerTypeSymbol
+            || boundRight.Type is PointerTypeSymbol or FunctionPointerTypeSymbol)
         {
             var pointerResult = TryBindPointerBinaryExpression(syntax, boundLeft, boundRight);
             if (pointerResult != null)

--- a/test/Compiler.Tests/Emit/Issue3286FunctionPointerNilComparisonEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3286FunctionPointerNilComparisonEmitTests.cs
@@ -1,0 +1,192 @@
+// <copyright file="Issue3286FunctionPointerNilComparisonEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>Issue #3286: function-pointer equality and inequality use native pointer semantics.</summary>
+public class Issue3286FunctionPointerNilComparisonEmitTests
+{
+    [Fact]
+    public async Task FunctionPointerComparisons_AllValueSources_CompileAndRun()
+    {
+        const string Source = """
+            package Probe
+            import System
+
+            unsafe func identity(x int32) int32 { return x }
+            unsafe func other(x int32) int32 { return x + 1 }
+            unsafe func nilManaged() *func(int32) int32 { return nil }
+            unsafe func nilCdecl() unmanaged[Cdecl] (int32) -> int32 { return nil }
+
+            unsafe class ManagedBox {
+                let Value *func(int32) int32
+                init(value *func(int32) int32) { Value = value }
+            }
+
+            unsafe class CdeclBox {
+                let Value unmanaged[Cdecl] (int32) -> int32
+                init(value unmanaged[Cdecl] (int32) -> int32) { Value = value }
+            }
+
+            unsafe {
+                var nilFp *func(int32) int32 = nil
+                var boundFp *func(int32) int32 = &identity
+                var otherFp *func(int32) int32 = &other
+                Console.WriteLine(nilFp == nil)
+                Console.WriteLine(nil == nilFp)
+                Console.WriteLine(nilFp != nil)
+                Console.WriteLine(nil != nilFp)
+                Console.WriteLine(boundFp == nil)
+                Console.WriteLine(nil == boundFp)
+                Console.WriteLine(boundFp != nil)
+                Console.WriteLine(nil != boundFp)
+                Console.WriteLine(boundFp == boundFp)
+                Console.WriteLine(boundFp != otherFp)
+
+                var nilUf unmanaged[Cdecl] (int32) -> int32 = nil
+                var nilUf2 unmanaged[Cdecl] (int32) -> int32 = nil
+                Console.WriteLine(nilUf == nil)
+                Console.WriteLine(nil == nilUf)
+                Console.WriteLine(nilUf != nil)
+                Console.WriteLine(nil != nilUf)
+                Console.WriteLine(nilUf == nilUf2)
+                Console.WriteLine(nilUf != nilUf2)
+
+                var managedBox = ManagedBox(nil)
+                var managedItems = []*func(int32) int32{nil, &identity}
+                Console.WriteLine(managedBox.Value == nil)
+                Console.WriteLine(managedItems[0] == nil)
+                Console.WriteLine(managedItems[1] != nil)
+                Console.WriteLine(nilManaged() == nil)
+
+                var cdeclBox = CdeclBox(nil)
+                var cdeclItems = []unmanaged[Cdecl] (int32) -> int32{nil, nil}
+                Console.WriteLine(cdeclBox.Value == nil)
+                Console.WriteLine(cdeclItems[0] == nil)
+                Console.WriteLine(cdeclItems[1] != nil)
+                Console.WriteLine(nilCdecl() == nil)
+            }
+            """;
+
+        Assert.Equal(
+            """
+            True
+            True
+            False
+            False
+            False
+            False
+            True
+            True
+            True
+            True
+            True
+            True
+            False
+            False
+            True
+            False
+            True
+            True
+            True
+            True
+            True
+            True
+            False
+            True
+
+            """.ReplaceLineEndings("\n"),
+            await CompileAndRun(Source));
+    }
+
+    private static async Task<string> CompileAndRun(string source)
+    {
+        var outputDirectory = Path.Combine(AppContext.BaseDirectory, "issue3286", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(outputDirectory);
+        try
+        {
+            var sourcePath = Path.Combine(outputDirectory, "Program.gs");
+            var outputPath = Path.Combine(outputDirectory, "Issue3286.dll");
+            File.WriteAllText(sourcePath, source);
+
+            using var standardOut = new StringWriter();
+            using var standardError = new StringWriter();
+            var previousOut = Console.Out;
+            var previousError = Console.Error;
+            Console.SetOut(standardOut);
+            Console.SetError(standardError);
+            int exitCode;
+            try
+            {
+                exitCode = Program.Main(new[]
+                {
+                    "/out:" + outputPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    sourcePath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+                Console.SetError(previousError);
+            }
+
+            Assert.True(
+                exitCode == 0,
+                $"gsc failed (exit {exitCode}):\nstdout:\n{standardOut}\nstderr:\n{standardError}");
+
+            var startInfo = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = outputDirectory,
+            };
+            startInfo.ArgumentList.Add("exec");
+            startInfo.ArgumentList.Add("--runtimeconfig");
+            startInfo.ArgumentList.Add(Path.ChangeExtension(outputPath, ".runtimeconfig.json"));
+            startInfo.ArgumentList.Add(outputPath);
+
+            using var process = Process.Start(startInfo)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec.");
+            var stdoutTask = process.StandardOutput.ReadToEndAsync();
+            var stderrTask = process.StandardError.ReadToEndAsync();
+            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            try
+            {
+                await process.WaitForExitAsync(timeout.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                process.Kill(entireProcessTree: true);
+                Assert.Fail("dotnet exec timed out.");
+            }
+
+            var stdout = await stdoutTask;
+            var stderr = await stderrTask;
+            Assert.True(
+                process.ExitCode == 0,
+                $"sample exited {process.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+            return stdout.ReplaceLineEndings("\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(outputDirectory, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3286FunctionPointerNilComparisonBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3286FunctionPointerNilComparisonBinderTests.cs
@@ -1,0 +1,38 @@
+// <copyright file="Issue3286FunctionPointerNilComparisonBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>Issue #3286: function-pointer comparisons only accept native-pointer operands.</summary>
+public class Issue3286FunctionPointerNilComparisonBinderTests
+{
+    [Theory]
+    [InlineData("fp == \"x\"", "==")]
+    [InlineData("\"x\" != fp", "!=")]
+    public void FunctionPointerComparedWithNonPointer_ReportsGS0129(string expression, string operatorText)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(
+            $$"""
+            package P
+
+            unsafe func run() {
+                var fp *func(int32) int32 = nil
+                var bad = {{expression}}
+            }
+            """));
+        var compilation = new Compilation(tree);
+        using var peStream = new MemoryStream();
+
+        var diagnostic = Assert.Single(compilation.Emit(peStream).Diagnostics.Where(d => d.Id == "GS0129"));
+
+        Assert.Equal(operatorText, diagnostic.Location.Text.ToString(diagnostic.Location.Span));
+    }
+}

--- a/test/Interpreter.Tests/Issue2956InterpreterBoundaryTests.cs
+++ b/test/Interpreter.Tests/Issue2956InterpreterBoundaryTests.cs
@@ -161,6 +161,26 @@ public class Issue2956InterpreterBoundaryTests
     }
 
     [Fact]
+    public void FunctionPointerNilComparisonsExecute()
+    {
+        var result = RunGsi(
+            nameof(FunctionPointerNilComparisonsExecute),
+            """
+            import System
+
+            unsafe {
+                let pointer *func(int32) int32 = nil
+                Console.WriteLine(pointer == nil)
+                Console.WriteLine(nil == pointer)
+                Console.WriteLine(pointer != nil)
+                Console.WriteLine(nil != pointer)
+            }
+            """);
+
+        AssertRan(result, "True\nTrue\nFalse\nFalse\n");
+    }
+
+    [Fact]
     public void UnsafeBlockWithoutStorageOnlyConstructEvaluatesNormally()
     {
         var result = RunGsi(


### PR DESCRIPTION
Fixes #3286.

## Summary

- Extend the existing native-pointer binary-operation gate to `FunctionPointerTypeSymbol` instead of adding a parallel function-pointer comparison path.
- Generalize the shared comparison lowering's nil target so both unmanaged data pointers and function pointers lower through `nint`.
- Add an end-to-end runtime matrix covering operand order, equality/inequality, managed and Cdecl function pointers, function-pointer pairs, and local/field/array/return value sources.

## Interaction with #3275

This branch is based on `main` after #3275. Its `nil -> FunctionPointerTypeSymbol` emission supplies the zero native pointer consumed by the existing shared comparison lowering; no #3275 files are modified here.
