### PR TITLE
Fix partial member import provenance

### DIFF
--- a/docs/adr/0144-partial-types.md
+++ b/docs/adr/0144-partial-types.md
@@ -189,10 +189,13 @@ This merge-the-syntax design was chosen over binding each part into a shared
 symbol with accumulating installers (the higher-blast-radius alternative).
 G# imports are file-scoped, so binding uses each composed child node's retained
 `SyntaxTree` for type clauses, annotations, declaration expressions, and shared
-initializer blocks. Syntax nodes carry no `Parent` reference, so composing
-children drawn from different parts/files under one synthetic parent remains
-safe: diagnostics and import lookup both use the declaring file, while the
-synthetic parent's tree remains only the aggregate anchor described above.
+initializer blocks. Matching generic-parameter lists are retained from every
+part; constraint binding selects the first list that resolves independently in
+its own file, without unioning imports. Syntax nodes carry no `Parent` reference,
+so composing children drawn from different parts/files under one synthetic
+parent remains safe: diagnostics and import lookup both use the declaring file,
+while the synthetic parent's tree remains only the aggregate anchor described
+above.
 
 **Nested partial types** are handled by the same merger recursively: when it
 builds (or passes through) a type node, it merges the partial nested types in

--- a/docs/adr/0144-partial-types.md
+++ b/docs/adr/0144-partial-types.md
@@ -190,12 +190,14 @@ symbol with accumulating installers (the higher-blast-radius alternative).
 G# imports are file-scoped, so binding uses each composed child node's retained
 `SyntaxTree` for type clauses, annotations, declaration expressions, and shared
 initializer blocks. Matching generic-parameter lists are retained from every
-part; constraint binding selects the first list that resolves independently in
-its own file, without unioning imports. Syntax nodes carry no `Parent` reference,
-so composing children drawn from different parts/files under one synthetic
-parent remains safe: diagnostics and import lookup both use the declaring file,
-while the synthetic parent's tree remains only the aggregate anchor described
-above.
+part and bind independently in their own files, without unioning imports. One
+successful binding supplies the contract when other parts lack the needed
+import; multiple successful bindings must resolve to equivalent signatures or
+report `GS0480`. If none resolve, each part keeps its own constraint diagnostics.
+Syntax nodes carry no `Parent` reference, so composing children drawn from
+different parts/files under one synthetic parent remains safe: diagnostics and
+import lookup both use the declaring file, while the synthetic parent's tree
+remains only the aggregate anchor described above.
 
 **Nested partial types** are handled by the same merger recursively: when it
 builds (or passes through) a type node, it merges the partial nested types in

--- a/docs/adr/0144-partial-types.md
+++ b/docs/adr/0144-partial-types.md
@@ -186,13 +186,13 @@ through the body binder's existing duplicate detection (`GS0102`), since all
 parts' members now live in one node.
 
 This merge-the-syntax design was chosen over binding each part into a shared
-symbol with accumulating installers (the higher-blast-radius alternative) because
-two invariants make it sound: G# **imports are compilation-global** (`BindGlobalScope`
-binds every tree's `ImportSyntax` into one shared scope), so a member body merged
-from another file still resolves its type names; and G# **syntax nodes carry no
-`Parent` reference**, so composing child nodes drawn from different parts/files
-under one synthetic parent is safe — each child keeps its own `SyntaxTree`, so
-diagnostics still point at the correct file and span.
+symbol with accumulating installers (the higher-blast-radius alternative).
+G# imports are file-scoped, so binding uses each composed child node's retained
+`SyntaxTree` for type clauses, annotations, declaration expressions, and shared
+initializer blocks. Syntax nodes carry no `Parent` reference, so composing
+children drawn from different parts/files under one synthetic parent remains
+safe: diagnostics and import lookup both use the declaring file, while the
+synthetic parent's tree remains only the aggregate anchor described above.
 
 **Nested partial types** are handled by the same merger recursively: when it
 builds (or passes through) a type node, it merges the partial nested types in
@@ -272,6 +272,6 @@ single `.cctor`.
   installer in the ~2 000-line body binder to accumulate, seeding cross-part
   duplicate detection, and making base-class / primary-constructor / type-param
   binding "set once" across parts — a large, error-prone surface. The syntax
-  merge confines all partial logic to one pre-pass and leaves the binder,
-  installers, symbols, and emitter untouched. It is sound only because imports
-  are compilation-global and syntax nodes have no `Parent` (see §E).
+  merge confines partial composition to one pre-pass and reuses child-node
+  `SyntaxTree` provenance during binding; installers, symbols, and emitter stay
+  unchanged (see §E).

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -1012,7 +1012,7 @@ public sealed class Binder
                 ? syntax.BaseTypeClauses[0]
                 : syntax.BaseTypeIdentifier == null
                     ? null
-                    : new TypeClauseSyntax(syntax.SyntaxTree, syntax.BaseTypeIdentifier);
+                    : new TypeClauseSyntax(syntax.BaseTypeIdentifier.SyntaxTree, syntax.BaseTypeIdentifier);
             var baseName = baseType?.QualifierIdentifierTokens.LastOrDefault()?.Text
                 ?? baseType?.Identifier?.Text;
             if (symbol.IsClass && baseName != null && declarationsByName.TryGetValue(baseName, out var candidates))
