### PR TITLE
Spike G# compiler self-migration through Core semantic binding

### DIFF
--- a/build/run-cs2gs-oahu.sh
+++ b/build/run-cs2gs-oahu.sh
@@ -31,6 +31,11 @@ git -C "$source_dir" fetch --quiet origin "$ref"
 git -C "$source_dir" checkout --quiet --detach FETCH_HEAD
 actual_commit=$(git -C "$source_dir" rev-parse HEAD)
 
+# Keep MSBuild from importing Directory.Build.* files above the isolated clone
+# when OAHU_GATE_ROOT is placed under this repository.
+[[ -e "$source_dir/Directory.Build.props" ]] || printf '<Project />\n' > "$source_dir/Directory.Build.props"
+[[ -e "$source_dir/Directory.Build.targets" ]] || printf '<Project />\n' > "$source_dir/Directory.Build.targets"
+
 if [[ "$ref" == "$pinned_commit" && "$actual_commit" != "$pinned_commit" ]]; then
   echo "Expected pinned Oahu commit $pinned_commit, got $actual_commit." >&2
   exit 1

--- a/docs/self-migration-spike-3394.md
+++ b/docs/self-migration-spike-3394.md
@@ -1,0 +1,325 @@
+# G# compiler self-migration spike (#3394)
+
+## Executive summary
+
+This spike exercised the migration loop from issue #3394 rather than only
+planning it:
+
+1. translate `src/Core` from C# to G# with cs2gs;
+2. round-trip parse every generated G# file;
+3. compile the generated project with the current C#-implemented G# compiler;
+4. fix compiler, translator, SDK-selection, and migration-harness defects;
+5. repeat;
+6. validate the same fixes against the pinned Oahu corpus.
+
+The spike proves that cs2gs can translate the complete Core source tree:
+
+- 578 C# inputs;
+- 580 emitted G# files;
+- zero unsupported translation diagnostics;
+- every emitted file round-trip parses.
+
+Core does not yet compile. The semantic frontier moved from 1,126 diagnostics
+in cycle 14 to 291 in cycle 49, removing 835 diagnostics (74.2%). Because Core
+does not compile, this spike did not claim Core IL verification, test parity,
+self-hosted recompilation, or migration of gsc, gsi, gsgen, or cs2gs.
+
+The independent Oahu gate reached full parity: all 15 projects pass
+translation, compilation, IL verification, and test parity.
+
+No generated migrated compiler source is committed. This branch contains only
+durable compiler, translator, test, pipeline, harness, and documentation
+changes.
+
+## Baseline and toolchain
+
+- Repository base: `6ceb8ef0` (`main`, including PR #3398)
+- Branch: `oats/3394-gsharp-self-migration`
+- .NET SDK: `10.0.301`
+- gsc: `0.4.4+6ceb8ef0c4`
+- local SDK package:
+  `Gsharp.NET.Sdk.0.4.4-g6ceb8ef0c4.nupkg`
+- Oahu commit: `0ac1fece4415d31955ae7a1dcf7da31e343d363d`
+
+Primary Core command:
+
+```sh
+dotnet out/bin/Release/Cs2Gs.Cli/cs2gs.dll migrate \
+  --diagnostic-run \
+  --corpus src/Core \
+  --out artifacts/issue-3394/core-cycle-N \
+  --config Release
+```
+
+Final Core run:
+
+```text
+artifacts/issue-3394/core-cycle-49/2026-08-13T17-29-08Z_e7e65c
+```
+
+Final Oahu run:
+
+```text
+artifacts/issue-3394/oahu-gate/runs-cycle-6/2026-08-13T17-31-31Z_e2de53
+```
+
+## Core cycle results
+
+Cycles 1–13 established complete translation, deterministic SDK selection, and
+the first semantic compile. Cycle 14 exposed 1,126 compile diagnostics. The
+remaining measured frontier was:
+
+| Cycle | Translation | Compile diagnostics | Notes |
+|---:|:---:|---:|---|
+| 14 | pass | 1,126 | First complete semantic frontier |
+| 15 | pass | 916 | High-fanout generic/type fixes |
+| 16 | pass | 832 |  |
+| 17 | pass | 785 |  |
+| 18 | fail | — | Temporary translator regression |
+| 19 | fail | — | Temporary translator regression |
+| 20 | pass | 755 | Translation regressions repaired |
+| 21 | pass | 738 |  |
+| 22 | pass | 657 |  |
+| 23 | pass | 654 |  |
+| 24 | pass | 647 |  |
+| 25 | pass | 639 |  |
+| 26 | pass | 539 | Largest single later reduction |
+| 27 | pass | 531 |  |
+| 28 | pass | 518 |  |
+| 29 | pass | 509 |  |
+| 30 | pass | 499 |  |
+| 31 | pass | 483 |  |
+| 32 | pass | 474 |  |
+| 33 | pass | 1 | Invalid result; binder stack overflow aborted analysis |
+| 34 | pass | 462 | Adapter recursion fixed; real frontier restored |
+| 35 | pass | 444 |  |
+| 36 | pass | 430 |  |
+| 37 | pass | 412 |  |
+| 38 | pass | 359 |  |
+| 39 | pass | 359 | Diagnostic-neutral correctness fixes |
+| 40 | pass | 351 |  |
+| 41 | pass | 336 |  |
+| 42 | pass | 320 |  |
+| 43 | pass | 306 |  |
+| 44 | pass | 299 |  |
+| 45 | pass | 290 | Lowest intermediate count |
+| 46 | pass | 292 | Final-tree remeasurement after reverted experiment |
+| 47 | pass | 292 |  |
+| 48 | pass | 291 | Removed generated out-variable scope regression |
+| 49 | pass | **291** | Final measured frontier |
+
+Cycle 33 is deliberately not counted as progress. Binding recursively adapted
+a lambda return conversion until the compiler stack overflowed. The pipeline
+then observed only the diagnostic reached before the abort, masking hundreds
+of later failures. Exact target-return shaping fixed the recursion and cycle 34
+restored the real frontier.
+
+## Durable fixes
+
+### Parser and syntax
+
+- Bounded multi-assignment lookahead to remove exponential parsing.
+- Iterator accessor and local-function `yield break` support.
+- Type-test/property-pattern versus if-expression disambiguation.
+- Nullable array elements in generic-call lookahead.
+- Newline disambiguation between indexing and following blocks.
+- Receiver-clause operator versus trailing-lambda disambiguation.
+- Postfix continuation after `++` and `--`.
+- Composite/function type binding in `typeof`.
+
+### Compiler binding and emit
+
+- Nested generic symbolic type argument preservation.
+- Nullable tuple-element CLR construction.
+- Constructed generic enumerable/interface element substitution.
+- Imported class-constraint dispatch through generic type parameters.
+- Open-generic overload specificity.
+- Better user-defined conversion target ranking.
+- Imported array params pass-through.
+- Symbolic return, out, and delegate projection for imported generic calls.
+- Extension-call symbolic method argument propagation.
+- Tuple-recursive generic inference.
+- Deferred lambda and method-group target agreement by type signature.
+- Exact lambda return adapters, avoiding recursive adapter construction.
+- Conditional common typing through imported user-defined conversions.
+- Stackalloc `Span<T>.Slice` concrete return projection.
+- Source-type delegate materialization for constructed generic constructors,
+  including capturing lambdas (`Lazy<SourceType>` no longer emits
+  `Func<object>` invalid IL).
+- Index-slot `??=` support where CLR default null is the valid empty value.
+
+### cs2gs translation
+
+- Typed property-pattern lowering.
+- Declaration-site identifier sanitization.
+- Nested source and metadata generic type rendering.
+- Constructor initializer default argument materialization.
+- Boxing/reference/typed-null cast correction.
+- User-defined reference conversions remain conversion calls rather than
+  `as` tests.
+- Nullable sink and flow assertions.
+- Multiple, mutable, and nullable negated-pattern guard hoisting.
+- Generic and short-circuit pattern narrowing casts.
+- Recursive capture-free static local-function SCC lifting.
+- Static local-function dependency lifting.
+- Cross-file nullability and foreign syntax-tree analysis safety.
+- Native `out` call rendering.
+
+### SDK, pipeline, and harness
+
+- Current local SDK package selection.
+- Isolated `NUGET_PACKAGES` for deterministic same-version SDK extraction.
+- Process environment propagation through migration runners.
+- Oahu clone-root `Directory.Build.props` and
+  `Directory.Build.targets` isolation boundaries.
+
+## Oahu validation
+
+The Oahu baseline passed before migration:
+
+- build: zero warnings and errors;
+- CLI tests: 342 passed;
+- Foundation tests: 2 passed;
+- CLI E2E tests: 5 passed;
+- smoke test: passed.
+
+The migrated gate progressed through these frontiers:
+
+1. Eleven projects crashed during translation with
+   `ArgumentException: SyntaxTree is not part of the compilation`.
+2. After guarding cross-project nullability syntax, all 15 translated; compile
+   failures remained in Foundation, Decrypt, and dependents.
+3. Source nested-type qualification and concrete `Span<T>.Slice` projection
+   brought four projects fully green and all projects compiling except the
+   Decrypt dependency chain.
+4. All projects compiled; one Decrypt IL verification failure and two CLI test
+   parity failures remained.
+5. Symbolic capturing delegate materialization fixed the Decrypt
+   `Func<object>`/`Func<MetadataItems>` stack mismatch.
+6. Correct user-defined nullable reference cast translation fixed JsonNode
+   string extraction in CLI tests.
+7. Final rerun: 15 of 15 projects passed all four stages.
+
+This result matters because it proves the branch's fixes against an external,
+multi-project, runtime-tested corpus rather than only synthetic Core fixtures.
+
+## Final Core diagnostic taxonomy
+
+Final total: 291.
+
+| Diagnostic | Count |
+|---|---:|
+| GS0159 | 58 |
+| GS0154 | 42 |
+| GS0125 | 33 |
+| GS0238 | 28 |
+| GS0155 | 25 |
+| GS0130 | 23 |
+| GS0158 | 19 |
+| GS0157 | 18 |
+| GS0266 | 9 |
+| Other 20 diagnostic IDs | 36 |
+
+Largest file concentrations:
+
+| Generated file | Count |
+|---|---:|
+| `ExpressionBinder.Access.Accessor.gs` | 58 |
+| `ControlFlowGraph.gs` | 30 |
+| `DeclarationBinder.Attributes.gs` | 21 |
+| `StatementBinder.Blocks.gs` | 21 |
+| `OverloadResolver.Arguments.gs` | 16 |
+| `Binder.gs` | 16 |
+| `ReflectionMetadataEmitter.gs` | 9 |
+
+Repeated messages show that raw diagnostic count overstates independent root
+causes:
+
+- 20 missing recursive `Add` calls plus `NewLabel`, `NewChoice`, `Collect`,
+  and `Find` cascades;
+- 14 unresolved `Add` calls and 8 unresolved `Where` calls after generic type
+  information is lost;
+- repeated pointer/pointee mismatches for `ImmutableArray<SourceType>` out
+  parameters;
+- paired definite-assignment diagnostics after those out calls fail;
+- escaped short-circuit pattern binders;
+- a smaller set of overload ambiguities, nullable/reference conversions, and
+  generic construction failures.
+
+## Proven remaining blockers
+
+The spike minimized and filed four independent blockers:
+
+- [#3399](https://github.com/DavidObando/gsharp/issues/3399):
+  capturing recursive/mutually-recursive local functions;
+- [#3400](https://github.com/DavidObando/gsharp/issues/3400):
+  out/ref kind loss for imported generics over source types;
+- [#3401](https://github.com/DavidObando/gsharp/issues/3401):
+  params-array pass-through infers a nested array;
+- [#3402](https://github.com/DavidObando/gsharp/issues/3402):
+  short-circuit pattern binders escape generated scope.
+
+### Capturing recursion
+
+cs2gs can now lift recursive capture-free static local functions. Core still
+contains recursive local-function groups that capture builders, counters,
+labels, and other mutable outer state. G# local `let = func` bindings are not
+recursive or forward-visible. A faithful solution needs a generated
+closure/helper type or a recursive local-function language feature.
+
+### Byref symbolic generics
+
+`out ImmutableArray<Kind>` works when `Kind` is imported, but loses ref kind
+when `Kind` is declared in the same compilation. Calls then compare
+`*ImmutableArray<Kind>` to a value parameter and produce paired GS0154/GS0238
+diagnostics.
+
+### Params-array pass-through
+
+`ImmutableArray.Create(values)` with `values : []Item?` infers
+`ImmutableArray<[]Item?>` instead of selecting normal-form params pass-through
+with `T = Item?`.
+
+### Pattern scope
+
+C# binders introduced in `is T x && ...` conditions are sometimes lowered into
+an embedded G# if-expression. Later conjuncts and the true body then reference a
+name whose generated scope has ended.
+
+## Validation
+
+Local validation used focused project/test gates rather than the complete
+solution matrix:
+
+- targeted Core parser/binder regressions: 236 passed;
+- targeted compiler delegate/conversion emit tests: 19 passed, including
+  runtime and ILVerify;
+- cs2gs project sweep: 2,017 passed and exposed six changed-output/regression
+  tests; all six were repaired and passed focused rerun;
+- final Oahu migrated gate: 15/15 projects green.
+
+CI remains the authority for the full repository matrix.
+
+## Feasibility conclusion
+
+Migration is feasible, but self-hosting is not yet proven.
+
+The spike moved Core past the earlier translation/syntax barrier and removed
+most semantic debt. Oahu's complete green result demonstrates that the
+compiler and translator can already sustain a substantial real application,
+including IL verification and runtime tests.
+
+The remaining Core work is no longer a single broad "cs2gs cannot translate
+the compiler" problem. It is a smaller set of compiler-language and symbolic
+binding gaps with large diagnostic fan-out. Capturing recursion is the clearest
+architectural gap; byref symbolic generics, params pass-through, and pattern
+scope are concrete compiler/translator defects with minimal reproductions.
+
+Required sequence remains:
+
+1. close the minimized blockers and rerun Core until compile succeeds;
+2. ILVerify the migrated Core assembly;
+3. run Core test parity;
+4. compile Core with the migrated Core implementation;
+5. only then continue in order through gsc, gsi, gsgen, and cs2gs.
+

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -205,7 +205,11 @@ public sealed class Binder
             bindExpressionWithTargetType: (syntax, targetType) => Expressions.BindExpression(syntax, targetType),
             isFormattableStringTargetType: ExpressionBinder.IsFormattableStringTargetType,
             bindInterpolatedStringAsFormattable: (syntax, targetType) => Expressions.BindInterpolatedStringAsFormattable(syntax, targetType),
-            createErasedFunctionLiteralAdapter: (literal, targetFunctionType) => Lambdas.CreateErasedFunctionLiteralAdapter(literal, targetFunctionType),
+            createErasedFunctionLiteralAdapter: (literal, targetFunctionType, exactTargetReturnType) =>
+                Lambdas.CreateErasedFunctionLiteralAdapter(
+                    literal,
+                    targetFunctionType,
+                    exactTargetReturnType: exactTargetReturnType),
             createClrMethodGroupAdapter: (group, targetFunctionType) => Lambdas.CreateClrMethodGroupAdapter(group, targetFunctionType),
             createUserExtensionMethodGroupAdapter: group => Lambdas.CreateUserExtensionMethodGroupAdapter(group),
             getMethodGroupObservableReturnType: (method, returnType) =>
@@ -4982,6 +4986,18 @@ public sealed class Binder
             && pr.Rank == ar.Rank)
         {
             InferTypeArguments(pr.ElementType, ar.ElementType, substitution);
+        }
+        else if (parameterType is TupleTypeSymbol parameterTuple
+            && argumentType is TupleTypeSymbol argumentTuple
+            && parameterTuple.Arity == argumentTuple.Arity)
+        {
+            for (var i = 0; i < parameterTuple.Arity; i++)
+            {
+                InferTypeArguments(
+                    parameterTuple.ElementTypes[i],
+                    argumentTuple.ElementTypes[i],
+                    substitution);
+            }
         }
         else if (parameterType is SequenceTypeSymbol pseq)
         {

--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -1289,6 +1289,16 @@ public sealed class Conversion
             return Conversion.None;
         }
 
+        // Fixed arrays have the same CLR interface surface as slices. Their
+        // element type can remain symbolic while binding, so use the symbolic
+        // element check instead of the erased array's object-based interface.
+        if (from is ArrayTypeSymbol arrayForIface && to?.ClrType != null && to.ClrType.IsInterface)
+        {
+            return ArrayElementConvertsToInterfaceSymbolically(arrayForIface.ElementType, to)
+                ? Conversion.Implicit
+                : Conversion.None;
+        }
+
         // Same rule for an SZ-array returned from imported metadata. Reflection
         // exposes that value as ImportedTypeSymbol(T[]) rather than []T, but G#
         // must not gain broader CLR array covariance because of symbol shape.

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -1485,12 +1485,34 @@ internal sealed class ConversionClassifier
             return null;
         }
 
+        // Symbolic inference can leave an Error/null slot when a deferred
+        // method group supplies that type only to CLR inference. Preserve the
+        // symbolic slots and fill unresolved ones from the selected closure.
+        var effectiveMethodTypeArgs = methodTypeArgs;
+        if (!method.IsGenericMethodDefinition
+            && methodTypeArgs.Any(static type => type == null || type == TypeSymbol.Error))
+        {
+            var closedTypeArgs = method.GetGenericArguments();
+            var merged = ImmutableArray.CreateBuilder<TypeSymbol?>(methodTypeArgs.Length);
+            for (var i = 0; i < methodTypeArgs.Length; i++)
+            {
+                var symbolicType = methodTypeArgs[i];
+                merged.Add(symbolicType != null && symbolicType != TypeSymbol.Error
+                    ? symbolicType
+                    : (uint)i < (uint)closedTypeArgs.Length
+                        ? TypeSymbol.FromClrType(closedTypeArgs[i])
+                        : null);
+            }
+
+            effectiveMethodTypeArgs = merged.MoveToImmutable();
+        }
+
         var mapped = MemberLookup.MapOpenClrTypeToSymbolic(
             openParamType,
             openDefinition: null,
             typeArguments: default,
             openMethodDefinition: openMethod,
-            methodTypeArguments: methodTypeArgs);
+            methodTypeArguments: effectiveMethodTypeArgs);
         mapped = PreserveParameterTopLevelNullability(openParams[paramIndex], mapped);
 
         return mapped != null

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -67,7 +67,7 @@ internal sealed class ConversionClassifier
     private readonly Func<ExpressionSyntax, TypeSymbol, BoundExpression> bindExpressionWithTargetType;
     private readonly Func<TypeSymbol, bool> isFormattableStringTargetType;
     private readonly Func<InterpolatedStringExpressionSyntax, TypeSymbol, BoundExpression> bindInterpolatedStringAsFormattable;
-    private readonly Func<BoundFunctionLiteralExpression, FunctionTypeSymbol, BoundFunctionLiteralExpression> createErasedFunctionLiteralAdapter;
+    private readonly Func<BoundFunctionLiteralExpression, FunctionTypeSymbol, bool, BoundFunctionLiteralExpression> createErasedFunctionLiteralAdapter;
     private readonly Func<BoundClrMethodGroupExpression, FunctionTypeSymbol, BoundExpression> createClrMethodGroupAdapter;
     private readonly Func<BoundMethodGroupExpression, BoundExpression> createUserExtensionMethodGroupAdapter;
     private readonly Func<FunctionSymbol, TypeSymbol, TypeSymbol> getMethodGroupObservableReturnType;
@@ -125,7 +125,7 @@ internal sealed class ConversionClassifier
         Func<ExpressionSyntax, TypeSymbol, BoundExpression> bindExpressionWithTargetType,
         Func<TypeSymbol, bool> isFormattableStringTargetType,
         Func<InterpolatedStringExpressionSyntax, TypeSymbol, BoundExpression> bindInterpolatedStringAsFormattable,
-        Func<BoundFunctionLiteralExpression, FunctionTypeSymbol, BoundFunctionLiteralExpression> createErasedFunctionLiteralAdapter,
+        Func<BoundFunctionLiteralExpression, FunctionTypeSymbol, bool, BoundFunctionLiteralExpression> createErasedFunctionLiteralAdapter,
         Func<BoundClrMethodGroupExpression, FunctionTypeSymbol, BoundExpression> createClrMethodGroupAdapter,
         Func<BoundMethodGroupExpression, BoundExpression> createUserExtensionMethodGroupAdapter,
         Func<FunctionSymbol, TypeSymbol, TypeSymbol> getMethodGroupObservableReturnType,
@@ -508,7 +508,7 @@ internal sealed class ConversionClassifier
             && type is FunctionTypeSymbol targetFunctionType
             && TypeSymbol.ContainsTypeParameter(targetFunctionType))
         {
-            return createErasedFunctionLiteralAdapter(literal, targetFunctionType);
+            return createErasedFunctionLiteralAdapter(literal, targetFunctionType, false);
         }
 
         // Issue #2716: a throw-expression lambda naturally has a `never`
@@ -521,7 +521,7 @@ internal sealed class ConversionClassifier
             && !ReferenceEquals(neverTargetFnType.ReturnType, TypeSymbol.Never)
             && Conversion.Classify(neverCandidateFnType, neverTargetFnType).IsImplicit)
         {
-            var shaped = createErasedFunctionLiteralAdapter(neverCandidateLiteral, neverTargetFnType);
+            var shaped = createErasedFunctionLiteralAdapter(neverCandidateLiteral, neverTargetFnType, false);
             if (!ReferenceEquals(shaped, neverCandidateLiteral))
             {
                 return BindConversion(diagnosticLocation, shaped, type, allowExplicit, callParameter);
@@ -545,7 +545,7 @@ internal sealed class ConversionClassifier
             && voidTargetFnType.Arity == voidCandidateFnType.Arity
             && !ReferenceEquals(type, voidCandidateFnType))
         {
-            var voidized = createErasedFunctionLiteralAdapter(voidCandidateLiteral, voidTargetFnType);
+            var voidized = createErasedFunctionLiteralAdapter(voidCandidateLiteral, voidTargetFnType, false);
             if (!ReferenceEquals(voidized, voidCandidateLiteral))
             {
                 return BindConversion(diagnosticLocation, voidized, type, allowExplicit, callParameter);
@@ -572,10 +572,32 @@ internal sealed class ConversionClassifier
             && !ReferenceEquals(widenCandidateFnType.ReturnType, widenTargetFnType.ReturnType)
             && IsNumericReturnWideningCore(widenCandidateFnType.ReturnType, widenTargetFnType.ReturnType))
         {
-            var widened = createErasedFunctionLiteralAdapter(widenCandidateLiteral, widenTargetFnType);
+            var widened = createErasedFunctionLiteralAdapter(widenCandidateLiteral, widenTargetFnType, false);
             if (!ReferenceEquals(widened, widenCandidateLiteral))
             {
                 return BindConversion(diagnosticLocation, widened, type, allowExplicit, callParameter);
+            }
+        }
+
+        if (expression is BoundFunctionLiteralExpression adaptedCandidateLiteral
+            && adaptedCandidateLiteral.FunctionType is FunctionTypeSymbol adaptedCandidateFnType
+            && adaptedCandidateFnType.ReturnType != TypeSymbol.Void
+            && adaptedCandidateFnType.ReturnType != TypeSymbol.Error
+            && MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(type, out var adaptedTargetFnType)
+            && adaptedTargetFnType.ReturnType != TypeSymbol.Void
+            && adaptedTargetFnType.ReturnType != TypeSymbol.Error
+            && adaptedTargetFnType.Arity == adaptedCandidateFnType.Arity
+            && !ReferenceEquals(adaptedCandidateFnType.ReturnType, adaptedTargetFnType.ReturnType)
+            && !IsNumericReturnWideningCore(adaptedCandidateFnType.ReturnType, adaptedTargetFnType.ReturnType)
+            && Conversion.Classify(adaptedCandidateFnType.ReturnType, adaptedTargetFnType.ReturnType).IsImplicit)
+        {
+            var adapted = createErasedFunctionLiteralAdapter(
+                adaptedCandidateLiteral,
+                adaptedTargetFnType,
+                true);
+            if (!ReferenceEquals(adapted, adaptedCandidateLiteral))
+            {
+                return BindConversion(diagnosticLocation, adapted, type, allowExplicit, callParameter);
             }
         }
 
@@ -843,6 +865,10 @@ internal sealed class ConversionClassifier
     /// a bare <c>default</c> argument when a method type-argument erased to the
     /// reference-context <c>object</c> placeholder (e.g.
     /// <c>Task.FromResult[T?](default)</c>).</param>
+    /// <param name="parameterTypeOverrides">Optional symbolic parameter types
+    /// keyed by resolved parameter index. Constructed generic constructors use
+    /// this to retain delegate targets such as <c>Func&lt;Foo&gt;</c> when
+    /// reflection exposes only the erased <c>Func&lt;object&gt;</c> shape.</param>
     /// <returns>The (possibly rebound) argument array.</returns>
     public ImmutableArray<BoundExpression> BindClrParameterConversions(
         ImmutableArray<BoundExpression> arguments,
@@ -852,7 +878,8 @@ internal sealed class ConversionClassifier
         int receiverArgCount = 0,
         MethodInfo? method = null,
         TypeSymbol? receiverType = null,
-        ImmutableArray<TypeSymbol?> symbolicMethodTypeArgs = default)
+        ImmutableArray<TypeSymbol?> symbolicMethodTypeArgs = default,
+        IReadOnlyDictionary<int, TypeSymbol>? parameterTypeOverrides = null)
     {
         ImmutableArray<BoundExpression>.Builder? builder = null;
         for (var i = 0; i < arguments.Length; i++)
@@ -911,8 +938,17 @@ internal sealed class ConversionClassifier
                     // boxed at the bind boundary (which would leave a
                     // verifier-rejecting `box T → !0 expected value` IL
                     // sequence at the call site).
-                    var substituted = TrySubstituteParameterTypeFromReceiver(
-                        method, paramIndex, receiverType, symbolicMethodTypeArgs);
+                    TypeSymbol? substituted = null;
+                    if (parameterTypeOverrides != null)
+                    {
+                        parameterTypeOverrides.TryGetValue(paramIndex, out substituted);
+                    }
+
+                    if (substituted == null)
+                    {
+                        substituted = TrySubstituteParameterTypeFromReceiver(
+                            method, paramIndex, receiverType, symbolicMethodTypeArgs);
+                    }
 
                     // Issue #1512/#2643: a function-typed argument bound to a
                     // generic method's delegate parameter (e.g.
@@ -1060,10 +1096,9 @@ internal sealed class ConversionClassifier
                     // MethodInfo/function overload matching targetType's
                     // Invoke signature, the same way it already does for a
                     // user-defined generic function's method-group argument.
-                    var isUnresolvedMethodGroupTarget = ClrOverloadResolution.IsUnresolvedMethodGroupArgument(argument);
-
+                    var isMethodGroupTarget = argument is BoundMethodGroupExpression or BoundClrMethodGroupExpression;
                     if (argument.Type != targetType
-                        && (Conversion.Classify(argument.Type, targetType).Exists || isExpressionTreeLiteralTarget || isUnresolvedMethodGroupTarget)
+                        && (Conversion.Classify(argument.Type, targetType).Exists || isExpressionTreeLiteralTarget || isMethodGroupTarget)
                         && !IsNaturalStructuralDelegateTarget(argument.Type, targetType)
                         && NeedsBindClrParameterConversion(argument.Type, parameterType, substituted))
                     {

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
@@ -1385,7 +1385,11 @@ internal sealed partial class ExpressionBinder
 
         var extensionSymbolicArgs = MemberLookup.BuildSymbolicArgTypeVector(
             receiver.Type,
-            ImmutableArray.CreateRange(arguments.Select(a => a.Type)));
+            ImmutableArray.CreateRange(arguments.Select(argument =>
+                argument is BoundMethodGroupExpression userGroup
+                    && TryGetSymbolicUserMethodGroupType(userGroup, out var symbolicGroupType)
+                        ? Invariant.Required(symbolicGroupType, "a symbolic method-group type was resolved")
+                        : argument.Type)));
         var candidates = MemberLookup.ExcludeErasureOnlyEnumCandidates(
             this.memberLookup.CollectImportedExtensionMethods(methodName),
             extensionSymbolicArgs,
@@ -1500,7 +1504,11 @@ internal sealed partial class ExpressionBinder
             delegateRefKindArgumentCheck: MakeDelegateRefKindArgumentCheck(arguments, argumentOffset: 1),
             methodGroupInference: MakeMethodGroupInference(arguments, GetEffectiveArgumentClrTypeForOverloadResolution, argumentOffset: 1),
             methodGroupArgumentCheck: MakeMethodGroupArgumentCheck(arguments, argumentOffset: 1),
-            deferredInferenceArgs: deferredInferenceArgs);
+            deferredInferenceArgs: deferredInferenceArgs,
+            functionLiteralArgumentCheck: argumentIndex =>
+                argumentIndex > 0
+                && argumentIndex - 1 < arguments.Length
+                && arguments[argumentIndex - 1] is BoundFunctionLiteralExpression);
 
         switch (resolution.Outcome)
         {
@@ -1619,6 +1627,9 @@ internal sealed partial class ExpressionBinder
             extensionDelegateRebindMode,
             out var extensionHandlerPrelude,
             out var extensionUpdatedReceiver,
+            method: best,
+            symbolicMethodTypeArgs: extensionTypeArgSymbolsForCall,
+            receiverType: receiver.Type,
             receiverArgCount: 1);
         if (extensionUpdatedReceiver != null && extensionUpdatedReceiver != receiver)
         {
@@ -1791,19 +1802,36 @@ internal sealed partial class ExpressionBinder
         TypeSymbol? receiverType = null,
         bool hasConversionReceiverTypeOverride = false,
         TypeSymbol? conversionReceiverType = null,
-        int receiverArgCount = 0)
+        int receiverArgCount = 0,
+        IReadOnlyDictionary<int, TypeSymbol>? parameterTypeOverrides = null)
     {
         var rebound = RebindFormattableInterpolationArguments(arguments, argumentSyntax, parameters, parameterMapping, receiverArgCount);
         var handlerArgs = ApplyInterpolatedStringHandlers(parameters, rebound, receiver, location, parameterMapping, out preludeStatements, out updatedReceiver);
         var delegateArgs = delegateRebindMode == ClrCallDelegateRebindMode.Full
-            ? RebindFunctionLiteralDelegateArguments(handlerArgs, parameters, parameterMapping, method, symbolicMethodTypeArgs, receiverType)
+            ? RebindFunctionLiteralDelegateArguments(
+                handlerArgs,
+                parameters,
+                parameterMapping,
+                method,
+                symbolicMethodTypeArgs,
+                receiverType,
+                parameterTypeOverrides)
             : RebindNumericReturnWideningDelegateArguments(handlerArgs, parameters, parameterMapping);
         var effectiveConversionReceiverType = hasConversionReceiverTypeOverride ? conversionReceiverType : receiverType;
         var conversionSymbolicMethodTypeArgs = symbolicMethodTypeArgs.IsDefault
             ? default
             : ImmutableArray.CreateRange<TypeSymbol?>(
                 symbolicMethodTypeArgs.Select(symbol => symbol ?? TypeSymbol.Error));
-        return conversions.BindClrParameterConversions(delegateArgs, parameters, call, parameterMapping, receiverArgCount, method, effectiveConversionReceiverType, conversionSymbolicMethodTypeArgs);
+        return conversions.BindClrParameterConversions(
+            delegateArgs,
+            parameters,
+            call,
+            parameterMapping,
+            receiverArgCount,
+            method,
+            effectiveConversionReceiverType,
+            conversionSymbolicMethodTypeArgs,
+            parameterTypeOverrides);
     }
 
     private ImmutableArray<BoundExpression> RebindFunctionLiteralDelegateArguments(
@@ -1812,7 +1840,8 @@ internal sealed partial class ExpressionBinder
         ImmutableArray<int> parameterMapping = default,
         MethodInfo? method = null,
         ImmutableArray<TypeSymbol?> symbolicMethodTypeArgs = default,
-        TypeSymbol? receiverType = null)
+        TypeSymbol? receiverType = null,
+        IReadOnlyDictionary<int, TypeSymbol>? parameterTypeOverrides = null)
     {
         ImmutableArray<BoundExpression>.Builder? builder = null;
         for (var i = 0; i < arguments.Length; i++)
@@ -1820,11 +1849,26 @@ internal sealed partial class ExpressionBinder
             var paramIndex = parameterMapping.IsDefault ? i : parameterMapping[i];
             var argument = arguments[i];
             var rebound = argument;
+            TypeSymbol? parameterTypeOverride = null;
+            if (parameterTypeOverrides != null)
+            {
+                parameterTypeOverrides.TryGetValue(paramIndex, out parameterTypeOverride);
+            }
+
+            FunctionTypeSymbol? targetFunctionType = null;
+            var hasTargetFunctionType = parameterTypeOverride != null
+                ? MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(parameterTypeOverride, out targetFunctionType)
+                : paramIndex < parameters.Length
+                    && MemberLookup.TryGetLambdaTargetFunctionType(parameters[paramIndex].ParameterType, out targetFunctionType);
             if (paramIndex < parameters.Length
                 && LambdaBinder.TryGetFunctionLiteral(argument, out var literal)
-                && MemberLookup.TryGetLambdaTargetFunctionType(parameters[paramIndex].ParameterType, out var targetFunctionType)
+                && hasTargetFunctionType
                 && literal.FunctionType != targetFunctionType)
             {
+                targetFunctionType = Invariant.Required(
+                    targetFunctionType,
+                    "successful delegate target lookup returns a function type");
+
                 // Issue #1512: when the call is a generic method whose delegate
                 // parameter mentions a method type parameter, the closed CLR
                 // parameter type erases that slot to `object`, so the literal
@@ -3010,10 +3054,11 @@ internal sealed partial class ExpressionBinder
     }
 
     /// <summary>
-    /// Issue #943: binds an instance call dispatched through a type parameter's
-    /// imported CLR interface constraint (e.g. <c>a.CompareTo(b)</c> where
-    /// <c>a : T</c> and <c>T : IComparable[T]</c>). The method is resolved
-    /// against the constraint interface's (type-erased) CLR type; the resulting
+    /// Issue #943 / #3394: binds an instance call dispatched through a type
+    /// parameter's imported CLR interface or base-class constraint (for example,
+    /// <c>a.CompareTo(b)</c> with <c>T : IComparable[T]</c>, or
+    /// <c>m.GetParameters()</c> with <c>T : MethodBase</c>). The method is
+    /// resolved against the constraint's CLR type; the resulting
     /// <see cref="BoundImportedInstanceCallExpression"/> carries the constrained
     /// type parameter and the symbolic interface type so the emitter produces a
     /// verifiable <c>constrained. !!T  callvirt</c> sequence with the
@@ -3021,14 +3066,14 @@ internal sealed partial class ExpressionBinder
     /// (<c>IComparable`1&lt;!!T&gt;::CompareTo(!0)</c>).
     /// </summary>
     /// <param name="receiver">The bound receiver (its type is the constrained type parameter).</param>
-    /// <param name="tp">The receiver's type parameter, carrying the CLR interface constraint.</param>
+    /// <param name="tp">The receiver's type parameter, carrying the CLR constraint.</param>
     /// <param name="methodName">The invoked method name.</param>
     /// <param name="arguments">The bound argument expressions.</param>
     /// <param name="ce">The originating call-expression syntax.</param>
     /// <param name="argumentNames">Optional named-argument labels in source order.</param>
     /// <param name="result">The bound constrained call on success.</param>
-    /// <returns><see langword="true"/> when a matching interface method was found and bound.</returns>
-    private bool TryBindConstrainedClrInterfaceCall(
+    /// <returns><see langword="true"/> when a matching constrained method was found and bound.</returns>
+    private bool TryBindConstrainedClrCall(
         BoundExpression receiver,
         TypeParameterSymbol tp,
         string methodName,
@@ -3038,9 +3083,9 @@ internal sealed partial class ExpressionBinder
         [NotNullWhen(true)] out BoundExpression? result)
     {
         result = null;
-        var constraintInterface = tp.ClrInterfaceConstraint;
-        var clrType = constraintInterface?.ClrType;
-        if (constraintInterface == null || clrType is not { IsInterface: true })
+        var constraintType = tp.ClrInterfaceConstraint ?? tp.ClassConstraint;
+        var clrType = constraintType?.ClrType;
+        if (constraintType == null || clrType == null)
         {
             return false;
         }
@@ -3097,13 +3142,13 @@ internal sealed partial class ExpressionBinder
 
         var parameters = method.GetParameters();
 
-        // Return type: a return that names the interface type-variable is
-        // recovered by projecting through the constructed constraint interface;
+        // Return type: a return that names the constraint type-variable is
+        // recovered by projecting through the constructed constraint;
         // a concrete return (e.g. IComparable.CompareTo -> int32) falls back to
         // the direct CLR mapping.
-        var returnType = MemberLookup.GetClrMethodReturnTypeSymbol(constraintInterface, method);
-        var declaringInterface = MemberLookup.GetClrMemberDeclaringTypeSymbol(
-            constraintInterface,
+        var returnType = MemberLookup.GetClrMethodReturnTypeSymbol(constraintType, method);
+        var declaringConstraint = MemberLookup.GetClrMemberDeclaringTypeSymbol(
+            constraintType,
             method);
 
         // Issue #1852: re-lower each interpolated-string argument whose
@@ -3140,7 +3185,7 @@ internal sealed partial class ExpressionBinder
             refKinds,
             default,
             constrainedReceiverTypeParameter: tp,
-            constrainedInterfaceType: declaringInterface);
+            constrainedInterfaceType: declaringConstraint);
         return true;
     }
 
@@ -3207,7 +3252,7 @@ internal sealed partial class ExpressionBinder
         // declares an IFormattable/FormattableString/handler parameter, so an
         // interpolated-string argument could never take the Tier-4
         // (ADR-0055) conversion path against any candidate here regardless of
-        // the flag. Unlike TryBindConstrainedClrInterfaceCall above, this path
+        // the flag. Unlike TryBindConstrainedClrCall above, this path
         // does run the full CLR parameter-conversion pass afterward, but that
         // fact is irrelevant given no candidate parameter shape could match.
         // Constant-narrowing is intentionally omitted for the same reason:

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -411,16 +411,7 @@ internal sealed partial class ExpressionBinder
 
         var mapped = MemberLookup.MapOpenClrTypeToSymbolic(openReturn, imp.OpenDefinition, imp.TypeArguments);
 
-        // Issue #1100: keep the symbolic projection when the recovered return
-        // type references a same-compilation user type as well (not only an
-        // in-scope type parameter). A constructed BCL generic over a
-        // same-compilation class — e.g. `Queue[Entry].Dequeue()` — projects the
-        // open `T` return to the user `Entry` symbol (whose `ClrType` is null
-        // while being emitted). Without this the result type-erases to `object`
-        // and an `Entry`-typed target fails to bind (GS0155).
-        return TypeSymbol.RequiresSymbolicProjection(mapped)
-            ? mapped
-            : null;
+        return mapped;
     }
 
     /// <summary>
