### PR TITLE
Emit native zero for pointer defaults

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
+++ b/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
@@ -175,6 +175,18 @@ internal sealed class ImportedMemberRefFactory
             return this.GetTypeReference(this.emitCtx.CoreStringType);
         }
 
+        // Issue #3285 sibling sweep: an unmanaged pointer used as an array
+        // element must be encoded as a TypeSpec (`PTR T`). A TypeRef whose name
+        // is `System.Int32*` is not a real runtime type and fails to load.
+        if (element is PointerTypeSymbol pointerElement)
+        {
+            var sigBlob = new BlobBuilder();
+            this.signatures.EncodeTypeSymbol(
+                new BlobEncoder(sigBlob).TypeSpecificationSignature(),
+                pointerElement);
+            return this.emitCtx.Metadata.AddTypeSpecification(this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
+        }
+
         if (element is ArrayTypeSymbol nestedArr)
         {
             var sigBlob = new BlobBuilder();

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
@@ -38,14 +38,13 @@ internal sealed partial class MethodBodyEmitter
 
     private void EmitConversion(BoundConversionExpression conv)
     {
-        // ADR-0122 / issues #1014 and #3268: `nil` materialises a null pointer
-        // as a zero native int. Emit it directly (the source `nil` would
-        // otherwise push an object `ldnull`, which is not a pointer value).
-        if (conv.Type is PointerTypeSymbol or FunctionPointerTypeSymbol
-            && conv.Expression.Type == TypeSymbol.Null)
+        // ADR-0122 / issues #1014, #3268, and #3285: `nil` materialises a null
+        // pointer as a zero native int. Emit it directly (the source `nil`
+        // would otherwise push an object `ldnull`, which is not a pointer
+        // value).
+        if (conv.Expression.Type == TypeSymbol.Null
+            && this.TryEmitPointerLikeDefault(conv.Type))
         {
-            this.il.LoadConstantI4(0);
-            this.il.OpCode(ILOpCode.Conv_i);
             return;
         }
 
@@ -1160,6 +1159,14 @@ internal sealed partial class MethodBodyEmitter
     {
         var type = node.Type;
 
+        // Issue #3285: pointer defaults use the same native-int zero as
+        // explicit `nil` conversions. `ldnull` is an object reference and is
+        // invalid when the evaluation-stack slot expects a pointer.
+        if (this.TryEmitPointerLikeDefault(type))
+        {
+            return;
+        }
+
         // Issue #774: a type parameter or erased open generic (e.g. `T` or
         // `List[T]`) may close to either a reference type or a value type
         // at runtime; `ldnull` is invalid for the value-type case. Always
@@ -1204,6 +1211,18 @@ internal sealed partial class MethodBodyEmitter
         this.il.Token(this.outer.memberRefs.GetElementTypeToken(type));
 
         this.il.LoadLocal(slot);
+    }
+
+    private bool TryEmitPointerLikeDefault(TypeSymbol type)
+    {
+        if (type is not PointerTypeSymbol and not FunctionPointerTypeSymbol)
+        {
+            return false;
+        }
+
+        this.il.LoadConstantI4(0);
+        this.il.OpCode(ILOpCode.Conv_i);
+        return true;
     }
 
     /// <summary>

--- a/test/Compiler.Tests/Emit/Issue3285PointerDefaultEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3285PointerDefaultEmitTests.cs
@@ -1,0 +1,241 @@
+// <copyright file="Issue3285PointerDefaultEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>Issue #3285: pointer defaults materialize as native-int zero, never <c>ldnull</c>.</summary>
+public class Issue3285PointerDefaultEmitTests
+{
+    private static readonly string[] UnsafeIlVerifyIgnored =
+    {
+        "UnmanagedPointer",
+        "StackUnexpected",
+        "StackByRef",
+        "ExpectedPtr",
+        "StackUnexpectedArrayType",
+    };
+
+    [Fact]
+    public async Task PointerDefaults_AllSupportedPositions_CompileAndRun()
+    {
+        const string Source = """
+            package Issue3285
+            import System
+
+            struct Point {
+                var X int32
+                var Y int32
+            }
+
+            class RefBox {}
+
+            unsafe class PointerFields {
+                var Raw *int32 = default
+                var Fn *func(int32) int32 = default
+            }
+
+            unsafe func rawOptional(value *int32 = nil) {
+                Console.WriteLine(nint(value))
+            }
+
+            unsafe func fnOptional(value *func(int32) int32 = default(*func(int32) int32)) {
+                Console.WriteLine(nint(value))
+            }
+
+            unsafe func rawDefault() *int32 { return default(*int32) }
+            unsafe func fnDefault() *func(int32) int32 { return default(*func(int32) int32) }
+            unsafe func rawNil() *int32 { return nil }
+            unsafe func fnNil() *func(int32) int32 { return nil }
+            func refDefault() RefBox? { return default(RefBox?) }
+            func nullableDefault() int32? { return default(int32?) }
+            func pointDefault() Point { return default(Point) }
+
+            unsafe {
+                rawOptional()
+                fnOptional()
+
+                var fields = PointerFields()
+                Console.WriteLine(nint(fields.Raw))
+                Console.WriteLine(nint(fields.Fn))
+
+                let rawBare *int32 = default
+                let fnBare *func(int32) int32 = default
+                Console.WriteLine(nint(rawBare))
+                Console.WriteLine(nint(fnBare))
+                Console.WriteLine(nint(rawDefault()))
+                Console.WriteLine(nint(fnDefault()))
+                Console.WriteLine(nint(rawNil()))
+                Console.WriteLine(nint(fnNil()))
+
+                var rawElements = []*int32{default(*int32), default, nil}
+                var fnElements = []*func(int32) int32{default(*func(int32) int32), default, nil}
+                Console.WriteLine(nint(rawElements[0]))
+                Console.WriteLine(nint(rawElements[1]))
+                Console.WriteLine(nint(rawElements[2]))
+                Console.WriteLine(nint(fnElements[0]))
+                Console.WriteLine(nint(fnElements[1]))
+                Console.WriteLine(nint(fnElements[2]))
+
+                var rawZeros = [2]*int32
+                var fnZeros = [2]*func(int32) int32
+                Console.WriteLine(nint(rawZeros[0]))
+                Console.WriteLine(nint(rawZeros[1]))
+                Console.WriteLine(nint(fnZeros[0]))
+                Console.WriteLine(nint(fnZeros[1]))
+
+                Console.WriteLine(refDefault() == nil)
+                Console.WriteLine(nullableDefault() == nil)
+                var point = pointDefault()
+                Console.WriteLine(point.X)
+                var delegateDefault () -> int32 = default(() -> int32)
+                Console.WriteLine(delegateDefault == nil)
+            }
+            """;
+
+        var (output, opcodes) = await CompileInspectAndRun(
+            Source,
+            "rawDefault",
+            "fnDefault",
+            "rawNil",
+            "fnNil",
+            "refDefault");
+
+        Assert.Equal(
+            string.Concat(Enumerable.Repeat($"0{Environment.NewLine}", 20))
+                + $"True{Environment.NewLine}"
+                + $"True{Environment.NewLine}"
+                + $"0{Environment.NewLine}"
+                + $"True{Environment.NewLine}",
+            output);
+
+        var nativeZero = new[] { (byte)ILOpCode.Ldc_i4_0, (byte)ILOpCode.Conv_i, (byte)ILOpCode.Ret };
+        Assert.Equal(nativeZero, opcodes["rawDefault"]);
+        Assert.Equal(nativeZero, opcodes["fnDefault"]);
+        Assert.Equal(nativeZero, opcodes["rawNil"]);
+        Assert.Equal(nativeZero, opcodes["fnNil"]);
+        Assert.Equal(new[] { (byte)ILOpCode.Ldnull, (byte)ILOpCode.Ret }, opcodes["refDefault"]);
+    }
+
+    private static async Task<(string Output, IReadOnlyDictionary<string, byte[]> OpCodes)> CompileInspectAndRun(
+        string source,
+        params string[] methods)
+    {
+        var outputDirectory = Path.Combine(AppContext.BaseDirectory, "issue3285", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(outputDirectory);
+        try
+        {
+            var sourcePath = Path.Combine(outputDirectory, "Program.gs");
+            var outputPath = Path.Combine(outputDirectory, "Issue3285.dll");
+            File.WriteAllText(sourcePath, source);
+
+            using var standardOut = new StringWriter();
+            using var standardError = new StringWriter();
+            var previousOut = Console.Out;
+            var previousError = Console.Error;
+            Console.SetOut(standardOut);
+            Console.SetError(standardError);
+            int exitCode;
+            try
+            {
+                exitCode = Program.Main(new[]
+                {
+                    "/out:" + outputPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    sourcePath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+                Console.SetError(previousError);
+            }
+
+            Assert.True(
+                exitCode == 0,
+                $"gsc failed (exit {exitCode}):\nstdout:\n{standardOut}\nstderr:\n{standardError}");
+
+            var opcodes = methods.ToDictionary(
+                method => method,
+                method => ReadMethodIl(outputPath, method));
+
+            IlVerifier.Verify(outputPath, null, UnsafeIlVerifyIgnored);
+
+            var startInfo = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = outputDirectory,
+            };
+            startInfo.ArgumentList.Add("exec");
+            startInfo.ArgumentList.Add("--runtimeconfig");
+            startInfo.ArgumentList.Add(Path.ChangeExtension(outputPath, ".runtimeconfig.json"));
+            startInfo.ArgumentList.Add(outputPath);
+
+            using var process = Process.Start(startInfo)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec.");
+            var stdoutTask = process.StandardOutput.ReadToEndAsync();
+            var stderrTask = process.StandardError.ReadToEndAsync();
+            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            try
+            {
+                await process.WaitForExitAsync(timeout.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                process.Kill(entireProcessTree: true);
+                Assert.Fail("dotnet exec timed out.");
+            }
+
+            var stdout = await stdoutTask;
+            var stderr = await stderrTask;
+            Assert.True(
+                process.ExitCode == 0,
+                $"sample exited {process.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return (stdout.ReplaceLineEndings(Environment.NewLine), opcodes);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(outputDirectory, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    private static byte[] ReadMethodIl(string assemblyPath, string methodName)
+    {
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+        var metadata = peReader.GetMetadataReader();
+        foreach (var methodHandle in metadata.MethodDefinitions)
+        {
+            var method = metadata.GetMethodDefinition(methodHandle);
+            if (metadata.GetString(method.Name) != methodName || method.RelativeVirtualAddress == 0)
+            {
+                continue;
+            }
+
+            return peReader.GetMethodBody(method.RelativeVirtualAddress).GetILBytes() ?? Array.Empty<byte>();
+        }
+
+        throw new InvalidOperationException($"Method '{methodName}' was not found in '{assemblyPath}'.");
+    }
+}


### PR DESCRIPTION
Fixes #3285.

## Root cause

`EmitConversion` already materialized `nil` for `PointerTypeSymbol` and `FunctionPointerTypeSymbol` as `ldc.i4.0; conv.i`, but `EmitDefault` independently classified ordinary pointers as references and emitted `ldnull`. Omitted optional `*int32 = nil` arguments are synthesized as `BoundDefaultExpression`, so the call site received an object-reference stack value where native int/pointer was required and failed at JIT time.

The required direct-array matrix also exposed a sibling token bug: raw pointer array elements were emitted as a TypeRef named `System.Int32*`, which is not a loadable runtime type. Pointer element tokens now use a `PTR T` TypeSpec.

## Design

Both explicit `nil` conversions and `BoundDefaultExpression` now route through one `TryEmitPointerLikeDefault` helper. It recognizes ordinary and function pointers and emits the canonical native zero once. Reference, nullable-value, struct, type-parameter, and delegate defaults retain their existing paths.

## Runtime matrix

One end-to-end test compiles with `gsc`, runs with `dotnet exec`, asserts exit codes and exact stdout, then supplements runtime evidence with focused IL bytes.

| Position | `*int32` | `*func(int32) int32` |
|---|---|---|
| optional parameter | omitted `= nil` | omitted `= default(*func(...))` |
| field initializer | bare `default` | bare `default` |
| default expressions | bare and `default(*int32)` | bare and `default(*func(...))` |
| explicit nil conversion | return/array element | return/array element |
| explicit array elements | `default(T)`, bare `default`, `nil` | `default(T)`, bare `default`, `nil` |
| zero-initialized array | `[2]*int32` | `[2]*func(int32) int32` |

Controls prove no spillover: class reference default stays null, `int32?` stays missing, struct stays zero-initialized, and structural delegate default stays null.

## Evidence

Before: exact issue repro compiled rc 0, then `dotnet exec` exited 134 with `InvalidProgramException`.

After: same repro compiles rc 0, runs rc 0, exact stdout `0\n`.

Focused IL assertions:

- raw/function pointer `default` and explicit `nil`: `16 d3 2a` (`ldc.i4.0; conv.i; ret`)
- reference default control: `14 2a` (`ldnull; ret`)

ILVerify remains supplemental because unsafe-pointer ignores include the defect's `StackUnexpected` class; runtime execution is the gate.

## Validation

- `dotnet build GSharp.sln -c Release --no-restore --nologo` — 0 warnings, 0 errors
- focused Compiler emit/runtime set — 49 passed
- focused Core default/binder set — 20 passed
- Issue1035 function-pointer runtime tests — 7 passed
- Issue3285 matrix — 1 passed
- manual `gsc` + `dotnet exec` repro — compile rc 0, run rc 0, stdout `0`
