### PR TITLE
Fix interpreter CI hangs and process cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,6 +98,7 @@ jobs:
   tests:
     name: tests (${{ matrix.name }})
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: discover-tests
     strategy:
       fail-fast: false
@@ -138,6 +139,9 @@ jobs:
           if [[ -n "$TEST_FILTER" ]]; then
             args+=(--filter "$TEST_FILTER")
           fi
+          if [[ "${{ matrix.name }}" == "interpreter" ]]; then
+            args+=(--blame-hang --blame-hang-timeout 2m --blame-hang-dump-type mini)
+          fi
           dotnet test "${args[@]}"
 
       - name: Upload test results
@@ -145,7 +149,7 @@ jobs:
         uses: actions/upload-artifact@v5
         with:
           name: test-results-${{ matrix.name }}
-          path: TestResults/**/*.trx
+          path: TestResults/**/*
 
   e2e:
     runs-on: ubuntu-latest

--- a/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
+++ b/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
@@ -1335,8 +1335,11 @@ public sealed class ReferenceResolver : IDisposable
 
     private static ImmutableArray<Assembly> BuildHostAssemblies()
     {
+        // Constructing the first resolver loads this dependency after the host
+        // snapshot unless it is forced here, making two unchanged snapshots differ.
+        _ = typeof(MetadataLoadContext).Assembly;
+
         var builder = ImmutableArray.CreateBuilder<Assembly>();
-        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
         {
@@ -1354,11 +1357,7 @@ public sealed class ReferenceResolver : IDisposable
                 continue;
             }
 
-            var name = asm.GetName().FullName;
-            if (seen.Add(name))
-            {
-                builder.Add(asm);
-            }
+            builder.Add(asm);
         }
 
         foreach (var name in WellKnownBclAssemblyNames)
@@ -1366,10 +1365,7 @@ public sealed class ReferenceResolver : IDisposable
             try
             {
                 var asm = Assembly.Load(new AssemblyName(name));
-                if (seen.Add(asm.GetName().FullName))
-                {
-                    builder.Add(asm);
-                }
+                builder.Add(asm);
             }
             catch (FileNotFoundException)
             {
@@ -1382,7 +1378,14 @@ public sealed class ReferenceResolver : IDisposable
             }
         }
 
-        return builder.ToImmutable();
+        return builder
+            .OrderBy(static assembly => assembly.GetName().FullName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(static assembly => AssemblyLoadContext.GetLoadContext(assembly) == AssemblyLoadContext.Default ? 0 : 1)
+            .ThenBy(static assembly => AssemblyLoadContext.GetLoadContext(assembly)?.Name, StringComparer.Ordinal)
+            .ThenBy(static assembly => assembly.Location, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(static assembly => assembly.ManifestModule.ModuleVersionId)
+            .DistinctBy(static assembly => assembly.GetName().FullName, StringComparer.OrdinalIgnoreCase)
+            .ToImmutableArray();
     }
 
     private static string? ChooseCoreAssemblyName(string[] paths)

--- a/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
+++ b/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
@@ -1335,11 +1335,27 @@ public sealed class ReferenceResolver : IDisposable
 
     private static ImmutableArray<Assembly> BuildHostAssemblies()
     {
-        // Constructing the first resolver loads this dependency after the host
-        // snapshot unless it is forced here, making two unchanged snapshots differ.
-        _ = typeof(MetadataLoadContext).Assembly;
+        // Load resolver dependencies before taking the snapshot so the first
+        // and subsequent snapshots retain AppDomain's native assembly order.
+        foreach (var name in WellKnownBclAssemblyNames.Append("System.Reflection.MetadataLoadContext"))
+        {
+            try
+            {
+                _ = Assembly.Load(new AssemblyName(name));
+            }
+            catch (FileNotFoundException)
+            {
+            }
+            catch (FileLoadException)
+            {
+            }
+            catch (BadImageFormatException)
+            {
+            }
+        }
 
         var builder = ImmutableArray.CreateBuilder<Assembly>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
         {
@@ -1357,35 +1373,14 @@ public sealed class ReferenceResolver : IDisposable
                 continue;
             }
 
-            builder.Add(asm);
-        }
-
-        foreach (var name in WellKnownBclAssemblyNames)
-        {
-            try
+            var name = asm.GetName().FullName;
+            if (seen.Add(name))
             {
-                var asm = Assembly.Load(new AssemblyName(name));
                 builder.Add(asm);
             }
-            catch (FileNotFoundException)
-            {
-            }
-            catch (FileLoadException)
-            {
-            }
-            catch (BadImageFormatException)
-            {
-            }
         }
 
-        return builder
-            .OrderBy(static assembly => assembly.GetName().FullName, StringComparer.OrdinalIgnoreCase)
-            .ThenBy(static assembly => AssemblyLoadContext.GetLoadContext(assembly) == AssemblyLoadContext.Default ? 0 : 1)
-            .ThenBy(static assembly => AssemblyLoadContext.GetLoadContext(assembly)?.Name, StringComparer.Ordinal)
-            .ThenBy(static assembly => assembly.Location, StringComparer.OrdinalIgnoreCase)
-            .ThenBy(static assembly => assembly.ManifestModule.ModuleVersionId)
-            .DistinctBy(static assembly => assembly.GetName().FullName, StringComparer.OrdinalIgnoreCase)
-            .ToImmutableArray();
+        return builder.ToImmutable();
     }
 
     private static string? ChooseCoreAssemblyName(string[] paths)

--- a/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
+++ b/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
@@ -56,6 +56,10 @@ public sealed class ReferenceResolver : IDisposable
         "mscorlib",
     };
 
+    private static readonly object DefaultTypeNameIndexGate = new();
+    private static ImmutableArray<Assembly> defaultTypeNameIndexAssemblies = ImmutableArray<Assembly>.Empty;
+    private static Lazy<Dictionary<string, Type>>? defaultTypeNameIndex;
+
     private readonly ImmutableArray<Assembly> assemblies;
     private readonly MetadataLoadContext? metadataContext;
     private readonly AssemblyLoadContext? runtimeContext;
@@ -172,15 +176,14 @@ public sealed class ReferenceResolver : IDisposable
         ImmutableArray<Assembly> assemblies,
         MetadataLoadContext? metadataContext,
         ImmutableArray<string> missingTransitiveReferences,
-        AssemblyLoadContext? runtimeContext = null)
+        AssemblyLoadContext? runtimeContext = null,
+        Lazy<Dictionary<string, Type>>? typeNameIndex = null)
     {
         this.assemblies = assemblies;
         this.metadataContext = metadataContext;
         this.runtimeContext = runtimeContext;
         this.missingTransitiveReferences = missingTransitiveReferences;
-        this.typeNameIndex = new Lazy<Dictionary<string, Type>>(
-            this.BuildTypeNameIndex,
-            System.Threading.LazyThreadSafetyMode.ExecutionAndPublication);
+        this.typeNameIndex = typeNameIndex ?? CreateTypeNameIndex(assemblies);
     }
 
     private sealed class NotFoundSentinel
@@ -231,11 +234,6 @@ public sealed class ReferenceResolver : IDisposable
     /// </remarks>
     public void Dispose()
     {
-        if (metadataContext is null && runtimeContext is null)
-        {
-            return;
-        }
-
         metadataContext?.Dispose();
         runtimeContext?.Unload();
 
@@ -388,7 +386,12 @@ public sealed class ReferenceResolver : IDisposable
             }
         }
 
-        return new ReferenceResolver(BuildHostAssemblies(), metadataContext: null);
+        var assemblies = BuildHostAssemblies();
+        return new ReferenceResolver(
+            assemblies,
+            metadataContext: null,
+            missingTransitiveReferences: ImmutableArray<string>.Empty,
+            typeNameIndex: GetDefaultTypeNameIndex(assemblies));
     }
 
     /// <summary>
@@ -550,7 +553,7 @@ public sealed class ReferenceResolver : IDisposable
             }
         }
 
-        var resolver = new FallbackMetadataAssemblyResolver(resolverPaths);
+        var resolver = new FallbackMetadataAssemblyResolver(resolverPaths, fallbackHostPaths);
         var mlc = new MetadataLoadContext(resolver, coreAssemblyName: ChooseCoreAssemblyName(resolverPaths.ToArray()));
 
         var builder = ImmutableArray.CreateBuilder<Assembly>();
