### PR TITLE
Continue Core self-migration toward semantic compile

### DIFF
--- a/docs/self-migration-spike-3394.md
+++ b/docs/self-migration-spike-3394.md
@@ -345,10 +345,11 @@ remain green. Core compile diagnostics moved:
 | 62 | 116 | Explicit statement-array element typing |
 | 63 | 115 | Mutable narrowing-frame locals |
 | 64 | 111 | Positional-record property deduplication |
-| 65 | **110** | Nullable reference interface-signature matching |
+| 65 | 110 | Nullable reference interface-signature matching |
+| 66 | **108** | Final remeasurement after CI repairs |
 
-Continuation reduction is 291 → 110 (181 removed, 62.2%). From cycle 14,
-Core semantic diagnostics are 1,126 → 110 (1,016 removed, 90.2%).
+Continuation reduction is 291 → 108 (183 removed, 62.9%). From cycle 14,
+Core semantic diagnostics are 1,126 → 108 (1,018 removed, 90.4%).
 
 Durable continuation fixes include capturing recursive and mutually recursive
 local-function lifting with transitive captures and by-ref mutable state;
@@ -358,7 +359,7 @@ open generic CLR type aliases; exhaustive-switch out-parameter analysis;
 nullable array-allocation element preservation; positional-record property
 deduplication; and nullable-reference-insensitive CLR interface matching.
 
-Cycle 65's largest remaining IDs are GS0155 (21), GS0159 (19), GS0158 (17),
+Cycle 66's largest remaining IDs are GS0155 (21), GS0159 (19), GS0158 (17),
 GS0154 (11), GS0266 (6), and GS0125 (6). Core still does not compile, so
 ILVerify, test parity, self-hosted Core recompilation, and downstream project
 migrations remain gated exactly as before.

--- a/docs/self-migration-spike-3394.md
+++ b/docs/self-migration-spike-3394.md
@@ -323,3 +323,42 @@ Required sequence remains:
 4. compile Core with the migrated Core implementation;
 5. only then continue in order through gsc, gsi, gsgen, and cs2gs.
 
+## Continuation through cycle 65
+
+Follow-up branch `oats/3394-core-compile-continuation`, based on `02a8ca99`,
+continued the same Core-first sequence. Translation and round-trip parsing
+remain green. Core compile diagnostics moved:
+
+| Cycle | Diagnostics | Milestone |
+|---:|---:|---|
+| 51 | 291 | Fresh-main baseline |
+| 52 | 208 | #3399–#3402 root-fix cluster |
+| 53 | 200 | Ref-kind local-function and scope follow-up |
+| 54 | 183 | Nested negated-pattern binders |
+| 55 | 157 | Generic CLR import aliases |
+| 56 | 140 | Exhaustive-switch definite assignment and nullable arrays |
+| 57 | 135 | Lifted-helper capture nullability |
+| 58 | 127 | Pattern binders after short-circuit prefixes |
+| 59 | 129 | Diagnostic-neutral nested-builder experiment |
+| 60 | 123 | Inferred generic `Enum.TryParse` rendering |
+| 61 | 122 | Constant-pattern binder scope |
+| 62 | 116 | Explicit statement-array element typing |
+| 63 | 115 | Mutable narrowing-frame locals |
+| 64 | 111 | Positional-record property deduplication |
+| 65 | **110** | Nullable reference interface-signature matching |
+
+Continuation reduction is 291 → 110 (181 removed, 62.2%). From cycle 14,
+Core semantic diagnostics are 1,126 → 110 (1,016 removed, 90.2%).
+
+Durable continuation fixes include capturing recursive and mutually recursive
+local-function lifting with transitive captures and by-ref mutable state;
+ref/out local-function lifting; structural by-ref pointee matching; params
+normal-form specificity; wider short-circuit and nested pattern-binder scope;
+open generic CLR type aliases; exhaustive-switch out-parameter analysis;
+nullable array-allocation element preservation; positional-record property
+deduplication; and nullable-reference-insensitive CLR interface matching.
+
+Cycle 65's largest remaining IDs are GS0155 (21), GS0159 (19), GS0158 (17),
+GS0154 (11), GS0266 (6), and GS0125 (6). Core still does not compile, so
+ILVerify, test parity, self-hosted Core recompilation, and downstream project
+migrations remain gated exactly as before.

--- a/src/Core/CodeAnalysis/Binding/BoundScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundScope.cs
@@ -668,6 +668,14 @@ public sealed class BoundScope
         }
 
         var mangled = name + "`" + arity;
+        if (TryLookupImport(name, out var aliasImport)
+            && aliasImport.IsAlias
+            && References.TryResolveType(aliasImport.Target + "`" + arity, out var aliasedType))
+        {
+            type = aliasedType;
+            return true;
+        }
+
         foreach (var import in EnumerateImports())
         {
             var typeName = import.Target + "." + mangled;

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -2041,7 +2041,9 @@ internal sealed class ConversionClassifier
             if (argument is BoundAddressOfExpression addr)
             {
                 var operandType = addr.Operand?.Type;
-                if (operandType == expectedType || operandType == TypeSymbol.Error || expectedType == TypeSymbol.Error)
+                if (DeclarationBinder.TypeSignaturesEquivalent(operandType, expectedType)
+                    || operandType == TypeSymbol.Error
+                    || expectedType == TypeSymbol.Error)
                 {
                     return argument;
                 }
@@ -2055,7 +2057,9 @@ internal sealed class ConversionClassifier
                 // parameter positions. The shared pointee type was validated
                 // by BindConditionalRefArgument.
                 var pointeeType = condAddr.PointeeType;
-                if (pointeeType == expectedType || pointeeType == TypeSymbol.Error || expectedType == TypeSymbol.Error)
+                if (DeclarationBinder.TypeSignaturesEquivalent(pointeeType, expectedType)
+                    || pointeeType == TypeSymbol.Error
+                    || expectedType == TypeSymbol.Error)
                 {
                     return argument;
                 }

--- a/src/Core/CodeAnalysis/Binding/DefiniteAssignmentAnalyzer.cs
+++ b/src/Core/CodeAnalysis/Binding/DefiniteAssignmentAnalyzer.cs
@@ -746,6 +746,17 @@ internal static class DefiniteAssignmentAnalyzer
             any = true;
         }
 
+        if (hasDefault && !any)
+        {
+            // Every exhaustive arm terminates inside its recursively analyzed
+            // region. The outer CFG models pattern switches as opaque and still
+            // carries a synthetic fall-through edge, so mark out parameters as
+            // assigned on that unreachable continuation. Any real return missing
+            // an assignment was already reported while analyzing its arm.
+            assigned.UnionWith(outParams);
+            return;
+        }
+
         if (any && meet is not null)
         {
             assigned.Clear();

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -2828,25 +2828,29 @@ internal sealed partial class ExpressionBinder
             return null;
         }
 
-        return (index, clrParameterType) =>
+        return (index, parameterType) =>
         {
             var argIndex = index - argumentOffset;
-            if (argIndex < 0 || argIndex >= boundArguments.Count || clrParameterType == null)
+            if (argIndex < 0 || argIndex >= boundArguments.Count || parameterType == null)
             {
                 return false;
             }
 
+            var effectiveParameterType = parameterType;
+
             // A constant literal can never bind by-ref; peel defensively so a
             // by-ref parameter maps to its element type rather than a managed
             // pointer (which TypeSymbol.FromClrType cannot represent).
-            if (clrParameterType.IsByRef)
+            if (effectiveParameterType.IsByRef)
             {
-                clrParameterType = Invariant.Required(
-                    clrParameterType.GetElementType(),
+                effectiveParameterType = Invariant.Required(
+                    effectiveParameterType.GetElementType(),
                     "a by-ref parameter has an element type");
             }
 
-            return IsImplicitConstantNarrowingArgument(boundArguments[argIndex], TypeSymbol.FromClrType(clrParameterType));
+            return IsImplicitConstantNarrowingArgument(
+                boundArguments[argIndex],
+                TypeSymbol.FromClrType(effectiveParameterType));
         };
     }
 

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -4873,6 +4873,18 @@ internal sealed class MemberLookup
             return SameTypeSymbol(nullableA.UnderlyingType, nullableB.UnderlyingType);
         }
 
+        if (a is NullableTypeSymbol nullableReferenceA
+            && !NullableLifting.IsAnyValueTypeNullable(nullableReferenceA))
+        {
+            return SameTypeSymbol(nullableReferenceA.UnderlyingType, b);
+        }
+
+        if (b is NullableTypeSymbol nullableReferenceB
+            && !NullableLifting.IsAnyValueTypeNullable(nullableReferenceB))
+        {
+            return SameTypeSymbol(a, nullableReferenceB.UnderlyingType);
+        }
+
         // Constructed user generics are interned (StructSymbol.Construct uses a
         // cache), so reference identity usually holds; fall back to a
         // structural comparison by definition + ordered type arguments.

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/ClrOverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/ClrOverloadResolution.cs
@@ -3997,21 +3997,16 @@ internal static class ClrOverloadResolution
         candidate = PeelByRef(candidate) ?? candidate;
         other = PeelByRef(other) ?? other;
 
+        // C# better-member specificity treats a concrete type as more specific
+        // than a method type parameter. Two type-parameter slots are tied.
+        if (candidate.IsGenericParameter || other.IsGenericParameter)
+        {
+            return other.IsGenericParameter;
+        }
+
         if (ClrTypeUtilities.AreSame(candidate, other))
         {
             return true;
-        }
-
-        // C# better-member specificity treats a concrete type as more specific
-        // than a method type parameter. Two type-parameter slots are tied.
-        if (other.IsGenericParameter)
-        {
-            return true;
-        }
-
-        if (candidate.IsGenericParameter)
-        {
-            return false;
         }
 
         if (candidate.IsArray && other.IsArray

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
@@ -390,14 +390,19 @@ internal sealed partial class OverloadResolver
             return clrCtorCall;
         }
 
