### PR TITLE
Guard the value-type spill on triviality; scrub stale range-slice wording

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2646DeclarationPatternPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2646DeclarationPatternPipelineTests.cs
@@ -89,7 +89,9 @@ public sealed class Issue2646DeclarationPatternPipelineTests
             MigrationPipeline.SanitizeAppId(app.AppId),
             "Program.gs"));
         Assert.Contains("var code int32", translated, StringComparison.Ordinal);
-        Assert.Contains("code = int32(__spill0)", translated, StringComparison.Ordinal);
+        // Issue #3360: `rewriteCode` is a bare local — no spill needed.
+        Assert.Contains("code = int32(rewriteCode)", translated, StringComparison.Ordinal);
+        Assert.DoesNotContain("__spill", translated, StringComparison.Ordinal);
         Assert.DoesNotContain("let code = rewriteCode", translated, StringComparison.Ordinal);
         Assert.DoesNotContain("return rewriteCode", translated, StringComparison.Ordinal);
     }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2646DeclarationPatternTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2646DeclarationPatternTranslationTests.cs
@@ -44,13 +44,21 @@ public sealed class Issue2646DeclarationPatternTranslationTests
             }
             """);
 
-        Assert.Contains("let __spill0 = rewriteCode", printed, StringComparison.Ordinal);
+        // Issue #3360: `rewriteCode` is a bare local, so the scrutinee needs no
+        // spill — it is read twice (guard + narrowing conversion) but is safe to
+        // duplicate. The narrowing SHAPE is unchanged: a separate typed binder
+        // local, so `code` does not depend on flow narrowing surviving this
+        // enclosing try/block, which is the whole point of issue #2646.
+        Assert.DoesNotContain("__spill", printed, StringComparison.Ordinal);
         Assert.Contains("var code int32", printed, StringComparison.Ordinal);
-        Assert.Contains("if __spill0 is int32", printed, StringComparison.Ordinal);
-        Assert.Contains("code = int32(__spill0)", printed, StringComparison.Ordinal);
+        Assert.Contains("if rewriteCode is int32", printed, StringComparison.Ordinal);
+        Assert.Contains("code = int32(rewriteCode)", printed, StringComparison.Ordinal);
         Assert.Contains("return code", printed, StringComparison.Ordinal);
+        // `code` must be its own typed local, not a smart-cast alias of
+        // `rewriteCode` — that is issue #2646's whole point, and it is unchanged.
+        // (The guard now TESTS `rewriteCode` directly rather than a spill temp,
+        // which is issue #3360 and is orthogonal.)
         Assert.DoesNotContain("let code = rewriteCode", printed, StringComparison.Ordinal);
-        Assert.DoesNotContain("if rewriteCode is int32", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("return rewriteCode", printed, StringComparison.Ordinal);
     }
 
@@ -80,7 +88,9 @@ public sealed class Issue2646DeclarationPatternTranslationTests
             """);
 
         Assert.Contains("var code int32", printed, StringComparison.Ordinal);
