### PR TITLE
Resolve prior-cell package members from their own submission assembly

### DIFF
--- a/src/Core/CodeAnalysis/Binding/SubmissionImports.cs
+++ b/src/Core/CodeAnalysis/Binding/SubmissionImports.cs
@@ -169,7 +169,7 @@ public sealed class SubmissionImports
             var metadataName = arity == 0
                 ? name
                 : name + "`" + arity.ToString(CultureInfo.InvariantCulture);
-            return references.TryResolveType(submission.PackageName + "." + metadataName, out clrType);
+            return references.TryResolveTypeInAssembly(submission.AssemblyName, submission.PackageName + "." + metadataName, out clrType);
         }
 
         return false;
@@ -225,8 +225,14 @@ public sealed class SubmissionImports
         return arities.Contains(0) ? 0 : arities[0];
     }
 
+    // Issue #3297: resolve against the declaring submission's own assembly,
+    // not the flat namespace-qualified name. Two cells that redeclare the
+    // same `package foo` each emit a `foo.<Program>` container into their own
+    // submission assembly (`gsi$1`, `gsi$2`); the flat lookup collides on the
+    // newest, which made the older cell's declarations unreachable even
+    // though the newest-first declaration walk had correctly found them.
     private static bool TryResolveProgramType(ReferenceResolver references, SubmissionReference submission, out Type programType)
-        => references.TryResolveType(submission.PackageName + "." + ProgramTypeName, out programType);
+        => references.TryResolveTypeInAssembly(submission.AssemblyName, submission.PackageName + "." + ProgramTypeName, out programType);
 }
 
 /// <summary>

--- a/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
+++ b/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
@@ -728,6 +728,74 @@ public sealed class ReferenceResolver : IDisposable
     }
 
     /// <summary>
