### PR TITLE
Lower capturing recursive local functions to nullable function locals (#3399)

### DIFF
--- a/docs/self-migration-spike-3394.md
+++ b/docs/self-migration-spike-3394.md
@@ -259,13 +259,20 @@ The spike minimized and filed four independent blockers:
 - [#3402](https://github.com/DavidObando/gsharp/issues/3402):
   short-circuit pattern binders escape generated scope.
 
-### Capturing recursion
+### Capturing recursion (resolved — #3399)
 
-cs2gs can now lift recursive capture-free static local functions. Core still
-contains recursive local-function groups that capture builders, counters,
-labels, and other mutable outer state. G# local `let = func` bindings are not
-recursive or forward-visible. A faithful solution needs a generated
-closure/helper type or a recursive local-function language feature.
+cs2gs lifted recursive capture-free local functions on the `let`/hoist path,
+which G# supports for self- and mutual recursion. Capturing recursive or
+mutually recursive local functions (builders, counters, labels, other mutable
+outer state) now lower to the documented G# scheme (ADR-0137 / ADR-0069): the
+whole SCC of recursive sibling functions is bound as nil-initialized
+nullable-function-typed `var` locals — declarations first, assignments after —
+instead of plain `let`/`func` literals, because `let` is not recursive or
+forward-visible across siblings (GS0130/GS0125). Sibling calls inside the
+closure bodies then go through postfix null assertions, and the captured
+mutable outer state stays a single shared `var` binding, preserving C#'s
+shared-mutation semantics. Capture-free SCCs keep the canonical `let` path
+untouched.
 
 ### Byref symbolic generics
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3399CapturingRecursiveLocalFunctionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3399CapturingRecursiveLocalFunctionTranslationTests.cs
@@ -1,0 +1,352 @@
+// <copyright file="Issue3399CapturingRecursiveLocalFunctionTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3399: C# local functions that capture locals and recurse (directly or
+/// mutually) failed to translate — the canonical <c>let name = func ...</c>
+/// binding a body uses to call itself is not recursive/forward-visible to gsc
+/// (GS0130/GS0125). These are now lowered to G#'s nullable function-typed local
+/// scheme: every strongly connected component member is first declared
+/// <c>var Name ((…) -> R)? = nil</c> (all declarations precede the first
+/// assignment — a G# closure body cannot reference a not-yet-declared sibling
+/// local), then bound with <c>Name = func ...</c>; SCC partners are
+/// referenced from inside a closure body through a postfix null assertion
+/// (<c>Partner!!(…)</c>, ADR-0069). G#'s reference capture preserves C#'s
+/// shared mutation of the captured sibling locals, so behavior (not just
+/// binding) is preserved.
+/// </summary>
+public class Issue3399CapturingRecursiveLocalFunctionTranslationTests
+{
+    [Fact]
+    public void SelfRecursiveCapturingLocalFunction_TranslatesAndPreservesCapture()
+    {
+        string printed = LocalFunctionHoistTranslationTests.TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public void M()
+        {
+            int sum = 0;
+
+            void Add(int n)
+            {
+                if (n > 0)
+                {
+                    Add(n - 1);
+                }
+
+                sum++;
+            }
+
+            Add(2);
+        }
+    }
+}");
+
+        // The recursive member must be a mutable function local, not a plain
+        // `let` binding, and the self-recursive call site inside the closure
+        // body must carry the postfix null assertion.
+        Assert.DoesNotContain("let Add", printed, StringComparison.Ordinal);
+        Assert.Contains("var Add", printed, StringComparison.Ordinal);
+        Assert.Contains("Add = func", printed, StringComparison.Ordinal);
+        Assert.Contains("Add!!(", printed, StringComparison.Ordinal);
+
+        LocalFunctionHoistTranslationTests.CompileAndRun(printed, "C().M()");
+    }
+
+    [Fact]
+    public void MutuallyRecursiveCapturingLocalFunctions_AllDeclaredBeforeFirstAssignment()
+    {
+        string printed = LocalFunctionHoistTranslationTests.TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public void M()
+        {
+            int calls = 0;
+
+            void Even(int n)
+            {
+                calls++;
+                if (n > 0)
+                {
+                    Odd(n - 1);
+                }
+            }
+
+            void Odd(int n)
+            {
+                calls++;
+                if (n > 0)
+                {
+                    Even(n - 1);
+                }
+            }
+
+            Even(3);
+        }
+    }
+}");
+
+        Assert.DoesNotContain("let Even", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("let Odd", printed, StringComparison.Ordinal);
+        Assert.Contains("var Even", printed, StringComparison.Ordinal);
+        Assert.Contains("var Odd", printed, StringComparison.Ordinal);
+        Assert.Contains("Even!!(", printed, StringComparison.Ordinal);
+        Assert.Contains("Odd!!(", printed, StringComparison.Ordinal);
+
+        // Both nil-initialized declarations must precede the first literal
+        // assignment of either member (G# closure bodies cannot
+        // forward-reference a not-yet-declared sibling local).
+        int evenDecl = IndexOf(printed, "var Even");
+        int oddDecl = IndexOf(printed, "var Odd");
+        int firstAssign = Math.Min(IndexOf(printed, "Even = func"), IndexOf(printed, "Odd = func"));
+        Assert.True(evenDecl < firstAssign, "The whole SCC's declarations must precede its first assignment.\n" + printed);
+        Assert.True(oddDecl < firstAssign, "The whole SCC's declarations must precede its first assignment.\n" + printed);
+
+        LocalFunctionHoistTranslationTests.CompileAndRun(printed, "C().M()");
+    }
+
+    [Fact]
+    public void NestedRecursiveCapturingLocalFunctions_ProjectRegionsShape_Translates()
+    {
+        string printed = LocalFunctionHoistTranslationTests.TranslateUnit(@"
+using System.Collections.Generic;
+namespace Demo
+{
+    public class C
+    {
+        public List<int> Project(List<int> entries)
+        {
+            var builder = new List<int>();
+            int choiceOrdinal = 0;
+            int routeCount = 0;
+
+            void RouteTransfer(int region, int depth)
+            {
+                routeCount++;
+                if (depth > 0)
+                {
+                    NewLabel(region, depth - 1);
+                }
+            }
+
+            void NewLabel(int region, int depth)
+            {
+                if (entries.Count > 0)
+                {
+                    choiceOrdinal++;
+                }
+
+                builder.Add(region + choiceOrdinal);
+                if (routeCount < 2)
+                {
+                    CollectLabels(region, depth);
+                }
+            }
+
+            void CollectLabels(int region, int depth)
+            {
+                if (depth > 0)
+                {
+                    RouteTransfer(region, 2);
+                }
+            }
+
+            CollectLabels(10, 1);
+            return builder;
+        }
+    }
+}");
+
+        // Three-way SCC — every member goes through the nullable function-local
+        // lowering; cross-sibling calls inside closure bodies carry `!!`.
+        Assert.Contains("var RouteTransfer", printed, StringComparison.Ordinal);
+        Assert.Contains("var NewLabel", printed, StringComparison.Ordinal);
+        Assert.Contains("var CollectLabels", printed, StringComparison.Ordinal);
+        Assert.Contains("NewLabel!!(", printed, StringComparison.Ordinal);
+        Assert.Contains("RouteTransfer!!(", printed, StringComparison.Ordinal);
+        Assert.Contains("CollectLabels!!(", printed, StringComparison.Ordinal);
+
+        LocalFunctionHoistTranslationTests.CompileAndRun(printed, "C().Project(List[int32]())");
+    }
+
+    [Fact]
+    public void CaptureFreeMember_HoistedByHoister_StillJoiningCapturingScc_TranslatesAndRuns()
+    {
+        // Regression guard: a SCC member that captures nothing itself must
+        // STILL join the nullable function-local lowering because its SCC
+        // contains a capturing member — the group lowers as one unit, and a
+        // `let`/`var` mix inside one sibling group (plus the closure bodies'
+        // cross-references, which the hoister may reorder) is exactly the
+        // shape gsc rejects (GS0130/GS0125).
+        string printed = LocalFunctionHoistTranslationTests.TranslateUnit(@"
+using System;
+namespace Demo
+{
+    public class C
+    {
+        public void M()
+        {
+            int count = 0;
+
+            void A()
+            {
+                B();
+            }
+
+            void B()
+            {
+                if (count < 2)
+                {
+                    count++;
+                    A();
+                }
+            }
+
+            A();
+            System.Console.WriteLine(count);
+        }
+    }
+}");
+
+        Assert.Contains("var A", printed, StringComparison.Ordinal);
+        Assert.Contains("var B", printed, StringComparison.Ordinal);
+        Assert.Contains("B!!(", printed, StringComparison.Ordinal);
+        Assert.Contains("A!!(", printed, StringComparison.Ordinal);
+
+        string output = CompileAndCaptureRun(printed, "C().M()");
+        Assert.Contains("2", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NonRecursiveCapturingLocalFunction_KeepsPlainLetBinding()
+    {
+        // A capturing local function that is NOT part of a recursive SCC keeps
+        // the existing canonical `let` binding (no spurious nullable
+        // function-local downgrade).
+        string printed = LocalFunctionHoistTranslationTests.TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public int M()
+        {
+            int seed = 5;
+
+            int Helper(int x)
+            {
+                return x + seed;
+            }
+
+            return Helper(1);
+        }
+    }
+}");
+
+        Assert.Contains("let Helper", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("!!", printed, StringComparison.Ordinal);
+
+        LocalFunctionHoistTranslationTests.CompileAndRun(printed, "C().M()");
+    }
+
+    [Fact]
+    public void SharedCaptureSemantics_PreservedAcrossRecursionBoundaries()
+    {
+        // The mutated scalar is captured by reference: the self-recursive body
+        // and a second call must observe the SAME backing storage (C#
+        // semantics) — `Add(2)` increments `sum` 3 times (n = 2, 1, 0) plus
+        // one extra direct increment, so `sum` prints as 4.
+        string printed = LocalFunctionHoistTranslationTests.TranslateUnit(@"
+using System;
+namespace Demo
+{
+    public class C
+    {
+        public void M()
+        {
+            int sum = 0;
+
+            void Add(int n)
+            {
+                if (n > 0)
+                {
+                    Add(n - 1);
+                }
+
+                sum++;
+            }
+
+            Add(2);
+            sum++;
+            System.Console.WriteLine(sum);
+        }
+    }
+}");
+
+        string output = CompileAndCaptureRun(printed, "C().M()");
+        Assert.Contains("4", output, StringComparison.Ordinal);
+    }
+
+    private static int IndexOf(string haystack, string needle)
+    {
+        int index = haystack.IndexOf(needle, StringComparison.Ordinal);
+        Assert.True(index >= 0, $"'{needle}' should be present.\n" + haystack);
+        return index;
+    }
+
+    /// <summary>
+    /// Same as <see cref="LocalFunctionHoistTranslationTests.CompileAndRun"/>
+    /// but returns the program's stdout so value-level assertions are
+    /// possible (the shared helper only asserts a successful exit).
+    /// </summary>
+    private static string CompileAndCaptureRun(string printed, string callExpression)
+    {
+        string compiler = LocalFunctionHoistTranslationTests.FindCompiler();
+        Assert.True(compiler != null, "gsc.dll must be built (dotnet build GSharp.sln) before running this test.");
+
+        string workDir = Path.Combine(AppContext.BaseDirectory, "issue-3399-e2e", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workDir);
+        string gsPath = Path.Combine(workDir, "Snippet.gs");
+        string dllPath = Path.Combine(workDir, "Snippet.dll");
+        File.WriteAllText(gsPath, printed + Environment.NewLine + callExpression + Environment.NewLine);
+
+        (int compileExit, string compileOut) = RunLocal($"\"{compiler}\" /target:exe /out:\"{dllPath}\" \"{gsPath}\"");
+        Assert.True(
+            compileExit == 0 && !compileOut.Contains("error", StringComparison.OrdinalIgnoreCase),
+            "gsc must compile the translated snippet with zero errors. Output:\n" + compileOut +
+                "\n\nTranslated G#:\n" + printed);
+
+        (int runExit, string runOut) = RunLocal($"\"{dllPath}\"");
+        Assert.True(runExit == 0, "Translated snippet must run successfully. Output:\n" + runOut);
+        return runOut;
+    }
+
+    private static (int Exit, string Output) RunLocal(string arguments)
+    {
+        var psi = new ProcessStartInfo("dotnet", arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        using var process = Process.Start(psi);
+        var output = new StringBuilder();
+        output.Append(process.StandardOutput.ReadToEnd());
+        output.Append(process.StandardError.ReadToEnd());
+        process.WaitForExit();
+        return (process.ExitCode, output.ToString());
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/LocalFunctionHoistTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/LocalFunctionHoistTranslationTests.cs
@@ -264,9 +264,13 @@ namespace Demo
     }
 }");
 
+    // Issue #3399 hybrid: a capturing recursive local lowers to G#'s
+    // nullable function-typed local, not a synthesized capture-passing helper.
     Assert.DoesNotContain("let Add", printed, StringComparison.Ordinal);
-    Assert.Contains("ref sum int32", printed, StringComparison.Ordinal);
-    Assert.Contains("__local_Run_Add_", printed, StringComparison.Ordinal);
+    Assert.DoesNotContain("__local_Run_Add_", printed, StringComparison.Ordinal);
+    Assert.Contains("var Add", printed, StringComparison.Ordinal);
+    Assert.Contains("Add = func", printed, StringComparison.Ordinal);
+    Assert.Contains("Add!!(", printed, StringComparison.Ordinal);
     CompileAndRun(
         printed,
         "C().Run(3)\nConsole.WriteLine(\"ok\")",
@@ -313,10 +317,16 @@ namespace Demo
     }
 }");
 
+    // Issue #3399 hybrid: a capturing mutually recursive SCC lowers to G#'s
+    // nullable function-typed locals, not synthesized capture-passing helpers.
     Assert.DoesNotContain("let AddEven", printed, StringComparison.Ordinal);
     Assert.DoesNotContain("let AddOdd", printed, StringComparison.Ordinal);
-    Assert.Contains("__local_Run_AddEven_", printed, StringComparison.Ordinal);
-    Assert.Contains("__local_Run_AddOdd_", printed, StringComparison.Ordinal);
+    Assert.DoesNotContain("__local_Run_AddEven_", printed, StringComparison.Ordinal);
+    Assert.DoesNotContain("__local_Run_AddOdd_", printed, StringComparison.Ordinal);
+    Assert.Contains("var AddEven", printed, StringComparison.Ordinal);
+    Assert.Contains("var AddOdd", printed, StringComparison.Ordinal);
+    Assert.Contains("AddEven!!(", printed, StringComparison.Ordinal);
+    Assert.Contains("AddOdd!!(", printed, StringComparison.Ordinal);
     CompileAndRun(
         printed,
         "C().Run(3)\nConsole.WriteLine(\"ok\")",
@@ -392,8 +402,11 @@ namespace Demo
     }
 }");
 
-    Assert.Contains("values List[int32]", printed, StringComparison.Ordinal);
-    Assert.DoesNotContain("values List[int32]?", printed, StringComparison.Ordinal);
+    // Issue #3399 hybrid: the captured local stays a plain non-nullable G#
+    // local (`let values = List[int32]()`) captured by the nullable function
+    // literal — no nullable reference type is introduced for the capture.
+    Assert.Contains("let values = List[int32]()", printed, StringComparison.Ordinal);
+    Assert.DoesNotContain("List[int32]?", printed, StringComparison.Ordinal);
     CompileAndRun(
         printed,
         "C().Run(3)\nConsole.WriteLine(\"ok\")",
@@ -468,7 +481,7 @@ class C {
         Assert.Contains("GS0130", compile.Output, StringComparison.Ordinal);
     }
 
-    private static string TranslateUnit(string source, string roundTripOnlyReason = null)
+    internal static string TranslateUnit(string source, string roundTripOnlyReason = null)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
         Assert.True(
@@ -498,10 +511,10 @@ class C {
     /// forward-reference bug is a binder-time error that a parse-only round-trip
     /// cannot catch).
     /// </summary>
-    private static void CompileAndRun(
+    internal static void CompileAndRun(
         string printed,
         string callExpression,
-        string expectedOutput)
+        string expectedOutput = null)
     {
         string compiler = FindCompiler();
         Assert.True(compiler != null, "gsc.dll must be built (dotnet build GSharp.sln) before running this test.");
@@ -535,10 +548,13 @@ class C {
         Assert.True(
             run.ExitCode == 0,
             "Translated snippet must run successfully. Output:\n" + run.Output);
-        Assert.Equal(expectedOutput, run.Stdout.Trim());
+        if (expectedOutput is not null)
+        {
+            Assert.Equal(expectedOutput, run.Stdout.Trim());
+        }
     }
 
-    private static string FindCompiler()
+    internal static string FindCompiler()
     {
         var dir = new DirectoryInfo(AppContext.BaseDirectory);
         while (dir is not null)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
@@ -1485,6 +1485,12 @@ public sealed partial class CSharpToGSharpTranslator
         {
             var statements = new List<GStatement>();
             IReadOnlyList<StatementSyntax> ordered = this.HoistCallBeforeDeclLocalFunctions(block);
+
+            // Issue #3399: registering the capturing recursive local function
+            // groups first lets `RegisterRecursiveLocalFunctionLifts` skip SCC
+            // members — those lower to nullable function locals instead of
+            // synthesized instance helpers.
+            this.RegisterCapturingRecursiveLocalFunctions(ordered);
             this.RegisterRecursiveLocalFunctionLifts(ordered);
             foreach (StatementSyntax statement in ordered)
             {
@@ -1496,6 +1502,15 @@ public sealed partial class CSharpToGSharpTranslator
 
         private void RegisterRecursiveLocalFunctionLifts(IEnumerable<StatementSyntax> statements)
         {
+            // Issue #3399 (hybrid lowering): members of a registering SCC of
+            // capturing local functions lower to G# nullable function locals
+            // (see `RegisterCapturingRecursiveLocalFunctions`, which runs first)
+            // instead of synthetic instance helpers — skip them here so both
+            // the registration and the `TranslateLocalFunction` helper emission
+            // stay out of the way.
+            bool IsCapturingRecursiveGroupMember(IMethodSymbol symbol) =>
+                this.state.RecursiveLocalFunctionGroups.ContainsKey(symbol);
+
             var localFunctions = new List<(LocalFunctionStatementSyntax Syntax, IMethodSymbol Symbol)>();
             foreach (LocalFunctionStatementSyntax localFunction in statements
                 .OfType<LocalFunctionStatementSyntax>())
@@ -1595,7 +1610,8 @@ public sealed partial class CSharpToGSharpTranslator
             foreach (var pair in localFunctions.Where(pair => pair.Symbol.IsStatic))
             {
                 if (this.state.LiftedStaticLocalFunctions.ContainsKey(pair.Symbol)
-                    || !toLift.Contains(pair.Symbol))
+                    || !toLift.Contains(pair.Symbol)
+                    || IsCapturingRecursiveGroupMember(pair.Symbol))
                 {
                     continue;
                 }
@@ -1607,7 +1623,9 @@ public sealed partial class CSharpToGSharpTranslator
             }
 
             var capturingLocals = localFunctions
-                .Where(pair => !pair.Symbol.IsStatic && toLift.Contains(pair.Symbol))
+                .Where(pair => !pair.Symbol.IsStatic
+                    && toLift.Contains(pair.Symbol)
+                    && !IsCapturingRecursiveGroupMember(pair.Symbol))
                 .ToList();
             if (capturingLocals.Count == 0)
             {
@@ -1712,6 +1730,254 @@ public sealed partial class CSharpToGSharpTranslator
                         containingMethod?.IsStatic != false,
                         captures);
             }
+        }
+
+        // Issue #3399: recursive or mutually recursive C# local functions that
+        // CAPTURE locals cannot be lifted as static helpers (they need the
+        // captured values), and G#'s non-recursive `let` binding fails when the
+        // body calls the binding itself (GS0130 "Function 'Foo' doesn't exist"
+        // / GS0125). Each strongly-connected component is instead registered so
+        // <see cref="TranslateLocalFunction"/> lowers it to G#'s
+        // nullable-function-local scheme: every member is first declared
+        // nil-initialized as `var Name (… -> R)? = nil` (a G# closure body cannot
+        // reference a sibling local that is not yet declared, so the whole SCC's
+        // declarations must precede its first assignment), then each member binds
+        // its function literal (`Name = func …`); SCC partners are reached from a
+        // closure body through the nullable local via a null assertion
+        // (`Partner!!(…)` — ADR-0069/ADR-0137). G#'s capture-by-reference
+        // closures preserve C#'s shared mutation of the captured sibling locals.
+        private void RegisterCapturingRecursiveLocalFunctions(IReadOnlyList<StatementSyntax> statements)
+        {
+            // `DescendantNodes()` excludes the node itself — local functions that
+            // ARE a top-level statement of the block must be included explicitly;
+            // local functions nested inside other local functions' bodies must be
+            // included too (mutual recursion crosses that nesting — issue #3399's
+            // ProjectRegionsForDefiniteReturn shape: a nested helper calling its
+            // outer siblings).
+            var localFunctionStatements = statements
+                .SelectMany(statement => statement.DescendantNodes().Prepend(statement))
+                .Distinct()
+                .ToList();
+            var functions = new List<(LocalFunctionStatementSyntax Syntax, IMethodSymbol Symbol)>();
+            foreach (LocalFunctionStatementSyntax localFunction in localFunctionStatements.OfType<LocalFunctionStatementSyntax>())
+            {
+                    using IDisposable modelScope = this.context.UseSemanticModelFor(localFunction.SyntaxTree);
+                    if (this.context.GetDeclaredSymbol(localFunction) is not IMethodSymbol symbol)
+                    {
+                        continue;
+                    }
+
+                    // A generic local function's type parameters cannot be expressed
+                    // on a function-typed local, and a ref-returning local is an
+                    // unsupported gap either way — both stay on the existing path.
+                    if (localFunction.TypeParameterList != null || symbol.ReturnsByRef)
+                    {
+                        continue;
+                    }
+
+                    // A static local function already lifted as a shared helper has
+                    // working recursion there — nothing to do for it.
+                    if (localFunction.Modifiers.Any(SyntaxKind.StaticKeyword)
+                        && this.state.PendingStaticSynthHelpers is not null
+                        && this.state.LiftedStaticLocalFunctions.ContainsKey(symbol))
+                    {
+                        continue;
+                    }
+
+                    functions.Add((localFunction, symbol));
+            }
+
+            if (functions.Count == 0)
+            {
+                return;
+            }
+
+            var reachableFunctions = new HashSet<IMethodSymbol>(
+                functions.Select(f => f.Symbol), SymbolEqualityComparer.Default);
+            var edges = new Dictionary<IMethodSymbol, HashSet<IMethodSymbol>>(SymbolEqualityComparer.Default);
+            foreach ((LocalFunctionStatementSyntax syntax, IMethodSymbol symbol) in functions)
+            {
+                using IDisposable modelScope = this.context.UseSemanticModelFor(syntax.SyntaxTree);
+                var dependencies = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
+                foreach (SyntaxNode node in syntax.DescendantNodes())
+                {
+                    if (this.context.GetSymbolInfo(node).Symbol is IMethodSymbol dependency
+                        && reachableFunctions.Contains(dependency))
+                    {
+                        dependencies.Add(dependency);
+                    }
+                }
+
+                edges[symbol] = dependencies;
+            }
+
+            var reach = new Dictionary<IMethodSymbol, HashSet<IMethodSymbol>>(SymbolEqualityComparer.Default);
+            foreach (IMethodSymbol symbol in reachableFunctions)
+            {
+                var reachable = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
+                var stack = new Stack<IMethodSymbol>();
+                stack.Push(symbol);
+                while (stack.Count > 0)
+                {
+                    IMethodSymbol current = stack.Pop();
+                    foreach (IMethodSymbol dependency in edges[current])
+                    {
+                        if (reachable.Add(dependency))
+                        {
+                            stack.Push(dependency);
+                        }
+                    }
+                }
+
+                reach[symbol] = reachable;
+            }
+
+            // A symbol that can reach itself is recursive; each recursive symbol
+            // belongs to the strongly-connected component formed by the recursive
+            // symbols it mutually reaches (transitive within one component, so the
+            // first matching group is the right one).
+            var groups = new List<List<(LocalFunctionStatementSyntax Syntax, IMethodSymbol Symbol)>>();
+            foreach ((LocalFunctionStatementSyntax syntax, IMethodSymbol symbol) in functions)
+            {
+                if (!reach[symbol].Contains(symbol))
+                {
+                    continue;
+                }
+
+                List<(LocalFunctionStatementSyntax Syntax, IMethodSymbol Symbol)> group = null;
+                foreach (List<(LocalFunctionStatementSyntax Syntax, IMethodSymbol Symbol)> candidate in groups)
+                {
+                    IMethodSymbol head = candidate[0].Symbol;
+                    if (reach[head].Contains(symbol) && reach[symbol].Contains(head))
+                    {
+                        group = candidate;
+                    }
+                }
+
+                if (group == null)
+                {
+                    group = new List<(LocalFunctionStatementSyntax Syntax, IMethodSymbol Symbol)>();
+                    groups.Add(group);
+                }
+
+                group.Add((syntax, symbol));
+            }
+
+            foreach (List<(LocalFunctionStatementSyntax Syntax, IMethodSymbol Symbol)> group in groups)
+            {
+                // G#'s plain `let`/hoisting path supports SELF- and MUTUAL
+                // recursion of local functions (sibling letrec visibility — the
+                // pre-#3399 canonical lowering, left intact). The GS0130/GS0125
+                // failure #3399 hits appears only when a member CAPTURES outer
+                // locals: gsc's closure lowering loses the shared sibling
+                // visibility. SCCs with no capturing member therefore keep the
+                // canonical `let`/hoist path entirely.
+                if (!group.Any(f => this.CapturesOuterState(f.Syntax, f.Symbol)))
+                {
+                    continue;
+                }
+
+                // An outer block's registration (which walks descendant local
+                // functions) is always processed before the nested block's own, so
+                // a fully-registered group here is a re-discovery — keep the first.
+                if (group.All(f => this.state.RecursiveLocalFunctionGroups.ContainsKey(f.Symbol)))
+                {
+                    continue;
+                }
+
+                var members = new List<IMethodSymbol>();
+                var names = new List<string>();
+                var declarations = new List<GStatement>();
+                foreach ((LocalFunctionStatementSyntax syntax, IMethodSymbol symbol) in group)
+                {
+                    using IDisposable modelScope = this.context.UseSemanticModelFor(syntax.SyntaxTree);
+                    var parameterTypes = new List<GTypeReference>();
+                    foreach (ParameterSyntax parameter in syntax.ParameterList.Parameters)
+                    {
+                        parameterTypes.Add(this.MapLambdaParameter(parameter).Type);
+                    }
+
+                    bool isAsync = syntax.Modifiers.Any(SyntaxKind.AsyncKeyword);
+                    var returns = new List<GTypeReference>();
+                    if (!symbol.ReturnsVoid)
+                    {
+                        GTypeReference returnType = this.MapDelegateLikeReturnType(
+                            symbol, isAsync, syntax.ReturnType.GetLocation());
+                        if (returnType != null)
+                        {
+                            returns.Add(returnType);
+                        }
+                    }
+
+                    string name = SanitizeIdentifier(syntax.Identifier.Text);
+                    members.Add(symbol);
+                    names.Add(name);
+                    declarations.Add(new LocalDeclarationStatement(
+                        BindingKind.Var,
+                        name,
+                        new ArrowTypeReference(parameterTypes, returns, isAsync) { IsNullable = true },
+                        initializer: LiteralExpression.Null()));
+                }
+
+                foreach (IMethodSymbol member in members)
+                {
+                    this.state.RecursiveLocalFunctionGroups[member] =
+                        new RecursiveLocalFunctionGroup(members, names, declarations);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Issue #3399: true when the local function body reads state declared
+        /// OUTSIDE the function itself — an enclosing local or an enclosing
+        /// method parameter. Such a function becomes a gsc closure, which is
+        /// the shape that breaks G#'s shared sibling <c>let</c> visibility
+        /// (GS0130/GS0125) — it must take the nullable-function-local path.
+        /// References to the function's own parameters/locals and SCC siblings
+        /// (method symbols) are not captures; lambda parameters are fresh
+        /// locals born inside the body, so lambda-kind containing methods are
+        /// excluded (a <c>this</c> access resolves to member symbols, not to
+        /// locals/parameters, so it does not change the <c>let</c> path —
+        /// instance-member recursion is the #1757 shape that works as-is).
+        /// </summary>
+        private bool CapturesOuterState(LocalFunctionStatementSyntax syntax, IMethodSymbol functionSymbol)
+        {
+            foreach (IdentifierNameSyntax identifier in syntax.DescendantNodes().OfType<IdentifierNameSyntax>())
+            {
+                ISymbol symbol = this.context.GetSymbolInfo(identifier).Symbol;
+                if (symbol is null || symbol.Kind == SymbolKind.Alias)
+                {
+                    continue;
+                }
+
+                // Note: `this` is a ThisExpressionSyntax (not an IdentifierName)
+                // and resolves to member symbols — instance capture needs no
+                // check in this loop.
+                if (symbol is ILocalSymbol local && IsOuterCapture(local.ContainingSymbol, functionSymbol))
+                {
+                    return true;
+                }
+
+                if (symbol is IParameterSymbol parameter && IsOuterCapture(parameter.ContainingSymbol, functionSymbol))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Issue #3399: the containing method of a local/parameter is an OUTER
+        /// method (not the local function under inspection) and not a lambda —
+        /// lambda parameters are fresh locals born inside the body, so a
+        /// lambda-kind containing method is not a capture.
+        /// </summary>
+        private static bool IsOuterCapture(ISymbol containing, IMethodSymbol functionSymbol)
+        {
+            return containing is IMethodSymbol parent
+                && !SymbolEqualityComparer.Default.Equals(parent, functionSymbol)
+                && parent.MethodKind is not MethodKind.LambdaMethod;
         }
 
         // C# local functions are hoisted (callable before their lexical
@@ -2001,7 +2267,7 @@ public sealed partial class CSharpToGSharpTranslator
                     return new[] { this.TranslateLock(lockStatement) };
 
                 case LocalFunctionStatementSyntax localFunction:
-                    return new[] { this.TranslateLocalFunction(localFunction) };
+                    return this.TranslateLocalFunction(localFunction);
 
                 case CheckedStatementSyntax checkedStatement:
                     // Issue #1881: a C# `checked { }`/`unchecked { }` block maps to

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Declarations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Declarations.cs
@@ -251,6 +251,7 @@ public sealed partial class CSharpToGSharpTranslator
             List<StatementSyntax> flatStatements = globalStatements.Select(gs => gs.Statement).ToList();
             TextSpan enclosingSpan = TextSpan.FromBounds(flatStatements[0].SpanStart, flatStatements[^1].Span.End);
             IReadOnlyList<StatementSyntax> ordered = this.HoistCallBeforeDeclLocalFunctions(flatStatements, enclosingSpan);
+            this.RegisterCapturingRecursiveLocalFunctions(ordered);
 
             // Issue #1904 (mirrored here): the synthesized top-level entry
             // point's own implicit parameter is always literally named "args"

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
@@ -1194,7 +1194,7 @@ public sealed partial class CSharpToGSharpTranslator
             }
         }
 
-        private GStatement TranslateLocalFunction(LocalFunctionStatementSyntax localFunction)
+        private IReadOnlyList<GStatement> TranslateLocalFunction(LocalFunctionStatementSyntax localFunction)
         {
             if (this.context.GetDeclaredSymbol(localFunction) is IMethodSymbol recursiveLocal
                 && this.state.LiftedRecursiveLocalFunctions.TryGetValue(
@@ -1267,7 +1267,10 @@ public sealed partial class CSharpToGSharpTranslator
                         .Add(helper);
                 }
 
-                return new RawStatement($"// lifted recursive local function {recursiveLift.Name}");
+                return new GStatement[]
+                {
+                    new RawStatement($"// lifted recursive local function {recursiveLift.Name}"),
+                };
             }
 
             if (localFunction.Modifiers.Any(SyntaxKind.StaticKeyword)
@@ -1297,7 +1300,10 @@ public sealed partial class CSharpToGSharpTranslator
                     visibility: Visibility.Private,
                     isAsync: liftedIsAsync,
                     isRefReturn: staticLocal.ReturnsByRef));
-                return new RawStatement($"// lifted static local function {liftedName}");
+                return new GStatement[]
+                {
+                    new RawStatement($"// lifted static local function {liftedName}"),
+                };
             }
 
             // Issue #1900: a ref-returning local function (`static ref int
@@ -1316,7 +1322,10 @@ public sealed partial class CSharpToGSharpTranslator
                 this.context.ReportUnsupported(
                     localFunction,
                     $"ref-returning local function '{localFunction.Identifier.Text}' has no canonical G# form: a local function lowers to a `func` literal, and G#'s `ref` return modifier only exists on a genuine top-level/method function declaration (issue #1900).");
-                return new RawStatement($"// unsupported: ref-returning local function '{localFunction.Identifier.Text}'");
+                return new GStatement[]
+                {
+                    new RawStatement($"// unsupported: ref-returning local function '{localFunction.Identifier.Text}'"),
+                };
             }
 
             // A C# local function maps to a G# local `let` bound to a function
@@ -1412,7 +1421,46 @@ public sealed partial class CSharpToGSharpTranslator
                 .Select(tp => SanitizeIdentifier(tp.Identifier.Text))
                 .ToList();
 
-            return new LocalFunctionStatement(SanitizeIdentifier(localFunction.Identifier.Text), lambda, typeParameters);
+            // Issue #3399: this local participates in a recursive/mutually
+            // recursive SCC of capturing local functions — a bare non-recursive
+            // `let` binding of the literal cannot reference itself, so gsc loses
+            // the binding for every call (GS0130/GS0125). Lower the whole SCC via
+            // G#'s nullable-function-local scheme instead: emit the members'
+            // nil-initialized `var Name (… -> R)? = nil` declarations exactly once
+            // (the first member translated in document order; all declarations
+            // must precede the first assignment because a G# closure body cannot
+            // reference a not-yet-declared sibling local), then assign this
+            // member's function literal to its own local. SCC partners are
+            // reached from a closure body through the nullable local via `!!`
+            // (see the TranslateIdentifierName/Invocations rewrite). G#'s
+            // capture-by-reference closures preserve C#'s shared mutation of the
+            // captured sibling locals.
+            if (localSymbol is not null
+                && this.state.RecursiveLocalFunctionGroups.TryGetValue(
+                    localSymbol, out RecursiveLocalFunctionGroup recursiveBinding))
+            {
+                var statements = new List<GStatement>();
+                if (!recursiveBinding.Members.Any(m => this.state.EmittedRecursiveGroupMembers.Contains(m)))
+                {
+                    recursiveBinding.DeclarationsEmitted = true;
+                    foreach (IMethodSymbol member in recursiveBinding.Members)
+                    {
+                        this.state.EmittedRecursiveGroupMembers.Add(member);
+                    }
+
+                    statements.AddRange(recursiveBinding.Declarations);
+                }
+
+                statements.Add(new AssignmentStatement(
+                    new IdentifierExpression(recursiveBinding.NameOf(localSymbol)),
+                    lambda));
+                return statements;
+            }
+
+            return new GStatement[]
+            {
+                new LocalFunctionStatement(SanitizeIdentifier(localFunction.Identifier.Text), lambda, typeParameters),
+            };
         }
 
         private static bool CaptureHasExplicitNullableType(ISymbol symbol)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -55,6 +55,28 @@ public sealed partial class CSharpToGSharpTranslator
                     liftedName);
             }
 
+            // Issue #3399: a member of a recursive/mutually recursive SCC of
+            // capturing local functions is bound through a nullable function-typed
+            // local (`var X ((…) -> …)? = nil; X = func …`), so a bare reference
+            // from another SCC member's closure body must go through the local
+            // itself — `X` would be GS0125 at its declared type, which has the
+            // `nil` default. The postfix null assertion unwraps the nullable
+            // (ADR-0069), mirroring gsc's own lowering (its `var` decl also
+            // emits as `(p) → R? = nil`).
+            if (this.context.GetSymbolInfo(identifier).Symbol is IMethodSymbol
+                    { MethodKind: MethodKind.LocalFunction } recursiveLocal
+                && this.state.RecursiveLocalFunctionGroups.TryGetValue(
+                    recursiveLocal, out RecursiveLocalFunctionGroup recursiveGroup)
+                && recursiveGroup.Members.Contains(recursiveLocal))
+            {
+                // `IsDirectWrite` is intentionally NOT consulted: a write to a
+                // function-typed function local would be a C# compile error
+                // ("Cannot assign to ... because it is a local function"), so a
+                // rewrite here cannot change meaning.
+                return new NonNullAssertionExpression(
+                    new IdentifierExpression(recursiveGroup.NameOf(recursiveLocal)));
+            }
+
             // A switch-expression property-pattern binding (`Circle { Radius: var r }`)
             // has no G# equivalent; references to the bound local are rewritten to a
             // member access on the arm's type-pattern designator (`circle.Radius`).

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -246,6 +246,19 @@ public sealed partial class CSharpToGSharpTranslator
                     typeArguments = this.MapTypeArguments(liftedGeneric);
                 }
             }
+            else if (this.context.GetSymbolInfo(invocation).Symbol is IMethodSymbol
+                    { MethodKind: MethodKind.LocalFunction } groupMember
+                && this.state.RecursiveLocalFunctionGroups.TryGetValue(
+                    groupMember, out RecursiveLocalFunctionGroup recursiveGroup)
+                && recursiveGroup.Members.Contains(groupMember, SymbolEqualityComparer.Default))
+            {
+                // Issue #3399: a call to a recursive SCC partner from inside a
+                // closure body — the partner is a nullable function-typed local,
+                // so pass it through a postfix null assertion (`X!!`, ADR-0069)
+                // that unwraps the declared local's `nil` default.
+                target = new NonNullAssertionExpression(
+                    new IdentifierExpression(recursiveGroup.NameOf(groupMember)));
+            }
             else if (invocation.Expression is GenericNameSyntax generic)
             {
                 target = new IdentifierExpression(SanitizeIdentifier(generic.Identifier.Text));

--- a/tools/cs2gs/Cs2Gs.Translator/DocumentTranslationState.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/DocumentTranslationState.cs
@@ -206,6 +206,28 @@ internal sealed class DocumentTranslationState
     public Dictionary<IMethodSymbol, LiftedRecursiveLocalFunction> LiftedRecursiveLocalFunctions { get; } =
         new Dictionary<IMethodSymbol, LiftedRecursiveLocalFunction>(SymbolEqualityComparer.Default);
 
+    // Issue #3399: local functions participating (directly or transitively) in
+    // recursion/mutual recursion that cannot be lifted as static helpers
+    // (they capture sibling locals), so G#'s non-recursive `let name = func …`
+    // binding fails with GS0130/GS0125. Each such strongly-connected component
+    // is instead lowered to G#'s nullable-function-local scheme: every member
+    // is FIRST declared nil-initialized as `var Name (… -> R)? = nil` (G#
+    // closures cannot forward-reference not-yet-declared siblings, so the whole
+    // SCC's declarations must precede its first assignment), then each member
+    // binds its function literal `Name = func …`; SCC partners are reached from
+    // a closure body through the nullable local via a postfix null assertion
+    // `Partner!!(…)` (ADR-0137/ADR-0069). Reference-capture semantics preserve
+    // C#'s shared mutation of the captured locals.
+    public Dictionary<IMethodSymbol, RecursiveLocalFunctionGroup> RecursiveLocalFunctionGroups { get; } =
+        new Dictionary<IMethodSymbol, RecursiveLocalFunctionGroup>(SymbolEqualityComparer.Default);
+
+    // Issue #3399: state-level dedup for the SCC declarations emission — the
+    // first member translated for a group is the one that emits the shared
+    // nil-initialized declarations; tracked by member symbol (not by group
+    // instance) so re-registered copies of the same SCC cannot double-emit.
+    public HashSet<IMethodSymbol> EmittedRecursiveGroupMembers { get; } =
+        new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
+
     // The exception variable bound by the innermost enclosing `catch` clause,
     // used to translate a C# re-throw (`throw;`) — which has no bare G# form —
     // to `throw <caughtVar>` (ADR-0115 §B).
@@ -253,6 +275,46 @@ internal sealed class LiftedLocalFunctionCapture
 /// scope nodes compare by reference (the same <c>SyntaxNode</c> instance is what
 /// every call site passes for a given symbol).
 /// </summary>
+/// <summary>
+/// Issue #3399: the per-SCC emission state for the nullable-function-local
+/// lowering of a capturing recursive C# local function (see
+/// <see cref="DocumentTranslationState.RecursiveLocalFunctionGroups"/>).
+/// Member names and the shared nil-initialized declarations are resolved at
+/// registration time; <see cref="DeclarationsEmitted"/> lets the FIRST member
+/// translated in document order emit the whole SCC's `var Name … = nil`
+/// declarations ahead of its own `Name = func …` assignment (all declarations
+/// must precede the first assignment, because a G# closure body cannot
+/// reference a sibling local that is not yet declared).
+/// </summary>
+internal sealed class RecursiveLocalFunctionGroup
+{
+    public RecursiveLocalFunctionGroup(
+        IEnumerable<IMethodSymbol> members,
+        IReadOnlyList<string> names,
+        IReadOnlyList<GStatement> declarations)
+    {
+        this.MemberNames = new Dictionary<IMethodSymbol, string>(SymbolEqualityComparer.Default);
+        int index = 0;
+        foreach (IMethodSymbol member in members)
+        {
+            this.MemberNames[member] = names[index++];
+        }
+
+        this.Members = new HashSet<IMethodSymbol>(this.MemberNames.Keys, SymbolEqualityComparer.Default);
+        this.Declarations = declarations;
+    }
+
+    public HashSet<IMethodSymbol> Members { get; }
+
+    public Dictionary<IMethodSymbol, string> MemberNames { get; }
+
+    public IReadOnlyList<GStatement> Declarations { get; }
+
+    public bool DeclarationsEmitted { get; set; }
+
+    public string NameOf(IMethodSymbol symbol) => this.MemberNames[symbol];
+}
+
 internal sealed class SymbolScopeKeyComparer : IEqualityComparer<(ISymbol Symbol, SyntaxNode Scope)>
 {
     public static readonly SymbolScopeKeyComparer Instance = new SymbolScopeKeyComparer();


### PR DESCRIPTION
Fixes #3399

Produced using `qwen3.8:27b` running locally, with the Copilot CLI as the harness.

## Summary

- Lower **capturing** recursive / mutually recursive C# local functions to the documented G# recursion scheme (ADR-0137 / ADR-0069) instead of `let`/`func` bindings, which are not recursive or forward-visible across siblings (gsc rejected them with GS0130/GS0125).
- The whole strongly-connected component (SCC) of recursive sibling functions is now bound as nil-initialized, nullable-function-typed `var` locals — **declarations first, assignments after** — so each can reference itself and not-yet-assigned siblings.
- Sibling calls inside closure bodies go through postfix null assertions (`X!!`); captured mutable outer state stays a single shared `var` binding, preserving C# shared-mutation semantics.
- **Capture-free** recursive SCCs keep the canonical `let`/hoisted-helper path (origin's work) untouched. Both paths coexist in one translation pass, routed per-SCC by `IsCapturingRecursiveGroupMember`.
- This is the reconciled result of this branch's nullable-function-local lowering with origin/main's independent helper-lifting fix; the rebase keeps both rather than one overwriting the other.
- Updated the self-migration spike doc (#3394) to mark "capturing recursion" resolved.

## Verification

- **Build:** `dotnet build tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj` — 0 warnings / 0 errors (Debug); Release packaging also built clean (0/0) to produce the same-version `Gsharp.Cs2Gs` + `Gsharp.NET.Sdk` nupkg pair.
- **Full suite:** `Cs2Gs.Tests` = **2047 / 2047 pass** (no skips, no fails), with a consistent fresh nupkg set built from this commit.
- **Targeted (hybrid):** `LocalFunctionHoistTranslationTests` + `Issue3399…Tests` = **18 / 18 pass**.
- **Witness (ADR-0154):** the 6 new `Issue3399…` tests were run against the **pre-change** translator (`origin/main`, capturing lowering removed) on the same test code:
  - pre-change: **4 failed / 2 passed** (the 2 passing are the deliberate negative / capture-free controls)
  - with this change: **6 / 6 pass**
  - i.e. the discriminating assertion (self-/mutual-recursive capture lowering to nullable locals) is red without the change and green with it.
- **Not run:** none left outstanding. An earlier full-suite red (Issue2506 / Issue2819 "packed tool + SDK" pipeline tests, and the "pre-existing" Issue1723/Issue2414) was diagnosed as **local build-artifact nupkg resolution** (stale `out/bin/Release/nupkgs/0.3.651` shadowing the fresh `0.4.8`), not a code regression; rebuilding a consistent Release+Debug nupkg set cleared all of them.
- **Byte-level check:** the G# `translate` output for the #3399 fixtures is equivalent between the hybrid and origin trees; only the *lowering of capturing recursion* differs, exactly as intended.

## Checklist

- [x] Behavioral tests carry a witness of discrimination (ADR-0154): see Verification — 4 new/changed tests are RED on the pre-change translator, GREEN with it; the 2 remaining are intentional negative controls.
- [x] Self-review verdict recorded: **MERGEABLE**. Residual: the full-suite green depends on a consistent local nupkg set (Release and Debug both freshly built from the same commit); a stale `out/bin/Release/nupkgs` cache can make the "packed tool + SDK" pipeline tests flaky. Filed as a doc note rather than a blocker since it is environment, not product code.