@@ -1223,7 +1226,26 @@ public sealed class ReferenceResolver : IDisposable
         return false;
     }
 
-    private Dictionary<string, Type> BuildTypeNameIndex()
+    private static Lazy<Dictionary<string, Type>> CreateTypeNameIndex(ImmutableArray<Assembly> assemblies)
+        => new(
+            () => BuildTypeNameIndex(assemblies),
+            System.Threading.LazyThreadSafetyMode.ExecutionAndPublication);
+
+    private static Lazy<Dictionary<string, Type>> GetDefaultTypeNameIndex(ImmutableArray<Assembly> assemblies)
+    {
+        lock (DefaultTypeNameIndexGate)
+        {
+            if (defaultTypeNameIndex is null || !defaultTypeNameIndexAssemblies.SequenceEqual(assemblies))
+            {
+                defaultTypeNameIndexAssemblies = assemblies;
+                defaultTypeNameIndex = CreateTypeNameIndex(assemblies);
+            }
+
+            return defaultTypeNameIndex;
+        }
+    }
+
+    private static Dictionary<string, Type> BuildTypeNameIndex(ImmutableArray<Assembly> assemblies)
     {
         var index = new Dictionary<string, Type>(StringComparer.Ordinal);
 
@@ -1605,27 +1627,35 @@ public sealed class ReferenceResolver : IDisposable
     /// </summary>
     private sealed class FallbackMetadataAssemblyResolver : MetadataAssemblyResolver
     {
+        private static readonly ConcurrentDictionary<string, byte[]> SharedHostAssemblyBytes =
+            new(StringComparer.OrdinalIgnoreCase);
+
         private readonly Dictionary<string, byte[]> assemblyBytes = new(StringComparer.OrdinalIgnoreCase);
         private readonly Dictionary<string, string> assemblyPaths = new(StringComparer.OrdinalIgnoreCase);
         private readonly HashSet<string> unresolved = new(StringComparer.OrdinalIgnoreCase);
         private readonly object gate = new();
 
-        public FallbackMetadataAssemblyResolver(IEnumerable<string> paths)
+        public FallbackMetadataAssemblyResolver(IEnumerable<string> paths, IEnumerable<string> sharedPaths)
         {
+            var shared = sharedPaths
+                .Select(Path.GetFullPath)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
             // Read each assembly into memory so no file handles are held open.
             // This prevents MSBuild CopyRefAssembly from being blocked (#853).
             foreach (var path in paths)
             {
-                var fileName = Path.GetFileNameWithoutExtension(path);
+                var fullPath = Path.GetFullPath(path);
+                var fileName = Path.GetFileNameWithoutExtension(fullPath);
                 if (!assemblyBytes.ContainsKey(fileName))
                 {
                     try
                     {
-                        using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
-                        var bytes = new byte[fs.Length];
-                        fs.ReadExactly(bytes);
+                        var bytes = shared.Contains(fullPath)
+                            ? SharedHostAssemblyBytes.GetOrAdd(fullPath, ReadAssemblyBytes)
+                            : ReadAssemblyBytes(fullPath);
                         assemblyBytes[fileName] = bytes;
-                        assemblyPaths[fileName] = path;
+                        assemblyPaths[fileName] = fullPath;
                     }
                     catch (Exception ex) when (
                         ex is IOException or UnauthorizedAccessException or BadImageFormatException)
@@ -1720,6 +1750,14 @@ public sealed class ReferenceResolver : IDisposable
             // tolerance in ClrOverloadResolution then skips that member rather than
             // aborting the whole lookup.
             return null;
+        }
+
+        private static byte[] ReadAssemblyBytes(string path)
+        {
+            using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+            var bytes = new byte[stream.Length];
+            stream.ReadExactly(bytes);
+            return bytes;
         }
     }
 }

--- a/src/Repl/Engine/EmittedSessionEngine.cs
+++ b/src/Repl/Engine/EmittedSessionEngine.cs
@@ -39,6 +39,7 @@ public sealed class EmittedSessionEngine : ISessionEngine, IDisposable
 {
     private readonly List<Cell> cells = new();
     private readonly List<SubmissionState> submissions = new(); // newest first
+    private readonly List<ReferenceResolver> discardedResolvers = new();
     private readonly List<ImportSymbol> sessionImports = new();
     private readonly IReadOnlyList<string> userReferences;
     private readonly InteractiveSessionHost host;
@@ -198,17 +199,16 @@ public sealed class EmittedSessionEngine : ISessionEngine, IDisposable
     public void Reset()
     {
         host.Reset();
-        submissions.Clear();
+        ReleaseCompilations();
         sessionImports.Clear();
         cells.Clear();
-        TryDeleteSubmissionFiles();
     }
 
     /// <inheritdoc/>
     public void Dispose()
     {
         host.Dispose();
-        TryDeleteSubmissionFiles();
+        ReleaseCompilations();
         try
         {
             Directory.Delete(submissionsDirectory, recursive: true);
@@ -305,86 +305,115 @@ public sealed class EmittedSessionEngine : ISessionEngine, IDisposable
             ? ReferenceResolver.WithReferences(referencePaths)
             : ReferenceResolver.Default();
 
-        var compilation = new Compilation(resolver, tree)
+        string? dllPath = null;
+        var ownershipTransferred = false;
+        try
         {
-            Submission = new SubmissionBindingOptions
+            var compilation = new Compilation(resolver, tree)
             {
-                Imports = SubmissionImports.Create(
-                    submissions.Select(s => new SubmissionReference(s.AssemblyName, s.PackageName, s.GlobalScope)).ToImmutableArray()),
-                DefaultPackageName = packageName,
-                ReplayImports = sessionImports.ToImmutableArray(),
-            },
-        };
+                Submission = new SubmissionBindingOptions
+                {
+                    Imports = SubmissionImports.Create(
+                        submissions.Select(s => new SubmissionReference(s.AssemblyName, s.PackageName, s.GlobalScope)).ToImmutableArray()),
+                    DefaultPackageName = packageName,
+                    ReplayImports = sessionImports.ToImmutableArray(),
+                },
+            };
 
-        using var peStream = new MemoryStream();
-        var emitResult = compilation.Emit(peStream, pdbStream: null, refStream: null, assemblyName: assemblyName);
-        var hasError = emitResult.Diagnostics.Any(d => d.IsError) || !emitResult.Success;
-        if (hasError)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            return new Cell(index, text, null, emitResult.Diagnostics, true, stdout?.ToString() ?? string.Empty, stderr?.ToString() ?? string.Empty);
-        }
-
-        // Flush the PE to the session directory before running: future
-        // submissions' reference resolvers read it from disk.
-        var peImage = peStream.ToArray();
-        var dllPath = Path.Combine(submissionsDirectory, assemblyName + ".dll");
-        File.WriteAllBytes(dllPath, peImage);
-
-        // A cell that declares its own `package X` emits its members (and the
-        // synthesized `<Program>` holding `<Result>$` and the globals) under
-        // that namespace, not under the session default. Track the package the
-        // members were actually emitted under so the echo read below and the
-        // chain's SubmissionReference stay truthful (Phase 3d follow-up to the
-        // 3c note "a package-declaring cell succeeds silently with no echo").
-        var emittedPackageName = compilation.GlobalScope.Package?.Name ?? packageName;
-
-        // assemblyName is assigned for every submission before emit.
-        var runResult = host.RunSubmission(peImage, assemblyName!);
-        if (runResult.UnhandledException is not null)
-        {
-            // Runtime failure: the submission's declarations are discarded
-            // (the chain stays at the last good submission), but side effects
-            // it already applied to earlier submissions' state persist —
-            // matching the evaluator engine's partial-state behavior.
-            TryDeleteFile(dllPath);
-            var ex = runResult.UnhandledException;
-            var diag = new Diagnostic(default, "GSI002", DiagnosticSeverity.Error, $"Unhandled exception. {ex.GetType().Name}: {ex.Message}");
-            cancellationToken.ThrowIfCancellationRequested();
-            return new Cell(index, text, null, emitResult.Diagnostics.Add(diag), true, stdout?.ToString() ?? string.Empty, stderr?.ToString() ?? string.Empty);
-        }
-
-        var value = host.ReadStaticField(
-            runResult.Assembly,
-            emittedPackageName + "." + SubmissionImports.ProgramTypeName,
-            SubmissionImports.ResultFieldName)
-            ?? runResult.ReturnValue;
-
-        // The only cancellation checkpoint: if the caller interrupted before
-        // this (possibly long-running) submission finished, discard the result
-        // instead of committing it to the transcript or the chain.
-        cancellationToken.ThrowIfCancellationRequested();
-
-        submissions.Insert(0, new SubmissionState(compilation, compilation.GlobalScope, assemblyName, emittedPackageName, dllPath, runResult.Assembly));
-        foreach (var import in compilation.GlobalScope.Imports)
-        {
-            if (!sessionImports.Any(i =>
-                string.Equals(i.Name, import.Name, StringComparison.Ordinal)
-                && string.Equals(i.Target, import.Target, StringComparison.Ordinal)))
+            using var peStream = new MemoryStream();
+            var emitResult = compilation.Emit(peStream, pdbStream: null, refStream: null, assemblyName: assemblyName);
+            var hasError = emitResult.Diagnostics.Any(d => d.IsError) || !emitResult.Success;
+            if (hasError)
             {
-                sessionImports.Add(new ImportSymbol(import.Name, import.Target, declaration: null));
+                cancellationToken.ThrowIfCancellationRequested();
+                return new Cell(index, text, null, emitResult.Diagnostics, true, stdout?.ToString() ?? string.Empty, stderr?.ToString() ?? string.Empty);
+            }
+
+            // Flush the PE to the session directory before running: future
+            // submissions' reference resolvers read it from disk.
+            var peImage = peStream.ToArray();
+            dllPath = Path.Combine(submissionsDirectory, assemblyName + ".dll");
+            File.WriteAllBytes(dllPath, peImage);
+
+            // A cell that declares its own `package X` emits its members (and the
+            // synthesized `<Program>` holding `<Result>$` and the globals) under
+            // that namespace, not under the session default. Track the package the
+            // members were actually emitted under so the echo read below and the
+            // chain's SubmissionReference stay truthful (Phase 3d follow-up to the
+            // 3c note "a package-declaring cell succeeds silently with no echo").
+            var emittedPackageName = compilation.GlobalScope.Package?.Name ?? packageName;
+
+            // assemblyName is assigned for every submission before emit.
+            var runResult = host.RunSubmission(peImage, assemblyName!);
+            if (runResult.UnhandledException is not null)
+            {
+                // Runtime failure: the submission's declarations are discarded
+                // (the chain stays at the last good submission), but side effects
+                // it already applied to earlier submissions' state persist —
+                // matching the evaluator engine's partial-state behavior.
+                var ex = runResult.UnhandledException;
+                var diag = new Diagnostic(default, "GSI002", DiagnosticSeverity.Error, $"Unhandled exception. {ex.GetType().Name}: {ex.Message}");
+                cancellationToken.ThrowIfCancellationRequested();
+                return new Cell(index, text, null, emitResult.Diagnostics.Add(diag), true, stdout?.ToString() ?? string.Empty, stderr?.ToString() ?? string.Empty);
+            }
+
+            var value = host.ReadStaticField(
+                runResult.Assembly,
+                emittedPackageName + "." + SubmissionImports.ProgramTypeName,
+                SubmissionImports.ResultFieldName)
+                ?? runResult.ReturnValue;
+
+            // The only cancellation checkpoint: if the caller interrupted before
+            // this (possibly long-running) submission finished, discard the result
+            // instead of committing it to the transcript or the chain.
+            cancellationToken.ThrowIfCancellationRequested();
+
+            submissions.Insert(0, new SubmissionState(compilation, compilation.GlobalScope, assemblyName, emittedPackageName, dllPath, runResult.Assembly));
+            ownershipTransferred = true;
+            foreach (var import in compilation.GlobalScope.Imports)
+            {
+                if (!sessionImports.Any(i =>
+                    string.Equals(i.Name, import.Name, StringComparison.Ordinal)
+                    && string.Equals(i.Target, import.Target, StringComparison.Ordinal)))
+                {
+                    sessionImports.Add(new ImportSymbol(import.Name, import.Target, declaration: null));
+                }
+            }
+
+            return new Cell(index, text, value, emitResult.Diagnostics, false, stdout?.ToString() ?? string.Empty, stderr?.ToString() ?? string.Empty);
+        }
+        finally
+        {
+            if (!ownershipTransferred)
+            {
+                if (dllPath is not null)
+                {
+                    TryDeleteFile(dllPath);
+                }
+
+                // Disposing a resolver clears process-wide symbol caches. Keep
+                // failed/cancelled resolvers until this session ends so a live
+                // prior submission never observes a mid-chain cache reset.
+                discardedResolvers.Add(resolver);
             }
         }
-
-        return new Cell(index, text, value, emitResult.Diagnostics, false, stdout?.ToString() ?? string.Empty, stderr?.ToString() ?? string.Empty);
     }
 
-    private void TryDeleteSubmissionFiles()
+    private void ReleaseCompilations()
     {
         foreach (var submission in submissions)
         {
             TryDeleteFile(submission.DllPath);
+            submission.Compilation.References?.Dispose();
         }
+
+        submissions.Clear();
+        foreach (var resolver in discardedResolvers)
+        {
+            resolver.Dispose();
+        }
+
+        discardedResolvers.Clear();
     }
 
     private static void TryDeleteFile(string path)

--- a/test/Core.Tests/CodeAnalysis/Symbols/ReferenceResolverTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/ReferenceResolverTests.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Linq;
+using System.Reflection;
 using GSharp.Core.CodeAnalysis.Symbols;
 using Xunit;
 
@@ -31,6 +32,19 @@ public class ReferenceResolverTests
         var resolver = ReferenceResolver.Default();
         Assert.False(resolver.TryResolveType("System.ThisTypeDoesNotExist", out var type));
         Assert.Null(type);
+    }
+
+    [Fact]
+    public void Default_Reuses_TypeNameIndex_WhileHostAssembliesAreUnchanged()
+    {
+        var first = ReferenceResolver.Default();
+        var second = ReferenceResolver.Default();
+        var indexField = typeof(ReferenceResolver).GetField(
+            "typeNameIndex",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Assert.NotNull(indexField);
+        Assert.Same(indexField.GetValue(first), indexField.GetValue(second));
     }
 
     [Fact]

--- a/test/Core.Tests/CodeAnalysis/Symbols/ReferenceResolverTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/ReferenceResolverTests.cs
@@ -44,6 +44,9 @@ public class ReferenceResolverTests
             BindingFlags.Instance | BindingFlags.NonPublic);
 
         Assert.NotNull(indexField);
+        Assert.Equal(
+            first.Assemblies.Select(assembly => assembly.GetName().FullName),
+            second.Assemblies.Select(assembly => assembly.GetName().FullName));
         Assert.Same(indexField.GetValue(first), indexField.GetValue(second));
     }
 

