### PR TITLE
Complete ADR-0156 Phase 3d: docs sweep, dead-seam trims, package-cell echo

### DIFF
--- a/docs/adr/0010-aspirational-samples.md
+++ b/docs/adr/0010-aspirational-samples.md
@@ -1,6 +1,6 @@
 # ADR-0010: Aspirational samples policy — rewrite to today's subset, re-expand per phase
 
-- **Status**: Accepted
+- **Status**: Accepted; dormant — the interpreter-only harness this policy relied on (`AspirationalSamplesTests` over `Compilation.Evaluate`) was removed by [ADR-0156](0156-gsi-emit-to-memory-execution.md) Phase 3c, and `samples/aspirational/` is empty; a future parked sample would need a new runner policy
 - **Date**: 2026-05-22
 - **Phase**: Phase 0 (policy), every later phase (re-expansion)
 - **Related**: gaps doc §5.6; execution plan §0 D10, §0.2; design doc D10

--- a/docs/adr/0023-async-state-machine.md
+++ b/docs/adr/0023-async-state-machine.md
@@ -1,6 +1,6 @@
 # ADR-0023: `async func` / `await` — state-machine strategy
 
-- **Status**: Shipped (interpreter and emit)
+- **Status**: Shipped (emit; originally also the interpreter, whose backend was removed by [ADR-0156](0156-gsi-emit-to-memory-execution.md) Phase 3c — the state-machine emission design remains current)
 - **Date**: 2026-05-25
 - **Phase**: Phase 5 (lock before 5.1)
 - **Related**: ADR-0002 (concurrency model), ADR-0022 (go/chan/select lowering), ADR-0040 (`sequence[T]` + `yield`); execution plan §§5.1 – 5.2, 5.8; issue #51 (Roslyn-fork option)

--- a/docs/adr/0039-byref-pointers-and-clr-interop.md
+++ b/docs/adr/0039-byref-pointers-and-clr-interop.md
@@ -1,6 +1,6 @@
 # ADR-0039: By-ref pointers (`&` / `*`) and CLR interop for `ref` / `out` / `in` parameters
 
