### PR TITLE
Fix #3311: interop member lookup on open-generic map receivers via the symbolic Dictionary view

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
@@ -601,7 +601,7 @@ internal sealed partial class ExpressionBinder
 
                     return BindExtensionMethodGroupOrError(receiver, ne);
                 }
-                else if (CanBindClrInstanceMember(receiver))
+                else if (TryGetClrInstanceMemberReceiverType(receiver, out var clrInstanceReceiverType))
                 {
                     // Phase 4 exit: read a public instance property or field on
                     // a CLR receiver (e.g. `lst.Count`, `sb.Length`,
@@ -609,8 +609,12 @@ internal sealed partial class ExpressionBinder
                     // ImportedClassSymbol; this path covers instances. Permit a
                     // chained CLR member whose oblivious metadata made its
                     // result nullable, while explicit nullable variables still
-                    // require narrowing or `?.`.
-                    var clrReceiverType = receiver.Type.ClrType;
+                    // require narrowing or `?.`. Issue #3311: an open-generic
+                    // `map[K, V]` receiver (null ClrType) is normalized to its
+                    // symbolic Dictionary view so `.Keys`/`.Count`/… resolve
+                    // over the erased closed shape with symbolic [K, V]
+                    // re-projection, exactly as on `Dictionary[K, V]`.
+                    var clrReceiverType = clrInstanceReceiverType.ClrType;
                     var memberName = ne.IdentifierToken.Text;
 
                     // Issue #529: use interface-aware lookup so that members
@@ -645,7 +649,7 @@ internal sealed partial class ExpressionBinder
                         // surfaces as `ICollection[K]` (a generic shape
                         // containing the in-scope `K`) instead of the
                         // type-erased `ICollection<object>`.
-                        var receiverOverride = ResolveInstancePropertyTypeFromReceiver(receiver.Type, prop);
+                        var receiverOverride = ResolveInstancePropertyTypeFromReceiver(clrInstanceReceiverType, prop);
                         var propType = receiverOverride
                             ?? (prop.PropertyType.IsByRef
                                 ? MapClrMemberType(prop.PropertyType)
@@ -747,6 +751,38 @@ internal sealed partial class ExpressionBinder
         return receiver?.Type?.ClrType != null
             && (receiver.Type is not NullableTypeSymbol
                 || receiver is BoundClrPropertyAccessExpression);
+    }
+
+    /// <summary>
+    /// Issue #3311: resolves the effective receiver type used for CLR
+    /// instance-member lookup. A receiver with a loadable
+    /// <see cref="TypeSymbol.ClrType"/> is used as-is
+    /// (<see cref="CanBindClrInstanceMember"/>); an open-generic
+    /// <c>map[K, V]</c> receiver — whose ClrType is null by construction when
+    /// K or V is a type parameter — surfaces the symbolic constructed
+    /// <c>Dictionary[K, V]</c> view instead, so the interop member surface
+    /// (<c>.Keys</c>, <c>.Values</c>, <c>.Count</c>, method groups) resolves
+    /// exactly as on an explicitly-typed <c>Dictionary[K, V]</c> receiver.
+    /// </summary>
+    /// <param name="receiver">The bound receiver expression.</param>
+    /// <param name="effectiveType">The effective lookup type, on success.</param>
+    /// <returns><see langword="true"/> when CLR instance lookup may proceed.</returns>
+    private static bool TryGetClrInstanceMemberReceiverType(BoundExpression receiver, out TypeSymbol effectiveType)
+    {
+        if (CanBindClrInstanceMember(receiver))
+        {
+            effectiveType = receiver.Type;
+            return true;
+        }
+
+        if (MemberLookup.TryGetSymbolicOpenMapReceiverView(receiver?.Type, out var mapView))
+        {
+            effectiveType = mapView;
+            return true;
+        }
+
+        effectiveType = null;
+        return false;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -200,6 +200,11 @@ internal sealed partial class ExpressionBinder
     /// <see cref="ImportedTypeSymbol"/> over the erased array CLR type
     /// (e.g. <c>object[]</c>), reaching parity with a primitive-element array
     /// (which finds the non-generic <c>GetEnumerator()</c>).</item>
+    /// <item>issue #3311: open <c>map[K, V]</c> (null ClrType) → the symbolic
+    /// constructed <c>Dictionary[K, V]</c> view, so the CLR-interop member
+    /// surface (<c>ContainsKey</c>, <c>TryGetValue</c>, <c>GetEnumerator</c>,
+    /// …) resolves exactly as on an explicit <c>Dictionary[K, V]</c>
+    /// receiver.</item>
     /// </list>
     /// The bound call keeps the original receiver expression; the emitter
     /// already normalizes sequence/array receivers
@@ -235,6 +240,26 @@ internal sealed partial class ExpressionBinder
                 if (MemberLookup.TryProjectErasedClrType(receiverType, out var erasedArray))
                 {
                     normalized = ImportedTypeSymbol.Get(erasedArray);
+                    return true;
+                }
+
+                return false;
+            case MapTypeSymbol:
+                // Issue #3311: interop member calls on an open-generic map
+                // receiver (`items.ContainsKey(k)` where `items : map[K, V]`
+                // with type-parameter K/V) dead-ended with GS0159 because the
+                // receiver's ClrType is null by construction. Its runtime
+                // backing is always `Dictionary<K, V>`, so normalize to the
+                // same symbolic constructed shape an explicit
+                // `Dictionary[K, V]` receiver carries (#313/#794/#1107): the
+                // erased closed ClrType drives member lookup, the symbolic
+                // [K, V] arguments drive return/parameter/out-var
+                // re-projection, and the emitter parents the MemberRefs at
+                // the `Dictionary<!K, !V>` TypeSpec
+                // (TryNormalizeToSymbolicContainer's map arm).
+                if (MemberLookup.TryGetSymbolicOpenMapReceiverView(receiverType, out var mapView))
+                {
+                    normalized = mapView;
                     return true;
                 }
 
@@ -2980,7 +3005,12 @@ internal sealed partial class ExpressionBinder
                         // any inline `out var`/`out let`/`out _` placeholders
                         // against the resolved by-ref parameter so the new
                         // local is declared with the inferred pointee type.
-                        arguments = RebindInlineOutVarArguments(ce, arguments, resolution.Best, resolution.ParameterMapping, receiver?.Type, typeArgSymbols);
+                        // Issue #3311: pass the NORMALIZED receiver type so an
+                        // open map's `out TValue` (e.g. TryGetValue) recovers
+                        // the symbolic V via the Dictionary view's symbolic
+                        // arguments, exactly as an explicit Dictionary[K, V]
+                        // receiver does (#1107).
+                        arguments = RebindInlineOutVarArguments(ce, arguments, resolution.Best, resolution.ParameterMapping, effectiveReceiverType, typeArgSymbols);
 
                         // Issue #1512: for a genuine INSTANCE method the receiver
                         // is `this`, not a formal parameter — `GetParameters()`
@@ -3020,6 +3050,18 @@ internal sealed partial class ExpressionBinder
                         // Issue #1638: shared CLR call-argument-construction
                         // pipeline (interpolation rebind → handler args →
                         // delegate rebind → parameter conversions).
+                        // Issue #3311: the parameter-conversion pass keeps the
+                        // RAW receiver type per #1512/#1320, EXCEPT for an open
+                        // map — its MapTypeSymbol carries no OpenDefinition, so
+                        // TrySubstituteParameterTypeFromReceiver could not
+                        // recover the symbolic `!0` parameter slot and a K
+                        // argument (e.g. ContainsKey(k)) would box to the
+                        // erased `object`, tripping the verifier against the
+                        // symbolic `Dictionary<!K, !V>` MemberRef. Feed it the
+                        // normalized Dictionary view instead.
+                        var instConversionReceiverType = MemberLookup.TryGetSymbolicOpenMapReceiverView(receiver?.Type, out _)
+                            ? effectiveReceiverType
+                            : receiver?.Type;
                         var instConvertedArgs = BuildResolvedClrCallArguments(
                             instExpandedArgs,
                             ce.Arguments,
@@ -3035,7 +3077,7 @@ internal sealed partial class ExpressionBinder
                             symbolicMethodTypeArgs: instTypeArgSymbolsForCall,
                             receiverType: effectiveReceiverType,
                             hasConversionReceiverTypeOverride: true,
-                            conversionReceiverType: receiver?.Type);
+                            conversionReceiverType: instConversionReceiverType);
                         var instArguments = OverloadResolver.BuildOrderedCallArguments(instConvertedArgs, instDownstreamMapping, instParameters);
                         var instRefKinds = ComputeArgumentRefKinds(instParameters);
                         overloads.ValidateRefArguments(instArguments, instRefKinds, methodName, ce.Location);

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -2067,6 +2067,43 @@ internal sealed class MemberLookup
     }
 
     /// <summary>
