### PR TITLE
Fix #3303: generic map[K,V] fields — nil-compare binding, open-map object widening, and the pinned #3306 field matrix

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
@@ -522,6 +522,26 @@ public sealed record BoundBinaryOperator
             return true;
         }
 
+        // Issue #3303: a `map[K, V]` is unconditionally a CLR reference type
+        // (`System.Collections.Generic.Dictionary<K, V>`), regardless of
+        // whether its `ClrType` is materialized (it is null when K or V
+        // structurally references an in-scope type parameter or a
+        // same-compilation struct). A bare map slot can genuinely hold a CLR
+        // null — a declared-but-unassigned `var items map[K, V]` field is nil
+        // until `init()` runs — so `m == nil` / `m != nil` must bind exactly
+        // like the reference-shaped structural types above (#796). This is
+        // comparison-only, mirroring function types: bare-slot nil ASSIGNMENT
+        // still requires the explicit `map[K, V]?` spelling (ADR-0104), which
+        // binds through the NullableTypeSymbol arm at the top. The emitter's
+        // generic `ldnull; ceq` tail is verifier-clean for the reference-typed
+        // operand, including the open `Dictionary<!0, !1>` shape. Slices and
+        // channels intentionally keep their current GS0129 rejection —
+        // widening those is a separate language-surface decision.
+        if (nullableOrUnderlying is MapTypeSymbol)
+        {
+            return true;
+        }
+
         // Issue #2300: interface-typed operands are always CLR reference
         // types (a G#-declared InterfaceSymbol or an imported interface),
         // so `iface == nil` / `iface != nil` must bind exactly like the

--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -817,6 +817,23 @@ public sealed class Conversion
             return Conversion.Implicit;
         }
 
+        // Issue #3303: a `map[K, V]` is unconditionally a CLR reference type
+        // (`System.Collections.Generic.Dictionary<K, V>`), but its `ClrType`
+        // is null when the key or value structurally references an in-scope
+        // type parameter (e.g. a `map[K, V]` field of a generic class) or a
+        // same-compilation struct, so the general CLR-backed widening rule
+        // above cannot fire. Widening such a reference to `object` is still a
+        // no-op at the IL level — the emitter's #1481 arm in
+        // MethodBodyEmitter.IsReferenceCompatible already recognizes exactly
+        // this shape. Without this, `Console.WriteLine(items)` and `object`-typed
+        // parameter/return positions reported GS0155/GS0159 for open maps
+        // while the monomorphic equivalent bound fine.
+        if (from is MapTypeSymbol
+            && (to == TypeSymbol.Object || to?.ClrType.IsSameAs(typeof(object)) == true))
+        {
+            return Conversion.Implicit;
+        }
+
         // Boxing conversion for user value types to System.Object.
         if (from is StructSymbol fromStruct && !fromStruct.IsClass && to?.ClrType.IsSameAs(typeof(object)) == true)
         {

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -1525,6 +1525,31 @@ internal sealed partial class ExpressionBinder
             }
         }
 
+        // Issue #3303: a `map[K, V]` whose key or value has no CLR backing (a
+        // generic type parameter or a same-compilation user type) has a null
+        // `ClrType`, so `GetEffectiveArgumentClrType` returned null above. Its
+        // runtime backing is still a `Dictionary<,>` reference whose key/value
+        // ride through to their erasure (type parameter / user type →
+        // `object`, enum → `int`), exactly like the slice arm above — so
+        // surface the erased closed `Dictionary<…>` shape. Without this the
+        // argument produced no effective CLR type at all, overload resolution
+        // never ran, and `Console.WriteLine(items)` on a generic class's
+        // `map[K, V]` field dead-ended with GS0159 while the monomorphic
+        // equivalent bound fine. The emitter needs no adjustment: the
+        // `map → object`-shaped parameter slots this unlocks are no-op
+        // reference conversions (MethodBodyEmitter.IsReferenceCompatible).
+        if (typeSymbol is MapTypeSymbol openMapArg)
+        {
+            var keyClr = GetEffectiveArgumentClrTypeForOverloadResolution(openMapArg.KeyType);
+            var valueClr = GetEffectiveArgumentClrTypeForOverloadResolution(openMapArg.ValueType);
+            if (keyClr != null && valueClr != null
+                && !keyClr.IsByRef && !keyClr.IsPointer
+                && !valueClr.IsByRef && !valueClr.IsPointer)
+            {
+                return typeof(System.Collections.Generic.Dictionary<,>).MakeGenericType(keyClr, valueClr);
+            }
+        }
+
         // Issue #2142: a nullable user reference type (`UserClass?`) erases to
         // the same CLR ride-through as its non-nullable form — nullability is an
         // annotation only for reference types, so overload resolution (and the

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -1892,6 +1892,37 @@ internal sealed class MemberLookup
                 }
 
                 return false;
