### PR TITLE
Fix cross-assembly generic base override substitution

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExternalClrOverrideResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/ExternalClrOverrideResolver.cs
@@ -28,7 +28,8 @@ internal static class ExternalClrOverrideResolver
         bool sawName = false;
         var externalBase = FindExternalBaseType(derivedType);
         var reflectionBaseType = GetReflectionBaseType(externalBase);
-        var typeArguments = GetSymbolicTypeArguments(externalBase);
+        var typeSubstitutions = BuildTypeArgumentSubstitutions(externalBase);
+        var methodTypeArguments = BuildMethodTypeArguments(typeParameters);
         foreach (var method in EnumerateMethods(reflectionBaseType, name))
         {
             if (!IsAccessibleOverrideTarget(method, accessibility))
@@ -38,8 +39,8 @@ internal static class ExternalClrOverrideResolver
 
             sawName = true;
             if (method.GetGenericArguments().Length != typeParameters.Length
-                || !ParametersMatch(method.GetParameters(), parameters, typeParameters, typeArguments, reflectionBaseType)
-                || !ReturnMatches(method.ReturnType, returnType, returnRefKind, typeParameters, typeArguments, reflectionBaseType))
+                || !ParametersMatch(method.GetParameters(), parameters, typeSubstitutions, method, methodTypeArguments)
+                || !ReturnMatches(method.ReturnType, returnType, returnRefKind, typeSubstitutions, method, methodTypeArguments))
             {
                 continue;
             }
@@ -67,7 +68,7 @@ internal static class ExternalClrOverrideResolver
         bool sawName = false;
         var externalBase = FindExternalBaseType(derivedType);
         var reflectionBaseType = GetReflectionBaseType(externalBase);
-        var typeArguments = GetSymbolicTypeArguments(externalBase);
+        var typeSubstitutions = BuildTypeArgumentSubstitutions(externalBase);
         foreach (var property in EnumerateProperties(reflectionBaseType, name))
         {
             var getter = property.GetGetMethod(nonPublic: true);
@@ -83,8 +84,8 @@ internal static class ExternalClrOverrideResolver
                 || (hasSetter && setter == null)
                 || (!hasGetter && getter != null)
                 || (!hasSetter && setter != null)
-                || !ParametersMatch(property.GetIndexParameters(), indexParameters, ImmutableArray<TypeParameterSymbol>.Empty, typeArguments, reflectionBaseType)
-                || !PropertyTypeMatches(property.PropertyType, propertyType, hasSetter, typeArguments, reflectionBaseType))
+                || !ParametersMatch(property.GetIndexParameters(), indexParameters, typeSubstitutions)
+                || !PropertyTypeMatches(property.PropertyType, propertyType, hasSetter, typeSubstitutions))
             {
                 continue;
             }
@@ -110,7 +111,7 @@ internal static class ExternalClrOverrideResolver
         bool sawName = false;
         var externalBase = FindExternalBaseType(derivedType);
         var reflectionBaseType = GetReflectionBaseType(externalBase);
-        var typeArguments = GetSymbolicTypeArguments(externalBase);
+        var typeSubstitutions = BuildTypeArgumentSubstitutions(externalBase);
         foreach (var eventInfo in EnumerateEvents(reflectionBaseType, name))
         {
             var add = eventInfo.GetAddMethod(nonPublic: true);
@@ -122,7 +123,7 @@ internal static class ExternalClrOverrideResolver
             }
 
             sawName = true;
-            if (!TypeMatches(eventInfo.EventHandlerType, handlerType, ImmutableArray<TypeParameterSymbol>.Empty, typeArguments, reflectionBaseType))
+            if (!TypeMatches(eventInfo.EventHandlerType, handlerType, typeSubstitutions))
             {
                 continue;
             }
@@ -169,6 +170,61 @@ internal static class ExternalClrOverrideResolver
         => importedBase is ImportedTypeSymbol { OpenDefinition: not null, HasSubstitutableTypeArgument: true } imported
             ? imported.TypeArguments
             : ImmutableArray<TypeSymbol>.Empty;