-        if (!hasNonConstructorCallable && syntax.Arguments.Count == 1 && lookupTypeWithArity(syntax.Identifier.Text, ctorPreferredArity) is TypeSymbol type)
+        var conversionType = lookupTypeWithArity(
+            syntax.Identifier.Text,
+            ctorPreferredArity);
+        if (!hasNonConstructorCallable
+            && syntax.Arguments.Count == 1
+            && conversionType is TypeSymbol)
         {
             // Issue #663: when the call carries a `?` token (e.g. `string?(x)`),
             // wrap the resolved type in NullableTypeSymbol so the conversion
             // targets the nullable form.
             if (syntax.NullableQuestionToken != null)
             {
-                type = NullableTypeSymbol.Get(type);
+                conversionType = NullableTypeSymbol.Get(conversionType);
             }
 
             // A single-arg call to a primitive-typed name is a conversion
@@ -409,7 +414,7 @@ internal sealed partial class OverloadResolver
             // value struct (e.g. a `data struct`) declaring a primary
             // constructor is likewise positionally constructible — `Entry(1)`
             // builds the struct, not a conversion to it.
-            if (!(type is StructSymbol singleArgStruct
+            if (!(conversionType is StructSymbol singleArgStruct
                   && (singleArgStruct.IsClass
                       || singleArgStruct.IsInline
                       || singleArgStruct.HasPrimaryConstructor
@@ -417,8 +422,14 @@ internal sealed partial class OverloadResolver
             {
                 // ADR-0047 §6 / #175: `Type(x)` as an explicit conversion
                 // is still a use of the named type.
-                reportObsoleteUseIfApplicable(syntax.Identifier.Location, type, type.Name);
-                return conversions.BindConversion(syntax.Arguments[0], type, allowExplicit: true);
+                reportObsoleteUseIfApplicable(
+                    syntax.Identifier.Location,
+                    conversionType,
+                    conversionType.Name);
+                return conversions.BindConversion(
+                    syntax.Arguments[0],
+                    conversionType,
+                    allowExplicit: true);
             }
         }
 
@@ -1582,7 +1593,8 @@ internal sealed partial class OverloadResolver
                         continue;
                     }
 
-                    if (operandType != expectedType && operandType != TypeSymbol.Error)
+                    if (!DeclarationBinder.TypeSignaturesEquivalent(operandType, expectedType)
+                        && operandType != TypeSymbol.Error)
                     {
                         Diagnostics.ReportWrongArgumentType(
                             Invariant.Required(parameterSyntax[i], "a ref argument has source syntax").Location,

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
@@ -1063,7 +1063,9 @@ internal sealed partial class OverloadResolver
             if (parameter.RefKind != RefKind.None && argument is BoundAddressOfExpression addrCtor)
             {
                 var pointee = addrCtor.Operand?.Type;
-                if (pointee == paramType || pointee == TypeSymbol.Error || paramType == TypeSymbol.Error)
+                if (DeclarationBinder.TypeSignaturesEquivalent(pointee, paramType)
+                    || pointee == TypeSymbol.Error
+                    || paramType == TypeSymbol.Error)
                 {
                     convertedArguments.Add(argument);
                     continue;
@@ -1072,7 +1074,9 @@ internal sealed partial class OverloadResolver
             else if (parameter.RefKind != RefKind.None && argument is BoundConditionalAddressExpression condAddrCtor)
             {
                 var pointee = condAddrCtor.PointeeType;
-                if (pointee == paramType || pointee == TypeSymbol.Error || paramType == TypeSymbol.Error)
+                if (DeclarationBinder.TypeSignaturesEquivalent(pointee, paramType)
+                    || pointee == TypeSymbol.Error
+                    || paramType == TypeSymbol.Error)
                 {
                     convertedArguments.Add(argument);
                     continue;
@@ -1532,7 +1536,9 @@ internal sealed partial class OverloadResolver
             if (parameter.RefKind != RefKind.None && argument is BoundAddressOfExpression addrInit)
             {
                 var pointee = addrInit.Operand?.Type;
-                if (pointee == parameter.Type || pointee == TypeSymbol.Error || parameter.Type == TypeSymbol.Error)
+                if (DeclarationBinder.TypeSignaturesEquivalent(pointee, parameter.Type)
+                    || pointee == TypeSymbol.Error
+                    || parameter.Type == TypeSymbol.Error)
                 {
                     convertedArgs.Add(argument);
                     continue;
@@ -1541,7 +1547,9 @@ internal sealed partial class OverloadResolver
             else if (parameter.RefKind != RefKind.None && argument is BoundConditionalAddressExpression condAddrInit)
             {
                 var pointee = condAddrInit.PointeeType;
-                if (pointee == parameter.Type || pointee == TypeSymbol.Error || parameter.Type == TypeSymbol.Error)
+                if (DeclarationBinder.TypeSignaturesEquivalent(pointee, parameter.Type)
+                    || pointee == TypeSymbol.Error
+                    || parameter.Type == TypeSymbol.Error)
                 {
                     convertedArgs.Add(argument);
                     continue;

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Invocations.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Invocations.cs
@@ -620,7 +620,8 @@ internal sealed partial class OverloadResolver
                     {
                         argument = bindRefArgumentExpression(inlineOut, parameter);
                     }
-                    else if (address.Operand.Type != parameter.Type && address.Operand.Type != TypeSymbol.Error)
+                    else if (!DeclarationBinder.TypeSignaturesEquivalent(address.Operand.Type, parameter.Type)
+                        && address.Operand.Type != TypeSymbol.Error)
                     {
                         Diagnostics.ReportWrongArgumentType(argumentLocation, parameter.Name, parameter.Type, address.Operand.Type);
                         hasErrors = true;
@@ -628,7 +629,7 @@ internal sealed partial class OverloadResolver
                 }
                 else if (argument is BoundConditionalAddressExpression conditionalAddress)
                 {
-                    if (conditionalAddress.PointeeType != parameter.Type
+                    if (!DeclarationBinder.TypeSignaturesEquivalent(conditionalAddress.PointeeType, parameter.Type)
                         && conditionalAddress.PointeeType != TypeSymbol.Error)
                     {
                         Diagnostics.ReportWrongArgumentType(argumentLocation, parameter.Name, parameter.Type, conditionalAddress.PointeeType);

--- a/src/Core/CodeAnalysis/Binding/PatternBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/PatternBinder.cs
@@ -427,9 +427,9 @@ internal sealed class PatternBinder
     {
         switch (expression)
         {
-            case BoundLiteralExpression lit when lit.Value is object literalValue
-                && ExpressionBinder.IsIntegerLiteralValue(literalValue):
-                value = literalValue;
+            case BoundLiteralExpression lit when lit.Value != null
+                && ExpressionBinder.IsIntegerLiteralValue(lit.Value):
+                value = lit.Value;
                 return true;
 
             case BoundUnaryExpression unary

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Conditionals.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Conditionals.cs
@@ -31,7 +31,9 @@ internal sealed partial class StatementBinder
             // Phase 3.C.4/6.6: recognise one top-level nullable guard. Boolean
             // conjunction/disjunction flow (for example `s != nil && IsValid(s)`)
             // is intentionally deferred for the nil-guard classifier.
-            var (thenNarrow, elseNarrow) = TryClassifyNilGuard(condition);
+            Dictionary<AccessPath, TypeSymbol>? thenNarrow;
+            Dictionary<AccessPath, TypeSymbol>? elseNarrow;
+            (thenNarrow, elseNarrow) = TryClassifyNilGuard(condition);
             if (thenNarrow == null && elseNarrow == null)
             {
                 (thenNarrow, elseNarrow) = TryClassifyBoolCallNarrowing(condition);
@@ -71,7 +73,9 @@ internal sealed partial class StatementBinder
         var initStatement = BindStatement(syntax.Initializer);
         var initCondition = bindExpressionWithTargetType(syntax.Condition, TypeSymbol.Bool);
 
-        var (initThenNarrow, initElseNarrow) = TryClassifyNilGuard(initCondition);
+        Dictionary<AccessPath, TypeSymbol>? initThenNarrow;
+        Dictionary<AccessPath, TypeSymbol>? initElseNarrow;
+        (initThenNarrow, initElseNarrow) = TryClassifyNilGuard(initCondition);
         if (initThenNarrow == null && initElseNarrow == null)
         {
             (initThenNarrow, initElseNarrow) = TryClassifyBoolCallNarrowing(initCondition);
@@ -965,8 +969,8 @@ internal sealed partial class StatementBinder
 
     private BoundStatement BindMultiAssignmentStatement(MultiAssignmentStatementSyntax syntax)
     {
-        var targets = syntax.Targets.ToImmutableArray();
-        var values = syntax.Values.ToImmutableArray();
+        ImmutableArray<ExpressionSyntax> targets = syntax.Targets.ToImmutableArray();
+        ImmutableArray<ExpressionSyntax> values = syntax.Values.ToImmutableArray();
 
         var isShortDecl = syntax.OperatorToken.Kind == SyntaxKind.ColonEqualsToken;
 

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Loops.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Loops.cs
@@ -1017,7 +1017,7 @@ internal sealed partial class StatementBinder
             var boundInner = BindStatement(inner);
             return new BoundBlockStatement(
                 syntax,
-                ImmutableArray.Create(
+                ImmutableArray.Create<BoundStatement>(
                     new BoundLabelStatement(syntax, userLabel),
                     Invariant.Required(boundInner, "a labeled statement has a bound inner statement")));
         }

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
@@ -866,7 +866,9 @@ internal sealed partial class StatementBinder
     /// </summary>
     private (Dictionary<AccessPath, TypeSymbol>? Then, Dictionary<AccessPath, TypeSymbol>? Else) ComputeConditionNarrowing(BoundExpression condition)
     {
-        var (thenNarrow, elseNarrow) = TryClassifyNilGuard(condition);
+        Dictionary<AccessPath, TypeSymbol>? thenNarrow;
+        Dictionary<AccessPath, TypeSymbol>? elseNarrow;
+        (thenNarrow, elseNarrow) = TryClassifyNilGuard(condition);
         if (thenNarrow == null && elseNarrow == null)
         {
             (thenNarrow, elseNarrow) = TryClassifyBoolCallNarrowing(condition);

--- a/src/Core/CodeAnalysis/Documentation/SymbolDocumentationIdProvider.cs
+++ b/src/Core/CodeAnalysis/Documentation/SymbolDocumentationIdProvider.cs
@@ -673,51 +673,28 @@ internal static class SymbolDocumentationIdProvider
 
     private static bool DeclaresTypeParameter(TypeSymbol type, TypeParameterSymbol typeParameter)
     {
-        var ordinal = typeParameter.Ordinal;
-        if (ordinal < 0)
+        if (typeParameter.Ordinal < 0)
         {
             return false;
         }
 
-        if (type is StructSymbol structSymbol)
+        foreach (var parameter in GetOwnTypeParameters(type))
         {
-            var list = structSymbol.Declaration?.TypeParameterList;
-            if (list != null)
+            if (ReferenceEquals(parameter, typeParameter)
+                || string.Equals(
+                    parameter.Name,
+                    typeParameter.Name,
+                    StringComparison.Ordinal))
             {
-                return ordinal < list.Parameters.Count &&
-                    string.Equals(
-                        list.Parameters[ordinal].Identifier.Text,
-                        typeParameter.Name,
-                        StringComparison.Ordinal);
+                return true;
             }
         }
 
-        if (type is InterfaceSymbol interfaceSymbol)
-        {
-            var list = interfaceSymbol.Declaration?.TypeParameterList;
-            if (list != null)
-            {
-                return ordinal < list.Parameters.Count &&
-                    string.Equals(
-                        list.Parameters[ordinal].Identifier.Text,
-                        typeParameter.Name,
-                        StringComparison.Ordinal);
-            }
-        }
+        return false;
+    }
 
-        if (type is DelegateTypeSymbol delegateSymbol)
-        {
-            var list = delegateSymbol.Declaration?.TypeParameterList;
-            if (list != null)
-            {
-                return ordinal < list.Parameters.Count &&
-                    string.Equals(
-                        list.Parameters[ordinal].Identifier.Text,
-                        typeParameter.Name,
-                        StringComparison.Ordinal);
-            }
-        }
-
+    private static ImmutableArray<TypeParameterSymbol> GetOwnTypeParameters(TypeSymbol type)
+    {
         var parameters = type switch
         {
             StructSymbol structType => structType.TypeParameters,
@@ -725,9 +702,10 @@ internal static class SymbolDocumentationIdProvider
             DelegateTypeSymbol delegateType => delegateType.TypeParameters,
             _ => ImmutableArray<TypeParameterSymbol>.Empty,
         };
-        return ordinal < parameters.Length &&
-            (ReferenceEquals(parameters[ordinal], typeParameter) ||
-             string.Equals(parameters[ordinal].Name, typeParameter.Name, StringComparison.Ordinal));
+        var ownArity = GetOwnArity(type);
+        return ownArity > 0 && parameters.Length > ownArity
+            ? parameters.Slice(parameters.Length - ownArity, ownArity)
+            : parameters;
     }
 
     private static void AppendClrTypeReference(StringBuilder builder, Type? type)

--- a/src/Core/CodeAnalysis/Documentation/SymbolDocumentationIdProvider.cs
+++ b/src/Core/CodeAnalysis/Documentation/SymbolDocumentationIdProvider.cs
@@ -17,10 +17,10 @@ internal static class SymbolDocumentationIdProvider
     {
         return symbol switch
         {
-            PackageSymbol package => GetDocumentationId(package),
-            TypeSymbol type when IsSourceNamedType(type) => GetDocumentationId(type),
-            EnumMemberSymbol enumMember => GetDocumentationId(enumMember),
-            FunctionSymbol function => GetDocumentationId(function),
+            PackageSymbol package => GetDocumentationId(package: package),
+            TypeSymbol type when IsSourceNamedType(type) => GetDocumentationId(type: type),
+            EnumMemberSymbol enumMember => GetDocumentationId(member: enumMember),
+            FunctionSymbol function => GetDocumentationId(function: function),
             _ => null,
         };
     }
@@ -29,10 +29,10 @@ internal static class SymbolDocumentationIdProvider
     {
         return member switch
         {
-            FieldSymbol field => GetDocumentationId(field, ownerType),
-            PropertySymbol property => GetDocumentationId(property, ownerType),
-            EventSymbol @event => GetDocumentationId(@event, ownerType),
-            FunctionSymbol function => GetDocumentationId(function),
+            FieldSymbol field => GetDocumentationId(field: field, ownerType: ownerType),
+            PropertySymbol property => GetDocumentationId(property: property, ownerType: ownerType),
+            EventSymbol @event => GetDocumentationId(@event: @event, ownerType: ownerType),
+            FunctionSymbol function => GetDocumentationId(function: function),
             _ => null,
         };
     }
@@ -677,19 +677,6 @@ internal static class SymbolDocumentationIdProvider
         if (ordinal < 0)
         {
             return false;
-        }
-
-        switch (type)
-        {
-            case StructSymbol { Declaration.TypeParameterList: { } list }:
-                return ordinal < list.Parameters.Count &&
-                    string.Equals(list.Parameters[ordinal].Identifier.Text, typeParameter.Name, StringComparison.Ordinal);
-            case InterfaceSymbol { Declaration.TypeParameterList: { } list }:
-                return ordinal < list.Parameters.Count &&
-                    string.Equals(list.Parameters[ordinal].Identifier.Text, typeParameter.Name, StringComparison.Ordinal);
-            case DelegateTypeSymbol { Declaration.TypeParameterList: { } list }:
-                return ordinal < list.Parameters.Count &&
-                    string.Equals(list.Parameters[ordinal].Identifier.Text, typeParameter.Name, StringComparison.Ordinal);
         }
 
         var parameters = type switch

--- a/src/Core/CodeAnalysis/Documentation/SymbolDocumentationIdProvider.cs
+++ b/src/Core/CodeAnalysis/Documentation/SymbolDocumentationIdProvider.cs
@@ -679,6 +679,45 @@ internal static class SymbolDocumentationIdProvider
             return false;
         }
 
+        if (type is StructSymbol structSymbol)
+        {
+            var list = structSymbol.Declaration?.TypeParameterList;
+            if (list != null)
+            {
+                return ordinal < list.Parameters.Count &&
+                    string.Equals(
+                        list.Parameters[ordinal].Identifier.Text,
+                        typeParameter.Name,
+                        StringComparison.Ordinal);
+            }
+        }
+
+        if (type is InterfaceSymbol interfaceSymbol)
+        {
+            var list = interfaceSymbol.Declaration?.TypeParameterList;
+            if (list != null)
+            {
+                return ordinal < list.Parameters.Count &&
+                    string.Equals(
+                        list.Parameters[ordinal].Identifier.Text,
+                        typeParameter.Name,
+                        StringComparison.Ordinal);
+            }
+        }
+
+        if (type is DelegateTypeSymbol delegateSymbol)
+        {
+            var list = delegateSymbol.Declaration?.TypeParameterList;
+            if (list != null)
+            {
+                return ordinal < list.Parameters.Count &&
+                    string.Equals(
+                        list.Parameters[ordinal].Identifier.Text,
+                        typeParameter.Name,
+                        StringComparison.Ordinal);
+            }
+        }
+
         var parameters = type switch
         {
             StructSymbol structType => structType.TypeParameters,

--- a/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
@@ -195,8 +195,12 @@ internal sealed class TypeDefEmitter
         EnsureStructFirstField(firstFieldRow, ref firstField);
 
         var (typeAccessibility, structNamespace) = this.ResolveStructNamespaceAndAccessibility(structSym);
-        var (typeAttrs, baseType) = this.ResolveStructTypeShape(structSym, typeAccessibility);
-        typeAttrs = SuppressBeforeFieldInitForStruct(structSym, typeAttrs);
+        var (resolvedTypeAttrs, baseType) = this.ResolveStructTypeShape(
+            structSym,
+            typeAccessibility);
+        var typeAttrs = SuppressBeforeFieldInitForStruct(
+            structSym,
+            resolvedTypeAttrs);
         var handle2 = this.EmitStructTypeDefinition(
             structSym, typeAttrs, structNamespace, baseType, firstField, methodListRow);
         this.EmitStructClassLayout(handle2, structSym);

--- a/src/Core/CodeAnalysis/Lowering/Iterators/IteratorMoveNextBodyBuilder.cs
+++ b/src/Core/CodeAnalysis/Lowering/Iterators/IteratorMoveNextBodyBuilder.cs
@@ -438,7 +438,9 @@ public static class IteratorMoveNextBodyBuilder
 
             return new BoundBlockStatement(
                 null,
-                ImmutableArray.Create(new BoundLabelStatement(null, entryLabel), result));
+                ImmutableArray.Create<BoundStatement>(
+                    new BoundLabelStatement(null, entryLabel),
+                    result));
         }
 
         protected override BoundStatement RewriteReturnStatement(BoundReturnStatement node)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2273ImportTypeAliasTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2273ImportTypeAliasTests.cs
@@ -60,6 +60,20 @@ var result = R.Sqrt(16.0)
     }
 
     [Fact]
+    public void Alias_To_Imported_Open_Generic_Type_Accepts_Type_Arguments()
+    {
+        var result = Evaluate(@"
+import L = System.Collections.Generic.List
+
+let values = L[int32]()
+values.Add(42)
+var result = values[0]
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
     public void Alias_To_CrossPackage_Source_Type_Resolves_In_TypeClause_Position()
     {
         var holderTree = @"

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3394InlineOutTupleBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3394InlineOutTupleBindingTests.cs
@@ -331,6 +331,23 @@ public class Issue3394InlineOutTupleBindingTests
     }
 
     [Fact]
+    public void NullAssertedListOfSourceType_PreservesAdd()
+    {
+        var result = EmittedOracle.Evaluate("""
+            import System.Collections.Generic
+
+            class Item {}
+
+            let items = List[Item]()
+            items!!.Add(Item())
+            items.Count
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(1, result.Value);
+    }
+
+    [Fact]
     public void LinqWhere_PreservesNestedSymbolicTupleReceiver()
     {
         var result = EmittedOracle.Evaluate("""
@@ -432,6 +449,70 @@ public class Issue3394InlineOutTupleBindingTests
     }
 
     [Fact]
+    public void UserCall_PreservesOutRefKindForImportedGenericOfSourceType()
+    {
+        var result = EmittedOracle.Evaluate("""
+            import System.Collections.Immutable
+
+            enum Kind { A }
+
+            class C {
+                func inner(out value ImmutableArray[Kind]) bool {
+                    value = default(ImmutableArray[Kind])
+                    return true
+                }
+            }
+
+            func run(c C, out value ImmutableArray[Kind]) bool -> c.inner(out value)
+
+            var value ImmutableArray[Kind] = default
+            run(C(), out value)
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(true, result.Value);
+    }
+
+    [Fact]
+    public void ImmutableArrayCreate_PassesThroughSourceTypeSlice()
+    {
+        var result = EmittedOracle.Evaluate("""
+            import System.Collections.Immutable
+
+            class Item {}
+
+            func build(values []Item?) ImmutableArray[Item?] ->
+                ImmutableArray.Create(values)
+
+            0
+            """);
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void ClrOverloadResolution_PrefersNormalParamsArrayShape()
+    {
+        var candidates = typeof(ImmutableArray).GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Where(method => method.Name == nameof(ImmutableArray.Create) && method.IsGenericMethodDefinition)
+            .ToArray();
+        var paramsCandidate = candidates.Single(method =>
+            method.GetParameters() is [var parameter]
+            && ClrOverloadResolution.IsParamsArrayParameter(parameter));
+
+        var paramsOnly = ClrOverloadResolution.Resolve(new[] { paramsCandidate }, new[] { typeof(object[]) });
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.Resolved, paramsOnly.Outcome);
+
+        var result = ClrOverloadResolution.Resolve(candidates, new[] { typeof(object[]) });
+
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
+        Assert.False(result.IsExpanded);
+        Assert.True(
+            ClrOverloadResolution.IsParamsArrayParameter(Assert.Single(result.Best!.GetParameters())),
+            ClrOverloadResolution.FormatMethodSignature(result.Best));
+    }
+
+    [Fact]
     public void LinqMethodGroup_PreservesSameCompilationElementType()
     {
         var result = EmittedOracle.Evaluate("""
@@ -496,4 +577,39 @@ public class Issue3394InlineOutTupleBindingTests
         Assert.Empty(result.Diagnostics);
         Assert.Equal(true, result.Value);
     }
+
+    [Fact]
+    public void DictionaryTryGetValue_PreservesSourceTupleKeyAndImportedValue()
+    {
+        var result = EmittedOracle.Evaluate("""
+            import System.Collections.Generic
+            import System.Reflection.Metadata
+
+            class Item {}
+
+            let values = Dictionary[(Item, EntityHandle), EntityHandle]()
+            let found = values.TryGetValue((Item(), default(EntityHandle)), out var handle)
+            !found && handle.IsNil
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(true, result.Value);
+    }
+
+    [Fact]
+    public void NullableReferenceParameter_ImplementsSymbolicClrInterfaceSlot()
+    {
+        var result = EmittedOracle.Evaluate("""
+            import System
+
+            class Item : IEquatable[Item] {
+                func Equals(other Item?) bool -> other != nil
+            }
+
+            0
+            """);
+
+        Assert.Empty(result.Diagnostics);
+    }
+
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/RefKindDefiniteAssignmentTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/RefKindDefiniteAssignmentTests.cs
@@ -22,6 +22,31 @@ namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 /// </summary>
 public class RefKindDefiniteAssignmentTests
 {
+    [Fact]
+    public void OutParameter_AssignedInEveryTerminalSwitchArm_IsAccepted()
+    {
+        var result = EmittedOracle.Evaluate("""
+            func tryParse(text string, out kind int32) bool {
+                switch text {
+                    case "a" {
+                        kind = 1
+                        return true
+                    }
+                    default {
+                        kind = 0
+                        return false
+                    }
+                }
+            }
+
+            var kind = -1
+            tryParse("a", out kind)
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(true, result.Value);
+    }
+
     private static EmittedOracleResult Compile(string source)
     {
         return EmittedOracle.Evaluate(source);

--- a/tools/cs2gs/Cs2Gs.Tests/BlockLambdaArrowTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/BlockLambdaArrowTranslationTests.cs
@@ -140,10 +140,8 @@ namespace Demo
     }
 
     [Fact]
-    public void LocalFunction_StaysFuncLiteral()
+    public void RecursiveLocalFunction_LiftsToMethod()
     {
-        // A C# local function is NOT an arrow lambda: it keeps the
-        // function-literal form with an explicit return type (supports recursion).
         string printed = TranslateUnit(@"
 namespace Demo
 {
@@ -166,10 +164,10 @@ namespace Demo
             return Fact(5);
         }
     }
-}",
-            "Recursive local functions lower to non-recursive let bindings, a documented G# letrec limitation.");
+}");
 
-        Assert.Contains("let Fact = func (n int32) int32 {", printed);
+        Assert.Contains("__local_F_Fact_", printed);
+        Assert.DoesNotContain("let Fact = func", printed);
         Assert.DoesNotContain("(n int32) -> {", printed);
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1212NullableArrayElementTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1212NullableArrayElementTranslationTests.cs
@@ -85,6 +85,24 @@ namespace Demo
         Assert.Contains("F(items []?object?)", printed);
     }
 
+    [Fact]
+    public void NullableReferenceElementArrayCreation_RendersElementNullable()
+    {
+        string printed = TranslateUnit(@"
+#nullable enable
+namespace Demo
+{
+    public class C
+    {
+        public object?[] F(int count) => new object?[count];
+    }
+}");
+
+        Assert.True(
+            printed.Split("object?", StringSplitOptions.None).Length >= 3,
+            printed);
+    }
+
     private static string TranslateUnit(string source)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1567CollectionInitializerObjectInitTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1567CollectionInitializerObjectInitTranslationTests.cs
@@ -30,6 +30,7 @@ public class Issue1567CollectionInitializerObjectInitTranslationTests
     [Fact]
     public void GetOnlyCollectionProperty_EmitsBracedMemberInitializer()
     {
+        _ = System.Text.Json.JsonSerializerOptions.Default;
         string printed = TranslateUnit(@"
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1567CollectionInitializerObjectInitTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1567CollectionInitializerObjectInitTranslationTests.cs
@@ -3,11 +3,14 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Cs2Gs.CodeModel.Ast;
 using Cs2Gs.CodeModel.Printing;
 using Cs2Gs.CodeModel.RoundTrip;
 using Cs2Gs.Translator;
 using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
 using Xunit;
 
 namespace Cs2Gs.Tests;
@@ -30,7 +33,6 @@ public class Issue1567CollectionInitializerObjectInitTranslationTests
     [Fact]
     public void GetOnlyCollectionProperty_EmitsBracedMemberInitializer()
     {
-        _ = System.Text.Json.JsonSerializerOptions.Default;
         string printed = TranslateUnit(@"
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -45,7 +47,9 @@ namespace Demo
             Converters = { new JsonStringEnumConverter() },
         };
     }
-}");
+}",
+            MetadataReference.CreateFromFile(
+                typeof(System.Text.Json.JsonSerializerOptions).Assembly.Location));
 
         // Braced member form, not an array-literal assignment.
         Assert.Contains("Converters: {", printed);
@@ -108,9 +112,20 @@ namespace Demo
         Assert.Contains("\"b\"", printed);
     }
 
-    private static string TranslateUnit(string source)
+    private static string TranslateUnit(
+        string source,
+        params MetadataReference[] additionalReferences)
     {
-        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        IReadOnlyList<MetadataReference> references = additionalReferences.Length == 0
+            ? null
+            : CSharpProjectLoader.RuntimeReferences()
+                .Concat(additionalReferences)
+                .GroupBy(reference => reference.Display, StringComparer.Ordinal)
+                .Select(group => group.First())
+                .ToList();
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Snippet.cs", source) },
+            references);
         Assert.True(
             project.BoundWithoutErrors,
             "Snippet should bind with no C# errors: " +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2211FullyQualifiedNoUsingImportSynthesisTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2211FullyQualifiedNoUsingImportSynthesisTests.cs
@@ -148,6 +148,36 @@ namespace Demo
     }
 
     [Fact]
+    public void NestedSourceHomonym_DoesNotQualifyImportedTopLevelGeneric()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class Container
+    {
+        public class List { }
+    }
+
+    public class C
+    {
+        public int Count()
+        {
+            var values = new System.Collections.Generic.List<int> { 1 };
+            values.Add(2);
+            return values.Count;
+        }
+    }
+}");
+
+        Assert.Contains("import System.Collections.Generic", printed);
+        Assert.Contains(
+            "import __cs2gs_System_Collections_Generic_List = System.Collections.Generic.List",
+            printed);
+        Assert.Contains("let values = __cs2gs_System_Collections_Generic_List[int32]", printed);
+        Assert.DoesNotContain("let values = System.Collections.Generic.List", printed);
+    }
+
+    [Fact]
     public void NamespaceAlreadyCoveredByUsing_NoDuplicateImportSynthesized()
     {
         // Control: when a `using` already exists for the shortened

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3394BoxingCastTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3394BoxingCastTranslationTests.cs
@@ -41,7 +41,7 @@ namespace Demo
     }
 
     [Fact]
-    public void TypeParameterPatternBinding_UsesExplicitNarrowingCast()
+    public void TypeParameterPatternBinding_UsesScopedIfLet()
     {
         const string source = @"
 using System.Reflection;
@@ -65,7 +65,7 @@ namespace Demo
 
         string rendered = Translate(source);
 
-        Assert.Contains("(value as MethodInfo)!!", rendered, StringComparison.Ordinal);
+        Assert.Contains("if let method = value as MethodInfo", rendered, StringComparison.Ordinal);
         TranslationTestValidation.AssertBinds(rendered);
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3394NegatedPatternGuardTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3394NegatedPatternGuardTranslationTests.cs
@@ -235,4 +235,132 @@ namespace Demo
         Assert.Contains("return present", rendered, StringComparison.Ordinal);
         TranslationTestValidation.AssertBinds(rendered);
     }
+
+    [Fact]
+    public void BoxedValueNegatedPattern_HoistsSurvivingBinder()
+    {
+        const string source = @"
+namespace Demo
+{
+    public static class C
+    {
+        public static bool Read(object value)
+        {
+            if (value is not bool present)
+            {
+                return false;
+            }
+
+            return present;
+        }
+    }
+}
+";
+
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Snippet.cs", source) });
+        Assert.True(project.BoundWithoutErrors, string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(
+            project.Compilation,
+            document.SemanticModel,
+            document.FilePath);
+        string rendered = GSharpPrinter.Print(
+            new CSharpToGSharpTranslator().TranslateDocument(document, context));
+
+        Assert.Contains("let present bool? = value as bool?", rendered, StringComparison.Ordinal);
+        Assert.Contains("return present", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+
+    [Fact]
+    public void NestedPropertyPatternBinder_HoistsAcrossExitingGuard()
+    {
+        const string source = @"
+namespace Demo
+{
+    public class Base { }
+    public sealed class Candidate : Base { public int Value; }
+    public sealed class Holder
+    {
+        public Base Child;
+    }
+
+    public static class C
+    {
+        public static int Read(Holder value)
+        {
+            if (value is not Holder { Child: Candidate candidate })
+            {
+                return 0;
+            }
+
+            return candidate.Value;
+        }
+    }
+}
+";
+
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Snippet.cs", source) });
+        Assert.True(project.BoundWithoutErrors, string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(
+            project.Compilation,
+            document.SemanticModel,
+            document.FilePath);
+        string rendered = GSharpPrinter.Print(
+            new CSharpToGSharpTranslator().TranslateDocument(document, context));
+
+        Assert.Contains("var candidate Candidate?", rendered, StringComparison.Ordinal);
+        Assert.Contains("return candidate!!.Value", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+
+    [Fact]
+    public void PriorOrGuard_WithElse_KeepsPatternBinderInElseScope()
+    {
+        const string source = @"
+namespace Demo
+{
+    public class Base { }
+    public sealed class Candidate : Base { public int Value; }
+
+    public static class C
+    {
+        private static Base Get(Base value) => value;
+
+        public static int Read(bool skip, Base value)
+        {
+            if (skip || !(Get(value) is Candidate candidate))
+            {
+                return 0;
+            }
+            else
+            {
+                return candidate.Value;
+            }
+        }
+    }
+}
+";
+
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Snippet.cs", source) });
+        Assert.True(project.BoundWithoutErrors, string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(
+            project.Compilation,
+            document.SemanticModel,
+            document.FilePath);
+        string rendered = GSharpPrinter.Print(
+            new CSharpToGSharpTranslator().TranslateDocument(document, context));
+
+        Assert.Contains("let candidate Candidate?", rendered, StringComparison.Ordinal);
+        Assert.Contains("return candidate.Value", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
 }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3394NestedGenericTypeTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3394NestedGenericTypeTranslationTests.cs
@@ -22,6 +22,41 @@ namespace Cs2Gs.Tests;
 public class Issue3394NestedGenericTypeTranslationTests
 {
     [Fact]
+    public void ImmutableArrayBuilder_PreservesContainingElementType()
+    {
+        const string source = """
+            using System.Collections.Immutable;
+
+            namespace Demo
+            {
+                public class Item { }
+
+                public static class C
+                {
+                    public static int Count(ImmutableArray<Item>.Builder builder) =>
+                        builder.Count;
+                }
+            }
+            """;
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Snippet.cs", source) });
+        Assert.True(project.BoundWithoutErrors, string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(
+            project.Compilation,
+            document.SemanticModel,
+            document.FilePath);
+        string rendered = GSharpPrinter.Print(
+            new CSharpToGSharpTranslator().TranslateDocument(document, context));
+
+        Assert.Contains(
+            "builder ImmutableArray[Item].Builder",
+            rendered,
+            StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+
+    [Fact]
     public void ImmutableArrayBuilder_RetainsContainingElementType()
     {
         const string source = @"
@@ -49,6 +84,35 @@ namespace Demo
         string rendered = GSharpPrinter.Print(unit);
 
         Assert.Contains("ImmutableArray[int32].Builder?", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+
+    [Fact]
+    public void PositionalRecordProperty_RedeclarationDoesNotDuplicateMember()
+    {
+        const string source = @"
+namespace Demo
+{
+    public readonly record struct Key(string Name)
+    {
+        public string Name { get; } = Name ?? string.Empty;
+    }
+}
+";
+
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Snippet.cs", source) });
+        Assert.True(project.BoundWithoutErrors, string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(
+            project.Compilation,
+            document.SemanticModel,
+            document.FilePath);
+        string rendered = GSharpPrinter.Print(
+            new CSharpToGSharpTranslator().TranslateDocument(document, context));
+
+        Assert.Equal(1, rendered.Split("Name string", StringSplitOptions.None).Length - 1);
         TranslationTestValidation.AssertBinds(rendered);
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3402ShortCircuitPatternBinderTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3402ShortCircuitPatternBinderTranslationTests.cs
@@ -1,0 +1,161 @@
+// <copyright file="Issue3402ShortCircuitPatternBinderTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3402: a pattern binder at the start of an && chain remains visible
+/// through later conjuncts and the true body.
+/// </summary>
+public class Issue3402ShortCircuitPatternBinderTranslationTests
+{
+    [Fact]
+    public void PatternBinder_WithLaterOutVar_RemainsInScope()
+    {
+        const string source = """
+            namespace Demo
+            {
+                public class Base { }
+                public sealed class Candidate : Base
+                {
+                    public int Value;
+                }
+
+                public static class C
+                {
+                    private static Base Get(Base value) => value;
+
+                    private static bool TryRead(out int value)
+                    {
+                        value = 2;
+                        return true;
+                    }
+
+                    public static int Read(Base value)
+                    {
+                        if (Get(value) is Candidate candidate
+                            && candidate.Value > 0
+                            && TryRead(out var extra)
+                            && extra > 0)
+                        {
+                            return candidate.Value + extra;
+                        }
+
+                        return 0;
+                    }
+                }
+            }
+            """;
+
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Snippet.cs", source) });
+        Assert.True(project.BoundWithoutErrors, string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(
+            project.Compilation,
+            document.SemanticModel,
+            document.FilePath);
+        string rendered = GSharpPrinter.Print(
+            new CSharpToGSharpTranslator().TranslateDocument(document, context));
+
+        Assert.Contains("if let candidate = C.Get(value) as Candidate", rendered, StringComparison.Ordinal);
+        Assert.Contains("candidate.Value > 0 && C.TryRead(out var extra) && extra > 0", rendered, StringComparison.Ordinal);
+        Assert.Contains("return candidate.Value + extra", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("if if let", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+
+    [Fact]
+    public void PatternBinder_AfterOutVarPrefix_RemainsInScope()
+    {
+        const string source = """
+            namespace Demo
+            {
+                public class Base { }
+                public sealed class Candidate : Base
+                {
+                    public int Value;
+                }
+
+                public static class C
+                {
+                    private static bool TryGet(Base input, out Base value)
+                    {
+                        value = input;
+                        return true;
+                    }
+
+                    public static int Read(Base input)
+                    {
+                        if (TryGet(input, out var value)
+                            && value is Candidate candidate
+                            && candidate.Value > 0)
+                        {
+                            return candidate.Value;
+                        }
+
+                        return 0;
+                    }
+                }
+            }
+            """;
+
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Snippet.cs", source) });
+        Assert.True(project.BoundWithoutErrors, string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(
+            project.Compilation,
+            document.SemanticModel,
+            document.FilePath);
+        string rendered = GSharpPrinter.Print(
+            new CSharpToGSharpTranslator().TranslateDocument(document, context));
+
+        Assert.Contains("if C.TryGet(input, out var value)", rendered, StringComparison.Ordinal);
+        Assert.Contains("if let candidate = value as Candidate", rendered, StringComparison.Ordinal);
+        Assert.Contains("return candidate.Value", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+
+    [Fact]
+    public void InferredGenericEnumTryParse_RendersExplicitTypeArgument()
+    {
+        const string source = """
+            using System;
+
+            namespace Demo
+            {
+                public static class C
+                {
+                    public static bool Parse<T>(string text, out T result)
+                        where T : struct, Enum =>
+                        Enum.TryParse(text, false, out result);
+                }
+            }
+            """;
+
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Snippet.cs", source) });
+        Assert.True(project.BoundWithoutErrors, string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(
+            project.Compilation,
+            document.SemanticModel,
+            document.FilePath);
+        string rendered = GSharpPrinter.Print(
+            new CSharpToGSharpTranslator().TranslateDocument(document, context));
+
+        Assert.Contains("Enum.TryParse[T]", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/LocalFunctionHoistTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/LocalFunctionHoistTranslationTests.cs
@@ -196,13 +196,6 @@ namespace Demo
     [Fact]
     public void MutuallyRecursiveLocalFunctions_AreBothHoistedBeforeFirstExternalUse()
     {
-        // Issue #2231, case (d): `A` and `B` call each other and are both used
-        // (via `A`) before either's textual declaration. Both `let` bindings
-        // must land before the external use, in their original relative
-        // order. (Whether the mutual recursion itself binds in gsc is a
-        // pre-existing, separate `let`-recursion limitation — see
-        // Issue2231MutualRecursionRemainsUnsupportedByGscLetBindings below —
-        // this test only checks the hoist ordering.)
         string printed = TranslateUnit(@"
 namespace Demo
 {
@@ -226,21 +219,167 @@ namespace Demo
             }
         }
     }
-}",
-            "Mutually recursive local functions use non-recursive G# let bindings, as documented by the compiler-gap test below.");
+}");
 
-        int aDeclIndex = printed.IndexOf("let A", StringComparison.Ordinal);
-        int bDeclIndex = printed.IndexOf("let B", StringComparison.Ordinal);
-        int ifIndex = printed.IndexOf("if ", StringComparison.Ordinal);
-        Assert.True(ifIndex >= 0, "The external `if` call site should be present.\n" + printed);
-        int useIndex = printed.IndexOf("A()", ifIndex, StringComparison.Ordinal);
-        Assert.True(aDeclIndex >= 0 && bDeclIndex >= 0, "Both bindings should be present.\n" + printed);
-        Assert.True(
-            aDeclIndex < useIndex && bDeclIndex < useIndex,
-            "Both mutually-recursive local functions must be hoisted above the first external use.\n" + printed);
-        Assert.True(
-            aDeclIndex < bDeclIndex,
-            "Original relative declaration order (A before B) must be preserved.\n" + printed);
+    Assert.DoesNotContain("let A", printed, StringComparison.Ordinal);
+    Assert.DoesNotContain("let B", printed, StringComparison.Ordinal);
+    Assert.Contains("__local_M_A_", printed, StringComparison.Ordinal);
+    Assert.Contains("__local_M_B_", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CapturingRecursiveLocalFunction_LiftsMutableCaptureByRef()
+    {
+    string printed = TranslateUnit(@"
+using System;
+namespace Demo
+{
+    public class C
+    {
+    public void Run(int input)
+    {
+        int sum = 0;
+
+        void Add(int current)
+        {
+            sum += current;
+            if (current > 0)
+            {
+                Add(current - 1);
+            }
+        }
+
+        Add(input);
+        if (sum != 6)
+        {
+            throw new Exception(""wrong sum"");
+        }
+    }
+    }
+}");
+
+    Assert.DoesNotContain("let Add", printed, StringComparison.Ordinal);
+    Assert.Contains("ref sum int32", printed, StringComparison.Ordinal);
+    Assert.Contains("__local_Run_Add_", printed, StringComparison.Ordinal);
+    CompileAndRun(printed, "C().Run(3)");
+    }
+
+    [Fact]
+    public void MutuallyRecursiveLocalFunctions_ForwardSharedMutableCapture()
+    {
+    string printed = TranslateUnit(@"
+using System;
+namespace Demo
+{
+    public class C
+    {
+    public void Run(int input)
+    {
+        int sum = 0;
+
+        void AddEven(int current)
+        {
+            sum += current;
+            if (current > 0)
+            {
+                AddOdd(current - 1);
+            }
+        }
+
+        void AddOdd(int current)
+        {
+            sum += current;
+            if (current > 0)
+            {
+                AddEven(current - 1);
+            }
+        }
+
+        AddEven(input);
+        if (sum != 6)
+        {
+            throw new Exception(""wrong sum"");
+        }
+    }
+    }
+}");
+
+    Assert.DoesNotContain("let AddEven", printed, StringComparison.Ordinal);
+    Assert.DoesNotContain("let AddOdd", printed, StringComparison.Ordinal);
+    Assert.Contains("__local_Run_AddEven_", printed, StringComparison.Ordinal);
+    Assert.Contains("__local_Run_AddOdd_", printed, StringComparison.Ordinal);
+    CompileAndRun(printed, "C().Run(3)");
+    }
+
+    [Fact]
+    public void CapturingLocalFunction_WithOutParameters_LiftsToMethod()
+    {
+    string printed = TranslateUnit(@"
+using System;
+namespace Demo
+{
+    public class C
+    {
+    public void Run(int input)
+    {
+        int offset = 2;
+
+        int Read(out int doubled)
+        {
+            doubled = input * 2;
+            return doubled + offset;
+        }
+
+        int result = Read(out var doubled);
+        if (result != 8 || doubled != 6)
+        {
+            throw new Exception(""wrong result"");
+        }
+    }
+    }
+}");
+
+    Assert.DoesNotContain("let Read", printed, StringComparison.Ordinal);
+    Assert.Contains("__local_Run_Read_", printed, StringComparison.Ordinal);
+    Assert.Contains("out doubled int32", printed, StringComparison.Ordinal);
+    CompileAndRun(printed, "C().Run(3)");
+    }
+
+    [Fact]
+    public void RecursiveHelper_CaptureKeepsNonNullableReferenceType()
+    {
+    string printed = TranslateUnit(@"
+using System;
+using System.Collections.Generic;
+namespace Demo
+{
+    public class C
+    {
+    public void Run(int input)
+    {
+        var values = new List<int>();
+
+        void Add(int current)
+        {
+            values.Add(current);
+            if (current > 0)
+            {
+                Add(current - 1);
+            }
+        }
+
+        Add(input);
+        if (values[0] != input)
+        {
+            throw new Exception(""wrong value"");
+        }
+    }
+    }
+}");
+
+    Assert.Contains("values List[int32]", printed, StringComparison.Ordinal);
+    Assert.DoesNotContain("values List[int32]?", printed, StringComparison.Ordinal);
+    CompileAndRun(printed, "C().Run(3)");
     }
 
     [Fact]
@@ -275,11 +414,8 @@ namespace Demo
     [Fact]
     public void Issue2231MutualRecursionRemainsUnsupportedByGscLetBindings()
     {
-        // Documents a pre-existing, separate gsc limitation (not addressed by
-        // this fix, per the issue's own scoping guidance): `let` bindings are
-        // not letrec — a lambda cannot forward-reference a `let` name bound
-        // later in the same block, so two mutually-recursive `let`-lambdas
-        // can never both bind successfully, regardless of hoist order.
+        // Raw G# `let` bindings remain non-recursive. cs2gs avoids this form for
+        // recursive C# local functions by lifting them to helper methods.
         const string Source = @"
 package p
 class C {

--- a/tools/cs2gs/Cs2Gs.Tests/LocalFunctionHoistTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/LocalFunctionHoistTranslationTests.cs
@@ -3,12 +3,11 @@
 // </copyright>
 
 using System;
-using System.Diagnostics;
 using System.IO;
-using System.Text;
 using Cs2Gs.CodeModel.Ast;
 using Cs2Gs.CodeModel.Printing;
 using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Pipeline;
 using Cs2Gs.Translator;
 using Cs2Gs.Translator.Loading;
 using Xunit;
@@ -31,6 +30,8 @@ public class LocalFunctionHoistTranslationTests
     public void LocalFunctionCalledBeforeDeclaration_IsHoistedToTop()
     {
         string printed = TranslateUnit(@"
+using System;
+
 namespace Demo
 {
     public class C
@@ -106,13 +107,15 @@ namespace Demo
             declIndex < useIndex,
             "Local function must still be hoisted above its first use.\n" + printed);
 
-        CompileAndRun(printed, "C().M()");
+        CompileAndRun(printed, "Console.WriteLine(C().M())", "6");
     }
 
     [Fact]
     public void ExpressionBodiedLocalFunction_ReturnsConditionalValue()
     {
         string printed = TranslateUnit(@"
+using System;
+
 namespace Demo
 {
     public class C
@@ -126,7 +129,7 @@ namespace Demo
 }");
 
         Assert.Contains("return if first", printed, StringComparison.Ordinal);
-        CompileAndRun(printed, "C().M(true)");
+        CompileAndRun(printed, "Console.WriteLine(C().M(true))", "first");
     }
 
     [Fact]
@@ -158,7 +161,10 @@ namespace Demo
             declIndex < actionIndex,
             "`let handler` must be hoisted above `let action = handler`.\n" + printed);
 
-        CompileAndRun(printed, "C().M()");
+        CompileAndRun(
+            printed,
+            "C().M()\nConsole.WriteLine(\"ok\")",
+            "ok");
     }
 
     [Fact]
@@ -261,7 +267,10 @@ namespace Demo
     Assert.DoesNotContain("let Add", printed, StringComparison.Ordinal);
     Assert.Contains("ref sum int32", printed, StringComparison.Ordinal);
     Assert.Contains("__local_Run_Add_", printed, StringComparison.Ordinal);
-    CompileAndRun(printed, "C().Run(3)");
+    CompileAndRun(
+        printed,
+        "C().Run(3)\nConsole.WriteLine(\"ok\")",
+        "ok");
     }
 
     [Fact]
@@ -308,7 +317,10 @@ namespace Demo
     Assert.DoesNotContain("let AddOdd", printed, StringComparison.Ordinal);
     Assert.Contains("__local_Run_AddEven_", printed, StringComparison.Ordinal);
     Assert.Contains("__local_Run_AddOdd_", printed, StringComparison.Ordinal);
-    CompileAndRun(printed, "C().Run(3)");
+    CompileAndRun(
+        printed,
+        "C().Run(3)\nConsole.WriteLine(\"ok\")",
+        "ok");
     }
 
     [Fact]
@@ -342,7 +354,10 @@ namespace Demo
     Assert.DoesNotContain("let Read", printed, StringComparison.Ordinal);
     Assert.Contains("__local_Run_Read_", printed, StringComparison.Ordinal);
     Assert.Contains("out doubled int32", printed, StringComparison.Ordinal);
-    CompileAndRun(printed, "C().Run(3)");
+    CompileAndRun(
+        printed,
+        "C().Run(3)\nConsole.WriteLine(\"ok\")",
+        "ok");
     }
 
     [Fact]
@@ -379,13 +394,18 @@ namespace Demo
 
     Assert.Contains("values List[int32]", printed, StringComparison.Ordinal);
     Assert.DoesNotContain("values List[int32]?", printed, StringComparison.Ordinal);
-    CompileAndRun(printed, "C().Run(3)");
+    CompileAndRun(
+        printed,
+        "C().Run(3)\nConsole.WriteLine(\"ok\")",
+        "ok");
     }
 
     [Fact]
     public void StaticRecursiveLocalFunction_IsLiftedToSharedHelper()
     {
         string printed = TranslateUnit(@"
+using System;
+
 namespace Demo
 {
     public class C
@@ -408,7 +428,10 @@ namespace Demo
         Assert.DoesNotContain("let IsBaseCase", printed, StringComparison.Ordinal);
         Assert.Contains("__local_Factorial_Visit_", printed, StringComparison.Ordinal);
         Assert.Contains("__local_Factorial_IsBaseCase_", printed, StringComparison.Ordinal);
-        CompileAndRun(printed, "C().Factorial(5)");
+        CompileAndRun(
+            printed,
+            "Console.WriteLine(C().Factorial(5))",
+            "120");
     }
 
     [Fact]
@@ -433,9 +456,16 @@ class C {
         string dllPath = Path.Combine(workDir, "Snippet.dll");
         File.WriteAllText(gsPath, Source);
 
-        (int exit, string output) = RunDotnet($"\"{compiler}\" /target:exe /out:\"{dllPath}\" \"{gsPath}\"");
-        Assert.True(exit != 0, "Forward-referencing `let` recursion is expected to still fail today:\n" + output);
-        Assert.Contains("GS0130", output, StringComparison.Ordinal);
+        ProcessRunResult compile = ProcessRunner.Run(
+            "dotnet",
+            new[] { compiler, "/target:exe", $"/out:{dllPath}", gsPath },
+            timeout: TimeSpan.FromSeconds(30));
+        Assert.False(compile.TimedOut, compile.Output);
+        Assert.True(
+            compile.ExitCode != 0,
+            "Forward-referencing `let` recursion is expected to still fail today:\n" +
+                compile.Output);
+        Assert.Contains("GS0130", compile.Output, StringComparison.Ordinal);
     }
 
     private static string TranslateUnit(string source, string roundTripOnlyReason = null)
@@ -468,7 +498,10 @@ class C {
     /// forward-reference bug is a binder-time error that a parse-only round-trip
     /// cannot catch).
     /// </summary>
-    private static void CompileAndRun(string printed, string callExpression)
+    private static void CompileAndRun(
+        string printed,
+        string callExpression,
+        string expectedOutput)
     {
         string compiler = FindCompiler();
         Assert.True(compiler != null, "gsc.dll must be built (dotnet build GSharp.sln) before running this test.");
@@ -479,32 +512,30 @@ class C {
         string dllPath = Path.Combine(workDir, "Snippet.dll");
         File.WriteAllText(gsPath, printed + Environment.NewLine + callExpression + Environment.NewLine);
 
-        (int compileExit, string compileOut) = RunDotnet(
-            $"\"{compiler}\" /target:exe /out:\"{dllPath}\" \"{gsPath}\"");
+        ProcessRunResult compile = ProcessRunner.Run(
+            "dotnet",
+            new[] { compiler, "/target:exe", $"/out:{dllPath}", gsPath },
+            timeout: TimeSpan.FromSeconds(30));
+        Assert.False(
+            compile.TimedOut,
+            $"gsc timed out and was killed. Output:\n{compile.Output}");
         Assert.True(
-            compileExit == 0 && !compileOut.Contains("error", StringComparison.OrdinalIgnoreCase),
-            "gsc must compile the translated snippet with zero errors. Output:\n" + compileOut +
+            compile.ExitCode == 0
+                && !compile.Output.Contains("error", StringComparison.OrdinalIgnoreCase),
+            "gsc must compile the translated snippet with zero errors. Output:\n" + compile.Output +
                 "\n\nTranslated G#:\n" + printed);
 
-        (int runExit, string runOut) = RunDotnet($"\"{dllPath}\"");
-        Assert.True(runExit == 0, "Translated snippet must run successfully. Output:\n" + runOut);
-    }
-
-    private static (int Exit, string Output) RunDotnet(string arguments)
-    {
-        var psi = new ProcessStartInfo("dotnet", arguments)
-        {
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-        };
-
-        using var process = Process.Start(psi);
-        var output = new StringBuilder();
-        output.Append(process.StandardOutput.ReadToEnd());
-        output.Append(process.StandardError.ReadToEnd());
-        process.WaitForExit();
-        return (process.ExitCode, output.ToString());
+        ProcessRunResult run = ProcessRunner.Run(
+            "dotnet",
+            new[] { dllPath },
+            timeout: TimeSpan.FromSeconds(30));
+        Assert.False(
+            run.TimedOut,
+            $"Translated program timed out and was killed. Output:\n{run.Output}");
+        Assert.True(
+            run.ExitCode == 0,
+            "Translated snippet must run successfully. Output:\n" + run.Output);
+        Assert.Equal(expectedOutput, run.Stdout.Trim());
     }
 
     private static string FindCompiler()

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
@@ -1485,7 +1485,7 @@ public sealed partial class CSharpToGSharpTranslator
         {
             var statements = new List<GStatement>();
             IReadOnlyList<StatementSyntax> ordered = this.HoistCallBeforeDeclLocalFunctions(block);
-            this.RegisterStaticLocalFunctionLifts(ordered);
+            this.RegisterRecursiveLocalFunctionLifts(ordered);
             foreach (StatementSyntax statement in ordered)
             {
                 statements.AddRange(this.TranslateStatement(statement));
@@ -1494,26 +1494,25 @@ public sealed partial class CSharpToGSharpTranslator
             return new BlockStatement(statements);
         }
 
-        private void RegisterStaticLocalFunctionLifts(IEnumerable<StatementSyntax> statements)
+        private void RegisterRecursiveLocalFunctionLifts(IEnumerable<StatementSyntax> statements)
         {
-            var staticLocals = new List<(LocalFunctionStatementSyntax Syntax, IMethodSymbol Symbol)>();
+            var localFunctions = new List<(LocalFunctionStatementSyntax Syntax, IMethodSymbol Symbol)>();
             foreach (LocalFunctionStatementSyntax localFunction in statements
-                .OfType<LocalFunctionStatementSyntax>()
-                .Where(candidate => candidate.Modifiers.Any(SyntaxKind.StaticKeyword)))
+                .OfType<LocalFunctionStatementSyntax>())
             {
                 using IDisposable modelScope = this.context.UseSemanticModelFor(localFunction.SyntaxTree);
                 if (this.context.GetDeclaredSymbol(localFunction) is IMethodSymbol symbol)
                 {
-                    staticLocals.Add((localFunction, symbol));
+                    localFunctions.Add((localFunction, symbol));
                 }
             }
 
             var symbols = new HashSet<IMethodSymbol>(
-                staticLocals.Select(pair => pair.Symbol),
+                localFunctions.Select(pair => pair.Symbol),
                 SymbolEqualityComparer.Default);
             var edges = new Dictionary<IMethodSymbol, HashSet<IMethodSymbol>>(
                 SymbolEqualityComparer.Default);
-            foreach (var pair in staticLocals)
+            foreach (var pair in localFunctions)
             {
                 using IDisposable modelScope = this.context.UseSemanticModelFor(pair.Syntax.SyntaxTree);
                 var dependencies = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
@@ -1554,12 +1553,22 @@ public sealed partial class CSharpToGSharpTranslator
             }
 
             var toLift = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
-            foreach (var pair in staticLocals)
+            foreach (var pair in localFunctions)
             {
-                if (IsRecursive(
-                    pair.Symbol,
-                    pair.Symbol,
-                    new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default)))
+                bool usedAsMethodGroup = statements
+                    .SelectMany(statement => statement.DescendantNodes().OfType<IdentifierNameSyntax>())
+                    .Any(identifier =>
+                        SymbolEqualityComparer.Default.Equals(
+                            this.context.GetSymbolInfo(identifier).Symbol,
+                            pair.Symbol)
+                        && (identifier.Parent is not InvocationExpressionSyntax invocation
+                            || !ReferenceEquals(invocation.Expression, identifier)));
+                if ((!usedAsMethodGroup
+                        && pair.Symbol.Parameters.Any(parameter => parameter.RefKind != RefKind.None))
+                    || IsRecursive(
+                        pair.Symbol,
+                        pair.Symbol,
+                        new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default)))
                 {
                     toLift.Add(pair.Symbol);
                 }
@@ -1583,7 +1592,7 @@ public sealed partial class CSharpToGSharpTranslator
                 }
             }
 
-            foreach (var pair in staticLocals)
+            foreach (var pair in localFunctions.Where(pair => pair.Symbol.IsStatic))
             {
                 if (this.state.LiftedStaticLocalFunctions.ContainsKey(pair.Symbol)
                     || !toLift.Contains(pair.Symbol))
@@ -1595,6 +1604,113 @@ public sealed partial class CSharpToGSharpTranslator
                 string localName = SanitizeIdentifier(pair.Syntax.Identifier.Text);
                 this.state.LiftedStaticLocalFunctions[pair.Symbol] =
                     $"__local_{ownerName}_{localName}_{pair.Syntax.SpanStart}";
+            }
+
+            var capturingLocals = localFunctions
+                .Where(pair => !pair.Symbol.IsStatic && toLift.Contains(pair.Symbol))
+                .ToList();
+            if (capturingLocals.Count == 0)
+            {
+                return;
+            }
+
+            var directCaptures = new Dictionary<IMethodSymbol, HashSet<ISymbol>>(
+                SymbolEqualityComparer.Default);
+            foreach (var pair in capturingLocals)
+            {
+                var captures = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+                foreach (IdentifierNameSyntax identifier in pair.Syntax.DescendantNodes().OfType<IdentifierNameSyntax>())
+                {
+                    ISymbol symbol = this.context.GetSymbolInfo(identifier).Symbol;
+                    if (symbol is not ILocalSymbol and not IParameterSymbol)
+                    {
+                        continue;
+                    }
+
+                    bool lexicalOwner = false;
+                    for (ISymbol owner = pair.Symbol.ContainingSymbol;
+                        owner is IMethodSymbol;
+                        owner = owner.ContainingSymbol)
+                    {
+                        if (SymbolEqualityComparer.Default.Equals(symbol.ContainingSymbol, owner))
+                        {
+                            lexicalOwner = true;
+                            break;
+                        }
+                    }
+
+                    if (!lexicalOwner)
+                    {
+                        continue;
+                    }
+
+                    bool declaredInside = symbol.DeclaringSyntaxReferences.Any(reference =>
+                        pair.Syntax.Span.Contains(reference.Span));
+                    if (!declaredInside)
+                    {
+                        captures.Add(symbol);
+                    }
+                }
+
+                directCaptures[pair.Symbol] = captures;
+            }
+
+            bool changed;
+            do
+            {
+                changed = false;
+                foreach (var pair in capturingLocals)
+                {
+                    if (!edges.TryGetValue(pair.Symbol, out HashSet<IMethodSymbol> dependencies))
+                    {
+                        continue;
+                    }
+
+                    foreach (IMethodSymbol dependency in dependencies)
+                    {
+                        if (!directCaptures.TryGetValue(dependency, out HashSet<ISymbol> dependencyCaptures))
+                        {
+                            continue;
+                        }
+
+                        foreach (ISymbol capture in dependencyCaptures)
+                        {
+                            changed |= directCaptures[pair.Symbol].Add(capture);
+                        }
+                    }
+                }
+            }
+            while (changed);
+
+            foreach (var pair in capturingLocals)
+            {
+                if (this.state.LiftedRecursiveLocalFunctions.ContainsKey(pair.Symbol))
+                {
+                    continue;
+                }
+
+                var captures = directCaptures[pair.Symbol]
+                    .OrderBy(symbol => symbol.Locations.FirstOrDefault()?.SourceSpan.Start ?? int.MaxValue)
+                    .ThenBy(symbol => symbol.Name, StringComparer.Ordinal)
+                    .Select(symbol => new LiftedLocalFunctionCapture(
+                        symbol,
+                        capturingLocals.Any(candidate =>
+                            directCaptures[candidate.Symbol].Contains(symbol)
+                            && this.IsSymbolReassigned(symbol, candidate.Syntax))))
+                    .ToList();
+                IMethodSymbol containingMethod = pair.Symbol.ContainingSymbol as IMethodSymbol;
+                while (containingMethod?.MethodKind == MethodKind.LocalFunction)
+                {
+                    containingMethod = containingMethod.ContainingSymbol as IMethodSymbol;
+                }
+
+                string ownerName = SanitizeIdentifier(pair.Symbol.ContainingSymbol?.Name ?? "scope");
+                string localName = SanitizeIdentifier(pair.Syntax.Identifier.Text);
+                this.state.LiftedRecursiveLocalFunctions[pair.Symbol] =
+                    new LiftedRecursiveLocalFunction(
+                        $"__local_{ownerName}_{localName}_{pair.Syntax.SpanStart}",
+                        containingMethod?.IsStatic != false,
+                        captures);
             }
         }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.ControlFlow.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.ControlFlow.cs
@@ -568,9 +568,18 @@ public sealed partial class CSharpToGSharpTranslator
         {
             result = null;
 
-            if (ifStatement.Condition is not IsPatternExpressionSyntax isPattern ||
+            DecomposeConjunction(
+                ifStatement.Condition,
+                out ExpressionSyntax leftmost,
+                out List<ExpressionSyntax> guards);
+            if (leftmost is not IsPatternExpressionSyntax isPattern ||
                 !TryExtractSingleVarTypePattern(
                     isPattern.Pattern, out TypeSyntax typeSyntax, out SingleVariableDesignationSyntax single))
+            {
+                return false;
+            }
+
+            if (guards.Any(guard => ContainsSpillHoistingConstruct(guard, includeOutVarDeclarations: false)))
             {
                 return false;
             }
@@ -592,7 +601,7 @@ public sealed partial class CSharpToGSharpTranslator
 
             if (targetSymbol.IsValueType)
             {
-                result = this.BuildPositiveValueGuardHoist(ifStatement, localName, targetType, receiver);
+                result = this.BuildPositiveValueGuardHoist(ifStatement, guards, localName, targetType, receiver);
                 return true;
             }
 
@@ -621,6 +630,11 @@ public sealed partial class CSharpToGSharpTranslator
             GExpression guard = targetSymbol.IsValueType
                 ? new BinaryExpression(local, "is", new TypeExpression(targetType))
                 : new BinaryExpression(local, "!=", LiteralExpression.Null());
+            foreach (ExpressionSyntax conjunct in guards)
+            {
+                guard = new BinaryExpression(guard, "&&", this.TranslateExpression(conjunct));
+            }
+
             BlockStatement then = this.TranslateStatementAsBlock(ifStatement.Statement);
 
             GStatement elseBranch = null;
@@ -651,6 +665,7 @@ public sealed partial class CSharpToGSharpTranslator
 
         private IReadOnlyList<GStatement> BuildPositiveValueGuardHoist(
             IfStatementSyntax ifStatement,
+            IReadOnlyList<ExpressionSyntax> guards,
             string localName,
             GTypeReference targetType,
             GExpression receiver)
@@ -695,11 +710,28 @@ public sealed partial class CSharpToGSharpTranslator
             {
                 new AssignmentStatement(new IdentifierExpression(localName), narrowed),
             };
-            thenStatements.AddRange(this.TranslateStatementAsBlock(ifStatement.Statement).Statements);
 
             GStatement elseBranch = ifStatement.Else == null
                 ? null
                 : this.TranslateElseStatement(ifStatement.Else.Statement);
+            BlockStatement body = this.TranslateStatementAsBlock(ifStatement.Statement);
+            if (guards.Count == 0)
+            {
+                thenStatements.AddRange(body.Statements);
+            }
+            else
+            {
+                GExpression guardExpression = null;
+                foreach (ExpressionSyntax guardClause in guards)
+                {
+                    GExpression translated = this.TranslateExpression(guardClause);
+                    guardExpression = guardExpression == null
+                        ? translated
+                        : new BinaryExpression(guardExpression, "&&", translated);
+                }
+
+                thenStatements.Add(new IfStatement(guardExpression, body, elseBranch));
+            }
 
             var statements = new List<GStatement>();
             if (hoist != null)
@@ -708,7 +740,10 @@ public sealed partial class CSharpToGSharpTranslator
             }
 
             statements.Add(binder);
-            statements.Add(new IfStatement(guard, new BlockStatement(thenStatements), elseBranch));
+            statements.Add(new IfStatement(
+                guard,
+                new BlockStatement(thenStatements),
+                guards.Count == 0 ? elseBranch : null));
             return statements;
         }
 
@@ -791,6 +826,11 @@ public sealed partial class CSharpToGSharpTranslator
 
             var terms = new List<ExpressionSyntax>();
             CollectLogicalOrTerms(ifStatement.Condition, terms);
+            if (this.TryBuildNestedNegatedGuardHoist(ifStatement, terms, out result))
+            {
+                return true;
+            }
+
             int negatedPatternCount = terms.Count(term =>
                 TryExtractNegatedGuardPattern(term, out _, out _, out _, out _));
             if (negatedPatternCount > 1)
@@ -833,7 +873,8 @@ public sealed partial class CSharpToGSharpTranslator
             }
 
             if (patternIndex > 0
-                && (ifStatement.Else != null || !StatementAlwaysExits(ifStatement.Statement)))
+                && ifStatement.Else == null
+                && !StatementAlwaysExits(ifStatement.Statement))
             {
                 return false;
             }
@@ -862,15 +903,20 @@ public sealed partial class CSharpToGSharpTranslator
                 targetType = this.MapTypeSyntax(typeSyntax);
                 if (targetSymbol.IsValueType)
                 {
-                    if (this.context.GetTypeInfo(isPattern.Expression).Type is not INamedTypeSymbol receiverType
-                        || receiverType.OriginalDefinition.SpecialType != SpecialType.System_Nullable_T
-                        || receiverType.TypeArguments.Length != 1
-                        || !SymbolEqualityComparer.Default.Equals(receiverType.TypeArguments[0], targetSymbol))
+                    if (this.context.GetTypeInfo(isPattern.Expression).Type is INamedTypeSymbol receiverType
+                        && receiverType.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T
+                        && receiverType.TypeArguments.Length == 1
+                        && SymbolEqualityComparer.Default.Equals(receiverType.TypeArguments[0], targetSymbol))
                     {
-                        return false;
+                        hoistInitializer = receiver;
                     }
-
-                    hoistInitializer = receiver;
+                    else
+                    {
+                        hoistInitializer = new BinaryExpression(
+                            receiver,
+                            "as",
+                            new TypeExpression(MakeNullable(targetType)));
+                    }
                 }
                 else
                 {
@@ -956,11 +1002,163 @@ public sealed partial class CSharpToGSharpTranslator
                         : new BinaryExpression(prefixGuard, "||", translated);
                 }
 
+                if (elseBranch != null)
+                {
+                    result = new GStatement[]
+                    {
+                        new IfStatement(
+                            prefixGuard,
+                            then,
+                            new BlockStatement(
+                                new GStatement[]
+                                {
+                                    hoist,
+                                    new IfStatement(guard, then, elseBranch),
+                                })),
+                    };
+                    return true;
+                }
+
                 statements.Add(new IfStatement(prefixGuard, then));
             }
 
             statements.Add(hoist);
             statements.Add(new IfStatement(guard, then, elseBranch));
+            result = statements;
+            return true;
+        }
+
+        private bool TryBuildNestedNegatedGuardHoist(
+            IfStatementSyntax ifStatement,
+            IReadOnlyList<ExpressionSyntax> terms,
+            out IReadOnlyList<GStatement> result)
+        {
+            result = null;
+            if (ifStatement.Else != null || !StatementAlwaysExits(ifStatement.Statement))
+            {
+                return false;
+            }
+
+            IsPatternExpressionSyntax isPattern = null;
+            PatternSyntax positivePattern = null;
+            SingleVariableDesignationSyntax designation = null;
+            int patternIndex = -1;
+            for (var i = 0; i < terms.Count; i++)
+            {
+                if (!TryGetNegatedPattern(
+                        terms[i],
+                        out IsPatternExpressionSyntax candidatePattern,
+                        out PatternSyntax candidatePositive))
+                {
+                    continue;
+                }
+
+                var designations = candidatePositive.DescendantNodesAndSelf()
+                    .OfType<SingleVariableDesignationSyntax>()
+                    .ToList();
+                if (designations.Count != 1
+                    || candidatePositive is DeclarationPatternSyntax
+                    || candidatePositive is RecursivePatternSyntax
+                    {
+                        Designation: SingleVariableDesignationSyntax,
+                    })
+                {
+                    continue;
+                }
+
+                if (patternIndex >= 0)
+                {
+                    return false;
+                }
+
+                patternIndex = i;
+                isPattern = candidatePattern;
+                positivePattern = candidatePositive;
+                designation = designations[0];
+            }
+
+            if (patternIndex < 0
+                || this.context.GetDeclaredSymbol(designation) is not ILocalSymbol binder
+                || terms.Where((_, index) => index != patternIndex)
+                    .Any(term => term.DescendantNodesAndSelf()
+                        .OfType<IsPatternExpressionSyntax>()
+                        .Any(pattern => PatternIntroducesBinding(pattern.Pattern))))
+            {
+                return false;
+            }
+
+            BlockStatement then = this.TranslateStatementAsBlock(ifStatement.Statement);
+            var statements = new List<GStatement>();
+            for (var i = 0; i < patternIndex; i++)
+            {
+                statements.Add(new IfStatement(this.TranslateExpression(terms[i]), then));
+            }
+
+            GExpression receiver = this.TranslateExpression(isPattern.Expression);
+            if (!IsTrivialOperand(receiver))
+            {
+                string spillName = $"__spill{this.state.SpillCounter++}";
+                statements.Add(new LocalDeclarationStatement(
+                    BindingKind.Let,
+                    spillName,
+                    initializer: receiver));
+                receiver = new IdentifierExpression(spillName);
+            }
+
+            bool hadPrevious = this.state.PatternBindings.TryGetValue(
+                binder,
+                out GExpression previous);
+            GExpression positiveTest;
+            GExpression replacement;
+            try
+            {
+                positiveTest = this.TranslatePatternTest(
+                    receiver,
+                    positivePattern,
+                    this.context.GetTypeInfo(isPattern.Expression).Type,
+                    isPattern.Expression);
+                this.state.PatternBindings.TryGetValue(binder, out replacement);
+            }
+            finally
+            {
+                if (hadPrevious)
+                {
+                    this.state.PatternBindings[binder] = previous;
+                }
+                else
+                {
+                    this.state.PatternBindings.Remove(binder);
+                }
+            }
+
+            if (replacement == null)
+            {
+                return false;
+            }
+
+            string localName = SanitizeIdentifier(designation.Identifier.Text);
+            GTypeReference localType = MakeNullable(
+                this.typeMapper.Map(
+                    binder.Type,
+                    this.context,
+                    designation.GetLocation()));
+            statements.Add(new LocalDeclarationStatement(
+                BindingKind.Var,
+                localName,
+                localType));
+            statements.Add(new IfStatement(Negate(positiveTest), then));
+            statements.Add(new AssignmentStatement(
+                new IdentifierExpression(localName),
+                replacement));
+
+            var narrowed = new NonNullAssertionExpression(
+                new IdentifierExpression(localName));
+            this.state.PatternBindings[binder] = narrowed;
+            for (var i = patternIndex + 1; i < terms.Count; i++)
+            {
+                statements.Add(new IfStatement(this.TranslateExpression(terms[i]), then));
+            }
+
             result = statements;
             return true;
         }
@@ -1100,26 +1298,12 @@ public sealed partial class CSharpToGSharpTranslator
             out VariableDesignationSyntax designation,
             out RecursivePatternSyntax residualPattern)
         {
-            condition = Unparenthesize(condition);
-            PatternSyntax negatedPattern;
-            if (condition is IsPatternExpressionSyntax directPattern
-                && directPattern.Pattern is UnaryPatternSyntax notPattern
-                && notPattern.IsKind(SyntaxKind.NotPattern))
+            if (!TryGetNegatedPattern(condition, out isPattern, out PatternSyntax negatedPattern))
             {
-                isPattern = directPattern;
-                negatedPattern = notPattern.Pattern;
-            }
-            else if (condition is PrefixUnaryExpressionSyntax logicalNot
-                && logicalNot.IsKind(SyntaxKind.LogicalNotExpression)
-                && Unparenthesize(logicalNot.Operand) is IsPatternExpressionSyntax parenthesizedPattern)
-            {
-                isPattern = parenthesizedPattern;
-                negatedPattern = parenthesizedPattern.Pattern;
-            }
-            else
-            {
-                isPattern = null;
-                negatedPattern = null;
+                typeSyntax = null;
+                designation = null;
+                residualPattern = null;
+                return false;
             }
 
             typeSyntax = null;
@@ -1161,6 +1345,35 @@ public sealed partial class CSharpToGSharpTranslator
                 default:
                     return false;
             }
+        }
+
+        private static bool TryGetNegatedPattern(
+            ExpressionSyntax condition,
+            out IsPatternExpressionSyntax isPattern,
+            out PatternSyntax positivePattern)
+        {
+            condition = Unparenthesize(condition);
+            if (condition is IsPatternExpressionSyntax directPattern
+                && directPattern.Pattern is UnaryPatternSyntax notPattern
+                && notPattern.IsKind(SyntaxKind.NotPattern))
+            {
+                isPattern = directPattern;
+                positivePattern = notPattern.Pattern;
+                return true;
+            }
+
+            if (condition is PrefixUnaryExpressionSyntax logicalNot
+                && logicalNot.IsKind(SyntaxKind.LogicalNotExpression)
+                && Unparenthesize(logicalNot.Operand) is IsPatternExpressionSyntax parenthesizedPattern)
+            {
+                isPattern = parenthesizedPattern;
+                positivePattern = parenthesizedPattern.Pattern;
+                return true;
+            }
+
+            isPattern = null;
+            positivePattern = null;
+            return false;
         }
 
         private static bool StatementAlwaysExits(StatementSyntax statement) =>

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
@@ -1254,11 +1254,17 @@ public sealed partial class CSharpToGSharpTranslator
                     isRefReturn: recursiveLocal.ReturnsByRef);
                 if (recursiveLift.IsStatic)
                 {
-                    this.state.PendingStaticSynthHelpers?.Add(helper);
+                    (this.state.PendingStaticSynthHelpers
+                        ?? throw new InvalidOperationException(
+                            "A recursive static local-function lift must be emitted inside an aggregate."))
+                        .Add(helper);
                 }
                 else
                 {
-                    this.state.PendingInstanceSynthHelpers?.Add(helper);
+                    (this.state.PendingInstanceSynthHelpers
+                        ?? throw new InvalidOperationException(
+                            "A recursive instance local-function lift must be emitted inside an aggregate."))
+                        .Add(helper);
                 }
 
                 return new RawStatement($"// lifted recursive local function {recursiveLift.Name}");

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
@@ -1196,6 +1196,74 @@ public sealed partial class CSharpToGSharpTranslator
 
         private GStatement TranslateLocalFunction(LocalFunctionStatementSyntax localFunction)
         {
+            if (this.context.GetDeclaredSymbol(localFunction) is IMethodSymbol recursiveLocal
+                && this.state.LiftedRecursiveLocalFunctions.TryGetValue(
+                    recursiveLocal,
+                    out LiftedRecursiveLocalFunction recursiveLift))
+            {
+                bool liftedIsAsync = localFunction.Modifiers.Any(SyntaxKind.AsyncKeyword);
+                List<Parameter> liftedParameters = this.MapParameters(
+                    recursiveLocal,
+                    localFunction.ParameterList,
+                    skipFirst: false);
+                foreach (LiftedLocalFunctionCapture capture in recursiveLift.Captures)
+                {
+                    ITypeSymbol captureType = capture.Symbol switch
+                    {
+                        ILocalSymbol local => local.Type,
+                        IParameterSymbol parameter => parameter.Type,
+                        _ => null,
+                    };
+                    if (captureType == null)
+                    {
+                        continue;
+                    }
+
+                    if (captureType.IsReferenceType
+                        && !CaptureHasExplicitNullableType(capture.Symbol))
+                    {
+                        captureType = captureType.WithNullableAnnotation(
+                            NullableAnnotation.NotAnnotated);
+                    }
+
+                    liftedParameters.Add(new Parameter(
+                        SanitizeIdentifier(capture.Symbol.Name),
+                        this.typeMapper.Map(
+                            captureType,
+                            this.context,
+                            capture.Symbol.Locations.FirstOrDefault()),
+                        refKind: capture.IsByRef ? "ref" : null));
+                }
+
+                GTypeReference liftedReturnType = this.MapDelegateLikeReturnType(
+                    recursiveLocal,
+                    liftedIsAsync,
+                    localFunction.ReturnType.GetLocation());
+                List<TypeParameter> liftedTypeParameters = this.MapMethodTypeParameters(recursiveLocal);
+                BlockStatement liftedBody = this.TranslateBody(
+                    localFunction,
+                    $"recursive local function '{localFunction.Identifier.Text}'");
+                var helper = new MethodDeclaration(
+                    recursiveLift.Name,
+                    liftedParameters,
+                    liftedReturnType,
+                    liftedBody,
+                    liftedTypeParameters,
+                    visibility: Visibility.Private,
+                    isAsync: liftedIsAsync,
+                    isRefReturn: recursiveLocal.ReturnsByRef);
+                if (recursiveLift.IsStatic)
+                {
+                    this.state.PendingStaticSynthHelpers?.Add(helper);
+                }
+                else
+                {
+                    this.state.PendingInstanceSynthHelpers?.Add(helper);
+                }
+
+                return new RawStatement($"// lifted recursive local function {recursiveLift.Name}");
+            }
+
             if (localFunction.Modifiers.Any(SyntaxKind.StaticKeyword)
                 && this.context.GetDeclaredSymbol(localFunction) is IMethodSymbol staticLocal
                 && this.state.LiftedStaticLocalFunctions.TryGetValue(staticLocal, out string liftedName)
@@ -1339,6 +1407,28 @@ public sealed partial class CSharpToGSharpTranslator
                 .ToList();
 
             return new LocalFunctionStatement(SanitizeIdentifier(localFunction.Identifier.Text), lambda, typeParameters);
+        }
+
+        private static bool CaptureHasExplicitNullableType(ISymbol symbol)
+        {
+            foreach (SyntaxReference reference in symbol.DeclaringSyntaxReferences)
+            {
+                SyntaxNode syntax = reference.GetSyntax();
+                TypeSyntax type = syntax switch
+                {
+                    ParameterSyntax parameter => parameter.Type,
+                    VariableDeclaratorSyntax { Parent: VariableDeclarationSyntax declaration } =>
+                        declaration.Type,
+                    _ => null,
+                };
+
+                if (type is NullableTypeSyntax)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.IfLet.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.IfLet.cs
@@ -231,24 +231,45 @@ public sealed partial class CSharpToGSharpTranslator
 
             // Eligibility is decided BEFORE anything is translated: a mid-way
             // bail-out would leave a half-emitted spill prologue behind.
-            DecomposeConjunction(ifStatement.Condition, out ExpressionSyntax leftmost, out List<ExpressionSyntax> guards);
+            var clauses = new List<ExpressionSyntax>();
+            FlattenAndClauses(ifStatement.Condition, clauses);
+            IsPatternExpressionSyntax isPattern = null;
+            SingleVariableDesignationSyntax designation = null;
+            RecursivePatternSyntax residualPattern = null;
+            TypeSyntax typeSyntax = null;
+            var patternIndex = -1;
+            for (var i = 0; i < clauses.Count; i++)
+            {
+                if (clauses[i] is not IsPatternExpressionSyntax candidatePattern
+                    || !TryExtractSingleTopLevelIfLetPattern(
+                        candidatePattern.Pattern,
+                        out TypeSyntax candidateType,
+                        out SingleVariableDesignationSyntax candidateDesignation,
+                        out RecursivePatternSyntax candidateResidual))
+                {
+                    continue;
+                }
 
-            if (leftmost is not IsPatternExpressionSyntax isPattern)
+                if (patternIndex >= 0)
+                {
+                    return false;
+                }
+
+                patternIndex = i;
+                isPattern = candidatePattern;
+                typeSyntax = candidateType;
+                designation = candidateDesignation;
+                residualPattern = candidateResidual;
+            }
+
+            if (patternIndex < 0)
             {
                 return false;
             }
 
-            SingleVariableDesignationSyntax designation;
-            RecursivePatternSyntax residualPattern;
+            List<ExpressionSyntax> prefix = clauses.Take(patternIndex).ToList();
+            List<ExpressionSyntax> guards = clauses.Skip(patternIndex + 1).ToList();
             GTypeReference asTarget = null;
-            if (!TryExtractSingleTopLevelIfLetPattern(
-                isPattern.Pattern,
-                out TypeSyntax typeSyntax,
-                out designation,
-                out residualPattern))
-            {
-                return false;
-            }
 
             bool bareNonNullPattern = typeSyntax == null;
             if (!bareNonNullPattern)
@@ -262,10 +283,10 @@ public sealed partial class CSharpToGSharpTranslator
                     return false;
                 }
 
-                if (IsTrivialPatternReceiver(isPattern.Expression)
-                    || (residualPattern == null
-                        && guards.Count == 0
-                        && !targetSymbol.IsValueType))
+                if (prefix.Count == 0
+                    && guards.Count == 0
+                    && (IsTrivialPatternReceiver(isPattern.Expression)
+                        || (residualPattern == null && !targetSymbol.IsValueType)))
                 {
                     return false;
                 }
@@ -304,7 +325,15 @@ public sealed partial class CSharpToGSharpTranslator
             // A guard that itself hoists a spill would need a statement seam
             // ahead of the `if`, but the spill may read the binding — which is
             // only in scope inside the `if let`. Leave those to the general path.
-            if (guards.Any(ContainsSpillHoistingConstruct))
+            if (prefix.Concat(guards).Any(guard =>
+                    ContainsSpillHoistingConstruct(
+                        guard,
+                        includeOutVarDeclarations: false))
+                || prefix.SelectMany(clause => clause.DescendantNodesAndSelf())
+                    .OfType<SingleVariableDesignationSyntax>()
+                    .Any(designationNode =>
+                        this.context.GetDeclaredSymbol(designationNode) is ILocalSymbol prefixBinder
+                        && ReadsSymbol(ifStatement.Statement, prefixBinder)))
             {
                 return false;
             }
@@ -381,42 +410,61 @@ public sealed partial class CSharpToGSharpTranslator
                 elseBranch = this.TranslateElseStatement(ifStatement.Else.Statement);
             }
 
+            GStatement inner;
             if (directBinding)
             {
-                result = new GStatement[]
+                inner = new BlockStatement(
+                    new GStatement[]
+                    {
+                        new LocalDeclarationStatement(
+                            this.IsLocalReassigned(binder)
+                                ? BindingKind.Var
+                                : BindingKind.Let,
+                            name,
+                            initializer: initializer),
+                        new IfStatement(
+                            guard ?? LiteralExpression.Bool(true),
+                            then,
+                            elseBranch),
+                    });
+            }
+            else
+            {
+                // Statement-form `if let` has no guard clause. Nest the residual
+                // test/extra conjuncts inside its binding scope. Reuse the same else
+                // branch both when binding fails and when the nested guard fails.
+                if (guard != null)
                 {
-                    new BlockStatement(
-                        new GStatement[]
-                        {
-                            new LocalDeclarationStatement(
-                                this.IsLocalReassigned(binder)
-                                    ? BindingKind.Var
-                                    : BindingKind.Let,
-                                name,
-                                initializer: initializer),
-                            new IfStatement(
-                                guard ?? LiteralExpression.Bool(true),
-                                then,
-                                elseBranch),
-                        }),
-                };
+                    then = new BlockStatement(
+                        new GStatement[] { new IfStatement(guard, then, elseBranch) });
+                }
+
+                inner = new IfLetStatement(
+                    new List<IfLetBinding> { new IfLetBinding(name, initializer) },
+                    then,
+                    elseBranch);
+            }
+
+            if (prefix.Count == 0)
+            {
+                result = new[] { inner };
                 return true;
             }
 
-            // Statement-form `if let` has no guard clause. Nest the residual
-            // test/extra conjuncts inside its binding scope. Reuse the same else
-            // branch both when binding fails and when the nested guard fails.
-            if (guard != null)
+            GExpression prefixGuard = null;
+            foreach (ExpressionSyntax clause in prefix)
             {
-                then = new BlockStatement(
-                    new GStatement[] { new IfStatement(guard, then, elseBranch) });
+                GExpression translated = this.TranslateExpression(clause);
+                prefixGuard = prefixGuard == null
+                    ? translated
+                    : new BinaryExpression(prefixGuard, "&&", translated);
             }
 
             result = new GStatement[]
             {
-                new IfLetStatement(
-                    new List<IfLetBinding> { new IfLetBinding(name, initializer) },
-                    then,
+                new IfStatement(
+                    prefixGuard,
+                    new BlockStatement(new[] { inner }),
                     elseBranch),
             };
             return true;
@@ -869,7 +917,12 @@ public sealed partial class CSharpToGSharpTranslator
         /// Anonymous-function bodies are skipped: they open their own seam and
         /// can never leak into this one.
         /// </summary>
-        private static bool ContainsSpillHoistingConstruct(SyntaxNode node)
+        private static bool ContainsSpillHoistingConstruct(SyntaxNode node) =>
+            ContainsSpillHoistingConstruct(node, includeOutVarDeclarations: true);
+
+        private static bool ContainsSpillHoistingConstruct(
+            SyntaxNode node,
+            bool includeOutVarDeclarations)
         {
             foreach (SyntaxNode descendant in node.DescendantNodesAndSelf(
                 descendIntoChildren: n => n is not AnonymousFunctionExpressionSyntax || n == node))
@@ -882,7 +935,7 @@ public sealed partial class CSharpToGSharpTranslator
                         when PatternIntroducesBinding(isPattern.Pattern):
                     case AssignmentExpressionSyntax assignment
                         when AssignmentRequiresStatementLowering(assignment):
-                    case DeclarationExpressionSyntax:
+                    case DeclarationExpressionSyntax when includeOutVarDeclarations:
                     case SwitchExpressionSyntax:
                         return true;
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -40,6 +40,78 @@ public sealed partial class CSharpToGSharpTranslator
                 this.typeMapper.TrackExtensionMethodNamespace(invocationExtMethod);
             }
 
+            if (this.context.GetSymbolInfo(invocation).Symbol is IMethodSymbol
+                    { MethodKind: MethodKind.LocalFunction } recursiveLocal
+                && this.state.LiftedRecursiveLocalFunctions.TryGetValue(
+                    recursiveLocal,
+                    out LiftedRecursiveLocalFunction recursiveLift))
+            {
+                var recursiveArguments = this.TranslateCallArguments(
+                    invocation,
+                    invocation.ArgumentList.Arguments).ToList();
+                for (var i = recursiveArguments.Count; i < recursiveLocal.Parameters.Length; i++)
+                {
+                    IParameterSymbol parameter = recursiveLocal.Parameters[i];
+                    GTypeReference parameterType = this.typeMapper.Map(
+                        parameter.Type,
+                        this.context,
+                        parameter.Locations.FirstOrDefault());
+                    recursiveArguments.Add(
+                        this.BuildOptionalParameterDefault(
+                            parameter,
+                            parameterType,
+                            invocation)
+                        ?? LiteralExpression.Null());
+                }
+
+                foreach (LiftedLocalFunctionCapture capture in recursiveLift.Captures)
+                {
+                    GExpression captureArgument =
+                        new IdentifierExpression(SanitizeIdentifier(capture.Symbol.Name));
+                    recursiveArguments.Add(capture.IsByRef
+                        ? new UnaryExpression("&", captureArgument)
+                        : captureArgument);
+                }
+
+                GExpression recursiveTarget = recursiveLift.IsStatic
+                    && recursiveLocal.ContainingType is { } recursiveContainingType
+                        ? new MemberAccessExpression(
+                            this.StaticQualifierReceiver(recursiveContainingType, invocation.GetLocation()),
+                            recursiveLift.Name)
+                        : new IdentifierExpression(recursiveLift.Name);
+                IReadOnlyList<GTypeReference> recursiveTypeArguments =
+                    invocation.Expression is GenericNameSyntax recursiveGeneric
+                        ? this.MapTypeArguments(recursiveGeneric)
+                        : null;
+                return new InvocationExpression(
+                    recursiveTarget,
+                    recursiveArguments,
+                    recursiveTypeArguments);
+            }
+
+            if (this.context.GetSymbolInfo(invocation).Symbol is IMethodSymbol enumTryParse
+                && enumTryParse.ContainingType.SpecialType == SpecialType.System_Enum
+                && enumTryParse.Name == "TryParse"
+                && enumTryParse.IsGenericMethod
+                && invocation.Expression is MemberAccessExpressionSyntax enumMember)
+            {
+                target = new MemberAccessExpression(
+                    this.TranslateExpression(enumMember.Expression),
+                    "TryParse");
+                typeArguments = enumTryParse.TypeArguments
+                    .Select(type => this.typeMapper.Map(
+                        type,
+                        this.context,
+                        invocation.GetLocation()))
+                    .ToList();
+                return new InvocationExpression(
+                    target,
+                    this.TranslateCallArguments(
+                        invocation,
+                        invocation.ArgumentList.Arguments),
+                    typeArguments);
+            }
+
             // C# delegate/event invocation `d.Invoke(args)` / `d?.Invoke(args)` maps
             // to G#'s direct function-call form `d(args)` / `d?(args)`: G# invokes a
             // function-typed value (delegate field or event) directly and has no

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
@@ -126,6 +126,18 @@ public sealed partial class CSharpToGSharpTranslator
 
                 case PropertyDeclarationSyntax property:
                     var propertySymbol = this.context.GetDeclaredSymbol(property) as IPropertySymbol;
+                    if (ownerKind is TypeDeclarationKind.DataClass or TypeDeclarationKind.DataStruct
+                        && primaryCtorParamNames?.Contains(
+                            property.Identifier.Text,
+                            StringComparer.Ordinal) == true
+                        && propertySymbol is { IsStatic: false }
+                        && property.AccessorList?.Accessors.All(accessor =>
+                            accessor.Body == null
+                            && accessor.ExpressionBody == null) == true)
+                    {
+                        break;
+                    }
+
                     if (propertySymbol != null &&
                         lift.PropertiesAsPrimaryParameters.Contains(propertySymbol))
                     {

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -1883,8 +1883,7 @@ public sealed partial class CSharpToGSharpTranslator
 
         private GTypeReference GetArrayElementType(ExpressionSyntax arrayExpression, TypeSyntax elementTypeSyntax)
         {
-            bool nullableElementSyntax =
-                elementTypeSyntax?.ToString().EndsWith("?", System.StringComparison.Ordinal) == true;
+            bool nullableElementSyntax = elementTypeSyntax is NullableTypeSyntax;
 
             TypeInfo info = this.context.GetTypeInfo(arrayExpression);
             ITypeSymbol arrayType = info.Type ?? info.ConvertedType;

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -1883,22 +1883,34 @@ public sealed partial class CSharpToGSharpTranslator
 
         private GTypeReference GetArrayElementType(ExpressionSyntax arrayExpression, TypeSyntax elementTypeSyntax)
         {
+            bool nullableElementSyntax =
+                elementTypeSyntax?.ToString().EndsWith("?", System.StringComparison.Ordinal) == true;
+
             TypeInfo info = this.context.GetTypeInfo(arrayExpression);
             ITypeSymbol arrayType = info.Type ?? info.ConvertedType;
             if (arrayType is IArrayTypeSymbol array)
             {
-                return this.typeMapper.Map(array.ElementType, this.context, arrayExpression.GetLocation());
+                GTypeReference mapped = this.typeMapper.Map(
+                    array.ElementType,
+                    this.context,
+                    arrayExpression.GetLocation());
+                return nullableElementSyntax ? MakeNullable(mapped) : mapped;
             }
 
             if (arrayType is INamedTypeSymbol { IsGenericType: true } generic &&
                 generic.TypeArguments.Length == 1)
             {
-                return this.typeMapper.Map(generic.TypeArguments[0], this.context, arrayExpression.GetLocation());
+                GTypeReference mapped = this.typeMapper.Map(
+                    generic.TypeArguments[0],
+                    this.context,
+                    arrayExpression.GetLocation());
+                return nullableElementSyntax ? MakeNullable(mapped) : mapped;
             }
 
             if (elementTypeSyntax != null)
             {
-                return this.MapTypeSyntax(elementTypeSyntax);
+                GTypeReference mapped = this.MapTypeSyntax(elementTypeSyntax);
+                return nullableElementSyntax ? MakeNullable(mapped) : mapped;
             }
 
             return new NamedTypeReference("object");

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -354,6 +354,19 @@ public sealed partial class CSharpToGSharpTranslator
         // skipping the file's own package (needs no import) and any namespace
         // an explicit `using` already covers.
         var allImports = imports is List<ImportDirective> list ? list : imports.ToList();
+        var existingAliases = new HashSet<string>(
+            allImports.Where(import => import.Alias != null).Select(import => import.Alias),
+            StringComparer.Ordinal);
+        foreach (var alias in typeMapper.SynthesizedTypeAliases.OrderBy(
+            pair => pair.Key,
+            StringComparer.Ordinal))
+        {
+            if (existingAliases.Add(alias.Key))
+            {
+                allImports.Add(new ImportDirective(alias.Value, alias.Key));
+            }
+        }
+
         var alreadyImported = new HashSet<string>(allImports.Select(i => i.Name));
         foreach (string ns in typeMapper.ShortenedNamespaces.OrderBy(n => n, System.StringComparer.Ordinal))
         {

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -96,6 +96,9 @@ public sealed class CSharpTypeMapper
     /// </summary>
     private readonly List<TypeDeclaration> pendingAnonymousDataClasses = new();
 
+    private readonly Dictionary<string, string> synthesizedTypeAliases =
+        new(System.StringComparer.Ordinal);
+
     /// <summary>
     /// Issue #1174: cached per-compilation census of source-declared type simple
     /// names (built lazily on first use), used to decide whether a source nested
@@ -151,6 +154,12 @@ public sealed class CSharpTypeMapper
     /// this mapper so far (see <see cref="shortenedNamespaces"/>).
     /// </summary>
     public IReadOnlyCollection<string> ShortenedNamespaces => this.shortenedNamespaces;
+
+    /// <summary>
+    /// Gets metadata type aliases synthesized to disambiguate source homonyms.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> SynthesizedTypeAliases =>
+        this.synthesizedTypeAliases;
 
     /// <summary>
     /// Gets the synthesized anonymous-type <c>data class</c> declarations
@@ -731,6 +740,19 @@ public sealed class CSharpTypeMapper
                 return this.MapDelegate(named.DelegateInvokeMethod, context, location);
             }
 
+            if (named.ContainingType != null
+                && named.Name == "Builder"
+                && named.ContainingType.OriginalDefinition.ToDisplayString()
+                    == "System.Collections.Immutable.ImmutableArray<T>")
+            {
+                return new NamedTypeReference(
+                    "Builder",
+                    containingType: this.Map(
+                        named.ContainingType,
+                        context,
+                        location));
+            }
+
             if (HasGenericContainingType(named))
             {
                 IReadOnlyList<ITypeSymbol> ownTypeArguments = named.Arity == 0
@@ -844,6 +866,15 @@ public sealed class CSharpTypeMapper
             if (!ambiguous)
             {
                 return simpleName;
+            }
+
+            if (!named.Locations.Any(candidate => candidate.IsInSource)
+                && named.ContainingNamespace is { IsGlobalNamespace: false } aliasNamespace)
+            {
+                string target = $"{aliasNamespace.ToDisplayString()}.{simpleName}";
+                string alias = $"__cs2gs_{target.Replace('.', '_')}";
+                this.synthesizedTypeAliases[alias] = target;
+                return alias;
             }
 
             return named.ContainingNamespace is { IsGlobalNamespace: false } containingNs

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -874,6 +874,9 @@ public sealed class CSharpTypeMapper
                     == "System.Collections.Generic"
                 && named.ContainingNamespace is { IsGlobalNamespace: false } aliasNamespace)
             {
+                // ponytail: Core only needs the List<T> collision. Generalize
+                // when imported CLR type aliases bind reliably in type and
+                // constructor positions for arbitrary metadata types.
                 string target = $"{aliasNamespace.ToDisplayString()}.{simpleName}";
                 string alias = $"__cs2gs_{target.Replace('.', '_')}";
                 this.synthesizedTypeAliases[alias] = target;

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -869,6 +869,9 @@ public sealed class CSharpTypeMapper
             }
 
             if (!named.Locations.Any(candidate => candidate.IsInSource)
+                && named.Name == "List"
+                && named.ContainingNamespace?.ToDisplayString()
+                    == "System.Collections.Generic"
                 && named.ContainingNamespace is { IsGlobalNamespace: false } aliasNamespace)
             {
                 string target = $"{aliasNamespace.ToDisplayString()}.{simpleName}";

--- a/tools/cs2gs/Cs2Gs.Translator/DocumentTranslationState.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/DocumentTranslationState.cs
@@ -203,10 +203,45 @@ internal sealed class DocumentTranslationState
     public Dictionary<IMethodSymbol, string> LiftedStaticLocalFunctions { get; } =
         new Dictionary<IMethodSymbol, string>(SymbolEqualityComparer.Default);
 
+    public Dictionary<IMethodSymbol, LiftedRecursiveLocalFunction> LiftedRecursiveLocalFunctions { get; } =
+        new Dictionary<IMethodSymbol, LiftedRecursiveLocalFunction>(SymbolEqualityComparer.Default);
+
     // The exception variable bound by the innermost enclosing `catch` clause,
     // used to translate a C# re-throw (`throw;`) — which has no bare G# form —
     // to `throw <caughtVar>` (ADR-0115 §B).
     public string CurrentCatchVariable { get; set; }
+}
+
+internal sealed class LiftedRecursiveLocalFunction
+{
+    public LiftedRecursiveLocalFunction(
+        string name,
+        bool isStatic,
+        IReadOnlyList<LiftedLocalFunctionCapture> captures)
+    {
+        Name = name;
+        IsStatic = isStatic;
+        Captures = captures;
+    }
+
+    public string Name { get; }
+
+    public bool IsStatic { get; }
+
+    public IReadOnlyList<LiftedLocalFunctionCapture> Captures { get; }
+}
+
+internal sealed class LiftedLocalFunctionCapture
+{
+    public LiftedLocalFunctionCapture(ISymbol symbol, bool isByRef)
+    {
+        Symbol = symbol;
+        IsByRef = isByRef;
+    }
+
+    public ISymbol Symbol { get; }
+
+    public bool IsByRef { get; }
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary

Refs #3394 and #3400. Closes #3399, #3401, and #3402.

Continues the existing Core-first self-migration spike from merged #3403/#3404.

- keeps all 578 Core C# inputs translating to 580 round-trip-valid G# files
- reduces Core semantic compile diagnostics from 291 to **108**
- reduces the original 1,126 frontier to 108 (**90.4% removed**)
- lifts capturing recursive/mutually-recursive local functions into helper methods with transitive captures and by-ref mutable state
- preserves source-type by-ref pointee identity and params normal-form pass-through
- extends short-circuit/nested pattern binder scope lowering
- adds generic CLR type aliases for source homonym collisions
- fixes exhaustive-switch out-parameter analysis and several high-fanout translation/type-shaping defects
- updates `docs/self-migration-spike-3394.md`
- commits no generated migrated `.gs` sources, logs, binaries, packages, or artifacts

## Core cycles

| Cycle | Diagnostics |
|---:|---:|
| 51 baseline | 291 |
| 52 | 208 |
| 53 | 200 |
| 54 | 183 |
| 55 | 157 |
| 56 | 140 |
| 57 | 135 |
| 58 | 127 |
| 59 | 129 |
| 60 | 123 |
| 61 | 122 |
| 62 | 116 |
| 63 | 115 |
| 64 | 111 |
| 65 | 110 |
| 66 final | **108** |

Final measured run:

```text
artifacts/issue-3394/core-cycle-66-final/2026-08-16T03-16-05Z_942086
translate: PASS
compile:  FAIL(108)
```

#3400's filed reproduction passes, but a broader imported-static symbolic by-ref family remains, so this PR references rather than closes it.

## Validation

- Core targeted compiler/binder regressions: 48 passed
- cs2gs targeted translator/runtime regressions: 38 passed
- pinned Oahu local gate: 15/15 green across translate, compile, ILVerify, and parity
- full GitHub Actions matrix green after CI repairs on commit `a97d1d3e`
- repeated full Core migration diagnostic cycles through cycle 66
- `git diff --check`

Core compile is still gated; therefore ILVerify/test parity/self-host and downstream gsc/gsi/gsgen/cs2gs migrations remain correctly unstarted.
