### PR TITLE
ADR-0158 (Accepted): synchronization story — SyncMap library type + docs, no synchronized modifier

### DIFF
--- a/docs/adr/0158-synchronization-story.md
+++ b/docs/adr/0158-synchronization-story.md
@@ -1,0 +1,311 @@
+# ADR-0158: The G# synchronization story — a Sync library type plus documented interop, not a `synchronized` modifier
+
+- **Status**: Proposed — owner decision requested
+  ([#3209](https://github.com/DavidObando/gsharp/issues/3209); feasibility
+  spike in `test/Interpreter.Tests/Adr0158SyncMapSpikeTests.cs`, no product
+  changes in this PR)
+- **Date**: 2026-08-06
+- **Phase**: Language surface / concurrency ergonomics (ADR-0156 Phase 3
+  semantic-alignment follow-up)
+- **Related**: [#3209](https://github.com/DavidObando/gsharp/issues/3209)
+  (this question), [#3205](https://github.com/DavidObando/gsharp/issues/3205)
+  (decided: emitted maps are plain `Dictionary<,>`, not goroutine-safe —
+  Go parity), [#3163](https://github.com/DavidObando/gsharp/issues/3163) /
+  [#3176](https://github.com/DavidObando/gsharp/issues/3176) (campaign
+  tracking), ADR-0002 (concurrency model: Go surface, .NET runtime, Kotlin
+  scopes), ADR-0022 (`go`/`chan`/`select` lowering), ADR-0034 (imported CLR
+  interop), ADR-0084 (G#-authored `Gsharp.Extensions` packages — the
+  Optional precedent), issue [#1885](https://github.com/DavidObando/gsharp/issues/1885)
+  (the `lock` statement), issue [#1799](https://github.com/DavidObando/gsharp/issues/1799)
+  (the evaluator's implicit map lock, retired with ADR-0156 Phase 3c;
+  pre-deletion tests at commit `5cd0d766`),
+  [#2485](https://github.com/DavidObando/gsharp/issues/2485) (Swift-style
+  actors — open, positioned against below); spike fallout filed as
+  [#3303](https://github.com/DavidObando/gsharp/issues/3303) (generic
+  `map[K,V]` field NRE) and
+  [#3304](https://github.com/DavidObando/gsharp/issues/3304) (`go` rejects
+  void operands)
+
+## Context
+
+When ADR-0156 Phase 3c deleted the tree-walking evaluator, its implicit
+per-instance map lock (#1799) died with it: a G# `map[K,V]` is a plain
+`Dictionary<K,V>` in IL, and concurrent goroutine access is not
+goroutine-safe. #3205 decided that interim state deliberately — Go's own
+maps are unsynchronized and Go declares concurrent map writes fatal — and
+#3209 asks for the first-class successor story. The owner's framing there is
+the constraint that matters: G# already has `lock` and full
+`System.Threading` / `System.Collections.Concurrent` interop, so **the goal
+is ergonomics, not capability**.
+
+Five facts about the language as it exists today frame the answer.
+
+**1. G# already has a synchronization statement.** `lock expr { body }`
+(reserved keyword, Go-shaped headerless syntax) is lowered entirely in the
+binder — there is no `BoundLockStatement`; `StatementBinder.Loops.cs`
+(`BindLockStatement`) evaluates the target once into a synthesized readonly
+local, rejects value-type targets (the C# CS0185 rule), and builds
+`Monitor.Enter(tmp); try { body } finally { Monitor.Exit(tmp) }` from
+imported `System.Threading.Monitor` symbols (#1885). Any new construct that
+means "hold a monitor around this region" already has its lowering built.
+
+**2. The interop floor is real, today.** The spike below compiles and runs a
+G# program that constructs `ConcurrentDictionary[string, int32]` (after
+`import System.Collections.Concurrent`), `TryAdd`s from 24 goroutines, and
+reads back with `TryGetValue(k, out v)` — all writes survive, no compiler
+change involved. Capability is genuinely not the gap.
+
+**3. The concurrency identity is Go's, and Go's answer is not a modifier.**
+ADR-0002 fixed the surface: `go` / `chan T` / `<-` / `select` plus
+structured `scope { }` blocks, lowered to `Task.Run` and
+`System.Threading.Channels`. Go's doctrine for this exact problem is "share
+memory by communicating"; where sharing is unavoidable, Go ships `sync.Map`
+— a **method-based library type** (`Store`/`Load`/`Range`), deliberately
+without index syntax — plus a race detector. Java's `synchronized` is the
+foreign lineage here, and it is the one precedent whose own ecosystem
+retreated from it: synchronized collections gave way to
+`java.util.concurrent`, and the instance-as-monitor design (any foreign code
+can lock your object) is the pitfall #3209 already flags. .NET walked the
+same road: `lock(this)`, `SyncRoot`, and `MethodImplOptions.Synchronized`
+all moved from guidance to warning over the years, for the same two reasons
+— wrong granularity (method-scoped monitors serialize non-conflicting
+operations) and false safety (they still cannot make *compound*
+check-then-act operations atomic).
+
+**4. Nothing in the corpus wants this.** Across `samples/*.gs` and the
+cs2gs corpus there are **zero** uses of `lock`, `Monitor`, `Mutex`,
+`Interlocked`, or `ConcurrentDictionary`, and **no program shares a map
+across goroutines**. The programs that do share state across goroutines
+(`GoScope.gs`, `PortScan.gs`) share buffered channels joined by `scope` —
+the idiom working as designed. The triggering artifact for #3209 was a test
+suite pinning evaluator internals, not user demand.
+
+**5. Syntax would be the cheap part.** For completeness: a `synchronized`
+(or `sync`) modifier would slot into the existing contextual-modifier loop
+in `Parser.Declarations.cs` / `Parser.Members.cs` exactly like `data`,
+`partial`, `inline`, and `unsafe` did — no new reserved keyword needed. The
+argument against it is not implementation cost; it is that the construct is
+the wrong shape (fact 3) for a need that does not exist (fact 4) and is
+already served (facts 1–2), while a plausible future language surface for
+shared state — actors, #2485, open — would supersede it.
+
+## Decision (proposed — owner decides)
+
+**Ship the synchronization story as library plus documentation, and add no
+language surface:**
+
+1. **`Gsharp.Extensions.Sync`** — a G#-authored SDK package (the ADR-0084
+   Optional/Sequences precedent) whose first type is **`SyncMap[K, V]`**,
+   G#'s `sync.Map` analog: a generic class wrapping a private
+   `ConcurrentDictionary[K, V]`, method-based API, no literal or index
+   syntax:
+
+   ```gsharp
+   import Gsharp.Extensions.Sync
+
+   var m = SyncMap[string, int32]()
+   m.Store("k", 1)
+   m.Update("k", func(v int32) int32 { return v + 1 })  // atomic RMW
+   let v = m.Load("k")      // zero value when absent — map-read parity
+   m.Range(func(k string, v int32) { ... })
+   ```
+
+   Sketched surface (implementation PR finalizes): `Store`, `Load`,
+   `Update(key, f)` (atomic read-modify-write), `Delete`, `Len`,
+   `Contains`, `Keys()` (snapshot slice), `Range(action)`. Absent-key
+   `Load` returns the zero value, mirroring G# map reads (which lower to
+   `TryGetValue`, not `get_Item`). The backing dictionary is private and
+   never leaked — the hidden-monitor discipline #3209 requires — and the
+   nullable-interop `!!` and function-literal papercuts the spike hit stay
+   *inside* the library, which is itself an ergonomics argument for
+   shipping it rather than documenting the raw pattern.
+
+   The method-based API is a deliberate semantic choice, not a limitation:
+   Go's `sync.Map` has no index syntax either, because `m[k] = m[k] + 1`
+   *looks* atomic and is not. `Update` exists precisely because per-call
+   locking cannot express compound operations through indexer sugar.
+
+2. **A `docs/concurrency.md` page** (the first concurrency topic page; flat
+   docs convention) that teaches, in order: the idiom (goroutines +
+   channels + `scope` — "share memory by communicating"), `lock` for
+   protecting arbitrary state, the CLR interop menu
+   (`ConcurrentDictionary`, `Interlocked`, `ReaderWriterLockSlim`,
+   `Mutex`/`SemaphoreSlim`), and `SyncMap` for the shared-map case. This is
+   the "documented interim guidance" leg of #3209, kept even after the
+   library lands.
+
+3. **Plain `map[K, V]` stays unsynchronized, and concurrent access stays
+   undefined behavior, documented** — #3205's stance becomes the permanent
+   spec position. No Go-style runtime fault: `Dictionary<,>` already
+   surfaces a best-effort corruption exception (the spike's mutant runs
+   show it), but *guaranteeing* detection would mean wrapping every map
+   operation in every compiled program with checking — a tax on all code
+   for a race no corpus program can currently hit, and a divergence from
+   the "map is a plain `Dictionary`" interop contract. A debug-only checked
+   map remains available as future work if demand appears.
+
+4. **No `synchronized` modifier**, now or as a follow-up — and the retired
+   #1799 guarantees return as `SyncMap` guarantees (the spike tests are
+   their successors), attached to the type that can actually honor them.
+
+### The retired Issue1799 guarantees, restated for their successor
+
+| Evaluator-era guarantee (deleted at `5cd0d766`) | Successor (attaches to `SyncMap`, not `map`) |
+|---|---|
+| N goroutines writing distinct keys: all writes survive | Same, exact (spike: 24 goroutines, sum 300/300) |
+| Racy `m[k] = m[k] + 1`: never corrupts, value in range | **Stronger**: `Update` is atomic — exactly N increments (spike: 50/50, every run) |
+| Enumeration while writing: never throws | Same, via `Range` (spike: 30 stress runs) |
+| `len` / `ContainsKey` / `Keys` under write load: never throws | Same, via `Len` / `Contains` / `Keys()` (spike: 30 stress runs) |
+
+Plain `map[K, V]` carries none of these — that is #3205, unchanged.
+
+## Evidence — feasibility spike
+
+`test/Interpreter.Tests/Adr0158SyncMapSpikeTests.cs` (trait
+`Category=Adr0158Spike`, run via
+`dotnet test test/Interpreter.Tests --filter "FullyQualifiedName~Adr0158"`)
+proves the mechanism end-to-end with **zero product changes**, over real
+emitted execution (`test/Shared/EmittedOracle`). The prototype `SyncMap` is
+written in G# *inside the test source* using only today's surface: a class
+with a private map field as hidden monitor, `lock` statements,
+function-typed parameters for `Update`, slice/`append` for `Keys`.
+
+All 6 tests green; suite wall time ~1 s (the stress tests each recompile
+and rerun the emitted program 30–40 times under `Parallel.For`):
+
+| Test | Result |
+|---|---|
+| 24 goroutines, distinct keys (Issue1799-A successor) | sum exactly 300 — all writes survive |
+| 50 goroutines incrementing one key, × 40 runs (Issue1799-B successor) | exactly 50 every run — atomic `Update`, stronger than the evaluator's racy guarantee |
+| `Range` while 16 writers store, × 30 runs (Issue1799-C successor) | never throws |
+| `Len`/`Contains`/`Keys` under write load, × 30 runs (Issue1799-D successor) | never throws |
+| Interop floor: raw `ConcurrentDictionary` from G#, 24 goroutines | all writes survive — the docs-guidance leg needs no compiler work |
+| Generic shape: `GenericSyncMap[K, V any]` over a `ConcurrentDictionary[K, V]` field, two closed instantiations | compiles and runs — **the shipped generic library type needs zero compiler changes** |
+
+**Discrimination witness (ADR-0154, mutant form).** Deleting the `lock`
+statements from the prototype (`sed 's/lock items {/{/'` — the
+unsynchronized mutant) breaks the guarantees loudly. Across two recorded
+mutant runs: the increment count collapsed to values as low as **1**
+(observed result sets `[1, 1, 1, 49, 26, …]`, `[43, 15, 33, 29, 44, …]`
+instead of fifty 50s), distinct-key writes were lost, and both enumeration
+tests died with the CLR's *"Operations that change non-concurrent
+collections must have exclusive access. A concurrent update was performed on
+this collection and corrupted its state."* Which guarantees fail varies
+per run with scheduling — all four failed at least once, none ever fails
+with the locks in place.
+
+**Spike fallout, filed.** Two real gaps surfaced and are now issues rather
+than footnotes:
+
+- [#3303](https://github.com/DavidObando/gsharp/issues/3303): a generic
+  class with a `map[K, V]` field over its own type parameters compiles but
+  the `map[K, V]{}` literal never reaches the field (NRE at first use), and
+  `map[K, V] != nil` does not bind. This is why the recommended backing is
+  `ConcurrentDictionary[K, V]` — which the spike shows works generically
+  today — rather than a locked plain map; it is also the better backing on
+  merits (lock-free reads, safe enumeration).
+- [#3304](https://github.com/DavidObando/gsharp/issues/3304): `go f()`
+  rejects void-returning operands ("Expression must have a value."), which
+  is why every goroutine in the corpus carries a dummy `return 0`.
+  Unrelated to synchronization, but it is the largest concurrency-ergonomics
+  papercut the spike actually hit — worth fixing regardless of this ADR's
+  outcome.
+
+## Consequences
+
+- The shared-map question gets a first-class, teachable answer —
+  `import Gsharp.Extensions.Sync`, use `SyncMap` — with zero new grammar,
+  binder, emit, or spec surface, and the retired evaluator-era guarantees
+  come back attached to a type that can honor them under the one remaining
+  engine.
+- G# stays aligned with **both** parents at once: Go (maps unsynchronized;
+  the blessed shared map is a method-based library type) and .NET
+  (`ConcurrentDictionary` is the platform primitive; a G# `SyncMap` handed
+  across the interop boundary is an ordinary class wrapping one).
+- The actor horizon (#2485) stays clean. If actors ever land, they become
+  the language-surface answer for owned mutable state, and `SyncMap`
+  remains a useful leaf type — whereas a `synchronized` modifier shipped
+  now would be a second, weaker, permanent language mechanism the actor
+  design would have to coexist with and teach around.
+- Cost: one more `Gsharp.Extensions` package to maintain (small, and the
+  pattern is established); `SyncMap`'s contract (zero-value `Load`,
+  snapshot `Keys`, atomicity of `Update`) needs package-doc treatment; users
+  wanting other synchronized shapes (sets, queues) drop to the documented
+  interop menu until demand justifies more types.
+- Nothing is foreclosed. A future compiler-bound `syncmap[K, V]` sugar, a
+  checked debug map, or actors can all be layered on later without breaking
+  the library API; the modifier path remains *possible* — this ADR's claim
+  is that it should stay untaken.
+
+## Alternatives considered
+
+### A `synchronized` / `sync` modifier on classes, methods, or instances
+
+The #3205 sketch. Mechanically cheap: contextual-modifier parsing precedent
+(`data`, `partial`, `inline`), and the `lock` lowering (#1885) already
+builds the monitor discipline — a G# version would lock a private
+synthesized monitor field, never object identity, avoiding Java's
+public-monitor mistake. Rejected on the merits anyway:
+
+- **Wrong lineage for this language.** ADR-0002 made the Go surface G#'s
+  identity; Go pointedly has no monitor modifier, and its own shared-map
+  answer is a library type. A Java-shaped modifier would be the first
+  concurrency construct in G# with no ancestor in either Go or modern C#.
+- **Wrong granularity, false safety.** Method-scoped monitors serialize
+  operations that don't conflict and still fail the operations that matter
+  — `if !m.Contains(k) { m.Store(k, v) }` is a race under per-method
+  locking no matter how the methods are marked. Java's synchronized
+  collections and .NET's `SyncRoot`/`Synchronized` wrappers were abandoned
+  by their own platforms for exactly this; `SyncMap.Update` exists because
+  compound atomicity must be expressed in the API, not sprinkled on with a
+  keyword.
+- **Permanent spec surface for zero demonstrated demand** (corpus: zero
+  `lock`, zero shared maps), purchased one campaign after ADR-0156/0157
+  spent heavily to *shrink* divergence and surface area.
+- **A dead-end investment against the actor horizon.** #2485 is open and is
+  the credible future language answer to shared mutable state. Betting
+  language surface now on the monitor model prejudges that design in the
+  wrong direction (Swift and Kotlin both went isolation/actors, not
+  synchronized classes).
+
+### A compiler-bound `syncmap[K, V]` builtin type (the `map`/`chan` pattern)
+
+`MapTypeSymbol`/`ChannelTypeSymbol` show the recipe: bind a keyworded type
+to a chosen CLR backing. Rejected as premature: it buys literal/index sugar
+at the cost of new type-symbol, parser, binder, and emit surface — and
+index sugar on a concurrent map is an anti-feature (it invites
+`m[k] = m[k] + 1`, the exact racy idiom the type exists to kill; Go's
+`sync.Map` refuses index syntax deliberately). Revisitable later as pure
+sugar over the library type if usage ever justifies it.
+
+### Emit synchronized accessors on plain `map` (restore the implicit lock)
+
+Already rejected by #3205: it taxes every map in every program, diverges
+from both Go semantics and the `Dictionary<,>` interop contract, and still
+doesn't make compound operations atomic — the evaluator's lock was an
+implementation artifact, not a keepable promise.
+
+### Go-style runtime fault on concurrent map access
+
+Guaranteed detection requires checked wrappers around every map operation
+program-wide; today's behavior (undefined, with `Dictionary`'s best-effort
+corruption exception, which the mutant runs show does fire under enumeration
+races) matches Go's contract at zero cost. Kept as possible future
+debug-mode work; the spec records "not goroutine-safe; behavior undefined."
+
+### Actors now (#2485)
+
+The right long-term direction and deliberately *not* prejudged here — but
+the wrong scope for #3209: an actor design (isolation rules, reentrancy,
+executor mapping onto the Task pool, interop with `scope`/channels) is a
+multi-ADR effort and still would not answer "I have a map shared by two
+goroutines today" without one. The library type serves that need now and
+survives an actor future as an ordinary type.
+
+### Documentation only (pure v0)
+
+Viable — capability exists — but it leaves the retired #1799 guarantees
+with no successor tests, no idiomatic spelling for the one shape Go itself
+found common enough to bless, and pushes the nullable-interop/`out`-param
+papercuts the spike hit onto every user who follows the docs. The library
+type is small, spike-proven, and carries the docs page with it.

--- a/docs/adr/0158-synchronization-story.md
+++ b/docs/adr/0158-synchronization-story.md
@@ -1,9 +1,13 @@
 # ADR-0158: The G# synchronization story — a Sync library type plus documented interop, not a `synchronized` modifier
 
-- **Status**: Proposed — owner decision requested
-  ([#3209](https://github.com/DavidObando/gsharp/issues/3209); feasibility
-  spike in `test/Interpreter.Tests/Adr0158SyncMapSpikeTests.cs`, no product
-  changes in this PR)
+- **Status**: Accepted — 2026-08-06
+  ([#3209](https://github.com/DavidObando/gsharp/issues/3209); implemented
+  in the same change — `src/Sdk/Gsharp.Extensions/Sync/Sync.gs`, pinned by
+  `test/Extensions.Tests/SyncMapTests.cs` (behavior + the four successor
+  guarantees) and `test/Interpreter.Tests/SyncMapImportEmittedOracleTests.cs`
+  (G#-side `import` consumption); the feasibility spike stays untouched as
+  evidence at `test/Interpreter.Tests/Adr0158SyncMapSpikeTests.cs`, per the
+  ADR-0156/0157 precedent)
 - **Date**: 2026-08-06
 - **Phase**: Language surface / concurrency ergonomics (ADR-0156 Phase 3
   semantic-alignment follow-up)
@@ -89,7 +93,7 @@ the wrong shape (fact 3) for a need that does not exist (fact 4) and is
 already served (facts 1–2), while a plausible future language surface for
 shared state — actors, #2485, open — would supersede it.
 
-## Decision (proposed — owner decides)
+## Decision
 
 **Ship the synchronization story as library plus documentation, and add no
 language surface:**
@@ -110,13 +114,17 @@ language surface:**
    m.Range(func(k string, v int32) { ... })
    ```
 
-   Sketched surface (implementation PR finalizes): `Store`, `Load`,
-   `Update(key, f)` (atomic read-modify-write), `Delete`, `Len`,
-   `Contains`, `Keys()` (snapshot slice), `Range(action)`. Absent-key
-   `Load` returns the zero value, mirroring G# map reads (which lower to
-   `TryGetValue`, not `get_Item`). The backing dictionary is private and
+   Shipped surface (`Sync.gs`): `Store(key, value)`, `Load(key) V`
+   (zero value when absent, mirroring G# map reads — which lower to
+   `TryGetValue`, not `get_Item`), `Update(key, f) V` (atomic
+   read-modify-write, returns the stored result), `Delete(key) bool`,
+   `Len() int32`, `Contains(key) bool`, `Keys() []K` (snapshot),
+   `Range(action)`. Reads and enumeration are lock-free on the concurrent
+   backing; the three writes serialize on the private backing instance as
+   hidden monitor — that is what makes `Update` atomic against *all*
+   writes, not just other `Update`s. The backing dictionary is private and
    never leaked — the hidden-monitor discipline #3209 requires — and the
-   nullable-interop `!!` and function-literal papercuts the spike hit stay
+   nullable-interop and function-literal papercuts the spike hit stay
    *inside* the library, which is itself an ergonomics argument for
    shipping it rather than documenting the raw pattern.
 
@@ -125,14 +133,19 @@ language surface:**
    *looks* atomic and is not. `Update` exists precisely because per-call
    locking cannot express compound operations through indexer sugar.
 
-2. **A `docs/concurrency.md` page** (the first concurrency topic page; flat
-   docs convention) that teaches, in order: the idiom (goroutines +
-   channels + `scope` — "share memory by communicating"), `lock` for
-   protecting arbitrary state, the CLR interop menu
-   (`ConcurrentDictionary`, `Interlocked`, `ReaderWriterLockSlim`,
-   `Mutex`/`SemaphoreSlim`), and `SyncMap` for the shared-map case. This is
-   the "documented interim guidance" leg of #3209, kept even after the
-   library lands.
+2. **Documentation** teaching, in order: the idiom (goroutines + channels
+   + `scope` — "share memory by communicating"), `lock` for protecting
+   arbitrary state, the CLR interop menu (`ConcurrentDictionary`,
+   `Interlocked`, `ReaderWriterLockSlim`, `Mutex`/`SemaphoreSlim`), and
+   `SyncMap` for the shared-map case — the "documented interim guidance"
+   leg of #3209, kept even after the library lands. Shipped as
+   `docs/concurrency.md` (engineering-side) plus the user-facing website
+   pages: a "Synchronization and shared state" section in
+   `website/docs/guide/concurrency.md`, a `Gsharp.Extensions.Sync` API
+   reference in `website/docs/ref/standard-library.md` (with the map
+   non-guarantee noted in its Maps section), and the
+   `website/docs/extensions/go-concurrency.md` shared-map note updated to
+   point at `SyncMap` instead of at #3209.
 
 3. **Plain `map[K, V]` stays unsynchronized, and concurrent access stays
    undefined behavior, documented** — #3205's stance becomes the permanent
@@ -158,6 +171,66 @@ language surface:**
 | `len` / `ContainsKey` / `Keys` under write load: never throws | Same, via `Len` / `Contains` / `Keys()` (spike: 30 stress runs) |
 
 Plain `map[K, V]` carries none of these — that is #3205, unchanged.
+
+### Representation and magic — map vs SyncMap
+
+Two owner-settled decisions bound this design's representation choices, and
+they are two faces of one rule.
+
+**Plain `map[K, V]` stays a compiler-known ("magic") type with `Dictionary`
+identity — a library `Map[K, V]` was considered and rejected.**
+
+- **Identity is the interop superpower.** A G# `map[K, V]` *is* a
+  `Dictionary<K, V>`: it flows directly into every BCL and C# API that
+  takes one, comes back unchanged, and makes cs2gs's `Dictionary`→`map`
+  translation trivially correct. A wrapper type would trade that away for
+  nothing — either it leaks its backing (no encapsulation gained) or it
+  interposes on every boundary crossing (friction everywhere).
+- **Zero-runtime-dependency.** A program that uses maps needs only the
+  BCL. A library-defined map would make every G# program depend on
+  `Gsharp.Extensions` and deepen the SDK bootstrap cycle (`Gsharp.Extensions`
+  itself is compiled by a bootstrap that exists precisely because an
+  assembly cannot reference itself while being built).
+- **Precedent.** Go keeps `map` intrinsic and ships `sync.Map` in a
+  package; languages with map *syntax* keep the syntactic type intrinsic.
+- **The bug-factory concern has a better answer.** The intrinsic's magic
+  plumbing has produced real bugs (#3301, and this campaign's #3303), but
+  the fix is consolidating the emit surface — the symbolic-MemberRef
+  funnel PR [#3306](https://github.com/DavidObando/gsharp/pull/3306)
+  landed for #3301 — not changing representation. If an ergonomic method
+  surface on maps is ever wanted, extension functions provide it without
+  touching representation.
+
+**`SyncMap` is deliberately NOT magic — the inverse of the same
+principle.** A type earns compiler magic only when it carries syntax the
+compiler must bind, and `SyncMap`'s design rejects syntax on purpose:
+
+- **Index syntax on a concurrent map is a lie.** `sm[k] = sm[k] + 1`
+  looks atomic and races; the method API *is* the safety contract, with
+  atomicity boundaries visible at every call site. `ConcurrentDictionary`'s
+  own history makes the point: it has an indexer, but its real API is
+  `GetOrAdd`/`AddOrUpdate`/`TryUpdate`.
+- **The valuable operations are method-shaped and want to grow.**
+  `Update` today; `GetOrAdd`, compare-and-swap, richer snapshots later —
+  in library releases, not compiler releases.
+- **Concurrency semantics belong to library-versioned doc contracts.**
+  Range's snapshot-vs-live behavior, `Keys` timing, and memory-model notes
+  can evolve with the library; baked into language syntax they would be
+  spec commitments requiring compiler releases to change.
+- **Identity would be a bug here.** If the backing `ConcurrentDictionary`
+  were reachable, callers could bypass `Update`'s atomicity or lock the
+  monitor from outside (the Java pitfall above). Encapsulation is
+  load-bearing — the exact property that would be wrong for `map` is the
+  one `SyncMap` cannot live without.
+- **Zero compiler cost, proven.** The spike and the shipped implementation
+  required no compiler change at all; a magic `syncmap` would buy a second
+  copy of the intrinsic-plumbing maintenance tax (#3301/#3303's class)
+  for negative value.
+
+**The composed rule:** syntax-bearing types are compiler-known and
+identity-transparent to their BCL backing (`map` ≡ `Dictionary`);
+concurrency types are library-defined, method-shaped, and
+encapsulation-opaque (`SyncMap` hides its `ConcurrentDictionary`).
 
 ## Evidence — feasibility spike
 
@@ -210,6 +283,38 @@ than footnotes:
   Unrelated to synchronization, but it is the largest concurrency-ergonomics
   papercut the spike actually hit — worth fixing regardless of this ADR's
   outcome.
+
+### Implementation evidence (same change)
+
+The shipped `SyncMap` (`src/Sdk/Gsharp.Extensions/Sync/Sync.gs`, ~200
+lines of documented G#) compiles through the normal bootstrap build with
+no compiler changes, confirming the spike's central claim. Its pins:
+
+- `test/Extensions.Tests/SyncMapTests.cs` — 17 tests directly against the
+  compiled assembly with real threads: unit coverage of every method plus
+  the four successor guarantees (64 distinct keys × 200 runs; 200
+  concurrent `Update` increments × 100 runs, exact every run; `Update`
+  atomic against interleaved `Store`/`Delete` churn; `Range` and
+  `Len`/`Contains`/`Keys` looped against 8 continuous writer tasks). Also
+  pins the hidden-monitor rule structurally (no public fields, no
+  dictionary-typed properties).
+- `test/Interpreter.Tests/SyncMapImportEmittedOracleTests.cs` — G#-side
+  `import Gsharp.Extensions.Sync` consumption through real emitted
+  execution: full-surface smoke plus the #3205 repro shape (50 goroutines
+  bumping one key in a `scope`), exactly 50 every run.
+- **Product-mutant witnesses (ADR-0154)**, run against the real library:
+  stripping `Sync.gs`'s `lock` statements fails both increment guarantees
+  (observed 72/200 and 1/200); swapping the `ConcurrentDictionary` backing
+  for a plain `Dictionary` fails both enumeration guarantees with the
+  CLR's "Collection was modified" exception. Each guarantee is killed by
+  the mutation it exists to police.
+
+Two boundary notes recorded while implementing, both stays-inside-the-
+library per the ergonomics argument above: the `append` builtin is gated
+behind `Gsharp.Extensions.Go` (GS0317), so `Keys()` builds its snapshot
+via `List[K]` + `ToArray`; and across the imported-assembly boundary
+`Keys()`'s `[]K` binds as a CLR array (`.Length`, not `len`) — noted in
+the consumption test.
 
 ## Consequences
 

--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -1,0 +1,105 @@
+# Concurrency and synchronization in G#
+
+Engineering-side reference for G#'s synchronization story, recorded with
+ADR-0158 (issue #3209). User-facing guidance lives on the website:
+[guide/concurrency](../website/docs/guide/concurrency.md),
+[extensions/go-concurrency](../website/docs/extensions/go-concurrency.md),
+and the [standard-library reference](../website/docs/ref/standard-library.md).
+
+## The idiom: share memory by communicating
+
+G#'s concurrency surface is Go-shaped over the .NET runtime (ADR-0002,
+ADR-0022): `go f(args)` lowers to `Task.Run`, `chan T` to
+`System.Threading.Channels.Channel<T>`, `select` orchestrates channel
+operations, and structured `scope { ... }` blocks join everything they own.
+The first answer to "how do goroutines share state" is the same as Go's:
+don't — pass values through channels, and let `scope` own the joins. Every
+concurrency sample in the repo works this way.
+
+## `lock` — protecting arbitrary shared state
+
+When sharing is unavoidable, G# has a `lock` statement (issue #1885):
+
+```gsharp
+lock guard {
+    // critical section
+}
+```
+
+`lock expr { body }` is binder-lowered to the classic
+`Monitor.Enter(tmp); try { body } finally { Monitor.Exit(tmp) }` shape with
+the target evaluated once into a synthesized local; value-typed targets are
+rejected (the C# CS0185 rule). Lock on a **private object that never leaks**
+— never on `this` or any value foreign code can reach (the Java
+synchronized-on-instance pitfall).
+
+## The interop menu
+
+Everything in `System.Threading` and `System.Collections.Concurrent` is one
+import away (ADR-0034); capability was never the gap (ADR-0158 records the
+measured proof). Commonly useful:
+
+| Need | Reach for |
+| --- | --- |
+| Concurrent map, lock-free reads | `ConcurrentDictionary[K, V]` (`import System.Collections.Concurrent`) |
+| Atomic counters / flags | `Interlocked` (`import System.Threading`) |
+| Many readers, few writers | `ReaderWriterLockSlim` |
+| Async-friendly mutual exclusion / throttling | `SemaphoreSlim` |
+| Cross-process mutual exclusion | `Mutex` |
+
+## Maps are not goroutine-safe — `SyncMap` is the blessed shape
+
+A G# `map[K,V]` **is** a plain `Dictionary<K,V>` (identity, no wrapper —
+see ADR-0158's representation section). It has no implicit
+synchronization; concurrent goroutine access is **undefined behavior**,
+matching Go's "maps are not safe for concurrent use" (#3205). There is no
+runtime concurrent-access fault; the CLR may surface a best-effort
+corruption exception, but nothing is guaranteed.
+
+For a map that is *meant* to be shared, use the G#-authored
+`Gsharp.Extensions.Sync.SyncMap[K, V]`
+(`src/Sdk/Gsharp.Extensions/Sync/Sync.gs`, ADR-0158):
+
+```gsharp
+import Gsharp.Extensions.Go
+import Gsharp.Extensions.Sync
+
+func bump(m SyncMap[string, int32]) int32 {
+    m.Update("hits", func(v int32) int32 { return v + 1 })  // atomic
+    return 0
+}
+
+func run() int32 {
+    var m = SyncMap[string, int32]()
+    scope {
+        for var i = 0; i < 50; i++ {
+            go bump(m)
+        }
+    }
+
+    return m.Load("hits")   // exactly 50
+}
+```
+
+Design contract (details in the type's doc comments and
+`test/Extensions.Tests/SyncMapTests.cs`):
+
+- **Method-based, no index syntax** — `m[k] = m[k] + 1` on a shared map
+  looks atomic and races; compound read-modify-write is spelled `Update`
+  and is atomic against every other write.
+- **Reads and enumeration are lock-free** (`Load`, `Len`, `Contains`,
+  `Keys`, `Range`) on the private `ConcurrentDictionary` backing; writes
+  (`Store`, `Delete`, `Update`) serialize on a hidden monitor that never
+  leaks.
+- **Absent-key `Load` returns `V`'s zero value**, mirroring a G# map read.
+- The guarantees carried by the retired evaluator-era implicit map lock
+  (#1799, deleted with ADR-0156 Phase 3c) live on here: distinct-key
+  concurrent writes all survive, `Update` counts are exact, and
+  enumeration/size/membership reads never throw under write load.
+
+## History
+
+- ADR-0002 — concurrency model (Go surface, .NET runtime, Kotlin scopes).
+- ADR-0022 — `go`/`chan`/`select` lowering targets.
+- #1799 → #3205 → #3209 / ADR-0158 — the evaluator's implicit map lock,
+  its retirement with the emitted-only engine, and the `SyncMap` successor.

--- a/src/Sdk/Gsharp.Extensions/Sync/Sync.gs
+++ b/src/Sdk/Gsharp.Extensions/Sync/Sync.gs
@@ -1,0 +1,207 @@
+// ADR-0158 / issue #3209. `Gsharp.Extensions.Sync` — the G# synchronization
+// helper surface. First (and currently only) type: `SyncMap[K, V]`, G#'s
+// `sync.Map` analog for state shared across goroutines.
+//
+// Design decisions (ADR-0158):
+//
+//   * Method-based API, deliberately without literal or index syntax:
+//     `m[k] = m[k] + 1` *looks* atomic and is not, which is exactly the
+//     race this type exists to kill. Compound read-modify-write is spelled
+//     `Update` and is atomic. (Go's `sync.Map` refuses index syntax for
+//     the same reason.)
+//
+//   * Backed by a private `ConcurrentDictionary[K, V]` — not a locked
+//     plain `map[K, V]` (a generic map field is blocked by #3303, and the
+//     concurrent backing is better on merits: lock-free reads and
+//     mutation-safe enumeration). Reads (`Load`, `Len`, `Contains`) and
+//     enumeration (`Keys`, `Range`) never take the monitor.
+//
+//   * Writes (`Store`, `Delete`, `Update`) serialize on a hidden monitor —
+//     the private backing dictionary itself, which never leaks out of this
+//     class. Foreign code therefore cannot contend on or interfere with
+//     the monitor (the Java synchronized-on-instance pitfall #3209 calls
+//     out). Serializing *all* writes is what makes `Update` atomic with
+//     respect to every other write, not just other `Update` calls.
+//
+//   * `Load` returns `V`'s zero value when the key is absent, mirroring a
+//     G# map read (which lowers to `TryGetValue`, not `get_Item`).
+//
+// The retired evaluator-era map-concurrency guarantees (#1799, deleted
+// with ADR-0156 Phase 3c) live again here, attached to this type:
+// distinct-key concurrent writes all survive, `Update` increments are
+// exact, and enumeration / size / membership reads never throw under
+// concurrent write load. `test/Extensions.Tests/SyncMapTests.cs` pins all
+// four against the compiled assembly.
+
+package Gsharp.Extensions.Sync
+
+import System
+import System.Collections.Concurrent
+import System.Collections.Generic
+import System.Runtime.CompilerServices
+
+/// A goroutine-safe map for `K` → `V`, G#'s `sync.Map` analog
+/// (ADR-0158). Use it when a map must be shared across goroutines; plain
+/// `map[K, V]` is not goroutine-safe and concurrent access to one is
+/// undefined behavior.
+///
+/// Reads and enumeration are lock-free on a concurrent backing store;
+/// writes serialize on a private monitor so
+/// [Update](cref:Gsharp.Extensions.Sync.SyncMap.Update) is an atomic
+/// read-modify-write. There is deliberately no index syntax — compound
+/// operations must go through `Update`, because `m[k] = m[k] + 1` on a
+/// shared map is a race no per-operation locking can fix.
+///
+/// ```gs
+/// import Gsharp.Extensions.Go
+/// import Gsharp.Extensions.Sync
+///
+/// var m = SyncMap[string, int32]()
+/// scope {
+///     for var i = 0; i < 50; i++ {
+///         go bump(m)   // func bump: m.Update("hits", func(v int32) int32 { return v + 1 })
+///     }
+/// }
+/// let hits = m.Load("hits")   // exactly 50
+/// ```
+class SyncMap[K, V any] {
+    // The backing store doubles as the hidden monitor for writes. It is
+    // private and never returned, stored, or otherwise leaked, so no code
+    // outside this class can lock it (ADR-0158's hidden-monitor rule).
+    private var items ConcurrentDictionary[K, V]
+
+    init() {
+        items = ConcurrentDictionary[K, V]()
+    }
+
+    /// Stores `value` under `key`, replacing any existing entry.
+    ///
+    /// @param key the key to write.
+    /// @param value the value to store.
+    func Store(key K, value V) {
+        lock items {
+            items[key] = value
+        }
+    }
+
+    /// Returns the value stored under `key`, or `V`'s zero value when the
+    /// key is absent — the same absent-key behavior as a G# map read.
+    ///
+    /// Lock-free; never blocks writers.
+    ///
+    /// @param key the key to read.
+    /// @returns the stored value, or the zero value of `V` when absent.
+    @MethodImpl(MethodImplOptions.AggressiveInlining)
+    func Load(key K) V {
+        var v V
+        if items.TryGetValue(key, out v) {
+            return v
+        }
+
+        // Absent: fall back to V's zero value. (After a failed TryGetValue
+        // the out local is V? under nullable interop flow — MaybeNullWhen —
+        // so a fresh zero-valued local is returned instead.)
+        var zero V
+        return zero
+    }
+
+    /// Atomically replaces the value under `key` with `f(current)`, where
+    /// `current` is the stored value or `V`'s zero value when the key is
+    /// absent. The read-modify-write is atomic with respect to every other
+    /// write on this map (`Store`, `Delete`, and other `Update` calls),
+    /// which makes `m.Update(k, func(v int32) int32 { return v + 1 })` an
+    /// exact concurrent counter.
+    ///
+    /// `f` runs while the map's write monitor is held: keep it small, and
+    /// do not block in it. (Re-entrant writes to the same map from inside
+    /// `f` do not deadlock — the monitor is reentrant — but they see the
+    /// pre-`Update` state and are almost never what you want.)
+    ///
+    /// @param key the key to update.
+    /// @param f applied to the current value (or zero value) under the
+    ///          write monitor; must not be `nil`.
+    /// @returns the value produced by `f` and stored.
+    /// @exception ArgumentNullException `f` is `nil`.
+    func Update(key K, f (V) -> V) V {
+        if f == nil {
+            throw ArgumentNullException("f")
+        }
+
+        lock items {
+            let next = f(Load(key))
+            items[key] = next
+            return next
+        }
+    }
+
+    /// Removes the entry under `key`, if present.
+    ///
+    /// @param key the key to remove.
+    /// @returns `true` when an entry was removed, `false` when the key was
+    ///          absent.
+    func Delete(key K) bool {
+        lock items {
+            var removed V
+            return items.TryRemove(key, out removed)
+        }
+    }
+
+    /// Returns the number of entries.
+    ///
+    /// Lock-free; never blocks writers. Under concurrent writes the count
+    /// is a snapshot that may be stale by the time it is observed.
+    ///
+    /// @returns the entry count.
+    @MethodImpl(MethodImplOptions.AggressiveInlining)
+    func Len() int32 {
+        return items.Count
+    }
+
+    /// Reports whether `key` currently has an entry.
+    ///
+    /// Lock-free; never blocks writers.
+    ///
+    /// @param key the key to test.
+    /// @returns `true` when the key is present.
+    @MethodImpl(MethodImplOptions.AggressiveInlining)
+    func Contains(key K) bool {
+        return items.ContainsKey(key)
+    }
+
+    /// Returns a snapshot slice of the keys present when the snapshot was
+    /// taken. Safe under concurrent writes (never throws); keys added or
+    /// removed while snapshotting may or may not appear.
+    ///
+    /// @returns a new slice holding the snapshot keys, in no particular
+    ///          order.
+    func Keys() []K {
+        // List + ToArray rather than the `append` builtin: append is gated
+        // behind `import Gsharp.Extensions.Go` (GS0317 / ADR-0083), which
+        // this assembly should not self-import just to build a snapshot.
+        var ks = List[K]()
+        for k in items.Keys {
+            ks.Add(k)
+        }
+
+        return ks.ToArray()
+    }
+
+    /// Invokes `action` for each entry. Safe under concurrent writes
+    /// (never throws): enumeration walks the concurrent backing store, so
+    /// entries added or removed while ranging may or may not be visited.
+    /// The write monitor is NOT held during `Range` — `action` may write
+    /// to this map freely.
+    ///
+    /// @param action invoked with each key and value; must not be `nil`.
+    /// @exception ArgumentNullException `action` is `nil`.
+    func Range(action (K, V) -> void) {
+        if action == nil {
+            throw ArgumentNullException("action")
+        }
+
+        var e = items.GetEnumerator()
+        while e.MoveNext() {
+            action(e.Current.Key, e.Current.Value)
+        }
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue2962ConstrainedStaticPropertyChainTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2962ConstrainedStaticPropertyChainTests.cs
@@ -200,7 +200,11 @@ public class Issue2962ConstrainedStaticPropertyChainTests
                 sourcePath);
 
             Assert.Equal(1, exitCode);
-            Assert.Contains("error GS0156: Cannot convert type 'string?' to 'string'.", output, StringComparison.Ordinal);
+
+            // #3296 retired the legacy any-to-string conversion arm and
+            // re-anchored the string? -> string rejection to GS0155 (the
+            // #1627 Kotlin-model nullability rule); same message, new id.
+            Assert.Contains("error GS0155: Cannot convert type 'string?' to 'string'.", output, StringComparison.Ordinal);
             Assert.DoesNotContain("GS9998", output, StringComparison.Ordinal);
         }
         finally

--- a/test/Extensions.Tests/SyncMapTests.cs
+++ b/test/Extensions.Tests/SyncMapTests.cs
@@ -1,0 +1,311 @@
+// <copyright file="SyncMapTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Gsharp.Extensions.Sync;
+using Xunit;
+
+namespace GSharp.Extensions.Tests;
+
+/// <summary>
+/// Coverage for <c>Gsharp.Extensions.Sync.SyncMap[K, V]</c> (ADR-0158 /
+/// issue #3209), exercised directly against the compiled G#-authored
+/// assembly with real threads.
+///
+/// The four concurrency guarantees here are the successors of the
+/// evaluator-era Issue1799 map-concurrency suite deleted with ADR-0156
+/// Phase 3c (pre-deletion sources at commit <c>5cd0d766</c>): distinct-key
+/// writes all survive, read-modify-write increments are exact (stronger
+/// than the deleted racy-increment guarantee — <c>Update</c> is atomic),
+/// enumeration while writing never throws, and size/membership/key-snapshot
+/// reads under write load never throw. Per ADR-0158 they attach to
+/// <c>SyncMap</c>; plain <c>map[K, V]</c> deliberately carries none of them
+/// (#3205).
+///
+/// Discrimination witnesses (ADR-0154, product mutants — recorded in PR
+/// #3305): stripping the <c>lock</c> statements from <c>Sync.gs</c> breaks
+/// <see cref="Update_ConcurrentIncrements_AreExact"/>; swapping the backing
+/// <c>ConcurrentDictionary</c> for a plain <c>Dictionary</c> breaks the
+/// enumeration-under-write guarantees.
+/// </summary>
+public class SyncMapTests
+{
+    // ---- Unit coverage -------------------------------------------------
+
+    [Fact]
+    public void StoreAndLoad_RoundTrips()
+    {
+        var m = new SyncMap<string, int>();
+        m.Store("a", 42);
+        Assert.Equal(42, m.Load("a"));
+
+        m.Store("a", 7);
+        Assert.Equal(7, m.Load("a"));
+    }
+
+    [Fact]
+    public void Load_AbsentKey_ReturnsZeroValue()
+    {
+        var m = new SyncMap<string, int>();
+        Assert.Equal(0, m.Load("missing"));
+    }
+
+    [Fact]
+    public void Update_AbsentKey_AppliesToZeroValue_AndStores()
+    {
+        var m = new SyncMap<string, int>();
+        var result = m.Update("k", v => v + 5);
+        Assert.Equal(5, result);
+        Assert.Equal(5, m.Load("k"));
+    }
+
+    [Fact]
+    public void Update_PresentKey_AppliesToCurrent_AndReturnsNewValue()
+    {
+        var m = new SyncMap<string, int>();
+        m.Store("k", 10);
+        Assert.Equal(11, m.Update("k", v => v + 1));
+        Assert.Equal(11, m.Load("k"));
+    }
+
+    [Fact]
+    public void Update_NullProjection_Throws()
+    {
+        var m = new SyncMap<string, int>();
+        Assert.Throws<ArgumentNullException>(() => m.Update("k", null!));
+    }
+
+    [Fact]
+    public void Delete_ReportsPresence_AndRemoves()
+    {
+        var m = new SyncMap<string, int>();
+        m.Store("k", 1);
+        Assert.True(m.Delete("k"));
+        Assert.False(m.Contains("k"));
+        Assert.False(m.Delete("k"));
+    }
+
+    [Fact]
+    public void LenAndContains_TrackEntries()
+    {
+        var m = new SyncMap<string, int>();
+        Assert.Equal(0, m.Len());
+        Assert.False(m.Contains("a"));
+
+        m.Store("a", 1);
+        m.Store("b", 2);
+        Assert.Equal(2, m.Len());
+        Assert.True(m.Contains("a"));
+        Assert.True(m.Contains("b"));
+    }
+
+    [Fact]
+    public void Keys_ReturnsSnapshotOfAllKeys()
+    {
+        var m = new SyncMap<string, int>();
+        m.Store("a", 1);
+        m.Store("b", 2);
+        m.Store("c", 3);
+
+        var keys = m.Keys();
+        Assert.Equal(new[] { "a", "b", "c" }, keys.OrderBy(k => k).ToArray());
+
+        // Snapshot: later writes do not mutate an already-taken snapshot.
+        m.Store("d", 4);
+        Assert.Equal(3, keys.Length);
+    }
+
+    [Fact]
+    public void Range_VisitsEveryEntry()
+    {
+        var m = new SyncMap<string, int>();
+        m.Store("a", 1);
+        m.Store("b", 2);
+
+        var seen = new ConcurrentDictionary<string, int>();
+        m.Range((k, v) => seen[k] = v);
+
+        Assert.Equal(2, seen.Count);
+        Assert.Equal(1, seen["a"]);
+        Assert.Equal(2, seen["b"]);
+    }
+
+    [Fact]
+    public void Range_NullAction_Throws()
+    {
+        var m = new SyncMap<string, int>();
+        Assert.Throws<ArgumentNullException>(() => m.Range(null!));
+    }
+
+    [Fact]
+    public void ReferenceValueType_RoundTrips()
+    {
+        var m = new SyncMap<int, string>();
+        m.Store(1, "one");
+        Assert.Equal("one", m.Load(1));
+    }
+
+    // ---- Issue1799 successor guarantee A: distinct-key writes ----------
+
+    [Fact]
+    public void ManyThreads_WriteDistinctKeys_AllWritesSurvive()
+    {
+        const int keys = 64;
+        const int iterations = 200;
+
+        for (var run = 0; run < iterations; run++)
+        {
+            var m = new SyncMap<string, int>();
+            Parallel.For(
+                0,
+                keys,
+                new ParallelOptions { MaxDegreeOfParallelism = 16 },
+                i => m.Store("k" + i, i + 1));
+
+            Assert.Equal(keys, m.Len());
+            for (var i = 0; i < keys; i++)
+            {
+                Assert.Equal(i + 1, m.Load("k" + i));
+            }
+        }
+    }
+
+    // ---- Issue1799 successor guarantee B: exact concurrent increments --
+
+    [Fact]
+    public void Update_ConcurrentIncrements_AreExact()
+    {
+        // The deleted evaluator-era test could only assert "no corruption,
+        // value in range" for racy `m[k] = m[k] + 1`; Update holds the
+        // write monitor across the read-modify-write, so the count is
+        // exact — the strictly stronger successor guarantee.
+        const int increments = 200;
+        const int iterations = 100;
+
+        for (var run = 0; run < iterations; run++)
+        {
+            var m = new SyncMap<string, int>();
+            Parallel.For(
+                0,
+                increments,
+                new ParallelOptions { MaxDegreeOfParallelism = 16 },
+                _ => m.Update("k", v => v + 1));
+
+            Assert.Equal(increments, m.Load("k"));
+        }
+    }
+
+    [Fact]
+    public async Task Update_IsAtomicAgainstStoreAndDelete()
+    {
+        // Update must serialize against ALL writes, not just other
+        // Updates: interleave Store/Delete churn on other keys plus
+        // increments on a shared counter key and require the counter to
+        // stay exact.
+        const int increments = 200;
+        var m = new SyncMap<string, int>();
+
+        var churn = Task.Run(() =>
+        {
+            for (var i = 0; i < 500; i++)
+            {
+                m.Store("noise" + (i % 8), i);
+                m.Delete("noise" + ((i + 4) % 8));
+            }
+        });
+
+        Parallel.For(
+            0,
+            increments,
+            new ParallelOptions { MaxDegreeOfParallelism = 16 },
+            _ => m.Update("counter", v => v + 1));
+
+        await churn;
+        Assert.Equal(increments, m.Load("counter"));
+    }
+
+    // ---- Issue1799 successor guarantee C: enumeration while writing ----
+
+    [Fact]
+    public async Task Range_WhileWriting_NeverThrows()
+    {
+        var m = new SyncMap<string, int>();
+        using var stop = new CancellationTokenSource();
+
+        var writers = Enumerable.Range(0, 8).Select(w => Task.Run(() =>
+        {
+            var i = 0;
+            while (!stop.Token.IsCancellationRequested)
+            {
+                m.Store("k" + (i % 32), i);
+                m.Delete("k" + ((i + 16) % 32));
+                i++;
+            }
+        })).ToArray();
+
+        // The guarantee under test: ranging concurrently with writers never
+        // throws (no "collection was modified", no corruption).
+        for (var pass = 0; pass < 400; pass++)
+        {
+            var total = 0;
+            m.Range((k, v) => total += v);
+        }
+
+        stop.Cancel();
+        await Task.WhenAll(writers);
+    }
+
+    // ---- Issue1799 successor guarantee D: Len/Contains/Keys under load --
+
+    [Fact]
+    public async Task LenContainsAndKeys_UnderWriteLoad_NeverThrow()
+    {
+        var m = new SyncMap<string, int>();
+        using var stop = new CancellationTokenSource();
+
+        var writers = Enumerable.Range(0, 8).Select(w => Task.Run(() =>
+        {
+            var i = 0;
+            while (!stop.Token.IsCancellationRequested)
+            {
+                m.Store("k" + (i % 32), i);
+                m.Delete("k" + ((i + 16) % 32));
+                i++;
+            }
+        })).ToArray();
+
+        for (var pass = 0; pass < 400; pass++)
+        {
+            var len = m.Len();
+            Assert.InRange(len, 0, 32);
+            _ = m.Contains("k0");
+            var keys = m.Keys();
+            Assert.True(keys.Length <= 32);
+        }
+
+        stop.Cancel();
+        await Task.WhenAll(writers);
+    }
+
+    // ---- Encapsulation: the monitor/backing store never leaks ----------
+
+    [Fact]
+    public void BackingStoreIsPrivate_NoPublicFieldsOrDictionaryProperties()
+    {
+        // ADR-0158's hidden-monitor rule is load-bearing: if the backing
+        // ConcurrentDictionary were reachable, callers could bypass
+        // Update's atomicity or lock the monitor from outside (the Java
+        // synchronized-on-instance pitfall). Pin it structurally.
+        var type = typeof(SyncMap<string, int>);
+        Assert.Empty(type.GetFields()); // no public instance fields
+        Assert.DoesNotContain(
+            type.GetProperties(),
+            p => typeof(System.Collections.IDictionary).IsAssignableFrom(p.PropertyType)
+                 || p.PropertyType.Name.Contains("Dictionary"));
+    }
+}

--- a/test/Interpreter.Tests/Adr0158SyncMapSpikeTests.cs
+++ b/test/Interpreter.Tests/Adr0158SyncMapSpikeTests.cs
@@ -1,0 +1,479 @@
+// <copyright file="Adr0158SyncMapSpikeTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Text;
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// ADR-0158 feasibility spike (issue #3209): a G#-authored synchronized map
+/// prototype — a plain <c>map[K,V]</c> field guarded by <c>lock</c> on a
+/// private, never-leaked monitor — expressed entirely with today's language
+/// surface and exercised through real emitted execution.
+///
+/// These tests are also the successors to the four deleted
+/// <c>Issue1799MapAndInterfaceSlotConcurrencyInterpreterTests</c> map
+/// concurrency guarantees (see the pre-deletion sources at commit
+/// <c>5cd0d766</c>): distinct-key writes all survive, concurrent increments
+/// never corrupt (and are exact here, because <c>Update</c> is atomic —
+/// stronger than the evaluator-era racy guarantee), enumeration-while-writing
+/// never throws, and <c>Len</c>/<c>Contains</c>/<c>Keys</c> reads under write
+/// load never throw. The guarantees attach to the <c>SyncMap</c> type, not to
+/// plain <c>map[K,V]</c>, which stays unsynchronized per #3205.
+///
+/// Discrimination witness (ADR-0154): removing the <c>lock</c> statements
+/// from <see cref="SyncMapPrototype"/> (the unsynchronized mutant) makes the
+/// stress tests below fail — see the ADR's Evidence section for the recorded
+/// mutant runs.
+/// </summary>
+[Trait("Category", "Adr0158Spike")]
+public class Adr0158SyncMapSpikeTests
+{
+    /// <summary>
+    /// The spike's G#-authored synchronized map. Everything here is today's
+    /// language surface: a class with a private map field used as the hidden
+    /// monitor (never leaked, so no foreign code can lock it — the
+    /// Java-synchronized pitfall the design must avoid), `lock` statements
+    /// (which already lower to Monitor.Enter/try/finally/Monitor.Exit per
+    /// issue #1885), function-typed parameters for the atomic Update, and
+    /// slice/append for the Keys snapshot. The shipped
+    /// Gsharp.Extensions.Sync version is the generic, ConcurrentDictionary-
+    /// backed form of this class (see SyncMapGenericShape_CompilesAndRuns;
+    /// the generic map-field variant is blocked by #3303).
+    /// </summary>
+    private const string SyncMapPrototype = """
+        class SyncMap {
+            private var items map[string, int32]
+
+            init() {
+                items = map[string, int32]{}
+            }
+
+            func Store(key string, value int32) {
+                lock items {
+                    items[key] = value
+                }
+            }
+
+            func Load(key string) int32 {
+                lock items {
+                    return items[key]
+                }
+            }
+
+            func Update(key string, f (int32) -> int32) {
+                lock items {
+                    items[key] = f(items[key])
+                }
+            }
+
+            func Delete(key string) {
+                lock items {
+                    delete(items, key)
+                }
+            }
+
+            func Len() int32 {
+                lock items {
+                    return len(items)
+                }
+            }
+
+            func Contains(key string) bool {
+                lock items {
+                    return items.ContainsKey(key)
+                }
+            }
+
+            func Keys() []string {
+                lock items {
+                    var ks = []string{}
+                    for k in items.Keys {
+                        ks = append(ks, k!!)
+                    }
+                    return ks
+                }
+            }
+
+            func Range(action (string, int32) -> void) {
+                lock items {
+                    var e = items.GetEnumerator()
+                    while e.MoveNext() {
+                        action(e.Current.Key!!, e.Current.Value)
+                    }
+                }
+            }
+        }
+        """;
+
+    /// <summary>
+    /// Successor of Issue1799 test A
+    /// (ManyGoroutines_WriteDistinctKeysOnSharedMap_AllWritesSurvive):
+    /// N goroutines each write a distinct key into one shared SyncMap; every
+    /// write must survive. The evaluator-era emitted-oracle pilot measured
+    /// 274/300 surviving writes for plain map — the SyncMap guarantee is
+    /// all 300.
+    /// </summary>
+    [Fact]
+    public void SyncMap_ManyGoroutines_WriteDistinctKeys_AllWritesSurvive()
+    {
+        const int goroutines = 24;
+        var sb = new StringBuilder();
+        sb.AppendLine(SyncMapPrototype);
+        sb.AppendLine();
+        for (var i = 0; i < goroutines; i++)
+        {
+            sb.AppendLine($"func setK{i}(m SyncMap) int32 {{\n    m.Store(\"k{i}\", {i + 1})\n    return 0\n}}");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("func run() int32 {");
+        sb.AppendLine("    var m = SyncMap()");
+        sb.AppendLine("    scope {");
+        for (var i = 0; i < goroutines; i++)
+        {
+            sb.AppendLine($"        go setK{i}(m)");
+        }
+
+        sb.AppendLine("    }");
+        sb.Append("    return ");
+        for (var i = 0; i < goroutines; i++)
+        {
+            sb.Append($"m.Load(\"k{i}\")");
+            if (i < goroutines - 1)
+            {
+                sb.Append(" + ");
+            }
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("}");
+        sb.AppendLine();
+        sb.AppendLine("run()");
+
+        var expectedSum = 0;
+        for (var i = 0; i < goroutines; i++)
+        {
+            expectedSum += i + 1;
+        }
+
+        var result = Evaluate(sb.ToString());
+        AssertNoRealDiagnostics(result);
+        Assert.Equal(expectedSum, result.Value);
+    }
+
+    /// <summary>
+    /// Successor of Issue1799 test B
+    /// (ManyConcurrentRuns_GoroutinesWritingSharedMap_NeverCorruptsOrCrashes):
+    /// 50 goroutines increment the same key. The deleted test could only
+    /// assert "no corruption, value in range" because `m[k] = m[k] + 1` is a
+    /// racy read-modify-write; SyncMap.Update(key, f) holds the monitor
+    /// across the read-modify-write, so the count is exact — a strictly
+    /// stronger guarantee. Stressed under Parallel.For to maximize the odds
+    /// that a synchronization bug would surface.
+    /// </summary>
+    [Fact]
+    public void SyncMap_ConcurrentIncrements_AreExact_NeverCorruptOrCrash()
+    {
+        var source = SyncMapPrototype + """
+
+
+            func bump(m SyncMap) int32 {
+                m.Update("k", func(v int32) int32 { return v + 1 })
+                return 0
+            }
+
+            func run() int32 {
+                var m = SyncMap()
+                scope {
+                    for var i = 0; i < 50; i++ {
+                        go bump(m)
+                    }
+                }
+
+                return m.Load("k")
+            }
+
+            run()
+            """;
+
+        const int iterations = 40;
+        var exceptions = new System.Collections.Concurrent.ConcurrentBag<System.Exception>();
+        var wrongCounts = new System.Collections.Concurrent.ConcurrentBag<int>();
+        System.Threading.Tasks.Parallel.For(
+            0,
+            iterations,
+            new System.Threading.Tasks.ParallelOptions { MaxDegreeOfParallelism = 8 },
+            i =>
+            {
+                try
+                {
+                    var result = Evaluate(source);
+                    AssertNoRealDiagnostics(result);
+                    var value = (int)result.Value;
+                    if (value != 50)
+                    {
+                        wrongCounts.Add(value);
+                    }
+                }
+                catch (System.Exception ex)
+                {
+                    exceptions.Add(ex);
+                }
+            });
+
+        Assert.Empty(exceptions);
+        Assert.Empty(wrongCounts);
+    }
+
+    /// <summary>
+    /// Successor of Issue1799 test C
+    /// (ManyConcurrentRuns_OneGoroutineRangesWhileOthersWrite_NeverThrowsCollectionModified):
+    /// one goroutine repeatedly Ranges over the SyncMap while 16 writers
+    /// store — no InvalidOperationException ("collection was modified"), no
+    /// corruption, ever.
+    /// </summary>
+    [Fact]
+    public void SyncMap_RangeWhileWriting_NeverThrows()
+    {
+        var source = SyncMapPrototype + """
+
+
+            func writer(m SyncMap, key string, value int32) int32 {
+                for var i = 0; i < 20; i++ {
+                    m.Store(key, value)
+                }
+                return 0
+            }
+
+            func rangeReader(m SyncMap) int32 {
+                var total = 0
+                for var i = 0; i < 20; i++ {
+                    m.Range(func(k string, v int32) {
+                        total = total + v
+                    })
+                }
+                return total
+            }
+
+            func run() int32 {
+                var m = SyncMap()
+                scope {
+                    go rangeReader(m)
+                    for var i = 0; i < 16; i++ {
+                        go writer(m, "k" + i.ToString(), i)
+                    }
+                }
+
+                return 0
+            }
+
+            run()
+            """;
+
+        RunStress(source, iterations: 30);
+    }
+
+    /// <summary>
+    /// Successor of Issue1799 test D
+    /// (ManyConcurrentRuns_LenAndContainsKeyAndKeysReadWhileWriting_NeverThrows):
+    /// Len(), Contains(), and a Keys() snapshot are read continuously while
+    /// 16 writer goroutines store — never throws.
+    /// </summary>
+    [Fact]
+    public void SyncMap_LenContainsAndKeysUnderWriteLoad_NeverThrows()
+    {
+        var source = SyncMapPrototype + """
+
+
+            func writer(m SyncMap, key string, value int32) int32 {
+                for var i = 0; i < 20; i++ {
+                    m.Store(key, value)
+                }
+                return 0
+            }
+
+            func reader(m SyncMap) int32 {
+                var total = 0
+                for var i = 0; i < 20; i++ {
+                    total = total + m.Len()
+                    if m.Contains("k0") {
+                        total = total + 1
+                    }
+                    for k in m.Keys() {
+                        total = total + 1
+                    }
+                }
+                return total
+            }
+
+            func run() int32 {
+                var m = SyncMap()
+                scope {
+                    go reader(m)
+                    for var i = 0; i < 16; i++ {
+                        go writer(m, "k" + i.ToString(), i)
+                    }
+                }
+
+                return 0
+            }
+
+            run()
+            """;
+
+        RunStress(source, iterations: 30);
+    }
+
+    /// <summary>
+    /// The v0 (docs-guidance) leg of the ADR: ConcurrentDictionary is fully
+    /// reachable from G# today via plain CLR interop — no compiler change,
+    /// no library type. This is the capability floor the issue records
+    /// ("the goal is ergonomics, not capability").
+    /// </summary>
+    [Fact]
+    public void InteropToday_ConcurrentDictionary_DistinctKeyWrites_AllSurvive()
+    {
+        var source = """
+            import System.Collections.Concurrent
+
+            func store(m ConcurrentDictionary[string, int32], key string, value int32) int32 {
+                var ok = m.TryAdd(key, value)
+                return 0
+            }
+
+            func run() int32 {
+                var m = ConcurrentDictionary[string, int32]()
+                scope {
+                    for var i = 0; i < 24; i++ {
+                        go store(m, "k" + i.ToString(), i + 1)
+                    }
+                }
+
+                var total = 0
+                for var i = 0; i < 24; i++ {
+                    var v = 0
+                    var ok = m.TryGetValue("k" + i.ToString(), out v)
+                    total = total + v
+                }
+
+                return total
+            }
+
+            run()
+            """;
+
+        var result = Evaluate(source);
+        AssertNoRealDiagnostics(result);
+        Assert.Equal(300, result.Value);
+    }
+
+    /// <summary>
+    /// Feasibility probe for the shipped Gsharp.Extensions.Sync form: a
+    /// generic SyncMap[K, V] backed by a ConcurrentDictionary[K, V] interop
+    /// field, used at two closed instantiations. This compiles and runs
+    /// today, so the generic library type needs no compiler work at all.
+    /// (The lock-based monomorphic prototype above does NOT generalize yet:
+    /// a `map[K, V]` field over type parameters compiles but NREs at
+    /// runtime — its `map[K, V]{}` literal never reaches the field — and
+    /// `map[K, V] != nil` is not a defined operator. Recorded in the ADR as
+    /// a filed compiler gap; the ConcurrentDictionary backing sidesteps it
+    /// and is the better backing anyway.)
+    /// </summary>
+    [Fact]
+    public void SyncMapGenericShape_CompilesAndRuns()
+    {
+        var source = """
+            import System.Collections.Concurrent
+
+            class GenericSyncMap[K, V any] {
+                private var items ConcurrentDictionary[K, V]
+
+                init() {
+                    items = ConcurrentDictionary[K, V]()
+                }
+
+                func Store(key K, value V) {
+                    items[key] = value
+                }
+
+                func Load(key K) V {
+                    var v V
+                    var ok = items.TryGetValue(key, out v)
+                    return v
+                }
+
+                func Len() int32 {
+                    return items.Count
+                }
+            }
+
+            func run() int32 {
+                var m = GenericSyncMap[string, int32]()
+                m.Store("a", 40)
+                m.Store("b", 2)
+                m.Store("c", 58)
+
+                var names = GenericSyncMap[int32, string]()
+                names.Store(1, "one")
+
+                var total = m.Load("a") + m.Load("b") + m.Load("c") + m.Len()
+                if names.Load(1) == "one" {
+                    total = total + 100
+                }
+
+                return total
+            }
+
+            run()
+            """;
+
+        var result = Evaluate(source);
+        AssertNoRealDiagnostics(result);
+        Assert.Equal(40 + 2 + 58 + 3 + 100, result.Value);
+    }
+
+    private static void RunStress(string source, int iterations)
+    {
+        var exceptions = new System.Collections.Concurrent.ConcurrentBag<System.Exception>();
+        System.Threading.Tasks.Parallel.For(
+            0,
+            iterations,
+            new System.Threading.Tasks.ParallelOptions { MaxDegreeOfParallelism = 8 },
+            i =>
+            {
+                try
+                {
+                    var result = Evaluate(source);
+                    AssertNoRealDiagnostics(result);
+                    Assert.Equal(0, result.Value);
+                }
+                catch (System.Exception ex)
+                {
+                    exceptions.Add(ex);
+                }
+            });
+
+        Assert.Empty(exceptions);
+    }
+
+    private static EmittedOracleResult Evaluate(string source)
+    {
+        // ADR-0082 / issue #722: `go` is gated behind this import.
+        var fullSource = "import Gsharp.Extensions.Go\n" + source;
+        return EmittedOracle.Evaluate(fullSource);
+    }
+
+    /// <summary>
+    /// GS0286 (ADR-0066 D5) flags declaration-before-use ordering as a
+    /// warning, not an error — same allowance as the sibling concurrency
+    /// suites.
+    /// </summary>
+    private static void AssertNoRealDiagnostics(EmittedOracleResult result)
+    {
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id != "GS0286");
+    }
+}

--- a/test/Interpreter.Tests/SyncMapImportEmittedOracleTests.cs
+++ b/test/Interpreter.Tests/SyncMapImportEmittedOracleTests.cs
@@ -1,0 +1,163 @@
+// <copyright file="SyncMapImportEmittedOracleTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.IO;
+using System.Linq;
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// ADR-0158 / issue #3209: G#-side consumption of
+/// <c>Gsharp.Extensions.Sync.SyncMap[K, V]</c> through real emitted
+/// execution — `import Gsharp.Extensions.Sync`, construct, and hammer from
+/// goroutines. The concurrent-increment test is the language-level
+/// successor of the deleted Issue1799 racy-increment shape (#3205's
+/// original repro), now exact because <c>Update</c> is atomic.
+/// C#-side behavioral coverage lives in
+/// <c>test/Extensions.Tests/SyncMapTests.cs</c>.
+/// </summary>
+public class SyncMapImportEmittedOracleTests
+{
+    [Fact]
+    public void SyncMap_BasicSurface_FromGsharp()
+    {
+        var source = """
+            import Gsharp.Extensions.Sync
+
+            func run() int32 {
+                var m = SyncMap[string, int32]()
+                m.Store("a", 40)
+                m.Store("b", 2)
+                m.Store("gone", 99)
+
+                var total = 0
+                if m.Delete("gone") {
+                    total = total + 100
+                }
+
+                total = total + m.Load("a") + m.Load("b")   // 40 + 2
+                total = total + m.Load("missing")           // + zero value
+                total = total + m.Len()                     // + 2
+                if m.Contains("a") {
+                    total = total + 100
+                }
+
+                // Note: across the imported-assembly boundary Keys()'s
+                // []K binds as a CLR array (string[]), so size is read
+                // via .Length rather than the len builtin.
+                total = total + m.Keys().Length             // + 2
+
+                var sum = 0
+                m.Range(func(k string, v int32) {
+                    sum = sum + v
+                })
+                total = total + sum                         // + 42
+
+                return total
+            }
+
+            run()
+            """;
+
+        var result = Evaluate(source);
+        AssertNoRealDiagnostics(result);
+        Assert.Equal(100 + 40 + 2 + 0 + 2 + 100 + 2 + 42, result.Value);
+    }
+
+    [Fact]
+    public void SyncMap_GoroutineIncrements_AreExact()
+    {
+        // The #3205 repro shape (50 goroutines bumping one key of a shared
+        // map inside a scope), which lost updates on a plain map — spelled
+        // with SyncMap.Update the count is exactly 50 every run.
+        var source = """
+            import Gsharp.Extensions.Sync
+
+            func bump(m SyncMap[string, int32]) int32 {
+                m.Update("k", func(v int32) int32 { return v + 1 })
+                return 0
+            }
+
+            func run() int32 {
+                var m = SyncMap[string, int32]()
+                scope {
+                    for var i = 0; i < 50; i++ {
+                        go bump(m)
+                    }
+                }
+
+                return m.Load("k")
+            }
+
+            run()
+            """;
+
+        var result = Evaluate(source);
+        AssertNoRealDiagnostics(result);
+        Assert.Equal(50, result.Value);
+    }
+
+    private static EmittedOracleResult Evaluate(string source)
+    {
+        // Same host-assembly seeding as Issue750ConstraintOverloadEmittedOracleTests:
+        // the Compilation.Default reference resolver enumerates loaded
+        // assemblies, so anchor the extensions assembly via typeof and
+        // Assembly.LoadFrom the on-disk Gsharp.Extensions.dll for .NET 10's
+        // lazy test host.
+        _ = typeof(Gsharp.Extensions.Sync.SyncMap<,>);
+
+        var extPath = LocateGsharpExtensionsAssembly();
+        if (extPath != null)
+        {
+            try
+            {
+                System.Reflection.Assembly.LoadFrom(extPath);
+            }
+            catch
+            {
+            }
+        }
+
+        // ADR-0082 / issue #722: `go` is gated behind this import.
+        var fullSource = "import Gsharp.Extensions.Go\n" + source;
+        return EmittedOracle.Evaluate(fullSource);
+    }
+
+    private static string LocateGsharpExtensionsAssembly()
+    {
+        var dir = new DirectoryInfo(Path.GetDirectoryName(typeof(SyncMapImportEmittedOracleTests).Assembly.Location));
+        while (dir != null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "GSharp.sln")))
+            {
+                foreach (var cfg in new[] { "Debug", "Release" })
+                {
+                    var candidate = Path.Combine(dir.FullName, "out", "bin", cfg, "Gsharp.Extensions", "Gsharp.Extensions.dll");
+                    if (File.Exists(candidate))
+                    {
+                        return candidate;
+                    }
+                }
+
+                return null;
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// GS0286 (ADR-0066 D5) flags declaration-before-use ordering as a
+    /// warning, not an error — same allowance as the sibling concurrency
+    /// suites.
+    /// </summary>
+    private static void AssertNoRealDiagnostics(EmittedOracleResult result)
+    {
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id != "GS0286");
+    }
+}

--- a/website/docs/extensions/go-concurrency.md
+++ b/website/docs/extensions/go-concurrency.md
@@ -181,10 +181,13 @@ what every driver (including `gsi`) executes since ADR-0156.
 
 Note that G# maps (`map[K,V]`) are backed by plain `Dictionary<K,V>`
 with no implicit synchronization, so concurrent access from multiple
-goroutines is not goroutine-safe — the same posture as Go maps. Guard
-shared maps with `lock`, or use `System.Collections.Concurrent` types
-via CLR interop; a first-class G# synchronization surface is tracked in
-[#3209](https://github.com/DavidObando/gsharp/issues/3209).
+goroutines is not goroutine-safe — the same posture as Go maps. For a
+map that is meant to be shared across goroutines, use
+[`SyncMap[K, V]`](../ref/standard-library#gsharpextensionssync) from
+`Gsharp.Extensions.Sync` (ADR-0158) — its `Update` is an atomic
+read-modify-write. For other shared state, `lock` and the
+`System.Collections.Concurrent` / `System.Threading` types via CLR
+interop are one import away.
 
 ## See also
 

--- a/website/docs/guide/concurrency.md
+++ b/website/docs/guide/concurrency.md
@@ -169,9 +169,71 @@ they do in straight-line code. The runtime is the standard .NET
 (`SemaphoreSlim`, channels, locks) from `System.Threading.*` are all
 available through normal imports.
 
+## Synchronization and shared state
+
+The first answer to "how do concurrent tasks share state" is the same
+as Go's: prefer not to — pass values through channels (or task results)
+and let `scope` own the joins.
+
+When sharing is unavoidable, the toolbox is, in order:
+
+1. **`lock`** — a statement that guards a critical section with the
+   .NET monitor:
+
+   ```gsharp
+   lock guard {
+       // critical section
+   }
+   ```
+
+   The target must be a reference type, is evaluated once, and the body
+   runs under `Monitor.Enter`/`Monitor.Exit` with an implicit
+   `try`/`finally`. Lock on a private object that never leaves your
+   type — never on a value other code can reach.
+
+2. **The BCL via interop** — `ConcurrentDictionary[K, V]`
+   (`import System.Collections.Concurrent`) for concurrent maps,
+   `Interlocked` for atomic counters, `ReaderWriterLockSlim`,
+   `SemaphoreSlim`, and friends (`import System.Threading`).
+
+3. **`SyncMap[K, V]`** (`import Gsharp.Extensions.Sync`) — the
+   idiomatic G# shape for a map shared across goroutines, analogous to
+   Go's `sync.Map`. It is method-based on purpose: on a shared map
+   `m[k] = m[k] + 1` *looks* atomic and races, so compound
+   read-modify-write is spelled `Update` and is atomic:
+
+   ```gsharp
+   import Gsharp.Extensions.Go
+   import Gsharp.Extensions.Sync
+
+   func bump(m SyncMap[string, int32]) int32 {
+       m.Update("hits", func(v int32) int32 { return v + 1 })
+       return 0
+   }
+
+   func run() int32 {
+       var m = SyncMap[string, int32]()
+       scope {
+           for var i = 0; i < 50; i++ {
+               go bump(m)
+           }
+       }
+
+       return m.Load("hits")   // exactly 50
+   }
+   ```
+
+Plain `map[K,V]` is **not** goroutine-safe: it is a bare
+`Dictionary<K,V>` with no implicit synchronization, and concurrent
+access to one is undefined behavior — the same posture as Go maps. See
+the [standard-library reference](../ref/standard-library#gsharpextensionssync)
+for the full `SyncMap` API.
+
 ## See also
 
 - [Tutorial: Async and sequences](../tutorials/async-and-sequences)
 - [Extensions: Go-flavored concurrency](../extensions/go-concurrency)
   — channels, `go`, `select`, and `close` for projects that import
   `Gsharp.Extensions.Go`.
+- [Standard library: Gsharp.Extensions.Sync](../ref/standard-library#gsharpextensionssync)
+  — the `SyncMap[K, V]` API reference.

--- a/website/docs/ref/standard-library.md
+++ b/website/docs/ref/standard-library.md
@@ -97,6 +97,8 @@ Console.WriteLine(len(counts))
 
 The .NET `Dictionary[K,V]` type is also usable through CLR interop when you import `System.Collections.Generic`; that surface is the BCL, not the language-defined map intrinsic.
 
+Maps are **not goroutine-safe**: `map[K,V]` carries no implicit synchronization, and concurrent access from multiple goroutines is undefined behavior — the same posture as Go maps. For a map that is meant to be shared across goroutines, use [`SyncMap[K, V]`](#gsharpextensionssync) from `Gsharp.Extensions.Sync`.
+
 ## Sequences and iteration
 
 `sequence[T]` is the G# type-clause spelling for `IEnumerable[T]`. Iterator functions that return a sequence can use `yield expr`. `async sequence[T]` is the spelling for `IAsyncEnumerable[T]`, and `await for` iterates async streams. Sequence APIs beyond iteration come from the BCL, such as LINQ extension methods imported from `System.Linq`.
@@ -108,6 +110,7 @@ The `Gsharp.Extensions` assembly ships with `Gsharp.NET.Sdk` and is referenced b
 - `Gsharp.Extensions.Optional` — extension methods on `T?` for projection, fallback, side-effects, and filtering.
 - `Gsharp.Extensions.Sequences` — static builders and extension transformers over `sequence[T]`.
 - `Gsharp.Extensions.Go` — Go-flavored concurrency surface and built-ins gated behind the import.
+- `Gsharp.Extensions.Sync` — synchronization helpers for state shared across goroutines; currently `SyncMap[K, V]`.
 
 ### Gsharp.Extensions.Optional
 
@@ -171,6 +174,33 @@ G#-shaped collectors:
 ### Gsharp.Extensions.Go
 
 The Go-flavored concurrency cluster — `go`, `chan T`, `<-`, `select`, `close(ch)`, `make(chan T)` — and the Go-style built-ins `len`, `cap`, `append`, `delete`, `make` are all gated behind `import Gsharp.Extensions.Go`. The [Intrinsic functions](#intrinsic-functions-and-operations) table above summarises the diagnostic codes the binder emits when the import is missing.
+
+### Gsharp.Extensions.Sync
+
+Synchronization helpers for state shared across goroutines (ADR-0158). The first type is `SyncMap[K, V]`, G#'s analog of Go's `sync.Map`: a goroutine-safe map with a method-based API — deliberately no literal or index syntax, because `m[k] = m[k] + 1` on a shared map looks atomic and races. Reads and enumeration are lock-free on a private concurrent backing store; writes serialize on a hidden monitor so `Update` is an atomic read-modify-write.
+
+```gsharp
+import Gsharp.Extensions.Sync
+
+var m = SyncMap[string, int32]()
+m.Store("hits", 1)
+m.Update("hits", func(v int32) int32 { return v + 1 })   // atomic; returns 2
+Console.WriteLine(m.Load("hits"))
+```
+
+| Symbol | Form | One-line description |
+| --- | --- | --- |
+| `SyncMap` | `SyncMap[K, V]()` | Construct an empty goroutine-safe map. |
+| `Store` | `func Store(key K, value V)` | Set `key` to `value`, replacing any existing entry. |
+| `Load` | `func Load(key K) V` | Read `key`; returns `V`'s zero value when absent (map-read parity). Lock-free. |
+| `Update` | `func Update(key K, f (V) -> V) V` | Atomically replace the value with `f(current)` (`current` is the zero value when absent); returns the stored result. Atomic against all other writes. |
+| `Delete` | `func Delete(key K) bool` | Remove the entry; reports whether one was present. |
+| `Len` | `func Len() int32` | Entry count. Lock-free snapshot. |
+| `Contains` | `func Contains(key K) bool` | Membership test. Lock-free. |
+| `Keys` | `func Keys() []K` | Snapshot slice of the keys. Safe under concurrent writes. |
+| `Range` | `func Range(action (K, V) -> void)` | Invoke `action` per entry; safe under concurrent writes, and `action` may itself write to the map (the monitor is not held). |
+
+`Load`, `Len`, and `Contains` carry `[MethodImpl(MethodImplOptions.AggressiveInlining)]`. `Update` runs `f` while the internal write monitor is held — keep it small and non-blocking. Plain `map[K,V]` deliberately carries none of these guarantees; see [Maps](#maps).
 
 ## Functions, delegates, and closures
 


### PR DESCRIPTION
Closes #3209. Part of #3163. **ADR-0158 is Accepted (owner-confirmed); implementation lands in this same change**, per the ADR-0157/#3299 precedent.

## Summary

- **Decision**: the #3209 synchronization story ships as **library + docs, no language surface** — `Gsharp.Extensions.Sync.SyncMap[K, V]` (Go `sync.Map` analog) plus concurrency documentation. Plain `map[K, V]` stays unsynchronized; concurrent access stays **undefined** (no Go-style runtime fault) — #3205 becomes the permanent spec position. A `synchronized`-style modifier is a rejected alternative (wrong lineage for the Go-shaped surface, wrong granularity for compound ops, zero corpus demand, dead-end against the #2485 actor horizon).
- **Implemented `SyncMap[K, V]`** in G# (`src/Sdk/Gsharp.Extensions/Sync/Sync.gs`, new `Sync` package, zero compiler changes): `Store` / `Load` (zero value when absent — map-read parity) / `Update(key, f)` (atomic RMW, returns result) / `Delete → bool` / `Len` / `Contains` / `Keys() []K` snapshot / `Range(action)`. Private `ConcurrentDictionary[K, V]` backing doubles as the hidden write monitor (never leaked — the Java-pitfall guard); reads and enumeration are lock-free; the three writes serialize so `Update` is atomic against **all** writes.
- **ADR-0158** (`docs/adr/0158-synchronization-story.md`): Accepted, with implementation evidence and the owner-settled **"Representation and magic — map vs SyncMap"** section — `map[K,V]` stays compiler-known with `Dictionary` identity (interop identity, zero runtime dependency, Go precedent; magic-plumbing bugs are answered by the #3306 emit funnel, not representation change); `SyncMap` is deliberately **not** magic (index syntax on a concurrent map is a lie; method-shaped ops grow in library releases; encapsulation is load-bearing). Composed rule: syntax-bearing types are compiler-known and identity-transparent; concurrency types are library-defined, method-shaped, encapsulation-opaque.
- **Docs**: new `docs/concurrency.md` (idiom → `lock` → interop menu → `SyncMap`); website: "Synchronization and shared state" section in `guide/concurrency.md`, `Gsharp.Extensions.Sync` API table + Maps goroutine-safety note in `ref/standard-library.md`, and `extensions/go-concurrency.md`'s shared-map note now points at `SyncMap` instead of the #3209 placeholder.
- **Issue1799 successor guarantees promoted** to `test/Extensions.Tests/SyncMapTests.cs` (17 tests, real threads against the compiled assembly) + G#-side `import` consumption in `test/Interpreter.Tests/SyncMapImportEmittedOracleTests.cs` (incl. the #3205 repro shape: 50 goroutines bumping one key — exactly 50). The feasibility spike (`Adr0158SyncMapSpikeTests.cs`) stays untouched as ADR evidence.

## Verification

- Release solution build: **0 warnings, 0 errors** (Gsharp.Extensions builds through the normal bootstrap — no special path needed).
- `dotnet test test/Extensions.Tests` (**full suite**): **121/121 passed**.
- `dotnet test test/Interpreter.Tests --filter "SyncMapImport|Adr0158"`: **8/8 passed** (2 import-consumption + 6 spike).
- **Witnesses (ADR-0154, product mutants on `Sync.gs`)**: lock-stripped mutant → `Update_ConcurrentIncrements_AreExact` 200→**72**, `Update_IsAtomicAgainstStoreAndDelete` 200→**1**; `Dictionary`-backed mutant → `Range_WhileWriting_NeverThrows` and `LenContainsAndKeys_UnderWriteLoad_NeverThrow` fail with "Collection was modified". Each guarantee is killed by the mutation it polices; all 17 green on the real implementation.
- CI fix (pre-existing, owner-directed): re-anchored the `Issue2962ConstrainedStaticPropertyChainTests` nullable-assignment pin from GS0156 to GS0155 per the #3296/#1627 re-anchor (reproduced against gsc; same message, new id); swept every other GS0156-referencing test class — all green, no other stale string-family pins.
- NOT RUN: full Interpreter.Tests / Core.Tests / other suites (no compiler, oracle, or submission-surface changes — the product change is a new G#-authored SDK library file plus tests/docs); Cs2Gs golden suites (unrelated; known flaky host).

## Spike evidence (unchanged from the Proposed round)

6/6 spike tests green; details in the ADR's Evidence section (distinct-key 300/300; atomic increments 50/50 × 40 runs; enumeration + Len/Contains/Keys stress never throw; raw ConcurrentDictionary interop floor; generic ConcurrentDictionary-backed shape needs zero compiler work). Spike fallout filed: #3303 (generic `map[K,V]` field NRE), #3304 (`go` rejects void operands).

## Checklist

- [x] Behavioral tests carry a witness of discrimination (ADR-0154): product mutants recorded above and in the ADR.
- [x] Self-review verdict recorded: **MERGEABLE** — library + tests + docs, Release build clean, full Extensions suite green; residuals filed as #3303 / #3304 rather than dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
