### PR TITLE
Report the emitted G# line in compile triage, or say why not

### DIFF
--- a/tools/cs2gs/Cs2Gs.Pipeline/CompileStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/CompileStage.cs
@@ -124,6 +124,88 @@ public sealed class CompileStage : IMigrationStage
     /// Maps a set of parsed error-severity diagnostics into triage artifacts,
     /// shared by both the gsc-direct and <c>--via-sdk</c> compile paths.
     /// </summary>
+    /// <summary>
+    /// Resolves the <c>.gs</c> file a gsc diagnostic points at, so the triage
+    /// artifact can quote the emitted line (see <c>TriageBuilder.CompileError</c>).
+    /// </summary>
+    /// <remarks>
+    /// Matching has to cope with two diagnostic shapes. Direct gsc invocation
+    /// reports an absolute path; the <c>--via-sdk</c> path routes through MSBuild,
+    /// which may report a path relative to the project directory and appends a
+    /// <c>[project.gsproj]</c> suffix that the parser leaves on the MESSAGE, not
+    /// the file.
+    /// <para>
+    /// Issue #3347: a basename collision across sibling projects — common in a
+    /// repository-layout run, where <c>EmittedFiles</c> also carries referenced
+    /// projects' files — used to make the ambiguous case return null, which
+    /// silently degraded every downstream field. The app's OWN files are now
+    /// preferred before falling back to siblings.
+    /// </para>
+    /// </remarks>
+    /// <param name="files">The emitted files for this app, plus referenced siblings.</param>
+    /// <param name="diagnosticFile">The file path as reported by gsc or MSBuild.</param>
+    /// <returns>The matching file, or <see langword="null"/> when it cannot be resolved.</returns>
+    internal static EmittedGsFile MatchEmittedFile(IReadOnlyList<EmittedGsFile> files, string diagnosticFile)
+    {
+        if (files is null || files.Count == 0)
+        {
+            return null;
+        }
+
+        if (!string.IsNullOrEmpty(diagnosticFile))
+        {
+            string diagnosticFullPath = Path.GetFullPath(diagnosticFile);
+            EmittedGsFile exactMatch = files.FirstOrDefault(f =>
+                string.Equals(Path.GetFullPath(f.GsPath), diagnosticFullPath, StringComparison.OrdinalIgnoreCase));
+            if (exactMatch is not null)
+            {
+                return exactMatch;
+            }
+
+            // A relative path from MSBuild resolves against cs2gs's working
+            // directory above, which is not the project directory — so compare
+            // path SUFFIXES too. `/a/b/Foo/Bar.gs` matches a reported `Foo/Bar.gs`.
+            string normalizedDiagnostic = NormalizeSeparators(diagnosticFile);
+            EmittedGsFile[] suffixMatches = files
+                .Where(f => NormalizeSeparators(f.GsPath)
+                    .EndsWith(normalizedDiagnostic, StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+            EmittedGsFile suffixMatch = PreferOwnProject(suffixMatches);
+            if (suffixMatch is not null)
+            {
+                return suffixMatch;
+            }
+
+            string name = Path.GetFileName(diagnosticFile);
+            EmittedGsFile[] matches = files.Where(f =>
+                string.Equals(Path.GetFileName(f.GsPath), name, StringComparison.OrdinalIgnoreCase)).ToArray();
+            EmittedGsFile nameMatch = PreferOwnProject(matches);
+            if (nameMatch is not null)
+            {
+                return nameMatch;
+            }
+        }
+
+        return files.Count == 1 ? files[0] : null;
+    }
+
+    // A basename can collide across sibling projects. The app's own files are the
+    // only ones charged against it (a sibling's error is measured in its own run),
+    // so prefer those; a remaining ambiguity is genuinely unresolvable.
+    private static EmittedGsFile PreferOwnProject(EmittedGsFile[] candidates)
+    {
+        if (candidates.Length == 1)
+        {
+            return candidates[0];
+        }
+
+        EmittedGsFile[] own = candidates.Where(f => !f.IsFromReferencedProject).ToArray();
+        return own.Length == 1 ? own[0] : null;
+    }
+
+    private static string NormalizeSeparators(string path) =>
+        path.Replace('\\', '/');
+
     private static StageOutcome BuildFailureOutcome(
         StageExecutionContext context, IReadOnlyList<GscDiagnostic> errors, string syntheticMessageOnNoDiagnostics)
     {
@@ -258,30 +340,6 @@ public sealed class CompileStage : IMigrationStage
         return Directory.EnumerateFiles(runtimeDir, "*.dll", SearchOption.TopDirectoryOnly)
             .OrderBy(p => p, StringComparer.Ordinal)
             .ToList();
-    }
-
-    private static EmittedGsFile MatchEmittedFile(IReadOnlyList<EmittedGsFile> files, string diagnosticFile)
-    {
-        if (!string.IsNullOrEmpty(diagnosticFile))
-        {
-            string diagnosticFullPath = Path.GetFullPath(diagnosticFile);
-            EmittedGsFile exactMatch = files.FirstOrDefault(f =>
-                string.Equals(Path.GetFullPath(f.GsPath), diagnosticFullPath, StringComparison.OrdinalIgnoreCase));
-            if (exactMatch is not null)
-            {
-                return exactMatch;
-            }
-
-            string name = Path.GetFileName(diagnosticFile);
-            EmittedGsFile[] matches = files.Where(f =>
-                string.Equals(Path.GetFileName(f.GsPath), name, StringComparison.OrdinalIgnoreCase)).ToArray();
-            if (matches.Length == 1)
-            {
-                return matches[0];
-            }
-        }
-
-        return files.Count == 1 ? files[0] : null;
     }
 
     private static string Truncate(string value)

--- a/tools/cs2gs/Cs2Gs.Pipeline/TriageBuilder.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TriageBuilder.cs
@@ -20,6 +20,15 @@ namespace Cs2Gs.Pipeline;
 /// </summary>
 public sealed class TriageBuilder
 {
+    /// <summary>
+    /// Stands in for the emitted G# line when the diagnostic's file cannot be
+    /// resolved back to an <c>EmittedGsFile</c>. Explicit rather than silently
+    /// substituting the diagnostic message, so a lookup failure is visible in the
+    /// report instead of masquerading as source (issue #3347).
+    /// </summary>
+    internal const string UnresolvedEmittedLine =
+        "<emitted G# line unavailable: diagnostic file did not resolve to an emitted .gs>";
+
     private const int SnippetMaxLength = 160;
 
     // The leading identifier/keyword token of a (trimmed) line — the position
@@ -255,8 +264,15 @@ public sealed class TriageBuilder
             throw new ArgumentNullException(nameof(diagnostic));
         }
 
+        // Issue #3347: when the emitted file cannot be resolved, say so. This used
+        // to fall back to `diagnostic.Message`, which put the DIAGNOSTIC TEXT in
+        // the "Offending line" field — indistinguishable from a real source line
+        // to anyone reading the report, and the reason a whole oahu triage cycle
+        // showed no usable source at all. An explicit marker keeps the failure
+        // visible instead of plausible.
         string snippet = file is null ? null : LineAt(file.GSharpSource, diagnostic.Line);
         string kind = ClassifyGsLine(snippet);
+        string offendingLine = snippet ?? UnresolvedEmittedLine;
 
         var artifact = this.NewArtifact(MigrationStageKind.Compile, TriageCategory.CompileError);
         artifact.Diagnostic = new TriageDiagnostic
@@ -277,8 +293,13 @@ public sealed class TriageBuilder
         artifact.OffendingCSharpConstruct = new TriageOffendingConstruct
         {
             Kind = kind,
-            Snippet = Truncate(snippet ?? diagnostic.Message),
+            Snippet = Truncate(offendingLine),
         };
+
+        // The fingerprint deliberately keeps using the diagnostic message rather
+        // than the marker: the marker is a constant, so hashing it would make
+        // every unresolved artifact identical. (Message normalization still
+        // dedups genuinely-similar diagnostics — see issue #1750.)
         artifact.Fingerprint = Fingerprint.Compute(
             artifact.Category,
             artifact.Stage,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3347TriageEmittedLineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3347TriageEmittedLineTests.cs
@@ -1,0 +1,135 @@
+// <copyright file="Issue3347TriageEmittedLineTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3347: a compile-error triage artifact must quote the EMITTED G# line
+/// the diagnostic points at, and must say so plainly when it cannot.
+/// <para>
+/// Working through the oahu gate, every failing app reported the diagnostic
+/// MESSAGE in the "Offending line" field and left "Emitted G#" blank — because
+/// the file lookup returned null and <c>CompileError</c> silently substituted
+/// <c>diagnostic.Message</c>. Indistinguishable from a real source line to
+/// anyone reading the report, and it made four CI round-trips necessary to find
+/// what one local run would have shown.
+/// </para>
+/// </summary>
+public class Issue3347TriageEmittedLineTests
+{
+    private const string GsSource = "func F() {\n    let x = broken(\n}\n";
+
+    private static TriageBuilder NewBuilder() =>
+        new TriageBuilder("run_1", "2026-08-11T00:00:00Z", "0.3.0+abc", "src/App/App.csproj");
+
+    /// <summary>
+    /// The resolved case: the artifact quotes the emitted line, not the message.
+    /// </summary>
+    [Fact]
+    public void ResolvedFile_QuotesTheEmittedLine()
+    {
+        var emitted = new EmittedGsFile(
+            "/abs/migrated/src/App/Program.gs", "src_App/Program.gs", "/abs/src/App/Program.cs", GsSource);
+        var diagnostic = new GscDiagnostic(
+            "GS0100", "some diagnostic text", "error", "/abs/migrated/src/App/Program.gs", 2, 13);
+
+        TriageArtifact artifact = NewBuilder().CompileError(diagnostic, emitted);
+
+        Assert.Contains("let x = broken(", artifact.OffendingCSharpConstruct.Snippet, StringComparison.Ordinal);
+        Assert.DoesNotContain("some diagnostic text", artifact.OffendingCSharpConstruct.Snippet, StringComparison.Ordinal);
+        Assert.Equal("src_App/Program.gs", artifact.SourceLocation.GsFile);
+    }
+
+    /// <summary>
+    /// The unresolved case must be self-describing rather than silently
+    /// substituting the diagnostic message.
+    /// </summary>
+    [Fact]
+    public void UnresolvedFile_SaysSo_RatherThanQuotingTheMessage()
+    {
+        var diagnostic = new GscDiagnostic(
+            "GS0100", "some diagnostic text", "error", "/abs/migrated/src/App/Program.gs", 2, 13);
+
+        TriageArtifact artifact = NewBuilder().CompileError(diagnostic, file: null);
+
+        Assert.Contains(
+            "emitted G# line unavailable",
+            artifact.OffendingCSharpConstruct.Snippet,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("some diagnostic text", artifact.OffendingCSharpConstruct.Snippet, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The <c>--via-sdk</c> path routes gsc through MSBuild, which may report a
+    /// path relative to the project directory. Resolving that against cs2gs's
+    /// working directory does not match, so the matcher compares path suffixes.
+    /// </summary>
+    [Fact]
+    public void ProjectRelativeDiagnosticPath_Resolves()
+    {
+        var emitted = new EmittedGsFile(
+            "/abs/migrated/src/App/Auxiliary/Helper.gs",
+            "src_App/Auxiliary/Helper.gs",
+            "/abs/src/App/Auxiliary/Helper.cs",
+            GsSource);
+
+        EmittedGsFile match = CompileStage.MatchEmittedFile(
+            new[] { emitted }, "Auxiliary/Helper.gs");
+
+        Assert.Same(emitted, match);
+    }
+
+    /// <summary>
+    /// An absolute path from a direct gsc invocation resolves exactly.
+    /// </summary>
+    [Fact]
+    public void AbsoluteDiagnosticPath_Resolves()
+    {
+        var emitted = new EmittedGsFile(
+            "/abs/migrated/src/App/Program.gs", "src_App/Program.gs", "/abs/src/App/Program.cs", GsSource);
+
+        EmittedGsFile match = CompileStage.MatchEmittedFile(
+            new[] { emitted }, "/abs/migrated/src/App/Program.gs");
+
+        Assert.Same(emitted, match);
+    }
+
+    /// <summary>
+    /// A basename shared with a referenced sibling project used to make the
+    /// lookup ambiguous and return null, which silently degraded the whole
+    /// artifact. The app's own file wins.
+    /// </summary>
+    [Fact]
+    public void BasenameCollidingWithSibling_PrefersTheAppsOwnFile()
+    {
+        var own = new EmittedGsFile(
+            "/abs/migrated/src/App/Extensions.gs", "src_App/Extensions.gs", "/abs/a.cs", GsSource);
+        var sibling = new EmittedGsFile(
+            "/abs/migrated/src/Other/Extensions.gs", "src_Other/Extensions.gs", "/abs/b.cs", GsSource)
+        {
+            IsFromReferencedProject = true,
+        };
+
+        EmittedGsFile match = CompileStage.MatchEmittedFile(new[] { sibling, own }, "Extensions.gs");
+
+        Assert.Same(own, match);
+    }
+
+    /// <summary>
+    /// A genuinely ambiguous basename — two of the app's OWN files — stays
+    /// unresolved rather than guessing, which the explicit marker then reports.
+    /// </summary>
+    [Fact]
+    public void AmbiguousBasenameAcrossOwnFiles_StaysUnresolved()
+    {
+        var first = new EmittedGsFile("/abs/a/Shared.gs", "app/a/Shared.gs", "/abs/a.cs", GsSource);
+        var second = new EmittedGsFile("/abs/b/Shared.gs", "app/b/Shared.gs", "/abs/b.cs", GsSource);
+
+        Assert.Null(CompileStage.MatchEmittedFile(new[] { first, second }, "Shared.gs"));
+    }
+}


### PR DESCRIPTION
Refs #3347. The tooling fix requested while working through the spill plan.

## Why

Working the oahu gate on #3349, every failing app's triage artifact showed this:

```
- Diagnostic: `GS0155` — Cannot convert type 'string?' to 'string'. [.../Oahu.Foundation.gsproj]
- Emitted G#: `` (27,16)
- Offending line: `Cannot convert type 'string?' to 'string'. [.../Oahu.Foundation.gsproj]`
```

"Offending line" is the **diagnostic message**, not source — indistinguishable from a real line to a
reader. That is why four CI round-trips (~30 min each) produced no usable source, and the fix each
time had to be inferred from error text plus a line number, or by cloning the corpus locally.

The cause is `CompileError`'s `snippet ?? diagnostic.Message` fallback, which fires whenever
`MatchEmittedFile` cannot resolve the diagnostic's file back to an emitted `.gs`.

## Changes

**The fallback is explicit.** An unresolved line now reads
`<emitted G# line unavailable: diagnostic file did not resolve to an emitted .gs>`. A lookup failure
is visible rather than plausible.

The **fingerprint** deliberately keeps using the message: the marker is a constant, so hashing it
would make every unresolved artifact identical.

**`MatchEmittedFile` handles the shapes it actually sees.** Direct gsc invocation reports an absolute
path; `--via-sdk` routes through MSBuild, which may report a path relative to the project directory —
resolving that against cs2gs's working directory does not match, so suffix comparison is added. A
basename shared with a referenced sibling project (common in a repository-layout run, where
`EmittedFiles` carries siblings) now prefers the app's own file instead of giving up.

## Honesty about the root cause

The sibling-basename collision is my best hypothesis for the original oahu failure, **not a confirmed
diagnosis** — the report does not record the raw diagnostic path, and I did not reproduce it. What is
certain is the symptom and its mechanism. The explicit marker means a recurrence announces itself
instead of masquerading as content.

I also dropped a claim I had been making: that the fallback poisoned the fingerprint and collapsed
unrelated errors onto one hash. Writing the test disproved it — `Fingerprint.Compute` normalizes
messages by design (#1750), and oahu's 15 apps genuinely shared two root causes in a common project,
so the repeated hashes were correct.

## Tests

`Issue3347TriageEmittedLineTests` (6, new). `MatchEmittedFile` is made `internal` (the project
already has `InternalsVisibleTo`) so the tests exercise the real matcher — an earlier draft
reimplemented its suffix rule locally and would have passed with the production code deleted.

- artifact quotes the emitted line when resolved; says so plainly when not
- absolute path resolves; project-relative path resolves
- sibling-basename collision prefers the app's own file
- genuinely ambiguous basename stays unresolved rather than guessing

Targeted classes pass locally. The full `Cs2Gs.Tests` run hit the known pre-existing MSB4166 host
crash rather than any test failure, so the full suite is left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)