+    /// Issue #3297: tries to resolve a fully-qualified type name from the
+    /// specific referenced assembly whose simple name is
+    /// <paramref name="assemblySimpleName"/>, rather than across the whole
+    /// reference set. Interactive submission binding needs this
+    /// assembly-qualified steering: two REPL cells that redeclare the same
+    /// <c>package foo</c> emit into distinct submission assemblies
+    /// (<c>gsi$1</c>, <c>gsi$2</c>) that each define a <c>foo.&lt;Program&gt;</c>
+    /// container, so the flat name lookup of
+    /// <see cref="TryResolveType(string, out System.Type)"/> can only ever answer with one
+    /// of them and the other submission's declarations become unreachable.
+    /// Resolving against the declaring submission's own assembly keeps every
+    /// submission's members addressable. Enforces the same external-visibility
+    /// gate as the user-facing flat lookup.
+    /// </summary>
+    /// <param name="assemblySimpleName">The simple name of the declaring assembly (e.g. <c>gsi$3</c>).</param>
+    /// <param name="fullName">The fully-qualified type name (e.g. <c>foo.&lt;Program&gt;</c>).</param>
+    /// <param name="type">The resolved <see cref="Type"/>, if found.</param>
+    /// <returns><c>true</c> if the named assembly defines a matching, externally visible type; otherwise <c>false</c>.</returns>
+    public bool TryResolveTypeInAssembly(string assemblySimpleName, string fullName, out Type type)
+    {
+        type = null;
+        if (string.IsNullOrEmpty(assemblySimpleName) || string.IsNullOrEmpty(fullName))
+        {
+            return false;
+        }
+
+        // "::" cannot occur in a CLR type full name (nested types use '+',
+        // generics use '`'), so these keys never collide with the flat
+        // full-name keys sharing the cache.
+        var cacheKey = assemblySimpleName + "::" + fullName;
+        if (resolveCache.TryGetValue(cacheKey, out var cached))
+        {
+            if (ReferenceEquals(cached, MissTypeSentinel))
+            {
+                return false;
+            }
+
+            type = cached;
+            return true;
+        }
+
+        Type resolved = null;
+        foreach (var asm in assemblies)
+        {
+            if (!string.Equals(asm.GetName().Name, assemblySimpleName, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            resolved = SafeGetType(asm, fullName);
+            if (resolved != null)
+            {
+                break;
+            }
+        }
+
+        if (resolved == null || !IsExternallyResolvable(resolved))
+        {
+            resolveCache.TryAdd(cacheKey, MissTypeSentinel);
+            return false;
+        }
+
+        resolveCache.TryAdd(cacheKey, resolved);
+        type = resolved;
+        return true;
+    }
+
+    /// <summary>
     /// Issue #526: resolves a nested CLR type by name on a containing
     /// <paramref name="containingType"/>. Used by the binder to walk a
     /// dotted-qualifier type clause (e.g. <c>Outer.Inner.DeepInner</c>) one

--- a/test/Interpreter.Tests/PackageDeclaringCellEchoTests.cs
+++ b/test/Interpreter.Tests/PackageDeclaringCellEchoTests.cs
@@ -18,8 +18,10 @@ namespace GSharp.Interpreter.Tests;
 /// because the chain recorded the wrong package. The engine now records
 /// the emitted package (<c>GlobalScope.Package</c>), making the echo and
 /// cross-cell visibility work. The one structural residue — two cells
-/// redeclaring the <em>same</em> package — is pinned below and tracked by
-/// <see href="https://github.com/DavidObando/gsharp/issues/3297">#3297</see>.
+/// redeclaring the <em>same</em> package — was
+/// <see href="https://github.com/DavidObando/gsharp/issues/3297">#3297</see>,
+/// fixed by assembly-qualified steering in <c>SubmissionImports</c>; see
+/// <see cref="PackageRedeclarationAcrossCellsTests"/> for the full matrix.
 /// </summary>
 public sealed class PackageDeclaringCellEchoTests : IDisposable
 {
@@ -71,15 +73,17 @@ public sealed class PackageDeclaringCellEchoTests : IDisposable
     }
 
     [Fact]
-    public void SamePackageTwiceOlderDeclarationCurrentlyUnreachable()
+    public void SamePackageTwiceExtendsThePackage()
     {
-        // Pins the #3297 limitation: SubmissionImports resolves a prior
-        // cell's members via the namespace-qualified "foo.<Program>" name
-        // only, so when two submission assemblies both emit namespace
-        // `foo`, resolution collides on the newest and the older cell's
-        // declarations cannot be reached. When #3297 lands
-        // assembly-qualified steering, `a()` should evaluate to 1 and this
-        // pin flips into the positive assertion.
+        // #3297: a later `package foo` cell EXTENDS the package. Each
+        // submission emits into its own assembly (`gsi$1`, `gsi$2`), so the
+        // two `foo.<Program>` containers never physically collide; the
+        // historical failure was that SubmissionImports resolved a prior
+        // cell's container through the namespace-qualified name only, and
+        // the flat lookup always answered with the newest assembly's copy.
+        // Assembly-qualified steering (ReferenceResolver.TryResolveTypeInAssembly)
+        // resolves each submission's members from that submission's own
+        // assembly, so both cells' declarations stay reachable.
         Assert.False(engine.Evaluate("package foo\nfunc a() int {\n    return 1\n}").HasError);
         Assert.False(engine.Evaluate("package foo\nfunc b() int {\n    return 2\n}").HasError);
 
@@ -88,7 +92,7 @@ public sealed class PackageDeclaringCellEchoTests : IDisposable
         Assert.Equal(2, useNewest.Value);
 
         var useOldest = engine.Evaluate("a()");
-        Assert.True(useOldest.HasError);
-        Assert.Contains(useOldest.Diagnostics, d => d.Message.Contains("a", StringComparison.Ordinal));
+        Assert.False(useOldest.HasError, string.Join("; ", useOldest.Diagnostics));
+        Assert.Equal(1, useOldest.Value);
     }
 }

--- a/test/Interpreter.Tests/PackageRedeclarationAcrossCellsTests.cs
+++ b/test/Interpreter.Tests/PackageRedeclarationAcrossCellsTests.cs
@@ -1,0 +1,166 @@
+// <copyright file="PackageRedeclarationAcrossCellsTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using GSharp.Repl.Engine;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #3297 witness matrix: redeclaring the same <c>package X</c> in a
+/// later REPL cell EXTENDS the package — the new cell's members join the
+/// package for subsequent cells, and a redefinition of an existing name
+/// follows the engine's newest-wins shadowing model. Structurally, every
+/// submission still emits into its own assembly (<c>gsi$N</c>), so two
+/// same-package <c>foo.&lt;Program&gt;</c> containers never collide in
+/// metadata; <c>SubmissionImports</c> resolves each prior submission's
+/// members from that submission's own assembly
+/// (<see cref="GSharp.Core.CodeAnalysis.Symbols.ReferenceResolver"/>
+/// assembly-qualified steering) instead of the flat namespace-qualified
+/// lookup that always answered with the newest assembly's copy.
+/// </summary>
+public sealed class PackageRedeclarationAcrossCellsTests : IDisposable
+{
+    private readonly EmittedSessionEngine engine = new();
+
+    public void Dispose() => engine.Dispose();
+
+    [Fact]
+    public void SamePackageTwoCellsFunctionsGlobalsAndTypesAllReachable()
+    {
+        var first = engine.Evaluate(
+            "package foo\n" +
+            "struct Point {\n    var X int\n    var Y int\n}\n" +
+            "var origin = 10\n" +
+            "func a() int {\n    return 1\n}");
+        Assert.False(first.HasError, string.Join("; ", first.Diagnostics));
+
+        var second = engine.Evaluate(
+            "package foo\n" +
+            "struct Pair {\n    var L int\n    var R int\n}\n" +
+            "var offset = 20\n" +
+            "func b() int {\n    return 2\n}");
+        Assert.False(second.HasError, string.Join("; ", second.Diagnostics));
+
+        // Functions from both cells.
+        var older = engine.Evaluate("a()");
+        Assert.False(older.HasError, string.Join("; ", older.Diagnostics));
+        Assert.Equal(1, older.Value);
+
+        var newer = engine.Evaluate("b()");
+        Assert.False(newer.HasError, string.Join("; ", newer.Diagnostics));
+        Assert.Equal(2, newer.Value);
+
+        // Globals from both cells.
+        var globals = engine.Evaluate("origin + offset");
+        Assert.False(globals.HasError, string.Join("; ", globals.Diagnostics));
+        Assert.Equal(30, globals.Value);
+
+        // Types from both cells.
+        var olderType = engine.Evaluate("var p = Point{X: 3, Y: 4}\np.X + p.Y");
+        Assert.False(olderType.HasError, string.Join("; ", olderType.Diagnostics));
+        Assert.Equal(7, olderType.Value);
+
+        var newerType = engine.Evaluate("var q = Pair{L: 5, R: 6}\nq.L + q.R");
+        Assert.False(newerType.HasError, string.Join("; ", newerType.Diagnostics));
+        Assert.Equal(11, newerType.Value);
+    }
+
+    [Fact]
+    public void MemberAddedInSecondPackageCellVisibleToThirdCell()
+    {
+        Assert.False(engine.Evaluate("package foo\nfunc a() int {\n    return 1\n}").HasError);
+        Assert.False(engine.Evaluate("package foo\nfunc b() int {\n    return a() + 1\n}").HasError);
+
+        var third = engine.Evaluate("a() + b()");
+        Assert.False(third.HasError, string.Join("; ", third.Diagnostics));
+        Assert.Equal(3, third.Value);
+    }
+
+    [Fact]
+    public void RedefinitionInsideSamePackageAcrossCellsNewestWins()
+    {
+        Assert.False(engine.Evaluate("package foo\nfunc f() int {\n    return 1\n}").HasError);
+
+        var beforeRedefinition = engine.Evaluate("f()");
+        Assert.False(beforeRedefinition.HasError, string.Join("; ", beforeRedefinition.Diagnostics));
+        Assert.Equal(1, beforeRedefinition.Value);
+
+        Assert.False(engine.Evaluate("package foo\nfunc f() int {\n    return 2\n}").HasError);
+
+        var afterRedefinition = engine.Evaluate("f()");
+        Assert.False(afterRedefinition.HasError, string.Join("; ", afterRedefinition.Diagnostics));
+        Assert.Equal(2, afterRedefinition.Value);
+    }
+
+    [Fact]
+    public void GlobalRedefinitionInsideSamePackageAcrossCellsNewestWins()
+    {
+        Assert.False(engine.Evaluate("package foo\nvar x = 1").HasError);
+        Assert.False(engine.Evaluate("package foo\nvar x = 2").HasError);
+
+        var read = engine.Evaluate("x");
+        Assert.False(read.HasError, string.Join("; ", read.Diagnostics));
+        Assert.Equal(2, read.Value);
+    }
+
+    [Fact]
+    public void DifferentPackagesInDifferentCellsBothReachable()
+    {
+        Assert.False(engine.Evaluate("package foo\nfunc a() int {\n    return 1\n}").HasError);
+        Assert.False(engine.Evaluate("package bar\nfunc b() int {\n    return 2\n}").HasError);
+
+        var both = engine.Evaluate("a() + b()");
+        Assert.False(both.HasError, string.Join("; ", both.Diagnostics));
+        Assert.Equal(3, both.Value);
+    }
+
+    [Fact]
+    public void PackageCellsInterleavedWithPackagelessCells()
+    {
+        Assert.False(engine.Evaluate("package foo\nfunc a() int {\n    return 1\n}").HasError);
+        Assert.False(engine.Evaluate("func plain() int {\n    return 10\n}").HasError);
+        Assert.False(engine.Evaluate("package foo\nfunc b() int {\n    return 2\n}").HasError);
+
+        var all = engine.Evaluate("a() + plain() + b()");
+        Assert.False(all.HasError, string.Join("; ", all.Diagnostics));
+        Assert.Equal(13, all.Value);
+    }
+
+    [Fact]
+    public void SnapshotShowsMembersFromBothSamePackageCells()
+    {
+        Assert.False(engine.Evaluate("package foo\nvar first = 1\nfunc a() int {\n    return 1\n}").HasError);
+        Assert.False(engine.Evaluate("package foo\nvar second = 2\nfunc b() int {\n    return 2\n}").HasError);
+
+        var state = engine.Snapshot();
+        Assert.Contains(state.Functions, s => s.Display.Contains("a", StringComparison.Ordinal));
+        Assert.Contains(state.Functions, s => s.Display.Contains("b", StringComparison.Ordinal));
+        Assert.Contains(state.Variables, s => s.Display.Contains("first", StringComparison.Ordinal));
+        Assert.Contains(state.Variables, s => s.Display.Contains("second", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ResetClearsSamePackageChain()
+    {
+        Assert.False(engine.Evaluate("package foo\nfunc a() int {\n    return 1\n}").HasError);
+        Assert.False(engine.Evaluate("package foo\nfunc b() int {\n    return 2\n}").HasError);
+
+        engine.Reset();
+
+        Assert.Empty(engine.Cells);
+        Assert.Empty(engine.Snapshot().Functions);
+
+        var afterReset = engine.Evaluate("a()");
+        Assert.True(afterReset.HasError);
+
+        // The package can be rebuilt from scratch after Reset.
+        Assert.False(engine.Evaluate("package foo\nfunc a() int {\n    return 41\n}").HasError);
+        Assert.False(engine.Evaluate("package foo\nfunc plusOne() int {\n    return a() + 1\n}").HasError);
+        var rebuilt = engine.Evaluate("plusOne()");
+        Assert.False(rebuilt.HasError, string.Join("; ", rebuilt.Diagnostics));
+        Assert.Equal(42, rebuilt.Value);
+    }
+}


### PR DESCRIPTION
Fixes #3297. Part of #3163.

## Summary

- **Semantics: a later `package foo` cell EXTENDS the package.** Its members join `foo` for subsequent cells; redefinition of an existing name follows the engine's existing newest-wins shadowing walk. Rejected alternatives: erroring on redeclaration (hostile to REPL iteration and would regress the #3298 cross-cell guarantee) and reset-package semantics (silently destroys prior state, inconsistent with how packageless cells accumulate).
- Structurally, no new container naming was needed: submissions already emit into distinct assemblies (`gsi$1`, `gsi$2`), so two same-package `foo.<Program>` containers never collide in metadata. The bug was resolution: `SubmissionImports` resolved a prior cell's container through the flat namespace-qualified name only, so the lookup always answered with the newest assembly's copy and the older cell's declarations were unreachable ("Cannot find function a.").
- `ReferenceResolver.TryResolveTypeInAssembly(assemblySimpleName, fullName)`: additive assembly-qualified steering — resolves a full type name from the specific referenced assembly, same external-visibility gate and miss-caching as the flat lookup (cache keys use `::`, impossible in a CLR type full name). No existing resolution path changed.
- `SubmissionImports.TryResolveProgramType` / `TryResolveType` steer through `SubmissionReference.AssemblyName`, so the submission the newest-first declaration walk chose is also the assembly the member binds (and emits a memberref) against. Entirely behind the submission seam — gsc / gsi-file compilation untouched.
- Flipped the `SamePackageTwiceOlderDeclarationCurrentlyUnreachable` pin into its positive assertion and added the #3297 witness matrix (`PackageRedeclarationAcrossCellsTests`).

## Verification

- Release solution build: 0 warnings, 0 errors.
- ADR-0154 witness: the matrix red on pre-fix code — 4 failures, each "Cannot find function a." (same-package reachability, member-added-in-cell-2, interleaving, flipped pin); green after the fix (13/13 in the two affected files).
- Witness matrix: same package in 2 cells (funcs + globals + types) ✔; member added in cell 2 visible in cell 3 ✔; func and global redefinition inside the package across cells (newest-wins) ✔; different packages in different cells ✔; package cells interleaved with packageless cells ✔; snapshot/sidebar shows both cells' members ✔; Reset clears and the package is rebuildable ✔.
- Full Interpreter.Tests: 1405/1405 passed.
- Full Core.Tests: 7215 passed, 1 skipped (RegenerateBaseline, standing skip).
- LanguageConformance filter: 126/126 passed (shared-surface guard: emit naming unchanged, resolver change is additive).
- NOT RUN: Compiler.Tests outside the LanguageConformance filter, LanguageServer.Tests, Sdk.Tests, Extensions.Tests — no code in those surfaces changed; the only Core change is an additive resolver method plus submission-seam-only steering, and Cs2Gs full-suite runs are flaky per standing note.

## Checklist

- [x] Behavioral tests carry a witness of discrimination (ADR-0154): each new/changed test fails on the pre-change code (pre-fix commit, reverted hunk, or an applied product mutant) and passes with it.
- [x] Self-review verdict recorded when one was run (MERGEABLE / BLOCKER / SHOULD-FIX / NIT), with residuals filed as issues rather than dropped.

Self-review verdict: MERGEABLE — no residuals; the resolver addition is additive, all consumers are behind the submission seam, and the conformance guard is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)