### PR TITLE
Complete CLR ValueType and Enum boxing coverage

### DIFF
--- a/test/Core.Tests/CodeAnalysis/Emit/Issue3280ValueTypeBaseBoxingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue3280ValueTypeBaseBoxingTests.cs
@@ -12,7 +12,8 @@ namespace GSharp.Core.Tests.CodeAnalysis.Emit;
 
 /// <summary>
 /// Issue #3280: CLR value types box implicitly to <see cref="ValueType"/>,
-/// and enum values box implicitly to <see cref="Enum"/>, in every call shape.
+/// and enum values box implicitly to <see cref="Enum"/>, <see cref="ValueType"/>,
+/// and <see cref="object"/>, in every call shape.
 /// </summary>
 public sealed class Issue3280ValueTypeBaseBoxingTests
 {
@@ -27,57 +28,90 @@ public sealed class Issue3280ValueTypeBaseBoxingTests
             MatrixSource(shape),
             "System.ValueType[]",
             "System.Int32",
-            "5",
+            "42",
+            "System.ValueType[]",
+            "System.DayOfWeek",
+            "Friday",
             "System.Enum[]",
             "System.DayOfWeek",
             "Sunday",
             "System.Object[]",
+            "System.DayOfWeek",
+            "Monday",
+            "System.IComparable[]",
+            "System.Int32",
+            "7",
+            "System.Object[]",
             "System.Int32",
             "11",
+            "System.IComparable[]",
+            "System.Int32",
+            "12",
             "System.ValueType[]",
             "System.Int32",
             "22",
+            "System.ValueType[]",
+            "System.DayOfWeek",
+            "Saturday",
             "System.Enum[]",
             "System.DayOfWeek",
-            "Monday",
+            "Tuesday",
+            "System.Object[]",
+            "System.DayOfWeek",
+            "Wednesday",
             "System.DayOfWeek[]",
             "System.DayOfWeek",
-            "Tuesday");
+            "Thursday");
     }
 
     [Fact]
-    public void AlreadyBoxedValueTypeArgument_PreservesTargetTypeAndValue()
+    public void ReferenceBaseUpcasts_PreserveExistingBox()
     {
         AssertRuns(
             """
-            package Issue3280AlreadyBoxed
+            package Issue3280ReferenceBaseUpcasts
             import System
 
-            func Show[T](value T) {
-                Console.WriteLine([]T{value}.GetType())
-                Console.WriteLine(value.GetType())
-                Console.WriteLine(value)
-            }
+            func Reify[T](value T) T -> value
 
-            let boxed ValueType = 31
-            Show[ValueType](boxed)
+            let enumReference Enum = DayOfWeek.Wednesday
+            let valueTypeReference = Reify[ValueType](enumReference)
+            let objectReference = Reify[object](valueTypeReference)
+
+            Console.WriteLine(Object.ReferenceEquals(enumReference, valueTypeReference))
+            Console.WriteLine(Object.ReferenceEquals(valueTypeReference, objectReference))
+            Console.WriteLine([]ValueType{valueTypeReference}.GetType())
+            Console.WriteLine(objectReference.GetType())
+            Console.WriteLine(objectReference)
             """,
+            "True",
+            "True",
             "System.ValueType[]",
-            "System.Int32",
-            "31");
+            "System.DayOfWeek",
+            "Wednesday");
     }
 
     [Fact]
