### PR TITLE
Close instance method groups over the receiver's construction

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -57,13 +57,34 @@ internal sealed partial class ExpressionBinder
         if (methods.Length == 1 && !methods[0].IsGeneric)
         {
             var only = methods[0];
+
+            // Issue #3248: the candidate comes from the receiver type's
+            // DEFINITION (a constructed StructSymbol forwards `Methods` to
+            // it), so its parameter/return types still reference the
+            // declaring class's own type parameters. Substitute the
+            // signature through the receiver's construction of the declaring
+            // definition (resolved along the base chain) so the group's
+            // FunctionType carries the receiver's instantiation. Without
+            // this, a deferred method group like `holder.Count` inside
+            // `GetCounter[T](holder Holder[T])` kept `Holder`'s class type
+            // parameter in its function type and the emitter encoded the
+            // delegate TypeSpec with a class `Var` slot in a context that
+            // only has method generics (invalid metadata;
+            // BadImageFormatException at runtime).
+            var owner = receiver?.Type is StructSymbol receiverStruct
+                && only.ReceiverType is StructSymbol declaredReceiver
+                    ? TypeMemberModel.ResolveStaticMemberOwner(receiverStruct, declaredReceiver)
+                    : null;
+
             var paramTypes = ImmutableArray.CreateBuilder<TypeSymbol>(only.Parameters.Length);
             foreach (var p in only.Parameters)
             {
-                paramTypes.Add(p.Type);
+                paramTypes.Add(owner?.SubstituteMemberType(p.Type) ?? p.Type);
             }
 
-            var fnType = FunctionTypeSymbol.Get(paramTypes.MoveToImmutable(), this.MethodGroupObservableReturnType(only));
+            var returnType = this.MethodGroupObservableReturnType(only);
+            returnType = owner?.SubstituteMemberType(returnType) ?? returnType;
+            var fnType = FunctionTypeSymbol.Get(paramTypes.MoveToImmutable(), returnType);
             return new BoundMethodGroupExpression(null, receiver, only, fnType);
         }
 

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -1786,6 +1786,27 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
+        // Issue #3248: an instance method group's candidates come from the
+        // receiver type's DEFINITION (a constructed StructSymbol forwards
+        // `Methods` to it), so their parameter/return types still reference
+        // the declaring class's own type parameters. Resolve the receiver's
+        // construction of the declaring definition (walking the base chain)
+        // and substitute the signature through it, so the closed signature —
+        // and the delegate FunctionType the conversion builds from it —
+        // carries the receiver's instantiation. Without this, a deferred
+        // method group like `holder.Count` inside `GetCounter[T](holder
+        // Holder[T])` kept `Holder`'s class type parameter in its function
+        // type and the emitter encoded the delegate TypeSpec with a class
+        // `Var` slot in a context that only has method generics (invalid
+        // metadata; BadImageFormatException at runtime).
+        if (candidateOwner == null
+            && !candidate.IsExtension
+            && receiver?.Type is StructSymbol receiverStruct
+            && candidate.ReceiverType is StructSymbol declaredReceiver)
+        {
+            candidateOwner = TypeMemberModel.ResolveStaticMemberOwner(receiverStruct, declaredReceiver);
+        }
+
         Dictionary<TypeParameterSymbol, TypeSymbol> substitution = null;
         if (candidate.IsGeneric)
         {

--- a/test/Interpreter.Tests/Issue2992SymbolicClrTypeInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2992SymbolicClrTypeInterpreterTests.cs
@@ -204,7 +204,7 @@ public class Issue2992SymbolicClrTypeInterpreterTests
         Assert.Equal("2\n", RunSubmission(source));
     }
 
