### PR TITLE
Validate emitted G# by binding in cs2gs tests

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Adr0143PartialMethodTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Adr0143PartialMethodTests.cs
@@ -244,7 +244,7 @@ namespace Demo
             CompilationUnit unit = new CSharpToGSharpTranslator(preservePartialParts).TranslateDocument(document, context);
 
             string printed = GSharpPrinter.Print(unit);
-            RoundTripResult result = GSharpRoundTrip.Validate(printed);
+            RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
             Assert.True(
                 result.Success,
                 "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Adr0145PreservePartialModeTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Adr0145PreservePartialModeTests.cs
@@ -187,7 +187,7 @@ namespace Demo
             CompilationUnit unit = new CSharpToGSharpTranslator(preservePartialParts).TranslateDocument(document, context);
 
             string printed = GSharpPrinter.Print(unit);
-            RoundTripResult result = GSharpRoundTrip.Validate(printed);
+            RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
             Assert.True(
                 result.Success,
                 "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Adr0145PreservePartialModeTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Adr0145PreservePartialModeTests.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Cs2Gs.CodeModel.Ast;
 using Cs2Gs.CodeModel.Printing;
-using Cs2Gs.CodeModel.RoundTrip;
 using Cs2Gs.Translator;
 using Cs2Gs.Translator.Loading;
 using Xunit;
@@ -187,14 +186,10 @@ namespace Demo
             CompilationUnit unit = new CSharpToGSharpTranslator(preservePartialParts).TranslateDocument(document, context);
 
             string printed = GSharpPrinter.Print(unit);
-            RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
-            Assert.True(
-                result.Success,
-                "Translated G# must round-trip. Errors:\n" +
-                    string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
             printedFiles.Add((System.IO.Path.GetFileName(document.FilePath), printed));
         }
 
+        TranslationTestValidation.AssertBinds(printedFiles.Select(file => file.Printed).ToArray());
         return printedFiles;
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Adr0151IfLetExpressionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Adr0151IfLetExpressionTranslationTests.cs
@@ -599,7 +599,7 @@ namespace Demo
             });
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Printed G# must round-trip. Errors:\n" +
@@ -625,7 +625,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Adr0151IfLetExpressionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Adr0151IfLetExpressionTranslationTests.cs
@@ -490,7 +490,8 @@ namespace Demo
 
         public string Name() => Find() is { } n && Reassign(ref n) ? n : ""anonymous"";
     }
-}");
+}",
+            "Reassigned pattern binders currently keep a spill fallback that cannot declare the mutable designator in G#.");
 
         Assert.DoesNotContain("if let n =", printed, StringComparison.Ordinal);
     }
@@ -599,7 +600,9 @@ namespace Demo
             });
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
+        RoundTripResult result = TranslationTestValidation.ValidateRoundTripOnly(
+            printed,
+            "Printer-only expression fixtures deliberately use undefined placeholder identifiers.");
         Assert.True(
             result.Success,
             "Printed G# must round-trip. Errors:\n" +
@@ -612,7 +615,7 @@ namespace Demo
         return printed.Substring(start, end - start).TrimEnd();
     }
 
-    private static string TranslateUnit(string source)
+    private static string TranslateUnit(string source, string roundTripOnlyReason = null)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
         Assert.True(
@@ -625,7 +628,9 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
+        RoundTripResult result = roundTripOnlyReason is null
+            ? TranslationTestValidation.AssertBinds(printed)
+            : TranslationTestValidation.ValidateRoundTripOnly(printed, roundTripOnlyReason);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Adr0161AssignmentExpressionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Adr0161AssignmentExpressionTranslationTests.cs
@@ -165,7 +165,7 @@ public sealed class C
             context.Diagnostics,
             d => d.Severity == TranslationSeverity.Unsupported && d.Message.Contains("1723"));
 
-        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+        RoundTripResult roundTrip = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             roundTrip.Success,
             "Translated G# must round-trip. Errors:\n" + string.Join("\n", roundTrip.Errors)

--- a/tools/cs2gs/Cs2Gs.Tests/BareFormExtensionCallTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/BareFormExtensionCallTranslationTests.cs
@@ -97,7 +97,7 @@ namespace Demo
         var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
         Cs2Gs.CodeModel.Ast.CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/BlockLambdaArrowTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/BlockLambdaArrowTranslationTests.cs
@@ -166,13 +166,14 @@ namespace Demo
             return Fact(5);
         }
     }
-}");
+}",
+            "Recursive local functions lower to non-recursive let bindings, a documented G# letrec limitation.");
 
         Assert.Contains("let Fact = func (n int32) int32 {", printed);
         Assert.DoesNotContain("(n int32) -> {", printed);
     }
 
-    private static string TranslateUnit(string source)
+    private static string TranslateUnit(string source, string roundTripOnlyReason = null)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
         Assert.True(
@@ -185,7 +186,9 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
+        RoundTripResult result = roundTripOnlyReason is null
+            ? TranslationTestValidation.AssertBinds(printed)
+            : TranslationTestValidation.ValidateRoundTripOnly(printed, roundTripOnlyReason);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/BlockLambdaArrowTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/BlockLambdaArrowTranslationTests.cs
@@ -185,7 +185,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/BodyTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/BodyTranslationTests.cs
@@ -37,7 +37,7 @@ public class BodyTranslationTests
         (CompilationUnit unit, TranslationContext context) = await TranslateL1CorpusAsync();
         string printed = GSharpPrinter.Print(unit);
 
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated L1 must round-trip-parse. Errors:\n" +
@@ -68,7 +68,7 @@ public class BodyTranslationTests
         (CompilationUnit unit, TranslationContext context) = await TranslateConsoleCorpusAsync("L4-Console", "L4-Console.csproj");
         string printed = GSharpPrinter.Print(unit);
 
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated L4 must round-trip-parse. Errors:\n" +
@@ -610,7 +610,7 @@ namespace S
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Snippet G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Coverage/PrinterExhaustivenessTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Coverage/PrinterExhaustivenessTests.cs
@@ -90,7 +90,9 @@ public class PrinterExhaustivenessTests
         // ArgumentException for unsupported nodes).
         var printed = GSharpPrinter.Print(unit);
 
-        var result = GSharpRoundTrip.Validate(printed);
+        var result = TranslationTestValidation.ValidateRoundTripOnly(
+            printed,
+            "Printer exhaustiveness samples are minimal syntax fixtures, not complete bindable programs.");
         if (KnownRoundTripGaps.TryGetValue(type, out var reason))
         {
             Assert.False(

--- a/tools/cs2gs/Cs2Gs.Tests/FaithfulUnsafeFormTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/FaithfulUnsafeFormTranslationTests.cs
@@ -275,7 +275,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/ForEachNullForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/ForEachNullForgivenessTranslationTests.cs
@@ -146,7 +146,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/GoldenTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/GoldenTests.cs
@@ -494,7 +494,7 @@ public class GoldenTests
         Assert.Contains("func Negate()", printed);
 
         // ...and the real parser + binder now accept it warning-free.
-        var result = GSharpRoundTrip.Validate(printed);
+        var result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(result.Success);
         Assert.DoesNotContain(result.Errors, e => e.StartsWith("GS0005", System.StringComparison.Ordinal));
         Assert.DoesNotContain(result.Errors, e => e.Contains("GS0314", System.StringComparison.Ordinal));
@@ -909,7 +909,7 @@ public class GoldenTests
         var printed = GSharpPrinter.Print(unit);
         Assert.Contains("init(message string) : base(message) {", printed);
 
-        var result = GSharpRoundTrip.Validate(printed);
+        var result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(result.Success, "Round-trip errors:\n" + string.Join("\n", result.Errors));
     }
 
@@ -981,7 +981,9 @@ public class GoldenTests
         // Determinism: the same AST prints byte-identically.
         Assert.Equal(printed, GSharpPrinter.Print(unit));
 
-        var result = GSharpRoundTrip.Validate(printed);
+        var result = TranslationTestValidation.ValidateRoundTripOnly(
+            printed,
+            "Golden printer samples intentionally use semantically incomplete hand-built ASTs.");
         Assert.True(result.Success, "Round-trip errors:\n" + string.Join("\n", result.Errors));
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/ImportedStructConstructionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/ImportedStructConstructionTranslationTests.cs
@@ -158,7 +158,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1072FieldInitNullableTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1072FieldInitNullableTests.cs
@@ -142,7 +142,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1072NullCheckedAsNullableTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1072NullCheckedAsNullableTranslationTests.cs
@@ -232,7 +232,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1174NestedTypeQualificationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1174NestedTypeQualificationTranslationTests.cs
@@ -95,7 +95,7 @@ namespace Corpus
         Assert.Contains("SttsBox.SampleEntry", printed);
 
         // The emitted G# parses cleanly...
-        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+        RoundTripResult roundTrip = TranslationTestValidation.AssertBinds(printed);
         Assert.True(roundTrip.Success, string.Join(Environment.NewLine, roundTrip.Errors));
 
         // ...and fully binds with no member-resolution error (GS0158) — proving
@@ -114,7 +114,7 @@ namespace Corpus
         // qualification) and still binds.
         Assert.DoesNotContain("SttsBox.Entry", printed);
 
-        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+        RoundTripResult roundTrip = TranslationTestValidation.AssertBinds(printed);
         Assert.True(roundTrip.Success, string.Join(Environment.NewLine, roundTrip.Errors));
 
         var diagnostics = BindDiagnostics(printed);
@@ -128,7 +128,7 @@ namespace Corpus
 
         Assert.Contains("class Reader : Host.IReader", printed);
 
-        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+        RoundTripResult roundTrip = TranslationTestValidation.AssertBinds(printed);
         Assert.True(roundTrip.Success, string.Join(Environment.NewLine, roundTrip.Errors));
 
         var diagnostics = BindDiagnostics(printed);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1212NullableArrayElementTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1212NullableArrayElementTranslationTests.cs
@@ -98,7 +98,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1272ArrayAllocationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1272ArrayAllocationTranslationTests.cs
@@ -92,7 +92,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1281RedundantNumericArgumentWrapTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1281RedundantNumericArgumentWrapTests.cs
@@ -163,7 +163,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1354PropertyNullableTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1354PropertyNullableTranslationTests.cs
@@ -185,7 +185,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1528VerbatimIdentifierTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1528VerbatimIdentifierTranslationTests.cs
@@ -67,7 +67,7 @@ namespace Corpus.Issue1528
     {
         string rendered = Render();
 
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1535ExtensionReceiverNullableTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1535ExtensionReceiverNullableTranslationTests.cs
@@ -105,7 +105,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1567CollectionInitializerObjectInitTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1567CollectionInitializerObjectInitTranslationTests.cs
@@ -120,7 +120,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1721PrinterPrecedenceTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1721PrinterPrecedenceTests.cs
@@ -198,7 +198,7 @@ namespace N { public class C { public static int F(int x) => - -x; } }");
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
         string printed = GSharpPrinter.Print(unit);
 
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1722CharLiteralEscapeTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1722CharLiteralEscapeTests.cs
@@ -123,7 +123,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1723ValuePositionAssignmentTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1723ValuePositionAssignmentTranslationTests.cs
@@ -1135,7 +1135,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1725NullCoalescingResultTypeTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1725NullCoalescingResultTypeTranslationTests.cs
@@ -168,7 +168,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1727NamedArgumentReorderTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1727NamedArgumentReorderTranslationTests.cs
@@ -232,7 +232,7 @@ namespace Demo
     {
         (CompilationUnit unit, _) = Translate(source);
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +
@@ -242,7 +242,7 @@ namespace Demo
 
     private static void AssertRoundTrip(string printed)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1728ObjectInitializerWithCtorArgsTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1728ObjectInitializerWithCtorArgsTranslationTests.cs
@@ -326,7 +326,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1730SwitchPatternBindingTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1730SwitchPatternBindingTests.cs
@@ -176,7 +176,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1731DoubleEvaluationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1731DoubleEvaluationTranslationTests.cs
@@ -492,7 +492,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1732LoopLoweringTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1732LoopLoweringTranslationTests.cs
@@ -363,7 +363,7 @@ namespace Demo
             d => d.Severity == TranslationSeverity.Unsupported);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1734DeclarationSiteSanitizationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1734DeclarationSiteSanitizationTests.cs
@@ -371,7 +371,7 @@ namespace Corpus.Issue1734
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1735AssignmentTargetNullForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1735AssignmentTargetNullForgivenessTranslationTests.cs
@@ -193,7 +193,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1737ExplicitTypedLocalNullableTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1737ExplicitTypedLocalNullableTranslationTests.cs
@@ -153,7 +153,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1739PositionalStructCtorTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1739PositionalStructCtorTranslationTests.cs
@@ -194,7 +194,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1743MemoizedSymbolQueryTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1743MemoizedSymbolQueryTranslationTests.cs
@@ -143,7 +143,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1745PrinterCodeModelCleanupTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1745PrinterCodeModelCleanupTests.cs
@@ -55,7 +55,7 @@ namespace Demo
         // segment, plus the `$x` interpolation hole for the expression.
         Assert.Contains(@"""a\\b\""c$$d\u0001e$x""", printed, StringComparison.Ordinal);
 
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(result.Success, "Translated G# must round-trip. Errors:\n" + string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
     }
 
@@ -123,7 +123,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1839PatternDesignatorAndEnumExtensionTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1839PatternDesignatorAndEnumExtensionTests.cs
@@ -181,7 +181,9 @@ namespace Corpus.Issue1839
 }
 ");
 
-        AssertRoundTripParses(rendered);
+        AssertRoundTripParses(
+            rendered,
+            "Single-file multi-namespace translation still flattens both Circle declarations into one G# package.");
     }
 
     [Fact]
@@ -260,9 +262,11 @@ namespace Corpus.Issue3357
         Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
     }
 
-    private static void AssertRoundTripParses(string rendered)
+    private static void AssertRoundTripParses(string rendered, string roundTripOnlyReason = null)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = roundTripOnlyReason is null
+            ? TranslationTestValidation.AssertBinds(rendered)
+            : TranslationTestValidation.ValidateRoundTripOnly(rendered, roundTripOnlyReason);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1845ChainedAssignmentReadBackTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1845ChainedAssignmentReadBackTests.cs
@@ -218,7 +218,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1849NullSeamHelperLoweringTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1849NullSeamHelperLoweringTests.cs
@@ -153,7 +153,8 @@ public class Issue3355NullSeamBlockExpressionLoweringTests
                     public Derived() : base(flag: GetA() is { X: 1, Y: 2 }) { }
                 }
             }
-            """);
+            """,
+            "Named base-constructor arguments remain a known G# binding gap; this test isolates block lowering.");
 
         Assert.Equal(2, CountOccurrences(printed, "GetA()"));
         Assert.Contains(": base(flag: {", printed, StringComparison.Ordinal);
@@ -331,7 +332,9 @@ public class Issue3355NullSeamBlockExpressionLoweringTests
         return count;
     }
 
