### PR TITLE
Fix XML documentation symbol coverage and DocIDs

### DIFF
--- a/src/Core/CodeAnalysis/Compilation/Compilation.cs
+++ b/src/Core/CodeAnalysis/Compilation/Compilation.cs
@@ -515,7 +515,7 @@ public class Compilation
 
             if (docStream is not null)
             {
-                DocumentationFileEmitter.Emit(docStream, assemblyName ?? program.PackageName, program.Structs, program.Functions.Keys);
+                DocumentationFileEmitter.Emit(docStream, assemblyName ?? program.PackageName, program);
             }
         }
         catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)

--- a/src/Core/CodeAnalysis/Documentation/DocumentationFileEmitter.cs
+++ b/src/Core/CodeAnalysis/Documentation/DocumentationFileEmitter.cs
@@ -141,6 +141,16 @@ internal static class DocumentationFileEmitter
                 AddIfDocumented(members, method);
             }
 
+            foreach (var method in type.PrivateMethods)
+            {
+                AddIfDocumented(members, method);
+            }
+
+            foreach (var method in type.StaticPrivateMethods)
+            {
+                AddIfDocumented(members, method);
+            }
+
             foreach (var property in type.Properties)
             {
                 AddIfDocumented(members, property, type);

--- a/src/Core/CodeAnalysis/Documentation/DocumentationFileEmitter.cs
+++ b/src/Core/CodeAnalysis/Documentation/DocumentationFileEmitter.cs
@@ -8,17 +8,19 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Xml;
+using GSharp.Core.CodeAnalysis.Binding;
 using GSharp.Core.CodeAnalysis.Symbols;
 
 namespace GSharp.Core.CodeAnalysis.Documentation;
 
 internal static class DocumentationFileEmitter
 {
-    public static void Emit(Stream xmlStream, string? assemblyName, IEnumerable<StructSymbol> types, IEnumerable<FunctionSymbol> topLevelFunctions)
+    public static void Emit(Stream xmlStream, string? assemblyName, BoundProgram program)
     {
         ArgumentNullException.ThrowIfNull(xmlStream);
+        ArgumentNullException.ThrowIfNull(program);
 
-        var members = CollectMembers(types ?? Enumerable.Empty<StructSymbol>(), topLevelFunctions ?? Enumerable.Empty<FunctionSymbol>())
+        var members = CollectMembers(program)
             .OrderBy(entry => entry.DocId, StringComparer.Ordinal)
             .ToArray();
 
@@ -66,11 +68,11 @@ internal static class DocumentationFileEmitter
         streamWriter.Flush();
     }
 
-    private static IEnumerable<MemberDocumentation> CollectMembers(IEnumerable<StructSymbol> types, IEnumerable<FunctionSymbol> topLevelFunctions)
+    private static IEnumerable<MemberDocumentation> CollectMembers(BoundProgram program)
     {
         var members = new List<MemberDocumentation>();
 
-        foreach (var type in types)
+        foreach (var type in program.Structs)
         {
             AddIfDocumented(members, type);
 
@@ -99,6 +101,11 @@ internal static class DocumentationFileEmitter
                 AddIfDocumented(members, field, type);
             }
 
+            foreach (var field in type.ConstFields)
+            {
+                AddIfDocumented(members, field, type);
+            }
+
             foreach (var property in type.StaticProperties)
             {
                 AddIfDocumented(members, property, type);
@@ -120,7 +127,56 @@ internal static class DocumentationFileEmitter
             }
         }
 
-        foreach (var function in topLevelFunctions)
+        foreach (var type in program.Interfaces)
+        {
+            AddIfDocumented(members, type);
+
+            foreach (var method in type.Methods)
+            {
+                AddIfDocumented(members, method);
+            }
+
+            foreach (var method in type.StaticMethods)
+            {
+                AddIfDocumented(members, method);
+            }
+
+            foreach (var property in type.Properties)
+            {
+                AddIfDocumented(members, property, type);
+            }
+
+            foreach (var @event in type.Events)
+            {
+                AddIfDocumented(members, @event, type);
+            }
+
+            foreach (var field in type.StaticFields)
+            {
+                AddIfDocumented(members, field, type);
+            }
+
+            foreach (var field in type.ConstFields)
+            {
+                AddIfDocumented(members, field, type);
+            }
+        }
+
+        foreach (var type in program.Enums)
+        {
+            AddIfDocumented(members, type);
+            foreach (var member in type.Members)
+            {
+                AddIfDocumented(members, member);
+            }
+        }
+
+        foreach (var type in program.Delegates)
+        {
+            AddIfDocumented(members, type);
+        }
+
+        foreach (var function in program.Functions.Keys)
         {
             if (function.ReceiverType is null && function.StaticOwnerType is null)
             {
@@ -148,7 +204,7 @@ internal static class DocumentationFileEmitter
         members.Add(new MemberDocumentation(docId, DocumentationXmlWriter.WriteXmlFragment(documentation)));
     }
 
-    private static void AddIfDocumented(List<MemberDocumentation> members, Symbol symbol, StructSymbol ownerType)
+    private static void AddIfDocumented(List<MemberDocumentation> members, Symbol symbol, TypeSymbol ownerType)
     {
         var documentation = symbol.GetDocumentation();
         if (documentation is null)

--- a/src/Core/CodeAnalysis/Documentation/SymbolDocumentationIdProvider.cs
+++ b/src/Core/CodeAnalysis/Documentation/SymbolDocumentationIdProvider.cs
@@ -303,6 +303,9 @@ internal static class SymbolDocumentationIdProvider
                 AppendTypeReference(builder, pointerType.PointeeType, ownerType, function);
                 builder.Append('*');
                 return;
+            case TupleTypeSymbol tupleType:
+                AppendTupleTypeReference(builder, tupleType.ElementTypes, 0, tupleType.Arity, ownerType, function);
+                return;
             case FunctionTypeSymbol functionType:
                 AppendFunctionTypeReference(builder, functionType, ownerType, function);
                 return;
@@ -336,6 +339,38 @@ internal static class SymbolDocumentationIdProvider
 
                 return;
         }
+    }
+
+    private static void AppendTupleTypeReference(
+        StringBuilder builder,
+        ImmutableArray<TypeSymbol> elementTypes,
+        int start,
+        int count,
+        TypeSymbol? ownerType,
+        FunctionSymbol? function)
+    {
+        // TupleTypeSymbol retains only positional element types, which also
+        // erases tuple element names as required by XML documentation IDs.
+        builder.Append("System.ValueTuple{");
+
+        var directCount = Math.Min(count, 7);
+        for (var i = 0; i < directCount; i++)
+        {
+            if (i > 0)
+            {
+                builder.Append(',');
+            }
+
+            AppendTypeReference(builder, elementTypes[start + i], ownerType, function);
+        }
+
+        if (count > 7)
+        {
+            builder.Append(',');
+            AppendTupleTypeReference(builder, elementTypes, start + 7, count - 7, ownerType, function);
+        }
+
+        builder.Append('}');
     }
 
     private static void AppendFunctionTypeReference(

--- a/src/Core/CodeAnalysis/Documentation/SymbolDocumentationIdProvider.cs
+++ b/src/Core/CodeAnalysis/Documentation/SymbolDocumentationIdProvider.cs
@@ -18,13 +18,14 @@ internal static class SymbolDocumentationIdProvider
         return symbol switch
         {
             PackageSymbol package => GetDocumentationId(package),
-            StructSymbol type => GetDocumentationId(type),
+            TypeSymbol type when IsSourceNamedType(type) => GetDocumentationId(type),
+            EnumMemberSymbol enumMember => GetDocumentationId(enumMember),
             FunctionSymbol function => GetDocumentationId(function),
             _ => null,
         };
     }
 
-    public static string? GetDocumentationId(Symbol member, StructSymbol? ownerType)
+    public static string? GetDocumentationId(Symbol member, TypeSymbol? ownerType)
     {
         return member switch
         {
@@ -41,9 +42,9 @@ internal static class SymbolDocumentationIdProvider
         return package is null ? null : $"N:{package.Name}";
     }
 
-    internal static string? GetDocumentationId(StructSymbol type)
+    internal static string? GetDocumentationId(TypeSymbol type)
     {
-        if (type is null)
+        if (type is null || !IsSourceNamedType(type))
         {
             return null;
         }
@@ -61,7 +62,10 @@ internal static class SymbolDocumentationIdProvider
         }
 
         var builder = new StringBuilder("M:");
-        var ownerType = function.ReceiverType as StructSymbol ?? function.StaticOwnerType as StructSymbol;
+        var candidateOwner = function.ReceiverType ?? function.StaticOwnerType;
+        var ownerType = candidateOwner is not null && IsSourceNamedType(candidateOwner)
+            ? candidateOwner
+            : null;
         if (ownerType is not null)
         {
             AppendTypeDeclarationName(builder, ownerType);
@@ -84,10 +88,18 @@ internal static class SymbolDocumentationIdProvider
         }
 
         AppendParameterList(builder, function, ownerType);
+
+        if (string.Equals(function.Name, "op_Implicit", StringComparison.Ordinal) ||
+            string.Equals(function.Name, "op_Explicit", StringComparison.Ordinal))
+        {
+            builder.Append('~');
+            AppendTypeReference(builder, function.Type, ownerType, function);
+        }
+
         return builder.ToString();
     }
 
-    private static string? GetDocumentationId(FieldSymbol field, StructSymbol? ownerType)
+    private static string? GetDocumentationId(FieldSymbol field, TypeSymbol? ownerType)
     {
         if (field is null || ownerType is null)
         {
@@ -100,7 +112,7 @@ internal static class SymbolDocumentationIdProvider
         return builder.ToString();
     }
 
-    private static string? GetDocumentationId(PropertySymbol property, StructSymbol? ownerType)
+    private static string? GetDocumentationId(PropertySymbol property, TypeSymbol? ownerType)
     {
         if (property is null || ownerType is null)
         {
@@ -110,10 +122,11 @@ internal static class SymbolDocumentationIdProvider
         var builder = new StringBuilder("P:");
         AppendTypeDeclarationName(builder, ownerType);
         builder.Append('.').Append(EncodeName(property.Name));
+        AppendParameterList(builder, property.Parameters, ownerType);
         return builder.ToString();
     }
 
-    private static string? GetDocumentationId(EventSymbol @event, StructSymbol? ownerType)
+    private static string? GetDocumentationId(EventSymbol @event, TypeSymbol? ownerType)
     {
         if (@event is null || ownerType is null)
         {
@@ -123,6 +136,19 @@ internal static class SymbolDocumentationIdProvider
         var builder = new StringBuilder("E:");
         AppendTypeDeclarationName(builder, ownerType);
         builder.Append('.').Append(EncodeName(@event.Name));
+        return builder.ToString();
+    }
+
+    private static string? GetDocumentationId(EnumMemberSymbol member)
+    {
+        if (member is null)
+        {
+            return null;
+        }
+
+        var builder = new StringBuilder("F:");
+        AppendTypeDeclarationName(builder, member.EnumType);
+        builder.Append('.').Append(EncodeName(member.Name));
         return builder.ToString();
     }
 
@@ -137,7 +163,7 @@ internal static class SymbolDocumentationIdProvider
         builder.Append(EncodeName(function.Name));
     }
 
-    private static void AppendParameterList(StringBuilder builder, FunctionSymbol function, StructSymbol? ownerType)
+    private static void AppendParameterList(StringBuilder builder, FunctionSymbol function, TypeSymbol? ownerType)
     {
         var start = function.ReceiverType != null && function.ExplicitReceiverParameter != null ? 1 : 0;
         if (function.Parameters.Length <= start)
@@ -168,13 +194,67 @@ internal static class SymbolDocumentationIdProvider
         builder.Append(')');
     }
 
-    private static void AppendTypeDeclarationName(StringBuilder builder, StructSymbol type)
+    private static void AppendParameterList(
+        StringBuilder builder,
+        ImmutableArray<ParameterSymbol> parameters,
+        TypeSymbol? ownerType)
     {
-        var definition = type.Definition ?? type;
-        AppendSourceTypeDeclarationName(builder, definition.PackageName, definition.Name, definition.TypeParameters.Length);
+        if (parameters.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        builder.Append('(');
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            if (i > 0)
+            {
+                builder.Append(',');
+            }
+
+            AppendTypeReference(builder, parameters[i].Type, ownerType, function: null);
+            if (parameters[i].RefKind != RefKind.None)
+            {
+                builder.Append('@');
+            }
+        }
+
+        builder.Append(')');
     }
 
-    private static void AppendTypeReference(StringBuilder builder, TypeSymbol type, StructSymbol? ownerType, FunctionSymbol function)
+    private static void AppendTypeDeclarationName(StringBuilder builder, TypeSymbol type)
+    {
+        var chain = SourceNestingChain(GetSourceDefinition(type));
+        if (chain.Count == 0)
+        {
+            builder.Append(EncodeName(type.Name));
+            return;
+        }
+
+        var packageName = GetPackageName(chain[0]);
+        if (!string.IsNullOrEmpty(packageName))
+        {
+            builder.Append(packageName).Append('.');
+        }
+
+        for (var i = 0; i < chain.Count; i++)
+        {
+            if (i > 0)
+            {
+                builder.Append('.');
+            }
+
+            var level = chain[i];
+            builder.Append(EncodeName(level.Name));
+            var arity = GetOwnArity(level);
+            if (arity > 0)
+            {
+                builder.Append('`').Append(arity);
+            }
+        }
+    }
+
+    private static void AppendTypeReference(StringBuilder builder, TypeSymbol type, TypeSymbol? ownerType, FunctionSymbol? function)
     {
         switch (type)
         {
@@ -182,7 +262,15 @@ internal static class SymbolDocumentationIdProvider
                 builder.Append("System.Void");
                 return;
             case TypeParameterSymbol typeParameter:
-                builder.Append(IsMethodTypeParameter(typeParameter, function) ? "``" : "`").Append(typeParameter.Ordinal);
+                if (IsMethodTypeParameter(typeParameter, function))
+                {
+                    builder.Append("``").Append(typeParameter.Ordinal);
+                }
+                else
+                {
+                    builder.Append('`').Append(GetTypeParameterOrdinal(typeParameter, ownerType));
+                }
+
                 return;
             case ArrayTypeSymbol arrayType:
                 AppendTypeReference(builder, arrayType.ElementType, ownerType, function);
@@ -199,15 +287,36 @@ internal static class SymbolDocumentationIdProvider
                 builder.Append('@');
                 return;
             case NullableTypeSymbol nullableType:
-                builder.Append("System.Nullable`1{");
-                AppendTypeReference(builder, nullableType.UnderlyingType, ownerType, function);
-                builder.Append('}');
+                if (NullableLifting.IsAnyValueTypeNullable(nullableType))
+                {
+                    builder.Append("System.Nullable{");
+                    AppendTypeReference(builder, nullableType.UnderlyingType, ownerType, function);
+                    builder.Append('}');
+                }
+                else
+                {
+                    AppendTypeReference(builder, nullableType.UnderlyingType, ownerType, function);
+                }
+
+                return;
+            case PointerTypeSymbol pointerType:
+                AppendTypeReference(builder, pointerType.PointeeType, ownerType, function);
+                builder.Append('*');
+                return;
+            case FunctionTypeSymbol functionType:
+                AppendFunctionTypeReference(builder, functionType, ownerType, function);
                 return;
             case StructSymbol structType:
                 AppendSourceTypeReference(builder, structType, ownerType, function);
                 return;
             case InterfaceSymbol interfaceType:
                 AppendSourceTypeReference(builder, interfaceType, ownerType, function);
+                return;
+            case EnumSymbol enumType:
+                AppendSourceTypeReference(builder, enumType, ownerType, function);
+                return;
+            case DelegateTypeSymbol delegateType:
+                AppendSourceTypeReference(builder, delegateType, ownerType, function);
                 return;
             case ImportedTypeSymbol importedType when importedType.OpenDefinition is not null && !importedType.TypeArguments.IsDefaultOrEmpty:
                 AppendClrConstructedTypeReference(builder, importedType.OpenDefinition, importedType.TypeArguments, ownerType, function);
@@ -229,68 +338,320 @@ internal static class SymbolDocumentationIdProvider
         }
     }
 
-    private static void AppendSourceTypeReference(StringBuilder builder, StructSymbol type, StructSymbol? ownerType, FunctionSymbol function)
-    {
-        var definition = type.Definition ?? type;
-        AppendSourceNamedTypeReference(builder, definition.PackageName, definition.Name, definition.TypeParameters.Length, type.TypeArguments, ownerType, function);
-    }
-
-    private static void AppendSourceTypeReference(StringBuilder builder, InterfaceSymbol type, StructSymbol? ownerType, FunctionSymbol function)
-    {
-        var definition = type.Definition ?? type;
-        AppendSourceNamedTypeReference(builder, definition.PackageName, definition.Name, definition.TypeParameters.Length, type.TypeArguments, ownerType, function);
-    }
-
-    private static void AppendSourceNamedTypeReference(
+    private static void AppendFunctionTypeReference(
         StringBuilder builder,
-        string packageName,
-        string name,
-        int arity,
-        ImmutableArray<TypeSymbol> typeArguments,
-        StructSymbol? ownerType,
-        FunctionSymbol function)
+        FunctionTypeSymbol type,
+        TypeSymbol? ownerType,
+        FunctionSymbol? function)
     {
-        if (!string.IsNullOrEmpty(packageName))
+        var returnsVoid = ReferenceEquals(type.ReturnType, TypeSymbol.Void);
+        builder.Append(returnsVoid ? "System.Action" : "System.Func");
+
+        var argumentCount = type.ParameterTypes.Length + (returnsVoid ? 0 : 1);
+        if (argumentCount == 0)
         {
-            builder.Append(packageName).Append('.');
-        }
-
-        builder.Append(EncodeName(name));
-        if (!typeArguments.IsDefaultOrEmpty && typeArguments.Length > 0)
-        {
-            builder.Append('{');
-            for (var i = 0; i < typeArguments.Length; i++)
-            {
-                if (i > 0)
-                {
-                    builder.Append(',');
-                }
-
-                AppendTypeReference(builder, typeArguments[i], ownerType, function);
-            }
-
-            builder.Append('}');
             return;
         }
 
-        if (arity > 0)
+        builder.Append('{');
+        for (var i = 0; i < type.ParameterTypes.Length; i++)
         {
-            builder.Append('`').Append(arity);
+            if (i > 0)
+            {
+                builder.Append(',');
+            }
+
+            AppendTypeReference(builder, type.ParameterTypes[i], ownerType, function);
         }
+
+        if (!returnsVoid)
+        {
+            if (type.ParameterTypes.Length > 0)
+            {
+                builder.Append(',');
+            }
+
+            AppendTypeReference(builder, type.ReturnType, ownerType, function);
+        }
+
+        builder.Append('}');
     }
 
-    private static void AppendSourceTypeDeclarationName(StringBuilder builder, string packageName, string name, int arity)
+    private static void AppendSourceTypeReference(
+        StringBuilder builder,
+        TypeSymbol type,
+        TypeSymbol? ownerType,
+        FunctionSymbol? function)
     {
+        var chain = SourceNestingChain(GetSourceDefinition(type));
+        if (chain.Count == 0)
+        {
+            builder.Append(EncodeName(type.Name));
+            return;
+        }
+
+        var packageName = GetPackageName(chain[0]);
         if (!string.IsNullOrEmpty(packageName))
         {
             builder.Append(packageName).Append('.');
         }
 
-        builder.Append(EncodeName(name));
-        if (arity > 0)
+        var enclosingArguments = GetEnclosingTypeArguments(type);
+        var ownArguments = GetOwnTypeArguments(type);
+        var enclosingArgumentIndex = 0;
+
+        for (var i = 0; i < chain.Count; i++)
         {
+            if (i > 0)
+            {
+                builder.Append('.');
+            }
+
+            var level = chain[i];
+            builder.Append(EncodeName(level.Name));
+
+            var arity = GetOwnArity(level);
+            if (arity == 0)
+            {
+                continue;
+            }
+
+            if (i < chain.Count - 1 &&
+                enclosingArgumentIndex + arity <= enclosingArguments.Length)
+            {
+                AppendSourceTypeArguments(
+                    builder,
+                    enclosingArguments,
+                    enclosingArgumentIndex,
+                    arity,
+                    ownerType,
+                    function);
+                enclosingArgumentIndex += arity;
+                continue;
+            }
+
+            if (i == chain.Count - 1 && ownArguments.Length == arity)
+            {
+                AppendSourceTypeArguments(builder, ownArguments, 0, arity, ownerType, function);
+                continue;
+            }
+
+            if (TryGetOwnerGenericOffset(level, ownerType, out var ownerOffset))
+            {
+                builder.Append('{');
+                for (var a = 0; a < arity; a++)
+                {
+                    if (a > 0)
+                    {
+                        builder.Append(',');
+                    }
+
+                    builder.Append('`').Append(ownerOffset + a);
+                }
+
+                builder.Append('}');
+                continue;
+            }
+
             builder.Append('`').Append(arity);
         }
+    }
+
+    private static void AppendSourceTypeArguments(
+        StringBuilder builder,
+        ImmutableArray<TypeSymbol> arguments,
+        int start,
+        int count,
+        TypeSymbol? ownerType,
+        FunctionSymbol? function)
+    {
+        builder.Append('{');
+        for (var i = 0; i < count; i++)
+        {
+            if (i > 0)
+            {
+                builder.Append(',');
+            }
+
+            AppendTypeReference(builder, arguments[start + i], ownerType, function);
+        }
+
+        builder.Append('}');
+    }
+
+    private static bool IsSourceNamedType(TypeSymbol type)
+    {
+        return type is StructSymbol or InterfaceSymbol or EnumSymbol or DelegateTypeSymbol;
+    }
+
+    private static TypeSymbol GetSourceDefinition(TypeSymbol type)
+    {
+        return type switch
+        {
+            StructSymbol structType => structType.Definition ?? structType,
+            InterfaceSymbol interfaceType => interfaceType.Definition ?? interfaceType,
+            EnumSymbol enumType => enumType.Definition ?? enumType,
+            DelegateTypeSymbol delegateType => delegateType.Definition ?? delegateType,
+            _ => type,
+        };
+    }
+
+    private static TypeSymbol? GetContainingSourceType(TypeSymbol type)
+    {
+        return type switch
+        {
+            StructSymbol structType => structType.ContainingType,
+            InterfaceSymbol interfaceType => interfaceType.ContainingType,
+            EnumSymbol enumType => enumType.ContainingType,
+            _ => null,
+        };
+    }
+
+    private static List<TypeSymbol> SourceNestingChain(TypeSymbol type)
+    {
+        var chain = new List<TypeSymbol>();
+        for (TypeSymbol? current = GetSourceDefinition(type);
+             current is not null;
+             current = GetContainingSourceType(current) is { } containing
+                 ? GetSourceDefinition(containing)
+                 : null)
+        {
+            chain.Insert(0, current);
+        }
+
+        return chain;
+    }
+
+    private static string GetPackageName(TypeSymbol type)
+    {
+        return type switch
+        {
+            StructSymbol structType => structType.PackageName,
+            InterfaceSymbol interfaceType => interfaceType.PackageName,
+            EnumSymbol enumType => enumType.PackageName,
+            DelegateTypeSymbol delegateType => delegateType.PackageName,
+            _ => string.Empty,
+        };
+    }
+
+    private static int GetOwnArity(TypeSymbol type)
+    {
+        return type switch
+        {
+            StructSymbol { Declaration: { } declaration } =>
+                declaration.TypeParameterList?.Parameters.Count ?? 0,
+            StructSymbol structType => structType.TypeParameters.Length,
+            InterfaceSymbol { Declaration: { } declaration } =>
+                declaration.TypeParameterList?.Parameters.Count ?? 0,
+            InterfaceSymbol interfaceType => interfaceType.TypeParameters.Length,
+            DelegateTypeSymbol { Declaration: { } declaration } =>
+                declaration.TypeParameterList?.Parameters.Count ?? 0,
+            DelegateTypeSymbol delegateType => delegateType.TypeParameters.Length,
+            _ => 0,
+        };
+    }
+
+    private static ImmutableArray<TypeSymbol> GetEnclosingTypeArguments(TypeSymbol type)
+    {
+        return type switch
+        {
+            StructSymbol structType => structType.EnclosingTypeArguments,
+            EnumSymbol enumType => enumType.EnclosingTypeArguments,
+            _ => ImmutableArray<TypeSymbol>.Empty,
+        };
+    }
+
+    private static ImmutableArray<TypeSymbol> GetOwnTypeArguments(TypeSymbol type)
+    {
+        return type switch
+        {
+            StructSymbol structType => structType.TypeArguments,
+            InterfaceSymbol interfaceType => interfaceType.TypeArguments,
+            DelegateTypeSymbol delegateType => delegateType.TypeArguments,
+            _ => ImmutableArray<TypeSymbol>.Empty,
+        };
+    }
+
+    private static bool TryGetOwnerGenericOffset(TypeSymbol type, TypeSymbol? ownerType, out int offset)
+    {
+        offset = 0;
+        if (ownerType is null || !IsSourceNamedType(ownerType))
+        {
+            return false;
+        }
+
+        foreach (var ownerLevel in SourceNestingChain(GetSourceDefinition(ownerType)))
+        {
+            if (ReferenceEquals(GetSourceDefinition(ownerLevel), GetSourceDefinition(type)))
+            {
+                return true;
+            }
+
+            offset += GetOwnArity(ownerLevel);
+        }
+
+        offset = 0;
+        return false;
+    }
+
+    private static int GetTypeParameterOrdinal(TypeParameterSymbol typeParameter, TypeSymbol? ownerType)
+    {
+        if (ownerType is null || !IsSourceNamedType(ownerType))
+        {
+            return typeParameter.Ordinal;
+        }
+
+        var chain = SourceNestingChain(GetSourceDefinition(ownerType));
+        var offsets = new int[chain.Count];
+        var offset = 0;
+        for (var i = 0; i < chain.Count; i++)
+        {
+            offsets[i] = offset;
+            offset += GetOwnArity(chain[i]);
+        }
+
+        for (var i = chain.Count - 1; i >= 0; i--)
+        {
+            if (DeclaresTypeParameter(chain[i], typeParameter))
+            {
+                return offsets[i] + typeParameter.Ordinal;
+            }
+        }
+
+        return typeParameter.Ordinal;
+    }
+
+    private static bool DeclaresTypeParameter(TypeSymbol type, TypeParameterSymbol typeParameter)
+    {
+        var ordinal = typeParameter.Ordinal;
+        if (ordinal < 0)
+        {
+            return false;
+        }
+
+        switch (type)
+        {
+            case StructSymbol { Declaration.TypeParameterList: { } list }:
+                return ordinal < list.Parameters.Count &&
+                    string.Equals(list.Parameters[ordinal].Identifier.Text, typeParameter.Name, StringComparison.Ordinal);
+            case InterfaceSymbol { Declaration.TypeParameterList: { } list }:
+                return ordinal < list.Parameters.Count &&
+                    string.Equals(list.Parameters[ordinal].Identifier.Text, typeParameter.Name, StringComparison.Ordinal);
+            case DelegateTypeSymbol { Declaration.TypeParameterList: { } list }:
+                return ordinal < list.Parameters.Count &&
+                    string.Equals(list.Parameters[ordinal].Identifier.Text, typeParameter.Name, StringComparison.Ordinal);
+        }
+
+        var parameters = type switch
+        {
+            StructSymbol structType => structType.TypeParameters,
+            InterfaceSymbol interfaceType => interfaceType.TypeParameters,
+            DelegateTypeSymbol delegateType => delegateType.TypeParameters,
+            _ => ImmutableArray<TypeParameterSymbol>.Empty,
+        };
+        return ordinal < parameters.Length &&
+            (ReferenceEquals(parameters[ordinal], typeParameter) ||
+             string.Equals(parameters[ordinal].Name, typeParameter.Name, StringComparison.Ordinal));
     }
 
     private static void AppendClrTypeReference(StringBuilder builder, Type? type)
@@ -384,8 +745,8 @@ internal static class SymbolDocumentationIdProvider
         StringBuilder builder,
         Type openDefinition,
         ImmutableArray<TypeSymbol> typeArguments,
-        StructSymbol? ownerType,
-        FunctionSymbol function)
+        TypeSymbol? ownerType,
+        FunctionSymbol? function)
     {
         var chain = NestingChain(openDefinition);
         var outermost = chain[0];
@@ -475,7 +836,7 @@ internal static class SymbolDocumentationIdProvider
         return tick >= 0 ? name.Substring(0, tick) : name;
     }
 
-    private static bool IsMethodTypeParameter(TypeParameterSymbol typeParameter, FunctionSymbol function)
+    private static bool IsMethodTypeParameter(TypeParameterSymbol typeParameter, FunctionSymbol? function)
     {
         if (function is null || function.TypeParameters.IsDefaultOrEmpty)
         {

--- a/src/Core/CodeAnalysis/Syntax/DocumentationAttacher.cs
+++ b/src/Core/CodeAnalysis/Syntax/DocumentationAttacher.cs
@@ -132,6 +132,15 @@ internal static class DocumentationAttacher
 
         foreach (var member in root.Members)
         {
+            // Named delegates are top-level-only. Keep their attachment path
+            // outside nested aggregate traversal until syntax and binding
+            // support nested delegate declarations.
+            if (member is DelegateDeclarationSyntax @delegate)
+            {
+                result.Add(@delegate);
+                continue;
+            }
+
             CollectFromMember(member, result);
         }
 
@@ -160,10 +169,6 @@ internal static class DocumentationAttacher
 
             case TypeAliasDeclarationSyntax alias:
                 result.Add(alias);
-                break;
-
-            case DelegateDeclarationSyntax @delegate:
-                result.Add(@delegate);
                 break;
 
             case StructDeclarationSyntax structDecl:

--- a/src/Core/CodeAnalysis/Syntax/DocumentationAttacher.cs
+++ b/src/Core/CodeAnalysis/Syntax/DocumentationAttacher.cs
@@ -162,6 +162,10 @@ internal static class DocumentationAttacher
                 result.Add(alias);
                 break;
 
+            case DelegateDeclarationSyntax @delegate:
+                result.Add(@delegate);
+                break;
+
             case StructDeclarationSyntax structDecl:
                 result.Add(structDecl);
                 CollectFromStructBody(structDecl, result);
@@ -243,6 +247,11 @@ internal static class DocumentationAttacher
                 result.Add(method);
             }
         }
+
+        foreach (var nestedType in structDecl.NestedTypes)
+        {
+            CollectFromMember(nestedType, result);
+        }
     }
 
     private static void CollectFromEnumBody(EnumDeclarationSyntax enumDecl, List<SyntaxNode> result)
@@ -268,6 +277,11 @@ internal static class DocumentationAttacher
         foreach (var method in interfaceDecl.Methods)
         {
             result.Add(method);
+        }
+
+        foreach (var field in interfaceDecl.StaticFields)
+        {
+            result.Add(field);
         }
     }
 