--- a/test/Interpreter.Tests/CollectibleAssembly.cs
+++ b/test/Interpreter.Tests/CollectibleAssembly.cs
@@ -1,0 +1,58 @@
+// <copyright file="CollectibleAssembly.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace GSharp.Interpreter.Tests;
+
+internal static class CollectibleAssembly
+{
+    public static void Inspect(string assemblyPath, Action<Assembly> inspect)
+        => Inspect(
+            assemblyPath,
+            assembly =>
+            {
+                inspect(assembly);
+                return true;
+            });
+
+    public static T Inspect<T>(string assemblyPath, Func<Assembly, T> inspect)
+    {
+        var directory = Path.GetDirectoryName(assemblyPath)!;
+        var loadContext = new AssemblyLoadContext(
+            "gsharp-test-inspection-" + Guid.NewGuid().ToString("N"),
+            isCollectible: true);
+        loadContext.Resolving += (context, name) =>
+        {
+            var localPath = Path.Combine(directory, name.Name + ".dll");
+            if (File.Exists(localPath))
+            {
+                using var dependency = File.OpenRead(localPath);
+                return context.LoadFromStream(dependency);
+            }
+
+            try
+            {
+                return Assembly.Load(name);
+            }
+            catch (Exception ex) when (ex is FileNotFoundException or FileLoadException or BadImageFormatException)
+            {
+                return null;
+            }
+        };
+
+        try
+        {
+            using var stream = File.OpenRead(assemblyPath);
+            return inspect(loadContext.LoadFromStream(stream));
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+}

--- a/test/Interpreter.Tests/DotnetProcess.cs
+++ b/test/Interpreter.Tests/DotnetProcess.cs
@@ -1,0 +1,172 @@
+// <copyright file="DotnetProcess.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GSharp.Interpreter.Tests;
+
+internal static class DotnetProcess
+{
+    private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan CleanupTimeout = TimeSpan.FromSeconds(5);
+
+    public static DotnetProcessResult Run(string workingDirectory, params string[] arguments)
+        => RunAsync(workingDirectory, arguments).GetAwaiter().GetResult();
+
+    public static async Task<DotnetProcessResult> RunAsync(
+        string workingDirectory,
+        IEnumerable<string> arguments,
+        TimeSpan? timeout = null)
+    {
+        var argumentList = arguments.ToArray();
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = workingDirectory,
+        };
+        foreach (var argument in argumentList)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start dotnet.");
+        var standardOutput = new StringBuilder();
+        var standardError = new StringBuilder();
+        var outputPump = PumpAsync(process.StandardOutput, standardOutput);
+        var errorPump = PumpAsync(process.StandardError, standardError);
+
+        try
+        {
+            try
+            {
+                await process.WaitForExitAsync().WaitAsync(timeout ?? DefaultTimeout);
+            }
+            catch (TimeoutException)
+            {
+                await TerminateAsync(process);
+                await StopPumpsAsync(process, outputPump, errorPump);
+                throw new TimeoutException(FormatFailure(
+                    process,
+                    argumentList,
+                    workingDirectory,
+                    "timed out",
+                    standardOutput,
+                    standardError));
+            }
+
+            try
+            {
+                await Task.WhenAll(outputPump, errorPump).WaitAsync(CleanupTimeout);
+            }
+            catch (TimeoutException)
+            {
+                await StopPumpsAsync(process, outputPump, errorPump);
+                throw new TimeoutException(FormatFailure(
+                    process,
+                    argumentList,
+                    workingDirectory,
+                    "exited but output streams did not close",
+                    standardOutput,
+                    standardError));
+            }
+
+            return new DotnetProcessResult(
+                process.ExitCode,
+                Snapshot(standardOutput),
+                Snapshot(standardError));
+        }
+        finally
+        {
+            if (!process.HasExited)
+            {
+                await TerminateAsync(process);
+            }
+        }
+    }
+
+    private static async Task PumpAsync(StreamReader reader, StringBuilder output)
+    {
+        var buffer = new char[4096];
+        try
+        {
+            while (await reader.ReadAsync(buffer.AsMemory()) is var count && count > 0)
+            {
+                lock (output)
+                {
+                    output.Append(buffer, 0, count);
+                }
+            }
+        }
+        catch (Exception ex) when (ex is IOException or ObjectDisposedException)
+        {
+        }
+    }
+
+    private static async Task StopPumpsAsync(Process process, Task outputPump, Task errorPump)
+    {
+        process.StandardOutput.Dispose();
+        process.StandardError.Dispose();
+        try
+        {
+            await Task.WhenAll(outputPump, errorPump).WaitAsync(CleanupTimeout);
+        }
+        catch (TimeoutException)
+        {
+        }
+    }
+
+    private static async Task TerminateAsync(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+        }
+        catch (InvalidOperationException) when (process.HasExited)
+        {
+        }
+
+        try
+        {
+            await process.WaitForExitAsync().WaitAsync(CleanupTimeout);
+        }
+        catch (TimeoutException)
+        {
+        }
+    }
+
+    private static string FormatFailure(
+        Process process,
+        IReadOnlyList<string> arguments,
+        string workingDirectory,
+        string reason,
+        StringBuilder standardOutput,
+        StringBuilder standardError)
+        => $"dotnet process {reason}; pid={process.Id}; cwd={workingDirectory}; args={string.Join(" ", arguments)}"
+            + $"\nstdout:\n{Snapshot(standardOutput)}\nstderr:\n{Snapshot(standardError)}";
+
+    private static string Snapshot(StringBuilder output)
+    {
+        lock (output)
+        {
+            return output.ToString();
+        }
+    }
+}
+
+internal sealed record DotnetProcessResult(int ExitCode, string StandardOutput, string StandardError)
+{
+    public string Combined => StandardOutput + StandardError;
+}