+
+    private static ImmutableArray<TypeArgumentSubstitution> BuildTypeArgumentSubstitutions(TypeSymbol? externalBase)
+    {
+        var root = new TypeArgumentSubstitution(
+            GetReflectionBaseType(externalBase),
+            GetSymbolicTypeArguments(externalBase));
+        if (externalBase is not ImportedTypeSymbol { OpenDefinition: not null } imported
+            || imported.TypeArguments.IsDefaultOrEmpty)
+        {
+            return ImmutableArray.Create(root);
+        }
+
+        var substitutions = ImmutableArray.CreateBuilder<TypeArgumentSubstitution>();
+        substitutions.Add(root);
+        for (var current = imported.OpenDefinition.BaseType; current != null; current = current.BaseType)
+        {
+            if (!current.IsGenericType)
+            {
+                continue;
+            }
+
+            var openDefinition = current.IsGenericTypeDefinition
+                ? current
+                : current.GetGenericTypeDefinition();
+            if (ClrTypeUtilities.AreSame(openDefinition, imported.OpenDefinition)
+                || !MemberLookup.TryMapConstructedTypeArgumentsThroughHierarchy(
+                    imported,
+                    openDefinition,
+                    out var mappedArguments))
+            {
+                continue;
+            }
+
+            substitutions.Add(new TypeArgumentSubstitution(openDefinition, mappedArguments));
+        }
+
+        return substitutions.ToImmutable();
+    }
+
+    private static ImmutableArray<TypeSymbol?> BuildMethodTypeArguments(
+        ImmutableArray<TypeParameterSymbol> typeParameters)
+    {
+        if (typeParameters.IsDefaultOrEmpty)
+        {
+            return default;
+        }
+
+        var typeArguments = ImmutableArray.CreateBuilder<TypeSymbol?>(typeParameters.Length);
+        foreach (var typeParameter in typeParameters)
+        {
+            typeArguments.Add(typeParameter);
+        }
+
+        return typeArguments.MoveToImmutable();
+    }
 
     private static IEnumerable<MethodInfo> EnumerateMethods(Type? baseType, string name)
     {
@@ -245,9 +301,9 @@ internal static class ExternalClrOverrideResolver
     private static bool ParametersMatch(
         ParameterInfo[] clrParameters,
         ImmutableArray<ParameterSymbol> parameters,
-        ImmutableArray<TypeParameterSymbol> typeParameters,
-        ImmutableArray<TypeSymbol> containingTypeArguments,
-        Type? openDefinition)
+        ImmutableArray<TypeArgumentSubstitution> typeSubstitutions,
+        MethodInfo? openMethodDefinition = null,
+        ImmutableArray<TypeSymbol?> methodTypeArguments = default)
     {
         if (clrParameters.Length != parameters.Length)
         {
@@ -270,7 +326,12 @@ internal static class ExternalClrOverrideResolver
             }
 
             if (clrRefKind != parameters[i].RefKind
-                || !TypeMatches(clrType, parameters[i].Type, typeParameters, containingTypeArguments, openDefinition))
+                || !TypeMatches(
+                    clrType,
+                    parameters[i].Type,
+                    typeSubstitutions,
+                    openMethodDefinition,
+                    methodTypeArguments))
             {
                 return false;
             }
@@ -283,9 +344,9 @@ internal static class ExternalClrOverrideResolver
         Type? clrReturnType,
         TypeSymbol returnType,
         RefKind returnRefKind,
-        ImmutableArray<TypeParameterSymbol> typeParameters,
-        ImmutableArray<TypeSymbol> containingTypeArguments,
-        Type? openDefinition)
+        ImmutableArray<TypeArgumentSubstitution> typeSubstitutions,
+        MethodInfo? openMethodDefinition = null,
+        ImmutableArray<TypeSymbol?> methodTypeArguments = default)
     {
         if (clrReturnType == null)
         {
@@ -307,7 +368,12 @@ internal static class ExternalClrOverrideResolver
             }
         }
 
-        if (TypeMatches(clrReturnType, returnType, typeParameters, containingTypeArguments, openDefinition))
+        if (TypeMatches(
+            clrReturnType,
+            returnType,
+            typeSubstitutions,
+            openMethodDefinition,
+            methodTypeArguments))
         {
             return true;
         }