+    /// Issue #3311: normalizes a <c>map[K, V]</c> receiver whose
+    /// <see cref="TypeSymbol.ClrType"/> is <see langword="null"/> (K or V is
+    /// an in-scope type parameter — null by construction — or a
+    /// same-compilation user class) to the symbolic constructed
+    /// <see cref="ImportedTypeSymbol"/> view an explicitly-typed
+    /// <c>Dictionary[K, V]</c> receiver already carries (#313/#794/#1107):
+    /// the type-erased closed <c>Dictionary&lt;…&gt;</c> shape drives
+    /// reflection member lookup, while the symbolic <c>[K, V]</c> arguments
+    /// drive return / parameter / out-var re-projection
+    /// (<see cref="MapOpenClrTypeToSymbolic(Type, Type, ImmutableArray{TypeSymbol})"/>)
+    /// and symbolic MemberRef parenting at emit
+    /// (<c>ImportedMemberRefFactory.TryNormalizeToSymbolicContainer</c>).
+    /// Concrete maps (loadable ClrType) are left on the existing reflection
+    /// fast path. Returns <see langword="false"/> when no normalization
+    /// applies.
+    /// </summary>
+    /// <param name="receiverType">The receiver's static type symbol.</param>
+    /// <param name="view">The symbolic Dictionary view, on success.</param>
+    /// <returns><see langword="true"/> when a symbolic view was produced.</returns>
+    public static bool TryGetSymbolicOpenMapReceiverView(TypeSymbol receiverType, out ImportedTypeSymbol view)
+    {
+        view = null;
+        if (receiverType is not MapTypeSymbol map
+            || map.ClrType != null
+            || !TryProjectErasedClrType(map, out var erasedMap))
+        {
+            return false;
+        }
+
+        view = ImportedTypeSymbol.GetConstructed(
+            erasedMap,
+            typeof(System.Collections.Generic.Dictionary<,>),
+            ImmutableArray.Create(map.KeyType, map.ValueType));
+        return true;
+    }
+
+    /// <summary>
     /// Probes a user-defined <see cref="StructSymbol"/> for the
     /// duck-typed enumerable shape (<c>GetEnumerator() → MoveNext() / Current</c>).
     /// </summary>

--- a/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
+++ b/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
@@ -1129,6 +1129,20 @@ internal sealed class ImportedMemberRefFactory
                 openDefinition = typeof(System.Nullable<>);
                 typeArguments = ImmutableArray.Create<TypeSymbol>(nullableTp);
                 return true;
+            case MapTypeSymbol map when map.ClrType == null:
+                // Issue #3311: a `map[K, V]` receiver over type-parameter (or
+                // other not-yet-loadable) arguments has no closed CLR
+                // Dictionary here — parent its interop member refs at the
+                // symbolic `Dictionary<!K, !V>` TypeSpec. This is the
+                // general-member counterpart of the dedicated #1481/#3306 map
+                // helpers (GetMapCtorReference / GetMapTryGetValueReference /
+                // …), covering the whole reflected member surface
+                // (ContainsKey, Keys, Count, GetEnumerator, …) that binding
+                // now resolves through the symbolic Dictionary view
+                // (MemberLookup.TryGetSymbolicOpenMapReceiverView).
+                openDefinition = typeof(System.Collections.Generic.Dictionary<,>);
+                typeArguments = ImmutableArray.Create(map.KeyType, map.ValueType);
+                return true;
             default:
                 openDefinition = null;
                 typeArguments = default;

