### PR TITLE
Adopt ADR-0157: display-side REPL value formatting (accepted), with ADR + feasibility spike

### DIFF
--- a/docs/adr/0157-default-tostring-synthesis.md
+++ b/docs/adr/0157-default-tostring-synthesis.md
@@ -1,7 +1,8 @@
 # ADR-0157: Default pretty-printing for user types — display-side, not synthesized
 
-- **Status**: Proposed — owner decision requested
-  ([#3208](https://github.com/DavidObando/gsharp/issues/3208))
+- **Status**: Accepted — 2026-08-06
+  ([#3208](https://github.com/DavidObando/gsharp/issues/3208); implementation
+  of the display-side `ReplValueFormatter` follows in a separate PR)
 - **Date**: 2026-08-06
 - **Phase**: Language surface / REPL ergonomics (ADR-0156 Phase 3
   semantic-alignment follow-up)

--- a/docs/adr/0157-default-tostring-synthesis.md
+++ b/docs/adr/0157-default-tostring-synthesis.md
@@ -1,0 +1,269 @@
+# ADR-0157: Default pretty-printing for user types — display-side, not synthesized
+
+- **Status**: Proposed — owner decision requested
+  ([#3208](https://github.com/DavidObando/gsharp/issues/3208))
+- **Date**: 2026-08-06
+- **Phase**: Language surface / REPL ergonomics (ADR-0156 Phase 3
+  semantic-alignment follow-up)
+- **Related**: [#3208](https://github.com/DavidObando/gsharp/issues/3208)
+  (this question), [#3204](https://github.com/DavidObando/gsharp/issues/3204)
+  (decided: plain types keep CLR `ToString` semantics, no soft deprecation),
+  [#3163](https://github.com/DavidObando/gsharp/issues/3163) /
+  [#3176](https://github.com/DavidObando/gsharp/issues/3176) (campaign
+  tracking), ADR-0029 (`data` struct synthesized members — the existing
+  opt-in), ADR-0025 (`record` keyword alias), ADR-0032 (`data` ergonomics),
+  ADR-0156 (one emitted semantics everywhere), ADR-0034 (imported CLR
+  interop); precedent issues
+  [#2896](https://github.com/DavidObando/gsharp/issues/2896) (user
+  `override func ToString` on plain structs),
+  [#2361](https://github.com/DavidObando/gsharp/issues/2361) (transparent
+  user takeover of the synthesized data ToString),
+  [#2338](https://github.com/DavidObando/gsharp/issues/2338) (data-class
+  inheritance re-override), [#2363](https://github.com/DavidObando/gsharp/issues/2363)
+  (zero-field data types)
+
+## Context
+
+Issue [#3204](https://github.com/DavidObando/gsharp/issues/3204) closed the
+last rendering divergence of the evaluator era: the retired tree-walking
+evaluator gave every plain struct a record-style `Name(Field=...)` rendering
+that the emitted program never had. The owner's decision was to keep **CLR
+semantics** — a plain struct or class without a `ToString` override prints its
+CLR type name — with no soft deprecation. That decision stands; the follow-up
+question filed as [#3208](https://github.com/DavidObando/gsharp/issues/3208)
+is the general language question this ADR answers: should G# synthesize a
+default pretty-printing `ToString()` for user structs and classes,
+transparently overridable, the way C# records do?
+
+Three facts about the current codebase frame the answer.
+
+**1. The records-style opt-in already exists, completely.** ADR-0029's `data`
+modifier (with the `record` alias, ADR-0025) synthesizes the full value-type
+member set as *real emitted overrides* —
+`Equals(object)`, `Equals(T)`, `GetHashCode`, `ToString`
+(`Name(F1=v1, F2=v2)` via `Convert.ToString` invariant-culture),
+`op_Equality`/`op_Inequality`, `Deconstruct` — in
+`src/Core/CodeAnalysis/Emit/DataStructSynthesizer.cs`. The transparent-
+override model #3208 names is already implemented there: a user-declared
+`ToString` on a `data` type simply takes over the synthesized slot with
+identical vtable attributes (#2361,
+`DataStructSynthesizer.HasUserToStringOverride` +
+`IsDataObjectOverrideFinal`), and data-class hierarchies re-override
+correctly, non-final while open (#2338). Separately, any *plain* struct or
+class may declare `override func ToString() string` and it dispatches
+correctly everywhere, including BCL-initiated virtual calls (#2896, #3116).
+
+**2. Emitted synthesis is row-planned, per-type, and paid forever.**
+`ReflectionMetadataEmitter.PlanClassMethods`/`PlanStructMethods` reserve
+MethodDef rows in fixed order that must agree 1:1 with what
+`DataStructSynthesizer` later emits; the #2361 (user-ToString skip) and #2363
+(zero-field / no-Deconstruct skip) special cases show what every conditional
+synthesized member costs in planner/emitter agreement surface. The metadata
+itself is not free either: the spike below measures **+1,024 bytes of PE**
+for one two-field struct's data-member set (ToString is one of its seven
+members) — paid by every compiled assembly, whether or not anything is ever
+printed, and multiplied across every user type under an always-on rule.
+
+**3. The actual pain is the REPL echo, and the echo is one line of code.**
+Post-#3204, `Cell.Value` holds the live emitted value and the echo is
+`cell.Value.ToString()` (`src/Repl/Screens/ReplScreen.cs:316`,
+`src/Repl/Compat/GSharpRepl.cs:32`, and the sidebar's
+`Truncate(value.ToString(), 20)` in
+`src/Repl/Engine/EmittedSessionEngine.cs:134`). A user who types
+`Point{X: 1, Y: 2}` into gsi sees `gsi1.Point` — correct CLR semantics,
+useless feedback. This is precisely the problem Roslyn interactive solved
+**display-side**: csi never touched C#'s `ToString` semantics; its
+`ObjectFormatter` pretty-prints submission results structurally at echo time.
+
+## Decision
+
+**Do not synthesize a default `ToString` for plain structs and classes.
+Emitted semantics stay CLR-aligned, exactly as #3204 decided; `data` (and
+`override func ToString`) remain the two existing opt-ins for a real emitted
+override. The REPL echo gap is closed display-side: a reflection-based value
+formatter in the REPL (working name `ReplValueFormatter`,
+`src/Repl/Engine`) renders a value structurally when — and only when — its
+runtime type has no `ToString` override below `object`/`ValueType`, and
+defers to the real override otherwise.** This is the "competing smaller
+design" named in #3208, recommended here as the primary one.
+
+The formatter replaces the raw `ToString()` call at the three echo sites
+(`ReplScreen`, compat `GSharpRepl`, the `EmittedSessionEngine` sidebar
+values). Nothing in `Core`, the emitter, the language spec, or any emitted
+assembly changes; `gsc` output is byte-identical before and after.
+
+### Rendering contract (tool-level, explicitly not a spec guarantee)
+
+The format is **diagnostics-only**: it may change in any release, is never
+part of the language specification, and programs must not parse it. This is
+the key liberty the display-side placement buys — an emitted `ToString` would
+freeze these answers into every compiled assembly forever. The contract the
+spike validates:
+
+- **Trigger**: the runtime type's resolved public parameterless `ToString`
+  is declared by `object` or `System.ValueType` — i.e. nothing anywhere in
+  the hierarchy overrides it. Synthesized `data` members, user
+  `override func ToString`, primitives, enums, and imported CLR overrides
+  all win transparently by construction (they *are* overrides), matching
+  CLR virtual dispatch with no special-casing.
+- **Shape**: G# composite-literal syntax, `Name{Member: value, ...}` — the
+  echo of `Point{X: 1, Y: 2}` is `Point{X: 1, Y: 2}`, keeping the transcript
+  close to round-trippable input (and distinct from the `data` family's
+  emitted `Name(F=v)` shape, so the two sources of rendering are
+  distinguishable at a glance).
+- **Members**: public instance fields, then public readable non-indexer
+  properties, in metadata order; a throwing property getter renders
+  `<error>` rather than aborting the echo. Non-public state is never shown
+  (accessibility answer: public-only).
+- **Nesting/depth**: recursive, depth-capped (spike: 4), eliding deeper
+  values as `...`.
+- **Reference cycles**: reference values already on the current rendering
+  path elide as `...` — handled with one identity set in the formatter,
+  something an emitted per-type `ToString` cannot do without runtime
+  cycle-tracking machinery in every type.
+- **Collections**: values with no override that implement `IEnumerable`
+  render element-wise, capped (spike: 8) with a trailing `...`.
+- **`nil`**: renders as the G# keyword `nil`; strings render quoted; other
+  overridden types render via `Convert.ToString` invariant culture (the same
+  convention `DataStructSynthesizer` compiled in).
+- **Inheritance**: no emitted member exists, so there is no slot/re-override
+  question; the formatter reflects over the *runtime* type, which naturally
+  includes inherited public fields. Data-class hierarchies keep ADR-0029's
+  already-solved emitted behavior (#2338).
+- **Interop**: unchanged, by construction. A G# plain class consumed from C#
+  behaves exactly like the equivalent C# class (`string.Format`,
+  interpolation, debugger, logging); only `data` types expose synthesized
+  overrides — which is today's contract and matches the C# records
+  precedent one-to-one (`class`/`struct` plain, `record` synthesized).
+- **Cost**: zero metadata; measured ~5 µs per echo (spike), paid once per
+  cell render, only in the REPL.
+
+One scoping knob is left to the implementation PR: whether the trigger
+applies to *any* override-less value (Roslyn's `ObjectFormatter` posture —
+also improves override-less imported CLR types) or is restricted to types
+from session/user assemblies. The spike implements and this ADR recommends
+the general trigger, with the throwing-getter guard as the safety net.
+
+### What this deliberately leaves alone
+
+- `EmittedOracle.ValueText` and all test oracles keep raw `ToString`
+  semantics — the oracle mirrors product semantics, not display sugar.
+- `gsc`-compiled programs, the LSP, and the debugger see no change.
+- The `data` modifier keeps its meaning: *the* opt-in for value semantics as
+  a set (equality + hash + rendering + deconstruction), not a rendering
+  flag.
+
+## Evidence — feasibility spike
+
+`test/Interpreter.Tests/Adr0157PrettyDisplaySpikeTests.cs` (trait
+`Category=Adr0157Spike`, excluded from no gates, run via
+`dotnet test test/Interpreter.Tests --filter "FullyQualifiedName~Adr0157"`)
+proves the recommended mechanism end-to-end with **zero product changes**,
+over values produced by real emitted execution (`test/Shared/EmittedOracle`):
+
+| Case | Result |
+|---|---|
+| Plain two-field struct | today's contract pinned (`ToString` slot is `ValueType`'s, echo is the CLR type name — #3204), formatter renders `Point{X: 1, Y: 2}` |
+| `data struct` | emitted override confirmed on the type itself (interop-visible), formatter defers: `Point(X=1, Y=2)` |
+| `override func ToString` on a plain struct | formatter defers: `tag:11` |
+| Nested class + `nil` field | `Node{Name: "root", Next: Node{Name: "leaf", Next: nil}}` |
+| Reference cycle (`a.Next = b; b.Next = a`) | terminates: `Node{Name: "a", Next: Node{Name: "b", Next: ...}}` |
+| `[]int32` small / 12 elements | `[1, 2, 3]` / capped `[1, 2, 3, 4, 5, 6, 7, 8, ...]` |
+
+Measurements (Debug, .NET 10, Apple Silicon; all 7 tests green):
+
+- **Formatter latency**: 5.1 µs per `Format` call steady-state
+  (1,000 iterations, nested two-node graph) — three orders of magnitude
+  below the ~47 ms per-submission cost ADR-0156 measured, i.e. free at echo
+  time.
+- **Metadata cost of the rejected always-on alternative**: one identical
+  program compiled with `struct Point` vs `data struct Point`:
+  2,560 → 3,584 bytes PE (**+1,024 bytes** for the seven synthesized
+  members, of which `ToString` is one). An always-on rule pays a per-type
+  slice of this in every assembly for every user type, plus the
+  planner/emitter row-agreement surface, independent of whether anything is
+  ever printed.
+
+The formatter prototype (~130 lines including the contract's guards) lives
+in the spike as `SpikeValueFormatter`; the implementation PR moves it to
+`src/Repl/Engine` and swaps the three echo sites.
+
+## Consequences
+
+- The REPL echo becomes useful for plain types (`Point{X: 1, Y: 2}` instead
+  of `gsi1.Point`) with no change to language semantics, emitted metadata,
+  interop surface, or spec obligations.
+- #3204's decision is preserved intact: emitted CLR semantics *are* the
+  language behavior; the pretty rendering is visibly a tool affordance and
+  can evolve (colorization, truncation tuning, dictionary rendering) without
+  compatibility process.
+- The `data`/plain distinction keeps carrying meaning: users who want a real,
+  interop-visible, stable `ToString` say `data` (or write the override) —
+  both already implemented, tested, and inheritance-correct.
+- The C#-alignment invariant survives: a G# type and its C# equivalent
+  behave identically from either side of the interop boundary. No new
+  divergence class is created one campaign after ADR-0156 eliminated the
+  last one.
+- Cost: a small REPL-side formatter to maintain (rendering-contract tests
+  live with it); REPL echo and compiled `Console.WriteLine(p)` output differ
+  for plain types — the same deliberate asymmetry csi/fsi/Python REPLs have,
+  and the emitted behavior is always one `data` keyword away.
+- If the owner later wants language-level synthesis after all, nothing here
+  forecloses it: the formatter simply starts deferring to the new overrides
+  by construction (its trigger is "no override exists").
+
+## Alternatives considered
+
+### Always-on synthesized `ToString` for every user type without one (records-style, emitted)
+
+The primary design named in #3208: emit a real override so interop,
+interpolation, and the debugger all see pretty output. Rejected:
+
+- **It re-creates the divergence class G# just paid to eliminate.** A G#
+  `class Point` and the equivalent C# `class Point` would observably differ
+  (`string.Format`, interpolation, logging, debugger) — the same
+  "G# quietly renders differently" property #3204 retired, moved from the
+  evaluator into permanent emitted metadata. C# deliberately reserves
+  synthesis for `record`; G# already mirrors that split with `data`.
+- **It erases the `data` distinction.** `data`'s contract is value semantics
+  as a coherent set. Plain types acquiring the rendering member alone
+  creates a third, half-value category (pretty printing, reference
+  equality), and the modifier's rendering benefit silently vanishes.
+- **The rendering contract becomes spec, permanently.** Field order, depth,
+  cycles (unsolvable in per-type emitted code without runtime tracking
+  machinery — the spike's cycle case), collections, accessibility, and
+  format stability would all need normative answers frozen into compiled
+  assemblies. Display-side, every one of these is a revisable tool choice.
+- **Per-type, always-paid cost.** Measured +1,024 bytes PE for one
+  two-field struct's synthesized set; a ToString-only variant still pays a
+  MethodDef row, IL body, and user-string blobs per type, plus the
+  `PlanClassMethods`/`PlanStructMethods` row-agreement surface (#2361/#2363
+  show its maintenance shape), plus trimming/AOT surface for members nothing
+  may ever call.
+
+### Opt-out synthesis (always-on minus an escape attribute)
+
+All of the above, plus new attribute surface whose only purpose is undoing a
+default the user never asked for. Rejected.
+
+### A new opt-in modifier/attribute for ToString-only synthesis
+
+Rejected as redundant surface: the opt-in space is already occupied twice —
+`data` for the full synthesized set and `override func ToString` for exactly
+one method (a two-field one is a one-liner arrow function). A third opt-in
+adds grammar, binder, planner, and docs cost without new capability.
+
+### REPL-display formatting scoped to session assemblies only
+
+A narrower trigger than the recommended "no override anywhere" rule.
+Retained as an implementation knob rather than the decision: the general
+rule is simpler, matches Roslyn `ObjectFormatter` behavior, benefits
+override-less imported CLR types, and the throwing-getter guard plus depth
+and element caps bound the risk. The implementation PR may tighten this if
+real sessions surface pathological BCL shapes.
+
+### Do nothing (status quo)
+
+Keeps `gsi1.Point` as the echo for the most common beginner-visible case in
+the tool most used to answer "what does this expression do". Rejected: the
+fix is small, display-only, and reversible.

--- a/docs/adr/0157-default-tostring-synthesis.md
+++ b/docs/adr/0157-default-tostring-synthesis.md
@@ -1,8 +1,9 @@
 # ADR-0157: Default pretty-printing for user types — display-side, not synthesized
 
 - **Status**: Accepted — 2026-08-06
-  ([#3208](https://github.com/DavidObando/gsharp/issues/3208); implementation
-  of the display-side `ReplValueFormatter` follows in a separate PR)
+  ([#3208](https://github.com/DavidObando/gsharp/issues/3208); implemented in
+  the same change — `src/Repl/Engine/ReplValueFormatter.cs`, wired at the
+  three REPL echo sites and pinned by `Adr0157ReplValueFormatterTests`)
 - **Date**: 2026-08-06
 - **Phase**: Language surface / REPL ergonomics (ADR-0156 Phase 3
   semantic-alignment follow-up)
@@ -139,11 +140,14 @@ spike validates:
 - **Cost**: zero metadata; measured ~5 µs per echo (spike), paid once per
   cell render, only in the REPL.
 
-One scoping knob is left to the implementation PR: whether the trigger
-applies to *any* override-less value (Roslyn's `ObjectFormatter` posture —
-also improves override-less imported CLR types) or is restricted to types
-from session/user assemblies. The spike implements and this ADR recommends
-the general trigger, with the throwing-getter guard as the safety net.
+One scoping knob stays open for tuning: whether the trigger applies to
+*any* override-less value (Roslyn's `ObjectFormatter` posture — also
+improves override-less imported CLR types) or is restricted to types from
+session/user assemblies. The implementation ships the general trigger, as
+the spike validated and this ADR recommends, with the throwing-getter guard
+as the safety net; it may be tightened later if real sessions surface
+pathological BCL shapes (the format is diagnostics-only, so tightening is
+not a compatibility event).
 
 ### What this deliberately leaves alone
 
@@ -186,8 +190,11 @@ Measurements (Debug, .NET 10, Apple Silicon; all 7 tests green):
   ever printed.
 
 The formatter prototype (~130 lines including the contract's guards) lives
-in the spike as `SpikeValueFormatter`; the implementation PR moves it to
-`src/Repl/Engine` and swaps the three echo sites.
+in the spike as `SpikeValueFormatter`; the accepted implementation is
+`src/Repl/Engine/ReplValueFormatter.cs`, wired at the three echo sites,
+with behavioral pins (including the ADR-0154 reverted-hunk witness) in
+`test/Interpreter.Tests/Adr0157ReplValueFormatterTests.cs`. The spike file
+stays untouched as ADR evidence, per the ADR-0156 precedent.
 
 ## Consequences
 

--- a/src/Repl/Compat/GSharpRepl.cs
+++ b/src/Repl/Compat/GSharpRepl.cs
@@ -29,7 +29,8 @@ public sealed class GSharpRepl : IDisposable
 
         if (!cell.HasError && cell.Value is not null)
         {
-            Console.WriteLine(cell.Value);
+            // ADR-0157: display-side pretty echo — never emitted semantics.
+            Console.WriteLine(ReplValueFormatter.Format(cell.Value));
         }
     }
 

--- a/src/Repl/Engine/EmittedSessionEngine.cs
+++ b/src/Repl/Engine/EmittedSessionEngine.cs
@@ -131,7 +131,9 @@ public sealed class EmittedSessionEngine : ISessionEngine, IDisposable
                         v.Name);
                     if (value is not null)
                     {
-                        display += $" = {Truncate(value.ToString(), 20)}";
+                        // ADR-0157: display-side pretty rendering for the
+                        // sidebar values column, same contract as the echo.
+                        display += $" = {Truncate(ReplValueFormatter.Format(value), 20)}";
                     }
 
                     vars.Add(new ReplSymbol(display));

--- a/src/Repl/Engine/ReplValueFormatter.cs
+++ b/src/Repl/Engine/ReplValueFormatter.cs
@@ -1,0 +1,167 @@
+// <copyright file="ReplValueFormatter.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Reflection;
+
+namespace GSharp.Repl.Engine;
+
+/// <summary>
+/// ADR-0157: the display-side pretty-printer for REPL value echo. Renders a
+/// value structurally in G# composite-literal shape
+/// (<c>Name{Member: value, ...}</c>) when — and only when — its runtime type
+/// has no <c>ToString</c> override below <see cref="object"/> /
+/// <see cref="ValueType"/>, and defers transparently to the real override
+/// otherwise (synthesized <c>data</c> members, user
+/// <c>override func ToString</c>, primitives, enums, imported CLR types).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The format is <b>diagnostics-only</b>: a tool affordance of the REPL, not
+/// a language or spec guarantee — it may change in any release and programs
+/// must not parse it. Emitted semantics are untouched by design (issue
+/// #3204's decision): a plain struct or class still has no <c>ToString</c>
+/// row, and compiled programs, interop, interpolation, and the debugger all
+/// keep CLR behavior. See docs/adr/0157-default-tostring-synthesis.md.
+/// </para>
+/// <para>
+/// Rendering contract (validated by the ADR-0157 spike and pinned by
+/// <c>Adr0157ReplValueFormatterTests</c>): <c>nil</c> for null, quoted
+/// strings/chars, overridden types via <see cref="Convert.ToString(object, IFormatProvider)"/>
+/// invariant culture, element-wise capped collections, public instance
+/// fields then public readable non-indexer properties in metadata order
+/// (throwing getters render <c>&lt;error&gt;</c>), a recursion depth cap,
+/// and reference-cycle elision — all elisions render as <c>...</c>.
+/// </para>
+/// </remarks>
+public static class ReplValueFormatter
+{
+    private const int MaxDepth = 4;
+    private const int MaxElements = 8;
+    private const string Elision = "...";
+
+    /// <summary>
+    /// Formats <paramref name="value"/> for the REPL transcript echo and the
+    /// state-sidebar values column.
+    /// </summary>
+    /// <param name="value">The value to render; may be <see langword="null"/>.</param>
+    /// <returns>The rendered text; never <see langword="null"/>.</returns>
+    public static string Format(object? value)
+        => Format(value, new HashSet<object>(ReferenceEqualityComparer.Instance), depth: 0);
+
+    private static string Format(object? value, HashSet<object> path, int depth)
+    {
+        if (value is null)
+        {
+            return "nil";
+        }
+
+        if (value is string text)
+        {
+            return "\"" + text + "\"";
+        }
+
+        if (value is char character)
+        {
+            return "'" + character + "'";
+        }
+
+        var type = value.GetType();
+        if (HasToStringOverride(type))
+        {
+            // Any real override — synthesized data members, user overrides,
+            // primitives, enums, imported CLR types — wins transparently,
+            // matching CLR virtual dispatch.
+            return Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty;
+        }
+
+        if (depth >= MaxDepth)
+        {
+            return Elision;
+        }
+
+        // Reference-cycle guard: a reference value already on the current
+        // rendering path elides instead of recursing forever.
+        var track = !type.IsValueType;
+        if (track && !path.Add(value))
+        {
+            return Elision;
+        }
+
+        try
+        {
+            return value is IEnumerable enumerable
+                ? FormatCollection(enumerable, path, depth)
+                : FormatMembers(value, type, path, depth);
+        }
+        finally
+        {
+            if (track)
+            {
+                path.Remove(value);
+            }
+        }
+    }
+
+    private static string FormatMembers(object value, Type type, HashSet<object> path, int depth)
+    {
+        var parts = new List<string>();
+        foreach (var field in type.GetFields(BindingFlags.Public | BindingFlags.Instance))
+        {
+            parts.Add(field.Name + ": " + Format(field.GetValue(value), path, depth + 1));
+        }
+
+        foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (!property.CanRead || property.GetIndexParameters().Length != 0)
+            {
+                continue;
+            }
+
+            object? propertyValue;
+            try
+            {
+                propertyValue = property.GetValue(value);
+            }
+            catch (Exception ex) when (ex is TargetInvocationException or NotSupportedException)
+            {
+                parts.Add(property.Name + ": <error>");
+                continue;
+            }
+
+            parts.Add(property.Name + ": " + Format(propertyValue, path, depth + 1));
+        }
+
+        return type.Name + "{" + string.Join(", ", parts) + "}";
+    }
+
+    private static string FormatCollection(IEnumerable enumerable, HashSet<object> path, int depth)
+    {
+        var parts = new List<string>();
+        var truncated = false;
+        foreach (var element in enumerable)
+        {
+            if (parts.Count == MaxElements)
+            {
+                truncated = true;
+                break;
+            }
+
+            parts.Add(Format(element, path, depth + 1));
+        }
+
+        return "[" + string.Join(", ", parts) + (truncated ? ", " + Elision : string.Empty) + "]";
+    }
+
+    private static bool HasToStringOverride(Type type)
+    {
+        var method = type.GetMethod("ToString", Type.EmptyTypes);
+        return method is not null
+            && method.DeclaringType != typeof(object)
+            && method.DeclaringType != typeof(ValueType);
+    }
+}

--- a/src/Repl/Screens/ReplScreen.cs
+++ b/src/Repl/Screens/ReplScreen.cs
@@ -313,7 +313,8 @@ public sealed class ReplScreen : ITabScreen, IDisposable
 
             if (!cell.HasError && cell.Value is not null)
             {
-                cellRows.Add(new Markup($"    [{primary}]{Markup.Escape(cell.Value.ToString() ?? string.Empty)}[/]"));
+                // ADR-0157: display-side pretty echo — never emitted semantics.
+                cellRows.Add(new Markup($"    [{primary}]{Markup.Escape(ReplValueFormatter.Format(cell.Value))}[/]"));
             }
 
             transcript.Add(new Backdrop(new Rows(cellRows), cellBg));

--- a/test/Interpreter.Tests/Adr0157PrettyDisplaySpikeTests.cs
+++ b/test/Interpreter.Tests/Adr0157PrettyDisplaySpikeTests.cs
@@ -1,0 +1,408 @@
+// <copyright file="Adr0157PrettyDisplaySpikeTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Tests;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// ADR-0157 feasibility spike: a display-side pretty-printer for REPL value
+/// echo, applied over values produced by real emitted execution. Proves the
+/// recommended mechanism end-to-end with zero product changes: a
+/// reflection-based formatter renders a plain (non-<c>data</c>) struct or
+/// class structurally when — and only when — no <c>ToString</c> override
+/// exists anywhere below <see cref="object"/>/<see cref="ValueType"/>, and
+/// defers transparently to synthesized (<c>data</c>) or user-declared
+/// (<c>override func ToString</c>) overrides otherwise. Also measures the
+/// evidence the ADR's cost sections cite: formatter latency and the emitted
+/// metadata cost of the rejected always-on synthesis alternative
+/// (plain-struct vs <c>data</c>-struct PE size for the same program).
+/// </summary>
+/// <remarks>
+/// This is spike evidence for docs/adr/0157-default-tostring-synthesis.md,
+/// not part of any conformance gate, and the formatter here is a prototype —
+/// the product implementation would live REPL-side (near
+/// <c>ReplScreen</c>/<c>Cell</c>), never in emitted code. Keep it cheap.
+/// </remarks>
+[Collection("ConsoleIo")]
+[Trait("Category", "Adr0157Spike")]
+public sealed class Adr0157PrettyDisplaySpikeTests
+{
+    private readonly ITestOutputHelper output;
+
+    public Adr0157PrettyDisplaySpikeTests(ITestOutputHelper output) => this.output = output;
+
+    /// <summary>
+    /// Today's contract (issue #3204): a plain struct emits no ToString
+    /// override, so the REPL echo (<c>Cell.Value.ToString()</c>) shows the
+    /// CLR type name. The display-side formatter turns exactly that case
+    /// into a G# composite-literal rendering without touching emitted
+    /// metadata.
+    /// </summary>
+    [Fact]
+    public void PlainStruct_NoEmittedOverride_FormatterRendersCompositeLiteral()
+    {
+        var result = EmittedOracle.Evaluate("""
+            struct Point {
+                var X int32
+                var Y int32
+            }
+            let p = Point{X: 1, Y: 2}
+            """);
+
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Null(result.UnhandledException);
+        Assert.NotNull(result.Value);
+
+        // Pin the current world: no ToString row is emitted for a plain
+        // struct — the resolved slot is System.ValueType's — and the raw
+        // echo is the CLR type name (#3204's decided behavior).
+        var valueType = result.Value.GetType();
+        var toString = valueType.GetMethod("ToString", Type.EmptyTypes);
+        Assert.NotNull(toString);
+        Assert.Equal(typeof(ValueType), toString.DeclaringType);
+        Assert.Equal(valueType.ToString(), result.ValueText);
+
+        // The display-side answer: structural rendering in G# literal shape.
+        Assert.Equal("Point{X: 1, Y: 2}", SpikeValueFormatter.Format(result.Value));
+    }
+
+    /// <summary>
+    /// A <c>data</c> struct already carries a real emitted ToString override
+    /// (ADR-0029, interop-visible). The formatter must defer to it — the
+    /// transparent-override contract holds with no special-casing, because
+    /// the trigger is "no override below object/ValueType".
+    /// </summary>
+    [Fact]
+    public void DataStruct_EmittedSynthesizedOverride_WinsTransparently()
+    {
+        var result = EmittedOracle.Evaluate("""
+            data struct Point {
+                var X int32
+                var Y int32
+            }
+            let p = Point{X: 1, Y: 2}
+            """);
+
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.NotNull(result.Value);
+
+        // The synthesized override is a real emitted method on the type
+        // itself — visible to interop, interpolation, and the debugger.
+        var valueType = result.Value.GetType();
+        var toString = valueType.GetMethod("ToString", Type.EmptyTypes);
+        Assert.Equal(valueType, toString.DeclaringType);
+
+        Assert.Equal("Point(X=1, Y=2)", SpikeValueFormatter.Format(result.Value));
+    }
+
+    /// <summary>
+    /// A user-declared <c>override func ToString</c> on a plain struct
+    /// (issue #2896 dispatch semantics) likewise wins transparently.
+    /// </summary>
+    [Fact]
+    public void UserDeclaredOverride_WinsTransparently()
+    {
+        var result = EmittedOracle.Evaluate("""
+            struct Tagged {
+                var Id int32
+                override func ToString() string -> "tag:11"
+            }
+            let t = Tagged{Id: 11}
+            """);
+
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.NotNull(result.Value);
+        Assert.Equal("tag:11", SpikeValueFormatter.Format(result.Value));
+    }
+
+    /// <summary>
+    /// The rendering contract the ADR proposes for the display formatter:
+    /// nested user types render recursively, <c>nil</c> renders as the G#
+    /// keyword, and strings are quoted (the echo stays close to G# literal
+    /// syntax).
+    /// </summary>
+    [Fact]
+    public void NestedClass_NilField_RendersRecursively()
+    {
+        var result = EmittedOracle.Evaluate("""
+            class Node {
+                var Name string
+                var Next Node?
+            }
+            let leaf = Node{Name: "leaf"}
+            let root = Node{Name: "root", Next: leaf}
+            """);
+
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.NotNull(result.Value);
+        Assert.Equal(
+            "Node{Name: \"root\", Next: Node{Name: \"leaf\", Next: nil}}",
+            SpikeValueFormatter.Format(result.Value));
+    }
+
+    /// <summary>
+    /// Reference cycles terminate with an elision marker instead of
+    /// overflowing — a case an emitted always-on ToString cannot handle
+    /// without runtime cycle-tracking machinery in every type.
+    /// </summary>
+    [Fact]
+    public void ReferenceCycle_TerminatesWithElision()
+    {
+        var result = EmittedOracle.Evaluate("""
+            class Node {
+                var Name string
+                var Next Node?
+            }
+            let a = Node{Name: "a"}
+            let b = Node{Name: "b", Next: a}
+            a.Next = b
+            let cycle = a
+            """);
+
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.NotNull(result.Value);
+        Assert.Equal(
+            "Node{Name: \"a\", Next: Node{Name: \"b\", Next: ...}}",
+            SpikeValueFormatter.Format(result.Value));
+    }
+
+    /// <summary>
+    /// Collections (no ToString override on <see cref="Array"/>) render
+    /// element-wise with a cap, so a huge value cannot flood the transcript.
+    /// </summary>
+    [Fact]
+    public void Collections_RenderElementwise_WithCap()
+    {
+        var small = EmittedOracle.Evaluate("let xs = []int32{1, 2, 3}");
+        Assert.Empty(small.Diagnostics.Where(d => d.IsError));
+        Assert.Equal("[1, 2, 3]", SpikeValueFormatter.Format(small.Value));
+
+        var large = EmittedOracle.Evaluate("let xs = []int32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}");
+        Assert.Empty(large.Diagnostics.Where(d => d.IsError));
+        Assert.Equal("[1, 2, 3, 4, 5, 6, 7, 8, ...]", SpikeValueFormatter.Format(large.Value));
+    }
+
+    /// <summary>
+    /// Cost evidence for the ADR. (1) Formatter latency: steady-state
+    /// microseconds per Format call over a nested value — the display-side
+    /// design pays only at echo time, once per cell. (2) The rejected
+    /// always-on emitted alternative's metadata cost, bounded by comparing
+    /// the PE size of one identical program compiled with a plain struct vs
+    /// a <c>data</c> struct (the data path adds seven synthesized members,
+    /// of which ToString is one).
+    /// </summary>
+    [Fact]
+    public void CostEvidence_FormatterLatency_And_SynthesisMetadataSize()
+    {
+        var nested = EmittedOracle.Evaluate("""
+            class Node {
+                var Name string
+                var Next Node?
+            }
+            let leaf = Node{Name: "leaf"}
+            let root = Node{Name: "root", Next: leaf}
+            """);
+        Assert.NotNull(nested.Value);
+
+        // Warm-up, then measure.
+        _ = SpikeValueFormatter.Format(nested.Value);
+        const int iterations = 1000;
+        var timer = Stopwatch.StartNew();
+        for (var i = 0; i < iterations; i++)
+        {
+            _ = SpikeValueFormatter.Format(nested.Value);
+        }
+
+        timer.Stop();
+        var microsecondsPerCall = timer.Elapsed.TotalMilliseconds * 1000.0 / iterations;
+
+        // Metadata cost of the rejected always-on synthesis, upper-bounded
+        // by the full data-struct member set (ToString is 1 of its 7
+        // synthesized MethodDef rows).
+        var plainSize = EmitProgramSize("""
+            package Spike.Cost
+            import System
+            struct Point {
+                var X int32
+                var Y int32
+            }
+            let p = Point{X: 1, Y: 2}
+            Console.WriteLine(p.X)
+            """);
+        var dataSize = EmitProgramSize("""
+            package Spike.Cost
+            import System
+            data struct Point {
+                var X int32
+                var Y int32
+            }
+            let p = Point{X: 1, Y: 2}
+            Console.WriteLine(p.X)
+            """);
+
+        Assert.True(dataSize > plainSize, "data-struct synthesis should grow the PE");
+
+        this.output.WriteLine(
+            $"formatter steady-state: {microsecondsPerCall:F1} us per Format call ({iterations} iterations, nested two-node graph)");
+        this.output.WriteLine(
+            $"PE size, identical program: plain struct {plainSize} bytes, data struct {dataSize} bytes " +
+            $"(delta {dataSize - plainSize} bytes for 7 synthesized members; ToString is 1 of the 7)");
+    }
+
+    private static long EmitProgramSize(string source)
+    {
+        var compilation = new Compilation(SyntaxTree.Parse(source));
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        Assert.True(result.Success, string.Join("\n", result.Diagnostics));
+        return peStream.Length;
+    }
+
+    /// <summary>
+    /// The spike's prototype of the display-side formatter the ADR
+    /// recommends (working name <c>ReplValueFormatter</c>, to live in
+    /// <c>src/Repl/Engine</c>). Contract: defer to any ToString override
+    /// declared below <see cref="object"/>/<see cref="ValueType"/>
+    /// (synthesized <c>data</c> members, user overrides, imported CLR types,
+    /// primitives); otherwise render structurally in G# literal shape —
+    /// <c>Name{Member: value, ...}</c> — with <c>nil</c> for null, quoted
+    /// strings, element-wise capped collections, a depth cap, and
+    /// reference-cycle elision. The format is explicitly diagnostics-only,
+    /// never a spec guarantee.
+    /// </summary>
+    private static class SpikeValueFormatter
+    {
+        private const int MaxDepth = 4;
+        private const int MaxElements = 8;
+        private const string Elision = "...";
+
+        public static string Format(object value)
+            => Format(value, new HashSet<object>(ReferenceEqualityComparer.Instance), depth: 0);
+
+        private static string Format(object value, HashSet<object> path, int depth)
+        {
+            if (value is null)
+            {
+                return "nil";
+            }
+
+            if (value is string text)
+            {
+                return "\"" + text + "\"";
+            }
+
+            if (value is char character)
+            {
+                return "'" + character + "'";
+            }
+
+            var type = value.GetType();
+            if (HasToStringOverride(type))
+            {
+                // Any real override — synthesized data members, user
+                // overrides, primitives, enums, imported CLR types — wins
+                // transparently, matching CLR virtual dispatch.
+                return Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty;
+            }
+
+            if (depth >= MaxDepth)
+            {
+                return Elision;
+            }
+
+            // Reference-cycle guard: a reference value already on the
+            // current rendering path elides instead of recursing forever.
+            var track = !type.IsValueType;
+            if (track && !path.Add(value))
+            {
+                return Elision;
+            }
+
+            try
+            {
+                return value is IEnumerable enumerable
+                    ? FormatCollection(enumerable, path, depth)
+                    : FormatMembers(value, type, path, depth);
+            }
+            finally
+            {
+                if (track)
+                {
+                    path.Remove(value);
+                }
+            }
+        }
+
+        private static string FormatMembers(object value, Type type, HashSet<object> path, int depth)
+        {
+            var parts = new List<string>();
+            foreach (var field in type.GetFields(BindingFlags.Public | BindingFlags.Instance))
+            {
+                parts.Add(field.Name + ": " + Format(field.GetValue(value), path, depth + 1));
+            }
+
+            foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            {
+                if (!property.CanRead || property.GetIndexParameters().Length != 0)
+                {
+                    continue;
+                }
+
+                object propertyValue;
+                try
+                {
+                    propertyValue = property.GetValue(value);
+                }
+                catch (TargetInvocationException)
+                {
+                    parts.Add(property.Name + ": <error>");
+                    continue;
+                }
+
+                parts.Add(property.Name + ": " + Format(propertyValue, path, depth + 1));
+            }
+
+            return type.Name + "{" + string.Join(", ", parts) + "}";
+        }
+
+        private static string FormatCollection(IEnumerable enumerable, HashSet<object> path, int depth)
+        {
+            var parts = new List<string>();
+            var truncated = false;
+            foreach (var element in enumerable)
+            {
+                if (parts.Count == MaxElements)
+                {
+                    truncated = true;
+                    break;
+                }
+
+                parts.Add(Format(element, path, depth + 1));
+            }
+
+            return "[" + string.Join(", ", parts) + (truncated ? ", " + Elision : string.Empty) + "]";
+        }
+
+        private static bool HasToStringOverride(Type type)
+        {
+            var method = type.GetMethod("ToString", Type.EmptyTypes);
+            return method is not null
+                && method.DeclaringType != typeof(object)
+                && method.DeclaringType != typeof(ValueType);
+        }
+    }
+}

--- a/test/Interpreter.Tests/Adr0157ReplValueFormatterTests.cs
+++ b/test/Interpreter.Tests/Adr0157ReplValueFormatterTests.cs
@@ -1,0 +1,197 @@
+// <copyright file="Adr0157ReplValueFormatterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using GSharp.Repl.Engine;
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// ADR-0157 behavioral pins for the display-side REPL value formatter: the
+/// echo sites (compat console echo, state-sidebar values) render plain
+/// structs/classes structurally in G# composite-literal shape, defer
+/// transparently to real <c>ToString</c> overrides (<c>data</c>-synthesized
+/// per ADR-0029, user <c>override func ToString</c> per #2896), and honor
+/// the rendering contract (nil, nesting, reference cycles, capped
+/// collections, quoted strings). Emitted semantics stay untouched (#3204):
+/// <c>Cell.Value</c> remains the raw runtime object; only its display
+/// changes. Witness (ADR-0154): the echo/sidebar tests fail with the ADR's
+/// three wiring hunks reverted (raw <c>ToString</c> echo shows the CLR type
+/// name), and pass with them.
+/// </summary>
+[Collection("ConsoleIo")]
+public sealed class Adr0157ReplValueFormatterTests
+{
+    private const string PointStructCell = """
+        struct Point {
+            var X int32
+            var Y int32
+        }
+        let p = Point{X: 1, Y: 2}
+        """;
+
+    [Fact]
+    public void CompatEcho_PlainStruct_RendersCompositeLiteral()
+    {
+        Assert.Equal("Point{X: 1, Y: 2}\n", EchoOf(PointStructCell));
+    }
+
+    [Fact]
+    public void CompatEcho_DataStructOverride_Unchanged()
+    {
+        Assert.Equal(
+            "Point(X=1, Y=2)\n",
+            EchoOf("""
+                data struct Point {
+                    var X int32
+                    var Y int32
+                }
+                let p = Point{X: 1, Y: 2}
+                """));
+    }
+
+    [Fact]
+    public void CompatEcho_UserToStringOverride_Unchanged()
+    {
+        Assert.Equal(
+            "tag:11\n",
+            EchoOf("""
+                struct Tagged {
+                    var Id int32
+                    override func ToString() string -> "tag:11"
+                }
+                let t = Tagged{Id: 11}
+                """));
+    }
+
+    [Fact]
+    public void CompatEcho_NestedClassWithNilField_RendersRecursively()
+    {
+        Assert.Equal(
+            "Node{Name: \"root\", Next: Node{Name: \"leaf\", Next: nil}}\n",
+            EchoOf("""
+                class Node {
+                    var Name string
+                    var Next Node?
+                }
+                let leaf = Node{Name: "leaf"}
+                let root = Node{Name: "root", Next: leaf}
+                """));
+    }
+
+    [Fact]
+    public void CompatEcho_ReferenceCycle_TerminatesWithElision()
+    {
+        Assert.Equal(
+            "Node{Name: \"a\", Next: Node{Name: \"b\", Next: ...}}\n",
+            EchoOf("""
+                class Node {
+                    var Name string
+                    var Next Node?
+                }
+                let a = Node{Name: "a"}
+                let b = Node{Name: "b", Next: a}
+                a.Next = b
+                let cycle = a
+                """));
+    }
+
+    [Fact]
+    public void CompatEcho_Collections_RenderElementwiseWithCap()
+    {
+        Assert.Equal("[1, 2, 3]\n", EchoOf("let xs = []int32{1, 2, 3}"));
+        Assert.Equal(
+            "[1, 2, 3, 4, 5, 6, 7, 8, ...]\n",
+            EchoOf("let xs = []int32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}"));
+    }
+
+    [Fact]
+    public void SidebarSnapshot_PlainStructValue_RendersFormatted()
+    {
+        using var engine = new EmittedSessionEngine();
+        Assert.False(engine.Evaluate(PointStructCell).HasError);
+
+        var variable = Assert.Single(engine.Snapshot().Variables);
+        Assert.Contains("Point{X: 1, Y: 2}", variable.Display, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The formatter changes display only: <c>Cell.Value</c> stays the raw
+    /// runtime object, whose own <c>ToString</c> remains the CLR type name
+    /// for a plain struct — #3204's emitted semantics, pinned here so the
+    /// display-side placement never leaks into the value surface.
+    /// </summary>
+    [Fact]
+    public void CellValue_StaysRawRuntimeObject()
+    {
+        using var engine = new EmittedSessionEngine();
+        var cell = engine.Evaluate(PointStructCell);
+
+        Assert.False(cell.HasError);
+        Assert.NotNull(cell.Value);
+        Assert.Equal(cell.Value.GetType().ToString(), cell.Value.ToString());
+        Assert.Equal(typeof(ValueType), cell.Value.GetType().GetMethod("ToString", Type.EmptyTypes).DeclaringType);
+    }
+
+    /// <summary>
+    /// Direct contract pins on the formatter itself, over values produced by
+    /// real emitted execution: primitives and other overridden types defer
+    /// (invariant culture), strings quote, and nil renders as the keyword.
+    /// </summary>
+    [Fact]
+    public void Format_DefersToOverriddenTypes_AndQuotesStrings()
+    {
+        Assert.Equal("42", ReplValueFormatter.Format(EmittedOracle.Evaluate("40 + 2").Value));
+        Assert.Equal("True", ReplValueFormatter.Format(EmittedOracle.Evaluate("2 > 1").Value));
+        Assert.Equal("\"hi\"", ReplValueFormatter.Format(EmittedOracle.Evaluate("\"h\" + \"i\"").Value));
+        Assert.Equal("nil", ReplValueFormatter.Format(null));
+    }
+
+    /// <summary>
+    /// Depth cap: rendering elides below the cap instead of recursing
+    /// through an arbitrarily deep object graph.
+    /// </summary>
+    [Fact]
+    public void Format_DepthCap_Elides()
+    {
+        var result = EmittedOracle.Evaluate("""
+            class Node {
+                var Name string
+                var Next Node?
+            }
+            let n5 = Node{Name: "5"}
+            let n4 = Node{Name: "4", Next: n5}
+            let n3 = Node{Name: "3", Next: n4}
+            let n2 = Node{Name: "2", Next: n3}
+            let n1 = Node{Name: "1", Next: n2}
+            """);
+
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(
+            "Node{Name: \"1\", Next: Node{Name: \"2\", Next: Node{Name: \"3\", Next: Node{Name: \"4\", Next: ...}}}}",
+            ReplValueFormatter.Format(result.Value));
+    }
+
+    private static string EchoOf(string submission)
+    {
+        var previousOut = Console.Out;
+        using var writer = new StringWriter { NewLine = "\n" };
+        Console.SetOut(writer);
+        try
+        {
+            using var repl = new GSharpRepl();
+            repl.EvaluateSubmission(submission);
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+        }
+
+        return writer.ToString().Replace("\r\n", "\n", StringComparison.Ordinal);
+    }
+}

--- a/test/Interpreter.Tests/ParenthesizedReceiverEmittedSessionTests.cs
+++ b/test/Interpreter.Tests/ParenthesizedReceiverEmittedSessionTests.cs
@@ -17,7 +17,7 @@ public class ParenthesizedReceiverEmittedSessionTests
 {
     [Theory]
     [InlineData("(10 + 32).GetType()", "System.Int32")]
-    [InlineData("(10 + 32).ToString()", "42")]
+    [InlineData("(10 + 32).ToString()", "\"42\"")] // string result echoes quoted (ADR-0157 display formatter)
     [InlineData("(\"hello\").Length", "5")]
     [InlineData("([3]int32{10, 20, 30})[1]", "20")]
     public void EmittedSession_ParenthesizedReceiver_PrintsExpectedValue(string expr, string expected)


### PR DESCRIPTION
Closes #3208. Part of #3163. **ADR-0157 is Accepted (2026-08-06)** — this PR delivers the ADR, its feasibility spike, and the accepted implementation.

## Summary

**Decision: no default emitted `ToString` synthesis for plain structs and classes. Emitted CLR semantics stay intact (#3204's decision); the REPL echo gap is closed display-side** with `src/Repl/Engine/ReplValueFormatter.cs` — reflection-based structural rendering in G# composite-literal shape, applied only when the runtime type has no `ToString` override below `object`/`ValueType`, deferring transparently to `data`-synthesized (ADR-0029) and user `override func ToString` (#2896) overrides. The format is explicitly diagnostics-only, never spec.

- Add **ADR-0157** (`docs/adr/0157-default-tostring-synthesis.md`, Accepted): answers every question filed in #3208 — opt-in/opt-out/always-on (no new synthesis; `data` and `override func ToString` already occupy the opt-in space), synthesis site (display-side, not emitted), rendering contract (nil, quoted strings, public members in metadata order, depth cap, reference-cycle elision, capped collections; tool-level and revisable), inheritance (no emitted slot; formatter reflects the runtime type; data hierarchies keep #2338 behavior), interop (unchanged by construction), cost (zero metadata; ~5 µs per echo). Rejected alternatives documented with grounded reasons (always-on emitted synthesis, opt-out, a new ToString-only opt-in, assembly-scoped triggering, status quo).
- Add the feasibility spike `test/Interpreter.Tests/Adr0157PrettyDisplaySpikeTests.cs` (trait `Category=Adr0157Spike`, ADR evidence, untouched by the implementation per the ADR-0156 precedent).
- Implement **`ReplValueFormatter`** and wire the three echo sites the ADR identified: transcript echo (`ReplScreen.cs`), compat console echo (`Compat/GSharpRepl.cs`), and the state-sidebar values column (`EmittedSessionEngine.Snapshot`). `Cell.Value` stays the raw runtime object — display changes only.
- Add behavioral pins `test/Interpreter.Tests/Adr0157ReplValueFormatterTests.cs` (10 tests): echo before/after (`gsi$N.Point` → `Point{X: 1, Y: 2}`), data-struct (`Point(X=1, Y=2)`) and user-override (`tag:11`) echoes unchanged, nested/nil (`Node{Name: "root", Next: Node{Name: "leaf", Next: nil}}`), cycle elision, collection cap (`[1, 2, 3, 4, 5, 6, 7, 8, ...]`), sidebar rendering, depth cap, raw-`Cell.Value` pin.

## Spike evidence

| Case (real emitted values via `EmittedOracle`) | Result |
|---|---|
| Plain two-field struct | pins today's contract (`ToString` slot = `ValueType`, echo = CLR type name); formatter renders `Point{X: 1, Y: 2}` |
| `data struct` | emitted override confirmed on the type (interop-visible); formatter defers: `Point(X=1, Y=2)` |
| `override func ToString` on plain struct | formatter defers: `tag:11` |
| Nested class + `nil` / reference cycle / capped `[]int32` | contract shapes all hold |

Measurements: formatter steady-state **5.1 µs/call**; metadata cost of the rejected always-on alternative bounded by an identical program compiled plain vs `data`: **2,560 → 3,584 bytes PE (+1,024 bytes** for the 7 synthesized members; ToString is 1 of 7).

## Verification

- Release solution build: **0 warnings, 0 errors**.
- Witness (ADR-0154, reverted-hunk mutant): with the three echo-site wiring hunks reverted (formatter class kept), `Adr0157ReplValueFormatterTests` ran **5 failed / 5 passed** — exactly the wiring-dependent tests red (plain-struct echo, nested/nil, cycle, collections, sidebar; the pre-change echo shows the CLR type name) and the wiring-independent pins green. Wiring restored: **10/10 passed**.
- Spike: `--filter "FullyQualifiedName~Adr0157"` — spike 7/7 + behavioral 10/10, Debug and Release.
- Full `test/Interpreter.Tests` (the REPL suite): first run 1,413/1,414 — the single failure was the intended echo change itself (a pre-existing pin asserting a string-valued cell echoes unquoted, `ParenthesizedReceiverEmittedSessionTests`); pin updated to the quoted echo, targeted rerun of that suite + all Adr0157 tests **21/21 green**.
- NOT RUN: Core.Tests / Compiler.Tests / LanguageServer.Tests — no `src/Core`, compiler, or LSP code touched; the product change is confined to `src/Repl` (three files + the new formatter).

## Checklist

- [x] Behavioral tests carry a witness of discrimination (ADR-0154): reverted-hunk witness recorded above (5 red pre-wiring → 10 green wired).
- [x] Self-review verdict recorded when one was run (MERGEABLE / BLOCKER / SHOULD-FIX / NIT), with residuals filed as issues rather than dropped.

Self-review verdict: **MERGEABLE** — ADR (Accepted) + additive spike + a display-only REPL change with red→green witnessed pins; emitted semantics and `Cell.Value` pinned unchanged. Residual: the trigger-scoping knob is documented in the ADR as tunable follow-up, not blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