@@ -319,22 +385,19 @@ internal static class ExternalClrOverrideResolver
         Type? clrPropertyType,
         TypeSymbol propertyType,
         bool hasSetter,
-        ImmutableArray<TypeSymbol> containingTypeArguments,
-        Type? openDefinition)
+        ImmutableArray<TypeArgumentSubstitution> typeSubstitutions)
         => TypeMatches(
             clrPropertyType,
             propertyType,
-            ImmutableArray<TypeParameterSymbol>.Empty,
-            containingTypeArguments,
-            openDefinition)
+            typeSubstitutions)
             || (!hasSetter && IsCovariantReturn(clrPropertyType, propertyType));
 
     private static bool TypeMatches(
         Type? clrType,
         TypeSymbol type,
-        ImmutableArray<TypeParameterSymbol> methodTypeParameters,
-        ImmutableArray<TypeSymbol> containingTypeArguments,
-        Type? openDefinition)
+        ImmutableArray<TypeArgumentSubstitution> typeSubstitutions,
+        MethodInfo? openMethodDefinition = null,
+        ImmutableArray<TypeSymbol?> methodTypeArguments = default)
     {
         type = type switch
         {
@@ -342,18 +405,18 @@ internal static class ExternalClrOverrideResolver
             _ => type,
         };
 
-        if (clrType?.IsGenericParameter == true && clrType.DeclaringMethod != null)
+        foreach (var substitution in typeSubstitutions)
         {
-            return type is TypeParameterSymbol typeParameter
-                && typeParameter.Ordinal < methodTypeParameters.Length
-                && ReferenceEquals(typeParameter, methodTypeParameters[typeParameter.Ordinal])
-                && clrType.GenericParameterPosition == typeParameter.Ordinal;
-        }
-
-        var substituted = MemberLookup.MapOpenClrTypeToSymbolic(clrType, openDefinition, containingTypeArguments);
-        if (DeclarationBinder.TypeSignaturesEquivalent(substituted, type))
-        {
-            return true;
+            var substituted = MemberLookup.MapOpenClrTypeToSymbolic(
+                clrType,
+                substitution.OpenDefinition,
+                substitution.TypeArguments,
+                openMethodDefinition,
+                methodTypeArguments);
+            if (DeclarationBinder.TypeSignaturesEquivalent(substituted, type))
+            {
+                return true;
+            }
         }
 
         var effectiveClrType = NullableLifting.GetEffectiveClrType(type);
@@ -416,4 +479,8 @@ internal static class ExternalClrOverrideResolver
         bool SawName,
         bool IsSealed)
         where T : MemberInfo;
+
+    private readonly record struct TypeArgumentSubstitution(
+        Type? OpenDefinition,
+        ImmutableArray<TypeSymbol> TypeArguments);
 }

