### PR TITLE
Reject impossible string conversions before emit

### DIFF
--- a/docs/adr/0099-lsp-nil-quick-fixes.md
+++ b/docs/adr/0099-lsp-nil-quick-fixes.md
@@ -19,7 +19,7 @@ operators through correctly:
 | ---- | ----------- | ------- |
 | `GS0154` | `DiagnosticBag.ReportWrongArgumentType` | An argument of type `T?` was passed to a parameter declared `T`. |
 | `GS0155` | `DiagnosticBag.ReportCannotConvert` | An expression of type `T?` was used where `T` was required (assignment, return value, conditional arm, …). |
-| `GS0156` | `DiagnosticBag.ReportCannotConvertImplicitly` | Same as GS0155 but reported from an implicit-conversion context (typically nullable→non-nullable). |
+| `GS0156` | `DiagnosticBag.ReportCannotConvertImplicitly` | Same as GS0155, but the classifier proved an explicit conversion exists. |
 | `GS0158` | `DiagnosticBag.ReportUnableToFindMember` | A member access `a.b` did not find `b`; when the receiver is `T?` the binder reports this rather than a dedicated "deref of nullable" message — the `Nullable<T>` projection for value types and the NRT receiver path both flow here. |
 | `GS0274` | `DiagnosticBag.ReportNilNotAssignableToNonNullableParameter` | A literal `nil` was passed to a non-nullable parameter. |
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -117,8 +117,8 @@ IDs may be given as `GS0001`, `0001`, or the bare integer `1`; all three forms a
 | GS0152 | Error | Type argument does not satisfy constraint. | `f[MyStruct]()` where `MyStruct` does not implement the required interface constraint. |
 | GS0153 | Error | Constraint is neither an interface nor a class. | A generic type-parameter constraint must be an interface (any interface — sealed or not, generic or not;) or a base class; a value type such as a struct or enum is rejected. |
 | GS0154 | Error | Wrong argument type. | A positional argument's type does not match the parameter type. |
-| GS0155 | Error | Cannot convert type. | An explicit cast between incompatible types. |
-| GS0156 | Error | Cannot convert implicitly. | The source value is not implicitly compatible with the required target type; provide a value of the target type instead. |
+| GS0155 | Error | Cannot convert type. | No built-in or user-defined conversion exists; use a compatible value or an API that performs the transformation (for example, `Parse`/`TryParse` for text). |
+| GS0156 | Error | Cannot convert implicitly; explicit conversion exists. | `var x int32 = 3.14` — write `var x int32 = int32(3.14)` to apply the available explicit conversion. |
 | GS0157 | Error | Cannot find type (possibly missing import). | A package-qualified type name that resolves to nothing. |
 | GS0158 | Error | Cannot find member. | A field or property access that does not resolve. |
 | GS0159 | Error | Cannot resolve function call. | A function name does not resolve, or its nullable receiver lacks valid non-null narrowing. |

--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -811,13 +811,8 @@ public sealed class Conversion
             return Conversion.Explicit;
         }
 
-        if (from == TypeSymbol.String)
-        {
-            if (to == TypeSymbol.Bool || to == TypeSymbol.Int32)
-            {
-                return Conversion.Explicit;
-            }
-        }
+        // Issue #3288: parsing text is not an explicit CLR conversion.
+        // String-to-primitive code must use Parse/TryParse instead.
 
         // Issues #3245/#3246: the legacy builtin `string(T)` conversion
         // ("any value backed by a CLR type converts to string via

--- a/src/Core/CodeAnalysis/DiagnosticDescriptors.cs
+++ b/src/Core/CodeAnalysis/DiagnosticDescriptors.cs
@@ -72,7 +72,7 @@ internal static class DiagnosticDescriptors
     internal static readonly DiagnosticDescriptor ConstraintNotInterface = new("GS0153", DiagnosticSeverity.Error, "Type '{0}' cannot be used as a type-parameter constraint because it is neither an interface nor a class.");
     internal static readonly DiagnosticDescriptor WrongArgumentType = new("GS0154", DiagnosticSeverity.Error, "Parameter '{0}' requires a value of type '{1}' but was given a value of type '{2}'.");
     internal static readonly DiagnosticDescriptor CannotConvert = new("GS0155", DiagnosticSeverity.Error, "Cannot convert type '{0}' to '{1}'.");