-    private static (string Printed, TranslationContext Context) TranslateUnitWithContext(string source)
+    private static (string Printed, TranslationContext Context) TranslateUnitWithContext(
+        string source,
+        string roundTripOnlyReason = null)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
         Assert.True(
@@ -344,7 +347,9 @@ public class Issue3355NullSeamBlockExpressionLoweringTests
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = roundTripOnlyReason is null
+            ? TranslationTestValidation.AssertBinds(printed)
+            : TranslationTestValidation.ValidateRoundTripOnly(printed, roundTripOnlyReason);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1875CompoundLinkReadBackTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1875CompoundLinkReadBackTests.cs
@@ -322,7 +322,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1879ExtensionBlockTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1879ExtensionBlockTranslationTests.cs
@@ -391,7 +391,7 @@ namespace Corpus.Issue1879
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1880UnsignedRightShiftTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1880UnsignedRightShiftTranslationTests.cs
@@ -130,7 +130,7 @@ namespace Corpus.Issue1880
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1881CheckedUncheckedTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1881CheckedUncheckedTranslationTests.cs
@@ -170,7 +170,7 @@ namespace Corpus.Issue1881
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1882InterpolatedBraceEscapeTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1882InterpolatedBraceEscapeTranslationTests.cs
@@ -91,7 +91,7 @@ namespace Corpus.Issue1882
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1883LiteralReceiverMemberCallTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1883LiteralReceiverMemberCallTranslationTests.cs
@@ -161,7 +161,7 @@ namespace Corpus.Issue1883
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1884GotoLabelTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1884GotoLabelTranslationTests.cs
@@ -152,7 +152,7 @@ namespace Corpus.Issue1884
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1885LockStatementTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1885LockStatementTranslationTests.cs
@@ -91,7 +91,7 @@ namespace Demo
         Cs2Gs.CodeModel.Ast.CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1886StaticGenericLocalFunctionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1886StaticGenericLocalFunctionTranslationTests.cs
@@ -102,7 +102,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1887PositionalPatternTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1887PositionalPatternTranslationTests.cs
@@ -193,7 +193,7 @@ namespace Corpus.Issue1887
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1888VarPatternTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1888VarPatternTranslationTests.cs
@@ -213,7 +213,7 @@ namespace Corpus.Issue1888
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1889ListPatternTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1889ListPatternTranslationTests.cs
@@ -218,7 +218,7 @@ namespace Corpus.Issue1889
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1890TypePatternTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1890TypePatternTranslationTests.cs
@@ -129,7 +129,7 @@ namespace App.Auth
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1891ExtPropPatternTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1891ExtPropPatternTranslationTests.cs
@@ -142,7 +142,7 @@ namespace Corpus.Issue1891
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1892ObjectInitializerStrayAssignmentTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1892ObjectInitializerStrayAssignmentTests.cs
@@ -170,7 +170,7 @@ namespace Demo
         Assert.DoesNotContain(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1893MultiDimArrayTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1893MultiDimArrayTranslationTests.cs
@@ -210,7 +210,7 @@ namespace Corpus.Issue3354
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1894IndexLocalTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1894IndexLocalTranslationTests.cs
@@ -269,7 +269,7 @@ namespace Corpus.Issue1894
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1895DeconstructAssignTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1895DeconstructAssignTranslationTests.cs
@@ -315,7 +315,7 @@ namespace Corpus.Issue1895
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1896RangeSliceTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1896RangeSliceTranslationTests.cs
@@ -162,7 +162,7 @@ namespace Corpus.Issue1896
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1897CollectionExpressionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1897CollectionExpressionTranslationTests.cs
@@ -241,7 +241,7 @@ namespace Corpus.Issue1897
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1898AnonMethodTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1898AnonMethodTranslationTests.cs
@@ -198,7 +198,7 @@ namespace Corpus.Issue1898
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1899DelegateEventTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1899DelegateEventTranslationTests.cs
@@ -77,7 +77,9 @@ namespace Corpus.Issue1899
 ");
 
         Assert.Contains("event Ticked EventHandler", rendered, StringComparison.Ordinal);
-        AssertRoundTripParses(rendered);
+        AssertRoundTripParses(
+            rendered,
+            "G# cannot convert nominal System.EventHandler values to structural delegate locals.");
     }
 
     [Fact]
@@ -130,9 +132,11 @@ namespace Corpus.Issue1899
         AssertRoundTripParses(rendered);
     }
 
-    private static void AssertRoundTripParses(string rendered)
+    private static void AssertRoundTripParses(string rendered, string roundTripOnlyReason = null)
     {
-        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
+        RoundTripResult result = roundTripOnlyReason is null
+            ? TranslationTestValidation.AssertBinds(rendered)
+            : TranslationTestValidation.ValidateRoundTripOnly(rendered, roundTripOnlyReason);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1899DelegateEventTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1899DelegateEventTranslationTests.cs
@@ -132,7 +132,7 @@ namespace Corpus.Issue1899
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1900RefLocalsTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1900RefLocalsTranslationTests.cs
@@ -256,7 +256,7 @@ namespace Corpus.Issue1900
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1901LambdaDefaultsTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1901LambdaDefaultsTranslationTests.cs
@@ -393,7 +393,7 @@ namespace Corpus.Issue1901
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1901LambdaDefaultsTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1901LambdaDefaultsTranslationTests.cs
@@ -374,7 +374,9 @@ namespace Corpus.Issue1901
 
         Assert.Contains("x decimal = 1.5", rendered, StringComparison.Ordinal);
         Assert.Contains("Console.WriteLine(f(1.5))", rendered, StringComparison.Ordinal);
-        AssertRoundTripParses(rendered);
+        AssertRoundTripParses(
+            rendered,
+            "G# currently types decimal literal defaults as float64 and cannot bind them to decimal parameters.");
     }
 
     private static (Cs2Gs.CodeModel.Ast.CompilationUnit Unit, TranslationContext Context) Translate(string source)
@@ -391,9 +393,11 @@ namespace Corpus.Issue1901
         return (unit, context);
     }
 
-    private static void AssertRoundTripParses(string rendered)
+    private static void AssertRoundTripParses(string rendered, string roundTripOnlyReason = null)
     {
-        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
+        RoundTripResult result = roundTripOnlyReason is null
+            ? TranslationTestValidation.AssertBinds(rendered)
+            : TranslationTestValidation.ValidateRoundTripOnly(rendered, roundTripOnlyReason);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1902LinqQueryTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1902LinqQueryTranslationTests.cs
@@ -232,7 +232,7 @@ namespace Corpus.Issue1902
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1902LinqQueryTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1902LinqQueryTranslationTests.cs
@@ -174,7 +174,9 @@ namespace Corpus.Issue1902
             rendered,
             StringComparison.Ordinal);
         Assert.Contains("petGroup.Count()", rendered, StringComparison.Ordinal);
-        AssertRoundTripParses(rendered);
+        AssertRoundTripParses(
+            rendered,
+            "G# cannot yet bind the translated GroupJoin continuation and its inferred sequence element types.");
     }
 
     [Fact]
@@ -230,9 +232,11 @@ namespace Corpus.Issue1902
         AssertRoundTripParses(rendered);
     }
 
-    private static void AssertRoundTripParses(string rendered)
+    private static void AssertRoundTripParses(string rendered, string roundTripOnlyReason = null)
     {
-        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
+        RoundTripResult result = roundTripOnlyReason is null
+            ? TranslationTestValidation.AssertBinds(rendered)
+            : TranslationTestValidation.ValidateRoundTripOnly(rendered, roundTripOnlyReason);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1903AwaitUsingTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1903AwaitUsingTranslationTests.cs
@@ -143,7 +143,7 @@ namespace Corpus.Issue1903
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1904AsyncMainTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1904AsyncMainTranslationTests.cs
@@ -102,7 +102,7 @@ internal static class Program
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1905PointerMemberTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1905PointerMemberTranslationTests.cs
@@ -139,7 +139,9 @@ namespace Corpus.Issue1905
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.ValidateRoundTripOnly(
+            rendered,
+            "G# currently rejects managed-pointer parameter types even though native pointer-member syntax parses.");
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1907FieldKeywordTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1907FieldKeywordTranslationTests.cs
@@ -182,7 +182,7 @@ namespace Corpus.Issue1907
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1908CompoundAssignmentOperatorDeclarationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1908CompoundAssignmentOperatorDeclarationTests.cs
@@ -78,7 +78,7 @@ public class Issue1908CompoundAssignmentOperatorDeclarationTests
         string printed = GSharpPrinter.Print(unit);
         Assert.Contains("func operator " + compoundToken + "(amount int32)", printed, StringComparison.Ordinal);
 
-        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+        RoundTripResult roundTrip = TranslationTestValidation.AssertBinds(printed);
         Assert.True(roundTrip.Success, string.Join(Environment.NewLine, roundTrip.Errors));
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1909PrimaryConstructorTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1909PrimaryConstructorTranslationTests.cs
@@ -199,7 +199,7 @@ namespace Corpus.Issue1909
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1910PartialTypeMergeTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1910PartialTypeMergeTranslationTests.cs
@@ -260,7 +260,7 @@ namespace Demo
             CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
             string printed = GSharpPrinter.Print(unit);
-            RoundTripResult result = GSharpRoundTrip.Validate(printed);
+            RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
             Assert.True(
                 result.Success,
                 "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1911ExplicitInterfaceImplementationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1911ExplicitInterfaceImplementationTests.cs
@@ -119,7 +119,7 @@ namespace Corpus.Issue1911
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1912ExplicitEnumValueTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1912ExplicitEnumValueTranslationTests.cs
@@ -237,7 +237,7 @@ namespace Demo
             d => d.Severity == TranslationSeverity.Unsupported);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1913AttributeTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1913AttributeTranslationTests.cs
@@ -90,7 +90,7 @@ namespace Demo
             d => d.Severity == TranslationSeverity.Unsupported);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1914TupleAliasDirectiveTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1914TupleAliasDirectiveTests.cs
@@ -85,7 +85,7 @@ namespace Demo
             d => d.Severity == TranslationSeverity.Unsupported);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1915GenericStructCtorZipTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1915GenericStructCtorZipTranslationTests.cs
@@ -78,7 +78,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1915OpenGenericTypeOfTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1915OpenGenericTypeOfTranslationTests.cs
@@ -89,7 +89,7 @@ namespace Demo
         Assert.Empty(context.Diagnostics);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1922ForEachTupleDeconstructionTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1922ForEachTupleDeconstructionTests.cs
@@ -172,7 +172,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1923NestedPatternMemberForwardingTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1923NestedPatternMemberForwardingTests.cs
@@ -126,7 +126,7 @@ namespace Corpus.Issue1923
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1923NestedPatternMemberForwardingTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1923NestedPatternMemberForwardingTests.cs
@@ -121,12 +121,16 @@ namespace Corpus.Issue1923
         // `Friend` is declared nullable, so the outer member access still needs
         // its own guard — the fix must not over-correct into dropping it here.
         Assert.Contains("person.Friend != nil", rendered, StringComparison.Ordinal);
-        AssertRoundTripParses(rendered);
+        AssertRoundTripParses(
+            rendered,
+            "G# does not flow-narrow repeated nullable member access after the emitted nil guard.");
     }
 
-    private static void AssertRoundTripParses(string rendered)
+    private static void AssertRoundTripParses(string rendered, string roundTripOnlyReason = null)
     {
-        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
+        RoundTripResult result = roundTripOnlyReason is null
+            ? TranslationTestValidation.AssertBinds(rendered)
+            : TranslationTestValidation.ValidateRoundTripOnly(rendered, roundTripOnlyReason);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1930DeferBlockFormRoundTripTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1930DeferBlockFormRoundTripTests.cs
@@ -35,7 +35,9 @@ public class Issue1930DeferBlockFormRoundTripTests
     public void DeferStatement_PrintedForm_RoundTripsThroughRealParser()
     {
         var printed = GSharpPrinter.Print(DeferSample());
-        var result = GSharpRoundTrip.Validate(printed);
+        var result = TranslationTestValidation.ValidateRoundTripOnly(
+            printed,
+            "This parser regression fixture deliberately leaves cleanup() undefined.");
 
         Assert.True(result.Success, $"Printed G#:\n{printed}\nParse errors:\n{string.Join("\n", result.Errors)}");
     }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1943TypedPositionalSubpatternTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1943TypedPositionalSubpatternTests.cs
@@ -234,7 +234,7 @@ namespace Corpus.Issue1943
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1947InitializerValuePositionAssignmentTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1947InitializerValuePositionAssignmentTests.cs
@@ -199,7 +199,7 @@ namespace Demo
         Assert.DoesNotContain(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1954MultiDimArrayHardeningTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1954MultiDimArrayHardeningTests.cs
@@ -224,7 +224,7 @@ namespace Corpus.Issue1954
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1960DelegateEventFollowUpTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1960DelegateEventFollowUpTests.cs
@@ -223,7 +223,7 @@ namespace Corpus.Issue1960
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1962SwitchExprFollowUpTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1962SwitchExprFollowUpTests.cs
@@ -172,7 +172,8 @@ namespace Demo
             _ => ""other"",
         };
     }
-}");
+}",
+            "cs2gs currently drops guards from discard switch arms, leaving duplicate default arms in this shape test.");
 
         // The source's own unguarded `_ =>` already covers the total case —
         // no synthesized arm should be added on top of it.
@@ -215,7 +216,7 @@ namespace Demo
         Assert.Equal("other", CompileAndRun(printed, "C.Describe(\"hi\")").Trim());
     }
 
-    private static string TranslateAndValidate(string source)
+    private static string TranslateAndValidate(string source, string roundTripOnlyReason = null)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
         Assert.True(
@@ -232,7 +233,9 @@ namespace Demo
             d => d.Severity == TranslationSeverity.Unsupported);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
+        RoundTripResult result = roundTripOnlyReason is null
+            ? TranslationTestValidation.AssertBinds(printed)
+            : TranslationTestValidation.ValidateRoundTripOnly(printed, roundTripOnlyReason);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1962SwitchExprFollowUpTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1962SwitchExprFollowUpTests.cs
@@ -232,7 +232,7 @@ namespace Demo
             d => d.Severity == TranslationSeverity.Unsupported);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1967IndexRangeHardeningTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1967IndexRangeHardeningTests.cs
@@ -93,7 +93,7 @@ namespace Corpus.Issue1967
         // gsc's OWN parser actually accepts a from-end index in that position,
         // not just that the printer emitted the `^1` text (a printer-only check
         // would miss gsc silently rejecting it as unparseable G#).
-        RoundTripResult roundTrip = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult roundTrip = TranslationTestValidation.AssertBinds(rendered);
         Assert.True(roundTrip.Success, "Translated G# must parse. Errors:\n" +
             string.Join("\n", roundTrip.Errors) + "\n\nPrinted:\n" + rendered);
     }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1971ExtPropPatternFollowUpTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1971ExtPropPatternFollowUpTranslationTests.cs
@@ -90,7 +90,9 @@ namespace Corpus.Issue1971
 ");
 
         Assert.Contains("s.Start != nil && s.Start.X == 0", rendered, StringComparison.Ordinal);
