### PR TITLE
Reject indexed-element struct member writes through prior-cell globals with GS0499

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -2737,13 +2737,32 @@ internal sealed partial class ExpressionBinder
     /// <see cref="SubmissionWriteReceiverKind.None"/>. Crossing a
     /// reference-typed link makes the remaining chain heap-rooted (writable
     /// regardless of the root's read-only flag); crossing a computed
-    /// (property) link makes an in-place write impossible.
+    /// (property) link makes an in-place write impossible. Issue #3252: a
+    /// value-typed ELEMENT link (<c>ps[0]</c>, <c>m[k]</c>) is a struct
+    /// temporary — the element loads as a copy, so a member write through it
+    /// can never reach the stored element; when the collection chain roots
+    /// at a submission global the write classifies as
+    /// <see cref="SubmissionWriteReceiverKind.NotAddressable"/>, matching
+    /// the GS0499 rejection the identical same-cell shape reports.
     /// </summary>
     /// <param name="receiver">The bound member-write receiver.</param>
     /// <returns>The chain classification.</returns>
     private static SubmissionWriteReceiverKind ClassifySubmissionGlobalWriteReceiver(BoundExpression receiver)
     {
-        if (receiver is not BoundClrPropertyAccessExpression access || ReceiverTypeIsReference(access.Type))
+        if (receiver == null || ReceiverTypeIsReference(receiver.Type))
+        {
+            return SubmissionWriteReceiverKind.None;
+        }
+
+        // Issue #3252: the receiver IS an element load (`ps[0].X = v`).
+        if (TryGetElementAccessTarget(receiver, out var elementCollection))
+        {
+            return ChainHasSubmissionGlobalRoot(elementCollection)
+                ? SubmissionWriteReceiverKind.NotAddressable
+                : SubmissionWriteReceiverKind.None;
+        }
+
+        if (receiver is not BoundClrPropertyAccessExpression access)
         {
             return SubmissionWriteReceiverKind.None;
         }
@@ -2790,6 +2809,17 @@ internal sealed partial class ExpressionBinder
                 return SubmissionWriteReceiverKind.None;
             }
 
+            // Issue #3252: the value-typed field walk rests on an element
+            // load (`qs[0].B2.C = v`) — the chain bottoms out in a copied
+            // element, so the write is blocked when the collection roots at
+            // a submission global.
+            if (TryGetElementAccessTarget(access.Receiver, out var linkCollection))
+            {
+                return ChainHasSubmissionGlobalRoot(linkCollection)
+                    ? SubmissionWriteReceiverKind.NotAddressable
+                    : SubmissionWriteReceiverKind.None;
+            }
+
             if (access.Receiver is not BoundClrPropertyAccessExpression inner)
             {
                 return SubmissionWriteReceiverKind.None;
@@ -2800,19 +2830,60 @@ internal sealed partial class ExpressionBinder
     }
 
     /// <summary>
-    /// Issue #3185: whether a CLR member-access chain bottoms out at a prior
-    /// submission's addressable global static field.
+    /// Issue #3252: extracts the indexed collection from a bound element
+    /// load — <see cref="BoundIndexExpression"/> (arrays, slices, maps) or
+    /// <see cref="BoundClrIndexExpression"/> (CLR indexer, e.g. an imported
+    /// <c>Dictionary</c>).
     /// </summary>
-    /// <param name="access">The chain's innermost inspected link.</param>
-    /// <returns><c>true</c> when the chain root is a flagged submission global.</returns>
-    private static bool ChainHasSubmissionGlobalRoot(BoundClrPropertyAccessExpression access)
+    /// <param name="expression">The candidate element-access expression.</param>
+    /// <param name="collection">The indexed collection expression, when <paramref name="expression"/> is an element load.</param>
+    /// <returns><c>true</c> when <paramref name="expression"/> is an element load.</returns>
+    private static bool TryGetElementAccessTarget(BoundExpression expression, out BoundExpression collection)
     {
-        while (access.Receiver is BoundClrPropertyAccessExpression inner)
+        switch (expression)
         {
-            access = inner;
+            case BoundIndexExpression index:
+                collection = index.Target;
+                return true;
+            case BoundClrIndexExpression clrIndex:
+                collection = clrIndex.Target;
+                return true;
+            default:
+                collection = null;
+                return false;
         }
+    }
 
