### PR TITLE
Emit G#'s native multi-target assignment for deconstruction

### DIFF
--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GStatement.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GStatement.cs
@@ -202,6 +202,43 @@ public sealed class IfLetStatement : GStatement
 }
 
 /// <summary>
+/// A Go-style multi-target assignment — <c>a, b = x, y</c> (ADR-0015).
+/// </summary>
+/// <remarks>
+/// The native G# rendering of a C# deconstruction assignment into existing
+/// variables (issue #3358). ADR-0015 evaluates every right-hand expression
+/// left-to-right into temporaries BEFORE any write, then assigns left-to-right —
+/// exactly C#'s evaluate-then-assign order, so an aliasing swap
+/// (<c>(a, b) = (b, a)</c>) is correct.
+/// <para>
+/// Only plain identifier targets and <c>_</c> discards are representable: `gsc`
+/// rejects a storage target (<c>arr[i], o.F = …</c>, GS0005) and a mixed
+/// declaration (<c>a, let y = …</c>, GS0005), and will not unify a single
+/// tuple-valued right-hand side across N targets (<c>a, b = Pair()</c>,
+/// GS0167). Those shapes keep the <c>let (__deconN, …)</c> lowering.
+/// </para>
+/// </remarks>
+public sealed class MultiAssignmentStatement : GStatement
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MultiAssignmentStatement"/> class.
+    /// </summary>
+    /// <param name="targets">The assignment targets, in source order.</param>
+    /// <param name="values">The assigned values, one per target, in source order.</param>
+    public MultiAssignmentStatement(IReadOnlyList<GExpression> targets, IReadOnlyList<GExpression> values)
+    {
+        Targets = targets;
+        Values = values;
+    }
+
+    /// <summary>Gets the assignment targets, in source order.</summary>
+    public IReadOnlyList<GExpression> Targets { get; }
+
+    /// <summary>Gets the assigned values, one per target, in source order.</summary>
+    public IReadOnlyList<GExpression> Values { get; }
+}
+
+/// <summary>
 /// An assignment statement <c>target op value</c> (e.g. <c>x = 1</c>, <c>x += 2</c>).
 /// </summary>
 public sealed class AssignmentStatement : GStatement

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -1021,6 +1021,12 @@ public static class GSharpPrinter
             case AssignmentStatement assignment:
                 return $"{pad}{RenderExpression(assignment.Target, indent)} {assignment.Operator} {RenderExpression(assignment.Value, indent)}";
 
+            case MultiAssignmentStatement multiAssignment:
+                return $"{pad}" +
+                    string.Join(", ", multiAssignment.Targets.Select(target => RenderExpression(target, indent))) +
+                    " = " +
+                    string.Join(", ", multiAssignment.Values.Select(value => RenderExpression(value, indent)));
+
             case ReturnStatement ret:
                 return ret.Expression == null
                     ? $"{pad}return"

--- a/tools/cs2gs/Cs2Gs.Tests/Coverage/GNodeSamples.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Coverage/GNodeSamples.cs
@@ -136,6 +136,9 @@ public static class GNodeSamples
             [typeof(LocalDeclarationStatement)] = () => Stmts(new LocalDeclarationStatement(BindingKind.Var, "n", Type("int32"), Int("0"))),
             [typeof(ExpressionStatement)] = () => Stmts(new ExpressionStatement(new InvocationExpression(Id("f")))),
             [typeof(AssignmentStatement)] = () => Stmts(new AssignmentStatement(Id("x"), Int("1"))),
+            [typeof(MultiAssignmentStatement)] = () => Stmts(new MultiAssignmentStatement(
+                new GExpression[] { Id("a"), Id("b") },
+                new GExpression[] { Id("b"), Id("a") })),
             [typeof(IfLetStatement)] = () => Stmts(new IfLetStatement(
                 new[] { new IfLetBinding("v", Id("maybe")) },
                 new BlockStatement(new GStatement[] { new ExpressionStatement(Id("v")) }))),