-        Assert.Contains("code = int32(__spill0)", printed, StringComparison.Ordinal);
+        // Issue #3360: `value` is a bare parameter — no spill needed.
+        Assert.Contains("code = int32(value)", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("__spill", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("return value", printed, StringComparison.Ordinal);
         Assert.Equal(
             $"43{Environment.NewLine}-1",

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3360SpillTrivialityGuardTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3360SpillTrivialityGuardTests.cs
@@ -1,0 +1,130 @@
+// <copyright file="Issue3360SpillTrivialityGuardTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3360: two sites emitted a <c>__spillN</c> temp directly instead of
+/// going through <c>SpillOperand</c>, so they bypassed its
+/// <c>IsTrivialOperand</c> check and spilled even a bare
+/// local/parameter/<c>this</c>/literal — which is safe to duplicate and needs no
+/// temp at all.
+/// <para>
+/// <c>CaptureAssignmentValue</c> is deliberately NOT changed: its temp carries
+/// the CONVERTED assigned value, which a re-read of the target would not
+/// reproduce. It is load-bearing rather than noise.
+/// </para>
+/// </summary>
+public class Issue3360SpillTrivialityGuardTests
+{
+    /// <summary>
+    /// <c>BuildPositiveValueGuardHoist</c>: the scrutinee is read twice — by the
+    /// <c>is</c> guard and by the narrowing conversion — but a bare parameter is
+    /// safe to duplicate.
+    /// </summary>
+    [Fact]
+    public void ValueTypeGuard_TrivialScrutinee_EmitsNoSpill()
+    {
+        string printed = Translate(@"
+public sealed class C
+{
+    public void M(object o)
+    {
+        if (o is int i) { System.Console.WriteLine(i + 1); }
+    }
+}");
+
+        Assert.DoesNotContain("__spill", printed, StringComparison.Ordinal);
+
+        // The narrowing shape itself is unchanged: a separate typed binder local
+        // whose reads do not depend on flow narrowing surviving a try/block.
+        Assert.Contains("var i int32", printed, StringComparison.Ordinal);
+        Assert.Contains("if o is int32", printed, StringComparison.Ordinal);
+        Assert.Contains("i = int32(o)", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A non-trivial scrutinee is read twice by the same shape and still must be
+    /// evaluated exactly once.
+    /// </summary>
+    [Fact]
+    public void ValueTypeGuard_NonTrivialScrutinee_StillSpills()
+    {
+        string printed = Translate(@"
+public sealed class C
+{
+    private static object Get() { return 1; }
+
+    public void M()
+    {
+        if (Get() is int i) { System.Console.WriteLine(i + 1); }
+    }
+}");
+
+        Assert.Contains("__spill", printed, StringComparison.Ordinal);
+
+        // Evaluated exactly once: one declaration site, one call.
+        Assert.Equal(2, CountOccurrences(printed, "Get()"));
+    }
+
+    [Fact]
+    public void ValueTypeGuard_ThisScrutinee_EmitsNoSpill()
+    {
+        string printed = Translate(@"
+public sealed class C
+{
+    public void M()
+    {
+        if (this is object o) { System.Console.WriteLine(o); }
+    }
+}");
+
+        Assert.DoesNotContain("__spill", printed, StringComparison.Ordinal);
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        int count = 0;
+        for (int index = haystack.IndexOf(needle, StringComparison.Ordinal);
+            index >= 0;
+            index = haystack.IndexOf(needle, index + needle.Length, StringComparison.Ordinal))
+        {
+            count++;
+        }
+
+        return count;
+    }
+
+    private static string Translate(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Snippet.cs", "using System;\n\nnamespace Demo\n{\n" + source + "\n}\n") });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: "
+                + string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        string printed = GSharpPrinter.Print(unit);
+
+        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            roundTrip.Success,
+            "Translated G# must round-trip. Errors:\n" + string.Join("\n", roundTrip.Errors)
+                + "\n\nPrinted:\n" + printed);
+
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
@@ -1045,7 +1045,11 @@ public sealed partial class CSharpToGSharpTranslator
 
         // Issue #1731 N1: attribute-argument expressions here can never be an
         // `is`-pattern or a range-slice (i.e. can never reach `SpillOperand`'s
-        // no-seam fallback) — C# requires every attribute argument to be a
+        // no-seam fallback). Since #1896 a range-slice does not spill in ANY
+        // position — the native `recv[start..end]` form embeds each bound once —
+        // so only the `is`-pattern half of this argument still does any work; the
+        // range-slice half is kept because it remains true and costs nothing.
+        // C# requires every attribute argument to be a
         // compile-time constant (or a `typeof`/array of constants), and
         // neither an `is` pattern-match nor a `x[a..b]` range-slice is ever a
         // constant expression. So the double-evaluation gap this file

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.ControlFlow.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.ControlFlow.cs
@@ -307,7 +307,7 @@ public sealed partial class CSharpToGSharpTranslator
         private void HoistLoopConditionClause(ExpressionSyntax clause, List<GStatement> into)
         {
             // Any spill hoisted while translating `clause` (issue #1731 — e.g. a
-            // non-trivial pattern scrutinee or range-slice start nested inside the
+            // non-trivial pattern scrutinee nested inside the
             // condition) must land in `into`, which runs at the START of each loop
             // iteration — NOT in the enclosing loop STATEMENT's own prologue (that
             // would evaluate the operand once, before the loop, instead of once
@@ -651,13 +651,33 @@ public sealed partial class CSharpToGSharpTranslator
             GTypeReference targetType,
             GExpression receiver)
         {
-            string spillName = $"__spill{this.state.SpillCounter++}";
-            var spill = new IdentifierExpression(spillName);
-            var hoist = new LocalDeclarationStatement(
-                BindingKind.Let,
-                spillName,
-                type: null,
-                initializer: receiver);
+            // Issue #3360: only a non-trivial receiver needs spilling. The
+            // scrutinee is read twice below — once by the `is` guard and once by
+            // the narrowing conversion — but a bare local/parameter/`this`/literal
+            // is safe to duplicate, so spilling it only adds a `__spillN` nobody
+            // needs. This mirrors `SpillOperand`'s own `IsTrivialOperand` check,
+            // which this site bypassed by emitting the temp directly.
+            //
+            // The temp is NOT named after the C# binder (as
+            // `HoistLoopConditionClauseCore` does): that name is already taken by
+            // the typed binder local below. Collapsing the two into one smart-cast
+            // local would free the name, but the separate typed local is
+            // deliberate — see this method's summary — so that binder reads do not
+            // depend on flow narrowing surviving an enclosing try/block.
+            GExpression scrutinee = receiver;
+            LocalDeclarationStatement hoist = null;
+            if (!IsTrivialOperand(receiver))
+            {
+                string spillName = $"__spill{this.state.SpillCounter++}";
+                scrutinee = new IdentifierExpression(spillName);
+                hoist = new LocalDeclarationStatement(
+                    BindingKind.Let,
+                    spillName,
+                    type: null,
+                    initializer: receiver);
+            }
+
+            GExpression spill = scrutinee;
             var binder = new LocalDeclarationStatement(BindingKind.Var, localName, targetType);
             var guard = new BinaryExpression(spill, "is", new TypeExpression(targetType));
 
@@ -679,12 +699,15 @@ public sealed partial class CSharpToGSharpTranslator
                     ? this.TranslateIf(elseIf)
                     : this.TranslateStatementAsBlock(ifStatement.Else.Statement);
 
-            return new GStatement[]
+            var statements = new List<GStatement>();
+            if (hoist != null)
             {
-                hoist,
-                binder,
-                new IfStatement(guard, new BlockStatement(thenStatements), elseBranch),
-            };
+                statements.Add(hoist);
+            }
+
+            statements.Add(binder);
+            statements.Add(new IfStatement(guard, new BlockStatement(thenStatements), elseBranch));
+            return statements;
         }
 
         /// <summary>

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
@@ -1075,7 +1075,7 @@ public sealed partial class CSharpToGSharpTranslator
             }
 
             string message =
-                "a non-trivial pattern-scrutinee/range-slice operand here has no enclosing statement to host a " +
+                "a non-trivial pattern-scrutinee operand here has no enclosing statement to host a " +
                 "single-evaluation spill (a field/property initializer or a base(...)/this(...) constructor " +
                 "argument has no G# lowering for this yet); it is embedded as-is, which re-evaluates it if it " +
                 "is read more than once (issue #1731 N1).";
@@ -1085,7 +1085,7 @@ public sealed partial class CSharpToGSharpTranslator
 
         // Issue #1849: translates `expression` at a null-seam site (a field/
         // property initializer) so that a non-trivial `is`-pattern scrutinee or
-        // range-slice start operand nested inside it is evaluated exactly once
+        // operand nested inside it is evaluated exactly once
         // even though the site has no statement to host a spill `let`. When a
         // spill seam IS active (this null-seam site is unreachable, or is
         // nested inside one some other way), translation proceeds exactly as
@@ -1101,7 +1101,7 @@ public sealed partial class CSharpToGSharpTranslator
         // rewritten to call it, passing the captured operands (translated in
         // their original left-to-right order) as arguments. Each captured
         // operand is thus evaluated exactly once, by the CALLER, before the
-        // helper runs the pattern/range-slice logic against the parameter.
+        // helper runs the pattern logic against the parameter.
         private GExpression TranslateNullSeamExpression(ExpressionSyntax expression, INamedTypeSymbol containingType)
         {
             if (this.state.PendingSpillPrologue != null)
@@ -1226,7 +1226,7 @@ public sealed partial class CSharpToGSharpTranslator
         // <see cref="TranslateNullSeamArgument"/>). If translating `translate`
         // captured no NEW (non-pre-seeded) operand, the pre-seed is discarded and
         // the translated expression is returned unchanged — the common case:
-        // most initializers/arguments contain no non-trivial pattern/range-slice
+        // most initializers/arguments contain no non-trivial pattern
         // operand at all, so no helper is warranted just because the expression
         // happens to read a constructor parameter. Otherwise a private static
         // helper taking every capture (pre-seeded passthroughs plus newly
@@ -1271,7 +1271,7 @@ public sealed partial class CSharpToGSharpTranslator
             // argument expression this helper will be invoked with) can itself
             // reference a sibling capture's synthesized parameter name — this
             // happens when a null-seam operand is ITSELF nested inside another
-            // null-seam operand (e.g. a range-slice start spilled inside an
+            // null-seam operand (e.g. an operand spilled inside an
             // is-pattern scrutinee that is also spilled: `Y[Z()..a] is [1,2]`).
             // The inner spill's `__pN` placeholder only exists as a PARAMETER
             // inside this helper's own body — it is not in scope at the call

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -828,6 +828,15 @@ public sealed partial class CSharpToGSharpTranslator
             GExpression receiver,
             ExpressionSyntax receiverSyntax)
         {
+            // Issue #3360 considered adding an `IsTrivialOperand` guard here, as at
+            // `BuildPositiveValueGuardHoist`. It would be WRONG. `IsTrivialOperand`
+            // answers "is this safe to DUPLICATE", but the temp here exists for
+            // CAPTURE TIMING: a C# method group evaluates its receiver immediately
+            // and captures that value, whereas a G# lambda closing over the
+            // variable would re-read it at invocation. For a receiver that is
+            // reassigned between the method-group conversion and the call, those
+            // differ — and a bare identifier is exactly the shape that can be
+            // reassigned. The temp is load-bearing, like `CaptureAssignmentValue`'s.
             if (this.state.PendingSpillPrologue != null)
             {
                 string temp = $"__spill{this.state.SpillCounter++}";

--- a/tools/cs2gs/Cs2Gs.Translator/DocumentTranslationState.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/DocumentTranslationState.cs
@@ -170,7 +170,7 @@ internal sealed class DocumentTranslationState
 
     // The active statement-seam prologue (issue #1731): several lowerings
     // (lock targets, chained-assignment link targets, non-trivial pattern
-    // scrutinees, range-slice start operands) must embed the SAME translated
+    // scrutinees) must embed the SAME translated
     // operand at more than one output position; naively reusing the operand's
     // node would print — and so re-evaluate — it once per embed. `SpillOperand`
     // hoists such an operand into a fresh `let` appended here, evaluated
@@ -219,7 +219,7 @@ internal sealed class DocumentTranslationState
     // non-trivial operand is recorded here as a would-be synthetic helper
     // parameter (name + translated operand + resolved type) and replaced
     // with a bare reference to that parameter, so the surrounding
-    // pattern/range-slice lowering is unaffected — it just ends up reading a
+    // pattern lowering is unaffected — it just ends up reading a
     // parameter instead of a spilled local. The caller then synthesizes a
     // private static helper method taking these captures as parameters and
     // rewrites the null-seam expression into a call to it, passing the


### PR DESCRIPTION
Closes #3360 and #3361. Items six and seven from the plan in #3347, combined — both are small cs2gs
hygiene changes in the same area and the diff separates cleanly.

## #3360 — triviality guard

`BuildPositiveValueGuardHoist` emitted a `__spillN` directly instead of going through
`SpillOperand`, bypassing its `IsTrivialOperand` check.

| C# | Before | After |
|---|---|---|
| `if (o is int i)` | `let __spill0 = o` + guard | no spill — `if o is int32` directly |
| `if (Get() is int i)` | spills | still spills (`Get()` appears exactly twice) |

The narrowing **shape** is untouched — still a separate typed binder local, so binder reads don't
depend on flow narrowing surviving an enclosing `try`/block. That is issue #2646's invariant and it
was worth preserving: #2646's own scenario is inside a `try`.

### Two things deliberately not done

**Not renamed after the C# binder**, as the issue suggested. That name is already taken by the typed
binder local. Freeing it means collapsing to a single smart-cast local — exactly the shape #2646
avoids. Recorded in a comment.

**`CaptureMethodGroupReceiver` keeps its unconditional temp.** I applied the same guard there first,
and it is wrong. `IsTrivialOperand` answers *"safe to duplicate"*, but that temp exists for **capture
timing**: a C# method group evaluates its receiver immediately and captures that value, whereas a G#
lambda closing over the variable re-reads it at invocation. Identical only if the receiver is never
reassigned — and a bare identifier is precisely the shape that can be. `Issue2821` caught it;
reverted, with the reasoning left in the code so it is not re-added.

So `CaptureAssignmentValue` and `CaptureMethodGroupReceiver` are both documented as deliberately
unguarded, for different reasons — converted value, and capture timing.

## #3361 — stale wording

Eight range-slice mentions removed, including the **user-visible `Unsupported` diagnostic string**.
Range slices have not spilled since #1896 replaced the `.Slice` desugaring with the native
`recv[start..end]` form.

Three mentions in `Constructors.cs` are **kept**: they argue that an attribute argument must be a
compile-time constant and neither an `is`-pattern nor a range-slice is one — still true. A clarifier
notes range-slices no longer spill at all, so a future reader grepping for stale wording doesn't
delete a valid safety argument.

## Tests

`Issue3360SpillTrivialityGuardTests` (3, new) — trivial parameter and `this` receivers emit no spill;
a non-trivial receiver still spills and is evaluated exactly once.

Four existing tests asserted the old `__spillN` for now-trivial scrutinees and are updated. One
carried a `DoesNotContain("if rewriteCode is int32")` that this contradicts — #2646's actual
invariant (`code` is its own typed local, not a smart-cast alias) is still asserted by its
neighbours, and the removal is explained in place.

Full `Cs2Gs.Tests` locally: **1954 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)