### PR TITLE
Unify rejected call argument diagnostics

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -116,8 +116,8 @@ IDs may be given as `GS0001`, `0001`, or the bare integer `1`; all three forms a
 | GS0151 | Error | Type argument inference failed. | The compiler could not infer a type argument from the call arguments. |
 | GS0152 | Error | Type argument does not satisfy constraint. | `f[MyStruct]()` where `MyStruct` does not implement the required interface constraint. |
 | GS0153 | Error | Constraint is neither an interface nor a class. | A generic type-parameter constraint must be an interface (any interface — sealed or not, generic or not;) or a base class; a value type such as a struct or enum is rejected. |
-| GS0154 | Error | Wrong argument type. | A positional argument's type does not match the parameter type. |
-| GS0155 | Error | Cannot convert type. | No built-in or user-defined conversion exists; use a compatible value or an API that performs the transformation (for example, `Parse`/`TryParse` for text). |
+| GS0154 | Error | Wrong argument type. | A free, instance, extension, or shared call argument has no permitted conversion to its parameter type. |
+| GS0155 | Error | Cannot convert type. | Outside call-argument matching, no built-in or user-defined conversion exists; use a compatible value or an API that performs the transformation (for example, `Parse`/`TryParse` for text). |
 | GS0156 | Error | Cannot convert implicitly; explicit conversion exists. | `var x int32 = 3.14` — write `var x int32 = int32(3.14)` to apply the available explicit conversion. |
 | GS0157 | Error | Cannot find type (possibly missing import). | A package-qualified type name that resolves to nothing. |
 | GS0158 | Error | Cannot find member. | A field or property access that does not resolve. |

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -254,7 +254,7 @@ internal sealed class ConversionClassifier
     /// <summary>
     /// Binds <paramref name="syntax"/> as an expression and converts it to
     /// <paramref name="type"/>. Mirrors the
-    /// <see cref="BindConversion(TextLocation, BoundExpression, TypeSymbol, bool)"/>
+    /// <see cref="BindConversion(TextLocation, BoundExpression, TypeSymbol, bool, ParameterSymbol)"/>
     /// core overload after delegating to the still-on-<see cref="Binder"/>
     /// expression-binder for the initial bind.
     /// </summary>
@@ -361,8 +361,15 @@ internal sealed class ConversionClassifier
     /// <param name="allowExplicit">When <see langword="true"/>, suppresses
     /// the "implicit conversion required" diagnostic for an explicit-only
     /// classification.</param>
+    /// <param name="callParameter">The target parameter when binding a call
+    /// argument; supplies the call-specific GS0154 diagnostic contract.</param>
     /// <returns>The shaped bound expression.</returns>
-    public BoundExpression BindConversion(TextLocation diagnosticLocation, BoundExpression expression, TypeSymbol type, bool allowExplicit = false)
+    public BoundExpression BindConversion(
+        TextLocation diagnosticLocation,
+        BoundExpression expression,
+        TypeSymbol type,
+        bool allowExplicit = false,
+        ParameterSymbol? callParameter = null)
     {
         // Issue #1238: a deferred target-typed conditional/if/switch argument
         // placeholder (a BoundErrorExpression retaining the branchy syntax,
@@ -462,7 +469,19 @@ internal sealed class ConversionClassifier
 
         if (HasDelegateParameterRefKindMismatch(type, expression))
         {
-            Diagnostics.ReportCannotConvert(diagnosticLocation, expression.Type, type);
+            if (callParameter == null)
+            {
+                Diagnostics.ReportCannotConvert(diagnosticLocation, expression.Type, type);
+            }
+            else
+            {
+                ReportCallArgumentConversionFailure(
+                    diagnosticLocation,
+                    callParameter,
+                    type,
+                    expression.Type);
+            }
+
             return new BoundErrorExpression(expression.Syntax);
         }
 
@@ -486,7 +505,7 @@ internal sealed class ConversionClassifier
             var shaped = createErasedFunctionLiteralAdapter(neverCandidateLiteral, neverTargetFnType);
             if (!ReferenceEquals(shaped, neverCandidateLiteral))
             {
-                return BindConversion(diagnosticLocation, shaped, type, allowExplicit);
+                return BindConversion(diagnosticLocation, shaped, type, allowExplicit, callParameter);
             }
         }
 
