### PR TITLE
Continue Core self-migration to 60 diagnostics

### DIFF
--- a/docs/self-migration-spike-3394.md
+++ b/docs/self-migration-spike-3394.md
@@ -363,3 +363,55 @@ Cycle 66's largest remaining IDs are GS0155 (21), GS0159 (19), GS0158 (17),
 GS0154 (11), GS0266 (6), and GS0125 (6). Core still does not compile, so
 ILVerify, test parity, self-hosted Core recompilation, and downstream project
 migrations remain gated exactly as before.
+
+## Continuation through cycle 83
+
+Branch `oats/3394-core-compile-continuation-2`, based on `bf2602b6`, moved the
+Core semantic frontier from 108 to **60** diagnostics:
+
+| Cycle | Diagnostics | Milestone |
+|---:|---:|---|
+| 67 | 108 | Fresh-main review baseline |
+| 68 | 101 | Imported static generic managed by-ref projection; #3400 closed |
+| 69 | 93 | Source collection interface element inference |
+| 70 | 89 | Nested imported generic return substitution |
+| 71–73 | 88 → 87 → 86 | Structural generic erasure and method-type substitution |
+| 74 | 81 | Reference-nullable array/slice runtime identity |
+| 75 | 74 | Named-argument convertibility-aware overload selection |
+| 76 | 72 | Constructor accessibility filtering |
+| 77–79 | 67 → 66 → 65 | Imported class-constraint properties and pattern access |
+| 80–82 | 62 → 61 → 60 | Nullable nested-type rendering, named tuple patterns, attribute order |
+| 83 | **60** | Final remeasurement |
+
+Final run:
+
+```text
+artifacts/issue-3394/core-cycle-83-final/2026-08-16T05-20-12Z_936f92
+translate: PASS
+compile:  FAIL(60)
+```
+
+Continuation-2 removed 48 diagnostics (44.4%); the complete semantic effort is
+now 1,126 → 60 (1,066 removed, 94.7%).
+
+Durable fixes include:
+
+- recursive erased CLR projection for symbolic managed by-ref arguments,
+  proving generic `Volatile.Read/Write` over same-compilation reference types;
+- source collection-interface element inference;
+- preservation of symbolic nested imported generics through method/member
+  substitution;
+- structural erasure for slices, tuples, arrays, maps, and delegate targets;
+- runtime identity for reference-nullability-only wrapper differences;
+- convertibility-aware named-argument overload selection and inaccessible
+  constructor filtering;
+- imported class-constraint property access;
+- cross-file attribute-base recognition before base binding completes;
+- nullable promotion retaining nested containing types and array rank;
+- named tuple property patterns lowering to positional tuple members.
+
+Cycle 83's largest IDs are GS0159 (10), GS0155 (8), GS0158 (8), GS0125 (6),
+and GS0154 (4). The largest file remains
+`ExpressionBinder.Access.Accessor.gs` with 13 diagnostics. Core still does not
+compile; ILVerify, test parity, self-hosted Core recompilation, and downstream
+project migrations remain gated.

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -4575,6 +4575,16 @@ public sealed class Binder
         {
             hasSymbolicArgument = true;
 
+            // Issue #2919 follow-up: a nullable source enum keeps the same
+            // caller-selected leaf surrogate as the bare enum. A caller that
+            // erases Mode to object must therefore erase Mode? to object too;
+            // only callers selecting the Int32 backing may use Nullable<Int32>.
+            if (type is NullableTypeSymbol { UnderlyingType: EnumSymbol }
+                && !erasedArgument.IsValueType)
+            {
+                return scope.References.MapClrTypeToReferences(erasedArgument);
+            }
+
             if (type is SliceTypeSymbol
                     or ArrayTypeSymbol
                     or RectangularArrayTypeSymbol
@@ -5663,6 +5673,8 @@ public sealed class Binder
                     }
                     catch (System.ArgumentException)
                     {
+                        var assertMessage = $"Binder.SubstituteType: erased MakeGenericType failed for '{it.OpenDefinition}' with args [{string.Join(", ", erasedArgs.Select(t => t.ToString()))}] even after mapClrType projection.";
+                        System.Diagnostics.Debug.WriteLine(assertMessage);
                     }
                 }
             }

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -4575,7 +4575,18 @@ public sealed class Binder
         {
             hasSymbolicArgument = true;
 
-            if (MemberLookup.TryProjectErasedClrType(type, out var projected))
+            if (type is SliceTypeSymbol
+                    or ArrayTypeSymbol
+                    or RectangularArrayTypeSymbol
+                    or TupleTypeSymbol
+                    or MapTypeSymbol
+                    or FunctionTypeSymbol
+                    or SequenceTypeSymbol
+                    or AsyncSequenceTypeSymbol
+                    or ChannelTypeSymbol
+                    or NullableTypeSymbol
+                    or ImportedTypeSymbol
+                && MemberLookup.TryProjectErasedClrType(type, out var projected))
             {
                 return scope.References.MapClrTypeToReferences(projected);
             }

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -4575,11 +4575,7 @@ public sealed class Binder
         {
             hasSymbolicArgument = true;
 
-            // Issue #3087: a tuple must retain its ValueTuple shape while its
-            // symbolic elements ride through erased CLR placeholders.
-            if ((type is TupleTypeSymbol
-                    or NullableTypeSymbol { UnderlyingType: TupleTypeSymbol })
-                && MemberLookup.TryProjectErasedClrType(type, out var projected))
+            if (MemberLookup.TryProjectErasedClrType(type, out var projected))
             {
                 return scope.References.MapClrTypeToReferences(projected);
             }
@@ -5595,6 +5591,12 @@ public sealed class Binder
                 var allClr = true;
                 for (var i = 0; i < substitutedArgs.Length; i++)
                 {
+                    if (TypeSymbol.RequiresSymbolicProjection(substitutedArgs[i]))
+                    {
+                        allClr = false;
+                        break;
+                    }
+
                     var clr = substitutedArgs[i].ClrType;
                     if (clr == null)
                     {
@@ -5621,6 +5623,35 @@ public sealed class Binder
                         // rather than crash.
                         var assertMessage = $"Binder.SubstituteType: MakeGenericType failed for '{it.OpenDefinition}' with args [{string.Join(", ", clrArgs.Select(t => t.ToString()))}] even after mapClrType projection.";
                         System.Diagnostics.Debug.WriteLine(assertMessage);
+                    }
+                }
+            }
+
+            if (it.OpenDefinition != null)
+            {
+                var erasedArgs = new System.Type[substitutedArgs.Length];
+                var allErased = true;
+                for (var i = 0; i < substitutedArgs.Length; i++)
+                {
+                    if (!MemberLookup.TryProjectErasedClrType(substitutedArgs[i], out var erased)
+                        || erased == null)
+                    {
+                        allErased = false;
+                        break;
+                    }
+
+                    erasedArgs[i] = mapClrType != null ? mapClrType(erased) : erased;
+                }
+
+                if (allErased)
+                {
+                    try
+                    {
+                        var erasedClosed = it.OpenDefinition.MakeGenericType(erasedArgs);
+                        return ImportedTypeSymbol.GetConstructed(erasedClosed, it.OpenDefinition, substitutedArgs);
+                    }
+                    catch (System.ArgumentException)
+                    {
                     }
                 }
             }

--- a/src/Core/CodeAnalysis/Binding/BoundIsExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundIsExpression.cs
@@ -62,5 +62,6 @@ public sealed class BoundIsExpression : BoundExpression
     public TypeSymbol? TargetType => Pattern is BoundTypePattern typePattern ? typePattern.TargetType : null;
 
     /// <summary>Gets a value indicating whether this is a plain type test with no recursive suffix.</summary>
-    public bool IsSimpleTypeTest => Pattern is BoundTypePattern { PropertyPattern: null };
+    public bool IsSimpleTypeTest =>
+        Pattern is BoundTypePattern typePattern && typePattern.PropertyPattern == null;
 }

