### PR TITLE
Re-anchor Issue1714 reflection pins for ADR-0159 sound zero values

### DIFF
--- a/test/Compiler.Tests/Emit/Issue1714StringZeroValueEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1714StringZeroValueEmitTests.cs
@@ -231,15 +231,35 @@ public class Issue1714StringZeroValueEmitTests
         var structType = assembly.GetTypes().Single(t => t.Name == "StructFields");
         var structValue = Activator.CreateInstance(structType);
 
-        foreach (var name in new[] { "Text", "MaybeText", "Value", "Items", "ChildValue" })
+        foreach (var name in new[] { "Text", "MaybeText", "Value", "ChildValue" })
         {
             Assert.Null(classType.GetField(name)!.GetValue(classValue));
             Assert.Null(structType.GetField(name)!.GetValue(structValue));
         }
 
+        // ADR-0159: bare (non-nullable) slice fields zero-init to an empty
+        // instance, not CLR null, so `[]int32` slots are always safely usable.
+        // Class instance fields go through the emitted instance ctor, which the
+        // synthesized initializer hooks into. StructFields has no explicit
+        // members needing a synthesized ctor (#3219: all-public structs keep
+        // byte-identical emission with no ctor), and `Activator.CreateInstance`
+        // for a value type with no ctor bypasses G# initializer logic entirely
+        // (matching C#'s own `default(structWithList)` semantics) -- this
+        // reflects the CLR/raw-default case, not a G#-observed declaration.
+        // Struct-local zero-value initialization (`var s S` where S has a
+        // slice field) is filed as a follow-up: #3319.
+        Assert.Empty((Array)classType.GetField("Items")!.GetValue(classValue)!);
+        Assert.Null(structType.GetField("Items")!.GetValue(structValue));
+
+        // ClassFields' shared block has no explicit `init()`, so per ADR-0155 it
+        // stays beforefieldinit; reflection-based static field access does not
+        // reliably trigger a beforefieldinit type's initializer, so force it
+        // before observing SharedItems' ADR-0159 zero-value initializer.
+        System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(classType.TypeHandle);
+
         Assert.Null(classType.GetField("SharedText")!.GetValue(null));
         Assert.Null(classType.GetField("SharedValue")!.GetValue(null));
-        Assert.Null(classType.GetField("SharedItems")!.GetValue(null));
+        Assert.Empty((Array)classType.GetField("SharedItems")!.GetValue(null)!);
         Assert.Null(classType.GetField("SharedChild")!.GetValue(null));
         Assert.Equal(string.Empty, classType.GetField("Empty")!.GetValue(classValue));
 


### PR DESCRIPTION
Fixes the CI failure on main's `tests (compiler-issue1-remainder)` shard following ADR-0159 (#3314, merged).

## Root cause

`Issue1714StringZeroValueEmitTests.Reflection_ReferenceFields_UseClrNullAndPreserveAnnotationsAndInitializer` predates ADR-0159 and asserted `Assert.Null(...)` for every reference-shaped field, including `[]int32` slots. ADR-0159 gives bare `map[K,V]`/`[]T`/`[N]T`/`sequence[T]` slots sound empty-instance zero values instead of CLR null — the test's expectations were stale.

## Fix

- **Class instance and shared/static slice fields**: now assert an empty array via reflection (matches the ADR-0159 contract). The static field additionally needs `RuntimeHelpers.RunClassConstructor` before observation — reflection-based static field access doesn't reliably trigger a `beforefieldinit` type's initializer, and `ClassFields`' shared block has no explicit `init()` so it correctly stays `beforefieldinit` per ADR-0155. This is a general CLR reflection nuance (accessing a static field via IL triggers the type initializer; raw `FieldInfo.GetValue` is not guaranteed to), not new to this PR — it simply never mattered before because the field's uninitialized bit pattern already read as null.
- **Struct instance fields observed via raw `Activator.CreateInstance`**: stay `Assert.Null`, unchanged. This path has no G# initializer logic in play at all — an all-public struct (per #3219) has no synthesized parameterless ctor, so `Activator.CreateInstance` returns the true CLR zero value, exactly matching C#'s own `default(structWithList)` semantics. This is not a gap in #3314's scope.

## Follow-up filed

Investigating the struct case surfaced a real, narrower gap: **#3319** — a struct-typed *local* declared without an initializer (`var s SomeStruct`) does not recurse into its own magic-type fields to apply ADR-0159's zero-value initializer (confirmed via a minimal repro: NRE, not empty). This is distinct from the reflection-only case fixed here — top-level magic-type locals and class-field initializers already work; only fields nested inside a struct local are affected. Filed separately per house convention rather than expanding this PR's scope.

## Verification

- Release build: 0 warnings / 0 errors.
- `Issue1714*` targeted filter: 9/9 passed (run 3x for determinism).
- Full `Compiler.Tests` Emit area (`~Emit`): **4004/4004 passed**, 30m28s — no regressions from the test-only change.

NOT RUN: full suites beyond the Emit area (test-only change, no product surface touched); Cs2Gs.Tests (known flaky host crash policy).

Part of #3163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)