--- a/tools/cs2gs/Cs2Gs.Tests/Coverage/code-model-surface.golden.txt
+++ b/tools/cs2gs/Cs2Gs.Tests/Coverage/code-model-surface.golden.txt
@@ -64,6 +64,7 @@ LabeledStatement
 LocalDeclarationStatement
 LocalFunctionStatement
 LockStatement
+MultiAssignmentStatement
 RawStatement
 ReturnStatement
 SwitchStatement

--- a/tools/cs2gs/Cs2Gs.Tests/FaithfulUnsafeFormTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/FaithfulUnsafeFormTranslationTests.cs
@@ -218,8 +218,11 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("a = __decon", printed);
-        Assert.Contains("b = __decon", printed);
+        // Issue #3358: renders as G#'s native multi-target assignment (ADR-0015)
+        // rather than a decon binding plus per-target writes. The parenthesised
+        // C# TARGET-TUPLE form is still absent, which is what this test guards.
+        Assert.Contains("a, b = x, y", printed);
+        Assert.DoesNotContain("__decon", printed);
         Assert.DoesNotContain("(a, b) =", printed);
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1895DeconstructAssignTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1895DeconstructAssignTranslationTests.cs
@@ -63,9 +63,11 @@ namespace Corpus.Issue1895
 
         Assert.Contains("var x = 1", rendered, StringComparison.Ordinal);
         Assert.Contains("var y = 2", rendered, StringComparison.Ordinal);
-        Assert.Contains("let (__decon0, __decon1) = (y, x)", rendered, StringComparison.Ordinal);
-        Assert.Contains("x = __decon0", rendered, StringComparison.Ordinal);
-        Assert.Contains("y = __decon1", rendered, StringComparison.Ordinal);
+        // Issue #3358: G#'s native multi-target assignment (ADR-0015) evaluates
+        // every right-hand expression before any write, so the aliasing swap is
+        // correct without the tool synthesising its own temps.
+        Assert.Contains("x, y = y, x", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("__decon", rendered, StringComparison.Ordinal);
         Assert.DoesNotContain("let x", rendered, StringComparison.Ordinal);
         Assert.DoesNotContain("let y", rendered, StringComparison.Ordinal);
         AssertRoundTripParses(rendered);
@@ -92,8 +94,9 @@ namespace Corpus.Issue1895
 
         Assert.Contains("var x = 1", rendered, StringComparison.Ordinal);
         Assert.Contains("var z = 2", rendered, StringComparison.Ordinal);
-        Assert.Contains("x = __decon0", rendered, StringComparison.Ordinal);
-        Assert.Contains("z = __decon1", rendered, StringComparison.Ordinal);
+        // Issue #3358: native multi-target assignment, no temps.
+        Assert.Contains("x, z = 5, 6", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("__decon", rendered, StringComparison.Ordinal);
         AssertRoundTripParses(rendered);
     }
 
@@ -138,8 +141,10 @@ namespace Corpus.Issue1895
 }
 ");
 
