### PR TITLE
Fix cross-assembly imported package function calls

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundScope.cs
@@ -719,15 +719,12 @@ public sealed class BoundScope
     }
 
     /// <summary>
-    /// ADR-0134 (extended): enumerates the referenced-assembly CLR types brought
-    /// into unqualified static scope by a <em>type</em> import — the imported-CLR
-    /// analogue of <see cref="BinderContext.GetStaticImportTypes"/> (which only
-    /// covers same-compilation source classes). A C# <c>using static System.Math</c>
-    /// translates to <c>import System.Math</c>; when the dotted import target
-    /// itself resolves to a CLR type (rather than a namespace), that type's
-    /// <c>public static</c> members become available unqualified, mirroring
-    /// C#'s <c>using static</c>. Implicit (compiler-synthesized) and alias
-    /// imports never hoist, matching the source-class rule.
+    /// Issue #3334 / ADR-0134: enumerates referenced-assembly CLR types brought
+    /// into unqualified static scope by an import. A type import resolves the
+    /// target itself; a package import resolves the package's synthetic
+    /// <c>&lt;Program&gt;</c> type, which hosts public package-level functions
+    /// and globals. Implicit (compiler-synthesized) and alias imports never
+    /// hoist.
     /// </summary>
     /// <returns>The distinct imported static-import CLR types, in import order.</returns>
     public IEnumerable<System.Type> EnumerateStaticImportClrTypes()
@@ -745,7 +742,14 @@ public sealed class BoundScope
                 continue;
             }
 
-            if (References.TryResolveType(import.Target, out var type) && type != null)
+            if (!References.TryResolveType(import.Target, out var type))
+            {
+                References.TryResolveType(
+                    import.Target + "." + SubmissionImports.ProgramTypeName,
+                    out type);
+            }
+
+            if (type != null)
             {
                 seen ??= new System.Collections.Generic.HashSet<System.Type>();
                 if (seen.Add(type))

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
@@ -2836,14 +2836,11 @@ internal sealed partial class ExpressionBinder
     }
 
     /// <summary>
-    /// Issue #1201 (C# <c>using static</c>): attempts to resolve an unqualified
-    /// identifier against the <c>shared</c> (static) members — field, property,
-    /// or method group — of a type brought into scope by a non-alias type import
-    /// (<c>import Ns.Type</c>). Binds against the single match through the same
-    /// <see cref="BindUserTypeStaticMemberAccess"/> path used by an explicit
-    /// <c>Type.Member</c> access; reports GS0414 when two or more imported types
-    /// expose a member of that name (the value/identifier analog of the
-    /// call-site ambiguity rule in <c>OverloadResolver</c>).
+    /// Issues #1201 / #3334: attempts to resolve an unqualified identifier
+    /// against static members exposed by a non-alias imported type or referenced
+    /// package. Binds against the single match through the same static-member
+    /// paths used by explicit CLR type access; reports GS0414 when two or more
+    /// imported containers expose a member of that name.
     /// </summary>
     /// <param name="syntax">The bare-name reference being resolved.</param>
     /// <param name="result">The bound static-member access, when one is produced.</param>
@@ -2888,10 +2885,9 @@ internal sealed partial class ExpressionBinder
             return true;
         }
 
-        // ADR-0134 (extended): fall back to referenced-assembly CLR types brought
-        // into scope by a type import (`import System.Math` from C#'s
-        // `using static System.Math`). Only consulted when no same-compilation
-        // source class exposed the member above.
+        // Issues #3334 / ADR-0134: fall back to static members on imported CLR
+        // types and referenced packages' synthetic `<Program>` holders. Only
+        // consulted when no same-compilation source class exposed the member.
         System.Type? clrMatch = null;
         var clrAmbiguous = false;
         foreach (var clrType in scope.EnumerateStaticImportClrTypes())

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
@@ -786,12 +786,11 @@ internal sealed partial class OverloadResolver
                     }
                 }
 
-                // ADR-0134 (extended): an unqualified call may also resolve to a
-                // `public static` method of a referenced-assembly CLR type brought
-                // into scope by a type import (`import System.Math` from C#'s
-                // `using static System.Math`). Consulted only when no
-                // same-compilation source class matched above; the imported
-                // qualified static-call binder (`Type.method(args)`) provides full
+                // Issue #3334 / ADR-0134: an unqualified call may also resolve
+                // to a `public static` method on an imported CLR type or a
+                // referenced package's synthetic `<Program>` holder. Consulted
+                // only when no same-compilation source class matched above; the
+                // imported qualified static-call binder provides full
                 // optional/variadic/generic fidelity.
                 if (bindImportedClrStaticCall != null)
                 {

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3334ImportedPackageFunctionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3334ImportedPackageFunctionTests.cs
@@ -1,0 +1,69 @@
+// <copyright file="Issue3334ImportedPackageFunctionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+public sealed class Issue3334ImportedPackageFunctionTests
+{
+    [Fact]
+    public void ImportedPackage_PublicFunction_FromReferencedAssembly_Runs()
+    {
+        var outputDirectory = Path.Combine(AppContext.BaseDirectory, "Issue3334", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(outputDirectory);
+        try
+        {
+            var libraryPath = Path.Combine(outputDirectory, "FindingCrossAssemblyPackageFunction.dll");
+            var library = new Compilation(
+                SyntaxTree.Parse(SourceText.From(
+                    """
+                    package FindingCrossAssemblyPackageFunction
+
+                    public func Answer() int32 {
+                      return 42
+                    }
+                    """)))
+            {
+                IsLibrary = true,
+            };
+
+            using (var output = File.Create(libraryPath))
+            {
+                var emit = library.Emit(
+                    output,
+                    pdbStream: null,
+                    refStream: null,
+                    assemblyName: "FindingCrossAssemblyPackageFunction");
+                Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
+            }
+
+            var result = EmittedOracle.Evaluate(
+                """
+                package FindingCrossAssemblyPackageFunctionApp
+
+                import FindingCrossAssemblyPackageFunction
+
+                func Main() int32 {
+                  return Answer() == 42 ? 0 : 1
+                }
+                """,
+                new[] { libraryPath });
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Equal(0, result.ExitCode);
+            Assert.Equal(0, Assert.IsType<int>(result.Value));
+        }
+        finally
+        {
+            Directory.Delete(outputDirectory, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- resolve imported package synthetic `<Program>` containers through existing CLR static-import lookup
- preserve existing type-import, alias-import, ambiguity, and file-scoped import behavior
- add an emit-and-run regression proving a public package function works across an assembly reference

## Validation
- `dotnet test test/Core.Tests/Core.Tests.csproj --configuration Release --no-restore --nologo` (7,477 passed, 1 skipped)
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj --configuration Release --no-build --no-restore --filter 'FullyQualifiedName~Issue2403MethodCallVsImportedTypeEmitTests' --nologo` (4 passed)
- `dotnet build GSharp.sln --configuration Release --no-restore -graph --nologo`

Fixes #3334
