### PR TITLE
Fix #3301: map-element method calls emit via symbolic Dictionary MemberRefs (C#-parity copy-call)

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
+++ b/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
@@ -2044,6 +2044,80 @@ internal sealed class ImportedMemberRefFactory
             signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
     }
 
+    /// <summary>
+    /// Issue #3301: gets a MemberRef for
+    /// <c>Dictionary`2::TryGetValue(!0, out !1)</c> parented at the reified
+    /// <see cref="GetMapTypeSpec"/> TypeSpec, for a <c>map[K, V]</c> index
+    /// read whose <see cref="TypeSymbol.ClrType"/> is null — a map keyed or
+    /// valued by a same-compilation user struct (or an in-scope type
+    /// parameter, #1481). Mirrors <see cref="GetMapSetItemReference"/>.
+    /// </summary>
+    /// <param name="mapType">The map type whose backing dictionary is read.</param>
+    /// <returns>The <c>TryGetValue</c> MemberRef handle.</returns>
+    internal MemberReferenceHandle GetMapTryGetValueReference(MapTypeSymbol mapType)
+    {
+        var parent = this.GetMapTypeSpec(mapType);
+        var sigBlob = new BlobBuilder();
+        new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: true)
+            .Parameters(
+                2,
+                returnType: r => r.Type().Boolean(),
+                parameters: ps =>
+                {
+                    ps.AddParameter().Type().GenericTypeParameter(0);
+                    ps.AddParameter().Type(isByRef: true).GenericTypeParameter(1);
+                });
+        return this.emitCtx.Metadata.AddMemberReference(
+            parent: parent,
+            name: this.emitCtx.Metadata.GetOrAddString("TryGetValue"),
+            signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
+    }
+
+    /// <summary>
+    /// Issue #3301: gets a MemberRef for <c>Dictionary`2::Remove(!0)</c>
+    /// parented at the reified <see cref="GetMapTypeSpec"/> TypeSpec, for a
+    /// <c>delete(m, k)</c> on a <c>map[K, V]</c> whose
+    /// <see cref="TypeSymbol.ClrType"/> is null. Mirrors
+    /// <see cref="GetMapSetItemReference"/>.
+    /// </summary>
+    /// <param name="mapType">The map type whose backing dictionary is mutated.</param>
+    /// <returns>The <c>Remove</c> MemberRef handle.</returns>
+    internal MemberReferenceHandle GetMapRemoveReference(MapTypeSymbol mapType)
+    {
+        var parent = this.GetMapTypeSpec(mapType);
+        var sigBlob = new BlobBuilder();
+        new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: true)
+            .Parameters(
+                1,
+                returnType: r => r.Type().Boolean(),
+                parameters: ps => ps.AddParameter().Type().GenericTypeParameter(0));
+        return this.emitCtx.Metadata.AddMemberReference(
+            parent: parent,
+            name: this.emitCtx.Metadata.GetOrAddString("Remove"),
+            signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
+    }
+
+    /// <summary>
+    /// Issue #3301: gets a MemberRef for <c>Dictionary`2::get_Count()</c>
+    /// parented at the reified <see cref="GetMapTypeSpec"/> TypeSpec, for a
+    /// <c>len(m)</c> on a <c>map[K, V]</c> whose
+    /// <see cref="TypeSymbol.ClrType"/> is null. Mirrors
+    /// <see cref="GetMapSetItemReference"/>.
+    /// </summary>
+    /// <param name="mapType">The map type whose backing dictionary is counted.</param>
+    /// <returns>The <c>get_Count</c> MemberRef handle.</returns>
+    internal MemberReferenceHandle GetMapGetCountReference(MapTypeSymbol mapType)
+    {
+        var parent = this.GetMapTypeSpec(mapType);
+        var sigBlob = new BlobBuilder();
+        new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: true)
+            .Parameters(0, returnType: r => r.Type().Int32(), parameters: _ => { });
+        return this.emitCtx.Metadata.AddMemberReference(
+            parent: parent,
+            name: this.emitCtx.Metadata.GetOrAddString("get_Count"),
+            signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
+    }
+
     // ADR-0087 §3 R6: cache reified delegate metadata by function shape and
     // the active generic-remap scope (issue #3163). The same interned
     // FunctionTypeSymbol can encode as VAR inside a synthesized generic class

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
@@ -933,12 +933,17 @@ internal sealed partial class MethodBodyEmitter
         else if (len.Operand.Type is MapTypeSymbol mapType)
         {
             // Phase 3.A.4 emit: `len(m)` -> `callvirt Dictionary<K,V>.get_Count`.
-            var dictType = mapType.ClrType;
-            var getCount = dictType.GetMethod("get_Count")
-                ?? throw new InvalidOperationException(
-                    $"Dictionary type '{dictType.FullName}' has no get_Count method.");
+            // Issue #3301: same-compilation user-struct key/value — no erased
+            // CLR Dictionary<,> to reflect on; use the #1481-style symbolic
+            // TypeSpec-parented MemberRef instead.
+            var getCountRef = mapType.ClrType is { } dictType
+                ? this.outer.memberRefs.GetMethodReference(
+                    dictType.GetMethod("get_Count")
+                    ?? throw new InvalidOperationException(
+                        $"Dictionary type '{dictType.FullName}' has no get_Count method."))
+                : this.outer.memberRefs.GetMapGetCountReference(mapType);
             this.il.OpCode(ILOpCode.Callvirt);
-            this.il.Token(this.outer.memberRefs.GetMethodReference(getCount));
+            this.il.Token(getCountRef);
         }
         else
         {
@@ -1118,14 +1123,21 @@ internal sealed partial class MethodBodyEmitter
         // and pops the returned bool — `delete` is typed as void.
         var mapType = (MapTypeSymbol)del.Map.Type;
         var dictType = mapType.ClrType;
-        var remove = dictType.GetMethod("Remove", new[] { mapType.KeyType.ClrType })
-            ?? throw new InvalidOperationException(
-                $"Dictionary type '{dictType.FullName}' has no Remove(K) method.");
+
+        // Issue #3301: same-compilation user-struct key/value — no erased
+        // CLR Dictionary<,> to reflect on; use the #1481-style symbolic
+        // TypeSpec-parented MemberRef instead.
+        var removeRef = dictType == null
+            ? this.outer.memberRefs.GetMapRemoveReference(mapType)
+            : this.outer.memberRefs.GetMethodReference(
+                dictType.GetMethod("Remove", new[] { mapType.KeyType.ClrType })
+                ?? throw new InvalidOperationException(
+                    $"Dictionary type '{dictType.FullName}' has no Remove(K) method."));
 
         this.EmitExpression(del.Map);
         this.EmitExpression(del.Key);
         this.il.OpCode(ILOpCode.Callvirt);
-        this.il.Token(this.outer.memberRefs.GetMethodReference(remove));
+        this.il.Token(removeRef);
         this.il.OpCode(ILOpCode.Pop);
     }
 

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
@@ -367,18 +367,34 @@ internal sealed partial class MethodBodyEmitter
         // `get_Item` would.
         var mapType = (MapTypeSymbol)idx.Target.Type;
         var dictType = mapType.ClrType;