-        return access.Receiver == null && access.IsAddressableStaticField;
+    /// <summary>
+    /// Issue #3185: whether a CLR member-access chain bottoms out at a prior
+    /// submission's addressable global static field. Issue #3252: the walk
+    /// also crosses element-access links (<c>obj.Arr[0]</c>) so an indexed
+    /// collection reached through fields of a submission global still
+    /// classifies against the seam rules.
+    /// </summary>
+    /// <param name="expression">The chain's innermost inspected link.</param>
+    /// <returns><c>true</c> when the chain root is a flagged submission global.</returns>
+    private static bool ChainHasSubmissionGlobalRoot(BoundExpression expression)
+    {
+        while (true)
+        {
+            switch (expression)
+            {
+                case BoundClrPropertyAccessExpression { Receiver: null } root:
+                    return root.IsAddressableStaticField;
+                case BoundClrPropertyAccessExpression link:
+                    expression = link.Receiver;
+                    continue;
+                case BoundIndexExpression index:
+                    expression = index.Target;
+                    continue;
+                case BoundClrIndexExpression clrIndex:
+                    expression = clrIndex.Target;
+                    continue;
+                default:
+                    return false;
+            }
+        }
     }
 
     /// <summary>

--- a/test/Interpreter.Tests/Issue3252IndexedStructMemberWriteTests.cs
+++ b/test/Interpreter.Tests/Issue3252IndexedStructMemberWriteTests.cs
@@ -1,0 +1,218 @@
+// <copyright file="Issue3252IndexedStructMemberWriteTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Repl.Engine;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #3252 (ADR-0156 Phase 2 seam, part of #3176/#3163): a struct-field
+/// write through an indexed element of a prior-cell global
+/// (<c>ps[0].X = v</c>) bound successfully and SILENTLY DROPPED the write —
+/// the chain path evaluated the element into a value-typed temporary and
+/// stored into the copy. The identical same-cell shape is rejected cleanly
+/// with GS0499 (struct-temporary receiver, not writable storage). These
+/// tests pin cross-cell/same-cell parity across the shape matrix: simple,
+/// compound, and increment element-member writes; nested struct chains;
+/// array, slice, and map collections. The mutating-method shape
+/// (<c>ps[0].Bump()</c>) operates on an element copy in BOTH same-cell and
+/// cross-cell form (the pre-existing language rule), so it stays observable
+/// but unchanged, and reference-typed (class) elements stay writable
+/// through the element reference.
+/// </summary>
+public sealed class Issue3252IndexedStructMemberWriteTests
+{
+    private const string StructTemporaryMessageFragment = "not writable storage";
+
+    /// <summary>
+    /// The user's exact repro: a simple struct-field write through an
+    /// indexed element of a prior-cell array-of-struct global must report
+    /// GS0499 (same-cell parity) instead of silently writing a copy.
+    /// </summary>
+    [Fact]
+    public void CrossCellArrayElementStructFieldWriteReportsGs0499()
+    {
+        using var engine = new EmittedSessionEngine();
+        AssertOk(engine, "struct P { var X int }\nvar ps = [2]P{}");
+
+        AssertStructTemporaryError(engine, "ps[0].X = 7");
+
+        var probe = engine.Evaluate("ps[0].X");
+        Assert.False(probe.HasError, string.Join("; ", probe.Diagnostics));
+        Assert.Equal(0, probe.Value);
+    }
+
+    /// <summary>
+    /// Compound flavor (<c>ps[0].X += v</c>): same silent-drop class, same
+    /// GS0499 parity requirement.
+    /// </summary>
+    [Fact]
+    public void CrossCellArrayElementStructFieldCompoundWriteReportsGs0499()
+    {
+        using var engine = new EmittedSessionEngine();
+        AssertOk(engine, "struct P { var X int }\nvar ps = [2]P{}");
+
+        AssertStructTemporaryError(engine, "ps[0].X += 7");
+    }
+
+    /// <summary>
+    /// Increment flavor (<c>ps[0].X++</c>): desugars through the compound
+    /// chain path; must report GS0499 like its same-cell twin.
+    /// </summary>
+    [Fact]
+    public void CrossCellArrayElementStructFieldIncrementReportsGs0499()
+    {
+        using var engine = new EmittedSessionEngine();
+        AssertOk(engine, "struct P { var X int }\nvar ps = [2]P{}");
+
+        AssertStructTemporaryError(engine, "ps[0].X++");
+    }
+
+    /// <summary>
+    /// Nested chain (<c>qs[0].B2.C = v</c>): the value-typed field walk
+    /// bottoms out in a copied element, so the write must be blocked too.
+    /// </summary>
+    [Fact]
+    public void CrossCellNestedStructFieldWriteThroughElementReportsGs0499()
+    {
+        using var engine = new EmittedSessionEngine();
+        AssertOk(engine, "struct B { var C int }\nstruct A2 { var B2 B }\nvar qs = [2]A2{}");
+
+        AssertStructTemporaryError(engine, "qs[0].B2.C = 7");
+    }
+
+    /// <summary>
+    /// Map-of-struct flavor (<c>m[k].X = v</c>): a map element load is a
+    /// copy in the same way; same-cell reports GS0499, cross-cell must too.
+    /// </summary>
+    [Fact]
+    public void CrossCellMapElementStructFieldWriteReportsGs0499()
+    {
+        using var engine = new EmittedSessionEngine();
+        AssertOk(engine, "struct P { var X int }\nvar m = map[int, P]{1: P{}}");
+
+        AssertStructTemporaryError(engine, "m[1].X = 7");
+    }
+
+    /// <summary>
+    /// Slice-of-struct flavor (<c>ss[0].X = v</c>).
+    /// </summary>
+    [Fact]
+    public void CrossCellSliceElementStructFieldWriteReportsGs0499()
+    {
+        using var engine = new EmittedSessionEngine();
+        AssertOk(engine, "struct P { var X int }\nvar ss = []P{P{}, P{}}");
+
+        AssertStructTemporaryError(engine, "ss[0].X = 7");
+    }
+
+    /// <summary>
+    /// Same-cell parity pins: the identical shapes in a single cell report
+    /// GS0499 on main already — pinned so the parity target can't drift.
+    /// </summary>
+    [Theory]
+    [InlineData("struct P { var X int }\nvar ps = [2]P{}\nps[0].X = 7")]
+    [InlineData("struct P { var X int }\nvar ps = [2]P{}\nps[0].X += 7")]
+    [InlineData("struct P { var X int }\nvar ps = [2]P{}\nps[0].X++")]
+    [InlineData("struct B { var C int }\nstruct A2 { var B2 B }\nvar qs = [2]A2{}\nqs[0].B2.C = 7")]
+    [InlineData("struct P { var X int }\nvar m = map[int, P]{1: P{}}\nm[1].X = 7")]
+    [InlineData("struct P { var X int }\nvar ss = []P{P{}, P{}}\nss[0].X = 7")]
+    public void SameCellIndexedStructMemberWriteReportsGs0499(string cell)
+    {
+        using var engine = new EmittedSessionEngine();
+        AssertStructTemporaryError(engine, cell);
+    }
+
+    /// <summary>
+    /// Mutating-method parity: calling a mutating method on an indexed
+    /// element operates on an element COPY in both same-cell and cross-cell
+    /// form (the pre-existing language rule for method receivers). Pinned so
+    /// the seam fix doesn't change the method shape's semantics in either
+    /// direction.
+    /// </summary>
+    [Fact]
+    public void MutatingMethodOnIndexedElementOperatesOnCopyInBothForms()
+    {
+        const string decls = "struct P { var X int\n func Bump() { this.X = this.X + 1 } }\nvar ps = [2]P{}";
+
+        using var sameCell = new EmittedSessionEngine();
+        var same = sameCell.Evaluate(decls + "\nps[0].Bump()\nps[0].X");
+        Assert.False(same.HasError, string.Join("; ", same.Diagnostics));
+        Assert.Equal(0, same.Value);
+
+        using var crossCell = new EmittedSessionEngine();
+        AssertOk(crossCell, decls);
+        AssertOk(crossCell, "ps[0].Bump()");
+        var probe = crossCell.Evaluate("ps[0].X");
+        Assert.False(probe.HasError, string.Join("; ", probe.Diagnostics));
+        Assert.Equal(0, probe.Value);
+    }
+
+    /// <summary>
+    /// Reference-typed (class) elements are NOT struct temporaries: a member
+    /// write through an indexed element of a prior-cell array-of-class
+    /// global mutates the referenced heap object and must keep working.
+    /// </summary>
+    [Fact]
+    public void CrossCellClassElementMemberWriteStillMutatesHeapObject()
+    {
+        using var engine = new EmittedSessionEngine();
+        AssertOk(engine, "class C { var X int }\nvar cs = []C{C{}, C{}}");
+        AssertOk(engine, "cs[0].X = 7");
+
+        var probe = engine.Evaluate("cs[0].X");
+        Assert.False(probe.HasError, string.Join("; ", probe.Diagnostics));
+        Assert.Equal(7, probe.Value);
+    }
+
+    /// <summary>
+    /// The diagnostic's suggested remedy stays viable across cells: copy the
+    /// element to a mutable local, mutate it, and store it back through the
+    /// whole-element index assignment (#3251's seam).
+    /// </summary>
+    [Fact]
+    public void CrossCellRemedyCopyMutateStoreBackWorks()
+    {
+        using var engine = new EmittedSessionEngine();
+        AssertOk(engine, "struct P { var X int }\nvar ps = [2]P{}");
+        AssertOk(engine, "var tmp = ps[0]\ntmp.X = 7\nps[0] = tmp");
+
+        var probe = engine.Evaluate("ps[0].X");
+        Assert.False(probe.HasError, string.Join("; ", probe.Diagnostics));
+        Assert.Equal(7, probe.Value);
+    }
+
+    /// <summary>
+    /// Guard: whole-variable member writes through a prior-cell struct
+    /// global (issue #3185's addressable path, no indexing) stay writable
+    /// in place.
+    /// </summary>
+    [Fact]
+    public void CrossCellDirectStructGlobalMemberWriteStillMutatesInPlace()
+    {
+        using var engine = new EmittedSessionEngine();
+        AssertOk(engine, "struct P { var X int }\nvar p = P{}");
+        AssertOk(engine, "p.X = 7");
+
+        var probe = engine.Evaluate("p.X");
+        Assert.False(probe.HasError, string.Join("; ", probe.Diagnostics));
+        Assert.Equal(7, probe.Value);
+    }
+
+    private static void AssertOk(EmittedSessionEngine engine, string cell)
+    {
+        var result = engine.Evaluate(cell);
+        Assert.False(result.HasError, $"cell '{cell}': {string.Join("; ", result.Diagnostics)}");
+    }
+
+    private static void AssertStructTemporaryError(EmittedSessionEngine engine, string cell)
+    {
+        var result = engine.Evaluate(cell);
+        Assert.True(result.HasError, $"cell '{cell}' bound without error — the write would silently drop");
+        Assert.Contains(
+            result.Diagnostics,
+            d => d.ToString().Contains(StructTemporaryMessageFragment, System.StringComparison.Ordinal));
+    }
+}


