### PR TITLE
Keep LINQ query-clause hoists inside their own lambda

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue3348QueryClauseSpillSeamTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3348QueryClauseSpillSeamTests.cs
@@ -1,0 +1,333 @@
+// <copyright file="Issue3348QueryClauseSpillSeamTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Regression tests for issue #3348: a hoist performed while translating a LINQ
+/// query CLAUSE escaped into the enclosing method body. A query clause lowers to
+/// a lambda, but — unlike an explicit lambda — its body is not an
+/// <c>AnonymousFunctionExpressionSyntax</c>, so neither the spill seam
+/// (<c>TranslateLambda</c> suspends/reopens it) nor
+/// <c>CollectEmbeddedAssignments</c> (which stops at a lambda) treated it as its
+/// own evaluation scope.
+/// <para>
+/// Both kinds of hoist were affected — a single-evaluation spill (issue #1731)
+/// and an embedded value-position assignment (issue #1723) — and both produced
+/// the same two faults: the hoisted statement referenced the query's RANGE
+/// VARIABLE, which is not in scope in the enclosing body (so the emitted G# did
+/// not bind), and it ran once for the whole query instead of once per element.
+/// </para>
+/// <para>
+/// The emitted G# still PARSED, so <see cref="GSharpRoundTrip"/> validation —
+/// which every other cs2gs translation test relies on — could not catch this.
+/// Every case here therefore also asserts the output BINDS, via
+/// <see cref="BindDiagnostics"/>.
+/// </para>
+/// </summary>
+public class Issue3348QueryClauseSpillSeamTests
+{
+    // A non-trivial (member-access) scrutinee under a pattern that reads it more
+    // than once is the canonical #1731 spill trigger; putting it in a query
+    // clause is the #3348 reproducer.
+    private const string TagNode = @"
+public sealed class N { public object Tag; }
+";
+
+    [Fact]
+    public void WhereClause_PatternSpill_StaysInsideTheLambda()
+    {
+        string printed = TranslateQuery(
+            TagNode + @"
+public sealed class C
+{
+    public System.Collections.Generic.IEnumerable<N> M(System.Collections.Generic.IEnumerable<N> xs) =>
+        from x in xs where x.Tag is string s && s.Length > 0 select x;
+}");
+
+        AssertSpillIsInsideLambda(printed);
+    }
+
+    [Fact]
+    public void SelectClause_PatternSpill_StaysInsideTheLambda()
+    {
+        string printed = TranslateQuery(
+            TagNode + @"
+public sealed class C
+{
+    public System.Collections.Generic.IEnumerable<bool> M(System.Collections.Generic.IEnumerable<N> xs) =>
+        from x in xs select x.Tag is string { Length: > 0 };
+}");
+
+        AssertSpillIsInsideLambda(printed);
+    }
+
+    [Fact]
+    public void LetClause_PatternSpill_StaysInsideTheLambda()
+    {
+        string printed = TranslateQuery(
+            TagNode + @"
+public sealed class C
+{
+    public System.Collections.Generic.IEnumerable<bool> M(System.Collections.Generic.IEnumerable<N> xs) =>
+        from x in xs let ok = x.Tag is string { Length: > 0 } select ok;
+}");
+
+        AssertSpillIsInsideLambda(printed);
+    }
+
+    [Fact]
+    public void OrderByClause_PatternSpill_StaysInsideTheLambda()
+    {
+        string printed = TranslateQuery(
+            TagNode + @"
+public sealed class C
+{
+    public System.Collections.Generic.IEnumerable<N> M(System.Collections.Generic.IEnumerable<N> xs) =>
+        from x in xs orderby x.Tag is string { Length: > 0 } select x;
+}");
+
+        AssertSpillIsInsideLambda(printed);
+    }
+
+    [Fact]
+    public void AdditionalFromClause_PatternSpill_StaysInsideTheLambda()
+    {
+        string printed = TranslateQuery(@"
+public sealed class N { public System.Collections.Generic.IEnumerable<int> Items; }
+
+public sealed class C
+{
+    public System.Collections.Generic.IEnumerable<int> M(System.Collections.Generic.IEnumerable<N> xs) =>
+        from x in xs from i in (x.Items is { } items ? items : System.Linq.Enumerable.Empty<int>()) select i;
+}");
+
+        AssertSpillIsInsideLambda(printed);
+    }
+
+    [Fact]
+    public void JoinKeySelector_PatternSpill_StaysInsideTheLambda()
+    {
+        string printed = TranslateQuery(
+            TagNode + @"
+public sealed class C
+{
+    public System.Collections.Generic.IEnumerable<int> M(
+        System.Collections.Generic.IEnumerable<N> xs,
+        System.Collections.Generic.IEnumerable<bool> ys) =>
+        from x in xs
+        join y in ys on x.Tag is string { Length: > 0 } equals y
+        select 1;
+}");
+
+        AssertSpillIsInsideLambda(printed);
+    }
+
+    /// <summary>
+    /// The second half of #3348: an embedded value-position assignment inside a
+    /// query clause was hoisted by the ENCLOSING statement's
+    /// <c>CollectEmbeddedAssignments</c> scan, emitting `last = x` before the
+    /// query — where `x` does not exist — and running the write once instead of
+    /// once per element.
+    /// </summary>
+    [Fact]
+    public void WhereClause_ValuePositionAssignment_StaysInsideTheLambda()
+    {
+        string printed = TranslateQuery(@"
+public sealed class C
+{
+    public System.Collections.Generic.IEnumerable<int> M(System.Collections.Generic.IEnumerable<int> xs)
+    {
+        int last = 0;
+        return from x in xs where (last = x) > 0 select x;
+    }
+}");
+
+        // The write must be inside the lambda body, not ahead of the query.
+        int lambdaStart = printed.IndexOf("->", StringComparison.Ordinal);
+        int writeIndex = printed.IndexOf("last = x", StringComparison.Ordinal);
+        Assert.True(writeIndex >= 0, "Expected the `last = x` write to survive:\n" + printed);
+        Assert.True(
+            writeIndex > lambdaStart,
+            "The `last = x` write must be inside the query lambda, not hoisted ahead of it:\n" + printed);
+        AssertBinds(printed);
+    }
+
+    /// <summary>
+    /// Guard for the carve-out in <c>EagerQuerySources</c>: the FIRST `from`'s
+    /// source is evaluated eagerly, in the enclosing scope — it cannot reference
+    /// a range variable — so a hoist out of it is correct and must be preserved.
+    /// Regressing this would leave the assignment un-hoisted and silently drop
+    /// the write.
+    /// </summary>
+    [Fact]
+    public void FirstFromSource_ValuePositionAssignment_StillHoistsToEnclosingScope()
+    {
+        string printed = TranslateQuery(@"
+using System.Collections.Generic;
+using System.Linq;
+
+public sealed class C
+{
+    public IEnumerable<int> M(IEnumerable<int> a, IEnumerable<int> b)
+    {
+        IEnumerable<int> chosen;
+        return from x in (chosen = a) select x;
+    }
+}");
+
+        int writeIndex = printed.IndexOf("chosen = a", StringComparison.Ordinal);
+        int queryIndex = printed.IndexOf(".Select(", StringComparison.Ordinal);
+        Assert.True(writeIndex >= 0, "Expected the `chosen = a` write to survive:\n" + printed);
+        Assert.True(
+            queryIndex < 0 || writeIndex < queryIndex,
+            "The first `from` source is evaluated eagerly; its assignment must hoist ahead of the query:\n"
+                + printed);
+        AssertBinds(printed);
+    }
+
+    /// <summary>
+    /// A `join`'s `in` source is likewise eager — C# forbids it from referencing
+    /// a range variable — so it keeps hoisting to the enclosing scope.
+    /// </summary>
+    [Fact]
+    public void JoinInSource_ValuePositionAssignment_StillHoistsToEnclosingScope()
+    {
+        string printed = TranslateQuery(@"
+using System.Collections.Generic;
+using System.Linq;
+
+public sealed class C
+{
+    public IEnumerable<int> M(IEnumerable<int> a, IEnumerable<int> b)
+    {
+        IEnumerable<int> chosen;
+        return from x in a
+               join y in (chosen = b) on x equals y
+               select x;
+    }
+}");
+
+        int writeIndex = printed.IndexOf("chosen = b", StringComparison.Ordinal);
+        int joinIndex = printed.IndexOf(".Join(", StringComparison.Ordinal);
+        Assert.True(writeIndex >= 0, "Expected the `chosen = b` write to survive:\n" + printed);
+        Assert.True(
+            joinIndex < 0 || writeIndex < joinIndex,
+            "A join's `in` source is eager; its assignment must hoist ahead of the query:\n" + printed);
+        AssertBinds(printed);
+    }
+
+    /// <summary>
+    /// An explicit lambda with the same predicate was always correct (it is a real
+    /// <c>AnonymousFunctionExpressionSyntax</c>, so <c>TranslateLambda</c> opened a
+    /// seam). Kept as the control that isolates the fault to the query path.
+    /// </summary>
+    [Fact]
+    public void ExplicitLambda_PatternSpill_StaysInsideTheLambda_Control()
+    {
+        string printed = TranslateQuery(
+            TagNode + @"
+public sealed class C
+{
+    public System.Collections.Generic.IEnumerable<N> M(System.Collections.Generic.IEnumerable<N> xs) =>
+        System.Linq.Enumerable.Where(xs, x => x.Tag is string s && s.Length > 0);
+}");
+
+        AssertSpillIsInsideLambda(printed);
+    }
+
+    /// <summary>
+    /// A query with no hoist at all must keep the compact arrow-lambda form —
+    /// the fix must not force every clause lambda to become block-bodied.
+    /// </summary>
+    [Fact]
+    public void QueryWithoutHoist_KeepsArrowLambdaForm()
+    {
+        string printed = TranslateQuery(@"
+using System.Collections.Generic;
+using System.Linq;
+
+public sealed class C
+{
+    public IEnumerable<int> M(IEnumerable<int> xs) => from x in xs where x > 0 select x;
+}");
+
+        Assert.DoesNotContain("__spill", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("return ", printed, StringComparison.Ordinal);
+        AssertBinds(printed);
+    }
+
+    // The spill's `let` must appear AFTER the lambda arrow, i.e. inside the
+    // lambda body, and the range variable it reads must therefore be in scope.
+    private static void AssertSpillIsInsideLambda(string printed)
+    {
+        int spillIndex = printed.IndexOf("__spill", StringComparison.Ordinal);
+        Assert.True(spillIndex >= 0, "Expected a spill temp in:\n" + printed);
+
+        int lambdaStart = printed.IndexOf("->", StringComparison.Ordinal);
+        Assert.True(lambdaStart >= 0, "Expected a lambda in:\n" + printed);
+        Assert.True(
+            spillIndex > lambdaStart,
+            "The spill must be hoisted INSIDE the query lambda, not ahead of the query:\n" + printed);
+
+        AssertBinds(printed);
+    }
+
+    // The #3348 output parsed but did not bind (the hoisted statement read the
+    // lambda's range variable from the enclosing scope), so round-trip parsing
+    // alone is not a sufficient assertion for this class of defect.
+    private static void AssertBinds(string printed)
+    {
+        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            roundTrip.Success,
+            "Translated G# must round-trip. Errors:\n" + string.Join("\n", roundTrip.Errors)
+                + "\n\nPrinted:\n" + printed);
+
+        List<GSharp.Core.CodeAnalysis.Diagnostic> errors = BindDiagnostics(printed)
+            .Where(diagnostic => diagnostic.IsError)
+            .ToList();
+        Assert.True(
+            errors.Count == 0,
+            "Translated G# must bind without errors. Errors:\n"
+                + string.Join("\n", errors.Select(e => e.ToString())) + "\n\nPrinted:\n" + printed);
+    }
+
+    private static string TranslateQuery(string source)
+    {
+        const string Preamble = "using System;\nusing System.Collections.Generic;\nusing System.Linq;\n\n";
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Snippet.cs", Preamble + "namespace Demo\n{\n" + source + "\n}\n") });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: "
+                + string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        return GSharpPrinter.Print(unit);
+    }
+
+    private static IEnumerable<GSharp.Core.CodeAnalysis.Diagnostic> BindDiagnostics(string gsharpSource)
+    {
+        SyntaxTree tree = SyntaxTree.Parse(SourceText.From(gsharpSource));
+        BoundGlobalScope scope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+        return scope.Diagnostics;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
@@ -178,6 +178,32 @@ public sealed partial class CSharpToGSharpTranslator
                     yield break;
                 }
 
+                // Issue #3348: a query CLAUSE's expression is translated inside the
+                // lambda that clause lowers to (see <see cref="BuildScopeLambda"/> /
+                // <see cref="LowerLetClause"/>) — its own evaluation scope, exactly
+                // like an explicit lambda's, even though it is not an
+                // `AnonymousFunctionExpressionSyntax` syntactically. Hoisting an
+                // assignment out of one would move the write into the ENCLOSING
+                // statement, where the range variable it reads is not in scope at
+                // all, and would run it once for the whole query instead of once per
+                // element. Only the sub-expressions a query evaluates EAGERLY, in the
+                // enclosing scope, are scanned here: the source of the first `from`,
+                // and each `join`'s `in` source (C# forbids either from referencing a
+                // range variable, so neither can capture one). Every clause body is
+                // left to its own lambda's seam, which hoists into the lambda.
+                if (node is QueryExpressionSyntax query)
+                {
+                    foreach (ExpressionSyntax eager in EagerQuerySources(query))
+                    {
+                        foreach (AssignmentExpressionSyntax found in Scan(eager))
+                        {
+                            yield return found;
+                        }
+                    }
+
+                    yield break;
+                }
+
                 if (node is AssignmentExpressionSyntax assignment)
                 {
                     if (IsInitializerMember(assignment))
@@ -230,6 +256,28 @@ public sealed partial class CSharpToGSharpTranslator
             }
 
             return safe;
+        }
+
+        // Issue #3348: the sub-expressions of `query` that are evaluated EAGERLY, in
+        // the scope enclosing the query, rather than inside one of the lambdas its
+        // clauses lower to — the first `from`'s source, and every `join`'s `in`
+        // source (including those in an `into` continuation's body). C# forbids both
+        // from referencing a range variable, so a hoist out of either is safe.
+        // Everything else in a query is a clause body and belongs to its own lambda.
+        private static IEnumerable<ExpressionSyntax> EagerQuerySources(QueryExpressionSyntax query)
+        {
+            yield return query.FromClause.Expression;
+
+            for (QueryBodySyntax body = query.Body; body != null; body = body.Continuation?.Body)
+            {
+                foreach (QueryClauseSyntax clause in body.Clauses)
+                {
+                    if (clause is JoinClauseSyntax join)
+                    {
+                        yield return join.InExpression;
+                    }
+                }
+            }
         }
 
         // A `?:` arm owns a native G# block-expression seam. An enclosing seam

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
@@ -1812,7 +1812,11 @@ public sealed partial class CSharpToGSharpTranslator
             var prologue = new List<GStatement>();
             Parameter param = this.BuildScopeParameter(scope, prologue);
             this.ReportIfIndexOrRangeTypedRangeVariable(let, let.Identifier, this.context.GetTypeInfo(let.Expression).Type);
-            GExpression letValue = this.TranslateExpression(let.Expression);
+
+            // Issue #3348: as in `BuildScopeLambda`, the `let` value is evaluated
+            // inside this Select lambda — hoist into its own prologue, not the
+            // enclosing statement's.
+            GExpression letValue = this.TranslateQueryLambdaBody(let.Expression, prologue);
             GTypeReference letType = this.context.GetTypeInfo(let.Expression).Type is { } t
                 ? this.typeMapper.Map(t, this.context, let.GetLocation())
                 : new NamedTypeReference(CSharpTypeMapper.UnsupportedPlaceholderType);
@@ -1964,16 +1968,34 @@ public sealed partial class CSharpToGSharpTranslator
         {
             var prologue = new List<GStatement>();
             Parameter param = this.BuildScopeParameter(scope, prologue);
+
+            // Issue #3348: translate the clause body INSIDE this lambda's own seam.
+            // Anything it hoists — a single-evaluation spill (issue #1731) or an
+            // embedded value-position assignment (issue #1723) — lands in `prologue`,
+            // after the scope-parameter deconstruction it may read from, and so runs
+            // once per element inside the lambda. Left on the enclosing statement's
+            // ambient seam it would instead be emitted before the whole query, where
+            // the range variable it references is not in scope.
+            GExpression body = this.TranslateQueryLambdaBody(lambdaBody, prologue);
             if (prologue.Count == 0)
             {
-                return new LambdaExpression(
-                    new List<Parameter> { param },
-                    expressionBody: this.TranslateExpression(lambdaBody));
+                return new LambdaExpression(new List<Parameter> { param }, expressionBody: body);
             }
 
-            prologue.Add(new ReturnStatement(this.TranslateExpression(lambdaBody)));
+            prologue.Add(new ReturnStatement(body));
             return new LambdaExpression(new List<Parameter> { param }, blockBody: new BlockStatement(prologue));
         }
+
+        // Issue #3348: translates a query-clause expression as the body of the lambda
+        // that clause lowers to, redirecting every hoist into that lambda's own
+        // `prologue`. <see cref="TranslateConditionWithHoist"/> already implements
+        // exactly this contract for loop/if conditions — redirect the spill seam AND
+        // hoist embedded assignments into a caller-supplied statement list — so it is
+        // reused verbatim rather than duplicated. `CollectEmbeddedAssignments` no
+        // longer descends into a query clause (see <see cref="EagerQuerySources"/>),
+        // so the enclosing statement leaves these assignments for this call to hoist.
+        private GExpression TranslateQueryLambdaBody(ExpressionSyntax lambdaBody, List<GStatement> prologue) =>
+            this.TranslateConditionWithHoist(lambdaBody, prologue);
 
         // Builds the `(x1, x2) => new{x1, x2}` result-selector shape shared by
         // SelectMany/Join/GroupJoin (spec §12.19.3.3/.7/.8): one parameter for


### PR DESCRIPTION
Fixes #3348. First item from the plan in #3347.

## Problem

A query clause lowers to a lambda, but its body is not an
`AnonymousFunctionExpressionSyntax`, so neither the spill seam (`TranslateLambda` suspends and
reopens it) nor `CollectEmbeddedAssignments` (which stops at a lambda) treated it as its own
evaluation scope. Both kinds of hoist escaped:

```csharp
from x in xs where x.Tag is string s && s.Length > 0 select x
```
```gs
let __spill0 = x.Tag                                    // `x` is not in scope here
return xs.Where((x N) -> __spill0 is string && (__spill0 as string)!!.Length > 0)
```

Two faults: the identifier is undefined, and the operand is evaluated once for the whole query
instead of once per element. The same escape hit embedded value-position assignments:

```csharp
from x in xs where (last = x) > 0 select x
```
```gs
last = x                                 // same escape, same undefined `x`
return xs.Where((x int32) -> (last) > 0)
```

## Fix

`BuildScopeLambda` and `LowerLetClause` now translate the clause body through
`TranslateQueryLambdaBody`, which reuses the existing `TranslateConditionWithHoist` — it already
implements exactly the needed contract (redirect the spill seam *and* hoist embedded assignments
into a caller-supplied list). Hoists land in the lambda's own prologue, after the scope-parameter
deconstruction they may read from:

```gs
xs.Where((x N) -> {
    let __spill0 = x.Tag
    return __spill0 is string && (__spill0 as string)!!.Length > 0
})
```

`CollectEmbeddedAssignments` no longer descends into a query clause. `EagerQuerySources` carves out
the sub-expressions a query genuinely evaluates in the enclosing scope — the first `from`'s source
and each `join`'s `in` source, including through `into` continuations. C# forbids either from
referencing a range variable, so those keep hoisting exactly as before.

`BuildTransparentResultSelector` needed no change after all: it builds its body from bare
identifiers and never calls `TranslateExpression`, so it cannot spill. Correcting what #3348 claimed.

## Coverage

`Issue3348QueryClauseSpillSeamTests` — 11 tests:

- spill stays inside the lambda for `where`, `select`, `let`, `orderby`, an additional `from`, and a
  `join` key selector
- value-position assignment stays inside the lambda
- **guards for the carve-out**: an assignment in the first `from` source, and in a `join`'s `in`
  source, still hoist ahead of the query
- control: the same predicate as an explicit lambda (always worked)
- a hoist-free query keeps the compact arrow-lambda form

Every case asserts the output **binds**, not merely parses — parse-only validation is precisely
what let this defect through, so `GSharpRoundTrip` alone would not have caught it.

Verified the 7 behavioural tests fail without the source change and pass with it; the 4
control/guard tests pass both ways.

## Test run

Full `Cs2Gs.Tests` suite: **1918 passed, 0 failed** (9m39s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)