-        var tryGet = dictType.GetMethod(
-            "TryGetValue",
-            new[] { mapType.KeyType.ClrType, mapType.ValueType.ClrType.MakeByRefType() })
-            ?? throw new InvalidOperationException(
-                $"Dictionary type '{dictType.FullName}' has no TryGetValue(K, out V) method.");
+
+        // Issue #3301: a map keyed or valued by a same-compilation user
+        // struct has no erased CLR Dictionary<,> to reflect on
+        // (MapTypeSymbol.ClrType is null until after emission — the #409
+        // symbol-only value types), so the reflection lookup below would
+        // NRE. Route the call through the reified TypeSpec-parented
+        // MemberRef instead, mirroring the #1481 symbolic map-literal path.
+        MemberReferenceHandle tryGetRef;
+        if (dictType == null)
+        {
+            tryGetRef = this.outer.memberRefs.GetMapTryGetValueReference(mapType);
+        }
+        else
+        {
+            var tryGet = dictType.GetMethod(
+                "TryGetValue",
+                new[] { mapType.KeyType.ClrType, mapType.ValueType.ClrType.MakeByRefType() })
+                ?? throw new InvalidOperationException(
+                    $"Dictionary type '{dictType.FullName}' has no TryGetValue(K, out V) method.");
+            tryGetRef = this.outer.memberRefs.GetMethodReference(tryGet);
+        }
 
         var slot = this.mapIndexSlots[idx];
         this.EmitExpression(idx.Target);
         this.EmitExpression(idx.Index);
         this.il.LoadLocalAddress(slot);
         this.il.OpCode(ILOpCode.Callvirt);
