### PR TITLE
Emit statement-position `if let` instead of spilling the scrutinee

### DIFF
--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GStatement.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GStatement.cs
@@ -150,6 +150,58 @@ public sealed class ExpressionStatement : GStatement
 }
 
 /// <summary>
+/// An <c>if let</c> statement — ADR-0071:
+/// <c>if let a = e [, let b = e2]* { … } [else { … }]</c>.
+/// </summary>
+/// <remarks>
+/// The canonical G# rendering of C#'s <c>if (receiver is { } name) { … }</c>
+/// (issue #3359). The general pattern lowering must spill <c>receiver</c> into a
+/// <c>let __spillN</c> — the pattern reads the scrutinee more than once (issue
+/// #1731) — which destroys the author's binder name, forces a <c>!!</c> at every
+/// read, and adds a brace level to scope the temp. <c>if let</c> evaluates the
+/// receiver once by construction and binds the name at its non-null type.
+/// <para>
+/// Mirrors <see cref="Cs2Gs.CodeModel.Ast.IfLetExpression"/>, the value-position
+/// form added by ADR-0151, and reuses its
+/// <see cref="Cs2Gs.CodeModel.Ast.IfLetBinding"/> clause type.
+/// </para>
+/// </remarks>
+public sealed class IfLetStatement : GStatement
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IfLetStatement"/> class.
+    /// </summary>
+    /// <param name="bindings">The <c>let</c> binding clauses.</param>
+    /// <param name="then">The then-branch block.</param>
+    /// <param name="elseBranch">The optional else branch.</param>
+    /// <remarks>
+    /// Unlike ADR-0151's value-position <see cref="IfLetExpression"/>, the
+    /// STATEMENT grammar has no <c>&amp;&amp; guard</c> clause — `gsc` swallows a
+    /// trailing <c>&amp;&amp; …</c> into the binding's initializer. A C# guard is
+    /// therefore nested inside the then-branch by the translator, and no guard is
+    /// representable here.
+    /// </remarks>
+    public IfLetStatement(
+        IReadOnlyList<IfLetBinding> bindings,
+        BlockStatement then,
+        GStatement elseBranch = null)
+    {
+        Bindings = bindings;
+        Then = then;
+        Else = elseBranch;
+    }
+
+    /// <summary>Gets the <c>let</c> binding clauses.</summary>
+    public IReadOnlyList<IfLetBinding> Bindings { get; }
+
+    /// <summary>Gets the then-branch block.</summary>
+    public BlockStatement Then { get; }
+
+    /// <summary>Gets the optional else branch.</summary>
+    public GStatement Else { get; }
+}
+
+/// <summary>
 /// An assignment statement <c>target op value</c> (e.g. <c>x = 1</c>, <c>x += 2</c>).
 /// </summary>
 public sealed class AssignmentStatement : GStatement

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -1034,6 +1034,9 @@ public static class GSharpPrinter
             case IfStatement ifStatement:
                 return RenderIf(ifStatement, indent);
 
+            case IfLetStatement ifLetStatement:
+                return RenderIfLet(ifLetStatement, indent);
+
             case WhileStatement whileStatement:
                 return $"{pad}while {RenderExpression(whileStatement.Condition, indent)} {RenderBlock(whileStatement.Body, indent)}";
 
@@ -1161,6 +1164,42 @@ public static class GSharpPrinter
         // A "simple" statement (init/incr clause of a C-style for) is rendered
         // inline with no leading indentation.
         return RenderStatement(statement, indent).TrimStart();