--- a/src/Core/CodeAnalysis/Emit/UserTokenResolver.cs
+++ b/src/Core/CodeAnalysis/Emit/UserTokenResolver.cs
@@ -2162,8 +2162,18 @@ internal sealed class UserTokenResolver
         substitutedReturn = null;
         if (property == null
             || !ImportedMemberRefFactory.TryNormalizeToSymbolicContainer(receiverType, out var openDef, out var typeArguments)
-            || typeArguments.IsDefaultOrEmpty
-            || !typeArguments.Any(TypeSymbol.RequiresSymbolicProjection))
+            || typeArguments.IsDefaultOrEmpty)
+        {
+            return false;
+        }
+
+        // Issue #3311: mirror the symbolic-container MemberRef bail
+        // (ImportedMemberRefFactory line "#774 non-generic base"): a member
+        // declared on a non-generic type is emitted through the PLAIN
+        // MemberRef path (closed semantics), so the erasure-widening must
+        // stay in force for it.
+        var propDecl = property.DeclaringType;
+        if (propDecl != null && !propDecl.IsGenericType && propDecl != openDef)
         {
             return false;
         }
@@ -2175,7 +2185,26 @@ internal sealed class UserTokenResolver
         }
 
         substitutedReturn = MemberLookup.MapOpenClrTypeToSymbolic(openProp.PropertyType, openDef, typeArguments);
-        return substitutedReturn != null && substitutedReturn != TypeSymbol.Error;
+        if (substitutedReturn == null || substitutedReturn == TypeSymbol.Error)
+        {
+            return false;
+        }
+
+        // The symbolic-container MemberRef fires for ANY non-empty argument
+        // vector, so the runtime stack holds the SUBSTITUTED member type
+        // whenever it differs from the closed (possibly erased) CLR shape:
+        // a symbolic argument (in-scope type parameter / same-compilation
+        // user type — the original #774 case), or (issue #3311) a CONCRETE
+        // argument recovered through an erased closed receiver — e.g. the
+        // `IEnumerator[int32]` enumerator of `Dictionary[int32, V].Keys`,
+        // whose closed `Current` reports `object` while the emitted
+        // MemberRef returns `!0` = int32. In both shapes the widening must
+        // be skipped; when the substituted and closed CLR types agree the
+        // widening is a no-op either way, so returning false there keeps
+        // the historical IL byte-identical.
+        return typeArguments.Any(TypeSymbol.RequiresSymbolicProjection)
+            || (substitutedReturn.ClrType is { } substitutedClr
+                && !ClrTypeUtilities.AreSame(substitutedClr, property.PropertyType));
     }
 
     /// <summary>
@@ -2205,8 +2234,17 @@ internal sealed class UserTokenResolver
         substitutedReturn = null;
         if (method == null
             || !ImportedMemberRefFactory.TryNormalizeToSymbolicContainer(receiverType, out var openDef, out var typeArguments)
-            || typeArguments.IsDefaultOrEmpty
-            || !typeArguments.Any(TypeSymbol.RequiresSymbolicProjection))
+            || typeArguments.IsDefaultOrEmpty)
+        {
+            return false;
+        }
+
+        // Issue #3311: mirror the symbolic-container MemberRef bail — a
+        // method declared on a non-generic type goes through the PLAIN
+        // MemberRef path (closed semantics), so the erasure-widening must
+        // stay in force for it. See the property variant above.
+        var methodDecl = method.DeclaringType;
+        if (methodDecl != null && !methodDecl.IsGenericType && methodDecl != openDef)
         {
             return false;
         }
@@ -2224,7 +2262,18 @@ internal sealed class UserTokenResolver
         }
 
         substitutedReturn = MemberLookup.MapOpenClrTypeToSymbolic(openReturn, openDef, typeArguments);
-        return substitutedReturn != null && substitutedReturn != TypeSymbol.Error;
+        if (substitutedReturn == null || substitutedReturn == TypeSymbol.Error)
+        {
+            return false;
+        }
+
+        // Issue #3311: also fire for a CONCRETE argument recovered through an
+        // erased closed receiver (mixed instantiations such as
+        // `Dictionary[int32, V]`); see the property variant above for the
+        // rationale.
+        return typeArguments.Any(TypeSymbol.RequiresSymbolicProjection)
+            || (substitutedReturn.ClrType is { } substitutedClr
+                && !ClrTypeUtilities.AreSame(substitutedClr, method.ReturnType));
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/Lowerer.cs
@@ -1371,10 +1371,28 @@ public sealed class Lowerer : BoundTreeRewriter
                 // re-introduce the bug we fixed in the binder. Use the
                 // enumerator's symbolic type argument instead so the
                 // BoundClrPropertyAccessExpression carries the user's `T`.