--- a/test/Interpreter.Tests/DotnetProcessTests.cs
+++ b/test/Interpreter.Tests/DotnetProcessTests.cs
@@ -1,0 +1,101 @@
+// <copyright file="DotnetProcessTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+public sealed class DotnetProcessTests
+{
+    [Fact]
+    public async Task Timeout_KillsProcessTreeAndReportsCommandContext()
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            nameof(DotnetProcessTests),
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            var childSourcePath = Path.Combine(directory, "child.gs");
+            var childAssemblyPath = Path.Combine(directory, "child.dll");
+            File.WriteAllText(childSourcePath, "for {\n}");
+            Assert.Equal(
+                0,
+                GSharp.Compiler.Program.Main(
+                    ["/out:" + childAssemblyPath, "/target:exe", "/targetframework:net10.0", childSourcePath]));
+
+            var parentSourcePath = Path.Combine(directory, "parent.gs");
+            var parentAssemblyPath = Path.Combine(directory, "parent.dll");
+            File.WriteAllText(
+                parentSourcePath,
+                """
+                import System
+                import System.Diagnostics
+
+                let startInfo = ProcessStartInfo("dotnet")
+                startInfo.UseShellExecute = false
+                startInfo.ArgumentList.Add("child.dll")
+                let child Process = Process.Start(startInfo) ?? throw InvalidOperationException("child failed")
+                Console.WriteLine(child.Id)
+                for {
+                }
+                """);
+            Assert.Equal(
+                0,
+                GSharp.Compiler.Program.Main(
+                    ["/out:" + parentAssemblyPath, "/target:exe", "/targetframework:net10.0", parentSourcePath]));
+
+            var error = await Assert.ThrowsAsync<TimeoutException>(
+                () => DotnetProcess.RunAsync(
+                    directory,
+                    [parentAssemblyPath],
+                    TimeSpan.FromSeconds(2)));
+
+            Assert.Contains("timed out; pid=", error.Message, StringComparison.Ordinal);
+            Assert.Contains("cwd=" + directory, error.Message, StringComparison.Ordinal);
+            Assert.Contains("args=" + parentAssemblyPath, error.Message, StringComparison.Ordinal);
+            Assert.Contains("stdout:", error.Message, StringComparison.Ordinal);
+            Assert.Contains("stderr:", error.Message, StringComparison.Ordinal);
+
+            var childPid = int.Parse(error.Message
+                .Split("stdout:\n", StringSplitOptions.None)[1]
+                .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+                .First());
+            await AssertProcessExitedAsync(childPid);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static async Task AssertProcessExitedAsync(int processId)
+    {
+        for (var i = 0; i < 50; i++)
+        {
+            try
+            {
+                using var process = Process.GetProcessById(processId);
+                if (process.HasExited)
+                {
+                    return;
+                }
+            }
+            catch (ArgumentException)
+            {
+                return;
+            }
+
+            await Task.Delay(100);
+        }
+
+        Assert.Fail($"Child process {processId} was not terminated.");
+    }
+}

--- a/test/Interpreter.Tests/EmittedSessionEngineTests.cs
+++ b/test/Interpreter.Tests/EmittedSessionEngineTests.cs
@@ -326,6 +326,33 @@ public sealed class EmittedSessionEngineTests : IDisposable
         Assert.Equal(9, read.Value);
     }
 
+    [Fact]
+    public void DisposedSessionsDoNotRetainCompilerState()
+    {
+        using (var warmup = new EmittedSessionEngine())
+        {
+            Assert.False(warmup.Evaluate("var value = 40").HasError);
+            Assert.False(warmup.Evaluate("value + 2").HasError);
+        }
+
+        CollectGarbage();
+        var baseline = GC.GetTotalMemory(forceFullCollection: true);
+
+        for (var i = 0; i < 8; i++)
+        {
+            using var session = new EmittedSessionEngine();
+            Assert.False(session.Evaluate("var value = 40").HasError);
+            Assert.False(session.Evaluate("func add(n int) int {\n    return value + n\n}").HasError);
+            Assert.False(session.Evaluate("add(2)").HasError);
+        }
+
+        CollectGarbage();
+        var retained = GC.GetTotalMemory(forceFullCollection: true) - baseline;
+        Assert.True(
+            retained < 64 * 1024 * 1024,
+            $"Disposed sessions retained {retained / (1024 * 1024)} MiB of managed memory.");
+    }
+
     /// <summary>
     /// ADR-0156 Phase 2 deliberate semantic change: interactive submissions
     /// run real emitted code, so a class deinitializer executes as a genuine
