### PR TITLE
Preserve partial source file boundaries in cs2gs

### DIFF
--- a/docs/adr/0143-source-generators-in-cs2gs-migration.md
+++ b/docs/adr/0143-source-generators-in-cs2gs-migration.md
@@ -104,8 +104,8 @@ code-behind. These reproduce through the same gsgen path once gsgen forwards
 keeps the trigger intact by (a) discovering the project's `@(AdditionalFiles)` +
 `.axaml` (`CSharpProjectLoader`), (b) forwarding them — tagged
 `SourceItemGroup=AvaloniaXaml` — plus `RootNamespace`/`ProjectDir` options to the
-Compile stage's gsc invocation, and (c) marking the code-behind `partial` (the
-project's analyzer references already trigger `markMergedTypePartial`). The
+Compile stage's gsc invocation, and (c) preserving the code-behind as its own
+partial declaration (the default since issue #3410). The
 runtime side (Avalonia's `CompileAvaloniaXaml` IL-rewrite) is a language-agnostic
 post-compile MSBuild task that hooks the standard `AfterCompile` chain and needs
 no G# changes.

--- a/docs/adr/0145-source-generator-host-native-gsharp.md
+++ b/docs/adr/0145-source-generator-host-native-gsharp.md
@@ -298,9 +298,16 @@ this one):
   `markMergedTypePartial` flag, set only when the project has analyzer
   references, so every other translation is byte-for-byte unchanged.
 
-Both are opt-in (null/`false` by default) and exercised only when a project
-actually has analyzer references, so the ADR-0143 cs2gs-migration default
-behavior for the overwhelmingly common no-generator project is untouched.
+At issue #2215's delivery, both were opt-in (null/`false` by default) and
+exercised only when a project had analyzer references, so the ADR-0143
+cs2gs-migration default behavior for no-generator projects was untouched.
+
+Issue #3410 later made `preservePartialParts` the cs2gs default for all
+projects: each retained source file now emits its own G# `partial` declaration,
+and the compiler merges those declarations. `retainedFilePaths` still excludes
+generator-produced declarations from source-part ownership decisions;
+`markMergedTypePartial` remains available only to callers that explicitly
+select the legacy `preservePartialParts: false` merge mode.
 
 ## Implementation status
 

--- a/test/Core.Tests/CodeAnalysis/Adr0144PartialTypesBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Adr0144PartialTypesBinderTests.cs
@@ -702,6 +702,57 @@ Console.WriteLine(Config.A + Config.B)
     }
 
     [Fact]
+    public void CrossFileSharedBlocks_MergeDeterministicallyAndResolveSiblingMethods()
+    {
+        var blocksPart = SyntaxTree.Parse(SourceText.From(
+            """
+            package App
+
+            partial class StatementBinder {
+                shared {
+                    var Order string = ""
+
+                    init {
+                        Order = Order + "B"
+                    }
+
+                    func BindBlock() bool -> true
+                }
+            }
+            """,
+            "StatementBinder.Blocks.gs"));
+        var jumpsPart = SyntaxTree.Parse(SourceText.From(
+            """
+            package App
+
+            import System
+
+            partial class StatementBinder {
+                shared {
+                    init {
+                        Order = Order + "J"
+                    }
+
+                    func HasFunctionLocalRefScope() bool -> BindBlock()
+                }
+            }
+
+            Console.WriteLine(StatementBinder.Order)
+            Console.WriteLine(StatementBinder.HasFunctionLocalRefScope())
+            """,
+            "StatementBinder.Jumps.gs"));
+
+        // Reverse compiler input order. Partial merging still follows file-name
+        // order, and each shared block contributes its own members.
+        var output = CompileLoadInvokeCaptureStdout(
+            new[] { jumpsPart, blocksPart },
+            "Issue3410-CrossFileShared");
+
+        Assert.Contains("BJ", output);
+        Assert.Contains("True", output);
+    }
+
+    [Fact]
     public void LonePartialClass_CompilesFine()
     {
         var source = @"package App

--- a/tools/cs2gs/Cs2Gs.Pipeline/TestParityStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TestParityStage.cs
@@ -363,7 +363,7 @@ public sealed class TestParityStage : IMigrationStage
         // anonymousTypeRegistriesByPackage`) is shared too — otherwise two
         // files in the same package could each mint a colliding
         // `AnonymousTypeN` name for two DIFFERENT anonymous shapes (GS0102).
-        var translator = new CSharpToGSharpTranslator();
+        var translator = new CSharpToGSharpTranslator(preservePartialParts: true);
         foreach (LoadedDocument document in project.Documents)
         {
             cancellationToken.ThrowIfCancellationRequested();

--- a/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
@@ -313,22 +313,16 @@ public sealed class TranslateStage : IMigrationStage
                 }
             }
 