@@ -510,7 +529,7 @@ internal sealed class ConversionClassifier
             var voidized = createErasedFunctionLiteralAdapter(voidCandidateLiteral, voidTargetFnType);
             if (!ReferenceEquals(voidized, voidCandidateLiteral))
             {
-                return BindConversion(diagnosticLocation, voidized, type, allowExplicit);
+                return BindConversion(diagnosticLocation, voidized, type, allowExplicit, callParameter);
             }
         }
 
@@ -537,7 +556,7 @@ internal sealed class ConversionClassifier
             var widened = createErasedFunctionLiteralAdapter(widenCandidateLiteral, widenTargetFnType);
             if (!ReferenceEquals(widened, widenCandidateLiteral))
             {
-                return BindConversion(diagnosticLocation, widened, type, allowExplicit);
+                return BindConversion(diagnosticLocation, widened, type, allowExplicit, callParameter);
             }
         }
 
@@ -605,7 +624,18 @@ internal sealed class ConversionClassifier
                 }
                 else
                 {
-                    Diagnostics.ReportCannotConvert(diagnosticLocation, sourceType, targetType);
+                    if (callParameter == null)
+                    {
+                        Diagnostics.ReportCannotConvert(diagnosticLocation, sourceType, targetType);
+                    }
+                    else
+                    {
+                        ReportCallArgumentConversionFailure(
+                            diagnosticLocation,
+                            callParameter,
+                            targetType,
+                            sourceType);
+                    }
                 }
             }
 
@@ -614,7 +644,18 @@ internal sealed class ConversionClassifier
 
         if (!allowExplicit && conversion.IsExplicit)
         {
-            Diagnostics.ReportCannotConvertImplicitly(diagnosticLocation, expression.Type, type);
+            if (callParameter == null)
+            {
+                Diagnostics.ReportCannotConvertImplicitly(diagnosticLocation, expression.Type, type);
+            }
+            else
+            {
+                ReportCallArgumentConversionFailure(
+                    diagnosticLocation,
+                    callParameter,
+                    type,
+                    expression.Type);
+            }
         }
 
         if (conversion.IsIdentity)
@@ -1095,7 +1136,7 @@ internal sealed class ConversionClassifier
     /// declared parameter type is reachable only through a user-defined CLR
     /// <c>op_Implicit</c> (e.g. <c>[]T -&gt; System.ReadOnlySpan[T]</c> /
     /// <c>Span[T]</c>) is converted here, the same way local-init / explicit-
-    /// target conversions go through <see cref="BindConversion(TextLocation, BoundExpression, TypeSymbol, bool)"/>.
+    /// target conversions go through <see cref="BindConversion(TextLocation, BoundExpression, TypeSymbol, bool, ParameterSymbol)"/>.
     /// Built-in conversions (identity, numeric widening, ...) classify
     /// earlier and never reach this fallback, so existing overloads keep
     /// selecting unchanged. Returns true and emits a
@@ -1941,8 +1982,24 @@ internal sealed class ConversionClassifier
             }
         }
 
-        return BindConversion(location, argument, expectedType);
+        return BindConversion(location, argument, expectedType, callParameter: parameter);
     }