+                //
+                // Issue #3311: the synthesised `IEnumerator[ElementSym]` must
+                // take this path even when ElementSym happens to be CONCRETE —
+                // a MIXED instantiation such as `Dictionary[int32, V].Keys`
+                // recovers `IEnumerator[int32]` through the erased closed
+                // shape, and the emitted symbolic MemberRef
+                // (`IEnumerator`1<int32>::get_Current`) already leaves an
+                // int32 on the stack. Falling back to the closed `object`
+                // getter type here injected an `object → int32` conversion
+                // whose `unbox.any` tripped the verifier (StackObjRef) and
+                // crashed at runtime. Gate on the synthesised IEnumerator`1
+                // open definition so real struct enumerators (whose Current is
+                // NOT the first type argument, e.g. Dictionary's
+                // KeyValuePair-returning Enumerator) keep the reflected type.
                 TypeSymbol currentType = null;
                 if (enumeratorType is ImportedTypeSymbol enumImp
-                    && enumImp.HasSubstitutableTypeArgument
-                    && !enumImp.TypeArguments.IsDefaultOrEmpty)
+                    && !enumImp.TypeArguments.IsDefaultOrEmpty
+                    && (enumImp.HasSubstitutableTypeArgument
+                        || string.Equals(
+                            enumImp.OpenDefinition?.FullName,
+                            "System.Collections.Generic.IEnumerator`1",
+                            System.StringComparison.Ordinal)))
                 {
                     currentType = enumImp.TypeArguments[0];
                 }

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue3311OpenMapMemberLookupEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue3311OpenMapMemberLookupEmitTests.cs
@@ -394,6 +394,44 @@ public class Issue3311OpenMapMemberLookupEmitTests
         Assert.Equal(42, result.Value);
     }
 