@@ -385,6 +412,15 @@ public sealed class EmittedSessionEngineTests : IDisposable
         Assert.Single(engine.Cells);
         Assert.False(cell.HasError);
         Assert.Equal(2, cell.Value);
+    }
+
+    private static void CollectGarbage()
+    {
+        for (var i = 0; i < 3; i++)
+        {
+            GC.Collect(2, GCCollectionMode.Aggressive, blocking: true, compacting: true);
+            GC.WaitForPendingFinalizers();
+        }
     }
 
     /// <summary>

--- a/test/Interpreter.Tests/Issue2896StructObjectOverrideTests.cs
+++ b/test/Interpreter.Tests/Issue2896StructObjectOverrideTests.cs
@@ -3,7 +3,6 @@
 // </copyright>
 
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -940,8 +939,7 @@ public class Issue2896StructObjectOverrideTests
             $"gsc emit failed ({compile.ExitCode})\nstdout:\n{compile.StandardOutput}\nstderr:\n{compile.StandardError}");
         Assert.Equal(string.Empty, compile.StandardError);
 
-        var assembly = Assembly.Load(File.ReadAllBytes(outputPath));
-        Assert.NotEmpty(assembly.GetTypes());
+        CollectibleAssembly.Inspect(outputPath, assembly => Assert.NotEmpty(assembly.GetTypes()));
 
         var runtimeConfigPath = Path.ChangeExtension(outputPath, ".runtimeconfig.json");
         File.WriteAllText(runtimeConfigPath, """
@@ -953,38 +951,12 @@ public class Issue2896StructObjectOverrideTests
             }
             """);
 
-        var startInfo = new ProcessStartInfo("dotnet")
-        {
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            WorkingDirectory = directory,
-        };
-        startInfo.ArgumentList.Add("exec");
-        startInfo.ArgumentList.Add("--runtimeconfig");
-        startInfo.ArgumentList.Add(runtimeConfigPath);
-        startInfo.ArgumentList.Add(outputPath);
-
-        using var process = Process.Start(startInfo)
-            ?? throw new InvalidOperationException("Failed to start emitted assembly");
-        var stdoutTask = process.StandardOutput.ReadToEndAsync();
-        var stderrTask = process.StandardError.ReadToEndAsync();
-        try
-        {
-            await process.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(30));
-        }
-        catch (TimeoutException)
-        {
-            process.Kill(entireProcessTree: true);
-            await process.WaitForExitAsync();
-            throw new Xunit.Sdk.XunitException("Emitted assembly timed out");
-        }
-
-        var stdout = await stdoutTask;
-        var stderr = await stderrTask;
-        Assert.Equal(0, process.ExitCode);
-        Assert.Equal(string.Empty, stderr);
-        return stdout.Replace("\r\n", "\n", StringComparison.Ordinal);
+        var result = await DotnetProcess.RunAsync(
+            directory,
+            ["exec", "--runtimeconfig", runtimeConfigPath, outputPath]);
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(string.Empty, result.StandardError);
+        return result.StandardOutput.Replace("\r\n", "\n", StringComparison.Ordinal);
     }
 
     private static (int ExitCode, string StandardOutput, string StandardError) CaptureConsole(Func<int> action)