--- a/src/Core/CodeAnalysis/Syntax/FunctionDeclarationSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/FunctionDeclarationSyntax.cs
@@ -321,6 +321,7 @@ public sealed class FunctionDeclarationSyntax : MemberSyntax
     public SyntaxToken? AsyncModifier { get; }
 
     /// <summary>Gets or sets the optional <c>static</c> contextual keyword (ADR-0089 / issue #755). Non-null when the function was declared inside <c>interface { … }</c> as a static-virtual member; the binder rejects this token on non-interface members.</summary>
+    [SyntaxChildIgnore]
     public SyntaxToken? StaticModifier
     {
         get => staticModifier;

--- a/src/Core/CodeAnalysis/Syntax/PropertyDeclarationSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/PropertyDeclarationSyntax.cs
@@ -81,6 +81,7 @@ public sealed class PropertyDeclarationSyntax : SyntaxNode
     /// <c>shared { … }</c> block (ADR-0089 / issue #1019), or
     /// <see langword="null"/> for an ordinary instance property.
     /// </summary>
+    [SyntaxChildIgnore]
     public SyntaxToken? StaticModifier
     {
         get => staticModifier;

--- a/test/Core.Tests/CodeAnalysis/Documentation/DocumentationFileEmitterTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Documentation/DocumentationFileEmitterTests.cs
@@ -63,6 +63,136 @@ data struct Point {
     }
 
     [Fact]
+    public void EmitsDocumentedEnumsInterfacesAndNullableReferenceDocIds()
+    {
+        var source = """
+            package FindingXmlDocOmissions
+
+            /// Names a paint color.
+            public enum Color {
+              /// The red color.
+              Red,
+              Green
+            }
+
+            /// Greets a caller.
+            public interface Greeter {
+              /// Produces the greeting line.
+              func Greet() string;
+
+              /// Gets the greeter name.
+              prop Name string { get; }
+
+              /// Raised when a greeting is produced.
+              event Greeted () -> void
+
+              shared {
+                /// Default greeting count.
+                const DefaultCount int32 = 1
+              }
+            }
+
+            /// Hosts documented members.
+            public class Widget {
+              private func Hidden() {}
+
+              /// Runs the supplied callback.
+              /// @param callback The callback to run.
+              public func Configure(callback ((int32) -> void)?) {
+                callback?(1)
+              }
+            }
+            """;
+
+        var xml = EmitDocXml(source, "FindingXmlDocOmissions");
+
+        Assert.Contains("<member name=\"T:FindingXmlDocOmissions.Color\">", xml);
+        Assert.Contains("<member name=\"F:FindingXmlDocOmissions.Color.Red\">", xml);
+        Assert.DoesNotContain("F:FindingXmlDocOmissions.Color.Green", xml);
+        Assert.Contains("<member name=\"T:FindingXmlDocOmissions.Greeter\">", xml);
+        Assert.Contains("<member name=\"M:FindingXmlDocOmissions.Greeter.Greet\">", xml);
+        Assert.Contains("<member name=\"P:FindingXmlDocOmissions.Greeter.Name\">", xml);
+        Assert.Contains("<member name=\"E:FindingXmlDocOmissions.Greeter.Greeted\">", xml);
+        Assert.Contains("<member name=\"F:FindingXmlDocOmissions.Greeter.DefaultCount\">", xml);
+        Assert.Contains(
+            "<member name=\"M:FindingXmlDocOmissions.Widget.Configure(System.Action{System.Int32})\">",
+            xml);
+        Assert.DoesNotContain("System.Nullable`1{System.Action", xml);
+        Assert.DoesNotContain("M:FindingXmlDocOmissions.Widget.Hidden", xml);
+    }
+
+    [Fact]
+    public void EmitsStandardIdsForNestedGenericAndNullableMemberShapes()
+    {
+        var source = """
+            package DocShapes
+
+            import System.Collections.Generic
+
+            /// Handles a value.
+            public type Handler[T] = delegate func(value T) void
+
+            /// Owns nested types.
+            public class Outer[T] {
+              /// Stores an inner value.
+              public class Inner[U] {
+                /// Stored value.
+                public var Value U
+
+                /// Creates an inner value.
+                public init(value U) {
+                  Value = value
+                }
+
+                /// Gets the value at an index.
+                public prop this[index int32] U {
+                  get { return Value }
+                }
+
+                /// Raised when the value changes.
+                public event Changed (T) -> void
+
+                /// Exercises standard parameter DocID shapes.
+                public func Mix(
+                  callback ((int32) -> void)?,
+                  number int32?,
+                  values List[string?]?,
+                  handlers []Handler[U]?,
+                  other Inner[U],
+                  ref converter ((T) -> U)?) {
+                }
+
+                private func Hidden() {}
+              }
+            }
+
+            /// Stores a constrained value.
+            public struct ValueBox[T struct] {
+              /// Accepts a nullable value.
+              public func Take(value T?) {}
+            }
+            """;
+
+        var xml = EmitDocXml(source, "DocShapes");
+
+        Assert.Contains("<member name=\"T:DocShapes.Handler`1\">", xml);
+        Assert.Contains("<member name=\"T:DocShapes.Outer`1\">", xml);
+        Assert.Contains("<member name=\"T:DocShapes.Outer`1.Inner`1\">", xml);
+        Assert.Contains("<member name=\"F:DocShapes.Outer`1.Inner`1.Value\">", xml);
+        Assert.Contains("<member name=\"M:DocShapes.Outer`1.Inner`1.#ctor(`1)\">", xml);
+        Assert.Contains("<member name=\"P:DocShapes.Outer`1.Inner`1.Item(System.Int32)\">", xml);
+        Assert.Contains("<member name=\"E:DocShapes.Outer`1.Inner`1.Changed\">", xml);
+        Assert.Contains(
+            "<member name=\"M:DocShapes.Outer`1.Inner`1.Mix(System.Action{System.Int32},System.Nullable{System.Int32},System.Collections.Generic.List{System.String},DocShapes.Handler{`1}[],DocShapes.Outer{`0}.Inner{`1},System.Func{`0,`1}@)\">",
+            xml);
+        Assert.Contains("<member name=\"T:DocShapes.ValueBox`1\">", xml);
+        Assert.Contains(
+            "<member name=\"M:DocShapes.ValueBox`1.Take(System.Nullable{`0})\">",
+            xml);
+        Assert.DoesNotContain("M:DocShapes.Outer`1.Inner`1.Hidden", xml);
+    }
+
+    [Fact]
     public void EmitsAssemblyName()
     {
         var source = @"package Lib
@@ -112,7 +242,8 @@ func Alpha() {}
         var compilation = new Compilation(tree);
         using var peStream = new MemoryStream();
         using var docStream = new MemoryStream();
-        compilation.Emit(peStream, pdbStream: null, refStream: null, docStream, assemblyName);
+        var result = compilation.Emit(peStream, pdbStream: null, refStream: null, docStream, assemblyName);
+        Assert.True(result.Success, string.Join("\n", result.Diagnostics));
         return Encoding.UTF8.GetString(docStream.ToArray());
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Documentation/DocumentationFileEmitterTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Documentation/DocumentationFileEmitterTests.cs
@@ -193,6 +193,95 @@ data struct Point {
     }
 
     [Fact]
+    public void EmitsDocumentedPrivateInterfaceMethods()
+    {
+        var source = """
+            package PrivateInterfaceDocs
+
+            interface Helpers {
+              /// Formats an instance value.
+              private func Format(value int32) int32 { return value }
+
+              private func UndocumentedInstance() {}
+
+              shared {
+                /// Formats a static value.
+                private func FormatStatic(value string) string { return value }
+
+                private func UndocumentedStatic() {}
+              }
+            }
+            """;
+
+        var xml = EmitDocXml(source, "PrivateInterfaceDocs");
+
+        Assert.Contains(
+            "<member name=\"M:PrivateInterfaceDocs.Helpers.Format(System.Int32)\">",
+            xml);
+        Assert.Contains(
+            "<member name=\"M:PrivateInterfaceDocs.Helpers.FormatStatic(System.String)\">",
+            xml);
+        Assert.DoesNotContain("M:PrivateInterfaceDocs.Helpers.UndocumentedInstance", xml);
+        Assert.DoesNotContain("M:PrivateInterfaceDocs.Helpers.UndocumentedStatic", xml);
+    }
+
+    [Fact]
+    public void EmitsStandardIdsForTupleMemberShapes()
+    {
+        var source = """
+            package TupleDocs
+
+            import System.Collections.Generic
+
+            public class TupleHost[T] {
+              /// Exercises tuple parameter and function-return shapes.
+              public func Shapes(
+                pair (int32, string),
+                nullablePair (int32, string)?,
+                nested (T, (string, bool)),
+                nullableGeneric (T, string)?,
+                generic List[(T, string?)],
+                pairs [](T, string),
+                fixedPairs [2](T, string),
+                nullablePairs [](T, string)?,
+                ref byRef (T, string),
+                projector ((T, string)) -> (bool, T),
+                wide (int8, uint8, int16, uint16, int32, uint32, int64, uint64)) {
+              }
+            }
+
+            public struct TupleSource {
+            }
+
+            /// Converts a source value to a tuple.
+            func operator implicit (value TupleSource) (int32, string) {
+              return (0, "")
+            }
+            """;
+
+        var xml = EmitDocXml(source, "TupleDocs");
+        var expectedDocId =
+            "M:TupleDocs.TupleHost`1.Shapes(" +
+            "System.ValueTuple{System.Int32,System.String}," +
+            "System.Nullable{System.ValueTuple{System.Int32,System.String}}," +
+            "System.ValueTuple{`0,System.ValueTuple{System.String,System.Boolean}}," +
+            "System.Nullable{System.ValueTuple{`0,System.String}}," +
+            "System.Collections.Generic.List{System.ValueTuple{`0,System.String}}," +
+            "System.ValueTuple{`0,System.String}[]," +
+            "System.ValueTuple{`0,System.String}[]," +
+            "System.Nullable{System.ValueTuple{`0,System.String}}[]," +
+            "System.ValueTuple{`0,System.String}@," +
+            "System.Func{System.ValueTuple{`0,System.String},System.ValueTuple{System.Boolean,`0}}," +
+            "System.ValueTuple{System.SByte,System.Byte,System.Int16,System.UInt16," +
+            "System.Int32,System.UInt32,System.Int64,System.ValueTuple{System.UInt64}})";
+
+        Assert.Contains($"<member name=\"{expectedDocId}\">", xml);
+        Assert.Contains(
+            "<member name=\"M:TupleDocs.TupleSource.op_Implicit(TupleDocs.TupleSource)~System.ValueTuple{System.Int32,System.String}\">",
+            xml);
+    }
+
+    [Fact]
     public void EmitsAssemblyName()
     {
         var source = @"package Lib


### PR DESCRIPTION
## Summary
- emit documented interfaces, enums, delegates, nested types, enum members, and supported interface/type members
- generate canonical source DocIDs for nested generics, indexers, function/delegate shapes, and nullable reference versus value types
- attach documentation to named delegates, nested declarations, and interface static fields

## Tests
- `dotnet test test/Core.Tests/Core.Tests.csproj --nologo --no-restore --filter 'FullyQualifiedName~Documentation' --verbosity minimal` (99 passed)
- `dotnet format style GSharp.sln --no-restore --verify-no-changes --include <changed files> --verbosity minimal`
- `dotnet format analyzers GSharp.sln --no-restore --verify-no-changes --include <changed files> --verbosity minimal`

Fixes #3337