--- a/src/Core/CodeAnalysis/Binding/ExternalClrOverrideResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/ExternalClrOverrideResolver.cs
@@ -27,8 +27,9 @@ internal static class ExternalClrOverrideResolver
     {
         bool sawName = false;
         var externalBase = FindExternalBaseType(derivedType);
+        var reflectionBaseType = GetReflectionBaseType(externalBase);
         var typeArguments = GetSymbolicTypeArguments(externalBase);
-        foreach (var method in EnumerateMethods(GetReflectionBaseType(externalBase), name))
+        foreach (var method in EnumerateMethods(reflectionBaseType, name))
         {
             if (!IsAccessibleOverrideTarget(method, accessibility))
             {
@@ -37,8 +38,8 @@ internal static class ExternalClrOverrideResolver
 
             sawName = true;
             if (method.GetGenericArguments().Length != typeParameters.Length
-                || !ParametersMatch(method.GetParameters(), parameters, typeParameters, typeArguments)
-                || !ReturnMatches(method.ReturnType, returnType, returnRefKind, typeParameters, typeArguments))
+                || !ParametersMatch(method.GetParameters(), parameters, typeParameters, typeArguments, reflectionBaseType)
+                || !ReturnMatches(method.ReturnType, returnType, returnRefKind, typeParameters, typeArguments, reflectionBaseType))
             {
                 continue;
             }
@@ -65,8 +66,9 @@ internal static class ExternalClrOverrideResolver
     {
         bool sawName = false;
         var externalBase = FindExternalBaseType(derivedType);
+        var reflectionBaseType = GetReflectionBaseType(externalBase);
         var typeArguments = GetSymbolicTypeArguments(externalBase);
-        foreach (var property in EnumerateProperties(GetReflectionBaseType(externalBase), name))
+        foreach (var property in EnumerateProperties(reflectionBaseType, name))
         {
             var getter = property.GetGetMethod(nonPublic: true);
             var setter = property.GetSetMethod(nonPublic: true);
@@ -81,8 +83,8 @@ internal static class ExternalClrOverrideResolver
                 || (hasSetter && setter == null)
                 || (!hasGetter && getter != null)
                 || (!hasSetter && setter != null)
-                || !ParametersMatch(property.GetIndexParameters(), indexParameters, ImmutableArray<TypeParameterSymbol>.Empty, typeArguments)
-                || !PropertyTypeMatches(property.PropertyType, propertyType, hasSetter, typeArguments))
+                || !ParametersMatch(property.GetIndexParameters(), indexParameters, ImmutableArray<TypeParameterSymbol>.Empty, typeArguments, reflectionBaseType)
+                || !PropertyTypeMatches(property.PropertyType, propertyType, hasSetter, typeArguments, reflectionBaseType))
             {
                 continue;
             }
@@ -107,8 +109,9 @@ internal static class ExternalClrOverrideResolver
     {
         bool sawName = false;
         var externalBase = FindExternalBaseType(derivedType);
+        var reflectionBaseType = GetReflectionBaseType(externalBase);
         var typeArguments = GetSymbolicTypeArguments(externalBase);
-        foreach (var eventInfo in EnumerateEvents(GetReflectionBaseType(externalBase), name))
+        foreach (var eventInfo in EnumerateEvents(reflectionBaseType, name))
         {
             var add = eventInfo.GetAddMethod(nonPublic: true);
             var remove = eventInfo.GetRemoveMethod(nonPublic: true);
@@ -119,7 +122,7 @@ internal static class ExternalClrOverrideResolver
             }
 
             sawName = true;
-            if (!TypeMatches(eventInfo.EventHandlerType, handlerType, ImmutableArray<TypeParameterSymbol>.Empty, typeArguments))
+            if (!TypeMatches(eventInfo.EventHandlerType, handlerType, ImmutableArray<TypeParameterSymbol>.Empty, typeArguments, reflectionBaseType))
             {
                 continue;
             }
@@ -243,7 +246,8 @@ internal static class ExternalClrOverrideResolver
         ParameterInfo[] clrParameters,
         ImmutableArray<ParameterSymbol> parameters,
         ImmutableArray<TypeParameterSymbol> typeParameters,
-        ImmutableArray<TypeSymbol> containingTypeArguments)
+        ImmutableArray<TypeSymbol> containingTypeArguments,
+        Type? openDefinition)
     {
         if (clrParameters.Length != parameters.Length)
         {
@@ -266,7 +270,7 @@ internal static class ExternalClrOverrideResolver
             }
 
             if (clrRefKind != parameters[i].RefKind
-                || !TypeMatches(clrType, parameters[i].Type, typeParameters, containingTypeArguments))
+                || !TypeMatches(clrType, parameters[i].Type, typeParameters, containingTypeArguments, openDefinition))
             {
                 return false;
             }
@@ -280,7 +284,8 @@ internal static class ExternalClrOverrideResolver
         TypeSymbol returnType,
         RefKind returnRefKind,
         ImmutableArray<TypeParameterSymbol> typeParameters,
-        ImmutableArray<TypeSymbol> containingTypeArguments)
+        ImmutableArray<TypeSymbol> containingTypeArguments,
+        Type? openDefinition)
     {
         if (clrReturnType == null)
         {
@@ -302,7 +307,7 @@ internal static class ExternalClrOverrideResolver
             }
         }
 
-        if (TypeMatches(clrReturnType, returnType, typeParameters, containingTypeArguments))
+        if (TypeMatches(clrReturnType, returnType, typeParameters, containingTypeArguments, openDefinition))
         {
             return true;
         }