--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -2592,6 +2592,11 @@ public sealed class Conversion
             return false;
         }
 
+        if (TypeSymbol.AreRuntimeEquivalentIgnoringReferenceNullability(a, b))
+        {
+            return true;
+        }
+
         var elementConversion = Classify(a, b);
         return elementConversion.Exists && elementConversion.IsIdentity;
     }

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -1361,7 +1361,21 @@ internal sealed class ConversionClassifier
         // `Expression<Func<TEntity,TRelated>>`) is substituted in the SAME pass
         // as the receiver's `TEntity` — rather than only ever substituting one
         // or the other depending on which happens to be tried first.
-        var mapped = MemberLookup.MapOpenClrTypeToSymbolic(openParamType, openDef, imported.TypeArguments, openMethod, symbolicMethodTypeArgs);
+        var effectiveMethodTypeArgs = symbolicMethodTypeArgs;
+        if (effectiveMethodTypeArgs.IsDefaultOrEmpty
+            && method.IsGenericMethod
+            && !method.ContainsGenericParameters)
+        {
+            effectiveMethodTypeArgs = ImmutableArray.CreateRange<TypeSymbol?>(
+                method.GetGenericArguments().Select(static argument => TypeSymbol.FromClrType(argument)));
+        }
+
+        var mapped = MemberLookup.MapOpenClrTypeToSymbolic(
+            openParamType,
+            openDef,
+            imported.TypeArguments,
+            openMethod,
+            effectiveMethodTypeArgs);
         mapped = PreserveParameterTopLevelNullability(openParams[paramIndex], mapped);
         return mapped != null
             && mapped != TypeSymbol.Error

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Attributes.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Attributes.cs
@@ -557,8 +557,16 @@ internal sealed partial class DeclarationBinder
         return null;
     }
 