-        this.il.Token(this.outer.memberRefs.GetMethodReference(tryGet));
+        this.il.Token(tryGetRef);
 
         // Issue #1714: TryGetValue zero-initialises the out V parameter via the
         // CLR default when the key is missing — for V == string that CLR
@@ -415,9 +431,15 @@ internal sealed partial class MethodBodyEmitter
         var targetType = ixa.TargetExpression?.Type ?? ixa.Target.Type;
         var mapType = (MapTypeSymbol)targetType;
         var dictType = mapType.ClrType;
-        var setItem = dictType.GetMethod("set_Item")
-            ?? throw new InvalidOperationException(
-                $"Dictionary type '{dictType.FullName}' has no set_Item method.");
+
+        // Issue #3301: same-compilation user-struct key/value — no erased
+        // CLR Dictionary<,> to reflect on; use the #1481 symbolic MemberRef.
+        var setItemRef = dictType == null
+            ? this.outer.memberRefs.GetMapSetItemReference(mapType)
+            : this.outer.memberRefs.GetMethodReference(
+                dictType.GetMethod("set_Item")
+                ?? throw new InvalidOperationException(
+                    $"Dictionary type '{dictType.FullName}' has no set_Item method."));
 
         var tmp = this.indexAssignmentValueSlots[ixa];
         if (ixa.TargetExpression != null)
@@ -434,7 +456,7 @@ internal sealed partial class MethodBodyEmitter
         this.il.OpCode(ILOpCode.Dup);
         this.il.StoreLocal(tmp);
         this.il.OpCode(ILOpCode.Callvirt);
