### PR TITLE
Complete Core self-migration semantic compile

### DIFF
--- a/docs/self-migration-spike-3394.md
+++ b/docs/self-migration-spike-3394.md
@@ -19,10 +19,11 @@ The spike proves that cs2gs can translate the complete Core source tree:
 - zero unsupported translation diagnostics;
 - every emitted file round-trip parses.
 
-Core does not yet compile. The semantic frontier moved from 1,126 diagnostics
-in cycle 14 to 291 in cycle 49, removing 835 diagnostics (74.2%). Because Core
-does not compile, this spike did not claim Core IL verification, test parity,
-self-hosted recompilation, or migration of gsc, gsi, gsgen, or cs2gs.
+Continuation through cycle 111 proves complete Core translation and semantic
+compilation. The semantic frontier moved from 1,126 diagnostics in cycle 14 to
+zero. Core IL verification now fails with 163 diagnostics, so test parity,
+self-hosted recompilation, and migration of gsc, gsi, gsgen, or cs2gs remain
+blocked behind the emitted generic-ABI defect tracked by #3407.
 
 The independent Oahu gate reached full parity: all 15 projects pass
 translation, compilation, IL verification, and test parity.
@@ -412,6 +413,63 @@ Durable fixes include:
 
 Cycle 83's largest IDs are GS0159 (10), GS0155 (8), GS0158 (8), GS0125 (6),
 and GS0154 (4). The largest file remains
-`ExpressionBinder.Access.Accessor.gs` with 13 diagnostics. Core still does not
-compile; ILVerify, test parity, self-hosted Core recompilation, and downstream
-project migrations remain gated.
+`ExpressionBinder.Access.Accessor.gs` with 13 diagnostics.
+
+## Continuation through cycle 111
+
+Branch `oats/3394-core-compile-continuation-3`, based on `ed0f00f4`, removed
+the final 60 semantic diagnostics and then continued through the newly exposed
+emit failures:
+
+| Cycle | Result | Milestone |
+|---:|---:|---|
+| 85 | compile fail (60) | Fresh-main baseline |
+| 86–89 | 55 → 53 → 46 → 22 | Nested construction, mutable deconstruction, pattern/source shaping |
+| 90–95 | 1–4 diagnostics | Final semantic clusters |
+| 96–104 | emit failures | Latent iterator/tuple emit paths exposed after semantic diagnostics reached zero |
+| 105 | compile pass | First complete Core semantic compile |
+| 111 | compile pass | Final-tree confirmation; ILVerify fail (163) |
+
+Final run:
+
+```text
+artifacts/issue-3394/core-cycle-111-final/2026-08-16T08-23-34Z_24caa3
+translate: PASS
+compile:  PASS
+ilverify: FAIL(163)
+test parity: skipped
+```
+
+The original semantic frontier is therefore **1,126 → 0**. Durable fixes
+cover qualified nested constructor continuations, mutable by-ref
+deconstruction locals, pattern-variable scope-safe source shaping,
+nullable/default imported parameters, binding-context state, definite
+assignment, nested rewriter placement, unsupported migrated iterator/tuple
+helpers, and runtime-equivalent conversion emission.
+
+The ILVerify frontier is dominated by symbolic generic ABI mismatches:
+
+- 121 `StackUnexpected`;
+- 40 `PathStackUnexpected`;
+- one `DelegateCtor`;
+- one `ValueTypeExpected`;
+- 80 failures involving erased `ImmutableArray<object>` paths;
+- large concrete-enumerator versus open `IEnumerator<!0>` families.
+
+Issue #3407 tracks this proven emitted-metadata blocker. A direct symbolic
+MemberRef experiment reduced 163 failures to 79, but broke seven existing
+emitted-runtime generic call regressions (`List<Source>.Add`,
+`ConcurrentDictionary.GetOrAdd`, `Dictionary.TryGetValue`, and related
+families), proving that TypeSpec parenting, VAR/MVAR signature encoding, and
+call-site symbolic projection must be repaired together.
+
+Final focused validation:
+
+- Core migration/binder, SyntaxTree, and CLR utility regressions: 63 passed;
+- cs2gs nested-generic/deconstruction regressions: 7 passed;
+- SDK and cs2gs CLI Release builds passed;
+- `git diff --check` passed.
+
+Per the required sequence, test parity, self-hosted Core recompilation, and
+gsc/gsi/gsgen/cs2gs migration remain gated behind #3407 rather than running
+against unverifiable IL.

--- a/src/Compiler/Program.cs
+++ b/src/Compiler/Program.cs
@@ -262,12 +262,12 @@ public class Program
 
     internal static int ReportUnhandledException(Exception ex)
     {
-        Console.Out.WriteDiagnostics(new[] { Compilation.CreateInternalErrorDiagnostic(ex) });
         if (System.Environment.GetEnvironmentVariable("GS_DEBUG_STACK") != null)
         {
             Console.Out.WriteLine(ex.ToString());
         }
 
+        DiagnosticWriter.WriteDiagnostics(Console.Out, new[] { Compilation.CreateInternalErrorDiagnostic(ex) });
         return Error;
     }
 
@@ -323,7 +323,7 @@ public class Program
         if (result.Diagnostics.Any())
         {
             var effective = ApplySuppressPromote(result.Diagnostics, args);
-            Console.Out.WriteDiagnostics(effective);
+            DiagnosticWriter.WriteDiagnostics(Console.Out, effective);
             if (effective.Any(d => d.IsError))
             {
                 Console.Error.WriteLine("Failed.");
@@ -422,7 +422,7 @@ public class Program
         // Always print diagnostics (errors and warnings).
         if (effectiveDiagnostics.Any())
         {
-            Console.Out.WriteDiagnostics(effectiveDiagnostics);
+            DiagnosticWriter.WriteDiagnostics(Console.Out, effectiveDiagnostics);
         }
 
         bool hasErrors = !result.Success || effectiveDiagnostics.Any(d => d.IsError);

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -369,8 +369,10 @@ public sealed class Binder
                 // also accessible via bare name. Derived shadowing wins.
                 if (function.ReceiverType is StructSymbol receiverStruct)
                 {
-                    for (var t = receiverStruct; t != null; t = t.BaseClass)
+                    StructSymbol? currentReceiverType = receiverStruct;
+                    while (currentReceiverType != null)
                     {
+                        var t = currentReceiverType;
                         if (!t.Fields.IsDefaultOrEmpty)
                         {
                             foreach (var fld in t.Fields)
@@ -466,6 +468,8 @@ public sealed class Binder
                                 }
                             }
                         }
+
+                        currentReceiverType = t.BaseClass;
                     }
                 }
             }
@@ -3211,13 +3215,19 @@ public sealed class Binder
                 {
                     ret = AsyncSequenceTypeSymbol.Get(seq.ElementType);
                 }
-                else if (ret is NullableTypeSymbol nt && nt.UnderlyingType is SequenceTypeSymbol innerSeq)
+                else
                 {
-                    ret = NullableTypeSymbol.Get(AsyncSequenceTypeSymbol.Get(innerSeq.ElementType));
-                }
-                else if (!IsAsyncIteratorReturnType(ret))
-                {
-                    ret = lambdas.WrapAsTask(ret);
+                    var nt = ret as NullableTypeSymbol;
+                    var innerSeq = nt?.UnderlyingType as SequenceTypeSymbol;
+                    if (innerSeq != null)
+                    {
+                        ret = NullableTypeSymbol.Get(
+                            AsyncSequenceTypeSymbol.Get(innerSeq.ElementType));
+                    }
+                    else if (!IsAsyncIteratorReturnType(ret))
+                    {
+                        ret = lambdas.WrapAsTask(ret);
+                    }
                 }
             }
 
@@ -4647,7 +4657,9 @@ public sealed class Binder
             return AsyncSequenceTypeSymbol.Get(seq.ElementType);
         }
 
-        if (bound is NullableTypeSymbol nt && nt.UnderlyingType is SequenceTypeSymbol innerSeq)
+        var nt = bound as NullableTypeSymbol;
+        var innerSeq = nt?.UnderlyingType as SequenceTypeSymbol;
+        if (innerSeq != null)
         {
             return NullableTypeSymbol.Get(AsyncSequenceTypeSymbol.Get(innerSeq.ElementType));
         }
@@ -5893,9 +5905,14 @@ public sealed class Binder
             return true;
         }
 
-        if (type is ImportedTypeSymbol it && it.ClrType is { } clr)
+        var importedType = type as ImportedTypeSymbol;
+        if (importedType != null)
         {
-            return !clr.IsValueType;
+            var clr = importedType.ClrType;
+            if (clr != null)
+            {
+                return !clr.IsValueType;
+            }
         }
 
         return false;

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -5139,13 +5139,18 @@ public sealed class Binder
                 }
             }
         }
-        else if (parameterType is ImportedTypeSymbol pit && pit.HasTypeParameterArgument)
+
+        var importedParameterType = parameterType as ImportedTypeSymbol;
+        if (importedParameterType is not null && importedParameterType.HasTypeParameterArgument)
         {
+            var pit = importedParameterType;
+
             // #313: infer from a generic type parameterized by an in-scope type
             // parameter (e.g. parameter `List[T]` matched against argument
             // `List<int32>`). Unify the symbolic type arguments positionally
             // against the argument's CLR generic arguments.
-            var argClrArgs = GetClrGenericArguments(argumentType);
+            var argClrArgs = GetClrGenericArguments(
+                Invariant.Required(argumentType, "generic inference requires an argument type"));
             if (!argClrArgs.IsDefaultOrEmpty && argClrArgs.Length == pit.TypeArguments.Length)
             {
                 for (var i = 0; i < pit.TypeArguments.Length; i++)

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -848,14 +848,14 @@ public sealed class Binder
             }
         }
 
-        var importDeclarations = syntaxTrees.SelectMany(st => st.Root.Members)
+        var importDeclarations = syntaxTrees.SelectMany(st => st.Root.Members.AsEnumerable())
                                  .OfType<ImportSyntax>();
         foreach (var import in importDeclarations)
         {
             binder.BindImport(import);
         }
 
-        var typeAliasDeclarations = syntaxTrees.SelectMany(st => st.Root.Members)
+        var typeAliasDeclarations = syntaxTrees.SelectMany(st => st.Root.Members.AsEnumerable())
                                                .OfType<TypeAliasDeclarationSyntax>();
         foreach (var typeAlias in typeAliasDeclarations)
         {
@@ -868,7 +868,7 @@ public sealed class Binder
         // their members can reference delegates. Signatures are bound after all
         // interface/enum/struct shells exist, making delegate constraints,
         // parameters, and returns independent of syntax-tree order.
-        var delegateDeclarations = syntaxTrees.SelectMany(st => st.Root.Members)
+        var delegateDeclarations = syntaxTrees.SelectMany(st => st.Root.Members.AsEnumerable())
                                               .OfType<DelegateDeclarationSyntax>()
                                               .ToList();
         var declaredDelegates = new List<(DelegateDeclarationSyntax Syntax, DelegateTypeSymbol Symbol)>();
@@ -885,7 +885,7 @@ public sealed class Binder
         }
 
         var interfaceDeclarations = PartialTypeMerger.MergeInterfaces(
-            syntaxTrees.SelectMany(st => st.Root.Members).OfType<InterfaceDeclarationSyntax>(),
+            syntaxTrees.SelectMany(st => st.Root.Members.AsEnumerable()).OfType<InterfaceDeclarationSyntax>(),
             packageByTree,
             binder.Diagnostics);
 
@@ -907,7 +907,7 @@ public sealed class Binder
             }
         }
 
-        var enumDeclarations = syntaxTrees.SelectMany(st => st.Root.Members)
+        var enumDeclarations = syntaxTrees.SelectMany(st => st.Root.Members.AsEnumerable())
                                            .OfType<EnumDeclarationSyntax>();
         foreach (var enumSyntax in enumDeclarations)
         {
@@ -939,7 +939,7 @@ public sealed class Binder
         }
 
         var structDeclarations = PartialTypeMerger.MergeStructs(
-            syntaxTrees.SelectMany(st => st.Root.Members).OfType<StructDeclarationSyntax>(),
+            syntaxTrees.SelectMany(st => st.Root.Members.AsEnumerable()).OfType<StructDeclarationSyntax>(),
             packageByTree,
             binder.Diagnostics)
             .Concat(richAnonymousClasses.Select(r => r.Declaration))
@@ -1084,7 +1084,7 @@ public sealed class Binder
             RunWithPackage(owningPackage, ifaceSyntax.SyntaxTree, () => binder.declarations.BindInterfaceMembers(ifaceSyntax, ifaceSymbol, owningPackage));
         }
 
-        var functionDeclarations = syntaxTrees.SelectMany(st => st.Root.Members)
+        var functionDeclarations = syntaxTrees.SelectMany(st => st.Root.Members.AsEnumerable())
                                               .OfType<FunctionDeclarationSyntax>();
         foreach (var function in functionDeclarations)
         {
@@ -1125,7 +1125,7 @@ public sealed class Binder
         // SelectMany's iteration order.
         var globalStatements = syntaxTrees
             .OrderBy(st => st.Text?.FileName ?? string.Empty, StringComparer.Ordinal)
-            .SelectMany(st => st.Root.Members)
+            .SelectMany(st => st.Root.Members.AsEnumerable())
             .OfType<GlobalStatementSyntax>()
             .ToArray();
 
@@ -6860,7 +6860,7 @@ public sealed class Binder
         var classMain = explicitMain == null && !structs.IsDefaultOrEmpty
             ? structs
                 .Where(s => s.IsClass && !s.StaticMethods.IsDefaultOrEmpty)
-                .SelectMany(s => s.StaticMethods)
+                .SelectMany(s => s.StaticMethods.AsEnumerable())
                 .FirstOrDefault(m => m.Name == "Main")
             : null;
         explicitMain ??= classMain;

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -3827,20 +3827,28 @@ public sealed class Binder
             // references. Issue #1506: each segment now drives its own preferred
             // arity from its own type-argument list.
             var preferredArity = syntax.SegmentHasTypeArguments(i) ? SegmentTypeArguments(i).Count : -1;
-            if (scope.TryLookupNestedTypeAlias(ResolvedDefinition(i - 1), segmentTexts[i], preferredArity, out var nested))
+            var previousDefinition = ResolvedDefinition(i - 1);
+            if (scope.TryLookupNestedTypeAlias(previousDefinition, segmentTexts[i], preferredArity, out var nested))
             {
                 definitions[i] = nested;
+                continue;
             }
-            else if (ResolvedDefinition(i - 1) is StructSymbol containerStruct
-                && scope.TryLookupNestedTypeAliasIncludingInherited(containerStruct, segmentTexts[i], preferredArity, out var inheritedNested, out var declaringContainer))
+
+            var containerStruct = previousDefinition as StructSymbol;
+            if (containerStruct != null
+                && scope.TryLookupNestedTypeAliasIncludingInherited(
+                    containerStruct,
+                    segmentTexts[i],
+                    preferredArity,
+                    out var inheritedNested,
+                    out var declaringContainer))
             {
                 definitions[i - 1] = declaringContainer;
                 definitions[i] = inheritedNested;
+                continue;
             }
-            else
-            {
-                return null;
-            }
+
+            return null;
         }
 
         // The chain resolved to a user nested type. Construct generic segments

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -273,14 +273,20 @@ public sealed class Binder
                 ParameterAllowedTargets,
                 "a parameter declaration",
                 System.AttributeTargets.Parameter),
-            bindLambdaBodyExpression: syntax => Expressions.BindLambdaBodyExpression(syntax),
+            bindLambdaBodyExpression: BindLambdaBodyExpressionForLambdas,
             bindTypeParameterList: syntax => Declarations.BindTypeParameterList(syntax));
+        BoundExpression BindExpressionWithTargetTypeForStatements(
+            ExpressionSyntax syntax,
+            TypeSymbol targetType) =>
+            Expressions.BindExpression(syntax, targetType);
+        BoundExpression BindLambdaBodyExpressionForLambdas(ExpressionSyntax syntax) =>
+            Expressions.BindLambdaBodyExpression(syntax);
         statements = new StatementBinder(
             binderCtx,
             conversions,
             patterns,
             bindExpression: (syntax, canBeVoid) => Expressions.BindExpression(syntax, canBeVoid),
-            bindExpressionWithTargetType: (syntax, targetType) => Expressions.BindExpression(syntax, targetType),
+            bindExpressionWithTargetType: BindExpressionWithTargetTypeForStatements,
             bindTypeClause: BindTypeClause,
             bindLocalVariable: (identifier, isReadOnly, type) => Declarations.BindVariableDeclaration(identifier, isReadOnly, type),
             bindLocalVariableWithAccessibility: (identifier, isReadOnly, type, accessibility) => Declarations.BindVariableDeclaration(identifier, isReadOnly, type, accessibility),
@@ -295,13 +301,17 @@ public sealed class Binder
             bindLambdaWithTargetType: (syntax, targetType) => Lambdas.BindLambdaExpression(syntax, targetType),
             bindGenericLocalFunctionDeclaration: syntax => Lambdas.BindGenericLocalFunctionDeclaration(syntax),
             checkNonGenericLocalFunctionEnclosingTypeParameterReference: (location, name, literal) => Lambdas.CheckNonGenericLocalFunctionEnclosingTypeParameterReference(location, name, literal));
+        BoundExpression BindTypeOfExpressionForDeclarations(TypeOfExpressionSyntax syntax) =>
+            Expressions.BindTypeOfExpression(syntax);
+        BoundExpression BindExpressionForDeclarations(ExpressionSyntax syntax) =>
+            Expressions.BindExpression(syntax);
         declarations = new DeclarationBinder(
             binderCtx,
             conversions,
-            bindExpression: syntax => Expressions.BindExpression(syntax),
+            bindExpression: BindExpressionForDeclarations,
             bindTypeClause: BindTypeClause,
             bindReturnTypeClause: (syntax, isAsync) => BindReturnTypeClause(syntax, isAsync),
-            bindTypeOfExpression: syntax => Expressions.BindTypeOfExpression(syntax),
+            bindTypeOfExpression: BindTypeOfExpressionForDeclarations,
             bindArrayCreationExpression: syntax => Expressions.BindArrayCreationExpression(syntax),
             resolveAccessibility: ResolveAccessibility,
             lookupType: LookupType,
@@ -1032,13 +1042,28 @@ public sealed class Binder
                 var requestedPackage = nonNullBaseType.HasQualifier
                     ? nonNullBaseType.DottedName[..^(baseName.Length + 1)]
                     : symbol.PackageName;
-                var matchingPackage = candidates.Where(candidate =>
-                    declaredStructs[candidate].Symbol.IsClass &&
-                    declaredStructs[candidate].Symbol.PackageName == requestedPackage).ToList();
+                var matchingPackage = new List<int>();
+                var classCandidateCount = 0;
+                var soleClassCandidate = -1;
+                foreach (var candidate in candidates)
+                {
+                    if (!declaredStructs[candidate].Symbol.IsClass)
+                    {
+                        continue;
+                    }
+
+                    classCandidateCount++;
+                    soleClassCandidate = candidate;
+                    if (declaredStructs[candidate].Symbol.PackageName == requestedPackage)
+                    {
+                        matchingPackage.Add(candidate);
+                    }
+                }
+
                 var baseIndex = matchingPackage.Count == 1
                     ? matchingPackage[0]
-                    : candidates.Count(candidate => declaredStructs[candidate].Symbol.IsClass) == 1
-                        ? candidates.Single(candidate => declaredStructs[candidate].Symbol.IsClass)
+                    : classCandidateCount == 1
+                        ? soleClassCandidate
                         : -1;
                 if (baseIndex >= 0)
                 {
@@ -4995,6 +5020,13 @@ public sealed class Binder
             return;
         }
 
+        var importedParameterType = parameterType as ImportedTypeSymbol;
+        if (importedParameterType is not null && importedParameterType.HasTypeParameterArgument)
+        {
+            InferImportedTypeArguments(importedParameterType, argumentType, substitution);
+            return;
+        }
+
         if (parameterType is NullableTypeSymbol pn)
         {
             // Issue #1931: a `T?` parameter also accepts a non-nullable argument
@@ -5139,76 +5171,59 @@ public sealed class Binder
                 }
             }
         }
+    }
 
-        var importedParameterType = parameterType as ImportedTypeSymbol;
-        if (importedParameterType is not null && importedParameterType.HasTypeParameterArgument)
+    private static void InferImportedTypeArguments(
+        ImportedTypeSymbol parameterType,
+        TypeSymbol argumentType,
+        Dictionary<TypeParameterSymbol, TypeSymbol> substitution)
+    {
+        var argumentClrArguments = GetClrGenericArguments(argumentType);
+        if (!argumentClrArguments.IsDefaultOrEmpty
+            && argumentClrArguments.Length == parameterType.TypeArguments.Length)
         {
-            var pit = importedParameterType;
+            for (var i = 0; i < parameterType.TypeArguments.Length; i++)
+            {
+                InferTypeArguments(
+                    parameterType.TypeArguments[i],
+                    argumentClrArguments[i],
+                    substitution);
+            }
 
-            // #313: infer from a generic type parameterized by an in-scope type
-            // parameter (e.g. parameter `List[T]` matched against argument
-            // `List<int32>`). Unify the symbolic type arguments positionally
-            // against the argument's CLR generic arguments.
-            var argClrArgs = GetClrGenericArguments(
-                Invariant.Required(argumentType, "generic inference requires an argument type"));
-            if (!argClrArgs.IsDefaultOrEmpty && argClrArgs.Length == pit.TypeArguments.Length)
+            return;
+        }
+
+        var argumentClrType = argumentType.ClrType;
+        var matchedInterface = argumentClrType != null
+            && argumentClrType.IsArray
+            && parameterType.OpenDefinition != null
+                ? FindMatchingInterface(argumentClrType, parameterType.OpenDefinition)
+                : null;
+        if (matchedInterface != null)
+        {
+            var matchedArguments = matchedInterface.GetGenericArguments();
+            if (matchedArguments.Length == parameterType.TypeArguments.Length)
             {
-                for (var i = 0; i < pit.TypeArguments.Length; i++)
+                for (var i = 0; i < parameterType.TypeArguments.Length; i++)
                 {
-                    InferTypeArguments(pit.TypeArguments[i], argClrArgs[i], substitution);
+                    InferTypeArguments(
+                        parameterType.TypeArguments[i],
+                        TypeSymbol.FromClrType(matchedArguments[i]),
+                        substitution);
                 }
             }
-            else if (argClrArgs.IsDefaultOrEmpty)
-            {
-                // #611: slice/array → interface inference. A slice `[]T` or
-                // fixed-array `[N]T` is backed by CLR `T[]` which is not
-                // generic itself but implements generic interfaces
-                // (IEnumerable<T>, IReadOnlyList<T>, IList<T>, etc.). Walk
-                // the array's interface set to find a match for the
-                // parameter's open definition and extract its arguments.
-                var argClr = argumentType?.ClrType;
-                var matched = argClr != null && argClr.IsArray && pit.OpenDefinition != null
-                    ? FindMatchingInterface(argClr, pit.OpenDefinition)
-                    : null;
-                if (matched != null)
-                {
-                    var matchedArgs = matched.GetGenericArguments();
-                    if (matchedArgs.Length == pit.TypeArguments.Length)
-                    {
-                        for (var i = 0; i < pit.TypeArguments.Length; i++)
-                        {
-                            InferTypeArguments(pit.TypeArguments[i], TypeSymbol.FromClrType(matchedArgs[i]), substitution);
-                        }
-                    }
-                }
-                else if ((argumentType is SliceTypeSymbol || argumentType is ArrayTypeSymbol)
-                    && pit.TypeArguments.Length == 1
-                    && IsArrayCompatibleOpenInterface(pit.OpenDefinition))
-                {
-                    // Issue #2416: the reflection-based lookup above requires a
-                    // real CLR `Type` for the slice/array (`argumentType.ClrType`),
-                    // which is null for a same-compilation SOURCE element type
-                    // that has not been emitted yet (e.g. a source `struct`/
-                    // `class` used as `[]Chapter`). A CLR single-dimensional
-                    // array unconditionally implements `IEnumerable<T>`,
-                    // `ICollection<T>`, `IList<T>`, `IReadOnlyCollection<T>`,
-                    // and `IReadOnlyList<T>` with `T` equal to its own element
-                    // type — a guarantee of the CLR array contract, not
-                    // something that needs reflection to confirm. Unify
-                    // symbolically against the slice/array's own
-                    // <see cref="SliceTypeSymbol.ElementType"/> /
-                    // <see cref="ArrayTypeSymbol.ElementType"/> so this generic
-                    // extension/method inference doesn't depend on whether the
-                    // element type has a `ClrType` yet. This keeps working the
-                    // same way regardless of whether the array receiver came
-                    // from a bare member access, a null-asserted chain
-                    // (`x!!.Member`), a nested chain, or a for-loop element.
-                    var elementType = argumentType is SliceTypeSymbol slice
-                        ? slice.ElementType
-                        : ((ArrayTypeSymbol)argumentType).ElementType;
-                    InferTypeArguments(pit.TypeArguments[0], elementType, substitution);
-                }
-            }
+
+            return;
+        }
+
+        if ((argumentType is SliceTypeSymbol || argumentType is ArrayTypeSymbol)
+            && parameterType.TypeArguments.Length == 1
+            && IsArrayCompatibleOpenInterface(parameterType.OpenDefinition))
+        {
+            var elementType = argumentType is SliceTypeSymbol slice
+                ? slice.ElementType
+                : ((ArrayTypeSymbol)argumentType).ElementType;
+            InferTypeArguments(parameterType.TypeArguments[0], elementType, substitution);
         }
     }
 
@@ -5530,9 +5545,13 @@ public sealed class Binder
         // it surfaces as `Box[int32].Tag`. `Tag` declares no own type arguments,
         // so the emitter parents its use-site references/slots at
         // `Box`1+Tag`1<int32>` rather than the open `Box`1+Tag`1<!0>`.
+        Func<TypeSymbol, TypeSymbol> substituteEnclosingType =
+            nestedType => SubstituteType(nestedType, substitution, mapClrType);
         if (type is StructSymbol nestedRef && nestedRef.TypeArguments.IsDefaultOrEmpty)
         {
-            var newEnclosing = StructSymbol.SubstituteEnclosingArguments(nestedRef, t => SubstituteType(t, substitution, mapClrType));
+            var newEnclosing = StructSymbol.SubstituteEnclosingArguments(
+                nestedRef,
+                substituteEnclosingType);
             if (!newEnclosing.IsDefault)
             {
                 return StructSymbol.ConstructNested(nestedRef.Definition ?? nestedRef, newEnclosing, mapClrType);
@@ -5541,7 +5560,9 @@ public sealed class Binder
 
         if (type is EnumSymbol nestedEnum)
         {
-            var newEnclosing = EnumSymbol.SubstituteEnclosingArguments(nestedEnum, t => SubstituteType(t, substitution, mapClrType));
+            var newEnclosing = EnumSymbol.SubstituteEnclosingArguments(
+                nestedEnum,
+                substituteEnclosingType);
             if (!newEnclosing.IsDefault)
             {
                 return EnumSymbol.ConstructNested(nestedEnum.Definition ?? nestedEnum, newEnclosing);

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -1220,6 +1220,8 @@ public sealed class Binder
                             binder.scope.SetCurrentDeclaringPackage(packageByTree[tree]?.Name);
                             binder.scope.SetCurrentReferencingSyntaxTree(tree);
                         }
+
+                        return;
                     }));
             }
             finally
@@ -1697,7 +1699,7 @@ public sealed class Binder
 
                     AnalyzeFunctionBody(lowered, function, binder.Diagnostics);
 
-                    return (lowered, binder.Diagnostics.ToImmutableArray());
+                    return new BodyBindResult(lowered, binder.Diagnostics.ToImmutableArray());
                 }));
 
                 functionBodies.Add(function, loweredBody);
@@ -1746,7 +1748,7 @@ public sealed class Binder
 
                     AnalyzeFunctionBody(lowered, method, binder.Diagnostics);
 
-                    return (lowered, binder.Diagnostics.ToImmutableArray());
+                    return new BodyBindResult(lowered, binder.Diagnostics.ToImmutableArray());
                 }));
 
                 functionBodies.Add(method, loweredBody);
@@ -1900,7 +1902,7 @@ public sealed class Binder
 
                     var lowered = Lowerer.Lower(ctorBody, structSym);
                     AnalyzeFunctionBody(lowered, ctor.Function, ctorBinder.Diagnostics);
-                    return (lowered, ctorBinder.Diagnostics.ToImmutableArray());
+                    return new BodyBindResult(lowered, ctorBinder.Diagnostics.ToImmutableArray());
                 }));
                 functionBodies.Add(ctor.Function, ctorLoweredBody);
             }
@@ -2167,7 +2169,7 @@ public sealed class Binder
         FunctionSymbol member,
         SyntaxNode bodySyntax,
         ImmutableArray<Diagnostic>.Builder diagnostics,
-        Func<(BoundBlockStatement Body, ImmutableArray<Diagnostic> Diagnostics)> bindAndLower)
+        Func<BodyBindResult> bindAndLower)
     {
         var isDirty = dirtyTrees != null
             && bodySyntax?.SyntaxTree != null
@@ -2182,14 +2184,14 @@ public sealed class Binder
             return reusedBody;
         }
 
-        var (body, bodyDiagnostics) = bindAndLower();
-        AppendBodyDiagnostics(diagnostics, bodyDiagnostics, member);
+        var result = bindAndLower();
+        AppendBodyDiagnostics(diagnostics, result.Diagnostics, member);
 
         // bodySyntax is this method's own non-nullable parameter, never
         // reassigned above (the `bodySyntax?.SyntaxTree` read a few lines up
         // is a redundant null-conditional, not a narrowing of bodySyntax).
-        cache?.Store(member, bodySyntax!, body, bodyDiagnostics);
-        return body;
+        cache?.Store(member, bodySyntax!, result.Body, result.Diagnostics);
+        return result.Body;
     }
 
     private static void AppendBodyDiagnostics(
@@ -2289,7 +2291,7 @@ public sealed class Binder
 
             AnalyzeFunctionBody(lowered, method, binder.Diagnostics);
 
-            return (lowered, binder.Diagnostics.ToImmutableArray());
+            return new BodyBindResult(lowered, binder.Diagnostics.ToImmutableArray());
         }));
 
         functionBodies.Add(method, loweredBody);
@@ -2337,7 +2339,7 @@ public sealed class Binder
 
             AnalyzeFunctionBody(lowered, accessor, binder.Diagnostics);
 
-            return (lowered, binder.Diagnostics.ToImmutableArray());
+            return new BodyBindResult(lowered, binder.Diagnostics.ToImmutableArray());
         }));
 
         functionBodies.Add(accessor, loweredBody);
@@ -2389,7 +2391,7 @@ public sealed class Binder
 
             AnalyzeFunctionBody(lowered, member, binder.Diagnostics);
 
-            return (lowered, binder.Diagnostics.ToImmutableArray());
+            return new BodyBindResult(lowered, binder.Diagnostics.ToImmutableArray());
         }));
 
         functionBodies.Add(member, loweredBody);
@@ -2433,7 +2435,7 @@ public sealed class Binder
 
             AnalyzeFunctionBody(lowered, method, binder.Diagnostics);
 
-            return (lowered, binder.Diagnostics.ToImmutableArray());
+            return new BodyBindResult(lowered, binder.Diagnostics.ToImmutableArray());
         }));
 
         functionBodies.Add(method, loweredBody);
@@ -6181,7 +6183,18 @@ public sealed class Binder
             ?? ImmutableArray<TypeSymbol>.Empty;
         var constraintClrArgs = constraintClr.GetGenericArguments();
 
-        foreach (var candidate in EnumerateSelfAndInterfaces(typeArgClr))
+        var candidates = new List<Type>();
+        if (typeArgClr.IsInterface)
+        {
+            candidates.Add(typeArgClr);
+        }
+
+        foreach (var interfaceType in typeArgClr.GetInterfaces())
+        {
+            candidates.Add(interfaceType);
+        }
+
+        foreach (var candidate in candidates)
         {
             if (!candidate.IsGenericType
                 || !string.Equals(candidate.GetGenericTypeDefinition().FullName, openDefName, StringComparison.Ordinal))
@@ -6201,19 +6214,6 @@ public sealed class Binder
         }
 
         return false;
-    }
-
-    private static IEnumerable<Type> EnumerateSelfAndInterfaces(Type type)
-    {
-        if (type.IsInterface)
-        {
-            yield return type;
-        }
-
-        foreach (var i in type.GetInterfaces())
-        {
-            yield return i;
-        }
     }
 
     private static bool GenericConstraintArgumentsMatch(
@@ -6955,5 +6955,10 @@ public sealed class Binder
             symbol.SetDocumentation(doc);
         }
     }
+
+    private readonly record struct BodyBindResult(
+        BoundBlockStatement Body,
+        ImmutableArray<Diagnostic> Diagnostics);
+
 #pragma warning restore SA1202
 }

--- a/src/Core/CodeAnalysis/Binding/BinderContext.cs
+++ b/src/Core/CodeAnalysis/Binding/BinderContext.cs
@@ -536,6 +536,12 @@ internal sealed class BinderContext
         return new ConstructorInitializerContextScope(this);
     }
 
+    /// <summary>Leaves a base or delegating-constructor argument context.</summary>
+    public void LeaveConstructorInitializerContext()
+    {
+        ConstructorInitializerDepth--;
+    }
+
     /// <summary>
     /// Issue #1881. Enters a `checked`/`unchecked` arithmetic context for the
     /// lifetime of the returned token; disposing the token restores the
@@ -590,7 +596,7 @@ internal sealed class BinderContext
         {
             if (owner != null)
             {
-                owner.ConstructorInitializerDepth--;
+                owner.LeaveConstructorInitializerContext();
             }
         }
     }

--- a/src/Core/CodeAnalysis/Binding/BinderContext.cs
+++ b/src/Core/CodeAnalysis/Binding/BinderContext.cs
@@ -120,7 +120,8 @@ internal sealed class BinderContext
     /// computed by <see cref="GetStaticImportTypes"/>; invalidated when the
     /// import or struct count moves.
     /// </summary>
-    private ImmutableArray<StructSymbol>? cachedStaticImportTypes;
+    private ImmutableArray<StructSymbol> cachedStaticImportTypes;
+    private bool hasCachedStaticImportTypes;
 
     private int cachedStaticImportImportCount = -1;
 
@@ -304,12 +305,12 @@ internal sealed class BinderContext
     {
         var imports = RootScope.GetDeclaredImports();
         var structs = RootScope.GetDeclaredStructs();
-        if (cachedStaticImportTypes is { } cached
+        if (hasCachedStaticImportTypes
             && cachedStaticImportImportCount == imports.Length
             && cachedStaticImportStructCount == structs.Length
             && ReferenceEquals(cachedStaticImportSyntaxTree, RootScope.GetCurrentReferencingSyntaxTreeForCache()))
         {
-            return cached;
+            return cachedStaticImportTypes;
         }
 
         ImmutableArray<StructSymbol>.Builder? builder = null;
@@ -343,6 +344,7 @@ internal sealed class BinderContext
 
         var result = builder?.ToImmutable() ?? ImmutableArray<StructSymbol>.Empty;
         cachedStaticImportTypes = result;
+        hasCachedStaticImportTypes = true;
         cachedStaticImportImportCount = imports.Length;
         cachedStaticImportStructCount = structs.Length;
         cachedStaticImportSyntaxTree = RootScope.GetCurrentReferencingSyntaxTreeForCache();

--- a/src/Core/CodeAnalysis/Binding/BoundGlobalScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundGlobalScope.cs
@@ -352,9 +352,11 @@ public sealed class BoundGlobalScope
     public ImmutableArray<ImportSymbol> GetCumulativeImports()
     {
         var chain = new Stack<BoundGlobalScope>();
-        for (var scope = this; scope != null; scope = scope.Previous)
+        BoundGlobalScope? current = this;
+        while (current is not null)
         {
-            chain.Push(scope);
+            chain.Push(current);
+            current = current.Previous;
         }
 
         var builder = ImmutableArray.CreateBuilder<ImportSymbol>();

--- a/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
@@ -626,7 +626,7 @@ public static class BoundNodePrinter
 
         if (node.Type == TypeSymbol.Bool)
         {
-            writer.WriteKeyword(node.Value is true ? SyntaxKind.TrueKeyword : SyntaxKind.FalseKeyword);
+            writer.WriteKeyword(object.Equals(node.Value, true) ? SyntaxKind.TrueKeyword : SyntaxKind.FalseKeyword);
         }
         else if (node.Type == TypeSymbol.String)
         {

--- a/src/Core/CodeAnalysis/Binding/BoundScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundScope.cs
@@ -54,6 +54,8 @@ public sealed class BoundScope
     // Issue #2342: the ambient "current declaring package" (see
     // SetCurrentDeclaringPackage), lazily set/cleared only on the root scope
     // of the chain, exactly like anonymousTypeCache above.
+    // Empty string is the AsyncLocal storage sentinel for null; setter and
+    // getter normalize null <-> empty so save/restore preserves the contract.
     private AsyncLocal<string?> currentDeclaringPackageName = new AsyncLocal<string?>();
 
     // Issue #2456 (per-file import scoping / #2395 follow-up): the ambient

--- a/src/Core/CodeAnalysis/Binding/BoundScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundScope.cs
@@ -1669,14 +1669,17 @@ public sealed class BoundScope
     private bool TryGetAliasDeclaringPackageInChain(string key, [NotNullWhen(true)] out string? declaringPackageName)
     {
         declaringPackageName = null;
-        for (var s = this; s != null; s = s.Parent)
+        BoundScope? scope = this;
+        while (scope != null)
         {
-            if (s.aliasDeclaringPackages != null
-                && s.aliasDeclaringPackages.TryGetValue(key, out var foundPackage))
+            if (scope.aliasDeclaringPackages != null
+                && scope.aliasDeclaringPackages.TryGetValue(key, out var foundPackage))
             {
                 declaringPackageName = foundPackage;
                 return true;
             }
+
+            scope = scope.Parent;
         }
 
         return false;
@@ -1685,12 +1688,15 @@ public sealed class BoundScope
     /// <summary>Whether <paramref name="key"/> is visible anywhere in this scope chain.</summary>
     private bool TypeAliasVisible(string key)
     {
-        for (var s = this; s != null; s = s.Parent)
+        BoundScope? scope = this;
+        while (scope != null)
         {
-            if (s.typeAliases != null && s.typeAliases.ContainsKey(key))
+            if (scope.typeAliases != null && scope.typeAliases.ContainsKey(key))
             {
                 return true;
             }
+
+            scope = scope.Parent;
         }
 
         return false;
@@ -1704,13 +1710,16 @@ public sealed class BoundScope
     private bool TryGetTypeAliasInChain(string key, [NotNullWhen(true)] out TypeSymbol? value)
     {
         value = null;
-        for (var s = this; s != null; s = s.Parent)
+        BoundScope? scope = this;
+        while (scope != null)
         {
-            if (s.typeAliases != null && s.typeAliases.TryGetValue(key, out var foundValue))
+            if (scope.typeAliases != null && scope.typeAliases.TryGetValue(key, out var foundValue))
             {
                 value = foundValue;
                 return true;
             }
+
+            scope = scope.Parent;
         }
 
         return false;
@@ -1725,20 +1734,21 @@ public sealed class BoundScope
     {
         var result = new List<KeyValuePair<string, TypeSymbol>>();
         var seen = new HashSet<string>();
-        for (var s = this; s != null; s = s.Parent)
+        BoundScope? scope = this;
+        while (scope != null)
         {
-            if (s.typeAliases == null)
+            if (scope.typeAliases != null)
             {
-                continue;
-            }
-
-            foreach (var pair in s.typeAliases)
-            {
-                if (seen.Add(pair.Key))
+                foreach (var pair in scope.typeAliases)
                 {
-                    result.Add(pair);
+                    if (seen.Add(pair.Key))
+                    {
+                        result.Add(pair);
+                    }
                 }
             }
+
+            scope = scope.Parent;
         }
 
         return result;
@@ -1880,13 +1890,16 @@ public sealed class BoundScope
     private ImmutableArray<FunctionSymbol> CollectFunctionBucket(string key)
     {
         ImmutableArray<FunctionSymbol>.Builder? builder = null;
-        for (var s = this; s != null; s = s.Parent)
+        BoundScope? scope = this;
+        while (scope != null)
         {
-            if (s.functions != null && s.functions.TryGetValue(key, out var bucket) && bucket.Count > 0)
+            if (scope.functions != null && scope.functions.TryGetValue(key, out var bucket) && bucket.Count > 0)
             {
                 builder ??= ImmutableArray.CreateBuilder<FunctionSymbol>();
                 builder.AddRange(bucket);
             }
+
+            scope = scope.Parent;
         }
 
         return builder == null ? ImmutableArray<FunctionSymbol>.Empty : builder.ToImmutable();
@@ -2032,50 +2045,51 @@ public sealed class BoundScope
     private ImmutableArray<FunctionSymbol> CollectExtensionFunctionMatches(string key, TypeSymbol receiverType)
     {
         ImmutableArray<FunctionSymbol>.Builder? builder = null;
-        for (var s = this; s != null; s = s.Parent)
+        BoundScope? scope = this;
+        while (scope != null)
         {
-            if (s.extensionFunctionsByName == null
-                || !s.extensionFunctionsByName.TryGetValue(key, out var bucket))
+            if (scope.extensionFunctionsByName != null
+                && scope.extensionFunctionsByName.TryGetValue(key, out var bucket))
             {
-                continue;
+                foreach (var ext in bucket)
+                {
+                    var matches = ReceiverMatches(ext.ExtensionReceiverType, receiverType);
+                    if (!matches
+                        && !ext.TypeParameters.IsDefaultOrEmpty
+                        && ext.ExtensionReceiverType != null
+                        && ext.ExtensionReceiverType != TypeSymbol.Error
+                        && ReceiverMentionsAnyTypeParameter(ext.ExtensionReceiverType, ext.TypeParameters)
+                        && TryUnifyAndCheckConstraints(ext, receiverType, out _))
+                    {
+                        matches = true;
+                    }
+
+                    // Issue #1548: broaden to implicitly-convertible (subtype)
+                    // receivers with a CONCRETE declared receiver type. Open
+                    // receivers (those mentioning the function's own type
+                    // parameters) are handled by the unification pass above; a
+                    // concrete `R` is applicable whenever the call-site receiver is
+                    // implicitly convertible to it. Every applicable candidate is
+                    // collected so the caller's overload resolution — which scores
+                    // the receiver as parameter 0 — picks the most specific one.
+                    if (!matches
+                        && (ext.TypeParameters.IsDefaultOrEmpty
+                            || ext.ExtensionReceiverType == null
+                            || !ReceiverMentionsAnyTypeParameter(ext.ExtensionReceiverType, ext.TypeParameters))
+                        && ReceiverConvertible(ext.ExtensionReceiverType, receiverType))
+                    {
+                        matches = true;
+                    }
+
+                    if (matches)
+                    {
+                        builder ??= ImmutableArray.CreateBuilder<FunctionSymbol>();
+                        builder.Add(ext);
+                    }
+                }
             }
 
-            foreach (var ext in bucket)
-            {
-                var matches = ReceiverMatches(ext.ExtensionReceiverType, receiverType);
-                if (!matches
-                    && !ext.TypeParameters.IsDefaultOrEmpty
-                    && ext.ExtensionReceiverType != null
-                    && ext.ExtensionReceiverType != TypeSymbol.Error
-                    && ReceiverMentionsAnyTypeParameter(ext.ExtensionReceiverType, ext.TypeParameters)
-                    && TryUnifyAndCheckConstraints(ext, receiverType, out _))
-                {
-                    matches = true;
-                }
-
-                // Issue #1548: broaden to implicitly-convertible (subtype)
-                // receivers with a CONCRETE declared receiver type. Open
-                // receivers (those mentioning the function's own type
-                // parameters) are handled by the unification pass above; a
-                // concrete `R` is applicable whenever the call-site receiver is
-                // implicitly convertible to it. Every applicable candidate is
-                // collected so the caller's overload resolution — which scores
-                // the receiver as parameter 0 — picks the most specific one.
-                if (!matches
-                    && (ext.TypeParameters.IsDefaultOrEmpty
-                        || ext.ExtensionReceiverType == null
-                        || !ReceiverMentionsAnyTypeParameter(ext.ExtensionReceiverType, ext.TypeParameters))
-                    && ReceiverConvertible(ext.ExtensionReceiverType, receiverType))
-                {
-                    matches = true;
-                }
-
-                if (matches)
-                {
-                    builder ??= ImmutableArray.CreateBuilder<FunctionSymbol>();
-                    builder.Add(ext);
-                }
-            }
+            scope = scope.Parent;
         }
 
         return builder == null ? ImmutableArray<FunctionSymbol>.Empty : builder.ToImmutable();
@@ -2106,24 +2120,25 @@ public sealed class BoundScope
     {
         var suffix = "#" + name;
         HashSet<string>? otherKeys = null;
-        for (var s = this; s != null; s = s.Parent)
+        BoundScope? scope = this;
+        while (scope != null)
         {
-            if (s.extensionFunctionsByName == null)
+            if (scope.extensionFunctionsByName != null)
             {
-                continue;
-            }
-
-            foreach (var key in s.extensionFunctionsByName.Keys)
-            {
-                if (string.Equals(key, excludeKey, StringComparison.Ordinal)
-                    || !key.EndsWith(suffix, StringComparison.Ordinal))
+                foreach (var key in scope.extensionFunctionsByName.Keys)
                 {
-                    continue;
-                }
+                    if (string.Equals(key, excludeKey, StringComparison.Ordinal)
+                        || !key.EndsWith(suffix, StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
 
-                otherKeys ??= new HashSet<string>(StringComparer.Ordinal);
-                otherKeys.Add(key);
+                    otherKeys ??= new HashSet<string>(StringComparer.Ordinal);
+                    otherKeys.Add(key);
+                }
             }
+
+            scope = scope.Parent;
         }
 
         if (otherKeys == null)

--- a/src/Core/CodeAnalysis/Binding/BoundScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundScope.cs
@@ -62,8 +62,8 @@ public sealed class BoundScope
     // single member body, mirroring currentDeclaringPackageName exactly.
     // Import enumeration consults this to expose only imports declared in the
     // same file as the reference being resolved, plus implicit imports.
-    private AsyncLocal<GSharp.Core.CodeAnalysis.Syntax.SyntaxTree?> currentReferencingSyntaxTree =
-        new AsyncLocal<GSharp.Core.CodeAnalysis.Syntax.SyntaxTree?>();
+    private AsyncLocal<ReferencingSyntaxTreeState?> currentReferencingSyntaxTree =
+        new AsyncLocal<ReferencingSyntaxTreeState?>();
 
     // Issue #2455: the ambient "qualified construction package hint" (see
     // SetQualifiedConstructionPackageHint), set only while re-binding the
@@ -735,11 +735,12 @@ public sealed class BoundScope
     /// hoist.
     /// </summary>
     /// <returns>The distinct imported static-import CLR types, in import order.</returns>
-    public IEnumerable<System.Type> EnumerateStaticImportClrTypes()
+    public List<System.Type> EnumerateStaticImportClrTypes()
     {
+        var result = new List<System.Type>();
         if (References == null)
         {
-            yield break;
+            return result;
         }
 
         System.Collections.Generic.HashSet<System.Type>? seen = null;
@@ -753,7 +754,7 @@ public sealed class BoundScope
             if (!References.TryResolveType(import.Target, out var type))
             {
                 References.TryResolveType(
-                    import.Target + "." + SubmissionImports.ProgramTypeName,
+                    SubmissionImports.GetProgramTypeName(import.Target),
                     out type);
             }
 
@@ -762,10 +763,12 @@ public sealed class BoundScope
                 seen ??= new System.Collections.Generic.HashSet<System.Type>();
                 if (seen.Add(type))
                 {
-                    yield return type;
+                    result.Add(type);
                 }
             }
         }
+
+        return result;
     }
 
     /// <summary>
@@ -1438,8 +1441,9 @@ public sealed class BoundScope
             return Parent.SetCurrentDeclaringPackage(packageName);
         }
 
-        var previous = currentDeclaringPackageName.Value;
-        currentDeclaringPackageName.Value = packageName;
+        var stored = currentDeclaringPackageName.Value;
+        var previous = string.IsNullOrEmpty(stored) ? null : stored;
+        currentDeclaringPackageName.Value = packageName ?? string.Empty;
         return previous;
     }
 
@@ -1467,8 +1471,8 @@ public sealed class BoundScope
             return Parent.SetCurrentReferencingSyntaxTree(tree);
         }
 
-        var previous = currentReferencingSyntaxTree.Value;
-        currentReferencingSyntaxTree.Value = tree;
+        var previous = currentReferencingSyntaxTree.Value?.Tree;
+        currentReferencingSyntaxTree.Value = new ReferencingSyntaxTreeState(tree);
         return previous;
     }
 
@@ -1515,8 +1519,9 @@ public sealed class BoundScope
             return Parent.SetQualifiedConstructionPackageHint(packageName);
         }
 
-        var previous = qualifiedConstructionPackageHint.Value;
-        qualifiedConstructionPackageHint.Value = packageName;
+        var stored = qualifiedConstructionPackageHint.Value;
+        var previous = string.IsNullOrEmpty(stored) ? null : stored;
+        qualifiedConstructionPackageHint.Value = packageName ?? string.Empty;
         return previous;
     }
 
@@ -1526,7 +1531,15 @@ public sealed class BoundScope
     /// none is set.
     /// </summary>
     private string? GetCurrentDeclaringPackage()
-        => Parent != null ? Parent.GetCurrentDeclaringPackage() : currentDeclaringPackageName.Value;
+    {
+        if (Parent != null)
+        {
+            return Parent.GetCurrentDeclaringPackage();
+        }
+
+        var packageName = currentDeclaringPackageName.Value;
+        return string.IsNullOrEmpty(packageName) ? null : packageName;
+    }
 
     /// <summary>
     /// Issue #2456: gets the ambient "current referencing syntax tree" set by
@@ -1535,7 +1548,7 @@ public sealed class BoundScope
     /// import-based disambiguation this fix adds simply does not fire).
     /// </summary>
     private GSharp.Core.CodeAnalysis.Syntax.SyntaxTree? GetCurrentReferencingSyntaxTree()
-        => Parent != null ? Parent.GetCurrentReferencingSyntaxTree() : currentReferencingSyntaxTree.Value;
+        => Parent != null ? Parent.GetCurrentReferencingSyntaxTree() : currentReferencingSyntaxTree.Value?.Tree;
 
     /// <summary>
     /// Issue #2455: gets the ambient qualified-construction package hint set
@@ -1543,7 +1556,15 @@ public sealed class BoundScope
     /// <see langword="null"/> when none is set.
     /// </summary>
     private string? GetQualifiedConstructionPackageHint()
-        => Parent != null ? Parent.GetQualifiedConstructionPackageHint() : qualifiedConstructionPackageHint.Value;
+    {
+        if (Parent != null)
+        {
+            return Parent.GetQualifiedConstructionPackageHint();
+        }
+
+        var packageName = qualifiedConstructionPackageHint.Value;
+        return string.IsNullOrEmpty(packageName) ? null : packageName;
+    }
 
     /// <summary>
     /// Issue #2455: tries to resolve (<paramref name="name"/>, <paramref name="arity"/>)
@@ -1645,15 +1666,17 @@ public sealed class BoundScope
     /// </summary>
     private bool TryGetAliasDeclaringPackageInChain(string key, [NotNullWhen(true)] out string? declaringPackageName)
     {
+        declaringPackageName = null;
         for (var s = this; s != null; s = s.Parent)
         {
-            if (s.aliasDeclaringPackages != null && s.aliasDeclaringPackages.TryGetValue(key, out declaringPackageName))
+            if (s.aliasDeclaringPackages != null
+                && s.aliasDeclaringPackages.TryGetValue(key, out var foundPackage))
             {
+                declaringPackageName = foundPackage;
                 return true;
             }
         }
 
-        declaringPackageName = null;
         return false;
     }
 
@@ -1678,15 +1701,16 @@ public sealed class BoundScope
     /// </summary>
     private bool TryGetTypeAliasInChain(string key, [NotNullWhen(true)] out TypeSymbol? value)
     {
+        value = null;
         for (var s = this; s != null; s = s.Parent)
         {
-            if (s.typeAliases != null && s.typeAliases.TryGetValue(key, out value))
+            if (s.typeAliases != null && s.typeAliases.TryGetValue(key, out var foundValue))
             {
+                value = foundValue;
                 return true;
             }
         }
 
-        value = null;
         return false;
     }
 
@@ -1695,8 +1719,9 @@ public sealed class BoundScope
     /// scope first, yielding each key only once (the nearest-scope value wins,
     /// matching <see cref="TryGetTypeAliasInChain"/>).
     /// </summary>
-    private IEnumerable<KeyValuePair<string, TypeSymbol>> EnumerateTypeAliasesInChain()
+    private List<KeyValuePair<string, TypeSymbol>> EnumerateTypeAliasesInChain()
     {
+        var result = new List<KeyValuePair<string, TypeSymbol>>();
         var seen = new HashSet<string>();
         for (var s = this; s != null; s = s.Parent)
         {
@@ -1709,10 +1734,12 @@ public sealed class BoundScope
             {
                 if (seen.Add(pair.Key))
                 {
-                    yield return pair;
+                    result.Add(pair);
                 }
             }
         }
+
+        return result;
     }
 
     /// <summary>
@@ -2805,4 +2832,14 @@ public sealed class BoundScope
         EnumSymbol e => e.Accessibility == Accessibility.Private,
         _ => false,
     };
+
+    private sealed class ReferencingSyntaxTreeState
+    {
+        public ReferencingSyntaxTreeState(GSharp.Core.CodeAnalysis.Syntax.SyntaxTree? tree)
+        {
+            Tree = tree;
+        }
+
+        public GSharp.Core.CodeAnalysis.Syntax.SyntaxTree? Tree { get; }
+    }
 }

--- a/src/Core/CodeAnalysis/Binding/BoundScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundScope.cs
@@ -62,8 +62,8 @@ public sealed class BoundScope
     // single member body, mirroring currentDeclaringPackageName exactly.
     // Import enumeration consults this to expose only imports declared in the
     // same file as the reference being resolved, plus implicit imports.
-    private AsyncLocal<ReferencingSyntaxTreeState?> currentReferencingSyntaxTree =
-        new AsyncLocal<ReferencingSyntaxTreeState?>();
+    private AsyncLocal<object?> currentReferencingSyntaxTree =
+        new AsyncLocal<object?>();
 
     // Issue #2455: the ambient "qualified construction package hint" (see
     // SetQualifiedConstructionPackageHint), set only while re-binding the
@@ -1471,7 +1471,7 @@ public sealed class BoundScope
             return Parent.SetCurrentReferencingSyntaxTree(tree);
         }
 
-        var previous = currentReferencingSyntaxTree.Value?.Tree;
+        var previous = (currentReferencingSyntaxTree.Value as ReferencingSyntaxTreeState)?.Tree;
         currentReferencingSyntaxTree.Value = new ReferencingSyntaxTreeState(tree);
         return previous;
     }
@@ -1548,7 +1548,9 @@ public sealed class BoundScope
     /// import-based disambiguation this fix adds simply does not fire).
     /// </summary>
     private GSharp.Core.CodeAnalysis.Syntax.SyntaxTree? GetCurrentReferencingSyntaxTree()
-        => Parent != null ? Parent.GetCurrentReferencingSyntaxTree() : currentReferencingSyntaxTree.Value?.Tree;
+        => Parent != null
+            ? Parent.GetCurrentReferencingSyntaxTree()
+            : (currentReferencingSyntaxTree.Value as ReferencingSyntaxTreeState)?.Tree;
 
     /// <summary>
     /// Issue #2455: gets the ambient qualified-construction package hint set

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -1395,10 +1395,21 @@ public abstract class BoundTreeRewriter
             builder?.Add(newElement);
         }
 
-        var newElements = builder?.MoveToImmutable() ?? node.InitializerElements;
-        return newCount == node.Count && newElements == node.InitializerElements
-            ? node
-            : new BoundStackAllocExpression(node.Syntax, node.ResultType, node.ElementType, newCount, node.IsPointerForm, newElements);
+        var newElements = builder == null
+            ? node.InitializerElements
+            : ImmutableArray.CreateRange<BoundExpression>(builder);
+        if (newCount == node.Count && builder == null)
+        {
+            return node;
+        }
+
+        return new BoundStackAllocExpression(
+            node.Syntax,
+            node.ResultType,
+            node.ElementType,
+            newCount,
+            node.IsPointerForm,
+            newElements);
     }
 
     /// <summary>Rewrites a map literal expression.</summary>

--- a/src/Core/CodeAnalysis/Binding/BoundTreeWalker.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeWalker.cs
@@ -356,8 +356,8 @@ public abstract class BoundTreeWalker
     }
 
     /// <summary>Dispatch on a pattern.</summary>
-    /// <param name="node">The pattern to visit.</param>
-    public virtual void VisitPattern(BoundPattern node)
+    /// <param name="node">The pattern to visit. Recursive walkers may forward an absent optional pattern.</param>
+    public virtual void VisitPattern(BoundPattern? node)
     {
         if (node == null)
         {

--- a/src/Core/CodeAnalysis/Binding/BoundTreeWalker.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeWalker.cs
@@ -28,8 +28,8 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 public abstract class BoundTreeWalker
 {
     /// <summary>Dispatch on a generic node.</summary>
-    /// <param name="node">The bound node to visit. Null is tolerated.</param>
-    public virtual void Visit(BoundNode node)
+    /// <param name="node">The bound node to visit. Null is a legitimate absent optional child.</param>
+    public virtual void Visit(BoundNode? node)
     {
         if (node == null)
         {
@@ -56,8 +56,8 @@ public abstract class BoundTreeWalker
     }
 
     /// <summary>Dispatch on a statement.</summary>
-    /// <param name="node">The statement to visit.</param>
-    public virtual void VisitStatement(BoundStatement node)
+    /// <param name="node">The statement to visit. Recursive walkers forward absent optional statements as null.</param>
+    public virtual void VisitStatement(BoundStatement? node)
     {
         if (node == null)
         {
@@ -141,8 +141,8 @@ public abstract class BoundTreeWalker
     }
 
     /// <summary>Dispatch on an expression.</summary>
-    /// <param name="node">The expression to visit.</param>
-    public virtual void VisitExpression(BoundExpression node)
+    /// <param name="node">The expression to visit. Recursive walkers forward absent optional expressions as null.</param>
+    public virtual void VisitExpression(BoundExpression? node)
     {
         if (node == null)
         {

--- a/src/Core/CodeAnalysis/Binding/ClrOperatorResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/ClrOperatorResolution.cs
@@ -195,7 +195,7 @@ internal static class ClrOperatorResolution
             return;
         }
 
-        for (var t = type; t != null; t = SafeBaseType(t))
+        for (Type? t = type; t != null; t = SafeBaseType(t))
         {
             MethodInfo[] candidates;
             try

--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -296,11 +296,11 @@ public sealed class Conversion
             }
 
             var nativeIntPartner = to is PointerTypeSymbol ? from : to;
-            if (nativeIntPartner is { } nonNullNativeIntPartner
-                && (nonNullNativeIntPartner == TypeSymbol.NInt || nonNullNativeIntPartner == TypeSymbol.NUInt
-                || nonNullNativeIntPartner == TypeSymbol.Int32 || nonNullNativeIntPartner == TypeSymbol.UInt32
-                || nonNullNativeIntPartner == TypeSymbol.Int64 || nonNullNativeIntPartner == TypeSymbol.UInt64
-                || TypeSymbol.IsLegalPointeeType(nonNullNativeIntPartner)))
+            if (nativeIntPartner != null
+                && (nativeIntPartner == TypeSymbol.NInt || nativeIntPartner == TypeSymbol.NUInt
+                || nativeIntPartner == TypeSymbol.Int32 || nativeIntPartner == TypeSymbol.UInt32
+                || nativeIntPartner == TypeSymbol.Int64 || nativeIntPartner == TypeSymbol.UInt64
+                || TypeSymbol.IsLegalPointeeType(nativeIntPartner)))
             {
                 return Conversion.Explicit;
             }

--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -628,22 +628,26 @@ public sealed class Conversion
         // and constraint-satisfying interface targets so no narrowing or
         // otherwise-invalid conversion is admitted.
         if (from is NullableTypeSymbol fromNullableTypeParam
-            && fromNullableTypeParam.UnderlyingType is TypeParameterSymbol nullableUnderlyingTypeParam
-            && to is not NullableTypeSymbol
-            && !nullableUnderlyingTypeParam.HasReferenceTypeConstraint
-            && nullableUnderlyingTypeParam.ClassConstraint is null)
+            && to is not NullableTypeSymbol)
         {
-            if (to?.ClrType.IsSameAs(typeof(object)) == true)
+            var nullableUnderlyingTypeParam =
+                fromNullableTypeParam.UnderlyingType as TypeParameterSymbol;
+            if (nullableUnderlyingTypeParam != null
+                && !nullableUnderlyingTypeParam.HasReferenceTypeConstraint
+                && nullableUnderlyingTypeParam.ClassConstraint is null)
             {
-                return Conversion.Implicit;
-            }
+                if (to?.ClrType.IsSameAs(typeof(object)) == true)
+                {
+                    return Conversion.Implicit;
+                }
 
-            if (IsInterfaceLikeType(to)
-                && TypeParameterConvertsTo(
-                    nullableUnderlyingTypeParam,
-                    Invariant.Required(to, "a conversion target is present")))
-            {
-                return Conversion.Implicit;
+                if (IsInterfaceLikeType(to)
+                    && TypeParameterConvertsTo(
+                        nullableUnderlyingTypeParam,
+                        Invariant.Required(to, "a conversion target is present")))
+                {
+                    return Conversion.Implicit;
+                }
             }
         }
 
@@ -820,12 +824,17 @@ public sealed class Conversion
         // supported story. The `[]char → string` conversion (#1441, the G#
         // rendering of C# `new string(char[])`) is a real conversion with a
         // dedicated emit path and remains.
-        if (to == TypeSymbol.String
-            && from?.ClrType is { IsArray: true } fromCharArray
-            && fromCharArray.GetElementType() is System.Type fromCharElement
-            && fromCharElement.IsSameAs(typeof(char)))
+        if (to == TypeSymbol.String)
         {
-            return Conversion.Explicit;
+            var fromCharArray = from?.ClrType;
+            if (fromCharArray?.IsArray == true)
+            {
+                var fromCharElement = fromCharArray.GetElementType();
+                if (fromCharElement?.IsSameAs(typeof(char)) == true)
+                {
+                    return Conversion.Explicit;
+                }
+            }
         }
 
         // ADR-0045: every value-type primitive (and every user struct)
@@ -984,7 +993,7 @@ public sealed class Conversion
 
             if (to is InterfaceSymbol toInterface)
             {
-                for (var c = fromClass; c != null; c = c.BaseClass)
+                foreach (var c in GetStructHierarchy(fromClass))
                 {
                     foreach (var i in c.Interfaces)
                     {
@@ -1010,7 +1019,7 @@ public sealed class Conversion
             // `IEnumerable<T>`).
             if (to?.ClrType != null && to.ClrType.IsInterface)
             {
-                for (var c = fromClass; c != null; c = c.BaseClass)
+                foreach (var c in GetStructHierarchy(fromClass))
                 {
                     foreach (var iface in c.ImplementedClrInterfaces)
                     {
@@ -1058,7 +1067,7 @@ public sealed class Conversion
                 && !toClrClass.IsPointer
                 && !toClrClass.IsByRef)
             {
-                for (var c = fromClass; c != null; c = c.BaseClass)
+                foreach (var c in GetStructHierarchy(fromClass))
                 {
                     if (c.ImportedBaseType?.ClrType is Type importedBaseClr
                         && ClrTypeUtilities.IsAssignableByName(toClrClass, importedBaseClr))
@@ -1159,13 +1168,21 @@ public sealed class Conversion
         // the CLR allows array reference covariance, because G# slices are
         // invariant in their element type. The IL is a no-op since the
         // runtime representation is identical.
-        if (from is SliceTypeSymbol sliceSrc
-            && to?.ClrType != null && to.ClrType.IsArray && to.ClrType.GetArrayRank() == 1
-            && sliceSrc.ElementType?.ClrType != null
-            && to.ClrType.GetElementType() is Type targetElement
-            && string.Equals(targetElement.FullName, sliceSrc.ElementType.ClrType.FullName, StringComparison.Ordinal))
+        if (from is SliceTypeSymbol sliceSrc)
         {
-            return Conversion.Implicit;
+            var targetArray = to?.ClrType;
+            var sourceElement = sliceSrc.ElementType?.ClrType;
+            if (targetArray?.IsArray == true
+                && targetArray.GetArrayRank() == 1
+                && sourceElement != null)
+            {
+                var targetElement = targetArray.GetElementType();
+                if (targetElement != null
+                    && string.Equals(targetElement.FullName, sourceElement.FullName, StringComparison.Ordinal))
+                {
+                    return Conversion.Implicit;
+                }
+            }
         }
 
         // Issue #1162: same forward slice-to-array conversion when the
@@ -2065,6 +2082,19 @@ public sealed class Conversion
         return true;
     }
 
+    private static List<StructSymbol> GetStructHierarchy(StructSymbol type)
+    {
+        var hierarchy = new List<StructSymbol>();
+        StructSymbol? current = type;
+        while (current != null)
+        {
+            hierarchy.Add(current);
+            current = current.BaseClass;
+        }
+
+        return hierarchy;
+    }
+
     /// <summary>
     /// Issue #1248: determines whether a (possibly constructed generic) class
     /// <paramref name="fromClass"/> implicitly upcasts to a constructed generic
@@ -2092,7 +2122,7 @@ public sealed class Conversion
         // type arguments resolved in fromClass's context, composed across hops.
         Dictionary<TypeParameterSymbol, TypeSymbol>? running = null;
 
-        for (var c = fromClass; c != null; c = c.BaseClass)
+        foreach (var c in GetStructHierarchy(fromClass))
         {
             // The most-derived class itself is the identity case (handled by the
             // caller); only its base chain is an upcast target.

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -1599,8 +1599,12 @@ internal sealed class ConversionClassifier
 
         var invokeParams = invoke.GetParameters();
         var targetParameterRefKinds = DelegateRefKindUtilities.GetParameterRefKinds(invoke);
-        var closesExtensionReceiver = group.Receiver != null
-            && group.Candidates.All(candidate => candidate.IsStatic);
+        var closesExtensionReceiver = group.Receiver != null;
+        foreach (var candidate in group.Candidates)
+        {
+            closesExtensionReceiver &= candidate.IsStatic;
+        }
+
         var argTypes = new Type[invokeParams.Length + (closesExtensionReceiver ? 1 : 0)];
         if (closesExtensionReceiver)
         {

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -1741,6 +1741,9 @@ internal sealed class ConversionClassifier
             }
 
             candidateReturn = getMethodGroupObservableReturnType(candidate, candidateReturn);
+            var canonicalCandidateReturn = Invariant.Required(
+                candidateReturn,
+                "a successfully closed method-group candidate has a return type");
             var parameterOffset = candidate.IsExtension && group.Receiver != null ? 1 : 0;
             if (candidate.ReturnRefKind != targetReturnRefKind)
             {
@@ -1767,9 +1770,9 @@ internal sealed class ConversionClassifier
             }
 
             if (!TryCanonicalizeMethodGroupType(
-                candidateReturn,
+                canonicalCandidateReturn,
                 targetReturnType,
-                out candidateReturn))
+                out canonicalCandidateReturn))
             {
                 continue;
             }
@@ -1800,7 +1803,7 @@ internal sealed class ConversionClassifier
             pickOwner = candidateOwner;
             pickMethodTypeArguments = candidateMethodTypeArguments;
             pickParameterTypes = candidateParameterTypes;
-            pickReturnType = candidateReturn;
+            pickReturnType = canonicalCandidateReturn;
         }
 
         if (pick == null)
@@ -1813,7 +1816,7 @@ internal sealed class ConversionClassifier
         }
 
         var pickFnType = FunctionTypeSymbol.Get(
-            ImmutableArray.Create(Invariant.Required(pickParameterTypes, "a selected method group has parameter types")),
+            ImmutableArray.CreateRange(Invariant.Required(pickParameterTypes, "a selected method group has parameter types")),
             Invariant.Required(pickReturnType, "a selected method group has a return type"));
         var resolvedGroup = new BoundMethodGroupExpression(
             group.Syntax,
@@ -2871,8 +2874,8 @@ internal sealed class ConversionClassifier
             && TryGetIntegralMetadataTarget(parameterType, out var integralTarget))
         {
             if (integralTarget == TypeSymbol.Char
-                && integerValue >= char.MinValue
-                && integerValue <= char.MaxValue)
+                && integerValue >= (long)char.MinValue
+                && integerValue <= (long)char.MaxValue)
             {
                 value = (char)(ushort)integerValue;
                 return true;

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -420,18 +420,21 @@ internal sealed class ConversionClassifier
         // GS0362 instead of the generic "cannot convert ? → ?"
         // diagnostic. The explicit `default(T)` form is already typed and
         // flows through the regular conversion machinery below.
-        if (expression is BoundDefaultExpression placeholderDefault
-            && placeholderDefault.Type == TypeSymbol.Error
-            && placeholderDefault.Syntax is DefaultExpressionSyntax barePlaceholder
-            && barePlaceholder.TypeClause == null)
+        if (expression is BoundDefaultExpression placeholderDefault)
         {
-            if (type == null || type == TypeSymbol.Error)
+            var barePlaceholder = placeholderDefault.Syntax as DefaultExpressionSyntax;
+            if (placeholderDefault.Type == TypeSymbol.Error
+                && barePlaceholder != null
+                && barePlaceholder.TypeClause == null)
             {
-                Diagnostics.ReportBareDefaultNoTargetType(barePlaceholder.DefaultKeyword.Location);
-                return new BoundErrorExpression(barePlaceholder);
-            }
+                if (type == null || type == TypeSymbol.Error)
+                {
+                    Diagnostics.ReportBareDefaultNoTargetType(barePlaceholder.DefaultKeyword.Location);
+                    return new BoundErrorExpression(barePlaceholder);
+                }
 
-            return new BoundDefaultExpression(barePlaceholder, type);
+                return new BoundDefaultExpression(barePlaceholder, type);
+            }
         }
 
         var methodGroupReceiver = expression switch
@@ -514,17 +517,21 @@ internal sealed class ConversionClassifier
         // Issue #2716: a throw-expression lambda naturally has a `never`
         // result. Shape its synthesized method to the target result type; the
         // body still throws and therefore needs no value conversion.
-        if (expression is BoundFunctionLiteralExpression neverCandidateLiteral
-            && neverCandidateLiteral.FunctionType is FunctionTypeSymbol neverCandidateFnType
-            && neverCandidateFnType.ReturnType == TypeSymbol.Never
-            && MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(type, out var neverTargetFnType)
-            && !ReferenceEquals(neverTargetFnType.ReturnType, TypeSymbol.Never)
-            && Conversion.Classify(neverCandidateFnType, neverTargetFnType).IsImplicit)
+        if (expression is BoundFunctionLiteralExpression neverCandidateLiteral)
         {
-            var shaped = createErasedFunctionLiteralAdapter(neverCandidateLiteral, neverTargetFnType, false);
-            if (!ReferenceEquals(shaped, neverCandidateLiteral))
+            var neverCandidateFnType =
+                neverCandidateLiteral.FunctionType as FunctionTypeSymbol;
+            if (neverCandidateFnType != null
+                && neverCandidateFnType.ReturnType == TypeSymbol.Never
+                && MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(type, out var neverTargetFnType)
+                && !ReferenceEquals(neverTargetFnType.ReturnType, TypeSymbol.Never)
+                && Conversion.Classify(neverCandidateFnType, neverTargetFnType).IsImplicit)
             {
-                return BindConversion(diagnosticLocation, shaped, type, allowExplicit, callParameter);
+                var shaped = createErasedFunctionLiteralAdapter(neverCandidateLiteral, neverTargetFnType, false);
+                if (!ReferenceEquals(shaped, neverCandidateLiteral))
+                {
+                    return BindConversion(diagnosticLocation, shaped, type, allowExplicit, callParameter);
+                }
             }
         }
 
@@ -536,19 +543,23 @@ internal sealed class ConversionClassifier
         // that already yields void. Void-ize the literal through the erased
         // adapter (which now drops the return value), then continue the
         // conversion against the real delegate target.
-        if (expression is BoundFunctionLiteralExpression voidCandidateLiteral
-            && voidCandidateLiteral.FunctionType is FunctionTypeSymbol voidCandidateFnType
-            && voidCandidateFnType.ReturnType != TypeSymbol.Void
-            && voidCandidateFnType.ReturnType != TypeSymbol.Error
-            && MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(type, out var voidTargetFnType)
-            && voidTargetFnType.ReturnType == TypeSymbol.Void
-            && voidTargetFnType.Arity == voidCandidateFnType.Arity
-            && !ReferenceEquals(type, voidCandidateFnType))
+        if (expression is BoundFunctionLiteralExpression voidCandidateLiteral)
         {
-            var voidized = createErasedFunctionLiteralAdapter(voidCandidateLiteral, voidTargetFnType, false);
-            if (!ReferenceEquals(voidized, voidCandidateLiteral))
+            var voidCandidateFnType =
+                voidCandidateLiteral.FunctionType as FunctionTypeSymbol;
+            if (voidCandidateFnType != null
+                && voidCandidateFnType.ReturnType != TypeSymbol.Void
+                && voidCandidateFnType.ReturnType != TypeSymbol.Error
+                && MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(type, out var voidTargetFnType)
+                && voidTargetFnType.ReturnType == TypeSymbol.Void
+                && voidTargetFnType.Arity == voidCandidateFnType.Arity
+                && !ReferenceEquals(type, voidCandidateFnType))
             {
-                return BindConversion(diagnosticLocation, voidized, type, allowExplicit, callParameter);
+                var voidized = createErasedFunctionLiteralAdapter(voidCandidateLiteral, voidTargetFnType, false);
+                if (!ReferenceEquals(voidized, voidCandidateLiteral))
+                {
+                    return BindConversion(diagnosticLocation, voidized, type, allowExplicit, callParameter);
+                }
             }
         }
 
@@ -561,43 +572,51 @@ internal sealed class ConversionClassifier
         // C#'s implicit numeric conversion of a lambda body to an expected
         // delegate return type. Without it the literal would materialize as a
         // narrower-returning delegate flowing into a wider delegate slot.
-        if (expression is BoundFunctionLiteralExpression widenCandidateLiteral
-            && widenCandidateLiteral.FunctionType is FunctionTypeSymbol widenCandidateFnType
-            && widenCandidateFnType.ReturnType != TypeSymbol.Void
-            && widenCandidateFnType.ReturnType != TypeSymbol.Error
-            && MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(type, out var widenTargetFnType)
-            && widenTargetFnType.ReturnType != TypeSymbol.Void
-            && widenTargetFnType.ReturnType != TypeSymbol.Error
-            && widenTargetFnType.Arity == widenCandidateFnType.Arity
-            && !ReferenceEquals(widenCandidateFnType.ReturnType, widenTargetFnType.ReturnType)
-            && IsNumericReturnWideningCore(widenCandidateFnType.ReturnType, widenTargetFnType.ReturnType))
+        if (expression is BoundFunctionLiteralExpression widenCandidateLiteral)
         {
-            var widened = createErasedFunctionLiteralAdapter(widenCandidateLiteral, widenTargetFnType, false);
-            if (!ReferenceEquals(widened, widenCandidateLiteral))
+            var widenCandidateFnType =
+                widenCandidateLiteral.FunctionType as FunctionTypeSymbol;
+            if (widenCandidateFnType != null
+                && widenCandidateFnType.ReturnType != TypeSymbol.Void
+                && widenCandidateFnType.ReturnType != TypeSymbol.Error
+                && MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(type, out var widenTargetFnType)
+                && widenTargetFnType.ReturnType != TypeSymbol.Void
+                && widenTargetFnType.ReturnType != TypeSymbol.Error
+                && widenTargetFnType.Arity == widenCandidateFnType.Arity
+                && !ReferenceEquals(widenCandidateFnType.ReturnType, widenTargetFnType.ReturnType)
+                && IsNumericReturnWideningCore(widenCandidateFnType.ReturnType, widenTargetFnType.ReturnType))
             {
-                return BindConversion(diagnosticLocation, widened, type, allowExplicit, callParameter);
+                var widened = createErasedFunctionLiteralAdapter(widenCandidateLiteral, widenTargetFnType, false);
+                if (!ReferenceEquals(widened, widenCandidateLiteral))
+                {
+                    return BindConversion(diagnosticLocation, widened, type, allowExplicit, callParameter);
+                }
             }
         }
 
-        if (expression is BoundFunctionLiteralExpression adaptedCandidateLiteral
-            && adaptedCandidateLiteral.FunctionType is FunctionTypeSymbol adaptedCandidateFnType
-            && adaptedCandidateFnType.ReturnType != TypeSymbol.Void
-            && adaptedCandidateFnType.ReturnType != TypeSymbol.Error
-            && MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(type, out var adaptedTargetFnType)
-            && adaptedTargetFnType.ReturnType != TypeSymbol.Void
-            && adaptedTargetFnType.ReturnType != TypeSymbol.Error
-            && adaptedTargetFnType.Arity == adaptedCandidateFnType.Arity
-            && !ReferenceEquals(adaptedCandidateFnType.ReturnType, adaptedTargetFnType.ReturnType)
-            && !IsNumericReturnWideningCore(adaptedCandidateFnType.ReturnType, adaptedTargetFnType.ReturnType)
-            && Conversion.Classify(adaptedCandidateFnType.ReturnType, adaptedTargetFnType.ReturnType).IsImplicit)
+        if (expression is BoundFunctionLiteralExpression adaptedCandidateLiteral)
         {
-            var adapted = createErasedFunctionLiteralAdapter(
-                adaptedCandidateLiteral,
-                adaptedTargetFnType,
-                true);
-            if (!ReferenceEquals(adapted, adaptedCandidateLiteral))
+            var adaptedCandidateFnType =
+                adaptedCandidateLiteral.FunctionType as FunctionTypeSymbol;
+            if (adaptedCandidateFnType != null
+                && adaptedCandidateFnType.ReturnType != TypeSymbol.Void
+                && adaptedCandidateFnType.ReturnType != TypeSymbol.Error
+                && MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(type, out var adaptedTargetFnType)
+                && adaptedTargetFnType.ReturnType != TypeSymbol.Void
+                && adaptedTargetFnType.ReturnType != TypeSymbol.Error
+                && adaptedTargetFnType.Arity == adaptedCandidateFnType.Arity
+                && !ReferenceEquals(adaptedCandidateFnType.ReturnType, adaptedTargetFnType.ReturnType)
+                && !IsNumericReturnWideningCore(adaptedCandidateFnType.ReturnType, adaptedTargetFnType.ReturnType)
+                && Conversion.Classify(adaptedCandidateFnType.ReturnType, adaptedTargetFnType.ReturnType).IsImplicit)
             {
-                return BindConversion(diagnosticLocation, adapted, type, allowExplicit, callParameter);
+                var adapted = createErasedFunctionLiteralAdapter(
+                    adaptedCandidateLiteral,
+                    adaptedTargetFnType,
+                    true);
+                if (!ReferenceEquals(adapted, adaptedCandidateLiteral))
+                {
+                    return BindConversion(diagnosticLocation, adapted, type, allowExplicit, callParameter);
+                }
             }
         }
 

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Constructors.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Constructors.cs
@@ -347,7 +347,7 @@ internal sealed partial class DeclarationBinder
             }
 
             refKindsBuilder.Add(RefKind.None);
-            var targetType = TypeSymbol.FromClrType(clrParamType);
+            var targetType = ClrNullability.GetParameterTypeSymbol(ctorParams[i]);
             var argLoc = isExpanded && i == ctorParams.Length - 1
                 ? location
                 : argLocation(i);

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Constructors.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Constructors.cs
@@ -142,14 +142,16 @@ internal sealed partial class DeclarationBinder
                 // `Dispose` hard-resets `binderCtx.RootScope`, discarding the
                 // child scope created above regardless of any assignment here).
                 // See the matching comment in BindConstructorBaseInitializerCore.
+                System.Func<int, TextLocation> argumentLocation = i => baseArguments[i].Location;
+                System.Func<int, ExpressionSyntax> argumentSyntax = i => baseArguments[i];
                 if (importedBaseType?.ClrType is System.Type clrBase)
                 {
-                    clrInit = ResolveClrBaseConstructor(i => baseArguments[i].Location, clrBase, boundArguments, location, i => baseArguments[i]);
+                    clrInit = ResolveClrBaseConstructor(argumentLocation, clrBase, boundArguments, location, argumentSyntax);
                 }
                 else
                 {
                     gsharpInit = ResolveGSharpBaseConstructor(
-                        i => baseArguments[i].Location,
+                        argumentLocation,
                         structSymbol.Name,
                         Invariant.Required(baseClassSymbol, "a non-CLR base constructor has a declared GSharp base class"),
                         boundArguments,
@@ -185,9 +187,18 @@ internal sealed partial class DeclarationBinder
         TextLocation location,
         System.Func<int, ExpressionSyntax>? argSyntax = null)
     {
-        var ctors = ClrTypeUtilities.SafeGetConstructors(clrBase, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
-            .Where(c => c.IsPublic || c.IsFamily || c.IsFamilyOrAssembly)
-            .ToArray();
+        var visibleConstructors = new List<ConstructorInfo>();
+        foreach (var constructor in ClrTypeUtilities.SafeGetConstructors(
+                     clrBase,
+                     BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
+        {
+            if (constructor.IsPublic || constructor.IsFamily || constructor.IsFamilyOrAssembly)
+            {
+                visibleConstructors.Add(constructor);
+            }
+        }
+
+        var ctors = visibleConstructors.ToArray();
 
         RebindDeferredArgumentsWithCommonClrTargets(ctors, boundArguments);
 
@@ -218,7 +229,7 @@ internal sealed partial class DeclarationBinder
             // interpolated-string literals (base-ctor arguments are always
             // positional, never named).
             var interpolatedStringArgs = ComputeInterpolatedStringArgFlags(argSyntax, boundArguments.Count);
-            var resolution = ClrOverloadResolution.Resolve(
+            var resolution = ClrOverloadResolution.Resolve<ConstructorInfo>(
                 ctors,
                 argTypes,
                 interpolatedStringArgs: interpolatedStringArgs,
@@ -398,15 +409,21 @@ internal sealed partial class DeclarationBinder
         ConstructorInfo[] constructors,
         ImmutableArray<BoundExpression>.Builder boundArguments)
     {
-        var deferred = Enumerable.Range(0, boundArguments.Count)
-            .Where(index => ExpressionBinder.IsDeferredBranchyArgumentPlaceholder(boundArguments[index], out _))
-            .ToArray();
-        if (deferred.Length == 0)
+        var deferred = new List<int>();
+        for (var i = 0; i < boundArguments.Count; i++)
+        {
+            if (ExpressionBinder.IsDeferredBranchyArgumentPlaceholder(boundArguments[i], out _))
+            {
+                deferred.Add(i);
+            }
+        }
+
+        if (deferred.Count == 0)
         {
             return;
         }
 
-        var deferredSet = deferred.ToHashSet();
+        var deferredSet = new HashSet<int>(deferred);
         var applicabilityArgumentTypes = new System.Type?[boundArguments.Count];
         for (var i = 0; i < boundArguments.Count; i++)
         {
@@ -426,43 +443,80 @@ internal sealed partial class DeclarationBinder
         }
 
         var delegateRefKindCheck = ExpressionBinder.MakeDelegateRefKindArgumentCheck(boundArguments);
-        var compatible = constructors
-            .Select(constructor => (Constructor: constructor, Parameters: constructor.GetParameters()))
-            .Where(candidate => candidate.Parameters.Length == boundArguments.Count)
-            .Where(candidate => deferred.All(index =>
+        var compatible = new List<(ConstructorInfo Constructor, ParameterInfo[] Parameters)>();
+        foreach (var constructor in constructors)
+        {
+            var parameters = constructor.GetParameters();
+            if (parameters.Length != boundArguments.Count)
             {
-                var targetClrType = candidate.Parameters[index].ParameterType;
+                continue;
+            }
+
+            var deferredTargetsMatch = true;
+            foreach (var index in deferred)
+            {
+                var targetClrType = parameters[index].ParameterType;
                 if (targetClrType.IsByRef)
                 {
                     targetClrType = targetClrType.GetElementType() ?? targetClrType;
                 }
 
-                return ExpressionBinder.IsDeferredBranchyArgumentPlaceholder(boundArguments[index], out var syntax)
-                    && ExpressionBinder.CanTargetDependentBlockArgument(syntax, TypeSymbol.FromClrType(targetClrType));
-            }))
-            .Where(candidate => ClrOverloadResolution.Resolve(
-                [candidate.Constructor],
-                applicabilityArgumentTypes,
-                constantNarrowingArgumentCheck: ExpressionBinder.MakeConstantNarrowingArgumentCheck(boundArguments),
-                structuralProjectionArgumentCheck: ExpressionBinder.MakeStructuralProjectionArgumentCheck(boundArguments),
-                delegateRefKindArgumentCheck: (index, targetType) =>
-                    deferredSet.Contains(index) ? true : delegateRefKindCheck?.Invoke(index, targetType)).Outcome
-                == ClrOverloadResolution.ResolutionOutcome.Resolved)
-            .ToArray();
+                if (!ExpressionBinder.IsDeferredBranchyArgumentPlaceholder(boundArguments[index], out var syntax)
+                    || !ExpressionBinder.CanTargetDependentBlockArgument(syntax, TypeSymbol.FromClrType(targetClrType)))
+                {
+                    deferredTargetsMatch = false;
+                    break;
+                }
+            }
 
-        foreach (var index in deferred)
-        {
-            var targetTypes = compatible
-                .Select(candidate => candidate.Parameters[index].ParameterType)
-                .Select(type => type.IsByRef ? type.GetElementType() ?? type : type)
-                .Distinct()
-                .ToArray();
-            if (targetTypes.Length != 1)
+            if (!deferredTargetsMatch)
             {
                 continue;
             }
 
-            var targetType = TypeSymbol.FromClrType(targetTypes[0]);
+            System.Func<int, System.Type, bool?> refKindCheck = (index, targetType) =>
+                deferredSet.Contains(index) ? true : delegateRefKindCheck?.Invoke(index, targetType);
+            var resolution = ClrOverloadResolution.Resolve<ConstructorInfo>(
+                [constructor],
+                applicabilityArgumentTypes,
+                constantNarrowingArgumentCheck: ExpressionBinder.MakeConstantNarrowingArgumentCheck(boundArguments),
+                structuralProjectionArgumentCheck: ExpressionBinder.MakeStructuralProjectionArgumentCheck(boundArguments),
+                delegateRefKindArgumentCheck: refKindCheck);
+            if (resolution.Outcome == ClrOverloadResolution.ResolutionOutcome.Resolved)
+            {
+                compatible.Add((constructor, parameters));
+            }
+        }
+
+        foreach (var index in deferred)
+        {
+            System.Type? commonTargetType = null;
+            var targetsDisagree = false;
+            foreach (var candidate in compatible)
+            {
+                var candidateTargetType = candidate.Parameters[index].ParameterType;
+                if (candidateTargetType.IsByRef)
+                {
+                    candidateTargetType = candidateTargetType.GetElementType() ?? candidateTargetType;
+                }
+
+                if (commonTargetType is null)
+                {
+                    commonTargetType = candidateTargetType;
+                }
+                else if (!ClrTypeUtilities.AreSame(commonTargetType, candidateTargetType))
+                {
+                    targetsDisagree = true;
+                    break;
+                }
+            }
+
+            if (commonTargetType is null || targetsDisagree)
+            {
+                continue;
+            }
+
+            var targetType = TypeSymbol.FromClrType(commonTargetType);
             boundArguments[index] = conversions.BindConversion(
                 boundArguments[index].Syntax?.Location ?? default,
                 boundArguments[index],
@@ -1113,12 +1167,15 @@ internal sealed partial class DeclarationBinder
                 }
                 else if (importedBaseType?.ClrType is System.Type clrBase)
                 {
-                    init = ResolveClrBaseConstructor(i => ctorSyntax.BaseArguments[i].Location, clrBase, boundArguments, location, i => ctorSyntax.BaseArguments[i]);
+                    System.Func<int, TextLocation> argumentLocation = i => ctorSyntax.BaseArguments[i].Location;
+                    System.Func<int, ExpressionSyntax> argumentSyntax = i => ctorSyntax.BaseArguments[i];
+                    init = ResolveClrBaseConstructor(argumentLocation, clrBase, boundArguments, location, argumentSyntax);
                 }
                 else
                 {
+                    System.Func<int, TextLocation> argumentLocation = i => ctorSyntax.BaseArguments[i].Location;
                     init = ResolveGSharpBaseConstructor(
-                        i => ctorSyntax.BaseArguments[i].Location,
+                        argumentLocation,
                         structSymbol.Name,
                         Invariant.Required(baseClassSymbol, "a non-CLR base constructor has a declared GSharp base class"),
                         boundArguments,

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Functions.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Functions.cs
@@ -2565,9 +2565,20 @@ internal sealed partial class DeclarationBinder
                 }
 
                 var candidateClr = candidateIface.ClrType;
-                if (candidateClr != null
-                    && candidateClr.GetInterfaces().Any(inherited =>
-                        ClrTypeUtilities.AreSame(inherited, boundType.ClrType)))
+                var inheritsBoundInterface = false;
+                if (candidateClr != null)
+                {
+                    foreach (var inherited in candidateClr.GetInterfaces())
+                    {
+                        if (ClrTypeUtilities.AreSame(inherited, boundType.ClrType))
+                        {
+                            inheritsBoundInterface = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (inheritsBoundInterface)
                 {
                     return boundType;
                 }

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.InterfaceVerification.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.InterfaceVerification.cs
@@ -256,40 +256,6 @@ internal sealed partial class DeclarationBinder
                 }
             }
 
-            static bool ExplicitClrPropertyMatches(
-                PropertySymbol property,
-                TypeSymbol target,
-                PropertyInfo slot)
-            {
-                if (slot.Name != property.Name
-                    || (slot.GetMethod != null) != property.HasGetter
-                    || (slot.SetMethod != null) != property.HasSetter
-                    || !TypeSignaturesEquivalent(
-                        property.Type,
-                        MemberLookup.GetClrPropertyTypeSymbol(target, slot)))
-                {
-                    return false;
-                }
-
-                var slotParameters = slot.GetIndexParameters();
-                if (slotParameters.Length != property.Parameters.Length)
-                {
-                    return false;
-                }
-
-                for (var i = 0; i < slotParameters.Length; i++)
-                {
-                    if (!ClrTypeUtilities.AreSame(
-                        NullableLifting.GetEffectiveClrType(property.Parameters[i].Type),
-                        slotParameters[i].ParameterType))
-                    {
-                        return false;
-                    }
-                }
-
-                return true;
-            }
-
             SynthesizePositionalInterfaceProperties(structSymbol, positionalInterfaceProps);
             VerifyClrInterfaceImplementations(syntax, structSymbol);
             VerifyInheritedClrInterfaceSlots(syntax, structSymbol);
@@ -298,6 +264,40 @@ internal sealed partial class DeclarationBinder
             VerifyPrivateInterfaceHelpersNotOverridden(syntax, structSymbol);
             VerifyExplicitInterfaceClauseResolution(syntax, structSymbol);
         }
+    }
+
+    private static bool ExplicitClrPropertyMatches(
+        PropertySymbol property,
+        TypeSymbol target,
+        PropertyInfo slot)
+    {
+        if (slot.Name != property.Name
+            || (slot.GetMethod != null) != property.HasGetter
+            || (slot.SetMethod != null) != property.HasSetter
+            || !TypeSignaturesEquivalent(
+                property.Type,
+                MemberLookup.GetClrPropertyTypeSymbol(target, slot)))
+        {
+            return false;
+        }
+
+        var slotParameters = slot.GetIndexParameters();
+        if (slotParameters.Length != property.Parameters.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < slotParameters.Length; i++)
+        {
+            if (!ClrTypeUtilities.AreSame(
+                NullableLifting.GetEffectiveClrType(property.Parameters[i].Type),
+                slotParameters[i].ParameterType))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private void VerifyInterfaceMethodImplementationsAndDefaultConflicts(
@@ -2309,15 +2309,15 @@ internal sealed partial class DeclarationBinder
                 return TryEvaluateConstant(conv.Expression, out value);
 
             case BoundFieldAccessExpression fieldAccess
-                when fieldAccess.Field is { IsConst: true } constField
-                && constField.ConstantValue != null:
+                when fieldAccess.Field.IsConst
+                && fieldAccess.Field.ConstantValue != null:
                 // Issue #1193: a `const` field initializer composed of other
                 // `const` fields folds by reading the referenced field's
                 // already-computed compile-time value. Sibling const fields are
                 // folded in dependency order (see the fixpoint loop in the
                 // const-binding pass), so a referenced const's value is present
                 // by the time this initializer is evaluated.
-                value = constField.ConstantValue;
+                value = fieldAccess.Field.ConstantValue;
                 return true;
 
             case BoundUnaryExpression unary

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.InterfaceVerification.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.InterfaceVerification.cs
@@ -1830,7 +1830,7 @@ internal sealed partial class DeclarationBinder
         }
     }
 
-    private static bool StructSatisfiesClrSlot(StructSymbol structSymbol, in MemberLookup.ClrInterfaceSlot slot)
+    private static bool StructSatisfiesClrSlot(StructSymbol structSymbol, MemberLookup.ClrInterfaceSlot slot)
     {
         // Note: do NOT route through GetMethodsIncludingInherited here — it
         // dedups same-name overloads by parameter signature (ignoring return

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
@@ -1443,8 +1443,19 @@ internal sealed partial class DeclarationBinder
 
                     var primaryConstructorParameters = syntax.PrimaryConstructorParameters
                         ?? throw new InvalidOperationException("A data positional property requires primary constructor parameters.");
-                    var parameterSyntax = primaryConstructorParameters
-                        .First(candidate => candidate.Identifier.Text == parameter.Name);
+                    ParameterSyntax? parameterSyntax = null;
+                    foreach (var candidate in primaryConstructorParameters)
+                    {
+                        if (candidate.Identifier.Text == parameter.Name)
+                        {
+                            parameterSyntax = candidate;
+                            break;
+                        }
+                    }
+
+                    parameterSyntax = Invariant.Required(
+                        parameterSyntax,
+                        "a data positional property has matching primary constructor syntax");
                     var propertyAttributes = BindDataPositionalPropertyAttributes(parameterSyntax);
                     if (!propertyAttributes.IsDefaultOrEmpty)
                     {

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -657,7 +657,7 @@ internal sealed partial class DeclarationBinder
 
             var path = new List<StructSymbol>();
             var onPath = new HashSet<StructSymbol>();
-            var current = start;
+            StructSymbol? current = start;
             while (current != null)
             {
                 if (onPath.Contains(current))

--- a/src/Core/CodeAnalysis/Binding/DefiniteAssignmentAnalyzer.cs
+++ b/src/Core/CodeAnalysis/Binding/DefiniteAssignmentAnalyzer.cs
@@ -1380,8 +1380,13 @@ internal static class DefiniteAssignmentAnalyzer
             this.flowContext = flowContext;
         }
 
-        public override void VisitExpression(BoundExpression node)
+        public override void VisitExpression(BoundExpression? node)
         {
+            if (node == null)
+            {
+                return;
+            }
+
             switch (node)
             {
                 case BoundFunctionLiteralExpression literal:

--- a/src/Core/CodeAnalysis/Binding/DefiniteAssignmentAnalyzer.cs
+++ b/src/Core/CodeAnalysis/Binding/DefiniteAssignmentAnalyzer.cs
@@ -1401,8 +1401,8 @@ internal static class DefiniteAssignmentAnalyzer
                         lowered.PreEmitAnalysisBody ?? lowered,
                         literal.Function,
                         diagnostics,
-                        literal.CapturedVariables.Where(assigned.Contains),
-                        literal.CapturedVariables.Where(tracked.Contains));
+                        literal.CapturedVariables.Where(variable => assigned.Contains(variable)),
+                        literal.CapturedVariables.Where(variable => tracked.Contains(variable)));
                     return;
                 }
 

--- a/src/Core/CodeAnalysis/Binding/DefiniteAssignmentAnalyzer.cs
+++ b/src/Core/CodeAnalysis/Binding/DefiniteAssignmentAnalyzer.cs
@@ -781,9 +781,11 @@ internal static class DefiniteAssignmentAnalyzer
             return;
         }
 
-        if (rhs is BoundAddressOfExpression addr && addr.Operand is BoundVariableExpression bve)
+        var address = rhs as BoundAddressOfExpression;
+        var variable = address?.Operand as BoundVariableExpression;
+        if (variable is not null)
         {
-            pointerAliases[pointerVar] = bve.Variable;
+            pointerAliases[pointerVar] = variable.Variable;
         }
         else
         {
@@ -793,14 +795,19 @@ internal static class DefiniteAssignmentAnalyzer
 
     private static bool TryResolvePointerTarget(BoundExpression pointerExpr, Dictionary<VariableSymbol, VariableSymbol> pointerAliases, out VariableSymbol? target)
     {
-        if (pointerExpr is BoundAddressOfExpression addr && addr.Operand is BoundVariableExpression bve)
+        var address = pointerExpr as BoundAddressOfExpression;
+        var variable = address?.Operand as BoundVariableExpression;
+        if (variable is not null)
         {
-            target = bve.Variable;
+            target = variable.Variable;
             return true;
         }
 
-        if (pointerExpr is BoundVariableExpression pve && pointerAliases.TryGetValue(pve.Variable, out target))
+        var pointerVariable = pointerExpr as BoundVariableExpression;
+        if (pointerVariable is not null
+            && pointerAliases.TryGetValue(pointerVariable.Variable, out var aliasedTarget))
         {
+            target = aliasedTarget;
             return true;
         }
 

--- a/src/Core/CodeAnalysis/Binding/ExhaustivenessAnalyzer.cs
+++ b/src/Core/CodeAnalysis/Binding/ExhaustivenessAnalyzer.cs
@@ -248,24 +248,27 @@ public static class ExhaustivenessAnalyzer
     /// (<c>A or B or C</c>, <c>(A or B) or C</c>) is handled. An `and` conjunction narrows
     /// rather than covers, so it is never flattened and is returned as a single opaque leaf.
     /// </summary>
-    private static IEnumerable<BoundPattern> FlattenDisjunction(BoundPattern pattern)
+    private static List<BoundPattern> FlattenDisjunction(BoundPattern pattern)
     {
+        var result = new List<BoundPattern>();
         if (pattern is BoundBinaryPattern { IsConjunction: false } disjunction)
         {
             foreach (var leaf in FlattenDisjunction(disjunction.Left))
             {
-                yield return leaf;
+                result.Add(leaf);
             }
 
             foreach (var leaf in FlattenDisjunction(disjunction.Right))
             {
-                yield return leaf;
+                result.Add(leaf);
             }
         }
         else
         {
-            yield return pattern;
+            result.Add(pattern);
         }
+
+        return result;
     }
 
     private static bool IsSubclassOf(StructSymbol candidate, StructSymbol baseClass)

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
@@ -189,13 +189,55 @@ internal sealed partial class ExpressionBinder
         // be a chain of accessors (e.g. Guid.NewGuid().ToString()).
         var leftPart = syntax.LeftPart;
         var rightPart = syntax.RightPart;
+        var leftName = leftPart as NameExpressionSyntax;
         BoundExpression? receiver = null;
         ImportedClassSymbol? classSymbol = null;
         EnumSymbol? enumSymbol = null;
         StructSymbol? userStructSymbol = null;
         InterfaceSymbol? userInterfaceSymbol = null;
 
-        if (leftPart is NameExpressionSyntax leftName)
+        if (leftName is null)
+        {
+            var genericTypeIndex = leftPart as IndexExpressionSyntax;
+            if (genericTypeIndex is not null
+                && !genericTypeIndex.IsNullConditional
+                && TryResolveConstructedGenericTypeReceiver(
+                    genericTypeIndex,
+                    out var indexedStruct,
+                    out var indexedInterface,
+                    out var indexedImported))
+            {
+                return BindConstructedGenericTypeAccessorStep(
+                    indexedStruct,
+                    indexedInterface,
+                    indexedImported,
+                    rightPart,
+                    leftPart);
+            }
+
+            var genericTypeName = leftPart as GenericNameExpressionSyntax;
+            if (genericTypeName is not null
+                && TryResolveConstructedGenericTypeReceiver(
+                    genericTypeName,
+                    out var namedStruct,
+                    out var namedInterface,
+                    out var namedImported))
+            {
+                return BindConstructedGenericTypeAccessorStep(
+                    namedStruct,
+                    namedInterface,
+                    namedImported,
+                    rightPart,
+                    leftPart);
+            }
+        }
+
+        if (leftName is null)
+        {
+            receiver = BindExpression(leftPart);
+        }
+
+        if (leftName is not null)
         {
             var name = leftName.IdentifierToken.Text;
             var variableHit = scope.TryLookupSymbol(name) as VariableSymbol;
@@ -661,10 +703,6 @@ internal sealed partial class ExpressionBinder
                     break;
             }
         }
-        else
-        {
-            receiver = BindExpression(leftPart);
-        }
 
         if (enumSymbol != null)
         {
@@ -682,6 +720,31 @@ internal sealed partial class ExpressionBinder
         }
 
         return BindAccessorStep(receiver, classSymbol, rightPart, leftPart);
+    }
+
+    private BoundExpression BindConstructedGenericTypeAccessorStep(
+        StructSymbol? constructedStruct,
+        InterfaceSymbol? constructedInterface,
+        ImportedClassSymbol? constructedImported,
+        ExpressionSyntax rightPart,
+        ExpressionSyntax leftPart)
+    {
+        if (constructedInterface is not null)
+        {
+            return BindInterfaceStaticAccessorStep(constructedInterface, rightPart);
+        }
+
+        if (constructedStruct is not null)
+        {
+            return BindUserTypeStaticAccessorStep(constructedStruct, rightPart);
+        }
+
+        if (constructedImported is not null)
+        {
+            return BindAccessorStep(null, constructedImported, rightPart, leftPart);
+        }
+
+        return new BoundErrorExpression(null);
     }
 
     private bool TryResolveInheritedImportedNestedType(

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
@@ -121,8 +121,10 @@ internal sealed partial class ExpressionBinder
                 return overloads.BindConstructorCallExpression(nestedCall, nestedClassDef);
             }
 
-            if (syntax.RightPart is AccessorExpressionSyntax nestedAccess
-                && nestedAccess.LeftPart is CallExpressionSyntax nestedAccessCall
+            var nestedAccess = syntax.RightPart as AccessorExpressionSyntax;
+            var nestedAccessCall = nestedAccess?.LeftPart as CallExpressionSyntax;
+            if (nestedAccess != null
+                && nestedAccessCall != null
                 && scope.TryLookupNestedTypeAlias(
                     enclosingAliasType,
                     headIdentifier,

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
@@ -329,6 +329,13 @@ internal sealed partial class ExpressionBinder
                     // Issue #208: apply any [MemberNotNull] narrowing so that
                     // chained access like `_name.Length` after a [MemberNotNull]
                     // call is accepted without a nil-guard.
+                    Func<TypeSymbol, BoundExpression> makeNarrowedField = narrowedType =>
+                        new BoundFieldAccessExpression(
+                            null,
+                            new BoundVariableExpression(null, implicitField.Receiver),
+                            implicitField.StructType,
+                            implicitField.Field,
+                            narrowedType);
                     receiver = BuildNarrowedRead(
                         new BoundFieldAccessExpression(
                             null,
@@ -337,12 +344,7 @@ internal sealed partial class ExpressionBinder
                             implicitField.Field),
                         implicitField.Field.Type,
                         TryGetNarrowedType(implicitField),
-                        nt => new BoundFieldAccessExpression(
-                            null,
-                            new BoundVariableExpression(null, implicitField.Receiver),
-                            implicitField.StructType,
-                            implicitField.Field,
-                            nt));
+                        makeNarrowedField);
                 }
                 else if (variable is ImplicitStaticFieldVariableSymbol implicitStaticField)
                 {
@@ -416,11 +418,13 @@ internal sealed partial class ExpressionBinder
                 }
                 else
                 {
+                    Func<TypeSymbol, BoundExpression> makeNarrowedVariable =
+                        narrowedType => new BoundVariableExpression(null, variable, narrowedType);
                     receiver = BuildNarrowedRead(
                         new BoundVariableExpression(null, variable),
                         variable.Type,
                         TryGetNarrowedType(variable),
-                        narrowed => new BoundVariableExpression(null, variable, narrowed));
+                        makeNarrowedVariable);
                 }
             }
             else if (TryBindInheritedClrInstanceMemberByBareName(name, out var inheritedClrHead))
@@ -3253,22 +3257,27 @@ internal sealed partial class ExpressionBinder
         foreach (var argument in ce.Arguments)
         {
             var inner = OverloadResolver.UnwrapNamedArgumentValue(argument);
-            if (inner is RefArgumentExpressionSyntax refArg)
+            BoundExpression? boundArgument = null;
+            var refArgument = inner as RefArgumentExpressionSyntax;
+            if (refArgument is not null)
             {
-                boundArguments.Add(BindRefArgumentExpression(refArg, parameter: null));
+                boundArgument = BindRefArgumentExpression(refArgument, parameter: null);
             }
-            else if (IsUntypedArrowLambda(inner))
+
+            if (boundArgument is null && IsUntypedArrowLambda(inner))
             {
                 // Issue #951: defer un-typed arrow lambdas until the static
                 // method overload (and its delegate-typed parameters) is known.
                 (deferredStaticLambdaIndices ??= new List<int>()).Add(staticArgIndex);
-                boundArguments.Add(new BoundErrorExpression(inner));
-            }
-            else
-            {
-                boundArguments.Add(BindExpression(inner));
+                boundArgument = new BoundErrorExpression(inner);
             }
 
+            if (boundArgument is null)
+            {
+                boundArgument = BindExpression(inner);
+            }
+
+            boundArguments.Add(boundArgument);
             staticArgIndex++;
         }
 
@@ -3372,6 +3381,10 @@ internal sealed partial class ExpressionBinder
             // argument before the per-position conversion loop.
             var isVariadic = method.Parameters.Length > 0 && method.Parameters[method.Parameters.Length - 1].IsVariadic;
             var fixedParamCount = isVariadic ? method.Parameters.Length - 1 : method.Parameters.Length;
+            Func<int, string> methodParameterNameAt =
+                parameterIndex => method.Parameters[parameterIndex].Name;
+            Func<int, bool> methodParameterIsOptional =
+                parameterIndex => method.Parameters[parameterIndex].HasExplicitDefaultValue;
 
             // ADR-0063 / issue #936: count the leading non-optional parameters.
             // A static (`shared`) call may omit any trailing parameter that
@@ -3409,7 +3422,7 @@ internal sealed partial class ExpressionBinder
                 !overloads.ValidateExpandedVariadicNamedArguments(
                     argumentNames,
                     fixedParamCount,
-                    p => method.Parameters[p].Name,
+                    methodParameterNameAt,
                     method.Name,
                     ce))
             {
@@ -3423,8 +3436,8 @@ internal sealed partial class ExpressionBinder
                         ce.Arguments,
                         arguments,
                         method.Parameters.Length,
-                        p => method.Parameters[p].Name,
-                        p => method.Parameters[p].HasExplicitDefaultValue,
+                        methodParameterNameAt,
+                        methodParameterIsOptional,
                         method.Name,
                         out parameterSyntax,
                         out arguments))
@@ -3577,6 +3590,8 @@ internal sealed partial class ExpressionBinder
                 // uncoerced elements here). Coerce against the SUBSTITUTED
                 // slice's element type since generic type arguments may have
                 // been inferred/substituted above.
+                Func<int, TextLocation> variadicArgumentLocation =
+                    i => i < ce.Arguments.Count ? ce.Arguments[i].Location : ce.Identifier.Location;
                 permutedArgs = OverloadResolver.PackOrPassThroughVariadicArguments(
                     conversions,
                     Diagnostics,
@@ -3585,7 +3600,7 @@ internal sealed partial class ExpressionBinder
                     fixedParamCount,
                     substitutedSlice,
                     variadicParam.Name,
-                    i => i < ce.Arguments.Count ? ce.Arguments[i].Location : ce.Identifier.Location,
+                    variadicArgumentLocation,
                     ref hasVariadicErrors);
 
                 if (hasVariadicErrors)
@@ -3712,7 +3727,7 @@ internal sealed partial class ExpressionBinder
             var finalArguments = overloads.PreserveNamedArgumentEvaluationOrder(
                 ce.Arguments,
                 convertedArgs.ToImmutable(),
-                p => method.Parameters[p].Name);
+                methodParameterNameAt);
 
             BoundCallExpression MakeStaticGenericCall(TypeSymbol? substitutedReturnOverride)
             {

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
@@ -121,6 +121,21 @@ internal sealed partial class ExpressionBinder
                 return overloads.BindConstructorCallExpression(nestedCall, nestedClassDef);
             }
 
+            if (syntax.RightPart is AccessorExpressionSyntax nestedAccess
+                && nestedAccess.LeftPart is CallExpressionSyntax nestedAccessCall
+                && scope.TryLookupNestedTypeAlias(
+                    enclosingAliasType,
+                    headIdentifier,
+                    -1,
+                    out var nestedAccessType)
+                && nestedAccessType is StructSymbol nestedAccessClassDef)
+            {
+                var constructed = overloads.BindConstructorCallExpression(nestedAccessCall, nestedAccessClassDef);
+                return constructed is BoundErrorExpression
+                    ? constructed
+                    : BindAccessorStep(constructed, classSymbol: null, nestedAccess.RightPart);
+            }
+
             // Issue #1174: when a top-level type shares the nested type's simple
             // name, re-binding the right part by simple name would resolve to the
             // top-level homonym (which holds the simple key). Resolve the nested
@@ -1512,7 +1527,12 @@ internal sealed partial class ExpressionBinder
 
             switch (currentRight)
             {
-                case AccessorExpressionSyntax nested when nested.LeftPart is NameExpressionSyntax leftName:
+                case AccessorExpressionSyntax nested:
+                    if (nested.LeftPart is not NameExpressionSyntax leftName)
+                    {
+                        return false;
+                    }
+
                     typeNameSyntax = leftName;
                     remainder = nested.RightPart;
                     hasMoreChain = true;
@@ -1564,7 +1584,14 @@ internal sealed partial class ExpressionBinder
     {
         switch (segment)
         {
-            case IndexExpressionSyntax index when !index.IsNullConditional && index.Target is NameExpressionSyntax indexName:
+            case IndexExpressionSyntax index:
+                if (index.IsNullConditional || index.Target is not NameExpressionSyntax indexName)
+                {
+                    name = string.Empty;
+                    arity = 0;
+                    return false;
+                }
+
                 name = indexName.IdentifierToken.Text;
                 arity = index.Indices.Count;
                 return true;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
@@ -383,7 +383,8 @@ internal sealed partial class ExpressionBinder
                     // unaffected.
                     if (IsWithinType(structSym))
                     {
-                        for (var evtDeclType = structSym; evtDeclType != null; evtDeclType = evtDeclType.BaseClass)
+                        StructSymbol? evtDeclType = structSym;
+                        while (evtDeclType != null)
                         {
                             var evt = evtDeclType.Events.FirstOrDefault(e =>
                                 e.Name == ne.IdentifierToken.Text && e.IsFieldLike && e.BackingField != null);
@@ -391,6 +392,8 @@ internal sealed partial class ExpressionBinder
                             {
                                 return ApplyMemberNarrowing(new BoundFieldAccessExpression(null, receiver, evtDeclType, evt.BackingField!));
                             }
+
+                            evtDeclType = evtDeclType.BaseClass;
                         }
                     }
 
@@ -1251,45 +1254,51 @@ internal sealed partial class ExpressionBinder
         // matches the single argument by assignability).
         // Issue #209: when the target carries inner-position nullable flags,
         // use them to type the element correctly (e.g., `list[0]` on `List<string?>` → `string?`).
-        if (target.Type is TypeParameterSymbol tpIndexTarget
-            && tpIndexTarget.ClrInterfaceConstraint is TypeSymbol clrIndexConstraint
-            && clrIndexConstraint.ClrType is System.Type clrConstraintType)
+        if (target.Type is TypeParameterSymbol tpIndexTarget)
         {
-            var idxArgs = ImmutableArray.Create(BoundIndexArg());
-            if (this.memberLookup.TryResolveClrIndexer(
-                clrIndexConstraint,
-                clrConstraintType,
-                idxArgs,
-                out var idxProp,
-                out var resolvedIdxArgs))
+            var clrIndexConstraint = tpIndexTarget.ClrInterfaceConstraint;
+            var clrConstraintType = clrIndexConstraint?.ClrType;
+            if (clrIndexConstraint != null && clrConstraintType != null)
             {
-                if (idxProp!.GetGetMethod(nonPublic: false) == null)
+                var idxArgs = ImmutableArray.Create(BoundIndexArg());
+                if (this.memberLookup.TryResolveClrIndexer(
+                    clrIndexConstraint,
+                    clrConstraintType,
+                    idxArgs,
+                    out var idxProp,
+                    out var resolvedIdxArgs))
                 {
-                    Diagnostics.ReportTypeNotIndexable(targetLocation, target.Type);
-                    return new BoundErrorExpression(null);
-                }
+                    if (idxProp!.GetGetMethod(nonPublic: false) == null)
+                    {
+                        Diagnostics.ReportTypeNotIndexable(targetLocation, target.Type);
+                        return new BoundErrorExpression(null);
+                    }
 
-                var elementType = MemberLookup.GetClrPropertyTypeSymbol(clrIndexConstraint, idxProp);
-                var declaringInterface = MemberLookup.GetClrMemberDeclaringTypeSymbol(
-                    clrIndexConstraint,
-                    idxProp);
-                var convertedIdxArgs = BindClrIndexerArguments(
-                    clrIndexConstraint,
-                    idxProp!,
-                    resolvedIdxArgs,
-                    indexSyntax.Location);
-                return ConversionClassifier.AutoDereferenceRefReturn(
-                    new BoundClrIndexExpression(
-                        null,
-                        target,
-                        idxProp,
-                        convertedIdxArgs,
-                        elementType,
-                        tpIndexTarget,
-                        declaringInterface));
+                    var elementType = MemberLookup.GetClrPropertyTypeSymbol(clrIndexConstraint, idxProp);
+                    var declaringInterface = MemberLookup.GetClrMemberDeclaringTypeSymbol(
+                        clrIndexConstraint,
+                        idxProp);
+                    var convertedIdxArgs = BindClrIndexerArguments(
+                        clrIndexConstraint,
+                        idxProp!,
+                        resolvedIdxArgs,
+                        indexSyntax.Location);
+                    return ConversionClassifier.AutoDereferenceRefReturn(
+                        new BoundClrIndexExpression(
+                            null,
+                            target,
+                            idxProp,
+                            convertedIdxArgs,
+                            elementType,
+                            tpIndexTarget,
+                            declaringInterface));
+                }
             }
         }
-        else if (target.Type is NullabilityAnnotatedTypeSymbol annotIdx && annotIdx.ClrType is System.Type clrAnnotIdx)
+
+        var annotIdx = target.Type as NullabilityAnnotatedTypeSymbol;
+        var clrAnnotIdx = annotIdx?.ClrType;
+        if (annotIdx != null && clrAnnotIdx != null)
         {
             var idxArgsAnnot = ImmutableArray.Create(BoundIndexArg());
             if (this.memberLookup.TryResolveClrIndexer(target.Type, clrAnnotIdx, idxArgsAnnot, out var idxPropAnnot, out var resolvedIdxArgsAnnot))
@@ -1310,7 +1319,10 @@ internal sealed partial class ExpressionBinder
                 return ConversionClassifier.AutoDereferenceRefReturn(new BoundClrIndexExpression(null, target, idxPropAnnot, convertedIdxArgsAnnot, elemTypeAnnot));
             }
         }
-        else if ((target.Type is ImportedTypeSymbol || target.Type is StructSymbol) && target.Type.ClrType is System.Type clrTarget)
+
+        var clrTarget = target.Type.ClrType;
+        if ((target.Type is ImportedTypeSymbol || target.Type is StructSymbol)
+            && clrTarget != null)
         {
             var idxArgs = ImmutableArray.Create(BoundIndexArg());
             if (this.memberLookup.TryResolveClrIndexer(target.Type, clrTarget, idxArgs, out var idxProp, out var resolvedIdxArgs))

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
@@ -541,73 +541,10 @@ internal sealed partial class ExpressionBinder
 
                     return BindExtensionMethodGroupOrError(receiver, ne);
                 }
-                else if (receiver != null && receiver.Type is NullableTypeSymbol nullableSym
-                    && nullableSym.UnderlyingType?.ClrType is { IsValueType: true } nullableInnerClr
-                    && this.memberLookup.TryGetNullableConstructedType(nullableInnerClr, out var nullableClr))
+                else if (receiver != null
+                    && TryBindNullableInstanceMember(receiver, ne, out var nullableMember))
                 {
-                    // Issue #517: a value-type `T?` lowers to `System.Nullable<T>`
-                    // at the CLR layer (see `EncodeTypeSymbol`). Resolve `.Value`,
-                    // `.HasValue`, etc. against that constructed generic so the
-                    // BCL instance API surfaces the same way it does for any
-                    // other CLR struct. NRT receivers (reference-type underlying)
-                    // have no `Nullable<T>` projection and continue to fall
-                    // through to the existing GS0158 path below.
-                    var nullableMemberName = ne.IdentifierToken.Text;
-                    var nullableProp = ClrTypeUtilities.SafeGetProperty(nullableClr, nullableMemberName, BindingFlags.Public | BindingFlags.Instance);
-                    if (nullableProp != null && nullableProp.GetIndexParameters().Length == 0 && nullableProp.CanRead)
-                    {
-                        var nullablePropType = ClrNullability.GetPropertyTypeSymbol(nullableProp);
-                        return new BoundClrPropertyAccessExpression(null, receiver, nullableProp, nullablePropType);
-                    }
-
-                    if (TryBindClrMethodGroup(receiver, nullableClr, wantStatic: false, nullableMemberName, out var nullableGroup))
-                    {
-                        return nullableGroup;
-                    }
-
-                    return BindExtensionMethodGroupOrError(receiver, ne);
-                }
-                else if (receiver != null && receiver.Type is NullableTypeSymbol openNullableSym
-                    && openNullableSym.UnderlyingType is TypeParameterSymbol openTp
-                    && openTp.HasValueTypeConstraint)
-                {
-                    // Issue #806: a `T?` receiver where T is an open value-type
-                    // type parameter still lowers to `Nullable<T>` at IL emit
-                    // time, but the closed `Nullable<T>` CLR instance is not
-                    // available here. Resolve the member name against the open
-                    // `typeof(Nullable<>)` definition so `.HasValue`, `.Value`
-                    // and `.GetValueOrDefault()` bind successfully and lower
-                    // to a normal property/method access on the symbolic
-                    // constructed receiver.
-                    var openNullableMemberName = ne.IdentifierToken.Text;
-                    var openNullableDef = typeof(System.Nullable<>);
-                    var openProp = ClrTypeUtilities.SafeGetProperty(openNullableDef, openNullableMemberName, BindingFlags.Public | BindingFlags.Instance);
-                    if (openProp != null && openProp.GetIndexParameters().Length == 0 && openProp.CanRead)
-                    {
-                        // HasValue → bool (concrete); Value → the open T (the
-                        // property's PropertyType IS the open type parameter
-                        // itself in the reflection model). Substitute back to
-                        // the binder's symbolic T so downstream type checks
-                        // see the right symbol.
-                        TypeSymbol openPropType;
-                        if (openProp.PropertyType.IsGenericParameter)
-                        {
-                            openPropType = openTp;
-                        }
-                        else
-                        {
-                            openPropType = ClrNullability.GetPropertyTypeSymbol(openProp);
-                        }
-
-                        return new BoundClrPropertyAccessExpression(null, receiver, openProp, openPropType);
-                    }
-
-                    if (TryBindClrMethodGroup(receiver, openNullableDef, wantStatic: false, openNullableMemberName, out var openNullableGroup))
-                    {
-                        return openNullableGroup;
-                    }
-
-                    return BindExtensionMethodGroupOrError(receiver, ne);
+                    return nullableMember;
                 }
                 else if (TryGetClrInstanceMemberReceiverType(receiver, out var clrInstanceReceiverType))
                 {
@@ -762,6 +699,94 @@ internal sealed partial class ExpressionBinder
             default:
                 return new BoundErrorExpression(null);
         }
+    }
+
+    private bool TryBindNullableInstanceMember(
+        BoundExpression receiver,
+        NameExpressionSyntax name,
+        [NotNullWhen(true)] out BoundExpression? member)
+    {
+        member = null;
+        if (receiver.Type is not NullableTypeSymbol nullableType)
+        {
+            return false;
+        }
+
+        var memberName = name.IdentifierToken.Text;
+        var nullableInnerClr = nullableType.UnderlyingType?.ClrType;
+        if (nullableInnerClr?.IsValueType == true
+            && this.memberLookup.TryGetNullableConstructedType(nullableInnerClr, out var nullableClr))
+        {
+            var nullableProperty = ClrTypeUtilities.SafeGetProperty(
+                nullableClr,
+                memberName,
+                BindingFlags.Public | BindingFlags.Instance);
+            if (nullableProperty != null
+                && nullableProperty.GetIndexParameters().Length == 0
+                && nullableProperty.CanRead)
+            {
+                member = new BoundClrPropertyAccessExpression(
+                    null,
+                    receiver,
+                    nullableProperty,
+                    ClrNullability.GetPropertyTypeSymbol(nullableProperty));
+                return true;
+            }
+
+            if (TryBindClrMethodGroup(
+                receiver,
+                nullableClr,
+                wantStatic: false,
+                memberName,
+                out var nullableGroup))
+            {
+                member = nullableGroup;
+                return true;
+            }
+
+            member = BindExtensionMethodGroupOrError(receiver, name);
+            return true;
+        }
+
+        var openTypeParameter = nullableType.UnderlyingType as TypeParameterSymbol;
+        if (openTypeParameter?.HasValueTypeConstraint != true)
+        {
+            return false;
+        }
+
+        var openNullable = typeof(System.Nullable<>);
+        var openProperty = ClrTypeUtilities.SafeGetProperty(
+            openNullable,
+            memberName,
+            BindingFlags.Public | BindingFlags.Instance);
+        if (openProperty != null
+            && openProperty.GetIndexParameters().Length == 0
+            && openProperty.CanRead)
+        {
+            var propertyType = openProperty.PropertyType.IsGenericParameter
+                ? openTypeParameter
+                : ClrNullability.GetPropertyTypeSymbol(openProperty);
+            member = new BoundClrPropertyAccessExpression(
+                null,
+                receiver,
+                openProperty,
+                propertyType);
+            return true;
+        }
+
+        if (TryBindClrMethodGroup(
+            receiver,
+            openNullable,
+            wantStatic: false,
+            memberName,
+            out var openNullableGroup))
+        {
+            member = openNullableGroup;
+            return true;
+        }
+
+        member = BindExtensionMethodGroupOrError(receiver, name);
+        return true;
     }
 
     /// <summary>
@@ -1961,41 +1986,44 @@ internal sealed partial class ExpressionBinder
         // Phase 4 exit: CLR indexer write on an imported reference type
         // (e.g. `d["k"] = 1` on Dictionary[string, int]).
         // Issue #209: honour inner-position nullable flags when present.
-        if (targetType is TypeParameterSymbol tpIndexTarget
-            && tpIndexTarget.ClrInterfaceConstraint is TypeSymbol clrIndexConstraint
-            && clrIndexConstraint.ClrType is System.Type clrConstraintType)
+        if (targetType is TypeParameterSymbol tpIndexTarget)
         {
-            var idxArgs = ImmutableArray.Create(BindIndexValue());
-            if (this.memberLookup.TryResolveClrIndexer(
-                clrIndexConstraint,
-                clrConstraintType,
-                idxArgs,
-                out var idxProp,
-                out var resolvedIdxArgs))
+            var clrIndexConstraint = tpIndexTarget.ClrInterfaceConstraint;
+            var clrConstraintType = clrIndexConstraint?.ClrType;
+            if (clrIndexConstraint != null && clrConstraintType != null)
             {
-                if (idxProp!.GetSetMethod(nonPublic: false) == null)
+                var idxArgs = ImmutableArray.Create(BindIndexValue());
+                if (this.memberLookup.TryResolveClrIndexer(
+                    clrIndexConstraint,
+                    clrConstraintType,
+                    idxArgs,
+                    out var idxProp,
+                    out var resolvedIdxArgs))
                 {
-                    Diagnostics.ReportTypeNotIndexable(diagnosticLocation, targetType);
-                    return new BoundErrorExpression(null);
-                }
+                    if (idxProp!.GetSetMethod(nonPublic: false) == null)
+                    {
+                        Diagnostics.ReportTypeNotIndexable(diagnosticLocation, targetType);
+                        return new BoundErrorExpression(null);
+                    }
 
-                var elementType = MemberLookup.GetClrPropertyTypeSymbol(clrIndexConstraint, idxProp);
-                var declaringInterface = MemberLookup.GetClrMemberDeclaringTypeSymbol(
-                    clrIndexConstraint,
-                    idxProp);
-                var value = BindValue(elementType);
-                var convertedArgs = BindClrIndexerArguments(
-                    clrIndexConstraint,
-                    idxProp!,
-                    resolvedIdxArgs,
-                    indexSyntax.Location);
-                return MakeClrIndexAssignment(
-                    idxProp,
-                    convertedArgs,
-                    value,
-                    elementType,
-                    tpIndexTarget,
-                    declaringInterface);
+                    var elementType = MemberLookup.GetClrPropertyTypeSymbol(clrIndexConstraint, idxProp);
+                    var declaringInterface = MemberLookup.GetClrMemberDeclaringTypeSymbol(
+                        clrIndexConstraint,
+                        idxProp);
+                    var value = BindValue(elementType);
+                    var convertedArgs = BindClrIndexerArguments(
+                        clrIndexConstraint,
+                        idxProp!,
+                        resolvedIdxArgs,
+                        indexSyntax.Location);
+                    return MakeClrIndexAssignment(
+                        idxProp,
+                        convertedArgs,
+                        value,
+                        elementType,
+                        tpIndexTarget,
+                        declaringInterface);
+                }
             }
         }
         else if (targetType is NullabilityAnnotatedTypeSymbol annotWr && targetType.ClrType is System.Type clrAnnotWr)

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
@@ -2507,10 +2507,22 @@ internal sealed partial class ExpressionBinder
             // name lookup on the open type with the same instance-binding
             // flags is sufficient for the single-name, non-indexer
             // properties that surface real receiver-type generics.
-            var openType = closedProperty.DeclaringType != imp.ClrType && closedProperty.DeclaringType?.IsGenericType == true
-                ? imp.OpenDefinition.GetInterfaces().FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == closedProperty.DeclaringType.GetGenericTypeDefinition())
-                    ?? imp.OpenDefinition
-                : imp.OpenDefinition;
+            var openType = imp.OpenDefinition;
+            if (closedProperty.DeclaringType != imp.ClrType
+                && closedProperty.DeclaringType?.IsGenericType == true)
+            {
+                foreach (var candidateInterface in imp.OpenDefinition.GetInterfaces())
+                {
+                    if (candidateInterface.IsGenericType
+                        && candidateInterface.GetGenericTypeDefinition()
+                            == closedProperty.DeclaringType.GetGenericTypeDefinition())
+                    {
+                        openType = candidateInterface;
+                        break;
+                    }
+                }
+            }
+
             var openProperty = ClrTypeUtilities.SafeGetProperty(
                 openType,
                 closedProperty.Name,
@@ -2998,10 +3010,11 @@ internal sealed partial class ExpressionBinder
     private BoundExpression BindArraySlice(BoundExpression target, RangeExpressionSyntax range, TypeSymbol elementType)
     {
         var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+        Func<BoundExpression, BoundExpression> lengthOf = src => new BoundLenExpression(null, src);
         var (srcRef, startRef, lenRef) = BuildSliceBounds(
             target,
             range,
-            src => new BoundLenExpression(null, src),
+            lengthOf,
             statements);
 
         var resultType = SliceTypeSymbol.Get(elementType);
@@ -3032,10 +3045,11 @@ internal sealed partial class ExpressionBinder
     private BoundExpression BindStringSlice(BoundExpression target, RangeExpressionSyntax range)
     {
         var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+        Func<BoundExpression, BoundExpression> lengthOf = src => new BoundLenExpression(null, src);
         var (srcRef, startRef, lenRef) = BuildSliceBounds(
             target,
             range,
-            src => new BoundLenExpression(null, src),
+            lengthOf,
             statements);
 
         // System.String always declares the exact Substring(int, int) method.
@@ -3053,10 +3067,12 @@ internal sealed partial class ExpressionBinder
     private BoundExpression BindSpanLikeSlice(BoundExpression target, RangeExpressionSyntax range, MemberInfo lengthMember, MethodInfo sliceMethod)
     {
         var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+        Func<BoundExpression, BoundExpression> lengthOf =
+            src => new BoundClrPropertyAccessExpression(null, src, lengthMember, TypeSymbol.Int32);
         var (srcRef, startRef, lenRef) = BuildSliceBounds(
             target,
             range,
-            src => (BoundExpression)new BoundClrPropertyAccessExpression(null, src, lengthMember, TypeSymbol.Int32),
+            lengthOf,
             statements);
 
         var returnType = TypeSymbol.FromClrType(sliceMethod.ReturnType);
@@ -3170,10 +3186,11 @@ internal sealed partial class ExpressionBinder
         if (arrayElement != null)
         {
             var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+            Func<BoundExpression, BoundExpression> lengthOf = src => new BoundLenExpression(null, src);
             var (srcRef, startRef, lenRef) = BuildRangeValueBounds(
                 target,
                 rangeValue,
-                src => new BoundLenExpression(null, src),
+                lengthOf,
                 statements);
 
             var resultType = SliceTypeSymbol.Get(arrayElement);
@@ -3196,10 +3213,11 @@ internal sealed partial class ExpressionBinder
         if (target.Type == TypeSymbol.String)
         {
             var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+            Func<BoundExpression, BoundExpression> lengthOf = src => new BoundLenExpression(null, src);
             var (srcRef, startRef, lenRef) = BuildRangeValueBounds(
                 target,
                 rangeValue,
-                src => new BoundLenExpression(null, src),
+                lengthOf,
                 statements);
 
             // System.String always declares the exact Substring(int, int) method.

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
@@ -3865,7 +3865,7 @@ internal sealed partial class ExpressionBinder
     private static TypeSymbol SubstituteThroughConstructedInterface(TypeSymbol type, InterfaceSymbol constructedIface)
     {
         if (type is TypeParameterSymbol tp
-            && constructedIface?.Definition?.TypeParameters != null
+            && constructedIface?.Definition != null
             && !constructedIface.Definition.TypeParameters.IsDefaultOrEmpty
             && !constructedIface.TypeArguments.IsDefaultOrEmpty)
         {

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
@@ -190,8 +190,12 @@ internal sealed partial class ExpressionBinder
             // inner call through the accessor path (which resolves the
             // nested type constructor), then apply the initializer
             // assignments against the constructed instance.
-            case ObjectCreationExpressionSyntax objCreate
-                when objCreate.Target is CallExpressionSyntax innerCall:
+            case ObjectCreationExpressionSyntax objCreate:
+                if (objCreate.Target is not CallExpressionSyntax innerCall)
+                {
+                    return new BoundErrorExpression(null);
+                }
+
                 var ctorResult = BindAccessorCall(receiver, classSymbol, innerCall);
                 if (ctorResult is BoundErrorExpression)
                 {
@@ -2013,7 +2017,13 @@ internal sealed partial class ExpressionBinder
                     idxPropAnnotWr,
                     resolvedIdxArgsAnnotWr,
                     indexSyntax.Location);
-                return MakeClrIndexAssignment(idxPropAnnotWr, convertedIdxArgsAnnotWr, boundValueAnnotWr, valueTypeAnnotWr);
+                return MakeClrIndexAssignment(
+                    idxPropAnnotWr,
+                    convertedIdxArgsAnnotWr,
+                    boundValueAnnotWr,
+                    valueTypeAnnotWr,
+                    constrainedReceiverTypeParameter: null,
+                    constrainedInterfaceType: null);
             }
         }
         else if ((targetType is ImportedTypeSymbol || targetType is StructSymbol) && targetType.ClrType is System.Type clrTarget)
@@ -2051,7 +2061,13 @@ internal sealed partial class ExpressionBinder
                             ? byRef.PointeeType
                             : TypeSymbol.FromClrType(refGetter.ReturnType.GetElementType()!);
                         var refValue = BindValue(pointeeType);
-                        return MakeClrIndexAssignment(idxProp, convertedIdxArgs, refValue, pointeeType);
+                        return MakeClrIndexAssignment(
+                            idxProp,
+                            convertedIdxArgs,
+                            refValue,
+                            pointeeType,
+                            constrainedReceiverTypeParameter: null,
+                            constrainedInterfaceType: null);
                     }
 
                     Diagnostics.ReportTypeNotIndexable(diagnosticLocation, targetType);
@@ -2074,7 +2090,13 @@ internal sealed partial class ExpressionBinder
                     ? MapErasedIndexerElementType(imported, idxProp)
                     : ClrNullability.GetPropertyTypeSymbol(idxProp);
                 var boundValue = BindValue(valueType);
-                return MakeClrIndexAssignment(idxProp, convertedIdxArgs, boundValue, valueType);
+                return MakeClrIndexAssignment(
+                    idxProp,
+                    convertedIdxArgs,
+                    boundValue,
+                    valueType,
+                    constrainedReceiverTypeParameter: null,
+                    constrainedInterfaceType: null);
             }
         }
 
@@ -2858,10 +2880,10 @@ internal sealed partial class ExpressionBinder
         {
             ArrayTypeSymbol arr => arr.ElementType,
             SliceTypeSymbol slice => slice.ElementType,
-            ImportedTypeSymbol imp when imp.ClrType is { IsArray: true } clr && clr.GetArrayRank() == 1
-                => TypeSymbol.FromClrType(clr.GetElementType()),
-            NullabilityAnnotatedTypeSymbol annot when annot.ClrType is { IsArray: true } clr && clr.GetArrayRank() == 1
-                => annot.GetTypeArgumentSymbolForClrType(clr.GetElementType()),
+            ImportedTypeSymbol imp when imp.ClrType?.IsArray == true && imp.ClrType.GetArrayRank() == 1
+                => TypeSymbol.FromClrType(imp.ClrType.GetElementType()),
+            NullabilityAnnotatedTypeSymbol annot when annot.ClrType?.IsArray == true && annot.ClrType.GetArrayRank() == 1
+                => annot.GetTypeArgumentSymbolForClrType(annot.ClrType.GetElementType()),
             _ => null,
         };
     }
@@ -2994,7 +3016,7 @@ internal sealed partial class ExpressionBinder
         var (srcRef, startRef, lenRef) = BuildSliceBounds(
             target,
             range,
-            src => new BoundClrPropertyAccessExpression(null, src, lengthMember, TypeSymbol.Int32),
+            src => (BoundExpression)new BoundClrPropertyAccessExpression(null, src, lengthMember, TypeSymbol.Int32),
             statements);
 
         var returnType = TypeSymbol.FromClrType(sliceMethod.ReturnType);
@@ -3163,10 +3185,12 @@ internal sealed partial class ExpressionBinder
             if (TryFindSliceShape(clrType, out var lengthMember, out var sliceMethod))
             {
                 var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+                Func<BoundExpression, BoundExpression> lengthOf = src =>
+                    new BoundClrPropertyAccessExpression(null, src, lengthMember, TypeSymbol.Int32);
                 var (srcRef, startRef, lenRef) = BuildRangeValueBounds(
                     target,
                     rangeValue,
-                    src => new BoundClrPropertyAccessExpression(null, src, lengthMember, TypeSymbol.Int32),
+                    lengthOf,
                     statements);
 
                 var returnType = TypeSymbol.FromClrType(sliceMethod.ReturnType);
@@ -3464,10 +3488,10 @@ internal sealed partial class ExpressionBinder
             SliceTypeSymbol slice => slice.ElementType,
 
             // Issue #664: CLR T[] arrays (e.g. result of string.Split) are indexable.
-            ImportedTypeSymbol imp when imp.ClrType is { IsArray: true } clr && clr.GetArrayRank() == 1
-                => TypeSymbol.FromClrType(clr.GetElementType()),
-            NullabilityAnnotatedTypeSymbol annot when annot.ClrType is { IsArray: true } clr && clr.GetArrayRank() == 1
-                => annot.GetTypeArgumentSymbolForClrType(clr.GetElementType()),
+            ImportedTypeSymbol imp when imp.ClrType?.IsArray == true && imp.ClrType.GetArrayRank() == 1
+                => TypeSymbol.FromClrType(imp.ClrType.GetElementType()),
+            NullabilityAnnotatedTypeSymbol annot when annot.ClrType?.IsArray == true && annot.ClrType.GetArrayRank() == 1
+                => annot.GetTypeArgumentSymbolForClrType(annot.ClrType.GetElementType()),
             _ => null,
         };
     }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -466,10 +466,16 @@ internal sealed partial class ExpressionBinder
                 simpleName = nameHead.IdentifierToken.Text;
                 arity = 0;
                 break;
-            case AccessorExpressionSyntax { LeftPart: IndexExpressionSyntax { Target: NameExpressionSyntax indexNameHead } }:
+            case AccessorExpressionSyntax accessor:
                 // `Type[Args].Member`: a generic type receiver parses as an index
                 // expression (`Mp4Operation[int32]`), not a GenericName, when it
                 // appears as the left part of a member access.
+                if (accessor.LeftPart is not IndexExpressionSyntax index
+                    || index.Target is not NameExpressionSyntax indexNameHead)
+                {
+                    return false;
+                }
+
                 simpleName = indexNameHead.IdentifierToken.Text;
                 arity = 0;
                 break;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -1881,16 +1881,19 @@ internal sealed partial class ExpressionBinder
             // honour the user-given identifier.
             bool isReadOnly = syntax.DeclarationKeyword != null
                 && string.Equals(syntax.DeclarationKeyword.Text, "let", System.StringComparison.Ordinal);
-            string localName;
+            string? localName = null;
             if (syntax.DiscardToken != null)
             {
                 localName = $"<>out_discard_{binderCtx.OutDiscardCounter++}";
             }
-            else if (syntax.DeclarationIdentifier is { } identifierForName)
+
+            var identifierForName = syntax.DeclarationIdentifier;
+            if (syntax.DiscardToken == null && identifierForName != null)
             {
                 localName = identifierForName.Text;
             }
-            else
+
+            if (localName == null)
             {
                 return new BoundErrorExpression(null);
             }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -1164,20 +1164,22 @@ internal sealed partial class ExpressionBinder
         // base to the derived type, breaking bound-node parity. Left as a manual walk.
         if (isEventOperator && function?.ThisParameter != null && function.ReceiverType is StructSymbol receiverStruct)
         {
-            for (var t = receiverStruct; t != null; t = t.BaseClass)
+            StructSymbol? current = receiverStruct;
+            while (current != null)
             {
-                if (t.Events.IsDefaultOrEmpty)
+                var t = current;
+                if (!t.Events.IsDefaultOrEmpty)
                 {
-                    continue;
+                    var ev = t.Events.FirstOrDefault(e => e.Name == name);
+                    if (ev != null)
+                    {
+                        var receiver = new BoundVariableExpression(null, function.ThisParameter);
+                        var handler = BindEventSubscriptionHandler(syntax.Value, ev.Type);
+                        return new BoundEventSubscriptionExpression(null, receiver, t, ev, handler, isAdd);
+                    }
                 }
 
-                var ev = t.Events.FirstOrDefault(e => e.Name == name);
-                if (ev != null)
-                {
-                    var receiver = new BoundVariableExpression(null, function.ThisParameter);
-                    var handler = BindEventSubscriptionHandler(syntax.Value, ev.Type);
-                    return new BoundEventSubscriptionExpression(null, receiver, t, ev, handler, isAdd);
-                }
+                current = t.BaseClass;
             }
         }
 
@@ -2469,10 +2471,12 @@ internal sealed partial class ExpressionBinder
             return new BoundErrorExpression(null);
         }
 
-        if (receiverType is TypeParameterSymbol tpReceiver
-            && tpReceiver.ClrInterfaceConstraint is TypeSymbol clrInterfaceConstraint
-            && clrInterfaceConstraint.ClrType is Type constraintClrType
-            && constraintClrType.IsInterface)
+        var tpReceiver = receiverType as TypeParameterSymbol;
+        var clrInterfaceConstraint = tpReceiver?.ClrInterfaceConstraint;
+        var constraintClrType = clrInterfaceConstraint?.ClrType;
+        if (tpReceiver != null
+            && clrInterfaceConstraint != null
+            && constraintClrType?.IsInterface == true)
         {
             var clrProperty = ClrTypeUtilities.SafeGetPropertyIncludingInterfaces(
                 constraintClrType,

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
@@ -83,7 +83,8 @@ internal sealed partial class ExpressionBinder
         // compilation-wide, not file-scoped) could win over the receiver's
         // own compilation's source type for a static event/field compound
         // assignment, mirroring the BindAccessorExpression read-path bug.
-        if (accessor.LeftPart is NameExpressionSyntax staticLeftName
+        var staticLeftName = accessor.LeftPart as NameExpressionSyntax;
+        if (staticLeftName != null
             && EventReceiverNameCanBindAsType(staticLeftName, eventNameSyntax)
             && scope.TryLookupTypeAlias(staticLeftName.IdentifierToken.Text, out var staticTypeAlias)
             && staticTypeAlias is StructSymbol staticStruct)

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
@@ -365,17 +365,20 @@ internal sealed partial class ExpressionBinder
             flags = BindingFlags.Public | BindingFlags.Instance;
         }
 
-        var eventInfo = isEventCapableOperator
-            ? boundReceiver != null
+        EventInfo? eventInfo = null;
+        if (isEventCapableOperator && receiverClrType != null)
+        {
+            eventInfo = boundReceiver != null
                 ? MemberLookup.SafeGetEventIncludingSelfAndInterfaces(receiverClrType, eventName)
-                : ClrTypeUtilities.SafeGetEvent(receiverClrType, eventName, flags)
-            : null;
+                : ClrTypeUtilities.SafeGetEvent(receiverClrType, eventName, flags);
+        }
+
         if (eventInfo == null)
         {
             // Issue #648 (generalized by #2154): compound assignment fallback for
             // chained CLR member access (e.g. `obj.Prop += 1`, `obj.Prop *= 2` where
             // Prop is a field/property, not an event).
-            if (boundReceiver != null)
+            if (boundReceiver != null && receiverClrType != null)
             {
                 var clrCompound = TryBindChainedClrCompoundAssignment(
                     boundReceiver, receiverClrType, eventName, eventNameSyntax, syntax, baseOpSyntaxKind);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
@@ -293,7 +293,7 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
-        var selected = candidates[0];
+        FunctionSymbol? selected = candidates[0];
         if (candidates.Length > 1)
         {
             var allArguments = ImmutableArray.CreateBuilder<BoundExpression>(arguments.Length + 1);
@@ -320,7 +320,12 @@ internal sealed partial class ExpressionBinder
             }
         }
 
-        result = overloads.BindExtensionFunctionCall(receiver, selected, arguments, ce, argumentNames);
+        result = overloads.BindExtensionFunctionCall(
+            receiver,
+            Invariant.Required(selected, "a non-empty extension candidate set selects a function"),
+            arguments,
+            ce,
+            argumentNames);
         return true;
     }
 
@@ -389,8 +394,10 @@ internal sealed partial class ExpressionBinder
         CallExpressionSyntax ce,
         ImmutableArray<string> argumentNames)
     {
-        for (var c = receiverClass; c != null; c = c.BaseClass)
+        StructSymbol? current = receiverClass;
+        while (current != null)
         {
+            var c = current;
             foreach (var iface in c.Interfaces)
             {
                 if (iface == null)
@@ -419,6 +426,8 @@ internal sealed partial class ExpressionBinder
                     return selected;
                 }
             }
+
+            current = c.BaseClass;
         }
 
         return null;
@@ -450,14 +459,17 @@ internal sealed partial class ExpressionBinder
         {
             // Walk the base chain so an inherited delegate field on a base class
             // is invokable on a derived instance.
-            for (var c = receiverStruct; c != null; c = c.BaseClass)
+            StructSymbol? current = receiverStruct;
+            while (current != null)
             {
-                if (c.TryGetField(methodName, out var f))
+                if (current.TryGetField(methodName, out var f))
                 {
                     matchedField = f;
-                    declaringType = c;
+                    declaringType = current;
                     break;
                 }
+
+                current = current.BaseClass;
             }
         }
 
@@ -2045,7 +2057,8 @@ internal sealed partial class ExpressionBinder
     /// </summary>
     private static bool UserClassImplementsInterface(StructSymbol ss, System.Type target)
     {
-        for (var current = ss; current != null; current = current.BaseClass)
+        StructSymbol? current = ss;
+        while (current != null)
         {
             foreach (var iface in current.ImplementedClrInterfaces)
             {
@@ -2066,6 +2079,8 @@ internal sealed partial class ExpressionBinder
                     return true;
                 }
             }
+
+            current = current.BaseClass;
         }
 
         // Also check the imported CLR base type (if any) — it may implement
@@ -2708,12 +2723,16 @@ internal sealed partial class ExpressionBinder
     /// <returns>The CLR base type for inherited-member lookup.</returns>
     private static System.Type ResolveClrBaseSearchType(StructSymbol from)
     {
-        for (var t = from; t != null; t = t.BaseClass)
+        StructSymbol? current = from;
+        while (current != null)
         {
-            if (t.ImportedBaseType?.ClrType is System.Type clr)
+            var clr = current.ImportedBaseType?.ClrType;
+            if (clr != null)
             {
                 return clr;
             }
+
+            current = current.BaseClass;
         }
 
         return typeof(object);
@@ -3044,13 +3063,16 @@ internal sealed partial class ExpressionBinder
     private static bool IsBaseClassOf(StructSymbol derived, StructSymbol candidate)
     {
         var candidateDef = candidate.Definition ?? candidate;
-        for (var t = derived.BaseClass; t != null; t = t.BaseClass)
+        var current = derived.BaseClass;
+        while (current != null)
         {
-            var tDef = t.Definition ?? t;
-            if (ReferenceEquals(tDef, candidateDef) || ReferenceEquals(t, candidate))
+            var currentDef = current.Definition ?? current;
+            if (ReferenceEquals(currentDef, candidateDef) || ReferenceEquals(current, candidate))
             {
                 return true;
             }
+
+            current = current.BaseClass;
         }
 
         return false;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
@@ -635,6 +635,8 @@ internal sealed partial class ExpressionBinder
             // trailing elements get the same per-element coercion applied
             // at every other variadic pack site (previously packed raw,
             // uncoerced elements here).
+            Func<int, TextLocation> variadicArgumentLocation =
+                i => i < ce.Arguments.Count ? ce.Arguments[i].Location : ce.Location;
             permutedArgs = OverloadResolver.PackOrPassThroughVariadicArguments(
                 conversions,
                 Diagnostics,
@@ -643,7 +645,7 @@ internal sealed partial class ExpressionBinder
                 fldFixedCount,
                 sliceType,
                 methodName,
-                i => i < ce.Arguments.Count ? ce.Arguments[i].Location : ce.Location,
+                variadicArgumentLocation,
                 ref hasVariadicErrors);
 
             if (hasVariadicErrors)
@@ -1074,13 +1076,24 @@ internal sealed partial class ExpressionBinder
         // Issue #658 / #1634: supplementary interface check for user-class args,
         // threaded as a call-local parameter into Resolve instead of a shared
         // static so nested/concurrent binds can't clobber it.
-        Func<Type, Type, bool>? supplementaryInterfaceCheck = hasUserClassArg
-            ? (source, target) => IsUserClassAssignableToInterfaceFromArgs(arguments, argTypes, source, target)
-            : null;
+        Func<Type, Type, bool>? supplementaryInterfaceCheck = null;
+        if (hasUserClassArg)
+        {
+            supplementaryInterfaceCheck = CheckUserClassInterface;
+        }
+
+        bool CheckUserClassInterface(Type source, Type target) =>
+            IsUserClassAssignableToInterfaceFromArgs(arguments, argTypes, source, target);
 
         var inheritedSymbolicArgs = MemberLookup.BuildSymbolicArgTypeVector(
             null,
             ImmutableArray.CreateRange(arguments.Select(a => a.Type)));
+        Func<MethodInfo, bool, ImmutableArray<TypeSymbol?>> recoverInheritedTypeArgs =
+            (closed, isExpanded) => MemberLookup.BuildSymbolicMethodTypeArgs(
+                closed,
+                typeArgSymbols,
+                inheritedSymbolicArgs,
+                isExpanded);
         var resolution = ClrOverloadResolution.Resolve(
             candidates,
             argTypes,
@@ -1088,11 +1101,7 @@ internal sealed partial class ExpressionBinder
             scope.References.MapClrTypeToReferences,
             ComputeInterpolatedStringArgFlags(ce.Arguments, arguments.Length),
             argumentNames: argumentNames.IsDefault ? null : (IReadOnlyList<string>)argumentNames,
-            recoverTypeArgSymbols: (closed, isExpanded) => MemberLookup.BuildSymbolicMethodTypeArgs(
-                closed,
-                typeArgSymbols,
-                inheritedSymbolicArgs,
-                isExpanded),
+            recoverTypeArgSymbols: recoverInheritedTypeArgs,
             supplementaryInterfaceCheck: supplementaryInterfaceCheck,
             constantNarrowingArgumentCheck: MakeConstantNarrowingArgumentCheck(arguments),
             structuralProjectionArgumentCheck: MakeStructuralProjectionArgumentCheck(arguments),
@@ -1411,22 +1420,34 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
-        if (deferredInferenceArgs.Any(static deferred => deferred)
-            && receiverClrType is { IsGenericType: true })
+        var hasDeferredInferenceArgument = false;
+        foreach (var deferred in deferredInferenceArgs)
+        {
+            hasDeferredInferenceArgument |= deferred;
+        }
+
+        if (hasDeferredInferenceArgument && receiverClrType is { IsGenericType: true })
         {
             var receiverDefinition = receiverClrType.GetGenericTypeDefinition();
-            if (candidates.Any(candidate =>
+            var candidateMatchesReceiver = false;
+            foreach (var candidate in candidates)
             {
-                var parameters = candidate.GetParameters();
-                if (parameters.Length == 0 || !parameters[0].ParameterType.IsGenericType)
+                var candidateParameters = candidate.GetParameters();
+                if (candidateParameters.Length == 0 || !candidateParameters[0].ParameterType.IsGenericType)
                 {
-                    return false;
+                    continue;
                 }
 
-                return ClrTypeUtilities.AreSame(
-                    receiverDefinition,
-                    parameters[0].ParameterType.GetGenericTypeDefinition());
-            }))
+                if (ClrTypeUtilities.AreSame(
+                        receiverDefinition,
+                        candidateParameters[0].ParameterType.GetGenericTypeDefinition()))
+                {
+                    candidateMatchesReceiver = true;
+                    break;
+                }
+            }
+
+            if (candidateMatchesReceiver)
             {
                 Array.Clear(deferredInferenceArgs);
             }
@@ -1479,9 +1500,15 @@ internal sealed partial class ExpressionBinder
         // Issue #658 / #1634: supplementary interface check for user-class args,
         // threaded as a call-local parameter into Resolve instead of a shared
         // static so nested/concurrent binds can't clobber it.
-        Func<Type, Type, bool>? supplementaryInterfaceCheck = hasUserClassArg
-            ? (source, target) => IsUserClassAssignableToInterfaceFromArgs(arguments, argTypes, source, target)
-            : null;
+        Func<Type, Type, bool>? supplementaryInterfaceCheck = null;
+        if (hasUserClassArg)
+        {
+            supplementaryInterfaceCheck = CheckUserClassInterface;
+        }
+
+        bool CheckUserClassInterface(Type source, Type target) =>
+            IsUserClassAssignableToInterfaceFromArgs(arguments, argTypes, source, target);
+
         var argumentStructuralProjectionCheck = MakeStructuralProjectionArgumentCheck(arguments, argumentOffset: 1);
         bool ExtensionStructuralProjectionCheck(int index, Type target) =>
             index == 0
@@ -1498,6 +1525,16 @@ internal sealed partial class ExpressionBinder
         // consistently with the instance/inherited/static/ctor paths. Offset by
         // 1 (receiverArgCount) since slot 0 here is the receiver, not a
         // user-supplied argument.
+        Func<MethodInfo, bool, ImmutableArray<TypeSymbol?>> recoverExtensionTypeArgs =
+            (closed, isExpanded) => MemberLookup.BuildSymbolicMethodTypeArgs(
+                closed,
+                typeArgSymbols,
+                extensionSymbolicArgs,
+                isExpanded);
+        Func<int, bool> functionLiteralArgumentCheck = argumentIndex =>
+            argumentIndex > 0
+            && argumentIndex - 1 < arguments.Length
+            && arguments[argumentIndex - 1] is BoundFunctionLiteralExpression;
         var resolution = ClrOverloadResolution.Resolve(
             candidates,
             argTypes,
@@ -1505,11 +1542,7 @@ internal sealed partial class ExpressionBinder
             scope.References.MapClrTypeToReferences,
             ComputeInterpolatedStringArgFlags(ce.Arguments, argTypes.Length, receiverArgCount: 1),
             argumentNames: extensionArgumentNames,
-            recoverTypeArgSymbols: (closed, isExpanded) => MemberLookup.BuildSymbolicMethodTypeArgs(
-                closed,
-                typeArgSymbols,
-                extensionSymbolicArgs,
-                isExpanded),
+            recoverTypeArgSymbols: recoverExtensionTypeArgs,
             supplementaryInterfaceCheck: supplementaryInterfaceCheck,
             constantNarrowingArgumentCheck: MakeConstantNarrowingArgumentCheck(arguments, argumentOffset: 1),
             structuralProjectionArgumentCheck: ExtensionStructuralProjectionCheck,
@@ -1517,10 +1550,7 @@ internal sealed partial class ExpressionBinder
             methodGroupInference: MakeMethodGroupInference(arguments, GetEffectiveArgumentClrTypeForOverloadResolution, argumentOffset: 1),
             methodGroupArgumentCheck: MakeMethodGroupArgumentCheck(arguments, argumentOffset: 1),
             deferredInferenceArgs: deferredInferenceArgs,
-            functionLiteralArgumentCheck: argumentIndex =>
-                argumentIndex > 0
-                && argumentIndex - 1 < arguments.Length
-                && arguments[argumentIndex - 1] is BoundFunctionLiteralExpression);
+            functionLiteralArgumentCheck: functionLiteralArgumentCheck);
 
         switch (resolution.Outcome)
         {

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
@@ -1964,18 +1964,21 @@ internal sealed partial class ExpressionBinder
             var argument = arguments[i];
             var rebound = argument;
             if (paramIndex < parameters.Length
-                && LambdaBinder.TryGetFunctionLiteral(argument, out var literal)
-                && literal.FunctionType is FunctionTypeSymbol literalFnType
-                && literalFnType.ReturnType != TypeSymbol.Void
-                && literalFnType.ReturnType != TypeSymbol.Error
-                && MemberLookup.TryGetLambdaTargetFunctionType(parameters[paramIndex].ParameterType, out var targetFunctionType)
-                && targetFunctionType.ReturnType != TypeSymbol.Void
-                && targetFunctionType.ReturnType != TypeSymbol.Error
-                && targetFunctionType.Arity == literalFnType.Arity
-                && !ReferenceEquals(literalFnType.ReturnType, targetFunctionType.ReturnType)
-                && ConversionClassifier.IsNumericReturnWidening(literalFnType.ReturnType, targetFunctionType.ReturnType))
+                && LambdaBinder.TryGetFunctionLiteral(argument, out var literal))
             {
-                rebound = lambdas.CreateErasedFunctionLiteralAdapter(literal, targetFunctionType);
+                var literalFnType = literal.FunctionType as FunctionTypeSymbol;
+                if (literalFnType != null
+                    && literalFnType.ReturnType != TypeSymbol.Void
+                    && literalFnType.ReturnType != TypeSymbol.Error
+                    && MemberLookup.TryGetLambdaTargetFunctionType(parameters[paramIndex].ParameterType, out var targetFunctionType)
+                    && targetFunctionType.ReturnType != TypeSymbol.Void
+                    && targetFunctionType.ReturnType != TypeSymbol.Error
+                    && targetFunctionType.Arity == literalFnType.Arity
+                    && !ReferenceEquals(literalFnType.ReturnType, targetFunctionType.ReturnType)
+                    && ConversionClassifier.IsNumericReturnWidening(literalFnType.ReturnType, targetFunctionType.ReturnType))
+                {
+                    rebound = lambdas.CreateErasedFunctionLiteralAdapter(literal, targetFunctionType);
+                }
             }
 
             if (rebound != argument && builder == null)

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -145,15 +145,20 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
-        MethodInfo[] candidates;
+        List<MethodInfo> candidates;
         try
         {
-            candidates = classType
-                .GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance)
-                .Where(m => m.Name == methodName
-                    && m.IsGenericMethodDefinition
-                    && m.GetGenericArguments().Length == explicitTypeArgs.Length)
-                .ToArray();
+            candidates = new List<MethodInfo>();
+            foreach (var method in classType.GetMethods(
+                         BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance))
+            {
+                if (method.Name == methodName
+                    && method.IsGenericMethodDefinition
+                    && method.GetGenericArguments().Length == explicitTypeArgs.Length)
+                {
+                    candidates.Add(method);
+                }
+            }
         }
         catch (Exception)
         {
@@ -598,10 +603,16 @@ internal sealed partial class ExpressionBinder
             var visibleParameterCount = parameters.Length - parameterOffset;
             var hasParams = parameters.Length > parameterOffset
                 && ClrOverloadResolution.IsParamsArrayParameter(parameters[^1]);
-            var requiredCount = parameters
-                .Skip(parameterOffset)
-                .Take(hasParams ? visibleParameterCount - 1 : visibleParameterCount)
-                .Count(parameter => !parameter.IsOptional);
+            var requiredCount = 0;
+            var visibleEnd = parameterOffset + (hasParams ? visibleParameterCount - 1 : visibleParameterCount);
+            for (var i = parameterOffset; i < visibleEnd; i++)
+            {
+                if (!parameters[i].IsOptional)
+                {
+                    requiredCount++;
+                }
+            }
+
             if (sourceArgumentCount < requiredCount
                 || (!hasParams && sourceArgumentCount > visibleParameterCount))
             {
@@ -2310,7 +2321,12 @@ internal sealed partial class ExpressionBinder
             }
         }
 
-        var hasNamedArguments = ce.Arguments.Any(argument => argument is NamedArgumentExpressionSyntax);
+        var hasNamedArguments = false;
+        foreach (var argument in ce.Arguments)
+        {
+            hasNamedArguments |= argument is NamedArgumentExpressionSyntax;
+        }
+
         if (classSymbol == null && methodName == "copy" && (hasNamedArguments || (receiver?.Type is StructSymbol copyStruct && copyStruct.IsData)))
         {
             if (TryGetCopyOverrides(ce, out var overrides))
@@ -2421,7 +2437,9 @@ internal sealed partial class ExpressionBinder
                 var argName = argumentNames.IsDefault ? null : argumentNames[argSlot];
                 var symbolicReceiver = receiver?.Type as ImportedTypeSymbol
                     ?? classSymbol?.SymbolicReceiver;
-                if (symbolicReceiver != null
+                var lambdaHandled = false;
+                if (!lambdaHandled
+                    && symbolicReceiver != null
                     && !symbolicReceiver.TypeArguments.IsDefaultOrEmpty
                     && symbolicReceiver.TypeArguments.Any(TypeSymbol.RequiresSymbolicProjection))
                 {
@@ -2431,12 +2449,17 @@ internal sealed partial class ExpressionBinder
                     // target pass recovers the open delegate signature.
                     deferredArrowLambdaIndices.Add(argSlot);
                     boundArguments.Add(new BoundErrorExpression(inner));
+                    lambdaHandled = true;
                 }
-                else if (UserExtensionHasFunctionTypedParameterAt(receiver, methodName, argSlot))
+
+                if (!lambdaHandled
+                    && UserExtensionHasFunctionTypedParameterAt(receiver, methodName, argSlot))
                 {
                     boundArguments.Add(BindExpression(inner));
+                    lambdaHandled = true;
                 }
-                else
+
+                if (!lambdaHandled)
                 {
                     if (!delegateTargetCandidatesComputed)
                     {
@@ -2488,7 +2511,6 @@ internal sealed partial class ExpressionBinder
                     // overload resolution. The closed candidate supplies the
                     // shared function shape, but only the selected method can
                     // determine whether the lambda needs a named delegate.
-                    var lambdaHandled = false;
                     var lambdaSyntax = inner as LambdaExpressionSyntax;
                     if ((lambdaSyntax?.Body is BlockExpressionSyntax && !hasClosedTarget && blocked)
                         || (hasClosedTarget && sawOpen))
@@ -3164,13 +3186,24 @@ internal sealed partial class ExpressionBinder
                 // Issue #658 / #1634: supplementary interface check for user-class
                 // args, threaded as a call-local parameter into Resolve instead of
                 // a shared static so nested/concurrent binds can't clobber it.
-                Func<Type, Type, bool>? supplementaryInterfaceCheck = hasUserClassArg
-                    ? (source, target) => IsUserClassAssignableToInterfaceFromArgs(arguments, argTypes, source, target)
-                    : null;
+                Func<Type, Type, bool>? supplementaryInterfaceCheck = null;
+                if (hasUserClassArg)
+                {
+                    supplementaryInterfaceCheck = CheckUserClassInterface;
+                }
+
+                bool CheckUserClassInterface(Type source, Type target) =>
+                    IsUserClassAssignableToInterfaceFromArgs(arguments, argTypes, source, target);
 
                 var preResolutionSymbolicArgs = MemberLookup.BuildSymbolicArgTypeVector(
                     null,
                     ImmutableArray.CreateRange(arguments.Select(a => a.Type)));
+                Func<MethodInfo, bool, ImmutableArray<TypeSymbol?>> recoverTypeArgSymbols =
+                    (closed, isExpanded) => MemberLookup.BuildSymbolicMethodTypeArgs(
+                        closed,
+                        typeArgSymbols,
+                        preResolutionSymbolicArgs,
+                        isExpanded);
                 var resolution = ClrOverloadResolution.Resolve(
                     candidates,
                     argTypes,
@@ -3178,11 +3211,7 @@ internal sealed partial class ExpressionBinder
                     scope.References.MapClrTypeToReferences,
                     ComputeInterpolatedStringArgFlags(ce.Arguments, arguments.Length),
                     argumentNames.IsDefault ? null : (IReadOnlyList<string>)argumentNames,
-                    recoverTypeArgSymbols: (closed, isExpanded) => MemberLookup.BuildSymbolicMethodTypeArgs(
-                        closed,
-                        typeArgSymbols,
-                        preResolutionSymbolicArgs,
-                        isExpanded),
+                    recoverTypeArgSymbols: recoverTypeArgSymbols,
                     supplementaryInterfaceCheck: supplementaryInterfaceCheck,
                     constantNarrowingArgumentCheck: MakeConstantNarrowingArgumentCheck(arguments),
                     structuralProjectionArgumentCheck: MakeStructuralProjectionArgumentCheck(arguments),

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -2543,7 +2543,9 @@ internal sealed partial class ExpressionBinder
             // a target so the established GS0304 diagnostic still surfaces.
             foreach (var idx in deferredArrowLambdaIndices)
             {
-                if (mutableArgs[idx] is BoundErrorExpression placeholder && placeholder.Syntax is LambdaExpressionSyntax pendingLambda)
+                var placeholder = mutableArgs[idx] as BoundErrorExpression;
+                var pendingLambda = placeholder?.Syntax as LambdaExpressionSyntax;
+                if (pendingLambda != null)
                 {
                     mutableArgs[idx] = lambdas.BindLambdaExpression(pendingLambda);
                 }
@@ -2918,11 +2920,25 @@ internal sealed partial class ExpressionBinder
             // without this check protected inherited members would be
             // callable through any receiver expression, leaking accessibility.
             var allowProtectedInherited = IsCurrentThisReceiver(receiver);
-            if (receiver != null && receiver.Type is StructSymbol inheritedDerived
-                && (GetInheritedClrBaseType(inheritedDerived) ?? typeof(object)) is System.Type inheritedBaseClr
-                && TryBindInheritedClrInstanceCall(receiver, inheritedBaseClr, methodName, arguments, ce, out var inheritedCall, explicitTypeArgs, typeArgSymbols, argumentNames, allowProtectedInherited: allowProtectedInherited))
+            var inheritedDerived = receiver?.Type as StructSymbol;
+            if (inheritedDerived != null)
             {
-                return inheritedCall;
+                var inheritedBaseClr =
+                    GetInheritedClrBaseType(inheritedDerived) ?? typeof(object);
+                if (TryBindInheritedClrInstanceCall(
+                    receiver!,
+                    inheritedBaseClr,
+                    methodName,
+                    arguments,
+                    ce,
+                    out var inheritedCall,
+                    explicitTypeArgs,
+                    typeArgSymbols,
+                    argumentNames,
+                    allowProtectedInherited: allowProtectedInherited))
+                {
+                    return inheritedCall;
+                }
             }
 
             // Issue #1218: an enum value is a CLR value type whose base chain is

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -2488,13 +2488,17 @@ internal sealed partial class ExpressionBinder
                     // overload resolution. The closed candidate supplies the
                     // shared function shape, but only the selected method can
                     // determine whether the lambda needs a named delegate.
-                    if ((inner is LambdaExpressionSyntax { Body: BlockExpressionSyntax } && !hasClosedTarget && blocked)
+                    var lambdaHandled = false;
+                    var lambdaSyntax = inner as LambdaExpressionSyntax;
+                    if ((lambdaSyntax?.Body is BlockExpressionSyntax && !hasClosedTarget && blocked)
                         || (hasClosedTarget && sawOpen))
                     {
                         deferredArrowLambdaIndices.Add(argSlot);
                         boundArguments.Add(new BoundErrorExpression(inner));
+                        lambdaHandled = true;
                     }
-                    else if (inner is LambdaExpressionSyntax lambdaSyntax && hasClosedTarget)
+
+                    if (!lambdaHandled && lambdaSyntax != null && hasClosedTarget)
                     {
                         // target: non-null whenever hasClosedTarget is true
                         // ([NotNullWhen(true)] on TryResolveDelegateTargetFromCandidates).
@@ -2503,8 +2507,10 @@ internal sealed partial class ExpressionBinder
                             lambdaSyntax,
                             target!,
                             nominalTarget));
+                        lambdaHandled = true;
                     }
-                    else
+
+                    if (!lambdaHandled)
                     {
                         boundArguments.Add(BindExpression(inner));
                     }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -2816,19 +2816,22 @@ internal sealed partial class ExpressionBinder
             // the interface paths the method token is the class's own MethodDef
             // (resolved by EmitUserInstanceCall when the constraint type is not
             // an interface), so no interface MemberRef is produced.
-            if (receiver != null && receiver.Type is TypeParameterSymbol tpClassRecv
-                && tpClassRecv.ClassConstraint is StructSymbol tpClassConstraint)
+            if (receiver != null && receiver.Type is TypeParameterSymbol tpClassRecv)
             {
-                var tpClassOverloads = MemberLookup.CollectSourceInstanceMethods(tpClassRecv, methodName);
-                if (tpClassOverloads.Length > 0)
+                var tpClassConstraint = tpClassRecv.ClassConstraint as StructSymbol;
+                if (tpClassConstraint != null)
                 {
-                    var tpClassMethod = overloads.SelectInstanceOverloadOrReport(tpClassOverloads, arguments, ce, methodName, argumentNames);
-                    if (tpClassMethod == null)
+                    var tpClassOverloads = MemberLookup.CollectSourceInstanceMethods(tpClassRecv, methodName);
+                    if (tpClassOverloads.Length > 0)
                     {
-                        return new BoundErrorExpression(null);
-                    }
+                        var tpClassMethod = overloads.SelectInstanceOverloadOrReport(tpClassOverloads, arguments, ce, methodName, argumentNames);
+                        if (tpClassMethod == null)
+                        {
+                            return new BoundErrorExpression(null);
+                        }
 
-                    return overloads.BindUserInstanceCall(receiver, tpClassMethod, arguments, ce, argumentNames, constrainedReceiverTypeParameter: tpClassRecv);
+                        return overloads.BindUserInstanceCall(receiver, tpClassMethod, arguments, ce, argumentNames, constrainedReceiverTypeParameter: tpClassRecv);
+                    }
                 }
             }
 
@@ -3059,11 +3062,16 @@ internal sealed partial class ExpressionBinder
         // instance-method lookup (e.g. `GetValueOrDefault`, `Equals`,
         // `ToString`) must go through the constructed `Nullable<T>` type that
         // actually carries those members.
-        var clrType = receiver.Type is NullableTypeSymbol nullableRecv
-            && nullableRecv.UnderlyingType?.ClrType is { IsValueType: true } nullableInnerVt
-            && this.memberLookup.TryGetNullableConstructedType(nullableInnerVt, out var nullableConstructed)
-            ? nullableConstructed
-            : effectiveReceiverType.ClrType;
+        var clrType = effectiveReceiverType.ClrType;
+        if (receiver.Type is NullableTypeSymbol nullableRecv)
+        {
+            var nullableInnerVt = nullableRecv.UnderlyingType?.ClrType;
+            if (nullableInnerVt?.IsValueType == true
+                && this.memberLookup.TryGetNullableConstructedType(nullableInnerVt, out var nullableConstructed))
+            {
+                clrType = nullableConstructed;
+            }
+        }
 
         // Issue #529: use interface-aware method enumeration so that
         // methods declared on a base interface (e.g.

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -1935,7 +1935,7 @@ internal sealed partial class ExpressionBinder
             if (string.Equals(parameterFullName, "System.Delegate", StringComparison.Ordinal)
                 || string.Equals(parameterFullName, "System.MulticastDelegate", StringComparison.Ordinal))
             {
-                target = null;
+                target = default;
                 nominalTarget = null;
                 blockedByOpenGenericParameter = false;
                 sawOpenGenericParameter = false;
@@ -1955,7 +1955,7 @@ internal sealed partial class ExpressionBinder
             {
                 // Candidates disagree on the delegate shape — leave the lambda
                 // to be bound without a target (overload resolution decides).
-                target = null;
+                target = default;
                 nominalTarget = null;
                 blockedByOpenGenericParameter = false;
                 sawOpenGenericParameter = false;
@@ -2013,7 +2013,7 @@ internal sealed partial class ExpressionBinder
         ImmutableArray<TypeSymbol> symbolicTypeArgs,
         int sourceArgIndex,
         string? argName,
-        [NotNullWhen(true)] out (TypeSymbol DelegateType, FunctionTypeSymbol FunctionType)? target)
+        [NotNullWhen(true)] out SymbolicDelegateTarget? target)
     {
         target = null;
         if (openGenericDefinition == null || symbolicTypeArgs.IsDefaultOrEmpty)
@@ -2073,13 +2073,13 @@ internal sealed partial class ExpressionBinder
                 continue;
             }
 
-            if (target is null)
+            if (target == null)
             {
-                target = (mappedDelegate, candidate);
+                target = new SymbolicDelegateTarget(mappedDelegate, candidate);
             }
-            else if (!SameDelegateIdentity(target.Value.DelegateType, mappedDelegate)
-                || (!ReferenceEquals(target.Value.FunctionType, candidate)
-                    && !target.Value.FunctionType.Equals(candidate)))
+            else if (!SameDelegateIdentity(target.DelegateType, mappedDelegate)
+                || (!ReferenceEquals(target.FunctionType, candidate)
+                    && !target.FunctionType.Equals(candidate)))
             {
                 target = null;
                 return false;
@@ -2173,5 +2173,20 @@ internal sealed partial class ExpressionBinder
             out var noApplicableOverload);
         return bound || FinishClrConstructorBindingFailure(
             syntax, nestedType.Name, noApplicableOverload, ref result);
+    }
+
+    private sealed class SymbolicDelegateTarget
+    {
+        public SymbolicDelegateTarget(
+            TypeSymbol delegateType,
+            FunctionTypeSymbol functionType)
+        {
+            DelegateType = delegateType;
+            FunctionType = functionType;
+        }
+
+        public TypeSymbol DelegateType { get; }
+
+        public FunctionTypeSymbol FunctionType { get; }
     }
 }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -1876,7 +1876,7 @@ internal sealed partial class ExpressionBinder
         out bool blockedByOpenGenericParameter,
         out bool sawOpenGenericParameter)
     {
-        target = null;
+        target = default;
         nominalTarget = null;
         blockedByOpenGenericParameter = false;
         sawOpenGenericParameter = false;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -277,9 +277,14 @@ internal sealed partial class ExpressionBinder
         }
 
         var resultType = target.Type;
-        var hasNonIndexedElement = syntax.Elements.Any(e => e is not IndexedCollectionElementSyntax);
-        var hasSpreadElement = syntax.Elements.Any(
-            e => e is ExpressionCollectionElementSyntax { Expression: SpreadElementExpressionSyntax });
+        var hasNonIndexedElement = false;
+        var hasSpreadElement = false;
+        foreach (var element in syntax.Elements)
+        {
+            hasNonIndexedElement |= element is not IndexedCollectionElementSyntax;
+            var expressionElement = element as ExpressionCollectionElementSyntax;
+            hasSpreadElement |= expressionElement?.Expression is SpreadElementExpressionSyntax;
+        }
 
         // A collection initializer requires an accessible instance `Add` for the
         // bare / key:value element forms. Indexed `[k] = v` entries go through
@@ -792,15 +797,21 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
-        var nestedObjectAssignments = braced.Elements
-            .Select(element => (element as ExpressionCollectionElementSyntax)?.Expression as AssignmentExpressionSyntax)
-            .ToImmutableArray();
-        var isNestedObjectInitializer =
-            nestedObjectAssignments.Length > 0 &&
-            nestedObjectAssignments.All(assignment => assignment != null);
-        var hasNonIndexedElement = braced.Elements.Any(e => e is not IndexedCollectionElementSyntax);
-        var hasSpreadElement = braced.Elements.Any(
-            e => e is ExpressionCollectionElementSyntax { Expression: SpreadElementExpressionSyntax });
+        var nestedObjectAssignments = ImmutableArray.CreateBuilder<AssignmentExpressionSyntax?>(braced.Elements.Count);
+        var hasNonIndexedElement = false;
+        var hasSpreadElement = false;
+        var allElementsAreAssignments = braced.Elements.Count > 0;
+        foreach (var element in braced.Elements)
+        {
+            var expressionElement = element as ExpressionCollectionElementSyntax;
+            var assignment = expressionElement?.Expression as AssignmentExpressionSyntax;
+            nestedObjectAssignments.Add(assignment);
+            allElementsAreAssignments &= assignment is not null;
+            hasNonIndexedElement |= element is not IndexedCollectionElementSyntax;
+            hasSpreadElement |= expressionElement?.Expression is SpreadElementExpressionSyntax;
+        }
+
+        var isNestedObjectInitializer = allElementsAreAssignments;
         if (!isNestedObjectInitializer &&
             ((hasNonIndexedElement && !HasCollectionAdd(propRead.Type)) ||
              (hasSpreadElement && !HasUnaryCollectionAdd(propRead.Type))))
@@ -1273,14 +1284,32 @@ internal sealed partial class ExpressionBinder
             if (ImportedAssemblySemantics.TryGetTypeSemantics(resolvedClrType, out _))
             {
                 var primaryParameterCount = dataClassAggregate.PrimaryConstructorParameters.Length;
-                var primaryAcceptsArity =
-                    syntax.Arguments.Count <= primaryParameterCount
-                    && dataClassAggregate.PrimaryConstructorParameters
-                        .Skip(syntax.Arguments.Count)
-                        .All(parameter => parameter.HasExplicitDefaultValue);
-                if (!primaryAcceptsArity
-                    && ClrTypeUtilities.SafeGetConstructors(resolvedClrType, BindingFlags.Public | BindingFlags.Instance)
-                        .Any(ctor => ctor.GetParameters().Length == syntax.Arguments.Count))
+                var primaryAcceptsArity = syntax.Arguments.Count <= primaryParameterCount;
+                if (primaryAcceptsArity)
+                {
+                    for (var i = syntax.Arguments.Count; i < primaryParameterCount; i++)
+                    {
+                        primaryAcceptsArity &=
+                            dataClassAggregate.PrimaryConstructorParameters[i].HasExplicitDefaultValue;
+                    }
+                }
+
+                var hasMatchingSecondaryConstructor = false;
+                if (!primaryAcceptsArity)
+                {
+                    foreach (var constructor in ClrTypeUtilities.SafeGetConstructors(
+                                 resolvedClrType,
+                                 BindingFlags.Public | BindingFlags.Instance))
+                    {
+                        if (constructor.GetParameters().Length == syntax.Arguments.Count)
+                        {
+                            hasMatchingSecondaryConstructor = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (!primaryAcceptsArity && hasMatchingSecondaryConstructor)
                 {
                     var boundSecondary = TryBindClrConstructorFromType(
                         resolvedClrType,
@@ -1522,7 +1551,11 @@ internal sealed partial class ExpressionBinder
         // to the single-arg conversion path and reports the misleading GS0162
         // "named arguments are only supported for data-struct .copy(...)".
         var ctors = ClrTypeUtilities.SafeGetConstructors(clrType, BindingFlags.Public | BindingFlags.Instance);
-        var ctorParameterLists = ctors.Select(c => c.GetParameters()).ToList();
+        var ctorParameterLists = new List<ParameterInfo[]>(ctors.Length);
+        foreach (var constructor in ctors)
+        {
+            ctorParameterLists.Add(constructor.GetParameters());
+        }
 
         var boundArguments = ImmutableArray.CreateBuilder<BoundExpression>(syntax.Arguments.Count);
         var symbolicCtorDelegateTargets = new Dictionary<int, TypeSymbol>();
@@ -1644,9 +1677,14 @@ internal sealed partial class ExpressionBinder
             // implicit reference conversion. Threaded as a call-local
             // parameter (not a shared static) so concurrent/nested binds never
             // observe another call's closure.
-            Func<Type, Type, bool>? supplementaryInterfaceCheck = hasUserClassArg
-                ? (source, target) => IsUserClassAssignableToInterface(boundArguments, argTypes, source, target)
-                : null;
+            Func<Type, Type, bool>? supplementaryInterfaceCheck = null;
+            if (hasUserClassArg)
+            {
+                supplementaryInterfaceCheck = CheckUserClassInterface;
+            }
+
+            bool CheckUserClassInterface(Type source, Type target) =>
+                IsUserClassAssignableToInterface(boundArguments, argTypes, source, target);
 
             var resolution = ClrOverloadResolution.Resolve(
                 ctors,

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.IfLet.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.IfLet.cs
@@ -87,6 +87,7 @@ internal sealed partial class ExpressionBinder
         var anyInvalid = false;
         BoundExpression? guard = null;
         BoundExpression whenTrue;
+        BoundExpression BindInitializer(ExpressionSyntax initializer) => BindExpression(initializer);
         try
         {
             foreach (var binding in syntax.Bindings)
@@ -96,7 +97,7 @@ internal sealed partial class ExpressionBinder
                     Diagnostics,
                     conversions,
                     bindTypeClause,
-                    initializer => BindExpression(initializer),
+                    BindInitializer,
                     DeclareIfLetLocal);
 
                 if (!clause.IsValid)

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -538,11 +538,18 @@ internal sealed partial class ExpressionBinder
         [NotNullWhen(true)] out FunctionTypeSymbol? naturalType)
     {
         naturalType = null;
-        var closesReceiver = group.Receiver != null && group.Candidates.All(candidate => candidate.IsStatic);
+        var closesReceiver = group.Receiver != null;
+        foreach (var candidate in group.Candidates)
+        {
+            closesReceiver &= candidate.IsStatic;
+        }
+
         var receiverClr = closesReceiver
             ? NullableTypeSymbol.GetEffectiveClrType(Invariant.Required(group.Receiver, "a closed method group has a receiver").Type)
             : null;
-        var matches = new List<(MethodInfo Method, ClrOverloadResolution.ImplicitConversionKind ReceiverConversion)>();
+        MethodInfo? bestMethod = null;
+        var bestReceiverConversion = ClrOverloadResolution.ImplicitConversionKind.None;
+        var bestIsTied = false;
 
         foreach (var candidate in group.Candidates)
         {
@@ -552,8 +559,13 @@ internal sealed partial class ExpressionBinder
             }
 
             var parameters = candidate.GetParameters();
-            if (parameters.Any(parameter => parameter.ParameterType.IsByRef)
-                || (closesReceiver && (parameters.Length == 0 || receiverClr == null)))
+            var hasByRefParameter = false;
+            foreach (var parameter in parameters)
+            {
+                hasByRefParameter |= parameter.ParameterType.IsByRef;
+            }
+
+            if (hasByRefParameter || (closesReceiver && (parameters.Length == 0 || receiverClr == null)))
             {
                 continue;
             }
@@ -561,37 +573,43 @@ internal sealed partial class ExpressionBinder
             var receiverConversion = closesReceiver
                 ? ClrOverloadResolution.ClassifyImplicit(parameters[0].ParameterType, receiverClr)
                 : ClrOverloadResolution.ImplicitConversionKind.Identity;
-            if (receiverConversion != ClrOverloadResolution.ImplicitConversionKind.None)
+            if (receiverConversion == ClrOverloadResolution.ImplicitConversionKind.None)
             {
-                matches.Add((candidate, receiverConversion));
+                continue;
+            }
+
+            if (bestMethod is null || (int)receiverConversion < (int)bestReceiverConversion)
+            {
+                bestMethod = candidate;
+                bestReceiverConversion = receiverConversion;
+                bestIsTied = false;
+            }
+            else if (receiverConversion == bestReceiverConversion)
+            {
+                bestIsTied = true;
             }
         }
 
-        if (matches.Count == 0)
+        if (bestMethod is null || bestIsTied)
         {
             return false;
         }
 
-        var bestReceiverConversion = matches.Min(match => (int)match.ReceiverConversion);
-        var best = matches.Where(match => (int)match.ReceiverConversion == bestReceiverConversion).ToArray();
-        if (best.Length != 1)
-        {
-            return false;
-        }
-
-        var method = best[0].Method;
+        var method = bestMethod;
         var methodParameters = method.GetParameters();
         var offset = closesReceiver ? 1 : 0;
-        var parameterTypes = ImmutableArray.CreateBuilder<TypeSymbol>(methodParameters.Length - offset);
+        var parameterTypes = new TypeSymbol[methodParameters.Length - offset];
         for (var i = offset; i < methodParameters.Length; i++)
         {
-            parameterTypes.Add(ClrNullability.GetParameterTypeSymbol(methodParameters[i]));
+            parameterTypes[i - offset] = ClrNullability.GetParameterTypeSymbol(methodParameters[i]);
         }
 
         var returnType = method.ReturnType.IsSameAs(typeof(void))
             ? TypeSymbol.Void
             : ClrNullability.GetReturnTypeSymbol(method);
-        naturalType = FunctionTypeSymbol.Get(parameterTypes.MoveToImmutable(), returnType);
+        naturalType = FunctionTypeSymbol.Get(
+            ImmutableArray.CreateRange<TypeSymbol>(parameterTypes),
+            returnType);
         return naturalType.ClrType != null;
     }
 
@@ -1617,9 +1635,7 @@ internal sealed partial class ExpressionBinder
     {
         // The object-initializer lowering needs a constructed instance; require a
         // public parameterless constructor (the C# object-initializer contract).
-        var parameterlessCtor = ClrTypeUtilities
-            .SafeGetConstructors(clrType, BindingFlags.Public | BindingFlags.Instance)
-            .FirstOrDefault(c => c.GetParameters().Length == 0);
+        var parameterlessCtor = FindPublicParameterlessConstructor(clrType);
         if (parameterlessCtor == null)
         {
             Diagnostics.ReportUnableToFindType(syntax.TypeIdentifier.Location, syntax.TypeIdentifier.Text);
@@ -1659,9 +1675,7 @@ internal sealed partial class ExpressionBinder
     private BoundExpression BindImportedValueTypeLiteralExpression(StructLiteralExpressionSyntax syntax, Type clrType)
     {
         var resultType = TypeSymbol.FromClrType(clrType);
-        var parameterlessCtor = ClrTypeUtilities
-            .SafeGetConstructors(clrType, BindingFlags.Public | BindingFlags.Instance)
-            .FirstOrDefault(c => c.GetParameters().Length == 0);
+        var parameterlessCtor = FindPublicParameterlessConstructor(clrType);
         BoundExpression construction = parameterlessCtor != null
             ? new BoundClrConstructorCallExpression(
                 syntax,
@@ -1672,6 +1686,21 @@ internal sealed partial class ExpressionBinder
             : new BoundDefaultExpression(syntax, resultType);
 
         return BindImportedTypeObjectInitializer(syntax, clrType, resultType, construction);
+    }
+
+    private static ConstructorInfo? FindPublicParameterlessConstructor(Type clrType)
+    {
+        foreach (var constructor in ClrTypeUtilities.SafeGetConstructors(
+                     clrType,
+                     BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (constructor.GetParameters().Length == 0)
+            {
+                return constructor;
+            }
+        }
+
+        return null;
     }
 
     /// <summary>
@@ -2230,7 +2259,16 @@ internal sealed partial class ExpressionBinder
             elementType = CloseNestedEnumOverCurrentTypeParameters(bareElementEnum);
         }
 
-        if (syntax.Elements?.Any(element => element is SpreadElementExpressionSyntax) == true)
+        var hasSpreadElement = false;
+        if (syntax.Elements is not null)
+        {
+            foreach (var element in syntax.Elements)
+            {
+                hasSpreadElement |= element is SpreadElementExpressionSyntax;
+            }
+        }
+
+        if (hasSpreadElement)
         {
             return BindSpreadArrayCreationExpression(syntax, elementType);
         }
@@ -2415,9 +2453,9 @@ internal sealed partial class ExpressionBinder
             closedListType,
             openListType,
             ImmutableArray.Create(elementType));
-        var constructor = ClrTypeUtilities
-            .SafeGetConstructors(closedListType, BindingFlags.Public | BindingFlags.Instance)
-            .Single(candidate => candidate.GetParameters().Length == 0);
+        var constructor = Invariant.Required(
+            FindPublicParameterlessConstructor(closedListType),
+            "List<T> has a public parameterless constructor");
         return new BoundClrConstructorCallExpression(
             syntax,
             closedListType,

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -851,12 +851,16 @@ internal sealed partial class ExpressionBinder
         whenTrueNarrowing = MergeIfExpressionNarrowing(whenTrueNarrowing, typeWhenTrue);
         whenFalseNarrowing = MergeIfExpressionNarrowing(whenFalseNarrowing, typeWhenFalse);
 
+        Func<BoundExpression> bindWhenTrue =
+            () => BindBlockExpressionValue(syntax.ThenBlock, canBeVoid, targetType);
+        Func<BoundExpression> bindWhenFalse =
+            () => BindIfExpressionElseBranch(syntax.ElseExpression, canBeVoid, targetType);
         var whenTrue = BindWithNarrowing(
             whenTrueNarrowing,
-            () => BindBlockExpressionValue(syntax.ThenBlock, canBeVoid, targetType));
+            bindWhenTrue);
         var whenFalse = BindWithNarrowing(
             whenFalseNarrowing,
-            () => BindIfExpressionElseBranch(syntax.ElseExpression, canBeVoid, targetType));
+            bindWhenFalse);
 
         if (condition is BoundErrorExpression || whenTrue is BoundErrorExpression || whenFalse is BoundErrorExpression)
         {
@@ -1050,7 +1054,7 @@ internal sealed partial class ExpressionBinder
         bool canBeVoid = false,
         TypeSymbol? targetType = null,
         bool preserveEmptyBlock = false)
-        => BindInBlockExpressionScope(() => BindBlockExpressionValueCore(
+        => BindInBlockExpressionScope<BoundExpression>(() => BindBlockExpressionValueCore(
             syntax,
             canBeVoid,
             targetType,
@@ -1130,7 +1134,7 @@ internal sealed partial class ExpressionBinder
     {
         if (bodySyntax is BlockExpressionSyntax block)
         {
-            return BindInBlockExpressionScope(() => BindLambdaBlockBodyExpression(block));
+            return BindInBlockExpressionScope<BoundExpression>(() => BindLambdaBlockBodyExpression(block));
         }
 
         return BindExpression(bodySyntax, canBeVoid: true);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -1021,23 +1021,22 @@ internal sealed partial class ExpressionBinder
 
         BoundExpression? boundExpression = null;
         VariableSymbol? result = null;
-        var boundStatements = bindStatementList(
-            statements,
-            () =>
+        Func<BoundStatement> bindTrailingStatement = () =>
+        {
+            boundExpression = BindTrailingExpression();
+            if (boundExpression is BoundErrorExpression || boundExpression.Type == TypeSymbol.Void)
             {
-                boundExpression = BindTrailingExpression();
-                if (boundExpression is BoundErrorExpression || boundExpression.Type == TypeSymbol.Void)
-                {
-                    return new BoundExpressionStatement(expression, boundExpression);
-                }
+                return new BoundExpressionStatement(expression, boundExpression);
+            }
 
-                result = new LocalVariableSymbol(
-                    $"<blockResult{System.Threading.Interlocked.Increment(ref binderCtx.SyntheticLocalCounter)}>",
-                    isReadOnly: true,
-                    boundExpression.Type ?? TypeSymbol.Error);
-                scope.TryDeclareVariable(result);
-                return new BoundVariableDeclaration(expression, result, boundExpression);
-            });
+            result = new LocalVariableSymbol(
+                $"<blockResult{System.Threading.Interlocked.Increment(ref binderCtx.SyntheticLocalCounter)}>",
+                isReadOnly: true,
+                boundExpression.Type ?? TypeSymbol.Error);
+            scope.TryDeclareVariable(result);
+            return new BoundVariableDeclaration(expression, result, boundExpression);
+        };
+        var boundStatements = bindStatementList(statements, bindTrailingStatement);
         var resultExpression = result != null
             ? (BoundExpression)new BoundVariableExpression(expression, result)
             : boundExpression is BoundErrorExpression
@@ -1082,7 +1081,11 @@ internal sealed partial class ExpressionBinder
 
         // Bind prefix statements.
         var (boundStatements, boundExpression) =
-            BindBlockExpressionParts(syntax.Statements, syntax.Expression, canBeVoid, targetType);
+            BindBlockExpressionParts(
+                syntax.Statements,
+                Invariant.Required(syntax.Expression, "a block value has a trailing expression"),
+                canBeVoid,
+                targetType);
         if (IsDeferredBranchyArgumentPlaceholder(boundExpression, out _))
         {
             return new BoundErrorExpression(syntax);
@@ -1156,7 +1159,10 @@ internal sealed partial class ExpressionBinder
         }
 
         var (boundStatements, trailing) =
-            BindBlockExpressionParts(block.Statements, block.Expression, canBeVoid: true);
+            BindBlockExpressionParts(
+                block.Statements,
+                Invariant.Required(block.Expression, "a value-returning lambda block has a trailing expression"),
+                canBeVoid: true);
         if (boundStatements.Length == 0)
         {
             return trailing;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.SwitchExpr.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.SwitchExpr.cs
@@ -81,7 +81,7 @@ internal sealed partial class ExpressionBinder
                 var result = targetType == null
                     ? BindExpression(armSyntax.Result)
                     : BindExpression(armSyntax.Result, targetType);
-                boundArmBuilders.Add((armSyntax, pattern, null, result));
+                boundArmBuilders.Add((armSyntax, pattern, default(BoundExpression?), result));
                 continue;
             }
 

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -1381,19 +1381,35 @@ internal sealed partial class ExpressionBinder
             case DefaultExpressionSyntax { TypeClause: null }:
                 return targetType != TypeSymbol.Error && targetType != TypeSymbol.Void;
             case LambdaExpressionSyntax lambda:
-                if (lambda.Parameters.All(parameter => parameter.Type != null))
+                var allParametersTyped = true;
+                foreach (var parameter in lambda.Parameters)
+                {
+                    allParametersTyped &= parameter.Type != null;
+                }
+
+                if (allParametersTyped)
                 {
                     return true;
                 }
 
-                return MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(targetType, out var functionType)
-                    && functionType != null
-                    && functionType.Arity == lambda.Parameters.Count
-                    && lambda.Parameters
-                        .Select((parameter, index) =>
-                            parameter.IsVariadic
-                            == (!functionType.IsVariadic.IsDefaultOrEmpty && functionType.IsVariadic[index]))
-                        .All(matches => matches);
+                if (!MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(targetType, out var functionType)
+                    || functionType == null
+                    || functionType.Arity != lambda.Parameters.Count)
+                {
+                    return false;
+                }
+
+                for (var i = 0; i < lambda.Parameters.Count; i++)
+                {
+                    var targetIsVariadic =
+                        !functionType.IsVariadic.IsDefaultOrEmpty && functionType.IsVariadic[i];
+                    if (lambda.Parameters[i].IsVariadic != targetIsVariadic)
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
             case ConditionalExpressionSyntax conditional:
                 return CanTargetDependentExpression(conditional.WhenTrue, targetType)
                     && CanTargetDependentExpression(conditional.WhenFalse, targetType);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -865,7 +865,8 @@ internal sealed partial class ExpressionBinder
     {
         for (var i = binderCtx.NarrowedVariables.Count - 1; i >= 0; i--)
         {
-            if (binderCtx.NarrowedVariables[i].TryGetValue(path, out var narrowed))
+            if (binderCtx.NarrowedVariables[i].TryGetValue(path, out var narrowed)
+                && narrowed != null)
             {
                 return narrowed;
             }
@@ -892,76 +893,108 @@ internal sealed partial class ExpressionBinder
             return node;
         }
 
-        switch (node)
+        var fieldAccess = node as BoundFieldAccessExpression;
+        if (fieldAccess != null && fieldAccess.NarrowedType == null)
         {
-            case BoundFieldAccessExpression fa when fa.NarrowedType == null:
+                if (!SmartCastStability.TryGetStableMemberPath(fieldAccess, out var path, out _)
+                    || path == null)
                 {
-                    if (!SmartCastStability.TryGetStableMemberPath(fa, out var path, out _))
-                    {
-                        return node;
-                    }
-
-                    var narrowed = TryGetNarrowedType(path);
-                    return narrowed == null
-                        ? node
-                        : BuildNarrowedRead(
-                            new BoundFieldAccessExpression(null, fa.Receiver, fa.StructType, fa.Field),
-                            fa.Field.Type,
-                            narrowed,
-                            nt => new BoundFieldAccessExpression(null, fa.Receiver, fa.StructType, fa.Field, nt));
+                    return node;
                 }
 
-            case BoundPropertyAccessExpression pa when pa.NarrowedType == null:
+                var narrowed = TryGetNarrowedType(path);
+                if (narrowed == null)
                 {
-                    if (!SmartCastStability.TryGetStableMemberPath(pa, out var path, out _))
-                    {
-                        return node;
-                    }
-
-                    var narrowed = TryGetNarrowedType(path);
-                    return narrowed == null
-                        ? node
-                        : BuildNarrowedRead(
-                            new BoundPropertyAccessExpression(null, pa.Receiver, pa.StructType, pa.Property),
-                            pa.Property.Type,
-                            narrowed,
-                            nt => new BoundPropertyAccessExpression(null, pa.Receiver, pa.StructType, pa.Property, nt));
+                    return node;
                 }
 
-            case BoundClrPropertyAccessExpression ca:
-                {
-                    if (!SmartCastStability.TryGetStableMemberPath(ca, out var path, out _))
-                    {
-                        return node;
-                    }
+                var baseRead = new BoundFieldAccessExpression(
+                    null,
+                    fieldAccess.Receiver,
+                    fieldAccess.StructType,
+                    fieldAccess.Field);
+                return BuildNarrowedRead(
+                    baseRead,
+                    fieldAccess.Field.Type,
+                    narrowed,
+                    nt => new BoundFieldAccessExpression(
+                        null,
+                        fieldAccess.Receiver,
+                        fieldAccess.StructType,
+                        fieldAccess.Field,
+                        nt));
+        }
 
-                    var narrowed = TryGetNarrowedType(path);
-                    return narrowed == null
-                        ? node
-                        : BuildNarrowedRead(
-                            new BoundClrPropertyAccessExpression(
-                                null,
-                                ca.Receiver,
-                                ca.Member,
-                                ca.Type,
-                                ca.StaticContainerType,
-                                ca.ConstrainedReceiverTypeParameter,
-                                ca.ConstrainedInterfaceType),
-                            ca.Type,
-                            narrowed,
-                            nt => new BoundClrPropertyAccessExpression(
-                                null,
-                                ca.Receiver,
-                                ca.Member,
-                                nt,
-                                ca.StaticContainerType,
-                                ca.ConstrainedReceiverTypeParameter,
-                                ca.ConstrainedInterfaceType));
+        var propertyAccess = node as BoundPropertyAccessExpression;
+        if (propertyAccess != null && propertyAccess.NarrowedType == null)
+        {
+                if (!SmartCastStability.TryGetStableMemberPath(propertyAccess, out var path, out _)
+                    || path == null)
+                {
+                    return node;
                 }
 
-            default:
+                var narrowed = TryGetNarrowedType(path);
+                if (narrowed == null)
+                {
+                    return node;
+                }
+
+                var baseRead = new BoundPropertyAccessExpression(
+                    null,
+                    propertyAccess.Receiver,
+                    propertyAccess.StructType,
+                    propertyAccess.Property);
+                return BuildNarrowedRead(
+                    baseRead,
+                    propertyAccess.Property.Type,
+                    narrowed,
+                    nt => new BoundPropertyAccessExpression(
+                        null,
+                        propertyAccess.Receiver,
+                        propertyAccess.StructType,
+                        propertyAccess.Property,
+                        nt));
+        }
+
+        var clrAccess = node as BoundClrPropertyAccessExpression;
+        if (clrAccess == null)
+        {
                 return node;
         }
+
+        if (!SmartCastStability.TryGetStableMemberPath(clrAccess, out var clrPath, out _)
+                || clrPath == null)
+        {
+                return node;
+        }
+
+        var clrNarrowed = TryGetNarrowedType(clrPath);
+        if (clrNarrowed == null)
+        {
+                return node;
+        }
+
+        var clrBaseRead = new BoundClrPropertyAccessExpression(
+                null,
+                clrAccess.Receiver,
+                clrAccess.Member,
+                clrAccess.Type,
+                clrAccess.StaticContainerType,
+                clrAccess.ConstrainedReceiverTypeParameter,
+                clrAccess.ConstrainedInterfaceType);
+        return BuildNarrowedRead(
+                clrBaseRead,
+                clrAccess.Type,
+                clrNarrowed,
+                nt => new BoundClrPropertyAccessExpression(
+                    null,
+                    clrAccess.Receiver,
+                    clrAccess.Member,
+                    nt,
+                    clrAccess.StaticContainerType,
+                    clrAccess.ConstrainedReceiverTypeParameter,
+                    clrAccess.ConstrainedInterfaceType));
     }
 
     /// <summary>
@@ -2166,12 +2199,16 @@ internal sealed partial class ExpressionBinder
     /// <returns>The inherited CLR base type, or <see langword="null"/> when there is none.</returns>
     internal static Type? GetInheritedClrBaseType(StructSymbol structSymbol)
     {
-        for (var c = structSymbol; c != null; c = c.BaseClass)
+        StructSymbol? current = structSymbol;
+        while (current != null)
         {
-            if (c.ImportedBaseType?.ClrType is Type clr)
+            var clr = current.ImportedBaseType?.ClrType;
+            if (clr != null)
             {
                 return clr;
             }
+
+            current = current.BaseClass;
         }
 
         return null;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -359,15 +359,34 @@ internal sealed partial class ExpressionBinder
         // Preserve the regular conversion diagnostic for nullable delegate
         // targets instead of replacing it with target-parameter diagnostics.
         bound = null;
-        if (syntax is not LambdaExpressionSyntax lambda
-            || targetType == null
-            || (targetType is NullableTypeSymbol && lambda.Parameters.All(p => p.Type != null))
-            || !MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(targetType, out var targetFunctionType))
+        var lambda = syntax as LambdaExpressionSyntax;
+        if (lambda is null || targetType is null)
         {
             return false;
         }
 
-        bound = lambdas.BindLambdaExpression(lambda, targetFunctionType);
+        if (targetType is NullableTypeSymbol)
+        {
+            var allParametersTyped = true;
+            foreach (var parameter in lambda.Parameters)
+            {
+                allParametersTyped &= parameter.Type is not null;
+            }
+
+            if (allParametersTyped)
+            {
+                return false;
+            }
+        }
+
+        if (!MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(targetType, out var targetFunctionType))
+        {
+            return false;
+        }
+
+        bound = lambdas.BindLambdaExpression(
+            Invariant.Required(lambda, "lambda target typing requires lambda syntax"),
+            targetFunctionType);
         return true;
     }
 
@@ -687,6 +706,13 @@ internal sealed partial class ExpressionBinder
             // `field.Member` accesses after a [MemberNotNull] helper call are
             // accepted without a nil-guard.
             var narrowedFieldType = TryGetNarrowedType(implicitField);
+            Func<TypeSymbol, BoundExpression> makeNarrowedField = narrowedType =>
+                new BoundFieldAccessExpression(
+                    null,
+                    new BoundVariableExpression(null, implicitField.Receiver),
+                    implicitField.StructType,
+                    implicitField.Field,
+                    narrowedType);
             return BuildNarrowedRead(
                 new BoundFieldAccessExpression(
                     null,
@@ -695,12 +721,7 @@ internal sealed partial class ExpressionBinder
                     implicitField.Field),
                 implicitField.Field.Type,
                 narrowedFieldType,
-                nt => new BoundFieldAccessExpression(
-                    null,
-                    new BoundVariableExpression(null, implicitField.Receiver),
-                    implicitField.StructType,
-                    implicitField.Field,
-                    nt));
+                makeNarrowedField);
         }
 
         // Issue #261: bare static field name inside a shared method body.
@@ -769,11 +790,13 @@ internal sealed partial class ExpressionBinder
 
     private BoundExpression BuildNarrowedVariableRead(VariableSymbol variable)
     {
+        Func<TypeSymbol, BoundExpression> makeNarrowedVariable =
+            narrowedType => new BoundVariableExpression(null, variable, narrowedType);
         return BuildNarrowedRead(
             new BoundVariableExpression(null, variable),
             variable.Type,
             TryGetNarrowedType(variable),
-            narrowed => new BoundVariableExpression(null, variable, narrowed));
+            makeNarrowedVariable);
     }
 
     /// <summary>
@@ -913,16 +936,18 @@ internal sealed partial class ExpressionBinder
                     fieldAccess.Receiver,
                     fieldAccess.StructType,
                     fieldAccess.Field);
-                return BuildNarrowedRead(
-                    baseRead,
-                    fieldAccess.Field.Type,
-                    narrowed,
-                    nt => new BoundFieldAccessExpression(
+                Func<TypeSymbol, BoundExpression> makeNarrowedField = narrowedType =>
+                    new BoundFieldAccessExpression(
                         null,
                         fieldAccess.Receiver,
                         fieldAccess.StructType,
                         fieldAccess.Field,
-                        nt));
+                        narrowedType);
+                return BuildNarrowedRead(
+                    baseRead,
+                    fieldAccess.Field.Type,
+                    narrowed,
+                    makeNarrowedField);
         }
 
         var propertyAccess = node as BoundPropertyAccessExpression;
@@ -945,16 +970,18 @@ internal sealed partial class ExpressionBinder
                     propertyAccess.Receiver,
                     propertyAccess.StructType,
                     propertyAccess.Property);
-                return BuildNarrowedRead(
-                    baseRead,
-                    propertyAccess.Property.Type,
-                    narrowed,
-                    nt => new BoundPropertyAccessExpression(
+                Func<TypeSymbol, BoundExpression> makeNarrowedProperty = narrowedType =>
+                    new BoundPropertyAccessExpression(
                         null,
                         propertyAccess.Receiver,
                         propertyAccess.StructType,
                         propertyAccess.Property,
-                        nt));
+                        narrowedType);
+                return BuildNarrowedRead(
+                    baseRead,
+                    propertyAccess.Property.Type,
+                    narrowed,
+                    makeNarrowedProperty);
         }
 
         var clrAccess = node as BoundClrPropertyAccessExpression;
@@ -983,18 +1010,20 @@ internal sealed partial class ExpressionBinder
                 clrAccess.StaticContainerType,
                 clrAccess.ConstrainedReceiverTypeParameter,
                 clrAccess.ConstrainedInterfaceType);
+        Func<TypeSymbol, BoundExpression> makeNarrowedClrProperty = narrowedType =>
+            new BoundClrPropertyAccessExpression(
+                null,
+                clrAccess.Receiver,
+                clrAccess.Member,
+                narrowedType,
+                clrAccess.StaticContainerType,
+                clrAccess.ConstrainedReceiverTypeParameter,
+                clrAccess.ConstrainedInterfaceType);
         return BuildNarrowedRead(
                 clrBaseRead,
                 clrAccess.Type,
                 clrNarrowed,
-                nt => new BoundClrPropertyAccessExpression(
-                    null,
-                    clrAccess.Receiver,
-                    clrAccess.Member,
-                    nt,
-                    clrAccess.StaticContainerType,
-                    clrAccess.ConstrainedReceiverTypeParameter,
-                    clrAccess.ConstrainedInterfaceType));
+                makeNarrowedClrProperty);
     }
 
     /// <summary>
@@ -1287,7 +1316,15 @@ internal sealed partial class ExpressionBinder
             case DefaultExpressionSyntax { TypeClause: null }:
                 return true;
             case LambdaExpressionSyntax lambda:
-                return lambda.Parameters.Any(parameter => parameter.Type == null);
+                foreach (var parameter in lambda.Parameters)
+                {
+                    if (parameter.Type == null)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
             case ConditionalExpressionSyntax conditional:
                 return IsTargetDependentExpressionSyntax(conditional.WhenTrue)
                     || IsTargetDependentExpressionSyntax(conditional.WhenFalse);
@@ -1970,8 +2007,12 @@ internal sealed partial class ExpressionBinder
         if (argument is BoundClrMethodGroupExpression { ResolvedMethod: null } clrGroup)
         {
             var receiver = clrGroup.Receiver;
-            var closesExtensionReceiver = receiver != null
-                && clrGroup.Candidates.All(candidate => candidate.IsStatic);
+            var closesExtensionReceiver = receiver != null;
+            foreach (var candidate in clrGroup.Candidates)
+            {
+                closesExtensionReceiver &= candidate.IsStatic;
+            }
+
             var resolutionArguments = new Type[delegateParameterTypes.Count + (closesExtensionReceiver ? 1 : 0)];
             if (closesExtensionReceiver)
             {

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -1889,7 +1889,7 @@ internal sealed partial class ExpressionBinder
         return null;
     }
 
-    internal static Func<int, IReadOnlyList<Type>, Tuple<Type[], Type>?>? MakeMethodGroupInference(
+    internal static Func<int, IReadOnlyList<Type>, (Type[] Parameters, Type Return)?>? MakeMethodGroupInference(
         IReadOnlyList<BoundExpression> arguments,
         Func<TypeSymbol, Type?> projectType,
         int argumentOffset = 0)
@@ -1929,7 +1929,7 @@ internal sealed partial class ExpressionBinder
         };
     }
 
-    private static Tuple<Type[], Type>? ResolveMethodGroupInferenceSignature(
+    private static (Type[] Parameters, Type Return)? ResolveMethodGroupInferenceSignature(
         BoundExpression argument,
         IReadOnlyList<Type> delegateParameterTypes,
         Func<TypeSymbol, Type?> projectType)
@@ -1973,7 +1973,7 @@ internal sealed partial class ExpressionBinder
                 signatureParameters[i - parameterOffset] = parameters[i].ParameterType;
             }
 
-            return Tuple.Create(signatureParameters, method.ReturnType);
+            return (signatureParameters, method.ReturnType);
         }
 
         if (argument is not BoundMethodGroupExpression { FunctionType: null } userGroup)
@@ -1981,7 +1981,7 @@ internal sealed partial class ExpressionBinder
             return null;
         }
 
-        var matches = new List<(Tuple<Type[], Type> Signature, ClrOverloadResolution.ImplicitConversionKind[] Conversions)>();
+        var matches = new List<((Type[] Parameters, Type Return) Signature, ClrOverloadResolution.ImplicitConversionKind[] Conversions)>();
         foreach (var candidate in userGroup.Candidates)
         {
             var candidateOwner = userGroup.StaticOwnerType != null && candidate.StaticOwnerType is StructSymbol declaredOwner
@@ -2033,12 +2033,12 @@ internal sealed partial class ExpressionBinder
                 continue;
             }
 
-            matches.Add((Tuple.Create(parameterTypes, returnType), conversions));
+            matches.Add(((parameterTypes, returnType), conversions));
         }
 
         var best = matches.Where(candidate =>
             !matches.Any(other =>
-                !ReferenceEquals(candidate.Signature, other.Signature)
+                !ReferenceEquals(candidate.Signature.Parameters, other.Signature.Parameters)
                 && IsBetterMethodGroupConversion(other.Conversions, candidate.Conversions))).ToList();
         return best.Count == 1 ? best[0].Signature : null;
     }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -1082,7 +1082,10 @@ internal sealed partial class ExpressionBinder
         // StatementBinder.TryClassifyNilGuard.
         if (SmartCastStability.TryClassifyNilGuardLeaf(condition, restrictBareVariableToLocalsAndParams: true, referenceNullableOnly: true, out var nilTarget, out var nilUnderlying, out var nonNilWhenTrue))
         {
-            var nonNilFrame = new Dictionary<AccessPath, TypeSymbol> { [nilTarget] = nilUnderlying };
+            var nonNilFrame = new Dictionary<AccessPath, TypeSymbol>
+            {
+                [nilTarget] = Invariant.Required(nilUnderlying, "a classified nil guard has an underlying type"),
+            };
             return nonNilWhenTrue ? (nonNilFrame, null) : (null, nonNilFrame);
         }
 

--- a/src/Core/CodeAnalysis/Binding/ExternalClrOverrideResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/ExternalClrOverrideResolver.cs
@@ -205,7 +205,7 @@ internal static class ExternalClrOverrideResolver
 
     private static TypeSymbol? FindDeclaredExternalBaseType(StructSymbol type)
     {
-        for (var current = type; current != null; current = current.BaseClass)
+        foreach (var current in GetStructHierarchy(type))
         {
             if (current.ImportedBaseType != null)
             {
@@ -224,7 +224,7 @@ internal static class ExternalClrOverrideResolver
             return declaredBase;
         }
 
-        for (var current = type; current != null; current = current.BaseClass)
+        foreach (var current in GetStructHierarchy(type))
         {
             if (current.IsAttributeClass)
             {
@@ -241,12 +241,7 @@ internal static class ExternalClrOverrideResolver
         Type reflectionBaseType,
         ImmutableArray<TypeArgumentSubstitution> typeSubstitutions)
     {
-        var hierarchy = new List<Type>();
-        for (var current = reflectionBaseType; current != null; current = current.BaseType)
-        {
-            hierarchy.Add(current);
-        }
-
+        var hierarchy = GetTypeHierarchy(reflectionBaseType);
         hierarchy.Reverse();
 
         // Reconstruct effective CLR virtual slots base-first. A newslot method
@@ -422,9 +417,35 @@ internal static class ExternalClrOverrideResolver
             ? type.IsGenericTypeDefinition ? type : type.GetGenericTypeDefinition()
             : type;
 
+    private static List<StructSymbol> GetStructHierarchy(StructSymbol type)
+    {
+        var hierarchy = new List<StructSymbol>();
+        StructSymbol? current = type;
+        while (current != null)
+        {
+            hierarchy.Add(current);
+            current = current.BaseClass;
+        }
+
+        return hierarchy;
+    }
+
+    private static List<Type> GetTypeHierarchy(Type? type)
+    {
+        var hierarchy = new List<Type>();
+        var current = type;
+        while (current != null)
+        {
+            hierarchy.Add(current);
+            current = current.BaseType;
+        }
+
+        return hierarchy;
+    }
+
     private static SourceSlotStatus GetSourceSlotStatus(StructSymbol derivedType, MethodInfo slot)
     {
-        for (var current = derivedType; current != null; current = current.BaseClass)
+        foreach (var current in GetStructHierarchy(derivedType))
         {
             foreach (var method in current.Methods)
             {
@@ -462,12 +483,15 @@ internal static class ExternalClrOverrideResolver
 
     private static bool TargetsExternalSlot(FunctionSymbol method, MethodInfo slot)
     {
-        for (var current = method; current != null; current = current.OverriddenMethod)
+        FunctionSymbol? current = method;
+        while (current != null)
         {
             if (SameMethod(current.ExternalOverriddenMethod, slot))
             {
                 return true;
             }
+
+            current = current.OverriddenMethod;
         }
 
         return false;
@@ -478,7 +502,8 @@ internal static class ExternalClrOverrideResolver
         MethodInfo slot,
         out AccessorKind accessorKind)
     {
-        for (var current = property; current != null; current = current.OverriddenProperty)
+        PropertySymbol? current = property;
+        while (current != null)
         {
             if (SameMethod(current.ExternalOverriddenGetter, slot))
             {
@@ -491,6 +516,8 @@ internal static class ExternalClrOverrideResolver
                 accessorKind = AccessorKind.Setter;
                 return true;
             }
+
+            current = current.OverriddenProperty;
         }
 
         accessorKind = default;
@@ -518,7 +545,8 @@ internal static class ExternalClrOverrideResolver
         MethodInfo slot,
         out AccessorKind accessorKind)
     {
-        for (var current = eventSymbol; current != null; current = current.OverriddenEvent)
+        EventSymbol? current = eventSymbol;
+        while (current != null)
         {
             if (SameMethod(current.ExternalOverriddenAddMethod, slot))
             {
@@ -537,6 +565,8 @@ internal static class ExternalClrOverrideResolver
                 accessorKind = AccessorKind.Raise;
                 return true;
             }
+
+            current = current.OverriddenEvent;
         }
 
         accessorKind = default;
@@ -639,7 +669,7 @@ internal static class ExternalClrOverrideResolver
 
         var substitutions = ImmutableArray.CreateBuilder<TypeArgumentSubstitution>();
         substitutions.Add(root);
-        for (var current = imported.OpenDefinition.BaseType; current != null; current = current.BaseType)
+        foreach (var current in GetTypeHierarchy(imported.OpenDefinition.BaseType))
         {
             if (!current.IsGenericType)
             {
@@ -684,7 +714,7 @@ internal static class ExternalClrOverrideResolver
     private static List<MethodInfo> EnumerateMethods(Type? baseType, string name)
     {
         var result = new List<MethodInfo>();
-        for (var current = baseType; current != null; current = current.BaseType)
+        foreach (var current in GetTypeHierarchy(baseType))
         {
             MethodInfo[] methods;
             try
@@ -711,7 +741,7 @@ internal static class ExternalClrOverrideResolver
     private static List<PropertyInfo> EnumerateProperties(Type? baseType, string name)
     {
         var result = new List<PropertyInfo>();
-        for (var current = baseType; current != null; current = current.BaseType)
+        foreach (var current in GetTypeHierarchy(baseType))
         {
             PropertyInfo[] properties;
             try
@@ -738,7 +768,7 @@ internal static class ExternalClrOverrideResolver
     private static List<EventInfo> EnumerateEvents(Type? baseType, string name)
     {
         var result = new List<EventInfo>();
-        for (var current = baseType; current != null; current = current.BaseType)
+        foreach (var current in GetTypeHierarchy(baseType))
         {
             EventInfo[] events;
             try
@@ -909,7 +939,7 @@ internal static class ExternalClrOverrideResolver
 
         if (derivedReturnType is StructSymbol derivedStruct && derivedStruct.IsClass)
         {
-            for (var current = derivedStruct; current != null; current = current.BaseClass)
+            foreach (var current in GetStructHierarchy(derivedStruct))
             {
                 if (current.ImportedBaseType?.ClrType is Type imported
                     && ClrTypeUtilities.IsAssignableByName(baseReturnType, imported))

--- a/src/Core/CodeAnalysis/Binding/ExternalClrOverrideResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/ExternalClrOverrideResolver.cs
@@ -681,8 +681,9 @@ internal static class ExternalClrOverrideResolver
         return typeArguments.MoveToImmutable();
     }
 
-    private static IEnumerable<MethodInfo> EnumerateMethods(Type? baseType, string name)
+    private static List<MethodInfo> EnumerateMethods(Type? baseType, string name)
     {
+        var result = new List<MethodInfo>();
         for (var current = baseType; current != null; current = current.BaseType)
         {
             MethodInfo[] methods;
@@ -699,14 +700,17 @@ internal static class ExternalClrOverrideResolver
             {
                 if (string.Equals(method.Name, name, StringComparison.Ordinal))
                 {
-                    yield return method;
+                    result.Add(method);
                 }
             }
         }
+
+        return result;
     }
 
-    private static IEnumerable<PropertyInfo> EnumerateProperties(Type? baseType, string name)
+    private static List<PropertyInfo> EnumerateProperties(Type? baseType, string name)
     {
+        var result = new List<PropertyInfo>();
         for (var current = baseType; current != null; current = current.BaseType)
         {
             PropertyInfo[] properties;
@@ -723,14 +727,17 @@ internal static class ExternalClrOverrideResolver
             {
                 if (string.Equals(property.Name, name, StringComparison.Ordinal))
                 {
-                    yield return property;
+                    result.Add(property);
                 }
             }
         }
+
+        return result;
     }
 
-    private static IEnumerable<EventInfo> EnumerateEvents(Type? baseType, string name)
+    private static List<EventInfo> EnumerateEvents(Type? baseType, string name)
     {
+        var result = new List<EventInfo>();
         for (var current = baseType; current != null; current = current.BaseType)
         {
             EventInfo[] events;
@@ -747,10 +754,12 @@ internal static class ExternalClrOverrideResolver
             {
                 if (string.Equals(eventInfo.Name, name, StringComparison.Ordinal))
                 {
-                    yield return eventInfo;
+                    result.Add(eventInfo);
                 }
             }
         }
+
+        return result;
     }
 
     private static bool ParametersMatch(

--- a/src/Core/CodeAnalysis/Binding/ExternalClrOverrideResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/ExternalClrOverrideResolver.cs
@@ -66,13 +66,13 @@ internal static class ExternalClrOverrideResolver
 
             if (!method.IsVirtual || method.IsFinal)
             {
-                return new MatchResult<MethodInfo>(null, externalBase, sawName, IsSealed: true);
+                return new MatchResult<MethodInfo>(null, externalBase, sawName, isSealed: true);
             }
 
-            return new MatchResult<MethodInfo>(method, externalBase, sawName, IsSealed: false);
+            return new MatchResult<MethodInfo>(method, externalBase, sawName, isSealed: false);
         }
 
-        return new MatchResult<MethodInfo>(null, externalBase, sawName, IsSealed: false);
+        return new MatchResult<MethodInfo>(null, externalBase, sawName, isSealed: false);
     }
 
     internal static MatchResult<PropertyInfo> FindProperty(
@@ -119,13 +119,13 @@ internal static class ExternalClrOverrideResolver
             if ((getter != null && (!getter.IsVirtual || getter.IsFinal))
                 || (setter != null && (!setter.IsVirtual || setter.IsFinal)))
             {
-                return new MatchResult<PropertyInfo>(null, externalBase, sawName, IsSealed: true);
+                return new MatchResult<PropertyInfo>(null, externalBase, sawName, isSealed: true);
             }
 
-            return new MatchResult<PropertyInfo>(property, externalBase, sawName, IsSealed: false);
+            return new MatchResult<PropertyInfo>(property, externalBase, sawName, isSealed: false);
         }
 
-        return new MatchResult<PropertyInfo>(null, externalBase, sawName, IsSealed: false);
+        return new MatchResult<PropertyInfo>(null, externalBase, sawName, isSealed: false);
     }
 
     internal static MatchResult<EventInfo> FindEvent(
@@ -161,13 +161,13 @@ internal static class ExternalClrOverrideResolver
             if ((add != null && (!add.IsVirtual || add.IsFinal))
                 || (remove != null && (!remove.IsVirtual || remove.IsFinal)))
             {
-                return new MatchResult<EventInfo>(null, externalBase, sawName, IsSealed: true);
+                return new MatchResult<EventInfo>(null, externalBase, sawName, isSealed: true);
             }
 
-            return new MatchResult<EventInfo>(eventInfo, externalBase, sawName, IsSealed: false);
+            return new MatchResult<EventInfo>(eventInfo, externalBase, sawName, isSealed: false);
         }
 
-        return new MatchResult<EventInfo>(null, externalBase, sawName, IsSealed: false);
+        return new MatchResult<EventInfo>(null, externalBase, sawName, isSealed: false);
     }
 
     internal static ImmutableArray<UnimplementedAbstractMember> GetUnimplementedAbstractMembers(
@@ -953,12 +953,29 @@ internal static class ExternalClrOverrideResolver
         string MemberName,
         bool ReportedBySourceAbstractMethod);
 
-    internal readonly record struct MatchResult<T>(
-        T? Member,
-        TypeSymbol? ContainingType,
-        bool SawName,
-        bool IsSealed)
-        where T : MemberInfo;
+    internal readonly struct MatchResult<T>
+        where T : MemberInfo
+    {
+        public MatchResult(
+            T? member,
+            TypeSymbol? containingType,
+            bool sawName,
+            bool isSealed)
+        {
+            Member = member;
+            ContainingType = containingType;
+            SawName = sawName;
+            IsSealed = isSealed;
+        }
+
+        public T? Member { get; }
+
+        public TypeSymbol? ContainingType { get; }
+
+        public bool SawName { get; }
+
+        public bool IsSealed { get; }
+    }
 
     private readonly record struct TypeArgumentSubstitution(
         Type? OpenDefinition,

--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -1191,9 +1191,15 @@ internal sealed class LambdaBinder
         var closesStaticReceiver = method.IsStatic && group.Receiver != null;
         var parameterOffset = closesStaticReceiver ? 1 : 0;
         var invoke = targetFunctionType.ClrType?.GetMethodSafe("Invoke");
+        var hasByRefParameter = false;
+        foreach (var parameter in methodParameters)
+        {
+            hasByRefParameter |= parameter.ParameterType.IsByRef;
+        }
+
         if (invoke == null
             || methodParameters.Length != targetFunctionType.ParameterTypes.Length + parameterOffset
-            || methodParameters.Any(p => p.ParameterType.IsByRef))
+            || hasByRefParameter)
         {
             return group;
         }

--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -2974,7 +2974,7 @@ internal sealed class LambdaBinder
             base.VisitExpression(node);
         }
 
-        public override void VisitPattern(BoundPattern node)
+        public override void VisitPattern(BoundPattern? node)
         {
             if (node == null || Found != null)
             {

--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -2923,7 +2923,7 @@ internal sealed class LambdaBinder
             });
         }
 
-        public override void VisitExpression(BoundExpression node)
+        public override void VisitExpression(BoundExpression? node)
         {
             if (node == null || Found != null)
             {

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -188,7 +188,7 @@ internal sealed class MemberLookup
             return null;
         }
 
-        for (var current = clrType; current != null; current = GetBaseTypeSafe(current))
+        for (Type? current = clrType; current != null; current = GetBaseTypeSafe(current))
         {
             var candidates = GetDeclaredCandidates(current);
             if (candidates.Count > 1)
@@ -297,7 +297,7 @@ internal sealed class MemberLookup
             // Issues #2614 / #2638: an aggregate metadata walk may return a
             // usable but incomplete set. Always probe each declaration level
             // and union accessible methods without duplicating inherited slots.
-            for (var current = clrType; current != null; current = GetBaseTypeSafe(current))
+            for (Type? current = clrType; current != null; current = GetBaseTypeSafe(current))
             {
                 foreach (var m in ClrTypeUtilities.SafeGetMethods(
                     current,
@@ -1886,19 +1886,21 @@ internal sealed class MemberLookup
             return false;
         }
 
-        if (t is ImportedTypeSymbol imported
-            && imported.OpenDefinition is { } openDefinition
-            && !imported.TypeArguments.IsDefaultOrEmpty)
+        if (t is ImportedTypeSymbol imported)
         {
-            var contextObject = ResolveErasedObjectInContext(openDefinition);
-            erased = TryBuildErasedClosedGeneric(
-                openDefinition,
-                openDefinition.GetGenericArguments(),
-                imported.TypeArguments,
-                contextObject);
-            if (erased != null)
+            var openDefinition = imported.OpenDefinition;
+            if (openDefinition != null && !imported.TypeArguments.IsDefaultOrEmpty)
             {
-                return true;
+                var contextObject = ResolveErasedObjectInContext(openDefinition);
+                erased = TryBuildErasedClosedGeneric(
+                    openDefinition,
+                    openDefinition.GetGenericArguments(),
+                    imported.TypeArguments,
+                    contextObject);
+                if (erased != null)
+                {
+                    return true;
+                }
             }
         }
 
@@ -2412,7 +2414,7 @@ internal sealed class MemberLookup
                     NullableLifting.GetEffectiveClrType(classConstraint));
             }
 
-            for (var current = type as StructSymbol; current != null; current = current.BaseClass)
+            for (StructSymbol? current = type as StructSymbol; current != null; current = current.BaseClass)
             {
                 var importedBaseClr = NullableLifting.GetEffectiveClrType(current.ImportedBaseType);
                 if (importedBaseClr != null
@@ -4182,7 +4184,7 @@ internal sealed class MemberLookup
                 .Any(candidate => ClrTypeUtilities.AreSame(candidate, baseType));
         }
 
-        for (var current = derived.BaseType; current != null; current = current.BaseType)
+        for (Type? current = derived.BaseType; current != null; current = current.BaseType)
         {
             if (ClrTypeUtilities.AreSame(current, baseType))
             {

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -3296,7 +3296,7 @@ internal sealed class MemberLookup
 
             if (applicable.Count != 0)
             {
-                (PropertyInfo Property, ImmutableArray<TypeSymbol> ParameterTypes)? winner = default;
+                PropertyInfo? winnerProperty = null;
                 foreach (var candidate in applicable)
                 {
                     var betterThanAll = true;
@@ -3316,14 +3316,14 @@ internal sealed class MemberLookup
 
                     if (betterThanAll)
                     {
-                        winner = candidate;
+                        winnerProperty = candidate.Property;
                         break;
                     }
                 }
 
-                if (winner.HasValue)
+                if (winnerProperty != null)
                 {
-                    indexer = winner.Value.Property;
+                    indexer = winnerProperty;
                     resolvedArguments = ConversionClassifier.AppendOmittedOptionalArguments(
                         boundArguments,
                         indexer.GetIndexParameters());

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -3260,20 +3260,34 @@ internal sealed class MemberLookup
         resolvedArguments = default;
 
         var properties = CollectVisibleClrIndexers(targetType, clrTarget);
-        var hasSymbolicArgument = boundArguments.Any(static argument =>
-            argument.Type?.ClrType == null
-            || TypeSymbol.ContainsTypeParameter(argument.Type)
-            || TypeSymbol.ContainsSameCompilationUserType(argument.Type)
-            || argument.Type is ImportedTypeSymbol { HasSubstitutableTypeArgument: true });
-        var hasSetOnlyIndexer = properties.Any(static property => property.GetGetMethod(nonPublic: false) == null);
+        var hasSymbolicArgument = false;
+        foreach (var argument in boundArguments)
+        {
+            hasSymbolicArgument |= argument.Type?.ClrType == null
+                || TypeSymbol.ContainsTypeParameter(argument.Type)
+                || TypeSymbol.ContainsSameCompilationUserType(argument.Type)
+                || argument.Type is ImportedTypeSymbol { HasSubstitutableTypeArgument: true };
+        }
+
+        var hasSetOnlyIndexer = false;
+        foreach (var property in properties)
+        {
+            hasSetOnlyIndexer |= property.GetGetMethod(nonPublic: false) == null;
+        }
+
         if (hasSymbolicArgument || hasSetOnlyIndexer)
         {
             var applicable = new List<(PropertyInfo Property, ImmutableArray<TypeSymbol> ParameterTypes)>();
             foreach (var property in properties)
             {
                 var parameters = property.GetIndexParameters();
-                if (boundArguments.Length > parameters.Length
-                    || parameters.Skip(boundArguments.Length).Any(static parameter => !parameter.IsOptional))
+                var hasRequiredOmittedParameter = false;
+                for (var i = boundArguments.Length; i < parameters.Length; i++)
+                {
+                    hasRequiredOmittedParameter |= !parameters[i].IsOptional;
+                }
+
+                if (boundArguments.Length > parameters.Length || hasRequiredOmittedParameter)
                 {
                     continue;
                 }
@@ -3363,13 +3377,16 @@ internal sealed class MemberLookup
             }
         }
 
-        var resolution = ClrOverloadResolution.Resolve(
-            properties
-                .Select(static property => property.GetMethod)
-                .Where(static method => method != null)
-                .Cast<MethodInfo>()
-                .ToArray(),
-            argTypes);
+        var getterMethods = new List<MethodInfo>();
+        foreach (var property in properties)
+        {
+            if (property.GetMethod is not null)
+            {
+                getterMethods.Add(property.GetMethod);
+            }
+        }
+
+        var resolution = ClrOverloadResolution.Resolve<MethodInfo>(getterMethods, argTypes);
         if (resolution.Outcome != ClrOverloadResolution.ResolutionOutcome.Resolved)
         {
             return false;
@@ -3381,7 +3398,20 @@ internal sealed class MemberLookup
             return false;
         }
 
-        indexer = properties.First(property => ReferenceEquals(property.GetMethod, best));
+        foreach (var property in properties)
+        {
+            if (ReferenceEquals(property.GetMethod, best))
+            {
+                indexer = property;
+                break;
+            }
+        }
+
+        if (indexer is null)
+        {
+            return false;
+        }
+
         resolvedArguments = OverloadResolver.BuildOrderedCallArguments(
             boundArguments,
             resolution.ParameterMapping,
@@ -3421,9 +3451,17 @@ internal sealed class MemberLookup
         var result = new List<ImportedMethodProbe>();
         if (staticClassType != null)
         {
-            var statics = ClrTypeUtilities.SafeGetMethods(staticClassType, BindingFlags.Static | BindingFlags.Public)
-                .Where(m => string.Equals(m.Name, methodName, StringComparison.Ordinal))
-                .ToList();
+            var statics = new List<MethodInfo>();
+            foreach (var method in ClrTypeUtilities.SafeGetMethods(
+                         staticClassType,
+                         BindingFlags.Static | BindingFlags.Public))
+            {
+                if (string.Equals(method.Name, methodName, StringComparison.Ordinal))
+                {
+                    statics.Add(method);
+                }
+            }
+
             if (statics.Count > 0)
             {
                 result.Add(new ImportedMethodProbe(statics, receiverParameterOffset: 0));
@@ -3550,7 +3588,7 @@ internal sealed class MemberLookup
                 }
                 catch (ReflectionTypeLoadException ex)
                 {
-                    types = ex.Types.Where(t => t != null);
+                    types = ex.Types;
                 }
                 catch
                 {

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -78,13 +78,15 @@ internal sealed class MemberLookup
     /// </summary>
     /// <param name="t">The starting CLR type.</param>
     /// <returns>The type and its interfaces in walk order.</returns>
-    public static IEnumerable<Type> EnumerateSelfAndInterfaces(Type t)
+    public static List<Type> EnumerateSelfAndInterfaces(Type t)
     {
-        yield return t;
+        var result = new List<Type> { t };
         foreach (var i in t.GetInterfaces())
         {
-            yield return i;
+            result.Add(i);
         }
+
+        return result;
     }
 
     /// <summary>
@@ -2914,8 +2916,9 @@ internal sealed class MemberLookup
     /// </summary>
     /// <param name="ifaceSym">A CLR interface type symbol from the base clause.</param>
     /// <returns>The slots, or an empty sequence when the symbol is not a CLR interface.</returns>
-    public static IEnumerable<ClrInterfaceSlot> EnumerateClrInterfaceSlots(TypeSymbol ifaceSym)
+    public static List<ClrInterfaceSlot> EnumerateClrInterfaceSlots(TypeSymbol ifaceSym)
     {
+        var result = new List<ClrInterfaceSlot>();
         Type declared;
         ImmutableArray<TypeSymbol> symbolicArgs;
         if (TryGetSymbolicClrGenericInterface(ifaceSym, out var openDefinition, out var args)
@@ -2931,24 +2934,27 @@ internal sealed class MemberLookup
         }
         else
         {
-            yield break;
+            return result;
         }
 
         foreach (var slot in MethodsOf(declared, symbolicArgs, isInherited: false))
         {
-            yield return slot;
+            result.Add(slot);
         }
 
         foreach (var baseIface in declared.GetInterfaces())
         {
             foreach (var slot in MethodsOf(baseIface, symbolicArgs, isInherited: true))
             {
-                yield return slot;
+                result.Add(slot);
             }
         }
 
-        static IEnumerable<ClrInterfaceSlot> MethodsOf(Type iface, ImmutableArray<TypeSymbol> symbolicArgs, bool isInherited)
+        return result;
+
+        static List<ClrInterfaceSlot> MethodsOf(Type iface, ImmutableArray<TypeSymbol> symbolicArgs, bool isInherited)
         {
+            var slots = new List<ClrInterfaceSlot>();
             foreach (var method in iface.GetMethods(BindingFlags.Public | BindingFlags.Instance))
             {
                 if (method.IsSpecialName || !method.IsAbstract)
@@ -2956,8 +2962,10 @@ internal sealed class MemberLookup
                     continue;
                 }
 
-                yield return new ClrInterfaceSlot(method, symbolicArgs, isInherited);
+                slots.Add(new ClrInterfaceSlot(method, symbolicArgs, isInherited));
             }
+
+            return slots;
         }
     }
 
@@ -3057,7 +3065,10 @@ internal sealed class MemberLookup
         var slots = new List<ClrInterfaceSlot>();
         foreach (var ifaceSym in implementedClrInterfaces)
         {
-            slots.AddRange(EnumerateClrInterfaceSlots(ifaceSym));
+            foreach (var slot in EnumerateClrInterfaceSlots(ifaceSym))
+            {
+                slots.Add(slot);
+            }
         }
 
         if (slots.Count == 0)
@@ -4123,7 +4134,7 @@ internal sealed class MemberLookup
     {
         var declaringTypes = clrTarget.IsInterface
             ? EnumerateSelfAndInterfaces(clrTarget)
-            : new[] { clrTarget };
+            : new List<Type> { clrTarget };
         var collected = new List<PropertyInfo>();
         foreach (var declaringType in declaringTypes)
         {
@@ -5589,20 +5600,22 @@ internal sealed class MemberLookup
         return false;
     }
 
-    private static IEnumerable<Type> EnumerateOpenInterfacesAndBases(Type openDef)
+    private static List<Type> EnumerateOpenInterfacesAndBases(Type openDef)
     {
-        yield return openDef;
+        var result = new List<Type> { openDef };
         foreach (var iface in openDef.GetInterfaces())
         {
-            yield return iface;
+            result.Add(iface);
         }
 
         var baseType = openDef.BaseType;
         while (baseType != null && !baseType.IsSameAs(typeof(object)))
         {
-            yield return baseType;
+            result.Add(baseType);
             baseType = baseType.BaseType;
         }
+
+        return result;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -2921,22 +2921,24 @@ internal sealed class MemberLookup
     public static List<ClrInterfaceSlot> EnumerateClrInterfaceSlots(TypeSymbol ifaceSym)
     {
         var result = new List<ClrInterfaceSlot>();
-        Type declared;
-        ImmutableArray<TypeSymbol> symbolicArgs;
+        Type? declared = null;
+        var symbolicArgs = ImmutableArray<TypeSymbol>.Empty;
         if (TryGetSymbolicClrGenericInterface(ifaceSym, out var openDefinition, out var args)
             && openDefinition != null)
         {
             declared = openDefinition;
             symbolicArgs = args;
         }
-        else if (ifaceSym?.ClrType is Type clr && clr.IsInterface)
+
+        if (declared == null)
         {
+            var clr = ifaceSym?.ClrType;
+            if (clr == null || !clr.IsInterface)
+            {
+                return result;
+            }
+
             declared = clr;
-            symbolicArgs = ImmutableArray<TypeSymbol>.Empty;
-        }
-        else
-        {
-            return result;
         }
 
         foreach (var slot in MethodsOf(declared, symbolicArgs, isInherited: false))

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -2978,7 +2978,7 @@ internal sealed class MemberLookup
     /// <param name="method">The candidate G# method.</param>
     /// <param name="slot">The interface slot to satisfy.</param>
     /// <returns><see langword="true"/> when the method satisfies the slot.</returns>
-    public static bool MethodSatisfiesClrSlot(FunctionSymbol method, in ClrInterfaceSlot slot)
+    public static bool MethodSatisfiesClrSlot(FunctionSymbol method, ClrInterfaceSlot slot)
     {
         var clrParams = slot.Method.GetParameters();
         var callable = GetCallableParameters(method);
@@ -3296,7 +3296,7 @@ internal sealed class MemberLookup
 
             if (applicable.Count != 0)
             {
-                (PropertyInfo Property, ImmutableArray<TypeSymbol> ParameterTypes)? winner = null;
+                (PropertyInfo Property, ImmutableArray<TypeSymbol> ParameterTypes)? winner = default;
                 foreach (var candidate in applicable)
                 {
                     var betterThanAll = true;

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/ClrOverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/ClrOverloadResolution.cs
@@ -2390,7 +2390,7 @@ internal static class ClrOverloadResolution
                         // the recovered symbols satisfy the real constraints.
                         if (TryCloseOverUserValueTypePlaceholders(gmi, explicitTypeArgsArray, recoveredSymbols, out closed))
                         {
-                            paramTypeRewrite = static t => SubstituteClrType(t, typeof(UserValueTypeConstraintPlaceholder), typeof(object));
+                            paramTypeRewrite = RewriteUserValueTypePlaceholder;
                         }
                         else if (!TryCloseOverUserReferenceTypePlaceholders(gmi, explicitTypeArgsArray, recoveredSymbols, out closed))
                         {
@@ -2462,18 +2462,32 @@ internal static class ClrOverloadResolution
                             parameterToSource[sourceToParameter[sourceIndex]] = sourceIndex;
                         }
 
-                        inferenceMethodGroup = (parameterIndex, delegateParameters) =>
+                        (Type[] Parameters, Type Return)? MapNamedMethodGroup(
+                            int parameterIndex,
+                            IReadOnlyList<Type> delegateParameters) =>
                             parameterIndex >= 0
                                 && parameterIndex < parameterToSource.Length
                                 && parameterToSource[parameterIndex] >= 0
-                                ? methodGroupInference(parameterToSource[parameterIndex], delegateParameters)
-                                : null;
+                                    ? methodGroupInference(
+                                        parameterToSource[parameterIndex],
+                                        delegateParameters)
+                                    : null;
+                        inferenceMethodGroup = MapNamedMethodGroup;
                     }
                 }
 
                 var symbolicTypeArgs = recoverTypeArgSymbols?.Invoke(mi, false) ?? default;
                 Type[]? typeArgs = null;
-                var useRecoveredInference = deferredInferenceArgs?.Any(static deferred => deferred) == true
+                var hasDeferredInferenceArgument = false;
+                if (deferredInferenceArgs is not null)
+                {
+                    foreach (var deferred in deferredInferenceArgs)
+                    {
+                        hasDeferredInferenceArgument |= deferred;
+                    }
+                }
+
+                var useRecoveredInference = hasDeferredInferenceArgument
                     && TryRecoverErasedTypeArguments(
                         mi,
                         symbolicTypeArgs,
@@ -2534,7 +2548,7 @@ internal static class ClrOverloadResolution
                     // satisfy the real constraints.
                     if (TryCloseOverUserValueTypePlaceholders(mi, typeArgs, recoveredSymbols, out closed))
                     {
-                        paramTypeRewrite = static t => SubstituteClrType(t, typeof(UserValueTypeConstraintPlaceholder), typeof(object));
+                        paramTypeRewrite = RewriteUserValueTypePlaceholder;
                     }
                     else if (!TryCloseOverUserReferenceTypePlaceholders(mi, typeArgs, recoveredSymbols, out closed))
                     {
@@ -2760,7 +2774,7 @@ internal static class ClrOverloadResolution
                     var explicitTypeArgsArray = explicitTypeArgs.ToArray();
                     if (TryCloseOverUserValueTypePlaceholders(gmi, explicitTypeArgsArray, recoveredSymbols, out closed))
                     {
-                        paramTypeRewrite = static t => SubstituteClrType(t, typeof(UserValueTypeConstraintPlaceholder), typeof(object));
+                        paramTypeRewrite = RewriteUserValueTypePlaceholder;
                     }
                     else if (!TryCloseOverUserReferenceTypePlaceholders(gmi, explicitTypeArgsArray, recoveredSymbols, out closed))
                     {
@@ -2821,7 +2835,7 @@ internal static class ClrOverloadResolution
                 recoveredSymbols = recoverTypeArgSymbols?.Invoke(mi, true) ?? default;
                 if (TryCloseOverUserValueTypePlaceholders(mi, typeArgs, recoveredSymbols, out closed))
                 {
-                    paramTypeRewrite = static t => SubstituteClrType(t, typeof(UserValueTypeConstraintPlaceholder), typeof(object));
+                    paramTypeRewrite = RewriteUserValueTypePlaceholder;
                 }
                 else if (!TryCloseOverUserReferenceTypePlaceholders(mi, typeArgs, recoveredSymbols, out closed))
                 {
@@ -4699,6 +4713,9 @@ internal static class ClrOverloadResolution
 
         return true;
     }
+
+    private static Type RewriteUserValueTypePlaceholder(Type type) =>
+        SubstituteClrType(type, typeof(UserValueTypeConstraintPlaceholder), typeof(object));
 
     /// <summary>
     /// Issue #1325: structurally rewrites every occurrence of

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/ClrOverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/ClrOverloadResolution.cs
@@ -3784,7 +3784,7 @@ internal static class ClrOverloadResolution
         }
 
         var baseFullName = baseType.FullName;
-        for (var current = derived.BaseType; current != null; current = current.BaseType)
+        for (Type? current = derived.BaseType; current != null; current = current.BaseType)
         {
             if (current == baseType || current.FullName == baseFullName)
             {
@@ -4158,13 +4158,14 @@ internal static class ClrOverloadResolution
             // Issue #1601: a value-type-constrained generic type parameter (e.g.
             // a `TEnum` forwarded from an enclosing `[TEnum Enum struct]`) erases
             // the same way and must classify as a value type here too.
-            var argIsUserValueType = !typeArgSymbols.IsDefaultOrEmpty
+            TypeSymbol? argSymbol = !typeArgSymbols.IsDefaultOrEmpty
                 && i < typeArgSymbols.Length
-                && typeArgSymbols[i] is { } valueTypeSymbol
-                && IsValueTypeErasedSymbol(valueTypeSymbol);
-            var argIsUserReferenceType = !typeArgSymbols.IsDefaultOrEmpty
-                && i < typeArgSymbols.Length
-                && typeArgSymbols[i] is StructSymbol { IsClass: true, ClrType: null };
+                    ? typeArgSymbols[i]
+                    : null;
+            var argIsUserValueType =
+                argSymbol != null && IsValueTypeErasedSymbol(argSymbol);
+            var argIsUserReferenceType =
+                argSymbol is StructSymbol { IsClass: true, ClrType: null };
 
             if ((special & GenericParameterAttributes.ReferenceTypeConstraint) != 0)
             {
@@ -4197,7 +4198,7 @@ internal static class ClrOverloadResolution
                 if (!arg.IsValueType && !argIsUserValueType)
                 {
                     if (argIsUserReferenceType
-                        && typeArgSymbols[i] is StructSymbol userClass)
+                        && argSymbol is StructSymbol userClass)
                     {
                         if (userClass.IsAbstract
                             || userClass.HasPrimaryConstructor
@@ -4259,9 +4260,7 @@ internal static class ClrOverloadResolution
                 // instead of the placeholder. This is the Oahu
                 // SettingsManager.GetUserSettings[UserSettings]() shape.
                 if (constraint.IsInterface
-                    && !typeArgSymbols.IsDefaultOrEmpty
-                    && i < typeArgSymbols.Length
-                    && typeArgSymbols[i] is { } interfaceSymbol
+                    && argSymbol is { } interfaceSymbol
                     && interfaceSymbol.ClrType == null)
                 {
                     if (ErasedSymbolSatisfiesInterfaceConstraint(interfaceSymbol, constraint))
@@ -4293,7 +4292,7 @@ internal static class ClrOverloadResolution
                 // carries that same base bound.
                 if (argIsUserValueType && !constraint.IsInterface)
                 {
-                    if (typeArgSymbols[i] is { } constrainedValueTypeSymbol
+                    if (argSymbol is { } constrainedValueTypeSymbol
                         && ValueTypeErasedSymbolSatisfiesBaseConstraint(constrainedValueTypeSymbol, constraint))
                     {
                         continue;
@@ -4307,7 +4306,7 @@ internal static class ClrOverloadResolution
                 // its symbolic base chain for concrete class constraints.
                 if (argIsUserReferenceType && !constraint.IsInterface)
                 {
-                    if (typeArgSymbols[i] is StructSymbol userReferenceType
+                    if (argSymbol is StructSymbol userReferenceType
                         && UserReferenceTypeErasedSymbolSatisfiesBaseConstraint(
                             userReferenceType,
                             constraint))
@@ -4339,7 +4338,7 @@ internal static class ClrOverloadResolution
     {
         if (symbol is StructSymbol aggregate)
         {
-            for (var current = aggregate; current != null; current = current.BaseClass)
+            for (StructSymbol? current = aggregate; current != null; current = current.BaseClass)
             {
                 foreach (var implemented in current.ImplementedClrInterfaces)
                 {
@@ -4513,7 +4512,7 @@ internal static class ClrOverloadResolution
             return true;
         }
 
-        for (var current = symbol; current != null; current = current.BaseClass)
+        for (StructSymbol? current = symbol; current != null; current = current.BaseClass)
         {
             Type? importedBase = current.ImportedBaseType?.ClrType;
             if (importedBase != null)

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/ClrOverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/ClrOverloadResolution.cs
@@ -2414,8 +2414,14 @@ internal static class ClrOverloadResolution
                     return;
                 }
             }
-            else if (rawCandidate is MethodInfo mi && mi.IsGenericMethodDefinition)
+
+            var inferredMethod = rawCandidate as MethodInfo;
+            if (explicitTypeArgs == null
+                && inferredMethod != null
+                && inferredMethod.IsGenericMethodDefinition)
             {
+                var mi = inferredMethod;
+
                 // Issue #343: when named arguments are present, the per-source
                 // argTypes are not necessarily in parameter order. Build an
                 // ordered argTypes for inference by mapping each source index to
@@ -2777,8 +2783,14 @@ internal static class ClrOverloadResolution
                 return;
             }
         }
-        else if (rawCandidate is MethodInfo mi && mi.IsGenericMethodDefinition)
+
+        var inferredMethod = rawCandidate as MethodInfo;
+        if (explicitTypeArgs == null
+            && inferredMethod != null
+            && inferredMethod.IsGenericMethodDefinition)
         {
+            var mi = inferredMethod;
+
             if (!TryInferTypeArgumentsForExpandedParams(mi, argTypes, argumentNames, out var typeArgs))
             {
                 return;
@@ -4557,9 +4569,11 @@ internal static class ClrOverloadResolution
             }
 
             Type? importedBase = null;
-            for (var current = symbol; current != null && importedBase == null; current = current.BaseClass)
+            StructSymbol? current = symbol;
+            while (current != null && importedBase == null)
             {
                 importedBase = current.ImportedBaseType?.ClrType;
+                current = current.BaseClass;
             }
 
             if (importedBase == null)
@@ -5159,12 +5173,16 @@ internal static class ClrOverloadResolution
 
         try
         {
-            for (var t = type; t != null; t = t.BaseType)
+            Type? current = type;
+            while (current is not null)
             {
-                if (t.IsGenericType && MatchesOpenDefinition(t.GetGenericTypeDefinition(), openDefinition, openDefName))
+                if (current.IsGenericType
+                    && MatchesOpenDefinition(current.GetGenericTypeDefinition(), openDefinition, openDefName))
                 {
-                    return t;
+                    return current;
                 }
+
+                current = current.BaseType;
             }
         }
         catch (NotSupportedException)

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/ClrOverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/ClrOverloadResolution.cs
@@ -687,7 +687,7 @@ internal static class ClrOverloadResolution
     /// Optional callback identifying function-literal arguments whose body
     /// return may be implicitly converted to the candidate delegate return.
     /// </param>
-    public static Result<T> Resolve<T>(IEnumerable<T> candidates, IReadOnlyList<Type?> argTypes, IReadOnlyList<Type>? explicitTypeArgs = null, Func<Type, Type>? projectTypeArgument = null, IReadOnlyList<bool>? interpolatedStringArgs = null, IReadOnlyList<string?>? argumentNames = null, Func<MethodInfo, bool, ImmutableArray<TypeSymbol?>>? recoverTypeArgSymbols = null, Func<Type, Type, bool>? supplementaryInterfaceCheck = null, Func<int, Type, bool>? constantNarrowingArgumentCheck = null, Func<int, Type, bool>? structuralProjectionArgumentCheck = null, Func<int, Type, bool?>? delegateRefKindArgumentCheck = null, Func<int, IReadOnlyList<Type>, Tuple<Type[], Type>?>? methodGroupInference = null, Func<int, bool>? methodGroupArgumentCheck = null, IReadOnlyList<bool>? deferredInferenceArgs = null, Func<int, bool>? functionLiteralArgumentCheck = null)
+    public static Result<T> Resolve<T>(IEnumerable<T> candidates, IReadOnlyList<Type?> argTypes, IReadOnlyList<Type>? explicitTypeArgs = null, Func<Type, Type>? projectTypeArgument = null, IReadOnlyList<bool>? interpolatedStringArgs = null, IReadOnlyList<string?>? argumentNames = null, Func<MethodInfo, bool, ImmutableArray<TypeSymbol?>>? recoverTypeArgSymbols = null, Func<Type, Type, bool>? supplementaryInterfaceCheck = null, Func<int, Type, bool>? constantNarrowingArgumentCheck = null, Func<int, Type, bool>? structuralProjectionArgumentCheck = null, Func<int, Type, bool?>? delegateRefKindArgumentCheck = null, Func<int, IReadOnlyList<Type>, (Type[] Parameters, Type Return)?>? methodGroupInference = null, Func<int, bool>? methodGroupArgumentCheck = null, IReadOnlyList<bool>? deferredInferenceArgs = null, Func<int, bool>? functionLiteralArgumentCheck = null)
         where T : MethodBase
     {
         var applicable = new List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[]? Mapping, bool IsExpanded)>();
@@ -1107,7 +1107,7 @@ internal static class ClrOverloadResolution
         MethodInfo openMethod,
         IReadOnlyList<Type?> argTypes,
         [NotNullWhen(true)] out Type[]? typeArgs,
-        Func<int, IReadOnlyList<Type>, Tuple<Type[], Type>?>? methodGroupInference = null)
+        Func<int, IReadOnlyList<Type>, (Type[] Parameters, Type Return)?>? methodGroupInference = null)
     {
         typeArgs = null;
         if (openMethod is null || !openMethod.IsGenericMethodDefinition)
@@ -1440,7 +1440,7 @@ internal static class ClrOverloadResolution
         Type delegateType,
         int argumentIndex,
         Dictionary<string, Type> bounds,
-        Func<int, IReadOnlyList<Type>, Tuple<Type[], Type>?> methodGroupInference)
+        Func<int, IReadOnlyList<Type>, (Type[] Parameters, Type Return)?> methodGroupInference)
     {
         if (!TryGetDelegateSignature(delegateType, out var delegateParameters, out var delegateReturn))
         {
@@ -1460,9 +1460,9 @@ internal static class ClrOverloadResolution
         }
 
         var signature = methodGroupInference(argumentIndex, closedInputs);
-        if (signature?.Item1 is null
-            || signature.Item1.Length != delegateParameters.Length
-            || signature.Item2 is null)
+        if (!signature.HasValue
+            || signature.Value.Parameters.Length != delegateParameters.Length
+            || signature.Value.Return is null)
         {
             return false;
         }
@@ -1470,13 +1470,13 @@ internal static class ClrOverloadResolution
         var inferred = new Dictionary<string, Type>(bounds, StringComparer.Ordinal);
         for (var i = 0; i < delegateParameters.Length; i++)
         {
-            if (!UnifyForInference(delegateParameters[i], signature.Item1[i], inferred))
+            if (!UnifyForInference(delegateParameters[i], signature.Value.Parameters[i], inferred))
             {
                 return false;
             }
         }
 
-        if (!UnifyForInference(delegateReturn, signature.Item2, inferred))
+        if (!UnifyForInference(delegateReturn, signature.Value.Return, inferred))
         {
             return false;
         }
@@ -2323,7 +2323,7 @@ internal static class ClrOverloadResolution
     /// so the per-candidate work can be guarded against reflection load
     /// failures (issue #321) without disturbing the surrounding control flow.
     /// </summary>
-    private static void EvaluateCandidate<T>(T rawCandidate, IReadOnlyList<Type?> argTypes, IReadOnlyList<Type>? explicitTypeArgs, Func<Type, Type>? projectTypeArgument, List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[]? Mapping, bool IsExpanded)> applicable, IReadOnlyList<bool>? interpolatedStringArgs = null, IReadOnlyList<string?>? argumentNames = null, Func<MethodInfo, bool, ImmutableArray<TypeSymbol?>>? recoverTypeArgSymbols = null, Func<Type, Type, bool>? supplementaryInterfaceCheck = null, Func<int, Type, bool>? constantNarrowingArgumentCheck = null, Func<int, Type, bool>? structuralProjectionArgumentCheck = null, Func<int, Type, bool?>? delegateRefKindArgumentCheck = null, Func<int, IReadOnlyList<Type>, Tuple<Type[], Type>?>? methodGroupInference = null, Func<int, bool>? methodGroupArgumentCheck = null, IReadOnlyList<bool>? deferredInferenceArgs = null, Func<int, bool>? functionLiteralArgumentCheck = null)
+    private static void EvaluateCandidate<T>(T rawCandidate, IReadOnlyList<Type?> argTypes, IReadOnlyList<Type>? explicitTypeArgs, Func<Type, Type>? projectTypeArgument, List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[]? Mapping, bool IsExpanded)> applicable, IReadOnlyList<bool>? interpolatedStringArgs = null, IReadOnlyList<string?>? argumentNames = null, Func<MethodInfo, bool, ImmutableArray<TypeSymbol?>>? recoverTypeArgSymbols = null, Func<Type, Type, bool>? supplementaryInterfaceCheck = null, Func<int, Type, bool>? constantNarrowingArgumentCheck = null, Func<int, Type, bool>? structuralProjectionArgumentCheck = null, Func<int, Type, bool?>? delegateRefKindArgumentCheck = null, Func<int, IReadOnlyList<Type>, (Type[] Parameters, Type Return)?>? methodGroupInference = null, Func<int, bool>? methodGroupArgumentCheck = null, IReadOnlyList<bool>? deferredInferenceArgs = null, Func<int, bool>? functionLiteralArgumentCheck = null)
         where T : MethodBase
     {
         {
@@ -2688,30 +2688,30 @@ internal static class ClrOverloadResolution
     }
 
     private static bool IsMethodGroupSignatureCompatible(
-        Tuple<Type[], Type>? signature,
+        (Type[] Parameters, Type Return)? signature,
         IReadOnlyList<Type> delegateParameters,
         Type delegateReturn)
     {
-        if (signature?.Item1 is null
-            || signature.Item1.Length != delegateParameters.Count
-            || signature.Item2 is null)
+        if (!signature.HasValue
+            || signature.Value.Parameters.Length != delegateParameters.Count
+            || signature.Value.Return is null)
         {
             return false;
         }
 
         for (var i = 0; i < delegateParameters.Count; i++)
         {
-            if (ClassifyImplicit(signature.Item1[i], delegateParameters[i]) == ImplicitConversionKind.None)
+            if (ClassifyImplicit(signature.Value.Parameters[i], delegateParameters[i]) == ImplicitConversionKind.None)
             {
                 return false;
             }
         }
 
-        var methodVoid = string.Equals(signature.Item2.FullName, "System.Void", StringComparison.Ordinal);
+        var methodVoid = string.Equals(signature.Value.Return.FullName, "System.Void", StringComparison.Ordinal);
         var delegateVoid = string.Equals(delegateReturn?.FullName, "System.Void", StringComparison.Ordinal);
         return methodVoid || delegateVoid
             ? methodVoid && delegateVoid
-            : ClassifyImplicit(delegateReturn, signature.Item2) != ImplicitConversionKind.None;
+            : ClassifyImplicit(delegateReturn, signature.Value.Return) != ImplicitConversionKind.None;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Arguments.cs
@@ -661,8 +661,13 @@ internal sealed partial class OverloadResolver
         System.Func<int, string> parameterNameAt,
         int parameterOffset = 0)
     {
-        if (sourceArguments.Count == 0 ||
-            !sourceArguments.Any(argument => argument is NamedArgumentExpressionSyntax))
+        var hasNamedArgument = false;
+        foreach (var argument in sourceArguments)
+        {
+            hasNamedArgument |= argument is NamedArgumentExpressionSyntax;
+        }
+
+        if (sourceArguments.Count == 0 || !hasNamedArgument)
         {
             return parameterOrderedArguments;
         }
@@ -1052,8 +1057,7 @@ internal sealed partial class OverloadResolver
             }
 
             knownNames ??= MemberLookup.CollectClrParameterNames(receiverClrType, methodName, bindingFlags);
-            if (!knownNames.Any(parameterName =>
-                    ClrParameterNameMatches(parameterName, name)))
+            if (!ContainsClrParameterName(knownNames, name))
             {
                 var location = ce.Arguments[i] is NamedArgumentExpressionSyntax named ? named.NameToken.Location : ce.Arguments[i].Location;
                 Diagnostics.ReportNamedArgumentParameterNotFound(location, methodName, name);
@@ -1090,11 +1094,23 @@ internal sealed partial class OverloadResolver
             }
 
             knownNames ??= MemberLookup.CollectClrConstructorParameterNames(clrType);
-            if (!knownNames.Any(parameterName =>
-                    ClrParameterNameMatches(parameterName, name)))
+            if (!ContainsClrParameterName(knownNames, name))
             {
                 var location = ce.Arguments[i] is NamedArgumentExpressionSyntax named ? named.NameToken.Location : ce.Arguments[i].Location;
                 Diagnostics.ReportNamedArgumentParameterNotFound(location, clrType.Name, name);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ContainsClrParameterName(IEnumerable<string> parameterNames, string name)
+    {
+        foreach (var parameterName in parameterNames)
+        {
+            if (ClrParameterNameMatches(parameterName, name))
+            {
                 return true;
             }
         }

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
@@ -1645,27 +1645,30 @@ internal sealed partial class OverloadResolver
             // literal would materialise as a narrower-returning delegate flowing
             // into a wider delegate slot (unverifiable IL).
             if (!(substitution != null && TypeSymbol.ContainsTypeParameter(parameter.Type))
-                && tryGetFunctionLiteral(argument, out var widenLiteralArg)
-                && widenLiteralArg.FunctionType is FunctionTypeSymbol widenLiteralFnType
-                && widenLiteralFnType.ReturnType != TypeSymbol.Void
-                && widenLiteralFnType.ReturnType != TypeSymbol.Error
-                && expectedType is TypeSymbol widenExpectedType
-                && MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(widenExpectedType, out var widenTargetFn)
-                && widenTargetFn != null
-                && widenTargetFn.Arity == widenLiteralFnType.Arity
-                && widenTargetFn.ReturnType != TypeSymbol.Void
-                && widenTargetFn.ReturnType != TypeSymbol.Error
-                && !ReferenceEquals(widenLiteralFnType.ReturnType, widenTargetFn.ReturnType)
-                && Conversion.Classify(widenLiteralFnType.ReturnType, widenTargetFn.ReturnType).IsImplicit)
+                && tryGetFunctionLiteral(argument, out var widenLiteralArg))
             {
-                var widenLoc = i < parameterSyntax.Length
-                    ? Invariant.Required(parameterSyntax[i], "a widened lambda argument has source syntax").Location
-                    : syntax.Identifier.Location;
-                boundArguments[i] = conversions.BindConversion(
-                    widenLoc,
-                    argument,
-                    Invariant.Required(expectedType, "a widened lambda argument has a target type"));
-                continue;
+                var widenLiteralFnType = widenLiteralArg.FunctionType as FunctionTypeSymbol;
+                if (widenLiteralFnType != null
+                    && widenLiteralFnType.ReturnType != TypeSymbol.Void
+                    && widenLiteralFnType.ReturnType != TypeSymbol.Error
+                    && expectedType != null
+                    && MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(expectedType, out var widenTargetFn)
+                    && widenTargetFn != null
+                    && widenTargetFn.Arity == widenLiteralFnType.Arity
+                    && widenTargetFn.ReturnType != TypeSymbol.Void
+                    && widenTargetFn.ReturnType != TypeSymbol.Error
+                    && !ReferenceEquals(widenLiteralFnType.ReturnType, widenTargetFn.ReturnType)
+                    && Conversion.Classify(widenLiteralFnType.ReturnType, widenTargetFn.ReturnType).IsImplicit)
+                {
+                    var widenLoc = i < parameterSyntax.Length
+                        ? Invariant.Required(parameterSyntax[i], "a widened lambda argument has source syntax").Location
+                        : syntax.Identifier.Location;
+                    boundArguments[i] = conversions.BindConversion(
+                        widenLoc,
+                        argument,
+                        expectedType);
+                    continue;
+                }
             }
 
             // ADR-0055 Tier 4 (#369): an interpolated-string argument bound

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
@@ -682,7 +682,7 @@ internal sealed partial class OverloadResolver
                 var implicitReceiverExpr = new BoundVariableExpression(null, effThis);
 
                 // The callback uses null to mean that no explicit type arguments were supplied.
-                if (tryBindInheritedClrInstanceCall(implicitReceiverExpr, implicitBaseClr, syntax.Identifier.Text, boundArguments.ToImmutable(), syntax, out var implicitInheritedCall, inheritedClrTypeArgs!, inheritedTypeArgSymbols, argumentNames, allowProtectedInherited: true))
+                if (tryBindInheritedClrInstanceCall(implicitReceiverExpr, implicitBaseClr, syntax.Identifier.Text, boundArguments.ToImmutable(), syntax, out var implicitInheritedCall, inheritedClrTypeArgs, inheritedTypeArgSymbols, argumentNames, allowProtectedInherited: true))
                 {
                     return implicitInheritedCall;
                 }
@@ -925,7 +925,9 @@ internal sealed partial class OverloadResolver
         // variable goes through the `calli` path. Sites like `fp(1, 2)` where
         // `fp` is `let fp *func(int32, int32) int32 = &Add` reduce to a
         // BoundFunctionPointerInvocationExpression.
-        if (symbol is VariableSymbol fpVar && fpVar.Type is FunctionPointerTypeSymbol fpSym)
+        var fpVar = symbol as VariableSymbol;
+        var fpSym = fpVar?.Type as FunctionPointerTypeSymbol;
+        if (fpVar != null && fpSym != null)
         {
             if (syntax.Arguments.Count != fpSym.Arity)
             {
@@ -1008,7 +1010,10 @@ internal sealed partial class OverloadResolver
         // Phase 4.7: invoking a function-typed variable goes through the
         // indirect-call path. Sites like `add(1, 2)` where `add` is `let
         // add func(int, int) int = ...` reduce to BoundIndirectCallExpression.
-        if (symbol is VariableSymbol variable && (narrowedCallTargetType ?? variable.Type) is FunctionTypeSymbol fnType)
+        var variable = symbol as VariableSymbol;
+        var callableType = narrowedCallTargetType ?? variable?.Type;
+        var fnType = callableType as FunctionTypeSymbol;
+        if (variable != null && fnType != null)
         {
             if (!TryBindFunctionTypeArguments(
                     variable.Name,
@@ -1032,7 +1037,10 @@ internal sealed partial class OverloadResolver
         // ADR-0059 / issue #255: direct call syntax `h(args)` on a variable
         // of a user-declared named delegate type. Mirrors the CLR-delegate
         // branch below — both end up dispatching through Invoke.
-        if (symbol is VariableSymbol namedDelegateVar && (narrowedCallTargetType ?? namedDelegateVar.Type) is DelegateTypeSymbol namedDelegateSym)
+        var namedDelegateVar = symbol as VariableSymbol;
+        var namedDelegateSym =
+            (narrowedCallTargetType ?? namedDelegateVar?.Type) as DelegateTypeSymbol;
+        if (namedDelegateVar != null && namedDelegateSym != null)
         {
             if (!TryBindNamedDelegateArguments(
                 namedDelegateVar.Name,
@@ -1059,9 +1067,12 @@ internal sealed partial class OverloadResolver
         // mirroring native func-typed variables. Lower the call to an
         // invocation of the delegate's `Invoke` method, identical in behavior
         // to the explicit `f.Invoke(x)` form.
-        if (symbol is VariableSymbol delegateVar
-            && (narrowedCallTargetType ?? delegateVar.Type) is TypeSymbol delegateTargetType
-            && delegateTargetType.ClrType is System.Type delegateClrType
+        var delegateVar = symbol as VariableSymbol;
+        var delegateTargetType = narrowedCallTargetType ?? delegateVar?.Type;
+        var delegateClrType = delegateTargetType?.ClrType;
+        if (delegateVar != null
+            && delegateTargetType != null
+            && delegateClrType != null
             && ClrTypeUtilities.IsDelegateType(delegateClrType))
         {
             // Issue #2799 follow-up: the receiver load must honor every

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
@@ -149,6 +149,7 @@ internal sealed partial class OverloadResolver
         ImmutableArray<string> argumentNames)
     {
         var parameterCount = method.Parameters.Length;
+        Func<int, string> parameterNameAt = parameterIndex => method.Parameters[parameterIndex].Name;
         if (boundArguments.Length != parameterCount)
         {
             Diagnostics.ReportWrongArgumentCount(syntax.Location, method.Name, parameterCount, boundArguments.Length);
@@ -163,7 +164,7 @@ internal sealed partial class OverloadResolver
                     syntax.Arguments,
                     boundArguments,
                     parameterCount,
-                    p => method.Parameters[p].Name,
+                    parameterNameAt,
                     method.Name,
                     out permutedSyntax,
                     out permutedArguments))
@@ -194,7 +195,7 @@ internal sealed partial class OverloadResolver
         var finalArguments = PreserveNamedArgumentEvaluationOrder(
             syntax.Arguments,
             convertedArgs.MoveToImmutable(),
-            p => method.Parameters[p].Name);
+            parameterNameAt);
         return new BoundCallExpression(null, method, finalArguments);
     }
 
@@ -929,6 +930,8 @@ internal sealed partial class OverloadResolver
         var fpSym = fpVar?.Type as FunctionPointerTypeSymbol;
         if (fpVar != null && fpSym != null)
         {
+            Func<int, string> functionPointerParameterNameAt =
+                parameterIndex => fpVar.CallableParameterNames[parameterIndex];
             if (syntax.Arguments.Count != fpSym.Arity)
             {
                 Diagnostics.ReportWrongArgumentCount(syntax.Identifier.Location, fpVar.Name, fpSym.Arity, syntax.Arguments.Count);
@@ -953,7 +956,7 @@ internal sealed partial class OverloadResolver
                         syntax.Arguments,
                         fpArguments,
                         fpSym.Arity,
-                        p => fpVar.CallableParameterNames[p],
+                        functionPointerParameterNameAt,
                         fpVar.Name,
                         out fpParameterSyntax,
                         out fpArguments))
@@ -982,7 +985,7 @@ internal sealed partial class OverloadResolver
             var finalArguments = PreserveNamedArgumentEvaluationOrder(
                 syntax.Arguments,
                 fpConvertedArgs.MoveToImmutable(),
-                p => fpVar.CallableParameterNames[p]);
+                functionPointerParameterNameAt);
 
             return new BoundFunctionPointerInvocationExpression(
                 null,
@@ -1191,15 +1194,30 @@ internal sealed partial class OverloadResolver
                 }
 
                 explicitOverloadTypeArguments = explicitArguments.MoveToImmutable();
-                var constraintMatches = overloadSet
-                    .Where(candidate => candidate.TypeParameters.Length == explicitOverloadTypeArguments.Length)
-                    .Where(candidate => candidate.TypeParameters
-                        .Select((typeParameter, index) => satisfiesConstraint(explicitOverloadTypeArguments[index], typeParameter))
-                        .All(matches => matches))
-                    .ToImmutableArray();
-                if (!constraintMatches.IsDefaultOrEmpty)
+                var constraintMatches = ImmutableArray.CreateBuilder<FunctionSymbol>();
+                foreach (var candidate in overloadSet)
                 {
-                    overloadSet = constraintMatches;
+                    if (candidate.TypeParameters.Length != explicitOverloadTypeArguments.Length)
+                    {
+                        continue;
+                    }
+
+                    var constraintsSatisfied = true;
+                    for (var i = 0; i < candidate.TypeParameters.Length; i++)
+                    {
+                        constraintsSatisfied &=
+                            satisfiesConstraint(explicitOverloadTypeArguments[i], candidate.TypeParameters[i]);
+                    }
+
+                    if (constraintsSatisfied)
+                    {
+                        constraintMatches.Add(candidate);
+                    }
+                }
+
+                if (constraintMatches.Count > 0)
+                {
+                    overloadSet = constraintMatches.ToImmutable();
                 }
             }
 
@@ -1247,6 +1265,10 @@ internal sealed partial class OverloadResolver
 
         var isVariadic = function.Parameters.Length > 0 && function.Parameters[function.Parameters.Length - 1].IsVariadic;
         var fixedParamCount = isVariadic ? function.Parameters.Length - 1 : function.Parameters.Length;
+        Func<int, string> functionParameterNameAt =
+            parameterIndex => function.Parameters[parameterIndex].Name;
+        Func<int, bool> functionParameterIsOptional =
+            parameterIndex => function.Parameters[parameterIndex].HasExplicitDefaultValue;
 
         // ADR-0063: count of leading non-optional parameters (the minimum a
         // call must supply when there are no variadic parameters).
@@ -1267,7 +1289,7 @@ internal sealed partial class OverloadResolver
             !ValidateExpandedVariadicNamedArguments(
                 argumentNames,
                 fixedParamCount,
-                p => function.Parameters[p].Name,
+                functionParameterNameAt,
                 function.Name,
                 syntax))
         {
@@ -1334,8 +1356,8 @@ internal sealed partial class OverloadResolver
                     syntax.Arguments,
                     boundArguments.ToImmutable(),
                     function.Parameters.Length,
-                    p => function.Parameters[p].Name,
-                    hasOptional ? (p => function.Parameters[p].HasExplicitDefaultValue) : null,
+                    functionParameterNameAt,
+                    hasOptional ? functionParameterIsOptional : null,
                     function.Name,
                     out parameterSyntax,
                     out var permutedBound))
@@ -1943,6 +1965,8 @@ internal sealed partial class OverloadResolver
 
             // Issue #1630: pack/pass-through through the canonical helper
             // (applies #1493 element coercion when packing).
+            Func<int, TextLocation> argumentLocation =
+                argumentIndex => syntax.Arguments[argumentIndex].Location;
             var packedArgs = PackOrPassThroughVariadicArguments(
                 conversions,
                 Diagnostics,
@@ -1951,7 +1975,7 @@ internal sealed partial class OverloadResolver
                 fixedParamCount,
                 sliceType,
                 variadicParam.Name,
-                i => syntax.Arguments[i].Location,
+                argumentLocation,
                 ref hasErrors);
 
             if (!hasErrors)
@@ -1985,7 +2009,7 @@ internal sealed partial class OverloadResolver
         var finalBoundArguments = PreserveNamedArgumentEvaluationOrder(
             syntax.Arguments,
             boundArguments.ToImmutable(),
-            p => function.Parameters[p].Name);
+            functionParameterNameAt);
 
         if (substitution != null)
         {

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Candidates.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Candidates.cs
@@ -54,15 +54,30 @@ internal sealed partial class OverloadResolver
             }
 
             boundTypeArguments = explicitTypeArguments.MoveToImmutable();
-            var constraintMatches = overloads
-                .Where(candidate => candidate.TypeParameters.Length == boundTypeArguments.Length)
-                .Where(candidate => candidate.TypeParameters
-                    .Select((typeParameter, index) => satisfiesConstraint(boundTypeArguments[index], typeParameter))
-                    .All(matches => matches))
-                .ToImmutableArray();
-            if (!constraintMatches.IsDefaultOrEmpty)
+            var constraintMatches = ImmutableArray.CreateBuilder<FunctionSymbol>();
+            foreach (var candidate in overloads)
             {
-                overloads = constraintMatches;
+                if (candidate.TypeParameters.Length != boundTypeArguments.Length)
+                {
+                    continue;
+                }
+
+                var constraintsSatisfied = true;
+                for (var i = 0; i < candidate.TypeParameters.Length; i++)
+                {
+                    constraintsSatisfied &=
+                        satisfiesConstraint(boundTypeArguments[i], candidate.TypeParameters[i]);
+                }
+
+                if (constraintsSatisfied)
+                {
+                    constraintMatches.Add(candidate);
+                }
+            }
+
+            if (constraintMatches.Count > 0)
+            {
+                overloads = constraintMatches.ToImmutable();
             }
         }
 

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Candidates.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Candidates.cs
@@ -1448,8 +1448,10 @@ internal sealed partial class OverloadResolver
 
             var specializedTarget = candidate.Type switch
             {
-                SequenceTypeSymbol { ElementType: NullableTypeSymbol { UnderlyingType: TypeParameterSymbol target } } => target,
-                AsyncSequenceTypeSymbol { ElementType: NullableTypeSymbol { UnderlyingType: TypeParameterSymbol target } } => target,
+                SequenceTypeSymbol sequence when sequence.ElementType is NullableTypeSymbol
+                    => ((NullableTypeSymbol)sequence.ElementType).UnderlyingType as TypeParameterSymbol,
+                AsyncSequenceTypeSymbol sequence when sequence.ElementType is NullableTypeSymbol
+                    => ((NullableTypeSymbol)sequence.ElementType).UnderlyingType as TypeParameterSymbol,
                 _ => null,
             };
             if (specializedTarget == null)

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
@@ -312,6 +312,7 @@ internal sealed partial class OverloadResolver
         }
 
         var parameters = classType.PrimaryConstructorParameters;
+        Func<int, string> parameterNameAt = parameterIndex => parameters[parameterIndex].Name;
         var boundArguments = ImmutableArray.CreateBuilder<BoundExpression>(syntax.Arguments.Count);
         foreach (var argument in syntax.Arguments)
         {
@@ -517,7 +518,7 @@ internal sealed partial class OverloadResolver
             var optionalFinalArguments = PreserveNamedArgumentEvaluationOrder(
                 syntax.Arguments,
                 boundArguments.ToImmutable(),
-                p => parameters[p].Name);
+                parameterNameAt);
             return new BoundConstructorCallExpression(syntax, classType, optionalFinalArguments);
         }
 
@@ -722,7 +723,7 @@ internal sealed partial class OverloadResolver
         var finalArguments = PreserveNamedArgumentEvaluationOrder(
             syntax.Arguments,
             boundArguments.ToImmutable(),
-            p => parameters[p].Name);
+            parameterNameAt);
 
         if (classType.IsInline)
         {
@@ -817,17 +818,28 @@ internal sealed partial class OverloadResolver
                 parameterForArg = ctorOverloads[0].Parameters[ai];
             }
 
-            if (argument is RefArgumentExpressionSyntax refArg)
+            BoundExpression? boundArgument = null;
+            var refArgument = argument as RefArgumentExpressionSyntax;
+            if (refArgument is not null)
             {
                 // The callback uses null to mean that overload resolution has
                 // not identified the ref parameter yet; its legacy non-null
                 // annotation predates that two-pass binding contract.
-                boundArgumentsBuilder.Add(bindRefArgumentExpression(refArg, parameterForArg!));
+                boundArgument = bindRefArgumentExpression(refArgument, parameterForArg!);
             }
-            else
+
+            var lambdaArgument = argument as LambdaExpressionSyntax;
+            var lambdaTarget = parameterForArg?.Type as FunctionTypeSymbol;
+            if (boundArgument is null
+                && lambdaArgument is not null
+                && lambdaTarget is not null
+                && bindLambdaWithTarget is not null)
             {
-                boundArgumentsBuilder.Add(BindOverloadArgumentValue(argument));
+                boundArgument = bindLambdaWithTarget(lambdaArgument, lambdaTarget);
             }
+
+            boundArgument ??= BindOverloadArgumentValue(argument);
+            boundArgumentsBuilder.Add(boundArgument);
         }
 
         ConstructorSymbol? selectedCtor;
@@ -885,6 +897,7 @@ internal sealed partial class OverloadResolver
 
         selectedCtor = Invariant.Required(selectedCtor, "an applicable explicit constructor has a selected constructor symbol");
         var parameters = selectedCtor.Parameters;
+        Func<int, string> parameterNameAt = parameterIndex => parameters[parameterIndex].Name;
 
         // Issue #1214: for a closed generic construction, surface the
         // constructor's parameter types with the construction's type arguments
@@ -1181,7 +1194,7 @@ internal sealed partial class OverloadResolver
         var finalArguments = PreserveNamedArgumentEvaluationOrder(
             syntax.Arguments,
             convertedArguments.ToImmutable(),
-            p => parameters[p].Name);
+            parameterNameAt);
         return new BoundConstructorCallExpression(syntax, classType, finalArguments, selectedCtor);
     }
 

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Invocations.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Invocations.cs
@@ -335,6 +335,7 @@ internal sealed partial class OverloadResolver
 
         ExpressionSyntax?[] parameterSyntax;
         var permutedArgs = boundArguments;
+        Func<int, string> parameterNameAt = parameterIndex => parameterNames[parameterIndex];
         bool hasNamedArguments =
             syntax.Arguments.Any(argument => argument is NamedArgumentExpressionSyntax);
         if (hasNamedArguments)
@@ -361,7 +362,7 @@ internal sealed partial class OverloadResolver
                     !ValidateExpandedVariadicNamedArguments(
                         argumentNames,
                         fixedCount,
-                        p => parameterNames[p],
+                        parameterNameAt,
                         calleeName,
                         syntax))
                 {
@@ -374,7 +375,7 @@ internal sealed partial class OverloadResolver
                          syntax.Arguments,
                          boundArguments,
                          functionType.Arity,
-                         p => parameterNames[p],
+                         parameterNameAt,
                          calleeName,
                          out parameterSyntax,
                          out permutedArgs))
@@ -397,6 +398,7 @@ internal sealed partial class OverloadResolver
             // (applies #1493 element coercion when packing).
             var sliceType = (SliceTypeSymbol)functionType.ParameterTypes[functionType.Arity - 1];
             var hasElementErrors = false;
+            Func<int, TextLocation> argumentLocation = argumentIndex => syntax.Arguments[argumentIndex].Location;
             permutedArgs = PackOrPassThroughVariadicArguments(
                 conversions,
                 Diagnostics,
@@ -405,7 +407,7 @@ internal sealed partial class OverloadResolver
                 fixedCount,
                 sliceType,
                 calleeName,
-                i => syntax.Arguments[i].Location,
+                argumentLocation,
                 ref hasElementErrors);
 
             if (hasElementErrors)
@@ -438,7 +440,7 @@ internal sealed partial class OverloadResolver
         convertedArgs = PreserveNamedArgumentEvaluationOrder(
             syntax.Arguments,
             convertedBuilder.MoveToImmutable(),
-            p => parameterNames[p]);
+            parameterNameAt);
         return true;
     }
 
@@ -454,6 +456,9 @@ internal sealed partial class OverloadResolver
         argumentRefKinds = default;
 
         var parameters = delegateType.Parameters;
+        Func<int, string> parameterNameAt = parameterIndex => parameters[parameterIndex].Name;
+        Func<int, bool> parameterIsOptional =
+            parameterIndex => parameters[parameterIndex].HasExplicitDefaultValue;
         var isVariadic = parameters.Length > 0 && parameters[parameters.Length - 1].IsVariadic;
         var fixedCount = isVariadic ? parameters.Length - 1 : parameters.Length;
         if (isVariadic)
@@ -495,8 +500,8 @@ internal sealed partial class OverloadResolver
                     syntax.Arguments,
                     boundArguments,
                     parameters.Length,
-                    p => parameters[p].Name,
-                    p => parameters[p].HasExplicitDefaultValue,
+                    parameterNameAt,
+                    parameterIsOptional,
                     calleeName,
                     out parameterSyntax,
                     out arguments))
@@ -518,7 +523,7 @@ internal sealed partial class OverloadResolver
                 !ValidateExpandedVariadicNamedArguments(
                     argumentNames,
                     fixedCount,
-                    p => parameters[p].Name,
+                    parameterNameAt,
                     calleeName,
                     syntax))
             {
@@ -665,7 +670,7 @@ internal sealed partial class OverloadResolver
         convertedArgs = PreserveNamedArgumentEvaluationOrder(
             syntax.Arguments,
             converted.MoveToImmutable(),
-            p => parameters[p].Name);
+            parameterNameAt);
         argumentRefKinds = hasRefKinds ? refKinds.MoveToImmutable() : default;
         return true;
     }
@@ -1079,14 +1084,18 @@ internal sealed partial class OverloadResolver
         // the reorder below.
         ExpressionSyntax?[] permutedSyntax;
         ImmutableArray<BoundExpression> permutedArguments;
+        Func<int, string> extensionParameterNameAt =
+            parameterIndex => extension.Parameters[parameterIndex + 1].Name;
+        Func<int, bool> extensionParameterIsOptional =
+            parameterIndex => extension.Parameters[parameterIndex + 1].HasExplicitDefaultValue;
         if (!argumentNames.IsDefault)
         {
             if (!TryReorderUserCallArguments(
                     ce.Arguments,
                     arguments,
                     userParamCount,
-                    p => extension.Parameters[p + 1].Name,
-                    p => extension.Parameters[p + 1].HasExplicitDefaultValue,
+                    extensionParameterNameAt,
+                    extensionParameterIsOptional,
                     extension.Name,
                     out permutedSyntax,
                     out permutedArguments))
@@ -1271,7 +1280,7 @@ internal sealed partial class OverloadResolver
         var finalArguments = PreserveNamedArgumentEvaluationOrder(
             ce.Arguments,
             convertedArgs.MoveToImmutable(),
-            p => extension.Parameters[p + 1].Name,
+            extensionParameterNameAt,
             parameterOffset: 1);
 
         if (substitution != null)
@@ -1323,6 +1332,10 @@ internal sealed partial class OverloadResolver
         var isVariadic = method.Parameters.Length > 0
             && method.Parameters[method.Parameters.Length - 1].IsVariadic;
         var fixedCallableParamCount = isVariadic ? callableParameterCount - 1 : callableParameterCount;
+        Func<int, string> callableParameterNameAt =
+            parameterIndex => method.Parameters[parameterIndex + parameterOffset].Name;
+        Func<int, bool> callableParameterIsOptional =
+            parameterIndex => method.Parameters[parameterIndex + parameterOffset].HasExplicitDefaultValue;
 
         // ADR-0063 / issue #1319: count the leading non-optional callable
         // parameters. An instance / constructor call may omit any trailing
@@ -1347,7 +1360,7 @@ internal sealed partial class OverloadResolver
             !ValidateExpandedVariadicNamedArguments(
                 argumentNames,
                 fixedCallableParamCount,
-                p => method.Parameters[p + parameterOffset].Name,
+                callableParameterNameAt,
                 method.Name,
                 ce))
         {
@@ -1380,8 +1393,8 @@ internal sealed partial class OverloadResolver
                     ce.Arguments,
                     arguments,
                     callableParameterCount,
-                    p => method.Parameters[p + parameterOffset].Name,
-                    p => method.Parameters[p + parameterOffset].HasExplicitDefaultValue,
+                    callableParameterNameAt,
+                    callableParameterIsOptional,
                     method.Name,
                     out permutedSyntax,
                     out permutedArguments))
@@ -1689,7 +1702,7 @@ internal sealed partial class OverloadResolver
         var finalArguments = PreserveNamedArgumentEvaluationOrder(
             ce.Arguments,
             convertedArgs.ToImmutable(),
-            p => method.Parameters[p + parameterOffset].Name);
+            callableParameterNameAt);
 
         BoundUserInstanceCallExpression MakeCall(TypeSymbol? returnTypeOverride)
         {

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Invocations.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Invocations.cs
@@ -1742,8 +1742,11 @@ internal sealed partial class OverloadResolver
         // class's declaration-parameter -> (resolved) argument mappings, exactly
         // like Conversion.DerivesFromConstructed threads its map for subtyping.
         Dictionary<TypeParameterSymbol, TypeSymbol>? map = null;
-        for (var c = start; c != null; c = c.BaseClass)
+        StructSymbol? current = start;
+        while (current != null)
         {
+            var c = current;
+
             // Issue #1537: a receiver that is a generic type nested inside a
             // generic enclosing type (e.g. `Outer[int32].Middle[string]`)
             // carries the enclosing construction's arguments on
@@ -1774,6 +1777,7 @@ internal sealed partial class OverloadResolver
                 || c.TypeArguments.IsDefaultOrEmpty
                 || c.Definition.TypeParameters.IsDefaultOrEmpty)
             {
+                current = c.BaseClass;
                 continue;
             }
 
@@ -1793,6 +1797,8 @@ internal sealed partial class OverloadResolver
                 map ??= new Dictionary<TypeParameterSymbol, TypeSymbol>();
                 map[defTps[i]] = arg;
             }
+
+            current = c.BaseClass;
         }
 
         return map;

--- a/src/Core/CodeAnalysis/Binding/PartialTypeMerger.cs
+++ b/src/Core/CodeAnalysis/Binding/PartialTypeMerger.cs
@@ -198,9 +198,15 @@ internal static class PartialTypeMerger
         var sealedKeyword = parts.Select(p => p.SealedKeyword).FirstOrDefault(t => t != null);
 
         // GS0479: data / inline / ref must appear on every part or none.
-        RequireOnEveryPart(parts, p => p.DataKeyword != null, "data", name, diagnostics);
-        RequireOnEveryPart(parts, p => p.InlineKeyword != null, "inline", name, diagnostics);
-        RequireOnEveryPart(parts, p => p.RefModifier != null, "ref", name, diagnostics);
+        System.Func<StructDeclarationSyntax, bool> hasData =
+            part => part.DataKeyword != null;
+        System.Func<StructDeclarationSyntax, bool> hasInline =
+            part => part.InlineKeyword != null;
+        System.Func<StructDeclarationSyntax, bool> hasRef =
+            part => part.RefModifier != null;
+        RequireOnEveryPart(parts, hasData, "data", name, diagnostics);
+        RequireOnEveryPart(parts, hasInline, "inline", name, diagnostics);
+        RequireOnEveryPart(parts, hasRef, "ref", name, diagnostics);
 
         // GS0480: identical type-parameter lists (names + arity + constraints).
         var primaryTypeParams = NormalizeNodeText(primary.TypeParameterList);
@@ -268,10 +274,10 @@ internal static class PartialTypeMerger
             baseInfo.BaseTypeIdentifier,
             baseInfo.AdditionalBaseTypeIdentifiers,
             primary.OpenBraceToken,
-            Concat(parts, p => p.Fields),
-            Concat(parts, p => p.Properties),
-            Concat(parts, p => p.Events),
-            Concat(parts, p => p.Methods),
+            Concat<StructDeclarationSyntax, FieldDeclarationSyntax>(parts, p => p.Fields),
+            Concat<StructDeclarationSyntax, PropertyDeclarationSyntax>(parts, p => p.Properties),
+            Concat<StructDeclarationSyntax, EventDeclarationSyntax>(parts, p => p.Events),
+            Concat<StructDeclarationSyntax, FunctionDeclarationSyntax>(parts, p => p.Methods),
             primary.CloseBraceToken)
         {
             BaseTypeClauses = baseInfo.BaseTypeClauses,
@@ -279,9 +285,11 @@ internal static class PartialTypeMerger
             BaseConstructorOpenParenthesisToken = baseInfo.BaseConstructorOpenParenthesisToken,
             BaseConstructorArguments = baseInfo.BaseConstructorArguments,
             BaseConstructorCloseParenthesisToken = baseInfo.BaseConstructorCloseParenthesisToken,
-            Constructors = Concat(parts, p => p.Constructors),
+            Constructors = Concat<StructDeclarationSyntax, ConstructorDeclarationSyntax>(parts, p => p.Constructors),
             Deinitializer = deinit,
-            NestedTypes = MergePartialNestedTypes(Concat(parts, p => p.NestedTypes), diagnostics),
+            NestedTypes = MergePartialNestedTypes(
+                Concat<StructDeclarationSyntax, MemberSyntax>(parts, p => p.NestedTypes),
+                diagnostics),
             TypeParameterList = primary.TypeParameterList,
             RefModifier = parts.Select(p => p.RefModifier).FirstOrDefault(t => t != null),
             UnsafeModifier = parts.Select(p => p.UnsafeModifier).FirstOrDefault(t => t != null),
@@ -572,7 +580,15 @@ internal static class PartialTypeMerger
         string name,
         DiagnosticBag diagnostics)
     {
-        var withCount = parts.Count(hasModifier);
+        var withCount = 0;
+        foreach (var part in parts)
+        {
+            if (hasModifier(part))
+            {
+                withCount++;
+            }
+        }
+
         if (withCount == 0 || withCount == parts.Count)
         {
             return;
@@ -735,11 +751,11 @@ internal static class PartialTypeMerger
             tree,
             first.SharedKeyword,
             first.OpenBraceToken,
-            Concat(nonNullPresent, b => b.Fields),
-            Concat(nonNullPresent, b => b.Properties),
-            Concat(nonNullPresent, b => b.Events),
-            Concat(nonNullPresent, b => b.Methods),
-            Concat(nonNullPresent, b => b.InitBlocks),
+            Concat<SharedBlockSyntax, FieldDeclarationSyntax>(nonNullPresent, b => b.Fields),
+            Concat<SharedBlockSyntax, PropertyDeclarationSyntax>(nonNullPresent, b => b.Properties),
+            Concat<SharedBlockSyntax, EventDeclarationSyntax>(nonNullPresent, b => b.Events),
+            Concat<SharedBlockSyntax, FunctionDeclarationSyntax>(nonNullPresent, b => b.Methods),
+            Concat<SharedBlockSyntax, StaticInitializerBlockSyntax>(nonNullPresent, b => b.InitBlocks),
             first.CloseBraceToken);
     }
 

--- a/src/Core/CodeAnalysis/Binding/PatternBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/PatternBinder.cs
@@ -885,6 +885,19 @@ internal sealed class PatternBinder
             return true;
         }
 
+        var directClrType = lookupType.ClrType;
+        if (directClrType is not null
+            && TryBindClrPropertyPatternMember(
+                lookupType,
+                directClrType,
+                syntax,
+                bindingContext,
+                preferTypeNames,
+                out boundField))
+        {
+            return true;
+        }
+
         boundField = null;
         return false;
     }

--- a/src/Core/CodeAnalysis/Binding/PatternBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/PatternBinder.cs
@@ -766,6 +766,7 @@ internal sealed class PatternBinder
         bool preferTypeNames,
         out BoundPropertyPatternField? boundField)
     {
+        boundField = null;
         var name = syntax.Identifier.Text;
         if (lookupType is StructSymbol structType)
         {
@@ -797,7 +798,6 @@ internal sealed class PatternBinder
 
                     if (property.IsIndexer || property.IsStatic || !property.HasGetter)
                     {
-                        boundField = null;
                         return false;
                     }
 

--- a/src/Core/CodeAnalysis/Binding/RefStructAsyncLivenessAnalyzer.cs
+++ b/src/Core/CodeAnalysis/Binding/RefStructAsyncLivenessAnalyzer.cs
@@ -608,8 +608,13 @@ internal static class RefStructAsyncLivenessAnalyzer
 
         public bool ContainsAwait { get; private set; }
 
-        public override void VisitExpression(BoundExpression node)
+        public override void VisitExpression(BoundExpression? node)
         {
+            if (node == null)
+            {
+                return;
+            }
+
             if (node is BoundVariableExpression variableExpression && interesting.Contains(variableExpression.Variable))
             {
                 Reads.Add(variableExpression.Variable);
@@ -644,8 +649,13 @@ internal static class RefStructAsyncLivenessAnalyzer
             this.diagnostics = diagnostics;
         }
 
-        public override void VisitExpression(BoundExpression node)
+        public override void VisitExpression(BoundExpression? node)
         {
+            if (node == null)
+            {
+                return;
+            }
+
             if (node is BoundFunctionLiteralExpression literal)
             {
                 // Issue #2350: a function-literal body is bound but not

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Conditionals.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Conditionals.cs
@@ -790,11 +790,13 @@ internal sealed partial class StatementBinder
 
             // [NotNullWhen(rv)]: narrow a nullable argument to its underlying
             // non-nullable type on the arm where the call returns rv.
-            if (notNullWhenReturnValue is bool returnValue
-                && argExpr is BoundVariableExpression narrowVarExpr
-                && narrowVarExpr.Variable.Type is NullableTypeSymbol nullable)
+            var narrowVarExpr = argExpr as BoundVariableExpression;
+            var nullable = narrowVarExpr?.Variable.Type as NullableTypeSymbol;
+            if (notNullWhenReturnValue.HasValue
+                && narrowVarExpr != null
+                && nullable != null)
             {
-                var narrowThen = returnValue != negate;
+                var narrowThen = notNullWhenReturnValue.Value != negate;
                 var frame = narrowThen
                     ? (thenFrame ??= new Dictionary<AccessPath, TypeSymbol>())
                     : (elseFrame ??= new Dictionary<AccessPath, TypeSymbol>());
@@ -803,12 +805,13 @@ internal sealed partial class StatementBinder
 
             // [MaybeNullWhen(rv)]: widen a non-nullable argument to its nullable
             // counterpart on the arm where the call returns rv.
-            if (maybeNullWhenReturnValue is bool widenReturnValue
-                && argExpr is BoundVariableExpression widenVarExpr
+            var widenVarExpr = argExpr as BoundVariableExpression;
+            if (maybeNullWhenReturnValue.HasValue
+                && widenVarExpr != null
                 && widenVarExpr.Variable.Type is not NullableTypeSymbol
                 && widenVarExpr.Variable.Type != TypeSymbol.Null)
             {
-                var widenThen = widenReturnValue != negate;
+                var widenThen = maybeNullWhenReturnValue.Value != negate;
                 var widenFrame = widenThen
                     ? (thenFrame ??= new Dictionary<AccessPath, TypeSymbol>())
                     : (elseFrame ??= new Dictionary<AccessPath, TypeSymbol>());

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Conditionals.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Conditionals.cs
@@ -1196,13 +1196,15 @@ internal sealed partial class StatementBinder
         switch (bound)
         {
             case BoundAssignmentExpression assignment:
-                plan = new MultiAssignmentTargetPlan(
-                    assignment.Expression,
+                Func<BoundExpression, BoundExpression> createVariableWrite =
                     value => new BoundAssignmentExpression(
                         assignment.Syntax,
                         assignment.Variable,
                         value,
-                        assignment.AssignedValueType));
+                        assignment.AssignedValueType);
+                plan = new MultiAssignmentTargetPlan(
+                    assignment.Expression,
+                    createVariableWrite);
                 return true;
 
             case BoundFieldAssignmentExpression field:
@@ -1239,22 +1241,23 @@ internal sealed partial class StatementBinder
                 var propertyReceiver = property.Receiver == null
                     ? null
                     : CaptureMultiAssignmentReceiver(property.Receiver, targetSyntax, captures);
-                plan = new MultiAssignmentTargetPlan(
-                    property.Value,
+                Func<BoundExpression, BoundExpression> createPropertyWrite =
                     value => new BoundPropertyAssignmentExpression(
                         property.Syntax,
                         propertyReceiver,
                         property.StructType,
                         property.Property,
-                        value));
+                        value);
+                plan = new MultiAssignmentTargetPlan(
+                    property.Value,
+                    createPropertyWrite);
                 return true;
 
             case BoundClrPropertyAssignmentExpression clrProperty:
                 var clrPropertyReceiver = clrProperty.Receiver == null
                     ? null
                     : CaptureMultiAssignmentReceiver(clrProperty.Receiver, targetSyntax, captures);
-                plan = new MultiAssignmentTargetPlan(
-                    clrProperty.Value,
+                Func<BoundExpression, BoundExpression> createClrPropertyWrite =
                     value => new BoundClrPropertyAssignmentExpression(
                         clrProperty.Syntax,
                         clrPropertyReceiver,
@@ -1263,7 +1266,10 @@ internal sealed partial class StatementBinder
                         clrProperty.Type,
                         clrProperty.StaticContainerType,
                         clrProperty.ConstrainedReceiverTypeParameter,
-                        clrProperty.ConstrainedInterfaceType));
+                        clrProperty.ConstrainedInterfaceType);
+                plan = new MultiAssignmentTargetPlan(
+                    clrProperty.Value,
+                    createClrPropertyWrite);
                 return true;
 
             case BoundIndexAssignmentExpression index:
@@ -1352,12 +1358,14 @@ internal sealed partial class StatementBinder
         ImmutableArray<BoundStatement>.Builder captures)
     {
         var address = CaptureMultiAssignmentAddress(storage, targetSyntax, captures);
-        return new MultiAssignmentTargetPlan(
-            assignedValue,
+        Func<BoundExpression, BoundExpression> createWrite =
             value => new BoundIndirectAssignmentExpression(
                 targetSyntax,
                 new BoundVariableExpression(null, address),
-                value));
+                value);
+        return new MultiAssignmentTargetPlan(
+            assignedValue,
+            createWrite);
     }
 
     private LocalVariableSymbol CaptureMultiAssignmentAddress(

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Jumps.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Jumps.cs
@@ -228,7 +228,11 @@ internal sealed partial class StatementBinder
         RestoreDictionary(binderCtx.PendingSwitchExitFrames, pendingSwitchExitFrames);
         RestoreSet(binderCtx.DefinedUserLabels, definedUserLabels);
         userGotoHandlerRegions.Clear();
-        userGotoHandlerRegions.AddRange(userGotoHandlerSnapshot);
+        foreach (var region in userGotoHandlerSnapshot)
+        {
+            userGotoHandlerRegions.Add(region);
+        }
+
         binderCtx.SyntheticLocalCounter = syntheticLocalCounter;
 
         InvalidateInheritedNarrowings(narrowingInvalidations);

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Jumps.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Jumps.cs
@@ -170,6 +170,27 @@ internal sealed partial class StatementBinder
         var userGotoHandlerSnapshot = userGotoHandlerRegions.ToArray();
         var syntheticLocalCounter = binderCtx.SyntheticLocalCounter;
 
+        static void RestoreDictionary<TKey, TValue>(
+            Dictionary<TKey, TValue> destination,
+            KeyValuePair<TKey, TValue>[] snapshot)
+            where TKey : notnull
+        {
+            destination.Clear();
+            foreach (var entry in snapshot)
+            {
+                destination.Add(entry.Key, entry.Value);
+            }
+        }
+
+        static void RestoreSet<T>(HashSet<T> destination, T[] snapshot)
+        {
+            destination.Clear();
+            foreach (var item in snapshot)
+            {
+                destination.Add(item);
+            }
+        }
+
         // Issue #2943: first bind supplies exact assignment symbols and lowered
         // control flow. If a write can reach the back-edge, restore speculative
         // state, remove only inherited narrowings, and bind the body again.
@@ -227,27 +248,6 @@ internal sealed partial class StatementBinder
             finally
             {
                 binderCtx.LoopStack.Pop();
-            }
-        }
-
-        static void RestoreDictionary<TKey, TValue>(
-            Dictionary<TKey, TValue> destination,
-            KeyValuePair<TKey, TValue>[] snapshot)
-            where TKey : notnull
-        {
-            destination.Clear();
-            foreach (var entry in snapshot)
-            {
-                destination.Add(entry.Key, entry.Value);
-            }
-        }
-
-        static void RestoreSet<T>(HashSet<T> destination, T[] snapshot)
-        {
-            destination.Clear();
-            foreach (var item in snapshot)
-            {
-                destination.Add(item);
             }
         }
     }

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
@@ -1960,16 +1960,23 @@ internal sealed partial class StatementBinder
         foreach (var probe in probes)
         {
             var receiverOffset = probe.ReceiverParameterOffset;
-            var candidates = probe.Methods
-                .Where(method =>
+            var candidates = new List<MethodInfo>();
+            foreach (var candidate in probe.Methods)
+            {
+                var candidateParameters = candidate.GetParameters();
+                var parametersMatch = candidate.ReturnType.FullName == typeof(void).FullName
+                    && candidateParameters.Length == identifiers.Count + receiverOffset;
+                for (var i = receiverOffset; parametersMatch && i < candidateParameters.Length; i++)
                 {
-                    var parameters = method.GetParameters();
-                    return method.ReturnType.FullName == typeof(void).FullName
-                        && parameters.Length == identifiers.Count + receiverOffset
-                        && parameters.Skip(receiverOffset).All(parameter =>
-                            parameter.IsOut && parameter.ParameterType.IsByRef);
-                })
-                .ToList();
+                    parametersMatch &= candidateParameters[i].IsOut && candidateParameters[i].ParameterType.IsByRef;
+                }
+
+                if (parametersMatch)
+                {
+                    candidates.Add(candidate);
+                }
+            }
+
             if (candidates.Count == 0)
             {
                 continue;
@@ -1981,37 +1988,36 @@ internal sealed partial class StatementBinder
                 inferenceTypes[0] = receiverClrType;
             }
 
-            candidates = candidates
-                .Select(method =>
+            var closedCandidates = new List<MethodInfo>();
+            foreach (var candidate in candidates)
+            {
+                if (!candidate.IsGenericMethodDefinition)
                 {
-                    if (!method.IsGenericMethodDefinition)
+                    closedCandidates.Add(candidate);
+                    continue;
+                }
+
+                if (!ClrOverloadResolution.TryInferTypeArguments(candidate, inferenceTypes, out var typeArguments))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    for (var i = 0; i < typeArguments.Length; i++)
                     {
-                        return method;
+                        typeArguments[i] = scope.References.MapClrTypeToReferences(typeArguments[i])
+                            ?? typeArguments[i];
                     }
 
-                    if (!ClrOverloadResolution.TryInferTypeArguments(method, inferenceTypes, out var typeArguments))
-                    {
-                        return null;
-                    }
+                    closedCandidates.Add(candidate.MakeGenericMethod(typeArguments));
+                }
+                catch (ArgumentException)
+                {
+                }
+            }
 
-                    try
-                    {
-                        for (var i = 0; i < typeArguments.Length; i++)
-                        {
-                            typeArguments[i] = scope.References.MapClrTypeToReferences(typeArguments[i])
-                                ?? typeArguments[i];
-                        }
-
-                        return method.MakeGenericMethod(typeArguments);
-                    }
-                    catch (ArgumentException)
-                    {
-                        return null;
-                    }
-                })
-                .Where(method => method != null)
-                .Cast<MethodInfo>()
-                .ToList();
+            candidates = closedCandidates;
             if (candidates.Count == 0)
             {
                 continue;
@@ -2029,17 +2035,23 @@ internal sealed partial class StatementBinder
                 startIndex: receiverOffset,
                 count: identifiers.Count);
 
-            var resolution = ClrOverloadResolution.Resolve(
+            var resolution = ClrOverloadResolution.Resolve<MethodInfo>(
                 candidates,
                 argumentTypes,
                 projectTypeArgument: scope.References.MapClrTypeToReferences);
             if (resolution.Outcome == ClrOverloadResolution.ResolutionOutcome.Ambiguous)
             {
+                var signatures = new string[resolution.Ambiguous.Length];
+                for (var i = 0; i < signatures.Length; i++)
+                {
+                    signatures[i] = ClrOverloadResolution.FormatMethodSignature(resolution.Ambiguous[i]);
+                }
+
                 Diagnostics.ReportAmbiguousOverload(
                     location,
                     "Deconstruct",
                     resolution.Ambiguous.Length,
-                    resolution.Ambiguous.Select(ClrOverloadResolution.FormatMethodSignature));
+                    signatures);
                 DeclareErrorTypedLocals(identifiers);
                 statements = ImmutableArray<BoundStatement>.Empty;
                 return true;

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
@@ -978,8 +978,8 @@ internal sealed partial class StatementBinder
     private class AssignedRootsCollector : BoundTreeWalker
     {
         private readonly Func<BoundAssignmentExpression, TypeSymbol, bool>? assignmentPreservesNarrowing;
-        private readonly HashSet<(VariableSymbol? Receiver, FieldSymbol Field)> assignedFields = new();
-        private readonly HashSet<(VariableSymbol? Receiver, PropertySymbol Property)> assignedProperties = new();
+        private readonly HashSet<AssignedField> assignedFields = new();
+        private readonly HashSet<AssignedProperty> assignedProperties = new();
         private readonly Dictionary<VariableSymbol, List<BoundAssignmentExpression>> assignments = new();
 
         public AssignedRootsCollector(Func<BoundAssignmentExpression, TypeSymbol, bool>? assignmentPreservesNarrowing)
@@ -993,13 +993,13 @@ internal sealed partial class StatementBinder
         {
             return Roots.Contains(root)
                 || (root is ImplicitFieldVariableSymbol field
-                    && assignedFields.Contains((field.Receiver, field.Field)))
+                    && assignedFields.Contains(new AssignedField(field.Receiver, field.Field)))
                 || (root is ImplicitStaticFieldVariableSymbol staticField
-                    && assignedFields.Contains((null, staticField.Field)))
+                    && assignedFields.Contains(new AssignedField(null, staticField.Field)))
                 || (root is ImplicitPropertyVariableSymbol property
-                    && assignedProperties.Contains((property.Receiver, property.Property)))
+                    && assignedProperties.Contains(new AssignedProperty(property.Receiver, property.Property)))
                 || (root is ImplicitStaticPropertyVariableSymbol staticProperty
-                    && assignedProperties.Contains((null, staticProperty.Property)));
+                    && assignedProperties.Contains(new AssignedProperty(null, staticProperty.Property)));
         }
 
         public bool InvalidatesNarrowing(VariableSymbol root, TypeSymbol narrowedType)
@@ -1015,8 +1015,13 @@ internal sealed partial class StatementBinder
                 || rootAssignments.Any(assignment => !assignmentPreservesNarrowing(assignment, narrowedType));
         }
 
-        public override void VisitExpression(BoundExpression node)
+        public override void VisitExpression(BoundExpression? node)
         {
+            if (node == null)
+            {
+                return;
+            }
+
             if (node is BoundFunctionLiteralExpression literal && literal.Body != null)
             {
                 VisitStatement(literal.Body);
@@ -1046,7 +1051,7 @@ internal sealed partial class StatementBinder
         {
             if (node.ReceiverExpression == null)
             {
-                assignedFields.Add((node.Receiver, node.Field));
+                assignedFields.Add(new AssignedField(node.Receiver, node.Field));
             }
 
             base.VisitFieldAssignmentExpression(node);
@@ -1057,11 +1062,15 @@ internal sealed partial class StatementBinder
             var receiver = (node.Receiver as BoundVariableExpression)?.Variable;
             if (node.Receiver == null || receiver != null)
             {
-                assignedProperties.Add((receiver, node.Property));
+                assignedProperties.Add(new AssignedProperty(receiver, node.Property));
             }
 
             base.VisitPropertyAssignmentExpression(node);
         }
+
+        private readonly record struct AssignedField(VariableSymbol? Receiver, FieldSymbol Field);
+
+        private readonly record struct AssignedProperty(VariableSymbol? Receiver, PropertySymbol Property);
     }
 
     private sealed class LoopBackEdgeMutationCollector : AssignedRootsCollector
@@ -1073,8 +1082,13 @@ internal sealed partial class StatementBinder
 
         public bool MayMutateMemberPaths { get; private set; }
 
-        public override void VisitExpression(BoundExpression node)
+        public override void VisitExpression(BoundExpression? node)
         {
+            if (node == null)
+            {
+                return;
+            }
+
             if (IsPotentiallyMutatingMemberPathExpression(node.Kind))
             {
                 MayMutateMemberPaths = true;

--- a/src/Core/CodeAnalysis/Binding/StructuralProjectionPlan.cs
+++ b/src/Core/CodeAnalysis/Binding/StructuralProjectionPlan.cs
@@ -257,7 +257,8 @@ internal static class StructuralProjectionPlanner
 
         var initializerSlots = ImmutableArray.CreateBuilder<StructuralProjectionSlot>();
         var targetNames = new HashSet<string>(constructorNames, StringComparer.Ordinal);
-        for (var current = target; current != null; current = current.BaseClass)
+        StructSymbol? current = target;
+        while (current != null)
         {
             foreach (var field in current.Fields)
             {
@@ -308,6 +309,8 @@ internal static class StructuralProjectionPlanner
                         targetProperty: property));
                 }
             }
+
+            current = current.BaseClass;
         }
 
         plan = new StructuralProjectionPlan(

--- a/src/Core/CodeAnalysis/Binding/StructuralProjectionPlan.cs
+++ b/src/Core/CodeAnalysis/Binding/StructuralProjectionPlan.cs
@@ -409,9 +409,19 @@ internal static class StructuralProjectionPlanner
         ConstructorInfo? constructor = null;
         ParameterInfo[] constructorParameters = Array.Empty<ParameterInfo>();
         var constructors = ClrTypeUtilities.SafeGetConstructors(clrType, PublicInstance);
+        ConstructorInfo? parameterlessConstructor = null;
+        foreach (var candidate in constructors)
+        {
+            if (candidate.GetParameters().Length == 0)
+            {
+                parameterlessConstructor = candidate;
+                break;
+            }
+        }
+
         if (!clrType.IsValueType)
         {
-            constructor = constructors.FirstOrDefault(c => c.GetParameters().Length == 0);
+            constructor = parameterlessConstructor;
             if (constructor == null)
             {
                 foreach (var candidate in constructors)
@@ -435,7 +445,7 @@ internal static class StructuralProjectionPlanner
         }
         else
         {
-            constructor = constructors.FirstOrDefault(c => c.GetParameters().Length == 0);
+            constructor = parameterlessConstructor;
             if (constructor == null)
             {
                 foreach (var candidate in constructors)

--- a/src/Core/CodeAnalysis/Binding/StructuralProjectionPlan.cs
+++ b/src/Core/CodeAnalysis/Binding/StructuralProjectionPlan.cs
@@ -163,7 +163,7 @@ internal sealed class StructuralProjectionSourceMember
 
 internal static class StructuralProjectionPlanner
 {
-    private const BindingFlags PublicInstance = BindingFlags.Public | BindingFlags.Instance;
+    private static readonly BindingFlags PublicInstance = BindingFlags.Public | BindingFlags.Instance;
 
     public static bool CanProject(TypeSymbol? source, TypeSymbol? target)
         => TryCreate(source, target, strict: true, explicitMemberNames: null, out _, out _);

--- a/src/Core/CodeAnalysis/Binding/SubmissionImports.cs
+++ b/src/Core/CodeAnalysis/Binding/SubmissionImports.cs
@@ -49,6 +49,14 @@ public sealed class SubmissionImports
     public ImmutableArray<SubmissionReference> NewestFirst { get; }
 
     /// <summary>
+    /// Gets the metadata name of a package's synthesized top-level container.
+    /// </summary>
+    /// <param name="packageName">The declaring package.</param>
+    /// <returns>The package-qualified metadata type name.</returns>
+    public static string GetProgramTypeName(string packageName) =>
+        packageName + "." + ProgramTypeName;
+
+    /// <summary>
     /// Creates a <see cref="SubmissionImports"/> over the given prior
     /// submissions.
     /// </summary>
@@ -233,7 +241,10 @@ public sealed class SubmissionImports
     // newest, which made the older cell's declarations unreachable even
     // though the newest-first declaration walk had correctly found them.
     private static bool TryResolveProgramType(ReferenceResolver references, SubmissionReference submission, out Type? programType)
-        => references.TryResolveTypeInAssembly(submission.AssemblyName, submission.PackageName + "." + ProgramTypeName, out programType);
+        => references.TryResolveTypeInAssembly(
+            submission.AssemblyName,
+            GetProgramTypeName(submission.PackageName),
+            out programType);
 }
 
 /// <summary>

--- a/src/Core/CodeAnalysis/Compilation/Compilation.cs
+++ b/src/Core/CodeAnalysis/Compilation/Compilation.cs
@@ -232,7 +232,7 @@ public class Compilation
                 PrepareReferencesForBinding(assemblyName);
                 var globalScope = ReusedGlobalScope
                     ?? Binder.BindGlobalScope(previous: null, SyntaxTrees, References, ImplicitSystemImport, PreprocessorSymbols, IsLibrary, Submission);
-                Interlocked.CompareExchange(ref this.globalScope, globalScope, null);
+                Interlocked.CompareExchange<BoundGlobalScope?>(ref this.globalScope, globalScope, null);
             }
 
             return globalScope;
@@ -263,7 +263,7 @@ public class Compilation
             if (boundProgram == null)
             {
                 var bp = Binder.BindProgram(GlobalScope, References, BodyCache, DirtyBodyTrees);
-                Interlocked.CompareExchange(ref this.boundProgram, bp, null);
+                Interlocked.CompareExchange<BoundProgram?>(ref this.boundProgram, bp, null);
             }
 
             return boundProgram;
@@ -305,7 +305,7 @@ public class Compilation
     /// <returns>An emit result.</returns>
     public EmitResult Emit()
     {
-        var parseDiagnostics = SyntaxTrees.SelectMany(st => st.Diagnostics);
+        var parseDiagnostics = SyntaxTrees.SelectMany(st => st.Diagnostics.AsEnumerable());
         var syntaxDiagnostics = parseDiagnostics.Concat(GlobalScope.Diagnostics).ToImmutableArray();
 
         var program = BoundProgram;
@@ -434,7 +434,7 @@ public class Compilation
         string? targetFrameworkMoniker = null)
     {
         AssemblyName = assemblyName ?? AssemblyName;
-        var parseDiagnostics = SyntaxTrees.SelectMany(st => st.Diagnostics);
+        var parseDiagnostics = SyntaxTrees.SelectMany(st => st.Diagnostics.AsEnumerable());
         var syntaxDiagnostics = parseDiagnostics.Concat(GlobalScope.Diagnostics).ToImmutableArray();
 
         var program = BoundProgram;

--- a/src/Core/CodeAnalysis/Documentation/XmlDocumentationParser.cs
+++ b/src/Core/CodeAnalysis/Documentation/XmlDocumentationParser.cs
@@ -183,10 +183,26 @@ public static class XmlDocumentationParser
         var items = ImmutableArray.CreateBuilder<DocListItem>();
 
         // <listheader> describes the columns; model it as the first item's term/description.
-        foreach (var item in element.Elements().Where(e => e.Name.LocalName is "item" or "listheader"))
+        foreach (var item in element.Elements())
         {
-            var term = item.Elements().FirstOrDefault(e => e.Name.LocalName == "term");
-            var description = item.Elements().FirstOrDefault(e => e.Name.LocalName == "description");
+            if (item.Name.LocalName is not ("item" or "listheader"))
+            {
+                continue;
+            }
+
+            XElement? term = null;
+            XElement? description = null;
+            foreach (var child in item.Elements())
+            {
+                if (child.Name.LocalName == "term")
+                {
+                    term ??= child;
+                }
+                else if (child.Name.LocalName == "description")
+                {
+                    description ??= child;
+                }
+            }
 
             if (term == null && description == null)
             {

--- a/src/Core/CodeAnalysis/Emit/CustomAttributeEncoder.cs
+++ b/src/Core/CodeAnalysis/Emit/CustomAttributeEncoder.cs
@@ -1061,11 +1061,15 @@ internal sealed class CustomAttributeEncoder
 
         if (paramType.IsSameAs(typeof(bool)))
         {
-            bb.WriteBoolean((bool)Invariant.Required(value, "a bool-typed attribute parameter binds a bool constant"));
+            bb.WriteByte(object.Equals(value, true) ? (byte)1 : (byte)0);
         }
         else if (paramType.IsSameAs(typeof(char)))
         {
-            bb.WriteUInt16((char)Invariant.Required(value, "a char-typed attribute parameter binds a char constant"));
+            var charValue = System.Convert.ToUInt16(
+                value,
+                System.Globalization.CultureInfo.InvariantCulture);
+            bb.WriteByte((byte)charValue);
+            bb.WriteByte((byte)(charValue >> 8));
         }
         else if (paramType.IsSameAs(typeof(sbyte)))
         {

--- a/src/Core/CodeAnalysis/Emit/DataStructSynthesizer.cs
+++ b/src/Core/CodeAnalysis/Emit/DataStructSynthesizer.cs
@@ -758,22 +758,34 @@ internal sealed class DataStructSynthesizer
 
         if (baseClass.ClrType is { } importedBase)
         {
-            var candidates = ClrTypeUtilities.SafeGetMethods(
-                    importedBase,
-                    BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
-                .Where(method =>
-                    method.Name == "<Clone>$"
-                    && !method.IsGenericMethod
-                    && method.GetParameters().Length == 0
-                    && method.IsVirtual
-                    && ClrTypeUtilities.AreSame(method.ReturnType, importedBase))
-                .ToArray();
-            if (candidates.Length != 1)
+            MethodInfo? cloneMethod = null;
+            foreach (var method in ClrTypeUtilities.SafeGetMethods(
+                         importedBase,
+                         BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+            {
+                if (method.Name != "<Clone>$"
+                    || method.IsGenericMethod
+                    || method.GetParameters().Length != 0
+                    || !method.IsVirtual
+                    || !ClrTypeUtilities.AreSame(method.ReturnType, importedBase))
+                {
+                    continue;
+                }
+
+                if (cloneMethod is not null)
+                {
+                    return false;
+                }
+
+                cloneMethod = method;
+            }
+
+            if (cloneMethod is null)
             {
                 return false;
             }
 
-            cloneToken = this.resolveImportedMethodRef(candidates[0], baseClass);
+            cloneToken = this.resolveImportedMethodRef(cloneMethod, baseClass);
             return true;
         }
 

--- a/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
+++ b/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
@@ -656,8 +656,17 @@ internal sealed class ImportedMemberRefFactory
         }
 
         var parameters = ctor.GetParameters();
-        var fallback = open.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
-            .FirstOrDefault(candidate => candidate.GetParameters().Length == parameters.Length);
+        ConstructorInfo? fallback = null;
+        foreach (var candidate in open.GetConstructors(
+                     BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+        {
+            if (candidate.GetParameters().Length == parameters.Length)
+            {
+                fallback = candidate;
+                break;
+            }
+        }
+
         if (fallback != null)
         {
             return fallback;
@@ -1483,8 +1492,17 @@ internal sealed class ImportedMemberRefFactory
             }
         }
 
-        var fallback = openDefinition.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
-            .FirstOrDefault(candidate => candidate.GetParameters().Length == ctor.GetParameters().Length);
+        ConstructorInfo? fallback = null;
+        foreach (var candidate in openDefinition.GetConstructors(
+                     BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+        {
+            if (candidate.GetParameters().Length == ctor.GetParameters().Length)
+            {
+                fallback = candidate;
+                break;
+            }
+        }
+
         return fallback ?? ctor;
     }
 

--- a/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
+++ b/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
@@ -808,7 +808,6 @@ internal sealed class ImportedMemberRefFactory
         var openForMethodGenerics = openMethod.IsGenericMethod
             ? openMethod.GetGenericMethodDefinition()
             : openMethod;
-
         var sigBlob = new BlobBuilder();
         var sigEncoder = new BlobEncoder(sigBlob).MethodSignature(
             isInstanceMethod: !method.IsStatic,
@@ -1050,7 +1049,6 @@ internal sealed class ImportedMemberRefFactory
         var openForMethodGenerics = openMethod.IsGenericMethod
             ? openMethod.GetGenericMethodDefinition()
             : openMethod;
-
         var sigBlob = new BlobBuilder();
         var sigEncoder = new BlobEncoder(sigBlob).MethodSignature(
             isInstanceMethod: !method.IsStatic,
@@ -1169,14 +1167,14 @@ internal sealed class ImportedMemberRefFactory
                 openDefinition = typeof(System.Collections.Generic.IAsyncEnumerable<>);
                 typeArguments = ImmutableArray.Create<TypeSymbol>(aseq.ElementType);
                 return true;
-            case NullableTypeSymbol nul when nul.UnderlyingType is TypeParameterSymbol nullableTp && nullableTp.HasValueTypeConstraint:
+            case NullableTypeSymbol nul when nul.UnderlyingType is TypeParameterSymbol && ((TypeParameterSymbol)nul.UnderlyingType).HasValueTypeConstraint:
                 // Issue #806: a `T?` receiver where T is an open value-type
                 // type parameter has no constructed CLR `Nullable<T>` here —
                 // route member-ref encoding through the symbolic container
                 // path so the MemberRef parent is `Nullable<!!T>` against
                 // System.Runtime, not against the current assembly.
                 openDefinition = typeof(System.Nullable<>);
-                typeArguments = ImmutableArray.Create<TypeSymbol>(nullableTp);
+                typeArguments = ImmutableArray.Create<TypeSymbol>((TypeParameterSymbol)nul.UnderlyingType);
                 return true;
             case MapTypeSymbol map when map.ClrType == null:
                 // Issue #3311: a `map[K, V]` receiver over type-parameter (or

--- a/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
+++ b/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
@@ -97,6 +97,7 @@ internal sealed class ImportedMemberRefFactory
         // the `element.ClrType != null` branch via the NullableTypeSymbol
         // ctor that copies `underlying.ClrType`).
         if (element is NullableTypeSymbol nullableElement
+            && !NullableLifting.RequiresSymbolicNullableGetValue(nullableElement)
             && nullableElement.UnderlyingType?.ClrType is { IsValueType: true } nullableInnerClr)
         {
             // Issue #571: route Nullable<T> through the ReferenceResolver so the

--- a/src/Core/CodeAnalysis/Emit/LambdaEnclosingTypeParameterCollector.cs
+++ b/src/Core/CodeAnalysis/Emit/LambdaEnclosingTypeParameterCollector.cs
@@ -47,7 +47,7 @@ internal sealed class LambdaEnclosingTypeParameterCollector : BoundTreeWalker
         new LambdaEnclosingTypeParameterCollector(sink).VisitStatement(body);
     }
 
-    public override void VisitExpression(BoundExpression node)
+    public override void VisitExpression(BoundExpression? node)
     {
         if (node == null)
         {

--- a/src/Core/CodeAnalysis/Emit/LambdaEnclosingTypeParameterCollector.cs
+++ b/src/Core/CodeAnalysis/Emit/LambdaEnclosingTypeParameterCollector.cs
@@ -96,7 +96,7 @@ internal sealed class LambdaEnclosingTypeParameterCollector : BoundTreeWalker
         base.VisitExpression(node);
     }
 
-    public override void VisitPattern(BoundPattern node)
+    public override void VisitPattern(BoundPattern? node)
     {
         if (node == null)
         {

--- a/src/Core/CodeAnalysis/Emit/MaxStackTracker.cs
+++ b/src/Core/CodeAnalysis/Emit/MaxStackTracker.cs
@@ -153,7 +153,7 @@ internal static class MaxStackTracker
             short key = op.Value;
             if (op.Size == 2)
             {
-                key = unchecked((short)(0xFE00 | (op.Value & 0xFF)));
+                key = unchecked((short)(0xFE00 | ((int)op.Value & 0xFF)));
             }
 
             table[key] = new OpCodeInfo(

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Calls.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Calls.cs
@@ -285,7 +285,9 @@ internal sealed partial class MethodBodyEmitter
             return null;
         }
 
-        return receiver.FindConstructedGenericBase(def => ReferenceEquals(def, declaringDef));
+        bool IsDeclaringDefinition(StructSymbol definition) =>
+            ReferenceEquals(definition, declaringDef);
+        return receiver.FindConstructedGenericBase(IsDeclaringDefinition);
     }
 
     // ADR-0087 R5 / issue #765: bridges from a substituted FunctionSymbol on
@@ -770,7 +772,9 @@ internal sealed partial class MethodBodyEmitter
             && call.Receiver.Type is StructSymbol baseReceiver)
         {
             var baseDef = baseClass.Definition ?? baseClass;
-            var constructedBase = baseReceiver.FindConstructedGenericBase(d => ReferenceEquals(d, baseDef));
+            bool IsBaseDefinition(StructSymbol definition) =>
+                ReferenceEquals(definition, baseDef);
+            var constructedBase = baseReceiver.FindConstructedGenericBase(IsBaseDefinition);
             if (constructedBase != null)
             {
                 baseClass = constructedBase;

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
@@ -48,6 +48,14 @@ internal sealed partial class MethodBodyEmitter
             return;
         }
 
+        if (TypeSymbol.AreRuntimeEquivalentIgnoringReferenceNullability(
+            conv.Expression.Type,
+            conv.Type))
+        {
+            this.EmitExpression(conv.Expression);
+            return;
+        }
+
         // Issue #2840 / #2841: a nullable wrapper over a REFERENCE type is a
         // binder-level annotation only — it erases to the underlying type's CLR
         // representation — so the delegate-materialisation arms below classify

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
@@ -1649,7 +1649,8 @@ internal sealed partial class MethodBodyEmitter
             // TypeDef/TypeSpec tokens — mirroring the issue #1298 enum lift in
             // MethodBodyEmitter.Conversions. The same token path also serves a
             // value-constrained open type parameter (issue #814).
-            if (underlying?.ClrType is not { IsValueType: true })
+            if (NullableLifting.RequiresSymbolicNullableGetValue(nullableType)
+                || underlying?.ClrType is not { IsValueType: true })
             {
                 var nullableToken = this.outer.memberRefs.GetElementTypeToken(nullableType);
 

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
@@ -429,7 +429,9 @@ internal sealed partial class MethodBodyEmitter
             // `Nullable<T>::get_Value()` (when the result type is the
             // underlying `T`); both shapes leave a verifiable stack
             // matching the operator's declared result type.
-            if (b.Left.Type is NullableTypeSymbol leftNullable
+            var leftNullable = b.Left.Type as NullableTypeSymbol;
+            if (leftNullable != null
+                && !NullableLifting.RequiresSymbolicNullableGetValue(leftNullable)
                 && leftNullable.UnderlyingType?.ClrType is { IsValueType: true } innerClr)
             {
                 if (!this.nullableCoalesceSpillSlots.TryGetValue(b, out var slot))

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Patterns.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Patterns.cs
@@ -208,7 +208,7 @@ internal sealed partial class MethodBodyEmitter
             return;
         }
 
-        if (valueType == TypeSymbol.String)
+        if (IsStringOrNullableStringEmit(valueType))
         {
             loadValue();
             this.EmitExpression(cp.Value);

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
@@ -1381,8 +1381,13 @@ internal sealed partial class MethodBodyEmitter
             this.sink = sink;
         }
 
-        public override void VisitStatement(BoundStatement node)
+        public override void VisitStatement(BoundStatement? node)
         {
+            if (node == null)
+            {
+                return;
+            }
+
             if (this.entered)
             {
                 return;
@@ -1392,8 +1397,13 @@ internal sealed partial class MethodBodyEmitter
             base.VisitStatement(node);
         }
 
-        public override void VisitExpression(BoundExpression node)
+        public override void VisitExpression(BoundExpression? node)
         {
+            if (node == null)
+            {
+                return;
+            }
+
             // Post-order: a stackalloc nested inside another spilled
             // stackalloc's count/initializer must be materialised first so the
             // outer materialisation reads it back with an empty stack.
@@ -1421,8 +1431,13 @@ internal sealed partial class MethodBodyEmitter
             this.sink = sink;
         }
 
-        public override void VisitStatement(BoundStatement node)
+        public override void VisitStatement(BoundStatement? node)
         {
+            if (node == null)
+            {
+                return;
+            }
+
             if (this.entered)
             {
                 return;
@@ -1432,8 +1447,13 @@ internal sealed partial class MethodBodyEmitter
             base.VisitStatement(node);
         }
 
-        public override void VisitExpression(BoundExpression node)
+        public override void VisitExpression(BoundExpression? node)
         {
+            if (node == null)
+            {
+                return;
+            }
+
             base.VisitExpression(node);
             if (node is BoundChannelReceiveExpression recv)
             {

--- a/src/Core/CodeAnalysis/Emit/MethodBodyPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyPlanner.cs
@@ -1082,11 +1082,19 @@ internal sealed class MethodBodyPlanner
                         }
 
                         break;
-                    case BoundScopeStatement sc when sc.Body is BoundBlockStatement scBlock:
-                        this.CollectStatements(scBlock.Statements, function, locals, localTypes, labels, appendSlots, il, pass);
+                    case BoundScopeStatement sc:
+                        if (sc.Body is BoundBlockStatement scBlock)
+                        {
+                            this.CollectStatements(scBlock.Statements, function, locals, localTypes, labels, appendSlots, il, pass);
+                        }
+
                         break;
-                    case BoundFixedStatement fx when fx.Body is BoundBlockStatement fxBlock:
-                        this.CollectStatements(fxBlock.Statements, function, locals, localTypes, labels, appendSlots, il, pass);
+                    case BoundFixedStatement fx:
+                        if (fx.Body is BoundBlockStatement fxBlock)
+                        {
+                            this.CollectStatements(fxBlock.Statements, function, locals, localTypes, labels, appendSlots, il, pass);
+                        }
+
                         break;
                     case BoundSelectStatement sel:
                         foreach (var arm in sel.Cases)
@@ -1169,11 +1177,19 @@ internal sealed class MethodBodyPlanner
                         }
 
                         break;
-                    case BoundScopeStatement sc when sc.Body is BoundBlockStatement scBlock:
-                        this.CollectStatements(scBlock.Statements, function, locals, localTypes, labels, appendSlots, il, pass);
+                    case BoundScopeStatement sc:
+                        if (sc.Body is BoundBlockStatement scBlock)
+                        {
+                            this.CollectStatements(scBlock.Statements, function, locals, localTypes, labels, appendSlots, il, pass);
+                        }
+
                         break;
-                    case BoundFixedStatement fx when fx.Body is BoundBlockStatement fxBlock:
-                        this.CollectStatements(fxBlock.Statements, function, locals, localTypes, labels, appendSlots, il, pass);
+                    case BoundFixedStatement fx:
+                        if (fx.Body is BoundBlockStatement fxBlock)
+                        {
+                            this.CollectStatements(fxBlock.Statements, function, locals, localTypes, labels, appendSlots, il, pass);
+                        }
+
                         break;
                     case BoundSelectStatement sel:
                         foreach (var arm in sel.Cases)

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -1906,14 +1906,16 @@ internal sealed class ReflectionMetadataEmitter
                 // is what lets EmitExplicitInterfaceEventMethodImpls resolve
                 // the interface-side MethodImpl target token for an explicit
                 // event implementation (`event (IFoo) Changed T`).
-                if (ev.AddMethodSymbol != null)
+                var addMethodSymbol = ev.AddMethodSymbol;
+                if (addMethodSymbol != null)
                 {
-                    this.cache.MethodHandles[ev.AddMethodSymbol] = addHandle;
+                    this.cache.MethodHandles[addMethodSymbol] = addHandle;
                 }
 
-                if (ev.RemoveMethodSymbol != null)
+                var removeMethodSymbol = ev.RemoveMethodSymbol;
+                if (removeMethodSymbol != null)
                 {
-                    this.cache.MethodHandles[ev.RemoveMethodSymbol] = removeHandle;
+                    this.cache.MethodHandles[removeMethodSymbol] = removeHandle;
                 }
 
                 if (ev.RaiseMethodSymbol != null && raiseHandle.HasValue)
@@ -4032,12 +4034,12 @@ internal sealed class ReflectionMetadataEmitter
         this.assemblyAttrs.EmitUserModuleAttributes(moduleHandle);
 
         var assemblyHandle = this.emitCtx.Metadata.AddAssembly(
-            name: this.emitCtx.Metadata.GetOrAddString(assemblyName),
-            version: this.assemblyAttrs.ParseAssemblyVersion(),
-            culture: default(StringHandle),
-            publicKey: default(BlobHandle),
-            flags: 0,
-            hashAlgorithm: AssemblyHashAlgorithm.Sha1);
+            this.emitCtx.Metadata.GetOrAddString(assemblyName),
+            this.assemblyAttrs.ParseAssemblyVersion(),
+            default(StringHandle),
+            default(BlobHandle),
+            (AssemblyFlags)0,
+            AssemblyHashAlgorithm.Sha1);
 
         if (this.emitCtx.MetadataOnly)
         {

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -5162,11 +5162,13 @@ internal sealed class ReflectionMetadataEmitter
         // symbolic form, instance-method calls on the receiver would emit
         // `callvirt` + value-on-stack instead of `call` + managed pointer,
         // producing PEVerify-rejected IL.
-        if (type is NullableTypeSymbol nullableTp
-            && nullableTp.UnderlyingType is TypeParameterSymbol tp
-            && tp.HasValueTypeConstraint)
+        if (type is NullableTypeSymbol nullableTp)
         {
-            return true;
+            var tp = nullableTp.UnderlyingType as TypeParameterSymbol;
+            if (tp?.HasValueTypeConstraint == true)
+            {
+                return true;
+            }
         }
 
         // Issue #1298: `E?` over a user-declared enum lowers to the CLR struct

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -5185,6 +5185,12 @@ internal sealed class ReflectionMetadataEmitter
             return true;
         }
 
+        if (type is NullableTypeSymbol symbolicNullable
+            && NullableLifting.RequiresSymbolicNullableGetValue(symbolicNullable))
+        {
+            return true;
+        }
+
         // Issue #2335: a bare (non-nullable) value-type-constrained generic
         // type parameter (`where T : struct`, optionally combined with an
         // `Enum`/other constraint) lowers to an unboxed CLR value on the

--- a/src/Core/CodeAnalysis/Emit/SignatureEncoder.cs
+++ b/src/Core/CodeAnalysis/Emit/SignatureEncoder.cs
@@ -151,6 +151,19 @@ internal sealed class SignatureEncoder
         {
             var inner = nullable.UnderlyingType;
 
+            if (inner is ImportedTypeSymbol symbolicValueType
+                && symbolicValueType.OpenDefinition?.IsValueType == true
+                && !symbolicValueType.TypeArguments.IsDefaultOrEmpty)
+            {
+                var nullableOpen = typeof(System.Nullable<>);
+                var genericNullable = encoder.GenericInstantiation(
+                    this.outer.memberRefs.GetTypeReference(nullableOpen),
+                    genericArgumentCount: 1,
+                    isValueType: true);
+                this.EncodeTypeSymbol(genericNullable.AddArgument(), symbolicValueType);
+                return;
+            }
+
             // P2-7 / Issue #421: nullable over a value type encodes as
             // System.Nullable<T> (generic instantiation). We support inner
             // types backed by a CLR value type (primitives, BCL value types).

--- a/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
@@ -325,8 +325,13 @@ internal sealed class SlotPlanner
             this.currentScope = currentScope;
         }
 
-        public override void VisitExpression(BoundExpression node)
+        public override void VisitExpression(BoundExpression? node)
         {
+            if (node == null)
+            {
+                return;
+            }
+
             if (node is BoundIsExpression isExpression
                 && !isExpression.IsSimpleTypeTest)
             {
@@ -856,8 +861,13 @@ internal sealed class SlotPlanner
             this.sink = sink;
         }
 
-        public override void VisitStatement(BoundStatement node)
+        public override void VisitStatement(BoundStatement? node)
         {
+            if (node == null)
+            {
+                return;
+            }
+
             if (node is BoundLabelStatement label)
             {
                 this.sink.Add(label.Label);
@@ -877,8 +887,13 @@ internal sealed class SlotPlanner
             this.sink = sink;
         }
 
-        public override void VisitExpression(BoundExpression node)
+        public override void VisitExpression(BoundExpression? node)
         {
+            if (node == null)
+            {
+                return;
+            }
+
             if (node is BoundFunctionLiteralExpression lambda)
             {
                 this.sink.Add(lambda);
@@ -899,8 +914,13 @@ internal sealed class SlotPlanner
             this.sink = sink;
         }
 
-        public override void VisitExpression(BoundExpression node)
+        public override void VisitExpression(BoundExpression? node)
         {
+            if (node == null)
+            {
+                return;
+            }
+
             // Override the base dispatch so we descend into the body of any
             // BoundFunctionLiteralExpression we encounter — go statements
             // need to discover nested go statements inside lambda bodies too.
@@ -941,8 +961,13 @@ internal sealed class SlotPlanner
             this.VisitExpression(expression);
         }
 
-        public override void VisitExpression(BoundExpression node)
+        public override void VisitExpression(BoundExpression? node)
         {
+            if (node == null)
+            {
+                return;
+            }
+
             if (node is BoundVariableExpression ve)
             {
                 this.CaptureIfFree(ve.Variable);
@@ -1015,8 +1040,13 @@ internal sealed class SlotPlanner
             this.sink = sink;
         }
 
-        public override void VisitExpression(BoundExpression node)
+        public override void VisitExpression(BoundExpression? node)
         {
+            if (node == null)
+            {
+                return;
+            }
+
             if (node is BoundDefaultExpression de)
             {
                 this.sink.Add(de);
@@ -1036,8 +1066,13 @@ internal sealed class SlotPlanner
             this.sink = sink;
         }
 
-        public override void VisitExpression(BoundExpression node)
+        public override void VisitExpression(BoundExpression? node)
         {
+            if (node == null)
+            {
+                return;
+            }
+
             if (node is BoundStackAllocExpression sa)
             {
                 this.sink.Add(sa);
@@ -1059,8 +1094,13 @@ internal sealed class SlotPlanner
             this.sink = sink;
         }
 
-        public override void VisitStatement(BoundStatement node)
+        public override void VisitStatement(BoundStatement? node)
         {
+            if (node == null)
+            {
+                return;
+            }
+
             switch (node)
             {
                 case BoundExpressionStatement es:

--- a/src/Core/CodeAnalysis/Emit/StateMachineEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/StateMachineEmitter.cs
@@ -730,10 +730,25 @@ internal sealed class StateMachineEmitter
                     thisProxyField,
                     getEnumeratorObjectThisProxy)))));
 
-            this.IteratorKickoffBodies[plan.Function] = Lowerer.Lower(new BoundBlockStatement(null,
-                ImmutableArray.Create<BoundStatement>(
-                new BoundReturnStatement(null, this.CreateIteratorStateMachineLiteral(kickoffSmType, stateField, parameterFields, plan.Function.Parameters, p => new BoundVariableExpression(null, p),
-                    thisProxyField, plan.Function.ThisParameter != null ? new BoundVariableExpression(null, plan.Function.ThisParameter) : null)))));
+            Func<ParameterSymbol, BoundExpression> parameterValueFactory =
+                parameter => new BoundVariableExpression(null, parameter);
+            BoundExpression? thisProxyValue = plan.Function.ThisParameter != null
+                ? new BoundVariableExpression(null, plan.Function.ThisParameter)
+                : null;
+            this.IteratorKickoffBodies[plan.Function] = Lowerer.Lower(
+                new BoundBlockStatement(
+                    null,
+                    ImmutableArray.Create<BoundStatement>(
+                        new BoundReturnStatement(
+                            null,
+                            this.CreateIteratorStateMachineLiteral(
+                                kickoffSmType,
+                                stateField,
+                                parameterFields,
+                                plan.Function.Parameters,
+                                parameterValueFactory,
+                                thisProxyField,
+                                thisProxyValue)))));
             this.IteratorStateMachineInfos[smClass] = new IteratorStateMachineInfo(plan, smClass, scopeTPs, classTPs);
 
             // Issue #2907: closure materialization inside the SYNC MoveNext body is

--- a/src/Core/CodeAnalysis/Emit/UserTokenResolver.cs
+++ b/src/Core/CodeAnalysis/Emit/UserTokenResolver.cs
@@ -1418,11 +1418,7 @@ internal sealed class UserTokenResolver
     /// </summary>
     /// <param name="encoder">The return-type encoder.</param>
     /// <param name="fn">The function whose emitted return type to encode.</param>
-    /// <param name="returnTypeOverride">The constructed receiver's substituted return type, when applicable.</param>
-    private void EncodeFunctionReturnSymbol(
-        ReturnTypeEncoder encoder,
-        FunctionSymbol fn,
-        TypeSymbol? returnTypeOverride = null)
+    private void EncodeFunctionReturnSymbol(ReturnTypeEncoder encoder, FunctionSymbol fn)
     {
         if (fn.IsAsync && fn.StateMachineType != null)
         {
@@ -1445,10 +1441,7 @@ internal sealed class UserTokenResolver
             }
         }
 
-        this.signatures.EncodeReturnSymbol(
-            encoder,
-            returnTypeOverride ?? fn.Type,
-            fn.ReturnRefKind);
+        this.signatures.EncodeReturnSymbol(encoder, fn.Type, fn.ReturnRefKind);
     }
 
     /// <summary>
@@ -1488,38 +1481,12 @@ internal sealed class UserTokenResolver
         StructSymbol containingType,
         FunctionSymbol openMethod)
     {
-        var sigBlob = new BlobBuilder();
-        var paramCount = openMethod.Parameters.Length - (openMethod.ExplicitReceiverParameter == null ? 0 : 1);
-        var definition = containingType.Definition ?? containingType;
-        using (this.remaps.PushSmRemap(definition))
+        // Nested generic definitions re-ordinalize enclosing and own type
+        // parameters into one CLR VAR vector. Match the MethodDef encoding.
+        using (this.remaps.PushSmRemap(containingType.Definition ?? containingType))
         {
-            new BlobEncoder(sigBlob)
-                .MethodSignature(
-                    isInstanceMethod: openMethod.IsInstanceMethod,
-                    genericParameterCount: openMethod.TypeParameters.IsDefaultOrEmpty ? 0 : openMethod.TypeParameters.Length)
-                .Parameters(
-                    paramCount,
-                    r => this.EncodeFunctionReturnSymbol(
-                        r,
-                        openMethod,
-                        containingType.SubstituteMemberType(openMethod.Type)),
-                    ps =>
-                    {
-                        foreach (var p in openMethod.Parameters)
-                        {
-                            if (ReferenceEquals(p, openMethod.ThisParameter))
-                            {
-                                continue;
-                            }
-
-                            this.signatures.EncodeTypeSymbol(
-                                ps.AddParameter().Type(isByRef: p.RefKind != RefKind.None),
-                                containingType.SubstituteMemberType(p.Type));
-                        }
-                    });
+            return this.EncodeOpenMethodSignature(openMethod);
         }
-
-        return sigBlob;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Emit/UserTokenResolver.cs
+++ b/src/Core/CodeAnalysis/Emit/UserTokenResolver.cs
@@ -1418,7 +1418,11 @@ internal sealed class UserTokenResolver
     /// </summary>
     /// <param name="encoder">The return-type encoder.</param>
     /// <param name="fn">The function whose emitted return type to encode.</param>
-    private void EncodeFunctionReturnSymbol(ReturnTypeEncoder encoder, FunctionSymbol fn)
+    /// <param name="returnTypeOverride">The constructed receiver's substituted return type, when applicable.</param>
+    private void EncodeFunctionReturnSymbol(
+        ReturnTypeEncoder encoder,
+        FunctionSymbol fn,
+        TypeSymbol? returnTypeOverride = null)
     {
         if (fn.IsAsync && fn.StateMachineType != null)
         {
@@ -1441,7 +1445,10 @@ internal sealed class UserTokenResolver
             }
         }
 
-        this.signatures.EncodeReturnSymbol(encoder, fn.Type, fn.ReturnRefKind);
+        this.signatures.EncodeReturnSymbol(
+            encoder,
+            returnTypeOverride ?? fn.Type,
+            fn.ReturnRefKind);
     }
 
     /// <summary>
@@ -1481,12 +1488,38 @@ internal sealed class UserTokenResolver
         StructSymbol containingType,
         FunctionSymbol openMethod)
     {
-        // Nested generic definitions re-ordinalize enclosing and own type
-        // parameters into one CLR VAR vector. Match the MethodDef encoding.
-        using (this.remaps.PushSmRemap(containingType.Definition ?? containingType))
+        var sigBlob = new BlobBuilder();
+        var paramCount = openMethod.Parameters.Length - (openMethod.ExplicitReceiverParameter == null ? 0 : 1);
+        var definition = containingType.Definition ?? containingType;
+        using (this.remaps.PushSmRemap(definition))
         {
-            return this.EncodeOpenMethodSignature(openMethod);
+            new BlobEncoder(sigBlob)
+                .MethodSignature(
+                    isInstanceMethod: openMethod.IsInstanceMethod,
+                    genericParameterCount: openMethod.TypeParameters.IsDefaultOrEmpty ? 0 : openMethod.TypeParameters.Length)
+                .Parameters(
+                    paramCount,
+                    r => this.EncodeFunctionReturnSymbol(
+                        r,
+                        openMethod,
+                        containingType.SubstituteMemberType(openMethod.Type)),
+                    ps =>
+                    {
+                        foreach (var p in openMethod.Parameters)
+                        {
+                            if (ReferenceEquals(p, openMethod.ThisParameter))
+                            {
+                                continue;
+                            }
+
+                            this.signatures.EncodeTypeSymbol(
+                                ps.AddParameter().Type(isByRef: p.RefKind != RefKind.None),
+                                containingType.SubstituteMemberType(p.Type));
+                        }
+                    });
         }
+
+        return sigBlob;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Emit/UserTokenResolver.cs
+++ b/src/Core/CodeAnalysis/Emit/UserTokenResolver.cs
@@ -94,7 +94,7 @@ internal sealed class UserTokenResolver
     private readonly Dictionary<(StructSymbol Containing, FieldSymbol DefField, RemapScope Scope), EntityHandle> userStructFieldRefCache = new();
     private readonly Dictionary<(StructSymbol Containing, EntityHandle OpenMember, RemapScope Scope), EntityHandle> userStructMethodRefCache = new();
     private readonly Dictionary<(InterfaceSymbol Sym, RemapScope Scope), EntityHandle> userInterfaceTypeSpecCache = new();
-    private readonly Dictionary<(InterfaceSymbol Containing, EntityHandle OpenMember, RemapScope Scope), EntityHandle> userInterfaceMethodRefCache = new();
+    private readonly Dictionary<UserInterfaceMethodRefKey, EntityHandle> userInterfaceMethodRefCache = new();
     private readonly Dictionary<(InterfaceSymbol Containing, FieldSymbol DefField, RemapScope Scope), EntityHandle> userInterfaceFieldRefCache = new();
     private readonly Dictionary<(DelegateTypeSymbol Sym, RemapScope Scope), EntityHandle> userDelegateTypeSpecCache = new();
     private readonly Dictionary<(DelegateTypeSymbol Sym, RemapScope Scope), EntityHandle> userDelegateCtorRefCache = new();
@@ -1686,8 +1686,12 @@ internal sealed class UserTokenResolver
         string methodName,
         BlobBuilder signature)
     {
-        var key = (containingInterface, openMethodDef, this.remaps.CurrentScope);
-        if (this.userInterfaceMethodRefCache.TryGetValue(key, out var cached))
+        var key = new UserInterfaceMethodRefKey(
+            containingInterface,
+            openMethodDef,
+            this.remaps.CurrentScope);
+        EntityHandle cached;
+        if (this.userInterfaceMethodRefCache.TryGetValue(key, out cached))
         {
             return cached;
         }
@@ -1906,8 +1910,12 @@ internal sealed class UserTokenResolver
             return openDef;
         }
 
-        var key = (containingInterface, openDef, this.remaps.CurrentScope);
-        if (this.userInterfaceMethodRefCache.TryGetValue(key, out var cached))
+        var key = new UserInterfaceMethodRefKey(
+            containingInterface,
+            openDef,
+            this.remaps.CurrentScope);
+        EntityHandle cached;
+        if (this.userInterfaceMethodRefCache.TryGetValue(key, out cached))
         {
             return cached;
         }
@@ -2406,4 +2414,9 @@ internal sealed class UserTokenResolver
         return TypeSymbol.ContainsTypeParameter(fnType.ReturnType)
             || ReflectionMetadataEmitter.ArgIsSymbolicUserDefined(fnType.ReturnType);
     }
+
+    private readonly record struct UserInterfaceMethodRefKey(
+        InterfaceSymbol Containing,
+        EntityHandle OpenMember,
+        RemapScope Scope);
 }

--- a/src/Core/CodeAnalysis/Execution/EmittedProgramHost.cs
+++ b/src/Core/CodeAnalysis/Execution/EmittedProgramHost.cs
@@ -121,7 +121,9 @@ public static class EmittedProgramHost
     {
         var loadContext = new AssemblyLoadContext($"gsharp-emitted-{Guid.NewGuid():N}", isCollectible: true);
         var weakReference = new WeakReference(loadContext);
-        loadContext.Resolving += (context, assemblyName) => ResolveDependency(context, assemblyName, referencePaths);
+        Func<AssemblyLoadContext, AssemblyName, Assembly?> resolver =
+            (context, assemblyName) => ResolveDependency(context, assemblyName, referencePaths);
+        AddResolvingHandler(loadContext, resolver);
 
         try
         {
@@ -187,6 +189,14 @@ public static class EmittedProgramHost
         }
     }
 
+    private static void AddResolvingHandler(
+        AssemblyLoadContext loadContext,
+        Func<AssemblyLoadContext, AssemblyName, Assembly?> resolver)
+    {
+        var resolvingEvent = typeof(AssemblyLoadContext).GetEvent("Resolving");
+        resolvingEvent?.AddEventHandler(loadContext, resolver);
+    }
+
     private static Assembly? ResolveDependency(
         AssemblyLoadContext context,
         AssemblyName assemblyName,
@@ -196,10 +206,18 @@ public static class EmittedProgramHost
         // the program binds against exactly what it was compiled against.
         if (referencePaths is not null && assemblyName.Name is not null)
         {
-            var match = referencePaths.FirstOrDefault(path =>
-                !string.IsNullOrWhiteSpace(path)
-                && string.Equals(Path.GetFileNameWithoutExtension(path), assemblyName.Name, StringComparison.OrdinalIgnoreCase)
-                && File.Exists(path));
+            string? match = null;
+            foreach (var path in referencePaths)
+            {
+                if (!string.IsNullOrWhiteSpace(path)
+                    && string.Equals(Path.GetFileNameWithoutExtension(path), assemblyName.Name, StringComparison.OrdinalIgnoreCase)
+                    && File.Exists(path))
+                {
+                    match = path;
+                    break;
+                }
+            }
+
             if (match is not null)
             {
                 return context.LoadFromAssemblyPath(Path.GetFullPath(match));

--- a/src/Core/CodeAnalysis/Execution/InteractiveSessionHost.cs
+++ b/src/Core/CodeAnalysis/Execution/InteractiveSessionHost.cs
@@ -171,7 +171,17 @@ public sealed class InteractiveSessionHost : IDisposable
     {
         loadedByName = new Dictionary<string, Assembly>(StringComparer.OrdinalIgnoreCase);
         loadContext = new AssemblyLoadContext($"gsi-session-{Guid.NewGuid():N}", isCollectible: true);
-        loadContext.Resolving += ResolveDependency;
+        Func<AssemblyLoadContext, AssemblyName, Assembly?> resolver =
+            (context, assemblyName) => ResolveDependency(context, assemblyName);
+        AddResolvingHandler(loadContext, resolver);
+    }
+
+    private static void AddResolvingHandler(
+        AssemblyLoadContext context,
+        Func<AssemblyLoadContext, AssemblyName, Assembly?> resolver)
+    {
+        var resolvingEvent = typeof(AssemblyLoadContext).GetEvent("Resolving");
+        resolvingEvent?.AddEventHandler(context, resolver);
     }
 
     private Assembly? ResolveDependency(AssemblyLoadContext context, AssemblyName assemblyName)
@@ -192,10 +202,18 @@ public sealed class InteractiveSessionHost : IDisposable
 
         // User-supplied references win over any same-named host assembly so
         // the submission binds against exactly what it was compiled against.
-        var match = referencePaths.FirstOrDefault(path =>
-            !string.IsNullOrWhiteSpace(path)
-            && string.Equals(Path.GetFileNameWithoutExtension(path), assemblyName.Name, StringComparison.OrdinalIgnoreCase)
-            && File.Exists(path));
+        string? match = null;
+        foreach (var path in referencePaths)
+        {
+            if (!string.IsNullOrWhiteSpace(path)
+                && string.Equals(Path.GetFileNameWithoutExtension(path), assemblyName.Name, StringComparison.OrdinalIgnoreCase)
+                && File.Exists(path))
+            {
+                match = path;
+                break;
+            }
+        }
+
         if (match is not null)
         {
             return context.LoadFromAssemblyPath(Path.GetFullPath(match));

--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncBoundTreeQueries.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncBoundTreeQueries.cs
@@ -137,7 +137,7 @@ public static class AsyncBoundTreeQueries
 
         public bool Found { get; private set; }
 
-        public override void VisitStatement(BoundStatement node)
+        public override void VisitStatement(BoundStatement? node)
         {
             if (node == null)
             {
@@ -157,7 +157,7 @@ public static class AsyncBoundTreeQueries
             Found = Found || outerFound;
         }
 
-        public override void VisitExpression(BoundExpression node)
+        public override void VisitExpression(BoundExpression? node)
         {
             if (node == null)
             {

--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncExceptionHandlerRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncExceptionHandlerRewriter.cs
@@ -728,8 +728,13 @@ public static class AsyncExceptionHandlerRewriter
                 return collector.labels;
             }
 
-            public override void VisitStatement(BoundStatement node)
+            public override void VisitStatement(BoundStatement? node)
             {
+                if (node == null)
+                {
+                    return;
+                }
+
                 if (node is BoundLabelStatement labelStatement)
                 {
                     labels.Add(labelStatement.Label);

--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncMethodBuilderInfo.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncMethodBuilderInfo.cs
@@ -273,8 +273,16 @@ public sealed class AsyncMethodBuilderInfo
 
         // 3. Custom task-like via [AsyncMethodBuilder] on the return type.
         // ADR-0047 §6: recognised by type identity, not string name.
-        var attributeType = kickoffReturnClrType.GetCustomAttributesData()
-            .FirstOrDefault(a => a.AttributeType.IsSameAs(typeof(System.Runtime.CompilerServices.AsyncMethodBuilderAttribute)));
+        CustomAttributeData? attributeType = null;
+        foreach (var attribute in kickoffReturnClrType.GetCustomAttributesData())
+        {
+            if (attribute.AttributeType.IsSameAs(typeof(System.Runtime.CompilerServices.AsyncMethodBuilderAttribute)))
+            {
+                attributeType = attribute;
+                break;
+            }
+        }
+
         if (attributeType != null && attributeType.ConstructorArguments.Count == 1)
         {
             var customBuilder = attributeType.ConstructorArguments[0].Value as Type;

--- a/src/Core/CodeAnalysis/Lowering/Async/RefInitializationHoister.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/RefInitializationHoister.cs
@@ -77,15 +77,17 @@ public static class RefInitializationHoister
                 found |= CollectRefLocals(stmt, refLocals);
             }
         }
-        else if (statement is BoundVariableDeclaration decl
-            && decl.Variable is LocalVariableSymbol local
-            && local.Type is ByRefTypeSymbol
-            && decl.Initializer is BoundAddressOfExpression addressOf)
+        else if (statement is BoundVariableDeclaration decl)
         {
-            // Seed with the raw operand; the rewriter replaces this with the
-            // hoisted template when it visits the declaration.
-            refLocals[local] = addressOf.Operand;
-            found = true;
+            var local = decl.Variable as LocalVariableSymbol;
+            var addressOf = decl.Initializer as BoundAddressOfExpression;
+            if (local?.Type is ByRefTypeSymbol && addressOf != null)
+            {
+                // Seed with the raw operand; the rewriter replaces this with the
+                // hoisted template when it visits the declaration.
+                refLocals[local] = addressOf.Operand;
+                found = true;
+            }
         }
         else if (statement is BoundIfStatement ifStmt)
         {
@@ -142,9 +144,9 @@ public static class RefInitializationHoister
             // required field/element address probe. The rewritten template —
             // referencing only captured temps and repeatable storage — is
             // recorded for use-site reconstruction.
-            if (node.Variable is LocalVariableSymbol local
-                && local.Type is ByRefTypeSymbol
-                && node.Initializer is BoundAddressOfExpression addressOf)
+            var local = node.Variable as LocalVariableSymbol;
+            var addressOf = node.Initializer as BoundAddressOfExpression;
+            if (local?.Type is ByRefTypeSymbol && addressOf != null)
             {
                 var prelude = ImmutableArray.CreateBuilder<BoundStatement>();
                 var template = HoistOperand(addressOf.Operand, prelude);

--- a/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
@@ -1061,11 +1061,14 @@ public static class SpillSequenceSpiller
                 case BoundCapExpression cap:
                     return SpillOneOperand(cap, cap.Operand, operand => new BoundCapExpression(null, operand));
                 case BoundAppendExpression append:
+                    Func<BoundExpression, BoundExpression, BoundExpression> rebuildAppend =
+                        (slice, element) =>
+                            new BoundAppendExpression(null, slice, element, append.SliceType);
                     return SpillTwoOperand(
                         append,
                         append.Slice,
                         append.Element,
-                        (slice, element) => new BoundAppendExpression(null, slice, element, append.SliceType));
+                        rebuildAppend);
                 case BoundStructLiteralExpression structLiteral:
                     return SpillStructLiteral(structLiteral);
                 case BoundMakeChannelExpression makeChannel:

--- a/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
@@ -170,8 +170,13 @@ public static class SpillSequenceSpiller
 
         public bool Found { get; private set; }
 
-        public override void VisitStatement(BoundStatement node)
+        public override void VisitStatement(BoundStatement? node)
         {
+            if (node == null)
+            {
+                return;
+            }
+
             if (blockExpressionDepth > 0
                 && node.Kind is BoundNodeKind.GotoStatement
                     or BoundNodeKind.ConditionalGotoStatement

--- a/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
@@ -365,8 +365,9 @@ public static class SpillSequenceSpiller
             // A direct await is already in the shape MoveNext consumes only when
             // its operand contains no nested await. `await F(await G())` still
             // needs its inner call argument spilled before the outer await.
-            if (exprStmt.Expression is BoundAwaitExpression topLevelAwait &&
-                !HasAwait(topLevelAwait.Expression))
+            var topLevelAwait = exprStmt.Expression as BoundAwaitExpression;
+            if (topLevelAwait is not null
+                && !HasAwait(topLevelAwait.Expression))
             {
                 builder.Add(exprStmt);
                 return false;
@@ -374,9 +375,10 @@ public static class SpillSequenceSpiller
 
             // Same rule for `x = await ...`: a nested await in the awaited
             // operand still requires recursive spilling.
-            if (exprStmt.Expression is BoundAssignmentExpression assign &&
-                assign.Expression is BoundAwaitExpression assignedAwait &&
-                !HasAwait(assignedAwait.Expression))
+            var assignment = exprStmt.Expression as BoundAssignmentExpression;
+            var assignedAwait = assignment?.Expression as BoundAwaitExpression;
+            if (assignedAwait is not null
+                && !HasAwait(assignedAwait.Expression))
             {
                 builder.Add(exprStmt);
                 return false;

--- a/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
@@ -901,18 +901,20 @@ public static class SpillSequenceSpiller
                 case BoundClrPropertyAssignmentExpression { Receiver: null } staticPropAssign:
                     // A static member write has no receiver to spill, but its
                     // value still can be an await.
-                    return SpillOneOperand(
-                        staticPropAssign,
-                        staticPropAssign.Value,
-                        val => new BoundClrPropertyAssignmentExpression(
+                    Func<BoundExpression, BoundExpression> rebuildClrStaticPropertyAssignment =
+                        value => new BoundClrPropertyAssignmentExpression(
                             null,
                             null,
                             staticPropAssign.Member,
-                            val,
+                            value,
                             staticPropAssign.Type,
                             staticPropAssign.StaticContainerType,
                             staticPropAssign.ConstrainedReceiverTypeParameter,
-                            staticPropAssign.ConstrainedInterfaceType));
+                            staticPropAssign.ConstrainedInterfaceType);
+                    return SpillOneOperand(
+                        staticPropAssign,
+                        staticPropAssign.Value,
+                        rebuildClrStaticPropertyAssignment);
                 case BoundClrPropertyAssignmentExpression clrPropAssign:
                     return SpillTwoOperand(
                         clrPropAssign,
@@ -981,16 +983,18 @@ public static class SpillSequenceSpiller
                 case BoundEventSubscriptionExpression eventSub:
                     if (eventSub.Receiver == null)
                     {
-                        return SpillOneOperand(
-                            eventSub,
-                            eventSub.Handler,
+                        Func<BoundExpression, BoundExpression> rebuildStaticEventSubscription =
                             handler => new BoundEventSubscriptionExpression(
                                 null,
                                 receiver: null,
                                 eventSub.StructType,
                                 eventSub.Event,
                                 handler,
-                                eventSub.IsAdd));
+                                eventSub.IsAdd);
+                        return SpillOneOperand(
+                            eventSub,
+                            eventSub.Handler,
+                            rebuildStaticEventSubscription);
                     }
 
                     return SpillTwoOperand(
@@ -1007,22 +1011,31 @@ public static class SpillSequenceSpiller
                         return Trivial(propAccess);
                     }
 
+                    Func<BoundExpression, BoundExpression> rebuildPropertyAccess =
+                        receiver => new BoundPropertyAccessExpression(
+                            null,
+                            receiver,
+                            propAccess.StructType,
+                            propAccess.Property,
+                            propAccess.NarrowedType);
                     return SpillOneOperand(
                         propAccess,
                         propAccess.Receiver,
-                        recv => new BoundPropertyAccessExpression(null, recv, propAccess.StructType, propAccess.Property, propAccess.NarrowedType));
+                        rebuildPropertyAccess);
                 case BoundPropertyAssignmentExpression propAssign:
                     if (propAssign.Receiver == null)
                     {
-                        return SpillOneOperand(
-                            propAssign,
-                            propAssign.Value,
+                        Func<BoundExpression, BoundExpression> rebuildUserStaticPropertyAssignment =
                             value => new BoundPropertyAssignmentExpression(
                                 null,
                                 receiver: null,
                                 propAssign.StructType,
                                 propAssign.Property,
-                                value));
+                                value);
+                        return SpillOneOperand(
+                            propAssign,
+                            propAssign.Value,
+                            rebuildUserStaticPropertyAssignment);
                     }
 
                     return SpillTwoOperand(
@@ -1084,12 +1097,16 @@ public static class SpillSequenceSpiller
                         mapDelete.Key,
                         (map, key) => new BoundMapDeleteExpression(null, map, key));
                 case BoundIsExpression isExpr:
+                    Func<BoundExpression, BoundExpression> rebuildIsExpression =
+                        operand => new BoundIsExpression(null, operand, isExpr.Pattern);
                     return SpillOneOperand(
                         isExpr,
                         isExpr.Expression,
-                        operand => new BoundIsExpression(null, operand, isExpr.Pattern));
+                        rebuildIsExpression);
                 case BoundAsExpression asExpr:
-                    return SpillOneOperand(asExpr, asExpr.Expression, operand => new BoundAsExpression(null, operand, asExpr.TargetType));
+                    Func<BoundExpression, BoundExpression> rebuildAsExpression =
+                        operand => new BoundAsExpression(null, operand, asExpr.TargetType);
+                    return SpillOneOperand(asExpr, asExpr.Expression, rebuildAsExpression);
                 case BoundThrowExpression throwExpr:
                     return SpillOneOperand(throwExpr, throwExpr.Expression, operand => new BoundThrowExpression(null, operand));
                 case BoundAddressOfExpression addressOf:
@@ -2339,29 +2356,49 @@ public static class SpillSequenceSpiller
 
         private BoundSpillSequenceExpression SpillIndirectCall(BoundIndirectCallExpression call)
         {
+            Func<BoundExpression, ImmutableArray<BoundExpression>, BoundExpression> rebuild =
+                (target, arguments) => new BoundIndirectCallExpression(
+                    null,
+                    target,
+                    call.FunctionType,
+                    arguments,
+                    call.ArgumentRefKinds);
             return SpillTargetAndArguments(
                 call,
                 call.Target,
                 call.Arguments,
-                (target, args) => new BoundIndirectCallExpression(null, target, call.FunctionType, args, call.ArgumentRefKinds));
+                rebuild);
         }
 
         private BoundSpillSequenceExpression SpillFunctionPointerInvocation(BoundFunctionPointerInvocationExpression call)
         {
+            Func<BoundExpression, ImmutableArray<BoundExpression>, BoundExpression> rebuild =
+                (pointer, arguments) => new BoundFunctionPointerInvocationExpression(
+                    null,
+                    pointer,
+                    arguments,
+                    call.FunctionPointerType);
             return SpillTargetAndArguments(
                 call,
                 call.Pointer,
                 call.Arguments,
-                (pointer, args) => new BoundFunctionPointerInvocationExpression(null, pointer, args, call.FunctionPointerType));
+                rebuild);
         }
 
         private BoundSpillSequenceExpression SpillClrIndex(BoundClrIndexExpression index)
         {
+            Func<BoundExpression, ImmutableArray<BoundExpression>, BoundExpression> rebuild =
+                (target, arguments) => new BoundClrIndexExpression(
+                    null,
+                    target,
+                    index.Indexer,
+                    arguments,
+                    index.Type);
             return SpillTargetAndArguments(
                 index,
                 index.Target,
                 index.Arguments,
-                (target, args) => new BoundClrIndexExpression(null, target, index.Indexer, args, index.Type));
+                rebuild);
         }
 
         private BoundSpillSequenceExpression SpillClrIndexAssignment(BoundClrIndexAssignmentExpression assign)
@@ -2808,8 +2845,13 @@ public static class SpillSequenceSpiller
                     var spilledArg = SpillExpression(arg);
                     locals.AddRange(spilledArg.Locals);
                     sideEffects.AddRange(spilledArg.SideEffects);
-                    if (awaitIndices.Any(awaitIndex => awaitIndex > i)
-                        && !CanDeferAcrossLift(spilledArg.Value))
+                    var hasLaterAwait = false;
+                    foreach (var awaitIndex in awaitIndices)
+                    {
+                        hasLaterAwait |= awaitIndex > i;
+                    }
+
+                    if (hasLaterAwait && !CanDeferAcrossLift(spilledArg.Value))
                     {
                         var temp = MakeSpillTemp(arg.Type);
                         locals.Add(temp);

--- a/src/Core/CodeAnalysis/Lowering/InterpolatedStringHandlerLowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/InterpolatedStringHandlerLowerer.cs
@@ -754,8 +754,15 @@ internal sealed class InterpolatedStringHandlerLowerer : NestedFunctionBodyRewri
             }
         }
 
-        return HandlerType.GetMethods(BindingFlags.Public | BindingFlags.Instance)
-            .First(m => m.Name == "AppendFormatted" && m.IsGenericMethodDefinition);
+        foreach (var method in HandlerType.GetMethods(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (method.Name == "AppendFormatted" && method.IsGenericMethodDefinition)
+            {
+                return method;
+            }
+        }
+
+        throw new InvalidOperationException("DefaultInterpolatedStringHandler.AppendFormatted<T> was not found.");
     }
 
     private static ImmutableArray<TypeSymbol?> ToNullableTypeArguments(ImmutableArray<TypeSymbol> typeArguments)

--- a/src/Core/CodeAnalysis/Lowering/InterpolatedStringHandlerLowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/InterpolatedStringHandlerLowerer.cs
@@ -199,7 +199,9 @@ internal sealed class InterpolatedStringHandlerLowerer : NestedFunctionBodyRewri
                 continue;
             }
 
-            var value = part.Value;
+            var value = Invariant.Required(
+                part.Value,
+                "a formatted interpolated-string part has a bound value");
             var byRefLikeToString = TypeSymbol.IsByRefLike(value.Type) ? FindByRefLikeToString(value.Type) : null;
             if (byRefLikeToString != null)
             {

--- a/src/Core/CodeAnalysis/Lowering/Iterators/AsyncIteratorMoveNextBodyBuilder.cs
+++ b/src/Core/CodeAnalysis/Lowering/Iterators/AsyncIteratorMoveNextBodyBuilder.cs
@@ -6,6 +6,11 @@
 #pragma warning disable SA1028
 #pragma warning disable SA1116
 #pragma warning disable SA1117
+#pragma warning disable SA1202
+#pragma warning disable SA1304
+#pragma warning disable SA1307
+#pragma warning disable SA1401
+#pragma warning disable SA1508
 #pragma warning disable SA1611
 #pragma warning disable SA1615
 
@@ -50,31 +55,31 @@ public static class AsyncIteratorMoveNextBodyBuilder
         return ctx.BuildBody();
     }
 
-    private sealed class BuildContext
+    internal sealed class BuildContext
     {
-        private readonly AsyncIteratorPlan plan;
-        private readonly StructSymbol smClass;
-        private readonly ParameterSymbol thisParameter;
-        private readonly FieldSymbol stateField;
-        private readonly FieldSymbol currentField;
-        private readonly FieldSymbol promiseField;
-        private readonly FieldSymbol disposeModeField;
-        private readonly FieldSymbol disposeExceptionField;
-        private readonly FieldSymbol builderField;
-        private readonly Dictionary<VariableSymbol, FieldSymbol> fieldMap;
-        private readonly Dictionary<Type, FieldSymbol> awaiterPoolFields;
-        private readonly TryDispatchPlan awaitTryDispatch;
-        private readonly IteratorTryDispatchPlan yieldTryDispatch;
+        internal readonly AsyncIteratorPlan plan;
+        internal readonly StructSymbol smClass;
+        internal readonly ParameterSymbol thisParameter;
+        internal readonly FieldSymbol stateField;
+        internal readonly FieldSymbol currentField;
+        internal readonly FieldSymbol promiseField;
+        internal readonly FieldSymbol disposeModeField;
+        internal readonly FieldSymbol disposeExceptionField;
+        internal readonly FieldSymbol builderField;
+        internal readonly Dictionary<VariableSymbol, FieldSymbol> fieldMap;
+        internal readonly Dictionary<Type, FieldSymbol> awaiterPoolFields;
+        internal readonly TryDispatchPlan awaitTryDispatch;
+        internal readonly IteratorTryDispatchPlan yieldTryDispatch;
 
         // Labels for yield resume points
-        private readonly Dictionary<int, BoundLabel> yieldResumeLabels = new();
+        internal readonly Dictionary<int, BoundLabel> yieldResumeLabels = new();
 
         // Labels for await resume points
-        private readonly Dictionary<int, BoundLabel> awaitResumeLabels = new();
-        private readonly Dictionary<int, BoundLabel> awaitResumeAfterLabels = new();
+        internal readonly Dictionary<int, BoundLabel> awaitResumeLabels = new();
+        internal readonly Dictionary<int, BoundLabel> awaitResumeAfterLabels = new();
 
-        private readonly BoundLabel exitLabel = new BoundLabel("<>ai_exit");
-        private readonly BoundLabel endOfBodyLabel = new BoundLabel("<>ai_end");
+        internal readonly BoundLabel exitLabel = new BoundLabel("<>ai_exit");
+        internal readonly BoundLabel endOfBodyLabel = new BoundLabel("<>ai_end");
 
         public BuildContext(
             AsyncIteratorPlan plan,
@@ -164,7 +169,7 @@ public static class AsyncIteratorMoveNextBodyBuilder
                 jumpIfTrue: true));
 
             // Rewritten user body.
-            var rewriter = new InnerRewriter(this);
+            var rewriter = new AsyncIteratorBodyRewriter(this);
             var rewrittenBody = rewriter.RewriteStatement(plan.LoweredBody);
             if (rewrittenBody is BoundBlockStatement block)
             {
@@ -274,7 +279,7 @@ public static class AsyncIteratorMoveNextBodyBuilder
             return new BoundBlockStatement(null, stmts.ToImmutable());
         }
 
-        private BoundExpression EmitPromiseSetResult(bool value)
+        internal BoundExpression EmitPromiseSetResult(bool value)
         {
             var promiseFieldType = typeof(System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool>);
             var setResultMethod = promiseFieldType.GetMethod("SetResult", new[] { typeof(bool) });
@@ -291,12 +296,12 @@ public static class AsyncIteratorMoveNextBodyBuilder
                 ImmutableArray.Create<BoundExpression>(new BoundLiteralExpression(null, value)));
         }
 
-        private BoundExpression ReadField(FieldSymbol field)
+        internal BoundExpression ReadField(FieldSymbol field)
         {
             return new BoundFieldAccessExpression(null, new BoundVariableExpression(null, thisParameter), smClass, field);
         }
 
-        private BoundExpression WriteField(FieldSymbol field, BoundExpression value)
+        internal BoundExpression WriteField(FieldSymbol field, BoundExpression value)
         {
             return new BoundFieldAssignmentExpression(null, thisParameter, smClass, field, value);
         }
@@ -305,30 +310,42 @@ public static class AsyncIteratorMoveNextBodyBuilder
 
         private static BoundExpressionStatement Stmt(BoundExpression expr) => new BoundExpressionStatement(null, expr);
 
-        /// <summary>
-        /// Walks the user body, replacing yields, awaits, variable accesses (hoisted to fields),
-        /// and returns.
-        /// </summary>
-        private sealed class InnerRewriter : HoistedFieldRewriter
+    }
+}
+
+/// <summary>
+/// Walks an async-iterator body, replacing yields, awaits, variable accesses,
+/// and returns.
+/// </summary>
+internal sealed class AsyncIteratorBodyRewriter : HoistedFieldRewriter
         {
-            private readonly BuildContext ctx;
+            private readonly AsyncIteratorMoveNextBodyBuilder.BuildContext ctx;
             private int yieldIndex;
 
-            public InnerRewriter(BuildContext ctx)
+            public AsyncIteratorBodyRewriter(AsyncIteratorMoveNextBodyBuilder.BuildContext ctx)
                 : base(ctx.smClass, ctx.thisParameter, ctx.fieldMap)
             {
                 this.ctx = ctx;
             }
 
-            protected override BoundStatement RewriteVariableDeclaration(BoundVariableDeclaration node)
+            private static BoundExpression Literal(int value) => new BoundLiteralExpression(null, value);
+
+            private static BoundExpressionStatement Stmt(BoundExpression expr) => new BoundExpressionStatement(null, expr);
+
+            public override BoundStatement RewriteStatement(BoundStatement node)
             {
-                if (node.Initializer is BoundAwaitExpression awaitExpr)
+                if (node is not BoundVariableDeclaration declaration)
                 {
-                    return EmitPerAwaitSequence(awaitExpr, node.Variable);
+                    return base.RewriteStatement(node);
                 }
 
-                var rewrittenInit = node.Initializer != null ? RewriteExpression(node.Initializer) : null;
-                if (ctx.fieldMap.TryGetValue(node.Variable, out var field))
+                if (declaration.Initializer is BoundAwaitExpression awaitExpr)
+                {
+                    return EmitPerAwaitSequence(awaitExpr, declaration.Variable);
+                }
+
+                var rewrittenInit = declaration.Initializer != null ? RewriteExpression(declaration.Initializer) : null;
+                if (ctx.fieldMap.TryGetValue(declaration.Variable, out var field))
                 {
                     if (rewrittenInit != null)
                     {
@@ -338,12 +355,16 @@ public static class AsyncIteratorMoveNextBodyBuilder
                     return new BoundBlockStatement(null, ImmutableArray<BoundStatement>.Empty);
                 }
 
-                if (rewrittenInit != node.Initializer)
+                if (rewrittenInit != declaration.Initializer)
                 {
-                    return new BoundVariableDeclaration(null, node.Variable, rewrittenInit, node.ConstantValue);
+                    return new BoundVariableDeclaration(
+                        null,
+                        declaration.Variable,
+                        rewrittenInit,
+                        declaration.ConstantValue);
                 }
 
-                return node;
+                return declaration;
             }
 
             protected override BoundStatement RewriteYieldStatement(BoundYieldStatement node)
@@ -754,6 +775,4 @@ public static class AsyncIteratorMoveNextBodyBuilder
 
                 return new BoundBlockStatement(null, stmts.ToImmutable());
             }
-        }
-    }
 }

--- a/src/Core/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/Lowerer.cs
@@ -1475,12 +1475,14 @@ public sealed class Lowerer : BoundTreeRewriter
 
                 currentType ??= GetClrMemberType(currentMember);
 
-                moveNextCallFactory = receiver => new BoundImportedInstanceCallExpression(
-                    null,
-                    receiver,
-                    moveNext,
-                    TypeSymbol.Bool,
-                    ImmutableArray<BoundExpression>.Empty);
+                Func<BoundExpression, BoundExpression> createMoveNextCall =
+                    receiver => new BoundImportedInstanceCallExpression(
+                        null,
+                        receiver,
+                        moveNext,
+                        TypeSymbol.Bool,
+                        ImmutableArray<BoundExpression>.Empty);
+                moveNextCallFactory = createMoveNextCall;
                 currentAccessFactory = receiver => new BoundClrPropertyAccessExpression(
                     null,
                     receiver,

--- a/src/Core/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/Lowerer.cs
@@ -1295,7 +1295,7 @@ public sealed class Lowerer : BoundTreeRewriter
             userType.TryGetMethodIncludingInherited("GetEnumerator", out var userGetEnumerator) &&
             userGetEnumerator.Parameters.Length == 0)
         {
-            enumeratorType = userGetEnumerator.Type;
+            enumeratorType = userType.SubstituteMemberType(userGetEnumerator.Type);
             getEnumeratorCall = new BoundUserInstanceCallExpression(
                 null,
                 collection,

--- a/src/Core/CodeAnalysis/Lowering/ProtectedRegionBranchAnalysis.cs
+++ b/src/Core/CodeAnalysis/Lowering/ProtectedRegionBranchAnalysis.cs
@@ -83,8 +83,13 @@ internal sealed class ProtectedRegionBranchAnalysis
 
         public List<Branch> Branches { get; } = new();
 
-        public override void VisitStatement(BoundStatement node)
+        public override void VisitStatement(BoundStatement? node)
         {
+            if (node == null)
+            {
+                return;
+            }
+
             switch (node)
             {
                 case BoundLabelStatement label:

--- a/src/Core/CodeAnalysis/Symbols/ArrayTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ArrayTypeSymbol.cs
@@ -24,7 +24,7 @@ public sealed class ArrayTypeSymbol : TypeSymbol
 
         // TypeSymbol's legacy CLR-type constructor accepts null for symbolic
         // same-compilation element types.
-        : base($"[{length}]{elementType.Name}", NullableLifting.GetEffectiveClrType(elementType)?.MakeArrayType()!)
+        : base($"[{length}]{elementType.Name}", NullableLifting.GetEffectiveClrType(elementType)?.MakeArrayType())
     {
         ElementType = elementType;
         Length = length;

--- a/src/Core/CodeAnalysis/Symbols/ByRefTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ByRefTypeSymbol.cs
@@ -19,7 +19,7 @@ public sealed class ByRefTypeSymbol : TypeSymbol
 
         // TypeSymbol's legacy CLR-type constructor accepts null for symbolic
         // same-compilation pointee types.
-        : base($"*{pointeeType.Name}", pointeeType.ClrType?.MakeByRefType()!)
+        : base($"*{pointeeType.Name}", pointeeType.ClrType?.MakeByRefType())
     {
         PointeeType = pointeeType;
     }

--- a/src/Core/CodeAnalysis/Symbols/ChannelTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ChannelTypeSymbol.cs
@@ -25,7 +25,7 @@ public sealed class ChannelTypeSymbol : TypeSymbol
 
         // TypeSymbol's legacy CLR-type constructor accepts null for symbolic
         // same-compilation element types.
-        : base($"chan {elementType.Name}", MakeClrType(elementType)!)
+        : base($"chan {elementType.Name}", MakeClrType(elementType))
     {
         ElementType = elementType;
     }

--- a/src/Core/CodeAnalysis/Symbols/ClrNullability.cs
+++ b/src/Core/CodeAnalysis/Symbols/ClrNullability.cs
@@ -110,7 +110,18 @@ public static class ClrNullability
             ? parameter.ParameterType.GetElementType()
             : parameter.ParameterType;
         var baseSymbol = TypeSymbol.FromClrType(parameterType);
-        return ApplyReferenceNullabilityFull(baseSymbol, parameterType, parameter, parameter.Member);
+        var mapped = ApplyReferenceNullabilityFull(baseSymbol, parameterType, parameter, parameter.Member);
+        var rawDefault = parameter.HasDefaultValue || parameter.IsOptional
+            ? parameter.RawDefaultValue
+            : null;
+        return parameterType?.IsValueType == false
+            && (parameter.HasDefaultValue || parameter.IsOptional)
+            && (rawDefault == null
+                || ReferenceEquals(rawDefault, Missing.Value)
+                || ReferenceEquals(rawDefault, System.DBNull.Value))
+            && mapped is not NullableTypeSymbol
+                ? NullableTypeSymbol.Get(mapped)
+                : mapped;
     }
 
     internal static bool TryGetNotNullWhen(ParameterInfo parameter, out bool returnValue)

--- a/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
+++ b/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
@@ -545,7 +545,7 @@ public static class ClrTypeUtilities
     /// <param name="flags">The binding flags controlling visibility.</param>
     /// <returns>The properties whose signatures load cleanly.</returns>
     public static PropertyInfo[] SafeGetProperties(Type type, BindingFlags flags)
-        => SafeEnumerate(type, flags, t => t.GetProperties(flags));
+        => SafeEnumerate<PropertyInfo>(type, flags, t => t.GetProperties(flags));
 
     /// <summary>
     /// Enumerates a type's fields tolerantly (issue #338): fields whose type
@@ -555,7 +555,7 @@ public static class ClrTypeUtilities
     /// <param name="flags">The binding flags controlling visibility.</param>
     /// <returns>The fields whose signatures load cleanly.</returns>
     public static FieldInfo[] SafeGetFields(Type type, BindingFlags flags)
-        => SafeEnumerate(type, flags, t => t.GetFields(flags));
+        => SafeEnumerate<FieldInfo>(type, flags, t => t.GetFields(flags));
 
     /// <summary>
     /// Enumerates a type's events tolerantly (issue #338): events whose handler
@@ -565,7 +565,7 @@ public static class ClrTypeUtilities
     /// <param name="flags">The binding flags controlling visibility.</param>
     /// <returns>The events whose signatures load cleanly.</returns>
     public static EventInfo[] SafeGetEvents(Type type, BindingFlags flags)
-        => SafeEnumerate(type, flags, t => t.GetEvents(flags));
+        => SafeEnumerate<EventInfo>(type, flags, t => t.GetEvents(flags));
 
     /// <summary>
     /// Enumerates a type's constructors tolerantly (issue #338): constructors
@@ -576,7 +576,7 @@ public static class ClrTypeUtilities
     /// <param name="flags">The binding flags controlling visibility.</param>
     /// <returns>The constructors whose signatures load cleanly.</returns>
     public static ConstructorInfo[] SafeGetConstructors(Type type, BindingFlags flags)
-        => SafeEnumerate(type, flags, t => t.GetConstructors(flags));
+        => SafeEnumerate<ConstructorInfo>(type, flags, t => t.GetConstructors(flags));
 
     /// <summary>
     /// Enumerates a type's methods tolerantly (issue #338): methods whose
@@ -587,7 +587,7 @@ public static class ClrTypeUtilities
     /// <param name="flags">The binding flags controlling visibility.</param>
     /// <returns>The methods whose signatures load cleanly.</returns>
     public static MethodInfo[] SafeGetMethods(Type type, BindingFlags flags)
-        => SafeEnumerate(type, flags, t => t.GetMethods(flags));
+        => SafeEnumerate<MethodInfo>(type, flags, t => t.GetMethods(flags));
 
     /// <summary>
     /// Looks up a single property by name tolerantly (issue #338). When the

--- a/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
+++ b/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
@@ -1223,25 +1223,41 @@ public static class ClrTypeUtilities
         Type[] openTypeArguments,
         Type[] typeArguments)
     {
-        var matches = openType.GetMethods()
-            .Where(method => string.Equals(method.Name, name, StringComparison.Ordinal))
-            .Where(method =>
+        var matches = new List<MethodInfo>(2);
+        foreach (var method in openType.GetMethods())
+        {
+            if (!string.Equals(method.Name, name, StringComparison.Ordinal))
             {
-                var parameters = method.GetParameters();
-                return parameters.Length == parameterTypes.Length
-                    && parameters.Select(parameter => parameter.ParameterType)
-                    .Zip(parameterTypes, (open, constructed) =>
-                        MatchesConstructedParameterType(
-                            open,
-                            constructed,
-                            openTypeArguments,
-                            typeArguments))
-                    .All(matches => matches);
-            })
-            .Take(2)
-            .ToArray();
+                continue;
+            }
 
-        return matches.Length switch
+            var parameters = method.GetParameters();
+            if (parameters.Length != parameterTypes.Length)
+            {
+                continue;
+            }
+
+            var parametersMatch = true;
+            for (var i = 0; i < parameters.Length; i++)
+            {
+                parametersMatch &= MatchesConstructedParameterType(
+                    parameters[i].ParameterType,
+                    parameterTypes[i],
+                    openTypeArguments,
+                    typeArguments);
+            }
+
+            if (parametersMatch)
+            {
+                matches.Add(method);
+                if (matches.Count == 2)
+                {
+                    break;
+                }
+            }
+        }
+
+        return matches.Count switch
         {
             0 => null,
             1 => matches[0],
@@ -1306,19 +1322,33 @@ public static class ClrTypeUtilities
 
         if (open.IsConstructedGenericType || constructed.IsConstructedGenericType)
         {
-            return open.IsConstructedGenericType
-                && constructed.IsConstructedGenericType
-                && open.GetGenericTypeDefinition() == constructed.GetGenericTypeDefinition()
-                && open.GetGenericArguments()
-                    .Zip(
-                        constructed.GetGenericArguments(),
-                        (openArgument, constructedArgument) =>
-                            MatchesConstructedParameterType(
-                                openArgument,
-                                constructedArgument,
-                                openTypeArguments,
-                                typeArguments))
-                    .All(matches => matches);
+            if (!open.IsConstructedGenericType
+                || !constructed.IsConstructedGenericType
+                || open.GetGenericTypeDefinition() != constructed.GetGenericTypeDefinition())
+            {
+                return false;
+            }
+
+            var openArguments = open.GetGenericArguments();
+            var constructedArguments = constructed.GetGenericArguments();
+            if (openArguments.Length != constructedArguments.Length)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < openArguments.Length; i++)
+            {
+                if (!MatchesConstructedParameterType(
+                        openArguments[i],
+                        constructedArguments[i],
+                        openTypeArguments,
+                        typeArguments))
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         return open == constructed;

--- a/src/Core/CodeAnalysis/Symbols/Display/SymbolDisplay.cs
+++ b/src/Core/CodeAnalysis/Symbols/Display/SymbolDisplay.cs
@@ -49,7 +49,7 @@ public static class SymbolDisplay
     /// <returns>The rendered display string.</returns>
     public static string ToDisplayString(Type clrType, SymbolDisplayFormat format)
     {
-        return PartsToString(ToDisplayParts(clrType, format));
+        return PartsToString(ToDisplayParts(clrType: clrType, format: format));
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
@@ -515,7 +515,7 @@ public sealed class ImportedClassSymbol : Symbol
             | BindingFlags.Instance
             | BindingFlags.DeclaredOnly;
 
-        for (var current = ClassType; current != null; current = GetBaseTypeSafe(current))
+        for (Type? current = ClassType; current != null; current = GetBaseTypeSafe(current))
         {
             var methods = ClrTypeUtilities.SafeGetMethods(current, Flags)
                 .Where(m =>

--- a/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
@@ -327,9 +327,14 @@ public sealed class ImportedClassSymbol : Symbol
         // Issue #658 / #1634: supplementary interface check for user-class args,
         // threaded as a call-local parameter into Resolve instead of a shared
         // static so nested/concurrent binds can't clobber it.
-        Func<Type, Type, bool>? supplementaryInterfaceCheck = hasUserClassArg
-            ? (source, target) => IsUserClassAssignableToInterface(arguments, argTypes, source, target)
-            : null;
+        Func<Type, Type, bool>? supplementaryInterfaceCheck = null;
+        if (hasUserClassArg)
+        {
+            supplementaryInterfaceCheck = CheckUserClassInterface;
+        }
+
+        bool CheckUserClassInterface(Type source, Type target) =>
+            IsUserClassAssignableToInterface(arguments, argTypes, source, target);
 
         // Issue #1325: recover the symbolic type-argument vector per candidate
         // so the generic-constraint check can see through the `object`

--- a/src/Core/CodeAnalysis/Symbols/ImportedTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedTypeSymbol.cs
@@ -175,10 +175,16 @@ public sealed class ImportedTypeSymbol : TypeSymbol
             return Invariant.Required(ClrType, "an imported type always has a CLR representation");
         }
 
-        var contextObject = OpenDefinition.GetGenericArguments()
-            .Select(static parameter => parameter.BaseType)
-            .FirstOrDefault(static baseType =>
-                string.Equals(baseType?.FullName, "System.Object", StringComparison.Ordinal));
+        Type? contextObject = null;
+        foreach (var parameter in OpenDefinition.GetGenericArguments())
+        {
+            if (string.Equals(parameter.BaseType?.FullName, "System.Object", StringComparison.Ordinal))
+            {
+                contextObject = parameter.BaseType;
+                break;
+            }
+        }
+
         var args = new Type[TypeArguments.Length];
         for (var i = 0; i < args.Length; i++)
         {
@@ -335,7 +341,18 @@ public sealed class ImportedTypeSymbol : TypeSymbol
         try
         {
             var requiredModifiers = setter.ReturnParameter.GetRequiredCustomModifiers();
-            return requiredModifiers.Any(m => string.Equals(m.FullName, "System.Runtime.CompilerServices.IsExternalInit", StringComparison.Ordinal));
+            foreach (var modifier in requiredModifiers)
+            {
+                if (string.Equals(
+                        modifier.FullName,
+                        "System.Runtime.CompilerServices.IsExternalInit",
+                        StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
         catch
         {

--- a/src/Core/CodeAnalysis/Symbols/MapTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/MapTypeSymbol.cs
@@ -28,7 +28,7 @@ public sealed class MapTypeSymbol : TypeSymbol
 
         // TypeSymbol's legacy CLR-type constructor accepts null for symbolic
         // same-compilation key/value types.
-        : base($"map[{keyType.Name},{valueType.Name}]", MakeClrType(keyType, valueType)!)
+        : base($"map[{keyType.Name},{valueType.Name}]", MakeClrType(keyType, valueType))
     {
         KeyType = keyType;
         ValueType = valueType;

--- a/src/Core/CodeAnalysis/Symbols/NullableLifting.cs
+++ b/src/Core/CodeAnalysis/Symbols/NullableLifting.cs
@@ -29,10 +29,13 @@ public static class NullableLifting
     /// <returns>The CLR <see cref="Type"/> to use for overload resolution, or <see langword="null"/> if <paramref name="typeSymbol"/> is <see langword="null"/>.</returns>
     public static Type? GetEffectiveClrType(TypeSymbol? typeSymbol)
     {
-        if (typeSymbol is NullableTypeSymbol nullable
-            && nullable.UnderlyingType?.ClrType is { IsValueType: true } innerVt)
+        if (typeSymbol is NullableTypeSymbol nullable)
         {
-            return typeof(Nullable<>).MakeGenericType(innerVt);
+            var innerVt = nullable.UnderlyingType?.ClrType;
+            if (innerVt?.IsValueType == true)
+            {
+                return typeof(Nullable<>).MakeGenericType(innerVt);
+            }
         }
 
         return typeSymbol?.ClrType;
@@ -97,11 +100,14 @@ public static class NullableLifting
     /// </returns>
     public static Type? ResolveClrTypeForGenericArg(ReferenceResolver references, TypeSymbol? typeSymbol)
     {
-        if (typeSymbol is NullableTypeSymbol nullable
-            && nullable.UnderlyingType?.ClrType is { IsValueType: true } innerVt
-            && TryConstructNullable(references, innerVt, out var nullableClr))
+        if (typeSymbol is NullableTypeSymbol nullable)
         {
-            return nullableClr;
+            var innerVt = nullable.UnderlyingType?.ClrType;
+            if (innerVt?.IsValueType == true
+                && TryConstructNullable(references, innerVt, out var nullableClr))
+            {
+                return nullableClr;
+            }
         }
 
         var clr = typeSymbol?.ClrType;

--- a/src/Core/CodeAnalysis/Symbols/NullableLifting.cs
+++ b/src/Core/CodeAnalysis/Symbols/NullableLifting.cs
@@ -202,6 +202,9 @@ public static class NullableLifting
     {
         return IsUserValueTypeNullable(nullable)
             || nullable?.UnderlyingType is TupleTypeSymbol { ClrType: null }
+            || (nullable?.UnderlyingType is ImportedTypeSymbol imported
+                && imported.OpenDefinition?.IsValueType == true
+                && !imported.TypeArguments.IsDefaultOrEmpty)
             || (nullable?.UnderlyingType is TypeParameterSymbol tp && tp.HasValueTypeConstraint);
     }
 

--- a/src/Core/CodeAnalysis/Symbols/PointerTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/PointerTypeSymbol.cs
@@ -28,7 +28,7 @@ public sealed class PointerTypeSymbol : TypeSymbol
 
         // TypeSymbol's legacy CLR-type constructor accepts null for symbolic
         // same-compilation pointee types.
-        : base($"*{pointeeType.Name}", pointeeType.ClrType?.MakePointerType()!)
+        : base($"*{pointeeType.Name}", pointeeType.ClrType?.MakePointerType())
     {
         PointeeType = pointeeType;
     }

--- a/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
+++ b/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
@@ -1271,8 +1271,9 @@ public sealed class ReferenceResolver : IDisposable
     // the eager BuildTypeNameIndex and the cache-export ExportMetadataIndex
     // consume it so the warm and cold name sets (and their first-writer-wins
     // precedence) are guaranteed to match.
-    private static IEnumerable<Type> EnumerateDefinedAndForwardedTypes(Assembly asm)
+    private static List<Type> EnumerateDefinedAndForwardedTypes(Assembly asm)
     {
+        var result = new List<Type>();
         Type?[] definedTypes;
         try
         {
@@ -1298,7 +1299,7 @@ public sealed class ReferenceResolver : IDisposable
         {
             if (t != null)
             {
-                yield return t;
+                result.Add(t);
             }
         }
 
@@ -1321,9 +1322,11 @@ public sealed class ReferenceResolver : IDisposable
         {
             if (t != null)
             {
-                yield return t;
+                result.Add(t);
             }
         }
+
+        return result;
     }
 
     private static void RegisterAssemblyOriginalPath(Assembly assembly, string path)

--- a/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
+++ b/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
@@ -403,14 +403,33 @@ public sealed class ReferenceResolver : IDisposable
     /// <returns>The effective reference paths.</returns>
     public static IReadOnlyList<string> ResolveDriverReferencePaths(IEnumerable<string> referencePaths)
     {
-        var paths = referencePaths?
-            .Where(path => !string.IsNullOrWhiteSpace(path))
-            .ToList()
-            ?? new List<string>();
+        var paths = new List<string>();
+        if (referencePaths is not null)
+        {
+            foreach (var path in referencePaths)
+            {
+                if (!string.IsNullOrWhiteSpace(path))
+                {
+                    paths.Add(path);
+                }
+            }
+        }
 
         var extensionPath = FindBundledExtensionPath(AppContext.BaseDirectory);
-        if (extensionPath != null
-            && !paths.Any(path => string.Equals(Path.GetFullPath(path), extensionPath, StringComparison.OrdinalIgnoreCase)))
+        var hasExtensionPath = false;
+        if (extensionPath != null)
+        {
+            foreach (var path in paths)
+            {
+                if (string.Equals(Path.GetFullPath(path), extensionPath, StringComparison.OrdinalIgnoreCase))
+                {
+                    hasExtensionPath = true;
+                    break;
+                }
+            }
+        }
+
+        if (extensionPath != null && !hasExtensionPath)
         {
             paths.Add(extensionPath);
         }
@@ -474,8 +493,13 @@ public sealed class ReferenceResolver : IDisposable
         var runtimeAssemblies = new List<Assembly>();
         if (referencePaths is not null)
         {
-            foreach (var path in referencePaths.Where(path => !string.IsNullOrWhiteSpace(path)))
+            foreach (var path in referencePaths)
             {
+                if (string.IsNullOrWhiteSpace(path))
+                {
+                    continue;
+                }
+
                 var fullPath = Path.GetFullPath(path);
                 var assembly = runtimeContext.LoadReference(fullPath);
                 RegisterAssemblyOriginalPath(assembly, fullPath);
@@ -483,16 +507,25 @@ public sealed class ReferenceResolver : IDisposable
             }
         }
 
-        var runtimeNames = runtimeAssemblies
-            .Select(assembly => assembly.GetName().FullName)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-        var assemblies = BuildHostAssemblies()
-            .Where(assembly => !runtimeNames.Contains(assembly.GetName().FullName))
-            .Concat(runtimeAssemblies)
-            .ToImmutableArray();
+        var runtimeNames = new HashSet<string?>(StringComparer.OrdinalIgnoreCase);
+        foreach (var assembly in runtimeAssemblies)
+        {
+            runtimeNames.Add(assembly.GetName().FullName);
+        }
+
+        var assemblies = ImmutableArray.CreateBuilder<Assembly>();
+        foreach (var assembly in BuildHostAssemblies())
+        {
+            if (!runtimeNames.Contains(assembly.GetName().FullName))
+            {
+                assemblies.Add(assembly);
+            }
+        }
+
+        assemblies.AddRange(runtimeAssemblies);
 
         return new ReferenceResolver(
-            assemblies,
+            assemblies.ToImmutable(),
             metadataContext: null,
             missingTransitiveReferences: ImmutableArray<string>.Empty,
             runtimeContext: runtimeContext);

--- a/src/Core/CodeAnalysis/Symbols/SequenceTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/SequenceTypeSymbol.cs
@@ -19,7 +19,7 @@ public sealed class SequenceTypeSymbol : TypeSymbol
 
         // TypeSymbol's legacy CLR-type constructor accepts null for symbolic
         // same-compilation element types.
-        : base($"sequence[{elementType.Name}]", MakeClrType(elementType)!)
+        : base($"sequence[{elementType.Name}]", MakeClrType(elementType))
     {
         ElementType = elementType;
     }

--- a/src/Core/CodeAnalysis/Symbols/SliceTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/SliceTypeSymbol.cs
@@ -28,7 +28,7 @@ public sealed class SliceTypeSymbol : TypeSymbol
 
         // TypeSymbol's legacy CLR-type constructor accepts null for symbolic
         // same-compilation element types.
-        : base($"[]{elementType.Name}", NullableLifting.GetEffectiveClrType(elementType)?.MakeArrayType()!)
+        : base($"[]{elementType.Name}", NullableLifting.GetEffectiveClrType(elementType)?.MakeArrayType())
     {
         ElementType = elementType;
     }

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -2572,7 +2572,13 @@ public sealed class StructSymbol : TypeSymbol
                 // a bug. Log for diagnosability and fall back to the erased
                 // constructed form so both debug and release builds degrade
                 // gracefully rather than crash.
-                var assertMessage = $"StructSymbol.SubstituteTypeForConstruction: MakeGenericType failed for '{imported.OpenDefinition}' with args [{string.Join(", ", resolvedClrArgs.Select(t => t.ToString()))}] even after mapClrType projection.";
+                var renderedArguments = new string[resolvedClrArgs.Length];
+                for (var i = 0; i < resolvedClrArgs.Length; i++)
+                {
+                    renderedArguments[i] = resolvedClrArgs[i].ToString();
+                }
+
+                var assertMessage = $"StructSymbol.SubstituteTypeForConstruction: MakeGenericType failed for '{imported.OpenDefinition}' with args [{string.Join(", ", renderedArguments)}] even after mapClrType projection.";
                 System.Diagnostics.Debug.WriteLine(assertMessage);
                 return imported;
             }

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -345,7 +345,7 @@ public sealed class StructSymbol : TypeSymbol
             bool HasUnimplementedAbstractProperties()
             {
                 var effectiveProperties = new Dictionary<string, PropertySymbol>();
-                for (var current = this; current != null; current = current.BaseClass)
+                foreach (var current in GetHierarchy())
                 {
                     foreach (var property in current.Properties)
                     {
@@ -967,7 +967,7 @@ public sealed class StructSymbol : TypeSymbol
     /// <returns><c>true</c> when this class is or derives from <see cref="System.Attribute"/>.</returns>
     public bool DerivesFromSystemAttribute()
     {
-        for (var current = this; current != null; current = current.BaseClass)
+        foreach (var current in GetHierarchy())
         {
             if (current.IsAttributeClass)
             {
@@ -1037,7 +1037,7 @@ public sealed class StructSymbol : TypeSymbol
     /// <returns>True if found.</returns>
     public bool TryGetMethodIncludingInherited(string name, [NotNullWhen(true)] out FunctionSymbol? method)
     {
-        for (var c = this; c != null; c = c.BaseClass)
+        foreach (var c in GetHierarchy())
         {
             if (c.TryGetMethod(name, out method))
             {
@@ -1107,7 +1107,7 @@ public sealed class StructSymbol : TypeSymbol
     public System.Collections.Immutable.ImmutableArray<FunctionSymbol> GetMethodsIncludingInherited(string name)
     {
         System.Collections.Immutable.ImmutableArray<FunctionSymbol>.Builder? builder = null;
-        for (var c = this; c != null; c = c.BaseClass)
+        foreach (var c in GetHierarchy())
         {
             if (c.Methods.IsDefaultOrEmpty)
             {
@@ -1179,7 +1179,7 @@ public sealed class StructSymbol : TypeSymbol
         // each argument through the running map composes the substitution across hops.
         var levels = new List<(StructSymbol Cls, Dictionary<TypeParameterSymbol, TypeSymbol>? Subst)>();
         Dictionary<TypeParameterSymbol, TypeSymbol>? running = null;
-        for (var c = this; c != null; c = c.BaseClass)
+        foreach (var c in GetHierarchy())
         {
             if (c.Definition != null
                 && !c.TypeArguments.IsDefaultOrEmpty
@@ -1308,7 +1308,7 @@ public sealed class StructSymbol : TypeSymbol
     /// <returns>True if found.</returns>
     public bool TryGetFieldIncludingInherited(string name, [NotNullWhen(true)] out FieldSymbol? field, [NotNullWhen(true)] out StructSymbol? declaringType)
     {
-        for (var c = this; c != null; c = c.BaseClass)
+        foreach (var c in GetHierarchy())
         {
             if (c.TryGetField(name, out field))
             {
@@ -1504,7 +1504,7 @@ public sealed class StructSymbol : TypeSymbol
         }
 
         Dictionary<TypeParameterSymbol, TypeSymbol>? running = null;
-        for (var c = this; c != null; c = c.BaseClass)
+        foreach (var c in GetHierarchy())
         {
             // A constructed nested receiver already carries the argument shape
             // needed by its TypeSpec. Keep it verbatim: rebuilding a generic
@@ -1791,6 +1791,19 @@ public sealed class StructSymbol : TypeSymbol
         }
 
         return SubstituteTypeForConstruction(type, GetSubstitutionMap(), mapClrType);
+    }
+
+    private List<StructSymbol> GetHierarchy()
+    {
+        var hierarchy = new List<StructSymbol>();
+        StructSymbol? current = this;
+        while (current != null)
+        {
+            hierarchy.Add(current);
+            current = current.BaseClass;
+        }
+
+        return hierarchy;
     }
 
     private static TypeArgsKey BuildArgsKey(ImmutableArray<TypeSymbol> typeArguments) => new(typeArguments);

--- a/src/Core/CodeAnalysis/Symbols/TypeMemberModel.cs
+++ b/src/Core/CodeAnalysis/Symbols/TypeMemberModel.cs
@@ -58,7 +58,11 @@ public static class TypeMemberModel
             return members.ToImmutable();
         }
 
-        members.AddRange(type.Fields);
+        foreach (var field in type.Fields)
+        {
+            members.Add(field);
+        }
+
         foreach (var property in type.Properties)
         {
             if (!property.IsStatic && !property.IsIndexer && property.BackingField != null)
@@ -213,18 +217,19 @@ public static class TypeMemberModel
     /// <returns>True if found.</returns>
     public static bool TryGetField(TypeSymbol type, string name, [NotNullWhen(true)] out FieldSymbol? field)
     {
+        field = null;
         if (type is StructSymbol structSymbol)
         {
             for (var c = structSymbol; c != null; c = c.BaseClass)
             {
-                if (c.TryGetField(name, out field))
+                if (c.TryGetField(name, out var foundField))
                 {
+                    field = foundField;
                     return true;
                 }
             }
         }
 
-        field = null;
         return false;
     }
 
@@ -246,23 +251,27 @@ public static class TypeMemberModel
     /// <returns>True if found.</returns>
     public static bool TryGetFieldIncludingInherited(TypeSymbol type, string name, MemberQuery query, [NotNullWhen(true)] out FieldSymbol? field, [NotNullWhen(true)] out StructSymbol? declaringType)
     {
+        field = null;
+        declaringType = null;
         if ((query.Kinds & MemberKinds.Field) != 0 && type is StructSymbol structSymbol)
         {
             for (var c = structSymbol; c != null; c = c.BaseClass)
             {
-                if (query.IncludeInstance && c.TryGetField(name, out field))
+                if (query.IncludeInstance && c.TryGetField(name, out var foundInstanceField))
                 {
+                    field = foundInstanceField;
                     declaringType = c;
                     return true;
                 }
 
-                if (query.IncludeStatic && c.TryGetStaticField(name, out field))
+                if (query.IncludeStatic && c.TryGetStaticField(name, out var foundStaticField))
                 {
-                    if (!ReferenceEquals(c, structSymbol) && field.Accessibility == Accessibility.Private)
+                    if (!ReferenceEquals(c, structSymbol) && foundStaticField.Accessibility == Accessibility.Private)
                     {
                         break;
                     }
 
+                    field = foundStaticField;
                     declaringType = c;
                     return true;
                 }
@@ -274,8 +283,6 @@ public static class TypeMemberModel
             }
         }
 
-        field = null;
-        declaringType = null;
         return false;
     }
 

--- a/src/Core/CodeAnalysis/Symbols/TypeMemberModel.cs
+++ b/src/Core/CodeAnalysis/Symbols/TypeMemberModel.cs
@@ -134,7 +134,7 @@ public static class TypeMemberModel
         if (type is StructSymbol structSymbol)
         {
             ImmutableArray<FunctionSymbol>.Builder? builder = null;
-            for (var c = structSymbol; c != null; c = c.BaseClass)
+            foreach (var c in GetHierarchy(structSymbol))
             {
                 if (query.IncludeInstance)
                 {
@@ -220,7 +220,7 @@ public static class TypeMemberModel
         field = null;
         if (type is StructSymbol structSymbol)
         {
-            for (var c = structSymbol; c != null; c = c.BaseClass)
+            foreach (var c in GetHierarchy(structSymbol))
             {
                 if (c.TryGetField(name, out var foundField))
                 {
@@ -255,7 +255,7 @@ public static class TypeMemberModel
         declaringType = null;
         if ((query.Kinds & MemberKinds.Field) != 0 && type is StructSymbol structSymbol)
         {
-            for (var c = structSymbol; c != null; c = c.BaseClass)
+            foreach (var c in GetHierarchy(structSymbol))
             {
                 if (query.IncludeInstance && c.TryGetField(name, out var foundInstanceField))
                 {
@@ -314,7 +314,7 @@ public static class TypeMemberModel
         [NotNullWhen(true)] out FieldSymbol? field,
         [NotNullWhen(true)] out StructSymbol? declaringType)
     {
-        for (var c = type; c != null; c = c.BaseClass)
+        foreach (var c in GetHierarchy(type))
         {
             if (c.TryGetStaticField(name, out field))
             {
@@ -361,7 +361,7 @@ public static class TypeMemberModel
     {
         if (type is StructSymbol structSymbol)
         {
-            for (var c = structSymbol; c != null; c = c.BaseClass)
+            foreach (var c in GetHierarchy(structSymbol))
             {
                 foreach (var p in c.Properties)
                 {
@@ -422,7 +422,7 @@ public static class TypeMemberModel
     {
         if (type is StructSymbol structSymbol)
         {
-            for (var c = structSymbol; c != null; c = c.BaseClass)
+            foreach (var c in GetHierarchy(structSymbol))
             {
                 if (c.PrimaryConstructorParameters.IsDefaultOrEmpty)
                 {
@@ -479,7 +479,7 @@ public static class TypeMemberModel
         [NotNullWhen(true)] out PropertySymbol? property,
         [NotNullWhen(true)] out StructSymbol? declaringType)
     {
-        for (var c = type; c != null; c = c.BaseClass)
+        foreach (var c in GetHierarchy(type))
         {
             var effective = ResolveStaticMemberOwner(type, c);
             if (TryGetStaticProperty(effective, name, out property))
@@ -513,7 +513,7 @@ public static class TypeMemberModel
     {
         if (type is StructSymbol structSymbol)
         {
-            for (var c = structSymbol; c != null; c = c.BaseClass)
+            foreach (var c in GetHierarchy(structSymbol))
             {
                 foreach (var e in c.Events)
                 {
@@ -593,7 +593,7 @@ public static class TypeMemberModel
         [NotNullWhen(true)] out EventSymbol? @event,
         [NotNullWhen(true)] out StructSymbol? declaringType)
     {
-        for (var c = type; c != null; c = c.BaseClass)
+        foreach (var c in GetHierarchy(type))
         {
             var effective = ResolveStaticMemberOwner(type, c);
             if (TryGetStaticEvent(effective, name, out @event))
@@ -634,7 +634,7 @@ public static class TypeMemberModel
                 candidate => ReferenceEquals(candidate, declaredDefinition)) ?? declaredOwner;
         }
 
-        for (var c = lookupType; c != null; c = c.BaseClass)
+        foreach (var c in GetHierarchy(lookupType))
         {
             if (ReferenceEquals(c.Definition ?? c, declaredDefinition))
             {
@@ -650,7 +650,7 @@ public static class TypeMemberModel
     /// <returns>The imported base, or null.</returns>
     public static TypeSymbol? GetNearestImportedBase(StructSymbol type)
     {
-        for (var c = type; c != null; c = c.BaseClass)
+        foreach (var c in GetHierarchy(type))
         {
             if (c.ImportedBaseType?.ClrType != null)
             {
@@ -676,7 +676,7 @@ public static class TypeMemberModel
     {
         if (type is StructSymbol structSymbol)
         {
-            for (var c = structSymbol; c != null; c = c.BaseClass)
+            foreach (var c in GetHierarchy(structSymbol))
             {
                 if (c.TryGetMethod(name, out method))
                 {
@@ -724,7 +724,7 @@ public static class TypeMemberModel
     {
         if (type is StructSymbol structSymbol)
         {
-            for (var c = structSymbol; c != null; c = c.BaseClass)
+            foreach (var c in GetHierarchy(structSymbol))
             {
                 if (c.TryGetStaticMethod(name, out method))
                 {
@@ -773,9 +773,22 @@ public static class TypeMemberModel
         return false;
     }
 
+    private static List<StructSymbol> GetHierarchy(StructSymbol type)
+    {
+        var hierarchy = new List<StructSymbol>();
+        StructSymbol? current = type;
+        while (current != null)
+        {
+            hierarchy.Add(current);
+            current = current.BaseClass;
+        }
+
+        return hierarchy;
+    }
+
     private static IEnumerable<Symbol> EnumerateStructMembers(StructSymbol structSymbol, MemberQuery query)
     {
-        for (var c = structSymbol; c != null; c = c.BaseClass)
+        foreach (var c in GetHierarchy(structSymbol))
         {
             if ((query.Kinds & MemberKinds.Field) != 0)
             {
@@ -932,7 +945,7 @@ public static class TypeMemberModel
 
     private static Symbol? LookupStructMember(StructSymbol structSymbol, string name, MemberQuery query)
     {
-        for (var c = structSymbol; c != null; c = c.BaseClass)
+        foreach (var c in GetHierarchy(structSymbol))
         {
             if ((query.Kinds & MemberKinds.Property) != 0
                 && TryFirst(query.IncludeInstance ? c.Properties : ImmutableArray<PropertySymbol>.Empty, query.IncludeStatic ? c.StaticProperties : ImmutableArray<PropertySymbol>.Empty, name, out PropertySymbol? property))

--- a/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
@@ -503,7 +503,7 @@ public class TypeSymbol : Symbol
             return false;
         }
 
-        return AnyTypeParameter(type, outerMethodTypeParameters.Contains);
+        return AnyTypeParameter(type, parameter => outerMethodTypeParameters.Contains(parameter));
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
@@ -858,11 +858,23 @@ public class TypeSymbol : Symbol
         var rightParts = GetWrappedTypes(right).ToArray();
         if (leftParts.Length > 0 || rightParts.Length > 0)
         {
-            return leftParts.Length == rightParts.Length
-                && (left.ClrType == null
-                    || right.ClrType == null
-                    || ClrTypeUtilities.AreSame(left.ClrType, right.ClrType))
-                && leftParts.Zip(rightParts, AreRuntimeEquivalentIgnoringReferenceNullability).All(equal => equal);
+            if (leftParts.Length != rightParts.Length
+                || (left.ClrType != null
+                    && right.ClrType != null
+                    && !ClrTypeUtilities.AreSame(left.ClrType, right.ClrType)))
+            {
+                return false;
+            }
+
+            for (var i = 0; i < leftParts.Length; i++)
+            {
+                if (!AreRuntimeEquivalentIgnoringReferenceNullability(leftParts[i], rightParts[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         return left.ClrType != null

--- a/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
@@ -980,76 +980,103 @@ public class TypeSymbol : Symbol
     /// <returns>The type's immediate inner type(s); empty for a leaf kind.</returns>
     internal static IEnumerable<TypeSymbol> GetWrappedTypes(TypeSymbol type)
     {
+        var wrapped = new List<TypeSymbol>();
         switch (type)
         {
             case NullableTypeSymbol n:
-                yield return n.UnderlyingType;
+                if (n.UnderlyingType != null)
+                {
+                    wrapped.Add(n.UnderlyingType);
+                }
+
                 break;
             case SliceTypeSymbol s:
-                yield return s.ElementType;
+                wrapped.Add(s.ElementType);
                 break;
             case ArrayTypeSymbol a:
-                yield return a.ElementType;
+                wrapped.Add(a.ElementType);
                 break;
             case RectangularArrayTypeSymbol a:
-                yield return a.ElementType;
+                wrapped.Add(a.ElementType);
                 break;
             case PinnedTypeSymbol p:
-                yield return p.UnderlyingType;
+                wrapped.Add(p.UnderlyingType);
                 break;
             case NullabilityAnnotatedTypeSymbol na:
-                yield return na.BaseType;
+                wrapped.Add(na.BaseType);
                 break;
             case SequenceTypeSymbol seq:
-                yield return seq.ElementType;
+                wrapped.Add(seq.ElementType);
                 break;
             case AsyncSequenceTypeSymbol aseq:
-                yield return aseq.ElementType;
+                wrapped.Add(aseq.ElementType);
                 break;
             case ChannelTypeSymbol ch:
-                yield return ch.ElementType;
+                wrapped.Add(ch.ElementType);
                 break;
             case ByRefTypeSymbol br:
-                yield return br.PointeeType;
+                wrapped.Add(br.PointeeType);
                 break;
             case PointerTypeSymbol ptr:
-                yield return ptr.PointeeType;
+                wrapped.Add(ptr.PointeeType);
                 break;
             case MapTypeSymbol m:
-                yield return m.KeyType;
-                yield return m.ValueType;
+                wrapped.Add(m.KeyType);
+                wrapped.Add(m.ValueType);
                 break;
             case FunctionTypeSymbol fn:
                 foreach (var param in fn.ParameterTypes)
                 {
-                    yield return param;
+                    if (param != null)
+                    {
+                        wrapped.Add(param);
+                    }
                 }
 
-                yield return fn.ReturnType;
+                if (fn.ReturnType != null)
+                {
+                    wrapped.Add(fn.ReturnType);
+                }
+
                 break;
             case FunctionPointerTypeSymbol fp:
                 foreach (var param in fp.ParameterTypes)
                 {
-                    yield return param;
+                    if (param != null)
+                    {
+                        wrapped.Add(param);
+                    }
                 }
 
-                yield return fp.ReturnType;
+                if (fp.ReturnType != null)
+                {
+                    wrapped.Add(fp.ReturnType);
+                }
+
                 break;
             case TupleTypeSymbol tup:
                 foreach (var elem in tup.ElementTypes)
                 {
-                    yield return elem;
+                    if (elem != null)
+                    {
+                        wrapped.Add(elem);
+                    }
                 }
 
                 break;
             case ImportedTypeSymbol it when !it.TypeArguments.IsDefaultOrEmpty:
                 foreach (var arg in it.TypeArguments)
                 {
-                    yield return arg;
+                    if (arg != null)
+                    {
+                        wrapped.Add(arg);
+                    }
                 }
 
                 break;
         }
+
+        return wrapped;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Syntax/AssignmentTargetSyntaxFacts.cs
+++ b/src/Core/CodeAnalysis/Syntax/AssignmentTargetSyntaxFacts.cs
@@ -158,6 +158,9 @@ internal static class AssignmentTargetSyntaxFacts
         [MaybeNullWhen(false)] out SyntaxToken dotToken,
         [MaybeNullWhen(false)] out SyntaxToken fieldIdentifier)
     {
+        receiver = null;
+        dotToken = default;
+        fieldIdentifier = default;
         if (expression is AccessorExpressionSyntax accessor)
         {
             if (accessor.RightPart is NameExpressionSyntax name)
@@ -172,21 +175,20 @@ internal static class AssignmentTargetSyntaxFacts
                 && TryLiftTrailingMemberAccess(
                     accessor.RightPart,
                     out var innerReceiver,
-                    out dotToken,
-                    out fieldIdentifier))
+                    out var innerDotToken,
+                    out var innerFieldIdentifier))
             {
                 receiver = new AccessorExpressionSyntax(
                     expression.SyntaxTree,
                     accessor.LeftPart,
                     accessor.DotToken,
                     innerReceiver);
+                dotToken = innerDotToken;
+                fieldIdentifier = innerFieldIdentifier;
                 return true;
             }
         }
 
-        receiver = null;
-        dotToken = default;
-        fieldIdentifier = default;
         return false;
     }
 }

--- a/src/Core/CodeAnalysis/Syntax/AssignmentTargetSyntaxFacts.cs
+++ b/src/Core/CodeAnalysis/Syntax/AssignmentTargetSyntaxFacts.cs
@@ -154,13 +154,13 @@ internal static class AssignmentTargetSyntaxFacts
     /// </summary>
     public static bool TryLiftTrailingMemberAccess(
         ExpressionSyntax expression,
-        [MaybeNullWhen(false)] out ExpressionSyntax receiver,
-        [MaybeNullWhen(false)] out SyntaxToken dotToken,
-        [MaybeNullWhen(false)] out SyntaxToken fieldIdentifier)
+        [NotNullWhen(true)] out ExpressionSyntax? receiver,
+        [NotNullWhen(true)] out SyntaxToken? dotToken,
+        [NotNullWhen(true)] out SyntaxToken? fieldIdentifier)
     {
         receiver = null;
-        dotToken = default;
-        fieldIdentifier = default;
+        dotToken = null;
+        fieldIdentifier = null;
         if (expression is AccessorExpressionSyntax accessor)
         {
             if (accessor.RightPart is NameExpressionSyntax name)

--- a/src/Core/CodeAnalysis/Syntax/DocumentationAttacher.cs
+++ b/src/Core/CodeAnalysis/Syntax/DocumentationAttacher.cs
@@ -219,7 +219,7 @@ internal static class DocumentationAttacher
             result.Add(method);
         }
 
-        if (structDecl.Constructors != null)
+        if (!structDecl.Constructors.IsDefaultOrEmpty)
         {
             foreach (var ctor in structDecl.Constructors)
             {

--- a/src/Core/CodeAnalysis/Syntax/InterpolationFragment.cs
+++ b/src/Core/CodeAnalysis/Syntax/InterpolationFragment.cs
@@ -6,7 +6,8 @@ namespace GSharp.Core.CodeAnalysis.Syntax;
 
 /// <summary>
 /// A raw fragment produced by the lexer for an interpolated string literal.
-/// Stored as the <c>Value</c> of an <see cref="SyntaxKind.InterpolatedStringToken"/>.
+/// Stored inside the <see cref="InterpolationFragments"/> wrapper attached to an
+/// <see cref="SyntaxKind.InterpolatedStringToken"/>.
 /// Expression fragments still hold un-parsed text; the parser is responsible
 /// for lexing+parsing them into <see cref="ExpressionSyntax"/> nodes when it
 /// builds an <see cref="InterpolatedStringExpressionSyntax"/>.

--- a/src/Core/CodeAnalysis/Syntax/InterpolationFragments.cs
+++ b/src/Core/CodeAnalysis/Syntax/InterpolationFragments.cs
@@ -1,0 +1,25 @@
+// <copyright file="InterpolationFragments.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+
+namespace GSharp.Core.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Reference wrapper for interpolation fragments stored on a syntax token.
+/// </summary>
+internal sealed class InterpolationFragments
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InterpolationFragments"/> class.
+    /// </summary>
+    /// <param name="items">The lexer-produced fragments.</param>
+    public InterpolationFragments(ImmutableArray<InterpolationFragment> items)
+    {
+        Items = items;
+    }
+
+    /// <summary>Gets the lexer-produced fragments.</summary>
+    public ImmutableArray<InterpolationFragment> Items { get; }
+}

--- a/src/Core/CodeAnalysis/Syntax/Lexer.cs
+++ b/src/Core/CodeAnalysis/Syntax/Lexer.cs
@@ -951,7 +951,7 @@ public sealed class Lexer
             }
 
             kind = SyntaxKind.InterpolatedStringToken;
-            value = fragments.ToImmutableArray();
+            value = new InterpolationFragments(fragments.ToImmutableArray());
         }
     }
 

--- a/src/Core/CodeAnalysis/Syntax/Parser.Expressions.Literals.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.Expressions.Literals.cs
@@ -1497,11 +1497,10 @@ public partial class Parser
 
         // MatchToken(InterpolatedStringToken) guarantees the lexer attached the
         // fragment array as the token's value.
-        if (token.Value is not ImmutableArray<InterpolationFragment> fragments)
-        {
-            throw new InvalidOperationException(
-                "An interpolated-string token must carry its lexer fragment array.");
-        }
+        var fragments = Invariant.Required(
+            token.Value as InterpolationFragments,
+            "an interpolated-string token carries its lexer fragment wrapper")
+            .Items;
 
         var segments = ImmutableArray.CreateBuilder<InterpolatedStringSegment>(fragments.Length);
         foreach (var fragment in fragments)

--- a/src/Core/CodeAnalysis/Syntax/Parser.Expressions.Literals.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.Expressions.Literals.cs
@@ -1497,7 +1497,12 @@ public partial class Parser
 
         // MatchToken(InterpolatedStringToken) guarantees the lexer attached the
         // fragment array as the token's value.
-        var fragments = (ImmutableArray<InterpolationFragment>)token.Value!;
+        if (token.Value is not ImmutableArray<InterpolationFragment> fragments)
+        {
+            throw new InvalidOperationException(
+                "An interpolated-string token must carry its lexer fragment array.");
+        }
+
         var segments = ImmutableArray.CreateBuilder<InterpolatedStringSegment>(fragments.Length);
         foreach (var fragment in fragments)
         {

--- a/src/Core/CodeAnalysis/Syntax/SyntaxNode.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxNode.cs
@@ -119,7 +119,7 @@ public abstract class SyntaxNode
             switch (accessor.Kind)
             {
                 case ChildAccessorKind.Node:
-                    var child = (SyntaxNode)accessor.Getter(this);
+                    var child = accessor.Getter(this) as SyntaxNode;
                     if (child != null)
                     {
                         yield return child;
@@ -128,7 +128,7 @@ public abstract class SyntaxNode
                     break;
 
                 case ChildAccessorKind.SeparatedList:
-                    var separatedSyntaxList = (SeparatedSyntaxList)accessor.Getter(this);
+                    var separatedSyntaxList = accessor.Getter(this) as SeparatedSyntaxList;
                     if (separatedSyntaxList == null)
                     {
                         break;
@@ -142,7 +142,12 @@ public abstract class SyntaxNode
                     break;
 
                 case ChildAccessorKind.NodeList:
-                    var children = (IEnumerable<SyntaxNode>)accessor.Getter(this);
+                    var children = accessor.Getter(this) as IEnumerable<SyntaxNode>;
+                    if (children == null)
+                    {
+                        break;
+                    }
+
                     foreach (var enumeratedChild in children)
                     {
                         if (enumeratedChild != null)

--- a/src/Core/CodeAnalysis/Syntax/SyntaxNode.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxNode.cs
@@ -45,7 +45,7 @@ public abstract class SyntaxNode
     /// <c>null</c> means "not computed yet". Cleared by <see cref="InvalidateCachedSpan"/> when a
     /// parser-time mutation replaces a child-bearing property after construction.
     /// </summary>
-    private object? cachedSpan;
+    private SpanBox? cachedSpan;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SyntaxNode"/> class.
@@ -85,13 +85,13 @@ public abstract class SyntaxNode
             // through this property, so the computed span is cached after the first access
             // (issue #1675). The few parser-time mutations of child-bearing properties clear the
             // cache through InvalidateCachedSpan().
-            if (cachedSpan is TextSpan cached)
+            if (cachedSpan != null)
             {
-                return cached;
+                return cachedSpan.Value;
             }
 
             var computed = ComputeSpan();
-            cachedSpan = computed;
+            cachedSpan = new SpanBox(computed);
             return computed;
         }
     }
@@ -360,5 +360,12 @@ public abstract class SyntaxNode
         public ChildAccessorKind Kind { get; }
 
         public Func<SyntaxNode, object> Getter { get; }
+    }
+
+    private sealed class SpanBox
+    {
+        public SpanBox(TextSpan value) => Value = value;
+
+        public TextSpan Value { get; }
     }
 }

--- a/src/Core/CodeAnalysis/Syntax/SyntaxNode.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxNode.cs
@@ -116,6 +116,8 @@ public abstract class SyntaxNode
 
         foreach (var accessor in accessors)
         {
+            // Kind comes from the property's static type, so a failed `as`
+            // here can only represent a legitimate null child/list value.
             switch (accessor.Kind)
             {
                 case ChildAccessorKind.Node:

--- a/src/Core/CodeAnalysis/Syntax/SyntaxTree.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxTree.cs
@@ -16,25 +16,13 @@ public class SyntaxTree
 {
     private Dictionary<SyntaxNode, string>? documentationTable;
 
-    private SyntaxTree(SourceText text, ParseHandler handler)
+    private SyntaxTree(SourceText text)
     {
         Text = text;
-        handler(this, out var root, out var diagnostics, out var docTokens);
-
-        // Every ParseHandler assigns a root before returning. The token-only
-        // handler does so at the EndOfFileToken the lexer always produces, but
-        // that loop's `while (true)` defeats definite-assignment analysis, so
-        // its out parameter has to start null.
-        Root = root!;
-        Diagnostics = diagnostics;
-        DocumentationTokens = docTokens;
+        Root = null!;
+        Diagnostics = ImmutableArray<Diagnostic>.Empty;
+        DocumentationTokens = ImmutableArray<SyntaxToken>.Empty;
     }
-
-    private delegate void ParseHandler(
-        SyntaxTree syntaxTree,
-        out CompilationUnitSyntax? root,
-        out ImmutableArray<Diagnostic> diagnostics,
-        out ImmutableArray<SyntaxToken> documentationTokens);
 
     /// <summary>
     /// Gets the source text.
@@ -44,17 +32,17 @@ public class SyntaxTree
     /// <summary>
     /// Gets the diagnostics.
     /// </summary>
-    public ImmutableArray<Diagnostic> Diagnostics { get; }
+    public ImmutableArray<Diagnostic> Diagnostics { get; private set; }
 
     /// <summary>
     /// Gets the compilation unit root.
     /// </summary>
-    public CompilationUnitSyntax Root { get; }
+    public CompilationUnitSyntax Root { get; private set; }
 
     /// <summary>
     /// Gets the documentation comment tokens collected during lexing (ADR-0057 §7).
     /// </summary>
-    internal ImmutableArray<SyntaxToken> DocumentationTokens { get; }
+    internal ImmutableArray<SyntaxToken> DocumentationTokens { get; private set; }
 
     /// <summary>
     /// Parses the source text from the provided file path into a syntax tree.
@@ -87,15 +75,13 @@ public class SyntaxTree
     /// <returns>A parsed syntax tree.</returns>
     public static SyntaxTree Parse(SourceText text)
     {
-        static void Parse(SyntaxTree syntaxTree, out CompilationUnitSyntax? root, out ImmutableArray<Diagnostic> diagnostics, out ImmutableArray<SyntaxToken> docTokens)
-        {
-            var parser = new Parser(syntaxTree);
-            root = parser.ParseCompilationUnit();
-            diagnostics = parser.Diagnostics.ToImmutableArray();
-            docTokens = parser.DocumentationTokens;
-        }
-
-        return new SyntaxTree(text, Parse);
+        var syntaxTree = new SyntaxTree(text);
+        var parser = new Parser(syntaxTree);
+        syntaxTree.SetParseResult(
+            parser.ParseCompilationUnit(),
+            parser.Diagnostics.ToImmutableArray(),
+            parser.DocumentationTokens);
+        return syntaxTree;
     }
 
     /// <summary>
@@ -140,28 +126,25 @@ public class SyntaxTree
     public static ImmutableArray<SyntaxToken> ParseTokens(SourceText text, out ImmutableArray<Diagnostic> diagnostics)
     {
         var tokens = new List<SyntaxToken>();
-
-        void ParseTokens(SyntaxTree st, out CompilationUnitSyntax? root, out ImmutableArray<Diagnostic> d, out ImmutableArray<SyntaxToken> docTokens)
+        var syntaxTree = new SyntaxTree(text);
+        var lexer = new Lexer(syntaxTree);
+        CompilationUnitSyntax? root = null;
+        while (true)
         {
-            root = null;
-            docTokens = ImmutableArray<SyntaxToken>.Empty;
-            var l = new Lexer(st);
-            while (true)
+            var token = lexer.Lex();
+            if (token.Kind == SyntaxKind.EndOfFileToken)
             {
-                var token = l.Lex();
-                if (token.Kind == SyntaxKind.EndOfFileToken)
-                {
-                    root = new CompilationUnitSyntax(st, ImmutableArray<MemberSyntax>.Empty, token);
-                    break;
-                }
-
-                tokens.Add(token);
+                root = new CompilationUnitSyntax(syntaxTree, ImmutableArray<MemberSyntax>.Empty, token);
+                break;
             }
 
-            d = l.Diagnostics.ToImmutableArray();
+            tokens.Add(token);
         }
 
-        var syntaxTree = new SyntaxTree(text, ParseTokens);
+        syntaxTree.SetParseResult(
+            root,
+            lexer.Diagnostics.ToImmutableArray(),
+            ImmutableArray<SyntaxToken>.Empty);
         diagnostics = syntaxTree.Diagnostics;
         return tokens.ToImmutableArray();
     }
@@ -180,5 +163,15 @@ public class SyntaxTree
         }
 
         return documentationTable.TryGetValue(node, out var doc) ? doc : null;
+    }
+
+    private void SetParseResult(
+        CompilationUnitSyntax root,
+        ImmutableArray<Diagnostic> diagnostics,
+        ImmutableArray<SyntaxToken> documentationTokens)
+    {
+        Root = root;
+        Diagnostics = diagnostics;
+        DocumentationTokens = documentationTokens;
     }
 }

--- a/src/Core/CodeAnalysis/Syntax/SyntaxTree.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxTree.cs
@@ -15,11 +15,11 @@ namespace GSharp.Core.CodeAnalysis.Syntax;
 public class SyntaxTree
 {
     private Dictionary<SyntaxNode, string>? documentationTable;
+    private CompilationUnitSyntax? root;
 
     private SyntaxTree(SourceText text)
     {
         Text = text;
-        Root = null!;
         Diagnostics = ImmutableArray<Diagnostic>.Empty;
         DocumentationTokens = ImmutableArray<SyntaxToken>.Empty;
     }
@@ -37,7 +37,8 @@ public class SyntaxTree
     /// <summary>
     /// Gets the compilation unit root.
     /// </summary>
-    public CompilationUnitSyntax Root { get; private set; }
+    public CompilationUnitSyntax Root =>
+        Invariant.Required(root, "a syntax tree publishes its root before returning to callers");
 
     /// <summary>
     /// Gets the documentation comment tokens collected during lexing (ADR-0057 §7).
@@ -170,7 +171,7 @@ public class SyntaxTree
         ImmutableArray<Diagnostic> diagnostics,
         ImmutableArray<SyntaxToken> documentationTokens)
     {
-        Root = root;
+        this.root = root;
         Diagnostics = diagnostics;
         DocumentationTokens = documentationTokens;
     }

--- a/src/Core/IO/DiagnosticWriter.cs
+++ b/src/Core/IO/DiagnosticWriter.cs
@@ -1,0 +1,25 @@
+// <copyright file="DiagnosticWriter.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.IO;
+using GSharp.Core.CodeAnalysis;
+
+namespace GSharp.Core.IO;
+
+/// <summary>
+/// Provides an ordinary CLR type entry point for diagnostic rendering.
+/// </summary>
+public static class DiagnosticWriter
+{
+    /// <summary>
+    /// Writes diagnostics using the compiler's standard rendering.
+    /// </summary>
+    /// <param name="writer">The destination writer.</param>
+    /// <param name="diagnostics">The diagnostics to render.</param>
+    public static void WriteDiagnostics(TextWriter writer, IEnumerable<Diagnostic> diagnostics)
+    {
+        writer.WriteDiagnostics(diagnostics);
+    }
+}

--- a/src/Repl/Engine/Highlight.cs
+++ b/src/Repl/Engine/Highlight.cs
@@ -96,13 +96,13 @@ public static class Highlight
     /// </summary>
     private static IEnumerable<(int Start, string Text, SemanticColor Color)> ExpandToken(SyntaxToken token)
     {
-        if (token.Kind == SyntaxKind.InterpolatedStringToken && token.Value is ImmutableArray<InterpolationFragment> fragments)
+        if (token.Kind == SyntaxKind.InterpolatedStringToken && token.Value is InterpolationFragments fragments)
         {
             var cursor = token.Position;
             var tokenEnd = token.Position + token.Text.Length;
             var stringColor = Tokens.Tokens.StringLit;
 
-            foreach (var frag in fragments)
+            foreach (var frag in fragments.Items)
             {
                 if (!frag.IsExpression)
                 {

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3394InlineOutTupleBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3394InlineOutTupleBindingTests.cs
@@ -291,6 +291,89 @@ public class Issue3394InlineOutTupleBindingTests
     }
 
     [Fact]
+    public void QualifiedPrivateNestedTypeConstruction_AllowsTrailingInstanceCall()
+    {
+        var result = EmittedOracle.Evaluate("""
+            class Rewriter {}
+
+            class Outer {
+                private open class Rewriter {
+                    func value() int32 -> 42
+                }
+
+                shared {
+                    func make() int32 -> Outer.Rewriter().value()
+                }
+            }
+
+            Outer.make()
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void ImportedOptionalNullParameter_IsReferenceNullable()
+    {
+        var parameter = typeof(OptionalNullFixture)
+            .GetMethod(nameof(OptionalNullFixture.Accept))!
+            .GetParameters()[0];
+
+        Assert.IsType<NullableTypeSymbol>(ClrNullability.GetParameterTypeSymbol(parameter));
+    }
+
+    [Fact]
+    public void OpenOverride_RemainsOverridable()
+    {
+        var result = EmittedOracle.Evaluate("""
+            open class Base {
+                open func Value() int32 -> 1
+            }
+
+            open class Middle : Base {
+                open override func Value() int32 -> 2
+            }
+
+            class Derived : Middle {
+                override func Value() int32 -> 3
+            }
+
+            Derived().Value()
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(3, result.Value);
+    }
+
+    [Fact]
+    public void NestedPrivateType_CanOverrideInheritedOpenMethod()
+    {
+        var result = EmittedOracle.Evaluate("""
+            open class Base {
+                open func Value() int32 -> 1
+            }
+
+            open class Middle : Base {}
+
+            class Outer {
+                private class Derived : Middle {
+                    override func Value() int32 -> 3
+                }
+
+                shared {
+                    func Run() int32 -> Outer.Derived().Value()
+                }
+            }
+
+            Outer.Run()
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(3, result.Value);
+    }
+
+    [Fact]
     public void ImportedOverloadRanking_UsesBetterUserDefinedConversionTarget()
     {
         var result = EmittedOracle.Evaluate("""
@@ -829,4 +912,10 @@ public class Issue3394InlineOutTupleBindingTests
         Assert.Empty(result.Diagnostics);
     }
 
+    private static class OptionalNullFixture
+    {
+        public static void Accept(string value = null)
+        {
+        }
+    }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3394InlineOutTupleBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3394InlineOutTupleBindingTests.cs
@@ -374,6 +374,23 @@ public class Issue3394InlineOutTupleBindingTests
     }
 
     [Fact]
+    public void NullableImportedGenericResult_PreservesSourceElementType()
+    {
+        var result = EmittedOracle.Evaluate("""
+            import System.Collections.Immutable
+
+            class Item {}
+
+            let builder ImmutableArray[Item].Builder? = ImmutableArray.CreateBuilder[Item]()
+            let values = builder?.ToImmutable() ?? ImmutableArray[Item].Empty
+            values.Length
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(0, result.Value);
+    }
+
+    [Fact]
     public void ImportedOverloadRanking_UsesBetterUserDefinedConversionTarget()
     {
         var result = EmittedOracle.Evaluate("""

--- a/test/Core.Tests/CodeAnalysis/Binding/MultiAssignmentTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/MultiAssignmentTests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using GSharp.Core.CodeAnalysis.Binding;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -20,6 +21,19 @@ namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 /// </summary>
 public class MultiAssignmentTests
 {
+    [Fact]
+    public void MutableTupleDeconstruction_WithDiscard_Executes()
+    {
+        var result = EmittedOracle.Evaluate("""
+            var kept = 0
+            kept, _ = (7, 2)
+            kept
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(7, result.Value);
+    }
+
     [Fact]
     public void MultiDecl_AsTwoVarLines_Binds()
     {

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue3236NullableLiftedReferenceConversionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue3236NullableLiftedReferenceConversionTests.cs
@@ -35,6 +35,25 @@ namespace GSharp.Core.Tests.CodeAnalysis.Emit;
 public class Issue3236NullableLiftedReferenceConversionTests
 {
     [Fact]
+    public void RuntimeEquivalentReferenceNullabilityConversion_ExecutesAsIdentity()
+    {
+        var result = EmittedOracle.Evaluate("""
+            class Item { prop Value int32 }
+
+            func Lift(value Item) Item? -> value
+
+            let original = Item{}
+            original.Value = 42
+            let lifted = Lift(original)
+            lifted!!.Value
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
     public void CovariantInterfaceLift_LibraryShape_EmitsCleanly()
     {
         // The issue's first repro, on the exact channel that surfaced it:

--- a/test/Core.Tests/CodeAnalysis/Emit/NullableStringPatternEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/NullableStringPatternEmitTests.cs
@@ -1,0 +1,105 @@
+// <copyright file="NullableStringPatternEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Verifies that string constant patterns use value equality when the
+/// discriminant's static type is nullable.
+/// </summary>
+public class NullableStringPatternEmitTests
+{
+    [Fact]
+    public void SwitchStatement_NullableStringConstant_UsesValueEquality()
+    {
+        const string Source = """
+            package NullableStringSwitchStatement
+            import System
+            let value string? = string.Concat("System.", "Boolean")
+            var result = "miss"
+            switch value {
+                case "System.Boolean" { result = "hit" }
+                default { }
+            }
+            Console.WriteLine(result)
+            """;
+
+        Assert.Contains(
+            "hit",
+            CompileLoadInvokeCaptureStdout(Source, nameof(SwitchStatement_NullableStringConstant_UsesValueEquality)));
+    }
+
+    [Fact]
+    public void SwitchExpression_NullableStringConstant_UsesValueEquality()
+    {
+        const string Source = """
+            package NullableStringSwitchExpression
+            import System
+            let value string? = string.Concat("System.", "Boolean")
+            let result = switch value {
+                case "System.Boolean": "hit"
+                default: "miss"
+            }
+            Console.WriteLine(result)
+            """;
+
+        Assert.Contains(
+            "hit",
+            CompileLoadInvokeCaptureStdout(Source, nameof(SwitchExpression_NullableStringConstant_UsesValueEquality)));
+    }
+
+    private static string CompileLoadInvokeCaptureStdout(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        try
+        {
+            var assembly = loadContext.LoadFromStream(peStream);
+            var programType = assembly.GetTypes().FirstOrDefault(type => type.Name == "<Program>");
+            Assert.NotNull(programType);
+            var entryPoint = programType!.GetMethod(
+                "<Main>$",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(entryPoint);
+
+            var stdout = Console.Out;
+            var captured = new StringWriter();
+            Console.SetOut(captured);
+            try
+            {
+                entryPoint!.Invoke(
+                    null,
+                    entryPoint.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+            }
+            finally
+            {
+                Console.SetOut(stdout);
+            }
+
+            return captured.ToString();
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Syntax/LexerTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/LexerTests.cs
@@ -443,7 +443,7 @@ public class LexerTests
         var token = Assert.Single(tokens);
         Assert.Empty(diagnostics);
         Assert.Equal(SyntaxKind.InterpolatedStringToken, token.Kind);
-        var fragments = (ImmutableArray<InterpolationFragment>)token.Value;
+        var fragments = Assert.IsType<InterpolationFragments>(token.Value).Items;
         Assert.Equal(2, fragments.Length);
         Assert.False(fragments[0].IsExpression);
         Assert.Equal($"hello{Environment.NewLine}", fragments[0].Text);

--- a/test/Core.Tests/CodeAnalysis/Syntax/SyntaxTreeInvariantTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/SyntaxTreeInvariantTests.cs
@@ -1,0 +1,28 @@
+// <copyright file="SyntaxTreeInvariantTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Reflection;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+public class SyntaxTreeInvariantTests
+{
+    [Fact]
+    public void Root_BeforeParseResult_FailsLoudly()
+    {
+        var constructor = typeof(SyntaxTree).GetConstructor(
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            binder: null,
+            [typeof(SourceText)],
+            modifiers: null);
+        Assert.NotNull(constructor);
+        var tree = Assert.IsType<SyntaxTree>(
+            constructor.Invoke([SourceText.From(string.Empty)]));
+
+        Assert.Throws<InvalidOperationException>(() => tree.Root);
+    }
+}

--- a/test/Core.Tests/IO/TextWriterExtensionsTests.cs
+++ b/test/Core.Tests/IO/TextWriterExtensionsTests.cs
@@ -47,6 +47,21 @@ public class TextWriterExtensionsTests
     }
 
     [Fact]
+    public void DiagnosticWriter_WriteDiagnostics_RendersThroughStableType()
+    {
+        var diagnostic = new Diagnostic(
+            default,
+            "GS9999",
+            DiagnosticSeverity.Error,
+            "stable diagnostic entry point");
+
+        using var writer = new StringWriter();
+        DiagnosticWriter.WriteDiagnostics(writer, new[] { diagnostic });
+
+        Assert.Contains("error GS9999: stable diagnostic entry point", writer.ToString());
+    }
+
+    [Fact]
     public void WriteDiagnostics_SpanAtEndOfFile_DoesNotThrow()
     {
         var sourceText = SourceText.From("let x = 1\r\n", "test.gs");

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3394NestedGenericTypeTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3394NestedGenericTypeTranslationTests.cs
@@ -231,4 +231,45 @@ namespace Demo
             scope.Diagnostics,
             diagnostic => diagnostic.Severity == GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error);
     }
+
+    [Fact]
+    public void DeconstructedLocals_PassedByRef_AreMutable()
+    {
+        const string source = """
+            namespace Demo
+            {
+                public static class C
+                {
+                    private static (int?, int?) Pair() => (null, null);
+
+                    private static void Touch(ref int? value)
+                    {
+                    }
+
+                    public static void M()
+                    {
+                        var (left, right) = Pair();
+                        Touch(ref left);
+                        Touch(ref right);
+                    }
+                }
+            }
+            """;
+
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Snippet.cs", source) });
+        Assert.True(project.BoundWithoutErrors, string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(
+            project.Compilation,
+            document.SemanticModel,
+            document.FilePath);
+        string rendered = GSharpPrinter.Print(
+            new CSharpToGSharpTranslator().TranslateDocument(document, context));
+
+        Assert.Contains("var left", rendered, StringComparison.Ordinal);
+        Assert.Contains("var right", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
 }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
@@ -945,6 +945,11 @@ public sealed partial class CSharpToGSharpTranslator
                     if (designation is SingleVariableDesignationSyntax indexCheckSingle)
                     {
                         this.ReportIfIndexOrRangeTypedDesignation(indexCheckSingle);
+                        if (this.context.GetDeclaredSymbol(indexCheckSingle) is ILocalSymbol local
+                            && this.IsLocalReassigned(local))
+                        {
+                            binding = BindingKind.Var;
+                        }
                     }
                 }
 
@@ -971,6 +976,11 @@ public sealed partial class CSharpToGSharpTranslator
                     if (declaration.Designation is SingleVariableDesignationSyntax indexCheckSingle)
                     {
                         this.ReportIfIndexOrRangeTypedDesignation(indexCheckSingle);
+                        if (this.context.GetDeclaredSymbol(indexCheckSingle) is ILocalSymbol local
+                            && this.IsLocalReassigned(local))
+                        {
+                            binding = BindingKind.Var;
+                        }
                     }
                 }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
@@ -1987,11 +1987,34 @@ public sealed partial class CSharpToGSharpTranslator
 
                 if (this.TryGetDeconstructionTargets(assignment.Left, out BindingKind binding, out IReadOnlyList<string> names))
                 {
-                    // `var (a, b) = e` → `let (a, b) = e` (spec §Tuples).
+                    if (binding == BindingKind.Var)
+                    {
+                        var temps = names.Select(_ => $"__decon{this.state.DeconCounter++}").ToList();
+                        var statements = new List<GStatement>
+                        {
+                            new TupleDeconstructionStatement(
+                                BindingKind.Let,
+                                temps,
+                                this.TranslateExpression(assignment.Right)),
+                        };
+                        for (var i = 0; i < names.Count; i++)
+                        {
+                            if (names[i] != "_")
+                            {
+                                statements.Add(new LocalDeclarationStatement(
+                                    BindingKind.Var,
+                                    names[i],
+                                    initializer: new IdentifierExpression(temps[i])));
+                            }
+                        }
+
+                        return statements;
+                    }
+
                     return new[]
                     {
                         (GStatement)new TupleDeconstructionStatement(
-                            binding,
+                            BindingKind.Let,
                             names,
                             this.TranslateExpression(assignment.Right)),
                     };


### PR DESCRIPTION
## Summary

Refs #3394. Resolves #3407.

Continues Core-first self-migration from merged #3406.

- reduces the cycle-85 semantic frontier from **60 diagnostics to zero**
- removes the original semantic frontier: **1,126 → 0**
- produces the first complete translated Core semantic compile
- repairs the migrated-Core symbolic generic/nullable ABI and reduces ILVerify **163 → 0**
- keeps ordinary Core translate, compile, ILVerify, and reported parity green through cycle 218
- advances migrated-Core self-hosting from 25,338 diagnostics to a measured seven deeper semantic seams
- adds focused compiler, translator, nullable-contract, conversion-emit, and deconstruction regressions
- commits no generated migrated sources, artifacts, logs, binaries, packages, or caches

## Core cycles

| Cycle | Result | Milestone |
|---:|---:|---|
| 85 baseline | compile FAIL(60) | latest-main baseline |
| 86–104 | 55 → 0, then emit repairs | semantic and latent emit clusters removed |
| 105 | compile PASS | first complete semantic compile |
| 111 | compile PASS; ILVerify FAIL(163) | symbolic ABI frontier exposed |
| 124 | compile/ILVerify/parity PASS | migrated Core verification complete |
| 181–218 | ordinary cycle PASS | self-host frontier 25,338 → 7 |

## Validation

- Core.Tests: **7,610/7,610** in focused re-review validation
- review regressions: SyntaxTree fail-loud invariant, runtime-equivalent conversion emit, mutable deconstruction with discard
- nullable hygiene: pass
- full solution build: zero warnings/errors
- final Actions run [31968600990](https://github.com/DavidObando/gsharp/actions/runs/31968600990): all build, Core/compiler/cs2gs shards, corpus, Oahu, and ILVerify jobs green
- focused Opus re-review: no blockers

## Remaining self-host work

Cycle 218 measured seven deeper migrated-Core self-host diagnostics. No self-hosted Core assembly was emitted, so second-generation ILVerify/parity and gsc migration remain unproven and continue under #3394.

Distinct translator gaps are tracked separately: #3412 iterator/yield, #3413 nested private classes, #3414 method-group delegate conversion, and #3415 nullable AsyncLocal handling. Merged #3402 already covers pattern-in-`&&` scoping.