-    internal static readonly DiagnosticDescriptor CannotConvertImplicitly = new("GS0156", DiagnosticSeverity.Error, "Cannot convert type '{0}' to '{1}'. Provide a value of type '{1}' instead.");
+    internal static readonly DiagnosticDescriptor CannotConvertImplicitly = new("GS0156", DiagnosticSeverity.Error, "Cannot convert type '{0}' to '{1}'. An explicit conversion exists (are you missing a cast?)");
     internal static readonly DiagnosticDescriptor UnableToFindType = new("GS0157", DiagnosticSeverity.Error, "Cannot find type {0}. Are you missing an import?");
     internal static readonly DiagnosticDescriptor UnableToFindMember = new("GS0158", DiagnosticSeverity.Error, "Cannot find member {0}.");
     internal static readonly DiagnosticDescriptor UnableToFindFunction = new("GS0159", DiagnosticSeverity.Error, "{0}");

--- a/test/Compiler.Tests/Emit/Issue3288ImpossibleExplicitConversionTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3288ImpossibleExplicitConversionTests.cs
@@ -151,6 +151,39 @@ public sealed class Issue3288ImpossibleExplicitConversionTests
     }
 
     [Fact]
+    public void NullableToUnderlying_Gs0156CastGuidance_IsProvablyActionable()
+    {
+        const string invalidSource = """
+            let nullableValue int32? = 42
+            let value int32 = nullableValue
+            """;
+        var diagnostic = Assert.Single(GetErrors(invalidSource));
+
+        Assert.Equal("GS0156", diagnostic.Id);
+        Assert.Equal(
+            "Cannot convert type 'int32?' to 'int32'. An explicit conversion exists (are you missing a cast?)",
+            diagnostic.Message);
+        Assert.Equal(1, diagnostic.Location.StartLine);
+        Assert.Equal(18, diagnostic.Location.StartCharacter);
+        Assert.Equal(1, diagnostic.Location.EndLine);
+        Assert.Equal(31, diagnostic.Location.EndCharacter);
+        Assert.Equal("nullableValue", diagnostic.Location.Text.ToString(diagnostic.Location.Span));
+
+        var remedy = CompileAndRun("""
+            package Issue3288NullableGuidance
+            import System
+
+            let nullableValue int32? = 42
+            Console.WriteLine(int32(nullableValue))
+            """);
+
+        Assert.Equal(0, remedy.CompileExitCode);
+        Assert.Equal(0, remedy.RunExitCode);
+        Assert.Equal($"42{Environment.NewLine}", remedy.Stdout);
+        Assert.Equal(string.Empty, remedy.Stderr);
+    }
+
+    [Fact]
     public void LegalConversionLattice_CompilesAndRuns()
     {
         var result = CompileAndRun("""

--- a/test/Compiler.Tests/Emit/Issue3288ImpossibleExplicitConversionTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3288ImpossibleExplicitConversionTests.cs
@@ -1,0 +1,314 @@
+// <copyright file="Issue3288ImpossibleExplicitConversionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #3288: impossible string-to-primitive conversions are rejected by
+/// binding instead of reaching the emitter as GS9998.
+/// </summary>
+[Collection("ConsoleIo")]
+public sealed class Issue3288ImpossibleExplicitConversionTests
+{
+    public static TheoryData<string, string, string, int, int, int, int, string> InvalidConversions => new()
+    {
+        {
+            "int32(\"wrong\")",
+            "GS0155",
+            "Cannot convert type 'string' to 'int32'.",
+            0,
+            6,
+            0,
+            13,
+            "\"wrong\""
+        },
+        {
+            "bool(\"true\")",
+            "GS0155",
+            "Cannot convert type 'string' to 'bool'.",
+            0,
+            5,
+            0,
+            11,
+            "\"true\""
+        },
+        {
+            "func Id[T](value T) T -> value\nId[int32](\"wrong\")",
+            "GS0154",
+            "Parameter 'value' requires a value of type 'int32' but was given a value of type 'string'.",
+            1,
+            10,
+            1,
+            17,
+            "\"wrong\""
+        },
+        {
+            "class Box { func Id[T](value T) T -> value }\nBox().Id[int32](\"wrong\")",
+            "GS0155",
+            "Cannot convert type 'string' to 'int32'.",
+            1,
+            16,
+            1,
+            23,
+            "\"wrong\""
+        },
+        {
+            "func (self string) Id[T](value T) T -> value\n\"receiver\".Id[int32](\"wrong\")",
+            "GS0155",
+            "Cannot convert type 'string' to 'int32'.",
+            1,
+            21,
+            1,
+            28,
+            "\"wrong\""
+        },
+    };
+
+    [Theory]
+    [MemberData(nameof(InvalidConversions))]
+    public void ImpossibleConversions_ReportUserDiagnosticsAtOperand(
+        string source,
+        string expectedId,
+        string expectedMessage,
+        int startLine,
+        int startCharacter,
+        int endLine,
+        int endCharacter,
+        string coveredText)
+    {
+        var diagnostic = Assert.Single(GetErrors(source));
+
+        Assert.Equal(expectedId, diagnostic.Id);
+        Assert.Equal(expectedMessage, diagnostic.Message);
+        Assert.Equal(startLine, diagnostic.Location.StartLine);
+        Assert.Equal(startCharacter, diagnostic.Location.StartCharacter);
+        Assert.Equal(endLine, diagnostic.Location.EndLine);
+        Assert.Equal(endCharacter, diagnostic.Location.EndCharacter);
+        Assert.Equal(coveredText, diagnostic.Location.Text.ToString(diagnostic.Location.Span));
+    }
+
+    [Fact]
+    public void Classifier_SeparatesParsingFromRealExplicitConversions()
+    {
+        var dayOfWeek = TypeSymbol.FromClrType(typeof(DayOfWeek));
+        var disposable = TypeSymbol.FromClrType(typeof(IDisposable));
+        var nullableInt64 = NullableTypeSymbol.Get(TypeSymbol.Int64);
+        var nullableInt32 = NullableTypeSymbol.Get(TypeSymbol.Int32);
+
+        Assert.False(Conversion.Classify(TypeSymbol.String, TypeSymbol.Int32).Exists);
+        Assert.False(Conversion.Classify(TypeSymbol.String, TypeSymbol.Bool).Exists);
+        Assert.False(Conversion.Classify(disposable, TypeSymbol.Int32).Exists);
+        Assert.True(Conversion.Classify(TypeSymbol.Float64, TypeSymbol.Int32).IsExplicit);
+        Assert.True(Conversion.Classify(TypeSymbol.Int32, TypeSymbol.Int64).IsImplicit);
+        Assert.True(Conversion.Classify(dayOfWeek, TypeSymbol.Int32).IsExplicit);
+        Assert.True(Conversion.Classify(TypeSymbol.Int32, dayOfWeek).IsExplicit);
+        Assert.True(Conversion.Classify(TypeSymbol.String, TypeSymbol.Object).IsImplicit);
+        Assert.True(Conversion.Classify(TypeSymbol.Int32, TypeSymbol.Object).IsImplicit);
+        Assert.True(Conversion.Classify(TypeSymbol.Object, TypeSymbol.Int32).IsExplicit);
+        Assert.True(Conversion.Classify(nullableInt64, nullableInt32).IsExplicit);
+    }
+
+    [Fact]
+    public void Gs0156_CastGuidance_IsProvablyActionable()
+    {
+        const string invalidSource = "let value int32 = 3.14";
+        var diagnostic = Assert.Single(GetErrors(invalidSource));
+
+        Assert.Equal("GS0156", diagnostic.Id);
+        Assert.Equal(
+            "Cannot convert type 'float64' to 'int32'. An explicit conversion exists (are you missing a cast?)",
+            diagnostic.Message);
+        Assert.Equal(0, diagnostic.Location.StartLine);
+        Assert.Equal(18, diagnostic.Location.StartCharacter);
+        Assert.Equal(0, diagnostic.Location.EndLine);
+        Assert.Equal(22, diagnostic.Location.EndCharacter);
+        Assert.Equal("3.14", diagnostic.Location.Text.ToString(diagnostic.Location.Span));
+
+        var remedy = CompileAndRun("""
+            package Issue3288Guidance
+            import System
+
+            Console.WriteLine(int32(3.14))
+            """);
+
+        Assert.Equal(0, remedy.CompileExitCode);
+        Assert.Equal(0, remedy.RunExitCode);
+        Assert.Equal($"3{Environment.NewLine}", remedy.Stdout);
+        Assert.Equal(string.Empty, remedy.Stderr);
+    }
+
+    [Fact]
+    public void LegalConversionLattice_CompilesAndRuns()
+    {
+        var result = CompileAndRun("""
+            package Issue3288Controls
+            import System
+
+            enum Shade { Zero, One, Two }
+
+            struct Wrapped { var Value int32 }
+            func operator explicit (value int32) Wrapped {
+                return Wrapped{Value: value}
+            }
+
+            func CastClass[T class](value object) T -> T(value)
+            func CastStruct[T struct](value object) T -> T(value)
+            func Box[T](value T) object -> object(value)
+            func Narrow(value int64?) int32? -> int32?(value)
+
+            let widened int64 = 7
+            let boxed = Box[int32](8)
+            let nullableSource int64? = 9
+            let nullableValue = Narrow(nullableSource)
+            let referenced object = "reference"
+
+            Console.WriteLine(int32(3.14))
+            Console.WriteLine(widened)
+            Console.WriteLine(boxed.GetType())
+            Console.WriteLine(int32(boxed))
+            Console.WriteLine(int32(Shade.Two))
+            Console.WriteLine(Shade(1))
+            Console.WriteLine(nullableValue!!)
+            Console.WriteLine(Wrapped(10).Value)
+            Console.WriteLine(CastStruct[int32](object(11)))
+            Console.WriteLine(CastClass[string](referenced))
+            Console.WriteLine(int32.Parse("42"))
+
+            let wrongBox object = "wrong"
+            try {
+                Console.WriteLine(int32(wrongBox))
+            } catch (e InvalidCastException) {
+                Console.WriteLine(e.GetType().Name)
+            }
+            """);
+
+        Assert.Equal(0, result.CompileExitCode);
+        Assert.Equal(0, result.RunExitCode);
+        Assert.Equal(
+            string.Join(
+                Environment.NewLine,
+                "3",
+                "7",
+                "System.Int32",
+                "8",
+                "2",
+                "1",
+                "9",
+                "10",
+                "11",
+                "reference",
+                "42",
+                "InvalidCastException") + Environment.NewLine,
+            result.Stdout);
+        Assert.Equal(string.Empty, result.Stderr);
+    }
+
+    private static Diagnostic[] GetErrors(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source, "Issue3288.gs"));
+        var compilation = new Compilation(tree);
+        using var peStream = new MemoryStream();
+        return compilation.Emit(peStream).Diagnostics
+            .Where(diagnostic => diagnostic.IsError)
+            .ToArray();
+    }
+
+    private static (int CompileExitCode, int RunExitCode, string Stdout, string Stderr) CompileAndRun(string source)
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            "issue3288",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+
+        try
+        {
+            var sourcePath = Path.Combine(directory, "test.gs");
+            var assemblyPath = Path.Combine(directory, "test.dll");
+            File.WriteAllText(sourcePath, source);
+
+            using var compilerStdout = new StringWriter();
+            using var compilerStderr = new StringWriter();
+            var previousOut = Console.Out;
+            var previousError = Console.Error;
+            Console.SetOut(compilerStdout);
+            Console.SetError(compilerStderr);
+            int compileExitCode;
+            try
+            {
+                compileExitCode = Program.Main(new[]
+                {
+                    "/out:" + assemblyPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    sourcePath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+                Console.SetError(previousError);
+            }
+
+            if (compileExitCode != 0)
+            {
+                return (
+                    compileExitCode,
+                    -1,
+                    compilerStdout.ToString(),
+                    compilerStderr.ToString());
+            }
+
+            IlVerifier.Verify(assemblyPath);
+
+            var startInfo = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = directory,
+            };
+            startInfo.ArgumentList.Add("exec");
+            startInfo.ArgumentList.Add("--runtimeconfig");
+            startInfo.ArgumentList.Add(Path.ChangeExtension(assemblyPath, ".runtimeconfig.json"));
+            startInfo.ArgumentList.Add(assemblyPath);
+
+            using var process = Process.Start(startInfo)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec.");
+            var stdout = process.StandardOutput.ReadToEnd();
+            var stderr = process.StandardError.ReadToEnd();
+            Assert.True(process.WaitForExit(30_000), "dotnet exec timed out.");
+            return (
+                compileExitCode,
+                process.ExitCode,
+                stdout.ReplaceLineEndings(Environment.NewLine),
+                stderr.ReplaceLineEndings(Environment.NewLine));
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2851GenericDiagnosticDisplayTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2851GenericDiagnosticDisplayTests.cs
@@ -213,10 +213,10 @@ public class Issue2851GenericDiagnosticDisplayTests
         Assert.Collection(
             bag,
             diagnostic => Assert.Equal(
-                "Cannot convert type 'Box[int32]' to 'Box[int32]?'. Provide a value of type 'Box[int32]?' instead.",
+                "Cannot convert type 'Box[int32]' to 'Box[int32]?'. An explicit conversion exists (are you missing a cast?)",
                 diagnostic.Message),
             diagnostic => Assert.Equal(
-                "Cannot convert type 'Conv[int32]?' to 'Conv[int32]'. Provide a value of type 'Conv[int32]' instead.",
+                "Cannot convert type 'Conv[int32]?' to 'Conv[int32]'. An explicit conversion exists (are you missing a cast?)",
                 diagnostic.Message));
     }
 
@@ -232,7 +232,7 @@ public class Issue2851GenericDiagnosticDisplayTests
 
         var diagnostic = Assert.Single(bag);
         Assert.Equal(
-            "Cannot convert type 'System.Collections.Generic.List[int32]' to 'string'. Provide a value of type 'string' instead.",
+            "Cannot convert type 'System.Collections.Generic.List[int32]' to 'string'. An explicit conversion exists (are you missing a cast?)",
             diagnostic.Message);
     }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2947ImportedNestedGenericTypeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2947ImportedNestedGenericTypeTests.cs
@@ -51,7 +51,7 @@ public class Issue2947ImportedNestedGenericTypeTests
                 var error = Assert.Single(errors);
                 Assert.Equal("GS0156", error.Id);
                 Assert.Equal(
-                    "Cannot convert type 'glib.Outer[T].Color' to 'int32'. Provide a value of type 'int32' instead.",
+                    "Cannot convert type 'glib.Outer[T].Color' to 'int32'. An explicit conversion exists (are you missing a cast?)",
                     error.Message);
 
                 var function = compilation.BoundProgram.Functions.Keys.Single(symbol => symbol.Name == "Take");
@@ -82,7 +82,7 @@ public class Issue2947ImportedNestedGenericTypeTests
             Assert.Equal(
                 new[]
                 {
-                    "Cannot convert type 'glib.Outer[T].Color' to 'int32'. Provide a value of type 'int32' instead.",
+                    "Cannot convert type 'glib.Outer[T].Color' to 'int32'. An explicit conversion exists (are you missing a cast?)",
                 },
                 runtimeErrors.Select(diagnostic => diagnostic.Message));
         }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3267ExplicitGenericArgumentValidationTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3267ExplicitGenericArgumentValidationTests.cs
@@ -37,7 +37,7 @@ public class Issue3267ExplicitGenericArgumentValidationTests
             }
             Box().Id[int32]("wrong")
             """,
-            "GS0156",
+            "GS0155",
             "\"wrong\""
         },
         {
@@ -45,7 +45,7 @@ public class Issue3267ExplicitGenericArgumentValidationTests
             func (self string) IdExt[T](value T) T -> value
             "receiver".IdExt[int32]("wrong")
             """,
-            "GS0156",
+            "GS0155",
             "\"wrong\""
         },
         {
@@ -176,7 +176,7 @@ public class Issue3267ExplicitGenericArgumentValidationTests
     }
 
     [Fact]
-    public void ExplicitGenericArgumentMismatch_RecommendsCompatibleValue()
+    public void ExplicitGenericArgumentMismatch_ReportsNoConversion()
     {
         const string source = """
             class Box {
@@ -188,7 +188,7 @@ public class Issue3267ExplicitGenericArgumentValidationTests
         var diagnostic = Assert.Single(GetErrors(source));
 
         Assert.Equal(
-            "Cannot convert type 'string' to 'int32'. Provide a value of type 'int32' instead.",
+            "Cannot convert type 'string' to 'int32'.",
             diagnostic.Message);
     }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3282GenericInferenceArgumentValidationTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3282GenericInferenceArgumentValidationTests.cs
@@ -123,7 +123,7 @@ public class Issue3282GenericInferenceArgumentValidationTests
             }
             Box().Show(131, "str")
             """,
-            "GS0156",
+            "GS0155",
             "\"str\""
         },
         {
@@ -135,7 +135,7 @@ public class Issue3282GenericInferenceArgumentValidationTests
             func (self string) Show(a int32, b int32) { }
             "receiver".Show(131, "str")
             """,
-            "GS0156",
+            "GS0155",
             "\"str\""
         },
     };