+    }
+
+    private static string RenderIfLet(IfLetStatement ifLet, int indent)
+    {
+        var pad = Indent(indent);
+        var bindings = string.Join(
+            ", ",
+            ifLet.Bindings.Select(binding =>
+            {
+                var type = binding.DeclaredType == null
+                    ? string.Empty
+                    : $" {RenderType(binding.DeclaredType)}";
+                var initializer = RenderExpression(binding.Initializer, indent, IfLetInitializerPrecedence);
+                return $"let {binding.Name}{type} = {initializer}";
+            }));
+
+        // No guard clause: the statement grammar has none (see IfLetStatement).
+        var sb = new StringBuilder();
+        sb.Append($"{pad}if {bindings} {RenderBlock(ifLet.Then, indent)}");
+        if (ifLet.Else is IfStatement elseIf)
+        {
+            sb.Append(" else ");
+            sb.Append(RenderIf(elseIf, indent).TrimStart());
+        }
+        else if (ifLet.Else is IfLetStatement elseIfLet)
+        {
+            sb.Append(" else ");
+            sb.Append(RenderIfLet(elseIfLet, indent).TrimStart());
+        }
+        else if (ifLet.Else is BlockStatement elseBlock)
+        {
+            sb.Append(" else ");
+            sb.Append(RenderBlock(elseBlock, indent));
+        }
+
+        return sb.ToString();
     }
 
     private static string RenderIf(IfStatement ifStatement, int indent)

--- a/tools/cs2gs/Cs2Gs.Tests/Coverage/GNodeSamples.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Coverage/GNodeSamples.cs
@@ -136,6 +136,9 @@ public static class GNodeSamples
             [typeof(LocalDeclarationStatement)] = () => Stmts(new LocalDeclarationStatement(BindingKind.Var, "n", Type("int32"), Int("0"))),
             [typeof(ExpressionStatement)] = () => Stmts(new ExpressionStatement(new InvocationExpression(Id("f")))),
             [typeof(AssignmentStatement)] = () => Stmts(new AssignmentStatement(Id("x"), Int("1"))),
+            [typeof(IfLetStatement)] = () => Stmts(new IfLetStatement(
+                new[] { new IfLetBinding("v", Id("maybe")) },
+                new BlockStatement(new GStatement[] { new ExpressionStatement(Id("v")) }))),
             [typeof(ReturnStatement)] = () => Unit(new MethodDeclaration(
                 "One",
                 returnType: Type("int32"),

--- a/tools/cs2gs/Cs2Gs.Tests/Coverage/code-model-surface.golden.txt
+++ b/tools/cs2gs/Cs2Gs.Tests/Coverage/code-model-surface.golden.txt
@@ -57,6 +57,7 @@ ForInStatement
 ForStatement
 ForTupleInStatement
 GotoStatement
+IfLetStatement
 IfStatement
 IncrementDecrementStatement
 LabeledStatement

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2233NegatedBracePatternTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2233NegatedBracePatternTranslationTests.cs
@@ -136,6 +136,12 @@ namespace Demo
     /// Standalone positive bare pattern (<c>if (x is { } v) { ... }</c>, no
     /// trailing <c>&amp;&amp;</c>) is unaffected by this fix: it already
     /// compiles via the existing smart-cast/null-forgive lowering.
+    /// <para>
+    /// Issue #3359 does NOT apply here: the scrutinee <c>s</c> is a NON-nullable
+    /// <c>string</c>, and ADR-0071's <c>if let</c> requires a nullable
+    /// initializer (GS0296). C# still treats <c>s is { }</c> as a runtime null
+    /// test, so the smart-cast form is retained — and is already spill-free.
+    /// </para>
     /// </summary>
     [Fact]
     public void PositiveBracePattern_Standalone_StaysCorrect()
@@ -158,14 +164,20 @@ namespace Demo
 }");
 
         Assert.Contains("s != nil", printed);
+        Assert.DoesNotContain("if let", printed);
 
         CompileAndRun(printed, "C().G(\"hi\")");
     }
 
     /// <summary>
     /// Case B (issue #2233 fix-direction item 3): a positive bare pattern