@@ -2491,6 +2491,8 @@ public sealed class Binder
             var boundBlocks = ImmutableArray.CreateBuilder<BoundStatement>();
             foreach (var initBlock in initBlocks)
             {
+                // Issue #3336: merged partial blocks retain the declaring part's tree.
+                parentScope.SetCurrentReferencingSyntaxTree(initBlock.SyntaxTree);
                 boundBlocks.Add(binder.statements.BindBlockStatement(initBlock.Body));
             }
 
@@ -3671,40 +3673,51 @@ public sealed class Binder
 
     private TypeSymbol? BindTypeClause(TypeClauseSyntax? syntax)
     {
-        var bound = BindNonNullableTypeClause(syntax);
-        if (bound == null)
+        if (syntax == null)
         {
+            return null;
+        }
+
+        // Issue #3336: merged partial type clauses retain the declaring part's tree.
+        var bindingScope = scope;
+        var previousTree = bindingScope.SetCurrentReferencingSyntaxTree(syntax.SyntaxTree);
+        try
+        {
+            var bound = BindNonNullableTypeClause(syntax);
+            if (bound == null)
+            {
+                return null;
+            }
+
+            // Issue #1212: for an array/slice clause the trailing `?` is consumed
+            // by ApplyArraySuffix and applied to the element type (`[]T?`), so it
+            // must not also wrap the whole array. The *array* is made nullable only
+            // by an explicit `?` right after `]` (`[]?T` → `ArrayQuestionToken`).
+            if (syntax.IsArray)
+            {
+                bound = syntax.IsArrayNullable ? NullableTypeSymbol.Get(bound) : bound;
+            }
+            else if (syntax.IsNullable)
+            {
+                bound = NullableTypeSymbol.Get(bound);
+            }
+
+            // Issue #3315 / ADR-0159 addendum: the `?` after the closing `)` of a
+            // parenthesized type clause marks the WHOLE inner type nullable —
+            // `(chan int32)?` is a nullable channel, `([]T)?` equals `[]?T`. The
+            // already-nullable guard makes redundant spellings like `(int32?)?`
+            // collapse instead of double-wrapping.
+            if (syntax.IsParenthesizedNullable && bound is not NullableTypeSymbol)
+            {
+                bound = NullableTypeSymbol.Get(bound);
+            }
+
             return bound;
         }
-
-        // BindNonNullableTypeClause returns null immediately when its syntax
-        // argument is null, so a non-null bound here means syntax is non-null.
-        var nonNullSyntax = Invariant.Required(syntax, "BindNonNullableTypeClause returned non-null, so its syntax argument was non-null");
-
-        // Issue #1212: for an array/slice clause the trailing `?` is consumed
-        // by ApplyArraySuffix and applied to the element type (`[]T?`), so it
-        // must not also wrap the whole array. The *array* is made nullable only
-        // by an explicit `?` right after `]` (`[]?T` → `ArrayQuestionToken`).
-        if (nonNullSyntax.IsArray)
+        finally
         {
-            bound = nonNullSyntax.IsArrayNullable ? NullableTypeSymbol.Get(bound) : bound;
+            bindingScope.SetCurrentReferencingSyntaxTree(previousTree);
         }
-        else if (nonNullSyntax.IsNullable)
-        {
-            bound = NullableTypeSymbol.Get(bound);
-        }
-
-        // Issue #3315 / ADR-0159 addendum: the `?` after the closing `)` of a
-        // parenthesized type clause marks the WHOLE inner type nullable —
-        // `(chan int32)?` is a nullable channel, `([]T)?` equals `[]?T`. The
-        // already-nullable guard makes redundant spellings like `(int32?)?`
-        // collapse instead of double-wrapping.
-        if (nonNullSyntax.IsParenthesizedNullable && bound is not NullableTypeSymbol)
-        {
-            bound = NullableTypeSymbol.Get(bound);
-        }
-
-        return bound;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -1996,7 +1996,19 @@ internal sealed class ConversionClassifier
             return;
         }
 
-        var bound = bindExpression(defaultValue);
+        // Issue #3336: this expression can belong to a non-primary partial part.
+        var bindingScope = binderCtx.RootScope;
+        var previousTree = bindingScope.SetCurrentReferencingSyntaxTree(defaultValue.SyntaxTree);
+        BoundExpression bound;
+        try
+        {
+            bound = bindExpression(defaultValue);
+        }
+        finally
+        {
+            bindingScope.SetCurrentReferencingSyntaxTree(previousTree);
+        }
+
         if (bound == null || bound is BoundErrorExpression || parameter.Type == TypeSymbol.Error)
         {
             return;

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Attributes.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Attributes.cs
@@ -170,28 +170,38 @@ internal sealed partial class DeclarationBinder
                 continue;
             }
 