@@ -229,7 +229,7 @@ public class Issue3282GenericInferenceArgumentValidationTests
     }
 
     [Fact]
-    public void ConflictingInstanceInference_RecommendsCompatibleValue()
+    public void ConflictingInstanceInference_ReportsNoConversion()
     {
         const string source = """
             class Box {
@@ -241,7 +241,7 @@ public class Issue3282GenericInferenceArgumentValidationTests
         var diagnostic = Assert.Single(GetErrors(source));
 
         Assert.Equal(
-            "Cannot convert type 'string' to 'int32'. Provide a value of type 'int32' instead.",
+            "Cannot convert type 'string' to 'int32'.",
             diagnostic.Message);
     }
 

--- a/test/Interpreter.Tests/Issue2947ImportedNestedGenericDriverTests.cs
+++ b/test/Interpreter.Tests/Issue2947ImportedNestedGenericDriverTests.cs
@@ -78,8 +78,8 @@ public class Issue2947ImportedNestedGenericDriverTests
 
     private static readonly string[] ExpectedDiagnostics =
     {
-        "Cannot convert type 'glib.Outer[T].Color?' to 'glib.Outer[T].Color'. Provide a value of type 'glib.Outer[T].Color' instead.",
-        "Cannot convert type 'glib.Outer[T].Color' to 'int32'. Provide a value of type 'int32' instead.",
+        "Cannot convert type 'glib.Outer[T].Color?' to 'glib.Outer[T].Color'. An explicit conversion exists (are you missing a cast?)",
+        "Cannot convert type 'glib.Outer[T].Color' to 'int32'. An explicit conversion exists (are you missing a cast?)",
     };
 
     [Fact]

--- a/website/docs/ref/diagnostics.md
+++ b/website/docs/ref/diagnostics.md
@@ -117,8 +117,8 @@ IDs may be given as `GS0001`, `0001`, or the bare integer `1`; all three forms a
 | GS0152 | Error | Type argument does not satisfy constraint. | `f[MyStruct]()` where `MyStruct` does not implement the required interface constraint. |
 | GS0153 | Error | Constraint is neither an interface nor a class. | A generic type-parameter constraint must be an interface (any interface — sealed or not, generic or not;) or a base class; a value type such as a struct or enum is rejected. |
 | GS0154 | Error | Wrong argument type. | A positional argument's type does not match the parameter type. |
-| GS0155 | Error | Cannot convert type. | An explicit cast between incompatible types. |
-| GS0156 | Error | Cannot convert implicitly. | The source value is not implicitly compatible with the required target type; provide a value of the target type instead. |
+| GS0155 | Error | Cannot convert type. | No built-in or user-defined conversion exists; use a compatible value or an API that performs the transformation (for example, `Parse`/`TryParse` for text). |
+| GS0156 | Error | Cannot convert implicitly; explicit conversion exists. | `var x int32 = 3.14` — write `var x int32 = int32(3.14)` to apply the available explicit conversion. |
 | GS0157 | Error | Cannot find type (possibly missing import). | A package-qualified type name that resolves to nothing. |
 | GS0158 | Error | Cannot find member. | A field or property access that does not resolve. |
 | GS0159 | Error | Cannot resolve function call. | A function name does not resolve, or its nullable receiver lacks valid non-null narrowing. |


### PR DESCRIPTION
Fixes #3288

## Root cause

`Conversion.Classify` marked `string -> bool` and `string -> int32` as explicit conversions. Binding therefore accepted constructor-style casts such as `int32("wrong")`, but emitter had no lowering for that invented conversion and reported internal diagnostic GS9998.

## Fix

- Remove false `string -> bool/int32` classifier rule. Parsing text is API behavior (`Parse`/`TryParse`), not CLR conversion.
- Let existing binder contract handle missing conversions: GS0155 after symbolic/CLR user-defined conversions and structural projection have all failed; argument-specific free generic calls retain GS0154.
- Keep emitter unchanged. No catch, fallback, or masking of GS9998.
- Restore GS0156 cast guidance because that branch is reached only when classifier proved `conversion.IsExplicit` and context disallows explicit conversion.
- Update diagnostic docs and affected exact-message tests.

## Diagnostic evidence

Coordinates below are zero-based and tests also assert exact sliced source text:

| Form | Diagnostic | Span | Covered text |
| --- | --- | --- | --- |
| `int32("wrong")` | GS0155: `Cannot convert type 'string' to 'int32'.` | `0:6-0:13` | `"wrong"` |
| `bool("true")` | GS0155: `Cannot convert type 'string' to 'bool'.` | `0:5-0:11` | `"true"` |
| `Id[int32]("wrong")` | GS0154: `Parameter 'value' requires a value of type 'int32' but was given a value of type 'string'.` | `1:10-1:17` | `"wrong"` |
| instance generic | GS0155 | `1:16-1:23` | `"wrong"` |
| extension generic | GS0155 | `1:21-1:28` | `"wrong"` |
| nullable `int32? -> int32` assignment | GS0156: `Cannot convert type 'int32?' to 'int32'. An explicit conversion exists (are you missing a cast?)` | `1:18-1:31` | `nullableValue` |

No case reaches GS9998.

## Conversion-lattice controls

Runtime oracle covers:

- numeric narrowing (`int32(3.14)`) and widening
- enum/numeric conversions
- string non-conversion plus `int32.Parse("42")`
- reference widening
- boxing/unboxing
- nullable numeric conversion
- user-defined explicit operator
- class- and struct-constrained `object -> T` casts
- valid runtime casts that may throw (`InvalidCastException` remains observable)

Compiler rc: `0`. `dotnet exec` rc: `0`. Exact stdout:

```text
3
7
System.Int32
8
2
1
9
10
11
reference
42
InvalidCastException
```

GS0156 remediation is separately proved end-to-end: `let value int32 = 3.14` reports GS0156 over `3.14`; replacing value with `int32(3.14)` compiles, executes with rc `0`, and prints exactly `3`.

ADR-0099 nullable shape is also pinned: implicit `int32? -> int32` assignment reports GS0156 over exact text `nullableValue`; `int32(nullableValue)` compiles, executes with rc `0`, and prints exactly `42`.

## Validation

- Regression tests: 9/9 passed; prior old-classifier mutation reproduced GS9998/GS0156 before the fix.
- Affected binding tests: 106/106 passed.
- Affected interpreter tests: 9/9 passed.
- Broader focused conversion tests: Core 142/142; Compiler 99/99.
- LSP nullable conversion code-action test: 1/1 passed.
- Release CI solution build: 0 warnings, 0 errors.
- `git diff --check`: clean.
- GitHub Actions: all required build, docs, test, e2e, nullable-hygiene, and ILVerify checks passed.