### PR DESCRIPTION
Fixes #3252. Part of #3176, part of #3163.

## Summary

- Root cause: the issue #3185 submission write-seam classifier (`ClassifySubmissionGlobalWriteReceiver`) only walked `BoundClrPropertyAccessExpression` links, so a receiver containing an element load (`BoundIndexExpression` / `BoundClrIndexExpression`) classified as `None`; the CLR member-write path then stored the field into the element's value-typed copy — binding succeeded, echoed the value, and silently dropped the write.
- Classify a value-typed element load — as the receiver itself (`ps[0].X = v`) or at the bottom of a value-typed field walk (`qs[0].B2.C = v`) — as `NotAddressable` when the collection chain roots at an addressable submission global, producing the same GS0499 struct-temporary rejection the identical same-cell shape reports. `ChainHasSubmissionGlobalRoot` now also crosses element-access links.
- Seam-gated: the new classifications only fire on chains bottoming out at `IsAddressableStaticField`, which is only set behind `SubmissionImports != null` (issue #3185's read fallback). Non-REPL binding and emit paths are untouched.
- The in-place (`ldelema`-rooted) element write that would lift GS0499 for arrays/slices in both same-cell and cross-cell form is shared-path emitter surgery, filed as #3292.

## Per-shape disposition (same-cell behavior verified empirically; cross-cell aligned to it)

| Shape | Same-cell (main) | Cross-cell (main) | Cross-cell (this PR) |
|---|---|---|---|
| `ps[0].X = v` (array) | GS0499 | silent drop | GS0499 |
| `ps[0].X += v` (array, compound) | GS0499 | silent drop | GS0499 |
| `ps[0].X++` (array, increment) | GS0499 | silent drop | GS0499 |
| `qs[0].B2.C = v` (nested) | GS0499 | silent drop | GS0499 |
| `m[k].X = v` (map) | GS0499 | silent drop | GS0499 |
| `ss[0].X = v` (slice) | GS0499 | silent drop | GS0499 |
| `ps[0].Bump()` (mutating method) | operates on copy | operates on copy | unchanged (already at parity; #3292 tracks in-place) |
| `cs[0].X = v` (class element) | writes heap object | writes heap object | unchanged (pinned) |
| `p.X = v` (direct global, #3185) | in-place | in-place | unchanged (pinned) |
| copy-mutate-store-back remedy | works | works | unchanged (pinned) |

The issue's same-cell GS0499 parity claim is confirmed for every collection shape (arrays, slices, maps; simple/compound/increment/nested).

## Verification

- Release solution build: 0 warnings, 0 errors.
- Witness matrix (ADR-0154): 6 cross-cell write witnesses RED on main (bound without error — silent drop), GREEN after the fix; 10 parity pins/guards green on both sides. `Issue3252IndexedStructMemberWriteTests`: 16/16.
- Interpreter.Tests (full): 1376 passed, 0 failed, 3 skipped (pre-existing skips).
- Core.Tests (full): 7210 passed, 0 failed, 1 skipped (pre-existing).
- Compiler.Tests LanguageConformance filter: 126/126.
- NOT RUN: full Compiler.Tests outside the LanguageConformance filter, LanguageServer/Sdk/Extensions/Cs2Gs suites, e2etests — the change is a private static binder classifier gated on `IsAddressableStaticField` (set only behind the `SubmissionImports != null` seam); emit paths untouched, conformance filter run as the shared-path canary. Cs2Gs additionally has a known non-deterministic host crash.

## Checklist

- [x] Behavioral tests carry a witness of discrimination (ADR-0154): the 6 cross-cell witnesses fail on the pre-change code and pass with it; pins verified green on both sides.
- [x] Self-review verdict: MERGEABLE — seam-gated binder-only change; residual (in-place `ldelema` element writes, incl. the copy-semantics mutating-method shape) filed as #3292 rather than forced into the seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)