### PR TITLE
Fix #3324: zero-init string locals to "" per ADR-0008

### DIFF
--- a/docs/adr/0008-variable-bindings.md
+++ b/docs/adr/0008-variable-bindings.md
@@ -28,6 +28,8 @@ A `var` declaration may omit its initializer when an explicit type clause is pre
 
 > **Note (ADR-0159, issue #3310):** for the magic collection types the zero value is now a **sound empty instance**, not a null reference — `var m map[K, V]` binds an empty map, `var s []T` an empty slice, `var a [N]T` a zeroed length-N array, `var q sequence[T]` an empty sequence. `chan T` is carved out: it has no sensible default and a declaration without an initializer reports GS0520. See [ADR-0159](0159-magic-collection-zero-values-and-nil-comparison.md).
 
+> **Note (issue #3324):** this paragraph's `""` for `string` was, until #3324, aspirational for a genuine function-local declaration — the bare-`var` binder fell through to the CLR reference-type default (`null`), NRE-ing on any string-returning use like `len(s)`. Fixed for LOCALS only. This does **not** extend to class/struct fields, auto-property backing fields, a top-level (global) `var`, or the `default(string)` expression: those are a separate, already-settled contract (issue #1714 / PR #2788, pinned by `Issue1714StringZeroValueEmitTests`) that deliberately keeps the CLR storage default (`null`) for uninitialized reference-typed storage, distinct from a local binding's language-level zero value. A top-level `var` binds a `GlobalVariableSymbol` (emitted as a static field) and so falls on the field side of that line, not the local side.
+
 ## Consequences
 
 Positive:

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
@@ -1256,8 +1256,12 @@ internal sealed partial class StatementBinder
             // `chan T` slot has no zero value at all — whether that is an
             // error, and where, depends on the declared symbol's kind and is
             // decided after the symbol is created below (issue #3316). All
-            // other types keep the CLR default (0 / false / "" / all-zero
-            // struct / null for reference types) per ADR-0008.
+            // other types keep the CLR default (0 / false / all-zero struct /
+            // null for reference types) here — EXCEPT `string`, which is
+            // patched to `""` below (issue #3324) once we know whether the
+            // symbol is a true local or a global (see that comment for why
+            // this can't be decided in this branch, before the symbol
+            // exists).
             variableType = type ?? TypeSymbol.Error;
             channelSlotWithoutInitializer = MagicCollectionZeroValue.RequiresExplicitInitializer(variableType);
             convertedInitializer = MagicCollectionZeroValue.TrySynthesizeEmptyInstance(syntax, variableType)
@@ -1380,6 +1384,30 @@ internal sealed partial class StatementBinder
         if (channelSlotWithoutInitializer && variable is not LocalVariableSymbol)
         {
             Diagnostics.ReportChannelRequiresInitializer(syntax.Identifier.Location, syntax.Identifier.Text, variableType.Name);
+        }
+
+        // Issue #3324 (ADR-0008): a bare `var s string` / `let s string`
+        // LOCAL declared without an initializer zero-inits to `""`, per
+        // ADR-0008's documented Go-style string zero value ("`""` for
+        // string"). This is deliberately narrower than
+        // MagicCollectionZeroValue's dispatch above (which only special-cases
+        // the ADR-0159 magic collection types and otherwise falls back to
+        // BoundDefaultExpression, i.e. the CLR default `null` for `string`):
+        // class/struct FIELDS and the `default(string)` expression are a
+        // separate, already-settled contract (issue #1714, PR #2788) that
+        // deliberately keeps the CLR storage default (`null`) for
+        // uninitialized reference-typed fields — see
+        // Issue1714StringZeroValueEmitTests. A top-level `var` is emitted as
+        // a static field (see the channel comment above), so only a genuine
+        // LocalVariableSymbol gets the `""` treatment here; a
+        // GlobalVariableSymbol falls through to the same CLR-default path
+        // fields already use, keeping globals consistent with fields rather
+        // than with true function locals.
+        if (syntax.Initializer == null
+            && variableType == TypeSymbol.String
+            && variable is LocalVariableSymbol)
+        {
+            convertedInitializer = new BoundLiteralExpression(syntax, string.Empty, TypeSymbol.String);
         }
 
         variable.HasDefinitelyNonNullValue = isReadOnly

--- a/test/Compiler.Tests/Emit/Issue1714StringZeroValueEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1714StringZeroValueEmitTests.cs
@@ -25,6 +25,14 @@ namespace GSharp.Compiler.Tests.Emit;
 /// retired with the evaluator in ADR-0156 Phase 3c (#3176).
 /// Each source uses unique package/type names because the in-process
 /// <c>FunctionTypeSymbol</c> cache is name-keyed.
+///
+/// Issue #3324 (ADR-0008) added a THIRD zero-value bucket alongside the two
+/// above: a genuine function-local `var s string` / `let s string` declared
+/// without an initializer. ADR-0008 documents that as the language's
+/// Go-style `""` zero value (same as the map-miss case), distinct from the
+/// field/property/`default(string)`/top-level-`var` bucket above, which stays
+/// at the CLR storage default (`null`) by the already-settled #1714/#2788
+/// contract. See the <c>Local*</c>-prefixed facts below.
 /// </summary>
 public class Issue1714StringZeroValueEmitTests
 {
@@ -121,6 +129,100 @@ public class Issue1714StringZeroValueEmitTests
 
         var output = CompileAndRun(source);
         Assert.Equal("False\nTrue\n", output);    }
+
+    [Fact]
+    public void EndToEnd_LocalStringDeclaration_LenIsZero()
+    {
+        // Issue #3324: `len(s)` on a bare `var s string` local used to NRE —
+        // the CLR-default `null` fell straight into `.Length`. Direct
+        // repro from the issue.
+        const string source = """
+            package i3324locallen
+            import System
+            import Gsharp.Extensions.Go
+
+            func Main() {
+                var s string
+                Console.WriteLine(len(s))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("0\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_LocalStringDeclaration_DefaultsToEmptyString()
+    {
+        // Issue #3324 / ADR-0008: a genuine function-local `var s string`
+        // zero-inits to `""`, matching the language's documented Go-style
+        // string zero value — the opposite pin from
+        // EndToEnd_StructStringField_DefaultsToNull /
+        // EndToEnd_ClassStringField_DefaultsToNull above, which are fields
+        // and stay CLR-null by design (#1714/#2788).
+        const string source = """
+            package i3324locallet
+            import System
+
+            func Main() {
+                let s string = default(string)
+                var t string
+                System.Console.WriteLine(t == "")
+                System.Console.WriteLine(t == nil)
+                System.Console.WriteLine(s == nil)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+
+        // `t` (bare `var t string`) is the ADR-0008 local zero value: `""`,
+        // non-null. `s` (`default(string)`, unchanged by #3324) stays the
+        // CLR-default `null` — same source, two different initializer forms,
+        // two different documented contracts.
+        Assert.Equal("True\nFalse\nTrue\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_LocalStringDeclaration_ComparisonAndConcatenation()
+    {
+        // Issue #3324 witness matrix: comparison against `""` and direct
+        // concatenation/interpolation both observe the sound `""` value
+        // rather than crashing or observing `null`.
+        const string source = """
+            package i3324localops
+            import System
+
+            func Main() {
+                var s string
+                System.Console.WriteLine(s == "")
+                var concatenated = "[" + s + "]"
+                System.Console.WriteLine(concatenated)
+                System.Console.WriteLine("<${s}>")
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\n[]\n<>\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_TopLevelStringDeclaration_StaysNull()
+    {
+        // Issue #3324 scoping pin: a top-level `var g string` binds a
+        // GlobalVariableSymbol, emitted as a static field — the same
+        // #1714/#2788 CLR-null contract as an explicit field, NOT the
+        // function-local `""` contract above. This must NOT change.
+        const string source = """
+            package i3324localglobal
+            import System
+
+            var g string
+            Console.WriteLine(g == nil)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\n", output);
+    }
 
     [Fact]
     public void EndToEnd_NestedStructStringFields_DefaultToNull()

--- a/test/Core.Tests/CodeAnalysis/Binding/BareVariableDeclarationTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/BareVariableDeclarationTests.cs
@@ -45,13 +45,24 @@ b
     }
 
     [Fact]
-    public void BareVarDeclaration_String_DefaultsToNil()
+    public void BareVarDeclaration_String_TopLevel_DefaultsToNil()
     {
         // ADR-0100 / issue #795: `default(T)` aligned the interpreter
         // with the IL emit path. Reference types (including `string`)
         // default to `nil` rather than the Go-style empty value. Both
         // bare `var s string` (which lowers to `BoundDefaultExpression`)
         // and explicit `default(string)` now produce the same value.
+        //
+        // Issue #3324 (ADR-0008): this pin is specifically for a TOP-LEVEL
+        // `var s string` — a top-level declaration binds a
+        // GlobalVariableSymbol (emitted as a static field), which keeps the
+        // CLR-default `null` by the same already-settled contract as
+        // class/struct fields (issue #1714 / PR #2788 /
+        // Issue1714StringZeroValueEmitTests). A genuine function-local
+        // `var s string` now zero-inits to `""` per ADR-0008's documented
+        // Go-style string zero value — see the `EndToEnd_LocalString*` facts
+        // in Issue1714StringZeroValueEmitTests for that (different,
+        // local-only) contract.
         var source = @"
 var s string
 s


### PR DESCRIPTION
Fixes #3324. Part of #3163.

## ADR-0008 contract scope as implemented

ADR-0008 documents that a bare `var x T` (no initializer, explicit type clause) zero-inits to `T`'s default: `0` / `false` / `""` for `string` / all-zero for structs and enums. That `""` was aspirational for a genuine function-**local** — the bare-declaration binder fell through to the CLR reference-type default (`null`), so `len(s)` on `var s string` NREd.

**Implemented scope: function-local `var`/`let s string` declared without an initializer zero-inits to `""`.** This is deliberately **narrower** than "every uninitialized `string` slot everywhere":

- Class/struct fields, auto-property backing fields, and the `default(string)` expression are a separate, already-settled contract (issue #1714, PR #2788) that deliberately keeps the CLR storage default (`null`) — pinned by `Issue1714StringZeroValueEmitTests`. Re-verified on current main: these pins are correct as-is and are **not** changed.
- A top-level `var s string` binds a `GlobalVariableSymbol`, emitted as a static field — same bucket as class/struct fields, not as a true local. It keeps `null` (new regression pin: `EndToEnd_TopLevelStringDeclaration_StaysNull`).

ADR-0008 gets an addendum note recording this precise scope (locals only, fields/default/globals unaffected), mirroring the existing ADR-0159 addendum style.

## Shared-machinery finding relative to #3319

There **is** a single dispatch point for a bare-declared local's zero value: `StatementBinder.BindVariableDeclaration`'s `syntax.Initializer == null` branch (`src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs`), which calls `MagicCollectionZeroValue.TrySynthesizeEmptyInstance` and falls back to `BoundDefaultExpression`. It was "missing a string arm" in exactly that sense.

However, `MagicCollectionZeroValue.TrySynthesizeEmptyInstance` is **shared** with the struct/class FIELD zero-value dispatch in `DeclarationBinder.Structs.cs` (four call sites there). Adding a `string` case directly to that shared helper would have also changed FIELD behavior, breaking the settled #1714/#2788 null-field contract. So the fix is instead a narrow, local-only patch placed *after* symbol creation in `StatementBinder.Narrowing.cs`, gated on `variable is LocalVariableSymbol` (mirroring the existing `channelSlotWithoutInitializer` pattern in the same function) — `MagicCollectionZeroValue.cs` and `DeclarationBinder.Structs.cs` are untouched by this PR.

**#3319 is a different gap**, not the same dispatch point: it's about a magic-collection-typed **field inside a struct-typed local** (`var s S` where `S.Items []int32`) not getting zero-initialized, because bare struct locals go through `initobj`/`BoundDefaultExpression` rather than a field-recursion-aware constructor — that recursion logic lives in `DeclarationBinder.Structs.cs`'s ctor/field-initializer synthesis, which this PR does not touch. No file overlap with a likely #3319 fix beyond both living under `src/Core/CodeAnalysis/Binding/` in different files.

## Summary

- `StatementBinder.Narrowing.cs`: after the declared symbol is created, a bare (no-initializer) `string`-typed `LocalVariableSymbol`'s initializer is patched from `BoundDefaultExpression` (CLR `null`) to a `""` `BoundLiteralExpression`. `GlobalVariableSymbol` (top-level `var`) is left untouched.
- `docs/adr/0008-variable-bindings.md`: addendum note recording the as-implemented scope (locals only) and pointing at the #1714/#2788 field contract for the boundary.
- `test/Compiler.Tests/Emit/Issue1714StringZeroValueEmitTests.cs`: 4 new end-to-end (compile+run) facts — `len()` on a bare local (the issue's repro), `""`-vs-`null` local/default(string) contrast, comparison + concatenation + interpolation, and a top-level-`var`-stays-`null` regression pin. Docstring updated to describe the new local bucket.
- `test/Core.Tests/CodeAnalysis/Binding/BareVariableDeclarationTests.cs`: renamed/annotated the existing top-level `BareVarDeclaration_String_DefaultsToNil` pin to `..._TopLevel_DefaultsToNil` with a note explaining why it's unaffected (global, not local).

## Verification (sequential, Release)

- Release build: 0 warnings / 0 errors.
- Witness: `len(s)` repro confirmed **red** on main (`NullReferenceException`, exit 134) via a throwaway compiled repro; confirmed **green** with the fix (`0` / `True` / `[]`).
- Regression matrix (throwaway compiled repros + new xunit facts): struct field, class field, `default(string)`, and top-level `var` all still observe `null`/CLR-default, unchanged.
- Full Core.Tests: **7438/7439** (1 standing skip, pre-existing).
- Full Interpreter.Tests: **1492/1492**.
- LanguageConformance filter: **128/128**.

NOT RUN: Compiler.Tests outside the targeted Issue1714/BareVariableDeclaration/LanguageConformance filters (no surface touched beyond local string zero-value), LanguageServer/Sdk/Extensions suites (no surface touched), Cs2Gs.Tests (known flaky host crash policy — see prior session notes).

## Verdict

**MERGEABLE.** Narrow, well-isolated fix at a single call site; all pinned field/global/default(string) behavior re-verified unchanged; full Core.Tests, Interpreter.Tests, and LanguageConformance green.

## Checklist

- [x] Behavioral tests carry a witness of discrimination (ADR-0154): `EndToEnd_LocalStringDeclaration_LenIsZero` et al. fail on pre-fix code (confirmed via manual repro against unpatched build: NRE) and pass with the fix.
- [x] Self-review verdict recorded: MERGEABLE, no residuals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