-    public void ReferenceTypeArgument_RemainsReferenceTyped()
+    public void ConversionClassifier_UsesClrBoxingAndReferenceRules()
     {
+        var valueType = TypeSymbol.FromClrType(typeof(ValueType));
+        var enumType = TypeSymbol.FromClrType(typeof(Enum));
+        var dayOfWeek = TypeSymbol.FromClrType(typeof(DayOfWeek));
+
+        Assert.True(Conversion.Classify(TypeSymbol.Int32, valueType).IsImplicit);
+        Assert.True(Conversion.Classify(dayOfWeek, valueType).IsImplicit);
+        Assert.True(Conversion.Classify(dayOfWeek, enumType).IsImplicit);
+        Assert.True(Conversion.Classify(dayOfWeek, TypeSymbol.Object).IsImplicit);
+        Assert.True(Conversion.Classify(enumType, valueType).IsImplicit);
+        Assert.True(Conversion.Classify(valueType, TypeSymbol.Object).IsImplicit);
         Assert.False(
             Conversion.Classify(
                 TypeSymbol.String,
-                TypeSymbol.FromClrType(typeof(ValueType))).Exists);
+                valueType).Exists);
         Assert.False(
             Conversion.Classify(
                 TypeSymbol.Int32,
-                TypeSymbol.FromClrType(typeof(Enum))).Exists);
+                enumType).Exists);
 
         AssertRuns(
             """
@@ -123,24 +157,23 @@ public sealed class Issue3280ValueTypeBaseBoxingTests
     }
 
     [Fact]
-    public void StructConstrainedTypeParameter_BoxesToValueType()
+    public void StructConstrainedTypeParameter_BoxesWhenReifiedToValueType()
     {
         AssertRuns(
             """
             package Issue3280StructConstraint
             import System
 
-            func Take(value ValueType) {
-                Console.WriteLine(value.GetType())
-                Console.WriteLine(value)
-            }
+            func Reify[T](value T) T -> value
 
-            func Forward[T struct](value T) {
-                Take(value)
-            }
+            func Box[T struct](value T) ValueType -> Reify[ValueType](value)
 
-            Forward[int32](42)
+            let boxed = Box[int32](42)
+            Console.WriteLine([]ValueType{boxed}.GetType())
+            Console.WriteLine(boxed.GetType())
+            Console.WriteLine(boxed)
             """,
+            "System.ValueType[]",
             "System.Int32",
             "42");
     }
@@ -220,20 +253,42 @@ public sealed class Issue3280ValueTypeBaseBoxingTests
                 Console.WriteLine(value)
             }
             """;
+        const string objectMethodBody = """
+            {
+                Console.WriteLine([]object{value}.GetType())
+                Console.WriteLine(value.GetType())
+                Console.WriteLine(value)
+            }
+            """;
+        const string comparableMethodBody = """
+            {
+                Console.WriteLine([]IComparable{value}.GetType())
+                Console.WriteLine(value.GetType())
+                Console.WriteLine(value)
+            }
+            """;
 
         var declaration = shape switch
         {
             "top-level" => "func TakeValueType(value ValueType) " + valueTypeMethodBody
                 + " func TakeEnum(value Enum) " + enumMethodBody
+                + " func TakeObject(value object) " + objectMethodBody
+                + " func TakeComparable(value IComparable) " + comparableMethodBody
                 + " func Show[T](value T) " + genericMethodBody,
             "instance" => "class Runner { init() {} func TakeValueType(value ValueType) " + valueTypeMethodBody
                 + " func TakeEnum(value Enum) " + enumMethodBody
+                + " func TakeObject(value object) " + objectMethodBody
+                + " func TakeComparable(value IComparable) " + comparableMethodBody
                 + " func Show[T](value T) " + genericMethodBody + " }",
             "extension" => "func (self string) TakeValueType(value ValueType) " + valueTypeMethodBody
                 + " func (self string) TakeEnum(value Enum) " + enumMethodBody
+                + " func (self string) TakeObject(value object) " + objectMethodBody
+                + " func (self string) TakeComparable(value IComparable) " + comparableMethodBody
                 + " func (self string) Show[T](value T) " + genericMethodBody,
             "shared" => "class Runner { shared { func TakeValueType(value ValueType) " + valueTypeMethodBody
                 + " func TakeEnum(value Enum) " + enumMethodBody
+                + " func TakeObject(value object) " + objectMethodBody
+                + " func TakeComparable(value IComparable) " + comparableMethodBody
                 + " func Show[T](value T) " + genericMethodBody + " } }",
             _ => throw new ArgumentOutOfRangeException(nameof(shape)),
         };
@@ -252,12 +307,18 @@ public sealed class Issue3280ValueTypeBaseBoxingTests
 
             {{declaration}}
 
-            {{target}}TakeValueType(5)
+            {{target}}TakeValueType(42)
+            {{target}}TakeValueType(DayOfWeek.Friday)
             {{target}}TakeEnum(DayOfWeek.Sunday)
+            {{target}}TakeObject(DayOfWeek.Monday)
+            {{target}}TakeComparable(7)
             {{target}}Show[object](11)
+            {{target}}Show[IComparable](12)
             {{target}}Show[ValueType](22)
-            {{target}}Show[Enum](DayOfWeek.Monday)
-            {{target}}Show[DayOfWeek](DayOfWeek.Tuesday)
+            {{target}}Show[ValueType](DayOfWeek.Saturday)
+            {{target}}Show[Enum](DayOfWeek.Tuesday)
+            {{target}}Show[object](DayOfWeek.Wednesday)
+            {{target}}Show[DayOfWeek](DayOfWeek.Thursday)
             """;
     }
 


### PR DESCRIPTION
## Summary

- complete issue #3280's four-shape emitted-runtime matrix for ordinary CLR boxing to `System.ValueType`
- cover imported concrete enums flowing to `System.Enum`, `System.ValueType`, `object`, and their concrete enum type
- keep `object` and interface boxing controls beside the new rows
- prove already-reference-typed `Enum -> ValueType -> object` upcasts preserve the same boxed reference
- strengthen generic safeguards for open forwarding and `T : struct` reification to `ValueType`
- pin the exact positive and negative `Conversion.Classify` rules

Current `main` already contains the minimal shared production fix merged in #3284. This PR does not duplicate that classifier/emitter work; it completes the end-to-end regression contract needed to close the still-open issue.

## Root cause

The original defect was in the shared conversion classifier, not four independent call implementations: ordinary value-type boxing recognized `object` and implemented interfaces, but omitted `System.ValueType`; imported enums likewise lacked the `System.Enum` base-boxing classification. All four binder paths eventually materialize an implicit conversion, and `MethodBodyEmitter.Conversions` already emits the required single `box <source>` instruction for `ValueType`/`Enum` targets.

The shared rule now present on `main` classifies:

- value type -> `System.ValueType`: implicit boxing
- enum -> `System.Enum`: implicit boxing
- enum -> `System.ValueType` / `object`: implicit boxing
- `T : struct` -> `System.ValueType`: implicit boxing via `box !!T`
- `System.Enum` -> `System.ValueType` and `System.ValueType` -> `object`: implicit reference conversions, no second box

It still rejects unrelated rows such as `string -> ValueType` and `int32 -> Enum`.

## Four-shape runtime evidence

Manual `gsc` + `dotnet exec` probe compiled with rc 0 and ran with rc 0:

| shape | `int32 -> ValueType` | `DayOfWeek -> Enum` |
|---|---|---|
| free | `ValueType[] / Int32 / 42` | `Enum[] / DayOfWeek / Sunday` |
| instance | `ValueType[] / Int32 / 42` | `Enum[] / DayOfWeek / Monday` |
| extension | `ValueType[] / Int32 / 42` | `Enum[] / DayOfWeek / Tuesday` |
| shared | `ValueType[] / Int32 / 42` | `Enum[] / DayOfWeek / Wednesday` |

Automated matrix additionally runs enum -> `ValueType`/`object`, int -> `object`/`IComparable`, explicit generic `Show[ValueType]`/`Show[Enum]`/`Show[object]`/`Show[IComparable]`, and concrete-enum identity in every shape. Every oracle prints target array type, runtime type, and value.

## Generic and reference safeguards

- `Enum -> ValueType -> object` through explicitly reified calls prints `True` twice from `Object.ReferenceEquals`, proving no re-boxing or duplicate conversion.
- open `Forward[T] -> Show[T]`, closed with `int32`, remains `System.Int32[] / System.Int32 / 41`.
- `T : struct` reified to `ValueType` produces `System.ValueType[] / System.Int32 / 42`.
- nullable value-type and mutable constrained-struct controls remain green.
- IL inspection shows one `box System.Int32` or `box System.DayOfWeek` at each legal value-to-reference call site and no box on reference-base upcasts.

## Validation

- Release solution build with `ContinuousIntegrationBuild=true`: 0 warnings, 0 errors
- focused Core tests (#3267/#3271/#3280): 37 passed, 0 failed
- focused enum emit tests (#1218): 4 passed, 0 failed
- manual four-shape compile/run: compile rc 0, runtime rc 0, empty stderr
- targeted `dotnet-ilverify` on manual four-shape assembly: all classes and methods verified
- reverting the shared classifier rule made #3280 tests fail 6/10, including all four call shapes, constrained generic reification, and reference-base coverage; restored source hash exactly before final green run
- `git diff --check`: clean

## Scope boundary: #3289 / #3312

Rejected conversions remain intentionally untouched. Current `main` still reports `GS0154` for free `string -> ValueType`, while instance, extension, and shared report `GS0155`; a manual four-shape probe reproduced exactly that split. #3289/#3312 therefore remain open and are not claimed as resolved. #3280's concrete `int32 -> ValueType` diagnostic asymmetry disappears because conversion is legal; general rejected-conversion diagnostic unification is superseded/tracked by #3289/#3312 and remains open.

Fixes #3280