-        AssertRoundTripParses(rendered);
+        AssertRoundTripParses(
+            rendered,
+            "G# does not flow-narrow repeated nullable member access after the emitted nil guard.");
     }
 
     [Fact]
@@ -155,7 +157,9 @@ namespace Corpus.Issue1971
 ");
 
         Assert.Contains("a.B != nil && a.B.C != nil && a.B.C.Value == 0", rendered, StringComparison.Ordinal);
-        AssertRoundTripParses(rendered);
+        AssertRoundTripParses(
+            rendered,
+            "G# does not flow-narrow repeated nullable member access after emitted nil guards.");
     }
 
     [Fact]
@@ -409,9 +413,11 @@ namespace Corpus.Issue1971
         return (unit, context);
     }
 
-    private static void AssertRoundTripParses(string rendered)
+    private static void AssertRoundTripParses(string rendered, string roundTripOnlyReason = null)
     {
-        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
+        RoundTripResult result = roundTripOnlyReason is null
+            ? TranslationTestValidation.AssertBinds(rendered)
+            : TranslationTestValidation.ValidateRoundTripOnly(rendered, roundTripOnlyReason);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1971ExtPropPatternFollowUpTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1971ExtPropPatternFollowUpTranslationTests.cs
@@ -411,7 +411,7 @@ namespace Corpus.Issue1971
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1974ExpressionPositionDeconstructAssignTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1974ExpressionPositionDeconstructAssignTranslationTests.cs
@@ -211,7 +211,7 @@ namespace Corpus.Issue1974
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1980AwaitUsingFollowUpTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1980AwaitUsingFollowUpTests.cs
@@ -153,7 +153,7 @@ namespace Corpus.Issue1980
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1990MultiCtorStructUnsupportedTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1990MultiCtorStructUnsupportedTests.cs
@@ -135,7 +135,7 @@ namespace Demo
         Assert.Contains("class Unrelated", printed);
         Assert.Contains("struct Point", printed);
 
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# (with the unsupported type dropped) must still round-trip. Errors:\n" +
@@ -169,7 +169,7 @@ namespace Demo
 
     private static void AssertRoundTrips(string printed)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1998LinqFollowUpTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1998LinqFollowUpTests.cs
@@ -228,7 +228,7 @@ namespace Corpus.Issue1998
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2003FieldKeywordSynthesizedSiblingCollisionTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2003FieldKeywordSynthesizedSiblingCollisionTests.cs
@@ -98,7 +98,7 @@ namespace Corpus.Issue2003
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2005EnumTopBitValueTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2005EnumTopBitValueTranslationTests.cs
@@ -210,7 +210,7 @@ namespace Demo
                 d.Message.Contains("outside the int32 range", StringComparison.Ordinal));
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2009ExtensionBlockFollowUpTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2009ExtensionBlockFollowUpTranslationTests.cs
@@ -271,7 +271,7 @@ namespace Corpus.Issue2009
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2010ExplicitInterfaceImplementationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2010ExplicitInterfaceImplementationTests.cs
@@ -223,7 +223,7 @@ namespace Corpus.Issue2010
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2012OpenGenericTypeOfProducerTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2012OpenGenericTypeOfProducerTests.cs
@@ -135,7 +135,7 @@ namespace Demo
         Assert.Empty(context.Diagnostics);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2015RawInterpolatedStringBraceTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2015RawInterpolatedStringBraceTranslationTests.cs
@@ -92,7 +92,7 @@ namespace Corpus.Issue2015
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2113ObliviousNullableTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2113ObliviousNullableTranslationTests.cs
@@ -210,7 +210,9 @@ namespace Demo
         SemanticModel model = compilation.GetSemanticModel(tree);
         var document = new LoadedDocument("Snippet.cs", tree, model);
         var context = new TranslationContext(compilation, model, document.FilePath);
-        return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+        return PrintAndValidate(
+            new CSharpToGSharpTranslator().TranslateDocument(document, context),
+            "Consumer-only fixture omits the referenced C# metadata library from emitted G#.");
     }
 
     private static string TranslateOblivious(string source)
@@ -251,10 +253,12 @@ namespace Demo
         return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
     }
 
-    private static string PrintAndValidate(CompilationUnit unit)
+    private static string PrintAndValidate(CompilationUnit unit, string roundTripOnlyReason = null)
     {
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = roundTripOnlyReason is null
+            ? TranslationTestValidation.AssertBinds(printed)
+            : TranslationTestValidation.ValidateRoundTripOnly(printed, roundTripOnlyReason);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2154CompoundOperatorTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2154CompoundOperatorTranslationTests.cs
@@ -80,7 +80,7 @@ namespace Demo
 
         Assert.Contains($"h.V {compoundToken} 3", printed);
 
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated compound-assignment member access must round-trip-parse. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2157ObliviousPropertyTaintTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2157ObliviousPropertyTaintTranslationTests.cs
@@ -225,7 +225,7 @@ namespace Demo
     private static string PrintAndValidate(CompilationUnit unit)
     {
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2164LazySingletonNullForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2164LazySingletonNullForgivenessTranslationTests.cs
@@ -218,7 +218,7 @@ namespace Demo
     private static string PrintAndValidate(CompilationUnit unit)
     {
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2167TransitiveNullabilityTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2167TransitiveNullabilityTranslationTests.cs
@@ -188,7 +188,7 @@ namespace Demo
     private static string PrintAndValidate(CompilationUnit unit)
     {
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2202ExternalObliviousReturnForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2202ExternalObliviousReturnForgivenessTranslationTests.cs
@@ -366,7 +366,9 @@ public class ExternalResponse
     private static string PrintAndValidate(CompilationUnit unit)
     {
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.ValidateRoundTripOnly(
+            printed,
+            "Consumer-only fixture omits the referenced C# metadata library from emitted G#.");
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2202NullGuardNarrowedFieldForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2202NullGuardNarrowedFieldForgivenessTranslationTests.cs
@@ -216,7 +216,7 @@ namespace Demo
     private static string PrintAndValidate(CompilationUnit unit)
     {
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2202SwitchExpressionObliviousPromotionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2202SwitchExpressionObliviousPromotionTranslationTests.cs
@@ -124,7 +124,7 @@ namespace Demo
     private static string PrintAndValidate(CompilationUnit unit)
     {
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2202UnguardedTernaryArmForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2202UnguardedTernaryArmForgivenessTranslationTests.cs
@@ -283,7 +283,7 @@ namespace Demo
     private static string PrintAndValidate(CompilationUnit unit)
     {
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2211FullyQualifiedNoUsingImportSynthesisTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2211FullyQualifiedNoUsingImportSynthesisTests.cs
@@ -104,8 +104,8 @@ namespace Demo
         // ponytail: skip a second real-gsc compile here — the first test
         // already proves the mechanism compiles end-to-end; running gsc as a
         // subprocess for every generality case here multiplies process load
-        // for no extra coverage (GSharpRoundTrip.Validate inside TranslateUnit
-        // already proves the printed text re-parses).
+        // for no extra coverage (AssertBinds inside TranslateUnit already proves
+        // the printed text parses and binds).
     }
 
     [Fact]
@@ -183,7 +183,7 @@ namespace Demo
             d => d.Severity == TranslationSeverity.Unsupported);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2222TopLevelTypeQualificationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2222TopLevelTypeQualificationTranslationTests.cs
@@ -90,10 +90,7 @@ namespace Consumer
             "Inline C# source should bind with no errors: " +
                 string.Join(Environment.NewLine, project.ErrorDiagnostics));
 
-        LoadedDocument document = project.Documents.Single(d => d.FilePath.EndsWith("Caller.cs", StringComparison.Ordinal));
-        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
-        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
-        string printed = GSharpPrinter.Print(unit);
+        string printed = TranslateTargetAndAssertProjectBinds(project, "Caller.cs");
 
         // The `var` local's materialized type annotation is qualified...
         Assert.Contains("First.ChapterInfo", printed);
@@ -101,9 +98,6 @@ namespace Consumer
         // ...and the explicit constructor call keeps its qualification instead
         // of collapsing to the bare (ambiguous) `ChapterInfo()`.
         Assert.Contains("Second.ChapterInfo()", printed);
-
-        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
-        Assert.True(roundTrip.Success, string.Join(Environment.NewLine, roundTrip.Errors));
     }
 
     /// <summary>
@@ -179,7 +173,9 @@ namespace Consumer
         Assert.Equal(2, CountOccurrences(printed, "First.ChapterInfo"));
         Assert.DoesNotContain(" ChapterInfo(", printed);
 
-        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+        RoundTripResult roundTrip = TranslationTestValidation.ValidateRoundTripOnly(
+            printed,
+            "Target-only fixture omits the referenced metadata assembly from emitted G#.");
         Assert.True(roundTrip.Success, string.Join(Environment.NewLine, roundTrip.Errors));
     }
 
@@ -252,7 +248,9 @@ namespace Oahu.Core
         Assert.Contains("ICollection[Oahu.BooksDatabase.Codec]", printed);
         Assert.Contains("(c Oahu.BooksDatabase.Codec)", printed);
 
-        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+        RoundTripResult roundTrip = TranslationTestValidation.ValidateRoundTripOnly(
+            printed,
+            "Target-only fixture omits the referenced metadata assembly from emitted G#.");
         Assert.True(roundTrip.Success, string.Join(Environment.NewLine, roundTrip.Errors));
     }
 
@@ -317,10 +315,7 @@ namespace Consumer
             "Inline C# source should bind with no errors: " +
                 string.Join(Environment.NewLine, project.ErrorDiagnostics));
 
-        LoadedDocument document = project.Documents.Single(d => d.FilePath.EndsWith("Caller.cs", StringComparison.Ordinal));
-        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
-        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
-        string printed = GSharpPrinter.Print(unit);
+        string printed = TranslateTargetAndAssertProjectBinds(project, "Caller.cs");
 
         // The EARLIER reference (First.ChapterInfo) must be qualified even
         // though, at the point it's processed, no explicit `using Second;`
@@ -328,9 +323,6 @@ namespace Consumer
         Assert.Contains("First.ChapterInfo()", printed);
         Assert.Contains("Second.ChapterInfo()", printed);
         Assert.DoesNotContain(" ChapterInfo(", printed);
-
-        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
-        Assert.True(roundTrip.Success, string.Join(Environment.NewLine, roundTrip.Errors));
     }
 
     /// <summary>
@@ -387,17 +379,11 @@ namespace Consumer
             "Inline C# source should bind with no errors: " +
                 string.Join(Environment.NewLine, project.ErrorDiagnostics));
 
-        LoadedDocument document = project.Documents.Single(d => d.FilePath.EndsWith("Caller.cs", StringComparison.Ordinal));
-        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
-        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
-        string printed = GSharpPrinter.Print(unit);
+        string printed = TranslateTargetAndAssertProjectBinds(project, "Caller.cs");
 
         Assert.Contains("First.ChapterInfo()", printed);
         Assert.Contains("Second.ChapterInfo()", printed);
         Assert.DoesNotContain(" ChapterInfo(", printed);
-
-        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
-        Assert.True(roundTrip.Success, string.Join(Environment.NewLine, roundTrip.Errors));
     }
 
     private static int CountOccurrences(string haystack, string needle)
@@ -409,6 +395,32 @@ namespace Consumer
         }
 
         return count;
+    }
+
+    private static string TranslateTargetAndAssertProjectBinds(
+        LoadedCSharpProject project,
+        string targetFile)
+    {
+        var translator = new CSharpToGSharpTranslator();
+        var translated = project.Documents.Select(document =>
+        {
+            var context = new TranslationContext(
+                project.Compilation,
+                document.SemanticModel,
+                document.FilePath);
+            CompilationUnit unit = translator.TranslateDocument(document, context);
+            return (document.FilePath, Printed: GSharpPrinter.Print(unit));
+        }).ToArray();
+        foreach (var result in translated)
+        {
+            RoundTripResult roundTrip = TranslationTestValidation.ValidateRoundTripOnly(
+                result.Printed,
+                "Binder.BindGlobalScope flattens multi-package fixtures and cannot resolve their qualified source types.");
+            Assert.True(roundTrip.Success, string.Join(Environment.NewLine, roundTrip.Errors));
+        }
+
+        return translated.Single(
+            result => result.FilePath.EndsWith(targetFile, StringComparison.Ordinal)).Printed;
     }
 
     private static MetadataReference CompileLibrary(string libSource, string assemblyName)

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2224AnonymousObjectCreationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2224AnonymousObjectCreationTests.cs
@@ -198,7 +198,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2228AutoPropertyRecordDataClassTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2228AutoPropertyRecordDataClassTranslationTests.cs
@@ -134,7 +134,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2233NegatedBracePatternTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2233NegatedBracePatternTranslationTests.cs
@@ -222,7 +222,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2234IndexerMemberDeconstructAssignTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2234IndexerMemberDeconstructAssignTranslationTests.cs
@@ -240,7 +240,7 @@ namespace Corpus.Issue2234
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2235FilteredCatchFallthroughTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2235FilteredCatchFallthroughTranslationTests.cs
@@ -276,7 +276,7 @@ namespace Demo
         Assert.DoesNotContain(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2236NamedArgumentSkipNonLiteralDefaultTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2236NamedArgumentSkipNonLiteralDefaultTests.cs
@@ -33,7 +33,8 @@ namespace Demo
             Foo(a: 1, flag: 2);
         }
     }
-}");
+}",
+            "G# currently cannot bind decimal optional defaults emitted without a decimal literal suffix.");
         Assert.Contains("Foo(a: 1, flag: 2)", printed, StringComparison.Ordinal);
     }
 
@@ -55,7 +56,8 @@ namespace Demo
             Foo(1);
         }
     }
-}");
+}",
+            "G# currently cannot bind decimal optional defaults emitted without a decimal literal suffix.");
         Assert.Contains("price decimal = 1.5", printed, StringComparison.Ordinal);
         Assert.Contains("Foo(1)", printed, StringComparison.Ordinal);
     }
@@ -143,7 +145,7 @@ namespace Demo
         Assert.Contains("Foo(a: 1, flag: 2)", printed, StringComparison.Ordinal);
     }
 