+
+    /// <summary>Reports a rejected call argument through the shared GS0154 contract.</summary>
+    /// <param name="location">The offending argument's location.</param>
+    /// <param name="parameter">The target parameter.</param>
+    /// <param name="expectedType">The substituted parameter type.</param>
+    /// <param name="actualType">The argument type.</param>
+    public void ReportCallArgumentConversionFailure(
+        TextLocation location,
+        ParameterSymbol parameter,
+        TypeSymbol expectedType,
+        TypeSymbol actualType)
+        => Diagnostics.ReportWrongArgumentType(
+            location,
+            parameter.Name,
+            expectedType,
+            actualType);
 
     // ----- Optional / default-value argument shaping -----
 

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Arguments.cs
@@ -324,7 +324,7 @@ internal sealed partial class OverloadResolver
     /// site. When <paramref name="argument"/> is a constant integer expression
     /// whose value fits the (possibly narrower or cross-sign) integer parameter
     /// type <paramref name="parameterType"/>, re-materialise it as a literal of
-    /// exactly that type through <see cref="ConversionClassifier.BindConversion(TextLocation, BoundExpression, TypeSymbol, bool)"/>
+    /// exactly that type through <see cref="ConversionClassifier.BindConversion(TextLocation, BoundExpression, TypeSymbol, bool, ParameterSymbol)"/>
     /// — mirroring the declaration/assignment behaviour (ADR-0129) so call sites
     /// accept e.g. <c>f(5)</c> for a <c>uint16</c>/<c>uint32</c> parameter the same
     /// way <c>var x uint16 = 5</c> already does. Returns <see langword="true"/>

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
@@ -1740,9 +1740,9 @@ internal sealed partial class OverloadResolver
 
                 if (argument.Type != TypeSymbol.Error)
                 {
-                    Diagnostics.ReportWrongArgumentType(
+                    conversions.ReportCallArgumentConversionFailure(
                         Invariant.Required(parameterSyntax[i], "an argument with a conversion error has source syntax").Location,
-                        parameter.Name,
+                        parameter,
                         targetType,
                         argument.Type);
                 }

--- a/test/Compiler.Tests/Emit/Issue2669GenericClosureInvokeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2669GenericClosureInvokeEmitTests.cs
@@ -131,7 +131,7 @@ public class Issue2669GenericClosureInvokeEmitTests
         var result = compilation.Emit(output, pdbStream: null, refStream: null, assemblyName: "Issue2669.Negative");
 
         Assert.False(result.Success);
-        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0155");
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0154");
     }
 
     private static string CompileAndRun(string source, string caseName)

--- a/test/Compiler.Tests/Emit/Issue3288ImpossibleExplicitConversionTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3288ImpossibleExplicitConversionTests.cs
@@ -57,8 +57,8 @@ public sealed class Issue3288ImpossibleExplicitConversionTests
         },
         {
             "class Box { func Id[T](value T) T -> value }\nBox().Id[int32](\"wrong\")",
-            "GS0155",
-            "Cannot convert type 'string' to 'int32'.",
+            "GS0154",
+            "Parameter 'value' requires a value of type 'int32' but was given a value of type 'string'.",
             1,
             16,
             1,
@@ -67,8 +67,8 @@ public sealed class Issue3288ImpossibleExplicitConversionTests
         },
         {
             "func (self string) Id[T](value T) T -> value\n\"receiver\".Id[int32](\"wrong\")",
-            "GS0155",
-            "Cannot convert type 'string' to 'int32'.",
+            "GS0154",
+            "Parameter 'value' requires a value of type 'int32' but was given a value of type 'string'.",
             1,
             21,
             1,

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1238ConditionalArgumentTargetTypingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1238ConditionalArgumentTargetTypingTests.cs
@@ -181,7 +181,7 @@ class C {
     }
 }
 ";
-        Assert.Contains(EmitDiagnostics(Source), d => d.IsError && d.Id == "GS0155");
+        Assert.Contains(EmitDiagnostics(Source), d => d.IsError && d.Id == "GS0154");
     }
 
     [Fact]

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1248GenericUpcastBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1248GenericUpcastBinderTests.cs
@@ -137,7 +137,7 @@ class C {
     }
 
     [Fact]