-    [Fact(Skip = "Issue #3248: a method group over an open-generic receiver method deferred through a generic function emits bad IL (BadImageFormatException at runtime). Its only passing coverage was the tree-walking evaluator, retired in ADR-0156 Phase 3c (#3176). Unskip when #3248 lands.")]
+    [Fact]
     public void DeferredMethodGroupRetainsClassTypeArguments()
     {
         var source = """
@@ -230,6 +230,130 @@ public class Issue2992SymbolicClrTypeInterpreterTests
             """;
 
         Assert.Equal("3\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void DeferredMethodGroupRetainsClassTypeArgumentsAtReferenceType()
+    {
+        var source = """
+            import System.Collections.Generic
+
+            class Holder[T any] {
+                func Count(items List[T]) int32 {
+                    return items.Count
+                }
+            }
+
+            func GetCounter[T](holder Holder[T]) (List[T]) -> int32 {
+                return holder.Count
+            }
+
+            var holder = Holder[string]()
+            var counter = GetCounter[string](holder)
+            var words = List[string]()
+            words.Add("a")
+            words.Add("b")
+            Console.WriteLine(counter(words))
+            """;
+
+        Assert.Equal("2\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void DeferredMethodGroupOverloadPickRetainsClassTypeArguments()
+    {
+        // Issue #3248 (overload path): a multi-candidate group defers overload
+        // selection to the target-typed conversion, which closes each candidate
+        // signature through the receiver's construction.
+        var source = """
+            import System.Collections.Generic
+
+            class Holder[T any] {
+                func Count(items List[T]) int32 {
+                    return items.Count
+                }
+
+                func Count(items List[T], extra int32) int32 {
+                    return items.Count + extra
+                }
+            }
+
+            func GetCounter[T](holder Holder[T]) (List[T]) -> int32 {
+                return holder.Count
+            }
+
+            var holder = Holder[int32]()
+            var counter = GetCounter[int32](holder)
+            var numbers = List[int32]()
+            numbers.Add(4)
+            numbers.Add(5)
+            Console.WriteLine(counter(numbers))
+            """;
+
+        Assert.Equal("2\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void DeferredMethodGroupThroughBaseChainRetainsClassTypeArguments()
+    {
+        // Issue #3248 (base-chain shape): the candidate is declared on the
+        // generic base, so the substitution owner is resolved along the
+        // receiver's base chain.
+        var source = """
+            import System.Collections.Generic
+
+            open class Base[T any] {
+                func Count(items List[T]) int32 {
+                    return items.Count
+                }
+            }
+
+            class Derived[T any] : Base[T] {
+            }
+
+            func GetCounter[T](d Derived[T]) (List[T]) -> int32 {
+                return d.Count
+            }
+
+            var d = Derived[int32]{}
+            var counter = GetCounter[int32](d)
+            var numbers = List[int32]()
+            numbers.Add(7)
+            Console.WriteLine(counter(numbers))
+            """;
+
+        Assert.Equal("1\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void DeferredMethodGroupNaturalTypeRetainsClassTypeArguments()
+    {
+        // Issue #3248 (natural-type shape): the group materializes into a
+        // `var` local (no conversion target), so the natural FunctionType
+        // built at member lookup must already carry the receiver's
+        // instantiation.
+        var source = """
+            import System.Collections.Generic
+
+            class Holder[T any] {
+                func Count(items List[T]) int32 {
+                    return items.Count
+                }
+            }
+
+            func GetCount[T](holder Holder[T], items List[T]) int32 {
+                var counter = holder.Count
+                return counter(items)
+            }
+
+            var holder = Holder[int32]()
+            var numbers = List[int32]()
+            numbers.Add(1)
+            numbers.Add(2)
+            Console.WriteLine(GetCount[int32](holder, numbers))
+            """;
+
+        Assert.Equal("2\n", RunSubmission(source));
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #3248. Part of #3176, part of #3163.

## Summary

- Root cause: a constructed `StructSymbol` forwards `Methods` to its **definition**, so instance method-group candidates carry the declaring class's own type parameters in their signatures. Neither `BuildInstanceMethodGroup` (natural function type) nor `TryCloseMethodGroupCandidate` (target-typed overload closing) substituted the receiver's instantiation, so a deferred group like `holder.Count` inside `GetCounter[T](holder Holder[T])` kept `Holder`'s class type parameter in its `FunctionType`. The reified delegate TypeSpec (ADR-0087 §3 R6) then encoded a class `Var(0)` slot in a method whose generic context has only method generics — the ldftn side was already correct (#1467), so the emitted `ldftn Holder`1<!!T>::Count` / `newobj Func`2<List`1<!0>,int32>::.ctor` pair is invalid metadata → `BadImageFormatException` at JIT of `GetCounter[T]` (ILVerify crashes on the same token).
- Fix (binder, both group-materialization sites): resolve the candidate's declaring definition onto the receiver's construction via `TypeMemberModel.ResolveStaticMemberOwner` (base-chain aware) and substitute parameter/return types through it, so the receiver instantiation flows into the `FunctionType` and from there into the delegate-ctor token under the ambient remap scope. No emitter caches touched (GSA0004/RemapScope discipline unaffected).
- Witnesses: unskips the #3248-pinned `DeferredMethodGroupRetainsClassTypeArguments` and adds reference-type instantiation, overload-pick, base-chain, and natural-type (`var` local) shapes in `Issue2992SymbolicClrTypeInterpreterTests`.

## Verification

- Release solution build: 0 warnings / 0 errors (StyleCop + internal analyzers clean).
- ADR-0154 witness: all 5 witness tests RED on main sources (stash-run: 5/5 failed with `BadImageFormatException`), GREEN with the fix (witness class 16/16).
- ILVerify: repro + string-instantiation + base-chain + natural-type compiled outputs all "Verified" (on main, ILVerify faults with `SignatureTypeVariable` out-of-bounds on the repro).
- Area filters: Compiler.Tests `MethodGroup|Delegate` 344/344; Core.Tests `MethodGroup|Delegate` 180/180; `Issue1518NullableDelegateInferenceEmitTests` (the fc1dfb83 / #3234 lambda-into-substituted-delegate-slot guard) 5/5.
- Full Core.Tests: 7210 passed, 0 failed, 1 pre-existing skip.
- Full Interpreter.Tests: 1365 passed, 0 failed, 2 pre-existing skips.
- LanguageConformance filter: 126/126.
- NOT RUN: full Compiler.Tests outside the area + conformance filters (time; the touched binder paths are covered by the filters above); Cs2Gs.Tests full suite (known non-deterministic host crash — see repo memory; change is binder-level, no cs2gs surface); LanguageServer/Sdk/Extensions tests and e2etests (no surface touched).

## Checklist

- [x] Behavioral tests carry a witness of discrimination (ADR-0154): each new/changed test fails on the pre-change code (pre-fix commit, reverted hunk, or an applied product mutant) and passes with it.
- [x] Self-review verdict recorded when one was run (MERGEABLE / BLOCKER / SHOULD-FIX / NIT), with residuals filed as issues rather than dropped.

Self-review verdict: MERGEABLE — binder-scoped, substitution is identity for non-generic/self receivers, and the #3234/#1518 regression shapes plus both full suites are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)