-    private static string TranslateUnit(string source)
+    private static string TranslateUnit(string source, string roundTripOnlyReason = null)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
         Assert.True(
@@ -155,7 +157,9 @@ namespace Demo
         var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = roundTripOnlyReason is null
+            ? TranslationTestValidation.AssertBinds(printed)
+            : TranslationTestValidation.ValidateRoundTripOnly(printed, roundTripOnlyReason);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2259ObliviousNullConditionalIndexTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2259ObliviousNullConditionalIndexTranslationTests.cs
@@ -183,7 +183,7 @@ namespace Demo
     private static string PrintAndValidate(CompilationUnit unit)
     {
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2260NamedArgumentSkipExtensionReceiverTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2260NamedArgumentSkipExtensionReceiverTests.cs
@@ -125,7 +125,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
         Assert.DoesNotContain(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2281NonConstantRecordInitializerTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2281NonConstantRecordInitializerTests.cs
@@ -303,7 +303,7 @@ namespace Oahu.Cli.App
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2282AnonymousTypeCrossBoundaryTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2282AnonymousTypeCrossBoundaryTests.cs
@@ -115,7 +115,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2285InterfaceImplementationNullabilityTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2285InterfaceImplementationNullabilityTests.cs
@@ -241,7 +241,7 @@ namespace Demo
     private static string PrintAndValidate(CompilationUnit unit)
     {
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2292AnonymousTypePackageScopeTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2292AnonymousTypePackageScopeTests.cs
@@ -221,7 +221,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +
@@ -268,8 +268,7 @@ namespace Demo
         CompilationUnit unitB = translator.TranslateDocument(documentB, contextB);
         string printedB = GSharpPrinter.Print(unitB);
 
-        Assert.True(GSharpRoundTrip.Validate(printedA).Success, "File A must round-trip:\n" + printedA);
-        Assert.True(GSharpRoundTrip.Validate(printedB).Success, "File B must round-trip:\n" + printedB);
+        TranslationTestValidation.AssertBinds(printedA, printedB);
 
         return (printedA, printedB);
     }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2342CrossPackageAnonymousTypeCollisionTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2342CrossPackageAnonymousTypeCollisionTests.cs
@@ -10,7 +10,6 @@ using System.Text;
 using System.Text.RegularExpressions;
 using Cs2Gs.CodeModel.Ast;
 using Cs2Gs.CodeModel.Printing;
-using Cs2Gs.CodeModel.RoundTrip;
 using Cs2Gs.Translator;
 using Cs2Gs.Translator.Loading;
 using Xunit;
@@ -115,8 +114,7 @@ namespace Oahu.BooksDatabase.Migrations
         CompilationUnit unitB = translator.TranslateDocument(documentB, contextB);
         string printedB = GSharpPrinter.Print(unitB);
 
-        Assert.True(GSharpRoundTrip.Validate(printedA).Success, "File A must round-trip:\n" + printedA);
-        Assert.True(GSharpRoundTrip.Validate(printedB).Success, "File B must round-trip:\n" + printedB);
+        TranslationTestValidation.AssertBinds(printedA, printedB);
 
         return (printedA, printedB);
     }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2351ExtensionMethodImportSynthesisTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2351ExtensionMethodImportSynthesisTests.cs
@@ -134,8 +134,9 @@ namespace Demo
         // `GlobalUsings.cs` takes) rather than a per-file `using` — proves the
         // fix generalizes beyond BCL/System.Linq to any imported (same-
         // compilation, different-namespace) extension.
-        string printed = TranslateNamed(
+        string printed = TranslateNamedRoundTripOnly(
             "Consumer.cs",
+            "Target-only fixture omits the source extension declaration needed to bind the imported call.",
             ("Extensions.cs", @"
 namespace Acme.Extensions
 {
@@ -194,8 +195,9 @@ namespace Acme.App
     {
         // A custom extension declared in a multi-segment nested namespace,
         // reached through a global using rather than a per-file `using`.
-        string printed = TranslateNamed(
+        string printed = TranslateNamedRoundTripOnly(
             "Consumer.cs",
+            "Target-only fixture omits the source extension declaration needed to bind the imported call.",
             ("Extensions.cs", @"
 namespace Acme.Deep.Nested.Extensions
 {
@@ -266,8 +268,9 @@ namespace Demo
         // merges multiple same-file namespaces into one dominant package,
         // which would make them share a package and hide the cross-namespace
         // import requirement this test targets.
-        string printed = TranslateNamed(
+        string printed = TranslateNamedRoundTripOnly(
             "Consumer.cs",
+            "Target-only fixture omits the source extension declaration needed to bind the imported call.",
             ("Extensions.cs", @"
 namespace Acme.Extensions
 {
@@ -298,7 +301,25 @@ namespace Acme.App
         return TranslateNamed("Snippet.cs", ("Snippet.cs", source));
     }
 
-    private static string TranslateNamed(string targetFileName, params (string FileName, string Source)[] sources)
+    private static string TranslateNamedRoundTripOnly(
+        string targetFileName,
+        string reason,
+        params (string FileName, string Source)[] sources)
+    {
+        return TranslateNamed(targetFileName, reason, sources);
+    }
+
+    private static string TranslateNamed(
+        string targetFileName,
+        params (string FileName, string Source)[] sources)
+    {
+        return TranslateNamed(targetFileName, roundTripOnlyReason: null, sources);
+    }
+
+    private static string TranslateNamed(
+        string targetFileName,
+        string roundTripOnlyReason,
+        params (string FileName, string Source)[] sources)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(sources);
         Assert.True(
@@ -315,7 +336,9 @@ namespace Acme.App
             d => d.Severity == TranslationSeverity.Unsupported);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
+        RoundTripResult result = roundTripOnlyReason is null
+            ? TranslationTestValidation.AssertBinds(printed)
+            : TranslationTestValidation.ValidateRoundTripOnly(printed, roundTripOnlyReason);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2351ExtensionMethodImportSynthesisTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2351ExtensionMethodImportSynthesisTests.cs
@@ -315,7 +315,7 @@ namespace Acme.App
             d => d.Severity == TranslationSeverity.Unsupported);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2352BinaryNumericCoercionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2352BinaryNumericCoercionTranslationTests.cs
@@ -455,7 +455,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +
@@ -480,7 +480,7 @@ namespace Demo
             d => d.Severity == TranslationSeverity.Unsupported);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2362ExplicitInterfacePropertyTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2362ExplicitInterfacePropertyTests.cs
@@ -575,7 +575,7 @@ namespace Corpus.Issue2362
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2363EmptyPositionalRecordTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2363EmptyPositionalRecordTranslationTests.cs
@@ -143,7 +143,7 @@ namespace Oahu.Cli.App.Auth
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2370ExplicitInterfaceEventTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2370ExplicitInterfaceEventTests.cs
@@ -354,11 +354,20 @@ namespace Corpus.Issue2370
             "Snippet should bind with no C# errors: " +
                 string.Join(Environment.NewLine, project.ErrorDiagnostics));
 
-        LoadedDocument document = project.Documents.Single(d => d.FilePath == "Both.cs");
-        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
-        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
-
-        string printed = GSharpPrinter.Print(unit);
+        var translator = new CSharpToGSharpTranslator();
+        var translated = project.Documents.Select(document =>
+        {
+            var documentContext = new TranslationContext(
+                project.Compilation,
+                document.SemanticModel,
+                document.FilePath);
+            CompilationUnit documentUnit = translator.TranslateDocument(document, documentContext);
+            return (document, documentContext, documentUnit, printed: GSharpPrinter.Print(documentUnit));
+        }).ToArray();
+        var target = translated.Single(result => result.document.FilePath == "Both.cs");
+        TranslationContext context = target.documentContext;
+        CompilationUnit unit = target.documentUnit;
+        string printed = target.printed;
 
         TypeDeclaration both = unit.Members.OfType<TypeDeclaration>().Single(t => t.Name == "Both");
         var events = both.Members.OfType<EventDeclaration>().Where(e => e.Name == "Changed").ToList();
@@ -368,7 +377,13 @@ namespace Corpus.Issue2370
         Assert.Contains("(NsB.IWatcher) Changed", printed, StringComparison.Ordinal);
 
         Assert.DoesNotContain(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
-        AssertRoundTripParses(printed);
+        foreach (var result in translated)
+        {
+            RoundTripResult roundTrip = TranslationTestValidation.ValidateRoundTripOnly(
+                result.printed,
+                "Binder.BindGlobalScope cannot resolve qualified interfaces across this multi-package fixture.");
+            Assert.True(roundTrip.Success, string.Join(Environment.NewLine, roundTrip.Errors));
+        }
     }
 
     /// <summary>
@@ -406,7 +421,7 @@ namespace Corpus.Issue2370
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2370ExplicitInterfaceStaticMemberTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2370ExplicitInterfaceStaticMemberTests.cs
@@ -161,7 +161,7 @@ namespace Corpus.Issue2370Static
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
         Assert.True(
             result.Success,
             "Sanitized G# must round-trip-parse. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2382TopLevelStatementsTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2382TopLevelStatementsTranslationTests.cs
@@ -405,7 +405,9 @@ namespace Demo
 
     private static void AssertRoundTripParses(string printed)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.ValidateRoundTripOnly(
+            printed,
+            "CompileAndRunProgram binds the complete emitted file set after per-file parse checks.");
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2412CrossProjectObliviousNullabilityTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2412CrossProjectObliviousNullabilityTranslationTests.cs
@@ -459,8 +459,16 @@ namespace LibA
             new MetadataReference[] { projectB.Compilation.ToMetadataReference(), projectC.Compilation.ToMetadataReference() });
 
         var siblings = new[] { projectA.Compilation, projectB.Compilation, projectC.Compilation };
+        string printedB = TranslateProject(projectB, siblings);
         string printedC = TranslateProject(projectC, siblings);
         string printedA = TranslateProject(projectA, siblings);
+        foreach (string printed in new[] { printedA, printedB, printedC })
+        {
+            RoundTripResult roundTrip = TranslationTestValidation.ValidateRoundTripOnly(
+                printed,
+                "Binder.BindGlobalScope cannot resolve alias-qualified types across this multi-package fixture.");
+            Assert.True(roundTrip.Success, string.Join(Environment.NewLine, roundTrip.Errors));
+        }
 
         Assert.Contains("prop Name string {", printedC);
         Assert.DoesNotContain("prop Name string? {", printedC);
@@ -675,8 +683,10 @@ namespace LibCore
             });
 
         var siblings = new[] { projectCore.Compilation, projectData.Compilation, projectFoundation.Compilation };
+        string printedFoundation = TranslateProject(projectFoundation, siblings);
         string printedData = TranslateProject(projectData, siblings);
         string printedCore = TranslateProject(projectCore, siblings);
+        TranslationTestValidation.AssertBinds(printedCore, printedData, printedFoundation);
 
         // LibData's own standalone translation already promotes both endpoints
         // (issue #2285) — the interface member declared in Foundation AND its
@@ -722,6 +732,8 @@ namespace LibA
         string firstPrintedB = TranslateProject(projectB, siblings);
         string secondPrintedB = TranslateProject(projectB, siblings);
         string secondPrintedA = TranslateProject(projectA, siblings);
+        TranslationTestValidation.AssertBinds(firstPrintedA, firstPrintedB);
+        TranslationTestValidation.AssertBinds(secondPrintedA, secondPrintedB);
 
         Assert.Equal(firstPrintedA, secondPrintedA);
         Assert.Equal(firstPrintedB, secondPrintedB);
@@ -743,6 +755,7 @@ namespace LibA
         var siblings = new[] { projectA.Compilation, projectB.Compilation };
         string printedB = TranslateProject(projectB, siblings);
         string printedA = TranslateProject(projectA, siblings);
+        TranslationTestValidation.AssertBinds(printedA, printedB);
         return (printedB, printedA);
     }
 
@@ -817,18 +830,7 @@ namespace LibA
             siblingCompilations,
             repositoryCompilations: siblingCompilations);
         CompilationUnit unit = translator.TranslateDocument(document, context);
-        return PrintAndValidate(unit);
-    }
-
-    private static string PrintAndValidate(CompilationUnit unit)
-    {
-        string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
-        Assert.True(
-            result.Success,
-            "Translated G# must round-trip. Errors:\n" +
-                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
-        return printed;
+        return GSharpPrinter.Print(unit);
     }
 
     // Collapses incidental whitespace/newlines around composite-literal braces

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2412TernaryArmForgivenessGeneralizationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2412TernaryArmForgivenessGeneralizationTests.cs
@@ -591,6 +591,7 @@ namespace LibA
         var siblings = new[] { projectA.Compilation, projectB.Compilation };
         string printedB = TranslateProject(projectB, siblings);
         string printedA = TranslateProject(projectA, siblings);
+        TranslationTestValidation.AssertBinds(printedA, printedB);
         return (printedB, printedA);
     }
 
@@ -657,13 +658,13 @@ namespace LibA
         var context = new TranslationContext(
             project.Compilation, document.SemanticModel, document.FilePath, siblingCompilations);
         CompilationUnit unit = translator.TranslateDocument(document, context);
-        return PrintAndValidate(unit);
+        return GSharpPrinter.Print(unit);
     }
 
     private static string PrintAndValidate(CompilationUnit unit)
     {
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2414CrossProjectExtensionResolutionTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2414CrossProjectExtensionResolutionTests.cs
@@ -242,7 +242,9 @@ namespace Oahu.App
             project.Compilation, document.SemanticModel, document.FilePath, siblingCompilations);
         CompilationUnit unit = translator.TranslateDocument(document, context);
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.ValidateRoundTripOnly(
+            printed,
+            "CompileAndRun binds all three emitted packages together after per-project parse checks.");
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2421AsyncReturnTaintTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2421AsyncReturnTaintTranslationTests.cs
@@ -281,7 +281,7 @@ namespace Demo
     private static string PrintAndValidate(CompilationUnit unit)
     {
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2423InterfaceMethodContractTaintTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2423InterfaceMethodContractTaintTests.cs
@@ -333,7 +333,9 @@ namespace Demo
 
         LoadedDocument document = Assert.Single(project.Documents);
         var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
-        string printed = PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+        string printed = PrintAndValidate(
+            new CSharpToGSharpTranslator().TranslateDocument(document, context),
+            "Nullable-enabled control preserves a null-forgiven nil return that G# rejects at a non-null sink.");
 
         Assert.Contains("func Get() Task[string];", printed);
         Assert.Contains("async func Get() string ->", printed);
@@ -355,10 +357,12 @@ namespace Demo
         return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
     }
 
-    private static string PrintAndValidate(CompilationUnit unit)
+    private static string PrintAndValidate(CompilationUnit unit, string roundTripOnlyReason = null)
     {
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
+        RoundTripResult result = roundTripOnlyReason is null
+            ? TranslationTestValidation.AssertBinds(printed)
+            : TranslationTestValidation.ValidateRoundTripOnly(printed, roundTripOnlyReason);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2423InterfaceMethodContractTaintTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2423InterfaceMethodContractTaintTests.cs
@@ -358,7 +358,7 @@ namespace Demo
     private static string PrintAndValidate(CompilationUnit unit)
     {
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2425ExplicitLocalObliviousExternalForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2425ExplicitLocalObliviousExternalForgivenessTranslationTests.cs
@@ -572,7 +572,9 @@ public class ExtLib
     private static string PrintAndValidate(CompilationUnit unit)
     {
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.ValidateRoundTripOnly(
+            printed,
+            "Consumer-only fixture omits the referenced C# metadata library from emitted G#.");
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2427ObliviousExternalAssignmentForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2427ObliviousExternalAssignmentForgivenessTranslationTests.cs
@@ -686,7 +686,9 @@ public class ExtLib
     private static string PrintAndValidate(CompilationUnit unit)
     {
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.ValidateRoundTripOnly(
+            printed,
+            "Consumer-only fixture omits the referenced C# metadata library from emitted G#.");
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2429InitializerObliviousExternalForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2429InitializerObliviousExternalForgivenessTranslationTests.cs
@@ -946,7 +946,9 @@ public class ExtLib
     private static string PrintAndValidate(CompilationUnit unit)
     {
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.ValidateRoundTripOnly(
+            printed,
+            "Consumer-only fixture omits the referenced C# metadata library from emitted G#.");
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2432UnguardedForwardForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2432UnguardedForwardForgivenessTranslationTests.cs
@@ -617,7 +617,7 @@ namespace Demo
     private static string PrintAndValidate(CompilationUnit unit)
     {
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2434DelegateNullableInterfaceWideningTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2434DelegateNullableInterfaceWideningTranslationTests.cs
@@ -695,7 +695,7 @@ namespace Demo
     private static string PrintAndValidate(CompilationUnit unit)
     {
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2435MultiConstructorStructTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2435MultiConstructorStructTranslationTests.cs
@@ -269,7 +269,7 @@ namespace Demo
 
     private static void AssertRoundTrips(string printed)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2436ExplicitInterfacePrimaryConstructorLiftTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2436ExplicitInterfacePrimaryConstructorLiftTests.cs
@@ -154,7 +154,7 @@ namespace Demo
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
         Assert.True(
             result.Success,
             "Sanitized G# must round-trip-parse. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2438AsyncVoidEventHandlerTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2438AsyncVoidEventHandlerTranslationTests.cs
@@ -783,7 +783,11 @@ namespace Demo
             d => d.Severity == TranslationSeverity.Unsupported);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
+        RoundTripResult result = extraReferences is null
+            ? TranslationTestValidation.AssertBinds(printed)
+            : TranslationTestValidation.ValidateRoundTripOnly(
+                printed,
+                "Consumer fixture omits the referenced support assembly from emitted G#; CompileAndRun binds it below.");
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2438AsyncVoidEventHandlerTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2438AsyncVoidEventHandlerTranslationTests.cs
@@ -783,7 +783,7 @@ namespace Demo
             d => d.Severity == TranslationSeverity.Unsupported);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2462NestedSwitchBreakTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2462NestedSwitchBreakTranslationTests.cs
@@ -247,7 +247,7 @@ namespace Demo
             d => d.Severity == TranslationSeverity.Unsupported);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2467StaticExtensionConditionalReceiverTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2467StaticExtensionConditionalReceiverTests.cs
@@ -121,7 +121,8 @@ public class Issue2467StaticExtensionConditionalReceiverTests
                 public string Defaults(Box? box) => Ext.Join(box?.Value);
                 public string Params(Box? box) => Ext.Join(box?.Value, "-", "a", "b");
             }
-            """);
+            """,
+            "G# currently rejects nil as the default for an unconstrained generic optional parameter.");
 
         Assert.Contains("(box?.Value).Pick[string?](\"fallback\")", printed, StringComparison.Ordinal);
         Assert.Contains("(box?.Value).Pick(\"fallback\")", printed, StringComparison.Ordinal);
@@ -264,7 +265,7 @@ public class Issue2467StaticExtensionConditionalReceiverTests
         return count;
     }
 
-    private static string TranslateAndValidate(string source)
+    private static string TranslateAndValidate(string source, string roundTripOnlyReason = null)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
         Assert.True(
@@ -278,7 +279,9 @@ public class Issue2467StaticExtensionConditionalReceiverTests
         Assert.DoesNotContain(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = roundTripOnlyReason is null
+            ? TranslationTestValidation.AssertBinds(printed)
+            : TranslationTestValidation.ValidateRoundTripOnly(printed, roundTripOnlyReason);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2469TupleElementNullabilityTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2469TupleElementNullabilityTranslationTests.cs
@@ -258,7 +258,7 @@ namespace LibA
             siblingCompilations);
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2469TupleElementNullabilityTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2469TupleElementNullabilityTranslationTests.cs
@@ -191,7 +191,10 @@ namespace LibA
         var siblings = new[] { projectA.Compilation, projectB.Compilation };
 
         string printedB = TranslateProject(projectB, siblings);
-        string printedA = TranslateProject(projectA, siblings);
+        string printedA = TranslateProject(
+            projectA,
+            siblings,
+            "Consumer fixture omits the sibling Parser declaration from its emitted G# binding input.");
 
         Assert.Contains("func Parse() (string?, string)", printedB);
         Assert.Contains("func Parse() (string?, string)", printedA);
@@ -248,7 +251,8 @@ namespace LibA
 
     private static string TranslateProject(
         LoadedCSharpProject project,
-        IReadOnlyList<CSharpCompilation> siblingCompilations)
+        IReadOnlyList<CSharpCompilation> siblingCompilations,
+        string roundTripOnlyReason = null)
     {
         LoadedDocument document = Assert.Single(project.Documents);
         var context = new TranslationContext(
@@ -258,7 +262,9 @@ namespace LibA
             siblingCompilations);
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
+        RoundTripResult result = roundTripOnlyReason is null
+            ? TranslationTestValidation.AssertBinds(printed)
+            : TranslationTestValidation.ValidateRoundTripOnly(printed, roundTripOnlyReason);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2490TupleScalarNullabilityTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2490TupleScalarNullabilityTranslationTests.cs
@@ -391,7 +391,7 @@ public static class Repro
             siblingCompilations);
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2490TupleScalarNullabilityTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2490TupleScalarNullabilityTranslationTests.cs
@@ -286,7 +286,10 @@ namespace LibA
         var siblings = new[] { projectA.Compilation, projectB.Compilation };
 
         string printedB = TranslateProject(projectB, siblings);
-        string printedA = TranslateProject(projectA, siblings);
+        string printedA = TranslateProject(
+            projectA,
+            siblings,
+            "Consumer fixture omits the sibling Provider declaration from its emitted G# binding input.");
 
         Assert.Contains("func Gather(missing bool) (string?, int32)", printedB);
         Assert.Contains("func Count(value string?) int32", printedA);
@@ -381,7 +384,8 @@ public static class Repro
 
     private static string TranslateProject(
         LoadedCSharpProject project,
-        IReadOnlyList<CSharpCompilation> siblingCompilations)
+        IReadOnlyList<CSharpCompilation> siblingCompilations,
+        string roundTripOnlyReason = null)
     {
         LoadedDocument document = Assert.Single(project.Documents);
         var context = new TranslationContext(
@@ -391,7 +395,9 @@ public static class Repro
             siblingCompilations);
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
+        RoundTripResult result = roundTripOnlyReason is null
+            ? TranslationTestValidation.AssertBinds(printed)
+            : TranslationTestValidation.ValidateRoundTripOnly(printed, roundTripOnlyReason);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2496ExpressionTreeArgumentForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2496ExpressionTreeArgumentForgivenessTranslationTests.cs
@@ -220,7 +220,9 @@ public sealed class Issue2496ExpressionTreeArgumentForgivenessTranslationTests
         var context = new TranslationContext(compilation, model, document.FilePath);
         CompilationUnit translated = new CSharpToGSharpTranslator().TranslateDocument(document, context);
         string printed = GSharpPrinter.Print(translated);
-        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+        RoundTripResult roundTrip = TranslationTestValidation.ValidateRoundTripOnly(
+            printed,
+            "Consumer-only fixture omits the referenced expression-sink metadata library from emitted G#.");
         Assert.True(
             roundTrip.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2504NamedDelegateReturnTaintTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2504NamedDelegateReturnTaintTranslationTests.cs
@@ -182,7 +182,8 @@ public sealed class Issue2504NamedDelegateReturnTaintTranslationTests
                 private static ArrayCallback array = ArrayProduce;
                 private static NestedCallback nested = NestedProduce;
             }
-            """);
+            """,
+            "G# cannot yet convert this open generic method group to the constructed named delegate.");
 
         Assert.Contains("delegate func() T?", printed, StringComparison.Ordinal);
         Assert.Contains("type TaskCallback = delegate func() Task[Result?]", printed, StringComparison.Ordinal);
@@ -308,7 +309,10 @@ public sealed class Issue2504NamedDelegateReturnTaintTranslationTests
             new[] { producer.ToMetadataReference() },
             NullableContextOptions.Disable);
 
-        string printed = TranslateCompilation(consumer, new[] { producer, consumer });
+        string printed = TranslateCompilation(
+            consumer,
+            new[] { producer, consumer },
+            "Consumer-only fixture omits the referenced producer project from emitted G#.");
 
         Assert.Contains("type Callback = delegate func() Result?", printed, StringComparison.Ordinal);
         Assert.Contains("Factory.Produce", printed, StringComparison.Ordinal);
@@ -343,17 +347,23 @@ public sealed class Issue2504NamedDelegateReturnTaintTranslationTests
         Assert.DoesNotContain("Clean() Result?", printed, StringComparison.Ordinal);
     }
 
-    private static string TranslateOblivious(string source) =>
-        Translate(source, NullableContextOptions.Disable);
+    private static string TranslateOblivious(string source, string roundTripOnlyReason = null) =>
+        Translate(source, NullableContextOptions.Disable, roundTripOnlyReason);
 
-    private static string Translate(string source, NullableContextOptions nullableContext)
+    private static string Translate(
+        string source,
+        NullableContextOptions nullableContext,
+        string roundTripOnlyReason = null)
     {
         CSharpCompilation compilation = CreateCompilation(
             "Issue2504",
             source,
             references: null,
             nullableContext);
-        return TranslateCompilation(compilation, siblingCompilations: null);
+        return TranslateCompilation(
+            compilation,
+            siblingCompilations: null,
+            roundTripOnlyReason: roundTripOnlyReason);
     }
 
     private static CSharpCompilation CreateCompilation(
@@ -382,7 +392,8 @@ public sealed class Issue2504NamedDelegateReturnTaintTranslationTests
 
     private static string TranslateCompilation(
         CSharpCompilation compilation,
-        IReadOnlyList<CSharpCompilation> siblingCompilations)
+        IReadOnlyList<CSharpCompilation> siblingCompilations,
+        string roundTripOnlyReason = null)
     {
         var printed = new List<string>();
         foreach (SyntaxTree tree in compilation.SyntaxTrees)
@@ -396,7 +407,9 @@ public sealed class Issue2504NamedDelegateReturnTaintTranslationTests
                 siblingCompilations);
             CompilationUnit translated = new CSharpToGSharpTranslator().TranslateDocument(document, context);
             string text = GSharpPrinter.Print(translated);
-            RoundTripResult roundTrip = GSharpRoundTrip.Validate(text);
+            RoundTripResult roundTrip = roundTripOnlyReason is null
+                ? TranslationTestValidation.AssertBinds(text)
+                : TranslationTestValidation.ValidateRoundTripOnly(text, roundTripOnlyReason);
             Assert.True(
                 roundTrip.Success,
                 "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2504NamedDelegateReturnTaintTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2504NamedDelegateReturnTaintTranslationTests.cs
@@ -88,7 +88,8 @@ public sealed class Issue2504NamedDelegateReturnTaintTranslationTests
                     Changed += Produce;
                 }
             }
-            """);
+            """,
+            "G# currently does not bind source event names inside shared method bodies.");
 
         Assert.Contains("type Callback = delegate func(enforce bool = false) Result?", printed, StringComparison.Ordinal);
         Assert.Contains("func Clean(enforce bool) Result?", printed, StringComparison.Ordinal);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2506PromotedCallReceiverForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2506PromotedCallReceiverForgivenessTranslationTests.cs
@@ -89,7 +89,8 @@ public sealed class Issue2506PromotedCallReceiverForgivenessTranslationTests
                     return count;
                 }
             }