-    /// AND-combined with a further condition keeps its existing smart-cast
-    /// form (<c>x != nil &amp;&amp; ...x!!...</c>) — confirmed unchanged.
+    /// AND-combined with a further condition.
+    /// <para>
+    /// Issue #3359 replaced the smart-cast form (<c>x != nil &amp;&amp; …x!!…</c>)
+    /// with an <c>if let</c> whose guard is nested in the then-branch. Besides
+    /// keeping the binder name and dropping the <c>!!</c>, this reads the
+    /// nullable FIELD once instead of twice.
+    /// </para>
     /// </summary>
     [Fact]
     public void PositiveBracePattern_AndCombinedWithCondition_StaysSmartCastForm()
@@ -191,8 +203,8 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("promptShownAt != nil", printed);
-        Assert.Contains("promptShownAt!!", printed);
+        Assert.Contains("if let at = promptShownAt", printed);
+        Assert.DoesNotContain("promptShownAt!!", printed);
 
         CompileAndRun(printed, "C().ToastActive(DateTimeOffset.UtcNow)");
     }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3359IfLetStatementTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3359IfLetStatementTranslationTests.cs
@@ -1,0 +1,239 @@
+// <copyright file="Issue3359IfLetStatementTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3359: <c>if (receiver is { } name) { … }</c> translates to the
+/// canonical G# <c>if let</c> statement (ADR-0071) rather than spilling the
+/// scrutinee.
+/// <para>
+/// The general pattern lowering must spill a non-trivial scrutinee into a
+/// <c>let __spillN</c>, because the pattern reads it more than once (issue
+/// #1731). That costs three things at once: the author's chosen binder name is
+/// replaced by <c>__spillN</c>, every read becomes <c>__spillN!!</c>, and the
+/// statement gains a brace level to scope the temp. <c>if let</c> binds the name
+/// at its non-null type and evaluates the receiver once by construction.
+/// </para>
+/// <para>
+/// Measured at ~44 occurrences per 100k lines in dotnet/roslyn and ~186 per 100k
+/// in this repository — the largest single slice of spill site <b>S1</b>
+/// (issue #3347).
+/// </para>
+/// </summary>
+public class Issue3359IfLetStatementTranslationTests
+{
+    private const string NodeType = @"
+public sealed class Node
+{
+    public Node? StartTag;
+    public int X;
+}
+";
+
+    [Fact]
+    public void BareNonNullPattern_EmitsIfLet_WithNoSpill()
+    {
+        string printed = Translate(NodeType + @"
+public sealed class C
+{
+    public void M(Node node)
+    {
+        if (node.StartTag is { } startTag) { System.Console.WriteLine(startTag.X); }
+    }
+}");
+
+        Assert.Contains("if let startTag = node.StartTag", printed, StringComparison.Ordinal);
+
+        // The three costs the spill imposed, all gone.
+        Assert.DoesNotContain("__spill", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("!!", printed, StringComparison.Ordinal);
+        Assert.Contains("startTag.X", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WithElseBranch_EmitsIfLetElse()
+    {
+        string printed = Translate(NodeType + @"
+public sealed class C
+{
+    public void M(Node node)
+    {
+        if (node.StartTag is { } tag) { System.Console.WriteLine(tag.X); }
+        else { System.Console.WriteLine(-1); }
+    }
+}");
+
+        Assert.Contains("if let tag = node.StartTag", printed, StringComparison.Ordinal);
+        Assert.Contains("else", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("__spill", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The ADR-0071 STATEMENT grammar has no <c>&amp;&amp; guard</c> clause — only
+    /// ADR-0151's value-position form takes one, and `gsc` swallows a trailing
+    /// <c>&amp;&amp; …</c> into the binding's initializer. The guard is therefore
+    /// nested inside the then-branch, where it can read the bound name.
+    /// </summary>
+    [Fact]
+    public void ConjoinedGuard_IsNestedInsideTheBinding()
+    {
+        string printed = Translate(NodeType + @"
+public sealed class C
+{
+    public void M(Node node)
+    {
+        if (node.StartTag is { } tag && tag.X > 0) { System.Console.WriteLine(tag.X); }
+    }
+}");
+
+        Assert.Contains("if let tag = node.StartTag", printed, StringComparison.Ordinal);
+        Assert.Contains("if tag.X > 0", printed, StringComparison.Ordinal);
+
+        // The invalid form: a guard trailing the binding in the header.
+        Assert.DoesNotContain("if let tag = node.StartTag &&", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("__spill", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Nesting the guard is equivalent only when there is no else. With one,
+    /// <c>if let t = x { if g { THEN } } else { ELSE }</c> would skip ELSE when
+    /// the binding succeeds but the guard fails, whereas C# runs it. That
+    /// combination must decline the rewrite.
+    /// </summary>
+    [Fact]
+    public void ConjoinedGuardWithElse_DeclinesTheRewrite()
+    {
+        string printed = Translate(NodeType + @"
+public sealed class C
+{
+    public void M(Node node)
+    {
+        if (node.StartTag is { } tag && tag.X > 0) { System.Console.WriteLine(tag.X); }
+        else { System.Console.WriteLine(-1); }
+    }
+}");
+
+        Assert.DoesNotContain("if let tag =", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// An else branch that READS the binder is legal in C# when the then-branch
+    /// exits, but a G# <c>if let</c> binds only for the then-branch. The
+    /// negated-guard hoist handles that shape and must keep doing so.
+    /// </summary>
+    [Fact]
+    public void NegatedEarlyExit_KeepsTheNegatedGuardHoist()
+    {
+        string printed = Translate(NodeType + @"
+public sealed class C
+{
+    public void M(Node node)
+    {
+        if (node.StartTag is not { } tag) { return; }
+        System.Console.WriteLine(tag.X);
+    }
+}");
+
+        Assert.DoesNotContain("if let", printed, StringComparison.Ordinal);
+        Assert.Contains("if tag == nil", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A trivial scrutinee never spilled in the first place, but `if let` is
+    /// still the better rendering — it keeps the binder name instead of reusing
+    /// the receiver with a `!!` at each read.
+    /// </summary>
+    [Fact]
+    public void TrivialScrutinee_AlsoUsesIfLet()
+    {
+        string printed = Translate(@"
+#nullable enable
+public sealed class C
+{
+    public void M(string? s)
+    {
+        if (s is { } text) { System.Console.WriteLine(text.Length); }
+    }
+}");
+
+        Assert.Contains("if let text = s", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A type-test pattern (<c>is T t</c>) is a different shape and keeps the
+    /// positive-guard `as` hoist, which already avoids a spill.
+    /// </summary>
+    [Fact]
+    public void TypeTestPattern_KeepsTheAsHoist()
+    {
+        string printed = Translate(@"
+public sealed class C
+{
+    public void M(object o)
+    {
+        if (o is string s) { System.Console.WriteLine(s.Length); }
+    }
+}");
+
+        Assert.Contains("as string", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("__spill", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// ADR-0071 requires a NULLABLE initializer — the binding exists to strip the
+    /// nullability, and a non-nullable one is GS0296. C# still treats
+    /// <c>s is { }</c> on a non-nullable reference as a runtime null test, so
+    /// that shape must decline the rewrite and keep the existing (already
+    /// spill-free) smart-cast lowering.
+    /// </summary>
+    [Fact]
+    public void NonNullableScrutinee_DeclinesTheRewrite()
+    {
+        string printed = Translate(@"
+public sealed class C
+{
+    public int G(string s)
+    {
+        if (s is { } text) { return text.Length; }
+        return -1;
+    }
+}");
+
+        Assert.DoesNotContain("if let", printed, StringComparison.Ordinal);
+        Assert.Contains("s != nil", printed, StringComparison.Ordinal);
+    }
+
+    private static string Translate(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Snippet.cs", "#nullable enable\nusing System;\n\nnamespace Demo\n{\n" + source + "\n}\n") });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: "
+                + string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        string printed = GSharpPrinter.Print(unit);
+
+        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            roundTrip.Success,
+            "Translated G# must round-trip. Errors:\n" + string.Join("\n", roundTrip.Errors)
+                + "\n\nPrinted:\n" + printed);
+
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.ControlFlow.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.ControlFlow.cs
@@ -516,6 +516,18 @@ public sealed partial class CSharpToGSharpTranslator
         /// </summary>
         private IEnumerable<GStatement> TranslateIfStatements(IfStatementSyntax ifStatement)
         {
+            // Issue #3359: `if (recv is { } name) { … }` has a canonical G# form —
+            // the ADR-0071 `if let` statement — that binds the name at its
+            // non-null type and evaluates `recv` exactly once by construction.
+            // Tried FIRST because the general pattern lowering would otherwise
+            // spill `recv` into a `let __spillN`, destroying the author's binder
+            // name and adding a `!!` at every read. The helper is conservative
+            // and translates nothing when it declines.
+            if (this.TryBuildIfLetGuard(ifStatement, out IReadOnlyList<GStatement> ifLetHoisted))
+            {
+                return ifLetHoisted;
+            }
+
             if (this.TryBuildNegatedGuardHoist(ifStatement, out IReadOnlyList<GStatement> hoisted))
             {
                 return hoisted;

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.IfLet.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.IfLet.cs
@@ -138,6 +138,168 @@ public sealed partial class CSharpToGSharpTranslator
             return true;
         }
 
+        /// <summary>
+        /// Issue #3359: rewrites the STATEMENT form
+        /// <c>if (receiver is { } name [&amp;&amp; predicate]) { … } [else { … }]</c>
+        /// into the canonical G# <c>if let</c> statement (ADR-0071):
+        /// <code>
+        /// if let name = receiver [&amp;&amp; predicate] { … } [else { … }]
+        /// </code>
+        /// The statement-position counterpart of ADR-0151's
+        /// <see cref="TryTranslateIfLetConditional"/>, sharing its eligibility
+        /// rules. Without it the general lowering spills <c>receiver</c> into a
+        /// <c>let __spillN</c> (the pattern reads the scrutinee more than once,
+        /// issue #1731), which destroys the author's chosen binder name, forces a
+        /// <c>!!</c> at every read, and wraps the statement in an extra brace
+        /// level to scope the temp. Measured at ~44 occurrences per 100k lines in
+        /// dotnet/roslyn and ~186 per 100k in this repository (issue #3347).
+        /// </summary>
+        /// <param name="ifStatement">The C# <c>if</c> statement.</param>
+        /// <param name="result">The translated statements when the rewrite applies.</param>
+        /// <returns><see langword="true"/> when the rewrite applied.</returns>
+        private bool TryBuildIfLetGuard(
+            IfStatementSyntax ifStatement,
+            out IReadOnlyList<GStatement> result)
+        {
+            result = null;
+
+            // Eligibility is decided BEFORE anything is translated: a mid-way
+            // bail-out would leave a half-emitted spill prologue behind.
+            DecomposeConjunction(ifStatement.Condition, out ExpressionSyntax leftmost, out List<ExpressionSyntax> guards);
+
+            if (leftmost is not IsPatternExpressionSyntax isPattern
+                || !IsBareNonNullDeclarationPattern(isPattern.Pattern, out SingleVariableDesignationSyntax designation))
+            {
+                return false;
+            }
+
+            if (this.context.GetDeclaredSymbol(designation) is not ILocalSymbol binder)
+            {
+                return false;
+            }
+
+            // ADR-0071 requires a NULLABLE initializer — the binding exists to
+            // strip the nullability. C# allows `s is { } text` on a non-nullable
+            // reference too (it is still a runtime null test), but there the
+            // translated receiver is `string`, not `string?`, and `if let` is
+            // rejected with GS0296. Those keep the existing lowering, which is
+            // already spill-free for this shape.
+            GTypeReference receiverType = this.ResolveExpressionType(isPattern.Expression);
+            if (receiverType is not { IsNullable: true })
+            {
+                return false;
+            }
+
+            // A guard that itself hoists a spill would need a statement seam
+            // ahead of the `if`, but the spill may read the binding — which is
+            // only in scope inside the `if let`. Leave those to the general path.
+            if (guards.Any(ContainsSpillHoistingConstruct))
+            {
+                return false;
+            }
+
+            // The ADR-0071 STATEMENT grammar has no `&& guard` clause — gsc
+            // swallows a trailing `&& …` into the binding's initializer (only
+            // ADR-0151's value-position form takes a guard). A guard is therefore
+            // nested inside the then-branch, which is equivalent ONLY when there
+            // is no else: with one, `if let t = x { if g { THEN } } else { ELSE }`
+            // would skip ELSE when the binding succeeds but the guard fails,
+            // whereas C# runs it. Decline that combination.
+            if (guards.Count > 0 && ifStatement.Else != null)
+            {
+                return false;
+            }
+
+            // `if let` binds only for the then-branch, matching C#'s definite
+            // assignment. A binder READ in the else-branch (legal in C# when the
+            // then-branch exits) has no `if let` spelling; the negated-guard
+            // hoist handles that shape instead.
+            if (ifStatement.Else != null && ReadsSymbol(ifStatement.Else, binder))
+            {
+                return false;
+            }
+
+            // Issue #1967 parity with TranslateIsPattern: an Index/Range-typed
+            // designation has no canonical G# type. Report here so the gap
+            // surfaces exactly once on this path too.
+            this.ReportIndexOrRangeDesignationsInPattern(isPattern.Pattern);
+
+            GExpression receiver = this.TranslateExpression(isPattern.Expression);
+            string name = SanitizeIdentifier(designation.Identifier.Text);
+
+            // Inside the guard and the then-branch every reference to the C#
+            // pattern local reads as the bare G# binding — no `!!`, no `as`
+            // narrowing cast, no spill temp.
+            bool hadPrevious = this.state.PatternBindings.TryGetValue(binder, out GExpression previous);
+            this.state.PatternBindings[binder] = new IdentifierExpression(name);
+
+            GExpression guard = null;
+            BlockStatement then;
+            try
+            {
+                foreach (ExpressionSyntax conjunct in guards)
+                {
+                    GExpression translated = this.TranslateExpression(conjunct);
+                    guard = guard == null ? translated : new BinaryExpression(guard, "&&", translated);
+                }
+
+                then = this.TranslateStatementAsBlock(ifStatement.Statement);
+
+                // Nest the guard inside the binding's scope — the only place it
+                // can read the bound name.
+                if (guard != null)
+                {
+                    then = new BlockStatement(new GStatement[] { new IfStatement(guard, then) });
+                }
+            }
+            finally
+            {
+                if (hadPrevious)
+                {
+                    this.state.PatternBindings[binder] = previous;
+                }
+                else
+                {
+                    this.state.PatternBindings.Remove(binder);
+                }
+            }
+
+            // The else branch is translated with the binding OUT of scope.
+            GStatement elseBranch = null;
+            if (ifStatement.Else != null)
+            {
+                elseBranch = ifStatement.Else.Statement is IfStatementSyntax elseIf
+                    ? this.TranslateIf(elseIf)
+                    : this.TranslateStatementAsBlock(ifStatement.Else.Statement);
+            }
+
+            result = new GStatement[]
+            {
+                new IfLetStatement(
+                    new List<IfLetBinding> { new IfLetBinding(name, receiver) },
+                    then,
+                    elseBranch),
+            };
+            return true;
+        }
+
+        // True when `node` reads `symbol` anywhere. Used to keep an `if let` from
+        // swallowing a shape whose ELSE branch reads the pattern binder — legal in
+        // C# when the then-branch exits, but out of scope for a G# `if let`.
+        private bool ReadsSymbol(SyntaxNode node, ILocalSymbol symbol)
+        {
+            foreach (IdentifierNameSyntax identifier in node.DescendantNodesAndSelf().OfType<IdentifierNameSyntax>())
+            {
+                if (SymbolEqualityComparer.Default.Equals(
+                        this.context.GetSymbolInfo(identifier).Symbol, symbol))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         private static bool ContainsAssignmentNeedingBranchSeam(ExpressionSyntax branch)
         {
             return branch.DescendantNodesAndSelf(


### PR DESCRIPTION
Closes #3359. Fourth item from the plan in #3347, and the highest-leverage cs2gs-only change in it —
no language work required.

## Before / after

```csharp
if (node.StartTag is { } startTag) { Console.WriteLine(startTag.X); }
```

| Before | After |
|---|---|
| `{`<br>`  let __spill0 = node.StartTag`<br>`  if __spill0 != nil {`<br>`    Console.WriteLine(__spill0!!.X)`<br>`  }`<br>`}` | `if let startTag = node.StartTag {`<br>`  Console.WriteLine(startTag.X)`<br>`}` |

The general pattern lowering must spill a non-trivial scrutinee, because the pattern reads it more
than once (#1731). That costs three things at once — the author's binder name is replaced by
`__spillN`, every read becomes `__spillN!!`, and the statement gains a brace level to scope the temp.
`if let` (ADR-0071) binds the name at its non-null type and evaluates the receiver once by
construction.

Measured at **~44 occurrences per 100k LOC in dotnet/roslyn** and **~186 per 100k here** — the
largest single slice of spill site **S1** in #3347.

This is the statement-position counterpart of ADR-0151's `TryTranslateIfLetConditional` and shares
its eligibility helpers. A new `IfLetStatement` code-model node carries it, reusing the existing
`IfLetBinding`.

## Three deliberate declines

Most of the care here went into *not* applying the rewrite. Each has a test:

| Shape | Why it declines |
|---|---|
| non-nullable scrutinee — `string s`, `s is { } text` | ADR-0071 needs a nullable initializer; otherwise **GS0296**. C# still treats it as a runtime null test, and the existing smart-cast lowering is already spill-free. |
| conjoined guard **with** an else | The statement grammar has no `&& guard`, so the guard is nested in the then-branch — equivalent only without an else. With one, the nested form would skip `ELSE` when the binding succeeds but the guard fails, whereas C# runs it. |
| else branch that **reads** the binder | Legal in C# when the then-branch exits; `if let` binds only for the then-branch. The negated-guard hoist keeps that shape. |

Because the statement grammar cannot represent a guard, **`IfLetStatement` has no `Guard` property at
all** — emitting one would produce G# that parses but does not compile.

## Two things worth flagging for review

**The guard form was wrong at first.** I initially emitted `if let tag = x && tag.X > 0 { … }`,
assuming the statement form took a guard like ADR-0151's expression form. `gsc` swallows the trailing
`&&` into the initializer and fails with `GS0157: Cannot find type tag`. Round-trip validation passed
happily; only compiling the output caught it.

**One of the two `Issue2233` test failures was a real bug, not a stale assertion.** Its scrutinee is a
non-nullable `string`, which is what surfaced the GS0296 case above. Its assertion is restored
unchanged. The other — a nullable *field* — now asserts the `if let` form, which additionally reads
the field **once** instead of twice (`promptShownAt != nil && now - promptShownAt!! <= …`).

## Tests

`Issue3359IfLetStatementTranslationTests` (8, new) — bare pattern with no spill, with else, guard
nested, and the three declines, plus `is T t` keeping the `as` hoist. Every case round-trips;
`Issue2233`'s cases additionally compile-and-run.

Full `Cs2Gs.Tests` locally: **1942 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)