### PR TITLE
Fix channel types through generic substitution

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -5331,6 +5331,12 @@ public sealed class Binder
             return ReferenceEquals(inner, aseq.ElementType) ? type : AsyncSequenceTypeSymbol.Get(inner);
         }
 
+        if (type is ChannelTypeSymbol channel)
+        {
+            var inner = SubstituteType(channel.ElementType, substitution, mapClrType);
+            return ReferenceEquals(inner, channel.ElementType) ? type : ChannelTypeSymbol.Get(inner);
+        }
+
         if (type is MapTypeSymbol map)
         {
             // Issue #1481: substitute through `map[K, V]` so a call like
@@ -5410,18 +5416,10 @@ public sealed class Binder
             && !ReferenceEquals(ss.Definition, ss)
             && !ss.TypeArguments.IsDefaultOrEmpty)
         {
-            var newStructArgs = ImmutableArray.CreateBuilder<TypeSymbol>(ss.TypeArguments.Length);
-            var structChanged = false;
-            foreach (var arg in ss.TypeArguments)
-            {
-                var substituted = SubstituteType(arg, substitution, mapClrType);
-                structChanged |= !ReferenceEquals(substituted, arg);
-                newStructArgs.Add(substituted);
-            }
-
-            return structChanged
-                ? StructSymbol.Construct(ss.Definition, newStructArgs.MoveToImmutable(), mapClrType)
-                : type;
+            return StructSymbol.SubstituteConstructionArguments(
+                ss,
+                arg => SubstituteType(arg, substitution, mapClrType),
+                mapClrType);
         }
 
         // Issue #1521: a member-signature type that is a reference to a type

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
@@ -618,8 +618,10 @@ internal sealed partial class MethodBodyEmitter
             }
         }
 
-        throw new NotSupportedException(
-            $"Conversion from '{from.Name}' to '{to.Name}' is not yet supported by the emitter.");
+        EmitDiagnosticException.Wrap(
+            conv.Syntax,
+            new NotSupportedException(
+                $"Conversion from '{from.Name}' to '{to.Name}' is not yet supported by the emitter."));
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
@@ -819,18 +819,16 @@ internal sealed partial class MethodBodyEmitter
             }
         }
 
-        // Issue #1481: a `map[K, V]` is a CLR reference type
-        // (`System.Collections.Generic.Dictionary<,>`) and a function type is a
-        // reference-typed delegate. When the key/value/signature structurally
-        // references an in-scope type parameter (e.g. `map[string, T]`,
-        // `func(T) -> int32`), the symbol carries no ClrType during emit, so
-        // the CLR-backed `object`-widening rule above cannot fire. Widening
-        // such a reference to `object` is still a no-op (the slot already holds
-        // the reference). This unblocks a generic iterator whose element type
-        // is a `map[…]` / function: the synthesized non-generic
+        // Issue #1481 / #3255: maps, channels, and function types are CLR
+        // reference types. When their symbolic shape references an in-scope
+        // type parameter, the symbol carries no ClrType during emit, so the
+        // CLR-backed `object`-widening rule above cannot fire. Widening such a
+        // reference to `object` is still a no-op (the slot already holds the
+        // reference). This unblocks a generic iterator whose element type is a
+        // map, channel, or function: the synthesized non-generic
         // `IEnumerator.Current` getter converts the strongly-typed reified
         // `<>2__current` field to `object`.
