### PR TITLE
Preserve call syntax for precise GS0519 spans

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -620,7 +620,7 @@ public abstract class BoundTreeRewriter
         // Issue #1644: preserve the set-after-construction generic-owner properties
         // (#1209 / #1433) so the emitter still parents the call at the construction's
         // TypeSpec instead of a bare open-generic MethodDef.
-        return new BoundCallExpression(null, node.Function, builder.MoveToImmutable(), node.ReturnType, node.IsConditionalElided)
+        return new BoundCallExpression(node.Syntax, node.Function, builder.MoveToImmutable(), node.ReturnType, node.IsConditionalElided)
         {
             StaticGenericOwnerType = node.StaticGenericOwnerType,
             StaticGenericInterfaceOwnerType = node.StaticGenericInterfaceOwnerType,

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -507,7 +507,7 @@ internal sealed partial class ExpressionBinder
             // over that function. We only synthesize the group here; the
             // conversion classifier decides whether the surrounding context
             // actually accepts it (otherwise a cannot-convert is reported).
-            if (TryBindMethodGroup(name, out var methodGroup))
+            if (TryBindMethodGroup(syntax, out var methodGroup))
             {
                 return methodGroup;
             }
@@ -1304,9 +1304,10 @@ internal sealed partial class ExpressionBinder
         }
     }
 
-    private bool TryBindMethodGroup(string name, [NotNullWhen(true)] out BoundExpression? methodGroup)
+    private bool TryBindMethodGroup(NameExpressionSyntax syntax, [NotNullWhen(true)] out BoundExpression? methodGroup)
     {
         methodGroup = null;
+        var name = syntax.IdentifierToken.Text;
 
         // ADR-0063 §9: a name may resolve to multiple user-function overloads.
         // Gather every candidate so BindConversion can pick the one matching the
@@ -1329,12 +1330,12 @@ internal sealed partial class ExpressionBinder
 
             if (usable.Count == 1)
             {
-                return TryBindSingleMethodGroup(usable[0], out methodGroup);
+                return TryBindSingleMethodGroup(syntax, usable[0], out methodGroup);
             }
 
             if (usable.Count > 1)
             {
-                methodGroup = new BoundMethodGroupExpression(null, usable.ToImmutable());
+                methodGroup = new BoundMethodGroupExpression(syntax, usable.ToImmutable());
                 return true;
             }
         }
@@ -1379,7 +1380,7 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
-        return TryBindSingleMethodGroup(function, out methodGroup);
+        return TryBindSingleMethodGroup(syntax, function, out methodGroup);
     }
 
     private static bool IsMethodGroupCandidateUsable(FunctionSymbol function)
@@ -1404,7 +1405,7 @@ internal sealed partial class ExpressionBinder
         return true;
     }
 
-    private bool TryBindSingleMethodGroup(FunctionSymbol function, [NotNullWhen(true)] out BoundExpression? methodGroup)
+    private bool TryBindSingleMethodGroup(NameExpressionSyntax syntax, FunctionSymbol function, [NotNullWhen(true)] out BoundExpression? methodGroup)
     {
         methodGroup = null;
 
@@ -1415,7 +1416,7 @@ internal sealed partial class ExpressionBinder
 
         if (function.IsGeneric)
         {
-            methodGroup = new BoundMethodGroupExpression(null, ImmutableArray.Create(function));
+            methodGroup = new BoundMethodGroupExpression(syntax, ImmutableArray.Create(function));
             return true;
         }
 
@@ -1426,7 +1427,7 @@ internal sealed partial class ExpressionBinder
         }
 
         var fnType = FunctionTypeSymbol.Get(parameterTypes.MoveToImmutable(), this.MethodGroupObservableReturnType(function));
-        methodGroup = new BoundMethodGroupExpression(null, function, fnType);
+        methodGroup = new BoundMethodGroupExpression(syntax, function, fnType);
         return true;
     }
 

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
@@ -1915,16 +1915,16 @@ internal sealed partial class OverloadResolver
                 returnType = wrapAsTask(returnType, function.AsyncReturnsValueTask);
             }
 
-            return CreatePossiblyElidedCall(function, finalBoundArguments, returnType, methodTypeArguments);
+            return CreatePossiblyElidedCall(syntax, function, finalBoundArguments, returnType, methodTypeArguments);
         }
 
         if (function.IsAsync && !isAsyncIteratorReturnType(function.Type))
         {
             var asyncReturn = wrapAsTask(function.Type, function.AsyncReturnsValueTask);
-            return CreatePossiblyElidedCall(function, finalBoundArguments, asyncReturn, methodTypeArguments);
+            return CreatePossiblyElidedCall(syntax, function, finalBoundArguments, asyncReturn, methodTypeArguments);
         }
 