--- a/test/Interpreter.Tests/Issue2947ImportedNestedGenericDriverTests.cs
+++ b/test/Interpreter.Tests/Issue2947ImportedNestedGenericDriverTests.cs
@@ -3,7 +3,6 @@
 // </copyright>
 
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -299,27 +298,16 @@ public class Issue2947ImportedNestedGenericDriverTests
             }
             """);
 
-        var startInfo = new ProcessStartInfo("dotnet")
-        {
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            WorkingDirectory = directory,
-        };
-        startInfo.ArgumentList.Add("exec");
-        startInfo.ArgumentList.Add("--runtimeconfig");
-        startInfo.ArgumentList.Add(runtimeConfigPath);
-        startInfo.ArgumentList.Add(assemblyPath);
-
-        using var process = Process.Start(startInfo)
-            ?? throw new InvalidOperationException("Failed to start emitted assembly");
-        var stdout = process.StandardOutput.ReadToEnd();
-        var stderr = process.StandardError.ReadToEnd();
-        Assert.True(process.WaitForExit(30_000), "Emitted assembly timed out");
+        var result = DotnetProcess.Run(
+            directory,
+            "exec",
+            "--runtimeconfig",
+            runtimeConfigPath,
+            assemblyPath);
         Assert.True(
-            process.ExitCode == 0,
-            $"Emitted assembly exited {process.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
-        return Normalize(stdout);
+            result.ExitCode == 0,
+            $"Emitted assembly exited {result.ExitCode}\nstdout:\n{result.StandardOutput}\nstderr:\n{result.StandardError}");
+        return Normalize(result.StandardOutput);
     }
 
     private static string[] ExtractDiagnosticMessages(string output)

--- a/test/Interpreter.Tests/Issue3006FallthroughGuardDriverTests.cs
+++ b/test/Interpreter.Tests/Issue3006FallthroughGuardDriverTests.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -547,24 +546,11 @@ public class Issue3006FallthroughGuardDriverTests
             return (compile, new DriverResult(-1, string.Empty, string.Empty));
         }
 
-        var startInfo = new ProcessStartInfo("dotnet")
-        {
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            WorkingDirectory = directory,
-        };
-        startInfo.ArgumentList.Add(assemblyPath);
-        using var process = Process.Start(startInfo)
-            ?? throw new InvalidOperationException("Could not start emitted program.");
-        var stdout = process.StandardOutput.ReadToEndAsync();
-        var stderr = process.StandardError.ReadToEndAsync();
-        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-        await process.WaitForExitAsync(timeout.Token);
+        var result = await DotnetProcess.RunAsync(directory, [assemblyPath]);
         return (compile, new DriverResult(
-            process.ExitCode,
-            await stdout,
-            await stderr));
+            result.ExitCode,
+            result.StandardOutput,
+            result.StandardError));
     }
 
     private static DriverResult CaptureDriver(Func<int> driver)

--- a/test/Interpreter.Tests/Issue3010EntryPointDriverMatrixTests.cs
+++ b/test/Interpreter.Tests/Issue3010EntryPointDriverMatrixTests.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using Xunit;
 
@@ -195,24 +194,12 @@ public class Issue3010EntryPointDriverMatrixTests
         Assert.Equal(0, compile.ExitCode);
         Assert.True(File.Exists(assemblyPath), compile.StandardOutput + compile.StandardError);
 
-        var startInfo = new ProcessStartInfo("dotnet")
-        {
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-        };
-        startInfo.ArgumentList.Add(assemblyPath);
-
-        using var process = Process.Start(startInfo);
-        Assert.NotNull(process);
-        var standardOutput = process.StandardOutput.ReadToEnd();
-        var standardError = process.StandardError.ReadToEnd();
-        process.WaitForExit();
+        var result = DotnetProcess.Run(outputDirectory, assemblyPath);
 
         return (
-            process.ExitCode,
-            standardOutput.Replace("\r\n", "\n"),
-            standardError.Replace("\r\n", "\n"));
+            result.ExitCode,
+            result.StandardOutput.Replace("\r\n", "\n"),
+            result.StandardError.Replace("\r\n", "\n"));
     }
 
     private static (int ExitCode, string StandardOutput, string StandardError) CaptureConsole(

--- a/test/Interpreter.Tests/Issue3015ImportedBaseIdentityTests.cs
+++ b/test/Interpreter.Tests/Issue3015ImportedBaseIdentityTests.cs
@@ -225,11 +225,12 @@ public class Issue3015ImportedBaseIdentityTests
             });
 
             Assert.Equal(0, exit);
-            var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
-            var emittedType = Assert.Single(
-                assembly.GetTypes(),
-                static type => type.FullName == "Issue3015.CompilerDriver.Sentinel");
-            Assert.Equal(emittedType.FullName, oracleTypeName);
+            var emittedTypeName = CollectibleAssembly.Inspect(
+                assemblyPath,
+                assembly => Assert.Single(
+                    assembly.GetTypes(),
+                    static type => type.FullName == "Issue3015.CompilerDriver.Sentinel").FullName);
+            Assert.Equal(emittedTypeName, oracleTypeName);
         }
         finally
         {
@@ -310,17 +311,21 @@ public class Issue3015ImportedBaseIdentityTests
                 "/targetframework:net10.0",
                 emitSourcePath,
             }));
-            var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
-            Assert.NotEmpty(assembly.GetTypes());
-            var entryPoint = assembly.EntryPoint
-                ?? throw new InvalidOperationException("Emitted assembly has no entry point.");
-            var explicitEmit = CaptureDriver(() =>
-            {
-                entryPoint.Invoke(
-                    null,
-                    entryPoint.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
-                return 0;
-            });
+            var explicitEmit = CollectibleAssembly.Inspect(
+                assemblyPath,
+                assembly =>
+                {
+                    Assert.NotEmpty(assembly.GetTypes());
+                    var entryPoint = assembly.EntryPoint
+                        ?? throw new InvalidOperationException("Emitted assembly has no entry point.");
+                    return CaptureDriver(() =>
+                    {
+                        entryPoint.Invoke(
+                            null,
+                            entryPoint.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+                        return 0;
+                    });
+                });
 
             Assert.Equal(Expected, NormalizeGenericTypeNames(gscScript));
             Assert.Equal(Expected, NormalizeGenericTypeNames(explicitEmit));

--- a/test/Interpreter.Tests/Issue3099TypeArgumentReificationTests.cs
+++ b/test/Interpreter.Tests/Issue3099TypeArgumentReificationTests.cs
@@ -312,18 +312,22 @@ public class Issue3099TypeArgumentReificationTests
                 sourcePath,
             }));
 
-            var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
-            Assert.Contains(assembly.GetTypes(), type => type.FullName?.EndsWith(".Box`1", StringComparison.Ordinal) == true);
-            Assert.Contains(assembly.GetTypes(), type => type.FullName?.EndsWith(".Pair`2", StringComparison.Ordinal) == true);
-            var entryPoint = assembly.EntryPoint
-                ?? throw new InvalidOperationException("Emitted assembly has no entry point.");
-            var explicitEmit = CaptureDriver(() =>
-            {
-                entryPoint.Invoke(
-                    null,
-                    entryPoint.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
-                return 0;
-            });
+            var explicitEmit = CollectibleAssembly.Inspect(
+                assemblyPath,
+                assembly =>
+                {
+                    Assert.Contains(assembly.GetTypes(), type => type.FullName?.EndsWith(".Box`1", StringComparison.Ordinal) == true);
+                    Assert.Contains(assembly.GetTypes(), type => type.FullName?.EndsWith(".Pair`2", StringComparison.Ordinal) == true);
+                    var entryPoint = assembly.EntryPoint
+                        ?? throw new InvalidOperationException("Emitted assembly has no entry point.");
+                    return CaptureDriver(() =>
+                    {
+                        entryPoint.Invoke(
+                            null,
+                            entryPoint.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+                        return 0;
+                    });
+                });
 
             var expected = NormalizeGenericTypeNames(explicitEmit);
             var interactiveOutput = NormalizeGenericTypeNames(interactiveEmit);

--- a/test/Interpreter.Tests/Issue3100FieldOffsetDriverTests.cs
+++ b/test/Interpreter.Tests/Issue3100FieldOffsetDriverTests.cs
@@ -3,7 +3,6 @@
 // </copyright>
 
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -235,21 +234,11 @@ public class Issue3100FieldOffsetDriverTests
 
         verifyAssembly?.Invoke(outputPath);
 
-        var startInfo = new ProcessStartInfo("dotnet")
-        {
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-        };
-        startInfo.ArgumentList.Add(outputPath);
-
-        using var process = Process.Start(startInfo);
-        Assert.NotNull(process);
-        var runOut = process.StandardOutput.ReadToEnd();
-        var runErr = process.StandardError.ReadToEnd();
-        process.WaitForExit();
-        Assert.True(process.ExitCode == 0, $"emitted program failed ({process.ExitCode})\nstdout:\n{runOut}\nstderr:\n{runErr}");
-        return NormalizeValues(runOut);
+        var result = DotnetProcess.Run(directory, outputPath);
+        Assert.True(
+            result.ExitCode == 0,
+            $"emitted program failed ({result.ExitCode})\nstdout:\n{result.StandardOutput}\nstderr:\n{result.StandardError}");
+        return NormalizeValues(result.StandardOutput);
     }
 
     private static (string SourcePath, string Output) RunDiagnostic(
@@ -321,26 +310,30 @@ public class Issue3100FieldOffsetDriverTests
 
     private static void VerifyMetadata(string assemblyPath, string layoutCase)
     {
-        var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
-        var types = assembly.GetTypes();
-        var cell = types.Single(t => t.Name == "Cell");
-        var wrapper = types.Single(t => t.Name == "Wrapper");
-
-        var expectedLayout = layoutCase is "FullOverlap" or "PartialOverlap" or "ExplicitNoOverlap"
-            ? LayoutKind.Explicit
-            : LayoutKind.Sequential;
-        Assert.Equal(expectedLayout, cell.StructLayoutAttribute?.Value);
-        Assert.Equal(LayoutKind.Sequential, wrapper.StructLayoutAttribute?.Value);
-        Assert.Equal(0, Marshal.OffsetOf(wrapper, "Value").ToInt32());
-        Assert.Equal(0, Marshal.OffsetOf(cell, "Nested").ToInt32());
-        Assert.Equal(
-            layoutCase switch
+        CollectibleAssembly.Inspect(
+            assemblyPath,
+            assembly =>
             {
-                "FullOverlap" => 0,
-                "PartialOverlap" => 1,
-                _ => 4,
-            },
-            Marshal.OffsetOf(cell, "Alias").ToInt32());
+                var types = assembly.GetTypes();
+                var cell = types.Single(t => t.Name == "Cell");
+                var wrapper = types.Single(t => t.Name == "Wrapper");
+
+                var expectedLayout = layoutCase is "FullOverlap" or "PartialOverlap" or "ExplicitNoOverlap"
+                    ? LayoutKind.Explicit
+                    : LayoutKind.Sequential;
+                Assert.Equal(expectedLayout, cell.StructLayoutAttribute?.Value);
+                Assert.Equal(LayoutKind.Sequential, wrapper.StructLayoutAttribute?.Value);
+                Assert.Equal(0, Marshal.OffsetOf(wrapper, "Value").ToInt32());
+                Assert.Equal(0, Marshal.OffsetOf(cell, "Nested").ToInt32());
+                Assert.Equal(
+                    layoutCase switch
+                    {
+                        "FullOverlap" => 0,
+                        "PartialOverlap" => 1,
+                        _ => 4,
+                    },
+                    Marshal.OffsetOf(cell, "Alias").ToInt32());
+            });
     }
 
     private static (int ExitCode, string Stdout, string Stderr) CaptureConsole(Func<int> action)

--- a/test/Interpreter.Tests/Issue3110And3113ConstantPatternEqualityTests.cs
+++ b/test/Interpreter.Tests/Issue3110And3113ConstantPatternEqualityTests.cs
@@ -3,7 +3,6 @@
 // </copyright>
 
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -137,47 +136,13 @@ public class Issue3110And3113ConstantPatternEqualityTests
                 ["/out:" + outputPath, "/target:exe", "/targetframework:net10.0", sourcePath]));
         Assert.True(compileExit == 0, $"emit failed ({compileExit})\nstdout:\n{stdout}\nstderr:\n{stderr}");
 
-        var assembly = Assembly.Load(File.ReadAllBytes(outputPath));
-        _ = assembly.GetTypes();
+        CollectibleAssembly.Inspect(outputPath, assembly => Assert.NotEmpty(assembly.GetTypes()));
 
-        var startInfo = new ProcessStartInfo("dotnet")
-        {
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            WorkingDirectory = directory,
-        };
-        startInfo.ArgumentList.Add(outputPath);
-
-        using var process = Process.Start(startInfo);
-        Assert.NotNull(process);
-        var stdoutTask = process.StandardOutput.ReadToEndAsync();
-        var stderrTask = process.StandardError.ReadToEndAsync();
-        using var timeout = new CancellationTokenSource(30_000);
-        try
-        {
-            await process.WaitForExitAsync(timeout.Token);
-        }
-        catch (OperationCanceledException)
-        {
-            process.Kill(entireProcessTree: true);
-            using var killTimeout = new CancellationTokenSource(5_000);
-            try
-            {
-                await process.WaitForExitAsync(killTimeout.Token);
-            }
-            catch (OperationCanceledException)
-            {
-                Assert.Fail("emitted program did not exit after kill");
-            }
-
-            Assert.Fail("emitted program timed out after 30000 ms");
-        }
-
-        var runOut = await stdoutTask;
-        var runErr = await stderrTask;
-        Assert.True(process.ExitCode == 0, $"emitted program failed ({process.ExitCode})\nstdout:\n{runOut}\nstderr:\n{runErr}");
-        return NormalizeValues(runOut);
+        var result = await DotnetProcess.RunAsync(directory, [outputPath]);
+        Assert.True(
+            result.ExitCode == 0,
+            $"emitted program failed ({result.ExitCode})\nstdout:\n{result.StandardOutput}\nstderr:\n{result.StandardError}");
+        return NormalizeValues(result.StandardOutput);
     }
 
     private static (int ExitCode, string Stdout, string Stderr) CaptureConsole(Func<int> action)

--- a/test/Interpreter.Tests/Issue3114ReadOnlySpanDriverTests.cs
+++ b/test/Interpreter.Tests/Issue3114ReadOnlySpanDriverTests.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -533,35 +532,18 @@ public class Issue3114ReadOnlySpanDriverTests
 
         Assert.Equal(0, compile.ExitCode);
         Assert.True(File.Exists(assemblyPath), compile.StandardOutput + compile.StandardError);
-        Assert.NotEmpty(Assembly.Load(File.ReadAllBytes(assemblyPath)).GetTypes());
+        CollectibleAssembly.Inspect(assemblyPath, assembly => Assert.NotEmpty(assembly.GetTypes()));
         if (referencePath != null)
         {
             File.Copy(referencePath, Path.Combine(outputDirectory, Path.GetFileName(referencePath)));
         }
 
-        var startInfo = new ProcessStartInfo("dotnet")
-        {
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            WorkingDirectory = outputDirectory,
-        };
-        startInfo.ArgumentList.Add(assemblyPath);
-
-        using var process = Process.Start(startInfo);
-        Assert.NotNull(process);
-        var standardOutput = process.StandardOutput.ReadToEndAsync();
-        var standardError = process.StandardError.ReadToEndAsync();
-        if (!process.WaitForExit(30_000))
-        {
-            process.Kill(entireProcessTree: true);
-            throw new TimeoutException("Emitted program timed out.");
-        }
+        var result = DotnetProcess.Run(outputDirectory, assemblyPath);
 
         return (
-            process.ExitCode,
-            standardOutput.GetAwaiter().GetResult().Replace("\r\n", "\n"),
-            standardError.GetAwaiter().GetResult().Replace("\r\n", "\n"));
+            result.ExitCode,
+            result.StandardOutput.Replace("\r\n", "\n"),
+            result.StandardError.Replace("\r\n", "\n"));
     }
 
     private static void EmitOverloadedToStringRefStructAssembly(string outputPath)

--- a/test/Interpreter.Tests/Issue3119ImportedConstantCorpusTests.cs
+++ b/test/Interpreter.Tests/Issue3119ImportedConstantCorpusTests.cs
@@ -3,7 +3,6 @@
 // </copyright>
 
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using Xunit;
@@ -343,28 +342,17 @@ public class Issue3119ImportedConstantCorpusTests
             }
             """);
 