-            var bound = BindAttribute(annotation, defaultTarget, allowedTargets, positionDescription, defaultSystemTarget);
-            if (bound != null)
+            // Issue #3336: merged partial annotations retain the declaring part's tree.
+            var bindingScope = scope;
+            var previousTree = bindingScope.SetCurrentReferencingSyntaxTree(annotation.SyntaxTree);
+            try
             {
-                var key = (bound.AttributeType, bound.Target);
-                if (applications.TryGetValue(key, out var count))
+                var bound = BindAttribute(annotation, defaultTarget, allowedTargets, positionDescription, defaultSystemTarget);
+                if (bound != null)
                 {
-                    KnownAttributes.GetAttributeUsage(bound.AttributeType, out _, out var allowMultiple);
-                    if (!allowMultiple)
+                    var key = (bound.AttributeType, bound.Target);
+                    if (applications.TryGetValue(key, out var count))
                     {
-                        Diagnostics.ReportAttributeUsageDuplicate(
-                            GetAnnotationNameLocation(annotation),
-                            annotation.GetNameText());
+                        KnownAttributes.GetAttributeUsage(bound.AttributeType, out _, out var allowMultiple);
+                        if (!allowMultiple)
+                        {
+                            Diagnostics.ReportAttributeUsageDuplicate(
+                                GetAnnotationNameLocation(annotation),
+                                annotation.GetNameText());
+                        }
+
+                        applications[key] = count + 1;
+                    }
+                    else
+                    {
+                        applications[key] = 1;
                     }
 
-                    applications[key] = count + 1;
+                    builder.Add(bound);
                 }
-                else
-                {
-                    applications[key] = 1;
-                }
-
-                builder.Add(bound);
+            }
+            finally
+            {
+                bindingScope.SetCurrentReferencingSyntaxTree(previousTree);
             }
         }
 

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Constructors.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Constructors.cs
@@ -55,7 +55,10 @@ internal sealed partial class DeclarationBinder
             // ambient lookup preference (see field-initializer closure above
             // for the full rationale) for the duration of this deferred bind.
             var savedPackage = scope.SetCurrentDeclaringPackage(structSymbol.PackageName);
-            var savedTree = scope.SetCurrentReferencingSyntaxTree(syntax.SyntaxTree);
+            var savedTree = scope.SetCurrentReferencingSyntaxTree(
+                Invariant.Required(
+                    syntax.BaseConstructorOpenParenthesisToken,
+                    "a base-constructor argument list has an opening parenthesis").SyntaxTree);
             try
             {
                 BindBaseConstructorInitializerCore(syntax, structSymbol, baseClassSymbol, importedBaseType, primaryCtorParameters);

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Functions.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Functions.cs
@@ -1305,7 +1305,9 @@ internal sealed partial class DeclarationBinder
     private void ResolvePartialTypeParameterConstraints(
         TypeParameterListSyntax? primarySyntax,
         ImmutableArray<TypeParameterListSyntax> matchingPartialLists,
-        ImmutableArray<TypeParameterSymbol> symbols)
+        ImmutableArray<TypeParameterSymbol> symbols,
+        string typeName,
+        ImmutableArray<TextLocation> partialPartLocations)
     {
         if (matchingPartialLists.Length <= 1)
         {
@@ -1313,33 +1315,106 @@ internal sealed partial class DeclarationBinder
             return;
         }
 
-        // Issue #3336: matching partial headers share one contract, but each
-        // candidate must resolve through its own file's imports.
-        foreach (var candidate in matchingPartialLists)
+        // Issue #3336: bind every matching header through its own file imports.
+        var successfulBindings =
+            new List<(int PartIndex, TypeParameterListSyntax Syntax, ImmutableArray<TypeParameterSymbol> Symbols)>();
+        var diagnosticsByPart = new List<ImmutableArray<Diagnostic>>(matchingPartialLists.Length);
+        for (var partIndex = 0; partIndex < matchingPartialLists.Length; partIndex++)
         {
-            if (CanBindTypeParameterConstraints(candidate))
+            var candidate = matchingPartialLists[partIndex];
+            var diagnosticCount = Diagnostics.Count;
+            var candidateSymbols = CreateTypeParameterSymbols(candidate);
+            ImmutableArray<Diagnostic> candidateDiagnostics;
+            try
             {
-                ResolveTypeParameterConstraints(candidate, symbols);
-                return;
+                ResolveTypeParameterConstraints(candidate, candidateSymbols);
+                candidateDiagnostics = Diagnostics.Skip(diagnosticCount).ToImmutableArray();
+            }
+            finally
+            {
+                Diagnostics.TruncateTo(diagnosticCount);
+            }
+
+            diagnosticsByPart.Add(candidateDiagnostics);
+            if (!candidateDiagnostics.Any(diagnostic => diagnostic.IsError))
+            {
+                successfulBindings.Add((partIndex, candidate, candidateSymbols));
             }
         }
 
-        ResolveTypeParameterConstraints(primarySyntax, symbols);
+        if (successfulBindings.Count == 0)
+        {
+            // Preserve primary-part recovery state, but surface each part's own
+            // constraint diagnostics exactly once.
+            var diagnosticCount = Diagnostics.Count;
+            try
+            {
+                ResolveTypeParameterConstraints(primarySyntax, symbols);
+            }
+            finally
+            {
+                Diagnostics.TruncateTo(diagnosticCount);
+            }
+
+            foreach (var candidateDiagnostics in diagnosticsByPart)
+            {
+                Diagnostics.AddRange(candidateDiagnostics);
+            }
+
+            return;
+        }
+
+        var baseline = successfulBindings[0];
+        foreach (var candidate in successfulBindings.Skip(1))
+        {
+            if (!TypeParameterConstraintSignaturesEquivalent(baseline.Symbols, candidate.Symbols))
+            {
+                var location = candidate.PartIndex < partialPartLocations.Length
+                    ? partialPartLocations[candidate.PartIndex]
+                    : candidate.Syntax.Location;
+                Diagnostics.ReportPartialTypeParameterMismatch(location, typeName);
+            }
+        }
+
+        ResolveTypeParameterConstraints(baseline.Syntax, symbols);
     }
 
