### PR TITLE
Fix tuple-returning arrow-bodied functions

### DIFF
--- a/src/Core/CodeAnalysis/Syntax/Parser.Expressions.Creation.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.Expressions.Creation.cs
@@ -1008,10 +1008,17 @@ public partial class Parser
             // A function/tuple type clause is unambiguously a type shape.
             isComplex = true;
             pos++;
+            var sawEllipsis = false;
             if (Peek(pos).Kind != SyntaxKind.CloseParenthesisToken)
             {
                 while (true)
                 {
+                    if (Peek(pos).Kind == SyntaxKind.EllipsisToken)
+                    {
+                        sawEllipsis = true;
+                        pos++;
+                    }
+
                     if (!TryScanTypeClause(ref pos))
                     {
                         return false;
@@ -1035,13 +1042,18 @@ public partial class Parser
             pos++;
 
             // If `->` follows, this is an arrow function-type clause; scan the return type.
-            if (Peek(pos).Kind == SyntaxKind.RightArrowToken)
+            var isArrowFunction = Peek(pos).Kind == SyntaxKind.RightArrowToken;
+            if (isArrowFunction)
             {
                 pos++;
                 if (!TryScanTypeClause(ref pos))
                 {
                     return false;
                 }
+            }
+            else if (sawEllipsis)
+            {
+                return false;
             }
 
             // Optional trailing `?` for nullables (tuples and function types both support `?`).
@@ -1069,6 +1081,11 @@ public partial class Parser
             {
                 while (true)
                 {
+                    if (Peek(pos).Kind == SyntaxKind.EllipsisToken)
+                    {
+                        pos++;
+                    }
+
                     if (!TryScanTypeClause(ref pos))
                     {
                         return false;

--- a/src/Core/CodeAnalysis/Syntax/Parser.Members.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.Members.cs
@@ -1180,7 +1180,7 @@ public partial class Parser
             returnRefModifier = NextToken();
         }
 
-        var type = ParseOptionalTypeClause();
+        var type = ParseOptionalFunctionReturnTypeClause();
 
         // ADR-0086 / issue #727: a `;` in place of a `{ ... }` body marks the
         // declaration as a P/Invoke stub (`@DllImport`-annotated function with
@@ -1228,6 +1228,39 @@ public partial class Parser
         decl.ExplicitInterfaceType = explicitIfaceType;
         decl.ExplicitInterfaceCloseParenthesisToken = explicitIfaceCloseParen;
         return decl;
+    }
+
+    private TypeClauseSyntax? ParseOptionalFunctionReturnTypeClause()
+    {
+        if (LooksLikeTupleReturnTypeBeforeArrowBody())
+        {
+            return ParseTupleTypeClause();
+        }
+
+        return ParseOptionalTypeClause();
+    }
+
+    private bool LooksLikeTupleReturnTypeBeforeArrowBody()
+    {
+        // `(T1, T2) -> ...` is ambiguous with an arrow function type. Keep the
+        // type interpretation only when its complete scan reaches a declaration
+        // body marker; otherwise the arrow starts this function's expression body.
+        if (!LooksLikeArrowFunctionTypeClauseStart(0, out var hasTopLevelComma) ||
+            !hasTopLevelComma)
+        {
+            return false;
+        }
+
+        var functionTypeEnd = 0;
+        if (!TryScanTypeClause(ref functionTypeEnd))
+        {
+            return true;
+        }
+
+        return Peek(functionTypeEnd).Kind is not (
+            SyntaxKind.OpenBraceToken or
+            SyntaxKind.SemicolonToken or
+            SyntaxKind.RightArrowToken);
     }
 
     // Stream D: `func (a Point) operator +(b Point) Point { … }`. After the

--- a/src/Core/CodeAnalysis/Syntax/Parser.TypeClauses.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.TypeClauses.cs
@@ -847,6 +847,12 @@ public partial class Parser
 
     private bool LooksLikeArrowFunctionTypeClauseStart(int startOffset)
     {
+        return LooksLikeArrowFunctionTypeClauseStart(startOffset, out _);
+    }
+
+    private bool LooksLikeArrowFunctionTypeClauseStart(int startOffset, out bool hasTopLevelComma)
+    {
+        hasTopLevelComma = false;
         if (Peek(startOffset).Kind != SyntaxKind.OpenParenthesisToken)
         {
             return false;
@@ -905,6 +911,13 @@ public partial class Parser
                 {
                     braceDepth--;
                 }
+            }
+            else if (k == SyntaxKind.CommaToken &&
+                     parenDepth == 1 &&
+                     bracketDepth == 0 &&
+                     braceDepth == 0)
+            {
+                hasTopLevelComma = true;
             }
 
             offset++;

--- a/test/Compiler.Tests/Emit/Issue1278ArrowExpressionMemberEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1278ArrowExpressionMemberEmitTests.cs
@@ -35,6 +35,28 @@ public class Issue1278ArrowExpressionMemberEmitTests
     }
 
     [Fact]
+    public void Issue3375_TupleReturningArrowBody_RunsAndReturns()
+    {
+        var source = """
+            package P
+
+            class PairFactory {
+                shared {
+                    private func Pair() (int32, int32) -> (1, 2)
+                    func Sum() int32 {
+                        let pair = Pair()
+                        return pair.Item1 * 10 + pair.Item2
+                    }
+                }
+            }
+
+            public var result = PairFactory.Sum()
+            """;
+
+        Assert.Equal(12, RunAndGetIntResult(source));
+    }
+
+    [Fact]
     public void VoidMethodArrowBody_ExecutesSideEffect()
     {
         // A void method expression body is an executed statement (a call that

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1278ArrowExpressionMemberTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1278ArrowExpressionMemberTests.cs
@@ -34,6 +34,27 @@ var r = square(7)
     }
 
     [Fact]
+    public void Issue3375_TupleReturningArrowBody_BindsAndEvaluates()
+    {
+        var source = @"
+class PairFactory {
+    shared {
+        private func Pair() (int32, int32) -> (1, 2)
+        func Sum() int32 {
+            let pair = Pair()
+            return pair.Item1 * 10 + pair.Item2
+        }
+    }
+}
+
+var r = PairFactory.Sum()
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(12, result.Value);
+    }
+
+    [Fact]
     public void ReadOnlyPropertyArrow_BindsAndEvaluates()
     {
         var source = @"

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue1278ArrowExpressionMemberParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue1278ArrowExpressionMemberParserTests.cs
@@ -2,6 +2,7 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using System.Collections.Generic;
 using System.Linq;
 using GSharp.Core.CodeAnalysis.Syntax;
 using Xunit;
@@ -59,6 +60,59 @@ public class Issue1278ArrowExpressionMemberParserTests
         const string source = "package P\nstruct C {\n  var d int32\n}\nfunc operator implicit (c C) int32 -> c.d\n";
         var tree = SyntaxTree.Parse(source);
         Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void Issue3375_TupleReturningArrowBody_ParsesAsTupleReturn()
+    {
+        const string source =
+            "package P\n" +
+            "class C {\n" +
+            "  shared {\n" +
+            "    private func Pair() (int32, int32) -> (1, 2)\n" +
+            "  }\n" +
+            "}\n";
+        var tree = SyntaxTree.Parse(source);
+
+        Assert.Empty(tree.Diagnostics);
+        var func = Walk(tree.Root).OfType<FunctionDeclarationSyntax>().Single();
+        Assert.True(func.Type.IsTuple);
+        Assert.Equal(2, func.Type.TupleElements.Count);
+        var statement = Assert.Single(func.Body.Statements);
+        var returnStatement = Assert.IsType<ReturnStatementSyntax>(statement);
+        var tuple = Assert.IsType<TupleLiteralExpressionSyntax>(returnStatement.Expression);
+        Assert.Equal(2, tuple.Elements.Count);
+    }
+
+    [Fact]
+    public void Issue3375_TupleReturningArrowCallBody_ParsesAsTupleReturn()
+    {
+        const string source =
+            "package P\n" +
+            "func MakePair() (int32, int32) { return (1, 2) }\n" +
+            "func Pair() (int32, int32) -> MakePair()\n";
+        var tree = SyntaxTree.Parse(source);
+
+        Assert.Empty(tree.Diagnostics);
+        var pair = tree.Root.Members.OfType<FunctionDeclarationSyntax>().Last();
+        Assert.True(pair.Type.IsTuple);
+        Assert.IsType<CallExpressionSyntax>(
+            Assert.IsType<ReturnStatementSyntax>(Assert.Single(pair.Body.Statements)).Expression);
+    }
+
+    [Fact]
+    public void Issue3375_ArrowFunctionReturnWithArrowBody_RemainsFunctionType()
+    {
+        const string source =
+            "package P\n" +
+            "func Compare() (int32, int32) -> int32 -> (left int32, right int32) -> left - right\n";
+        var tree = SyntaxTree.Parse(source);
+
+        Assert.Empty(tree.Diagnostics);
+        var func = tree.Root.Members.OfType<FunctionDeclarationSyntax>().Single();
+        Assert.True(func.Type.IsArrowFunction);
+        Assert.IsType<LambdaExpressionSyntax>(
+            Assert.IsType<ReturnStatementSyntax>(Assert.Single(func.Body.Statements)).Expression);
     }
 
     [Fact]
@@ -146,5 +200,22 @@ public class Issue1278ArrowExpressionMemberParserTests
         var funcs = tree.Root.Members.OfType<FunctionDeclarationSyntax>().ToArray();
         Assert.Equal(3, funcs.Length);
         Assert.All(funcs, f => Assert.NotNull(f.Body));
+    }
+
+    private static IEnumerable<SyntaxNode> Walk(SyntaxNode node)
+    {
+        yield return node;
+        foreach (var child in node.GetChildren())
+        {
+            if (child is not SyntaxNode syntaxNode)
+            {
+                continue;
+            }
+
+            foreach (var descendant in Walk(syntaxNode))
+            {
+                yield return descendant;
+            }
+        }
     }
 }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1278ExpressionBodiedMemberTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1278ExpressionBodiedMemberTranslationTests.cs
@@ -7,6 +7,7 @@ using Cs2Gs.CodeModel.Ast;
 using Cs2Gs.CodeModel.Printing;
 using Cs2Gs.Translator;
 using Cs2Gs.Translator.Loading;
+using GSharp.Tests;
 using Xunit;
 
 namespace Cs2Gs.Tests;
@@ -35,6 +36,27 @@ namespace N
 
         Assert.Contains("func Square(x int32) int32 -> x * x", g, StringComparison.Ordinal);
         Assert.DoesNotContain("=>", g, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TupleReturningExpressionBodiedMethod_TranslatedGSharp_ParsesBindsAndCompiles()
+    {
+        string g = Render(@"
+namespace N
+{
+    public class C
+    {
+        private static (int, int) Pair() => (1, 2);
+    }
+}");
+
+        Assert.Contains("private func Pair() (int32, int32) -> (1, 2)", g, StringComparison.Ordinal);
+
+        var result = EmittedOracle.Evaluate(
+            new[] { g },
+            new EmittedOracleOptions { IsLibrary = true });
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+        Assert.Equal(0, result.ExitCode);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- disambiguate parenthesized tuple return types from arrow function type clauses in function declarations
- preserve function-type returns when a block, semicolon, or second expression-body arrow follows
- keep speculative type lookahead aligned with variadic arrow and legacy function types
- add parser, binding, emission, runtime, and exact cs2gs translation-to-compilation coverage

Fixes #3375

## Tests
- `dotnet test test/Core.Tests/Core.Tests.csproj --no-restore --filter 'FullyQualifiedName~Issue818AnonymousFunctionTypeVariadicParserTests|FullyQualifiedName~Issue1278ArrowExpressionMember|FullyQualifiedName~Issue715ArrowFunctionTypeClauseParserTests' --logger 'console;verbosity=minimal'`
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj --no-restore --filter 'FullyQualifiedName~Issue1278ArrowExpressionMemberEmitTests|FullyQualifiedName~Issue1499ClosureConstraintRemapEmitTests' --logger 'console;verbosity=minimal'`
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj --no-build --filter 'FullyQualifiedName~Issue1278ExpressionBodiedMemberTranslationTests' --logger 'console;verbosity=minimal'`