-        if ((a is MapTypeSymbol || a is FunctionTypeSymbol)
+        if ((a is MapTypeSymbol || a is FunctionTypeSymbol || a is ChannelTypeSymbol)
             && (b?.ClrType.IsSameAs(typeof(object)) == true || b == TypeSymbol.Object))
         {
             return true;

--- a/src/Core/CodeAnalysis/Symbols/FunctionTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/FunctionTypeSymbol.cs
@@ -385,6 +385,11 @@ public sealed class FunctionTypeSymbol : TypeSymbol
                 AppendIdentityKey(builder, aseq.ElementType);
                 builder.Append(')');
                 break;
+            case ChannelTypeSymbol channel:
+                builder.Append("!chan(");
+                AppendIdentityKey(builder, channel.ElementType);
+                builder.Append(')');
+                break;
             case MapTypeSymbol m:
                 builder.Append("!map(");
                 AppendIdentityKey(builder, m.KeyType);
@@ -411,8 +416,23 @@ public sealed class FunctionTypeSymbol : TypeSymbol
                 AppendIdentityKey(builder, br.PointeeType);
                 builder.Append(')');
                 break;
-            case StructSymbol st when !st.TypeArguments.IsDefaultOrEmpty:
+            case StructSymbol st when !st.EnclosingTypeArguments.IsDefaultOrEmpty || !st.TypeArguments.IsDefaultOrEmpty:
                 builder.Append("!struct:").Append(st.Definition?.Name ?? st.Name).Append('(');
+                if (!st.EnclosingTypeArguments.IsDefaultOrEmpty)
+                {
+                    for (var i = 0; i < st.EnclosingTypeArguments.Length; i++)
+                    {
+                        if (i > 0)
+                        {
+                            builder.Append(',');
+                        }
+
+                        AppendIdentityKey(builder, st.EnclosingTypeArguments[i]);
+                    }
+
+                    builder.Append('|');
+                }
+
                 for (var i = 0; i < st.TypeArguments.Length; i++)
                 {
                     if (i > 0)

--- a/src/Core/CodeAnalysis/Symbols/InterfaceSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/InterfaceSymbol.cs
@@ -863,20 +863,10 @@ public sealed class InterfaceSymbol : TypeSymbol
         // own recursive handling of nested constructed generics.
         if (type is StructSymbol structType && !structType.TypeArguments.IsDefaultOrEmpty)
         {
-            var substitutedArgs = ImmutableArray.CreateBuilder<TypeSymbol>(structType.TypeArguments.Length);
-            var changed = false;
-            for (var i = 0; i < structType.TypeArguments.Length; i++)
-            {
-                var substituted = SubstituteType(structType.TypeArguments[i], subst, mapClrType);
-                substitutedArgs.Add(substituted);
-                changed |= !ReferenceEquals(substituted, structType.TypeArguments[i]);
-            }
-
-            return changed
-                ? mapClrType is null
-                    ? StructSymbol.Construct(structType.Definition, substitutedArgs.MoveToImmutable())
-                    : StructSymbol.Construct(structType.Definition, substitutedArgs.MoveToImmutable(), mapClrType)
-                : structType;
+            return StructSymbol.SubstituteConstructionArguments(
+                structType,
+                argument => SubstituteType(argument, subst, mapClrType),
+                mapClrType);
         }
 
         // Issue #2340 follow-up (sibling to the #1503 branch already present
@@ -972,6 +962,12 @@ public sealed class InterfaceSymbol : TypeSymbol
         {
             var sub = SubstituteType(a.ElementType, subst, mapClrType);
             return sub == a.ElementType ? a : ArrayTypeSymbol.Get(sub, a.Length);
+        }
+
+        if (type is ChannelTypeSymbol channel)
+        {
+            var sub = SubstituteType(channel.ElementType, subst, mapClrType);
+            return sub == channel.ElementType ? channel : ChannelTypeSymbol.Get(sub);
         }
 
         if (type is NullableTypeSymbol n)

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -1758,8 +1758,8 @@ public sealed class StructSymbol : TypeSymbol
         var substitutedEnclosing = enclosingArguments.MoveToImmutable();
         var substitutedOwn = ownArguments.MoveToImmutable();
         return !substitutedEnclosing.IsDefaultOrEmpty
-            ? ConstructNestedGeneric(definition, substitutedEnclosing, substitutedOwn, mapClrType)!
-            : Construct(definition, substitutedOwn, mapClrType)!;
+            ? ConstructNestedGeneric(definition, substitutedEnclosing, substitutedOwn, mapClrType)
+            : Construct(definition, substitutedOwn, mapClrType);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -1721,6 +1721,47 @@ public sealed class StructSymbol : TypeSymbol
         return changed ? builder.MoveToImmutable() : default;
     }
 
+    internal static StructSymbol SubstituteConstructionArguments(
+        StructSymbol type,
+        Func<TypeSymbol, TypeSymbol> substituteOne,
+        Func<Type, Type>? mapClrType = null)
+    {
+        var definition = type.Definition;
+        if (definition == null)
+        {
+            return type;
+        }
+
+        var enclosingArguments = ImmutableArray.CreateBuilder<TypeSymbol>(type.EnclosingTypeArguments.Length);
+        var ownArguments = ImmutableArray.CreateBuilder<TypeSymbol>(type.TypeArguments.Length);
+        var changed = false;
+
+        foreach (var argument in type.EnclosingTypeArguments)
+        {
+            var substituted = substituteOne(argument);
+            changed |= !ReferenceEquals(substituted, argument);
+            enclosingArguments.Add(substituted);
+        }
+
+        foreach (var argument in type.TypeArguments)
+        {
+            var substituted = substituteOne(argument);
+            changed |= !ReferenceEquals(substituted, argument);
+            ownArguments.Add(substituted);
+        }
+
+        if (!changed)
+        {
+            return type;
+        }
+
+        var substitutedEnclosing = enclosingArguments.MoveToImmutable();
+        var substitutedOwn = ownArguments.MoveToImmutable();
+        return !substitutedEnclosing.IsDefaultOrEmpty
+            ? ConstructNestedGeneric(definition, substitutedEnclosing, substitutedOwn, mapClrType)!
+            : Construct(definition, substitutedOwn, mapClrType)!;
+    }
+
     /// <summary>
     /// Removes all entries from the static constructed-struct caches.
     /// Called by <see cref="ReferenceResolver.Dispose"/> to release stale
@@ -2424,18 +2465,7 @@ public sealed class StructSymbol : TypeSymbol
             && !ReferenceEquals(ss.Definition, ss)
             && !ss.TypeArguments.IsDefaultOrEmpty)
         {
-            var substitutedStructArgs = ImmutableArray.CreateBuilder<TypeSymbol>(ss.TypeArguments.Length);
-            var structChanged = false;
-            for (var i = 0; i < ss.TypeArguments.Length; i++)
-            {
-                var substituted = SubstituteNested(ss.TypeArguments[i]);
-                substitutedStructArgs.Add(substituted);
-                structChanged |= !ReferenceEquals(substituted, ss.TypeArguments[i]);
-            }
-
-            return structChanged
-                ? StructSymbol.Construct(ss.Definition, substitutedStructArgs.MoveToImmutable(), mapClrType)
-                : type;
+            return SubstituteConstructionArguments(ss, SubstituteNested, mapClrType);
         }
 
         // Issue #1521: a member type that is a reference to a type nested inside
@@ -2549,6 +2579,12 @@ public sealed class StructSymbol : TypeSymbol
         {
             var inner = SubstituteNested(a.ElementType);
             return ReferenceEquals(inner, a.ElementType) ? type : ArrayTypeSymbol.Get(inner, a.Length);
+        }
+
+        if (type is ChannelTypeSymbol channel)
+        {
+            var inner = SubstituteNested(channel.ElementType);
+            return ReferenceEquals(inner, channel.ElementType) ? type : ChannelTypeSymbol.Get(inner);
         }
 
         // Issue #1503: a `map[K, V]` element of a generic member (e.g. a

--- a/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
@@ -367,6 +367,8 @@ public class TypeSymbol : Symbol
                 return AnyTypeParameter(seq.ElementType, match);
             case AsyncSequenceTypeSymbol aseq:
                 return AnyTypeParameter(aseq.ElementType, match);
+            case ChannelTypeSymbol channel:
+                return AnyTypeParameter(channel.ElementType, match);
             case MapTypeSymbol m:
                 return AnyTypeParameter(m.KeyType, match) || AnyTypeParameter(m.ValueType, match);
             case FunctionTypeSymbol fn:
@@ -407,7 +409,15 @@ public class TypeSymbol : Symbol
                 }
 
                 return false;