-        var startInfo = new ProcessStartInfo("dotnet")
-        {
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            WorkingDirectory = directory,
-        };
-        startInfo.ArgumentList.Add("exec");
-        startInfo.ArgumentList.Add("--runtimeconfig");
-        startInfo.ArgumentList.Add(runtimeConfigPath);
-        startInfo.ArgumentList.Add(assemblyPath);
-
-        using var process = Process.Start(startInfo)
-            ?? throw new InvalidOperationException("Failed to start emitted assembly");
-        var stdout = process.StandardOutput.ReadToEnd();
-        var stderr = process.StandardError.ReadToEnd();
-        Assert.True(process.WaitForExit(30_000), "Emitted assembly timed out");
+        var result = DotnetProcess.Run(
+            directory,
+            "exec",
+            "--runtimeconfig",
+            runtimeConfigPath,
+            assemblyPath);
         Assert.True(
-            process.ExitCode == 0,
-            $"Emitted assembly exited {process.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
-        Assert.Equal(string.Empty, stderr);
-        return Normalize(stdout);
+            result.ExitCode == 0,
+            $"Emitted assembly exited {result.ExitCode}\nstdout:\n{result.StandardOutput}\nstderr:\n{result.StandardError}");
+        Assert.Equal(string.Empty, result.StandardError);
+        return Normalize(result.StandardOutput);
     }
 
     private static void CopyRuntimeDependency(string sourcePath, string directory)

--- a/test/Interpreter.Tests/Issue3130DriverReferenceTests.cs
+++ b/test/Interpreter.Tests/Issue3130DriverReferenceTests.cs
@@ -3,7 +3,6 @@
 // </copyright>
 
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -53,8 +52,7 @@ public sealed class Issue3130DriverReferenceTests
                     sourcePath);
                 AssertSucceeded(emit, sample + " emit");
 
-                var assembly = Assembly.Load(File.ReadAllBytes(outputPath));
-                Assert.NotEmpty(assembly.GetTypes());
+                CollectibleAssembly.Inspect(outputPath, assembly => Assert.NotEmpty(assembly.GetTypes()));
 
                 File.Copy(extensionsPath, Path.Combine(directory, "Gsharp.Extensions.dll"), overwrite: true);
                 var emitted = await RunAsync(
@@ -445,46 +443,15 @@ public sealed class Issue3130DriverReferenceTests
         builder.Save(outputPath);
     }
 
-    private static async Task<ProcessResult> RunAsync(string workingDirectory, params string[] arguments)
-    {
-        var startInfo = new ProcessStartInfo("dotnet")
-        {
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            WorkingDirectory = workingDirectory,
-        };
-        foreach (var argument in arguments)
-        {
-            startInfo.ArgumentList.Add(argument);
-        }
+    private static Task<DotnetProcessResult> RunAsync(string workingDirectory, params string[] arguments)
+        => DotnetProcess.RunAsync(workingDirectory, arguments);
 
-        using var process = Process.Start(startInfo)
-            ?? throw new InvalidOperationException("Failed to start dotnet");
-        var standardOutput = process.StandardOutput.ReadToEndAsync();
-        var standardError = process.StandardError.ReadToEndAsync();
-        try
-        {
-            await process.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(30));
-        }
-        catch (TimeoutException)
-        {
-            process.Kill(entireProcessTree: true);
-            throw new TimeoutException("dotnet process timed out");
-        }
-
-        return new ProcessResult(
-            process.ExitCode,
-            await standardOutput,
-            await standardError);
-    }
-
-    private static void AssertSucceeded(ProcessResult result, string operation)
+    private static void AssertSucceeded(DotnetProcessResult result, string operation)
         => Assert.True(
             result.ExitCode == 0,
             $"{operation} exited {result.ExitCode}\nstdout:\n{result.StandardOutput}\nstderr:\n{result.StandardError}");
 
-    private static void AssertRejectedReference(ProcessResult result, string referencePath, string operation)
+    private static void AssertRejectedReference(DotnetProcessResult result, string referencePath, string operation)
     {
         Assert.True(result.ExitCode != 0, $"{operation} unexpectedly succeeded");
         Assert.Contains("Unable to load reference", result.Combined);
@@ -528,9 +495,4 @@ public sealed class Issue3130DriverReferenceTests
     }
 
     private static string Normalize(string text) => text.Replace("\r\n", "\n", StringComparison.Ordinal);
-
-    private sealed record ProcessResult(int ExitCode, string StandardOutput, string StandardError)
-    {
-        public string Combined => StandardOutput + StandardError;
-    }
 }