-    private bool CanBindTypeParameterConstraints(TypeParameterListSyntax syntax)
+    private static bool TypeParameterConstraintSignaturesEquivalent(
+        ImmutableArray<TypeParameterSymbol> left,
+        ImmutableArray<TypeParameterSymbol> right)
     {
-        var diagnosticCount = Diagnostics.Count;
-        try
+        if (left.Length != right.Length)
         {
-            var symbols = CreateTypeParameterSymbols(syntax);
-            ResolveTypeParameterConstraints(syntax, symbols);
-            return !Diagnostics.Skip(diagnosticCount).Any(diagnostic => diagnostic.IsError);
+            return false;
         }
-        finally
+
+        var typeParameterMap = new Dictionary<TypeParameterSymbol, TypeSymbol>(left.Length);
+        for (var i = 0; i < left.Length; i++)
         {
-            Diagnostics.TruncateTo(diagnosticCount);
+            typeParameterMap[left[i]] = right[i];
         }
+
+        for (var i = 0; i < left.Length; i++)
+        {
+            var x = left[i];
+            var y = right[i];
+            if (!string.Equals(x.Name, y.Name, StringComparison.Ordinal)
+                || x.Ordinal != y.Ordinal
+                || x.Variance != y.Variance
+                || x.Constraint != y.Constraint
+                || x.HasReferenceTypeConstraint != y.HasReferenceTypeConstraint
+                || x.HasValueTypeConstraint != y.HasValueTypeConstraint
+                || x.HasDefaultConstructorConstraint != y.HasDefaultConstructorConstraint
+                || x.HasUnmanagedConstraint != y.HasUnmanagedConstraint
+                || !TypeSignaturesEquivalent(x.InterfaceConstraint, y.InterfaceConstraint, typeParameterMap)
+                || !TypeSignaturesEquivalent(x.ClrInterfaceConstraint, y.ClrInterfaceConstraint, typeParameterMap)
+                || !TypeSignaturesEquivalent(x.ClassConstraint, y.ClassConstraint, typeParameterMap))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Functions.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Functions.cs
@@ -1302,6 +1302,46 @@ internal sealed partial class DeclarationBinder
         }
     }
 
+    private void ResolvePartialTypeParameterConstraints(
+        TypeParameterListSyntax? primarySyntax,
+        ImmutableArray<TypeParameterListSyntax> matchingPartialLists,
+        ImmutableArray<TypeParameterSymbol> symbols)
+    {
+        if (matchingPartialLists.Length <= 1)
+        {
+            ResolveTypeParameterConstraints(primarySyntax, symbols);
+            return;
+        }
+
+        // Issue #3336: matching partial headers share one contract, but each
+        // candidate must resolve through its own file's imports.
+        foreach (var candidate in matchingPartialLists)
+        {
+            if (CanBindTypeParameterConstraints(candidate))
+            {
+                ResolveTypeParameterConstraints(candidate, symbols);
+                return;
+            }
+        }
+
+        ResolveTypeParameterConstraints(primarySyntax, symbols);
+    }
+
+    private bool CanBindTypeParameterConstraints(TypeParameterListSyntax syntax)
+    {
+        var diagnosticCount = Diagnostics.Count;
+        try
+        {
+            var symbols = CreateTypeParameterSymbols(syntax);
+            ResolveTypeParameterConstraints(syntax, symbols);
+            return !Diagnostics.Skip(diagnosticCount).Any(diagnostic => diagnostic.IsError);
+        }
+        finally
+        {
+            Diagnostics.TruncateTo(diagnosticCount);
+        }
+    }
+
     /// <summary>
     /// Resolves a non-keyword type-parameter constraint (anything other than
     /// <c>any</c> / <c>comparable</c>) as an interface bound and records it on

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Interfaces.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Interfaces.cs
@@ -90,7 +90,9 @@ internal sealed partial class DeclarationBinder
             ResolvePartialTypeParameterConstraints(
                 syntax.TypeParameterList,
                 syntax.PartialTypeParameterLists,
-                interfaceSymbol.TypeParameters);
+                interfaceSymbol.TypeParameters,
+                interfaceSymbol.Name,
+                syntax.PartialPartLocations);
             BindInterfaceMembersCore(syntax, interfaceSymbol, package);
         }
         finally

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Interfaces.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Interfaces.cs
@@ -87,7 +87,10 @@ internal sealed partial class DeclarationBinder
 
         try
         {
-            ResolveTypeParameterConstraints(syntax.TypeParameterList, interfaceSymbol.TypeParameters);
+            ResolvePartialTypeParameterConstraints(
+                syntax.TypeParameterList,
+                syntax.PartialTypeParameterLists,
+                interfaceSymbol.TypeParameters);
             BindInterfaceMembersCore(syntax, interfaceSymbol, package);
         }
         finally

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
@@ -74,7 +74,10 @@ internal sealed partial class DeclarationBinder
             // same-compilation constraint target can be published first.
             // Resolve constraints now, with the declaring shell and all sibling
             // source type shells visible, before binding signatures and members.
