### PR TITLE
Fix #3304: go statement accepts void-returning call operands

### DIFF
--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Blocks.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Blocks.cs
@@ -632,7 +632,13 @@ internal sealed partial class StatementBinder
         // the operand's call-shape still surface.
         binderCtx.ReportIfGoExtensionsImportMissing(syntax, syntax.GoKeyword.Location, "go");
 
-        var expression = bindExpression(syntax.Expression);
+        // Issue #3304: the spawned call's result is discarded (ADR-0022), so
+        // a void-returning operand is the natural goroutine shape — bind with
+        // canBeVoid so GS0124 does not force `return 0` boilerplate onto
+        // goroutine bodies. Non-call operands are still rejected below
+        // (GS0137), and the emit path already wraps a non-Task operand in an
+        // Action-shaped thunk whose body is an expression statement.
+        var expression = bindExpression(syntax.Expression, canBeVoid: true);
 
         if (expression is BoundErrorExpression)
         {

--- a/test/Compiler.Tests/Emit/Issue3304GoVoidOperandEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3304GoVoidOperandEmitTests.cs
@@ -1,0 +1,143 @@
+// <copyright file="Issue3304GoVoidOperandEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #3304: `go` with a void-returning call operand must compile to
+/// verifiable IL and run. The void operand lowers through the Action-shaped
+/// goroutine thunk (the closure's InvokeAction body is an expression
+/// statement, so a void call leaves nothing to pop), for both fire-and-forget
+/// and scope-joined launches.
+/// </summary>
+public class Issue3304GoVoidOperandEmitTests
+{
+    [Fact]
+    public void GoVoidOperandShapes_LoadVerifyAndRun()
+    {
+        const string Source = """
+            package Issue3304GoVoid
+            import System
+            import Gsharp.Extensions.Go
+
+            class Box {
+                func Poke(ch chan int32) {
+                    ch <- 7
+                }
+            }
+
+            func poke(ch chan int32) {
+                ch <- 42
+            }
+
+            let done = make(chan int32, 1)
+            go poke(done)
+            Console.WriteLine(<-done)
+
+            let b = Box{}
+            go b.Poke(done)
+            Console.WriteLine(<-done)
+
+            scope {
+                go poke(done)
+            }
+            Console.WriteLine(<-done)
+            """;
+
+        AssertRuns(Source, nameof(GoVoidOperandShapes_LoadVerifyAndRun), "42\n7\n42\n");
+    }
+
+    private static void AssertRuns(string source, string name, string expected)
+    {
+        var assemblyPath = Compile(source, name);
+        var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+        Assert.NotEmpty(assembly.GetTypes());
+
+        for (var i = 0; i < 3; i++)
+        {
+            Assert.Equal(expected, RunBounded(assemblyPath, name));
+        }
+
+        IlVerifier.Verify(assemblyPath);
+    }
+
+    private static string Compile(string source, string name)
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            nameof(Issue3304GoVoidOperandEmitTests),
+            name);
+        Directory.CreateDirectory(directory);
+        var sourcePath = Path.Combine(directory, "test.gs");
+        var assemblyPath = Path.Combine(directory, name + ".dll");
+        File.WriteAllText(sourcePath, source);
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousErr = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        int exitCode;
+        try
+        {
+            exitCode = Program.Main(new[]
+            {
+                "/out:" + assemblyPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                sourcePath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousErr);
+        }
+
+        Assert.True(exitCode == 0, $"{name}: gsc failed:\n{stdout}\n{stderr}");
+        return assemblyPath;
+    }
+
+    private static string RunBounded(string assemblyPath, string name)
+    {
+        using var process = Process.Start(new ProcessStartInfo("dotnet")
+        {
+            ArgumentList =
+            {
+                "exec",
+                "--runtimeconfig",
+                Path.ChangeExtension(assemblyPath, ".runtimeconfig.json"),
+                assemblyPath,
+            },
+            WorkingDirectory = Path.GetDirectoryName(assemblyPath),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        });
+
+        Assert.NotNull(process);
+        var outputTask = process.StandardOutput.ReadToEndAsync();
+        var errorTask = process.StandardError.ReadToEndAsync();
+        var exited = process.WaitForExit(10_000);
+        if (!exited)
+        {
+            process.Kill(entireProcessTree: true);
+            process.WaitForExit();
+        }
+
+        Assert.True(exited, $"{name}: emitted program timed out");
+        var output = outputTask.GetAwaiter().GetResult();
+        var error = errorTask.GetAwaiter().GetResult();
+        Assert.True(process.ExitCode == 0, $"{name}: emitted program failed:\n{error}");
+        return output.Replace("\r\n", "\n", StringComparison.Ordinal);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3304GoVoidOperandTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3304GoVoidOperandTests.cs
@@ -1,0 +1,189 @@
+// <copyright file="Issue3304GoVoidOperandTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #3304: `go f(args)` must accept a void-returning call operand.
+/// The spawned call's result is discarded (ADR-0022), so a `void` target is
+/// the most natural goroutine shape — pre-fix the binder bound the operand
+/// with `canBeVoid: false` and reported GS0124 ("Expression must have a
+/// value."), forcing `return 0` boilerplate onto every goroutine body in the
+/// corpus. Found by the ADR-0158 feasibility spike.
+/// </summary>
+public class Issue3304GoVoidOperandTests
+{
+    [Fact]
+    public void Go_OnVoidFunctionCall_BindsAndRuns()
+    {
+        // Exact repro from #3304: void top-level function launched as a
+        // goroutine, observable through a buffered channel rendezvous.
+        var source = """
+            var done = make(chan int32, 1)
+
+            func poke() {
+                done <- 42
+            }
+
+            func run() int32 {
+                go poke()
+                return <-done
+            }
+
+            run()
+            """;
+        var result = Evaluate(source);
+        AssertNoRealDiagnostics(result);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void Go_OnVoidInstanceMethodCall_BindsAndRuns()
+    {
+        // `go b.Poke(...)` — void user-instance-call operand shape.
+        var source = """
+            class Box {
+                func Poke(ch chan int32) {
+                    ch <- 7
+                }
+            }
+
+            func run() int32 {
+                let done = make(chan int32, 1)
+                let b = Box{}
+                go b.Poke(done)
+                return <-done
+            }
+
+            run()
+            """;
+        var result = Evaluate(source);
+        AssertNoRealDiagnostics(result);
+        Assert.Equal(7, result.Value);
+    }
+
+    [Fact]
+    public void Go_OnVoidFunctionValueCall_CapturingLocal_BindsAndRuns()
+    {
+        // Void indirect-call operand: a function literal capturing an
+        // enclosing local, launched by name (BoundIndirectCallExpression).
+        var source = """
+            let ch = make(chan int32, 1)
+
+            func run() int32 {
+                let x = 10
+                let send = func() {
+                    ch <- x
+                }
+                go send()
+                return <-ch
+            }
+
+            run()
+            """;
+        var result = Evaluate(source);
+        AssertNoRealDiagnostics(result);
+        Assert.Equal(10, result.Value);
+    }
+
+    [Fact]
+    public void Go_InScope_OnVoidCall_JoinsAtScopeExit()
+    {
+        // Structured concurrency: a scoped void goroutine must be joined at
+        // scope exit, so the buffered send is guaranteed complete before the
+        // receive that follows the scope.
+        var source = """
+            let done = make(chan int32, 1)
+
+            func poke() {
+                done <- 21
+            }
+
+            func run() int32 {
+                scope {
+                    go poke()
+                }
+                return <-done
+            }
+
+            run()
+            """;
+        var result = Evaluate(source);
+        AssertNoRealDiagnostics(result);
+        Assert.Equal(21, result.Value);
+    }
+
+    [Fact]
+    public void Go_OnValueReturningCall_StillBinds_ResultDiscarded()
+    {
+        // Regression pin: the pre-existing value-returning operand keeps
+        // working, and its result is discarded rather than leaking into the
+        // caller (see also Issue1651GoroutineIsolationEmittedOracleTests).
+        var source = """
+            let started = make(chan int32, 1)
+
+            func spawnee() int32 {
+                started <- 1
+                return 999
+            }
+
+            func run() int32 {
+                go spawnee()
+                let signal = <-started
+                return signal + 2
+            }
+
+            run()
+            """;
+        var result = Evaluate(source);
+        AssertNoRealDiagnostics(result);
+        Assert.Equal(3, result.Value);
+    }
+
+    [Fact]
+    public void Go_OnNonCallExpression_StillDiagnosesGS0137()
+    {
+        // Pin: only the void restriction is lifted — a non-call operand is
+        // still rejected with GS0137.
+        var source = """
+            let x = 42
+            go x
+            """;
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0137");
+    }
+
+    [Fact]
+    public void Go_OnBareFunctionLiteral_StillDiagnosesGS0137()
+    {
+        // Pin: a bare (uninvoked) function literal is not a call; Go itself
+        // requires `go func() { ... }()` — the literal alone stays rejected.
+        var source = """
+            go func() { }
+            """;
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0137");
+    }
+
+    private static EmittedOracleResult Evaluate(string source)
+    {
+        // ADR-0082 / issue #722: `go` is gated behind this import.
+        var fullSource = "import Gsharp.Extensions.Go\n" + source;
+        return EmittedOracle.Evaluate(fullSource);
+    }
+
+    /// <summary>
+    /// Fixtures declare a top-level channel ahead of the functions that use
+    /// it and place the driving call after them; GS0286 (ADR-0066 D5) flags
+    /// that split-TLS layout as a warning. Filter it the same way
+    /// <c>Issue1651GoroutineIsolationEmittedOracleTests</c> does.
+    /// </summary>
+    private static void AssertNoRealDiagnostics(EmittedOracleResult result)
+    {
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id != "GS0286");
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3304GoVoidOperandTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3304GoVoidOperandTests.cs
@@ -145,6 +145,27 @@ public class Issue3304GoVoidOperandTests
     }
 
     [Fact]
+    public void Go_OnAsyncNoResultFunctionCall_StillBindsViaTaskShape()
+    {
+        // Async interplay pin (unchanged by #3304): a call to an async
+        // no-result function is bound with a Task return type at the call
+        // site (OverloadResolver wraps via WrapAsTask), so it never hits the
+        // void-operand path — the goroutine takes the Func<Task> thunk and
+        // is a properly awaited spawn, before and after this fix.
+        var source = """
+            import System.Threading.Tasks
+
+            async func work() {
+                await Task.Delay(1)
+            }
+
+            go work()
+            """;
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
     public void Go_OnNonCallExpression_StillDiagnosesGS0137()
     {
         // Pin: only the void restriction is lifted — a non-call operand is

--- a/test/Interpreter.Tests/Issue3304GoVoidOperandSessionTests.cs
+++ b/test/Interpreter.Tests/Issue3304GoVoidOperandSessionTests.cs
@@ -22,23 +22,22 @@ public sealed class Issue3304GoVoidOperandSessionTests : IDisposable
     [Fact]
     public void GoOnVoidCall_InReplSubmission_RunsAndRendezvouses()
     {
-        // ADR-0082: the Go surface is gated per compilation unit, so each
-        // cell that uses `go`/`chan`/`<-` carries the import.
-        var declare = engine.Evaluate("""
+        // The whole rendezvous lives in one submission: a channel hoisted
+        // into session state is projected back as its CLR type
+        // (System.Threading.Channels.Channel[int32]), not a ChannelTypeSymbol,
+        // so a later cell's `<-done` is rejected — a pre-existing
+        // cross-submission limitation independent of #3304 (it fails
+        // identically for a value-returning goroutine target).
+        var cell = engine.Evaluate("""
             import Gsharp.Extensions.Go
             var done = make(chan int32, 1)
             func poke() {
                 done <- 42
             }
-            """);
-        Assert.False(declare.HasError);
-
-        var launch = engine.Evaluate("""
-            import Gsharp.Extensions.Go
             go poke()
             <-done
             """);
-        Assert.False(launch.HasError);
-        Assert.Equal(42, launch.Value);
+        Assert.False(cell.HasError, string.Join("; ", cell.Diagnostics));
+        Assert.Equal(42, cell.Value);
     }
 }

--- a/test/Interpreter.Tests/Issue3304GoVoidOperandSessionTests.cs
+++ b/test/Interpreter.Tests/Issue3304GoVoidOperandSessionTests.cs
@@ -1,0 +1,44 @@
+// <copyright file="Issue3304GoVoidOperandSessionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using GSharp.Repl.Engine;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #3304: `go` with a void-returning call operand must also work in an
+/// interactive submission (the emitted session engine), not just in a whole
+/// program — pre-fix the binder reported GS0124 on the `go` cell.
+/// </summary>
+public sealed class Issue3304GoVoidOperandSessionTests : IDisposable
+{
+    private readonly EmittedSessionEngine engine = new();
+
+    public void Dispose() => engine.Dispose();
+
+    [Fact]
+    public void GoOnVoidCall_InReplSubmission_RunsAndRendezvouses()
+    {
+        // ADR-0082: the Go surface is gated per compilation unit, so each
+        // cell that uses `go`/`chan`/`<-` carries the import.
+        var declare = engine.Evaluate("""
+            import Gsharp.Extensions.Go
+            var done = make(chan int32, 1)
+            func poke() {
+                done <- 42
+            }
+            """);
+        Assert.False(declare.HasError);
+
+        var launch = engine.Evaluate("""
+            import Gsharp.Extensions.Go
+            go poke()
+            <-done
+            """);
+        Assert.False(launch.HasError);
+        Assert.Equal(42, launch.Value);
+    }
+}

--- a/website/docs/ref/spec.md
+++ b/website/docs/ref/spec.md
@@ -1262,7 +1262,7 @@ DeferStmt = "defer" Expression .
 
 ### Go, scope, channel send and receive, and select
 
-`go expr` starts a concurrent call; binding requires the operand to be a call. `scope { ... }` is structured concurrency and joins registered child tasks at scope exit. Channel receive is a prefix expression `<-ch`; channel send is a statement `ch <- value`. `select` supports default, receive-discard, receive-bind (via `case let v = <-ch`), and send cases.
+`go expr` starts a concurrent call; binding requires the operand to be a call (`GS0137` otherwise). The operand may return `void` — the natural goroutine shape, matching Go — and any result a value-returning operand produces is discarded. `scope { ... }` is structured concurrency and joins registered child tasks at scope exit. Channel receive is a prefix expression `<-ch`; channel send is a statement `ch <- value`. `select` supports default, receive-discard, receive-bind (via `case let v = <-ch`), and send cases.
 
 The `go`, `chan T`, `<-` (send and receive), `select`, `close(ch)`, and `make(chan T)` forms are the **Go-flavored concurrency surface** and are gated behind a per-file `import Gsharp.Extensions.Go`. The binder reports `GS0316` at each offending keyword/operator (`go`, `chan`, `<-`, `select`, `close`) when the import is absent in the same compilation unit. `scope` itself is **not** gated. The gate is always opt-in and is independent of `/noimplicitimports`.
 


### PR DESCRIPTION
Fixes #3304. Part of #3163.

## Summary

- Root cause: `BindGoStatement` bound its operand through the default `canBeVoid: false` path, so a void call hit GS0124 ("Expression must have a value.") before the call-shape check ever ran — forcing `func f() int32 { ...; return 0 }` boilerplate onto every goroutine body in the corpus (found by the ADR-0158 spike, PR #3305).
- Fix: bind the `go` operand with `canBeVoid: true` (one line in `StatementBinder.Blocks.cs`). No lowering change needed — the goroutine thunk `ClosureEmitter.SynthesizeGoClosures` builds for a non-Task operand is already a void `InvokeAction` whose body is a `BoundExpressionStatement` (the emitter skips the pop when the call is void), dispatched via `Task.Run(Action)`; scope-joined and fire-and-forget shapes both keep working.
- Unchanged surfaces (pinned): non-call operands still report GS0137 (including a bare function literal); a value-returning operand still binds with its result discarded; `go asyncFunc()` is untouched — async call sites are Task-typed by `WrapAsTask` in `OverloadResolver.CallBinding`, so they never enter the void path and keep the `Func<Task>` thunk.
- Spec delta (`website/docs/ref/spec.md`, go-statement paragraph): now states the operand may return `void` (the natural goroutine shape, matching Go) and that a value-returning operand's result is discarded; names GS0137 for non-call operands.
- Not cleaned here: corpus/sample `return 0` boilerplate (e.g. `samples/GoScope.gs`, `GoChannelsGated.gs`, `Select.gs`, `PortScan.gs`) — the issue doesn't ask for it and touching shipped samples would force golden re-verification; follow-up cleanup candidate under #3163.
- Known pre-existing limitation surfaced while testing (unrelated, unfixed): a channel hoisted into REPL session state round-trips as its CLR projection (`System.Threading.Channels.Channel[int32]`), so `<-ch` in a *later* cell is rejected — fails identically for value-returning goroutine targets, so the session witness keeps the rendezvous in one cell.

## Verification

- Release solution build: 0 warnings / 0 errors.
- ADR-0154 witnesses (commit 1, red on main): 4 red with exactly `Expression must have a value.` — void top-level func (issue repro, GS0124), void instance method, void indirect call capturing a local, scoped void goroutine — plus the REPL-cell witness; all green after the fix commit.
- `Issue3304` filters post-fix: Core.Tests 8/8, Compiler.Tests 1/1 (compiles, runs 3x, **ILVerify clean**), Interpreter.Tests 1/1.
- Concurrency area filters: Core.Tests (Go/Scope/Channel/Select/722/Goroutine) 159/159; Interpreter.Tests (Goroutine/Channel/Go/SyncMap) 52/52; Compiler.Tests (Channel/Async/2965) 274/274.
- Full Core.Tests: 7247 passed, 1 skipped (standard `RegenerateBaseline`), 0 failed.
- Full Interpreter.Tests: 1448/1448.
- LanguageConformance filter: 127/127 (samples untouched, goldens unchanged).
- NOT RUN: full Compiler.Tests beyond the filters above (area filters + full LanguageConformance cover the touched surface; binder change is engine-agnostic and Core/Interpreter ran full); Cs2Gs.Tests (not touched; known flaky host crash — see repo memory); LanguageServer/Sdk/Extensions test suites (no surface touched).

Self-review verdict: **MERGEABLE** — one-line binder change riding on existing lowering, witnesses discriminate, no golden churn.

## Checklist

- [x] Behavioral tests carry a witness of discrimination (ADR-0154): each new/changed test fails on the pre-change code (pre-fix commit, reverted hunk, or an applied product mutant) and passes with it.
- [x] Self-review verdict recorded when one was run (MERGEABLE / BLOCKER / SHOULD-FIX / NIT), with residuals filed as issues rather than dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