-        return CreatePossiblyElidedCall(function, finalBoundArguments, returnType: null, methodTypeArguments);
+        return CreatePossiblyElidedCall(syntax, function, finalBoundArguments, returnType: null, methodTypeArguments);
     }
 
     /// <summary>
@@ -1967,14 +1967,14 @@ internal sealed partial class OverloadResolver
     /// Argument binding still ran above so wrong-type diagnostics on the
     /// elided arguments are reported normally.
     /// </summary>
-    private BoundExpression CreatePossiblyElidedCall(FunctionSymbol function, ImmutableArray<BoundExpression> arguments, TypeSymbol? returnType, ImmutableArray<TypeSymbol> methodTypeArguments = default)
+    private BoundExpression CreatePossiblyElidedCall(CallExpressionSyntax syntax, FunctionSymbol function, ImmutableArray<BoundExpression> arguments, TypeSymbol? returnType, ImmutableArray<TypeSymbol> methodTypeArguments = default)
     {
         if (KnownAttributes.IsConditionallyElided(function.Attributes, Scope.PreprocessorSymbols))
         {
             return new BoundCallExpression(null, function, ImmutableArray<BoundExpression>.Empty, returnType, isConditionalElided: true) { MethodTypeArguments = methodTypeArguments };
         }
 
-        return new BoundCallExpression(null, function, arguments, returnType) { MethodTypeArguments = methodTypeArguments };
+        return new BoundCallExpression(syntax, function, arguments, returnType) { MethodTypeArguments = methodTypeArguments };
     }
 
     /// <summary>

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3258BoundSyntaxDiagnosticTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3258BoundSyntaxDiagnosticTests.cs
@@ -1,0 +1,136 @@
+// <copyright file="Issue3258BoundSyntaxDiagnosticTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Lowering;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Regression tests for issue #3258: source syntax must survive direct-call
+/// binding and bound-tree rewriting so diagnostics can use it as a precise
+/// fallback when a synthesized interpolation hole has no syntax carrier.
+/// </summary>
+public class Issue3258BoundSyntaxDiagnosticTests
+{
+    private sealed class HoleSyntaxStrippingRewriter : BoundTreeRewriter
+    {
+        protected override BoundExpression RewriteInterpolatedStringExpression(BoundInterpolatedStringExpression node)
+        {
+            var parts = ImmutableArray.CreateBuilder<BoundInterpolatedStringPart>(node.Parts.Length);
+            foreach (var part in node.Parts)
+            {
+                parts.Add(
+                    part.IsLiteral
+                        ? part
+                        : BoundInterpolatedStringPart.FromHole(part.Value, part.Alignment, part.Format));
+            }
+
+            return new BoundInterpolatedStringExpression(node.Syntax, parts.MoveToImmutable(), node.Handler);
+        }
+    }
+
+    private sealed class ForceCallCloneRewriter : BoundTreeRewriter
+    {
+        public new BoundExpression RewriteExpression(BoundExpression node) => base.RewriteExpression(node);
+
+        protected override BoundExpression RewriteLiteralExpression(BoundLiteralExpression node)
+            => new BoundLiteralExpression(node.Syntax, node.Value);
+    }
+
+    [Fact]
+    public void SynthesizedHoleWithoutSyntax_ReportsGS0519AtCallSpan()
+    {
+        const string Source = """
+            ref struct Token {
+                var value int32
+            }
+
+            func MakeToken() Token {
+                return Token{value: 42}
+            }
+
+            func Main() {
+                Console.WriteLine("token=${MakeToken()}")
+            }
+            """;
+
+        var tree = SyntaxTree.Parse(SourceText.From(Source, "issue3258.gs"));
+        var compilation = new Compilation(tree);
+        Assert.Empty(tree.Diagnostics);
+        Assert.Empty(compilation.GlobalScope.Diagnostics);
+        Assert.DoesNotContain(compilation.BoundProgram.Diagnostics, diagnostic => diagnostic.IsError);
+
+        var program = StripHoleSyntax(compilation.BoundProgram);
+        var lowered = InterpolatedStringHandlerLowerer.Lower(program);
+        var diagnostic = Assert.Single(lowered.Diagnostics, diagnostic => diagnostic.Id == "GS0519");
+        var location = diagnostic.Location;
+
+        Assert.Equal(
+            (StartLine: 10, StartColumn: 32, EndLine: 10, EndColumn: 43),
+            (
+                StartLine: location.StartLine + 1,
+                StartColumn: location.StartCharacter + 1,
+                EndLine: location.EndLine + 1,
+                EndColumn: location.EndCharacter + 1));
+        Assert.Equal("MakeToken()", location.Text.ToString(location.Span));
+    }
+
+    [Fact]
+    public void RewriteCallExpression_PreservesSourceSyntax()
+    {
+        var tree = SyntaxTree.Parse("MakeToken(1)\n");
+        Assert.Empty(tree.Diagnostics);
+        var statement = Assert.IsType<GlobalStatementSyntax>(Assert.Single(tree.Root.Members)).Statement;
+        var expression = Assert.IsType<ExpressionStatementSyntax>(statement).Expression;
+        var syntax = Assert.IsType<CallExpressionSyntax>(expression);
+        var argumentSyntax = Assert.Single(syntax.Arguments);
+        var function = new FunctionSymbol("MakeToken", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Int32);
+        var call = new BoundCallExpression(
+            syntax,
+            function,
+            ImmutableArray.Create<BoundExpression>(new BoundLiteralExpression(argumentSyntax, 1)));
+
+        var rewritten = Assert.IsType<BoundCallExpression>(
+            new ForceCallCloneRewriter().RewriteExpression(call));
+
+        Assert.NotSame(call, rewritten);
+        Assert.Same(syntax, rewritten.Syntax);
+    }
+
+    private static BoundProgram StripHoleSyntax(BoundProgram program)
+    {
+        var rewriter = new HoleSyntaxStrippingRewriter();
+        var functions = ImmutableDictionary.CreateBuilder<FunctionSymbol, BoundBlockStatement>();
+        foreach (var pair in program.Functions)
+        {
+            functions.Add(pair.Key, (BoundBlockStatement)rewriter.RewriteStatement(pair.Value));
+        }
+
+        return new BoundProgram(
+            program.EntryPointPackage,
+            program.Packages,
+            program.Diagnostics,
+            functions.ToImmutable(),
+            program.EntryPoint,
+            (BoundBlockStatement)rewriter.RewriteStatement(program.Statement),
+            program.Structs,
+            program.Interfaces,
+            program.Enums,
+            program.Globals,
+            program.Delegates)
+        {
+            Imports = program.Imports,
+            FriendAssemblies = program.FriendAssemblies,
+            AssemblyAttributes = program.AssemblyAttributes,
+            ModuleAttributes = program.ModuleAttributes,
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- preserve source syntax when direct calls and free-function method groups are bound
- preserve existing call syntax when `BoundTreeRewriter` rebuilds a call after rewriting arguments
- add regression coverage for the exact `GS0519` span and the rewriter clone path

The product diff is the historical `+15/-14` syntax-propagation hunk from #3104, adapted to current nullable annotations and line layout.

## Root cause

PR #3260 made ordinary source interpolation holes carry their own `HoleSyntax`, but the underlying bound-node defect remained: direct-call binding, free-function method-group binding, and `BoundTreeRewriter.RewriteCallExpression` constructed replacements with `Syntax == null`.

When a synthesized/intermediate interpolation hole has no separate `HoleSyntax`, `InterpolatedStringHandlerLowerer` falls back to the bound value's syntax. The null call syntax then forces the diagnostic onto the enclosing string, producing `(10,23,10,45)` instead of the offending call `(10,32,10,43)`.

The new test deliberately removes the optional hole-level carrier, runs the real interpolation lowerer, and asserts `GS0519` plus all four coordinates. A second test forces the rewriter clone branch and verifies it retains the original call syntax.

## RED proof

With only the new tests applied to current `main` (before the product hunk):

```text
Failed SynthesizedHoleWithoutSyntax_ReportsGS0519AtCallSpan
Expected: Tuple (10, 32, 10, 43)
Actual:   Tuple (10, 23, 10, 45)

Failed RewriteCallExpression_PreservesSourceSyntax
Expected: CallExpression
Actual:   null

Total tests: 2
Failed: 2
TARGETED_RED_RC=1
```

Command:

```sh
dotnet test test/Core.Tests/Core.Tests.csproj \
  --filter 'FullyQualifiedName~Issue3258BoundSyntaxDiagnosticTests' \
  --no-restore --logger 'console;verbosity=normal'
```

## Green validation

- issue regression: **2 passed, 0 failed**
- focused `Issue3258` + interpolation + clone-preservation tests: **55 passed, 0 failed**
- existing GS0519 file-driver test: **3 passed, 0 failed**
- `dotnet build src/Compiler/Compiler.csproj --no-restore --configuration Debug`: **0 warnings, 0 errors**
- direct `gsc` emitted-path diagnostic: rc **1**, stdout contains `GS0519` at `(10,32,10,43)`, stderr is exactly `Failed.`

No evaluator/interpreter oracle used.

Fixes #3258


- GitHub Actions: **all executed checks passed** (build, e2e, ilverify, nullable hygiene, all test shards, extensions)