-            """);
+            """,
+            "G# parses class conversion syntax here as a constructor call, so the cast-shape fixture cannot bind.");
 
         Assert.Contains("Repro.Find()!!.Name", printed, StringComparison.Ordinal);
         Assert.Contains("Repro.Find()!!.Read()", printed, StringComparison.Ordinal);
@@ -212,7 +213,8 @@ public sealed class Issue2506PromotedCallReceiverForgivenessTranslationTests
                     }
                 }
             }
-            """);
+            """,
+            "G# currently rejects nullable disposable resources even though C# using is null-tolerant.");
 
         Assert.Contains("using let __using = Repro.Open()", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("Repro.Open()!!", printed, StringComparison.Ordinal);
@@ -239,7 +241,8 @@ public sealed class Issue2506PromotedCallReceiverForgivenessTranslationTests
                 public static string Conditional() => Find()?.Name;
                 public static Expression<Func<string>> Tree() => () => Find().Name;
             }
-            """);
+            """,
+            "Expression-tree fixtures intentionally omit runtime assertions that G# requires for ordinary delegates.");
 
         Assert.Contains("Repro.Find()?.Name", oblivious, StringComparison.Ordinal);
         Assert.DoesNotContain("Repro.Find()!!?.Name", oblivious, StringComparison.Ordinal);
@@ -318,7 +321,7 @@ public sealed class Issue2506PromotedCallReceiverForgivenessTranslationTests
         Assert.Equal(3, CountOccurrences(printed, "provider.Find()!!.Name"));
     }
 
-    private static string Translate(string source)
+    private static string Translate(string source, string roundTripOnlyReason = null)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
         Assert.True(
@@ -331,7 +334,9 @@ public sealed class Issue2506PromotedCallReceiverForgivenessTranslationTests
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
+        RoundTripResult result = roundTripOnlyReason is null
+            ? TranslationTestValidation.AssertBinds(printed)
+            : TranslationTestValidation.ValidateRoundTripOnly(printed, roundTripOnlyReason);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2506PromotedCallReceiverForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2506PromotedCallReceiverForgivenessTranslationTests.cs
@@ -331,7 +331,7 @@ public sealed class Issue2506PromotedCallReceiverForgivenessTranslationTests
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2509ConstraintTypeQualificationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2509ConstraintTypeQualificationTranslationTests.cs
@@ -281,10 +281,29 @@ public sealed class Issue2509ConstraintTypeQualificationTranslationTests
             "Inline C# should bind without errors: " +
                 string.Join(Environment.NewLine, project.ErrorDiagnostics));
 
-        LoadedDocument document = project.Documents.Single(
-            candidate => candidate.FilePath.EndsWith(targetFile, StringComparison.Ordinal));
-        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
-        return (PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context)), context);
+        var translator = new CSharpToGSharpTranslator();
+        var translated = project.Documents.Select(document =>
+        {
+            var context = new TranslationContext(
+                project.Compilation,
+                document.SemanticModel,
+                document.FilePath);
+            CompilationUnit unit = translator.TranslateDocument(document, context);
+            return (document.FilePath, Context: context, Printed: GSharpPrinter.Print(unit));
+        }).ToArray();
+        foreach (var result in translated)
+        {
+            RoundTripResult roundTrip = TranslationTestValidation.ValidateRoundTripOnly(
+                result.Printed,
+                "Binder.BindGlobalScope flattens multi-package fixtures and cannot resolve their qualified source types.");
+            Assert.True(
+                roundTrip.Success,
+                string.Join(Environment.NewLine, roundTrip.Errors) + Environment.NewLine + result.Printed);
+        }
+
+        var target = translated.Single(
+            result => result.FilePath.EndsWith(targetFile, StringComparison.Ordinal));
+        return (target.Printed, target.Context);
     }
 
     private static string TranslateWithReferences(
@@ -309,13 +328,16 @@ public sealed class Issue2509ConstraintTypeQualificationTranslationTests
         SemanticModel model = compilation.GetSemanticModel(target);
         var document = new LoadedDocument(target.FilePath, target, model);
         var context = new TranslationContext(compilation, model, document.FilePath);
-        return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+        return PrintAndValidateRoundTripOnly(
+            new CSharpToGSharpTranslator().TranslateDocument(document, context));
     }
 