+            case MapTypeSymbol map:
+                // Issue #3303: a `map[K, V]` whose key or value structurally
+                // references an open type parameter (e.g. the `map[K, V]`
+                // field of a generic class) or a same-compilation user type
+                // has a null ClrType, so the ClrType gate above missed it.
+                // Its runtime backing is still `Dictionary<K, V>` — erase the
+                // key/value (type parameter → `object`, mirroring the slice
+                // and sequence cases) and re-form the closed dictionary so
+                // overload resolution can rank `object`-shaped parameters as
+                // applicable (`Console.WriteLine(items)` previously
+                // dead-ended with GS0159 while the monomorphic map bound
+                // fine). Symbolic recovery downstream re-derives the real
+                // key/value types when a generic candidate is chosen.
+                if (TryProjectErasedClrType(map.KeyType, out var mapKeyErased)
+                    && TryProjectErasedClrType(map.ValueType, out var mapValueErased)
+                    && !mapKeyErased.IsByRef && !mapKeyErased.IsPointer
+                    && !mapValueErased.IsByRef && !mapValueErased.IsPointer)
+                {
+                    try
+                    {
+                        erased = typeof(System.Collections.Generic.Dictionary<,>)
+                            .MakeGenericType(mapKeyErased, mapValueErased);
+                        return true;
+                    }
+                    catch
+                    {
+                        return false;
+                    }
+                }
+
+                return false;
             case PointerTypeSymbol pointer:
                 // Issue #2838: `*T` under `T : unmanaged` — canonically the
                 // pointer bound by `fixed p *T = span` — has a null ClrType

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue3303GenericMapFieldEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue3303GenericMapFieldEmitTests.cs
@@ -1,0 +1,519 @@
+// <copyright file="Issue3303GenericMapFieldEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #3303 (ADR-0158 spike fallout, part of #3163): a generic class with
+/// a <c>map[K, V]</c> field over its own type parameters. Two sub-bugs:
+///
+/// <para>1. The field-shape NRE (the literal assigned in <c>init()</c>
+/// "never reaching" the field) was the #3301/#3306 family — the map
+/// index-read/assign/len/delete emit paths reflected over the null
+/// <c>MapTypeSymbol.ClrType</c> (null by construction when K or V is a type
+/// parameter). #3306's symbolic <c>Dictionary`2</c> MemberRef routing fixed
+/// the whole generic-field matrix; the tests here pin that matrix from the
+/// issue's own repro shapes (they are regression pins, green since #3306).</para>
+///
+/// <para>2. <c>m != nil</c> / <c>m == nil</c> on ANY map-typed operand
+/// (generic or monomorphic) failed to bind with GS0129 even though a map is
+/// unconditionally a reference-backed <c>Dictionary&lt;K, V&gt;</c> and a
+/// declared-but-unassigned map field genuinely IS nil at runtime. The fix
+/// adds <c>MapTypeSymbol</c> to the #796 reference-shaped nil-compare family
+/// (comparison-only — bare-slot nil ASSIGNMENT still requires the explicit
+/// <c>map[K, V]?</c> spelling per ADR-0104, mirroring function types). These
+/// witnesses were red before the fix. Related sweep fixes witnessed here:
+/// open-map → <c>object</c> conversion (GS0155) and open-map arguments in
+/// CLR overload resolution (GS0159 on <c>Console.WriteLine(items)</c>).</para>
+/// </summary>
+public class Issue3303GenericMapFieldEmitTests
+{
+    private const string GenericMapClass = """
+        class G[K, V any] {
+            var items map[K, V]
+            init() { items = map[K, V]{} }
+            func S(k K, v V) { items[k] = v }
+            func L(k K) V { return items[k] }
+            func Len() int32 { return len(items) }
+            func Del(k K) { delete(items, k) }
+        }
+        """;
+
+    // ---------------------------------------------------------------
+    // Sub-bug 1: generic map field matrix (regression pins for #3306's
+    // fix, expressed as the #3303 repro shapes).
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void GenericClassMapField_IssueRepro_StoreAndLoadRoundTrip()
+    {
+        // The exact issue #3303 repro: literal construction in init(),
+        // store/load through the field at [string, int32].
+        var result = EmittedOracle.Evaluate($$"""
+            package P3303Repro
+
+            import Gsharp.Extensions.Go
+
+            {{GenericMapClass}}
+
+            func run() int32 {
+                var g = G[string, int32]()
+                g.S("a", 42)
+                return g.L("a")
+            }
+
+            run()
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Severity == GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void GenericClassMapField_LenAndDelete_ThroughField()
+    {
+        var result = EmittedOracle.Evaluate($$"""
+            package P3303LenDelete
+
+            import Gsharp.Extensions.Go
+
+            {{GenericMapClass}}
+
+            func run() int32 {
+                var g = G[string, int32]()
+                g.S("a", 1)
+                g.S("b", 2)
+                let before = g.Len()
+                g.Del("a")
+                return before * 10 + g.Len()
+            }
+
+            run()
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Severity == GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error);
+        Assert.Equal(21, result.Value);
+    }
+
+    [Fact]
+    public void GenericClassMapField_UserStructValueArgument_RoundTrips()
+    {
+        // V substituted with a same-compilation user struct — the shape
+        // whose ClrType is null even monomorphically (#3301 family).
+        var result = EmittedOracle.Evaluate($$"""
+            package P3303StructValue
+
+            import Gsharp.Extensions.Go
+
+            struct Pt { var X int32 }
+
+            {{GenericMapClass}}
+
+            func run() int32 {
+                var h = G[int32, Pt]()
+                h.S(1, Pt{X: 7})
+                return h.L(1).X
+            }
+
+            run()
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Severity == GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error);
+        Assert.Equal(7, result.Value);
+    }
+
+    [Fact]
+    public void GenericClassMapField_UserStructKeyArgument_RoundTrips()
+    {
+        var result = EmittedOracle.Evaluate($$"""
+            package P3303StructKey
+
+            import Gsharp.Extensions.Go
+
+            struct Pt { var X int32 }
+
+            {{GenericMapClass}}
+
+            func run() string {
+                var p = G[Pt, string]()
+                p.S(Pt{X: 3}, "three")
+                return p.L(Pt{X: 3})
+            }
+
+            run()
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Severity == GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error);
+        Assert.Equal("three", result.Value);
+    }
+
+    [Fact]
+    public void GenericStructMapField_RoundTrips()
+    {
+        // Value-type generic container (struct, not class) with the same
+        // map[K, V] field shape.
+        var result = EmittedOracle.Evaluate("""
+            package P3303GenericStruct
+
+            struct SG[K, V any] {
+                var items map[K, V]
+                init() { items = map[K, V]{} }
+                func S(k K, v V) { items[k] = v }
+                func L(k K) V { return items[k] }
+            }
+
+            func run() int32 {
+                var g = SG[string, int32]()
+                g.S("a", 42)
+                return g.L("a")
+            }
+
+            run()
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Severity == GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void GenericClassMapField_NestedGenericValueArgument_RoundTrips()
+    {
+        // V substituted with another instantiation of the same generic
+        // class — map[string, G[string, int32]] through the field.
+        var result = EmittedOracle.Evaluate($$"""
+            package P3303Nested
+
+            import Gsharp.Extensions.Go
+
+            {{GenericMapClass}}
+
+            func run() int32 {
+                var g = G[string, int32]()
+                g.S("a", 42)
+                var u = G[string, G[string, int32]]()
+                u.S("inner", g)
+                return u.L("inner").L("a")
+            }
+
+            run()
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Severity == GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void GenericMethodLocalMap_OverMethodTypeParameters_RoundTrips()
+    {
+        // MVAR flavor: a map[K, V] local inside a generic top-level func.
+        var result = EmittedOracle.Evaluate("""
+            package P3303MethodLocal
+
+            func pick[K, V any](k K, v V) V {
+                var m = map[K, V]{}
+                m[k] = v
+                return m[k]
+            }
+
+            pick("z", 9)
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Severity == GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error);
+        Assert.Equal(9, result.Value);
+    }
+
+    [Fact]
+    public void NonGenericMapField_RegressionPin_RoundTrips()
+    {
+        // The monomorphic control from the issue — must stay green.
+        var result = EmittedOracle.Evaluate("""
+            package P3303Mono
+
+            class M {
+                var items map[string, int32]
+                init() { items = map[string, int32]{} }
+                func S(k string, v int32) { items[k] = v }
+                func L(k string) int32 { return items[k] }
+            }
+
+            func run() int32 {
+                var m = M()
+                m.S("a", 42)
+                return m.L("a")
+            }
+
+            run()
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Severity == GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error);
+        Assert.Equal(42, result.Value);
+    }
+
+    // ---------------------------------------------------------------
+    // Sub-bug 2: nil comparison on map-typed operands (red pre-fix).
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void GenericMapField_NotNilComparison_BindsAndIsTrueAfterInit()
+    {
+        // The issue's probe: `items != nil` inside the generic class
+        // reported GS0129 pre-fix.
+        var result = EmittedOracle.Evaluate("""
+            package P3303NilProbe
+
+            class G[K, V any] {
+                var items map[K, V]
+                init() { items = map[K, V]{} }
+                func Ready() bool { return items != nil }
+            }
+
+            func run() bool {
+                var g = G[string, int32]()
+                return g.Ready()
+            }
+
+            run()
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0129");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Severity == GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error);
+        Assert.Equal(true, result.Value);
+    }
+
+    [Fact]
+    public void GenericMapField_UnassignedField_IsNil()
+    {
+        // A declared-but-unassigned map field genuinely holds a CLR null:
+        // `items == nil` must bind AND observe it (the issue's silent-nil
+        // state made observable).
+        var result = EmittedOracle.Evaluate("""
+            package P3303UnassignedNil
+
+            class H[K, V any] {
+                var items map[K, V]
+                init() { }
+                func IsNil() bool { return items == nil }
+                func Fill() { items = map[K, V]{} }
+            }
+
+            func run() int32 {
+                var h = H[string, int32]()
+                var before = h.IsNil()
+                h.Fill()
+                var after = h.IsNil()
+                if before && !after {
+                    return 1
+                }
+
+                return 0
+            }
+
+            run()
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Severity == GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error);
+        Assert.Equal(1, result.Value);
+    }
+
+    [Theory]
+    [InlineData("m != nil", true)]
+    [InlineData("m == nil", false)]
+    [InlineData("nil != m", true)]
+    [InlineData("nil == m", false)]
+    public void MonomorphicMap_NilComparison_BothOperatorsBothOrders(string comparison, bool expected)
+    {
+        var result = EmittedOracle.Evaluate($$"""
+            package P3303MonoNil
+
+            var m = map[string, int32]{"a": 1}
+            {{comparison}}
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0129");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Severity == GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error);
+        Assert.Equal(expected, result.Value);
+    }
+
+    [Fact]
+    public void MapNilComparison_InValueContext_FlowsAsBool()
+    {
+        // Value (non-branch) context: the comparison result stored and
+        // combined as an ordinary bool.
+        var result = EmittedOracle.Evaluate("""
+            package P3303NilValueCtx
+
+            var m = map[string, int32]{}
+            var probe = m != nil
+            var count = 0
+            if probe {
+                count = count + 1
+            }
+
+            if m == nil {
+                count = count + 10
+            }
+
+            count
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Severity == GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error);
+        Assert.Equal(1, result.Value);
+    }
+
+    [Fact]
+    public void NullableMap_NarrowedBySmartCast_NilComparisonStillBinds()
+    {
+        // ADR-0104's `map[K, V]?` spelling already bound nil-compare via the
+        // NullableTypeSymbol arm — but after an assignment the smart-cast
+        // narrows the slot to the BARE map type, which then failed GS0129
+        // pre-fix. Pins the narrowing interplay.
+        var result = EmittedOracle.Evaluate("""
+            package P3303NarrowedNil
+
+            var n map[string, int32]? = nil
+            var first = n == nil
+            n = map[string, int32]{"a": 1}
+            var second = n != nil
+            first && second
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0129");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Severity == GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error);
+        Assert.Equal(true, result.Value);
+    }
+
+    [Fact]
+    public void NullableMap_ExplicitSpelling_RegressionPin()
+    {
+        // The pre-existing `map[K, V]?` nullable arm — green before and
+        // after this fix.
+        var result = EmittedOracle.Evaluate("""
+            package P3303NullableMapPin
+
+            class G[K, V any] {
+                var items map[K, V]?
+                init() { items = nil }
+                func IsNil() bool { return items == nil }
+                func Fill() { items = map[K, V]{} }
+            }
+
+            func run() bool {
+                var g = G[string, int32]()
+                var before = g.IsNil()
+                g.Fill()
+                return before && !g.IsNil()
+            }
+
+            run()
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Severity == GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error);
+        Assert.Equal(true, result.Value);
+    }
+
+    [Fact]
+    public void SliceNilComparison_ParityPin_StillRejectedWithGS0129()
+    {
+        // Slices deliberately keep their current rejection: widening
+        // slice/channel nil-compare is a separate language-surface decision
+        // (this fix is scoped to maps, which the issue demonstrates can be
+        // genuinely nil). A future change here must be deliberate.
+        var result = EmittedOracle.Evaluate("""
+            package P3303SlicePin
+
+            var s = []int32{1}
+            s != nil
+            """);
+
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0129");
+    }
+
+    [Fact]
+    public void ChannelNilComparison_ParityPin_StillRejectedWithGS0129()
+    {
+        var result = EmittedOracle.Evaluate("""
+            package P3303ChanPin
+
+            var c = make(chan int32, 1)
+            c != nil
+            """);
+
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0129");
+    }
+
+    [Fact]
+    public void BareMapNilAssignment_StillRequiresNullableSpelling()
+    {
+        // Comparison-only semantics: assigning nil INTO a bare map slot
+        // still requires the explicit `map[K, V]?` spelling (ADR-0104),
+        // exactly like bare function-typed slots (#715/#796).
+        var result = EmittedOracle.Evaluate("""
+            package P3303NoBareNilAssign
+
+            var m = map[string, int32]{}
+            m = nil
+            m == nil
+            """);
+
+        Assert.Contains(result.Diagnostics, d => d.Severity == GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error);
+    }
+
+    // ---------------------------------------------------------------
+    // Sweep fixes: open-map → object conversion and overload resolution.
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void GenericMapField_WidensToObject_InReturnPosition()
+    {
+        // Pre-fix: GS0155 "Cannot convert type 'map[K,V]' to 'object'" —
+        // the classify object-widening rule required a non-null ClrType.
+        var result = EmittedOracle.Evaluate("""
+            package P3303ObjectWiden
+
+            class G[K, V any] {
+                var items map[K, V]
+                init() { items = map[K, V]{} }
+                func AsObj() object { return items }
+            }
+
+            func run() bool {
+                var g = G[string, int32]()
+                return g.AsObj() != nil
+            }
+
+            run()
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0155");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Severity == GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error);
+        Assert.Equal(true, result.Value);
+    }
+
+    [Fact]
+    public void GenericMapField_AsClrCallArgument_ResolvesObjectOverload()
+    {
+        // Pre-fix: GS0159 "Cannot find function WriteLine" — the open map
+        // produced no effective CLR type for overload resolution, so the
+        // candidate set was abandoned before ranking `WriteLine(object)`.
+        var result = EmittedOracle.Evaluate("""
+            package P3303WriteLine
+
+            class G[K, V any] {
+                var items map[K, V]
+                init() { items = map[K, V]{} }
+                func Show() { Console.WriteLine(items) }
+            }
+
+            var g = G[string, int32]()
+            g.Show()
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0159");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Severity == GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error);
+        Assert.Contains("Dictionary", result.Output);
+    }
+}

--- a/test/Interpreter.Tests/Issue3303GenericMapFieldReplTests.cs
+++ b/test/Interpreter.Tests/Issue3303GenericMapFieldReplTests.cs
@@ -1,0 +1,138 @@
+// <copyright file="Issue3303GenericMapFieldReplTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Repl.Engine;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #3303 (ADR-0158 spike fallout): generic <c>map[K, V]</c> fields and
+/// map nil-comparison through the session engine, in both same-cell and
+/// cross-cell form. The same-cell arms exercise the null-ClrType shapes (the
+/// class TypeDef does not exist yet while the cell compiles); the cross-cell
+/// arms are the parity pins — a prior-cell class has a real loaded ClrType,
+/// which is why the #3301-family bugs historically only died same-cell.
+/// </summary>
+public sealed class Issue3303GenericMapFieldReplTests
+{
+    private const string GenericMapClassCell = """
+        class G[K, V any] {
+            var items map[K, V]
+            init() { items = map[K, V]{} }
+            func S(k K, v V) { items[k] = v }
+            func L(k K) V { return items[k] }
+            func Ready() bool { return items != nil }
+        }
+        """;
+
+    [Fact]
+    public void SameCell_GenericMapField_StoreLoadRoundTrips()
+    {
+        using var engine = new EmittedSessionEngine();
+        var result = engine.Evaluate(GenericMapClassCell + """
+
+
+            var g = G[string, int32]()
+            g.S("a", 42)
+            g.L("a")
+            """);
+
+        Assert.False(result.HasError, string.Join("; ", result.Diagnostics));
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void CrossCell_GenericMapField_StoreLoadRoundTrips()
+    {
+        using var engine = new EmittedSessionEngine();
+        AssertOk(engine, GenericMapClassCell);
+        AssertOk(engine, "var g = G[string, int32]()");
+        AssertOk(engine, "g.S(\"a\", 42)");
+
+        var probe = engine.Evaluate("g.L(\"a\")");
+        Assert.False(probe.HasError, string.Join("; ", probe.Diagnostics));
+        Assert.Equal(42, probe.Value);
+    }
+
+    [Fact]
+    public void SameCell_GenericMapField_NilCompareBinds()
+    {
+        using var engine = new EmittedSessionEngine();
+        var result = engine.Evaluate(GenericMapClassCell + """
+
+
+            var g = G[string, int32]()
+            g.Ready()
+            """);
+
+        Assert.False(result.HasError, string.Join("; ", result.Diagnostics));
+        Assert.Equal(true, result.Value);
+    }
+
+    [Fact]
+    public void CrossCell_GenericMapField_NilCompareBinds()
+    {
+        using var engine = new EmittedSessionEngine();
+        AssertOk(engine, GenericMapClassCell);
+        AssertOk(engine, "var g = G[string, int32]()");
+
+        var probe = engine.Evaluate("g.Ready()");
+        Assert.False(probe.HasError, string.Join("; ", probe.Diagnostics));
+        Assert.Equal(true, probe.Value);
+    }
+
+    [Fact]
+    public void SameCell_MonomorphicMap_NilCompare_BothOperators()
+    {
+        using var engine = new EmittedSessionEngine();
+        var result = engine.Evaluate("""
+            var m = map[string, int32]{"a": 1}
+            var notNil = m != nil
+            var isNil = m == nil
+            notNil && !isNil
+            """);
+
+        Assert.False(result.HasError, string.Join("; ", result.Diagnostics));
+        Assert.Equal(true, result.Value);
+    }
+
+    [Fact]
+    public void CrossCell_MonomorphicMap_NilCompare_OnPriorCellGlobal()
+    {
+        // The prior-cell map global has a real loaded ClrType — the
+        // comparison must bind identically in that state.
+        using var engine = new EmittedSessionEngine();
+        AssertOk(engine, "var m = map[string, int32]{\"a\": 1}");
+
+        var probe = engine.Evaluate("m != nil");
+        Assert.False(probe.HasError, string.Join("; ", probe.Diagnostics));
+        Assert.Equal(true, probe.Value);
+    }
+
+    [Fact]
+    public void SameCell_UnassignedGenericMapField_ObservedAsNil()
+    {
+        using var engine = new EmittedSessionEngine();
+        var result = engine.Evaluate("""
+            class H[K, V any] {
+                var items map[K, V]
+                init() { }
+                func IsNil() bool { return items == nil }
+            }
+
+            var h = H[string, int32]()
+            h.IsNil()
+            """);
+
+        Assert.False(result.HasError, string.Join("; ", result.Diagnostics));
+        Assert.Equal(true, result.Value);
+    }
+
+    private static void AssertOk(EmittedSessionEngine engine, string cell)
+    {
+        var result = engine.Evaluate(cell);
+        Assert.False(result.HasError, $"cell '{cell}': {string.Join("; ", result.Diagnostics)}");
+    }
+}


### PR DESCRIPTION
Fixes #3303. Part of #3163.

## Summary

- **Sub-bug 1 (generic `map[K, V]` field NRE): already fixed by #3306, now pinned from the issue's own repros.** The issue was filed ~90 minutes before #3306 merged; its root cause was the same #3301 family (map index-read/assign/len/delete emit sites reflecting over the null `MapTypeSymbol.ClrType`, which is null *by construction* for type-parameter K/V). On current main the exact repro compiles, runs, and returns 42 under `gsc`, `gsi`, EmittedOracle, and the session engine. This PR adds the missing regression pins across the whole matrix: exact repro, len/delete through the field, value-type / user-struct / nested-generic type arguments, struct-key maps, generic **struct** containers, MVAR generic-method locals, monomorphic control, same-cell + cross-cell REPL.
- **Sub-bug 2 (`m != nil` / `m == nil` fails to bind, GS0129): fixed.** `MapTypeSymbol` was missing from `IsNullCompare`'s reference-shaped family (#796 functions/sequences, #2300 interfaces, #2354 classes) even though a map is unconditionally a reference-backed `Dictionary<K, V>` and a declared-but-unassigned map field genuinely IS nil (this very issue's failure mode). **Semantics chosen: comparison-only, mirroring function types** — nil *assignment* into a bare map slot still requires the explicit `map[K, V]?` spelling (ADR-0104), pinned by test. Slices and channels do NOT bind nil-compare on main; they deliberately keep that rejection (pinned) — widening them is a separate language-surface decision.
- **ClrType-consumer sweep (completing #3306's consolidation):** two more open-map binder gaps found by the sweep and fixed — `map[K,V] → object` widening (GS0155) and open-map arguments in CLR overload resolution (GS0159 on `Console.WriteLine(items)`), both of which bound fine monomorphically.
- No emitter changes needed: the equality `ldnull; ceq` tail and the `map → object` no-op reference conversion (`IsReferenceCompatible`'s #1481 arm) were already verifier-clean for the open `Dictionary<!0, !1>` shape. No new caches (GSA0004/RemapScope not implicated).

## ClrType-consumer sweep table

| Site | Consumer | Handled how |
|---|---|---|
| `MethodBodyEmitter.EmitMapLiteral` | `literal.MapType.ClrType` | symbolic `Dictionary`2` ctor/set_Item MemberRefs since #1481 — pinned |
| `MethodBodyEmitter.EmitLen` (map arm) | `mapType.ClrType` | symbolic `get_Count` since #3306 — pinned |
| `MethodBodyEmitter.EmitMapDelete` | `mapType.ClrType` | symbolic `Remove` since #3306 — pinned |
| `MethodBodyEmitter.EmitMapIndexRead` | `mapType.ClrType` | symbolic `TryGetValue` since #3306 — pinned |
| `MethodBodyEmitter.EmitMapIndexAssignment` | `mapType.ClrType` | symbolic `set_Item` since #3306 — pinned |
| `SignatureEncoder.EncodeTypeSymbol` (field/local/param/state-machine sigs) | open-map arm | symbolic `GENERICINST Dictionary`2<K,V>` since #1481 — unchanged |
| `MethodBodyEmitter.IsReferenceCompatible` (map → object emit) | null-safe #1481 arm | unchanged; now actually reachable from the binder |
| `BoundBinaryOperator.IsNullCompare` | *(missing arm)* | **fixed here** — map joins the #796 reference-shaped nil-compare family |
| `Conversion.Classify` object widening | required `from.ClrType != null` | **fixed here** — reference-shaped map arm (mirrors #1229/#1421) |
| `MemberLookup.TryProjectErasedClrType` | no map case (#833 projection) | **fixed here** — erase K/V, re-form closed `Dictionary<,>` (mirrors slice/sequence cases) |
| `ExpressionBinder.GetEffectiveArgumentClrTypeForOverloadResolution` | no map arm (#2182 family) | **fixed here** — matching map arm |
| CLR interop **member lookup** on an open-map receiver (`items.ContainsKey/.Keys/.GetEnumerator`) | `receiver.Type.ClrType` reflection | **residual, clean diagnostic** (GS0159 "Cannot find function …", no NRE): receiver-side member reflection needs a closed CLR type; rerouting through the imported-generic machinery (which is how `ConcurrentDictionary[K, V]` works today) is follow-up-sized. Monomorphic maps unaffected. |
| `for k, v in range m` / containment | n/a | not a ClrType consumer: map range/`in` are unsupported for ALL maps today (GS0116), generic and monomorphic alike |

No `NullReferenceException` remains on any consumer for the null-ClrType map shapes.

## Verification

- Release solution build: 0 warnings, 0 errors (includes the bootstrap compile of `Gsharp.Extensions`' Sync.gs through the changed binder paths).
- Witnesses (ADR-0154), fix hunks stashed → rebuilt: **Core.Tests 10/22 red** (nil-compare witnesses with GS0129, object-widening with GS0155, overload-resolution with GS0159 — exact issue signatures), **Interpreter.Tests 6/7 red**; restored → **22/22 and 7/7 green**. Green-both-sides arms are the documented #3306 regression pins (sub-bug 1 was already fixed on main) plus the deliberate slice/channel/`map?`/no-bare-nil-assignment guards.
- Core.Tests (full): 7261 passed, 0 failed, 1 skipped (the always-skipped `RegenerateBaseline`).
- Interpreter.Tests (full): 1454 passed, 0 failed.
- Compiler.Tests LanguageConformance filter: 127/127 passed.
- Extensions.Tests (full, SyncMap surface): 121/121 passed.
- ILVerify: 4 CLI repro binaries built with the final compiler (full generic-field matrix incl. struct keys/values and nested generics; nil-compare both operators/orders; unassigned-field nil; `Console.WriteLine(items)`/object widening) — "All Classes and Methods Verified" for each. Driver parity: `gsi` prints identical results for all repro programs.
- NOT RUN: full Compiler.Tests outside the LanguageConformance filter, LanguageServer/Sdk/InternalAnalyzers suites, Cs2Gs.Tests (known non-deterministic host crash per repo memory), e2etests. Rationale: the change is four narrow binder arms in Core; Core.Tests + Interpreter.Tests + the conformance gate + Extensions.Tests exercise the shared binding/emit paths across drivers.

## Checklist

- [x] Behavioral tests carry a witness of discrimination (ADR-0154): stash-revert run recorded above; each nil-compare/sweep witness red pre-fix with the exact diagnostic id it pins, all green post-fix. #3306-matrix arms are explicit regression pins (documented as green-both-sides).
- [x] Self-review verdict: MERGEABLE — three additive binder arms mirroring long-established per-shape patterns (each new arm sits beside its #796/#1229/#833/#2182 sibling), comparison-only nil semantics inherited from the function-type precedent rather than invented, and the single residual (open-map interop member lookup, clean GS0159) documented above as follow-up-sized rather than half-patched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)