-    private static bool IsAttributeType(TypeSymbol? typeSymbol)
+    private bool IsAttributeType(TypeSymbol? typeSymbol)
+        => IsAttributeType(typeSymbol, new HashSet<TypeSymbol>());
+
+    private bool IsAttributeType(TypeSymbol? typeSymbol, HashSet<TypeSymbol> visited)
     {
+        if (typeSymbol == null || !visited.Add(typeSymbol))
+        {
+            return false;
+        }
+
         // Issue #1921: a same-compilation user class deriving from
         // System.Attribute (via either the `@Attribute` sugar or a plain
         // `: Attribute` / `: System.Attribute` base clause) has no CLR type
@@ -567,7 +575,23 @@ internal sealed partial class DeclarationBinder
         // walks the symbol-level BaseClass chain instead of relying on ClrType.
         if (typeSymbol is StructSymbol structSym)
         {
-            return structSym.DerivesFromSystemAttribute();
+            if (structSym.DerivesFromSystemAttribute())
+            {
+                return true;
+            }
+
+            if (structSym.Declaration != null)
+            {
+                foreach (var baseClause in structSym.Declaration.BaseTypeClauses)
+                {
+                    if (IsAttributeType(bindTypeClause(baseClause), visited))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
 
         var clr = typeSymbol?.ClrType;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
@@ -3580,6 +3580,38 @@ internal sealed partial class ExpressionBinder
             }
         }
 
+        var importedClassConstraint = tpRecv.ClassConstraint;
+        var importedClass = importedClassConstraint?.ClrType;
+        if (importedClassConstraint != null
+            && importedClass != null)
+        {
+            var clrProperty = ClrTypeUtilities.SafeGetPropertyIncludingInterfaces(
+                importedClass,
+                memberName,
+                BindingFlags.Public | BindingFlags.Instance);
+            if (clrProperty != null && clrProperty.GetIndexParameters().Length == 0)
+            {
+                if (clrProperty.GetGetMethod(nonPublic: false) == null)
+                {
+                    Diagnostics.ReportCannotAssign(ne.Location, memberName);
+                    return new BoundErrorExpression(null);
+                }
+
+                var propertyType = MemberLookup.GetClrPropertyTypeSymbol(importedClassConstraint, clrProperty);
+                var declaringConstraint = MemberLookup.GetClrMemberDeclaringTypeSymbol(
+                    importedClassConstraint,
+                    clrProperty);
+                return ConversionClassifier.AutoDereferenceRefReturn(
+                    new BoundClrPropertyAccessExpression(
+                        null,
+                        receiver,
+                        clrProperty,
+                        propertyType,
+                        constrainedReceiverTypeParameter: tpRecv,
+                        constrainedInterfaceType: declaringConstraint));
+            }
+        }
+
         // Interface constraint: an instance property declared on the (non-generic)
         // interface or any base interface. The getter dispatches through a
         // verifiable `box !!T; callvirt I::get_X` in the emitter.

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -1971,6 +1971,16 @@ internal sealed class MemberLookup
                 }
 
                 return false;
+            case ByRefTypeSymbol byRef:
+                if (TryProjectErasedClrType(byRef.PointeeType, out var byRefPointee)
+                    && byRefPointee != null
+                    && !byRefPointee.IsByRef)
+                {
+                    erased = byRefPointee.MakeByRefType();
+                    return true;
+                }
+
+                return false;
             case PointerTypeSymbol pointer:
                 // Issue #2838: `*T` under `T : unmanaged` — canonically the
                 // pointer bound by `fixed p *T = span` — has a null ClrType
@@ -5519,7 +5529,7 @@ internal sealed class MemberLookup
 
     private static TypeSymbol? TryGetElementType(TypeSymbol t)
     {
-        return t switch
+        var direct = t switch
         {
             SliceTypeSymbol s => s.ElementType,
             ArrayTypeSymbol a => a.ElementType,
@@ -5528,6 +5538,24 @@ internal sealed class MemberLookup
             AsyncSequenceTypeSymbol aseq => aseq.ElementType,
             _ => null,
         };
+        if (direct != null || t is not StructSymbol sourceType)
+        {
+            return direct;
+        }
+
+        foreach (var implemented in sourceType.ImplementedClrInterfaces)
+        {
+            if (implemented is ImportedTypeSymbol imported
+                && TryGetConstructedImportedProjection(imported, out var projected)
+                && projected != null
+                && TryMapThroughImplemented(projected, typeof(IEnumerable<>), out var arguments)
+                && arguments.Length == 1)
+            {
+                return arguments[0];
+            }
+        }
+
+        return null;
     }
 
     private static bool TryMapThroughImplemented(ImportedTypeSymbol imp, Type targetOpenDef, out ImmutableArray<TypeSymbol> liftedArgs)

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Candidates.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Candidates.cs
@@ -335,12 +335,17 @@ internal sealed partial class OverloadResolver
         // nullable/reference widening (e.g. []uint8 -> []?uint8). Drop such
         // non-convertible candidates here, conservatively (see skips below), so
         // the unique applicable overload is selected without a spurious GS0266.
-        if (applicable.Count > 1 && !HasNamedArguments(argumentNames))
+        if (applicable.Count > 1)
         {
             var convertible = new List<FunctionSymbol>(applicable.Count);
             foreach (var cand in applicable)
             {
-                if (IsConvertibilityApplicable(cand, argumentCount, boundArguments, GetCandidateSubstitution(cand)))
+                if (IsConvertibilityApplicable(
+                        cand,
+                        argumentCount,
+                        argumentNames,
+                        boundArguments,
+                        GetCandidateSubstitution(cand)))
                 {
                     convertible.Add(cand);
                 }
@@ -970,6 +975,7 @@ internal sealed partial class OverloadResolver
     private bool IsConvertibilityApplicable(
         FunctionSymbol candidate,
         int argumentCount,
+        ImmutableArray<string> argumentNames,
         ImmutableArray<BoundExpression>.Builder boundArguments,
         Dictionary<TypeParameterSymbol, TypeSymbol>? substitution = null)
     {
@@ -988,13 +994,24 @@ internal sealed partial class OverloadResolver
         var count = Math.Min(argumentCount, paramLen);
         for (var i = 0; i < count && i < boundArguments.Count; i++)
         {
+            var parameterSlot = MapArgumentIndexToParameterSlot(
+                candidate,
+                argumentNames,
+                i,
+                parameterOffset,
+                paramLen);
+            if (parameterSlot < 0)
+            {
+                return false;
+            }
+
             // The variadic tail binds its element(s) elsewhere; do not reject.
-            if (isVariadic && i >= fixedParamCount)
+            if (isVariadic && parameterSlot >= fixedParamCount)
             {
                 continue;
             }
 
-            var parameter = candidate.Parameters[i + parameterOffset];
+            var parameter = candidate.Parameters[parameterSlot + parameterOffset];
 
             // By-ref/out/in parameters have their own exact-type rules.
             if (parameter.RefKind != RefKind.None)
@@ -1061,6 +1078,7 @@ internal sealed partial class OverloadResolver
         // implicitly converts to the variadic element type — keeping
         // applicability/ranking in agreement with the final element coercion.
         if (isVariadic
+            && !HasNamedArguments(argumentNames)
             && candidate.Parameters[candidate.Parameters.Length - 1].Type is SliceTypeSymbol variadicSlice)
         {
             var elementType = variadicSlice.ElementType;

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
@@ -794,6 +794,17 @@ internal sealed partial class OverloadResolver
         // Issue #1214: for a closed generic construction, the constructor table
         // lives on the open definition (EffectiveExplicitConstructors).
         var ctorOverloads = classType.EffectiveExplicitConstructors;
+        var accessibleCtorOverloads = ctorOverloads
+            .Where(ctor => AccessibilityChecker.IsAccessible(
+                ctor.Function.Accessibility,
+                ctor.DeclaringType ?? classType,
+                getCurrentFunction()))
+            .ToImmutableArray();
+        if (!accessibleCtorOverloads.IsDefaultOrEmpty)
+        {
+            ctorOverloads = accessibleCtorOverloads;
+        }
+
         var boundArgumentsBuilder = ImmutableArray.CreateBuilder<BoundExpression>(syntax.Arguments.Count);
         for (var ai = 0; ai < syntax.Arguments.Count; ai++)
         {

--- a/src/Core/CodeAnalysis/Symbols/InterfaceSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/InterfaceSymbol.cs
@@ -929,7 +929,9 @@ public sealed class InterfaceSymbol : TypeSymbol
             var resolvedClrArgs = new System.Type[substitutedArgs.Count];
             for (var i = 0; i < substitutedArgs.Count; i++)
             {
-                var clr = substitutedArgs[i].ClrType ?? typeof(object);
+                var clr = MemberLookup.TryProjectErasedClrType(substitutedArgs[i], out var projected)
+                    ? projected
+                    : substitutedArgs[i].ClrType ?? typeof(object);
                 resolvedClrArgs[i] = mapClrType != null ? mapClrType(clr) : clr;
             }
 

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -2540,7 +2540,9 @@ public sealed class StructSymbol : TypeSymbol
             var resolvedClrArgs = new System.Type[substitutedArgs.Count];
             for (var i = 0; i < substitutedArgs.Count; i++)
             {
-                var clr = substitutedArgs[i].ClrType ?? typeof(object);
+                var clr = MemberLookup.TryProjectErasedClrType(substitutedArgs[i], out var projected)
+                    ? projected
+                    : substitutedArgs[i].ClrType ?? typeof(object);
                 resolvedClrArgs[i] = mapClrType != null ? mapClrType(clr) : clr;
             }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2919ImportedGenericProjectionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2919ImportedGenericProjectionTests.cs
@@ -8,6 +8,7 @@ using GSharp.Core.CodeAnalysis.Binding;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -35,7 +36,10 @@ public class Issue2919ImportedGenericProjectionTests
                 nested List[Src].Enumerator,
                 unqualifiedEnum List[Mode],
                 qualifiedEnum System.Collections.Generic.List[Mode],
-                nestedEnum List[Mode].Enumerator) {}
+                nestedEnum List[Mode].Enumerator,
+                unqualifiedNullableEnum List[Mode?],
+                qualifiedNullableEnum System.Collections.Generic.List[Mode?],
+                nestedNullableEnum List[Mode?].Enumerator) {}
             """);
 
         Assert.Empty(scope.Diagnostics);
@@ -56,6 +60,34 @@ public class Issue2919ImportedGenericProjectionTests
             "System.Collections.Generic.List`1+Enumerator",
             "System.Object",
             "Mode");
+        AssertNullableEnumProjection(
+            parameters[6].Type,
+            "System.Collections.Generic.List`1");
+        AssertNullableEnumProjection(
+            parameters[7].Type,
+            "System.Collections.Generic.List`1");
+        AssertNullableEnumProjection(
+            parameters[8].Type,
+            "System.Collections.Generic.List`1+Enumerator");
+    }
+
+    [Fact]
+    public void NullableSourceEnum_GenericArguments_EmitAndRun()
+    {
+        var result = EmittedOracle.Evaluate("""
+            import System.Collections.Generic
+
+            enum Mode { First, Second }
+
+            let unqualified = List[Mode?]()
+            let qualified = System.Collections.Generic.List[Mode?]()
+            unqualified.Add(Mode.Second)
+            qualified.Add(Mode.First)
+            unqualified[0] == Mode.Second && qualified[0] == Mode.First
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(true, result.Value);
     }
 
     private static void AssertProjection(
@@ -69,6 +101,21 @@ public class Issue2919ImportedGenericProjectionTests
         Assert.Equal(expectedOpenDefinition, imported.OpenDefinition.FullName);
         Assert.Equal(expectedClrArgument, Assert.Single(imported.ClrType.GetGenericArguments()).FullName);
         Assert.Equal(expectedSymbolicArgument, Assert.Single(imported.TypeArguments).Name);
+    }
+
+    private static void AssertNullableEnumProjection(
+        TypeSymbol type,
+        string expectedOpenDefinition)
+    {
+        var imported = Assert.IsType<ImportedTypeSymbol>(type);
+        Assert.NotNull(imported.OpenDefinition);
+        Assert.Equal(expectedOpenDefinition, imported.OpenDefinition.FullName);
+        Assert.Equal(
+            typeof(object).FullName,
+            Assert.Single(imported.ClrType.GetGenericArguments()).FullName);
+
+        var symbolicArgument = Assert.IsType<NullableTypeSymbol>(Assert.Single(imported.TypeArguments));
+        Assert.Equal("Mode", symbolicArgument.UnderlyingType.Name);
     }
 
     private static BoundGlobalScope BindSource(string source)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3394InlineOutTupleBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3394InlineOutTupleBindingTests.cs
@@ -474,6 +474,223 @@ public class Issue3394InlineOutTupleBindingTests
     }
 
     [Fact]
+    public void ImportedStaticGenericByRef_PreservesSourceReferenceType()
+    {
+        var result = EmittedOracle.Evaluate("""
+            import System.Threading
+
+            class Item {
+                prop Value int32
+            }
+
+            let item = Item()
+            item.Value = 42
+            var source Item? = item
+            let value = Volatile.Read(&source)
+            var destination Item? = nil
+            Volatile.Write(&destination, value)
+            destination!!.Value
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void GenericSourceEnumerable_ToImmutableArrayPreservesElementType()
+    {
+        var result = EmittedOracle.Evaluate("""
+            import System.Collections
+            import System.Collections.Generic
+            import System.Collections.Immutable
+
+            class Item {}
+
+            class Items[T] : IEnumerable[T] {
+                func GetEnumerator() IEnumerator[T] -> List[T]().GetEnumerator()
+                private func GetEnumerator() IEnumerator -> GetEnumerator()
+            }
+
+            let items = Items[Item]()
+            let values ImmutableArray[Item] = items.ToImmutableArray()
+            values.Length
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(0, result.Value);
+    }
+
+    [Fact]
+    public void UserGenericNestedImportedReturn_PreservesIterationElementType()
+    {
+        var result = EmittedOracle.Evaluate("""
+            import System.Collections.Generic
+
+            open class Base {}
+            class Item : Base {}
+
+            func group[T Base](value T) List[List[T]] {
+                let result = List[List[T]]()
+                let items = List[T]()
+                items.Add(value)
+                result.Add(items)
+                return result
+            }
+
+            var count = 0
+            for items in group(Item()) {
+                let item Item = items[0]
+                count += if item != nil { items.Count } else { 0 }
+            }
+            count
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(1, result.Value);
+    }
+
+    [Fact]
+    public void ConcurrentDictionaryGetOrAdd_PrefersFactoryForGenericSliceValue()
+    {
+        const string Source = """
+            import System.Collections.Concurrent
+
+            open class Item {}
+            class Value : Item {}
+
+            class Cache[T Item] {
+                shared {
+                    let Values ConcurrentDictionary[(string, int32), []T] =
+                        ConcurrentDictionary[(string, int32), []T]()
+                }
+            }
+
+            func get[T Item]() []T ->
+                Cache[T].Values.GetOrAdd(("items", 0), (key (string, int32)) -> [0]T)
+
+            get[Value]().Length
+            """;
+
+        var result = EmittedOracle.Evaluate(Source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(0, result.Value);
+    }
+
+    [Fact]
+    public void ConcurrentDictionaryGetOrAdd_SubstitutesConcreteMethodTypeArgument()
+    {
+        var result = EmittedOracle.Evaluate("""
+            import System
+            import System.Collections.Concurrent
+
+            class Item {}
+
+            func create(type_ Type, name string) Item -> Item()
+
+            let cache = ConcurrentDictionary[Type, Item]()
+            cache.GetOrAdd(typeof(Item), create, "consumer").GetType().Name
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("Item", result.Value);
+    }
+
+    [Fact]
+    public void SliceReferenceElementNullability_IsRuntimeIdentity()
+    {
+        var result = EmittedOracle.Evaluate("""
+            class Item {}
+
+            let values = [1]Item
+            let nullableValues []Item? = values
+            nullableValues.Length
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(1, result.Value);
+    }
+
+    [Fact]
+    public void ConstructorOverload_RejectsSiblingForShorterCandidate()
+    {
+        var result = EmittedOracle.Evaluate("""
+            open class Owner {}
+            class StructOwner : Owner {}
+            class InterfaceOwner : Owner {}
+
+            class Symbol {
+                init(receiver StructOwner?) {}
+                init(receiver Owner?, isOpen bool = false, isOverride bool = false) {}
+            }
+
+            Symbol(receiver: InterfaceOwner())
+            42
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void ConstructorOverload_IgnoresInaccessiblePrivateCandidate()
+    {
+        var result = EmittedOracle.Evaluate("""
+            open class Expression {}
+            class Variable : Expression {}
+
+            class Assignment {
+                init(receiver Variable?) {}
+                private init(receiver Expression) {}
+            }
+
+            Assignment(nil)
+            42
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void ImportedClassConstraint_ExposesInstanceProperties()
+    {
+        var result = EmittedOracle.Evaluate("""
+            import System
+            import System.Reflection
+
+            func name[T MemberInfo](member T) string -> member.Name
+
+            let property = typeof(string).GetProperty("Length")!!
+            name(property)
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("Length", result.Value);
+    }
+
+    [Fact]
+    public void CrossFileAttributeUse_BindsBeforeExplicitBaseDeclaration()
+    {
+        var result = EmittedOracle.Evaluate(
+            new[]
+            {
+                """
+                package P
+                @Note
+                class C {}
+                """,
+                """
+                package P
+                import System
+                @AttributeUsage(AttributeTargets.Class)
+                class NoteAttribute : Attribute {}
+                """,
+            });
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
     public void ImmutableArrayCreate_PassesThroughSourceTypeSlice()
     {
         var result = EmittedOracle.Evaluate("""

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3394NestedGenericTypeTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3394NestedGenericTypeTranslationTests.cs
@@ -88,6 +88,75 @@ namespace Demo
     }
 
     [Fact]
+    public void NullablePromotedNestedGenericLocal_RetainsContainingType()
+    {
+        const string source = """
+            #nullable enable
+            using System.Collections.Immutable;
+
+            namespace Demo
+            {
+                public class C
+                {
+                    public void M()
+                    {
+                        var builder = ImmutableArray.CreateBuilder<int>();
+                        builder = null;
+                    }
+                }
+            }
+            """;
+
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Snippet.cs", source) });
+        Assert.True(project.BoundWithoutErrors, string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(
+            project.Compilation,
+            document.SemanticModel,
+            document.FilePath);
+        string rendered = GSharpPrinter.Print(
+            new CSharpToGSharpTranslator().TranslateDocument(document, context));
+
+        Assert.Contains("builder ImmutableArray[int32].Builder?", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+
+    [Fact]
+    public void NamedTuplePropertyPattern_UsesPositionalMember()
+    {
+        const string source = """
+            #nullable enable
+
+            namespace Demo
+            {
+                public static class C
+                {
+                    public static bool HasValue((int Id, string? FunctionType)? target) =>
+                        target is { FunctionType: not null };
+                }
+            }
+            """;
+
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Snippet.cs", source) });
+        Assert.True(project.BoundWithoutErrors, string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(
+            project.Compilation,
+            document.SemanticModel,
+            document.FilePath);
+        string rendered = GSharpPrinter.Print(
+            new CSharpToGSharpTranslator().TranslateDocument(document, context));
+
+        Assert.Contains("target!!.Item2 != nil", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("target!!.FunctionType", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+
+    [Fact]
     public void PositionalRecordProperty_RedeclarationDoesNotDuplicateMember()
     {
         const string source = @"

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.ControlFlow.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.ControlFlow.cs
@@ -1394,9 +1394,9 @@ public sealed partial class CSharpToGSharpTranslator
             return reference switch
             {
                 NamedTypeReference named =>
-                    new NamedTypeReference(named.Name, named.TypeArguments) { IsNullable = true },
+                    new NamedTypeReference(named.Name, named.TypeArguments, named.ContainingType) { IsNullable = true },
                 ArrayTypeReference array =>
-                    new ArrayTypeReference(array.ElementType) { IsNullable = true },
+                    new ArrayTypeReference(array.ElementType, array.Rank) { IsNullable = true },
                 PointerTypeReference pointer =>
                     new PointerTypeReference(pointer.ElementType) { IsNullable = true },
                 TupleTypeReference tuple =>

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -1117,7 +1117,7 @@ public sealed partial class CSharpToGSharpTranslator
                     GExpression memberTest;
                     if (sub.NameColon != null)
                     {
-                        string memberName = sub.NameColon.Name.Identifier.Text;
+                        string memberName = this.GetSubpatternMemberName(sub);
                         GExpression memberAccess = new MemberAccessExpression(memberReceiver, SanitizeIdentifier(memberName));
                         ITypeSymbol memberType = this.TryGetSubpatternMemberType(sub);
                         memberTest = this.TranslatePatternTest(memberAccess, sub.Pattern, memberType, isNestedPatternMember: true);
@@ -1230,6 +1230,19 @@ public sealed partial class CSharpToGSharpTranslator
                 IFieldSymbol f => f.Type,
                 _ => null,
             };
+        }
+
+        private string GetSubpatternMemberName(SubpatternSyntax sub)
+        {
+            string name = sub.NameColon?.Name.Identifier.Text;
+            if (sub.NameColon != null
+                && this.context.SemanticModel.GetSymbolInfo(sub.NameColon.Name).Symbol
+                    is IFieldSymbol { ContainingType.IsTupleType: true } tupleField)
+            {
+                name = (tupleField.CorrespondingTupleField ?? tupleField).Name;
+            }
+
+            return name;
         }
 
         // Splits an extended property subpattern's dotted member path


### PR DESCRIPTION
## Summary

Refs #3394. Fixes #3400.

Continues Core-first compiler self-migration from merged #3405.

- keeps all Core inputs translating and round-trip parsing clean
- reduces Core semantic diagnostics from 108 to **60**
- reduces original 1,126 frontier to 60 (**94.7% removed**)
- fixes imported static generic managed by-ref projection and closes #3400
- preserves source collection elements and nested symbolic generic returns
- fixes structural erasure, nullable slice identity, and method-type substitution
- makes named-argument overload applicability conversion-aware
- filters inaccessible constructor overloads before selection
- exposes imported class-constraint properties
- removes cross-file attribute base-binding order dependence
- preserves nullable nested containing types and named tuple property members in cs2gs
- commits no generated migrated sources, artifacts, logs, binaries, packages, or caches

## Core cycles

| Cycle | Diagnostics |
|---:|---:|
| 67 baseline | 108 |
| 68 | 101 |
| 69 | 93 |
| 70 | 89 |
| 71 | 88 |
| 72 | 87 |
| 73 | 86 |
| 74 | 81 |
| 75 | 74 |
| 76 | 72 |
| 77 | 67 |
| 78 | 66 |
| 79 | 65 |
| 80 | 62 |
| 81 | 61 |
| 82–83 final | **60** |

Final measured run:

```text
artifacts/issue-3394/core-cycle-83-final/2026-08-16T05-20-12Z_936f92
translate: PASS
compile:  FAIL(60)
```

## Validation

- `Issue3394InlineOutTupleBindingTests`: 36/36 passed
- `Issue3394NestedGenericTypeTranslationTests`: 6/6 passed
- SDK and cs2gs CLI Release builds passed
- repeated full Core migration diagnostic cycles through cycle 83
- `git diff --check`

Core does not yet compile, so ILVerify/test parity/self-host and gsc/gsi/gsgen/cs2gs remain gated.