-    private static string PrintAndValidate(CompilationUnit unit)
+    private static string PrintAndValidateRoundTripOnly(CompilationUnit unit)
     {
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+        RoundTripResult roundTrip = TranslationTestValidation.ValidateRoundTripOnly(
+            printed,
+            "Target-only fixture omits source or metadata declarations used solely to test type qualification.");
         Assert.True(
             roundTrip.Success,
             string.Join(Environment.NewLine, roundTrip.Errors) + Environment.NewLine + printed);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2511NullableIndexArgumentForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2511NullableIndexArgumentForgivenessTranslationTests.cs
@@ -53,7 +53,8 @@ public sealed class Issue2511NullableIndexArgumentForgivenessTranslationTests
                     return items[key];
                 }
             }
-            """);
+            """,
+            "G# rejects ??= on the oblivious Dictionary value because its indexer type is non-nullable.");
 
         Assert.Contains("items[key!!] = \"value\"", printed, StringComparison.Ordinal);
         Assert.Contains("let value = items[key!!]", printed, StringComparison.Ordinal);
@@ -257,7 +258,8 @@ public sealed class Issue2511NullableIndexArgumentForgivenessTranslationTests
                         + text[1..^1].Length + grid[row, column];
                 }
             }
-            """);
+            """,
+            "Expression-tree index arguments deliberately retain nullable references that G# cannot bind to string.");
 
         Assert.Contains("items[key]", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("key!!", printed, StringComparison.Ordinal);
@@ -272,12 +274,19 @@ public sealed class Issue2511NullableIndexArgumentForgivenessTranslationTests
         Assert.DoesNotContain("column!!", printed, StringComparison.Ordinal);
     }
 
-    private static string TranslateOblivious(string source) =>
-        Translate(source, NullableContextOptions.Disable);
+    private static string TranslateOblivious(string source, string roundTripOnlyReason = null) =>
+        Translate(source, NullableContextOptions.Disable, roundTripOnlyReason);
 
     private static string Translate(
         string source,
         NullableContextOptions nullableContext,
+        params MetadataReference[] additionalReferences) =>
+        Translate(source, nullableContext, roundTripOnlyReason: null, additionalReferences);
+
+    private static string Translate(
+        string source,
+        NullableContextOptions nullableContext,
+        string roundTripOnlyReason,
         params MetadataReference[] additionalReferences)
     {
         SyntaxTree tree = CSharpSyntaxTree.ParseText(
@@ -300,8 +309,10 @@ public sealed class Issue2511NullableIndexArgumentForgivenessTranslationTests
         var context = new TranslationContext(compilation, model, document.FilePath);
         CompilationUnit translated = new CSharpToGSharpTranslator().TranslateDocument(document, context);
         string printed = GSharpPrinter.Print(translated);
-        RoundTripResult roundTrip = additionalReferences.Length == 0
-            ? TranslationTestValidation.AssertBinds(printed)
+        RoundTripResult roundTrip = roundTripOnlyReason is not null
+            ? TranslationTestValidation.ValidateRoundTripOnly(printed, roundTripOnlyReason)
+            : additionalReferences.Length == 0
+                ? TranslationTestValidation.AssertBinds(printed)
             : TranslationTestValidation.ValidateRoundTripOnly(
                 printed,
                 "Consumer-only fixture omits the referenced indexer metadata library from emitted G#.");

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2511NullableIndexArgumentForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2511NullableIndexArgumentForgivenessTranslationTests.cs
@@ -300,7 +300,11 @@ public sealed class Issue2511NullableIndexArgumentForgivenessTranslationTests
         var context = new TranslationContext(compilation, model, document.FilePath);
         CompilationUnit translated = new CSharpToGSharpTranslator().TranslateDocument(document, context);
         string printed = GSharpPrinter.Print(translated);
-        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+        RoundTripResult roundTrip = additionalReferences.Length == 0
+            ? TranslationTestValidation.AssertBinds(printed)
+            : TranslationTestValidation.ValidateRoundTripOnly(
+                printed,
+                "Consumer-only fixture omits the referenced indexer metadata library from emitted G#.");
         Assert.True(
             roundTrip.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2538AnonymousConstructionPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2538AnonymousConstructionPipelineTests.cs
@@ -78,7 +78,7 @@ public sealed class Issue2538AnonymousConstructionPipelineTests
         Assert.DoesNotContain(envelopeType + "{", printed, StringComparison.Ordinal);
         Assert.DoesNotContain(apiType + "{", printed, StringComparison.Ordinal);
 
-        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+        RoundTripResult roundTrip = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             roundTrip.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2538ConvenienceInitializerTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2538ConvenienceInitializerTests.cs
@@ -83,7 +83,7 @@ public sealed class Issue2538ConvenienceInitializerTests
         int parameterShadow = printed.IndexOf("var seed = seed", StringComparison.Ordinal);
         Assert.True(delegation >= 0 && parameterShadow > delegation, printed);
 
-        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+        RoundTripResult roundTrip = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             roundTrip.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2552NestedBreakTargetTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2552NestedBreakTargetTests.cs
@@ -217,7 +217,7 @@ namespace Demo
         Assert.DoesNotContain(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(result.Success, string.Join(Environment.NewLine, result.Errors) + Environment.NewLine + printed);
         return printed;
     }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2579NullableReferenceFidelityTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2579NullableReferenceFidelityTranslationTests.cs
@@ -131,7 +131,7 @@ public sealed class Issue2579NullableReferenceFidelityTranslationTests
         var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(result.Success, string.Join(Environment.NewLine, result.Errors) + "\n" + printed);
         return printed;
     }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2580EnumSwitchFallbackTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2580EnumSwitchFallbackTranslationTests.cs
@@ -191,7 +191,7 @@ public sealed class Issue2580EnumSwitchFallbackTranslationTests
             diagnostic => diagnostic.Severity == TranslationSeverity.Unsupported);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2635ConstantContextNullabilityTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2635ConstantContextNullabilityTranslationTests.cs
@@ -51,7 +51,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2661ExpressionTreeNullableTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2661ExpressionTreeNullableTranslationTests.cs
@@ -47,7 +47,8 @@ public sealed class Issue2661ExpressionTreeNullableTranslationTests
                             b.Conversion.Region == profileId.Region)
                         .Select(b => b.PurchaseDate.Value);
             }
-            """);
+            """,
+            "Queryable expression-tree lambdas intentionally omit runtime assertions that ordinary G# binding requires.");
 
         Assert.Contains("b.PurchaseDate != nil", printed, StringComparison.Ordinal);
         Assert.Contains(".Select((b Book) -> b.PurchaseDate.Value)", printed, StringComparison.Ordinal);
@@ -94,7 +95,7 @@ public sealed class Issue2661ExpressionTreeNullableTranslationTests
         Assert.Contains("book.PurchaseDate!!", printed, StringComparison.Ordinal);
     }
 
-    private static string Translate(string source)
+    private static string Translate(string source, string? roundTripOnlyReason = null)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("BookLibrary.cs", source) });
         Assert.True(
@@ -105,7 +106,9 @@ public sealed class Issue2661ExpressionTreeNullableTranslationTests
         var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
         CompilationUnit translated = new CSharpToGSharpTranslator().TranslateDocument(document, context);
         string printed = GSharpPrinter.Print(translated);
-        RoundTripResult roundTrip = TranslationTestValidation.AssertBinds(printed);
+        RoundTripResult roundTrip = roundTripOnlyReason is null
+            ? TranslationTestValidation.AssertBinds(printed)
+            : TranslationTestValidation.ValidateRoundTripOnly(printed, roundTripOnlyReason);
         Assert.True(
             roundTrip.Success,
             "Translated G# must round-trip:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2661ExpressionTreeNullableTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2661ExpressionTreeNullableTranslationTests.cs
@@ -105,7 +105,7 @@ public sealed class Issue2661ExpressionTreeNullableTranslationTests
         var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
         CompilationUnit translated = new CSharpToGSharpTranslator().TranslateDocument(document, context);
         string printed = GSharpPrinter.Print(translated);
-        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+        RoundTripResult roundTrip = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             roundTrip.Success,
             "Translated G# must round-trip:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2704RecordInitializerTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2704RecordInitializerTranslationTests.cs
@@ -63,7 +63,7 @@ public sealed class Issue2704RecordInitializerTranslationTests
         Assert.DoesNotContain("data class LibraryItem(Asin", printed, StringComparison.Ordinal);
         Assert.Contains("LibraryItem{Asin: asin, Title: title", printed, StringComparison.Ordinal);
 
-        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+        RoundTripResult roundTrip = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             roundTrip.Success,
             string.Join(Environment.NewLine, roundTrip.Errors) + Environment.NewLine + printed);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2743NullableObjectInitializerWideningTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2743NullableObjectInitializerWideningTranslationTests.cs
@@ -123,7 +123,9 @@ public sealed class Issue2743NullableObjectInitializerWideningTranslationTests
         LoadedDocument document = Assert.Single(project.Documents);
         string printed = GSharpPrinter.Print(
             new CSharpToGSharpTranslator().TranslateDocument(document));
-        RoundTripResult roundTrip = TranslationTestValidation.AssertBinds(printed);
+        RoundTripResult roundTrip = TranslationTestValidation.ValidateRoundTripOnly(
+            printed,
+            "G# currently requires a Dictionary constructor argument before binding collection initializer entries.");
         Assert.True(roundTrip.Success, string.Join(Environment.NewLine, roundTrip.Errors));
         return printed;
     }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2743NullableObjectInitializerWideningTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2743NullableObjectInitializerWideningTranslationTests.cs
@@ -123,7 +123,7 @@ public sealed class Issue2743NullableObjectInitializerWideningTranslationTests
         LoadedDocument document = Assert.Single(project.Documents);
         string printed = GSharpPrinter.Print(
             new CSharpToGSharpTranslator().TranslateDocument(document));
-        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+        RoundTripResult roundTrip = TranslationTestValidation.AssertBinds(printed);
         Assert.True(roundTrip.Success, string.Join(Environment.NewLine, roundTrip.Errors));
         return printed;
     }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2766ValueTypeConstructorAbiTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2766ValueTypeConstructorAbiTests.cs
@@ -93,7 +93,7 @@ public sealed class Issue2766ValueTypeConstructorAbiTests
         Assert.Contains("init(level int32)", printed, StringComparison.Ordinal);
         Assert.Contains("init(publicValue int32, privateValue int32, propertyValue int32)", printed, StringComparison.Ordinal);
         Assert.Contains("convenience init(all int32)", printed, StringComparison.Ordinal);
-        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+        RoundTripResult roundTrip = TranslationTestValidation.AssertBinds(printed);
         Assert.True(roundTrip.Success, string.Join(Environment.NewLine, roundTrip.Errors));
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2821OwnedExtensionMemberTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2821OwnedExtensionMemberTranslationTests.cs
@@ -9,7 +9,6 @@ using System.IO;
 using System.Linq;
 using Cs2Gs.CodeModel.Ast;
 using Cs2Gs.CodeModel.Printing;
-using Cs2Gs.CodeModel.RoundTrip;
 using Cs2Gs.Translator;
 using Cs2Gs.Translator.Loading;
 using GSharp.Core.CodeAnalysis.Binding;
@@ -1069,14 +1068,10 @@ public static class MeterExtensions
                 document.FilePath);
             CompilationUnit unit = translator.TranslateDocument(document, context);
             string printed = GSharpPrinter.Print(unit);
-            RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
-            Assert.True(
-                roundTrip.Success,
-                "Translated G# must round-trip. Errors:\n" +
-                    string.Join("\n", roundTrip.Errors) + "\n\nPrinted:\n" + printed);
             result.Add(document.FilePath, printed);
         }
 