-- **Status**: Accepted
+- **Status**: Accepted (the emit design remains current; §6's evaluator mapping is historical — the tree-walking evaluator was removed by [ADR-0156](0156-gsi-emit-to-memory-execution.md) Phase 3c)
 - **Date**: 2026-05-25
 - **Phase**: Phase 7 follow-up — async emitter milestone (state-machine kickoff / MoveNext); also closes CLR interop gaps tracked since ADR-0034
 - **Related**: ADR-0023 (async state machine), ADR-0034 (imported CLR interop), ADR-0035 (user operator overloads), ADR-0038 (generic method inference); async emitter plan (field-map, kickoff, MoveNext)

--- a/docs/adr/0156-gsi-emit-to-memory-execution.md
+++ b/docs/adr/0156-gsi-emit-to-memory-execution.md
@@ -1,6 +1,6 @@
 # ADR-0156: Emit-to-memory execution for gsi and bare gsc
 
-- **Status**: Accepted — Phases 1–3d implemented (Phase 3c, [#3176](https://github.com/DavidObando/gsharp/issues/3176): the tree-walking evaluator, `Compilation.Evaluate`, the evaluator SessionEngine, and the `--engine evaluator` escape hatch were deleted; Phase 3d removed stale evaluator guidance and pinned the website `gsi --help` transcript; the conformance gate is the two-host emitted parity gate)
+- **Status**: Accepted — Phases 1–3d implemented, campaign complete (Phase 3c, [#3176](https://github.com/DavidObando/gsharp/issues/3176): the tree-walking evaluator, `Compilation.Evaluate`, the evaluator SessionEngine, and the `--engine evaluator` escape hatch were deleted; Phase 3d removed stale evaluator guidance, pinned the website `gsi --help` transcript, swept the residual docs/sample references, trimmed the dead `Compilation.Previous` / `StructValue` evaluator seams, and made package-declaring REPL cells echo and chain correctly; the conformance gate is the two-host emitted parity gate)
 - **Date**: 2026-08-03
 - **Phase**: Interpreter conformance / execution architecture
 - **Related**: #3176 (tracking), #3163 (code-health P2 headline item), ADR-0152

--- a/docs/lexical.md
+++ b/docs/lexical.md
@@ -147,7 +147,7 @@ Malformed holes are diagnosed: an unterminated hole is **GS0222**, an empty hole
 
 Binding and lowering are unified through a dedicated `BoundInterpolatedStringExpression` node that preserves each literal/hole part with its alignment/format intent (ADR-0055). Lowering is *late* and chosen by context:
 
-* Default — formatting defaults to the current culture. The tree-walk interpreter renders the node directly via composite formatting; compiled code lowers it to the .NET `DefaultInterpolatedStringHandler` pattern, so value-type holes are appended without boxing (issue #368).
+* Default — formatting defaults to the current culture. The expression lowers to the .NET `DefaultInterpolatedStringHandler` pattern, so value-type holes are appended without boxing (issue #368).
 * The contextual target type is `System.IFormattable` or `System.FormattableString` → `FormattableStringFactory.Create(format, args)` (ADR-0055 Tier 4, #369). Formatting is **deferred**: the caller chooses the culture via `ToString(IFormatProvider)`, e.g. `fs.ToString(CultureInfo.InvariantCulture)`. The default culture is `CultureInfo.CurrentCulture`.
 
 A *contextual target type* is supplied by a typed `let` declaration, a function return whose declared type is `IFormattable`/`FormattableString`, an explicit conversion (cast), or a **call argument** whose parameter type is one of those (functions, methods, constructors, and imported CLR overloads). In an overloaded call the interpolation keeps its natural `string` type for applicability, so a `string` overload is still preferred over a `FormattableString` overload (C# parity); the interpolation is re-lowered to `FormattableStringFactory.Create` only once a `FormattableString`/`IFormattable` parameter is actually chosen.

--- a/new-repl.md
+++ b/new-repl.md
@@ -2,10 +2,11 @@
 
 > **Historical note (2026-08):** this plan shipped as `src/Repl`. Its eval
 > core has since moved on: per [ADR-0156](docs/adr/0156-gsi-emit-to-memory-execution.md)
-> Phase 3a the interactive default engine is the emitted submission-chaining
-> `EmittedSessionEngine`, not the `Compilation.ContinueWith`/`Evaluate`
-> `SessionEngine` described below (which survives only behind the deprecated
-> `--engine evaluator` escape hatch until Phase 3c).
+> the engine is the emitted submission-chaining `EmittedSessionEngine`, not
+> the `Compilation.ContinueWith`/`Evaluate` `SessionEngine` described below —
+> Phase 3c deleted that evaluator engine, `Compilation.Evaluate`, and the
+> `--engine evaluator` escape hatch. This document is a historical design
+> record; read it for the TUI architecture, not the eval core.
 
 ## 1. Goal
 

--- a/samples/AsyncTask.gs
+++ b/samples/AsyncTask.gs
@@ -1,4 +1,4 @@
-// file: aspirational/AsyncTask.gs
+// file: AsyncTask.gs
 //
 // Phase 5 exit sample. Pure async/await interoperating with the BCL `Task`
 // surface — `async func` declarations (5.1), `await` (5.1+5.2), and a top-level

--- a/samples/CountWords.gs
+++ b/samples/CountWords.gs
@@ -18,9 +18,8 @@
 // Runs on both backends. Originally landed under `samples/aspirational/`
 // (PR #66) because the emit pipeline could not yet encode CLR
 // constructors / member access / for-range. The emit-parity work in PRs
-// #67+ closes that gap, so this sample is now part of the top-level
-// emit conformance harness (SampleConformanceTests) in addition to its
-// interpreter-side sibling CountWordsSampleTests.
+// #67+ closed that gap, so this sample is part of the top-level
+// emit conformance harness (SampleConformanceTests).
 
 package GSharp.Example.CountWords
 

--- a/samples/Patterns.gs
+++ b/samples/Patterns.gs
@@ -1,7 +1,7 @@
-// file: aspirational/Patterns.gs
+// file: Patterns.gs
 //
-// Phase 6.2 sample. Pattern matching is interpreter-only for now;
-// emit is deferred with the same posture as Phase 5 surfaces.
+// Phase 6.2 sample. Pattern matching originally landed interpreter-only
+// under samples/aspirational/; it was promoted here once emit caught up.
 
 package GSharp.Samples.Patterns
 

--- a/samples/PortScan.gs
+++ b/samples/PortScan.gs
@@ -1,16 +1,16 @@
-// file: aspirational/PortScan.gs
+// file: PortScan.gs
 //
 // Phase 5 exit sample. Combines the entire Go-shaped concurrency surface that
 // landed in Phase 5: `chan T` (5.4), send/receive (5.5), `go` (5.3), structured
 // concurrency `scope { ... }` (5.7), and a `select { ... }` with a timeout arm
-// (5.6) — all on the interpreter backend. The synthetic "scanner" assigns even
+// (5.6). The synthetic "scanner" assigns even
 // ports as open and odd ports as closed; the timeout demo prefers a pre-loaded
 // timeout channel over a worker that never sends.
 //
-// Lives under samples/aspirational/ because Phase 5 emit is deferred (ADR-0022
-// §Consequences). The matching test harness — AspirationalSamplesTests in
-// test/Core.Tests/LanguageConformance — runs this through the interpreter and
-// matches stdout against PortScan.golden.
+// Originally lived under samples/aspirational/ while Phase 5 emit was
+// deferred (ADR-0022 §Consequences); it was promoted here once the emit
+// backend covered the full concurrency surface, and the regular conformance
+// harness now matches stdout against PortScan.golden.
 
 package GSharp.Samples.PortScan
 

--- a/samples/aspirational/README.md
+++ b/samples/aspirational/README.md
@@ -1,8 +1,8 @@
 # `samples/aspirational/`
 
-Per ADR-0010 (aspirational samples policy), this folder holds samples that exercise GSharp features for which **emit is deferred**. They are deliberately excluded from `test/Compiler.Tests`' end-to-end conformance harness (which compiles through `gsc` and runs the emitted assembly under `dotnet`) and are instead run through the interpreter only.
+Per ADR-0010 (aspirational samples policy), this folder held samples that exercised GSharp features for which **emit was deferred**. They were deliberately excluded from `test/Compiler.Tests`' end-to-end conformance harness (which compiles through `gsc` and runs the emitted assembly under `dotnet`) and were instead run through the tree-walking interpreter only.
 
-A sibling test, `test/Core.Tests/LanguageConformance/AspirationalSamplesTests`, discovers every `*.gs` file in this folder that has a paired `*.golden`, parses + binds + evaluates it through the same `Compilation.Evaluate(...)` path as the in-repo unit tests, and compares captured stdout against the golden.
+That interpreter-only harness (`AspirationalSamplesTests`, built on `Compilation.Evaluate(...)`) was removed together with the evaluator in ADR-0156 Phase 3c — emit is now the only execution backend, so an "interpreter-runs-it, emit-doesn't" sample can no longer execute at all.
 
 ## Current contents
 
@@ -26,4 +26,4 @@ backend caught up. See "Previously promoted samples" below for the history._
 
 ## When to add a sample here
 
-Add a sample here if it exercises a surface that the **interpreter** accepts end-to-end but the **emit backend** does not yet (see the coverage matrix's Emit column). Once emit catches up, the sample MAY be promoted out of `aspirational/` into top-level `samples/` so the regular conformance suite covers it on both backends.
+Historically: a sample landed here when the **interpreter** accepted it end-to-end but the **emit backend** did not yet; once emit caught up it was promoted into top-level `samples/`. With the evaluator removed (ADR-0156 Phase 3c) that split no longer exists — a new sample for an unimplemented emit surface has nowhere to run, so this folder is expected to stay empty. If a future feature ships parsing/binding ahead of emit and wants a parked sample, it needs a new policy (e.g. a bind-only golden), decided at that time.

--- a/src/Core/CodeAnalysis/Compilation/Compilation.cs
+++ b/src/Core/CodeAnalysis/Compilation/Compilation.cs
@@ -36,7 +36,7 @@ public class Compilation
     /// </summary>
     /// <param name="syntaxTrees">The syntax trees.</param>
     public Compilation(params SyntaxTree[] syntaxTrees)
-        : this(null, references: null, syntaxTrees)
+        : this(references: null, syntaxTrees)
     {
     }
 
@@ -47,28 +47,13 @@ public class Compilation
     /// <param name="references">The reference resolver to use for imported CLR type lookups.</param>
     /// <param name="syntaxTrees">The syntax trees.</param>
     public Compilation(ReferenceResolver references, params SyntaxTree[] syntaxTrees)
-        : this(null, references, syntaxTrees)
     {
-    }
-
-    private Compilation(Compilation previous, ReferenceResolver references, SyntaxTree[] syntaxTrees)
-    {
-        Previous = previous;
         SyntaxTrees = syntaxTrees.ToImmutableArray();
-        References = references ?? previous?.References;
-        ImplicitSystemImport = previous?.ImplicitSystemImport ?? true;
-        IsLibrary = previous?.IsLibrary ?? false;
-        PreprocessorSymbols = previous?.PreprocessorSymbols ?? ImmutableHashSet<string>.Empty;
-        WarnOnMissingDocumentation = previous?.WarnOnMissingDocumentation ?? false;
-        Logger = previous?.Logger ?? NullLogger.Instance;
-        EmbeddedResources = previous?.EmbeddedResources ?? ImmutableArray<(string Name, byte[] Data, bool IsPublic)>.Empty;
-        debugInformation = CloneDebugInformation(previous?.DebugInformation);
+        References = references;
+        ImplicitSystemImport = true;
+        EmbeddedResources = ImmutableArray<(string Name, byte[] Data, bool IsPublic)>.Empty;
+        debugInformation = CloneDebugInformation(null);
     }
-
-    /// <summary>
-    /// Gets the previous compilation.
-    /// </summary>
-    public Compilation Previous { get; }
 
     /// <summary>
     /// Gets the syntax trees.
@@ -96,9 +81,7 @@ public class Compilation
     /// executable. When <see langword="true"/>, top-level statements are an
     /// error (ADR-0066 deferred decision D4 — mirrors C#'s CS8805), since
     /// the synthesized <c>&lt;Main&gt;$</c> would never run from a library
-    /// assembly. Defaults to <see langword="false"/>. Inherits from
-    /// <see cref="Previous"/> when chained, matching the inheritance shape
-    /// of <see cref="ImplicitSystemImport"/>.
+    /// assembly. Defaults to <see langword="false"/>.
     /// </summary>
     public bool IsLibrary { get; set; } = false;
 
@@ -117,9 +100,7 @@ public class Compilation
     /// emitted normally. Defaults to <see cref="ImmutableHashSet{T}.Empty"/>
     /// — equivalent to "no preprocessor symbols defined" — so
     /// conditional methods are elided by default unless the embedder opts
-    /// in. Setting <c>null</c> is normalised to the empty set. Inherits
-    /// from <see cref="Previous"/> when chained, matching the inheritance
-    /// shape of <see cref="ImplicitSystemImport"/>.
+    /// in. Setting <c>null</c> is normalised to the empty set.
     /// </summary>
     public ImmutableHashSet<string> PreprocessorSymbols
     {
@@ -132,11 +113,8 @@ public class Compilation
     /// <see cref="DebugInformationOptions"/> instance with
     /// <see cref="DebugInformationOptions.Format"/> set to
     /// <see cref="DebugInformationFormat.None"/>, so callers that do not
-    /// opt in produce bit-for-bit identical PE output. Inherits from
-    /// <see cref="Previous"/> when chained, mirroring
-    /// <see cref="ImplicitSystemImport"/> / <see cref="PreprocessorSymbols"/>.
-    /// Setting <see langword="null"/> is normalised to a fresh default
-    /// instance.
+    /// opt in produce bit-for-bit identical PE output. Setting
+    /// <see langword="null"/> is normalised to a fresh default instance.
     /// </summary>
     public DebugInformationOptions DebugInformation
     {
@@ -253,7 +231,7 @@ public class Compilation
                 // Emit.
                 PrepareReferencesForBinding(assemblyName);
                 var globalScope = ReusedGlobalScope
-                    ?? Binder.BindGlobalScope(Previous?.GlobalScope, SyntaxTrees, References, ImplicitSystemImport, PreprocessorSymbols, IsLibrary, Submission);
+                    ?? Binder.BindGlobalScope(previous: null, SyntaxTrees, References, ImplicitSystemImport, PreprocessorSymbols, IsLibrary, Submission);
                 Interlocked.CompareExchange(ref this.globalScope, globalScope, null);
             }
 

--- a/src/Core/CodeAnalysis/StructValue.cs
+++ b/src/Core/CodeAnalysis/StructValue.cs
@@ -26,52 +26,31 @@ namespace GSharp.Core.CodeAnalysis;
 /// </summary>
 public sealed class StructValue
 {
-    private static readonly MethodInfo ObjectEqualsMethod = typeof(object).GetMethod(
-        nameof(object.Equals),
-        [typeof(object)]);
-
-    private static readonly MethodInfo ObjectGetHashCodeMethod = typeof(object).GetMethod(
-        nameof(object.GetHashCode),
-        Type.EmptyTypes);
-
-    private static readonly MethodInfo ObjectToStringMethod = typeof(object).GetMethod(
-        nameof(object.ToString),
-        Type.EmptyTypes);
-
-    private readonly ObjectOverrideDispatcher objectOverrideDispatcher;
     private readonly LayoutRuntime explicitLayout;
     private readonly object explicitLayoutValue;
 
     /// <summary>Initializes a new instance of the <see cref="StructValue"/> class.</summary>
     /// <param name="structType">The struct type symbol.</param>
     public StructValue(StructSymbol structType)
-        : this(structType, (ObjectOverrideDispatcher)null)
-    {
-    }
-
-    internal StructValue(StructSymbol structType, ObjectOverrideDispatcher objectOverrideDispatcher)
     {
         StructType = structType;
-        this.objectOverrideDispatcher = objectOverrideDispatcher;
         Fields = new FieldCollection(this);
 
         if (structType.LayoutMetadata?.Layout == LayoutKind.Explicit)
         {
             explicitLayout = LayoutRuntime.Get(structType);
             explicitLayoutValue = explicitLayout.CreateDefault();
-            explicitLayout.ReadFields(explicitLayoutValue, Fields, objectOverrideDispatcher);
+            explicitLayout.ReadFields(explicitLayoutValue, Fields);
         }
     }
 
     private StructValue(
         StructSymbol structType,
         ConcurrentDictionary<string, object> fields,
-        ObjectOverrideDispatcher objectOverrideDispatcher,
         LayoutRuntime explicitLayout = null,
         object explicitLayoutValue = null)
     {
         StructType = structType;
-        this.objectOverrideDispatcher = objectOverrideDispatcher;
         Fields = new FieldCollection(this);
         foreach (var field in fields)
         {
@@ -82,90 +61,20 @@ public sealed class StructValue
         this.explicitLayoutValue = explicitLayoutValue;
     }
 
-    internal delegate bool ObjectOverrideDispatcher(
-        StructValue receiver,
-        MethodInfo method,
-        object[] arguments,
-        out object result);
-
     /// <summary>Gets the struct type.</summary>
     public StructSymbol StructType { get; }
 
-    // Issue #1718: class-typed StructValue instances (Evaluator.Assign skips
-    // Copy() for IsClass structs) are shared by reference, including the
-    // heap "box" cells CaptureBoxingRewriter synthesizes for a mutable
-    // variable captured by a function literal (isClass: true). Any number
-    // of goroutines that received the same class instance/box (as an
-    // argument, a captured variable, or a field) can write distinct fields
-    // on it at the same time, so this dictionary needs the same
-    // concurrent-write safety as an interpreter locals frame. Plain
-    // Dictionary&lt;,&gt; is not thread-safe under concurrent writes.
+    // Issue #1718 (historical): under the evaluator, class-typed StructValue
+    // instances were shared by reference across goroutines, so this storage
+    // uses a ConcurrentDictionary rather than a plain Dictionary. The
+    // concurrent shape is retained for the surviving explicit-layout uses.
 
     /// <summary>Gets the mutable field storage backing this instance.</summary>
     public FieldCollection Fields { get; }
 
-    /// <summary>
-    /// Gets or sets the CLR backing instance for a GSharp class that inherits an
-    /// imported CLR base type (issue #319). When non-null, the interpreter routes
-    /// reflection-based access to inherited CLR instance state (properties, fields,
-    /// methods) through this real CLR object so the base constructor's side-effects
-    /// (e.g. <see cref="System.Exception.Message"/>) are observable. Always null
-    /// for value-type structs and for class instances whose ultimate base is
-    /// <c>object</c> or another GSharp class.
-    /// </summary>
-    public object ClrBacking { get; set; }
-
-    /// <summary>Creates a shallow copy of this struct value (value-semantics).</summary>
-    /// <returns>A new instance with the same fields.</returns>
-    public StructValue Copy()
-    {
-        if (explicitLayout != null)
-        {
-            object layoutCopy;
-            lock (explicitLayoutValue)
-            {
-                layoutCopy = RuntimeHelpers.GetObjectValue(explicitLayoutValue);
-            }
-
-            var fieldsCopy = new ConcurrentDictionary<string, object>();
-            explicitLayout.ReadFields(layoutCopy, fieldsCopy, objectOverrideDispatcher);
-            return new StructValue(
-                StructType,
-                fieldsCopy,
-                objectOverrideDispatcher,
-                explicitLayout,
-                layoutCopy)
-            {
-                ClrBacking = this.ClrBacking,
-            };
-        }
-
-        var copy = new ConcurrentDictionary<string, object>();
-        foreach (var kvp in Fields)
-        {
-            copy[kvp.Key] = kvp.Value is StructValue { StructType.IsClass: false } inner
-                ? inner.Copy()
-                : kvp.Value;
-        }
-
-        return new StructValue(StructType, copy, objectOverrideDispatcher)
-        {
-            // Issue #319: copy carries the same CLR backing reference. A copy is
-            // only ever created for value-type structs (Evaluator.Assign skips it
-            // for classes), so the backing is expected to be null here; we copy
-            // it defensively for symmetry.
-            ClrBacking = this.ClrBacking,
-        };
-    }
-
     /// <inheritdoc/>
     public override bool Equals(object obj)
     {
-        if (TryInvokeObjectOverride(ObjectEqualsMethod, [obj], out var result))
-        {
-            return (bool)result;
-        }
-
         if (StructType.IsClass && !StructType.IsData)
         {
             return ReferenceEquals(this, obj);
@@ -197,11 +106,6 @@ public sealed class StructValue
     /// <inheritdoc/>
     public override int GetHashCode()
     {
-        if (TryInvokeObjectOverride(ObjectGetHashCodeMethod, [], out var result))
-        {
-            return (int)result;
-        }
-
         if (StructType.IsClass && !StructType.IsData)
         {
             return RuntimeHelpers.GetHashCode(this);
@@ -221,11 +125,6 @@ public sealed class StructValue
     /// <inheritdoc/>
     public override string ToString()
     {
-        if (TryInvokeObjectOverride(ObjectToStringMethod, [], out var result))
-        {
-            return (string)result;
-        }
-
         var sb = new StringBuilder();
         sb.Append(StructType.Name).Append('(');
         var first = true;
@@ -268,17 +167,6 @@ public sealed class StructValue
         }
     }
 
-    private bool TryInvokeObjectOverride(MethodInfo method, object[] arguments, out object result)
-    {
-        if (objectOverrideDispatcher == null)
-        {
-            result = null;
-            return false;
-        }
-
-        return objectOverrideDispatcher(this, method, arguments, out result);
-    }
-
     private void SetField(string name, object value)
     {
         if (explicitLayout != null)
@@ -287,7 +175,7 @@ public sealed class StructValue
             {
                 if (explicitLayout.TrySetField(explicitLayoutValue, name, value))
                 {
-                    explicitLayout.ReadFields(explicitLayoutValue, Fields, objectOverrideDispatcher);
+                    explicitLayout.ReadFields(explicitLayoutValue, Fields);
                     return;
                 }
             }
@@ -424,10 +312,7 @@ public sealed class StructValue
             return true;
         }
 
-        public void ReadFields(
-            object source,
-            FieldCollection destination,
-            ObjectOverrideDispatcher objectOverrideDispatcher)
+        public void ReadFields(object source, FieldCollection destination)
         {
             foreach (var field in symbol.Fields)
             {
@@ -435,27 +320,18 @@ public sealed class StructValue
                 {
                     destination.SetRaw(
                         field.Name,
-                        ToInterpreterValue(
-                            field.Type,
-                            runtimeField.GetValue(source),
-                            objectOverrideDispatcher));
+                        ToInterpreterValue(field.Type, runtimeField.GetValue(source)));
                 }
             }
         }
 
-        public void ReadFields(
-            object source,
-            ConcurrentDictionary<string, object> destination,
-            ObjectOverrideDispatcher objectOverrideDispatcher)
+        public void ReadFields(object source, ConcurrentDictionary<string, object> destination)
         {
             foreach (var field in symbol.Fields)
             {
                 if (fields.TryGetValue(field.Name, out var runtimeField))
                 {
-                    destination[field.Name] = ToInterpreterValue(
-                        field.Type,
-                        runtimeField.GetValue(source),
-                        objectOverrideDispatcher);
+                    destination[field.Name] = ToInterpreterValue(field.Type, runtimeField.GetValue(source));
                 }
             }
         }
@@ -562,10 +438,7 @@ public sealed class StructValue
             return value;
         }
 
-        private static object ToInterpreterValue(
-            TypeSymbol type,
-            object value,
-            ObjectOverrideDispatcher objectOverrideDispatcher)
+        private static object ToInterpreterValue(TypeSymbol type, object value)
         {
             if (type is StructSymbol nested
                 && !nested.IsClass
@@ -573,12 +446,11 @@ public sealed class StructValue
             {
                 var runtime = Get(nested);
                 var fields = new ConcurrentDictionary<string, object>();
-                runtime.ReadFields(value, fields, objectOverrideDispatcher);
+                runtime.ReadFields(value, fields);
                 var keepBacking = nested.LayoutMetadata?.Layout == LayoutKind.Explicit;
                 return new StructValue(
                     nested,
                     fields,
-                    objectOverrideDispatcher,
                     keepBacking ? runtime : null,
                     keepBacking ? RuntimeHelpers.GetObjectValue(value) : null);
             }

--- a/src/Core/CodeAnalysis/StructValue.cs
+++ b/src/Core/CodeAnalysis/StructValue.cs
@@ -115,9 +115,6 @@ public sealed class StructValue
     /// </summary>
     public object ClrBacking { get; set; }
 
-    /// <summary>Gets a value indicating whether this value represents a CLR box.</summary>
-    internal bool IsBoxed { get; private set; }
-
     /// <summary>Creates a shallow copy of this struct value (value-semantics).</summary>
     /// <returns>A new instance with the same fields.</returns>
     public StructValue Copy()
@@ -146,7 +143,7 @@ public sealed class StructValue
         var copy = new ConcurrentDictionary<string, object>();
         foreach (var kvp in Fields)
         {
-            copy[kvp.Key] = kvp.Value is StructValue { IsBoxed: false, StructType.IsClass: false } inner
+            copy[kvp.Key] = kvp.Value is StructValue { StructType.IsClass: false } inner
                 ? inner.Copy()
                 : kvp.Value;
         }
@@ -247,15 +244,6 @@ public sealed class StructValue
 
         sb.Append(')');
         return sb.ToString();
-    }
-
-    /// <summary>Creates an identity-preserving boxed copy of this struct value.</summary>
-    /// <returns>A boxed copy.</returns>
-    internal StructValue Box()
-    {
-        var box = Copy();
-        box.IsBoxed = true;
-        return box;
     }
 
     internal static bool TryGetStorageSize(StructSymbol structType, out int size)

--- a/src/LanguageServer/ProjectState.cs
+++ b/src/LanguageServer/ProjectState.cs
@@ -380,13 +380,6 @@ public class ProjectState
             return null;
         }
 
-        // The REPL/append chain shape is not produced here; only handle the flat
-        // single-compilation shape the language server builds.
-        if (previous.Previous != null)
-        {
-            return null;
-        }
-
         // Pair the previous and current trees by file path. Any added or removed
         // file makes this not a single-file body edit.
         var previousTrees = previous.SyntaxTrees;

--- a/src/Repl/Engine/EmittedSessionEngine.cs
+++ b/src/Repl/Engine/EmittedSessionEngine.cs
@@ -329,6 +329,14 @@ public sealed class EmittedSessionEngine : ISessionEngine, IDisposable
         var dllPath = Path.Combine(submissionsDirectory, assemblyName + ".dll");
         File.WriteAllBytes(dllPath, peImage);
 
+        // A cell that declares its own `package X` emits its members (and the
+        // synthesized `<Program>` holding `<Result>$` and the globals) under
+        // that namespace, not under the session default. Track the package the
+        // members were actually emitted under so the echo read below and the
+        // chain's SubmissionReference stay truthful (Phase 3d follow-up to the
+        // 3c note "a package-declaring cell succeeds silently with no echo").
+        var emittedPackageName = compilation.GlobalScope.Package?.Name ?? packageName;
+
         var runResult = host.RunSubmission(peImage, assemblyName);
         if (runResult.UnhandledException is not null)
         {
@@ -345,7 +353,7 @@ public sealed class EmittedSessionEngine : ISessionEngine, IDisposable
 
         var value = host.ReadStaticField(
             runResult.Assembly,
-            packageName + "." + SubmissionImports.ProgramTypeName,
+            emittedPackageName + "." + SubmissionImports.ProgramTypeName,
             SubmissionImports.ResultFieldName)
             ?? runResult.ReturnValue;
 
@@ -354,7 +362,7 @@ public sealed class EmittedSessionEngine : ISessionEngine, IDisposable
         // instead of committing it to the transcript or the chain.
         cancellationToken.ThrowIfCancellationRequested();
 
-        submissions.Insert(0, new SubmissionState(compilation, compilation.GlobalScope, assemblyName, packageName, dllPath, runResult.Assembly));
+        submissions.Insert(0, new SubmissionState(compilation, compilation.GlobalScope, assemblyName, emittedPackageName, dllPath, runResult.Assembly));
         foreach (var import in compilation.GlobalScope.Imports)
         {
             if (!sessionImports.Any(i =>

--- a/test/Interpreter.Tests/PackageDeclaringCellEchoTests.cs
+++ b/test/Interpreter.Tests/PackageDeclaringCellEchoTests.cs
@@ -1,0 +1,94 @@
+// <copyright file="PackageDeclaringCellEchoTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using GSharp.Repl.Engine;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// ADR-0156 Phase 3d (#3176): a REPL cell that declares its own
+/// <c>package X</c> emits its members — including the synthesized
+/// <c>&lt;Program&gt;</c> type holding <c>&lt;Result&gt;$</c> and the
+/// globals — under that namespace rather than the session default
+/// <c>gsiN</c>. The Phase 3c note observed such cells "succeed silently,
+/// no echo"; worse, their declarations were invisible to later cells
+/// because the chain recorded the wrong package. The engine now records
+/// the emitted package (<c>GlobalScope.Package</c>), making the echo and
+/// cross-cell visibility work. The one structural residue — two cells
+/// redeclaring the <em>same</em> package — is pinned below and tracked by
+/// <see href="https://github.com/DavidObando/gsharp/issues/3297">#3297</see>.
+/// </summary>
+public sealed class PackageDeclaringCellEchoTests : IDisposable
+{
+    private readonly EmittedSessionEngine engine = new();
+
+    public void Dispose() => engine.Dispose();
+
+    [Fact]
+    public void PackageCellEchoesTrailingExpression()
+    {
+        var cell = engine.Evaluate("package foo\n1 + 2");
+        Assert.False(cell.HasError, string.Join("; ", cell.Diagnostics));
+        Assert.Equal(3, cell.Value);
+    }
+
+    [Fact]
+    public void PackageCellFunctionVisibleToLaterCells()
+    {
+        var decl = engine.Evaluate("package foo\nfunc addOne(n int) int {\n    return n + 1\n}");
+        Assert.False(decl.HasError, string.Join("; ", decl.Diagnostics));
+        Assert.Null(decl.Value);
+
+        var call = engine.Evaluate("addOne(41)");
+        Assert.False(call.HasError, string.Join("; ", call.Diagnostics));
+        Assert.Equal(42, call.Value);
+    }
+
+    [Fact]
+    public void PackageCellGlobalVisibleToLaterCells()
+    {
+        var decl = engine.Evaluate("package bar\nvar counter = 10");
+        Assert.False(decl.HasError, string.Join("; ", decl.Diagnostics));
+
+        var read = engine.Evaluate("counter + 5");
+        Assert.False(read.HasError, string.Join("; ", read.Diagnostics));
+        Assert.Equal(15, read.Value);
+    }
+
+    [Fact]
+    public void DefaultCellThenPackageCellBothEcho()
+    {
+        var plain = engine.Evaluate("40 + 1");
+        Assert.False(plain.HasError);
+        Assert.Equal(41, plain.Value);
+
+        var packaged = engine.Evaluate("package baz\n41 + 1");
+        Assert.False(packaged.HasError, string.Join("; ", packaged.Diagnostics));
+        Assert.Equal(42, packaged.Value);
+    }
+
+    [Fact]
+    public void SamePackageTwiceOlderDeclarationCurrentlyUnreachable()
+    {
+        // Pins the #3297 limitation: SubmissionImports resolves a prior
+        // cell's members via the namespace-qualified "foo.<Program>" name
+        // only, so when two submission assemblies both emit namespace
+        // `foo`, resolution collides on the newest and the older cell's
+        // declarations cannot be reached. When #3297 lands
+        // assembly-qualified steering, `a()` should evaluate to 1 and this
+        // pin flips into the positive assertion.
+        Assert.False(engine.Evaluate("package foo\nfunc a() int {\n    return 1\n}").HasError);
+        Assert.False(engine.Evaluate("package foo\nfunc b() int {\n    return 2\n}").HasError);
+
+        var useNewest = engine.Evaluate("b()");
+        Assert.False(useNewest.HasError, string.Join("; ", useNewest.Diagnostics));
+        Assert.Equal(2, useNewest.Value);
+
+        var useOldest = engine.Evaluate("a()");
+        Assert.True(useOldest.HasError);
+        Assert.Contains(useOldest.Diagnostics, d => d.Message.Contains("a", StringComparison.Ordinal));
+    }
+}

--- a/website/docs/extensions/go-concurrency.md
+++ b/website/docs/extensions/go-concurrency.md
@@ -176,10 +176,15 @@ ran
 done
 ```
 
-In the interpreter, `go` is implemented with `Task.Run` and some
-evaluation is serialized internally; timing behavior may differ from
-emitted assemblies. Use emitted builds when reasoning about production
-concurrency behavior.
+`go` lowers to task-based scheduling in the emitted assembly, which is
+what every driver (including `gsi`) executes since ADR-0156.
+
+Note that G# maps (`map[K,V]`) are backed by plain `Dictionary<K,V>`
+with no implicit synchronization, so concurrent access from multiple
+goroutines is not goroutine-safe — the same posture as Go maps. Guard
+shared maps with `lock`, or use `System.Collections.Concurrent` types
+via CLR interop; a first-class G# synchronization surface is tracked in
+[#3209](https://github.com/DavidObando/gsharp/issues/3209).
 
 ## See also
 

--- a/website/docs/ref/spec.md
+++ b/website/docs/ref/spec.md
@@ -220,7 +220,7 @@ Array and slice element access (`a[i]`, read or write) accepts **any** integer-t
 
 ### Maps
 
-Maps are written `map[K,V]` and are backed by `Dictionary<K,V>` in the implementation. Map literals use key-value entries, indexing reads values, and indexed assignment updates entries.
+Maps are written `map[K,V]` and are backed by `Dictionary<K,V>` in the implementation. Map literals use key-value entries, indexing reads values, and indexed assignment updates entries. Maps carry no implicit synchronization: concurrent access from multiple goroutines is not goroutine-safe (consistent with Go), and callers must synchronize explicitly (`lock`, or concurrent CLR collections via interop); a first-class synchronization surface is tracked in [#3209](https://github.com/DavidObando/gsharp/issues/3209).
 
 ```gsharp
 let counts = map[string,int32]{"g": 1, "sharp": 2}

--- a/website/docs/tutorials/control-flow.md
+++ b/website/docs/tutorials/control-flow.md
@@ -352,7 +352,7 @@ A `default` arm is the easiest way to make the result total.
 Some pattern features originated on the interpreter path. The `Patterns` sample remains useful as the shortest expression-switch walkthrough:
 
 ```gsharp title="Patterns.gs"
-// file: aspirational/Patterns.gs
+// file: Patterns.gs
 //
 // Short expression-switch walkthrough using relational and list patterns.
 


### PR DESCRIPTION
Part of #3176 (ADR-0156 Phase 3d — final), part of #3163.

## Summary

- sweep the residual evaluator-era guidance the grep-driven inventory found after #3261/#3296, per file below
- add the interim map goroutine-safety non-guarantee note promised by #3209 (spec Maps section + go-concurrency extension page)
- trim the dead evaluator seams: `Compilation.Previous`, `StructValue.Box()`/`IsBoxed`, then the wider dead `StructValue` surface (`Copy()`, `ClrBacking`, the always-null `ObjectOverrideDispatcher` hook)
- fix the 3c-noted package-declaring-cell nuance: such cells now echo and their declarations chain; the same-package-redeclared residue is pinned and tracked as #3297
- record Phase 3d completion in the ADR-0156 status header

## Documentation disposition (grep-driven inventory)

Grep terms: `evaluator`, `interpreter`, `tree-walking`, `GS0510|GS0511|GS0513|GS0514`, `--engine`, `GSI_ENGINE`, `Compilation.Evaluate`, `EvaluationResult`, `evaluate mode`, `print(`/`input()`/`rnd(`, `string(T)` — case-insensitive across docs/, website/docs (current version), README.md, new-repl.md, src/**/*.md, samples, e2etests. `website/versioned_docs/version-0.3` excluded as a historical Docusaurus snapshot.

| File | Disposition |
| --- | --- |
| `docs/lexical.md` | **updated** — dropped present-tense tree-walk interpolation rendering claim |
| `new-repl.md` | **historical marker tightened** — Phase 3c completed; explicitly a historical design record (root doc retained, not deleted; residual value is the TUI architecture) |
| `samples/aspirational/README.md` | **updated** — interpreter-only harness removed with 3c; folder expected to stay empty; promotion history kept |
| `samples/{Patterns,PortScan,AsyncTask,CountWords}.gs` | **updated** — stale `aspirational/` paths and "interpreter-only" claims made past-tense history |
| `website/docs/extensions/go-concurrency.md` | **updated** — stale "in the interpreter" paragraph replaced; #3209 map non-guarantee added |
| `website/docs/ref/spec.md` | **updated** — one-sentence #3209 map non-guarantee in the Maps section |
| `website/docs/tutorials/control-flow.md` | **updated** — quoted sample path fixed; historical phase labels retained |
| `docs/adr/0010`, `0023`, `0039` | **status-header note only** (bodies immutable): 0010 dormant (harness gone), 0023 "Shipped (interpreter and emit)" → emit-only reality, 0039 §6 evaluator mapping historical |
| `docs/adr/0156` | **status-header updated** — Phases 1–3d complete |
| `docs/adr/0152`, `0153`, `0068` | **no-change** — already superseded/partially superseded in 3c, verified no drift |
| other `docs/adr/*` bodies (49 files with matches) | **no-change** — immutable historical records; statuses do not imply evaluator currency |
| `docs/diagnostics.md`, `website/docs/ref/diagnostics.md` | **no-change** — retired GS0510/11/13/14 + GS9999 sections verified current; severity-sync gate (`DiagnosticIdUniquenessTests`) green in the full Core.Tests run |
| `docs/emit-pipeline.md`, `website/docs/intro.md`, `website/docs/tooling/compiler-architecture.md` | **no-change** — already current from #3261 |
| `website/docs/tooling/repl.md` | **no-change** — `--engine`/`GSI_ENGINE` text verified against `src/Repl/Program.cs` and the pinned `--help` transcript test |
| `website/docs/ref/feature-matrix.md` | **no-change** — evaluator column explicitly labeled "removed Phase 3c" (intentional history) |
| `website/docs/ref/standard-library.md` | **no-change** — builtin retirement note landed with #3296 |
| `website/docs/release-notes.md` | **no-change** — historical release record |
| `README.md`, `docs/{lsp,debug-info,coverage-matrix,sdk-usage}.md`, Sdk template READMEs, e2etests | **no-change** — no stale mentions (Sdk docs swept by #3296; e2etests has no READMEs) |

## Code trims

Applied (each its own commit, Release build clean after each):

- `Compilation.Previous` — property, private chaining ctor, `previous?.X` inheritance defaults, `Previous?.GlobalScope` argument, and the language server's dead REPL-chain guard (`ProjectState`)
- `StructValue.Box()` / `IsBoxed` — the #3195 rebase-note residue; `Copy()`'s guard collapses to the `IsClass` test
- `StructValue.Copy()`, `ClrBacking`, `ObjectOverrideDispatcher` — zero callers; dispatcher was always null so the Equals/GetHashCode/ToString override hook was unreachable. Explicit-layout machinery untouched (`StructLayoutBinder.TryGetStorageSize`, #3100 invariants)

Deferred (listed, not trimmed — conservative):

- `BoundGlobalScope.Previous` chain: every product/test caller now passes `previous: null`, but removal touches `Binder.CreateParentScope`, the `BoundGlobalScope` ctor family, and `IncrementalGlobalScopeReuse` — follow-up-sized
- `GSharp.Interpreter.Layouts` dynamic-assembly name in `StructValue.LayoutRuntime` — cosmetic
- `ISessionEngine` single-implementation interface — kept for host/test seam

## Package-declaring-cell echo (3c note)

Reproduced: worse than "no echo" — the chain recorded `gsiN` while the members were emitted under the declared package, so the `<Result>$` read missed **and** later cells could not see the cell's declarations. Fixed at the engine seam (`CompileAndRun` now records `GlobalScope.Package`); `PackageDeclaringCellEchoTests` pins echo, cross-cell function/global visibility, and mixed default/package sessions. The structural residue — two cells redeclaring the *same* package collide on the namespace-qualified `foo.<Program>` lookup — is filed as #3297 and pinned as current behavior.

## Verification

- Release solution build: 0 warnings / 0 errors after every trim commit
- Full Core.Tests: **7215 passed, 0 failed, 1 skipped** (pre-existing `RegenerateBaseline` skip)
- Full Interpreter.Tests: **1397 passed, 0 failed, 0 skipped**
- `SampleConformanceTests` (two-host parity gate): **125 passed, 0 failed, 0 skipped** — a full pass over all 122 paired samples plus harness facts (the "126" in the 3c-era status comment reflected that date's sample census; this branch touches only sample header comments, which cannot change discovery)
- Website: `npm ci` + `docusaurus build` succeeded (broken-link check is part of the build); touched markdown additionally fence/link sanity-checked
- ADR-0154 witness: the three core `PackageDeclaringCellEchoTests` facts were run RED against the pre-fix engine (echo `null`, "Function 'addOne' doesn't exist", "Variable 'counter' doesn't exist") before the one-seam fix turned them green
- NOT RUN: Compiler.Tests / LanguageServer.Tests / Sdk.Tests full suites (no changes in their surfaces beyond the ProjectState dead-guard deletion, which Core+LS compile and the LS-consumed Core paths cover; full-suite runs are 45+ min and memory-heavy per repo convention of one suite at a time); cs2gs suites (pre-existing flaky host crash, per repo memory — verify via GoldenTests filter only when touched, untouched here)

## Checklist

- [x] Behavioral tests carry a witness of discrimination (ADR-0154): each new/changed test fails on the pre-change code (pre-fix commit, reverted hunk, or an applied product mutant) and passes with it.
- [x] Self-review verdict recorded when one was run (MERGEABLE / BLOCKER / SHOULD-FIX / NIT), with residuals filed as issues rather than dropped.

Self-review verdict: **MERGEABLE** — residuals filed as #3297; deferred trims listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
