### PR TITLE
Diagnose inaccessible imported abstract members

### DIFF
--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.InterfaceVerification.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.InterfaceVerification.cs
@@ -62,6 +62,20 @@ internal sealed partial class DeclarationBinder
                     abstractMethod.ReceiverType?.Name ?? structSymbol.Name,
                     abstractMethod.Name);
             }
+
+            foreach (var abstractMember in ExternalClrOverrideResolver.GetUnimplementedAbstractMembers(structSymbol))
+            {
+                if (abstractMember.ReportedBySourceAbstractMethod)
+                {
+                    continue;
+                }
+
+                Diagnostics.ReportAbstractMemberNotImplemented(
+                    syntax.Identifier.Location,
+                    structSymbol.Name,
+                    abstractMember.DeclaringTypeName,
+                    abstractMember.MemberName);
+            }
         }
     }
 

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
@@ -1140,7 +1140,8 @@ internal sealed partial class DeclarationBinder
                                 returnType,
                                 methodReturnRefKind,
                                 methodTypeParameters,
-                                methodAccessibility);
+                                methodAccessibility,
+                                binderCtx.References);
                             if (externalMatch.Member != null)
                             {
                                 externalOverriddenMethod = externalMatch.Member;
@@ -1621,6 +1622,7 @@ internal sealed partial class DeclarationBinder
                 // Validate: override needs base property
                 PropertyInfo? externalOverriddenProperty = null;
                 TypeSymbol? externalPropertyContainingType = null;
+                PropertySymbol? overriddenProperty = null;
                 if (isOverride)
                 {
                     if (structSymbol.BaseClass != null && TypeMemberModel.TryGetProperty(structSymbol.BaseClass, propName, out var baseProp))
@@ -1628,6 +1630,10 @@ internal sealed partial class DeclarationBinder
                         if (!baseProp.IsVirtual && !baseProp.IsOverride)
                         {
                             Diagnostics.ReportOverrideOfSealedMethod(propSyntax.Identifier.Location, propName);
+                        }
+                        else
+                        {
+                            overriddenProperty = baseProp;
                         }
                     }
                     else
@@ -1639,7 +1645,9 @@ internal sealed partial class DeclarationBinder
                             propType,
                             hasGetter,
                             hasSetter,
-                            propAccessibility);
+                            getterAccessibility,
+                            setterAccessibility,
+                            binderCtx.References);
                         if (externalMatch.Member != null)
                         {
                             externalOverriddenProperty = externalMatch.Member;
@@ -1678,6 +1686,7 @@ internal sealed partial class DeclarationBinder
                     IsIndexer = isIndexer,
                     Parameters = indexerParameters,
                 };
+                propertySymbol.OverriddenProperty = overriddenProperty;
                 Binder.AttachDocumentation(propertySymbol, propSyntax);
                 if (externalOverriddenProperty != null)
                 {
@@ -1854,6 +1863,7 @@ internal sealed partial class DeclarationBinder
 
                 EventInfo? externalOverriddenEvent = null;
                 TypeSymbol? externalEventContainingType = null;
+                EventSymbol? overriddenEvent = null;
                 if (isOverride)
                 {
                     if (structSymbol.BaseClass != null && TypeMemberModel.TryGetEvent(structSymbol.BaseClass, eventName, out var baseEvent))
@@ -1866,6 +1876,10 @@ internal sealed partial class DeclarationBinder
                         {
                             Diagnostics.ReportOverrideSignatureMismatch(eventSyntax.Identifier.Location, eventName);
                         }
+                        else
+                        {
+                            overriddenEvent = baseEvent;
+                        }
                     }
                     else
                     {
@@ -1873,7 +1887,8 @@ internal sealed partial class DeclarationBinder
                             structSymbol,
                             eventName,
                             handlerType,
-                            eventAccessibility);
+                            eventAccessibility,
+                            binderCtx.References);
                         if (externalMatch.Member != null)
                         {
                             externalOverriddenEvent = externalMatch.Member;
@@ -1902,6 +1917,7 @@ internal sealed partial class DeclarationBinder
                     isVirtual,
                     isOverride,
                     declaration: eventSyntax);
+                eventSymbol.OverriddenEvent = overriddenEvent;
                 Binder.AttachDocumentation(eventSymbol, eventSyntax);
                 if (externalOverriddenEvent != null)
                 {

--- a/src/Core/CodeAnalysis/Binding/ExternalClrOverrideResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/ExternalClrOverrideResolver.cs
@@ -17,6 +17,23 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// </summary>
 internal static class ExternalClrOverrideResolver
 {
+    private enum SourceSlotStatus
+    {
+        Missing,
+        Implemented,
+        AbstractMethod,
+        AbstractAccessor,
+    }
+
+    private enum AccessorKind
+    {
+        Getter,
+        Setter,
+        Add,
+        Remove,
+        Raise,
+    }
+
     internal static MatchResult<MethodInfo> FindMethod(
         StructSymbol derivedType,
         string name,
@@ -893,23 +910,6 @@ internal static class ExternalClrOverrideResolver
         }
 
         return false;
-    }
-
-    private enum SourceSlotStatus
-    {
-        Missing,
-        Implemented,
-        AbstractMethod,
-        AbstractAccessor,
-    }
-
-    private enum AccessorKind
-    {
-        Getter,
-        Setter,
-        Add,
-        Remove,
-        Raise,
     }
 
     internal readonly record struct UnimplementedAbstractMember(

--- a/src/Core/CodeAnalysis/Binding/ExternalClrOverrideResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/ExternalClrOverrideResolver.cs
@@ -295,6 +295,9 @@ internal static class ExternalClrOverrideResolver
         MethodInfo baseMethod,
         ImmutableArray<TypeArgumentSubstitution> typeSubstitutions)
     {
+        derived = GetOpenDeclaringMethod(derived);
+        baseMethod = GetOpenDeclaringMethod(baseMethod);
+
         if (!string.Equals(derived.Name, baseMethod.Name, StringComparison.Ordinal))
         {
             return false;
@@ -338,6 +341,34 @@ internal static class ExternalClrOverrideResolver
         }
 
         return true;
+    }
+
+    private static MethodInfo GetOpenDeclaringMethod(MethodInfo method)
+    {
+        var declaringType = method.DeclaringType;
+        if (declaringType is not { IsGenericType: true, IsGenericTypeDefinition: false })
+        {
+            return method;
+        }
+
+        try
+        {
+            var openDefinition = declaringType.GetGenericTypeDefinition();
+            foreach (var candidate in ClrTypeUtilities.SafeGetMethods(
+                openDefinition,
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly))
+            {
+                if (candidate.MetadataToken == method.MetadataToken && candidate.Module == method.Module)
+                {
+                    return candidate;
+                }
+            }
+        }
+        catch (Exception ex) when (ClrTypeUtilities.IsMetadataLoadFailure(ex))
+        {
+        }
+
+        return method;
     }
 
     private static ImmutableArray<TypeSymbol?> BuildCanonicalMethodTypeArguments(int arity)

--- a/src/Core/CodeAnalysis/Binding/ExternalClrOverrideResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/ExternalClrOverrideResolver.cs
@@ -934,12 +934,8 @@ internal static class ExternalClrOverrideResolver
                 && references.CanAccessInternalMembers(method.DeclaringType?.Assembly);
         }
 