-            ResolveTypeParameterConstraints(syntax.TypeParameterList, structSymbol.TypeParameters);
+            ResolvePartialTypeParameterConstraints(
+                syntax.TypeParameterList,
+                syntax.PartialTypeParameterLists,
+                structSymbol.TypeParameters);
             BindStructDeclarationBodyCore(syntax, package, structSymbol);
         }
         finally

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
@@ -648,14 +648,14 @@ internal sealed partial class DeclarationBinder
                 // identifier tokens in the base/interface clause.
                 if (allBaseTypes.Count == 0 && syntax.BaseTypeIdentifier != null)
                 {
-                    allBaseTypes.Add(new TypeClauseSyntax(syntax.SyntaxTree, syntax.BaseTypeIdentifier));
+                    allBaseTypes.Add(new TypeClauseSyntax(syntax.BaseTypeIdentifier.SyntaxTree, syntax.BaseTypeIdentifier));
                     if (!syntax.AdditionalBaseTypeIdentifiers.IsDefaultOrEmpty)
                     {
                         foreach (var token in syntax.AdditionalBaseTypeIdentifiers)
                         {
                             if (token != null)
                             {
-                                allBaseTypes.Add(new TypeClauseSyntax(syntax.SyntaxTree, token));
+                                allBaseTypes.Add(new TypeClauseSyntax(token.SyntaxTree, token));
                             }
                         }
                     }

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
@@ -77,7 +77,9 @@ internal sealed partial class DeclarationBinder
             ResolvePartialTypeParameterConstraints(
                 syntax.TypeParameterList,
                 syntax.PartialTypeParameterLists,
-                structSymbol.TypeParameters);
+                structSymbol.TypeParameters,
+                structSymbol.Name,
+                syntax.PartialPartLocations);
             BindStructDeclarationBodyCore(syntax, package, structSymbol);
         }
         finally

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -151,7 +151,21 @@ internal sealed partial class DeclarationBinder
     {
         this.binderCtx = binderCtx ?? throw new ArgumentNullException(nameof(binderCtx));
         this.conversions = conversions ?? throw new ArgumentNullException(nameof(conversions));
-        this.bindExpression = bindExpression ?? throw new ArgumentNullException(nameof(bindExpression));
+        ArgumentNullException.ThrowIfNull(bindExpression);
+        this.bindExpression = syntax =>
+        {
+            // Issue #3336: merged partial expressions retain the declaring part's tree.
+            var bindingScope = this.scope;
+            var previousTree = bindingScope.SetCurrentReferencingSyntaxTree(syntax.SyntaxTree);
+            try
+            {
+                return bindExpression(syntax);
+            }
+            finally
+            {
+                bindingScope.SetCurrentReferencingSyntaxTree(previousTree);
+            }
+        };
         this.bindTypeClause = bindTypeClause ?? throw new ArgumentNullException(nameof(bindTypeClause));
         this.bindReturnTypeClause = bindReturnTypeClause ?? throw new ArgumentNullException(nameof(bindReturnTypeClause));
         this.bindTypeOfExpression = bindTypeOfExpression ?? throw new ArgumentNullException(nameof(bindTypeOfExpression));

--- a/src/Core/CodeAnalysis/Binding/PartialTypeMerger.cs
+++ b/src/Core/CodeAnalysis/Binding/PartialTypeMerger.cs
@@ -204,8 +204,10 @@ internal static class PartialTypeMerger
 
         // GS0480: identical type-parameter lists (names + arity + constraints).
         var primaryTypeParams = NormalizeNodeText(primary.TypeParameterList);
+        var typeParametersMatch = true;
         foreach (var part in parts.Skip(1).Where(p => NormalizeNodeText(p.TypeParameterList) != primaryTypeParams))
         {
+            typeParametersMatch = false;
             diagnostics.ReportPartialTypeParameterMismatch(part.Identifier?.Location ?? default, name);
         }
 
@@ -286,6 +288,9 @@ internal static class PartialTypeMerger
             PartialModifier = parts.Select(p => p.PartialModifier).FirstOrDefault(t => t != null),
             SealedKeyword = sealedKeyword,
             PartialPartLocations = parts.Select(p => p.Identifier?.Location ?? default).ToImmutableArray(),
+            PartialTypeParameterLists = typeParametersMatch
+                ? parts.Select(p => p.TypeParameterList).OfType<TypeParameterListSyntax>().ToImmutableArray()
+                : ImmutableArray<TypeParameterListSyntax>.Empty,
         };
 
         merged.WithAnnotations(UnionAnnotations(parts));
@@ -432,8 +437,10 @@ internal static class PartialTypeMerger
 
         // GS0480: identical type-parameter lists.
         var primaryTypeParams = NormalizeNodeText(primary.TypeParameterList);
+        var typeParametersMatch = true;
         foreach (var part in parts.Skip(1).Where(p => NormalizeNodeText(p.TypeParameterList) != primaryTypeParams))
         {
+            typeParametersMatch = false;
             diagnostics.ReportPartialTypeParameterMismatch(part.Identifier?.Location ?? default, name);
         }
 
@@ -485,6 +492,9 @@ internal static class PartialTypeMerger
             StaticFields = Concat(parts, p => p.StaticFields),
             PartialModifier = parts.Select(p => p.PartialModifier).FirstOrDefault(t => t != null),
             PartialPartLocations = parts.Select(p => p.Identifier?.Location ?? default).ToImmutableArray(),
+            PartialTypeParameterLists = typeParametersMatch
+                ? parts.Select(p => p.TypeParameterList).OfType<TypeParameterListSyntax>().ToImmutableArray()
+                : ImmutableArray<TypeParameterListSyntax>.Empty,
         };
 
         merged.WithAnnotations(UnionAnnotations(parts));

--- a/src/Core/CodeAnalysis/Syntax/InterfaceDeclarationSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/InterfaceDeclarationSyntax.cs
@@ -279,4 +279,11 @@ public sealed class InterfaceDeclarationSyntax : MemberSyntax
             InvalidateCachedSpan();
         }
     }
+
+    /// <summary>
+    /// Gets or sets matching type-parameter lists retained from merged partial
+    /// declarations so constraint binding can use each list's syntax-tree provenance.
+    /// Empty for ordinary declarations and GS0480-mismatched partial groups.
+    /// </summary>
+    internal ImmutableArray<TypeParameterListSyntax> PartialTypeParameterLists { get; set; } = ImmutableArray<TypeParameterListSyntax>.Empty;
 }