+        TranslationTestValidation.AssertBinds(result.Values.ToArray());
         return result;
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2821OwnedExtensionMemberTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2821OwnedExtensionMemberTranslationTests.cs
@@ -821,7 +821,8 @@ public static class User
     [Fact]
     public void NullConditionalStaticHelper_ChainedPrefixPreservesPointerAccess()
     {
-        IReadOnlyDictionary<string, string> printed = TranslateFiles(
+        IReadOnlyDictionary<string, string> printed = TranslateFilesRoundTripOnly(
+            "Managed pointer member chains remain outside current G# binding support.",
             ("Types.cs", @"
 #nullable enable
 namespace Demo;
@@ -1046,11 +1047,26 @@ public static class MeterExtensions
     private static IReadOnlyDictionary<string, string> TranslateFiles(
         params (string FileName, string Source)[] files)
     {
-        return TranslateFiles(new CSharpToGSharpTranslator(), files);
+        return TranslateFiles(new CSharpToGSharpTranslator(), roundTripOnlyReason: null, files);
+    }
+
+    private static IReadOnlyDictionary<string, string> TranslateFilesRoundTripOnly(
+        string reason,
+        params (string FileName, string Source)[] files)
+    {
+        return TranslateFiles(new CSharpToGSharpTranslator(), reason, files);
     }
 
     private static IReadOnlyDictionary<string, string> TranslateFiles(
         CSharpToGSharpTranslator translator,
+        params (string FileName, string Source)[] files)
+    {
+        return TranslateFiles(translator, roundTripOnlyReason: null, files);
+    }
+
+    private static IReadOnlyDictionary<string, string> TranslateFiles(
+        CSharpToGSharpTranslator translator,
+        string roundTripOnlyReason,
         params (string FileName, string Source)[] files)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(files);
@@ -1071,7 +1087,19 @@ public static class MeterExtensions
             result.Add(document.FilePath, printed);
         }
 
-        TranslationTestValidation.AssertBinds(result.Values.ToArray());
+        if (roundTripOnlyReason is null)
+        {
+            TranslationTestValidation.AssertBinds(result.Values.ToArray());
+        }
+        else
+        {
+            foreach (string source in result.Values)
+            {
+                var roundTrip = TranslationTestValidation.ValidateRoundTripOnly(source, roundTripOnlyReason);
+                Assert.True(roundTrip.Success, string.Join(Environment.NewLine, roundTrip.Errors));
+            }
+        }
+
         return result;
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2842CrossProjectObliviousLocalPromotionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2842CrossProjectObliviousLocalPromotionTranslationTests.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Cs2Gs.CodeModel.Ast;
 using Cs2Gs.CodeModel.Printing;
-using Cs2Gs.CodeModel.RoundTrip;
 using Cs2Gs.Translator;
 using Cs2Gs.Translator.Loading;
 using Microsoft.CodeAnalysis;
@@ -62,7 +61,10 @@ namespace Core
             "Core",
             new MetadataReference[] { data.Compilation.ToMetadataReference() });
 
-        string printed = TranslateProject(core, new[] { core.Compilation, data.Compilation });
+        var compilations = new[] { core.Compilation, data.Compilation };
+        string printedData = TranslateProject(data, compilations);
+        string printed = TranslateProject(core, compilations);
+        TranslationTestValidation.AssertBinds(printed, printedData);
 
         string compact = Compact(printed);
         Assert.Contains("let reason = conversion.FailureReason!!", compact);
@@ -78,7 +80,10 @@ namespace Core
             "Core",
             new MetadataReference[] { data.Compilation.ToMetadataReference() });
 
-        string printed = TranslateProject(core, new[] { core.Compilation, data.Compilation });
+        var compilations = new[] { core.Compilation, data.Compilation };
+        string printedData = TranslateProject(data, compilations);
+        string printed = TranslateProject(core, compilations);
+        TranslationTestValidation.AssertBinds(printed, printedData);
 
         string compact = Compact(printed);
         Assert.Contains("let reason = conversion.FailureReason!!", compact);
@@ -147,6 +152,7 @@ namespace App
         var compilations = new[] { app.Compilation, mid.Compilation, data.Compilation };
         string printedData = TranslateProject(data, compilations);
         string printedApp = TranslateProject(app, compilations);
+        TranslationTestValidation.AssertBinds(printedApp, printedData);
 
         Assert.Contains("prop FailureReason string?", Compact(printedData));
 
@@ -233,13 +239,7 @@ namespace App
             siblingCompilations,
             repositoryCompilations: siblingCompilations);
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
-        string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
-        Assert.True(
-            result.Success,
-            "Translated G# must round-trip. Errors:\n" +
-                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
-        return printed;
+        return GSharpPrinter.Print(unit);
     }
 
     private static string Compact(string printed) =>

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3083WithLambdaRoundTripTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3083WithLambdaRoundTripTests.cs
@@ -184,7 +184,7 @@ public sealed class Issue3083WithLambdaRoundTripTests
 
     private static void AssertRoundTrip(string printed)
     {
-        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+        RoundTripResult roundTrip = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             roundTrip.Success,
             string.Join(Environment.NewLine, roundTrip.Errors) + Environment.NewLine + printed);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3085PrimitiveStaticReceiverTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3085PrimitiveStaticReceiverTranslationTests.cs
@@ -140,7 +140,7 @@ public class Issue3085PrimitiveStaticReceiverTranslationTests
 
     private static void AssertRoundTrip(string printed)
     {
-        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+        RoundTripResult roundTrip = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             roundTrip.Success,
             string.Join(Environment.NewLine, roundTrip.Errors) + Environment.NewLine + printed);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3090AwaitInvocationArgumentTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3090AwaitInvocationArgumentTests.cs
@@ -414,7 +414,7 @@ public sealed class Issue3090AwaitInvocationArgumentTests
 
     private static void AssertRoundTrip(string printed)
     {
-        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+        RoundTripResult roundTrip = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             roundTrip.Success,
             string.Join(Environment.NewLine, roundTrip.Errors) + Environment.NewLine + printed);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3092NullConditionalRangeSliceTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3092NullConditionalRangeSliceTests.cs
@@ -212,7 +212,7 @@ public sealed class Issue3092NullConditionalRangeSliceTests
 
     private static void AssertRoundTrip(string printed)
     {
-        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+        RoundTripResult roundTrip = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             roundTrip.Success,
             string.Join(Environment.NewLine, roundTrip.Errors) +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3096CollectionSpreadInitializerTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3096CollectionSpreadInitializerTranslationTests.cs
@@ -50,7 +50,7 @@ public sealed class Issue3096CollectionSpreadInitializerTranslationTests
         Assert.DoesNotContain(".AddRange(", rendered, StringComparison.Ordinal);
         Assert.DoesNotContain("CS2GS-GAP", rendered, StringComparison.Ordinal);
 
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
         Assert.True(
             result.Success,
             string.Join(Environment.NewLine, result.Errors) + Environment.NewLine + rendered);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3348QueryClauseSpillSeamTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3348QueryClauseSpillSeamTests.cs
@@ -3,17 +3,10 @@
 // </copyright>
 
 using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
 using Cs2Gs.CodeModel.Ast;
 using Cs2Gs.CodeModel.Printing;
-using Cs2Gs.CodeModel.RoundTrip;
 using Cs2Gs.Translator;
 using Cs2Gs.Translator.Loading;
-using GSharp.Core.CodeAnalysis.Binding;
-using GSharp.Core.CodeAnalysis.Syntax;
-using GSharp.Core.CodeAnalysis.Text;
 using Xunit;
 
 namespace Cs2Gs.Tests;
@@ -34,10 +27,9 @@ namespace Cs2Gs.Tests;
 /// not bind), and it ran once for the whole query instead of once per element.
 /// </para>
 /// <para>
-/// The emitted G# still PARSED, so <see cref="GSharpRoundTrip"/> validation —
-/// which every other cs2gs translation test relies on — could not catch this.
-/// Every case here therefore also asserts the output BINDS, via
-/// <see cref="BindDiagnostics"/>.
+/// The emitted G# still PARSED, so round-trip validation could not catch this.
+/// Issue #3382 made binding the shared default for cs2gs translation tests via
+/// <see cref="TranslationTestValidation.AssertBinds(string[])"/>.
 /// </para>
 /// </summary>
 public class Issue3348QueryClauseSpillSeamTests
@@ -165,7 +157,7 @@ public sealed class C
         Assert.True(
             writeIndex > lambdaStart,
             "The `last = x` write must be inside the query lambda, not hoisted ahead of it:\n" + printed);
-        AssertBinds(printed);
+        TranslationTestValidation.AssertBinds(printed);
     }
 
     /// <summary>
@@ -198,7 +190,7 @@ public sealed class C
             queryIndex < 0 || writeIndex < queryIndex,
             "The first `from` source is evaluated eagerly; its assignment must hoist ahead of the query:\n"
                 + printed);
-        AssertBinds(printed);
+        TranslationTestValidation.AssertBinds(printed);
     }
 
     /// <summary>
@@ -229,7 +221,7 @@ public sealed class C
         Assert.True(
             joinIndex < 0 || writeIndex < joinIndex,
             "A join's `in` source is eager; its assignment must hoist ahead of the query:\n" + printed);
-        AssertBinds(printed);
+        TranslationTestValidation.AssertBinds(printed);
     }
 
     /// <summary>
@@ -269,7 +261,7 @@ public sealed class C
 
         Assert.DoesNotContain("__spill", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("return ", printed, StringComparison.Ordinal);
-        AssertBinds(printed);
+        TranslationTestValidation.AssertBinds(printed);
     }
 
     // The spill's `let` must appear AFTER the lambda arrow, i.e. inside the
@@ -285,27 +277,7 @@ public sealed class C
             spillIndex > lambdaStart,
             "The spill must be hoisted INSIDE the query lambda, not ahead of the query:\n" + printed);
 
-        AssertBinds(printed);
-    }
-
-    // The #3348 output parsed but did not bind (the hoisted statement read the
-    // lambda's range variable from the enclosing scope), so round-trip parsing
-    // alone is not a sufficient assertion for this class of defect.
-    private static void AssertBinds(string printed)
-    {
-        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
-        Assert.True(
-            roundTrip.Success,
-            "Translated G# must round-trip. Errors:\n" + string.Join("\n", roundTrip.Errors)
-                + "\n\nPrinted:\n" + printed);
-
-        List<GSharp.Core.CodeAnalysis.Diagnostic> errors = BindDiagnostics(printed)
-            .Where(diagnostic => diagnostic.IsError)
-            .ToList();
-        Assert.True(
-            errors.Count == 0,
-            "Translated G# must bind without errors. Errors:\n"
-                + string.Join("\n", errors.Select(e => e.ToString())) + "\n\nPrinted:\n" + printed);
+        TranslationTestValidation.AssertBinds(printed);
     }
 
     private static string TranslateQuery(string source)
@@ -322,12 +294,5 @@ public sealed class C
         var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
         return GSharpPrinter.Print(unit);
-    }
-
-    private static IEnumerable<GSharp.Core.CodeAnalysis.Diagnostic> BindDiagnostics(string gsharpSource)
-    {
-        SyntaxTree tree = SyntaxTree.Parse(SourceText.From(gsharpSource));
-        BoundGlobalScope scope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
-        return scope.Diagnostics;
     }
 }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3352WhileLetTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3352WhileLetTranslationTests.cs
@@ -309,7 +309,7 @@ public sealed class Issue3352WhileLetTranslationTests
         var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
         var printed = GSharpPrinter.Print(unit);
-        var roundTrip = GSharpRoundTrip.Validate(printed);
+        var roundTrip = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             roundTrip.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3358NativeMultiAssignmentTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3358NativeMultiAssignmentTranslationTests.cs
@@ -198,7 +198,8 @@ public sealed class C
         int a = 0, b = 0;
         (a, b) = new Pair();
     }
-}");
+}",
+            "G# deconstruction currently supports tuples and data structs, not C# Deconstruct methods.");
 
         Assert.Contains("__decon", printed, StringComparison.Ordinal);
     }
@@ -243,7 +244,7 @@ public sealed class C
         Assert.Contains("__decon", printed, StringComparison.Ordinal);
     }
 
-    private static string Translate(string source)
+    private static string Translate(string source, string roundTripOnlyReason = null)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
             new[] { ("Snippet.cs", "using System;\n\nnamespace Demo\n{\n" + source + "\n}\n") });
@@ -257,7 +258,9 @@ public sealed class C
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
         string printed = GSharpPrinter.Print(unit);
 
-        RoundTripResult roundTrip = TranslationTestValidation.AssertBinds(printed);
+        RoundTripResult roundTrip = roundTripOnlyReason is null
+            ? TranslationTestValidation.AssertBinds(printed)
+            : TranslationTestValidation.ValidateRoundTripOnly(printed, roundTripOnlyReason);
         Assert.True(
             roundTrip.Success,
             "Translated G# must round-trip. Errors:\n" + string.Join("\n", roundTrip.Errors)

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3358NativeMultiAssignmentTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3358NativeMultiAssignmentTranslationTests.cs
@@ -257,7 +257,7 @@ public sealed class C
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
         string printed = GSharpPrinter.Print(unit);
 
-        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+        RoundTripResult roundTrip = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             roundTrip.Success,
             "Translated G# must round-trip. Errors:\n" + string.Join("\n", roundTrip.Errors)

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3359IfLetStatementTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3359IfLetStatementTranslationTests.cs
@@ -228,7 +228,7 @@ public sealed class C
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
         string printed = GSharpPrinter.Print(unit);
 
-        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+        RoundTripResult roundTrip = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             roundTrip.Success,
             "Translated G# must round-trip. Errors:\n" + string.Join("\n", roundTrip.Errors)

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3360SpillTrivialityGuardTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3360SpillTrivialityGuardTests.cs
@@ -124,7 +124,7 @@ public sealed class C
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
         string printed = GSharpPrinter.Print(unit);
 
-        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+        RoundTripResult roundTrip = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             roundTrip.Success,
             "Translated G# must round-trip. Errors:\n" + string.Join("\n", roundTrip.Errors)

--- a/tools/cs2gs/Cs2Gs.Tests/Issue914ArrayLengthCoercionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914ArrayLengthCoercionTranslationTests.cs
@@ -95,7 +95,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue914DecryptNarrowingTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914DecryptNarrowingTranslationTests.cs
@@ -170,7 +170,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue914DiscardedSwitchExpressionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914DiscardedSwitchExpressionTranslationTests.cs
@@ -109,7 +109,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue914FoundationSinkTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914FoundationSinkTranslationTests.cs
@@ -229,7 +229,7 @@ namespace Demo
     private static string PrintAndValidate(CompilationUnit unit)
     {
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue914IndexCoercionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914IndexCoercionTranslationTests.cs
@@ -198,7 +198,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue914NumericCoercionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914NumericCoercionTranslationTests.cs
@@ -448,7 +448,8 @@ namespace Demo
             GetHolder().Handler?.Invoke(x);
         }
     }
-}");
+}",
+            "G# currently keeps a nullable result type after coalescing nullable delegates.");
 
         Assert.Contains("(Left())?(x)", printed);
         Assert.Contains("(Left() ?? Right())?(x)", printed);
@@ -618,7 +619,7 @@ namespace Demo
         Assert.Contains("int32(uint16.MaxValue)", printed);
     }
 
-    private static string TranslateUnit(string source)
+    private static string TranslateUnit(string source, string roundTripOnlyReason = null)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
         Assert.True(
@@ -631,7 +632,9 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
+        RoundTripResult result = roundTripOnlyReason is null
+            ? TranslationTestValidation.AssertBinds(printed)
+            : TranslationTestValidation.ValidateRoundTripOnly(printed, roundTripOnlyReason);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue914NumericCoercionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914NumericCoercionTranslationTests.cs
@@ -631,7 +631,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue914ObliviousSinkTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914ObliviousSinkTranslationTests.cs
@@ -333,7 +333,7 @@ namespace Demo
     private static string PrintAndValidate(CompilationUnit unit)
     {
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue914ObliviousSinkTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914ObliviousSinkTranslationTests.cs
@@ -143,7 +143,8 @@ namespace Demo
 
         public C() : this(null, null) { }
     }
-}");
+}",
+            "Nullable-enabled C# permits null-forgiven calls that G# rejects at non-null parameters.");
 
         Assert.Contains("init(context string, message string)", printed);
         Assert.DoesNotContain("string?", printed);
@@ -308,7 +309,7 @@ namespace Demo
         return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
     }
 
-    private static string TranslateEnabled(string source)
+    private static string TranslateEnabled(string source, string roundTripOnlyReason = null)
     {
         var parseOptions = new CSharpParseOptions(LanguageVersion.Latest);
         SyntaxTree tree = CSharpSyntaxTree.ParseText(source, parseOptions, path: "Snippet.cs");
@@ -327,13 +328,17 @@ namespace Demo
         SemanticModel model = compilation.GetSemanticModel(tree);
         var document = new LoadedDocument("Snippet.cs", tree, model);
         var context = new TranslationContext(compilation, model, document.FilePath);
-        return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+        return PrintAndValidate(
+            new CSharpToGSharpTranslator().TranslateDocument(document, context),
+            roundTripOnlyReason);
     }
 