-        Assert.Contains("let (__decon0, _) = (2, 3)", rendered, StringComparison.Ordinal);
-        Assert.Contains("x = __decon0", rendered, StringComparison.Ordinal);
+        // Issue #3358: `_` is a native multi-assignment target, so the discarded
+        // element needs no temp either.
+        Assert.Contains("x, _ = 2, 3", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("__decon", rendered, StringComparison.Ordinal);
         AssertRoundTripParses(rendered);
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3358NativeMultiAssignmentTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3358NativeMultiAssignmentTranslationTests.cs
@@ -1,0 +1,214 @@
+// <copyright file="Issue3358NativeMultiAssignmentTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3358: a C# deconstruction assignment into existing variables renders
+/// as G#'s native multi-target assignment (<c>a, b = b, a</c>, ADR-0015) rather
+/// than the <c>let (__decon0, __decon1) = …</c> plus per-target-write triple.
+/// <para>
+/// ADR-0015 evaluates every right-hand expression left-to-right into temporaries
+/// BEFORE any write, then assigns left-to-right — exactly the order C# specifies,
+/// so an aliasing swap stays correct without the tool synthesising its own temps.
+/// </para>
+/// <para>
+/// This corrects a mis-classification in issue #3347, which recorded
+/// <c>__deconN</c> as a G# language gap. It is not: the native form covers 378 of
+/// the 389 deconstruction assignments measured in dotnet/roslyn (97%).
+/// </para>
+/// </summary>
+public class Issue3358NativeMultiAssignmentTranslationTests
+{
+    [Fact]
+    public void Swap_UsesNativeMultiAssignment()
+    {
+        string printed = Translate(@"
+public sealed class C
+{
+    public void M()
+    {
+        int a = 1, b = 2;
+        (a, b) = (b, a);
+        System.Console.WriteLine(a + b);
+    }
+}");
+
+        Assert.Contains("a, b = b, a", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("__decon", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Discard_UsesNativeMultiAssignment()
+    {
+        string printed = Translate(@"
+public sealed class C
+{
+    public void M()
+    {
+        int a = 0;
+        (a, _) = (1, 2);
+        System.Console.WriteLine(a);
+    }
+}");
+
+        Assert.Contains("a, _ = 1, 2", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("__decon", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ThreeTargets_UsesNativeMultiAssignment()
+    {
+        string printed = Translate(@"
+public sealed class C
+{
+    public void M()
+    {
+        int a = 0, b = 0, c = 0;
+        (a, b, c) = (1, 2, 3);
+        System.Console.WriteLine(a + b + c);
+    }
+}");
+
+        Assert.Contains("a, b, c = 1, 2, 3", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("__decon", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A storage target is GS0005 in the native form (`arr[i], o.F = …`), so it
+    /// keeps the existing lowering — including the receiver/index spill that
+    /// preserves C#'s targets-then-value order (#2234).
+    /// </summary>
+    [Fact]
+    public void StorageTargets_KeepTheDeconLowering()
+    {
+        string printed = Translate(@"
+public sealed class C
+{
+    public void M(int[] arr, int i)
+    {
+        (arr[i], arr[i + 1]) = (1, 2);
+    }
+}");
+
+        Assert.Contains("__decon", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A bare-identifier target that is a FIELD or property is still a storage
+    /// location, not a local, and must not be mistaken for one.
+    /// </summary>
+    [Fact]
+    public void PropertyTarget_KeepsTheDeconLowering()
+    {
+        string printed = Translate(@"
+public sealed class C
+{
+    public int P { get; set; }
+
+    public void M()
+    {
+        (P, _) = (5, 6);
+    }
+}");
+
+        Assert.Contains("__decon", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("P, _ = 5, 6", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// `gsc` will not spread a single tuple-valued right-hand side across N
+    /// targets (GS0167), so a tuple-returning call keeps the decon lowering.
+    /// </summary>
+    [Fact]
+    public void TupleReturningCall_KeepsTheDeconLowering()
+    {
+        string printed = Translate(@"
+public sealed class C
+{
+    private static (int, int) Pair() { return (1, 2); }
+
+    public void M()
+    {
+        int a = 0, b = 0;
+        (a, b) = Pair();
+        System.Console.WriteLine(a + b);
+    }
+}");
+
+        Assert.Contains("__decon", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A mixed declaration (`a, let y = …`) is GS0005 in the native form.
+    /// </summary>
+    [Fact]
+    public void MixedDeclaration_KeepsTheDeconLowering()
+    {
+        string printed = Translate(@"
+public sealed class C
+{
+    public void M()
+    {
+        int a = 0;
+        (a, var y) = (1, 2);
+        System.Console.WriteLine(a + y);
+    }
+}");
+
+        Assert.Contains("__decon", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A nested target tuple has no flat multi-target form.
+    /// </summary>
+    [Fact]
+    public void NestedTargets_KeepTheDeconLowering()
+    {
+        string printed = Translate(@"
+public sealed class C
+{
+    public void M()
+    {
+        int a = 0, b = 0, c = 0;
+        ((a, b), c) = ((1, 2), 3);
+        System.Console.WriteLine(a + b + c);
+    }
+}");
+
+        Assert.Contains("__decon", printed, StringComparison.Ordinal);
+    }
+
+    private static string Translate(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Snippet.cs", "using System;\n\nnamespace Demo\n{\n" + source + "\n}\n") });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: "
+                + string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        string printed = GSharpPrinter.Print(unit);
+
+        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            roundTrip.Success,
+            "Translated G# must round-trip. Errors:\n" + string.Join("\n", roundTrip.Errors)
+                + "\n\nPrinted:\n" + printed);
+
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
@@ -637,10 +637,97 @@ public sealed partial class CSharpToGSharpTranslator
             TupleExpressionSyntax leftTuple,
             ExpressionSyntax right)
         {
+            // Issue #3358: G# has a native multi-target assignment (`a, b = b, a`,
+            // ADR-0015) whose evaluate-all-then-write order is exactly C#'s, so the
+            // common shape needs no temps at all. Tried first; the helper declines
+            // every shape gsc cannot express.
+            if (this.TryLowerNativeMultiAssignment(leftTuple, right, out IReadOnlyList<GStatement> native))
+            {
+                return native;
+            }
+
             var statements = new List<GStatement>();
             Dictionary<ExpressionSyntax, GExpression> captured = this.CaptureDeconstructionStorageTargets(leftTuple, statements);
             this.LowerTuplePattern(leftTuple, this.TranslateExpression(right), forceRealTemps: false, statements, captured);
             return statements;
+        }
+
+        /// <summary>
+        /// Issue #3358: renders a C# deconstruction assignment as G#'s native
+        /// multi-target assignment (<c>a, b = b, a</c>, ADR-0015) when every part
+        /// of the shape is expressible, replacing the
+        /// <c>let (__decon0, __decon1) = …</c> plus per-target-write triple.
+        /// </summary>
+        /// <remarks>
+        /// ADR-0015 evaluates every right-hand expression left-to-right into
+        /// temporaries before any write, then assigns left-to-right — exactly the
+        /// order C# specifies, so an aliasing swap stays correct.
+        /// <para>
+        /// Declines whenever `gsc` cannot express the shape: a storage target
+        /// (<c>arr[i], o.F = …</c>) or a mixed declaration (<c>a, let y = …</c>)
+        /// is GS0005, and a single tuple-valued right-hand side will not unify
+        /// across N targets (<c>a, b = Pair()</c>) — GS0167. A nested target
+        /// tuple has no flat form either. All of those keep the existing
+        /// lowering.
+        /// </para>
+        /// </remarks>
+        /// <param name="leftTuple">The C# deconstruction target tuple.</param>
+        /// <param name="right">The right-hand side.</param>
+        /// <param name="result">The emitted statements when the rewrite applies.</param>
+        /// <returns><see langword="true"/> when the rewrite applied.</returns>
+        private bool TryLowerNativeMultiAssignment(
+            TupleExpressionSyntax leftTuple,
+            ExpressionSyntax right,
+            out IReadOnlyList<GStatement> result)
+        {
+            result = null;
+
+            // The right-hand side must be a tuple LITERAL so it can be split into
+            // one value per target; gsc will not spread a tuple-valued call.
+            ExpressionSyntax unwrappedRight = right;
+            while (unwrappedRight is ParenthesizedExpressionSyntax parenthesized)
+            {
+                unwrappedRight = parenthesized.Expression;
+            }
+
+            if (unwrappedRight is not TupleExpressionSyntax rightTuple
+                || rightTuple.Arguments.Count != leftTuple.Arguments.Count)
+            {
+                return false;
+            }
+
+            // Every target must be a plain identifier or a discard.
+            foreach (ArgumentSyntax argument in leftTuple.Arguments)
+            {
+                ExpressionSyntax target = argument.Expression;
+                if (target is IdentifierNameSyntax identifier)
+                {
+                    if (identifier.Identifier.Text == "_")
+                    {
+                        continue;
+                    }
+
+                    // A write to a FIELD or property — even when spelled as a bare
+                    // identifier — is a storage target, not a local.
+                    if (this.context.GetSymbolInfo(target).Symbol is ILocalSymbol or IParameterSymbol)
+                    {
+                        continue;
+                    }
+                }
+
+                return false;
+            }
+
+            var targets = new List<GExpression>(leftTuple.Arguments.Count);
+            var values = new List<GExpression>(rightTuple.Arguments.Count);
+            for (int i = 0; i < leftTuple.Arguments.Count; i++)
+            {
+                targets.Add(this.TranslateExpression(leftTuple.Arguments[i].Expression));
+                values.Add(this.TranslateExpression(rightTuple.Arguments[i].Expression));
+            }
+
+            result = new GStatement[] { new MultiAssignmentStatement(targets, values) };
+            return true;
         }
 
         // Expression-position deconstruction assignment (`var r = ((x, y) =


### PR DESCRIPTION
Closes #3358. Fifth item from the plan in #3347.

## Before / after

```csharp
(a, b) = (b, a);
```

| Before | After |
|---|---|
| `let (__decon0, __decon1) = (b, a)`<br>`a = __decon0`<br>`b = __decon1` | `a, b = b, a` |

## This corrects a mis-classification in #3347

The report recorded `__deconN` as a **G# language gap** — "G# has no tuple-assignment form". It does:
ADR-0015 has specified Go-style multi-target assignment since Phase 2. cs2gs simply never emitted it.
The native form covers **378 of the 389** deconstruction assignments measured in dotnet/roslyn (97%),
at 6.0/100k LOC there and 71.8/100k here.

## Evaluation order verified at runtime

ADR-0015 evaluates every right-hand expression left-to-right into temporaries *before* any write. That
is exactly C#'s order, and it is the property that makes substituting the native form safe — get it
wrong and an aliasing swap silently produces `x=2 y=2`. Checked rather than assumed:

```
x, y = y, x           ->  x=2 y=1
a, b, c = c, a, b     ->  a=3 b=1 c=2
p, q = p + q, p - q   ->  p=30 q=-10
```

all reading pre-write values.

## Five declines, each tested

| Shape | Why |
|---|---|
| storage targets — `(arr[i], o.F) = …` | GS0005 natively; keeps the lowering **and** its #2234 receiver/index spill that preserves targets-then-value order |
| property/field target spelled as a bare identifier | still a storage location — eligibility checks the resolved symbol is `ILocalSymbol or IParameterSymbol`, not the syntax |
| tuple-returning call — `(a, b) = Pair()` | gsc will not spread one tuple across N targets (GS0167) |
| mixed declaration — `(a, var y) = …` | GS0005 natively |
| nested targets — `((a, b), c) = …` | no flat multi-target form |

## Test updates

Four existing tests asserted the `__deconN` shape for cases now handled natively. I verified each was
an improvement rather than a regression before touching it — the runtime aliasing check above is what
settled it. The parenthesised C# target-tuple form that `FaithfulUnsafeFormTranslationTests` also
guards against remains absent.

`Issue3358NativeMultiAssignmentTranslationTests` (8, new) covers the three native shapes and all five
declines.

Full `Cs2Gs.Tests` locally: **1951 passed, 0 failed**.

## Unrelated bug found while working on this

[#3375](https://github.com/DavidObando/gsharp/issues/3375) — cs2gs emits `func Pair() (int32, int32) -> (1, 2)`
for a C# expression-bodied tuple-returning method, and that form does not parse. Pre-existing, not
touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)