@@ -314,19 +319,22 @@ internal static class ExternalClrOverrideResolver
         Type? clrPropertyType,
         TypeSymbol propertyType,
         bool hasSetter,
-        ImmutableArray<TypeSymbol> containingTypeArguments)
+        ImmutableArray<TypeSymbol> containingTypeArguments,
+        Type? openDefinition)
         => TypeMatches(
             clrPropertyType,
             propertyType,
             ImmutableArray<TypeParameterSymbol>.Empty,
-            containingTypeArguments)
+            containingTypeArguments,
+            openDefinition)
             || (!hasSetter && IsCovariantReturn(clrPropertyType, propertyType));
 
     private static bool TypeMatches(
         Type? clrType,
         TypeSymbol type,
         ImmutableArray<TypeParameterSymbol> methodTypeParameters,
-        ImmutableArray<TypeSymbol> containingTypeArguments)
+        ImmutableArray<TypeSymbol> containingTypeArguments,
+        Type? openDefinition)
     {
         type = type switch
         {
@@ -334,20 +342,18 @@ internal static class ExternalClrOverrideResolver
             _ => type,
         };
 
-        if (clrType?.IsGenericParameter == true)
+        if (clrType?.IsGenericParameter == true && clrType.DeclaringMethod != null)
         {
-            if (clrType.DeclaringMethod != null)
-            {
-                return type is TypeParameterSymbol typeParameter
-                    && typeParameter.Ordinal < methodTypeParameters.Length
-                    && ReferenceEquals(typeParameter, methodTypeParameters[typeParameter.Ordinal])
-                    && clrType.GenericParameterPosition == typeParameter.Ordinal;
-            }
+            return type is TypeParameterSymbol typeParameter
+                && typeParameter.Ordinal < methodTypeParameters.Length
+                && ReferenceEquals(typeParameter, methodTypeParameters[typeParameter.Ordinal])
+                && clrType.GenericParameterPosition == typeParameter.Ordinal;
+        }
 
-            return clrType.GenericParameterPosition < containingTypeArguments.Length
-                && DeclarationBinder.TypeSignaturesEquivalent(
-                    containingTypeArguments[clrType.GenericParameterPosition],
-                    type);
+        var substituted = MemberLookup.MapOpenClrTypeToSymbolic(clrType, openDefinition, containingTypeArguments);
+        if (DeclarationBinder.TypeSignaturesEquivalent(substituted, type))
+        {
+            return true;
         }
 
         var effectiveClrType = NullableLifting.GetEffectiveClrType(type);

--- a/src/Core/CodeAnalysis/Binding/ExternalClrOverrideResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/ExternalClrOverrideResolver.cs
@@ -334,22 +334,20 @@ internal static class ExternalClrOverrideResolver
             _ => type,
         };
 
-        if (type is TypeParameterSymbol typeParameter)
+        if (clrType?.IsGenericParameter == true)
         {
-            if (clrType == null || !clrType.IsGenericParameter)
-            {
-                return false;
-            }
-
             if (clrType.DeclaringMethod != null)
             {
-                return typeParameter.Ordinal < methodTypeParameters.Length
+                return type is TypeParameterSymbol typeParameter
+                    && typeParameter.Ordinal < methodTypeParameters.Length
                     && ReferenceEquals(typeParameter, methodTypeParameters[typeParameter.Ordinal])
                     && clrType.GenericParameterPosition == typeParameter.Ordinal;
             }
 
             return clrType.GenericParameterPosition < containingTypeArguments.Length
-                && TypeSymbolsMatch(containingTypeArguments[clrType.GenericParameterPosition], typeParameter);
+                && DeclarationBinder.TypeSignaturesEquivalent(
+                    containingTypeArguments[clrType.GenericParameterPosition],
+                    type);
         }
 
         var effectiveClrType = NullableLifting.GetEffectiveClrType(type);
@@ -359,18 +357,6 @@ internal static class ExternalClrOverrideResolver
         }
 
         return false;