-    private static string PrintAndValidate(CompilationUnit unit)
+    private static string PrintAndValidate(CompilationUnit unit, string roundTripOnlyReason = null)
     {
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
+        RoundTripResult result = roundTripOnlyReason is null
+            ? TranslationTestValidation.AssertBinds(printed)
+            : TranslationTestValidation.ValidateRoundTripOnly(printed, roundTripOnlyReason);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue914ObliviousTypeParameterReturnPromotionTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914ObliviousTypeParameterReturnPromotionTests.cs
@@ -168,7 +168,7 @@ namespace Demo
     private static string PrintAndValidate(CompilationUnit unit)
     {
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue914PointerConversionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914PointerConversionTranslationTests.cs
@@ -157,7 +157,7 @@ namespace Corpus.Issue914
 
     private static void AssertRoundTripParses(string rendered)
     {
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue914StaticFormExtensionCallTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914StaticFormExtensionCallTranslationTests.cs
@@ -114,7 +114,7 @@ namespace Demo
         var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
         Cs2Gs.CodeModel.Ast.CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue914StaticInitializerBlockTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914StaticInitializerBlockTranslationTests.cs
@@ -93,7 +93,8 @@ namespace Demo
             Total = acc + Scaled;
         }
     }
-}");
+}",
+            "G# currently rejects assignments to let fields inside their static initializer block.");
 
         Assert.Contains("shared {", printed);
         Assert.Contains("init {", printed);
@@ -131,7 +132,7 @@ namespace Demo
         Assert.Contains("B", printed);
     }
 
-    private static string TranslateUnit(string source)
+    private static string TranslateUnit(string source, string roundTripOnlyReason = null)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
         Assert.True(
@@ -144,7 +145,9 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
+        RoundTripResult result = roundTripOnlyReason is null
+            ? TranslationTestValidation.AssertBinds(printed)
+            : TranslationTestValidation.ValidateRoundTripOnly(printed, roundTripOnlyReason);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue914StaticInitializerBlockTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914StaticInitializerBlockTranslationTests.cs
@@ -144,7 +144,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue914TranslatorFidelityTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914TranslatorFidelityTests.cs
@@ -295,7 +295,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue914WhileConditionHoistTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914WhileConditionHoistTranslationTests.cs
@@ -198,7 +198,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue975To977CanonicalizationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue975To977CanonicalizationTests.cs
@@ -138,7 +138,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue986BaseCallTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue986BaseCallTranslationTests.cs
@@ -56,7 +56,7 @@ public class Issue986BaseCallTranslationTests
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/L1DeclarationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/L1DeclarationTranslationTests.cs
@@ -92,7 +92,7 @@ namespace Corpus.L1
         (CompilationUnit unit, TranslationContext context) = TranslateL1();
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
 
         Assert.True(
             result.Success,
@@ -252,7 +252,7 @@ namespace Corpus.L1
 
         string printed = GSharpPrinter.Print(unit);
         Assert.DoesNotContain("// pending", printed);
-        Assert.True(GSharpRoundTrip.Validate(printed).Success);
+        Assert.True(TranslationTestValidation.AssertBinds(printed).Success);
     }
 
     private static (CompilationUnit Unit, TranslationContext Context) TranslateL1()

--- a/tools/cs2gs/Cs2Gs.Tests/L1MigrationEndToEndTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/L1MigrationEndToEndTests.cs
@@ -37,7 +37,7 @@ public class L1MigrationEndToEndTests
     {
         (CompilationUnit unit, TranslationContext context, string printed) = await TranslateL1Async();
 
-        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+        RoundTripResult roundTrip = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             roundTrip.Success,
             "Canonical L1 must round-trip-parse. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/L2TranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/L2TranslationTests.cs
@@ -330,7 +330,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/L3TranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/L3TranslationTests.cs
@@ -568,7 +568,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/L5ConstructTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/L5ConstructTranslationTests.cs
@@ -293,7 +293,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/LocalExplicitTypePreservationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/LocalExplicitTypePreservationTests.cs
@@ -151,7 +151,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/LocalFunctionHoistTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/LocalFunctionHoistTranslationTests.cs
@@ -285,7 +285,7 @@ class C {
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/LocalFunctionHoistTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/LocalFunctionHoistTranslationTests.cs
@@ -226,7 +226,8 @@ namespace Demo
             }
         }
     }
-}");
+}",
+            "Mutually recursive local functions use non-recursive G# let bindings, as documented by the compiler-gap test below.");
 
         int aDeclIndex = printed.IndexOf("let A", StringComparison.Ordinal);
         int bDeclIndex = printed.IndexOf("let B", StringComparison.Ordinal);
@@ -272,7 +273,7 @@ class C {
         Assert.Contains("GS0130", output, StringComparison.Ordinal);
     }
 
-    private static string TranslateUnit(string source)
+    private static string TranslateUnit(string source, string roundTripOnlyReason = null)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
         Assert.True(
@@ -285,7 +286,9 @@ class C {
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
+        RoundTripResult result = roundTripOnlyReason is null
+            ? TranslationTestValidation.AssertBinds(printed)
+            : TranslationTestValidation.ValidateRoundTripOnly(printed, roundTripOnlyReason);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/LockKeywordSanitizationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/LockKeywordSanitizationTranslationTests.cs
@@ -62,7 +62,7 @@ namespace Corpus.LockSanitize
     {
         string rendered = Render();
 
-        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
 
         Assert.True(
             result.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/NullableFlowForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/NullableFlowForgivenessTranslationTests.cs
@@ -177,7 +177,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
@@ -234,7 +234,8 @@ namespace Demo
             return null;
         }
     }
-}");
+}",
+            "Fixture deliberately places nil at invalid non-null sinks to verify cs2gs never invents non-null assertions.");
 
         Assert.Contains("[\"error\"] = nil", printed);
         Assert.Contains("response[\"error\"] = nil", printed);
@@ -892,7 +893,7 @@ namespace Demo
         Assert.Contains("return (a!!,", printed);
     }
 
-    private static string TranslateUnit(string source)
+    private static string TranslateUnit(string source, string roundTripOnlyReason = null)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
         Assert.True(
@@ -905,7 +906,9 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
+        RoundTripResult result = roundTripOnlyReason is null
+            ? TranslationTestValidation.AssertBinds(printed)
+            : TranslationTestValidation.ValidateRoundTripOnly(printed, roundTripOnlyReason);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
@@ -905,7 +905,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/OahuFoundationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuFoundationTranslationTests.cs
@@ -219,7 +219,8 @@ namespace Demo
     {
         public System.Type T() => typeof(System.Collections.Generic.IEnumerable<>);
     }
-}");
+}",
+            "G# parses unbound generic typeof placeholders but cannot resolve the metadata generic definition.");
 
         // Issue #2012 (S1): cs2gs now emits the explicit-arity `_` placeholder
         // form (#1989/#2011) rather than the bare generic-definition name.
@@ -697,9 +698,9 @@ namespace Demo
         Assert.Contains("this.handler!!(value)", printed);
     }
 
-    private static string TranslateUnit(string source)
+    private static string TranslateUnit(string source, string roundTripOnlyReason = null)
     {
-        (string printed, RoundTripResult result) = TranslateAndValidate(source);
+        (string printed, RoundTripResult result) = TranslateAndValidate(source, roundTripOnlyReason);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +
@@ -727,14 +728,19 @@ namespace Demo
         return (printed, context);
     }
 
-    private static (string Printed, RoundTripResult Result) TranslateAndValidate(string source)
+    private static (string Printed, RoundTripResult Result) TranslateAndValidate(
+        string source,
+        string roundTripOnlyReason = null)
     {
         LoadedCSharpProject project = LoadProject(source);
         LoadedDocument document = Assert.Single(project.Documents);
         var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
         string printed = GSharpPrinter.Print(unit);
-        return (printed, TranslationTestValidation.AssertBinds(printed));
+        RoundTripResult result = roundTripOnlyReason is null
+            ? TranslationTestValidation.AssertBinds(printed)
+            : TranslationTestValidation.ValidateRoundTripOnly(printed, roundTripOnlyReason);
+        return (printed, result);
     }
 
     private static LoadedCSharpProject LoadProject(string source)

--- a/tools/cs2gs/Cs2Gs.Tests/OahuFoundationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuFoundationTranslationTests.cs
@@ -717,7 +717,9 @@ namespace Demo
         // The emitted G# must round-trip through the real parser even on the
         // unsafe-interop surface (the binder, not the parser, flags GS0243).
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.ValidateRoundTripOnly(
+            printed,
+            "Unsafe interop fixtures intentionally exercise forms the G# binder rejects with GS0243.");
         Assert.True(
             result.Success,
             "Emitted G# must round-trip. Errors:\n" +
@@ -732,7 +734,7 @@ namespace Demo
         var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
         string printed = GSharpPrinter.Print(unit);
-        return (printed, GSharpRoundTrip.Validate(printed));
+        return (printed, TranslationTestValidation.AssertBinds(printed));
     }
 
     private static LoadedCSharpProject LoadProject(string source)

--- a/tools/cs2gs/Cs2Gs.Tests/ObliviousPromotionSinkCompilationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/ObliviousPromotionSinkCompilationTests.cs
@@ -237,7 +237,7 @@ namespace Demo
     private static string PrintAndValidate(CompilationUnit unit)
     {
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/PromotionConsolidationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/PromotionConsolidationTests.cs
@@ -104,7 +104,7 @@ namespace Demo
     private static string PrintAndValidate(CompilationUnit unit)
     {
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/StringConcatenationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/StringConcatenationTranslationTests.cs
@@ -135,7 +135,7 @@ namespace Demo
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/TranslationTestValidation.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/TranslationTestValidation.cs
@@ -1,0 +1,65 @@
+// <copyright file="TranslationTestValidation.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Cs2Gs.CodeModel.RoundTrip;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Shared validation for G# emitted by cs2gs translation tests.
+/// </summary>
+internal static class TranslationTestValidation
+{
+    /// <summary>
+    /// Asserts that emitted G# parses and binds without errors.
+    /// </summary>
+    /// <param name="sources">One or more emitted G# source files.</param>
+    /// <returns>The first source's round-trip result for callers that retain detailed parse assertions.</returns>
+    public static RoundTripResult AssertBinds(params string[] sources)
+    {
+        Assert.NotNull(sources);
+        Assert.NotEmpty(sources);
+
+        RoundTripResult firstResult = null;
+        var trees = sources.Select((source, index) =>
+        {
+            RoundTripResult result = GSharpRoundTrip.Validate(source);
+            firstResult ??= result;
+            Assert.True(
+                result.Success,
+                $"Translated G# source {index + 1} must round-trip. Errors:\n"
+                    + string.Join("\n", result.Errors) + "\n\nPrinted:\n" + source);
+            return SyntaxTree.Parse(SourceText.From(source));
+        }).ToImmutableArray();
+
+        BoundGlobalScope scope = Binder.BindGlobalScope(previous: null, trees);
+        var errors = scope.Diagnostics.Where(diagnostic => diagnostic.IsError).ToArray();
+        Assert.True(
+            errors.Length == 0,
+            "Translated G# must bind without errors. Errors:\n"
+                + string.Join("\n", errors.Select(error => error.ToString()))
+                + "\n\nPrinted:\n" + string.Join("\n\n", sources));
+
+        return firstResult;
+    }
+
+    /// <summary>
+    /// Runs parse-only validation for a deliberate language gap.
+    /// </summary>
+    /// <param name="source">Emitted G# source.</param>
+    /// <param name="reason">Why binding cannot gate this test.</param>
+    /// <returns>The round-trip result for the caller to assert.</returns>
+    public static RoundTripResult ValidateRoundTripOnly(string source, string reason)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(reason);
+        return GSharpRoundTrip.Validate(source);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/TranslationTestValidation.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/TranslationTestValidation.cs
@@ -41,7 +41,10 @@ internal static class TranslationTestValidation
         }).ToImmutableArray();
 
         BoundGlobalScope scope = Binder.BindGlobalScope(previous: null, trees);
-        var errors = scope.Diagnostics.Where(diagnostic => diagnostic.IsError).ToArray();
+        var errors = scope.Diagnostics
+            .Concat(Binder.BindProgram(scope).Diagnostics)
+            .Where(diagnostic => diagnostic.IsError)
+            .ToArray();
         Assert.True(
             errors.Length == 0,
             "Translated G# must bind without errors. Errors:\n"

--- a/tools/cs2gs/Cs2Gs.Tests/TranslationTestValidationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/TranslationTestValidationTests.cs
@@ -24,6 +24,16 @@ public class TranslationTestValidationTests
     }
 
     [Fact]
+    public void AssertBinds_RejectsUnboundReferenceInsideFunctionBody()
+    {
+        TrueException exception = Assert.Throws<TrueException>(
+            () => TranslationTestValidation.AssertBinds(
+                "package Demo\nfunc Run() {\n    let value = missing\n}\n"));
+
+        Assert.Contains("missing", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ValidateRoundTripOnly_RequiresAJustification()
     {
         Assert.Throws<ArgumentException>(

--- a/tools/cs2gs/Cs2Gs.Tests/TranslationTestValidationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/TranslationTestValidationTests.cs
@@ -1,0 +1,44 @@
+// <copyright file="TranslationTestValidationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.RoundTrip;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Tests for the default bind gate and deliberate round-trip-only escape hatch.
+/// </summary>
+public class TranslationTestValidationTests
+{
+    [Fact]
+    public void AssertBinds_RejectsSourceThatParsesButDoesNotBind()
+    {
+        TrueException exception = Assert.Throws<TrueException>(
+            () => TranslationTestValidation.AssertBinds("package Demo\nvar value = missing\n"));
+
+        Assert.Contains("missing", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ValidateRoundTripOnly_RequiresAJustification()
+    {
+        Assert.Throws<ArgumentException>(
+            () => TranslationTestValidation.ValidateRoundTripOnly(
+                "package Demo\nvar value = missing\n",
+                reason: string.Empty));
+    }
+
+    [Fact]
+    public void ValidateRoundTripOnly_AllowsDeliberateUnboundSource()
+    {
+        RoundTripResult result = TranslationTestValidation.ValidateRoundTripOnly(
+            "package Demo\nvar value = missing\n",
+            "This test proves the explicit parse-only escape hatch.");
+
+        Assert.True(result.Success);
+    }
+}


### PR DESCRIPTION
Fixes #3382

## Summary
- add shared `TranslationTestValidation.AssertBinds` using round-trip parse plus `Binder.BindGlobalScope` and `Binder.BindProgram`, so function and method bodies are validated
- migrate cs2gs translation tests from parse-only validation to binding by default, including multi-file binding where fixtures provide every source
- require a non-empty reason for explicit `ValidateRoundTripOnly` opt-outs covering omitted metadata, multi-package binder limits, and known G# language/compiler gaps
- add focused tests proving unresolved top-level and function-body references fail the default gate while opt-outs require justification

Semantic tests that already compile/run emitted output keep that stronger oracle.

## Validation
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj --no-build --no-restore --nologo --verbosity quiet --logger "trx;LogFileName=cs2gs-bind-program-final.trx" --results-directory artifacts/issue3382-bind-program-final`
- 1,981 passed; 0 failed; 0 skipped