-        if (method.IsFamilyAndAssembly)
-        {
-            return accessibility == Accessibility.Protected
-                && references.CanAccessInternalMembers(method.DeclaringType?.Assembly);
-        }
-
+        // FamANDAssem requires private-protected visibility. G# cannot emit
+        // that combined accessibility, and Family would widen the override.
         return false;
     }
 

--- a/src/Core/CodeAnalysis/Binding/ExternalClrOverrideResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/ExternalClrOverrideResolver.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Reflection;
 using GSharp.Core.CodeAnalysis.Symbols;
 
@@ -23,7 +24,8 @@ internal static class ExternalClrOverrideResolver
         TypeSymbol returnType,
         RefKind returnRefKind,
         ImmutableArray<TypeParameterSymbol> typeParameters,
-        Accessibility accessibility)
+        Accessibility accessibility,
+        ReferenceResolver references)
     {
         bool sawName = false;
         var externalBase = FindExternalBaseType(derivedType);
@@ -32,7 +34,7 @@ internal static class ExternalClrOverrideResolver
         var methodTypeArguments = BuildMethodTypeArguments(typeParameters);
         foreach (var method in EnumerateMethods(reflectionBaseType, name))
         {
-            if (!IsAccessibleOverrideTarget(method, accessibility))
+            if (!IsAccessibleOverrideTarget(method, accessibility, references))
             {
                 continue;
             }
@@ -63,7 +65,9 @@ internal static class ExternalClrOverrideResolver
         TypeSymbol propertyType,
         bool hasGetter,
         bool hasSetter,
-        Accessibility accessibility)
+        Accessibility getterAccessibility,
+        Accessibility setterAccessibility,
+        ReferenceResolver references)
     {
         bool sawName = false;
         var externalBase = FindExternalBaseType(derivedType);
@@ -73,18 +77,23 @@ internal static class ExternalClrOverrideResolver
         {
             var getter = property.GetGetMethod(nonPublic: true);
             var setter = property.GetSetMethod(nonPublic: true);
-            var representative = getter ?? setter;
-            if (representative == null || !IsAccessibleOverrideTarget(representative, accessibility))
+            if (getter == null && setter == null)
+            {
+                continue;
+            }
+
+            if ((hasGetter && getter == null)
+                || (hasSetter && setter == null)
+                || (!hasGetter && getter != null)
+                || (!hasSetter && setter != null)
+                || (getter != null && !IsAccessibleOverrideTarget(getter, getterAccessibility, references))
+                || (setter != null && !IsAccessibleOverrideTarget(setter, setterAccessibility, references)))
             {
                 continue;
             }
 
             sawName = true;
-            if ((hasGetter && getter == null)
-                || (hasSetter && setter == null)
-                || (!hasGetter && getter != null)
-                || (!hasSetter && setter != null)
-                || !ParametersMatch(property.GetIndexParameters(), indexParameters, typeSubstitutions)
+            if (!ParametersMatch(property.GetIndexParameters(), indexParameters, typeSubstitutions)
                 || !PropertyTypeMatches(property.PropertyType, propertyType, hasSetter, typeSubstitutions))
             {
                 continue;
@@ -106,7 +115,8 @@ internal static class ExternalClrOverrideResolver
         StructSymbol derivedType,
         string name,
         TypeSymbol handlerType,
-        Accessibility accessibility)
+        Accessibility accessibility,
+        ReferenceResolver references)
     {
         bool sawName = false;
         var externalBase = FindExternalBaseType(derivedType);
@@ -116,8 +126,11 @@ internal static class ExternalClrOverrideResolver
         {
             var add = eventInfo.GetAddMethod(nonPublic: true);
             var remove = eventInfo.GetRemoveMethod(nonPublic: true);
-            var representative = add ?? remove;
-            if (representative == null || !IsAccessibleOverrideTarget(representative, accessibility))
+            var raise = eventInfo.GetRaiseMethod(nonPublic: true);
+            if ((add == null && remove == null)
+                || (add != null && !IsAccessibleOverrideTarget(add, accessibility, references))
+                || (remove != null && !IsAccessibleOverrideTarget(remove, accessibility, references))
+                || (raise != null && !IsAccessibleOverrideTarget(raise, accessibility, references)))
             {
                 continue;
             }
@@ -140,7 +153,40 @@ internal static class ExternalClrOverrideResolver
         return new MatchResult<EventInfo>(null, externalBase, sawName, IsSealed: false);
     }
 
-    private static TypeSymbol? FindExternalBaseType(StructSymbol type)
+    internal static ImmutableArray<UnimplementedAbstractMember> GetUnimplementedAbstractMembers(
+        StructSymbol derivedType)
+    {
+        var externalBase = FindDeclaredExternalBaseType(derivedType);
+        var reflectionBaseType = GetReflectionBaseType(externalBase);
+        if (reflectionBaseType == null || !reflectionBaseType.IsAbstract)
+        {
+            return ImmutableArray<UnimplementedAbstractMember>.Empty;
+        }
+
+        var typeSubstitutions = BuildTypeArgumentSubstitutions(externalBase);
+        ImmutableArray<UnimplementedAbstractMember>.Builder? builder = null;
+        foreach (var slot in GetEffectiveAbstractSlots(reflectionBaseType, typeSubstitutions))
+        {
+            var sourceStatus = GetSourceSlotStatus(derivedType, slot);
+            if (sourceStatus == SourceSlotStatus.Implemented)
+            {
+                continue;
+            }
+
+            builder ??= ImmutableArray.CreateBuilder<UnimplementedAbstractMember>();
+            builder.Add(new UnimplementedAbstractMember(
+                GetDeclaringTypeDisplayName(slot.DeclaringType),
+                GetMemberDisplayName(slot),
+                sourceStatus == SourceSlotStatus.AbstractMethod));
+        }
+
+        return builder?.ToImmutable() ?? ImmutableArray<UnimplementedAbstractMember>.Empty;
+    }
+
+    internal static bool HasUnimplementedAbstractMembers(StructSymbol derivedType)
+        => !GetUnimplementedAbstractMembers(derivedType).IsDefaultOrEmpty;
+
+    private static TypeSymbol? FindDeclaredExternalBaseType(StructSymbol type)
     {
         for (var current = type; current != null; current = current.BaseClass)
         {
@@ -148,7 +194,21 @@ internal static class ExternalClrOverrideResolver
             {
                 return current.ImportedBaseType;
             }
+        }
 
+        return null;
+    }
+
+    private static TypeSymbol? FindExternalBaseType(StructSymbol type)
+    {
+        var declaredBase = FindDeclaredExternalBaseType(type);
+        if (declaredBase != null)
+        {
+            return declaredBase;
+        }
+
+        for (var current = type; current != null; current = current.BaseClass)
+        {
             if (current.IsAttributeClass)
             {
                 // Attribute sugar emits System.Attribute rather than the CLR
@@ -158,6 +218,353 @@ internal static class ExternalClrOverrideResolver
         }
 
         return type != null ? TypeSymbol.Object : null;
+    }
+
+    private static ImmutableArray<MethodInfo> GetEffectiveAbstractSlots(
+        Type reflectionBaseType,
+        ImmutableArray<TypeArgumentSubstitution> typeSubstitutions)
+    {
+        var hierarchy = new List<Type>();
+        for (var current = reflectionBaseType; current != null; current = current.BaseType)
+        {
+            hierarchy.Add(current);
+        }
+
+        hierarchy.Reverse();
+
+        // Reconstruct effective CLR virtual slots base-first. A newslot method
+        // must not satisfy a same-signature abstract slot hidden beneath it.
+        var slots = new List<MethodInfo>();
+        foreach (var current in hierarchy)
+        {
+            var declaredMethods = ClrTypeUtilities.SafeGetMethods(
+                current,
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
+            foreach (var method in declaredMethods)
+            {
+                if (method.IsStatic || !method.IsVirtual)
+                {
+                    continue;
+                }
+
+                if (ClrTypeUtilities.SafeIsOverride(method))
+                {
+                    var overriddenSlot = -1;
+                    for (var i = slots.Count - 1; i >= 0; i--)
+                    {
+                        if (SlotSignaturesMatch(method, slots[i], typeSubstitutions))
+                        {
+                            overriddenSlot = i;
+                            break;
+                        }
+                    }
+
+                    if (overriddenSlot >= 0)
+                    {
+                        slots[overriddenSlot] = method;
+                        continue;
+                    }
+                }
+
+                slots.Add(method);
+            }
+        }
+
+        return slots.Where(method => method.IsAbstract).ToImmutableArray();
+    }
+
+    private static bool SlotSignaturesMatch(
+        MethodInfo derived,
+        MethodInfo baseMethod,
+        ImmutableArray<TypeArgumentSubstitution> typeSubstitutions)
+    {
+        if (!string.Equals(derived.Name, baseMethod.Name, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var derivedMethodArguments = derived.GetGenericArguments();
+        var baseMethodArguments = baseMethod.GetGenericArguments();
+        if (derivedMethodArguments.Length != baseMethodArguments.Length)
+        {
+            return false;
+        }
+
+        var derivedParameters = derived.GetParameters();
+        var baseParameters = baseMethod.GetParameters();
+        if (derivedParameters.Length != baseParameters.Length)
+        {
+            return false;
+        }
+
+        var canonicalMethodArguments = BuildCanonicalMethodTypeArguments(derivedMethodArguments.Length);
+        var derivedSubstitution = FindTypeArgumentSubstitution(derived.DeclaringType, typeSubstitutions);
+        var baseSubstitution = FindTypeArgumentSubstitution(baseMethod.DeclaringType, typeSubstitutions);
+        for (var i = 0; i < derivedParameters.Length; i++)
+        {
+            var derivedType = MemberLookup.MapOpenClrTypeToSymbolic(
+                derivedParameters[i].ParameterType,
+                derivedSubstitution.OpenDefinition,
+                derivedSubstitution.TypeArguments,
+                derived,
+                canonicalMethodArguments);
+            var baseType = MemberLookup.MapOpenClrTypeToSymbolic(
+                baseParameters[i].ParameterType,
+                baseSubstitution.OpenDefinition,
+                baseSubstitution.TypeArguments,
+                baseMethod,
+                canonicalMethodArguments);
+            if (!DeclarationBinder.TypeSignaturesEquivalent(derivedType, baseType))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static ImmutableArray<TypeSymbol?> BuildCanonicalMethodTypeArguments(int arity)
+    {
+        if (arity == 0)
+        {
+            return default;
+        }
+
+        var builder = ImmutableArray.CreateBuilder<TypeSymbol?>(arity);
+        for (var i = 0; i < arity; i++)
+        {
+            builder.Add(new TypeParameterSymbol(
+                $"T{i}",
+                i,
+                TypeParameterConstraint.Any,
+                TypeParameterVariance.None)
+            {
+                IsMethodTypeParameter = true,
+            });
+        }
+
+        return builder.MoveToImmutable();
+    }
+
+    private static TypeArgumentSubstitution FindTypeArgumentSubstitution(
+        Type? declaringType,
+        ImmutableArray<TypeArgumentSubstitution> typeSubstitutions)
+    {
+        var declaringDefinition = GetGenericDefinition(declaringType);
+        if (declaringDefinition == null)
+        {
+            return default;
+        }
+
+        foreach (var substitution in typeSubstitutions)
+        {
+            if (ClrTypeUtilities.AreSame(
+                GetGenericDefinition(substitution.OpenDefinition),
+                declaringDefinition))
+            {
+                return substitution;
+            }
+        }
+
+        return default;
+    }
+
+    private static Type? GetGenericDefinition(Type? type)
+        => type?.IsGenericType == true
+            ? type.IsGenericTypeDefinition ? type : type.GetGenericTypeDefinition()
+            : type;
+
+    private static SourceSlotStatus GetSourceSlotStatus(StructSymbol derivedType, MethodInfo slot)
+    {
+        for (var current = derivedType; current != null; current = current.BaseClass)
+        {
+            foreach (var method in current.Methods)
+            {
+                if (TargetsExternalSlot(method, slot))
+                {
+                    return method.IsAbstract
+                        ? SourceSlotStatus.AbstractMethod
+                        : SourceSlotStatus.Implemented;
+                }
+            }
+
+            foreach (var property in current.Properties)
+            {
+                if (TryGetPropertyAccessorKind(property, slot, out var accessorKind))
+                {
+                    return IsPropertyAccessorImplemented(property, accessorKind)
+                        ? SourceSlotStatus.Implemented
+                        : SourceSlotStatus.AbstractAccessor;
+                }
+            }
+
+            foreach (var eventSymbol in current.Events)
+            {
+                if (TryGetEventAccessorKind(eventSymbol, slot, out var accessorKind))
+                {
+                    return IsEventAccessorImplemented(eventSymbol, accessorKind)
+                        ? SourceSlotStatus.Implemented
+                        : SourceSlotStatus.AbstractAccessor;
+                }
+            }
+        }
+
+        return SourceSlotStatus.Missing;
+    }
+
+    private static bool TargetsExternalSlot(FunctionSymbol method, MethodInfo slot)
+    {
+        for (var current = method; current != null; current = current.OverriddenMethod)
+        {
+            if (SameMethod(current.ExternalOverriddenMethod, slot))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryGetPropertyAccessorKind(
+        PropertySymbol property,
+        MethodInfo slot,
+        out AccessorKind accessorKind)
+    {
+        for (var current = property; current != null; current = current.OverriddenProperty)
+        {
+            if (SameMethod(current.ExternalOverriddenGetter, slot))
+            {
+                accessorKind = AccessorKind.Getter;
+                return true;
+            }
+
+            if (SameMethod(current.ExternalOverriddenSetter, slot))
+            {
+                accessorKind = AccessorKind.Setter;
+                return true;
+            }
+        }
+
+        accessorKind = default;
+        return false;
+    }
+
+    private static bool IsPropertyAccessorImplemented(
+        PropertySymbol property,
+        AccessorKind accessorKind)
+        => accessorKind switch
+        {
+            AccessorKind.Getter => property.HasGetter
+                && (property.IsAutoProperty
+                    || property.GetterBodySyntax != null
+                    || property.GetterSymbol is { IsAbstract: false }),
+            AccessorKind.Setter => property.HasSetter
+                && (property.IsAutoProperty
+                    || property.SetterBodySyntax != null
+                    || property.SetterSymbol is { IsAbstract: false }),
+            _ => false,
+        };
+
+    private static bool TryGetEventAccessorKind(
+        EventSymbol eventSymbol,
+        MethodInfo slot,
+        out AccessorKind accessorKind)
+    {
+        for (var current = eventSymbol; current != null; current = current.OverriddenEvent)
+        {
+            if (SameMethod(current.ExternalOverriddenAddMethod, slot))
+            {
+                accessorKind = AccessorKind.Add;
+                return true;
+            }
+
+            if (SameMethod(current.ExternalOverriddenRemoveMethod, slot))
+            {
+                accessorKind = AccessorKind.Remove;
+                return true;
+            }
+
+            if (SameMethod(current.ExternalOverriddenRaiseMethod, slot))
+            {
+                accessorKind = AccessorKind.Raise;
+                return true;
+            }
+        }
+
+        accessorKind = default;
+        return false;
+    }
+
+    private static bool IsEventAccessorImplemented(
+        EventSymbol eventSymbol,
+        AccessorKind accessorKind)
+        => accessorKind switch
+        {
+            AccessorKind.Add => eventSymbol.IsFieldLike || eventSymbol.AddBodySyntax != null,
+            AccessorKind.Remove => eventSymbol.IsFieldLike || eventSymbol.RemoveBodySyntax != null,
+            AccessorKind.Raise => eventSymbol.RaiseBodySyntax != null,
+            _ => false,
+        };
+
+    private static bool SameMethod(MethodInfo? left, MethodInfo right)
+    {
+        if (left == null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(left, right))
+        {
+            return true;
+        }
+
+        try
+        {
+            return left.MetadataToken == right.MetadataToken
+                && ClrTypeUtilities.AreSame(left.DeclaringType, right.DeclaringType);
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
+    private static string GetDeclaringTypeDisplayName(Type? declaringType)
+    {
+        var name = declaringType?.Name ?? "?";
+        var arityMarker = name.IndexOf('`');
+        return arityMarker >= 0 ? name[..arityMarker] : name;
+    }
+
+    private static string GetMemberDisplayName(MethodInfo slot)
+    {
+        var name = slot.Name;
+        if (name.StartsWith("get_", StringComparison.Ordinal))
+        {
+            return name[4..] + ".get";
+        }
+
+        if (name.StartsWith("set_", StringComparison.Ordinal))
+        {
+            return name[4..] + ".set";
+        }
+
+        if (name.StartsWith("add_", StringComparison.Ordinal))
+        {
+            return name[4..] + ".add";
+        }
+
+        if (name.StartsWith("remove_", StringComparison.Ordinal))
+        {
+            return name[7..] + ".remove";
+        }
+
+        if (name.StartsWith("raise_", StringComparison.Ordinal))
+        {
+            return name[6..] + ".raise";
+        }
+
+        return name;
     }
 
     private static Type? GetReflectionBaseType(TypeSymbol? importedBase)
@@ -458,7 +865,10 @@ internal static class ExternalClrOverrideResolver
         return false;
     }
 
-    private static bool IsAccessibleOverrideTarget(MethodInfo method, Accessibility accessibility)
+    private static bool IsAccessibleOverrideTarget(
+        MethodInfo method,
+        Accessibility accessibility,
+        ReferenceResolver references)
     {
         if (method.IsPublic)
         {
@@ -470,8 +880,25 @@ internal static class ExternalClrOverrideResolver
             return accessibility == Accessibility.Protected;
         }
 
+        if (method.IsAssembly)
+        {
+            return accessibility == Accessibility.Internal
+                && references.CanAccessInternalMembers(method.DeclaringType?.Assembly);
+        }
+
+        if (method.IsFamilyAndAssembly)
+        {
+            return accessibility == Accessibility.Protected
+                && references.CanAccessInternalMembers(method.DeclaringType?.Assembly);
+        }
+
         return false;
     }
+
+    internal readonly record struct UnimplementedAbstractMember(
+        string DeclaringTypeName,
+        string MemberName,
+        bool ReportedBySourceAbstractMethod);
 
     internal readonly record struct MatchResult<T>(
         T? Member,
@@ -483,4 +910,21 @@ internal static class ExternalClrOverrideResolver
     private readonly record struct TypeArgumentSubstitution(
         Type? OpenDefinition,
         ImmutableArray<TypeSymbol> TypeArguments);
+
+    private enum SourceSlotStatus
+    {
+        Missing,
+        Implemented,
+        AbstractMethod,
+        AbstractAccessor,
+    }
+
+    private enum AccessorKind
+    {
+        Getter,
+        Setter,
+        Add,
+        Remove,
+        Raise,
+    }
 }

--- a/src/Core/CodeAnalysis/Binding/ExternalClrOverrideResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/ExternalClrOverrideResolver.cs
@@ -895,22 +895,6 @@ internal static class ExternalClrOverrideResolver
         return false;
     }
 
-    internal readonly record struct UnimplementedAbstractMember(
-        string DeclaringTypeName,
-        string MemberName,
-        bool ReportedBySourceAbstractMethod);
-
-    internal readonly record struct MatchResult<T>(
-        T? Member,
-        TypeSymbol? ContainingType,
-        bool SawName,
-        bool IsSealed)
-        where T : MemberInfo;
-
-    private readonly record struct TypeArgumentSubstitution(
-        Type? OpenDefinition,
-        ImmutableArray<TypeSymbol> TypeArguments);
-
     private enum SourceSlotStatus
     {
         Missing,
@@ -927,4 +911,20 @@ internal static class ExternalClrOverrideResolver
         Remove,
         Raise,
     }
+
+    internal readonly record struct UnimplementedAbstractMember(
+        string DeclaringTypeName,
+        string MemberName,
+        bool ReportedBySourceAbstractMethod);
+
+    internal readonly record struct MatchResult<T>(
+        T? Member,
+        TypeSymbol? ContainingType,
+        bool SawName,
+        bool IsSealed)
+        where T : MemberInfo;
+
+    private readonly record struct TypeArgumentSubstitution(
+        Type? OpenDefinition,
+        ImmutableArray<TypeSymbol> TypeArguments);
 }

--- a/src/Core/CodeAnalysis/Symbols/EventSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/EventSymbol.cs
@@ -88,6 +88,9 @@ public sealed class EventSymbol : Symbol
     /// <summary>Gets or sets the imported CLR raise slot overridden by this event.</summary>
     public MethodInfo? ExternalOverriddenRaiseMethod { get; set; }
 
+    /// <summary>Gets or sets the source-declared base event overridden by this event.</summary>
+    public EventSymbol? OverriddenEvent { get; set; }
+
     /// <summary>Gets or sets the imported interface add slot explicitly implemented by this event.</summary>
     public MethodInfo? ExplicitInterfaceAddSlot { get; set; }
 

--- a/src/Core/CodeAnalysis/Symbols/PropertySymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/PropertySymbol.cs
@@ -155,6 +155,9 @@ public sealed class PropertySymbol : Symbol
     /// <summary>Gets or sets the imported CLR setter slot overridden by this property.</summary>
     public MethodInfo? ExternalOverriddenSetter { get; set; }
 
+    /// <summary>Gets or sets the source-declared base property overridden by this property.</summary>
+    public PropertySymbol? OverriddenProperty { get; set; }
+
     /// <summary>Gets or sets the imported interface getter slot explicitly implemented by this property.</summary>
     public MethodInfo? ExplicitInterfaceGetterSlot { get; set; }
 

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -359,7 +359,8 @@ public sealed class StructSymbol : TypeSymbol
 
             return (!IsData && GetDataCloneAncestor()?.IsAbstract == true)
                 || !GetUnimplementedAbstractMethods().IsDefaultOrEmpty
-                || HasUnimplementedAbstractProperties();
+                || HasUnimplementedAbstractProperties()
+                || ExternalClrOverrideResolver.HasUnimplementedAbstractMembers(this);
         }
     }
 
@@ -2277,6 +2278,10 @@ public sealed class StructSymbol : TypeSymbol
                 BackingField = p.BackingField,
                 GetterSymbol = p.GetterSymbol,
                 SetterSymbol = p.SetterSymbol,
+                OverriddenProperty = p.OverriddenProperty,
+                ExternalOverriddenGetter = p.ExternalOverriddenGetter,
+                ExternalOverriddenSetter = p.ExternalOverriddenSetter,
+                ExternalOverrideContainingType = p.ExternalOverrideContainingType,
                 GetterBodySyntax = p.GetterBodySyntax,
                 SetterBodySyntax = p.SetterBodySyntax,
             };

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1260BaseBclCallBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1260BaseBclCallBinderTests.cs
@@ -25,7 +25,7 @@ public class Issue1260BaseBclCallBinderTests
     {
         var source = @"
 import System.IO
-class MyStream : Stream {
+open class MyStream : Stream {
     open func Dispose(disposing bool) {
         base.Dispose(disposing)
     }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1260BaseBclCallBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1260BaseBclCallBinderTests.cs
@@ -23,6 +23,8 @@ public class Issue1260BaseBclCallBinderTests
     [Fact]
     public void BaseCall_IntoBclStream_BindsClean()
     {
+        // Stream has unrelated abstract members; keep this fixture open so
+        // the test isolates base-call binding.
         var source = @"
 import System.IO
 open class MyStream : Stream {

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3338ImportedAbstractMemberTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3338ImportedAbstractMemberTests.cs
@@ -1,0 +1,433 @@
+// <copyright file="Issue3338ImportedAbstractMemberTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Text;
+using GsCompilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
+using GsSyntaxTree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #3338: concrete source classes must satisfy every effective abstract
+/// CLR slot inherited from an imported base, including inaccessible internal
+/// slots that cannot be implemented outside their declaring assembly.
+/// </summary>
+public sealed class Issue3338ImportedAbstractMemberTests
+{
+    private const string InternalAbstractLibrarySource = """
+        package Issue3338.Library
+
+        @assembly:InternalsVisibleTo("Issue3338.Friend")
+
+        public open class Renderer {
+          internal open func Prepare();
+
+          internal open func Optional() {
+          }
+
+          public open func Render(value int32) int32;
+        }
+        """;
+
+    [Fact]
+    public void ConcreteExternalSubclassWithInaccessibleInternalAbstractMethod_ReportsGS0387()
+    {
+        var directory = CreateOutputDirectory();
+        try
+        {
+            var libraryPath = EmitGSharpLibrary(
+                directory,
+                "Issue3338.Library",
+                InternalAbstractLibrarySource);
+            var result = CompileGSharp(
+                """
+                package Issue3338.Consumer
+                import Issue3338.Library
+
+                public class BasicRenderer : Renderer {
+                  public override func Render(value int32) int32 -> value
+                }
+                """,
+                "Issue3338.Consumer",
+                libraryPath);
+
+            Assert.False(result.Success);
+            var diagnostic = Assert.Single(result.Diagnostics.Where(d => d.Id == "GS0387"));
+            Assert.Contains("Prepare", diagnostic.Message, StringComparison.Ordinal);
+            Assert.DoesNotContain("Optional", diagnostic.Message, StringComparison.Ordinal);
+            Assert.DoesNotContain("Render", diagnostic.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteOutputDirectory(directory);
+        }
+    }
+
+    [Fact]
+    public void FriendAssemblyCanOverrideInternalAbstractMethod()
+    {
+        var directory = CreateOutputDirectory();
+        try
+        {
+            var libraryPath = EmitGSharpLibrary(
+                directory,
+                "Issue3338.Library",
+                InternalAbstractLibrarySource);
+            var result = CompileGSharp(
+                """
+                package Issue3338.Friend
+                import Issue3338.Library
+
+                public class FriendlyRenderer : Renderer {
+                  internal override func Prepare() {
+                  }
+
+                  public override func Render(value int32) int32 -> value
+                }
+                """,
+                "Issue3338.Friend",
+                libraryPath);
+
+            Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics.Select(d => d.Message)));
+            Assert.DoesNotContain(result.Diagnostics, d => d.Id is "GS0183" or "GS0387");
+        }
+        finally
+        {
+            DeleteOutputDirectory(directory);
+        }
+    }
+
+    [Fact]
+    public void OpenExternalSubclassMayDeferInaccessibleSlotAndEmitsAbstract()
+    {
+        var directory = CreateOutputDirectory();
+        try
+        {
+            var libraryPath = EmitGSharpLibrary(
+                directory,
+                "Issue3338.Library",
+                InternalAbstractLibrarySource);
+            var result = CompileGSharp(
+                """
+                package Issue3338.Deferred
+                import Issue3338.Library
+
+                public open class DeferredRenderer : Renderer {
+                  public override func Render(value int32) int32 -> value
+                }
+                """,
+                "Issue3338.Deferred",
+                libraryPath);
+
+            Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics.Select(d => d.Message)));
+            Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0387");
+            AssertTypeIsAbstract(result.Image, "DeferredRenderer");
+        }
+        finally
+        {
+            DeleteOutputDirectory(directory);
+        }
+    }
+
+    [Fact]
+    public void SameCompilationInternalAbstractOverrideRemainsValid()
+    {
+        var result = CompileGSharp(
+            """
+            package Issue3338.Local
+
+            public open class LocalBase {
+              internal open func Prepare();
+            }
+
+            public class LocalDerived : LocalBase {
+              internal override func Prepare() {
+              }
+            }
+            """,
+            "Issue3338.Local");
+
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics.Select(d => d.Message)));
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0387");
+    }
+
+    [Fact]
+    public void TransitiveGenericMethodsPropertiesAndEventsUseEffectiveAbstractSlots()
+    {
+        var directory = CreateOutputDirectory();
+        try
+        {
+            var libraryPath = EmitCSharpLibrary(
+                directory,
+                "Issue3338.GenericLibrary",
+                """
+                using System;
+
+                namespace Issue3338.GenericLibrary;
+
+                public sealed class Box<T>
+                {
+                }
+
+                public abstract class Root<T>
+                {
+                    public abstract T Transform(T value);
+
+                    public abstract U Echo<U>(U value);
+
+                    public abstract T Current { get; set; }
+
+                    public abstract event EventHandler Changed;
+                }
+
+                public abstract class Mid<U> : Root<Box<U>>
+                {
+                    public override Box<U> Transform(Box<U> value) => value;
+                }
+
+                public abstract class ShadowMid<U> : Root<Box<U>>
+                {
+                    public new virtual Box<U> Transform(Box<U> value) => value;
+                }
+                """);
+
+            var complete = CompileGSharp(
+                """
+                package Issue3338.GenericConsumer
+                import System
+                import Issue3338.GenericLibrary
+
+                public class Payload {
+                }
+
+                public open class Deferred[T] : Mid[T] {
+                }
+
+                public class Complete : Deferred[Payload] {
+                  public override func Echo[U](value U) U -> value
+
+                  public override prop Current Box[Payload] {
+                    get {
+                      return Box[Payload]()
+                    }
+                    set {
+                    }
+                  }
+
+                  public override event Changed EventHandler {
+                    add {
+                    }
+                    remove {
+                    }
+                  }
+                }
+                """,
+                "Issue3338.GenericConsumer",
+                libraryPath);
+
+            Assert.True(complete.Success, string.Join(Environment.NewLine, complete.Diagnostics.Select(d => d.Message)));
+            Assert.DoesNotContain(complete.Diagnostics, d => d.Id == "GS0387");
+            AssertTypeIsAbstract(complete.Image, "Deferred`1");
+
+            var missingAccessors = CompileGSharp(
+                """
+                package Issue3338.GenericMissing
+                import Issue3338.GenericLibrary
+
+                public class Payload {
+                }
+
+                public class Missing : Mid[Payload] {
+                  public override func Echo[U](value U) U -> value
+                }
+                """,
+                "Issue3338.GenericMissing",
+                libraryPath);
+
+            Assert.False(missingAccessors.Success);
+            var missing = missingAccessors.Diagnostics
+                .Where(d => d.Id == "GS0387")
+                .Select(d => d.Message)
+                .ToArray();
+            Assert.Equal(4, missing.Length);
+            Assert.Contains(missing, message => message.Contains("Current.get", StringComparison.Ordinal));
+            Assert.Contains(missing, message => message.Contains("Current.set", StringComparison.Ordinal));
+            Assert.Contains(missing, message => message.Contains("Changed.add", StringComparison.Ordinal));
+            Assert.Contains(missing, message => message.Contains("Changed.remove", StringComparison.Ordinal));
+            Assert.DoesNotContain(missing, message => message.Contains("Transform", StringComparison.Ordinal));
+            Assert.DoesNotContain(missing, message => message.Contains("Echo", StringComparison.Ordinal));
+
+            var shadowedSlot = CompileGSharp(
+                """
+                package Issue3338.GenericShadow
+                import System
+                import Issue3338.GenericLibrary
+
+                public class Payload {
+                }
+
+                public class ShadowLeaf : ShadowMid[Payload] {
+                  public override func Transform(value Box[Payload]) Box[Payload] -> value
+
+                  public override func Echo[U](value U) U -> value
+
+                  public override prop Current Box[Payload] {
+                    get {
+                      return Box[Payload]()
+                    }
+                    set {
+                    }
+                  }
+
+                  public override event Changed EventHandler {
+                    add {
+                    }
+                    remove {
+                    }
+                  }
+                }
+                """,
+                "Issue3338.GenericShadow",
+                libraryPath);
+
+            Assert.False(shadowedSlot.Success);
+            var shadowedDiagnostic = Assert.Single(
+                shadowedSlot.Diagnostics.Where(d => d.Id == "GS0387"));
+            Assert.Contains("Transform", shadowedDiagnostic.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteOutputDirectory(directory);
+        }
+    }
+
+    private static CompileResult CompileGSharp(
+        string source,
+        string assemblyName,
+        params string[] references)
+    {
+        using var resolver = references.Length == 0
+            ? ReferenceResolver.Default()
+            : ReferenceResolver.WithReferences(references);
+        resolver.CurrentAssemblyName = assemblyName;
+        var compilation = new GsCompilation(
+            resolver,
+            GsSyntaxTree.Parse(SourceText.From(source)))
+        {
+            AssemblyName = assemblyName,
+        };
+
+        using var output = new MemoryStream();
+        var emit = compilation.Emit(
+            output,
+            pdbStream: null,
+            refStream: null,
+            assemblyName: assemblyName);
+        return new CompileResult(
+            emit.Success,
+            emit.Diagnostics.Select(d => new DiagnosticInfo(d.Id, d.Message)).ToArray(),
+            output.ToArray());
+    }
+
+    private static string EmitGSharpLibrary(
+        string directory,
+        string assemblyName,
+        string source)
+    {
+        var path = Path.Combine(directory, assemblyName + ".dll");
+        var compilation = new GsCompilation(
+            GsSyntaxTree.Parse(SourceText.From(source)))
+        {
+            AssemblyName = assemblyName,
+            IsLibrary = true,
+        };
+
+        using var output = File.Create(path);
+        var emit = compilation.Emit(
+            output,
+            pdbStream: null,
+            refStream: null,
+            assemblyName: assemblyName);
+        Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
+        return path;
+    }
+
+    private static string EmitCSharpLibrary(
+        string directory,
+        string assemblyName,
+        string source)
+    {
+        var references = ((AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string)
+                ?.Split(Path.PathSeparator)
+                ?? Array.Empty<string>())
+            .Where(File.Exists)
+            .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path));
+        var compilation = CSharpCompilation.Create(
+            assemblyName,
+            new[] { CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest)) },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        var path = Path.Combine(directory, assemblyName + ".dll");
+        using var output = File.Create(path);
+        var emit = compilation.Emit(output);
+        Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
+        return path;
+    }
+
+    private static void AssertTypeIsAbstract(byte[] image, string typeName)
+    {
+        using var stream = new MemoryStream(image);
+        using var peReader = new PEReader(stream);
+        var metadata = peReader.GetMetadataReader();
+        foreach (var handle in metadata.TypeDefinitions)
+        {
+            var type = metadata.GetTypeDefinition(handle);
+            if (metadata.GetString(type.Name) == typeName)
+            {
+                Assert.True((type.Attributes & TypeAttributes.Abstract) != 0);
+                return;
+            }
+        }
+
+        Assert.Fail($"Type '{typeName}' was not emitted.");
+    }
+
+    private static string CreateOutputDirectory()
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            nameof(Issue3338ImportedAbstractMemberTests),
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
+    private static void DeleteOutputDirectory(string directory)
+    {
+        try
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    private readonly record struct CompileResult(
+        bool Success,
+        DiagnosticInfo[] Diagnostics,
+        byte[] Image);
+
+    private readonly record struct DiagnosticInfo(string Id, string Message);
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3338ImportedAbstractMemberTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3338ImportedAbstractMemberTests.cs
@@ -66,7 +66,7 @@ public sealed class Issue3338ImportedAbstractMemberTests
             var diagnostic = Assert.Single(result.Diagnostics, d => d.Id == "GS0387");
             Assert.Contains("Prepare", diagnostic.Message, StringComparison.Ordinal);
             Assert.DoesNotContain("Optional", diagnostic.Message, StringComparison.Ordinal);
-            Assert.DoesNotContain("Render", diagnostic.Message, StringComparison.Ordinal);
+            Assert.DoesNotContain("Renderer.Render", diagnostic.Message, StringComparison.Ordinal);
         }
         finally
         {
@@ -195,12 +195,19 @@ public sealed class Issue3338ImportedAbstractMemberTests
                 {
                     public override Box<U> Transform(Box<U> value) => value;
                 }
-
-                public abstract class ShadowMid<U> : Root<Box<U>>
-                {
-                    public new virtual Box<U> Transform(Box<U> value) => value;
-                }
                 """);
+            var shadowLibraryPath = EmitGSharpLibrary(
+                directory,
+                "Issue3338.GenericShadowLibrary",
+                """
+                package Issue3338.GenericShadowLibrary
+                import Issue3338.GenericLibrary
+
+                public open class ShadowMid[U] : Root[Box[U]] {
+                  public open func Transform(value Box[U]) Box[U] -> value
+                }
+                """,
+                libraryPath);
 
             var complete = CompileGSharp(
                 """
@@ -273,6 +280,7 @@ public sealed class Issue3338ImportedAbstractMemberTests
                 package Issue3338.GenericShadow
                 import System
                 import Issue3338.GenericLibrary
+                import Issue3338.GenericShadowLibrary
 
                 public class Payload {
                 }
@@ -299,7 +307,8 @@ public sealed class Issue3338ImportedAbstractMemberTests
                 }
                 """,
                 "Issue3338.GenericShadow",
-                libraryPath);
+                libraryPath,
+                shadowLibraryPath);
 
             Assert.False(shadowedSlot.Success);
             var shadowedDiagnostic = Assert.Single(
@@ -344,10 +353,16 @@ public sealed class Issue3338ImportedAbstractMemberTests
     private static string EmitGSharpLibrary(
         string directory,
         string assemblyName,
-        string source)
+        string source,
+        params string[] references)
     {
         var path = Path.Combine(directory, assemblyName + ".dll");
+        using var resolver = references.Length == 0
+            ? ReferenceResolver.Default()
+            : ReferenceResolver.WithReferences(references);
+        resolver.CurrentAssemblyName = assemblyName;
         var compilation = new GsCompilation(
+            resolver,
             GsSyntaxTree.Parse(SourceText.From(source)))
         {
             AssemblyName = assemblyName,

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3338ImportedAbstractMemberTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3338ImportedAbstractMemberTests.cs
@@ -63,7 +63,7 @@ public sealed class Issue3338ImportedAbstractMemberTests
                 libraryPath);
 
             Assert.False(result.Success);
-            var diagnostic = Assert.Single(result.Diagnostics.Where(d => d.Id == "GS0387"));
+            var diagnostic = Assert.Single(result.Diagnostics, d => d.Id == "GS0387");
             Assert.Contains("Prepare", diagnostic.Message, StringComparison.Ordinal);
             Assert.DoesNotContain("Optional", diagnostic.Message, StringComparison.Ordinal);
             Assert.DoesNotContain("Render", diagnostic.Message, StringComparison.Ordinal);
@@ -303,7 +303,8 @@ public sealed class Issue3338ImportedAbstractMemberTests
 
             Assert.False(shadowedSlot.Success);
             var shadowedDiagnostic = Assert.Single(
-                shadowedSlot.Diagnostics.Where(d => d.Id == "GS0387"));
+                shadowedSlot.Diagnostics,
+                d => d.Id == "GS0387");
             Assert.Contains("Transform", shadowedDiagnostic.Message, StringComparison.Ordinal);
         }
         finally

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3338ImportedAbstractMemberTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3338ImportedAbstractMemberTests.cs
@@ -64,9 +64,9 @@ public sealed class Issue3338ImportedAbstractMemberTests
 
             Assert.False(result.Success);
             var diagnostic = Assert.Single(result.Diagnostics, d => d.Id == "GS0387");
-            Assert.Contains("Prepare", diagnostic.Message, StringComparison.Ordinal);
-            Assert.DoesNotContain("Optional", diagnostic.Message, StringComparison.Ordinal);
-            Assert.DoesNotContain("Renderer.Render", diagnostic.Message, StringComparison.Ordinal);
+            Assert.Equal(
+                "'BasicRenderer' does not implement inherited abstract member 'Renderer.Prepare' (issue #987).",
+                diagnostic.Message);
         }
         finally
         {
@@ -101,6 +101,82 @@ public sealed class Issue3338ImportedAbstractMemberTests
 
             Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics.Select(d => d.Message)));
             Assert.DoesNotContain(result.Diagnostics, d => d.Id is "GS0183" or "GS0387");
+        }
+        finally
+        {
+            DeleteOutputDirectory(directory);
+        }
+    }
+
+    [Fact]
+    public void PrivateProtectedAbstractMethodCannotUseGSharpProtectedOverride()
+    {
+        var directory = CreateOutputDirectory();
+        try
+        {
+            var libraryPath = EmitCSharpLibrary(
+                directory,
+                "Issue3338.PrivateProtectedLibrary",
+                """
+                using System.Runtime.CompilerServices;
+
+                [assembly: InternalsVisibleTo("Issue3338.PrivateProtectedFriend")]
+
+                namespace Issue3338.PrivateProtectedLibrary;
+
+                public abstract class RestrictedRenderer
+                {
+                    private protected abstract void Prepare();
+
+                    public abstract void Render();
+                }
+                """);
+            AssertMethodAttributes(
+                libraryPath,
+                "RestrictedRenderer",
+                "Prepare",
+                MethodAttributes.FamANDAssem
+                    | MethodAttributes.Abstract
+                    | MethodAttributes.Virtual
+                    | MethodAttributes.NewSlot,
+                MethodAttributes.Final);
+            var external = CompileGSharp(
+                """
+                package Issue3338.PrivateProtectedConsumer
+                import Issue3338.PrivateProtectedLibrary
+
+                public class ExternalRenderer : RestrictedRenderer {
+                  public override func Render() {
+                  }
+                }
+                """,
+                "Issue3338.PrivateProtectedConsumer",
+                libraryPath);
+
+            Assert.False(external.Success);
+            var missing = Assert.Single(external.Diagnostics, d => d.Id == "GS0387");
+            Assert.Equal(
+                "'ExternalRenderer' does not implement inherited abstract member 'RestrictedRenderer.Prepare' (issue #987).",
+                missing.Message);
+
+            var friend = CompileGSharp(
+                """
+                package Issue3338.PrivateProtectedFriend
+                import Issue3338.PrivateProtectedLibrary
+
+                public open class FriendlyRenderer : RestrictedRenderer {
+                  protected override func Prepare() {
+                  }
+
+                  public override func Render() {
+                  }
+                }
+                """,
+                "Issue3338.PrivateProtectedFriend",
+                libraryPath);
+
+            Assert.False(friend.Success);
+            Assert.Contains(friend.Diagnostics, d => d.Id == "GS0183");
         }
         finally
         {
@@ -208,6 +284,18 @@ public sealed class Issue3338ImportedAbstractMemberTests
                 }
                 """,
                 libraryPath);
+            AssertMethodAttributes(
+                libraryPath,
+                "Root`1",
+                "Transform",
+                MethodAttributes.Abstract | MethodAttributes.Virtual | MethodAttributes.NewSlot,
+                MethodAttributes.Final);
+            AssertMethodAttributes(
+                shadowLibraryPath,
+                "ShadowMid`1",
+                "Transform",
+                MethodAttributes.Virtual | MethodAttributes.NewSlot,
+                MethodAttributes.Abstract | MethodAttributes.Final);
 
             var complete = CompileGSharp(
                 """
@@ -414,6 +502,47 @@ public sealed class Issue3338ImportedAbstractMemberTests
                 Assert.True((type.Attributes & TypeAttributes.Abstract) != 0);
                 return;
             }
+        }
+
+        Assert.Fail($"Type '{typeName}' was not emitted.");
+    }
+
+    private static void AssertMethodAttributes(
+        string assemblyPath,
+        string typeName,
+        string methodName,
+        MethodAttributes required,
+        MethodAttributes forbidden)
+    {
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+        var metadata = peReader.GetMetadataReader();
+        foreach (var typeHandle in metadata.TypeDefinitions)
+        {
+            var type = metadata.GetTypeDefinition(typeHandle);
+            if (metadata.GetString(type.Name) != typeName)
+            {
+                continue;
+            }
+
+            foreach (var methodHandle in type.GetMethods())
+            {
+                var method = metadata.GetMethodDefinition(methodHandle);
+                if (metadata.GetString(method.Name) != methodName)
+                {
+                    continue;
+                }
+
+                Assert.True(
+                    (method.Attributes & required) == required,
+                    $"{typeName}.{methodName} attributes {method.Attributes} do not include {required}.");
+                Assert.True(
+                    (method.Attributes & forbidden) == 0,
+                    $"{typeName}.{methodName} attributes {method.Attributes} include forbidden {forbidden}.");
+                return;
+            }
+
+            Assert.Fail($"Method '{typeName}.{methodName}' was not emitted.");
         }
 
         Assert.Fail($"Type '{typeName}' was not emitted.");


### PR DESCRIPTION
## Summary
- reconstruct effective imported CLR virtual slots across generic/transitive base chains
- diagnose concrete subclasses that leave imported abstract methods or accessors unimplemented, including inaccessible internal slots
- preserve abstract open subclasses and allow internal overrides for same/friend assemblies
- add cross-assembly regressions for methods, properties, events, newslot barriers, generics, and friend access

## Validation
- local .NET build/test intentionally not run per stored constraint
- lightweight static diff/LSP checks passed
- GitHub CI validates full suite

Fixes #3338