-    }
-
-    private static bool TypeSymbolsMatch(TypeSymbol left, TypeSymbol right)
-    {
-        if (ReferenceEquals(left, right))
-        {
-            return true;
-        }
-
-        var leftClr = NullableLifting.GetEffectiveClrType(left);
-        var rightClr = NullableLifting.GetEffectiveClrType(right);
-        return leftClr != null && rightClr != null && ClrTypeUtilities.AreSame(leftClr, rightClr);
     }
 
     private static bool IsCovariantReturn(Type? baseReturnType, TypeSymbol derivedReturnType)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3335ImportedGenericBaseOverrideTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3335ImportedGenericBaseOverrideTests.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
@@ -22,6 +23,21 @@ public sealed class Issue3335ImportedGenericBaseOverrideTests
           public open func Write(data []float64) T;
           public open func ReadAll(items []T, data []float64);
           public open func WriteAll(data []float64) []T;
+          public open func EchoAll[U](items []U) []U;
+        }
+
+        public class Box[T] {
+        }
+
+        public open class DeepRoot[T] {
+          public open func Transform(item T) T;
+          public open prop Current T { get; }
+        }
+
+        public open class DeepBase[T] : DeepRoot[T] {
+        }
+
+        public open class DeepMid[T] : DeepBase[Box[T]] {
         }
         """;
 
@@ -60,6 +76,22 @@ public sealed class Issue3335ImportedGenericBaseOverrideTests
                   public override func WriteAll(data []float64) []Payload {
                     return []Payload{ Payload{ Value: data[0] } }
                   }
+
+                  public override func EchoAll[U](items []U) []U {
+                    return items
+                  }
+                }
+
+                public class DeepPayloadConverter : DeepMid[Payload] {
+                  public override func Transform(item Box[Payload]) Box[Payload] {
+                    return item
+                  }
+
+                  public override prop Current Box[Payload] {
+                    get {
+                      return Box[Payload]()
+                    }
+                  }
                 }
 
                 func Main() int32 {
@@ -68,7 +100,16 @@ public sealed class Issue3335ImportedGenericBaseOverrideTests
                   converter.Read(payload, []float64{ 2.5 })
                   let payloads = converter.WriteAll([]float64{ 3.5 })
                   converter.ReadAll(payloads, []float64{ 4.5 })
-                  return payload.Value == 2.5 && payloads[0].Value == 4.5 ? 0 : 1
+                  let echoed = converter.EchoAll[Payload](payloads)
+
+                  let deep = DeepPayloadConverter()
+                  let wrapped = Box[Payload]()
+                  let transformed = deep.Transform(wrapped)
+                  let current = deep.Current
+
+                  return payload.Value == 2.5
+                    && echoed[0].Value == 4.5
+                    && transformed == wrapped ? 0 : 1
                 }
                 """,
                 new[] { libraryPath });
@@ -115,11 +156,47 @@ public sealed class Issue3335ImportedGenericBaseOverrideTests
                   public override func WriteAll(data []float64) []Payload {
                     return []Payload{}
                   }