@@ -475,10 +466,10 @@ internal sealed partial class ExpressionBinder
             return null;
         }
 
-        var mapped = MemberLookup.MapOpenClrTypeToSymbolic(openPointee, imp.OpenDefinition, imp.TypeArguments);
-        return TypeSymbol.RequiresSymbolicProjection(mapped)
-            ? mapped
-            : null;
+        return MemberLookup.MapOpenClrTypeToSymbolic(
+            openPointee,
+            imp.OpenDefinition,
+            imp.TypeArguments);
     }
 
     /// <summary>
@@ -2006,7 +1997,8 @@ internal sealed partial class ExpressionBinder
                     // branch above only runs once a prior iteration set both).
                     if (agreedReturnTypes!.TryGetValue(idx, out var existingReturn))
                     {
-                        if (!slotReturnTypes.TryGetValue(idx, out var otherReturn) || !Equals(existingReturn, otherReturn))
+                        if (!slotReturnTypes.TryGetValue(idx, out var otherReturn)
+                            || !DeclarationBinder.TypeSignaturesEquivalent(existingReturn, otherReturn))
                         {
                             agreedReturnTypes.Remove(idx);
                         }
@@ -2072,7 +2064,9 @@ internal sealed partial class ExpressionBinder
 
             for (var i = 0; i < kv.Value.ParameterTypes.Length; i++)
             {
-                if (!Equals(kv.Value.ParameterTypes[i], other.ParameterTypes[i]))
+                if (!DeclarationBinder.TypeSignaturesEquivalent(
+                        kv.Value.ParameterTypes[i],
+                        other.ParameterTypes[i]))
                 {
                     return false;
                 }
@@ -2838,13 +2832,12 @@ internal sealed partial class ExpressionBinder
                 }
             }
 
-            // Issue #943: dispatch through a type parameter's *imported CLR*
-            // interface constraint (generic or not), e.g. `a.CompareTo(b)` where
-            // `a : T` and `T : IComparable[T]`. Emitted as a verifiable
-            // `constrained. !!T  callvirt IComparable`1<!!T>::CompareTo(!0)`.
+            // Issue #943 / #3394: dispatch through a type parameter's imported
+            // CLR interface or base-class constraint. Both shapes require a
+            // constrained call because the receiver's stack type remains !!T.
             if (receiver != null && receiver.Type is TypeParameterSymbol tpClrRecv
-                && tpClrRecv.ClrInterfaceConstraint != null
-                && TryBindConstrainedClrInterfaceCall(receiver, tpClrRecv, methodName, arguments, ce, argumentNames, out var constrainedCall))
+                && (tpClrRecv.ClrInterfaceConstraint != null || tpClrRecv.ClassConstraint?.ClrType != null)
+                && TryBindConstrainedClrCall(receiver, tpClrRecv, methodName, arguments, ce, argumentNames, out var constrainedCall))
             {
                 return constrainedCall;
             }
@@ -3404,8 +3397,8 @@ internal sealed partial class ExpressionBinder
                             constrainedReceiverTypeParameter: tpRecv));
                 }
 
-                if (tpRecv.ClrInterfaceConstraint != null
-                    && TryBindConstrainedClrInterfaceCall(narrowedReceiver, tpRecv, methodName, arguments, ce, argumentNames, out var constrainedCall))
+                if ((tpRecv.ClrInterfaceConstraint != null || tpRecv.ClassConstraint?.ClrType != null)
+                    && TryBindConstrainedClrCall(narrowedReceiver, tpRecv, methodName, arguments, ce, argumentNames, out var constrainedCall))
                 {
                     return Succeeded(constrainedCall);
                 }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -1525,7 +1525,7 @@ internal sealed partial class ExpressionBinder
         var ctorParameterLists = ctors.Select(c => c.GetParameters()).ToList();
 
         var boundArguments = ImmutableArray.CreateBuilder<BoundExpression>(syntax.Arguments.Count);
-        var symbolicCtorDelegateArgs = new HashSet<int>();
+        var symbolicCtorDelegateTargets = new Dictionary<int, TypeSymbol>();
         for (var i = 0; i < syntax.Arguments.Count; i++)
         {
             var argName = argumentNames.IsDefault ? null : argumentNames[i];
@@ -1560,7 +1560,7 @@ internal sealed partial class ExpressionBinder
                         literal,
                         resolvedSymbolicTarget.DelegateType)
                     : literal);
-                symbolicCtorDelegateArgs.Add(i);
+                symbolicCtorDelegateTargets[i] = resolvedSymbolicTarget.DelegateType;
                 continue;
             }
 
@@ -1597,7 +1597,7 @@ internal sealed partial class ExpressionBinder
             // inference elsewhere) keep the default enum→int ride-through.
             System.Type? t;
             var priorErase = eraseDelegateInnerEnumToObject;
-            eraseDelegateInnerEnumToObject = symbolicCtorDelegateArgs.Contains(i);
+            eraseDelegateInnerEnumToObject = symbolicCtorDelegateTargets.ContainsKey(i);
             try
             {
                 t = GetEffectiveArgumentClrTypeForOverloadResolution(boundArguments[i].Type);
@@ -1729,6 +1729,18 @@ internal sealed partial class ExpressionBinder
         // parameter order with optional slots filled — downstream reorderers
         // therefore consume an identity mapping.
         var ctorDownstreamMapping = ctorIsExpanded ? default : ctorMapping;
+        Dictionary<int, TypeSymbol>? ctorParameterTypeOverrides = null;
+        if (symbolicCtorDelegateTargets.Count > 0)
+        {
+            ctorParameterTypeOverrides = new Dictionary<int, TypeSymbol>();
+            foreach (var pair in symbolicCtorDelegateTargets)
+            {
+                var parameterIndex = ctorDownstreamMapping.IsDefault
+                    ? pair.Key
+                    : ctorDownstreamMapping[pair.Key];
+                ctorParameterTypeOverrides[parameterIndex] = pair.Value;
+            }
+        }
 
         // Issue #1638: route through the shared CLR call-argument-construction
         // pipeline (interpolation rebind → handler args → delegate rebind →
@@ -1745,7 +1757,8 @@ internal sealed partial class ExpressionBinder
             syntax,
             ClrCallDelegateRebindMode.Full,
             out var ctorHandlerPrelude,
-            out _);
+            out _,
+            parameterTypeOverrides: ctorParameterTypeOverrides);
         var ctorArgs = OverloadResolver.BuildOrderedCallArguments(ctorConvertedArgs, ctorDownstreamMapping, ctorParameters);
         if (!ctorRefKinds.IsDefault)
         {

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -74,9 +74,11 @@ internal sealed partial class ExpressionBinder
         // falls back to a same-named non-generic type (`typeof(Action[_])`
         // can never silently become non-generic `Action`).
         var typeClause = syntax.TypeClause;
-        var typeClauseIdentifier = Invariant.Required(typeClause.Identifier, "a type clause has an identifier");
         TypeSymbol? typeSymbol = null;
-        if (!typeClause.HasQualifier && !typeClause.IsArray && !typeClause.IsNullable)
+        if (typeClause.Identifier is { } typeClauseIdentifier
+            && !typeClause.HasQualifier
+            && !typeClause.IsArray
+            && !typeClause.IsNullable)
         {
             if (!typeClause.HasTypeArguments)
             {
@@ -595,7 +597,13 @@ internal sealed partial class ExpressionBinder
 
     private bool TryGetNaturalUserMethodGroupType(
         BoundMethodGroupExpression group,
-        out FunctionTypeSymbol? naturalType)
+        [NotNullWhen(true)] out FunctionTypeSymbol? naturalType)
+        => TryGetSymbolicUserMethodGroupType(group, out naturalType)
+            && naturalType.ClrType != null;
+
+    private bool TryGetSymbolicUserMethodGroupType(
+        BoundMethodGroupExpression group,
+        [NotNullWhen(true)] out FunctionTypeSymbol? naturalType)
     {
         naturalType = null;
         if (group.Candidates.Length != 1
@@ -619,7 +627,7 @@ internal sealed partial class ExpressionBinder
         naturalType = FunctionTypeSymbol.Get(
             parameterTypes.MoveToImmutable(),
             MethodGroupObservableReturnType(candidate));
-        return naturalType.ClrType != null;
+        return true;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -847,6 +847,10 @@ internal sealed partial class ExpressionBinder
             }
         }
 
+        var (typeWhenTrue, typeWhenFalse) = ClassifyTypeTestNarrowing(condition);
+        whenTrueNarrowing = MergeIfExpressionNarrowing(whenTrueNarrowing, typeWhenTrue);
+        whenFalseNarrowing = MergeIfExpressionNarrowing(whenFalseNarrowing, typeWhenFalse);
+
         var whenTrue = BindWithNarrowing(
             whenTrueNarrowing,
             () => BindBlockExpressionValue(syntax.ThenBlock, canBeVoid, targetType));
@@ -891,6 +895,29 @@ internal sealed partial class ExpressionBinder
         }
 
         return new BoundConditionalExpression(null, condition, convertedTrue, convertedFalse, resultType);
+    }
+
+    private static Dictionary<AccessPath, TypeSymbol>? MergeIfExpressionNarrowing(
+        Dictionary<AccessPath, TypeSymbol>? first,
+        Dictionary<AccessPath, TypeSymbol>? second)
+    {
+        if (first == null || first.Count == 0)
+        {
+            return second;
+        }
+
+        if (second == null || second.Count == 0)
+        {
+            return first;
+        }
+
+        var merged = new Dictionary<AccessPath, TypeSymbol>(first);
+        foreach (var pair in second)
+        {
+            merged[pair.Key] = pair.Value;
+        }
+
+        return merged;
     }
 
     /// <summary>
@@ -1315,8 +1342,10 @@ internal sealed partial class ExpressionBinder
         var leftToRight = Conversion.Classify(left, right);
         var rightToLeft = Conversion.Classify(right, left);
 
-        bool leftImplicit = leftToRight.IsImplicit;
-        bool rightImplicit = rightToLeft.IsImplicit;
+        bool leftImplicit = leftToRight.IsImplicit
+            || HasImportedUserDefinedImplicitConversion(left, right);
+        bool rightImplicit = rightToLeft.IsImplicit
+            || HasImportedUserDefinedImplicitConversion(right, left);
 
         // Identity already handled; treat IsIdentity here as implicit too.
         if (leftImplicit && !rightImplicit)
@@ -1345,6 +1374,22 @@ internal sealed partial class ExpressionBinder
         }
 
         return null;
+    }
+
+    private static bool HasImportedUserDefinedImplicitConversion(TypeSymbol source, TypeSymbol target)
+    {
+        if (source.ClrType == null || target.ClrType == null)
+        {
+            return false;
+        }
+
+        return ClrOperatorResolution.TryResolveConversion(
+                source.ClrType,
+                target.ClrType,
+                allowExplicit: false,
+                out _,
+                out var isExplicit)
+            && !isExplicit;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -1002,13 +1002,16 @@ internal sealed class LambdaBinder
     /// adapter must present to the delegate-typed parameter.</param>
     /// <param name="exactTargetParameterSlots">Parameter slots that must use
     /// their target type without generic-erasure preservation.</param>
+    /// <param name="exactTargetReturnType">Whether the adapter must expose the
+    /// target return type exactly instead of preserving symbolic erasure.</param>
     /// <returns>The adapter literal; its
     /// <see cref="BoundFunctionLiteralExpression.CapturedVariables"/>
     /// match the original literal's captures.</returns>
     public BoundFunctionLiteralExpression CreateErasedFunctionLiteralAdapter(
         BoundFunctionLiteralExpression literal,
         FunctionTypeSymbol targetFunctionType,
-        ImmutableArray<bool> exactTargetParameterSlots = default)
+        ImmutableArray<bool> exactTargetParameterSlots = default,
+        bool exactTargetReturnType = false)
     {
         // ADR-0087 §3 R6: if the literal's declared signature already
         // matches the (possibly substituted) target, the adapter would
@@ -1097,7 +1100,9 @@ internal sealed class LambdaBinder
 
         var adapterReturnType = targetFunctionType.ReturnType == TypeSymbol.Void
             ? TypeSymbol.Void
-            : GetAdapterSlotType(literal.Function.Type, targetFunctionType.ReturnType);
+            : exactTargetReturnType
+                ? targetFunctionType.ReturnType
+                : GetAdapterSlotType(literal.Function.Type, targetFunctionType.ReturnType);
 
         // Issue #2180: an async literal carries a DUAL return shape — the
         // FunctionSymbol's result type is the UNWRAPPED value (`T`), while its

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -1119,7 +1119,9 @@ internal sealed class MemberLookup
             // symbolic slice here the call's return would collapse to the
             // erased `object[]` and fail to convert to `[]Foo` (GS0155). Mirror
             // the generic-type branch below, which already honours #903.
-            if (TypeSymbol.RequiresSymbolicProjection(mappedElement))
+            if (TypeSymbol.RequiresSymbolicProjection(mappedElement)
+                || (openElement?.ContainsGenericParameters == true
+                    && mappedElement.ClrType?.ContainsGenericParameters == false))
             {
                 return SliceTypeSymbol.Get(mappedElement);
             }
@@ -1134,7 +1136,9 @@ internal sealed class MemberLookup
         {
             var openPointee = openClr.GetElementType();
             var mappedPointee = MapOpenClrTypeToSymbolic(openPointee, openDefinition, typeArguments, openMethodDefinition, methodTypeArguments);
-            if (TypeSymbol.RequiresSymbolicProjection(mappedPointee))
+            if (TypeSymbol.RequiresSymbolicProjection(mappedPointee)
+                || (openPointee?.ContainsGenericParameters == true
+                    && mappedPointee.ClrType?.ContainsGenericParameters == false))
             {
                 return ByRefTypeSymbol.Get(mappedPointee);
             }
@@ -1159,19 +1163,14 @@ internal sealed class MemberLookup
                 openMethodDefinition,
                 methodTypeArguments);
 
-            if (TypeSymbol.RequiresSymbolicProjection(mappedUnderlying))
-            {
-                return NullableTypeSymbol.Get(mappedUnderlying);
-            }
-
-            return TypeSymbol.FromClrType(openClr);
+            return NullableTypeSymbol.Get(mappedUnderlying);
         }
 