+    [Fact]
+    public void ExplicitDictionary_MixedArity_KeysIteration_Fixed()
+    {
+        // Companion latent bug fixed by the same change (pre-existing on
+        // main, NOT map-specific): iterating `.Keys` of an explicit
+        // `Dictionary[int32, V]` — a MIXED concrete/open instantiation —
+        // recovered `IEnumerator[int32]` through the erased closed shape,
+        // but the loop lowering fell back to the closed `object` Current
+        // (HasSubstitutableTypeArgument is false for [int32]) and the
+        // widening-skip guard required a symbolic type argument, injecting
+        // a spurious `unbox.any int32` (ILVerify StackObjRef, runtime NRE).
+        var result = EmittedOracle.Evaluate("""
+            package P3311DictMixed
+
+            import System.Collections.Generic
+
+            func SumKeys[V any](d Dictionary[int32, V]) int32 {
+                var total = 0
+                for k in d.Keys {
+                    total = total + k
+                }
+                return total
+            }
+
+            func run() int32 {
+                var m = Dictionary[int32, string]()
+                m[40] = "a"
+                m[2] = "b"
+                return SumKeys[string](m)
+            }
+
+            run()
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Severity == GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error);
+        Assert.Equal(42, result.Value);
+    }
+
     // ---------------------------------------------------------------
     // Regression pins.
     // ---------------------------------------------------------------

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue3311OpenMapMemberLookupEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue3311OpenMapMemberLookupEmitTests.cs
@@ -1,0 +1,488 @@
+// <copyright file="Issue3311OpenMapMemberLookupEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #3311 (residual from #3303 / PR #3309, part of #3163): CLR-interop
+/// member access on an OPEN-generic <c>map[K, V]</c> receiver —
+/// <c>items.ContainsKey(k)</c>, <c>items.Keys</c>, <c>items.Count</c>,
+/// <c>items.GetEnumerator()</c> — inside a generic function or generic type
+/// reported GS0159 (member not found) because member lookup reflected over
+/// <c>MapTypeSymbol.ClrType</c>, which is null by construction when K or V is
+/// a type parameter.
+///
+/// <para>The fix normalizes an open map receiver to the same symbolic
+/// constructed <c>Dictionary[K, V]</c> view an explicitly-typed
+/// <c>Dictionary[K, V]</c> receiver already carries (#313/#794/#1107): the
+/// erased closed shape drives reflection lookup, the symbolic [K, V]
+/// arguments drive return/parameter/out-var re-projection, and the emitter
+/// parents the MemberRefs at the <c>Dictionary&lt;!K, !V&gt;</c> TypeSpec
+/// (the general-member counterpart of the #1481/#3306 dedicated map
+/// helpers).</para>
+///
+/// <para>The builtin operations (<c>m[k]</c>, <c>len</c>, <c>delete</c>,
+/// <c>range</c>) already worked on open maps (#3306/#3309); regression pins
+/// for those, and for CONCRETE-map member access, are included at the
+/// bottom.</para>
+/// </summary>
+public class Issue3311OpenMapMemberLookupEmitTests
+{
+    // ---------------------------------------------------------------
+    // Generic FUNCTION context — the issue's headline repro shapes.
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void GenericFunc_ContainsKey_OnOpenMap_Binds_And_Runs()
+    {
+        var result = EmittedOracle.Evaluate("""
+            package P3311ContainsKey
+
+            func Has[K any, V any](items map[K, V], k K) bool {
+                return items.ContainsKey(k)
+            }
+
+            func run() bool {
+                var m = map[string, int32]{"a": 1}
+                return Has[string, int32](m, "a") && !Has[string, int32](m, "b")
+            }
+
+            run()
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Severity == GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error);
+        Assert.Equal(true, result.Value);
+    }
+
+    [Fact]
+    public void GenericFunc_TryGetValue_OutVar_Recovers_Symbolic_V()
+    {
+        // The out-var local must bind as the symbolic V (not the erased
+        // object) so it can be returned at the V-typed slot.
+        var result = EmittedOracle.Evaluate("""
+            package P3311TryGetValue
+
+            func Find[K any, V any](items map[K, V], k K, fb V) V {
+                var ok = items.TryGetValue(k, out var v)
+                if ok { return v }
+                return fb
+            }
+
+            func run() int32 {
+                var m = map[string, int32]{"a": 41}
+                return Find[string, int32](m, "a", 0) + Find[string, int32](m, "b", 1)
+            }
+
+            run()
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Severity == GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void GenericFunc_Keys_Iteration_Recovers_Symbolic_K()
+    {
+        // `.Keys` must surface as a keyed collection over the symbolic K so
+        // the iteration variable unifies with the K-typed return.
+        var result = EmittedOracle.Evaluate("""
+            package P3311Keys
+
+            func SumKeys[V any](items map[int32, V]) int32 {
+                var total = 0
+                for k in items.Keys {
+                    total = total + k
+                }
+                return total
+            }
+
+            func run() int32 {
+                var m = map[int32, string]{40: "a", 2: "b"}
+                return SumKeys[string](m)
+            }
+
+            run()
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Severity == GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void GenericFunc_Keys_FullyOpen_ReturnsFirstKey_As_K()
+    {
+        // Fully-open twin of the #794 `Dictionary[K, V]().Keys` shape, but
+        // through the map[K, V] spelling: the iteration variable must be K.
+        var result = EmittedOracle.Evaluate("""
+            package P3311KeysOpen
+
+            func FirstKey[K any, V any](items map[K, V], fb K) K {
+                for k in items.Keys {
+                    return k
+                }
+                return fb
+            }
+
+            func run() string {
+                var m = map[string, int32]{"hit": 1}
+                return FirstKey[string, int32](m, "miss")
+            }
+
+            run()
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Severity == GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error);
+        Assert.Equal("hit", result.Value);
+    }
+
+    [Fact]
+    public void GenericFunc_Values_Iteration_Recovers_Symbolic_V()
+    {
+        var result = EmittedOracle.Evaluate("""
+            package P3311Values
+
+            func SumValues[K any](items map[K, int32]) int32 {
+                var total = 0
+                for v in items.Values {
+                    total = total + v
+                }
+                return total
+            }
+
+            func run() int32 {
+                var m = map[string, int32]{"a": 40, "b": 2}
+                return SumValues[string](m)
+            }
+
+            run()
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Severity == GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void GenericFunc_Count_Property_OnOpenMap()
+    {
+        var result = EmittedOracle.Evaluate("""
+            package P3311Count
+
+            func Size[K any, V any](items map[K, V]) int32 {
+                return items.Count
+            }
+
+            func run() int32 {
+                var m = map[string, int32]{"a": 1, "b": 2, "c": 3}
+                return Size[string, int32](m)
+            }
+
+            run()
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Severity == GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error);
+        Assert.Equal(3, result.Value);
+    }
+
+    [Fact]
+    public void GenericFunc_GetEnumerator_ManualLoop_OnOpenMap()
+    {
+        // GetEnumerator() returns the symbolic Dictionary[K, V].Enumerator;
+        // MoveNext/Current.Key/Current.Value must chain through it.
+        var result = EmittedOracle.Evaluate("""
+            package P3311Enumerator
+
+            func Sum[K any](items map[K, int32]) int32 {
+                var total = 0
+                var e = items.GetEnumerator()
+                while e.MoveNext() {
+                    total = total + e.Current.Value
+                }
+                return total
+            }
+
+            func run() int32 {
+                var m = map[string, int32]{"a": 40, "b": 2}
+                return Sum[string](m)
+            }
+
+            run()
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Severity == GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error);
+        Assert.Equal(42, result.Value);
+    }
+
+    // ---------------------------------------------------------------
+    // Generic TYPE context — the member surface through a map field.
+    // ---------------------------------------------------------------
+
+    private const string GenericMapMemberClass = """
+        class G[K, V any] {
+            var items map[K, V]
+            init() { items = map[K, V]{} }
+            func S(k K, v V) { items[k] = v }
+            func Has(k K) bool { return items.ContainsKey(k) }
+            func Find(k K, fb V) V {
+                var ok = items.TryGetValue(k, out var v)
+                if ok { return v }
+                return fb
+            }
+            func N() int32 { return items.Count }
+        }
+        """;
+
+    [Fact]
+    public void GenericClass_ContainsKey_Through_MapField()
+    {
+        var result = EmittedOracle.Evaluate($$"""
+            package P3311ClassHas
+
+            {{GenericMapMemberClass}}
+
+            func run() bool {
+                var g = G[string, int32]()
+                g.S("a", 1)
+                return g.Has("a") && !g.Has("b")
+            }
+
+            run()
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Severity == GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error);
+        Assert.Equal(true, result.Value);
+    }
+
+    [Fact]
+    public void GenericClass_TryGetValue_And_Count_Through_MapField()
+    {
+        var result = EmittedOracle.Evaluate($$"""
+            package P3311ClassFind
+
+            {{GenericMapMemberClass}}
+
+            func run() int32 {
+                var g = G[string, int32]()
+                g.S("a", 40)
+                return g.Find("a", 0) + g.Find("b", 1) + g.N()
+            }
+
+            run()
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Severity == GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error);
+        Assert.Equal(42, result.Value);
+    }
+
+    // ---------------------------------------------------------------
+    // Instantiation matrix: value-type, reference-type, user-struct
+    // type arguments through the generic member surface.
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void GenericClass_ValueTypeInstantiation_MemberSurface()
+    {
+        var result = EmittedOracle.Evaluate($$"""
+            package P3311ValueInst
+
+            {{GenericMapMemberClass}}
+
+            func run() int32 {
+                var g = G[int32, int32]()
+                g.S(7, 40)
+                if g.Has(7) {
+                    return g.Find(7, 0) + g.N() + 1
+                }
+                return -1
+            }
+
+            run()
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Severity == GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void GenericClass_ReferenceTypeInstantiation_MemberSurface()
+    {
+        var result = EmittedOracle.Evaluate($$"""
+            package P3311RefInst
+
+            {{GenericMapMemberClass}}
+
+            func run() string {
+                var g = G[string, string]()
+                g.S("k", "hit")
+                if g.Has("k") {
+                    return g.Find("k", "miss")
+                }
+                return "miss"
+            }
+
+            run()
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Severity == GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error);
+        Assert.Equal("hit", result.Value);
+    }
+
+    [Fact]
+    public void GenericClass_UserStructValueInstantiation_MemberSurface()
+    {
+        // V substituted with a same-compilation user struct — the
+        // symbol-only value-type shape whose ClrType is null even
+        // monomorphically (#3301/#3306 family).
+        var result = EmittedOracle.Evaluate($$"""
+            package P3311StructInst
+
+            struct Pt { var X int32 }
+
+            {{GenericMapMemberClass}}
+
+            func run() int32 {
+                var g = G[string, Pt]()
+                g.S("a", Pt{X: 42})
+                if g.Has("a") {
+                    return g.Find("a", Pt{X: 0}).X
+                }
+                return -1
+            }
+
+            run()
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Severity == GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void GenericFunc_UserStructInstantiation_ContainsKey_And_Keys()
+    {
+        var result = EmittedOracle.Evaluate("""
+            package P3311StructFunc
+
+            struct Pt { var X int32 }
+
+            func Has[K any, V any](items map[K, V], k K) bool {
+                return items.ContainsKey(k)
+            }
+
+            func CountKeys[K any, V any](items map[K, V]) int32 {
+                var n = 0
+                for k in items.Keys {
+                    n = n + 1
+                }
+                return n
+            }
+
+            func run() int32 {
+                var m = map[string, Pt]{"a": Pt{X: 1}, "b": Pt{X: 2}}
+                if Has[string, Pt](m, "a") {
+                    return 40 + CountKeys[string, Pt](m)
+                }
+                return -1
+            }
+
+            run()
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Severity == GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error);
+        Assert.Equal(42, result.Value);
+    }
+
+    // ---------------------------------------------------------------
+    // Regression pins.
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void Pin_ConcreteMap_MemberAccess_Unchanged()
+    {
+        // Monomorphic control: the loadable-ClrType reflection fast path
+        // must keep working exactly as before.
+        var result = EmittedOracle.Evaluate("""
+            package P3311ConcretePin
+
+            import Gsharp.Extensions.Go
+
+            func run() int32 {
+                var m = map[string, int32]{"a": 40, "b": 2}
+                var total = 0
+                var ok = m.TryGetValue("b", out var v)
+                if m.ContainsKey("a") && ok {
+                    total = total + v + m.Count
+                }
+                for k in m.Keys {
+                    total = total + 1
+                }
+                return total * 6
+            }
+
+            run()
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Severity == GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error);
+        Assert.Equal(36, result.Value);
+    }
+
+    [Fact]
+    public void Pin_OpenMap_BuiltinOps_Unchanged()
+    {
+        // The #3306/#3309 arms: index read/assign, len, delete on an open
+        // map must keep working alongside the new member surface. (Map
+        // `for ... in` iteration is a separate pre-existing GS0116 gap for
+        // ALL maps — documented in #3309 — so it is not exercised here.)
+        var result = EmittedOracle.Evaluate("""
+            package P3311BuiltinPin
+
+            import Gsharp.Extensions.Go
+
+            func Mix[K any](items map[K, int32], k K) int32 {
+                items[k] = 40
+                var total = items[k] + len(items)
+                delete(items, k)
+                return total + len(items) + 1
+            }
+
+            func run() int32 {
+                var m = map[string, int32]{}
+                return Mix[string](m, "a")
+            }
+
+            run()
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Severity == GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void Pin_OpenMap_OverloadArgument_Unchanged()
+    {
+        // The #3309 overload-argument arm: an open map passed to a CLR
+        // overload set (object-shaped parameter) must keep resolving.
+        var result = EmittedOracle.Evaluate("""
+            package P3311OverloadPin
+
+            import System
+
+            func Show[K any, V any](items map[K, V]) {
+                Console.WriteLine(items)
+            }
+
+            func run() int32 {
+                var m = map[string, int32]{"a": 1}
+                Show[string, int32](m)
+                return 42
+            }
+
+            run()
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Severity == GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error);
+        Assert.Equal(42, result.Value);
+    }
+}

--- a/test/Interpreter.Tests/Issue3311OpenMapMemberReplTests.cs
+++ b/test/Interpreter.Tests/Issue3311OpenMapMemberReplTests.cs
@@ -1,0 +1,148 @@
+// <copyright file="Issue3311OpenMapMemberReplTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Repl.Engine;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #3311: CLR-interop member access on open-generic <c>map[K, V]</c>
+/// receivers (<c>ContainsKey</c> / <c>TryGetValue</c> / <c>Keys</c> /
+/// <c>Count</c>) through the session engine, in both same-cell and
+/// cross-cell form. The same-cell arms compile while the generic container's
+/// TypeDef is still being emitted; the cross-cell arms pin parity once the
+/// prior cell's class carries a real loaded ClrType.
+/// </summary>
+public sealed class Issue3311OpenMapMemberReplTests
+{
+    private const string GenericMapMemberClassCell = """
+        class G[K, V any] {
+            var items map[K, V]
+            init() { items = map[K, V]{} }
+            func S(k K, v V) { items[k] = v }
+            func Has(k K) bool { return items.ContainsKey(k) }
+            func Find(k K, fb V) V {
+                var ok = items.TryGetValue(k, out var v)
+                if ok { return v }
+                return fb
+            }
+            func N() int32 { return items.Count }
+            func SumKeys() int32 {
+                var n = 0
+                for k in items.Keys {
+                    n = n + 1
+                }
+                return n
+            }
+        }
+        """;
+
+    [Fact]
+    public void SameCell_GenericMapMember_ContainsKey_And_TryGetValue()
+    {
+        using var engine = new EmittedSessionEngine();
+        var result = engine.Evaluate(GenericMapMemberClassCell + """
+
+
+            var g = G[string, int32]()
+            g.S("a", 41)
+            var x = g.Find("a", 0)
+            var missing = g.Find("b", 1)
+            g.Has("a") && !g.Has("b") && x + missing == 42
+            """);
+
+        Assert.False(result.HasError, string.Join("; ", result.Diagnostics));
+        Assert.Equal(true, result.Value);
+    }
+
+    [Fact]
+    public void SameCell_GenericMapMember_Count_And_Keys()
+    {
+        using var engine = new EmittedSessionEngine();
+        var result = engine.Evaluate(GenericMapMemberClassCell + """
+
+
+            var g = G[string, string]()
+            g.S("a", "x")
+            g.S("b", "y")
+            g.N() * 10 + g.SumKeys()
+            """);
+
+        Assert.False(result.HasError, string.Join("; ", result.Diagnostics));
+        Assert.Equal(22, result.Value);
+    }
+
+    [Fact]
+    public void SameCell_GenericFunc_ContainsKey_On_OpenMapParameter()
+    {
+        using var engine = new EmittedSessionEngine();
+        var result = engine.Evaluate("""
+            func Has[K any, V any](items map[K, V], k K) bool {
+                return items.ContainsKey(k)
+            }
+
+            var m = map[string, int32]{"a": 1}
+            Has[string, int32](m, "a") && !Has[string, int32](m, "b")
+            """);
+
+        Assert.False(result.HasError, string.Join("; ", result.Diagnostics));
+        Assert.Equal(true, result.Value);
+    }
+
+    [Fact]
+    public void CrossCell_GenericMapMember_FullSurface()
+    {
+        using var engine = new EmittedSessionEngine();
+        AssertOk(engine, GenericMapMemberClassCell);
+        AssertOk(engine, "var g = G[string, int32]()");
+        AssertOk(engine, "g.S(\"a\", 40)");
+
+        var has = engine.Evaluate("g.Has(\"a\")");
+        Assert.False(has.HasError, string.Join("; ", has.Diagnostics));
+        Assert.Equal(true, has.Value);
+
+        var probe = engine.Evaluate("g.Find(\"a\", 0) + g.N() + g.SumKeys()");
+        Assert.False(probe.HasError, string.Join("; ", probe.Diagnostics));
+        Assert.Equal(42, probe.Value);
+    }
+
+    [Fact]
+    public void CrossCell_GenericFunc_MemberSurface_OnLaterCellMap()
+    {
+        using var engine = new EmittedSessionEngine();
+        AssertOk(engine, """
+            func Size[K any, V any](items map[K, V]) int32 {
+                return items.Count
+            }
+            """);
+        AssertOk(engine, "var m = map[string, int32]{\"a\": 1, \"b\": 2}");
+
+        var probe = engine.Evaluate("Size[string, int32](m)");
+        Assert.False(probe.HasError, string.Join("; ", probe.Diagnostics));
+        Assert.Equal(2, probe.Value);
+    }
+
+    [Fact]
+    public void SameCell_ConcreteMap_MemberAccess_Pin()
+    {
+        // Monomorphic control: loadable-ClrType member access through the
+        // session engine keeps working.
+        using var engine = new EmittedSessionEngine();
+        var result = engine.Evaluate("""
+            var m = map[string, int32]{"a": 40, "b": 2}
+            var ok = m.TryGetValue("b", out var v)
+            m.ContainsKey("a") && ok && m.Count + v == 4
+            """);
+
+        Assert.False(result.HasError, string.Join("; ", result.Diagnostics));
+        Assert.Equal(true, result.Value);
+    }
+
+    private static void AssertOk(EmittedSessionEngine engine, string cell)
+    {
+        var result = engine.Evaluate(cell);
+        Assert.False(result.HasError, string.Join("; ", result.Diagnostics));
+    }
+}


### PR DESCRIPTION
Fixes #3311. Part of #3163.

## Summary

- Kill the GS0159 family on CLR-interop member access over **open-generic map receivers**: `items.ContainsKey(k)`, `items.TryGetValue(k, out var v)`, `items.Keys`, `items.Values`, `items.Count`, `items.GetEnumerator()` now bind, emit, verify, and run when `items` is `map[K, V]` with type-parameter (or otherwise not-yet-loadable) arguments — in generic functions and generic types, at value-type / reference-type / user-struct instantiations, same-cell and cross-cell in the REPL.
- Root cause (as diagnosed in the issue): member lookup on map receivers reflected over `MapTypeSymbol.ClrType`, which is **null by construction** when K or V is a type parameter (`MapTypeSymbol.MakeClrType` bails when either argument's ClrType is null). Every lookup gate (`CanBindClrInstanceMember`, the instance-call `effectiveReceiverType?.ClrType == null` gate) then fell through to extension lookup and GS0159.

## The substitution design: reuse, not invention

The fix contains **no new substitution machinery**. An open `map[K, V]` is normalized to the *exact* symbolic constructed `Dictionary[K, V]` view that an explicitly-typed `Dictionary[K, V]` receiver has carried since #313/#794/#1107: `ImportedTypeSymbol.GetConstructed(erasedClosedDictionary, typeof(Dictionary<,>), [K, V])`, where the erased closed shape comes from the existing `TryProjectErasedClrType` map arm (#3303/#3309). From there, every layer is the established imported-generic machinery:

- **lookup** reflects over the erased closed `Dictionary<…>` (`SafeGetMethodsIncludingSelfAndInterfaces`, `SafeGetPropertyIncludingInterfaces`),
- **re-projection** of returns/parameters/out-vars runs through `MapOpenClrTypeToSymbolic` via the existing `ResolveInstanceReturnTypeFromReceiver` (#794), `ResolveInstancePropertyTypeFromReceiver` (#794), and `ResolveInstanceParameterPointeeTypeFromReceiver` (#1107) — so `.Keys` → `KeyCollection` over symbolic K, `TryGetValue`'s `out var` binds as V, `ContainsKey(K)`'s parameter binds against the type parameter (no boxing),
- **emit** parents the member refs at the `Dictionary<!K, !V>` TypeSpec through the existing symbolic-container path (`TryCreateMemberReferenceForConstructedSymbolicContainer`, #774/#832/#1330) — the general-member counterpart of the dedicated #1481/#3306 map helpers (`GetMapCtorReference` / `GetMapTryGetValueReference` / …), which are untouched and keep serving the builtin ops.

### The four hook points

1. `MemberLookup.TryGetSymbolicOpenMapReceiverView` (new, ~20 lines) — the shared normalizer. Gated on `MapTypeSymbol` **with null ClrType**, so concrete maps stay byte-for-byte on the loadable-ClrType reflection fast path.
2. Calls: `TryNormalizeSymbolicEnumerableReceiver` grows a map arm (sits beside its #1320 sequence/array siblings); the out-var rebind and the parameter-conversion pass are fed the normalized view (the raw receiver is kept for all other shapes per #1512/#1320).
3. Member access: `BindAccessorStep`'s CLR-instance arm accepts the normalized view via `TryGetClrInstanceMemberReceiverType` (wraps the untouched `CanBindClrInstanceMember`).
4. Emit: `TryNormalizeToSymbolicContainer` grows a map arm (beside its #774 sequence / #806 nullable siblings), which also wires the widening-skip guards and the #774 interface redirect for free.

## Two latent mixed-instantiation bugs fixed alongside (pre-existing on main for explicit `Dictionary` receivers)

The witness matrix surfaced two bugs that were **not map-specific** — both reproduce on main with an explicitly-typed `Dictionary[int32, V]` receiver (verified with a main-equivalent gsc: ILVerify `StackObjRef`, runtime NRE):

1. **Loop lowering** (`TryBuildMoveNextAndCurrent`): the synthesized symbolic `IEnumerator[Element]` only used its type argument for `Current` when the element was symbolic (`HasSubstitutableTypeArgument`). A MIXED instantiation (`Dictionary[int32, V].Keys` → element `int32`, concrete) fell back to the closed `object` getter type, injecting an `object → int32` conversion whose `unbox.any` tripped the verifier — while the emitted MemberRef (`IEnumerator`1<int32>::get_Current`) already left an `int32` on the stack. Now gated on the synthesized `IEnumerator`1` open definition (plus the original predicate), so real struct enumerators (whose `Current` is *not* the first type argument, e.g. Dictionary's KeyValuePair-returning `Enumerator`) keep the reflected type.
2. **Erasure-widening skip guards** (`TryGetSymbolicSubstitutedPropertyReturn` / `TryGetSymbolicSubstitutedInstanceMethodReturn`): required a symbolic type argument, but the symbolic-container MemberRef fires for *any* non-empty argument vector — so a concrete argument recovered through an erased closed receiver left the widening in force against a stack that already held the substituted type. The guards now fire whenever the substituted member type differs from the closed CLR shape (when they agree, the widening was a no-op, so historical IL is unchanged), and both gain the emit path's non-generic-declaring-type bail (a strictly-narrowing safety mirror of the plain-MemberRef fallback).

`ExplicitDictionary_MixedArity_KeysIteration_Fixed` pins the explicit-Dictionary twin.

## Members covered

`ContainsKey`, `TryGetValue` (incl. inline `out var` with symbolic V recovery), `Keys` (+ `for k in items.Keys` with K-typed iteration variable, fully-open and mixed), `Values` (+ iteration), `Count`, `GetEnumerator` (+ manual `MoveNext`/`Current.Key`/`Current.Value` loop over the symbolic `Dictionary<K,V>.Enumerator`) — and, because lookup now goes through the general imported-generic path, the rest of the reflected `Dictionary` surface (`Add`, `Remove`, `Clear`, chained access on member results, …) resolves the same way rather than being an allow-list.

**Scope notes.**
- `for k, v in m` / `for kv in m` over a *map-typed* value remains the pre-existing GS0116 gap **for all maps, concrete and generic alike** (documented as unsupported in #3309); this PR neither uses nor changes it. Iteration over the member surface (`.Keys`/`.Values`, `GetEnumerator`) is the supported and now-working form.
- Maps whose K/V is a same-compilation user **value struct** (null ClrType monomorphically) still project no erased shape (`TryProjectErasedClrType` has no value-struct arm), so their member surface keeps today's GS0159 — never a worse diagnostic. Type-parameter K/V — this issue's scope — covers those shapes *inside* generic bodies, where they matter.

## Verification

- **Red-on-main**: 13 emit witnesses + 5 REPL witnesses failed on `origin/main` with the exact issue diagnostics ("Cannot find function ContainsKey.", "Cannot find member Keys.", …); the 3 regression pins (concrete-map member access, #3306/#3309 open-map builtins, #3309 overload-argument arm) were green before the fix (commit ddddd60c).
- **Green**: all 17 emit witnesses + 6 REPL witnesses pass with the fix.
- **Full `Core.Tests`**: Passed! — Failed: 0, Passed: 7286, Skipped: 1 (RegenerateBaseline), Total: 7287 (4 m 35 s)
- **Full `Interpreter.Tests`**: Passed! — Failed: 0, Passed: 1461, Total: 1461 (2 m 44 s)
- **`LanguageConformance` filter (Compiler.Tests)**: Passed! — Failed: 0, Passed: 127, Total: 127 (2 m 14 s)
- **ILVerify** on gsc-compiled repro binaries (full matrix program exercising every member × instantiation combination, plus the issue's minimal repros): `All Classes and Methods Verified`, and the full-matrix exe **runs to completion** under `dotnet exec` (exit 0).
- **NOT RUN**: full Compiler.Tests / Sdk.Tests / LanguageServer.Tests / Extensions.Tests suites (only the LanguageConformance filter of Compiler.Tests, per the task's verification plan); Cs2Gs.Tests (pre-existing non-deterministic host crash — see repo memory).

## Coordination

A parallel change for #3310 (nil comparison + zero values) works in binder-declaration/emit-initialization territory; this PR touches member lookup/binding (`ExpressionBinder.Access.MemberLookup.cs`, `ExpressionBinder.Calls.Invocation.cs`, `MemberLookup.cs`), member-access emit (`ImportedMemberRefFactory.cs`, `UserTokenResolver.cs`), and the foreach lowering (`Lowerer.cs`). The only potentially shared file is `MemberLookup.cs`, where this PR adds one self-contained helper next to `TryProjectErasedClrType` — hunks should merge cleanly.

## Verdict

**MERGEABLE.** Red-first witnesses across the full matrix, all-green targeted suites (Core.Tests 7286, Interpreter.Tests 1461, LanguageConformance 127), ILVerify-clean and runtime-verified repro binaries, no new caches, concrete-map fast path untouched, and the two alongside fixes are strictly-narrowing guard corrections pinned by their own explicit-Dictionary witness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