+
+                  public override func EchoAll[U](items []U) []U {
+                    return items
+                  }
+                }
+
+                public open class BadMethodConverter : Converter[Payload] {
+                  public override func Read(item Payload, data []float64) {
+                  }
+
+                  public override func Write(data []float64) Payload {
+                    return Payload{}
+                  }
+
+                  public override func ReadAll(items []Payload, data []float64) {
+                  }
+
+                  public override func WriteAll(data []float64) []Payload {
+                    return []Payload{}
+                  }
+
+                  public override func EchoAll[U](items []U) []Payload {
+                    return []Payload{}
+                  }
+                }
+
+                public open class BadDeepConverter : DeepMid[Payload] {
+                  public override func Transform(item Box[float64]) Box[Payload] {
+                    return Box[Payload]()
+                  }
+
+                  public override prop Current Box[Payload] {
+                    get {
+                      return Box[Payload]()
+                    }
+                  }
                 }
                 """,
                 new[] { libraryPath });
 
-            Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0185");
+            Assert.Equal(3, result.Diagnostics.Count(diagnostic => diagnostic.Id == "GS0185"));
         }
         finally
         {

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3335ImportedGenericBaseOverrideTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3335ImportedGenericBaseOverrideTests.cs
@@ -1,0 +1,87 @@
+// <copyright file="Issue3335ImportedGenericBaseOverrideTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+public sealed class Issue3335ImportedGenericBaseOverrideTests
+{
+    [Fact]
+    public void ConsumerTypeArgument_SubstitutesImportedOverrideParameterAndReturn_Runs()
+    {
+        var outputDirectory = Path.Combine(AppContext.BaseDirectory, "Issue3335", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(outputDirectory);
+        try
+        {
+            var libraryPath = Path.Combine(outputDirectory, "FindingCrossAssemblyGenericOverride.dll");
+            var library = new Compilation(
+                SyntaxTree.Parse(SourceText.From(
+                    """
+                    package FindingCrossAssemblyGenericOverride
+
+                    public open class Converter[T] {
+                      public open func Read(item T, data []float64);
+                      public open func Write(data []float64) T;
+                    }
+                    """)))
+            {
+                IsLibrary = true,
+            };
+
+            using (var output = File.Create(libraryPath))
+            {
+                var emit = library.Emit(
+                    output,
+                    pdbStream: null,
+                    refStream: null,
+                    assemblyName: "FindingCrossAssemblyGenericOverride");
+                Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
+            }
+
+            var result = EmittedOracle.Evaluate(
+                """
+                package FindingCrossAssemblyGenericOverrideApp
+
+                import FindingCrossAssemblyGenericOverride
+
+                public class Payload {
+                  public var Value float64
+                }
+
+                public class PayloadConverter : Converter[Payload] {
+                  public override func Read(item Payload, data []float64) {
+                    item.Value = data[0]
+                  }
+
+                  public override func Write(data []float64) Payload {
+                    return Payload{ Value: data[0] }
+                  }
+                }
+
+                func Main() int32 {
+                  let converter Converter[Payload] = PayloadConverter()
+                  let payload = converter.Write([]float64{ 1.5 })
+                  converter.Read(payload, []float64{ 2.5 })
+                  return payload.Value == 2.5 ? 0 : 1
+                }
+                """,
+                new[] { libraryPath });
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Equal(0, result.ExitCode);
+            Assert.Equal(0, Assert.IsType<int>(result.Value));
+        }
+        finally
+        {
+            Directory.Delete(outputDirectory, recursive: true);
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3335ImportedGenericBaseOverrideTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3335ImportedGenericBaseOverrideTests.cs
@@ -14,37 +14,25 @@ namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 
 public sealed class Issue3335ImportedGenericBaseOverrideTests
 {
+    private const string LibrarySource = """
+        package FindingCrossAssemblyGenericOverride
+
+        public open class Converter[T] {
+          public open func Read(item T, data []float64);
+          public open func Write(data []float64) T;
+          public open func ReadAll(items []T, data []float64);
+          public open func WriteAll(data []float64) []T;
+        }
+        """;
+
     [Fact]
-    public void ConsumerTypeArgument_SubstitutesImportedOverrideParameterAndReturn_Runs()
+    public void ConsumerTypeArgument_SubstitutesImportedOverrideSignaturesRecursively_Runs()
     {
         var outputDirectory = Path.Combine(AppContext.BaseDirectory, "Issue3335", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(outputDirectory);
         try
         {
-            var libraryPath = Path.Combine(outputDirectory, "FindingCrossAssemblyGenericOverride.dll");
-            var library = new Compilation(
-                SyntaxTree.Parse(SourceText.From(
-                    """
-                    package FindingCrossAssemblyGenericOverride
-
-                    public open class Converter[T] {
-                      public open func Read(item T, data []float64);
-                      public open func Write(data []float64) T;
-                    }
-                    """)))
-            {
-                IsLibrary = true,
-            };
-
-            using (var output = File.Create(libraryPath))
-            {
-                var emit = library.Emit(
-                    output,
-                    pdbStream: null,
-                    refStream: null,
-                    assemblyName: "FindingCrossAssemblyGenericOverride");
-                Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
-            }
+            var libraryPath = EmitLibrary(outputDirectory);
 
             var result = EmittedOracle.Evaluate(
                 """
@@ -64,13 +52,23 @@ public sealed class Issue3335ImportedGenericBaseOverrideTests
                   public override func Write(data []float64) Payload {
                     return Payload{ Value: data[0] }
                   }