-    public void WrongTypeArgument_StillDiagnosticGS0155()
+    public void WrongTypeArgument_UsesCallArgumentDiagnostic()
     {
         // Negative: TransformBase[int64, int64] is NOT a FilterBase[int32].
         var source = @"
@@ -152,11 +152,11 @@ class C {
 }
 ";
         var result = Evaluate(source);
-        Assert.Contains(result.Diagnostics, d => d.Id == "GS0155");
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0154");
     }
 
     [Fact]
-    public void WrongTypeArgument_FlowingParameter_StillDiagnosticGS0155()
+    public void WrongTypeArgument_FlowingParameter_UsesCallArgumentDiagnostic()
     {
         // Negative: the FLOWING parameter is wrong (string instead of int32),
         // even though the non-flowing TOut happens to be int32.
@@ -172,11 +172,11 @@ class C {
 }
 ";
         var result = Evaluate(source);
-        Assert.Contains(result.Diagnostics, d => d.Id == "GS0155");
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0154");
     }
 
     [Fact]
-    public void UnrelatedType_StillDiagnosticGS0155()
+    public void UnrelatedType_UsesCallArgumentDiagnostic()
     {
         // Negative: an unrelated class is not a FilterBase at all.
         var source = @"
@@ -190,7 +190,7 @@ class C {
 }
 ";
         var result = Evaluate(source);
-        Assert.Contains(result.Diagnostics, d => d.Id == "GS0155");
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0154");
     }
 
     [Fact]

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1250GenericMemberSubstitutionBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1250GenericMemberSubstitutionBinderTests.cs
@@ -225,7 +225,7 @@ class C {
     }
 
     [Fact]
-    public void WrongTypeArgument_StillDiagnosticGS0155()
+    public void WrongTypeArgument_UsesCallArgumentDiagnostic()
     {
         // Negative: Box[int32].Put expects Holder[int32]; passing Holder[string]
         // must still fail even though the display name 'Holder' matches.
@@ -240,7 +240,7 @@ class C {
 }
 ";
         var result = Evaluate(source);
-        Assert.Contains(result.Diagnostics, d => d.Id == "GS0155");
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0154");
     }
 
     [Fact]

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3267ExplicitGenericArgumentValidationTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3267ExplicitGenericArgumentValidationTests.cs
@@ -37,7 +37,7 @@ public class Issue3267ExplicitGenericArgumentValidationTests
             }
             Box().Id[int32]("wrong")
             """,
-            "GS0155",
+            "GS0154",
             "\"wrong\""
         },
         {
@@ -45,7 +45,7 @@ public class Issue3267ExplicitGenericArgumentValidationTests
             func (self string) IdExt[T](value T) T -> value
             "receiver".IdExt[int32]("wrong")
             """,
-            "GS0155",
+            "GS0154",
             "\"wrong\""
         },
         {
@@ -79,7 +79,7 @@ public class Issue3267ExplicitGenericArgumentValidationTests
             func (self string) TakeExt[T](values []T) { }
             "receiver".TakeExt[int32]([]string{"wrong"})
             """,
-            "GS0155",
+            "GS0154",
             "[]string{\"wrong\"}"
         },
     };
@@ -176,7 +176,7 @@ public class Issue3267ExplicitGenericArgumentValidationTests
     }
 
     [Fact]
-    public void ExplicitGenericArgumentMismatch_ReportsNoConversion()
+    public void ExplicitGenericInstanceArgumentMismatch_UsesCallArgumentContract()
     {
         const string source = """
             class Box {
@@ -188,7 +188,7 @@ public class Issue3267ExplicitGenericArgumentValidationTests
         var diagnostic = Assert.Single(GetErrors(source));
 
         Assert.Equal(
-            "Cannot convert type 'string' to 'int32'.",
+            "Parameter 'value' requires a value of type 'int32' but was given a value of type 'string'.",
             diagnostic.Message);
     }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3282GenericInferenceArgumentValidationTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3282GenericInferenceArgumentValidationTests.cs
@@ -123,7 +123,7 @@ public class Issue3282GenericInferenceArgumentValidationTests
             }
             Box().Show(131, "str")
             """,
-            "GS0155",
+            "GS0154",
             "\"str\""
         },
         {
@@ -135,7 +135,7 @@ public class Issue3282GenericInferenceArgumentValidationTests
             func (self string) Show(a int32, b int32) { }
             "receiver".Show(131, "str")
             """,