-            // Issue #2215: a project with analyzer references may have had a
-            // generator-produced partial part excluded from `Documents` (it is
-            // recognized as generated, per `CSharpProjectLoader.
-            // IsGeneratedSource`, so BuildDocuments never translates it on its
-            // own) — so the translator must (a) keep the merged type `partial`
-            // (gsc's own gsgen run adds the missing part back) and (b) NOT
-            // merge that excluded part's members in here too (that would just
-            // duplicate what gsgen produces, causing a GS0102 collision). Every
-            // project with no analyzer references gets the exact prior
-            // (unfiltered, non-partial-marking) translator behavior.
+            // Issue #2215: exclude generator-produced parts from source-part
+            // ownership decisions. They are absent from `Documents` and gsc's
+            // own gsgen run adds them back later; retained source parts remain
+            // standalone partial declarations (issue #3410).
             bool hasAnalyzerReferences = currentProject.AnalyzerReferencePaths.Count > 0;
             List<string> retainedFilePaths = hasAnalyzerReferences
                 ? currentProject.Documents.Select(d => d.FilePath).ToList()
                 : null;
             var translator = new CSharpToGSharpTranslator(
-                markMergedTypePartial: hasAnalyzerReferences,
+                preservePartialParts: true,
                 retainedFilePaths: retainedFilePaths);
 
             PreserveGeneratedFriendAssemblyAnnotations(
@@ -365,7 +359,7 @@ public sealed class TranslateStage : IMigrationStage
                     CSharpToGSharpTranslator unitTranslator = package is null
                         ? translator
                         : new CSharpToGSharpTranslator(
-                            markMergedTypePartial: hasAnalyzerReferences,
+                            preservePartialParts: true,
                             retainedFilePaths: retainedFilePaths,
                             packageFilter: package,
                             includeFileAttributes: unitIndex == 0);

--- a/tools/cs2gs/Cs2Gs.Tests/Adr0145PreservePartialModeTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Adr0145PreservePartialModeTests.cs
@@ -16,14 +16,12 @@ namespace Cs2Gs.Tests;
 /// <summary>
 /// ADR-0145 (§C/§D): the source-generator host back-translates
 /// generator-produced C# (e.g. <c>partial class Foo { ...generated members... }</c>)
-/// into G# <c>partial</c> parts that augment the user's own type. This requires
-/// the OPPOSITE of the default cs2gs-migration behavior (issue #1910), which
-/// merges every C# <c>partial</c> part into ONE non-partial G# type emitted
-/// once. In the opt-in "preserve partial parts" mode
-/// (<c>new CSharpToGSharpTranslator(preservePartialParts: true)</c>), each
-/// <c>partial</c> declaration translates standalone — no cross-part merge — and
-/// carries the <c>partial</c> modifier onto the emitted G# type (ADR-0144). The
-/// default mode must remain byte-for-byte identical to today.
+/// into G# <c>partial</c> parts that augment the user's own type. In preserve
+/// mode, now also the cs2gs default (issue #3410), each <c>partial</c>
+/// declaration translates standalone — no cross-part merge — and carries the
+/// <c>partial</c> modifier onto the emitted G# type (ADR-0144). The legacy
+/// issue #1910 merge mode remains available through
+/// <c>preservePartialParts: false</c>.
 /// </summary>
 public class Adr0145PreservePartialModeTests
 {
@@ -96,9 +94,9 @@ namespace Demo
     }
 
     [Fact]
-    public void DefaultMode_SameTwoDocuments_StillMergeIntoOneNonPartialType()
+    public void LegacyMergeMode_SameTwoDocuments_MergesIntoOneNonPartialType()
     {
-        // Control: the SAME two documents in DEFAULT mode must still merge into
+        // Control: the SAME two documents in legacy merge mode still merge into
         // ONE non-partial `class Foo` containing BOTH members (issue #1910
         // behavior, unchanged).
         IReadOnlyList<string> printed = TranslateFiles(

--- a/tools/cs2gs/Cs2Gs.Tests/Adr0145PreservePartialModeTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Adr0145PreservePartialModeTests.cs
@@ -149,6 +149,28 @@ namespace Demo
         Assert.DoesNotContain("partial", printed);
     }
 
+    [Fact]
+    public void PreserveMode_ObliviousSourceField_RemainsNonNullable()
+    {
+        string printed = TranslateFiles(
+            preservePartialParts: true,
+            ("Bar.cs", """
+                #nullable disable
+
+                namespace Demo;
+
+                public partial class Bar
+                {
+                    private readonly string name = "x";
+
+                    public string Read() => name;
+                }
+                """)).Single();
+
+        Assert.Contains("let name string = \"x\"", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("name string?", printed, StringComparison.Ordinal);
+    }
+
     private static (string Generated, string User) TranslateBothInPreserveMode(
         (string FileName, string Source) generated,
         (string FileName, string Source) user)

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1910PartialTypeMergeTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1910PartialTypeMergeTranslationTests.cs
@@ -19,7 +19,8 @@ namespace Cs2Gs.Tests;
 /// translated each part independently, emitting one complete, duplicate G#
 /// type declaration per part (<c>GS0102 'Ledger' is already declared</c>,
 /// then <c>GS0159</c> for members landing on the wrong declaration). Partial
-/// merging must happen at translation time: every part shares one
+/// The legacy merge mode performs that translation-time merge: every part
+/// shares one
 /// <see cref="Microsoft.CodeAnalysis.INamedTypeSymbol"/> (with multiple
 /// <c>DeclaringSyntaxReferences</c>), so the translator now groups all parts
 /// by symbol and merges their members into ONE G# type declaration, emitted
@@ -257,7 +258,8 @@ namespace Demo
         foreach (LoadedDocument document in project.Documents)
         {
             var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
-            CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+            CompilationUnit unit = new CSharpToGSharpTranslator(
+                preservePartialParts: false).TranslateDocument(document, context);
 
             string printed = GSharpPrinter.Print(unit);
             RoundTripResult result = TranslationTestValidation.AssertBinds(printed);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2821OwnedExtensionMemberTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2821OwnedExtensionMemberTranslationTests.cs
@@ -78,12 +78,16 @@ public static class MeterExtensions
 }"));
 
         string combined = string.Join(Environment.NewLine, printed.Values);
-        string target = Assert.Single(printed.Values, text => text.Contains("class Meter", StringComparison.Ordinal));
+        string target = Assert.Single(
+            printed.Values,
+            text => text.Contains("func Adjust(", StringComparison.Ordinal));
 
+        Assert.Equal(2, CountOccurrences(combined, "class Meter"));
         Assert.Equal(1, CountOccurrences(combined, "func Adjust("));
         Assert.Contains("import System", target);
         Assert.Contains("    func Adjust()", target);
         Assert.Contains("var meter = this", target);
+        Assert.DoesNotContain("func Double(", target);
         Assert.DoesNotContain("func (meter Meter) Adjust", combined);
         Assert.DoesNotContain("class MeterExtensions", combined);
     }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3410PartialTypeFileOwnershipTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3410PartialTypeFileOwnershipTests.cs
@@ -1,0 +1,127 @@
+// <copyright file="Issue3410PartialTypeFileOwnershipTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3410: default cs2gs translation keeps each partial type member in
+/// the generated file corresponding to its declaring C# source file.
+/// </summary>
+public class Issue3410PartialTypeFileOwnershipTests
+{
+    [Fact]
+    public void StatementBinderParts_KeepMembersInDeclaringFiles_AndBindDeterministically()
+    {
+        (string FileName, string Source)[] files =
+        {
+            ("StatementBinder.Blocks.cs", """
+                namespace Demo;
+
+                internal sealed partial class StatementBinder
+                {
+                    private static bool BindBlock(BoundExpression expression) => expression != null;
+                }
+                """),
+            ("StatementBinder.Jumps.cs", """
+                namespace Demo;
+
+                internal class BoundExpression { }
+
+                internal class TypeSymbol { }
+
+                internal sealed class StructSymbol : TypeSymbol
+                {
+                    public bool IsClass { get; init; }
+                }
+
+                internal sealed class Receiver
+                {
+                    public TypeSymbol Type { get; init; } = new TypeSymbol();
+                }
+
+                internal sealed class FieldAccess : BoundExpression
+                {
+                    public Receiver Receiver { get; init; } = new Receiver();
+                }
+
+                internal sealed partial class StatementBinder
+                {
+                    private static bool HasFunctionLocalRefScope(BoundExpression expr)
+                    {
+                        if (expr is FieldAccess fa &&
+                            fa.Receiver is { Type: StructSymbol s } &&
+                            s.IsClass)
+                        {
+                            return BindBlock(expr);
+                        }
+
+                        return false;
+                    }
+                }
+                """),
+        };
+
+        IReadOnlyList<(string FileName, string Printed)> first = Translate(files);
+        IReadOnlyList<(string FileName, string Printed)> second = Translate(files);
+        Assert.Equal(first, second);
+
+        string blocks = first.Single(file => file.FileName == "StatementBinder.Blocks.gs").Printed;
+        string jumps = first.Single(file => file.FileName == "StatementBinder.Jumps.gs").Printed;
+
+        Assert.Contains("partial class StatementBinder", blocks, StringComparison.Ordinal);
+        Assert.Contains("shared {", blocks, StringComparison.Ordinal);
+        Assert.Contains("func BindBlock(", blocks, StringComparison.Ordinal);
+        Assert.DoesNotContain("HasFunctionLocalRefScope", blocks, StringComparison.Ordinal);
+
+        Assert.Contains("partial class StatementBinder", jumps, StringComparison.Ordinal);
+        Assert.Contains("shared {", jumps, StringComparison.Ordinal);
+        Assert.Contains("func HasFunctionLocalRefScope(", jumps, StringComparison.Ordinal);
+        Assert.DoesNotContain("func BindBlock(", jumps, StringComparison.Ordinal);
+
+        // Preserve PR #3417's native named-pattern translation while changing
+        // partial-file ownership.
+        Assert.Contains(
+            "fa.Receiver is { Type: StructSymbol s } && s.IsClass",
+            jumps,
+            StringComparison.Ordinal);
+
+        TranslationTestValidation.AssertBinds(first.Select(file => file.Printed).ToArray());
+    }
+
+    private static IReadOnlyList<(string FileName, string Printed)> Translate(
+        params (string FileName, string Source)[] files)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(files);
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        var translator = new CSharpToGSharpTranslator();
+        var output = new List<(string FileName, string Printed)>();
+        foreach (LoadedDocument document in project.Documents)
+        {
+            var context = new TranslationContext(
+                project.Compilation,
+                document.SemanticModel,
+                document.FilePath);
+            CompilationUnit unit = translator.TranslateDocument(document, context);
+            output.Add((
+                Path.ChangeExtension(Path.GetFileName(document.FilePath), ".gs"),
+                GSharpPrinter.Print(unit)));
+        }
+
+        return output;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Declarations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Declarations.cs
@@ -1359,14 +1359,11 @@ public sealed partial class CSharpToGSharpTranslator
             bool isUnsafe = node.Modifiers.Any(SyntaxKind.UnsafeKeyword) ||
                 (otherParts != null && otherParts.Any(p => p.Modifiers.Any(SyntaxKind.UnsafeKeyword)));
 
-            // ADR-0145 (§C/§D): only in preserve mode does a C# `partial` modifier
-            // survive onto the G# type — each part is emitted as a standalone
-            // `partial` part that augments the user's type (ADR-0144). Default
-            // cs2gs-migration mode always merges parts into ONE non-partial type,
-            // so `isPartial` stays false there (unchanged issue #1910 output) —
-            // UNLESS the project has analyzer references (issue #2215:
-            // `markMergedTypePartial`), in which case the merged type still
-            // keeps `partial` so gsc's own gsgen-produced part can merge into it.
+            // ADR-0145 (§C/§D) / issue #3410: default preserve mode carries the
+            // C# `partial` modifier onto each standalone G# part. Legacy merge
+            // mode drops it from the single merged type (issue #1910), unless
+            // `markMergedTypePartial` keeps it so gsc's own gsgen-produced part
+            // can merge into that result (issue #2215).
             bool sourceWasPartial = node.Modifiers.Any(m => m.IsKind(SyntaxKind.PartialKeyword)) ||
                 (otherParts != null && otherParts.Any(p => p.Modifiers.Any(m => m.IsKind(SyntaxKind.PartialKeyword))));
             bool isPartial = sourceWasPartial && (this.preservePartialParts || this.markMergedTypePartial);

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
@@ -1063,7 +1063,7 @@ public sealed partial class CSharpToGSharpTranslator
                 // context (Avalonia x:Name fields are the common case) retain
                 // C#'s ability to hold/test null when translated as a standalone
                 // generated partial part.
-                if (this.preservePartialParts &&
+                if (this.widenObliviousReferenceFields &&
                     symbol?.Type is { IsReferenceType: true, NullableAnnotation: NullableAnnotation.None })
                 {
                     type = MakeNullable(type);

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -86,6 +86,12 @@ public sealed partial class CSharpToGSharpTranslator
     // analyzer references; every other translation is byte-for-byte unchanged.
     private readonly bool markMergedTypePartial;
 
+    // Issue #2610: generator-produced nullable-oblivious reference fields
+    // (Avalonia x:Name fields are the common case) must remain nullable when
+    // back-translated. This is generator-host behavior, not a consequence of
+    // preserving ordinary source partial declarations (issue #3410).
+    private readonly bool widenObliviousReferenceFields;
+
     // Issue #2215: when set, restricts the "other partial parts to merge in"
     // set (`CollectPartialTypeParts`, built from `INamedTypeSymbol.
     // DeclaringSyntaxReferences` across the WHOLE compilation) to only the
@@ -141,15 +147,23 @@ public sealed partial class CSharpToGSharpTranslator
     /// attributes. Used for secondary package-split outputs so file-level
     /// metadata is emitted once.
     /// </param>
+    /// <param name="widenObliviousReferenceFields">
+    /// When <see langword="true"/>, nullable-oblivious reference fields are
+    /// emitted as nullable. Used by the source-generator host for generated
+    /// partial parts (issue #2610); ordinary source translation leaves this
+    /// <see langword="false"/>.
+    /// </param>
     public CSharpToGSharpTranslator(
         bool preservePartialParts = true,
         bool markMergedTypePartial = false,
         IReadOnlyCollection<string> retainedFilePaths = null,
         string packageFilter = null,
-        bool includeFileAttributes = true)
+        bool includeFileAttributes = true,
+        bool widenObliviousReferenceFields = false)
     {
         this.preservePartialParts = preservePartialParts;
         this.markMergedTypePartial = markMergedTypePartial;
+        this.widenObliviousReferenceFields = widenObliviousReferenceFields;
         this.retainedFilePaths = retainedFilePaths is null
             ? null
             : new HashSet<string>(retainedFilePaths, StringComparer.Ordinal);
@@ -257,7 +271,8 @@ public sealed partial class CSharpToGSharpTranslator
             partialTypeParts,
             ownedExtensions,
             this.preservePartialParts,
-            this.markMergedTypePartial);
+            this.markMergedTypePartial,
+            this.widenObliviousReferenceFields);
 
         IReadOnlyList<AttributeUse> fileAttributes = this.includeFileAttributes
             ? visitor.MapFileAttributes(
@@ -1068,6 +1083,10 @@ public sealed partial class CSharpToGSharpTranslator
         // Issue #2215: see `CSharpToGSharpTranslator.markMergedTypePartial`.
         private readonly bool markMergedTypePartial;
 
+        // Issue #2610: see
+        // `CSharpToGSharpTranslator.widenObliviousReferenceFields`.
+        private readonly bool widenObliviousReferenceFields;
+
         // Issue #1201 / ADR-0134: the types targeted by `using static X` in this
         // document. A bare reference to one of their static members is left
         // UNQUALIFIED (gsc resolves it through `import X`), unlike a sibling
@@ -1135,7 +1154,8 @@ public sealed partial class CSharpToGSharpTranslator
             Dictionary<INamedTypeSymbol, List<TypeDeclarationSyntax>> partialTypeParts,
             OwnedExtensionRegistry ownedExtensions,
             bool preservePartialParts = false,
-            bool markMergedTypePartial = false)
+            bool markMergedTypePartial = false,
+            bool widenObliviousReferenceFields = false)
         {
             this.context = context;
             this.typeMapper = typeMapper;
@@ -1145,6 +1165,7 @@ public sealed partial class CSharpToGSharpTranslator
             this.ownedExtensions = ownedExtensions ?? new OwnedExtensionRegistry(context.Compilation.Assembly);
             this.preservePartialParts = preservePartialParts;
             this.markMergedTypePartial = markMergedTypePartial;
+            this.widenObliviousReferenceFields = widenObliviousReferenceFields;
             this.efEntityTypes = ObliviousNullabilityAnalyzer.CollectEfEntityTypes(context.Compilation);
 
             // `entryPoint` is threaded in by the caller (`TranslateDocument`)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -69,19 +69,16 @@ public sealed partial class CSharpToGSharpTranslator
     // files (including partial target declarations).
     private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<Compilation, OwnedExtensionRegistry> OwnedExtensionsCache = new();
 
-    // ADR-0145 (§C/§D): opt-in "preserve partial parts" mode. In the DEFAULT
-    // (false) cs2gs-migration mode, all C# `partial` parts of a type are MERGED
-    // into ONE non-partial G# type, emitted once (issue #1910). The
-    // source-generator host needs the OPPOSITE: back-translate each generated C#
-    // `partial` declaration into a STANDALONE G# `partial` part (no cross-part
-    // merge) so a generated part augments the user's own G# type (ADR-0144).
-    // When true: partial parts are never merged (each declaration translates
-    // using only its own members) and a C# `partial` modifier is carried onto
-    // the emitted `TypeDeclaration` as `isPartial`.
+    // ADR-0145 (§C/§D) / issue #3410: preserve each C# `partial` declaration as
+    // a standalone G# `partial` part by default. This keeps members in the G#
+    // file corresponding to their declaring C# file and lets the G# compiler's
+    // partial-type merger combine the parts. The legacy issue #1910 translation
+    // shape remains available when false: all parts merge into one non-partial
+    // G# declaration emitted in the primary file.
     private readonly bool preservePartialParts;
 
-    // Issue #2215: cs2gs's own merge (the `!preservePartialParts` path above)
-    // still happens, but the MERGED result keeps a `partial` modifier when the
+    // Issue #2215: when the legacy merge path (`!preservePartialParts`) is used,
+    // the MERGED result keeps a `partial` modifier when the
     // C# source itself was `partial` — so gsc's own `/analyzer:`-triggered
     // gsgen run can later add a real, additional generated `partial` part
     // (ADR-0145) that merges into this type instead of colliding with it
@@ -113,14 +110,14 @@ public sealed partial class CSharpToGSharpTranslator
     /// Initializes a new instance of the <see cref="CSharpToGSharpTranslator"/> class.
     /// </summary>
     /// <param name="preservePartialParts">
-    /// When <see langword="false"/> (default), C# <c>partial</c> parts of a type
-    /// are merged into one non-partial G# type (issue #1910 cs2gs-migration
-    /// behavior). When <see langword="true"/> (ADR-0145 generator host), each
-    /// <c>partial</c> declaration is translated as a standalone G# <c>partial</c>
-    /// part with no cross-part merge.
+    /// When <see langword="true"/> (default), each C# <c>partial</c>
+    /// declaration is translated as a standalone G# <c>partial</c> part with
+    /// no cross-part merge, preserving source-file member ownership (issue
+    /// #3410). When <see langword="false"/>, all parts are merged into one
+    /// non-partial G# type (legacy issue #1910 behavior).
     /// </param>
     /// <param name="markMergedTypePartial">
-    /// When <see langword="true"/>, the merged type produced by the default
+    /// When <see langword="true"/>, the merged type produced by the legacy
     /// (<paramref name="preservePartialParts"/> <see langword="false"/>) path
     /// keeps a G# <c>partial</c> modifier if the C# source declared the type
     /// <c>partial</c> (issue #2215: the project has analyzer/generator
@@ -130,9 +127,10 @@ public sealed partial class CSharpToGSharpTranslator
     /// </param>
     /// <param name="retainedFilePaths">
     /// The caller's own file set considered eligible for translation (issue
-    /// #2215). When supplied, a partial type's OTHER declaring parts that fall
-    /// outside this set (i.e. excluded as generated) are not merged in. Pass
-    /// <see langword="null"/> (default) to keep every part regardless of file.
+    /// #2215). When supplied, partial declarations outside this set (i.e.
+    /// excluded as generated) do not participate in legacy merging or
+    /// source-part ownership selection. Pass <see langword="null"/> (default)
+    /// to keep every part regardless of file.
     /// </param>
     /// <param name="packageFilter">
     /// When supplied, emits only declarations whose containing namespace
@@ -144,7 +142,7 @@ public sealed partial class CSharpToGSharpTranslator
     /// metadata is emitted once.
     /// </param>
     public CSharpToGSharpTranslator(
-        bool preservePartialParts = false,
+        bool preservePartialParts = true,
         bool markMergedTypePartial = false,
         IReadOnlyCollection<string> retainedFilePaths = null,
         string packageFilter = null,

--- a/tools/gsgen/GSharp.GeneratorHost/GeneratedDocTranslator.cs
+++ b/tools/gsgen/GSharp.GeneratorHost/GeneratedDocTranslator.cs
@@ -80,7 +80,9 @@ public static class GeneratedDocTranslator
             SemanticModel model = compilation.GetSemanticModel(tree);
             var loaded = new LoadedDocument(doc.HintName, tree, model);
 
-            CompilationUnit unit = new CSharpToGSharpTranslator(preservePartialParts: true)
+            CompilationUnit unit = new CSharpToGSharpTranslator(
+                preservePartialParts: true,
+                widenObliviousReferenceFields: true)
                 .TranslateDocument(loaded);
 
             // Skip a generated document that carried no translatable content.


### PR DESCRIPTION
Closes #3410

## Summary

- make source-file-preserving partial translation the cs2gs default while retaining the legacy merged mode behind `preservePartialParts: false`
- keep each partial file's static members in its own generated `shared { }` block; rely on the compiler's deterministic partial merger
- preserve owned-extension placement and PR #3417 native named-pattern output
- add focused translator and compiler regressions for `StatementBinder.Blocks` / `StatementBinder.Jumps`

## Validation

- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --no-restore --filter 'FullyQualifiedName~Issue3410|FullyQualifiedName~Issue1910|FullyQualifiedName~Adr0145|FullyQualifiedName~Issue2821|FullyQualifiedName~Issue2645|FullyQualifiedName~Issue3409NativePatternVariableTranslationTests'` — 42 passed
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release --no-restore --filter 'FullyQualifiedName~Adr0144PartialTypesBinderTests'` — 28 passed
- affected pipeline filters (`Issue2215AnalyzerReferenceTests|Issue2599AvaloniaCodebehindTests|Issue3086GeneratedRegexPipelineTests|Issue2618DelegateLikePipelineTests`) — 6 passed
- Core diagnostic migration translation passed twice; `StatementBinder.Blocks.gs` and `StatementBinder.Jumps.gs` were byte-identical across runs, and `HasFunctionLocalRefScope` appeared only in `StatementBinder.Jumps.gs`
- Core compile reached the existing unrelated 8-gap baseline (`ValueTask<T>` / `MethodSemanticsAttributes` / `AddMethodSemantics` / `MakeGenericType`); no partial duplicate or binding diagnostics