-            case StructSymbol st when !st.TypeArguments.IsDefaultOrEmpty:
+            case StructSymbol st when !st.EnclosingTypeArguments.IsDefaultOrEmpty || !st.TypeArguments.IsDefaultOrEmpty:
+                foreach (var arg in st.EnclosingTypeArguments)
+                {
+                    if (AnyTypeParameter(arg, match))
+                    {
+                        return true;
+                    }
+                }
+
                 foreach (var arg in st.TypeArguments)
                 {
                     if (AnyTypeParameter(arg, match))
@@ -526,6 +536,9 @@ public class TypeSymbol : Symbol
                 return;
             case AsyncSequenceTypeSymbol asq:
                 CollectReferencedTypeParameters(asq.ElementType, sink);
+                return;
+            case ChannelTypeSymbol channel:
+                CollectReferencedTypeParameters(channel.ElementType, sink);
                 return;
             case MapTypeSymbol m:
                 CollectReferencedTypeParameters(m.KeyType, sink);

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3255ChannelTypeArgumentTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3255ChannelTypeArgumentTests.cs
@@ -1,0 +1,201 @@
+// <copyright file="Issue3255ChannelTypeArgumentTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Emit;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #3255: channels are first-class CLR-backed types and remain legal
+/// when they contain an open type parameter or appear as an enclosing generic
+/// type argument.
+/// </summary>
+public class Issue3255ChannelTypeArgumentTests
+{
+    [Fact]
+    public void ChannelAsEnclosingTypeArgument_EmitsWithReifiedElementType()
+    {
+        var result = EmittedOracle.Evaluate("""
+            package Issue3255Enclosing
+
+            import Gsharp.Extensions.Go
+
+            class Box[T] {}
+            class Owner[T] {
+                class Payload[U] {}
+            }
+
+            func Reify[T]() int32 {
+                let value = Box[Owner[chan T].Payload[string]]()
+                let channelType = value.GetType().GenericTypeArguments[0].GenericTypeArguments[0]
+                return channelType.GetGenericTypeDefinition().FullName == "System.Threading.Channels.Channel`1"
+                    && channelType.GenericTypeArguments[0].FullName == "System.Int32" ? 42 : 0
+            }
+
+            Reify[int32]()
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void ChannelAsEnclosingTypeArgument_SubstitutesNestedMemberType()
+    {
+        var result = EmittedOracle.Evaluate("""
+            package Issue3255NestedMember
+
+            import Gsharp.Extensions.Go
+
+            class Owner[T] {
+                class Payload[U] {
+                    var Value T
+                }
+            }
+
+            func Make[T](value T) Owner[chan T].Payload[T] {
+                let ch = make(chan T, 1)
+                ch <- value
+                return Owner[chan T].Payload[T]{Value: ch}
+            }
+
+            let payload = Make[int32](42)
+            <-payload.Value
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void OpenChannelType_SubstitutesAcrossCallsFieldsAndInterfaces()
+    {
+        var result = EmittedOracle.Evaluate("""
+            package Issue3255Substitution
+
+            import Gsharp.Extensions.Go
+
+            interface Reader[T] {
+                func Read(ch chan T) T;
+            }
+
+            class Box[T] : Reader[T] {
+                var Value chan T = make(chan T, 1)
+                func Read(ch chan T) T { return <-ch }
+            }
+
+            func Relay[T](reader Reader[T], ch chan T) T {
+                return reader.Read(ch)
+            }
+
+            let box = Box[int32]()
+            box.Value <- 20
+            let first = <-box.Value
+            let ch = make(chan int32, 1)
+            ch <- 22
+            first + Relay[int32](box, ch)
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void OpenChannelIteratorElement_EmitsAndRuns()
+    {
+        var result = EmittedOracle.Evaluate("""
+            package Issue3255Iterator
+
+            import Gsharp.Extensions.Go
+
+            func Channels[T](value T) sequence[chan T] {
+                let ch = make(chan T, 1)
+                ch <- value
+                yield ch
+            }
+
+            var result = 0
+            for ch in Channels[int32](42) {
+                result = <-ch
+            }
+            result
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void OpenChannelType_UsesElementParameterIdentityInFunctionTypeCache()
+    {
+        var t = new TypeParameterSymbol("T", 0, TypeParameterConstraint.Any, TypeParameterVariance.None);
+        var unrelatedT = new TypeParameterSymbol("T", 0, TypeParameterConstraint.Any, TypeParameterVariance.None);
+        var channelOfT = ChannelTypeSymbol.Get(t);
+        var channelOfUnrelatedT = ChannelTypeSymbol.Get(unrelatedT);
+
+        Assert.True(TypeSymbol.ContainsTypeParameter(channelOfT));
+
+        var first = FunctionTypeSymbol.Get(
+            ImmutableArray.Create<TypeSymbol>(channelOfT),
+            TypeSymbol.Void);
+        var second = FunctionTypeSymbol.Get(
+            ImmutableArray.Create<TypeSymbol>(channelOfUnrelatedT),
+            TypeSymbol.Void);
+
+        Assert.NotSame(first, second);
+    }
+
+    [Fact]
+    public void InternalDiagnostic_WithChannelAnchor_UsesOffendingTypeSpan()
+    {
+        const string Source = """
+            package Issue3255Anchor
+            class Box[T] {}
+            class Owner[T] { class Payload[U] {} }
+            func Reify[T]() {
+                let value = Box[Owner[chan T].Payload[string]]()
+            }
+            """;
+        var tree = SyntaxTree.Parse(SourceText.From(Source, "issue3255.gs"));
+        var channel = Descendants(tree.Root)
+            .OfType<TypeClauseSyntax>()
+            .Single(type => type.IsChannel);
+        var exception = new EmitDiagnosticException(
+            "channel type failure",
+            channel,
+            new ArgumentNullException("key"));
+
+        var diagnostic = Compilation.CreateInternalErrorDiagnostic(exception);
+
+        Assert.Equal("GS9998", diagnostic.Id);
+        Assert.Equal("ArgumentNullException: Value cannot be null. (Parameter 'key')", diagnostic.Message);
+        Assert.Equal("issue3255.gs", diagnostic.Location.FileName);
+        Assert.Equal(4, diagnostic.Location.StartLine);
+        Assert.Equal(26, diagnostic.Location.StartCharacter);
+        Assert.Equal(4, diagnostic.Location.EndLine);
+        Assert.Equal(32, diagnostic.Location.EndCharacter);
+    }
+
+    private static IEnumerable<SyntaxNode> Descendants(SyntaxNode node)
+    {
+        yield return node;
+        foreach (var child in node.GetChildren())
+        {
+            foreach (var descendant in Descendants(child))
+            {
+                yield return descendant;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- preserve `ChannelTypeSymbol` through generic call, member, interface, closure, and iterator substitution
- retain both enclosing and nested-own generic arguments instead of rebuilding nested types as top-level constructions
- include open channels and enclosing arguments in structural type-parameter detection and function-type cache keys
- treat open channels as CLR reference types when iterator bridges widen them to `object`
- anchor any remaining unsupported conversion ICE at its conversion syntax

## Decision

`chan T` is legal as an enclosing generic type argument. It is a first-class reference-backed type represented by `System.Threading.Channels.Channel<T>`; parser, metadata, and runtime support already accept that CLR shape.

## Root cause

Prior parser and driver fixes (#3262 and #3274) removed the original null-key parse fallback and hard-coded `(1,1,1,1)` driver span, but current `main` still dropped channel structure in shared type handling:

- three substitution paths omitted `ChannelTypeSymbol`;
- nested generic reconstruction substituted only a nested type's own arguments and discarded enclosing arguments such as `chan T`;
- structural type-parameter detection and function-type cache identity omitted channels/enclosing arguments;
- iterator `IEnumerator.Current` emission did not recognize an open channel as a reference-type no-op widening to `object`.

No null guard or fallback type was added.

## Tests

- Core targeted: 68 passed
- Compiler targeted: 30 passed
- Interpreter targeted: 25 passed
- final focused issue suite: 6 passed
- Release compiler build: 0 warnings, 0 errors
- manual rebuilt-`gsc` probes: enclosing nested member, generic call, generic field, interface, closure, and iterator all compile and run with output `42`

Fixes #3255