-            "GS0155",
+            "GS0154",
             "\"str\""
         },
     };
@@ -229,7 +229,7 @@ public class Issue3282GenericInferenceArgumentValidationTests
     }
 
     [Fact]
-    public void ConflictingInstanceInference_ReportsNoConversion()
+    public void ConflictingInstanceInference_UsesCallArgumentContract()
     {
         const string source = """
             class Box {
@@ -241,7 +241,7 @@ public class Issue3282GenericInferenceArgumentValidationTests
         var diagnostic = Assert.Single(GetErrors(source));
 
         Assert.Equal(
-            "Cannot convert type 'string' to 'int32'.",
+            "Parameter 'b' requires a value of type 'int32' but was given a value of type 'string'.",
             diagnostic.Message);
     }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3289CallArgumentDiagnosticConsistencyTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3289CallArgumentDiagnosticConsistencyTests.cs
@@ -1,0 +1,345 @@
+// <copyright file="Issue3289CallArgumentDiagnosticConsistencyTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issues #3289 and #3312: rejected call arguments use the same GS0154
+/// contract across free, instance, extension, and shared calls.
+/// </summary>
+public sealed class Issue3289CallArgumentDiagnosticConsistencyTests
+{
+    public static TheoryData<string, string, int, int, int, int, string> RejectedCalls => new()
+    {
+        {
+            "free explicit-generic control",
+            """
+            import System
+            func Take(value ValueType) { }
+            Take("wrong")
+            """,
+            2,
+            5,
+            2,
+            12,
+            "value"
+        },
+        {
+            "free explicit generic",
+            """
+            import System
+            func Take[T](value T) { }
+            Take[ValueType]("wrong")
+            """,
+            2,
+            16,
+            2,
+            23,
+            "value"
+        },
+        {
+            "instance explicit-generic control",
+            """
+            import System
+            class Runner { func Take(value ValueType) { } }
+            Runner().Take("wrong")
+            """,
+            2,
+            14,
+            2,
+            21,
+            "value"
+        },
+        {
+            "instance explicit generic",
+            """
+            import System
+            class Runner { func Take[T](value T) { } }
+            Runner().Take[ValueType]("wrong")
+            """,
+            2,
+            25,
+            2,
+            32,
+            "value"
+        },
+        {
+            "extension explicit-generic control",
+            """
+            import System
+            func (self string) Take(value ValueType) { }
+            "receiver".Take("wrong")
+            """,
+            2,
+            16,
+            2,
+            23,
+            "value"
+        },
+        {
+            "extension explicit generic",
+            """
+            import System
+            func (self string) Take[T](value T) { }
+            "receiver".Take[ValueType]("wrong")
+            """,
+            2,
+            27,
+            2,
+            34,
+            "value"
+        },
+        {
+            "shared explicit-generic control",
+            """
+            import System
+            class Runner { shared { func Take(value ValueType) { } } }
+            Runner.Take("wrong")
+            """,
+            2,
+            12,
+            2,
+            19,
+            "value"
+        },
+        {
+            "shared explicit generic",
+            """
+            import System
+            class Runner { shared { func Take[T](value T) { } } }
+            Runner.Take[ValueType]("wrong")
+            """,
+            2,
+            23,
+            2,
+            30,
+            "value"
+        },
+        {
+            "free inference control",
+            """
+            import System
+            func Take(expected ValueType, actual ValueType) { }
+            let expected ValueType = 42
+            Take(expected, "wrong")
+            """,
+            3,
+            15,
+            3,
+            22,
+            "actual"
+        },
+        {
+            "free inference",
+            """
+            import System
+            func Take[T](expected T, actual T) { }
+            let expected ValueType = 42
+            Take(expected, "wrong")
+            """,
+            3,
+            15,
+            3,
+            22,
+            "actual"
+        },
+        {
+            "instance inference control",
+            """
+            import System
+            class Runner { func Take(expected ValueType, actual ValueType) { } }
+            let expected ValueType = 42
+            Runner().Take(expected, "wrong")
+            """,
+            3,
+            24,
+            3,
+            31,
+            "actual"
+        },
+        {
+            "instance inference",
+            """
+            import System
+            class Runner { func Take[T](expected T, actual T) { } }
+            let expected ValueType = 42
+            Runner().Take(expected, "wrong")
+            """,
+            3,
+            24,
+            3,
+            31,
+            "actual"
+        },
+        {
+            "extension inference control",
+            """
+            import System
+            func (self string) Take(expected ValueType, actual ValueType) { }
+            let expected ValueType = 42
+            "receiver".Take(expected, "wrong")
+            """,
+            3,
+            26,
+            3,
+            33,
+            "actual"
+        },
+        {
+            "extension inference",
+            """
+            import System
+            func (self string) Take[T](expected T, actual T) { }
+            let expected ValueType = 42
+            "receiver".Take(expected, "wrong")
+            """,
+            3,
+            26,
+            3,
+            33,
+            "actual"
+        },
+        {
+            "shared inference control",
+            """
+            import System
+            class Runner { shared { func Take(expected ValueType, actual ValueType) { } } }
+            let expected ValueType = 42
+            Runner.Take(expected, "wrong")
+            """,
+            3,
+            22,
+            3,
+            29,
+            "actual"
+        },
+        {
+            "shared inference",
+            """
+            import System
+            class Runner { shared { func Take[T](expected T, actual T) { } } }
+            let expected ValueType = 42
+            Runner.Take(expected, "wrong")
+            """,
+            3,
+            22,
+            3,
+            29,
+            "actual"
+        },
+    };
+
+    public static TheoryData<string, string, int, int, int, int> ExplicitOnlyRejectedCalls => new()
+    {
+        {
+            "free",
+            """
+            func Take(value int32) { }
+            Take(3.14)
+            """,
+            1,
+            5,
+            1,
+            9
+        },
+        {
+            "instance",
+            """
+            class Runner { func Take(value int32) { } }
+            Runner().Take(3.14)
+            """,
+            1,
+            14,
+            1,
+            18
+        },
+        {
+            "extension",
+            """
+            func (self string) Take(value int32) { }
+            "receiver".Take(3.14)
+            """,
+            1,
+            16,
+            1,
+            20
+        },
+        {
+            "shared",
+            """
+            class Runner { shared { func Take(value int32) { } } }
+            Runner.Take(3.14)
+            """,
+            1,
+            12,
+            1,
+            16
+        },
+    };
+
+    [Theory]
+    [MemberData(nameof(RejectedCalls))]
+    public void RejectedArgument_UsesGs0154AtExactArgumentSpan(
+        string _,
+        string source,
+        int startLine,
+        int startCharacter,
+        int endLine,
+        int endCharacter,
+        string parameterName)
+    {
+        var diagnostic = Assert.Single(GetErrors(source));
+
+        Assert.Equal("GS0154", diagnostic.Id);
+        Assert.Equal(
+            $"Parameter '{parameterName}' requires a value of type 'System.ValueType' but was given a value of type 'string'.",
+            diagnostic.Message);
+        Assert.Equal(startLine, diagnostic.Location.StartLine);
+        Assert.Equal(startCharacter, diagnostic.Location.StartCharacter);
+        Assert.Equal(endLine, diagnostic.Location.EndLine);
+        Assert.Equal(endCharacter, diagnostic.Location.EndCharacter);
+        Assert.Equal("\"wrong\"", diagnostic.Location.Text.ToString(diagnostic.Location.Span));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExplicitOnlyRejectedCalls))]
+    public void ExplicitOnlyArgumentConversion_UsesGs0154AtExactArgumentSpan(
+        string _,
+        string source,
+        int startLine,
+        int startCharacter,
+        int endLine,
+        int endCharacter)
+    {
+        var diagnostic = Assert.Single(GetErrors(source));
+
+        Assert.Equal("GS0154", diagnostic.Id);
+        Assert.Equal(
+            "Parameter 'value' requires a value of type 'int32' but was given a value of type 'float64'.",
+            diagnostic.Message);
+        Assert.Equal(startLine, diagnostic.Location.StartLine);
+        Assert.Equal(startCharacter, diagnostic.Location.StartCharacter);
+        Assert.Equal(endLine, diagnostic.Location.EndLine);
+        Assert.Equal(endCharacter, diagnostic.Location.EndCharacter);
+        Assert.Equal("3.14", diagnostic.Location.Text.ToString(diagnostic.Location.Span));
+    }
+
+    private static IReadOnlyList<Diagnostic> GetErrors(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source, "Issue3289.gs"));
+        var compilation = new GSharp.Core.CodeAnalysis.Compilation.Compilation(tree);
+        using var peStream = new MemoryStream();
+        return compilation.Emit(peStream).Diagnostics
+            .Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+            .ToArray();
+    }
+}

--- a/website/docs/ref/diagnostics.md
+++ b/website/docs/ref/diagnostics.md
@@ -116,8 +116,8 @@ IDs may be given as `GS0001`, `0001`, or the bare integer `1`; all three forms a
 | GS0151 | Error | Type argument inference failed. | The compiler could not infer a type argument from the call arguments. |
 | GS0152 | Error | Type argument does not satisfy constraint. | `f[MyStruct]()` where `MyStruct` does not implement the required interface constraint. |
 | GS0153 | Error | Constraint is neither an interface nor a class. | A generic type-parameter constraint must be an interface (any interface — sealed or not, generic or not;) or a base class; a value type such as a struct or enum is rejected. |
-| GS0154 | Error | Wrong argument type. | A positional argument's type does not match the parameter type. |
-| GS0155 | Error | Cannot convert type. | No built-in or user-defined conversion exists; use a compatible value or an API that performs the transformation (for example, `Parse`/`TryParse` for text). |
+| GS0154 | Error | Wrong argument type. | A free, instance, extension, or shared call argument has no permitted conversion to its parameter type. |
+| GS0155 | Error | Cannot convert type. | Outside call-argument matching, no built-in or user-defined conversion exists; use a compatible value or an API that performs the transformation (for example, `Parse`/`TryParse` for text). |
 | GS0156 | Error | Cannot convert implicitly; explicit conversion exists. | `var x int32 = 3.14` — write `var x int32 = int32(3.14)` to apply the available explicit conversion. |
 | GS0157 | Error | Cannot find type (possibly missing import). | A package-qualified type name that resolves to nothing. |
 | GS0158 | Error | Cannot find member. | A field or property access that does not resolve. |


### PR DESCRIPTION
## Summary

- route rejected G# call arguments through one GS0154 reporting contract across free, instance, extension, and shared calls
- preserve argument source locations so every diagnostic covers the offending argument expression
- add explicit-generic, inferred-generic, non-generic control, and explicit-only conversion coverage
- update outgoing tests that cemented GS0155 on call paths while retaining GS0155 for non-call conversion failures

## Root cause and design

Free-function binding classified and reported a failed argument directly with `ReportWrongArgumentType` (GS0154). Instance, extension, and shared binding instead called `BindCallArgumentWithRefKind`, which delegated to context-free `BindConversion`; its missing-conversion exit reported GS0155, and its explicit-only exit reported GS0156.

`BindConversion` now accepts optional call-parameter context. `BindCallArgumentWithRefKind` supplies it, and the conversion failure exits call the shared `ReportCallArgumentConversionFailure` helper. The free path also calls that helper rather than spelling the diagnostic independently. Existing caller-provided argument locations remain unchanged, so spans stay on the argument.

## GS0154 / GS0155 usage audit

`rg` finds 13 `ReportCannotConvert(` occurrences including the declaration: 12 production invocations remain. Nine are direct non-call contexts (ref narrowing/assignment, interpolation/text conversion, lambda compatibility, and throw expression/statement validation). Three are in conversion binding: the two general failure exits are now call-context-sensitive, while standalone structural-projection binding remains GS0155.

Retained exact GS0155 pins include `int32("wrong")` and `bool("true")` in `Issue3288ImpossibleExplicitConversionTests`; return/assignment conversion tests also remain GS0155. Manual probes confirmed `int32("wrong")` and `let value ValueType = "wrong"` still report GS0155, while all four call shapes report GS0154. GS0156 assignment/cast-guidance tests remain unchanged.

## Rejected-call matrix

Coordinates are zero-based. Every pin asserts ID, exact start/end coordinates, full message, and `Location.Text.ToString(Location.Span) == "\"wrong\""`. Every explicit/inferred generic row has a non-generic control.

| shape | non-generic | explicit generic | inferred generic + paired control |
| --- | --- | --- | --- |
| free | GS0154 `2:5-2:12` | GS0154 `2:16-2:23` | GS0154 `3:15-3:22` |
| instance | GS0154 `2:14-2:21` | GS0154 `2:25-2:32` | GS0154 `3:24-3:31` |
| extension | GS0154 `2:16-2:23` | GS0154 `2:27-2:34` | GS0154 `3:26-3:33` |
| shared | GS0154 `2:12-2:19` | GS0154 `2:23-2:30` | GS0154 `3:22-3:29` |

Explicit-only `float64 -> int32` call arguments are also pinned as GS0154 over exact `3.14` spans: free `1:5-1:9`, instance `1:14-1:18`, extension `1:16-1:20`, shared `1:12-1:16`. Constructor-style explicit conversions from #3288 are separate non-call conversion contexts and remain GS0155.

## RED proof

Fixed commit: `7c6789137ccab96483ba56bd8dfde4131ab8c8cb` (tree `4f02a4a55af80019ec4b5dd16a19add9e92af8bc`). Reverted only the three product-source files to the parent while keeping all tests:

- affected Core run: **27 failed / 59 passed / 86 total**
- #3289 matrix alone: **15 failures** — 12 actual GS0155 failures for instance/extension/shared non-generic + explicit/inferred generic rows, and 3 actual GS0156 failures for explicit-only instance/extension/shared rows; all 5 free baseline rows stayed green
- affected Compiler run: **3 failed / 10 passed / 13 total** — #3288 instance/extension pins returned GS0155, and the generic-closure call pin returned GS0155

Restored the product files from the fixed commit. Source SHA-256 hashes round-tripped exactly, `git diff HEAD` and `git status --porcelain` were empty, then the same affected runs passed **86/86** and **13/13**.

## Diagnostics docs and descriptors

`DiagnosticDescriptors.WrongArgumentType` and `CannotConvert` remain unchanged. Updated only the GS0154/GS0155 catalogue descriptions in `docs/diagnostics.md` and its hand-maintained website mirror; the two rows are byte-identical between mirrors. Versioned historical docs were not changed.

## #3312 disposition

This fully subsumes #3312: free, instance, extension, and shared calls now match on ID and offending-argument span, with a dedicated four-shape matrix. No separate empty work remains.

## Validation

- Release solution build with `ContinuousIntegrationBuild=true`: **0 warnings, 0 errors**
- affected Core diagnostics: **86/86 passed**
- affected Compiler diagnostics: **13/13 passed**
- focused #3267/#3282/#3289 run before wider outgoing-pin audit: **53/53**, then **86/86** after all outgoing pins were updated
- focused #3288 run: **9/9 passed**
- full Core audit found only five outgoing GS0155 assertions; full Compiler audit found only one; updated affected reruns are green
- manual free/instance/extension/shared and non-call probes matched the contract
- `git diff --check`: clean
- committed-tree status: clean

Fixes #3289
Fixes #3312