+
+                  public override func ReadAll(items []Payload, data []float64) {
+                    items[0].Value = data[0]
+                  }
+
+                  public override func WriteAll(data []float64) []Payload {
+                    return []Payload{ Payload{ Value: data[0] } }
+                  }
                 }
 
                 func Main() int32 {
                   let converter Converter[Payload] = PayloadConverter()
                   let payload = converter.Write([]float64{ 1.5 })
                   converter.Read(payload, []float64{ 2.5 })
-                  return payload.Value == 2.5 ? 0 : 1
+                  let payloads = converter.WriteAll([]float64{ 3.5 })
+                  converter.ReadAll(payloads, []float64{ 4.5 })
+                  return payload.Value == 2.5 && payloads[0].Value == 4.5 ? 0 : 1
                 }
                 """,
                 new[] { libraryPath });
@@ -83,5 +81,67 @@ public sealed class Issue3335ImportedGenericBaseOverrideTests
         {
             Directory.Delete(outputDirectory, recursive: true);
         }
+    }
+
+    [Fact]
+    public void NestedConsumerTypeArgument_Mismatch_RemainsGS0185()
+    {
+        var outputDirectory = Path.Combine(AppContext.BaseDirectory, "Issue3335", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(outputDirectory);
+        try
+        {
+            var libraryPath = EmitLibrary(outputDirectory);
+            var result = EmittedOracle.Evaluate(
+                """
+                package FindingCrossAssemblyGenericOverrideApp
+
+                import FindingCrossAssemblyGenericOverride
+
+                public class Payload {
+                  public var Value float64
+                }
+
+                public open class BadConverter : Converter[Payload] {
+                  public override func Read(item Payload, data []float64) {
+                  }
+
+                  public override func Write(data []float64) Payload {
+                    return Payload{}
+                  }
+
+                  public override func ReadAll(items []float64, data []float64) {
+                  }
+
+                  public override func WriteAll(data []float64) []Payload {
+                    return []Payload{}
+                  }
+                }
+                """,
+                new[] { libraryPath });
+
+            Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0185");
+        }
+        finally
+        {
+            Directory.Delete(outputDirectory, recursive: true);
+        }
+    }
+
+    private static string EmitLibrary(string outputDirectory)
+    {
+        var libraryPath = Path.Combine(outputDirectory, "FindingCrossAssemblyGenericOverride.dll");
+        var library = new Compilation(SyntaxTree.Parse(SourceText.From(LibrarySource)))
+        {
+            IsLibrary = true,
+        };
+
+        using var output = File.Create(libraryPath);
+        var emit = library.Emit(
+            output,
+            pdbStream: null,
+            refStream: null,
+            assemblyName: "FindingCrossAssemblyGenericOverride");
+        Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
+        return libraryPath;
     }
 }


### PR DESCRIPTION
## Summary
- recursively project imported generic-base signatures through symbolic type arguments before override comparison
- carry positional method type arguments into `MapOpenClrTypeToSymbolic`, covering nested method-generic shapes such as `[]U`
- build reusable substitution contexts for every generic base level via `TryMapConstructedTypeArgumentsThroughHierarchy`, covering inherited `Base[Box[T]]` methods and properties
- share strict `TypeSignaturesEquivalent` matching across method parameters/returns, properties/indexers, and events

## Regression coverage
- direct consumer-owned `T` parameter and return substitution
- nested `[]T` parameter and return substitution
- nested method-level `[]U` parameter and return substitution
- deep `DeepMid[T] : DeepBase[Box[T]] : DeepRoot[T]` method and property overrides
- emitted consumer runs successfully
- three genuine mismatches (nested type, nested method type, deep remap) remain GS0185

## Validation
- `dotnet test test/Core.Tests/Core.Tests.csproj --configuration Release --filter 'FullyQualifiedName~Issue3335ImportedGenericBaseOverrideTests|FullyQualifiedName~ClassTests.Override_ConstructedGenericBase' --nologo --no-restore` (6 passed)
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj --configuration Release --filter 'FullyQualifiedName~Issue2443ExternalClrOverrideEmitTests|FullyQualifiedName~Issue1055OverrideGenericBaseEmitTests|FullyQualifiedName~Issue2863ImportedOverrideEmitTests' --nologo --no-restore` (20 passed)

Fixes #3335