-        this.il.Token(this.outer.memberRefs.GetMethodReference(setItem));
+        this.il.Token(setItemRef);
         this.il.LoadLocal(tmp);
     }
 

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue3301MapElementMethodCallEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue3301MapElementMethodCallEmitTests.cs
@@ -1,0 +1,208 @@
+// <copyright file="Issue3301MapElementMethodCallEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #3301: method calls (and the other dictionary-backed operations)
+/// on a map whose key or value is a same-compilation user struct crashed
+/// the emitter with GS9998 (NullReferenceException): every map-operation
+/// emit path except the #1481 map literal reflected over
+/// <c>MapTypeSymbol.ClrType</c>, which is null while the struct's own
+/// TypeDef is still being emitted. These witnesses pin the fixed routing
+/// through reified TypeSpec-parented MemberRefs and the chosen semantics:
+/// a method call on a map element operates on the copy the indexer read
+/// returns (C# parity for <c>dict[k].M()</c>, and G#'s own established
+/// rvalue-receiver behavior, e.g. <c>MakeItem().Bump()</c>) — mutations
+/// are discarded, unlike the #3292 in-place array/slice element calls.
+/// Map element member WRITES keep their GS0499 rejection (#3293).
+/// </summary>
+public class Issue3301MapElementMethodCallEmitTests
+{
+    private const string StructAndMapDecls = """
+        struct P {
+            var X int32
+
+            func Bump() {
+                this.X = this.X + 1
+            }
+
+            func Get() int32 {
+                return this.X
+            }
+
+            func Self() P {
+                return this
+            }
+        }
+
+        var m = map[int32, P]{1: P{X: 10}}
+        """;
+
+    [Fact]
+    public void MutatingMethodOnMapElement_CallsOnCopy_AndDiscardsMutation()
+    {
+        // The #3301 crash repro: this exact shape produced
+        // "GS9998: NullReferenceException" from EmitMapIndexRead.
+        var result = EmittedOracle.Evaluate($$"""
+            package P3301Mutating
+
+            {{StructAndMapDecls}}
+            m[1].Bump()
+            m[1].X
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS9998");
+        Assert.Equal(10, result.Value);
+    }
+
+    [Fact]
+    public void NonMutatingMethodOnMapElement_ReturnsElementValue()
+    {
+        var result = EmittedOracle.Evaluate($$"""
+            package P3301NonMutating
+
+            {{StructAndMapDecls}}
+            m[1].Get()
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS9998");
+        Assert.Equal(10, result.Value);
+    }
+
+    [Fact]
+    public void ChainedCallThroughMapElement_WorksOnCopies()
+    {
+        // `m[1].Self().Bump()` — the second receiver is an ordinary struct
+        // rvalue (the #409 spill path); the whole chain runs on copies.
+        var result = EmittedOracle.Evaluate($$"""
+            package P3301Chained
+
+            {{StructAndMapDecls}}
+            m[1].Self().Bump()
+            m[1].Self().Get() + m[1].X
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS9998");
+        Assert.Equal(20, result.Value);
+    }
+
+    [Fact]
+    public void MutatingMethodCall_EvaluatesSideEffectingKeyExactlyOnce()
+    {
+        // The #3302 once-only convention: the receiver `m[key()]` spills to
+        // a temp exactly once, so the key expression must not re-run.
+        var result = EmittedOracle.Evaluate($$"""
+            package P3301OnceKey
+
+            {{StructAndMapDecls}}
+            var calls = 0
+
+            func key() int32 {
+                calls = calls + 1
+                return 1
+            }
+
+            m[key()].Bump()
+            calls * 100 + m[1].X
+            """);
+
+        Assert.Equal(110, result.Value);
+    }
+
+    [Fact]
+    public void MapElementRead_WithStructValue_Works()
+    {
+        // The same root cause made ANY `m[k]` read over a user-struct value
+        // crash — not just method-call receivers.
+        var result = EmittedOracle.Evaluate($$"""
+            package P3301Read
+
+            {{StructAndMapDecls}}
+            var copy = m[1]
+            copy.X
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS9998");
+        Assert.Equal(10, result.Value);
+    }
+
+    [Fact]
+    public void MapWholeElementWrite_WithStructValue_Works()
+    {
+        // Whole-element assignment `m[k] = v` (the #3251 remedy seam) went
+        // through the same null-ClrType reflection and crashed too.
+        var result = EmittedOracle.Evaluate($$"""
+            package P3301Write
+
+            {{StructAndMapDecls}}
+            m[2] = P{X: 7}
+            var copy = m[1]
+            copy.X = 99
+            m[1] = copy
+            m[1].X + m[2].X
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS9998");
+        Assert.Equal(106, result.Value);
+    }
+
+    [Fact]
+    public void LenAndDelete_WithStructValue_Work()
+    {
+        var result = EmittedOracle.Evaluate($$"""
+            package P3301LenDelete
+
+            import Gsharp.Extensions.Go
+
+            {{StructAndMapDecls}}
+            m[2] = P{X: 7}
+            let before = len(m)
+            delete(m, 2)
+            before * 10 + len(m)
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS9998");
+        Assert.Equal(21, result.Value);
+    }
+
+    [Fact]
+    public void MapWithStructKey_ReadAndCall_Work()
+    {
+        // The key side of the TypeSpec is symbolic here (struct K, string V
+        // stays a real CLR type on the erased half).
+        var result = EmittedOracle.Evaluate("""
+            package P3301StructKey
+
+            struct K2 {
+                var Id int32
+            }
+
+            var m = map[K2, int32]{K2{Id: 1}: 42}
+            m[K2{Id: 1}]
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS9998");
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void MapElementFieldWrite_StillReportsGS0499()
+    {
+        // #3293's guard must not regress: a map element has no address, so
+        // direct member WRITES are still rejected — only method calls (which
+        // operate on the returned copy, like C#) are allowed.
+        var result = EmittedOracle.Evaluate($$"""
+            package P3301WriteGuard
+
+            {{StructAndMapDecls}}
+            m[1].X = 7
+            """);
+
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0499");
+    }
+}

--- a/test/Interpreter.Tests/Issue3252IndexedStructMemberWriteTests.cs
+++ b/test/Interpreter.Tests/Issue3252IndexedStructMemberWriteTests.cs
@@ -180,22 +180,64 @@ public sealed class Issue3252IndexedStructMemberWriteTests
     }
 
     /// <summary>
-    /// Mutating-method map guard: a map element has no address, so the
-    /// element-address receiver path must not leak into map elements. Today
-    /// a mutating method call on a map element fails outright with a
-    /// PRE-EXISTING emitter error (GS9998 NullReferenceException — present
-    /// on main before #3292, reproducible with `gsc` on
-    /// <c>m[1].Bump()</c>; tracked as issue #3301); pinned here only as
-    /// "does not silently succeed", so a change in either direction (fix or
-    /// in-place leak) is caught.
+    /// Mutating-method map arm (issue #3301): a map element has no address
+    /// (the Dictionary indexer returns a copy), so the element-address
+    /// receiver path must not leak into map elements. A mutating method
+    /// call on a map element instead operates on the returned COPY and the
+    /// mutation is discarded — C# parity for <c>dict[k].M()</c> and the
+    /// same rvalue-receiver semantics G# already gives
+    /// <c>MakeItem().Bump()</c>. Previously this crashed the emitter with
+    /// GS9998 (NullReferenceException in EmitMapIndexRead: a map keyed or
+    /// valued by a same-cell user struct has a null <c>ClrType</c>).
     /// </summary>
     [Fact]
-    public void MutatingMethodOnMapElementDoesNotSilentlySucceed()
+    public void SameCellMutatingMethodOnMapElementCallsOnCopyAndDiscardsMutation()
     {
         using var engine = new EmittedSessionEngine();
         var result = engine.Evaluate(
             "struct P { var X int\n func Bump() { this.X = this.X + 1 } }\nvar m = map[int, P]{1: P{}}\nm[1].Bump()\nm[1].X");
-        Assert.True(result.HasError, "map-element mutating call unexpectedly succeeded — semantics changed");
+        Assert.False(result.HasError, string.Join("; ", result.Diagnostics));
+        Assert.Equal(0, result.Value);
+    }
+
+    /// <summary>
+    /// Cross-cell flavor of the #3301 map arm: the mutating call through a
+    /// prior-cell submission-global map also runs on the element copy and
+    /// discards the mutation — parity with the same-cell form, and the
+    /// deliberate contrast with the in-place #3292 array/slice arm.
+    /// </summary>
+    [Fact]
+    public void CrossCellMutatingMethodOnMapElementCallsOnCopyAndDiscardsMutation()
+    {
+        using var engine = new EmittedSessionEngine();
+        AssertOk(engine, "struct P { var X int\n func Bump() { this.X = this.X + 1 } }\nvar m = map[int, P]{1: P{}}");
+        AssertOk(engine, "m[1].Bump()");
+
+        var probe = engine.Evaluate("m[1].X");
+        Assert.False(probe.HasError, string.Join("; ", probe.Diagnostics));
+        Assert.Equal(0, probe.Value);
+    }
+
+    /// <summary>
+    /// Non-mutating method calls on a map element read through the same
+    /// copy receiver; #3301's fix must keep (same-cell) and leave
+    /// (cross-cell) them working.
+    /// </summary>
+    [Fact]
+    public void NonMutatingMethodOnMapElementReturnsValueInBothForms()
+    {
+        const string decls = "struct P { var X int\n func Get() int { return this.X } }\nvar m = map[int, P]{1: P{X: 5}}";
+
+        using var sameCell = new EmittedSessionEngine();
+        var same = sameCell.Evaluate(decls + "\nm[1].Get()");
+        Assert.False(same.HasError, string.Join("; ", same.Diagnostics));
+        Assert.Equal(5, same.Value);
+
+        using var crossCell = new EmittedSessionEngine();
+        AssertOk(crossCell, decls);
+        var probe = crossCell.Evaluate("m[1].Get()");
+        Assert.False(probe.HasError, string.Join("; ", probe.Diagnostics));
+        Assert.Equal(5, probe.Value);
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #3301. Part of #3163.

## Summary

- Kill the GS9998 emitter crash (NullReferenceException) on `m[k].Bump()` — and on every other dictionary-backed map operation over a map keyed or valued by a same-compilation user struct.
- Root cause: `MapTypeSymbol.ClrType` is built by reflection (`Dictionary<,>.MakeGenericType(K.ClrType, V.ClrType)`) and is **null** whenever K or V is a user-defined struct still being emitted (the #409 symbol-only value types have `ClrType == null` until after emission). Four emit paths reflected over that null unconditionally: `EmitMapIndexRead` (TryGetValue — the `m[1].Bump()` receiver-spill crash site, NRE at `dictType.GetMethod(...)`), `EmitMapIndexAssignment` (set_Item), `EmitMapDelete` (Remove), `EmitLen` (get_Count). So not just method calls: plain `var x = m[1]`, `m[k] = v`, `len(m)`, and `delete(m, k)` all crashed identically outside the REPL (in later REPL cells the struct has a real loaded `ClrType`, which is why only the same-cell/straight-compile forms died).
- Fix: route those four sites through reified `Dictionary`2` TypeSpec-parented MemberRefs when `ClrType` is null — exactly the path #1481 already built for symbolic map *literals* (`GetMapCtorReference`/`GetMapSetItemReference`). Three new `ImportedMemberRefFactory` helpers mirror `GetMapSetItemReference`: `GetMapTryGetValueReference` (`bool TryGetValue(!0, out !1)`), `GetMapRemoveReference` (`bool Remove(!0)`), `GetMapGetCountReference` (`int32 get_Count()`). The reflection fast path is unchanged when `ClrType` is real.

## Semantics: copy-call (C# parity), chosen on existing rvalue precedent

Maps have no element address (the Dictionary indexer returns a copy — the #3292/#3293 GS0499 rationale). Two candidate behaviors for a **method call** on that copy:

- **(a) C#-parity copy-call** — spill the element into a temp, call on the temp's address, discard mutations. C# permits `dict[k].Bump()` (rvalue receiver; only *assignment* is CS1612).
- **(b) GS0499 clean error** — stricter than C#, consistent with map element *writes*.

**(a) is what this PR ships, on precedent:** G# already calls methods — including mutating ones — on rvalue struct receivers via the #409/#1688 spill-to-temp path: `MakeP().Bump()` compiles and runs on main today (verified empirically: builds, runs, mutation silently discarded, no diagnostic). With `EmitMapIndexRead` fixed, `m[k].Bump()` composes with that existing `EmitInstanceReceiver`/`TryEmitCachedReceiver` machinery with **zero receiver-path changes**: the element copy is spilled once and the call runs on the temp's address. Choosing (b) would have made `m[k].Bump()` stricter than the equivalent `MakeP().Bump()` rvalue call for no principled reason. Driver parity verified: `gsi` (interpreter) also prints the discarded-copy result (10) for the crash repro — no divergence.

- Map element member **writes** keep their GS0499 rejection (#3293) — unchanged and pinned.
- #3302's array/slice **in-place** element calls are untouched (`IsArrayBackedElementAccess` excludes maps by design) — pinned.
- The #3302 once-only convention holds: `m[key()].Bump()` evaluates the side-effecting key exactly once (the receiver spill evaluates `m[key()]` once into the temp) — pinned.
- Silent-discarded-mutation warning: G# has warning-severity diagnostic infrastructure but **no** existing warning for discarded struct mutations on rvalue receivers (`MakeP().Bump()` is equally silent today, as is C#). Not invented here; noted as a possible follow-up analyzer applying uniformly to all rvalue struct receivers, not just map elements.

## Verification

- Release solution build: 0 warnings, 0 errors.
- Witnesses (ADR-0154), red on pre-fix product (fix hunks stashed, tests kept, rebuilt):
  - CLI repro red on main first: `gsc MapBump.gs` → `error GS9998: NullReferenceException` with stack anchored at `MethodBodyEmitter.EmitMapIndexRead` line 370 (`dictType.GetMethod` on null `dictType`), reached via `TryEmitCachedReceiver` → `EmitInstanceReceiver` → `EmitUserInstanceCall` — the exact #3301 signature.
  - `Issue3301MapElementMethodCallEmitTests` (Core.Tests, EmittedOracle): pre-fix **8/9 FAIL** (mutating copy-call, non-mutating call, chained `m[1].Self().Bump()`, once-only side-effecting key, element read, whole-element write, len/delete, struct-keyed map), with the GS0499 map member-write guard green on both sides by design (no-regression pin). Post-fix **9/9 PASS**.
  - `Issue3252IndexedStructMemberWriteTests` (Interpreter.Tests): the old `MutatingMethodOnMapElementDoesNotSilentlySucceed` crash pin becomes the defined-semantics pair; pre-fix the same-cell mutating and non-mutating pins **FAIL** (GS9998), post-fix **19/19 PASS**. The cross-cell mutating arm was green pre-fix too (prior-cell structs have a real loaded `ClrType`) — kept as a same-cell/cross-cell parity pin, witnessed by the same-cell arm.
- Core.Tests (full): 7239 passed, 0 failed, 1 skipped (the always-skipped `RegenerateBaseline`).
- Interpreter.Tests (full): 1439 passed, 0 failed, 0 skipped.
- Compiler.Tests LanguageConformance filter: 127/127 passed.
- ILVerify: all five CLI repro binaries (`m[1].Bump()`, reads, writes, len/delete, once-only/chained matrix) verify clean ("All Classes and Methods Verified").
- NOT RUN: full Compiler.Tests outside the LanguageConformance filter, LanguageServer/Sdk/Extensions/InternalAnalyzers suites, Cs2Gs.Tests (known non-deterministic host crash per repo memory), e2etests. Rationale: the change is confined to four Core emit sites plus three signature-encoding helpers; Core.Tests + Interpreter.Tests + the conformance gate exercise the shared emit path across drivers.

## Checklist

- [x] Behavioral tests carry a witness of discrimination (ADR-0154): fix hunks stashed → 8/9 Core.Tests witnesses and both same-cell Interpreter.Tests pins red with the exact GS9998 signature; restored → all green. Guards (GS0499 map writes) green both sides by design.
- [x] Self-review verdict: MERGEABLE — narrow emit-site change mirroring an established (#1481) symbolic-MemberRef pattern; receiver semantics inherited from the existing rvalue spill path rather than new machinery; map GS0499 write arms and #3302 in-place arms pinned unchanged. Residual (possible discarded-mutation warning for all rvalue struct receivers) noted above as a follow-up candidate rather than invented here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