-        if (openClr.IsGenericType && !openClr.IsGenericTypeDefinition)
+        if (openClr.IsGenericType)
         {
             var openArgs = openClr.GetGenericArguments();
             var symbolic = ImmutableArray.CreateBuilder<TypeSymbol>(openArgs.Length);
-            var anyParam = false;
+            var anyParam = openClr.IsGenericTypeDefinition && !typeArguments.IsDefaultOrEmpty;
             foreach (var a in openArgs)
             {
                 var mapped = MapOpenClrTypeToSymbolic(a, openDefinition, typeArguments, openMethodDefinition, methodTypeArguments);
@@ -1185,7 +1184,9 @@ internal sealed class MemberLookup
                 // receiver keep the `Check` element identity instead of
                 // collapsing to the type-erased `IEnumerable<object>` (which
                 // for a value-type element is not even a legal up-cast).
-                if (TypeSymbol.RequiresSymbolicProjection(mapped))
+                if (TypeSymbol.RequiresSymbolicProjection(mapped)
+                    || (a.ContainsGenericParameters
+                        && mapped.ClrType?.ContainsGenericParameters == false))
                 {
                     anyParam = true;
                 }
@@ -2193,7 +2194,8 @@ internal sealed class MemberLookup
             return false;
         }
 
-        if (getEnumerator.Type is StructSymbol enumeratorType)
+        var effectiveEnumeratorType = type.SubstituteMemberType(getEnumerator.Type);
+        if (effectiveEnumeratorType is StructSymbol enumeratorType)
         {
             if (TypeMemberModel.TryGetMethodIncludingInherited(enumeratorType, "MoveNext", out var moveNext) &&
                 moveNext.Parameters.Length == 0 &&
@@ -2207,7 +2209,8 @@ internal sealed class MemberLookup
             return false;
         }
 
-        return TryGetClrEnumeratorElementType(getEnumerator.Type, out elementType);
+        return effectiveEnumeratorType != null
+            && TryGetClrEnumeratorElementType(effectiveEnumeratorType, out elementType);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/ClrOverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/ClrOverloadResolution.cs
@@ -683,7 +683,11 @@ internal static class ClrOverloadResolution
     /// therefore must not contribute erased evidence to generic inference.
     /// Their original CLR types still participate in applicability and ranking.
     /// </param>
-    public static Result<T> Resolve<T>(IEnumerable<T> candidates, IReadOnlyList<Type?> argTypes, IReadOnlyList<Type>? explicitTypeArgs = null, Func<Type, Type>? projectTypeArgument = null, IReadOnlyList<bool>? interpolatedStringArgs = null, IReadOnlyList<string?>? argumentNames = null, Func<MethodInfo, bool, ImmutableArray<TypeSymbol?>>? recoverTypeArgSymbols = null, Func<Type, Type, bool>? supplementaryInterfaceCheck = null, Func<int, Type, bool>? constantNarrowingArgumentCheck = null, Func<int, Type, bool>? structuralProjectionArgumentCheck = null, Func<int, Type, bool?>? delegateRefKindArgumentCheck = null, Func<int, IReadOnlyList<Type>, Tuple<Type[], Type>?>? methodGroupInference = null, Func<int, bool>? methodGroupArgumentCheck = null, IReadOnlyList<bool>? deferredInferenceArgs = null)
+    /// <param name="functionLiteralArgumentCheck">
+    /// Optional callback identifying function-literal arguments whose body
+    /// return may be implicitly converted to the candidate delegate return.
+    /// </param>
+    public static Result<T> Resolve<T>(IEnumerable<T> candidates, IReadOnlyList<Type?> argTypes, IReadOnlyList<Type>? explicitTypeArgs = null, Func<Type, Type>? projectTypeArgument = null, IReadOnlyList<bool>? interpolatedStringArgs = null, IReadOnlyList<string?>? argumentNames = null, Func<MethodInfo, bool, ImmutableArray<TypeSymbol?>>? recoverTypeArgSymbols = null, Func<Type, Type, bool>? supplementaryInterfaceCheck = null, Func<int, Type, bool>? constantNarrowingArgumentCheck = null, Func<int, Type, bool>? structuralProjectionArgumentCheck = null, Func<int, Type, bool?>? delegateRefKindArgumentCheck = null, Func<int, IReadOnlyList<Type>, Tuple<Type[], Type>?>? methodGroupInference = null, Func<int, bool>? methodGroupArgumentCheck = null, IReadOnlyList<bool>? deferredInferenceArgs = null, Func<int, bool>? functionLiteralArgumentCheck = null)
         where T : MethodBase
     {
         var applicable = new List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[]? Mapping, bool IsExpanded)>();
@@ -707,7 +711,7 @@ internal static class ClrOverloadResolution
             // rest.
             try
             {
-                EvaluateCandidate(rawCandidate, argTypes, explicitTypeArgs, projectTypeArgument, applicable, interpolatedStringArgs, argumentNames, recoverTypeArgSymbols, supplementaryInterfaceCheck, constantNarrowingArgumentCheck, structuralProjectionArgumentCheck, delegateRefKindArgumentCheck, methodGroupInference, methodGroupArgumentCheck, deferredInferenceArgs);
+                EvaluateCandidate(rawCandidate, argTypes, explicitTypeArgs, projectTypeArgument, applicable, interpolatedStringArgs, argumentNames, recoverTypeArgSymbols, supplementaryInterfaceCheck, constantNarrowingArgumentCheck, structuralProjectionArgumentCheck, delegateRefKindArgumentCheck, methodGroupInference, methodGroupArgumentCheck, deferredInferenceArgs, functionLiteralArgumentCheck);
             }
             catch (Exception ex) when (IsMetadataLoadFailure(ex))
             {
@@ -2319,7 +2323,7 @@ internal static class ClrOverloadResolution
     /// so the per-candidate work can be guarded against reflection load
     /// failures (issue #321) without disturbing the surrounding control flow.
     /// </summary>
-    private static void EvaluateCandidate<T>(T rawCandidate, IReadOnlyList<Type?> argTypes, IReadOnlyList<Type>? explicitTypeArgs, Func<Type, Type>? projectTypeArgument, List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[]? Mapping, bool IsExpanded)> applicable, IReadOnlyList<bool>? interpolatedStringArgs = null, IReadOnlyList<string?>? argumentNames = null, Func<MethodInfo, bool, ImmutableArray<TypeSymbol?>>? recoverTypeArgSymbols = null, Func<Type, Type, bool>? supplementaryInterfaceCheck = null, Func<int, Type, bool>? constantNarrowingArgumentCheck = null, Func<int, Type, bool>? structuralProjectionArgumentCheck = null, Func<int, Type, bool?>? delegateRefKindArgumentCheck = null, Func<int, IReadOnlyList<Type>, Tuple<Type[], Type>?>? methodGroupInference = null, Func<int, bool>? methodGroupArgumentCheck = null, IReadOnlyList<bool>? deferredInferenceArgs = null)
+    private static void EvaluateCandidate<T>(T rawCandidate, IReadOnlyList<Type?> argTypes, IReadOnlyList<Type>? explicitTypeArgs, Func<Type, Type>? projectTypeArgument, List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[]? Mapping, bool IsExpanded)> applicable, IReadOnlyList<bool>? interpolatedStringArgs = null, IReadOnlyList<string?>? argumentNames = null, Func<MethodInfo, bool, ImmutableArray<TypeSymbol?>>? recoverTypeArgSymbols = null, Func<Type, Type, bool>? supplementaryInterfaceCheck = null, Func<int, Type, bool>? constantNarrowingArgumentCheck = null, Func<int, Type, bool>? structuralProjectionArgumentCheck = null, Func<int, Type, bool?>? delegateRefKindArgumentCheck = null, Func<int, IReadOnlyList<Type>, Tuple<Type[], Type>?>? methodGroupInference = null, Func<int, bool>? methodGroupArgumentCheck = null, IReadOnlyList<bool>? deferredInferenceArgs = null, Func<int, bool>? functionLiteralArgumentCheck = null)
         where T : MethodBase
     {
         {
@@ -2653,6 +2657,12 @@ internal static class ClrOverloadResolution
                         && structuralProjectionArgumentCheck(i, paramTypes[i]))
                     {
                         conv = ImplicitConversionKind.StructuralProjection;
+                    }
+                    else if (functionLiteralArgumentCheck?.Invoke(i) == true
+                        && argTypes[i] != null
+                        && IsLambdaBodyConvertibleToDelegate(paramTypes[i], argTypes[i]!, supplementaryInterfaceCheck))
+                    {
+                        conv = ImplicitConversionKind.DelegateReturnCovariance;
                     }
                     else
                     {
@@ -3886,6 +3896,11 @@ internal static class ClrOverloadResolution
             return CompareReferenceTargets(paramA, paramB);
         }
 
+        if (ka == ImplicitConversionKind.UserDefinedImplicit)
+        {
+            return CompareReferenceTargets(paramA, paramB);
+        }
+
         // Issue #1150: when two candidates both convert a delegate argument by
         // numeric return-type widening, prefer the one whose delegate return is
         // the "better conversion target" for the source's return type — so a
@@ -3941,6 +3956,20 @@ internal static class ClrOverloadResolution
 
     private static bool IsAtLeastAsSpecific(MethodBase a, MethodBase b)
     {
+        // Compare generic definitions rather than their inferred closed forms.
+        // Closing can erase the distinction that makes one overload more
+        // specific, e.g. Enumerable.Min<T>(..., Func<T, int>) versus
+        // Min<T, TResult>(..., Func<T, TResult>) after TResult infers as int.
+        if (a is MethodInfo { IsGenericMethod: true } aGeneric)
+        {
+            a = aGeneric.GetGenericMethodDefinition();
+        }
+
+        if (b is MethodInfo { IsGenericMethod: true } bGeneric)
+        {
+            b = bGeneric.GetGenericMethodDefinition();
+        }
+
         var pa = a.GetParameters();
         var pb = b.GetParameters();
 
@@ -3954,13 +3983,71 @@ internal static class ClrOverloadResolution
             // a is "at least as specific" parameter-wise when each of its
             // parameter types is assignable to b's (i.e. a's parameter is
             // more derived or equal).
-            if (!ClrTypeUtilities.IsAssignableByName(pb[i].ParameterType, pa[i].ParameterType))
+            if (!IsParameterTypeAtLeastAsSpecific(pa[i].ParameterType, pb[i].ParameterType))
             {
                 return false;
             }
         }
 
         return true;
+    }
+
+    private static bool IsParameterTypeAtLeastAsSpecific(Type candidate, Type other)
+    {
+        candidate = PeelByRef(candidate) ?? candidate;
+        other = PeelByRef(other) ?? other;
+
+        if (ClrTypeUtilities.AreSame(candidate, other))
+        {
+            return true;
+        }
+
+        // C# better-member specificity treats a concrete type as more specific
+        // than a method type parameter. Two type-parameter slots are tied.
+        if (other.IsGenericParameter)
+        {
+            return true;
+        }
+
+        if (candidate.IsGenericParameter)
+        {
+            return false;
+        }
+
+        if (candidate.IsArray && other.IsArray
+            && candidate.GetArrayRank() == other.GetArrayRank())
+        {
+            var candidateElement = candidate.GetElementType();
+            var otherElement = other.GetElementType();
+            return candidateElement != null
+                && otherElement != null
+                && IsParameterTypeAtLeastAsSpecific(candidateElement, otherElement);
+        }
+
+        if (candidate.IsGenericType && other.IsGenericType
+            && ClrTypeUtilities.AreSame(
+                candidate.GetGenericTypeDefinition(),
+                other.GetGenericTypeDefinition()))
+        {
+            var candidateArguments = candidate.GetGenericArguments();
+            var otherArguments = other.GetGenericArguments();
+            if (candidateArguments.Length != otherArguments.Length)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < candidateArguments.Length; i++)
+            {
+                if (!IsParameterTypeAtLeastAsSpecific(candidateArguments[i], otherArguments[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        return ClrTypeUtilities.IsAssignableByName(other, candidate);
     }
 
     private static bool TryRecoverErasedTypeArguments(

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Arguments.cs
@@ -287,7 +287,8 @@ internal sealed partial class OverloadResolver
         ref bool hasErrors)
     {
         var trailingCount = boundArguments.Length - fixedCount;
-        var passThrough = trailingCount == 1 && boundArguments[fixedCount].Type == sliceType;
+        var passThrough = trailingCount == 1
+            && Conversion.Classify(boundArguments[fixedCount].Type, sliceType).IsImplicit;
 
         var result = ImmutableArray.CreateBuilder<BoundExpression>(fixedCount + 1);
         for (var i = 0; i < fixedCount; i++)
@@ -297,7 +298,10 @@ internal sealed partial class OverloadResolver
 
         if (passThrough)
         {
-            result.Add(boundArguments[fixedCount]);
+            result.Add(conversions.BindConversion(
+                locationAt(fixedCount),
+                boundArguments[fixedCount],
+                sliceType));
             return result.MoveToImmutable();
         }
 

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Candidates.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Candidates.cs
@@ -875,6 +875,13 @@ internal sealed partial class OverloadResolver
                 : ClrOverloadResolution.ImplicitConversionKind.StructuralProjection;
         }
 
+        if (!IsNumericPrimitive(argType)
+            && !IsNumericPrimitive(paramType)
+            && conversions.HasUserDefinedImplicitConversion(argType, paramType))
+        {
+            return ClrOverloadResolution.ImplicitConversionKind.UserDefinedImplicit;
+        }
+
         if (paramType is NullableTypeSymbol nullableParam && argType == nullableParam.UnderlyingType)
         {
             // Issue #2146: `T -> T?` is a genuine value-type nullable WRAP only
@@ -920,6 +927,10 @@ internal sealed partial class OverloadResolver
         // more of Conversion.Classify's structure, if this surfaces in practice.
         return ClrOverloadResolution.ImplicitConversionKind.Reference;
     }
+
+    private static bool IsNumericPrimitive(TypeSymbol type)
+        => type?.ClrType?.FullName is string fullName
+            && NumericWideningLattice.IsNumericPrimitive(fullName);
 
     /// <summary>
     /// Issue #1154: returns <see langword="true"/> when <paramref name="argumentNames"/>

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Jumps.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Jumps.cs
@@ -722,7 +722,11 @@ internal sealed partial class StatementBinder
             return new BoundExpressionStatement(syntax, boundRead);
         }
 
-        if (boundRead.Type is not NullableTypeSymbol nullableType)
+        var nullableType = boundRead.Type as NullableTypeSymbol;
+        var isNonNullableReferenceTarget = nullableType == null
+            && Conversion.IsReferenceLikeTarget(boundRead.Type)
+            && boundRead is BoundIndexExpression or BoundClrIndexExpression;
+        if (nullableType == null && !isNonNullableReferenceTarget)
         {
             Diagnostics.ReportNullCoalescingAssignmentTargetNotNullable(syntax.OperatorToken.Location, boundRead.Type);
             _ = bindExpression(syntax.Value, false);
@@ -732,7 +736,8 @@ internal sealed partial class StatementBinder
         // Bind the RHS, converting it to the LHS's nullable type so the
         // author can write either an underlying-typed value (which lifts
         // via the implicit T -> T? conversion) or another nullable value.
-        var boundRhs = bindExpressionWithTargetType(syntax.Value, nullableType);
+        var rhsTargetType = nullableType ?? boundRead.Type;
+        var boundRhs = bindExpressionWithTargetType(syntax.Value, rhsTargetType);
         if (boundRhs is BoundErrorExpression || boundRhs.Type == TypeSymbol.Error)
         {
             return new BoundExpressionStatement(syntax, boundRhs);
@@ -748,11 +753,20 @@ internal sealed partial class StatementBinder
         // Condition: read == nil. Routes through the existing nil-compare
         // operator so any value-type Nullable<T> lowering is handled in the
         // same code path as `x == nil` elsewhere.
+        BoundExpression conditionRead = read;
+        if (isNonNullableReferenceTarget)
+        {
+            conditionRead = new BoundConversionExpression(
+                syntax,
+                NullableTypeSymbol.Get(read.Type),
+                read);
+        }
+
         var nilLiteral = new BoundLiteralExpression(syntax, null, TypeSymbol.Null);
         var eqOp = Invariant.Required(
-            BoundBinaryOperator.Bind(SyntaxKind.EqualsEqualsToken, read.Type, TypeSymbol.Null),
+            BoundBinaryOperator.Bind(SyntaxKind.EqualsEqualsToken, conditionRead.Type, TypeSymbol.Null),
             "a nullable coalescing assignment target supports nil comparison");
-        BoundExpression condition = new BoundBinaryExpression(syntax, read, eqOp, nilLiteral);
+        BoundExpression condition = new BoundBinaryExpression(syntax, conditionRead, eqOp, nilLiteral);
 
         var thenStmt = new BoundExpressionStatement(syntax, write);
         BoundStatement ifStmt = new BoundIfStatement(syntax, condition, thenStmt, elseStatement: null);

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
@@ -984,12 +984,12 @@ internal sealed partial class MethodBodyEmitter
             return true;
         }
 
-        // Issue #2516: slice-to-array/interface compatibility is deliberately
-        // narrower than CLR array covariance. Reuse the binder's classification
-        // before the general CLR assignability shortcuts below: exact array and
-        // invariant-interface elements remain required, while covariant
-        // read-only interfaces may widen their reference element.
-        if ((a is SliceTypeSymbol or RectangularArrayTypeSymbol
+        // Issue #2516: slice/fixed-array-to-array/interface compatibility is
+        // deliberately narrower than CLR array covariance. Reuse the binder's
+        // classification before the general CLR assignability shortcuts below:
+        // exact array and invariant-interface elements remain required, while
+        // covariant read-only interfaces may widen their reference element.
+        if ((a is SliceTypeSymbol or ArrayTypeSymbol or RectangularArrayTypeSymbol
                 || a is ImportedTypeSymbol { ClrType: { IsArray: true } })
             && (b is SliceTypeSymbol or ArrayTypeSymbol or RectangularArrayTypeSymbol
                 || b?.ClrType?.IsArray == true
@@ -1023,8 +1023,8 @@ internal sealed partial class MethodBodyEmitter
             return true;
         }
 
-        // Issue #2140 / #3354: a G# slice or rectangular array (any element
-        // type) is CLR array-backed. Upcasting it to the base
+        // Issue #2140 / #3354: a G# slice, fixed array, or rectangular array
+        // (any element type) is CLR array-backed. Upcasting it to the base
         // class `System.Array` — or to any of the element-INDEPENDENT non-
         // generic array supertype interfaces (IEnumerable, ICollection,
         // IList, ICloneable, IStructuralComparable, IStructuralEquatable) —
@@ -1034,7 +1034,7 @@ internal sealed partial class MethodBodyEmitter
         // #570 CLR arms above; these arms additionally recognise the
         // generic-type-parameter / same-compilation-user element case whose
         // backing `ClrType` is null during emit.
-        if (a is SliceTypeSymbol or RectangularArrayTypeSymbol)
+        if (a is SliceTypeSymbol or ArrayTypeSymbol or RectangularArrayTypeSymbol)
         {
             var bClr = b?.ClrType;
             if (bClr != null

--- a/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
+++ b/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
@@ -953,7 +953,9 @@ public sealed class ReferenceResolver : IDisposable
         }
 
         var fullName = hostType.FullName;
-        if (!string.IsNullOrEmpty(fullName) && TryResolveType(fullName, out var mapped) && mapped != null)
+        if (!string.IsNullOrEmpty(fullName)
+            && TryResolveType(fullName, requireExternalVisibility: false, out var mapped)
+            && mapped != null)
         {
             return mapped;
         }

--- a/src/Core/CodeAnalysis/Symbols/TupleTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/TupleTypeSymbol.cs
@@ -124,7 +124,9 @@ public sealed class TupleTypeSymbol : TypeSymbol
         }
 
         var clrTypes = elementTypes
-            .Select(t => Invariant.Required(t.ClrType, "a CLR-backed tuple element has a CLR type"))
+            .Select(t => Invariant.Required(
+                NullableTypeSymbol.GetEffectiveClrType(t),
+                "a CLR-backed tuple element has a CLR type"))
             .ToArray();
         return BuildClrType(clrTypes);
     }

--- a/src/Core/CodeAnalysis/Syntax/Parser.Expressions.Creation.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.Expressions.Creation.cs
@@ -828,6 +828,11 @@ public partial class Parser
 
         if (nextKind == SyntaxKind.OpenBraceToken)
         {
+            if (IsTokenOnNewLineAfter(Peek(pos), Peek(pos - 1)))
+            {
+                return false;
+            }
+
             // Issue #1023: in a statement-header controlling expression
             // (`if`/`while`/`for` clauses, `switch`/`match` subject, …) the
             // trailing `{` opens the statement body, not a composite literal.
@@ -933,6 +938,10 @@ public partial class Parser
             }
 
             pos++;
+            if (Peek(pos).Kind == SyntaxKind.QuestionToken)
+            {
+                pos++;
+            }
         }
 
         if (!CanStartTypeClause(Peek(pos)))

--- a/src/Core/CodeAnalysis/Syntax/Parser.Expressions.Literals.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.Expressions.Literals.cs
@@ -424,9 +424,15 @@ public partial class Parser
                     // After the receiver clause a method declaration continues
                     // with its name followed by either a value-parameter list
                     // `Name(` or a type-parameter list `Name[` (generic method).
-                    return Peek(i + 1).Kind == SyntaxKind.IdentifierToken
-                        && (Peek(i + 2).Kind == SyntaxKind.OpenParenthesisToken
-                            || Peek(i + 2).Kind == SyntaxKind.OpenSquareBracketToken);
+                    if (Peek(i + 1).Kind == SyntaxKind.IdentifierToken)
+                    {
+                        return Peek(i + 2).Kind is
+                            SyntaxKind.OpenParenthesisToken or SyntaxKind.OpenSquareBracketToken;
+                    }
+
+                    return Peek(i + 1).Kind == SyntaxKind.OperatorKeyword
+                        && Peek(i + 2).Kind != SyntaxKind.EndOfFileToken
+                        && Peek(i + 3).Kind == SyntaxKind.OpenParenthesisToken;
                 }
             }
         }

--- a/src/Core/CodeAnalysis/Syntax/Parser.Expressions.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.Expressions.cs
@@ -458,6 +458,7 @@ public partial class Parser
         {
             var postfixOp = NextToken();
             left = BuildIncrementDecrementExpression(left, postfixOp, isPrefix: false);
+            left = ParsePostfixChain(left);
         }
 
         while (true)

--- a/src/Core/CodeAnalysis/Syntax/Parser.Patterns.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.Patterns.cs
@@ -61,7 +61,7 @@ public partial class Parser
 
         var caseKeyword = MatchToken(SyntaxKind.CaseKeyword);
         var value = ParsePattern(PatternParseContext.SwitchStatement);
-        var (whenKeyword, guard) = ParseOptionalWhenGuard();
+        var (whenKeyword, guard) = ParseOptionalWhenGuard(bodyFollows: true);
         var caseBody = ParseBlockStatement();
         return new SwitchCaseSyntax(syntaxTree, caseKeyword, value, whenKeyword, guard, caseBody);
     }
@@ -71,12 +71,12 @@ public partial class Parser
     // contextually as an identifier whose text is "when"; this keeps existing
     // identifiers named `when` usable everywhere else. Returns (null, null) when
     // no guard is present.
-    private (SyntaxToken? WhenKeyword, ExpressionSyntax? Guard) ParseOptionalWhenGuard()
+    private (SyntaxToken? WhenKeyword, ExpressionSyntax? Guard) ParseOptionalWhenGuard(bool bodyFollows = false)
     {
         if (Current.Kind == SyntaxKind.IdentifierToken && Current.Text == "when")
         {
             var whenKeyword = NextToken();
-            var guard = ParseExpression();
+            var guard = bodyFollows ? ParseExpressionInBodyHeader() : ParseExpression();
             return (whenKeyword, guard);
         }
 
@@ -487,6 +487,14 @@ public partial class Parser
     private PropertyPatternSyntax? TryParseTypePropertyPattern()
     {
         if (Current.Kind != SyntaxKind.OpenBraceToken)
+        {
+            return null;
+        }
+
+        if (patternParseContext == PatternParseContext.IsExpressionBodyHeader
+            && patternNestingDepth == 0
+            && Peek(1).Kind != SyntaxKind.CloseBraceToken
+            && (Peek(1).Kind != SyntaxKind.IdentifierToken || Peek(2).Kind != SyntaxKind.ColonToken))
         {
             return null;
         }

--- a/src/Core/CodeAnalysis/Syntax/Parser.Statements.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.Statements.cs
@@ -447,6 +447,11 @@ public partial class Parser
 
     private bool LooksLikeMultiAssignment()
     {
+        if (!HasTopLevelCommaBeforeAssignment())
+        {
+            return false;
+        }
+
         var savedPosition = position;
         var savedTokens = tokens;
         var savedDiagnosticCount = Diagnostics.Count;
@@ -473,6 +478,75 @@ public partial class Parser
             tokens = savedTokens;
             Diagnostics.TruncateTo(savedDiagnosticCount);
         }
+    }
+
+    private bool HasTopLevelCommaBeforeAssignment()
+    {
+        var parenthesisDepth = 0;
+        var bracketDepth = 0;
+        var braceDepth = 0;
+
+        for (var offset = 0; offset <= LookaheadMaxScan; offset++)
+        {
+            var kind = Peek(offset).Kind;
+            switch (kind)
+            {
+                case SyntaxKind.OpenParenthesisToken:
+                    parenthesisDepth++;
+                    break;
+                case SyntaxKind.CloseParenthesisToken:
+                    if (parenthesisDepth == 0)
+                    {
+                        return false;
+                    }
+
+                    parenthesisDepth--;
+                    break;
+                case SyntaxKind.OpenSquareBracketToken:
+                case SyntaxKind.QuestionOpenBracketToken:
+                    bracketDepth++;
+                    break;
+                case SyntaxKind.CloseSquareBracketToken:
+                    if (bracketDepth == 0)
+                    {
+                        return false;
+                    }
+
+                    bracketDepth--;
+                    break;
+                case SyntaxKind.OpenBraceToken:
+                    braceDepth++;
+                    break;
+                case SyntaxKind.CloseBraceToken:
+                    if (braceDepth == 0)
+                    {
+                        return false;
+                    }
+
+                    braceDepth--;
+                    break;
+            }
+
+            if (parenthesisDepth != 0 || bracketDepth != 0 || braceDepth != 0)
+            {
+                continue;
+            }
+
+            if (kind == SyntaxKind.CommaToken)
+            {
+                return true;
+            }
+
+            if (kind is SyntaxKind.EqualsToken
+                or SyntaxKind.ColonEqualsToken
+                or SyntaxKind.SemicolonToken
+                or SyntaxKind.EndOfFileToken)
+            {
+                return false;
+            }
+        }
+
+        return false;
     }
 
     private StatementSyntax ParseMultiAssignmentStatement()

--- a/test/Compiler.Tests/Emit/Issue1502DelegateUserTypeArgEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1502DelegateUserTypeArgEmitTests.cs
@@ -53,6 +53,32 @@ public class Issue1502DelegateUserTypeArgEmitTests
     }
 
     [Fact]
+    public void EndToEnd_FuncUserClass_LazyCapturingLambda_Runs()
+    {
+        const string source = """
+            package i1502funccapture
+            import System
+
+            class Foo { prop N int32 { get; init; } init(n int32) { N = n } }
+
+            class C {
+                let value int32
+
+                init() {
+                    value = 43
+                }
+
+                func Make() Lazy[Foo] -> Lazy[Foo](() -> Foo(value))
+            }
+
+            func Main() { System.Console.WriteLine(C().Make().Value.N) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal($"43{Environment.NewLine}", output);
+    }
+
+    [Fact]
     public void EndToEnd_FuncUserStruct_LazyLambda_Runs()
     {
         const string source = """

--- a/test/Compiler.Tests/Emit/Issue663UserDefinedConversionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue663UserDefinedConversionEmitTests.cs
@@ -140,6 +140,35 @@ public class Issue663UserDefinedConversionEmitTests
         Assert.Equal($"42{Environment.NewLine}", output);
     }
 
+    [Fact]
+    public void JsonNode_Implicit_String_InIndexerInitializer_Runs()
+    {
+        var source = """
+            package Test
+            import System
+            import System.Text.Json.Nodes
+
+            class Writer {
+                shared {
+                    const SchemaVersion string = "1"
+
+                    func Build(resourceName string) JsonObject ->
+                        JsonObject(){
+                            ["_schemaVersion"] = Writer.SchemaVersion,
+                            ["resource"] = resourceName,
+                        }
+                }
+            }
+
+            let obj = Writer.Build("queue")
+            Console.WriteLine(string?(obj["_schemaVersion"]) ?? "nil")
+            Console.WriteLine(string?(obj["resource"]) ?? "nil")
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal($"1{Environment.NewLine}queue{Environment.NewLine}", output);
+    }
+
     private static string CompileAndRun(string source)
     {
         var (exitCode, stdout, stderr) = CompileAndRunRaw(source);

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1024StackAllocBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1024StackAllocBinderTests.cs
@@ -214,6 +214,21 @@ func F() { var buf = stackalloc []string{""a"", ""b""} }
         Assert.Contains(diagnostics, d => d.Id == "GS0399");
     }
 
+    [Fact]
+    public void SafeSpanForm_PassesToImportedReadOnlySpanParameter()
+    {
+        const string source = @"
+package p
+import System.Text
+func F() {
+    let bytes = stackalloc [4]uint8
+    let text = Encoding.ASCII.GetString(bytes.Slice(0, 3))
+}
+";
+        var diagnostics = GetDiagnostics(source).ToList();
+        Assert.Empty(diagnostics);
+    }
+
     private static IEnumerable<Diagnostic> GetDiagnostics(string source)
     {
         var tree = SyntaxTree.Parse(SourceText.From(source));

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1162UserElementArrayBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1162UserElementArrayBinderTests.cs
@@ -139,6 +139,22 @@ func F(xs []SegA) int32 { return Take(xs) }
         Assert.Contains(diags, d => d.Id == "GS0154" || d.Id == "GS0155");
     }
 
+    [Fact]
+    public void Negative_FixedStructArray_ToMismatchedIEnumerable_Rejected()
+    {
+        const string source = @"
+package P
+import System.Collections.Generic
+struct SegA { let X uint32 }
+struct SegB { let Y uint32 }
+func Take(e IEnumerable[SegB]) int32 { return 0 }
+func F(xs [3]SegA) int32 { return Take(xs) }
+";
+        var diags = GetDiagnostics(source);
+        Assert.NotEmpty(diags);
+        Assert.Contains(diags, d => d.Id == "GS0154" || d.Id == "GS0155");
+    }
+
     private static ImmutableArrayOfDiagnostic GetDiagnostics(string source)
     {
         var tree = SyntaxTree.Parse(SourceText.From(source));

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2859ClassTypedForInBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2859ClassTypedForInBinderTests.cs
@@ -74,6 +74,30 @@ class C {
     }
 
     [Fact]
+    public void ForIn_ConstructedGenericClass_SubstitutesEnumeratorElementType()
+    {
+        const string source = @"
+package p
+import System.Collections.Generic
+class Item {
+    prop Name string { get; init; }
+}
+class Bag[T any] {
+    private let items List[T]
+    init() { items = List[T]() }
+    func GetEnumerator() IEnumerator[T] -> items.GetEnumerator()
+}
+class C {
+    func FirstName(b Bag[Item]) string {
+        for item in b { return item.Name }
+        return """"
+    }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
     public void ForIn_ClassWithUserDeclaredEnumerator_StillBinds()
     {
         // Control: the pre-existing user-declared-enumerator shape

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3394InlineOutTupleBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3394InlineOutTupleBindingTests.cs
@@ -52,6 +52,31 @@ public class Issue3394InlineOutTupleBindingTests
     }
 
     [Fact]
+    public void PartialSymbolicMethodInference_UsesClosedTypeForUnresolvedSlot()
+    {
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From("package P\nclass Item {}")));
+        var item = compilation.GlobalScope.Structs.Single(type => type.Name == "Item");
+        var select = typeof(Enumerable).GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Single(method => method.Name == nameof(Enumerable.Select)
+                && method.IsGenericMethodDefinition
+                && method.GetParameters().Length == 2
+                && method.GetParameters()[1].ParameterType.GetGenericArguments().Length == 2)
+            .MakeGenericMethod(typeof(object), typeof(System.Collections.Generic.Dictionary<string, string>));
+
+        var parameterType = Assert.IsType<ImportedTypeSymbol>(
+            ConversionClassifier.TrySubstituteParameterTypeFromMethodTypeArgs(
+                select,
+                1,
+                ImmutableArray.Create<TypeSymbol>(item, TypeSymbol.Error)));
+
+        Assert.True(MemberLookup.TryGetDelegateFunctionTypeFromSymbol(parameterType, out var functionType));
+        Assert.Same(item, Assert.Single(functionType.ParameterTypes));
+        Assert.Equal(
+            typeof(System.Collections.Generic.Dictionary<string, string>),
+            functionType.ReturnType.ClrType);
+    }
+
+    [Fact]
     public void SymbolicMethodInference_MapsDictionaryEntry()
     {
         var compilation = new Compilation(SyntaxTree.Parse(SourceText.From("package P\nclass Item {}")));

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3394InlineOutTupleBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3394InlineOutTupleBindingTests.cs
@@ -1,0 +1,474 @@
+// <copyright file="Issue3394InlineOutTupleBindingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #3394: inline out-var inference from a constructed generic receiver
+/// preserves tuple element nullability.
+/// </summary>
+public class Issue3394InlineOutTupleBindingTests
+{
+    [Fact]
+    public void SymbolicMethodInference_MapsImportedEnumerableInterface()
+    {
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From("package P\nclass Item {}")));
+        var item = compilation.GlobalScope.Structs.Single(type => type.Name == "Item");
+        var receiver = ImportedTypeSymbol.GetConstructed(
+            typeof(ImmutableArray<object>),
+            typeof(ImmutableArray<>),
+            ImmutableArray.Create<TypeSymbol>(item));
+        var any = typeof(Enumerable).GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Single(method => method.Name == nameof(Enumerable.Any)
+                && method.IsGenericMethodDefinition
+                && method.GetParameters().Length == 2
+                && method.GetParameters()[1].ParameterType.IsGenericType);
+
+        var closed = any.MakeGenericMethod(typeof(object));
+        var inferred = MemberLookup.BuildSymbolicMethodTypeArgs(
+            closed,
+            default,
+            ImmutableArray.Create<TypeSymbol>(receiver, TypeSymbol.Error));
+
+        Assert.Same(item, Assert.Single(inferred));
+        var parameterType = Assert.IsType<ImportedTypeSymbol>(
+            ConversionClassifier.TrySubstituteParameterTypeFromMethodTypeArgs(closed, 1, inferred));
+        Assert.Same(item, parameterType.TypeArguments[0]);
+        Assert.True(MemberLookup.TryGetDelegateFunctionTypeFromSymbol(parameterType, out var functionType));
+        Assert.Same(item, Assert.Single(functionType.ParameterTypes));
+    }
+
+    [Fact]
+    public void SymbolicMethodInference_MapsDictionaryEntry()
+    {
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From("package P\nclass Item {}")));
+        var item = compilation.GlobalScope.Structs.Single(type => type.Name == "Item");
+        var receiver = ImportedTypeSymbol.GetConstructed(
+            typeof(System.Collections.Generic.Dictionary<object, int>),
+            typeof(System.Collections.Generic.Dictionary<,>),
+            ImmutableArray.Create<TypeSymbol>(item, TypeSymbol.Int32));
+        var entry = ImportedTypeSymbol.GetConstructed(
+            typeof(System.Collections.Generic.KeyValuePair<object, int>),
+            typeof(System.Collections.Generic.KeyValuePair<,>),
+            ImmutableArray.Create<TypeSymbol>(item, TypeSymbol.Int32));
+        var selector = FunctionTypeSymbol.Get(
+            ImmutableArray.Create<TypeSymbol>(entry),
+            TypeSymbol.Int32);
+        var orderBy = typeof(Enumerable).GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Single(method => method.Name == nameof(Enumerable.OrderBy)
+                && method.IsGenericMethodDefinition
+                && method.GetParameters().Length == 2
+                && method.GetGenericArguments().Length == 2);
+
+        var inferred = MemberLookup.BuildSymbolicMethodTypeArgs(
+            orderBy.MakeGenericMethod(typeof(object), typeof(int)),
+            default,
+            ImmutableArray.Create<TypeSymbol>(receiver, selector));
+
+        var inferredEntry = Assert.IsType<ImportedTypeSymbol>(inferred[0]);
+        Assert.Same(item, inferredEntry.TypeArguments[0]);
+        Assert.Same(TypeSymbol.Int32, inferred[1]);
+    }
+
+    [Fact]
+    public void ClrOverloadResolution_SelectManyAcceptsStructEnumerableLambdaReturn()
+    {
+        Assert.NotEqual(
+            ClrOverloadResolution.ImplicitConversionKind.None,
+            ClrOverloadResolution.ClassifyImplicit(
+                typeof(System.Collections.Generic.IEnumerable<object>),
+                typeof(ImmutableArray<object>)));
+        var candidate = typeof(Enumerable).GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Single(method => method.Name == nameof(Enumerable.SelectMany)
+                && method.IsGenericMethodDefinition
+                && method.GetGenericArguments().Length == 2
+                && method.GetParameters().Length == 2
+                && method.GetParameters()[1].ParameterType.GetGenericArguments().Length == 2)
+            .MakeGenericMethod(typeof(object), typeof(object));
+        var result = ClrOverloadResolution.Resolve(
+            new[] { candidate },
+            new System.Type[]
+            {
+                typeof(ImmutableArray<object>),
+                typeof(System.Func<object, ImmutableArray<object>>),
+            },
+            functionLiteralArgumentCheck: index => index == 1);
+
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
+    }
+
+    [Fact]
+    public void ConditionalExpression_UsesImportedImplicitConversion()
+    {
+        var result = EmittedOracle.Evaluate("""
+            import System.Reflection.Metadata
+
+            let flag = true
+            let handle = if flag {
+                default(EntityHandle)
+            } else {
+                default(MethodDefinitionHandle)
+            }
+            handle.IsNil
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(true, result.Value);
+    }
+
+    [Fact]
+    public void InlineOutVarsInShortCircuitCondition_AreVisibleInThenBody()
+    {
+        var result = EmittedOracle.Evaluate("""
+            func tryRead(out left int32, out right int32) bool {
+                left = 20
+                right = 22
+                return true
+            }
+
+            func read() int32 {
+                if false {
+                    return -1
+                } else if true && tryRead(out var left, out var right) {
+                    return left + right
+                }
+                return 0
+            }
+
+            read()
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void BodyLocal_CanShadowReadOnlyParameter()
+    {
+        var result = EmittedOracle.Evaluate("""
+            func change(value int32) int32 {
+                var value = value
+                value = 42
+                return value
+            }
+
+            change(1)
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void UserOverloadRanking_PrefersIdentityOverImplicitOperator()
+    {
+        var result = EmittedOracle.Evaluate("""
+            open class Base {}
+            class Derived : Base {}
+            class Path {
+                func operator implicit(value Base) Path -> Path()
+            }
+
+            func pick(value Base) int32 -> 1
+            func pick(value Path) int32 -> 2
+
+            pick(Derived())
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(1, result.Value);
+    }
+
+    [Fact]
+    public void UserGenericInference_RecursesIntoImportedTupleArguments()
+    {
+        var result = EmittedOracle.Evaluate("""
+            import System.Collections.Generic
+
+            enum Kind { None, Some }
+
+            func inner[T](values List[(T, Kind)]) T -> values[0].Item1
+            func outer[T](values List[(T, Kind)]) T -> inner(values)
+
+            let values = List[(int32, Kind)]()
+            values.Add((42, Kind.Some))
+            outer(values)
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void NullCoalescingAssignment_AllowsClrDefaultNullReferenceSlot()
+    {
+        var result = EmittedOracle.Evaluate("""
+            var values = [1]string
+            values[0] ??= "filled"
+            values[0]
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("filled", result.Value);
+    }
+
+    [Fact]
+    public void LinqOrderBy_PreservesSymbolicDictionaryEntryType()
+    {
+        var result = EmittedOracle.Evaluate("""
+            import System.Collections.Generic
+            import System.Linq
+
+            class Item {}
+
+            func count(values Dictionary[Item, int32]) int32 {
+                return values.OrderBy((pair KeyValuePair[Item, int32]) -> pair.Value).Count()
+            }
+
+            0
+            """);
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void QualifiedPrivateNestedTypeConstruction_BindsInsideContainingType()
+    {
+        var result = EmittedOracle.Evaluate("""
+            class Rewriter {}
+
+            class Outer {
+                private open class Rewriter {}
+
+                shared {
+                    func make() object -> Outer.Rewriter()
+                }
+            }
+
+            Outer.make()
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.NotNull(result.Value);
+    }
+
+    [Fact]
+    public void ImportedOverloadRanking_UsesBetterUserDefinedConversionTarget()
+    {
+        var result = EmittedOracle.Evaluate("""
+            import System.Reflection.Metadata
+            import System.Reflection.Metadata.Ecma335
+
+            let handle = default(MethodDefinitionHandle)
+            MetadataTokens.GetToken(handle)
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(0x06000000, result.Value);
+    }
+
+    [Fact]
+    public void NullAssertedImportedGenericReceivers_PreserveInstanceMethods()
+    {
+        var result = EmittedOracle.Evaluate("""
+            import System.Collections.Generic
+            import System.Collections.Immutable
+
+            class Item {}
+
+            func check(name string) bool {
+                let seen = HashSet[string]()
+                seen!!.Add(name)
+
+                let items = ImmutableArray.CreateBuilder[Item]()
+                items!!.Add(Item())
+                return seen.Count == 1 && items.Count == 1
+            }
+
+            check("x")
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(true, result.Value);
+    }
+
+    [Fact]
+    public void LinqWhere_PreservesNestedSymbolicTupleReceiver()
+    {
+        var result = EmittedOracle.Evaluate("""
+            import System
+            import System.Collections.Generic
+            import System.Linq
+            import System.Reflection
+
+            class Resolver {
+                enum Kind { None, Identity }
+
+                shared {
+                    func isGeneric(method MethodBase) bool -> false
+
+                    func choose[T MethodBase](applicable List[(T, []Kind, []Type, []?int32, bool)]) int32 {
+                        let nonDominated = List[(T, []Kind, []Type, []?int32, bool)]()
+                        let direct = applicable.Where((w (T, []Kind, []Type, []?int32, bool)) -> w.Item1.GetParameters().Length > 0).ToList()
+                        var pool = if nonDominated.Count > 0 { nonDominated } else { applicable }
+                        let minParamCount = pool.Min((w (T, []Kind, []Type, []?int32, bool)) -> w.Item1.GetParameters().Length)
+                        let fewestParams = pool.Where((w (T, []Kind, []Type, []?int32, bool)) -> w.Item1.GetParameters().Length == minParamCount).ToList()
+                        let mostSpecific = pool.Where((w (T, []Kind, []Type, []?int32, bool)) -> pool.All((o (T, []Kind, []Type, []?int32, bool)) -> object.ReferenceEquals(w.Item1, o.Item1) || true)).ToList()
+                        let nonGeneric = pool.Where((w (T, []Kind, []Type, []?int32, bool)) -> !Resolver.isGeneric(w.Item1)).ToList()
+                        let mostConstrained = pool.Where((w (T, []Kind, []Type, []?int32, bool)) -> pool.All((o (T, []Kind, []Type, []?int32, bool)) -> object.ReferenceEquals(w.Item1, o.Item1) || true)).ToList()
+                        let selected = pool.Select((c (T, []Kind, []Type, []?int32, bool)) -> c.Item1).ToList()
+                        return direct.Count + fewestParams.Count + mostSpecific.Count + nonGeneric.Count + mostConstrained.Count + selected.Count
+                    }
+                }
+            }
+
+            0
+            """);
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void OverloadedUserCall_PreservesOutRefKind()
+    {
+        var result = EmittedOracle.Evaluate("""
+            import System
+            import System.Collections.Immutable
+            import GSharp.Core.CodeAnalysis.Binding
+            import GSharp.Core.CodeAnalysis.Syntax
+
+            class C {
+                func fill(
+                    sourceArguments GSharp.Core.CodeAnalysis.Syntax.SeparatedSyntaxList[ExpressionSyntax],
+                    sourceBound ImmutableArray[BoundExpression],
+                    parameterCount int32,
+                    parameterNameAt (int32) -> string,
+                    isOptionalAt ((int32) -> bool)?,
+                    calleeName string,
+                    out permutedSyntax []ExpressionSyntax?,
+                    out permutedBound ImmutableArray[BoundExpression]) bool {
+                    permutedSyntax = [parameterCount]ExpressionSyntax?
+                    permutedBound = sourceBound
+                    return true
+                }
+
+                func fill(
+                    sourceArguments GSharp.Core.CodeAnalysis.Syntax.SeparatedSyntaxList[ExpressionSyntax],
+                    sourceBound ImmutableArray[BoundExpression],
+                    parameterCount int32,
+                    parameterNameAt (int32) -> string,
+                    calleeName string,
+                    out permutedSyntax []ExpressionSyntax?,
+                    out permutedBound ImmutableArray[BoundExpression]) bool ->
+                    fill(sourceArguments, sourceBound, parameterCount, parameterNameAt, isOptionalAt: nil, calleeName, out permutedSyntax, out permutedBound)
+            }
+
+            42
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void OverloadedUserCall_PreservesOutRefKindForUserGenericStruct()
+    {
+        var result = EmittedOracle.Evaluate("""
+            struct Box[T] {}
+            class Item {}
+
+            class C {
+                func fill(value int32, out result Box[Item]) {
+                    result = default(Box[Item])
+                }
+
+                func fill(out result Box[Item]) {
+                    fill(42, out result)
+                }
+            }
+
+            0
+            """);
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void LinqMethodGroup_PreservesSameCompilationElementType()
+    {
+        var result = EmittedOracle.Evaluate("""
+            import System.Collections.Immutable
+            import System.Linq
+
+            class Item {
+                shared {
+                    func Keep(value Item) bool -> true
+                }
+            }
+
+            let values ImmutableArray[Item] = ImmutableArray.Create(Item())
+            values.Any(Item.Keep)
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(true, result.Value);
+    }
+
+    [Fact]
+    public void LinqSelectMany_PreservesSameCompilationSourceAndResultTypes()
+    {
+        var result = EmittedOracle.Evaluate("""
+            import System.Collections.Immutable
+            import System.Linq
+
+            class Node {}
+            class Root {
+                prop Members ImmutableArray[Node] { get; init; }
+            }
+            class Tree {
+                prop Root Root { get; init; }
+            }
+
+            func count(trees ImmutableArray[Tree]) int32 {
+                return trees.SelectMany((tree Tree) -> tree.Root.Members).Count()
+            }
+
+            0
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(0, result.Value);
+    }
+
+    [Fact]
+    public void DictionaryTryGetValue_PreservesNullableTupleElements()
+    {
+        var result = EmittedOracle.Evaluate("""
+            import System.Collections.Generic
+            import System.Reflection.Metadata
+
+            var direct (MethodDefinitionHandle?, MethodDefinitionHandle?) = default
+            let directMissing = direct.Item1 == nil
+            var values = Dictionary[string, (MethodDefinitionHandle?, MethodDefinitionHandle?)]()
+            let found = values.TryGetValue("missing", out var handles)
+            let missing = !found || handles.Item1 == nil
+            directMissing && missing
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(true, result.Value);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue711IfExpressionBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue711IfExpressionBindingTests.cs
@@ -121,6 +121,24 @@ let x = if true { a } else { b }
     }
 
     [Fact]
+    public void IfExpression_TypeTestNarrowsThenBranch()
+    {
+        var result = Evaluate(@"
+open class Base { }
+class Derived : Base {
+    prop Value int32 -> 42
+}
+func Read(value Base) int32 {
+    return if value is Derived { value.Value } else { 0 }
+}
+let answer = Read(Derived())
+");
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.ReadGlobal("answer"));
+    }
+
+    [Fact]
     public void IfExpression_NilAndReferenceBranches_BindNullableResult()
     {
         // `nil` on one arm and a nullable reference on the other unifies

--- a/test/Core.Tests/CodeAnalysis/Binding/TypeOfNameOfTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/TypeOfNameOfTests.cs
@@ -72,6 +72,17 @@ var t = typeof(int32?)
     }
 
     [Fact]
+    public void TypeOf_FunctionType_Resolves_To_DelegateType()
+    {
+        var (eval, vars) = EvaluateWithVariables(@"
+var t = typeof((object) -> void)
+");
+
+        Assert.Empty(eval.Diagnostics);
+        Assert.Equal(typeof(System.Action<object>), vars["t"]);
+    }
+
+    [Fact]
     public void NameOf_Local_Returns_Identifier()
     {
         var (eval, vars) = EvaluateWithVariables(@"

--- a/test/Core.Tests/CodeAnalysis/Binding/VariadicTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/VariadicTests.cs
@@ -22,6 +22,21 @@ namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 public class VariadicTests
 {
     [Fact]
+    public void Variadic_PassThroughImportedClrArray()
+    {
+        var result = Evaluate(@"
+import System
+
+func CountTypes(types ...Type) int32 -> len(types)
+
+CountTypes(Type.EmptyTypes)
+");
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(0, result.Value);
+    }
+
+    [Fact]
     public void Variadic_PacksTrailingArgs_IntoSlice()
     {
         var result = Evaluate(@"

--- a/test/Core.Tests/CodeAnalysis/Symbols/ReferenceResolverTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/ReferenceResolverTests.cs
@@ -206,6 +206,30 @@ public class ReferenceResolverTests
     }
 
     [Fact]
+    public void MapClrTypeToReferences_Projects_NonPublicNestedInfrastructureType()
+    {
+        Type section = typeof(System.Reflection.PortableExecutable.PEBuilder)
+            .GetNestedType("Section", BindingFlags.Public | BindingFlags.NonPublic);
+        Assert.NotNull(section);
+
+        var paths = new[]
+        {
+            typeof(object).Assembly.Location,
+            typeof(System.Reflection.PortableExecutable.PEBuilder).Assembly.Location,
+        }
+        .Where(path => !string.IsNullOrEmpty(path))
+        .Distinct(StringComparer.OrdinalIgnoreCase);
+        var resolver = ReferenceResolver.WithReferences(paths);
+
+        Assert.False(resolver.TryResolveType(section.FullName, out _));
+
+        Type projected = resolver.MapClrTypeToReferences(section);
+
+        Assert.NotSame(section, projected);
+        Assert.Equal(section.FullName, projected.FullName);
+    }
+
+    [Fact]
     public void MapClrTypeToReferences_Projects_ByRef_Types()
     {
         var resolver = BuildMetadataLoadContextResolver();

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue1278ArrowExpressionMemberParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue1278ArrowExpressionMemberParserTests.cs
@@ -202,6 +202,23 @@ public class Issue1278ArrowExpressionMemberParserTests
         Assert.All(funcs, f => Assert.NotNull(f.Body));
     }
 
+    [Fact]
+    public void ArrowCallOperatorBody_FollowedByReceiverOperator_ParsesCleanly()
+    {
+        const string source =
+            "package P\n" +
+            "struct B { func Equals(other B) bool { return true } }\n" +
+            "func (left B) operator ==(right B) bool -> left.Equals(right)\n" +
+            "func (left B) operator !=(right B) bool -> !left.Equals(right)\n";
+
+        var tree = SyntaxTree.Parse(source);
+
+        Assert.Empty(tree.Diagnostics);
+        var funcs = tree.Root.Members.OfType<FunctionDeclarationSyntax>().ToArray();
+        Assert.Equal(2, funcs.Length);
+        Assert.All(funcs, function => Assert.NotNull(function.Body));
+    }
+
     private static IEnumerable<SyntaxNode> Walk(SyntaxNode node)
     {
         yield return node;

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue1323GenericStaticReceiverParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue1323GenericStaticReceiverParserTests.cs
@@ -129,6 +129,27 @@ class C { func F() int32 { return Pair[int32, string].Make(5) } }
     }
 
     [Fact]
+    public void TupleTypeArg_WithNullableArrayElement_ParsesAsGenericConstruction()
+    {
+        const string source = """
+            package p
+            import System.Collections.Generic
+            func F() {
+                let values = List[(int32, []string, []?int32, bool)]()
+            }
+            """;
+
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var call = Descendants(tree.Root).OfType<CallExpressionSyntax>().Single();
+        var tuple = Assert.IsType<TypeClauseSyntax>(Assert.Single(call.TypeArgumentList.Arguments));
+        Assert.True(tuple.IsTuple);
+        Assert.Equal(4, tuple.TupleElements.Count);
+        Assert.True(tuple.TupleElements[2].IsArrayNullable);
+    }
+
+    [Fact]
     public void SimpleTypeArg_StaticCall_StillParsesAsIndexerThenMember()
     {
         // Regression guard: a single SIMPLE-name bracketed argument followed by

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue3351IsPatternParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue3351IsPatternParserTests.cs
@@ -69,6 +69,26 @@ public sealed class Issue3351IsPatternParserTests
     }
 
     [Fact]
+    public void IfExpression_TypeTest_DoesNotConsumeCallValuedBranchAsPropertyPattern()
+    {
+        var tree = SyntaxTree.Parse(
+            "let result = if value is string { Make(nil, value) } else { value }");
+
+        Assert.Empty(tree.Diagnostics);
+        var declaration = tree.Root.Members
+            .OfType<GlobalStatementSyntax>()
+            .Select(member => member.Statement)
+            .OfType<VariableDeclarationSyntax>()
+            .Single();
+        var expression = Assert.IsType<IfExpressionSyntax>(declaration.Initializer);
+        var typeTest = Assert.IsType<IsExpressionSyntax>(expression.Condition);
+        var candidate = Assert.IsType<TypeOrConstantPatternSyntax>(typeTest.Pattern);
+
+        Assert.Null(candidate.PropertyPattern);
+        Assert.IsType<CallExpressionSyntax>(expression.ThenBlock.Expression);
+    }
+
+    [Fact]
     public void BareTypeSwitchCase_DoesNotConsumeCaseBodyAsPropertySuffix()
     {
         var tree = SyntaxTree.Parse("switch value { case string { work() } default { } }");

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue3355GeneralBlockExpressionParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue3355GeneralBlockExpressionParserTests.cs
@@ -131,6 +131,35 @@ public class Issue3355GeneralBlockExpressionParserTests
         Assert.IsType<BlockExpressionSyntax>(send.Channel);
     }
 
+    [Fact]
+    public void StandaloneBlockAfterIndexedInitializer_RemainsStatementBlock()
+    {
+        const string source = """
+            package P
+
+            func F(values []int32) {
+                for var i = 0; i < values.Length; i++ {
+                    let current = values[i]
+                    {
+                        let next = values[i]
+                        if i < values.Length && next is int32 && check(current) {
+                            continue
+                        }
+                    }
+                    if current > 0 {
+                        return
+                    }
+                }
+            }
+            """;
+
+        var tree = SyntaxTree.Parse(source);
+
+        Assert.Empty(tree.Diagnostics);
+        Assert.Equal(5, Walk(tree.Root).OfType<BlockStatementSyntax>().Count());
+        Assert.Empty(Walk(tree.Root).OfType<BlockExpressionSyntax>());
+    }
+
     private static IEnumerable<SyntaxNode> Walk(SyntaxNode node)
     {
         yield return node;

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue3394MultiAssignmentLookaheadPerfParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue3394MultiAssignmentLookaheadPerfParserTests.cs
@@ -1,0 +1,42 @@
+// <copyright file="Issue3394MultiAssignmentLookaheadPerfParserTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Diagnostics;
+using System.Text;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Issue #3394: multi-assignment speculation must not recursively parse every
+/// block-lambda body in an ordinary expression statement.
+/// </summary>
+public class Issue3394MultiAssignmentLookaheadPerfParserTests
+{
+    [Fact]
+    public void DeeplyNestedBlockLambdaCalls_ParseQuickly()
+    {
+        const int nestingDepth = 22;
+        var body = new StringBuilder("Use()");
+        for (var i = 0; i < nestingDepth; i++)
+        {
+            body.Insert(0, "Sink(() -> {\n");
+            body.Append("\n})");
+        }
+
+        var source = "package p\nfunc F() {\n" + body + "\n}\n";
+
+        SyntaxTree.Parse("package p\nfunc Warmup() { Use() }");
+        var stopwatch = Stopwatch.StartNew();
+        var tree = SyntaxTree.Parse(source);
+        stopwatch.Stop();
+
+        Assert.Empty(tree.Diagnostics);
+        Assert.True(
+            stopwatch.ElapsedMilliseconds < 1000,
+            $"Parsing {nestingDepth} nested block-lambda calls took " +
+            $"{stopwatch.ElapsedMilliseconds}ms, expected < 1000ms.");
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue3394PostfixContinuationParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue3394PostfixContinuationParserTests.cs
@@ -1,0 +1,39 @@
+// <copyright file="Issue3394PostfixContinuationParserTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Issue #3394: postfix increment/decrement results remain valid receivers for
+/// member access, calls, and indexing.
+/// </summary>
+public class Issue3394PostfixContinuationParserTests
+{
+    [Fact]
+    public void PostIncrementResult_CanBeMemberAccessReceiver()
+    {
+        const string source = """
+            package P
+            func F() {
+                var count = 0
+                let text = count++.ToString()
+            }
+            """;
+
+        var tree = SyntaxTree.Parse(source);
+
+        Assert.Empty(tree.Diagnostics);
+        var declaration = tree.Root.Members
+            .OfType<FunctionDeclarationSyntax>()
+            .Single()
+            .Body.Statements
+            .OfType<VariableDeclarationSyntax>()
+            .Last();
+        Assert.IsType<AccessorExpressionSyntax>(declaration.Initializer);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Syntax/PatternParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/PatternParserTests.cs
@@ -99,6 +99,22 @@ public class PatternParserTests
         Assert.Equal(SyntaxKind.BinaryExpression, theCase.Guard.Kind);
     }
 
+    [Fact]
+    public void SwitchStatement_WhenCallGuard_DoesNotConsumeCaseBodyAsInitializer()
+    {
+        var tree = SyntaxTree.Parse(
+            "switch v { case > 0 when object.ReferenceEquals(v, other) { } case _ { } }");
+
+        Assert.Empty(tree.Diagnostics);
+        var statement = tree.Root.Members
+            .OfType<GlobalStatementSyntax>()
+            .Select(member => member.Statement)
+            .OfType<SwitchStatementSyntax>()
+            .Single();
+        Assert.Equal(2, statement.Cases.Length);
+        Assert.Equal(SyntaxKind.AccessorExpression, statement.Cases[0].Guard.Kind);
+    }
+
     [Theory]
     [InlineData("[..]", 1, 0)]
     [InlineData("[1, .., 3]", 3, 1)]

--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GTypeReference.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GTypeReference.cs
@@ -34,10 +34,15 @@ public sealed class NamedTypeReference : GTypeReference
     /// </summary>
     /// <param name="name">The (possibly dotted) type name.</param>
     /// <param name="typeArguments">The bracket type arguments, if any.</param>
-    public NamedTypeReference(string name, IReadOnlyList<GTypeReference> typeArguments = null)
+    /// <param name="containingType">The constructed containing type for a nested type, if any.</param>
+    public NamedTypeReference(
+        string name,
+        IReadOnlyList<GTypeReference> typeArguments = null,
+        GTypeReference containingType = null)
     {
         Name = name;
         TypeArguments = typeArguments ?? new List<GTypeReference>();
+        ContainingType = containingType;
     }
 
     /// <summary>Gets the (possibly dotted) type name.</summary>
@@ -45,6 +50,9 @@ public sealed class NamedTypeReference : GTypeReference
 
     /// <summary>Gets the bracket type arguments.</summary>
     public IReadOnlyList<GTypeReference> TypeArguments { get; }
+
+    /// <summary>Gets the constructed containing type for a nested type, if any.</summary>
+    public GTypeReference ContainingType { get; }
 }
 
 /// <summary>

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -155,12 +155,15 @@ public static class GSharpPrinter
         switch (type)
         {
             case NamedTypeReference named:
+                var name = named.ContainingType == null
+                    ? named.Name
+                    : $"{RenderType(named.ContainingType)}.{named.Name}";
                 if (named.TypeArguments.Count == 0)
                 {
-                    return named.Name;
+                    return name;
                 }
 
-                return $"{named.Name}[{string.Join(", ", named.TypeArguments.Select(RenderType))}]";
+                return $"{name}[{string.Join(", ", named.TypeArguments.Select(RenderType))}]";
 
             case ArrayTypeReference array:
                 return $"[{new string(',', array.Rank - 1)}]{RenderType(array.ElementType)}";

--- a/tools/cs2gs/Cs2Gs.Pipeline/GsharpTestProjectRunner.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/GsharpTestProjectRunner.cs
@@ -60,7 +60,7 @@ public class GsharpTestProjectRunner
     public string RepoRoot { get; }
 
     /// <summary>
-    /// Resolves the highest-versioned locally-built <c>Gsharp.NET.Sdk</c> nupkg
+    /// Resolves the most recently built local <c>Gsharp.NET.Sdk</c> nupkg
     /// under <c>out/bin/&lt;Config&gt;/nupkgs/</c>.
     /// </summary>
     /// <param name="repoRoot">The repository root.</param>
@@ -85,7 +85,7 @@ public class GsharpTestProjectRunner
                 continue;
             }
 
-            (string Path, string Version)? best = null;
+            (string Path, string Version, DateTime WrittenUtc)? best = null;
             foreach (string file in Directory.EnumerateFiles(nupkgDir, SdkPackagePrefix + "*.nupkg"))
             {
                 string version = ParseVersion(Path.GetFileName(file));
@@ -94,15 +94,19 @@ public class GsharpTestProjectRunner
                     continue;
                 }
 
-                if (best is null || CompareVersions(version, best.Value.Version) > 0)
+                DateTime writtenUtc = File.GetLastWriteTimeUtc(file);
+                if (best is null
+                    || writtenUtc > best.Value.WrittenUtc
+                    || (writtenUtc == best.Value.WrittenUtc
+                        && CompareVersions(version, best.Value.Version) > 0))
                 {
-                    best = (file, version);
+                    best = (file, version, writtenUtc);
                 }
             }
 
             if (best is not null)
             {
-                return best;
+                return (best.Value.Path, best.Value.Version);
             }
         }
 
@@ -502,7 +506,14 @@ public class GsharpTestProjectRunner
         // headroom than the default; still bounded so a wedged run fails the
         // batch instead of hanging it (#1748).
         ProcessRunResult result = ProcessRunner.Run(
-            "dotnet", arguments, workingDirectory, TimeSpan.FromMinutes(10));
+            "dotnet",
+            arguments,
+            workingDirectory,
+            TimeSpan.FromMinutes(10),
+            new Dictionary<string, string>
+            {
+                ["NUGET_PACKAGES"] = Path.Combine(workingDirectory, ".nuget-packages"),
+            });
         return (result.ExitCode, result.Output);
     }
 }

--- a/tools/cs2gs/Cs2Gs.Pipeline/ProcessRunner.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/ProcessRunner.cs
@@ -36,13 +36,15 @@ public static class ProcessRunner
     /// <param name="arguments">The argument list, passed unquoted via <see cref="ProcessStartInfo.ArgumentList"/>.</param>
     /// <param name="workingDirectory">The working directory, or <see langword="null"/> to inherit the current one.</param>
     /// <param name="timeout">The maximum wall-clock time to wait before killing the process tree; defaults to <see cref="DefaultTimeout"/>.</param>
+    /// <param name="environment">Environment variables to set or override for the child process.</param>
     /// <returns>The exit code, captured output, and whether the run timed out.</returns>
     public static ProcessRunResult Run(
         string fileName,
         IReadOnlyList<string> arguments,
         string workingDirectory = null,
-        TimeSpan? timeout = null) =>
-        RunAsync(fileName, arguments, workingDirectory, timeout).GetAwaiter().GetResult();
+        TimeSpan? timeout = null,
+        IReadOnlyDictionary<string, string> environment = null) =>
+        RunAsync(fileName, arguments, workingDirectory, timeout, environment: environment).GetAwaiter().GetResult();
 
     /// <summary>The async form of <see cref="Run"/>; see its remarks for behavior.</summary>
     /// <param name="fileName">The executable to launch (e.g. <c>dotnet</c>).</param>
@@ -50,13 +52,15 @@ public static class ProcessRunner
     /// <param name="workingDirectory">The working directory, or <see langword="null"/> to inherit the current one.</param>
     /// <param name="timeout">The maximum wall-clock time to wait before killing the process tree; defaults to <see cref="DefaultTimeout"/>.</param>
     /// <param name="cancellationToken">A token that, when canceled, also kills the process tree early.</param>
+    /// <param name="environment">Environment variables to set or override for the child process.</param>
     /// <returns>The exit code, captured output, and whether the run timed out.</returns>
     public static async Task<ProcessRunResult> RunAsync(
         string fileName,
         IReadOnlyList<string> arguments,
         string workingDirectory = null,
         TimeSpan? timeout = null,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        IReadOnlyDictionary<string, string> environment = null)
     {
         if (string.IsNullOrEmpty(fileName))
         {
@@ -80,6 +84,14 @@ public static class ProcessRunner
         foreach (string arg in arguments ?? Array.Empty<string>())
         {
             psi.ArgumentList.Add(arg);
+        }
+
+        if (environment is not null)
+        {
+            foreach ((string name, string value) in environment)
+            {
+                psi.Environment[name] = value;
+            }
         }
 
         using var process = new Process { StartInfo = psi };

--- a/tools/cs2gs/Cs2Gs.Pipeline/SdkCompileRunner.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/SdkCompileRunner.cs
@@ -103,10 +103,15 @@ public sealed class SdkCompileRunner
                 "-c",
                 config ?? "Release",
                 "-p:RestoreConfigFile=" + projectNugetConfig,
+                "-p:RestorePackagesPath=" + Path.Combine(artifactDirectory, ".nuget-packages"),
                 "-p:Cs2GsArtifactRoot=" + artifactDirectory,
             };
             ProcessRunResult result = ProcessRunner.Run(
-                "dotnet", args, projectDirectory, TimeSpan.FromMinutes(10));
+                "dotnet",
+                args,
+                projectDirectory,
+                TimeSpan.FromMinutes(10),
+                IsolatedNugetEnvironment(artifactDirectory));
             File.WriteAllText(Path.Combine(artifactDirectory, "sdk.build.log"), result.Output ?? string.Empty);
 
             IReadOnlyList<GscDiagnostic> diagnostics = GscInvoker.ParseDiagnostics(result.Output);
@@ -321,6 +326,7 @@ public sealed class SdkCompileRunner
         File.WriteAllText(projectPath, projectXml);
 
         var args = new List<string> { "build", projectPath, "-c", config ?? "Release" };
+        args.Add("-p:RestorePackagesPath=" + Path.Combine(appRunDir, ".nuget-packages"));
         string repoNugetConfig = Path.Combine(repoRoot, "nuget.config");
         if (File.Exists(repoNugetConfig))
         {
@@ -331,7 +337,12 @@ public sealed class SdkCompileRunner
             args.Add("-p:RestoreConfigFile=" + repoNugetConfig);
         }
 
-        ProcessRunResult result = ProcessRunner.Run("dotnet", args, appRunDir, TimeSpan.FromMinutes(10));
+        ProcessRunResult result = ProcessRunner.Run(
+            "dotnet",
+            args,
+            appRunDir,
+            TimeSpan.FromMinutes(10),
+            IsolatedNugetEnvironment(appRunDir));
         File.WriteAllText(Path.Combine(appRunDir, "sdk.build.log"), result.Output ?? string.Empty);
 
         IReadOnlyList<GscDiagnostic> diagnostics = GscInvoker.ParseDiagnostics(result.Output);
@@ -696,7 +707,8 @@ public sealed class SdkCompileRunner
                     "-p:Cs2GsArtifactRoot=" + artifactDirectory,
                 },
                 projectDirectory,
-                TimeSpan.FromMinutes(10));
+                TimeSpan.FromMinutes(10),
+                IsolatedNugetEnvironment(artifactDirectory));
         }
         finally
         {
@@ -907,7 +919,8 @@ public sealed class SdkCompileRunner
                 "-p:Cs2GsArtifactRoot=" + artifactDirectory,
             },
             projectDirectory,
-            TimeSpan.FromMinutes(2));
+            TimeSpan.FromMinutes(2),
+            IsolatedNugetEnvironment(artifactDirectory));
         if (result.ExitCode != 0)
         {
             return null;
@@ -1056,6 +1069,12 @@ public sealed class SdkCompileRunner
         return string.IsNullOrEmpty(home) ? null : Path.Combine(home, ".nuget", "packages");
     }
 
+    private static IReadOnlyDictionary<string, string> IsolatedNugetEnvironment(string root) =>
+        new Dictionary<string, string>
+        {
+            ["NUGET_PACKAGES"] = Path.Combine(root, ".nuget-packages"),
+        };
+
     private static (string NupkgPath, string Version)? ResolveFallbackSdkPackageFromLocalFeed(string repoRoot)
     {
         string feed = Path.Combine(repoRoot, ".nugs");
@@ -1064,7 +1083,7 @@ public sealed class SdkCompileRunner
             return null;
         }
 
-        (string Path, string Version)? best = null;
+        (string Path, string Version, DateTime WrittenUtc)? best = null;
         foreach (string file in Directory.EnumerateFiles(feed, SdkPackagePrefix + "*.nupkg"))
         {
             string version = GsharpTestProjectRunner.ParseVersion(Path.GetFileName(file));
@@ -1073,13 +1092,17 @@ public sealed class SdkCompileRunner
                 continue;
             }
 
-            if (best is null || GsharpTestProjectRunner.CompareVersions(version, best.Value.Version) > 0)
+            DateTime writtenUtc = File.GetLastWriteTimeUtc(file);
+            if (best is null
+                || writtenUtc > best.Value.WrittenUtc
+                || (writtenUtc == best.Value.WrittenUtc
+                    && GsharpTestProjectRunner.CompareVersions(version, best.Value.Version) > 0))
             {
-                best = (file, version);
+                best = (file, version, writtenUtc);
             }
         }
 
-        return best;
+        return best is null ? null : (best.Value.Path, best.Value.Version);
     }
 
     private static GscDiagnostic SynthesizeFallbackDiagnostic(ProcessRunResult result, IReadOnlyList<string> gsFilePaths)

--- a/tools/cs2gs/Cs2Gs.Tests/BodyTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/BodyTranslationTests.cs
@@ -88,7 +88,7 @@ public class BodyTranslationTests
         Assert.Contains("} catch (ex InsufficientStockException) {", printed);
         Assert.Contains("} finally {", printed);
         Assert.Contains("throw ex", printed);
-        Assert.Contains("let available = if _stock.TryGetValue(sku, &qty) {", printed);
+        Assert.Contains("let available = if _stock.TryGetValue(sku, out qty) {", printed);
         Assert.Contains("threshold ?? 0", printed);
     }
 
@@ -361,7 +361,7 @@ public class BodyTranslationTests
               n = v;",
             extraLocals: "var d = new System.Collections.Generic.Dictionary<string,int>();");
         Assert.Contains("var v int32", body);
-        Assert.Contains("d.TryGetValue(\"a\", &v)", body);
+        Assert.Contains("d.TryGetValue(\"a\", out v)", body);
     }
 
     /// <summary>A C# <c>using</c> statement maps to a scoped block whose resource

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1072NullCheckedAsNullableTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1072NullCheckedAsNullableTranslationTests.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System;
+using System.Linq;
 using Cs2Gs.CodeModel.Ast;
 using Cs2Gs.CodeModel.Printing;
 using Cs2Gs.CodeModel.RoundTrip;
@@ -129,6 +130,62 @@ namespace Demo
 }");
 
         Assert.Contains("F(s string)", printed);
+    }
+
+    [Fact]
+    public void FlowNarrowedNullableValue_IsAssertedAtNonNullSinks()
+    {
+        string printed = TranslateUnit(@"
+#nullable enable
+using System;
+
+namespace Demo
+{
+    public class C
+    {
+        private static void Use(Type value) { }
+
+        public static void M(Type? next)
+        {
+            if (next == null) return;
+
+            Use(next);
+            Type current = typeof(string);
+            current = next;
+            Type[] values = new Type[1];
+            values[0] = next;
+        }
+    }
+}");
+
+        Assert.Contains("Use(next!!)", printed);
+        Assert.Contains("current = next!!", printed);
+        Assert.Contains("values[0] = next!!", printed);
+    }
+
+    [Fact]
+    public void NotNullIfNotNullResult_IsAssertedAtNonNullSink()
+    {
+        string printed = TranslateUnit(@"
+#nullable enable
+using System.Diagnostics.CodeAnalysis;
+
+namespace Demo
+{
+    public class C
+    {
+        [return: NotNullIfNotNull(""value"")]
+        private static string? Echo(string? value) => value;
+
+        public static string M(string? value)
+        {
+            if (value == null) return """";
+            return Echo(value);
+        }
+    }
+}");
+
+        Assert.Contains("return C.Echo(value)!!", printed);
         Assert.DoesNotContain("s string?", printed);
     }
 
@@ -217,6 +274,71 @@ namespace Demo
 
         Assert.Contains("found Box? =", printed);
         Assert.DoesNotContain("let found =", printed);
+    }
+
+    [Fact]
+    public void CrossFilePromotedPropertyReceiver_GetsNonNullAssertion()
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[]
+        {
+            ("Scope.cs", @"
+namespace Demo
+{
+    public class Resolver { public void Run() { } }
+    public class Scope
+    {
+        public Resolver References { get; } = new Resolver();
+        public bool Missing() => References == null;
+    }
+}"),
+            ("Use.cs", @"
+namespace Demo
+{
+    public class Use
+    {
+        private Scope scope = new Scope();
+        public void Run() => scope.References.Run();
+    }
+}"),
+        });
+        Assert.True(project.BoundWithoutErrors, string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        var translator = new CSharpToGSharpTranslator();
+        string[] printed = project.Documents
+            .Select(document =>
+            {
+                var context = new TranslationContext(
+                    project.Compilation,
+                    document.SemanticModel,
+                    document.FilePath);
+                return GSharpPrinter.Print(translator.TranslateDocument(document, context));
+            })
+            .ToArray();
+
+        Assert.Contains("References Resolver?", printed[0], StringComparison.Ordinal);
+        Assert.Contains("scope_.References!!.Run()", printed[1], StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(printed);
+    }
+
+    [Fact]
+    public void FlowNarrowedProperty_InArrayInitializer_GetsNonNullAssertion()
+    {
+        string printed = TranslateUnit(@"
+#nullable enable
+namespace Demo
+{
+    public class Box { public string? Value { get; set; } }
+    public class C
+    {
+        public string[] Read(Box box)
+        {
+            if (box.Value is null) return System.Array.Empty<string>();
+            return new[] { box.Value };
+        }
+    }
+}");
+
+        Assert.Contains("[]string{box.Value!!}", printed, StringComparison.Ordinal);
     }
 
     private static string TranslateUnit(string source)

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1727NamedArgumentReorderTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1727NamedArgumentReorderTranslationTests.cs
@@ -228,6 +228,110 @@ namespace Demo
         Assert.Contains("Merge(additionalCapacity: 8, a, b)", printed, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void ConstructorInitializerNames_InParameterOrder_LowerToPositionalArguments()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class Base
+    {
+        public Base(int value, bool enabled) { }
+    }
+
+    public class Derived : Base
+    {
+        public Derived()
+            : base(value: 1, enabled: true)
+        {
+        }
+    }
+}");
+
+        Assert.Contains("base(1, true)", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("value:", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("enabled:", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ConstructorInitializer_TrailingOptionalArgument_IsMaterialized()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class Base
+    {
+        public Base(int value, string label = null) { }
+    }
+
+    public class Derived : Base
+    {
+        public Derived()
+            : base(1)
+        {
+        }
+    }
+}");
+
+        Assert.Contains("base(1, nil)", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ConstructorInitializerNames_SkippingOptionalParameters_MaterializeDefaults()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class Base
+    {
+        public Base(
+            int first,
+            int skipped = 2,
+            bool enabled = false,
+            string label = ""default"")
+        {
+        }
+    }
+
+    public class Derived : Base
+    {
+        public Derived()
+            : base(1, enabled: true, label: ""chosen"")
+        {
+        }
+    }
+}");
+
+        Assert.Contains("base(1, 2, true, \"chosen\")", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("enabled:", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("label:", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ConstructorInitializerNames_ReorderedTrivialValues_LowerPositionally()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class Base
+    {
+        public Base(int first = 0, int second = 0, int third = 0) { }
+    }
+
+    public class Derived : Base
+    {
+        public Derived()
+            : base(third: 3, first: 1)
+        {
+        }
+    }
+}");
+
+        Assert.Contains("base(1, 0, 3)", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("first:", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("third:", printed, StringComparison.Ordinal);
+    }
+
     private static string TranslateUnit(string source)
     {
         (CompilationUnit unit, _) = Translate(source);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1730SwitchPatternBindingTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1730SwitchPatternBindingTests.cs
@@ -163,6 +163,41 @@ namespace Demo
         Assert.DoesNotContain("return r", printed);
     }
 
+    [Fact]
+    public void TypedPropertyConstraints_LowerToArmGuards()
+    {
+        string printed = TranslateUnit(ShapesPrelude + @"
+    public class Center
+    {
+        public int X;
+    }
+
+    public class DetailedCircle : Shape
+    {
+        public int Radius;
+        public Center Center;
+    }
+
+    public static class Shapes
+    {
+        public static int Describe(Shape shape)
+        {
+            switch (shape)
+            {
+                case DetailedCircle { Radius: > 0, Center.X: 0 }:
+                    return 1;
+                default:
+                    return 0;
+            }
+        }
+    }
+}");
+
+        Assert.Contains("case detailedCircle is DetailedCircle when", printed);
+        Assert.Contains("detailedCircle.Radius > 0", printed);
+        Assert.Contains("detailedCircle.Center.X == 0", printed);
+    }
+
     private static string TranslateUnit(string source)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
@@ -174,6 +209,9 @@ namespace Demo
         LoadedDocument document = Assert.Single(project.Documents);
         var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.DoesNotContain(
+            context.Diagnostics,
+            diagnostic => diagnostic.Severity == TranslationSeverity.Unsupported);
 
         string printed = GSharpPrinter.Print(unit);
         RoundTripResult result = TranslationTestValidation.AssertBinds(printed);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1734DeclarationSiteSanitizationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1734DeclarationSiteSanitizationTests.cs
@@ -108,6 +108,31 @@ namespace Corpus.Issue1734
     }
 
     [Fact]
+    public void TupleDeconstruction_KeywordCollision_IsSanitizedConsistently()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1734
+{
+    public class Holder
+    {
+        private (int, int) Pair() => (1, 2);
+
+        public int Compute()
+        {
+            var (value, guard) = Pair();
+            return value + guard;
+        }
+    }
+}
+");
+
+        Assert.Contains("let (value, guard_)", rendered, StringComparison.Ordinal);
+        Assert.Contains("return value + guard_", rendered, StringComparison.Ordinal);
+        AssertNoRawKeywordCollision(rendered, "guard");
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
     public void DeclarationPatternDesignator_KeywordCollision_IsSanitizedConsistently()
     {
         string rendered = Render(@"

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1849NullSeamHelperLoweringTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1849NullSeamHelperLoweringTests.cs
@@ -158,7 +158,8 @@ public class Issue3355NullSeamBlockExpressionLoweringTests
             "Named base-constructor arguments remain a known G# binding gap; this test isolates block lowering.");
 
         Assert.Equal(2, CountOccurrences(printed, "GetA()"));
-        Assert.Contains(": base(flag:", printed, StringComparison.Ordinal);
+        Assert.Contains("init() : base(", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain(": base(flag:", printed, StringComparison.Ordinal);
         Assert.Contains("GetA() is { X: 1, Y: 2 }", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("__spill", printed, StringComparison.Ordinal);
         AssertNoHelperOrGap(printed, context);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1894IndexLocalTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1894IndexLocalTranslationTests.cs
@@ -66,6 +66,27 @@ namespace Corpus.Issue1894
     }
 
     [Fact]
+    public void TypeOfIndexAndRange_UseMetadataTypeNamesWithoutValueGap()
+    {
+        string rendered = Render(@"
+using System;
+namespace Corpus.Issue1894
+{
+    public class Holder
+    {
+        public Type IndexType() => typeof(Index);
+
+        public Type RangeType() => typeof(Range);
+    }
+}
+");
+
+        Assert.Contains("typeof(Index)", rendered, StringComparison.Ordinal);
+        Assert.Contains("typeof(Range)", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
     public void InlineRangeSlice_FromEndBound_StaysCanonicalNoGap()
     {
         // `a[1..^2]`, `a[^2..]`, `a[..^1]`: the `^n` bound is nested inside a

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2412CrossProjectObliviousNullabilityTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2412CrossProjectObliviousNullabilityTranslationTests.cs
@@ -171,6 +171,44 @@ namespace LibA
     }
 
     [Fact]
+    public void CrossProject_MethodArgumentPosition_FromUnpromotedReferencedProperty_DoesNotSwitchToForeignSyntaxTree()
+    {
+        const string libB = @"
+namespace LibB
+{
+    public class Widget
+    {
+        public string Name => ""fixed"";
+    }
+}";
+        const string libA = @"
+using LibB;
+
+namespace LibA
+{
+    public class Sink
+    {
+        public void Accept(string value) { }
+    }
+
+    public class Consumer
+    {
+        public void Run(Widget widget, Sink sink)
+        {
+            sink.Accept(widget.Name);
+        }
+    }
+}";
+
+        (_, string printedA) = TranslateTwoProjects(libB, libA);
+
+        // Referenced oblivious members use the existing conservative external
+        // member assertion policy. The regression is reaching that policy
+        // without asking LibA's compilation for LibB's foreign syntax tree.
+        Assert.Contains("sink.Accept(widget.Name!!)", Compact(printedA));
+    }
+
+    [Fact]
     public void CrossProject_ArgumentToPromotedSiblingParameter_DoesNotInsertRuntimeAssertion()
     {
         const string libB = @"

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2467StaticExtensionConditionalReceiverTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2467StaticExtensionConditionalReceiverTests.cs
@@ -126,7 +126,7 @@ public class Issue2467StaticExtensionConditionalReceiverTests
 
         Assert.Contains("(box?.Value).Pick[string?](\"fallback\")", printed, StringComparison.Ordinal);
         Assert.Contains("(box?.Value).Pick(\"fallback\")", printed, StringComparison.Ordinal);
-        Assert.Contains("(box?.Value).Flow(&x, &y, z)", printed, StringComparison.Ordinal);
+        Assert.Contains("(box?.Value).Flow(&x, out y, z)", printed, StringComparison.Ordinal);
         Assert.Contains("(box?.Value).Join()", printed, StringComparison.Ordinal);
         Assert.Contains("(box?.Value).Join(\"-\", \"a\", \"b\")", printed, StringComparison.Ordinal);
     }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2500NullableExplicitGenericArgumentsTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2500NullableExplicitGenericArgumentsTranslationTests.cs
@@ -19,6 +19,25 @@ namespace Cs2Gs.Tests;
 public sealed class Issue2500NullableExplicitGenericArgumentsTranslationTests
 {
     [Fact]
+    public void TypedNullCast_PreservesNamedReferenceNullability()
+    {
+        string printed = Translate("""
+            #nullable enable
+
+            namespace Demo;
+
+            public class Base {}
+
+            public static class C
+            {
+                public static Base? M() => (Base?)null;
+            }
+            """);
+
+        Assert.Contains("default(Base?)", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void SemanticTypeArguments_PreserveNullableWrappersAcrossCallAndTypeShapes()
     {
         string printed = Translate("""

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2506PromotedCallReceiverForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2506PromotedCallReceiverForgivenessTranslationTests.cs
@@ -104,7 +104,7 @@ public sealed class Issue2506PromotedCallReceiverForgivenessTranslationTests
         Assert.Contains("FindGeneric[Item]()!!.Name", printed, StringComparison.Ordinal);
         Assert.Equal(2, CountOccurrences(printed, "Repro.FindFactory()!!().Name"));
         Assert.Contains("(Repro.Find())!!.Name", printed, StringComparison.Ordinal);
-        Assert.Contains("(Item(Repro.Find()!!)).Name", printed, StringComparison.Ordinal);
+        Assert.Contains("((Repro.Find()!! as Item)!!).Name", printed, StringComparison.Ordinal);
         Assert.Contains(
             "(if condition { Repro.Find() } else { Repro.Always() })!!.Name",
             printed,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2835NominalDelegateTypeTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2835NominalDelegateTypeTranslationTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Linq;
 using Cs2Gs.CodeModel.Ast;
 using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
 using Cs2Gs.Translator;
 using Cs2Gs.Translator.Loading;
 using Xunit;
@@ -137,6 +138,42 @@ namespace Corpus.Delegates
         EventDeclaration message = broadcaster.Members.OfType<EventDeclaration>().Single(e => e.Name == "Message");
 
         Assert.Equal("MessageHandler", ((NamedTypeReference)message.Type).Name);
+    }
+
+    [Fact]
+    public void NestedDelegates_LiftToDistinctTopLevelNominalTypes()
+    {
+        const string nestedSource = @"
+namespace Corpus.Delegates
+{
+    public class First
+    {
+        internal delegate int Transform(int value);
+        private Transform transform = value => value + 1;
+
+        public int Apply(int value) => transform(value);
+    }
+
+    public class Second
+    {
+        internal delegate int Transform(int value);
+        private Transform transform = value => value + 2;
+
+        public int Apply(int value) => transform(value);
+    }
+}
+";
+
+        CompilationUnit unit = Translate(nestedSource);
+        string rendered = GSharpPrinter.Print(unit);
+
+        Assert.Contains("type First_Transform = delegate func", rendered, StringComparison.Ordinal);
+        Assert.Contains("type Second_Transform = delegate func", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("First.Transform", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("Second.Transform", rendered, StringComparison.Ordinal);
+
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Errors));
     }
 
     private static string Render() => GSharpPrinter.Print(Translate(Source));

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3083WithLambdaRoundTripTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3083WithLambdaRoundTripTests.cs
@@ -98,7 +98,7 @@ public sealed class Issue3083WithLambdaRoundTripTests
         string printed = Translate(TypedNullSource);
 
         Assert.Contains(
-            "Split(default([]char), StringSplitOptions.RemoveEmptyEntries)",
+            "Split(default([]?char), StringSplitOptions.RemoveEmptyEntries)",
             printed,
             StringComparison.Ordinal);
         AssertRoundTrip(printed);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3090AwaitInvocationArgumentTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3090AwaitInvocationArgumentTests.cs
@@ -179,7 +179,7 @@ public sealed class Issue3090AwaitInvocationArgumentTests
             printed,
             StringComparison.Ordinal);
         Assert.Contains(
-            "Scenario.SetOutAsync(&b, value: await Scenario.InnerAsync())",
+            "Scenario.SetOutAsync(out b, value: await Scenario.InnerAsync())",
             printed,
             StringComparison.Ordinal);
         Assert.DoesNotContain("__spill", printed, StringComparison.Ordinal);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3394BoxingCastTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3394BoxingCastTranslationTests.cs
@@ -1,0 +1,187 @@
+// <copyright file="Issue3394BoxingCastTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3394: an explicit value-type-to-interface boxing cast retains its
+/// target type without being misrendered as interface construction.
+/// </summary>
+public class Issue3394BoxingCastTranslationTests
+{
+    [Fact]
+    public void SameCompilationReferenceDowncast_UsesAsAssertion()
+    {
+        const string source = @"
+namespace Demo
+{
+    public class Base {}
+    public class Derived : Base {}
+
+    public static class C
+    {
+        public static Derived Cast(Base value) => (Derived)value;
+    }
+}
+";
+
+        string rendered = Translate(source);
+
+        Assert.Contains("(value as Derived)!!", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("Derived(value)", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+
+    [Fact]
+    public void TypeParameterPatternBinding_UsesExplicitNarrowingCast()
+    {
+        const string source = @"
+using System.Reflection;
+
+namespace Demo
+{
+    public static class C
+    {
+        public static bool Check<T>(T value) where T : MemberInfo
+        {
+            if (value is MethodInfo method && method.IsGenericMethod)
+            {
+                return method.GetGenericArguments().Length > 0;
+            }
+
+            return false;
+        }
+    }
+}
+";
+
+        string rendered = Translate(source);
+
+        Assert.Contains("(value as MethodInfo)!!", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+
+    [Fact]
+    public void ShortCircuitPatternBinding_UsesExplicitNarrowingCast()
+    {
+        const string source = @"
+namespace Demo
+{
+    public class Base {}
+    public sealed class Candidate : Base { public int Value; }
+
+    public static class C
+    {
+        public static bool Check(Base value) =>
+            value is Candidate candidate && candidate.Value > 0;
+    }
+}
+";
+
+        string rendered = Translate(source);
+
+        Assert.Contains("(value as Candidate)!!.Value", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+
+    [Fact]
+    public void BareRecursivePatternOnNullableValue_UsesAssertion()
+    {
+        const string source = @"
+namespace Demo
+{
+    public static class C
+    {
+        public static int Read(int? value)
+        {
+            switch (0)
+            {
+                case 0 when value is { } present:
+                    return present;
+                default:
+                    return 0;
+            }
+        }
+    }
+}
+";
+
+        string rendered = Translate(source);
+
+        Assert.Contains("return value!!", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+
+    [Fact]
+    public void ImmutableArrayToReadOnlyList_UsesTypedBlockLocal()
+    {
+        const string source = @"
+using System.Collections.Generic;
+using System.Collections.Immutable;
+namespace Demo
+{
+    public static class C
+    {
+        private static int Count(IReadOnlyList<string> values) => values.Count;
+
+        public static int Read(ImmutableArray<string> values) =>
+            Count((IReadOnlyList<string>)values);
+    }
+}
+";
+
+        string rendered = Translate(source);
+
+        Assert.Contains("let __cast", rendered, StringComparison.Ordinal);
+        Assert.Contains("IReadOnlyList[string] = values", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("IReadOnlyList[string](values)", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+
+    [Fact]
+    public void ReferenceTypedUserDefinedCast_UsesConversionCall()
+    {
+        const string source = @"
+using System.Text.Json.Nodes;
+namespace Demo
+{
+    public static class C
+    {
+        public static string? Read(JsonObject value) => (string?)value[""name""];
+    }
+}
+";
+
+        string rendered = Translate(source);
+
+        Assert.Contains("string?(value[\"name\"])", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("as string", rendered, StringComparison.Ordinal);
+        var roundTrip = TranslationTestValidation.ValidateRoundTripOnly(
+            rendered,
+            "The standalone binder fixture does not reference System.Text.Json.Nodes.");
+        Assert.True(roundTrip.Success, string.Join(Environment.NewLine, roundTrip.Errors));
+    }
+
+    private static string Translate(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Snippet.cs", source) });
+        Assert.True(project.BoundWithoutErrors, string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(
+            project.Compilation,
+            document.SemanticModel,
+            document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3394LocalSdkPackageSelectionTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3394LocalSdkPackageSelectionTests.cs
@@ -1,0 +1,49 @@
+// <copyright file="Issue3394LocalSdkPackageSelectionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3394: local migration builds must use the package produced by the
+/// latest build, even when an older branch left a higher semantic version.
+/// </summary>
+public class Issue3394LocalSdkPackageSelectionTests
+{
+    [Fact]
+    public void ResolveLocalSdkPackage_PrefersNewestBuildOverHigherVersion()
+    {
+        string root = Path.Combine(
+            AppContext.BaseDirectory,
+            "sdk-selection-tests",
+            Guid.NewGuid().ToString("N"));
+        string packages = Path.Combine(root, "out", "bin", "Release", "nupkgs");
+        Directory.CreateDirectory(packages);
+
+        try
+        {
+            string stale = Path.Combine(packages, "Gsharp.NET.Sdk.9.0.0-gstale.nupkg");
+            string current = Path.Combine(packages, "Gsharp.NET.Sdk.1.0.0-gcurrent.nupkg");
+            File.WriteAllBytes(stale, Array.Empty<byte>());
+            File.WriteAllBytes(current, Array.Empty<byte>());
+            File.SetLastWriteTimeUtc(stale, DateTime.UtcNow.AddMinutes(-1));
+            File.SetLastWriteTimeUtc(current, DateTime.UtcNow);
+
+            (string NupkgPath, string Version)? resolved =
+                GsharpTestProjectRunner.ResolveLocalSdkPackage(root);
+
+            Assert.NotNull(resolved);
+            Assert.Equal(current, resolved.Value.NupkgPath);
+            Assert.Equal("1.0.0-gcurrent", resolved.Value.Version);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3394NegatedPatternGuardTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3394NegatedPatternGuardTranslationTests.cs
@@ -1,0 +1,238 @@
+// <copyright file="Issue3394NegatedPatternGuardTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3394: a negated pattern binder behind an earlier short-circuit guard
+/// must keep evaluation order and remain in scope after an exiting guard.
+/// </summary>
+public class Issue3394NegatedPatternGuardTranslationTests
+{
+    [Fact]
+    public void PriorOrGuard_RunsBeforePatternReceiver_AndBinderSurvives()
+    {
+        const string source = @"
+namespace Demo
+{
+    public sealed class Candidate
+    {
+        public bool IsGeneric;
+        public int Value;
+    }
+
+    public static class C
+    {
+        public static bool TryRead(Candidate[] candidates, out int value)
+        {
+            value = 0;
+            if (candidates.Length != 1
+                || candidates[0] is not { IsGeneric: false } candidate)
+            {
+                return false;
+            }
+
+            value = candidate.Value;
+            return true;
+        }
+    }
+}
+";
+
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Snippet.cs", source) });
+        Assert.True(project.BoundWithoutErrors, string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(
+            project.Compilation,
+            document.SemanticModel,
+            document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        string rendered = GSharpPrinter.Print(unit);
+
+        int prefixGuard = rendered.IndexOf("if candidates.Length != 1", StringComparison.Ordinal);
+        int candidateHoist = rendered.IndexOf("let candidate", StringComparison.Ordinal);
+        Assert.True(prefixGuard >= 0 && candidateHoist > prefixGuard, rendered);
+        Assert.DoesNotContain("let __spill", rendered, StringComparison.Ordinal);
+        Assert.Contains("candidate.Value", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+
+    [Fact]
+    public void LogicalNotAroundDeclarationPattern_HoistsSurvivingBinder()
+    {
+        const string source = @"
+namespace Demo
+{
+    public class Base { }
+    public sealed class Candidate : Base
+    {
+        public int Value;
+    }
+
+    public static class C
+    {
+        public static int Read(Base value)
+        {
+            if (!(value is Candidate candidate))
+            {
+                return 0;
+            }
+
+            return candidate.Value;
+        }
+    }
+}
+";
+
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Snippet.cs", source) });
+        Assert.True(project.BoundWithoutErrors, string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(
+            project.Compilation,
+            document.SemanticModel,
+            document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        string rendered = GSharpPrinter.Print(unit);
+
+        Assert.Contains("let candidate Candidate?", rendered, StringComparison.Ordinal);
+        Assert.Contains("return candidate.Value", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+
+    [Fact]
+    public void MultipleNegatedPatterns_HoistEverySurvivingBinder()
+    {
+        const string source = @"
+namespace Demo
+{
+    public class Base { }
+    public sealed class Left : Base { public int Value; }
+    public sealed class Right : Base { public int Value; }
+
+    public static class C
+    {
+        public static int Read(Base left, Base right)
+        {
+            if (left is not Left typedLeft || right is not Right typedRight)
+            {
+                return 0;
+            }
+
+            return typedLeft.Value + typedRight.Value;
+        }
+    }
+}
+";
+
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Snippet.cs", source) });
+        Assert.True(project.BoundWithoutErrors, string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(
+            project.Compilation,
+            document.SemanticModel,
+            document.FilePath);
+        string rendered = GSharpPrinter.Print(
+            new CSharpToGSharpTranslator().TranslateDocument(document, context));
+
+        Assert.Contains("let typedLeft Left?", rendered, StringComparison.Ordinal);
+        Assert.Contains("let typedRight Right?", rendered, StringComparison.Ordinal);
+        Assert.Contains("typedLeft.Value + typedRight.Value", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+
+    [Fact]
+    public void ReassignedNegatedPatternBinder_IsMutable()
+    {
+        const string source = @"
+namespace Demo
+{
+    public class Base { }
+    public sealed class Candidate : Base { public int Value; }
+
+    public static class C
+    {
+        private static Candidate Normalize(Candidate value) => value;
+
+        public static int Read(Base value)
+        {
+            if (value is not Candidate candidate)
+            {
+                return 0;
+            }
+
+            candidate = Normalize(candidate);
+            return candidate.Value;
+        }
+    }
+}
+";
+
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Snippet.cs", source) });
+        Assert.True(project.BoundWithoutErrors, string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(
+            project.Compilation,
+            document.SemanticModel,
+            document.FilePath);
+        string rendered = GSharpPrinter.Print(
+            new CSharpToGSharpTranslator().TranslateDocument(document, context));
+
+        Assert.Contains("var candidate Candidate?", rendered, StringComparison.Ordinal);
+        Assert.Contains("candidate = C.Normalize(candidate)", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+
+    [Fact]
+    public void NullableValueNegatedPattern_HoistsSurvivingBinder()
+    {
+        const string source = @"
+namespace Demo
+{
+    public static class C
+    {
+        public static int Read(int? value)
+        {
+            if (value is not int present)
+            {
+                return 0;
+            }
+
+            return present;
+        }
+    }
+}
+";
+
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Snippet.cs", source) });
+        Assert.True(project.BoundWithoutErrors, string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(
+            project.Compilation,
+            document.SemanticModel,
+            document.FilePath);
+        string rendered = GSharpPrinter.Print(
+            new CSharpToGSharpTranslator().TranslateDocument(document, context));
+
+        Assert.Contains("let present int32? = value", rendered, StringComparison.Ordinal);
+        Assert.Contains("return present", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3394NestedGenericTypeTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3394NestedGenericTypeTranslationTests.cs
@@ -1,0 +1,101 @@
+// <copyright file="Issue3394NestedGenericTypeTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3394: nested metadata types retain type arguments carried by their
+/// constructed containing type.
+/// </summary>
+public class Issue3394NestedGenericTypeTranslationTests
+{
+    [Fact]
+    public void ImmutableArrayBuilder_RetainsContainingElementType()
+    {
+        const string source = @"
+#nullable enable
+using System.Collections.Immutable;
+namespace Demo
+{
+    public class C
+    {
+        public int Count(ImmutableArray<int>.Builder? builder) => builder?.Count ?? 0;
+    }
+}
+";
+
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Snippet.cs", source) });
+        Assert.True(project.BoundWithoutErrors, string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(
+            project.Compilation,
+            document.SemanticModel,
+            document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        string rendered = GSharpPrinter.Print(unit);
+
+        Assert.Contains("ImmutableArray[int32].Builder?", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+
+    [Fact]
+    public void SourceNestedBaseType_InsideGenericContainer_RemainsDirectlyInScope()
+    {
+        const string source = @"
+namespace Demo
+{
+    public class Outer<T>
+    {
+        private abstract class Format
+        {
+        }
+
+        private class TextFormat : Format
+        {
+            public TextFormat() : base()
+            {
+            }
+        }
+
+        private Format Make() => new TextFormat();
+    }
+}
+";
+
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Snippet.cs", source) });
+        Assert.True(project.BoundWithoutErrors, string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(
+            project.Compilation,
+            document.SemanticModel,
+            document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        string rendered = GSharpPrinter.Print(unit);
+
+        Assert.Contains("class TextFormat : Format", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("Outer[T].Format", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+
+        var tree = SyntaxTree.Parse(SourceText.From(rendered));
+        var scope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+        Assert.DoesNotContain(
+            scope.Diagnostics,
+            diagnostic => diagnostic.Severity == GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/LocalFunctionHoistTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/LocalFunctionHoistTranslationTests.cs
@@ -244,6 +244,35 @@ namespace Demo
     }
 
     [Fact]
+    public void StaticRecursiveLocalFunction_IsLiftedToSharedHelper()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public int Factorial(int value)
+        {
+            static bool IsBaseCase(int current) => current <= 1;
+
+            static int Visit(int current)
+            {
+                return IsBaseCase(current) ? 1 : current * Visit(current - 1);
+            }
+
+            return Visit(value);
+        }
+    }
+}");
+
+        Assert.DoesNotContain("let Visit", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("let IsBaseCase", printed, StringComparison.Ordinal);
+        Assert.Contains("__local_Factorial_Visit_", printed, StringComparison.Ordinal);
+        Assert.Contains("__local_Factorial_IsBaseCase_", printed, StringComparison.Ordinal);
+        CompileAndRun(printed, "C().Factorial(5)");
+    }
+
+    [Fact]
     public void Issue2231MutualRecursionRemainsUnsupportedByGscLetBindings()
     {
         // Documents a pre-existing, separate gsc limitation (not addressed by

--- a/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Cs2Gs.CodeModel.Ast;
 using Cs2Gs.CodeModel.Printing;
 using Cs2Gs.CodeModel.RoundTrip;
@@ -324,6 +325,71 @@ namespace Demo
         Assert.Contains("__iteratorExit", printed);
         Assert.DoesNotContain("yield break", printed);
         Assert.DoesNotContain("unsupported", printed);
+    }
+
+    /// <summary>
+    /// Issue #3394: iterator accessors and local functions use their own body
+    /// as the synthesized <c>yield break</c> target.
+    /// </summary>
+    [Fact]
+    public void YieldBreak_InGetterAndLocalFunction_UsesMatchingExitLabels()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public sealed class C
+    {
+        private bool stop;
+
+        public System.Collections.Generic.IEnumerable<int> Values
+        {
+            get
+            {
+                if (this.stop)
+                {
+                    yield break;
+                }
+
+                yield return 1;
+            }
+        }
+
+        public System.Collections.Generic.IEnumerable<int> Local()
+        {
+            System.Collections.Generic.IEnumerable<int> Inner()
+            {
+                if (this.stop)
+                {
+                    yield break;
+                }
+
+                yield return 2;
+            }
+
+            return Inner();
+        }
+    }
+}");
+
+        string[] exits = printed.Split('\n')
+            .Where(line => line.Contains("__iteratorExit", StringComparison.Ordinal))
+            .Select(line =>
+            {
+                int start = line.IndexOf("__iteratorExit", StringComparison.Ordinal);
+                int end = start + "__iteratorExit".Length;
+                while (end < line.Length && char.IsDigit(line[end]))
+                {
+                    end++;
+                }
+
+                return line.Substring(start, end - start);
+            })
+            .ToArray();
+
+        Assert.Equal(4, exits.Length);
+        Assert.Equal(2, exits.Distinct().Count());
+        Assert.All(exits.Distinct(), exit => Assert.Equal(2, exits.Count(candidate => candidate == exit)));
+        Assert.DoesNotContain("yield break", printed);
     }
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Tests/ProcessRunnerTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/ProcessRunnerTests.cs
@@ -103,6 +103,22 @@ public class ProcessRunnerTests
         Assert.Equal(args, lines);
     }
 
+    [Fact]
+    public void Run_EnvironmentOverrides_AreVisibleToChild()
+    {
+        ProcessRunResult result = ProcessRunner.Run(
+            "/bin/sh",
+            new[] { "-c", "printf '%s' \"$GSHARP_PROCESS_RUNNER_TEST\"" },
+            timeout: TimeSpan.FromSeconds(10),
+            environment: new System.Collections.Generic.Dictionary<string, string>
+            {
+                ["GSHARP_PROCESS_RUNNER_TEST"] = "current-package",
+            });
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("current-package", result.Stdout);
+    }
+
     /// <summary>
     /// Stage 4 (and every other stage) must never let a child inherit our
     /// console's stdin: <c>cat</c> with no input reads until EOF, so it only

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
@@ -331,8 +331,7 @@ public sealed partial class CSharpToGSharpTranslator
                     // form `init(params) : base(args) { ... }` (sample
                     // ExplicitConstructor.gs; ADR-0115 §B.13). This is how a custom
                     // exception forwards its message to System.Exception's ctor.
-                    baseArguments = this.TranslateNullSeamArguments(
-                        node.Initializer.ArgumentList.Arguments);
+                    baseArguments = this.TranslateConstructorInitializerArguments(node.Initializer);
                 }
                 else
                 {
@@ -340,8 +339,7 @@ public sealed partial class CSharpToGSharpTranslator
                     // `convenience init(params) { init(args); ... }`: the delegated
                     // arguments are retained on the constructor model so its
                     // canonical lowering always emits `init(args)` first.
-                    delegatingArguments = this.TranslateNullSeamArguments(
-                        node.Initializer.ArgumentList.Arguments);
+                    delegatingArguments = this.TranslateConstructorInitializerArguments(node.Initializer);
                 }
             }
 
@@ -369,6 +367,101 @@ public sealed partial class CSharpToGSharpTranslator
                 visibility: MapVisibility(symbol, this.context, node),
                 attributes: this.MapAttributes(node.AttributeLists),
                 delegatingArguments: delegatingArguments);
+        }
+
+        private List<GExpression> TranslateConstructorInitializerArguments(
+            ConstructorInitializerSyntax initializer)
+        {
+            SeparatedSyntaxList<ArgumentSyntax> arguments = initializer.ArgumentList.Arguments;
+            if (this.context.GetSymbolInfo(initializer).Symbol is not IMethodSymbol constructor
+                || arguments.Count > constructor.Parameters.Length)
+            {
+                this.context.ReportUnsupported(
+                    initializer,
+                    "named constructor-initializer arguments could not be mapped to positional parameter order.");
+                return this.TranslateNullSeamArguments(arguments);
+            }
+
+            bool hasNamedArguments = arguments.Any(argument => argument.NameColon != null);
+            if (!hasNamedArguments && arguments.Count == constructor.Parameters.Length)
+            {
+                return this.TranslateNullSeamArguments(arguments);
+            }
+
+            var explicitArguments = new Dictionary<int, ArgumentSyntax>();
+            int lastOrdinal = -1;
+            bool reordersArguments = false;
+            for (int i = 0; i < arguments.Count; i++)
+            {
+                ArgumentSyntax argument = arguments[i];
+                IParameterSymbol parameter = argument.NameColon == null
+                    ? constructor.Parameters[i]
+                    : constructor.Parameters.FirstOrDefault(candidate =>
+                        candidate.Name == argument.NameColon.Name.Identifier.Text);
+                if (parameter == null || !explicitArguments.TryAdd(parameter.Ordinal, argument))
+                {
+                    this.context.ReportUnsupported(
+                        initializer,
+                        "named constructor-initializer arguments could not be mapped uniquely to parameters.");
+                    return this.TranslateNullSeamArguments(arguments);
+                }
+
+                reordersArguments |= parameter.Ordinal <= lastOrdinal;
+                lastOrdinal = parameter.Ordinal;
+            }
+
+            if (hasNamedArguments
+                && reordersArguments
+                && arguments.Any(argument => !IsTrivialConstructorInitializerArgument(argument.Expression)))
+            {
+                this.context.ReportUnsupported(
+                    initializer,
+                    "named constructor-initializer arguments reorder side-effecting expressions; no faithful positional G# lowering is available.");
+                return this.TranslateNullSeamArguments(arguments);
+            }
+
+            var translated = new List<GExpression>(constructor.Parameters.Length);
+            for (int ordinal = 0; ordinal < constructor.Parameters.Length; ordinal++)
+            {
+                if (explicitArguments.TryGetValue(ordinal, out ArgumentSyntax argument))
+                {
+                    translated.Add(this.TranslateNullSeamArgument(argument, preserveName: false));
+                    continue;
+                }
+
+                IParameterSymbol parameter = constructor.Parameters[ordinal];
+                if (!parameter.HasExplicitDefaultValue)
+                {
+                    this.context.ReportUnsupported(
+                        initializer,
+                        $"named constructor-initializer argument skips required parameter '{parameter.Name}'.");
+                    return this.TranslateNullSeamArguments(arguments);
+                }
+
+                GExpression defaultValue = this.MapConstantDefault(parameter, initializer);
+                if (defaultValue == null)
+                {
+                    defaultValue = parameter.Type.IsValueType
+                        ? new DefaultValueExpression(
+                            this.typeMapper.Map(parameter.Type, this.context, initializer.GetLocation()))
+                        : LiteralExpression.Null();
+                }
+
+                translated.Add(defaultValue);
+            }
+
+            return translated;
+        }
+
+        private static bool IsTrivialConstructorInitializerArgument(ExpressionSyntax expression)
+        {
+            while (expression is ParenthesizedExpressionSyntax parenthesized)
+            {
+                expression = parenthesized.Expression;
+            }
+
+            return expression is IdentifierNameSyntax or ThisExpressionSyntax
+                or BaseExpressionSyntax or LiteralExpressionSyntax;
         }
 
         /// <summary>
@@ -971,7 +1064,8 @@ public sealed partial class CSharpToGSharpTranslator
         }
 
         private static bool HasYieldBreak(SyntaxNode bodyOwner)
-            => bodyOwner.DescendantNodes(n => n is not LocalFunctionStatementSyntax)
+            => bodyOwner.DescendantNodes(
+                    n => ReferenceEquals(n, bodyOwner) || n is not LocalFunctionStatementSyntax)
                 .OfType<YieldStatementSyntax>()
                 .Any(y => y.Expression == null);
 
@@ -1134,21 +1228,26 @@ public sealed partial class CSharpToGSharpTranslator
             {
                 BlockStatement body = this.TranslateBodyCore(bodyOwner, description);
                 body = this.WithParameterShadows(bodyOwner, body);
-                if (HasYieldBreak(bodyOwner))
-                {
-                    var statements = body.Statements.ToList();
-                    statements.Add(new LabeledStatement(
-                        IteratorExitLabelName(bodyOwner),
-                        new BlockStatement(new List<GStatement>())));
-                    body = new BlockStatement(statements, body.IsUnsafe);
-                }
-
-                return body;
+                return AddIteratorExitLabel(bodyOwner, body);
             }
             finally
             {
                 this.state.CurrentBodyScope = previousScope;
             }
+        }
+
+        private static BlockStatement AddIteratorExitLabel(SyntaxNode bodyOwner, BlockStatement body)
+        {
+            if (!HasYieldBreak(bodyOwner))
+            {
+                return body;
+            }
+
+            var statements = body.Statements.ToList();
+            statements.Add(new LabeledStatement(
+                IteratorExitLabelName(bodyOwner),
+                new BlockStatement(new List<GStatement>())));
+            return new BlockStatement(statements, body.IsUnsafe);
         }
 
         // Issue #1278 / ADR-0131: a C# expression-bodied member (`=> expr`)
@@ -1385,12 +1484,118 @@ public sealed partial class CSharpToGSharpTranslator
         private BlockStatement TranslateBlock(BlockSyntax block)
         {
             var statements = new List<GStatement>();
-            foreach (StatementSyntax statement in this.HoistCallBeforeDeclLocalFunctions(block))
+            IReadOnlyList<StatementSyntax> ordered = this.HoistCallBeforeDeclLocalFunctions(block);
+            this.RegisterStaticLocalFunctionLifts(ordered);
+            foreach (StatementSyntax statement in ordered)
             {
                 statements.AddRange(this.TranslateStatement(statement));
             }
 
             return new BlockStatement(statements);
+        }
+
+        private void RegisterStaticLocalFunctionLifts(IEnumerable<StatementSyntax> statements)
+        {
+            var staticLocals = new List<(LocalFunctionStatementSyntax Syntax, IMethodSymbol Symbol)>();
+            foreach (LocalFunctionStatementSyntax localFunction in statements
+                .OfType<LocalFunctionStatementSyntax>()
+                .Where(candidate => candidate.Modifiers.Any(SyntaxKind.StaticKeyword)))
+            {
+                using IDisposable modelScope = this.context.UseSemanticModelFor(localFunction.SyntaxTree);
+                if (this.context.GetDeclaredSymbol(localFunction) is IMethodSymbol symbol)
+                {
+                    staticLocals.Add((localFunction, symbol));
+                }
+            }
+
+            var symbols = new HashSet<IMethodSymbol>(
+                staticLocals.Select(pair => pair.Symbol),
+                SymbolEqualityComparer.Default);
+            var edges = new Dictionary<IMethodSymbol, HashSet<IMethodSymbol>>(
+                SymbolEqualityComparer.Default);
+            foreach (var pair in staticLocals)
+            {
+                using IDisposable modelScope = this.context.UseSemanticModelFor(pair.Syntax.SyntaxTree);
+                var dependencies = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
+                foreach (SyntaxNode node in pair.Syntax.DescendantNodes())
+                {
+                    if (this.context.GetSymbolInfo(node).Symbol is IMethodSymbol dependency
+                        && symbols.Contains(dependency))
+                    {
+                        dependencies.Add(dependency);
+                    }
+                }
+
+                edges[pair.Symbol] = dependencies;
+            }
+
+            bool IsRecursive(IMethodSymbol start, IMethodSymbol current, HashSet<IMethodSymbol> visited)
+            {
+                if (!edges.TryGetValue(current, out HashSet<IMethodSymbol> dependencies))
+                {
+                    return false;
+                }
+
+                foreach (IMethodSymbol dependency in dependencies)
+                {
+                    if (SymbolEqualityComparer.Default.Equals(dependency, start))
+                    {
+                        return true;
+                    }
+
+                    if (visited.Add(dependency)
+                        && IsRecursive(start, dependency, visited))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            var toLift = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
+            foreach (var pair in staticLocals)
+            {
+                if (IsRecursive(
+                    pair.Symbol,
+                    pair.Symbol,
+                    new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default)))
+                {
+                    toLift.Add(pair.Symbol);
+                }
+            }
+
+            var pending = new Stack<IMethodSymbol>(toLift);
+            while (pending.Count > 0)
+            {
+                IMethodSymbol current = pending.Pop();
+                if (!edges.TryGetValue(current, out HashSet<IMethodSymbol> dependencies))
+                {
+                    continue;
+                }
+
+                foreach (IMethodSymbol dependency in dependencies)
+                {
+                    if (toLift.Add(dependency))
+                    {
+                        pending.Push(dependency);
+                    }
+                }
+            }
+
+            foreach (var pair in staticLocals)
+            {
+                if (this.state.LiftedStaticLocalFunctions.ContainsKey(pair.Symbol)
+                    || !toLift.Contains(pair.Symbol))
+                {
+                    continue;
+                }
+
+                string ownerName = SanitizeIdentifier(pair.Symbol.ContainingSymbol?.Name ?? "scope");
+                string localName = SanitizeIdentifier(pair.Syntax.Identifier.Text);
+                this.state.LiftedStaticLocalFunctions[pair.Symbol] =
+                    $"__local_{ownerName}_{localName}_{pair.Syntax.SpanStart}";
+            }
         }
 
         // C# local functions are hoisted (callable before their lexical

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.ControlFlow.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.ControlFlow.cs
@@ -789,47 +789,53 @@ public sealed partial class CSharpToGSharpTranslator
         {
             result = null;
 
-            var extraGuards = new Stack<ExpressionSyntax>();
-            ExpressionSyntax condition = ifStatement.Condition;
-            while (condition is BinaryExpressionSyntax binary &&
-                   binary.IsKind(SyntaxKind.LogicalOrExpression))
+            var terms = new List<ExpressionSyntax>();
+            CollectLogicalOrTerms(ifStatement.Condition, terms);
+            int negatedPatternCount = terms.Count(term =>
+                TryExtractNegatedGuardPattern(term, out _, out _, out _, out _));
+            if (negatedPatternCount > 1)
             {
-                condition = binary.Left;
-                extraGuards.Push(binary.Right);
+                return this.TryBuildMultipleNegatedGuardHoists(ifStatement, terms, out result);
             }
 
-            if (condition is not IsPatternExpressionSyntax isPattern ||
-                isPattern.Pattern is not UnaryPatternSyntax notPattern ||
-                !notPattern.IsKind(SyntaxKind.NotPattern))
+            IsPatternExpressionSyntax isPattern = null;
+            TypeSyntax typeSyntax = null;
+            VariableDesignationSyntax designation = null;
+            RecursivePatternSyntax residualPattern = null;
+            int patternIndex = -1;
+            for (int i = 0; i < terms.Count; i++)
+            {
+                if (!TryExtractNegatedGuardPattern(
+                        terms[i],
+                        out IsPatternExpressionSyntax candidatePattern,
+                        out TypeSyntax candidateType,
+                        out VariableDesignationSyntax candidateDesignation,
+                        out RecursivePatternSyntax candidateResidualPattern))
+                {
+                    continue;
+                }
+
+                if (patternIndex >= 0)
+                {
+                    return false;
+                }
+
+                isPattern = candidatePattern;
+                typeSyntax = candidateType;
+                designation = candidateDesignation;
+                residualPattern = candidateResidualPattern;
+                patternIndex = i;
+            }
+
+            if (patternIndex < 0)
             {
                 return false;
             }
 
-            TypeSyntax typeSyntax;
-            VariableDesignationSyntax designation;
-            switch (notPattern.Pattern)
+            if (patternIndex > 0
+                && (ifStatement.Else != null || !StatementAlwaysExits(ifStatement.Statement)))
             {
-                case DeclarationPatternSyntax declaration:
-                    typeSyntax = declaration.Type;
-                    designation = declaration.Designation;
-                    break;
-
-                case RecursivePatternSyntax { Type: { } recursiveType } recursive
-                    when recursive.PropertyPatternClause is null or { Subpatterns.Count: 0 }:
-                    typeSyntax = recursiveType;
-                    designation = recursive.Designation;
-                    break;
-
-                case RecursivePatternSyntax { Type: null } bareRecursive
-                    when bareRecursive.PropertyPatternClause is null or { Subpatterns.Count: 0 }:
-                    // `is not { } t` — no explicit type test; the target type is
-                    // the receiver's own (non-null) type (issue #2233).
-                    typeSyntax = null;
-                    designation = bareRecursive.Designation;
-                    break;
-
-                default:
-                    return false;
+                return false;
             }
 
             if (designation is not SingleVariableDesignationSyntax single)
@@ -848,13 +854,28 @@ public sealed partial class CSharpToGSharpTranslator
                 // reference type (or nullable value type); a non-nullable value-type
                 // target keeps the existing then-block binding behaviour.
                 ITypeSymbol targetSymbol = this.context.GetTypeInfo(typeSyntax).Type;
-                if (targetSymbol == null || targetSymbol.IsValueType)
+                if (targetSymbol == null)
                 {
                     return false;
                 }
 
                 targetType = this.MapTypeSyntax(typeSyntax);
-                hoistInitializer = new BinaryExpression(receiver, "as", new TypeExpression(targetType));
+                if (targetSymbol.IsValueType)
+                {
+                    if (this.context.GetTypeInfo(isPattern.Expression).Type is not INamedTypeSymbol receiverType
+                        || receiverType.OriginalDefinition.SpecialType != SpecialType.System_Nullable_T
+                        || receiverType.TypeArguments.Length != 1
+                        || !SymbolEqualityComparer.Default.Equals(receiverType.TypeArguments[0], targetSymbol))
+                    {
+                        return false;
+                    }
+
+                    hoistInitializer = receiver;
+                }
+                else
+                {
+                    hoistInitializer = new BinaryExpression(receiver, "as", new TypeExpression(targetType));
+                }
             }
             else
             {
@@ -877,8 +898,15 @@ public sealed partial class CSharpToGSharpTranslator
             // `== nil` guard and the subsequent smart cast both type-check, while the
             // `as` cast (when present) keeps its non-nullable reference target (a
             // nullable `as T?` target is rejected at emit time).
+            ISymbol designationSymbol = this.context.GetDeclaredSymbol(single);
+            BindingKind binding = designationSymbol != null
+                && this.IsSymbolReassigned(
+                    designationSymbol,
+                    this.state.CurrentBodyScope ?? ifStatement)
+                    ? BindingKind.Var
+                    : BindingKind.Let;
             var hoist = new LocalDeclarationStatement(
-                BindingKind.Let,
+                binding,
                 localName,
                 MakeNullable(targetType),
                 hoistInitializer);
@@ -887,12 +915,25 @@ public sealed partial class CSharpToGSharpTranslator
             // fails the local is nil, so the original then-block runs.
             GExpression guard = new BinaryExpression(
                 new IdentifierExpression(localName), "==", LiteralExpression.Null());
-            while (extraGuards.Count > 0)
+            if (residualPattern != null)
+            {
+                if (!this.TryTranslateIfLetResidualPattern(
+                        residualPattern,
+                        localName,
+                        out GExpression residualGuard))
+                {
+                    return false;
+                }
+
+                guard = new BinaryExpression(guard, "||", Negate(residualGuard));
+            }
+
+            for (int i = patternIndex + 1; i < terms.Count; i++)
             {
                 guard = new BinaryExpression(
                     guard,
                     "||",
-                    this.TranslateExpression(extraGuards.Pop()));
+                    this.TranslateExpression(terms[i]));
             }
 
             BlockStatement then = this.TranslateStatementAsBlock(ifStatement.Statement);
@@ -903,9 +944,234 @@ public sealed partial class CSharpToGSharpTranslator
                 elseBranch = this.TranslateElseStatement(ifStatement.Else.Statement);
             }
 
-            result = new GStatement[] { hoist, new IfStatement(guard, then, elseBranch) };
+            var statements = new List<GStatement>();
+            if (patternIndex > 0)
+            {
+                GExpression prefixGuard = null;
+                for (int i = 0; i < patternIndex; i++)
+                {
+                    GExpression translated = this.TranslateExpression(terms[i]);
+                    prefixGuard = prefixGuard == null
+                        ? translated
+                        : new BinaryExpression(prefixGuard, "||", translated);
+                }
+
+                statements.Add(new IfStatement(prefixGuard, then));
+            }
+
+            statements.Add(hoist);
+            statements.Add(new IfStatement(guard, then, elseBranch));
+            result = statements;
             return true;
         }
+
+        private bool TryBuildMultipleNegatedGuardHoists(
+            IfStatementSyntax ifStatement,
+            IReadOnlyList<ExpressionSyntax> terms,
+            out IReadOnlyList<GStatement> result)
+        {
+            result = null;
+            if (ifStatement.Else != null || !StatementAlwaysExits(ifStatement.Statement))
+            {
+                return false;
+            }
+
+            BlockStatement then = this.TranslateStatementAsBlock(ifStatement.Statement);
+            var statements = new List<GStatement>();
+            foreach (ExpressionSyntax term in terms)
+            {
+                if (!TryExtractNegatedGuardPattern(
+                        term,
+                        out IsPatternExpressionSyntax isPattern,
+                        out TypeSyntax typeSyntax,
+                        out VariableDesignationSyntax designation,
+                        out RecursivePatternSyntax residualPattern))
+                {
+                    statements.Add(new IfStatement(this.TranslateExpression(term), then));
+                    continue;
+                }
+
+                if (designation is not SingleVariableDesignationSyntax single)
+                {
+                    return false;
+                }
+
+                string localName = SanitizeIdentifier(single.Identifier.Text);
+                GExpression receiver = this.TranslateExpression(isPattern.Expression);
+                GExpression initializer;
+                GTypeReference targetType;
+                if (typeSyntax != null)
+                {
+                    ITypeSymbol targetSymbol = this.context.GetTypeInfo(typeSyntax).Type;
+                    if (targetSymbol == null)
+                    {
+                        return false;
+                    }
+
+                    targetType = this.MapTypeSyntax(typeSyntax);
+                    if (targetSymbol.IsValueType)
+                    {
+                        if (this.context.GetTypeInfo(isPattern.Expression).Type is not INamedTypeSymbol receiverType
+                            || receiverType.OriginalDefinition.SpecialType != SpecialType.System_Nullable_T
+                            || receiverType.TypeArguments.Length != 1
+                            || !SymbolEqualityComparer.Default.Equals(receiverType.TypeArguments[0], targetSymbol))
+                        {
+                            return false;
+                        }
+
+                        initializer = receiver;
+                    }
+                    else
+                    {
+                        initializer = new BinaryExpression(receiver, "as", new TypeExpression(targetType));
+                    }
+                }
+                else
+                {
+                    ITypeSymbol receiverType = this.context.GetTypeInfo(isPattern.Expression).Type;
+                    if (receiverType == null)
+                    {
+                        return false;
+                    }
+
+                    targetType = this.typeMapper.Map(
+                        UnwrapNullable(receiverType),
+                        this.context,
+                        isPattern.Expression.GetLocation());
+                    initializer = receiver;
+                }
+
+                ISymbol designationSymbol = this.context.GetDeclaredSymbol(single);
+                BindingKind binding = designationSymbol != null
+                    && this.IsSymbolReassigned(
+                        designationSymbol,
+                        this.state.CurrentBodyScope ?? ifStatement)
+                        ? BindingKind.Var
+                        : BindingKind.Let;
+                statements.Add(new LocalDeclarationStatement(
+                    binding,
+                    localName,
+                    MakeNullable(targetType),
+                    initializer));
+
+                GExpression guard = new BinaryExpression(
+                    new IdentifierExpression(localName),
+                    "==",
+                    LiteralExpression.Null());
+                if (residualPattern != null)
+                {
+                    if (!this.TryTranslateIfLetResidualPattern(
+                            residualPattern,
+                            localName,
+                            out GExpression residualGuard))
+                    {
+                        return false;
+                    }
+
+                    guard = new BinaryExpression(guard, "||", Negate(residualGuard));
+                }
+
+                statements.Add(new IfStatement(guard, then));
+            }
+
+            result = statements;
+            return true;
+        }
+
+        private static void CollectLogicalOrTerms(
+            ExpressionSyntax expression,
+            List<ExpressionSyntax> terms)
+        {
+            if (expression is BinaryExpressionSyntax binary
+                && binary.IsKind(SyntaxKind.LogicalOrExpression))
+            {
+                CollectLogicalOrTerms(binary.Left, terms);
+                CollectLogicalOrTerms(binary.Right, terms);
+                return;
+            }
+
+            terms.Add(expression);
+        }
+
+        private static bool TryExtractNegatedGuardPattern(
+            ExpressionSyntax condition,
+            out IsPatternExpressionSyntax isPattern,
+            out TypeSyntax typeSyntax,
+            out VariableDesignationSyntax designation,
+            out RecursivePatternSyntax residualPattern)
+        {
+            condition = Unparenthesize(condition);
+            PatternSyntax negatedPattern;
+            if (condition is IsPatternExpressionSyntax directPattern
+                && directPattern.Pattern is UnaryPatternSyntax notPattern
+                && notPattern.IsKind(SyntaxKind.NotPattern))
+            {
+                isPattern = directPattern;
+                negatedPattern = notPattern.Pattern;
+            }
+            else if (condition is PrefixUnaryExpressionSyntax logicalNot
+                && logicalNot.IsKind(SyntaxKind.LogicalNotExpression)
+                && Unparenthesize(logicalNot.Operand) is IsPatternExpressionSyntax parenthesizedPattern)
+            {
+                isPattern = parenthesizedPattern;
+                negatedPattern = parenthesizedPattern.Pattern;
+            }
+            else
+            {
+                isPattern = null;
+                negatedPattern = null;
+            }
+
+            typeSyntax = null;
+            designation = null;
+            residualPattern = null;
+            if (isPattern == null)
+            {
+                return false;
+            }
+
+            switch (negatedPattern)
+            {
+                case DeclarationPatternSyntax declaration:
+                    typeSyntax = declaration.Type;
+                    designation = declaration.Designation;
+                    return true;
+
+                case RecursivePatternSyntax { Type: { } recursiveType } recursive:
+                    typeSyntax = recursiveType;
+                    designation = recursive.Designation;
+                    if (recursive.PositionalPatternClause != null
+                        || recursive.PropertyPatternClause is { Subpatterns.Count: > 0 })
+                    {
+                        residualPattern = recursive;
+                    }
+
+                    return true;
+
+                case RecursivePatternSyntax { Type: null } bareRecursive:
+                    designation = bareRecursive.Designation;
+                    if (bareRecursive.PositionalPatternClause != null
+                        || bareRecursive.PropertyPatternClause is { Subpatterns.Count: > 0 })
+                    {
+                        residualPattern = bareRecursive;
+                    }
+
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
+        private static bool StatementAlwaysExits(StatementSyntax statement) =>
+            statement switch
+            {
+                ReturnStatementSyntax or ThrowStatementSyntax or BreakStatementSyntax
+                    or ContinueStatementSyntax or GotoStatementSyntax => true,
+                BlockSyntax { Statements.Count: > 0 } block =>
+                    StatementAlwaysExits(block.Statements[block.Statements.Count - 1]),
+                _ => false,
+            };
 
         // Returns a nullable (`T?`) copy of a type reference, preserving the
         // concrete reference kind (named/array/pointer/tuple). Used when hoisting a

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Declarations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Declarations.cs
@@ -1000,7 +1000,9 @@ public sealed partial class CSharpToGSharpTranslator
             // Synthetic instance helpers are scoped to their owning aggregate;
             // nested type translation must not leak them outward.
             List<MethodDeclaration> outerInstanceSynthHelpers = this.state.PendingInstanceSynthHelpers;
+            List<MethodDeclaration> outerStaticSynthHelpers = this.state.PendingStaticSynthHelpers;
             this.state.PendingInstanceSynthHelpers = new List<MethodDeclaration>();
+            this.state.PendingStaticSynthHelpers = new List<MethodDeclaration>();
             try
             {
                 return this.VisitAggregateCore(node, kind.Value, symbol, otherParts);
@@ -1008,6 +1010,7 @@ public sealed partial class CSharpToGSharpTranslator
             finally
             {
                 this.state.PendingInstanceSynthHelpers = outerInstanceSynthHelpers;
+                this.state.PendingStaticSynthHelpers = outerStaticSynthHelpers;
             }
         }
 
@@ -1234,11 +1237,17 @@ public sealed partial class CSharpToGSharpTranslator
                         continue;
                     }
 
+                    if (translated is NamedDelegateDeclaration)
+                    {
+                        this.state.PendingTopLevelDeclarations.Add(translated);
+                        continue;
+                    }
+
                     // A nested type declaration (`class`/`struct`/`enum`/...) maps
                     // to a directly-nested G# type member; the parser does not allow
                     // a type declaration inside a `shared { }` block, so it is always
                     // placed in the enclosing type body regardless of staticness.
-                    if (translated is TypeDeclaration or EnumDeclaration or NamedDelegateDeclaration)
+                    if (translated is TypeDeclaration or EnumDeclaration)
                     {
                         instanceMembers.Add(translated);
                         continue;
@@ -1256,6 +1265,7 @@ public sealed partial class CSharpToGSharpTranslator
             }
 
             instanceMembers.AddRange(this.state.PendingInstanceSynthHelpers);
+            sharedMembers.AddRange(this.state.PendingStaticSynthHelpers);
 
             // OD-T1: if get-only auto-property initializers needed to move into a
             // constructor but the type declares no designated instance constructor,

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
@@ -862,7 +862,7 @@ public sealed partial class CSharpToGSharpTranslator
                     // (mirrors the plain-declaration path's mutability rule).
                     string name = declaration.Designation switch
                     {
-                        SingleVariableDesignationSyntax single => single.Identifier.Text,
+                        SingleVariableDesignationSyntax single => SanitizeIdentifier(single.Identifier.Text),
                         _ => "_",
                     };
 
@@ -936,7 +936,7 @@ public sealed partial class CSharpToGSharpTranslator
                 {
                     collected.Add(designation switch
                     {
-                        SingleVariableDesignationSyntax single => single.Identifier.Text,
+                        SingleVariableDesignationSyntax single => SanitizeIdentifier(single.Identifier.Text),
                         _ => "_",
                     });
 
@@ -962,7 +962,7 @@ public sealed partial class CSharpToGSharpTranslator
                     var declaration = (DeclarationExpressionSyntax)argument.Expression;
                     collected.Add(declaration.Designation switch
                     {
-                        SingleVariableDesignationSyntax single => single.Identifier.Text,
+                        SingleVariableDesignationSyntax single => SanitizeIdentifier(single.Identifier.Text),
                         _ => "_",
                     });
 
@@ -1041,12 +1041,14 @@ public sealed partial class CSharpToGSharpTranslator
             return this.TranslateWithBlockSpillSeam(() => this.TranslateExpression(expression));
         }
 
-        private List<GExpression> TranslateNullSeamArguments(SeparatedSyntaxList<ArgumentSyntax> arguments)
+        private List<GExpression> TranslateNullSeamArguments(
+            SeparatedSyntaxList<ArgumentSyntax> arguments,
+            bool preserveNames = true)
         {
-            return arguments.Select(this.TranslateNullSeamArgument).ToList();
+            return arguments.Select(argument => this.TranslateNullSeamArgument(argument, preserveNames)).ToList();
         }
 
-        private GExpression TranslateNullSeamArgument(ArgumentSyntax argument)
+        private GExpression TranslateNullSeamArgument(ArgumentSyntax argument, bool preserveName)
         {
             GExpression value;
             if (argument.RefKindKeyword.Kind() is SyntaxKind.RefKeyword or SyntaxKind.OutKeyword
@@ -1066,7 +1068,7 @@ public sealed partial class CSharpToGSharpTranslator
                     () => this.TranslateArgumentValue(argument));
             }
 
-            return argument.NameColon == null
+            return argument.NameColon == null || !preserveName
                 ? value
                 : new NamedArgumentExpression(
                     SanitizeIdentifier(argument.NameColon.Name.Identifier.Text),
@@ -1194,6 +1196,36 @@ public sealed partial class CSharpToGSharpTranslator
 
         private GStatement TranslateLocalFunction(LocalFunctionStatementSyntax localFunction)
         {
+            if (localFunction.Modifiers.Any(SyntaxKind.StaticKeyword)
+                && this.context.GetDeclaredSymbol(localFunction) is IMethodSymbol staticLocal
+                && this.state.LiftedStaticLocalFunctions.TryGetValue(staticLocal, out string liftedName)
+                && this.state.PendingStaticSynthHelpers != null)
+            {
+                bool liftedIsAsync = localFunction.Modifiers.Any(SyntaxKind.AsyncKeyword);
+                List<Parameter> liftedParameters = this.MapParameters(
+                    staticLocal,
+                    localFunction.ParameterList,
+                    skipFirst: false);
+                GTypeReference liftedReturnType = this.MapDelegateLikeReturnType(
+                    staticLocal,
+                    liftedIsAsync,
+                    localFunction.ReturnType.GetLocation());
+                List<TypeParameter> liftedTypeParameters = this.MapMethodTypeParameters(staticLocal);
+                BlockStatement liftedBody = this.TranslateBody(
+                    localFunction,
+                    $"static local function '{localFunction.Identifier.Text}'");
+                this.state.PendingStaticSynthHelpers.Add(new MethodDeclaration(
+                    liftedName,
+                    liftedParameters,
+                    liftedReturnType,
+                    liftedBody,
+                    liftedTypeParameters,
+                    visibility: Visibility.Private,
+                    isAsync: liftedIsAsync,
+                    isRefReturn: staticLocal.ReturnsByRef));
+                return new RawStatement($"// lifted static local function {liftedName}");
+            }
+
             // Issue #1900: a ref-returning local function (`static ref int
             // Pick(...)`) has no G# canonical form. A C# local function lowers to
             // a G# `func` LITERAL bound via `let` (ParseFunctionLiteralExpression
@@ -1252,13 +1284,16 @@ public sealed partial class CSharpToGSharpTranslator
             // inside a block body still opens its own fresh seam via
             // <see cref="TranslateStatement"/>.
             List<GStatement> outerSpillPrologue = this.state.PendingSpillPrologue;
+            SyntaxNode previousBodyScope = this.state.CurrentBodyScope;
             this.state.PendingSpillPrologue = null;
+            this.state.CurrentBodyScope = localFunction;
             LambdaExpression lambda;
             try
             {
                 if (localFunction.Body != null)
                 {
                     BlockStatement innerBody = this.WithParameterShadows(localFunction, this.TranslateBlock(localFunction.Body));
+                    innerBody = AddIteratorExitLabel(localFunction, innerBody);
                     lambda = isAsyncVoidHandler
                         ? new LambdaExpression(parameters, blockBody: this.BuildAsyncVoidHandlerWrapperBody(parameters, innerBody, localFunction.GetLocation()), isAsync: false, returnType: null, isFunctionLiteral: true)
                         : new LambdaExpression(parameters, blockBody: innerBody, isAsync: isAsync, returnType: returnType, isFunctionLiteral: true);
@@ -1292,6 +1327,7 @@ public sealed partial class CSharpToGSharpTranslator
             finally
             {
                 this.state.PendingSpillPrologue = outerSpillPrologue;
+                this.state.CurrentBodyScope = previousBodyScope;
             }
 
             // Issue #1886: a generic local function (`T First<T>(a, b) { ... }`)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -45,6 +45,16 @@ public sealed partial class CSharpToGSharpTranslator
 
         private GExpression TranslateIdentifierName(IdentifierNameSyntax identifier)
         {
+            if (this.context.GetSymbolInfo(identifier).Symbol is IMethodSymbol
+                    { MethodKind: MethodKind.LocalFunction } localFunction
+                && this.state.LiftedStaticLocalFunctions.TryGetValue(localFunction, out string liftedName)
+                && localFunction.ContainingType is { } containingType)
+            {
+                return new MemberAccessExpression(
+                    this.StaticQualifierReceiver(containingType, identifier.GetLocation()),
+                    liftedName);
+            }
+
             // A switch-expression property-pattern binding (`Circle { Radius: var r }`)
             // has no G# equivalent; references to the bound local are rewritten to a
             // member access on the arm's type-pattern designator (`circle.Radius`).
@@ -858,6 +868,18 @@ public sealed partial class CSharpToGSharpTranslator
             ISymbol targetSymbol,
             bool includePromotedValue = false)
         {
+            if (this.IsActivePatternBinding(value))
+            {
+                return translated;
+            }
+
+            if (value is ConditionalExpressionSyntax
+                && translated is IfLetExpression or BlockExpression
+                && this.context.GetTypeInfo(value).Nullability.FlowState == NullableFlowState.NotNull)
+            {
+                return translated;
+            }
+
             ILocalSymbol valueLocal = this.context.GetSymbolInfo(value).Symbol as ILocalSymbol
                 ?? GetReferencedLocal(this.context.SemanticModel.GetOperation(value));
             bool isFlowNarrowedLocal = valueLocal != null
@@ -870,12 +892,24 @@ public sealed partial class CSharpToGSharpTranslator
                     { RawKind: (int)SyntaxKind.SuppressNullableWarningExpression }
                 || targetSymbol is IFieldSymbol { IsConst: true } or ILocalSymbol { IsConst: true }
                 || this.IsWithinExpressionTreeLambda(value)
-                || !this.TargetWillRemainNonNullableReference(targetType, targetSymbol)
-                || (!this.NullableReferenceValueMayBeNull(value)
+                || !this.TargetWillRemainNonNullableReference(targetType, targetSymbol))
+            {
+                return translated;
+            }
+
+            TypeInfo valueTypeInfo = this.context.GetTypeInfo(value);
+            bool flowNarrowedAnnotatedValue =
+                valueTypeInfo.Nullability.FlowState == NullableFlowState.NotNull
+                && (valueTypeInfo.Nullability.Annotation == NullableAnnotation.Annotated
+                    || valueTypeInfo.Type?.NullableAnnotation == NullableAnnotation.Annotated);
+            bool flowRequiresAssertion = this.ReceiverNeedsNullForgiveness(value)
+                || flowNarrowedAnnotatedValue;
+            if (!flowRequiresAssertion
+                && !this.NullableReferenceValueMayBeNull(value)
                     && !(includePromotedValue
                         && !isFlowNarrowedLocal
                         && this.IsObliviousCompilation()
-                        && this.IsNullablePromotedValue(value))))
+                        && this.IsNullablePromotedValue(value)))
             {
                 return translated;
             }
@@ -933,9 +967,8 @@ public sealed partial class CSharpToGSharpTranslator
             };
 
             return nullableByShape
-                || (typeInfo.Nullability.FlowState == NullableFlowState.MaybeNull
-                && (type.NullableAnnotation == NullableAnnotation.Annotated
-                    || typeInfo.Nullability.Annotation == NullableAnnotation.Annotated));
+                || type.NullableAnnotation == NullableAnnotation.Annotated
+                || typeInfo.Nullability.Annotation == NullableAnnotation.Annotated;
         }
 
         private (ITypeSymbol Type, ISymbol Symbol) FindContextualValueTarget(ExpressionSyntax value)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -161,7 +161,20 @@ public sealed partial class CSharpToGSharpTranslator
 
             // A generic call `Foo<T>(...)` carries its type arguments on the name;
             // lift them onto the G# bracket-type-argument form `Foo[T](...)`.
-            if (invocation.Expression is GenericNameSyntax generic)
+            if (this.context.GetSymbolInfo(invocation).Symbol is IMethodSymbol
+                    { MethodKind: MethodKind.LocalFunction } localFunction
+                && this.state.LiftedStaticLocalFunctions.TryGetValue(localFunction, out string liftedName)
+                && localFunction.ContainingType is { } containingType)
+            {
+                target = new MemberAccessExpression(
+                    this.StaticQualifierReceiver(containingType, invocation.GetLocation()),
+                    liftedName);
+                if (invocation.Expression is GenericNameSyntax liftedGeneric)
+                {
+                    typeArguments = this.MapTypeArguments(liftedGeneric);
+                }
+            }
+            else if (invocation.Expression is GenericNameSyntax generic)
             {
                 target = new IdentifierExpression(SanitizeIdentifier(generic.Identifier.Text));
                 typeArguments = this.MapTypeArguments(generic);
@@ -1036,8 +1049,14 @@ public sealed partial class CSharpToGSharpTranslator
                     return new OutArgumentExpression("out", "_");
                 }
 
-                // `out existingVar` (pre-declared): pass by address (legacy form).
-                return new UnaryExpression("&", this.TranslateExpression(argument.Expression));
+                GExpression translatedExisting = this.TranslateExpression(argument.Expression);
+                if (translatedExisting is IdentifierExpression identifier)
+                {
+                    return new OutArgumentExpression("out", identifier.Name);
+                }
+
+                // Non-identifier lvalues keep the universal address form.
+                return new UnaryExpression("&", translatedExisting);
             }
 
             if (refKind == SyntaxKind.RefKeyword)
@@ -2417,7 +2436,10 @@ public sealed partial class CSharpToGSharpTranslator
             {
                 // Typed null keeps overload selection without an unparseable
                 // array conversion such as `[]char(nil)`.
-                return new DefaultValueExpression(targetType);
+                GTypeReference defaultType = cast.Type is NullableTypeSyntax && !targetType.IsNullable
+                    ? MakeNullable(targetType)
+                    : targetType;
+                return new DefaultValueExpression(defaultType);
             }
 
             GExpression operand = this.TranslateExpression(cast.Expression);
@@ -2436,11 +2458,31 @@ public sealed partial class CSharpToGSharpTranslator
             if (this.IsObliviousCompilation()
                 && targetSymbol is { IsReferenceType: true }
                 && targetSymbol.NullableAnnotation != NullableAnnotation.Annotated
+                && cast.Type is not NullableTypeSyntax
                 && !IsNullOrSuppressedNull(cast.Expression)
                 && cast.Expression is not PostfixUnaryExpressionSyntax { RawKind: (int)SyntaxKind.SuppressNullableWarningExpression }
                 && this.IsNullablePromotedValue(cast.Expression))
             {
                 operand = new NonNullAssertionExpression(operand);
+            }
+
+            Microsoft.CodeAnalysis.CSharp.Conversion conversion =
+                sourceSymbol == null || targetSymbol == null
+                    ? default
+                    : this.context.Compilation.ClassifyConversion(sourceSymbol, targetSymbol);
+            if (conversion.IsBoxing)
+            {
+                string localName = $"__cast{this.state.SpillCounter++}";
+                return new BlockExpression(
+                    new GStatement[]
+                    {
+                        new LocalDeclarationStatement(
+                            BindingKind.Let,
+                            localName,
+                            targetType,
+                            operand),
+                    },
+                    new IdentifierExpression(localName));
             }
 
             // Issue #914: a CLR REFERENCE conversion `(T)expr` (a downcast such as
@@ -2464,7 +2506,9 @@ public sealed partial class CSharpToGSharpTranslator
             // may be nil and is left unasserted.
             if (targetSymbol is { IsReferenceType: true }
                 && sourceSymbol != null
-                && this.context.Compilation.ClassifyConversion(sourceSymbol, targetSymbol).IsReference)
+                && !conversion.IsUserDefined
+                && (conversion.IsReference
+                    || (sourceSymbol.IsReferenceType && conversion.Exists)))
             {
                 GExpression converted = new BinaryExpression(operand, "as", new TypeExpression(targetType));
 
@@ -2481,7 +2525,11 @@ public sealed partial class CSharpToGSharpTranslator
                     : new NonNullAssertionExpression(new ParenthesizedExpression(converted));
             }
 
-            return new ConversionExpression(targetType, operand);
+            GTypeReference conversionTargetType = cast.Type is NullableTypeSyntax
+                && !targetType.IsNullable
+                    ? MakeNullable(targetType)
+                    : targetType;
+            return new ConversionExpression(conversionTargetType, operand);
         }
 
         private GExpression TranslateWith(WithExpressionSyntax with)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
@@ -960,12 +960,30 @@ public sealed partial class CSharpToGSharpTranslator
                 ? this.MapDelegateLikeReturnType(invoke, isAsync: false, node.ReturnType.GetLocation())
                 : this.MapTypeSyntax(node.ReturnType);
             List<TypeParameter> typeParameters = this.MapTypeParameters(symbol);
+            bool isNested = symbol?.ContainingType != null;
+            string name = isNested
+                ? CSharpTypeMapper.LiftedNestedDelegateName(symbol)
+                : SanitizeIdentifier(node.Identifier.Text);
+            Visibility visibility = MapVisibility(symbol, this.context, node);
+            if (isNested)
+            {
+                if (visibility == Visibility.Private)
+                {
+                    visibility = Visibility.Internal;
+                }
+
+                this.context.Report(new TranslationDiagnostic(
+                    nameof(SyntaxKind.DelegateDeclaration),
+                    $"nested delegate '{symbol.ToDisplayString()}' lifted to top-level '{name}' because G# named delegate declarations are top-level-only; non-public visibility is emitted as internal (ADR-0059/ADR-0110).",
+                    node.GetLocation(),
+                    TranslationSeverity.Info));
+            }
 
             return new NamedDelegateDeclaration(
-                SanitizeIdentifier(node.Identifier.Text),
+                name,
                 parameters,
                 returnType,
-                MapVisibility(symbol, this.context, node),
+                visibility,
                 this.MapAttributes(node.AttributeLists),
                 typeParameters);
         }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
@@ -49,14 +49,19 @@ public sealed partial class CSharpToGSharpTranslator
 
         private bool ComputeIsUsedAsNullable(ISymbol symbol, SyntaxNode scope)
         {
-            // The scope is scanned with the current document's semantic model, so a
-            // node from another syntax tree (e.g. an inherited field declared in a
-            // different file) cannot be queried here — `GetSymbolInfo` would throw
-            // "Syntax node is not within syntax tree". Such a symbol is promoted (if
-            // applicable) while its own document is translated; skip it here.
-            if (scope.SyntaxTree != this.context.SemanticModel.SyntaxTree)
+            // A source-backed ProjectReference can expose declaration syntax
+            // owned by the referenced project's separate compilation. Its
+            // whole-program taint result was already checked by the caller;
+            // this local syntax scan is valid only for this compilation.
+            if (!this.context.Compilation.ContainsSyntaxTree(scope.SyntaxTree))
             {
                 return false;
+            }
+
+            if (scope.SyntaxTree != this.context.SemanticModel.SyntaxTree)
+            {
+                using IDisposable modelScope = this.context.UseSemanticModelFor(scope.SyntaxTree);
+                return this.ComputeIsUsedAsNullable(symbol, scope);
             }
 
             foreach (SyntaxNode node in scope.DescendantNodes())

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -1418,7 +1418,23 @@ public sealed partial class CSharpToGSharpTranslator
         private GExpression BuildPatternNarrowingReplacement(
             GExpression receiver, ExpressionSyntax receiverSyntax, TypeSyntax narrowedTypeSyntax)
         {
-            if (receiverSyntax != null && this.IsSmartCastableScrutinee(receiverSyntax))
+            if (narrowedTypeSyntax == null
+                && receiverSyntax != null
+                && this.context.GetTypeInfo(receiverSyntax).Type is INamedTypeSymbol nullableReceiver
+                && nullableReceiver.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T)
+            {
+                return new NonNullAssertionExpression(receiver);
+            }
+
+            bool bindingUsedInsideCondition = narrowedTypeSyntax?.Ancestors().Any(node =>
+                node is WhenClauseSyntax
+                || (node is BinaryExpressionSyntax binary
+                    && (binary.IsKind(SyntaxKind.LogicalAndExpression)
+                        || binary.IsKind(SyntaxKind.LogicalOrExpression)))) == true;
+            if (!bindingUsedInsideCondition
+                && receiverSyntax != null
+                && this.IsSmartCastableScrutinee(receiverSyntax)
+                && this.context.GetTypeInfo(receiverSyntax).Type is not ITypeParameterSymbol)
             {
                 return receiver;
             }
@@ -1445,6 +1461,8 @@ public sealed partial class CSharpToGSharpTranslator
         private GExpression TranslateArrayCreation(ArrayCreationExpressionSyntax creation)
         {
             GTypeReference elementType = this.GetArrayElementType(creation, creation.Type.ElementType);
+            ITypeSymbol elementTypeSymbol =
+                (this.context.GetTypeInfo(creation).Type as IArrayTypeSymbol)?.ElementType;
 
             if (creation.Type.RankSpecifiers.Count > 0 && creation.Type.RankSpecifiers[0].Sizes.Count > 1)
             {
@@ -1484,7 +1502,8 @@ public sealed partial class CSharpToGSharpTranslator
                     return new ArrayAllocationExpression(
                         elementType,
                         dimensions,
-                        leaves.Select(this.TranslateExpression).ToList());
+                        leaves.Select(expression =>
+                            this.TranslateArrayInitializerElement(expression, elementTypeSymbol)).ToList());
                 }
 
                 return new ArrayAllocationExpression(
@@ -1500,7 +1519,10 @@ public sealed partial class CSharpToGSharpTranslator
                 // initializer) → the slice literal `[]T{a, b}`.
                 return new ArrayLiteralExpression(
                     elementType,
-                    creation.Initializer.Expressions.Select(this.TranslateExpression).ToList());
+                    creation.Initializer.Expressions
+                        .Select(expression =>
+                            this.TranslateArrayInitializerElement(expression, elementTypeSymbol))
+                        .ToList());
             }
 
             // `new T[n]` (runtime/constant length, no initializer) → the native
@@ -1659,17 +1681,67 @@ public sealed partial class CSharpToGSharpTranslator
         private GExpression TranslateImplicitStackAlloc(ImplicitStackAllocArrayCreationExpressionSyntax node)
         {
             GTypeReference elementType = this.GetArrayElementType(node, null);
-            List<GExpression> elements = node.Initializer.Expressions.Select(this.TranslateExpression).ToList();
+            ITypeSymbol elementTypeSymbol = GetCollectionElementTypeSymbol(
+                this.context.GetTypeInfo(node).ConvertedType ?? this.context.GetTypeInfo(node).Type);
+            List<GExpression> elements = node.Initializer.Expressions
+                .Select(expression =>
+                    this.TranslateArrayInitializerElement(expression, elementTypeSymbol))
+                .ToList();
             GExpression count = LiteralExpression.Int(
                 node.Initializer.Expressions.Count.ToString(CultureInfo.InvariantCulture));
 
             return new StackAllocExpression(elementType, count, elements);
         }
 
+        private GExpression TranslateArrayInitializerElement(
+            ExpressionSyntax expression,
+            ITypeSymbol elementType)
+        {
+            GExpression translated = this.TranslateExpression(expression);
+            translated = this.ForgiveNullableReferenceValue(
+                expression,
+                translated,
+                elementType,
+                targetSymbol: null);
+            if (translated is NonNullAssertionExpression
+                || !this.TargetWillRemainNonNullableReference(elementType, targetSymbol: null)
+                || IsNullOrSuppressedNull(expression))
+            {
+                return translated;
+            }
+
+            ISymbol symbol = this.context.GetSymbolInfo(expression).Symbol;
+            ITypeSymbol sourceType = symbol switch
+            {
+                IPropertySymbol property => property.Type,
+                IFieldSymbol field => field.Type,
+                ILocalSymbol local => local.Type,
+                IParameterSymbol parameter => parameter.Type,
+                IMethodSymbol method => method.ReturnType,
+                _ => null,
+            };
+            return sourceType is { IsReferenceType: true }
+                && (sourceType.NullableAnnotation == NullableAnnotation.Annotated
+                    || this.ShouldPromoteToNullableReference(symbol))
+                ? new NonNullAssertionExpression(translated)
+                : translated;
+        }
+
+        private static ITypeSymbol GetCollectionElementTypeSymbol(ITypeSymbol type) =>
+            type switch
+            {
+                IArrayTypeSymbol array => array.ElementType,
+                IPointerTypeSymbol pointer => pointer.PointedAtType,
+                INamedTypeSymbol { TypeArguments.Length: > 0 } named => named.TypeArguments[0],
+                _ => null,
+            };
+
         private GExpression TranslateImplicitArrayCreation(ImplicitArrayCreationExpressionSyntax creation)
         {
             GTypeReference elementType = this.GetArrayElementType(creation, null);
-            if (this.context.GetTypeInfo(creation).Type is IArrayTypeSymbol { Rank: > 1 } arrayType)
+            IArrayTypeSymbol arrayType = this.context.GetTypeInfo(creation).Type as IArrayTypeSymbol;
+            ITypeSymbol elementTypeSymbol = arrayType?.ElementType;
+            if (arrayType is { Rank: > 1 })
             {
                 var dims = new int[arrayType.Rank];
                 var leaves = new List<ExpressionSyntax>();
@@ -1683,12 +1755,16 @@ public sealed partial class CSharpToGSharpTranslator
                     elementType,
                     dims.Select(d => (GExpression)LiteralExpression.Int(
                         d.ToString(CultureInfo.InvariantCulture))).ToList(),
-                    leaves.Select(this.TranslateExpression).ToList());
+                    leaves.Select(expression =>
+                        this.TranslateArrayInitializerElement(expression, elementTypeSymbol)).ToList());
             }
 
             return new ArrayLiteralExpression(
                 elementType,
-                creation.Initializer.Expressions.Select(this.TranslateExpression).ToList());
+                creation.Initializer.Expressions
+                    .Select(expression =>
+                        this.TranslateArrayInitializerElement(expression, elementTypeSymbol))
+                    .ToList());
         }
 
         private GExpression TranslateInitializerExpression(InitializerExpressionSyntax initializer)
@@ -1708,7 +1784,8 @@ public sealed partial class CSharpToGSharpTranslator
                     rectangularElementType,
                     dims.Select(d => (GExpression)LiteralExpression.Int(
                         d.ToString(CultureInfo.InvariantCulture))).ToList(),
-                    leaves.Select(this.TranslateExpression).ToList());
+                    leaves.Select(expression =>
+                        this.TranslateArrayInitializerElement(expression, arrayType.ElementType)).ToList());
             }
 
             // A bare `{ a, b, c }` array initializer (a field/local of array type
@@ -1716,9 +1793,15 @@ public sealed partial class CSharpToGSharpTranslator
             // list reaching value position maps to the slice literal `[]T{ … }`,
             // using the bound (converted) element type.
             GTypeReference elementType = this.GetArrayElementType(initializer, null);
+            ITypeSymbol elementTypeSymbol = GetCollectionElementTypeSymbol(
+                this.context.GetTypeInfo(initializer).ConvertedType ??
+                this.context.GetTypeInfo(initializer).Type);
             return new ArrayLiteralExpression(
                 elementType,
-                initializer.Expressions.Select(this.TranslateExpression).ToList());
+                initializer.Expressions
+                    .Select(expression =>
+                        this.TranslateArrayInitializerElement(expression, elementTypeSymbol))
+                    .ToList());
         }
 
         // ADR-0161 / issue #3350: translates a C# assignment used in VALUE position

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
@@ -334,7 +334,10 @@ public sealed partial class CSharpToGSharpTranslator
                 return new NamedTypeReference(unboundName, placeholders);
             }
 
-            return this.MapTypeSyntax(type);
+            ITypeSymbol symbol = this.context.GetTypeInfo(type).Type;
+            return symbol != null
+                ? this.typeMapper.MapTypeOf(symbol, this.context, type.GetLocation())
+                : new NamedTypeReference(type.ToString());
         }
 
         private static bool IsUnboundGeneric(TypeSyntax type, out string name, out int arity)
@@ -942,7 +945,7 @@ public sealed partial class CSharpToGSharpTranslator
             // the end of the nearest iterator body regardless of nested loops.
             if (node.Expression == null)
             {
-                SyntaxNode target = GetBreakTarget(node);
+                SyntaxNode target = this.state.CurrentBodyScope ?? GetBreakTarget(node);
                 return new[] { (GStatement)new GotoStatement(IteratorExitLabelName(target)) };
             }
 
@@ -950,7 +953,9 @@ public sealed partial class CSharpToGSharpTranslator
         }
 
         private static SyntaxNode GetBreakTarget(YieldStatementSyntax node)
-            => node.Ancestors().First(n => n is MethodDeclarationSyntax or LocalFunctionStatementSyntax);
+            => node.Ancestors().FirstOrDefault(
+                n => n is BaseMethodDeclarationSyntax or AccessorDeclarationSyntax or LocalFunctionStatementSyntax)
+                ?? node;
 
         private static string IteratorExitLabelName(SyntaxNode node)
             => $"__iteratorExit{node.SpanStart}";
@@ -1464,22 +1469,28 @@ public sealed partial class CSharpToGSharpTranslator
             {
                 foreach (SubpatternSyntax sub in recursive.PropertyPatternClause.Subpatterns)
                 {
-                    if (sub.NameColon != null &&
-                        sub.Pattern is VarPatternSyntax { Designation: SingleVariableDesignationSyntax bound } &&
-                        this.context.GetDeclaredSymbol(bound) is { } boundSymbol)
-                    {
-                        bindings.Add((
-                            boundSymbol,
-                            new MemberAccessExpression(
-                                new IdentifierExpression(designator),
-                                SanitizeIdentifier(sub.NameColon.Name.Identifier.Text))));
-                    }
-                    else
+                    List<string> memberPath = sub.NameColon != null
+                        ? new List<string> { sub.NameColon.Name.Identifier.Text }
+                        : sub.ExpressionColon != null
+                            ? SplitMemberPath(sub.ExpressionColon.Expression)
+                            : null;
+                    if (memberPath == null)
                     {
                         this.context.ReportUnsupported(
                             sub,
-                            "typed property subpattern other than a 'var' binding has no canonical G# form yet (ADR-0115 §B).");
+                            "typed property subpattern has no member path (ADR-0115 §B).");
+                        continue;
                     }
+
+                    GExpression memberAccess = new IdentifierExpression(designator);
+                    foreach (string memberName in memberPath)
+                    {
+                        memberAccess = new MemberAccessExpression(
+                            memberAccess,
+                            SanitizeIdentifier(memberName));
+                    }
+
+                    this.AddTypedSubpatternTest(sub.Pattern, memberAccess, bindings, guards);
                 }
             }
 
@@ -1526,41 +1537,49 @@ public sealed partial class CSharpToGSharpTranslator
                         continue;
                     }
 
-                    if (sub.Pattern is VarPatternSyntax { Designation: SingleVariableDesignationSyntax posBound } &&
-                        this.context.GetDeclaredSymbol(posBound) is { } posBoundSymbol)
-                    {
-                        bindings.Add((
-                            posBoundSymbol,
-                            new MemberAccessExpression(
-                                new IdentifierExpression(designator),
-                                SanitizeIdentifier(memberName))));
-                        continue;
-                    }
-
                     GExpression memberAccess = new MemberAccessExpression(
                         new IdentifierExpression(designator), SanitizeIdentifier(memberName));
-                    var bindingsBefore = new HashSet<ISymbol>(this.state.PatternBindings.Keys, SymbolEqualityComparer.Default);
-                    GExpression memberTest = this.TranslatePatternTest(memberAccess, sub.Pattern, isNestedPatternMember: true);
-                    foreach (ISymbol added in this.state.PatternBindings.Keys.ToList())
-                    {
-                        if (!bindingsBefore.Contains(added))
-                        {
-                            // A nested subpattern (e.g. `Point(Sub(var a, 0), _)`)
-                            // binds its own designator directly into
-                            // `patternBindings` (the same mechanism an `is`
-                            // expression uses). Route it through `bindings` too so
-                            // the caller's install/remove-around-guard-and-body
-                            // scoping (mirroring the `is`-expression pattern
-                            // above) cleans it up like every other arm binding.
-                            bindings.Add((added, this.state.PatternBindings[added]));
-                        }
-                    }
-
-                    guards.Add(memberTest);
+                    this.AddTypedSubpatternTest(sub.Pattern, memberAccess, bindings, guards);
                 }
             }
 
             return new TypePattern(designator, this.MapTypeSyntax(recursive.Type));
+        }
+
+        private void AddTypedSubpatternTest(
+            PatternSyntax pattern,
+            GExpression memberAccess,
+            List<(ISymbol Symbol, GExpression Replacement)> bindings,
+            List<GExpression> guards)
+        {
+            if (pattern is DiscardPatternSyntax)
+            {
+                return;
+            }
+
+            if (pattern is VarPatternSyntax { Designation: SingleVariableDesignationSyntax bound } &&
+                this.context.GetDeclaredSymbol(bound) is { } boundSymbol)
+            {
+                bindings.Add((boundSymbol, memberAccess));
+                return;
+            }
+
+            var bindingsBefore = new HashSet<ISymbol>(
+                this.state.PatternBindings.Keys,
+                SymbolEqualityComparer.Default);
+            GExpression memberTest = this.TranslatePatternTest(
+                memberAccess,
+                pattern,
+                isNestedPatternMember: true);
+            foreach (ISymbol added in this.state.PatternBindings.Keys.ToList())
+            {
+                if (!bindingsBefore.Contains(added))
+                {
+                    bindings.Add((added, this.state.PatternBindings[added]));
+                }
+            }
+
+            guards.Add(memberTest);
         }
 
         private static string LowerCamel(string name)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -359,10 +359,10 @@ public sealed class CSharpTypeMapper
                 List<GTypeReference> delegateArgs = named.TypeArguments
                     .Select(a => this.Map(a, context, location))
                     .ToList();
-                return new NamedTypeReference(this.QualifiedTypeName(named, context, location), delegateArgs);
+                return new NamedTypeReference(this.DelegateTypeName(named, context, location), delegateArgs);
             }
 
-            return new NamedTypeReference(this.QualifiedTypeName(named, context, location));
+            return new NamedTypeReference(this.DelegateTypeName(named, context, location));
         }
 
         return this.Map(type, context, location);
@@ -460,6 +460,17 @@ public sealed class CSharpTypeMapper
         type is INamedTypeSymbol { ContainingNamespace.Name: "System", ContainingNamespace.ContainingNamespace.IsGlobalNamespace: true } named
             && (named.Name == "Index" || named.Name == "Range");
 
+    internal static string LiftedNestedDelegateName(INamedTypeSymbol named)
+    {
+        var parts = new List<string>();
+        for (INamedTypeSymbol current = named; current != null; current = current.ContainingType)
+        {
+            parts.Insert(0, CSharpToGSharpTranslator.SanitizeIdentifier(current.Name));
+        }
+
+        return string.Join("_", parts);
+    }
+
     /// <summary>
     /// Issue #2222: strips a leading `global::` alias-qualifier from a
     /// dotted namespace/type name (e.g. <c>using global::Foo.Bar;</c> yields
@@ -474,6 +485,13 @@ public sealed class CSharpTypeMapper
     /// <returns><paramref name="name"/> with any leading `global::` removed.</returns>
     internal static string StripGlobalPrefix(string name) =>
         name.StartsWith("global::", System.StringComparison.Ordinal) ? name.Substring("global::".Length) : name;
+
+    internal GTypeReference MapTypeOf(ITypeSymbol type, TranslationContext context, Location location)
+    {
+        return IsSystemIndexOrRange(type)
+            ? this.MapCore(type, context, location)
+            : this.Map(type, context, location);
+    }
 
     /// <summary>
     /// Issue #1906: maps a C# function-pointer type (<c>delegate*&lt;...&gt;</c>)
@@ -569,9 +587,12 @@ public sealed class CSharpTypeMapper
         switch (reference)
         {
             case NamedTypeReference named:
-                return new NamedTypeReference(named.Name, named.TypeArguments) { IsNullable = isNullable };
+                return new NamedTypeReference(named.Name, named.TypeArguments, named.ContainingType)
+                {
+                    IsNullable = isNullable,
+                };
             case ArrayTypeReference array:
-                return new ArrayTypeReference(array.ElementType) { IsNullable = isNullable };
+                return new ArrayTypeReference(array.ElementType, array.Rank) { IsNullable = isNullable };
             case PointerTypeReference pointer:
                 return new PointerTypeReference(pointer.ElementType) { IsNullable = isNullable };
             case TupleTypeReference tuple:
@@ -702,12 +723,40 @@ public sealed class CSharpTypeMapper
                 {
                     return named.IsGenericType
                         ? new NamedTypeReference(
-                            this.QualifiedTypeName(named, context, location),
+                            this.DelegateTypeName(named, context, location),
                             named.TypeArguments.Select(a => this.Map(a, context, location)).ToList())
-                        : new NamedTypeReference(this.QualifiedTypeName(named, context, location));
+                        : new NamedTypeReference(this.DelegateTypeName(named, context, location));
                 }
 
                 return this.MapDelegate(named.DelegateInvokeMethod, context, location);
+            }
+
+            if (HasGenericContainingType(named))
+            {
+                IReadOnlyList<ITypeSymbol> ownTypeArguments = named.Arity == 0
+                    ? System.Array.Empty<ITypeSymbol>()
+                    : named.TypeArguments.Skip(named.TypeArguments.Length - named.Arity).ToArray();
+                List<GTypeReference> mappedOwnTypeArguments = ownTypeArguments
+                    .Select(argument => this.Map(argument, context, location))
+                    .ToList();
+
+                // A source nested type used from inside its own generic
+                // containing type remains directly in scope. Qualifying it
+                // through Outer[T] makes gsc treat the inherited nested type
+                // as an external constructed lookup and fail to resolve it.
+                if (named.Locations.Any(candidate => candidate.IsInSource)
+                    && !this.HasSourceHomonym(named, context)
+                    && IsWithinContainingType(named, context, location))
+                {
+                    return new NamedTypeReference(
+                        CSharpToGSharpTranslator.SanitizeIdentifier(named.Name),
+                        mappedOwnTypeArguments);
+                }
+
+                return new NamedTypeReference(
+                    CSharpToGSharpTranslator.SanitizeIdentifier(named.Name),
+                    mappedOwnTypeArguments,
+                    this.Map(named.ContainingType, context, location));
             }
 
             if (named.IsGenericType)
@@ -722,6 +771,31 @@ public sealed class CSharpTypeMapper
         }
 
         return new NamedTypeReference(CSharpToGSharpTranslator.SanitizeIdentifier(type.Name));
+    }
+
+    private string DelegateTypeName(
+        INamedTypeSymbol named,
+        TranslationContext context,
+        Location location)
+    {
+        return IsSourceDeclaredDelegate(named) && named.ContainingType != null
+            ? LiftedNestedDelegateName(named)
+            : this.QualifiedTypeName(named, context, location);
+    }
+
+    private static bool HasGenericContainingType(INamedTypeSymbol named)
+    {
+        for (INamedTypeSymbol containing = named.ContainingType;
+            containing != null;
+            containing = containing.ContainingType)
+        {
+            if (containing.Arity > 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     // A nested type is referenced through its containing type(s)

--- a/tools/cs2gs/Cs2Gs.Translator/DocumentTranslationState.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/DocumentTranslationState.cs
@@ -197,6 +197,12 @@ internal sealed class DocumentTranslationState
     // Instance helpers synthesized while translating the current aggregate.
     public List<MethodDeclaration> PendingInstanceSynthHelpers { get; set; }
 
+    // Shared helpers synthesized from capture-free static local functions.
+    public List<MethodDeclaration> PendingStaticSynthHelpers { get; set; }
+
+    public Dictionary<IMethodSymbol, string> LiftedStaticLocalFunctions { get; } =
+        new Dictionary<IMethodSymbol, string>(SymbolEqualityComparer.Default);
+
     // The exception variable bound by the innermost enclosing `catch` clause,
     // used to translate a C# re-throw (`throw;`) — which has no bare G# form —
     // to `throw <caughtVar>` (ADR-0115 §B).


### PR DESCRIPTION
## Summary

Refs #3394.

Runs the compiler self-migration spike through 49 Core cycles and commits durable fixes only.

- translates all Core sources: 578 C# inputs → 580 G# files
- zero unsupported translation diagnostics; every generated file round-trip parses
- reduces Core compile diagnostics from 1,126 to 291 (74.2%)
- fixes parser, symbolic generic binding, overload, lambda/delegate, nullability, pattern, constructor, SDK-resolution, and cs2gs defects with regressions
- makes pinned Oahu migration fully green: 15/15 projects pass translate, compile, ILVerify, and test parity
- adds rigorous report: `docs/self-migration-spike-3394.md`
- does **not** commit generated migrated compiler sources

## Proven milestone

Core translation and parsing are proven. Core semantic compilation is not yet green, so Core ILVerify/test parity/self-hosting and downstream gsc/gsi/gsgen/cs2gs migration remain blocked.

Final Core frontier: 291 diagnostics in:

```text
artifacts/issue-3394/core-cycle-49/2026-08-13T17-29-08Z_e7e65c
```

Remaining minimized blockers:

- #3399 capturing recursive local functions
- #3400 out/ref kind loss for imported generics over source types
- #3401 params-array pass-through nested inference
- #3402 short-circuit pattern binder scope

## Validation

- Core targeted parser/binder tests: 236 passed
- Compiler delegate/conversion emit tests: 19 passed, including runtime + ILVerify
- cs2gs project sweep: 2,017 passed; six exposed expectation/regression failures fixed, focused rerun 6/6 passed
- final pinned Oahu gate: 15/15 projects green
  - CLI: 342/342
  - Foundation: 2/2
  - CLI E2E: 5/5
  - all migrated assemblies compile and ILVerify
- `git diff --check`

CI should run the full repository matrix.