--- a/test/Interpreter.Tests/Issue3140OutParameterWriteBackDriverTests.cs
+++ b/test/Interpreter.Tests/Issue3140OutParameterWriteBackDriverTests.cs
@@ -3,7 +3,6 @@
 // </copyright>
 
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -380,42 +379,21 @@ public class Issue3140OutParameterWriteBackDriverTests
             compile.ExitCode == 0,
             $"emit failed ({compile.ExitCode})\nstdout:\n{compile.Stdout}\nstderr:\n{compile.Stderr}");
         Assert.Equal(string.Empty, compile.Stderr);
-        Assert.NotEmpty(Assembly.Load(File.ReadAllBytes(assemblyPath)).GetTypes());
+        CollectibleAssembly.Inspect(assemblyPath, assembly => Assert.NotEmpty(assembly.GetTypes()));
 
-        var startInfo = new ProcessStartInfo("dotnet")
-        {
-            WorkingDirectory = directory,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-        };
-        startInfo.ArgumentList.Add("exec");
-        startInfo.ArgumentList.Add("--runtimeconfig");
-        startInfo.ArgumentList.Add(Path.ChangeExtension(assemblyPath, ".runtimeconfig.json"));
-        startInfo.ArgumentList.Add(assemblyPath);
-
-        using var process = Process.Start(startInfo);
-        Assert.NotNull(process);
-        var stdoutTask = process.StandardOutput.ReadToEndAsync();
-        var stderrTask = process.StandardError.ReadToEndAsync();
-        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-        try
-        {
-            await process.WaitForExitAsync(timeout.Token);
-        }
-        catch (OperationCanceledException)
-        {
-            process.Kill(entireProcessTree: true);
-            throw new TimeoutException("emitted program timed out");
-        }
-
-        var stdout = await stdoutTask;
-        var stderr = await stderrTask;
+        var result = await DotnetProcess.RunAsync(
+            directory,
+            [
+                "exec",
+                "--runtimeconfig",
+                Path.ChangeExtension(assemblyPath, ".runtimeconfig.json"),
+                assemblyPath,
+            ]);
         Assert.True(
-            process.ExitCode == 0,
-            $"emitted program failed ({process.ExitCode})\nstdout:\n{stdout}\nstderr:\n{stderr}");
-        Assert.Equal(string.Empty, stderr);
-        return Normalize(stdout, stripCompilerSuccess: false);
+            result.ExitCode == 0,
+            $"emitted program failed ({result.ExitCode})\nstdout:\n{result.StandardOutput}\nstderr:\n{result.StandardError}");
+        Assert.Equal(string.Empty, result.StandardError);
+        return Normalize(result.StandardOutput, stripCompilerSuccess: false);
     }
 
     private static DriverResult CaptureConsole(Func<int> action)

--- a/test/Interpreter.Tests/Issue3149NamedDelegateReificationDriverTests.cs
+++ b/test/Interpreter.Tests/Issue3149NamedDelegateReificationDriverTests.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Runtime.Loader;
@@ -248,7 +247,6 @@ public sealed class Issue3149NamedDelegateReificationDriverTests
         try
         {
             Assert.NotEmpty(typeof(Issue3149Greeter).Assembly.GetTypes());
-            Assert.NotEmpty(Assembly.Load(File.ReadAllBytes(assemblyPath)).GetTypes());
 
             var loadContext = new AssemblyLoadContext(
                 "Issue3149_" + Guid.NewGuid().ToString("N"),
@@ -419,39 +417,15 @@ public sealed class Issue3149NamedDelegateReificationDriverTests
             }
             """);
 
-        var startInfo = new ProcessStartInfo("dotnet")
-        {
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            WorkingDirectory = directory,
-        };
-        startInfo.ArgumentList.Add("exec");
-        startInfo.ArgumentList.Add("--runtimeconfig");
-        startInfo.ArgumentList.Add(runtimeConfigPath);
-        startInfo.ArgumentList.Add(assemblyPath);
-
         try
         {
-            using var process = Process.Start(startInfo)
-                ?? throw new InvalidOperationException("Failed to start emitted assembly.");
-            var stdout = process.StandardOutput.ReadToEndAsync();
-            var stderr = process.StandardError.ReadToEndAsync();
-            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-            try
-            {
-                await process.WaitForExitAsync(timeout.Token);
-            }
-            catch (OperationCanceledException)
-            {
-                process.Kill(entireProcessTree: true);
-                return new DriverResult(-1, await stdout, "timed out\n" + await stderr);
-            }
-
+            var result = await DotnetProcess.RunAsync(
+                directory,
+                ["exec", "--runtimeconfig", runtimeConfigPath, assemblyPath]);
             return new DriverResult(
-                process.ExitCode,
-                await stdout,
-                await stderr);
+                result.ExitCode,
+                result.StandardOutput,
+                result.StandardError);
         }
         catch (Exception ex)
         {

--- a/test/Shared/EmittedOracle.cs
+++ b/test/Shared/EmittedOracle.cs
@@ -63,6 +63,7 @@ namespace GSharp.Tests;
 /// </remarks>
 public static class EmittedOracle
 {
+    private static readonly object EvaluationGate = new();
     private static readonly object ConsoleGate = new();
     private static int submissionCounter;
 
@@ -109,6 +110,18 @@ public static class EmittedOracle
     /// <returns>The oracle result.</returns>
     public static EmittedOracleResult Evaluate(IReadOnlyList<string> sources, EmittedOracleOptions options = null)
     {
+        // ponytail: process-wide compiler symbol caches make independent
+        // one-shot compilations share a lifetime; serialize this test oracle
+        // so each run can release its resolver and caches without racing one
+        // still binding.
+        lock (EvaluationGate)
+        {
+            return EvaluateCore(sources, options);
+        }
+    }
+
+    private static EmittedOracleResult EvaluateCore(IReadOnlyList<string> sources, EmittedOracleOptions options)
+    {
         if (sources is null)
         {
             throw new ArgumentNullException(nameof(sources));
@@ -131,7 +144,7 @@ public static class EmittedOracle
         // excludes collectible-ALC assemblies from its host scan, so earlier
         // oracle runs' still-loaded emitted assemblies can never shadow this
         // compilation's source packages (issue #3235).
-        var resolver = referencePaths.Length > 0
+        using var resolver = referencePaths.Length > 0
             ? ReferenceResolver.WithReferences(referencePaths)
             : ReferenceResolver.Default();
 


### PR DESCRIPTION
## Summary
- stop interactive submissions from duplicating trusted-platform assembly images and rebuilding unchanged default type indexes
- release session/oracle compiler state and inspect emitted test assemblies in collectible load contexts
- centralize real `dotnet` launches behind concurrent output draining, bounded timeouts, whole-process-tree termination, and command/output diagnostics
- collect interpreter blame-hang dumps and all test results, with a 30-minute CI job ceiling

## Root cause
Each chained emitted submission created a new metadata resolver. Every resolver reread the full trusted-platform assembly set into fresh `byte[]` images, while submission resolvers, compiler symbol caches, and default-context test assemblies remained rooted. Severe Gen2/LOH pressure then stalled testhost long enough that nominal 30-second child-process timeouts surfaced minutes late, producing the Issue3130 failures and eventual runner cancellation seen in #3367.

Host metadata images are now shared while user/submission assemblies remain resolver-local. Submission resolvers have explicit session ownership, one-shot oracle resolvers are disposed safely, and emitted inspection assemblies are collectible.

## Memory evidence
- before: interpreter testhost reached roughly 6-7 GiB RSS; runtime counters reported over 10 GiB Gen2/LOH size and over 20 GiB GC committed memory, with long GC pauses
- after: full 1509-test shard completed under `DOTNET_GCHeapHardLimit=0x100000000`; measured peak tree RSS was 5015.9 MiB and testhost RSS was 4764.6 MiB
- chained-session regression also passed three consecutive runs and verifies disposed sessions retain less than 64 MiB after warmed shared state

## Validation
- `dotnet test test/Core.Tests/Core.Tests.csproj --configuration Release --no-restore --filter \"FullyQualifiedName~ReferenceResolverTests\"` — 23/23 passed
- process-spawning interpreter paths — 287/287 passed
- collectible assembly/process subset — 241/241 passed
- session/oracle/driver subset — 174/174 passed
- exact CI-style interpreter command with blame-hang options — 1509/1509 passed in 1m38s
- full interpreter shard under 4-GiB GC hard limit — 1509/1509 passed in 1m33s
- GitHub Actions — all checks passed, including `tests (interpreter)`

Fixes #3364
Related: #3367