--- a/src/Core/CodeAnalysis/Syntax/StructDeclarationSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/StructDeclarationSyntax.cs
@@ -628,4 +628,11 @@ public sealed class StructDeclarationSyntax : MemberSyntax
             InvalidateCachedSpan();
         }
     }
+
+    /// <summary>
+    /// Gets or sets matching type-parameter lists retained from merged partial
+    /// declarations so constraint binding can use each list's syntax-tree provenance.
+    /// Empty for ordinary declarations and GS0480-mismatched partial groups.
+    /// </summary>
+    internal ImmutableArray<TypeParameterListSyntax> PartialTypeParameterLists { get; set; } = ImmutableArray<TypeParameterListSyntax>.Empty;
 }

--- a/test/Core.Tests/CodeAnalysis/Adr0144PartialTypesBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Adr0144PartialTypesBinderTests.cs
@@ -97,12 +97,12 @@ Console.WriteLine(Foo().Sum())
     }
 
     [Fact]
-    public void CrossFile_PartsMergeAndGlobalImportsResolve()
+    public void CrossFile_PartsMergeAndMemberBodyUsesDeclaringFileImports()
     {
         // Part A declares a field; part B (a separate tree, with its OWN
         // `import System`) declares a method that references a System type.
-        // Compiling both trees together must merge the parts AND let part B's
-        // body resolve `System.Math` — proving imports are compilation-global.
+        // Compiling both trees together must merge the parts while preserving
+        // part B's syntax-tree provenance for its method body.
         var treeA = SyntaxTree.Parse(SourceText.From(
             @"package App
 
@@ -129,6 +129,177 @@ Console.WriteLine(c.Abs())
 
         var output = CompileLoadInvokeCaptureStdout(new[] { treeA, treeB }, "Adr0144-CrossFile");
         Assert.Contains("11", output);
+    }
+
+    [Fact]
+    public void CrossFile_FieldTypeUsesDeclaringPartImports_AndRuns()
+    {
+        var declaringPart = SyntaxTree.Parse(SourceText.From(
+            """
+            package FindingPartialImportBinding
+
+            import System.Text
+
+            public partial class Holder {
+                var sb StringBuilder?
+
+                public func Fill() {
+                    let local = StringBuilder()
+                    local.Append("ok")
+                    sb = local
+                }
+
+                public func Text() string {
+                    return sb?.ToString() ?? ""
+                }
+            }
+            """,
+            "Holder.gs"));
+        var featurePart = SyntaxTree.Parse(SourceText.From(
+            """
+            package FindingPartialImportBinding
+
+            import System
+
+            public partial class Holder {
+                public func Touch() {
+                }
+            }
+
+            let holder = Holder()
+            holder.Fill()
+            Console.WriteLine(holder.Text())
+            """,
+            "Holder.Feature.gs"));
+
+        var output = CompileLoadInvokeCaptureStdout(
+            new[] { declaringPart, featurePart },
+            "Issue3336-PartialFieldImport");
+
+        Assert.Contains("ok", output);
+    }
+
+    [Fact]
+    public void CrossFile_PrimaryPartImportDoesNotLeakToDeclaringPart()
+    {
+        var declaringPart = SyntaxTree.Parse(SourceText.From(
+            """
+            package FindingPartialImportBinding
+
+            public partial class Holder {
+                var sb StringBuilder?
+            }
+            """,
+            "Holder.gs"));
+        var featurePart = SyntaxTree.Parse(SourceText.From(
+            """
+            package FindingPartialImportBinding
+
+            import System.Text
+
+            public partial class Holder {
+            }
+            """,
+            "Holder.Feature.gs"));
+
+        using var peStream = new MemoryStream();
+        var result = new Compilation(new[] { declaringPart, featurePart }).Emit(peStream);
+
+        Assert.Contains(
+            result.Diagnostics,
+            diagnostic => diagnostic.Id == "GS0113"
+                && diagnostic.Location.FileName == "Holder.gs");
+    }
+
+    [Fact]
+    public void CrossFile_MergedMemberDeclarationsKeepDeclaringTreeProvenance()
+    {
+        var declaringPart = SyntaxTree.Parse(SourceText.From(
+            """
+            package FindingPartialImportBinding
+
+            import System.ComponentModel
+            import System.IO
+            import System.Text
+
+            public partial interface IBuilderSource {
+                func Build() StringBuilder;
+            }
+
+            @Description("holder")
+            public partial class Holder : MemoryStream, IBuilderSource {
+                var builder StringBuilder = StringBuilder()
+
+                public prop Value StringBuilder -> builder
+
+                shared {
+                    var Initialized string = ""
+
+                    init {
+                        let local = StringBuilder()
+                        local.Append("shared")
+                        Initialized = local.ToString()
+                    }
+                }
+
+                public class Token {
+                    var text StringBuilder = StringBuilder()
+
+                    public func Text() string {
+                        text.Append("nested")
+                        return text.ToString()
+                    }
+                }
+
+                private func Echo(value StringBuilder) StringBuilder {
+                    return value
+                }
+
+                private func Mode(value FileMode = FileMode.Open) FileMode {
+                    return value
+                }
+
+                public func Build() StringBuilder {
+                    builder.Append("ok")
+                    return Echo(Value)
+                }
+
+                public func ModeText() string {
+                    return Mode().ToString()
+                }
+            }
+            """,
+            "Holder.gs"));
+        var featurePart = SyntaxTree.Parse(SourceText.From(
+            """
+            package FindingPartialImportBinding
+
+            import System
+
+            public partial interface IBuilderSource {
+            }
+
+            public partial class Holder {
+                public func Touch() {
+                }
+            }
+
+            let holder = Holder()
+            Console.WriteLine(holder.Build().ToString())
+            Console.WriteLine(holder.ModeText())
+            Console.WriteLine(Holder.Token().Text())
+            Console.WriteLine(Holder.Initialized)
+            """,
+            "Holder.Feature.gs"));
+
+        var output = CompileLoadInvokeCaptureStdout(
+            new[] { featurePart, declaringPart },
+            "Issue3336-PartialMemberProvenance");
+
+        Assert.Contains("ok", output);
+        Assert.Contains("Open", output);
+        Assert.Contains("nested", output);
+        Assert.Contains("shared", output);
     }
 
     [Fact]
@@ -300,17 +471,18 @@ import System
 
 partial class Box {
     partial class Slot {
-        var value int32 = 7
+        func Read() string {
+            return value.ToString()
+        }
     }
 }", "A.gs"));
         var fileB = SyntaxTree.Parse(SourceText.From(@"package App
 import System
+import System.Text
 
 partial class Box {
     partial class Slot {
-        func Read() int32 {
-            return value
-        }
+        var value StringBuilder = StringBuilder(""nested"")
     }
 }
 
@@ -318,7 +490,7 @@ let s = Box.Slot()
 Console.WriteLine(s.Read())", "B.gs"));
 
         var output = CompileLoadInvokeCaptureStdout(new[] { fileA, fileB }, "Adr0144-NestedSplit");
-        Assert.Contains("7", output);
+        Assert.Contains("nested", output);
     }
 
     [Fact]

--- a/test/Core.Tests/CodeAnalysis/Adr0144PartialTypesBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Adr0144PartialTypesBinderTests.cs
@@ -212,6 +212,128 @@ Console.WriteLine(c.Abs())
     }
 
     [Fact]
+    public void CrossFile_GenericConstraintsUseImportingPartProvenance()
+    {
+        var declaringPart = SyntaxTree.Parse(SourceText.From(
+            """
+            package FindingPartialConstraintImport
+
+            import System.Collections.Generic
+
+            public partial class Holder[T IEnumerable[T]] {
+            }
+
+            public partial interface IHolder[T IEnumerable[T]] {
+            }
+
+            public partial class Outer {
+                partial class Nested[T IEnumerable[T]] {
+                }
+            }
+            """,
+            "Holder.gs"));
+        var featurePart = SyntaxTree.Parse(SourceText.From(
+            """
+            package FindingPartialConstraintImport
+
+            public partial class Holder[T IEnumerable[T]] {
+            }
+
+            public partial interface IHolder[T IEnumerable[T]] {
+            }
+
+            public partial class Outer {
+                partial class Nested[T IEnumerable[T]] {
+                }
+            }
+            """,
+            "Holder.Feature.gs"));
+
+        using var peStream = new MemoryStream();
+        var result = new Compilation(new[] { declaringPart, featurePart })
+        {
+            IsLibrary = true,
+        }.Emit(peStream);
+
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+    }
+
+    [Fact]
+    public void CrossFile_GenericConstraintImportDoesNotLeakFromUnrelatedFile()
+    {
+        var declaringPart = SyntaxTree.Parse(SourceText.From(
+            """
+            package FindingPartialConstraintImport
+
+            public partial class Holder[T IEnumerable[T]] {
+            }
+            """,
+            "Holder.gs"));
+        var featurePart = SyntaxTree.Parse(SourceText.From(
+            """
+            package FindingPartialConstraintImport
+
+            public partial class Holder[T IEnumerable[T]] {
+            }
+            """,
+            "Holder.Feature.gs"));
+        var unrelated = SyntaxTree.Parse(SourceText.From(
+            """
+            package FindingPartialConstraintImport
+
+            import System.Collections.Generic
+
+            public class Marker {
+            }
+            """,
+            "Unrelated.gs"));
+
+        using var peStream = new MemoryStream();
+        var result = new Compilation(new[] { unrelated, declaringPart, featurePart })
+        {
+            IsLibrary = true,
+        }.Emit(peStream);
+
+        Assert.Contains(
+            result.Diagnostics,
+            diagnostic => diagnostic.Id == "GS0113"
+                && diagnostic.Location.FileName == "Holder.Feature.gs");
+    }
+
+    [Fact]
+    public void CrossFile_GenericConstraintMismatchStillReportsGS0480()
+    {
+        var anyConstraint = SyntaxTree.Parse(SourceText.From(
+            """
+            package FindingPartialConstraintImport
+
+            public partial class Holder[T any] {
+            }
+            """,
+            "Holder.Feature.gs"));
+        var importedConstraint = SyntaxTree.Parse(SourceText.From(
+            """
+            package FindingPartialConstraintImport
+
+            import System.Collections.Generic
+
+            public partial class Holder[T IEnumerable[T]] {
+            }
+            """,
+            "Holder.gs"));
+
+        using var peStream = new MemoryStream();
+        var result = new Compilation(new[] { importedConstraint, anyConstraint })
+        {
+            IsLibrary = true,
+        }.Emit(peStream);
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0480");
+    }
+
+    [Fact]
     public void CrossFile_MergedMemberDeclarationsKeepDeclaringTreeProvenance()
     {
         var declaringPart = SyntaxTree.Parse(SourceText.From(

--- a/test/Core.Tests/CodeAnalysis/Adr0144PartialTypesBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Adr0144PartialTypesBinderTests.cs
@@ -260,6 +260,145 @@ Console.WriteLine(c.Abs())
             "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CrossFile_SameConstraintTextResolvingToDifferentTypesReportsGS0480(bool leftPartFirst)
+    {
+        var contract = SyntaxTree.Parse(SourceText.From(
+            """
+            package Contracts
+
+            public interface IConstraint[U any] {
+            }
+            """,
+            "Contract.gs"));
+        var leftMarker = SyntaxTree.Parse(SourceText.From(
+            """
+            package Left
+
+            public class Marker[U any] {
+            }
+            """,
+            "Left.Marker.gs"));
+        var rightMarker = SyntaxTree.Parse(SourceText.From(
+            """
+            package Right
+
+            public class Marker[U any] {
+            }
+            """,
+            "Right.Marker.gs"));
+        var leftPart = SyntaxTree.Parse(SourceText.From(
+            """
+            package App
+
+            import Contracts
+            import Left
+
+            public partial class Holder[T IConstraint[Marker[T]] class init()] {
+            }
+            """,
+            "Holder.Left.gs"));
+        var rightPart = SyntaxTree.Parse(SourceText.From(
+            """
+            package App
+
+            import Contracts
+            import Right
+
+            public partial class Holder[T IConstraint[Marker[T]] class init()] {
+            }
+            """,
+            "Holder.Right.gs"));
+        var parts = leftPartFirst
+            ? new[] { leftPart, rightPart }
+            : new[] { rightPart, leftPart };
+
+        using var peStream = new MemoryStream();
+        var result = new Compilation(
+            new[] { contract, leftMarker, rightMarker }.Concat(parts).ToArray())
+        {
+            IsLibrary = true,
+        }.Emit(peStream);
+
+        var mismatch = Assert.Single(result.Diagnostics.Where(diagnostic => diagnostic.Id == "GS0480"));
+        Assert.Equal("Holder.Right.gs", mismatch.Location.FileName);
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Id == "GS0496");
+    }
+
+    [Fact]
+    public void CrossFile_AllPartialConstraintBindingsFailReportsEachDeclaringFile()
+    {
+        var firstPart = SyntaxTree.Parse(SourceText.From(
+            """
+            package App
+
+            public partial class Holder[T MissingConstraint] {
+            }
+            """,
+            "Holder.Feature.gs"));
+        var secondPart = SyntaxTree.Parse(SourceText.From(
+            """
+            package App
+
+            public partial class Holder[T MissingConstraint] {
+            }
+            """,
+            "Holder.gs"));
+
+        using var peStream = new MemoryStream();
+        var result = new Compilation(firstPart, secondPart)
+        {
+            IsLibrary = true,
+        }.Emit(peStream);
+
+        var unresolved = result.Diagnostics
+            .Where(diagnostic => diagnostic.Id == "GS0113")
+            .OrderBy(diagnostic => diagnostic.Location.FileName, StringComparer.Ordinal)
+            .ToArray();
+        Assert.Equal(2, unresolved.Length);
+        Assert.Equal(
+            new[] { "Holder.Feature.gs", "Holder.gs" },
+            unresolved.Select(diagnostic => diagnostic.Location.FileName));
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Id == "GS0480");
+    }
+
+    [Fact]
+    public void CrossFile_PartialStructMatchingResolvedGenericConstraintsCompile()
+    {
+        var importingPart = SyntaxTree.Parse(SourceText.From(
+            """
+            package App
+
+            import System.Collections.Generic
+
+            public partial struct Holder[T IEnumerable[T] struct] {
+            }
+            """,
+            "Holder.gs"));
+        var featurePart = SyntaxTree.Parse(SourceText.From(
+            """
+            package App
+
+            import System.Collections.Generic
+
+            public partial struct Holder[T IEnumerable[T] struct] {
+            }
+            """,
+            "Holder.Feature.gs"));
+
+        using var peStream = new MemoryStream();
+        var result = new Compilation(featurePart, importingPart)
+        {
+            IsLibrary = true,
+        }.Emit(peStream);
+
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+    }
+
     [Fact]
     public void CrossFile_GenericConstraintImportDoesNotLeakFromUnrelatedFile()
     {


### PR DESCRIPTION
## Summary
- bind merged partial type clauses, annotations, and declaration expressions through each source node's declaring syntax tree
- preserve declaring-tree imports for base clauses, deferred defaults, field/shared initializers, and nested partial types
- retain matching partial generic headers and bind each constraint list through its own imports, without unioning imports
- accept equivalent successful constraint bindings, report GS0480 when identical text resolves to different contracts, and preserve per-part failures when none resolve
- add ordinal primary-part emit/run, import-isolation, generic constraint positive/non-leak/conflict, nested/interface/struct, and GS0480 coverage
- correct ADR-0144's stale compilation-global import assumption

## Tests
- `dotnet test test/Core.Tests/Core.Tests.csproj --no-restore --filter 'FullyQualifiedName~Adr0144PartialTypesBinderTests|FullyQualifiedName~Issue2395FileScopedImportTests|FullyQualifiedName~AttributeBinderTests|FullyQualifiedName~OverloadAndOptionalParameterTests|FullyQualifiedName~Issue2131StaticInitializerBlockTests|FullyQualifiedName~ConstraintTests|FullyQualifiedName~Issue2519SourceClassConstraintOrderingTests' --verbosity minimal` (198 passed)

Fixes #3336
