### PR TITLE
Preserve exact direct delegate signatures

### DIFF
--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Conditionals.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Conditionals.cs
@@ -1310,18 +1310,13 @@ internal sealed partial class StatementBinder
         switch (bound)
         {
             case BoundAssignmentExpression assignment:
-                Func<BoundExpression, BoundExpression> createVariableWrite =
-                    value =>
-                    {
-                        return new BoundAssignmentExpression(
-                            assignment.Syntax,
-                            assignment.Variable,
-                            value,
-                            assignment.AssignedValueType);
-                    };
                 plan = new MultiAssignmentTargetPlan(
                     assignment.Expression,
-                    createVariableWrite);
+                    value => new BoundAssignmentExpression(
+                        assignment.Syntax,
+                        assignment.Variable,
+                        value,
+                        assignment.AssignedValueType));
                 return true;
 
             case BoundFieldAssignmentExpression field:
@@ -1358,41 +1353,31 @@ internal sealed partial class StatementBinder
                 var propertyReceiver = property.Receiver == null
                     ? null
                     : CaptureMultiAssignmentReceiver(property.Receiver, targetSyntax, captures);
-                Func<BoundExpression, BoundExpression> createPropertyWrite =
-                    value =>
-                    {
-                        return new BoundPropertyAssignmentExpression(
-                            property.Syntax,
-                            propertyReceiver,
-                            property.StructType,
-                            property.Property,
-                            value);
-                    };
                 plan = new MultiAssignmentTargetPlan(
                     property.Value,
-                    createPropertyWrite);
+                    value => new BoundPropertyAssignmentExpression(
+                        property.Syntax,
+                        propertyReceiver,
+                        property.StructType,
+                        property.Property,
+                        value));
                 return true;
 
             case BoundClrPropertyAssignmentExpression clrProperty:
                 var clrPropertyReceiver = clrProperty.Receiver == null
                     ? null
                     : CaptureMultiAssignmentReceiver(clrProperty.Receiver, targetSyntax, captures);
-                Func<BoundExpression, BoundExpression> createClrPropertyWrite =
-                    value =>
-                    {
-                        return new BoundClrPropertyAssignmentExpression(
-                            clrProperty.Syntax,
-                            clrPropertyReceiver,
-                            clrProperty.Member,
-                            value,
-                            clrProperty.Type,
-                            clrProperty.StaticContainerType,
-                            clrProperty.ConstrainedReceiverTypeParameter,
-                            clrProperty.ConstrainedInterfaceType);
-                    };
                 plan = new MultiAssignmentTargetPlan(
                     clrProperty.Value,
-                    createClrPropertyWrite);
+                    value => new BoundClrPropertyAssignmentExpression(
+                        clrProperty.Syntax,
+                        clrPropertyReceiver,
+                        clrProperty.Member,
+                        value,
+                        clrProperty.Type,
+                        clrProperty.StaticContainerType,
+                        clrProperty.ConstrainedReceiverTypeParameter,
+                        clrProperty.ConstrainedInterfaceType));
                 return true;
 
             case BoundIndexAssignmentExpression index:
@@ -1406,15 +1391,12 @@ internal sealed partial class StatementBinder
                     var capturedIndex = CaptureMultiAssignmentValue(index.Index, targetSyntax, captures);
                     plan = new MultiAssignmentTargetPlan(
                         index.Value,
-                        value =>
-                        {
-                            return BoundIndexAssignmentExpression.WithExpressionTarget(
-                                index.Syntax,
-                                capturedTarget,
-                                capturedIndex,
-                                value,
-                                index.Type);
-                        });
+                        value => BoundIndexAssignmentExpression.WithExpressionTarget(
+                            index.Syntax,
+                            capturedTarget,
+                            capturedIndex,
+                            value,
+                            index.Type));
                     return true;
                 }
 
@@ -1449,18 +1431,15 @@ internal sealed partial class StatementBinder
 
                 plan = new MultiAssignmentTargetPlan(
                     clrIndex.Value,
-                    value =>
-                    {
-                        return BoundClrIndexAssignmentExpression.WithExpressionTarget(
-                            clrIndex.Syntax,
-                            capturedClrTarget,
-                            clrIndex.Indexer,
-                            capturedArguments.ToImmutable(),
-                            value,
-                            clrIndex.Type,
-                            clrIndex.ConstrainedReceiverTypeParameter,
-                            clrIndex.ConstrainedInterfaceType);
-                    });
+                    value => BoundClrIndexAssignmentExpression.WithExpressionTarget(
+                        clrIndex.Syntax,
+                        capturedClrTarget,
+                        clrIndex.Indexer,
+                        capturedArguments.ToImmutable(),
+                        value,
+                        clrIndex.Type,
+                        clrIndex.ConstrainedReceiverTypeParameter,
+                        clrIndex.ConstrainedInterfaceType));
                 return true;
 
             case BoundIndirectAssignmentExpression indirect:
@@ -1487,17 +1466,12 @@ internal sealed partial class StatementBinder
         ImmutableArray<BoundStatement>.Builder captures)
     {
         var address = CaptureMultiAssignmentAddress(storage, targetSyntax, captures);
-        Func<BoundExpression, BoundExpression> createWrite =
-            value =>
-            {
-                return new BoundIndirectAssignmentExpression(
-                    targetSyntax,
-                    new BoundVariableExpression(null, address),
-                    value);
-            };
         return new MultiAssignmentTargetPlan(
             assignedValue,
-            createWrite);
+            value => new BoundIndirectAssignmentExpression(
+                targetSyntax,
+                new BoundVariableExpression(null, address),
+                value));
     }
 
     private LocalVariableSymbol CaptureMultiAssignmentAddress(

--- a/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
@@ -902,41 +902,33 @@ public static class SpillSequenceSpiller
                     var propertyReceiver = clrPropAssign.Receiver;
                     if (propertyReceiver == null)
                     {
-                        Func<BoundExpression, BoundExpression> rebuildClrStaticPropertyAssignment =
-                            value =>
-                            {
-                                return new BoundClrPropertyAssignmentExpression(
-                                    null,
-                                    null,
-                                    clrPropAssign.Member,
-                                    value,
-                                    clrPropAssign.Type,
-                                    clrPropAssign.StaticContainerType,
-                                    clrPropAssign.ConstrainedReceiverTypeParameter,
-                                    clrPropAssign.ConstrainedInterfaceType);
-                            };
                         return SpillOneOperand(
                             clrPropAssign,
                             clrPropAssign.Value,
-                            rebuildClrStaticPropertyAssignment);
+                            value => new BoundClrPropertyAssignmentExpression(
+                                null,
+                                null,
+                                clrPropAssign.Member,
+                                value,
+                                clrPropAssign.Type,
+                                clrPropAssign.StaticContainerType,
+                                clrPropAssign.ConstrainedReceiverTypeParameter,
+                                clrPropAssign.ConstrainedInterfaceType));
                     }
 
                     return SpillTwoOperand(
                         clrPropAssign,
                         propertyReceiver,
                         clrPropAssign.Value,
-                        (recv, val) =>
-                        {
-                            return new BoundClrPropertyAssignmentExpression(
-                                null,
-                                recv,
-                                clrPropAssign.Member,
-                                val,
-                                clrPropAssign.Type,
-                                clrPropAssign.StaticContainerType,
-                                clrPropAssign.ConstrainedReceiverTypeParameter,
-                                clrPropAssign.ConstrainedInterfaceType);
-                        });
+                        (recv, val) => new BoundClrPropertyAssignmentExpression(
+                            null,
+                            recv,
+                            clrPropAssign.Member,
+                            val,
+                            clrPropAssign.Type,
+                            clrPropAssign.StaticContainerType,
+                            clrPropAssign.ConstrainedReceiverTypeParameter,
+                            clrPropAssign.ConstrainedInterfaceType));
                 case BoundClrBinaryOperatorExpression clrBinary:
                     // Issue #2388: preserve whichever of Method (imported CLR
                     // type) / Function (nullable-lifted same-compilation
@@ -945,92 +937,69 @@ public static class SpillSequenceSpiller
                         clrBinary,
                         clrBinary.Left,
                         clrBinary.Right,
-                        (l, r) =>
-                        {
-                            return clrBinary.Function != null
-                                ? new BoundClrBinaryOperatorExpression(null, clrBinary.OperatorKind, l, r, clrBinary.Function, clrBinary.FunctionOwnerType, clrBinary.Type)
-                                : new BoundClrBinaryOperatorExpression(null, clrBinary.OperatorKind, l, r, clrBinary.Method, clrBinary.Type);
-                        });
+                        (l, r) => clrBinary.Function != null
+                            ? new BoundClrBinaryOperatorExpression(null, clrBinary.OperatorKind, l, r, clrBinary.Function, clrBinary.FunctionOwnerType, clrBinary.Type)
+                            : new BoundClrBinaryOperatorExpression(null, clrBinary.OperatorKind, l, r, clrBinary.Method, clrBinary.Type));
                 case BoundClrUnaryOperatorExpression clrUnary:
                     return SpillOneOperand(
                         clrUnary,
                         clrUnary.Operand,
-                        operand =>
-                        {
-                            return new BoundClrUnaryOperatorExpression(null, clrUnary.OperatorKind, operand, clrUnary.Method, clrUnary.Type);
-                        });
+                        operand => new BoundClrUnaryOperatorExpression(null, clrUnary.OperatorKind, operand, clrUnary.Method, clrUnary.Type));
                 case BoundClrConversionCallExpression clrConv:
                     return SpillOneOperand(
                         clrConv,
                         clrConv.Source,
-                        src =>
-                        {
-                            return new BoundClrConversionCallExpression(null, src, clrConv.Method, clrConv.Type);
-                        });
+                        src => new BoundClrConversionCallExpression(null, src, clrConv.Method, clrConv.Type));
                 case BoundClrEventSubscriptionExpression clrEventSub:
                     if (clrEventSub.Receiver == null)
                     {
                         return SpillOneOperand(
                             clrEventSub,
                             clrEventSub.Handler,
-                            handler =>
-                            {
-                                return new BoundClrEventSubscriptionExpression(
-                                    null,
-                                    receiver: null,
-                                    clrEventSub.Event,
-                                    handler,
-                                    clrEventSub.IsAdd,
-                                    clrEventSub.ConstrainedReceiverTypeParameter,
-                                    clrEventSub.ConstrainedInterfaceType,
-                                    clrEventSub.EventContainingType);
-                            });
+                            handler => new BoundClrEventSubscriptionExpression(
+                                null,
+                                receiver: null,
+                                clrEventSub.Event,
+                                handler,
+                                clrEventSub.IsAdd,
+                                clrEventSub.ConstrainedReceiverTypeParameter,
+                                clrEventSub.ConstrainedInterfaceType,
+                                clrEventSub.EventContainingType));
                     }
 
                     return SpillTwoOperand(
                         clrEventSub,
                         clrEventSub.Receiver,
                         clrEventSub.Handler,
-                        (recv, handler) =>
-                        {
-                            return new BoundClrEventSubscriptionExpression(
-                                null,
-                                recv,
-                                clrEventSub.Event,
-                                handler,
-                                clrEventSub.IsAdd,
-                                clrEventSub.ConstrainedReceiverTypeParameter,
-                                clrEventSub.ConstrainedInterfaceType,
-                                clrEventSub.EventContainingType);
-                        });
+                        (recv, handler) => new BoundClrEventSubscriptionExpression(
+                            null,
+                            recv,
+                            clrEventSub.Event,
+                            handler,
+                            clrEventSub.IsAdd,
+                            clrEventSub.ConstrainedReceiverTypeParameter,
+                            clrEventSub.ConstrainedInterfaceType,
+                            clrEventSub.EventContainingType));
                 case BoundEventSubscriptionExpression eventSub:
                     if (eventSub.Receiver == null)
                     {
-                        Func<BoundExpression, BoundExpression> rebuildStaticEventSubscription =
-                            handler =>
-                            {
-                                return new BoundEventSubscriptionExpression(
-                                    null,
-                                    receiver: null,
-                                    eventSub.StructType,
-                                    eventSub.Event,
-                                    handler,
-                                    eventSub.IsAdd);
-                            };
                         return SpillOneOperand(
                             eventSub,
                             eventSub.Handler,
-                            rebuildStaticEventSubscription);
+                            handler => new BoundEventSubscriptionExpression(
+                                null,
+                                receiver: null,
+                                eventSub.StructType,
+                                eventSub.Event,
+                                handler,
+                                eventSub.IsAdd));
                     }
 
                     return SpillTwoOperand(
                         eventSub,
                         eventSub.Receiver,
                         eventSub.Handler,
-                        (recv, handler) =>
-                        {
-                            return new BoundEventSubscriptionExpression(null, recv, eventSub.StructType, eventSub.Event, handler, eventSub.IsAdd);
-                        });
+                        (recv, handler) => new BoundEventSubscriptionExpression(null, recv, eventSub.StructType, eventSub.Event, handler, eventSub.IsAdd));
 
                 case BoundFieldAccessExpression fieldAccess:
                     return SpillFieldAccess(fieldAccess);
@@ -1040,57 +1009,41 @@ public static class SpillSequenceSpiller
                         return Trivial(propAccess);
                     }
 
-                    Func<BoundExpression, BoundExpression> rebuildPropertyAccess =
-                        receiver =>
-                        {
-                            return new BoundPropertyAccessExpression(
-                                null,
-                                receiver,
-                                propAccess.StructType,
-                                propAccess.Property,
-                                propAccess.NarrowedType);
-                        };
                     return SpillOneOperand(
                         propAccess,
                         propAccess.Receiver,
-                        rebuildPropertyAccess);
+                        receiver => new BoundPropertyAccessExpression(
+                            null,
+                            receiver,
+                            propAccess.StructType,
+                            propAccess.Property,
+                            propAccess.NarrowedType));
                 case BoundPropertyAssignmentExpression propAssign:
                     if (propAssign.Receiver == null)
                     {
-                        Func<BoundExpression, BoundExpression> rebuildUserStaticPropertyAssignment =
-                            value =>
-                            {
-                                return new BoundPropertyAssignmentExpression(
-                                    null,
-                                    receiver: null,
-                                    propAssign.StructType,
-                                    propAssign.Property,
-                                    value);
-                            };
                         return SpillOneOperand(
                             propAssign,
                             propAssign.Value,
-                            rebuildUserStaticPropertyAssignment);
+                            value => new BoundPropertyAssignmentExpression(
+                                null,
+                                receiver: null,
+                                propAssign.StructType,
+                                propAssign.Property,
+                                value));
                     }
 
                     return SpillTwoOperand(
                         propAssign,
                         propAssign.Receiver,
                         propAssign.Value,
-                        (recv, val) =>
-                        {
-                            return new BoundPropertyAssignmentExpression(null, recv, propAssign.StructType, propAssign.Property, val);
-                        });
+                        (recv, val) => new BoundPropertyAssignmentExpression(null, recv, propAssign.StructType, propAssign.Property, val));
                 case BoundTupleLiteralExpression tupleLiteral:
                     return SpillTupleLiteral(tupleLiteral);
                 case BoundTupleElementAccessExpression tupleAccess:
                     return SpillOneOperand(
                         tupleAccess,
                         tupleAccess.Receiver,
-                        recv =>
-                        {
-                            return new BoundTupleElementAccessExpression(null, recv, tupleAccess.TupleType, tupleAccess.Index);
-                        });
+                        recv => new BoundTupleElementAccessExpression(null, recv, tupleAccess.TupleType, tupleAccess.Index));
                 case BoundInterpolatedStringExpression interpolated:
                     return SpillInterpolatedString(interpolated);
                 case BoundArrayCreationExpression arrayCreation:
@@ -1101,27 +1054,19 @@ public static class SpillSequenceSpiller
                     return SpillOneOperand(
                         len,
                         len.Operand,
-                        operand =>
-                        {
-                            return new BoundLenExpression(null, operand);
-                        });
+                        operand => new BoundLenExpression(null, operand));
                 case BoundCapExpression cap:
                     return SpillOneOperand(
                         cap,
                         cap.Operand,
-                        operand =>
-                        {
-                            return new BoundCapExpression(null, operand);
-                        });
+                        operand => new BoundCapExpression(null, operand));
                 case BoundAppendExpression append:
-                    Func<BoundExpression, BoundExpression, BoundExpression> rebuildAppend =
-                        (slice, element) =>
-                            new BoundAppendExpression(null, slice, element, append.SliceType);
                     return SpillTwoOperand(
                         append,
                         append.Slice,
                         append.Element,
-                        rebuildAppend);
+                        (slice, element) =>
+                            new BoundAppendExpression(null, slice, element, append.SliceType));
                 case BoundStructLiteralExpression structLiteral:
                     return SpillStructLiteral(structLiteral);
                 case BoundMakeChannelExpression makeChannel:
@@ -1133,26 +1078,17 @@ public static class SpillSequenceSpiller
                     return SpillOneOperand(
                         makeChannel,
                         makeChannel.Capacity,
-                        capacity =>
-                        {
-                            return new BoundMakeChannelExpression(null, makeChannel.ChannelType, capacity);
-                        });
+                        capacity => new BoundMakeChannelExpression(null, makeChannel.ChannelType, capacity));
                 case BoundChannelReceiveExpression channelReceive:
                     return SpillOneOperand(
                         channelReceive,
                         channelReceive.Channel,
-                        channel =>
-                        {
-                            return new BoundChannelReceiveExpression(null, channel, channelReceive.Type);
-                        });
+                        channel => new BoundChannelReceiveExpression(null, channel, channelReceive.Type));
                 case BoundChannelCloseExpression channelClose:
                     return SpillOneOperand(
                         channelClose,
                         channelClose.Channel,
-                        channel =>
-                        {
-                            return new BoundChannelCloseExpression(null, channel);
-                        });
+                        channel => new BoundChannelCloseExpression(null, channel));
                 case BoundMapLiteralExpression mapLiteral:
                     return SpillMapLiteral(mapLiteral);
                 case BoundMapDeleteExpression mapDelete:
@@ -1160,60 +1096,38 @@ public static class SpillSequenceSpiller
                         mapDelete,
                         mapDelete.Map,
                         mapDelete.Key,
-                        (map, key) =>
-                        {
-                            return new BoundMapDeleteExpression(null, map, key);
-                        });
+                        (map, key) => new BoundMapDeleteExpression(null, map, key));
                 case BoundIsExpression isExpr:
-                    Func<BoundExpression, BoundExpression> rebuildIsExpression =
-                        operand =>
-                        {
-                            return new BoundIsExpression(null, operand, isExpr.Pattern);
-                        };
                     return SpillOneOperand(
                         isExpr,
                         isExpr.Expression,
-                        rebuildIsExpression);
+                        operand => new BoundIsExpression(null, operand, isExpr.Pattern));
                 case BoundAsExpression asExpr:
-                    Func<BoundExpression, BoundExpression> rebuildAsExpression =
-                        operand =>
-                        {
-                            return new BoundAsExpression(null, operand, asExpr.TargetType);
-                        };
-                    return SpillOneOperand(asExpr, asExpr.Expression, rebuildAsExpression);
+                    return SpillOneOperand(
+                        asExpr,
+                        asExpr.Expression,
+                        operand => new BoundAsExpression(null, operand, asExpr.TargetType));
                 case BoundThrowExpression throwExpr:
                     return SpillOneOperand(
                         throwExpr,
                         throwExpr.Expression,
-                        operand =>
-                        {
-                            return new BoundThrowExpression(null, operand);
-                        });
+                        operand => new BoundThrowExpression(null, operand));
                 case BoundAddressOfExpression addressOf:
                     return SpillOneOperand(
                         addressOf,
                         addressOf.Operand,
-                        operand =>
-                        {
-                            return new BoundAddressOfExpression(null, operand);
-                        });
+                        operand => new BoundAddressOfExpression(null, operand));
                 case BoundDereferenceExpression dereference:
                     return SpillOneOperand(
                         dereference,
                         dereference.Operand,
-                        operand =>
-                        {
-                            return new BoundDereferenceExpression(null, operand);
-                        });
+                        operand => new BoundDereferenceExpression(null, operand));
                 case BoundIndirectAssignmentExpression indirectAssign:
                     return SpillTwoOperand(
                         indirectAssign,
                         indirectAssign.Pointer,
                         indirectAssign.Value,
-                        (ptr, val) =>
-                        {
-                            return new BoundIndirectAssignmentExpression(null, ptr, val);
-                        });
+                        (ptr, val) => new BoundIndirectAssignmentExpression(null, ptr, val));
 
                 // Switch expression — issue #1619 completion. The governing
                 // (discriminant) expression and each arm's result are spilled
@@ -2514,58 +2428,43 @@ public static class SpillSequenceSpiller
 
         private BoundSpillSequenceExpression SpillIndirectCall(BoundIndirectCallExpression call)
         {
-            Func<BoundExpression, ImmutableArray<BoundExpression>, BoundExpression> rebuild =
-                (target, arguments) =>
-                {
-                    return new BoundIndirectCallExpression(
-                        null,
-                        target,
-                        call.FunctionType,
-                        arguments,
-                        call.ArgumentRefKinds);
-                };
             return SpillTargetAndArguments(
                 call,
                 call.Target,
                 call.Arguments,
-                rebuild);
+                (target, arguments) => new BoundIndirectCallExpression(
+                    null,
+                    target,
+                    call.FunctionType,
+                    arguments,
+                    call.ArgumentRefKinds));
         }
 
         private BoundSpillSequenceExpression SpillFunctionPointerInvocation(BoundFunctionPointerInvocationExpression call)
         {
-            Func<BoundExpression, ImmutableArray<BoundExpression>, BoundExpression> rebuild =
-                (pointer, arguments) =>
-                {
-                    return new BoundFunctionPointerInvocationExpression(
-                        null,
-                        pointer,
-                        arguments,
-                        call.FunctionPointerType);
-                };
             return SpillTargetAndArguments(
                 call,
                 call.Pointer,
                 call.Arguments,
-                rebuild);
+                (pointer, arguments) => new BoundFunctionPointerInvocationExpression(
+                    null,
+                    pointer,
+                    arguments,
+                    call.FunctionPointerType));
         }
 
         private BoundSpillSequenceExpression SpillClrIndex(BoundClrIndexExpression index)
         {
-            Func<BoundExpression, ImmutableArray<BoundExpression>, BoundExpression> rebuild =
-                (target, arguments) =>
-                {
-                    return new BoundClrIndexExpression(
-                        null,
-                        target,
-                        index.Indexer,
-                        arguments,
-                        index.Type);
-                };
             return SpillTargetAndArguments(
                 index,
                 index.Target,
                 index.Arguments,
-                rebuild);
+                (target, arguments) => new BoundClrIndexExpression(
+                    null,
+                    target,
+                    index.Indexer,
+                    arguments,
+                    index.Type));
         }
 
         private BoundSpillSequenceExpression SpillClrIndexAssignment(BoundClrIndexAssignmentExpression assign)
@@ -2622,10 +2521,7 @@ public static class SpillSequenceSpiller
             return SpillOneOperand(
                 access,
                 access.Receiver,
-                recv =>
-                {
-                    return new BoundClrPropertyAccessExpression(null, recv, access.Member, access.Type, access.StaticContainerType);
-                });
+                recv => new BoundClrPropertyAccessExpression(null, recv, access.Member, access.Type, access.StaticContainerType));
         }
 
         private BoundSpillSequenceExpression SpillFieldAccess(BoundFieldAccessExpression fieldAccess)
@@ -2639,10 +2535,7 @@ public static class SpillSequenceSpiller
             return SpillOneOperand(
                 fieldAccess,
                 fieldAccess.Receiver,
-                recv =>
-                {
-                    return new BoundFieldAccessExpression(null, recv, BoundNodeForm.DeclaringType(fieldAccess), fieldAccess.Field, fieldAccess.NarrowedType);
-                });
+                recv => new BoundFieldAccessExpression(null, recv, BoundNodeForm.DeclaringType(fieldAccess), fieldAccess.Field, fieldAccess.NarrowedType));
         }
 
         private BoundSpillSequenceExpression SpillTupleLiteral(BoundTupleLiteralExpression tupleLiteral)
@@ -2799,10 +2692,7 @@ public static class SpillSequenceSpiller
                 return SpillOneOperand(
                     arrayCreation,
                     arrayCreation.LengthExpression,
-                    length =>
-                    {
-                        return new BoundArrayCreationExpression(null, arrayCreation.ContainerType, length);
-                    });
+                    length => new BoundArrayCreationExpression(null, arrayCreation.ContainerType, length));
             }
 
             var (locals, sideEffects, elements) = SpillArgumentList(arrayCreation.Elements);

--- a/src/Repl/Screens/ReplScreen.cs
+++ b/src/Repl/Screens/ReplScreen.cs
@@ -98,19 +98,7 @@ public sealed class ReplScreen : ITabScreen, IDisposable
         get
         {
             var tertiary = Tokens.Tokens.TextTertiary.Value.ToMarkup();
-            var diag = 0;
-            // Oats #3414: migrated gsi loses SelectMany/Count lambda result types (GS0158/GS0159).
-            foreach (var cell in engine.Cells)
-            {
-                foreach (var diagnostic in cell.Diagnostics)
-                {
-                    if (diagnostic.IsError)
-                    {
-                        diag++;
-                    }
-                }
-            }
-
+            var diag = engine.Cells.SelectMany(c => c.Diagnostics).Count(d => d.IsError);
             return diag == 0
                 ? $"[{Tokens.Tokens.StatusSuccess.Value.ToMarkup()}]●[/] gsharp [{tertiary}]· ready[/]"
                 : $"[{Tokens.Tokens.StatusError.Value.ToMarkup()}]●[/] gsharp [{tertiary}]· {diag} error(s)[/]";

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2292AnonymousTypePackageScopeTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2292AnonymousTypePackageScopeTests.cs
@@ -146,6 +146,7 @@ namespace Demo
     /// resolve end-to-end through the real <c>gsc</c> (not just round-trip
     /// parse). cs2gs sidesteps the generic-inference question entirely by
     /// annotating the lambda parameter with the CONCRETE synthesized type
+    /// and preserving the converted delegate's exact <c>object</c> return
     /// (resolved from the bound C# semantic model, not re-inferred by gsc),
     /// so gsc's binder never needs to flow a generic return type through
     /// <c>Func/Action</c> type arguments itself.
@@ -200,7 +201,9 @@ namespace Demo
         string name = AnonymousTypeNames(printed).Single();
         Assert.Contains($"data class {name}(Id int32, Title string)", printed);
         Assert.Contains($"CreateTableBuilder[{name}]", printed);
-        Assert.Contains($"(x {name}) -> x.Id", printed);
+        Assert.Matches(
+            $$"""table\.PrimaryKey\("PK_Books", func \(x {{Regex.Escape(name)}}\) object \{\s*return x\.Id\s*\}\)""",
+            printed);
 
         // The real proof (not just round-trip parse): gsc must actually BIND
         // the generic CreateTable/PrimaryKey calls and the x.Id member access

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2546MethodGroupPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2546MethodGroupPipelineTests.cs
@@ -43,7 +43,8 @@ public sealed class Issue2546MethodGroupPipelineTests
         string emitted = ReadAppOutput(outputRoot, result.RunId, app.AppId);
 
         Assert.Contains("records.Select(ToDictionary)", emitted, StringComparison.Ordinal);
-        Assert.Contains("selected.Where(byAsin", emitted, StringComparison.Ordinal);
+        Assert.Contains("selected.Where(func (__arg0 string) bool", emitted, StringComparison.Ordinal);
+        Assert.Contains("return byAsin.ContainsKey(__arg0)", emitted, StringComparison.Ordinal);
         Assert.Contains("sessions", emitted, StringComparison.Ordinal);
         Assert.Contains(".Count)", emitted, StringComparison.Ordinal);
         Assert.True(

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3414DelegateArgumentInferenceTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3414DelegateArgumentInferenceTests.cs
@@ -1,0 +1,382 @@
+// <copyright file="Issue3414DelegateArgumentInferenceTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Pipeline;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+[Collection(IlVerifyPipelineCollection.Name)]
+public sealed class Issue3414DelegateArgumentInferenceTests
+{
+    private const string CoreSource = """
+        namespace CoreModel;
+
+        public sealed class Diagnostic
+        {
+            public Diagnostic(bool isError)
+            {
+                IsError = isError;
+            }
+
+            public bool IsError { get; }
+        }
+        """;
+
+    private const string ReplSource = """
+        using System;
+        using System.Collections.Generic;
+        using System.Collections.Immutable;
+        using System.Linq;
+        using CoreModel;
+        using GSharp.LanguageServer.Protocol;
+        using ReplModel;
+
+        public sealed class Rebuilder
+        {
+            private readonly Func<Cell, object> rebuild;
+
+            public Rebuilder(Func<Cell, object> rebuild)
+            {
+                this.rebuild = rebuild;
+            }
+
+            public object Run(Cell cell) => rebuild(cell);
+        }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                IReadOnlyList<Cell> cells = new[]
+                {
+                    new Cell(ImmutableArray.Create(
+                        new CoreModel.Diagnostic(true),
+                        new CoreModel.Diagnostic(false))),
+                    new Cell(ImmutableArray.Create(new CoreModel.Diagnostic(true))),
+                };
+
+                Console.WriteLine(CountLambdas(cells));
+                Console.WriteLine(CountMethodGroups(cells));
+                Console.WriteLine(DescribeCell(cells[0]));
+                Console.WriteLine(RebuildCell(cells[0]).GetType().Name);
+            }
+
+            public static int CountLambdas(IReadOnlyList<Cell> cells) =>
+                cells.SelectMany(c => c.Diagnostics).Count(d => d.IsError);
+
+            public static int CountMethodGroups(IReadOnlyList<Cell> cells) =>
+                cells.SelectMany(DiagnosticsOf).Count(IsError);
+
+            public static object DescribeCell(Cell cell) =>
+                ApplyDescription(cell, Describe);
+
+            public static object RebuildCell(Cell cell) =>
+                new Rebuilder(value => new Cell(value.Diagnostics)).Run(cell);
+
+            private static object ApplyDescription(
+                Cell cell,
+                Func<Cell, object> describe) =>
+                describe(cell);
+
+            private static IEnumerable<CoreModel.Diagnostic> DiagnosticsOf(Cell cell) =>
+                cell.Diagnostics;
+
+            private static bool IsError(CoreModel.Diagnostic diagnostic) =>
+                diagnostic.IsError;
+
+            private static string Describe(object value) =>
+                value.GetType().Name;
+        }
+        """;
+
+    private const string CellSource = """
+        using System.Collections.Immutable;
+        using CoreModel;
+
+        namespace ReplModel;
+
+        public sealed class Cell
+        {
+            public Cell(ImmutableArray<Diagnostic> diagnostics)
+            {
+                Diagnostics = diagnostics;
+            }
+
+            public ImmutableArray<Diagnostic> Diagnostics { get; }
+        }
+        """;
+
+    private const string ProtocolSource = """
+        namespace GSharp.LanguageServer.Protocol;
+
+        public sealed class Diagnostic
+        {
+        }
+        """;
+
+    [Fact]
+    public void DirectLambdaAndMethodGroupArguments_PreserveExactDelegateTypes()
+    {
+        string[] translated = Translate(
+            ("Diagnostic.cs", CoreSource),
+            ("Cell.cs", CellSource),
+            ("Protocol.cs", ProtocolSource),
+            ("Program.cs", ReplSource));
+        string consumer = translated.Single(source => source.Contains("class Program", StringComparison.Ordinal));
+
+        Assert.Contains(
+            "SelectMany(func (c Cell) IEnumerable[CoreModel.Diagnostic]",
+            consumer,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "SelectMany((c Cell) -> c.Diagnostics)",
+            consumer,
+            StringComparison.Ordinal);
+        Assert.Contains("Count(", consumer, StringComparison.Ordinal);
+        Assert.Contains("DiagnosticsOf", consumer, StringComparison.Ordinal);
+        Assert.Contains("IsError", consumer, StringComparison.Ordinal);
+        Assert.Contains(
+            "ApplyDescription(cell, func (__arg0 Cell) object",
+            consumer,
+            StringComparison.Ordinal);
+        Assert.Contains("return Program.Describe(__arg0)", consumer, StringComparison.Ordinal);
+        Assert.Contains(
+            "Rebuilder(func (value Cell) object",
+            consumer,
+            StringComparison.Ordinal);
+        Assert.Contains("return Cell(value.Diagnostics)", consumer, StringComparison.Ordinal);
+        Assert.Contains("d CoreModel.Diagnostic", consumer, StringComparison.Ordinal);
+        Assert.All(
+            translated,
+            source =>
+            {
+                RoundTripResult roundTrip = GSharpRoundTrip.Validate(source);
+                Assert.True(
+                    roundTrip.Success,
+                    string.Join(Environment.NewLine, roundTrip.Errors));
+            });
+    }
+
+    [Fact]
+    public async Task ReplShape_TranslatesCompilesVerifiesAndRuns()
+    {
+        string compiler = FindCompiler();
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        Assert.NotNull(compiler);
+        Assert.NotNull(repoRoot);
+        Assert.NotNull(GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot, "Release"));
+        Assert.True(IlVerifyToolAvailable(), "dotnet-ilverify must be available.");
+
+        string sourceRoot = NewDirectory("scratch-projects");
+        Fixture fixture = WriteFixture(sourceRoot);
+        RunDotnetBuild(fixture.ReplProject);
+
+        string outputRoot = NewDirectory("pipeline-tests");
+        var pipeline = new MigrationPipeline(
+            new PipelineOptions
+            {
+                GscPath = compiler,
+                OutputRoot = outputRoot,
+                SourceRoot = sourceRoot,
+                Config = "Release",
+            },
+            new IMigrationStage[]
+            {
+                new TranslateStage(),
+                new CompileStage(),
+                new IlVerifyStage(),
+                new TestParityStage(),
+            });
+
+        RunResult result = await pipeline.RunAsync(new[]
+        {
+            new CorpusApp("test/Issue3414.Core", fixture.CoreProject, TargetKind.Library),
+            new CorpusApp(
+                "test/Issue3414.Repl",
+                fixture.ReplProject,
+                TargetKind.Exe,
+                stdoutGolden: fixture.StdoutGolden),
+        });
+        AppResult appResult = Assert.Single(
+            result.Apps,
+            app => app.AppId == "test/Issue3414.Repl");
+        string appDirectory = Path.Combine(
+            outputRoot,
+            result.RunId,
+            MigrationPipeline.SanitizeAppId(appResult.AppId));
+        string translated = string.Join(
+            Environment.NewLine,
+            Directory.GetFiles(appDirectory, "*.gs", SearchOption.AllDirectories)
+                .Select(File.ReadAllText));
+
+        Assert.Contains("SelectMany(", translated, StringComparison.Ordinal);
+        Assert.Contains("Count(", translated, StringComparison.Ordinal);
+        Assert.True(
+            appResult.Succeeded,
+            string.Join("; ", appResult.Stages.Select(stage => stage.Stage + "=" + stage.Status)));
+        Assert.Equal(
+            new[] { "passed", "passed", "passed", "passed" },
+            appResult.Stages.Select(stage => stage.Status).ToArray());
+        Assert.All(
+            result.Apps,
+            app => Assert.True(
+                app.Succeeded,
+                app.AppId + ": "
+                    + string.Join("; ", app.Stages.Select(stage => stage.Stage + "=" + stage.Status))));
+    }
+
+    private static string[] Translate(params (string Path, string Source)[] sources)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(sources);
+        Assert.True(
+            project.BoundWithoutErrors,
+            string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        return project.Documents.Select(document =>
+            {
+                var context = new TranslationContext(
+                    project.Compilation,
+                    document.SemanticModel,
+                    document.FilePath);
+                CompilationUnit translated =
+                    new CSharpToGSharpTranslator().TranslateDocument(document, context);
+                Assert.DoesNotContain(
+                    context.Diagnostics,
+                    diagnostic => diagnostic.Severity == TranslationSeverity.Unsupported);
+                return GSharpPrinter.Print(translated);
+            }).ToArray();
+    }
+
+    private static Fixture WriteFixture(string sourceRoot)
+    {
+        File.WriteAllText(Path.Combine(sourceRoot, "Directory.Build.props"), "<Project></Project>");
+
+        string coreDirectory = Path.Combine(sourceRoot, "CoreModel");
+        Directory.CreateDirectory(coreDirectory);
+        string coreProject = Path.Combine(coreDirectory, "CoreModel.csproj");
+        File.WriteAllText(coreProject, ProjectFile());
+        File.WriteAllText(Path.Combine(coreDirectory, "Diagnostic.cs"), CoreSource);
+
+        string replDirectory = Path.Combine(sourceRoot, "Repl");
+        Directory.CreateDirectory(replDirectory);
+        string replProject = Path.Combine(replDirectory, "Repl.csproj");
+        File.WriteAllText(
+            replProject,
+            ProjectFile("../CoreModel/CoreModel.csproj", outputType: "Exe"));
+        File.WriteAllText(Path.Combine(replDirectory, "Cell.cs"), CellSource);
+        File.WriteAllText(Path.Combine(replDirectory, "Protocol.cs"), ProtocolSource);
+        File.WriteAllText(Path.Combine(replDirectory, "Program.cs"), ReplSource);
+
+        string stdoutGolden = Path.Combine(sourceRoot, "baseline.stdout.golden");
+        File.WriteAllText(stdoutGolden, "2\n2\nCell\nCell\n");
+        return new Fixture(coreProject, replProject, stdoutGolden);
+    }
+
+    private static string ProjectFile(string projectReference = null, string outputType = null)
+    {
+        string output = outputType is null ? string.Empty : $"<OutputType>{outputType}</OutputType>";
+        string reference = projectReference is null
+            ? string.Empty
+            : $"""
+                <ItemGroup>
+                  <ProjectReference Include="{projectReference}" />
+                </ItemGroup>
+              """;
+        return $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>enable</Nullable>
+                {output}
+              </PropertyGroup>
+              {reference}
+            </Project>
+            """;
+    }
+
+    private static void RunDotnetBuild(string projectPath)
+    {
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        startInfo.ArgumentList.Add("build");
+        startInfo.ArgumentList.Add(projectPath);
+        startInfo.ArgumentList.Add("--nologo");
+        startInfo.ArgumentList.Add("--verbosity:quiet");
+
+        using Process process = Process.Start(startInfo);
+        string stdout = process.StandardOutput.ReadToEnd();
+        string stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        Assert.True(process.ExitCode == 0, "Fixture build failed:\n" + stdout + stderr);
+    }
+
+    private static bool IlVerifyToolAvailable()
+    {
+        try
+        {
+            return !IlVerifyRunner.IsEnabled || new IlVerifyRunner().EnsureToolAvailable();
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static string NewDirectory(string category)
+    {
+        string root = Path.Combine(
+            AppContext.BaseDirectory,
+            category,
+            "issue3414",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindCompiler()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            foreach (string configuration in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(
+                    directory.FullName,
+                    "out",
+                    "bin",
+                    configuration,
+                    "Compiler",
+                    "gsc.dll");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+
+    private sealed record Fixture(
+        string CoreProject,
+        string ReplProject,
+        string StdoutGolden);
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3414DelegateArgumentInferenceTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3414DelegateArgumentInferenceTests.cs
@@ -70,6 +70,9 @@ public sealed class Issue3414DelegateArgumentInferenceTests
                 Console.WriteLine(CountLambdas(cells));
                 Console.WriteLine(CountMethodGroups(cells));
                 Console.WriteLine(DescribeCell(cells[0]));
+                Console.WriteLine(DescribeCellBlock(cells[0], numeric: true));
+                Console.WriteLine(DescribeCellBlock(cells[0], numeric: false));
+                Console.WriteLine(VisitCell(cells[0]));
                 Console.WriteLine(RebuildCell(cells[0]).GetType().Name);
             }
 
@@ -82,6 +85,28 @@ public sealed class Issue3414DelegateArgumentInferenceTests
             public static object DescribeCell(Cell cell) =>
                 ApplyDescription(cell, Describe);
 
+            public static object DescribeCellBlock(Cell cell, bool numeric) =>
+                ApplyDescription(cell, value =>
+                {
+                    if (numeric)
+                    {
+                        return value.Diagnostics.Length;
+                    }
+
+                    return value.GetType().Name;
+                });
+
+            public static int VisitCell(Cell cell)
+            {
+                int count = 0;
+                ApplyVisit(cell, value =>
+                {
+                    count = value.Diagnostics.Length;
+                    return;
+                });
+                return count;
+            }
+
             public static object RebuildCell(Cell cell) =>
                 new Rebuilder(value => new Cell(value.Diagnostics)).Run(cell);
 
@@ -89,6 +114,9 @@ public sealed class Issue3414DelegateArgumentInferenceTests
                 Cell cell,
                 Func<Cell, object> describe) =>
                 describe(cell);
+
+            private static void ApplyVisit(Cell cell, Action<Cell> visit) =>
+                visit(cell);
 
             private static IEnumerable<CoreModel.Diagnostic> DiagnosticsOf(Cell cell) =>
                 cell.Diagnostics;
@@ -98,6 +126,33 @@ public sealed class Issue3414DelegateArgumentInferenceTests
 
             private static string Describe(object value) =>
                 value.GetType().Name;
+        }
+        """;
+
+    private const string ScopeIsolationSource = """
+        using System;
+        using ReplModel;
+
+        public static class ScopeIsolation
+        {
+            public static string Describe(Cell cell) =>
+                ApplyText(cell, value =>
+                {
+                    Func<Cell, int> nested = nestedValue =>
+                    {
+                        return nestedValue.Diagnostics.Length;
+                    };
+
+                    int Local(Cell localValue)
+                    {
+                        return localValue.Diagnostics.Length;
+                    }
+
+                    return value.GetType().Name + nested(value) + Local(value);
+                });
+
+            private static string ApplyText(Cell cell, Func<Cell, string> describe) =>
+                describe(cell);
         }
         """;
 
@@ -157,6 +212,14 @@ public sealed class Issue3414DelegateArgumentInferenceTests
             consumer,
             StringComparison.Ordinal);
         Assert.Contains("return Cell(value.Diagnostics)", consumer, StringComparison.Ordinal);
+        Assert.Contains(
+            "ApplyDescription(cell, func (value Cell) object",
+            consumer,
+            StringComparison.Ordinal);
+        Assert.Contains("return value.Diagnostics.Length", consumer, StringComparison.Ordinal);
+        Assert.Contains("return value.GetType().Name", consumer, StringComparison.Ordinal);
+        Assert.Contains("ApplyVisit(cell, (value Cell) -> {", consumer, StringComparison.Ordinal);
+        Assert.DoesNotContain("ApplyVisit(cell, func", consumer, StringComparison.Ordinal);
         Assert.Contains("d CoreModel.Diagnostic", consumer, StringComparison.Ordinal);
         Assert.All(
             translated,
@@ -167,6 +230,20 @@ public sealed class Issue3414DelegateArgumentInferenceTests
                     roundTrip.Success,
                     string.Join(Environment.NewLine, roundTrip.Errors));
             });
+    }
+
+    [Fact]
+    public void BlockLambdaReturnScan_ExcludesNestedLambdasAndLocalFunctions()
+    {
+        string[] translated = Translate(
+            ("Diagnostic.cs", CoreSource),
+            ("Cell.cs", CellSource),
+            ("ScopeIsolation.cs", ScopeIsolationSource));
+        string consumer = translated.Single(source =>
+            source.Contains("class ScopeIsolation", StringComparison.Ordinal));
+
+        Assert.Contains("ApplyText(cell, (value Cell) -> {", consumer, StringComparison.Ordinal);
+        Assert.DoesNotContain("ApplyText(cell, func", consumer, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -280,7 +357,7 @@ public sealed class Issue3414DelegateArgumentInferenceTests
         File.WriteAllText(Path.Combine(replDirectory, "Program.cs"), ReplSource);
 
         string stdoutGolden = Path.Combine(sourceRoot, "baseline.stdout.golden");
-        File.WriteAllText(stdoutGolden, "2\n2\nCell\nCell\n");
+        File.WriteAllText(stdoutGolden, "2\n2\nCell\n2\nCell\n2\nCell\n");
         return new Fixture(coreProject, replProject, stdoutGolden);
     }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -1197,11 +1197,12 @@ public sealed partial class CSharpToGSharpTranslator
             // CoerceNumericArgumentToConverted (issue #1281) emits the bare operand
             // when gsc accepts the conversion on its own and keeps the explicit
             // `T(x)` wrap only where gsc still needs it.
+            GExpression exactCallable = this.TranslateExactCallableArgument(argument);
             GExpression translated = this.CoercePointerConversion(
                 argument.Expression,
                 this.CoerceNumericArgumentToConverted(
                     argument,
-                    this.TranslateExpression(argument.Expression)));
+                    exactCallable ?? this.TranslateExpression(argument.Expression)));
             if (!IsNameOfArgument(argument)
                 && !isXunitNullAssertion
                 && targetRequiresNonNull
@@ -1216,6 +1217,213 @@ public sealed partial class CSharpToGSharpTranslator
             }
 
             return translated;
+        }
+
+        // Issue #3414: Roslyn has already fixed the converted delegate signature
+        // at a direct argument. Preserve it when the callable's natural signature
+        // differs, instead of leaving gsc to materialize the wrong delegate ABI.
+        private GExpression TranslateExactCallableArgument(ArgumentSyntax argument)
+        {
+            ExpressionSyntax expression = argument.Expression;
+            if (expression is AnonymousFunctionExpressionSyntax lambda
+                && this.TryGetConvertedDelegateInvoke(lambda, out IMethodSymbol lambdaInvoke))
+            {
+                return this.typeMapper.WithMetadataImportCollisionQualification(
+                    () => this.LambdaResultNeedsExactTarget(lambda, lambdaInvoke)
+                        ? this.TranslateLambda(lambda, lambdaInvoke)
+                        : this.TranslateLambda(lambda));
+            }
+
+            if (this.TryGetMethodGroupArgument(
+                    argument,
+                    out IMethodSymbol method,
+                    out IMethodSymbol methodGroupInvoke)
+                && MethodGroupNeedsExactTarget(method, methodGroupInvoke))
+            {
+                return this.typeMapper.WithMetadataImportCollisionQualification(
+                    () => this.TranslateExactMethodGroupArgument(
+                        expression,
+                        method,
+                        methodGroupInvoke));
+            }
+
+            return null;
+        }
+
+        private bool TryGetMethodGroupArgument(
+            ArgumentSyntax argument,
+            out IMethodSymbol method,
+            out IMethodSymbol invoke)
+        {
+            method = null;
+            invoke = null;
+            if (this.context.SemanticModel.GetOperation(argument) is not IArgumentOperation argumentOperation
+                || argumentOperation.Value is not IDelegateCreationOperation delegateCreation
+                || delegateCreation.Target is not IMethodReferenceOperation methodReference
+                || delegateCreation.Type is not INamedTypeSymbol delegateType)
+            {
+                return false;
+            }
+
+            method = methodReference.Method;
+            invoke = delegateType.DelegateInvokeMethod;
+            return method != null && invoke != null;
+        }
+
+        private bool TryGetConvertedDelegateInvoke(
+            ExpressionSyntax expression,
+            out IMethodSymbol invoke)
+        {
+            invoke = (this.context.GetTypeInfo(expression).ConvertedType as INamedTypeSymbol)
+                ?.DelegateInvokeMethod;
+            return invoke != null;
+        }
+
+        private bool LambdaResultNeedsExactTarget(
+            AnonymousFunctionExpressionSyntax lambda,
+            IMethodSymbol invoke)
+        {
+            if (lambda.Body is not ExpressionSyntax body
+                || invoke.ReturnsVoid)
+            {
+                return false;
+            }
+
+            ITypeSymbol targetResult = invoke.ReturnType;
+            if (lambda.AsyncKeyword.IsKind(SyntaxKind.AsyncKeyword)
+                && targetResult is INamedTypeSymbol task
+                && task.Name == "Task"
+                && task.ContainingNamespace?.ToDisplayString() == "System.Threading.Tasks")
+            {
+                if (!task.IsGenericType)
+                {
+                    return false;
+                }
+
+                targetResult = task.TypeArguments[0];
+            }
+
+            ITypeSymbol bodyType = this.context.GetTypeInfo(body).Type;
+            return bodyType != null
+                && !SymbolEqualityComparer.IncludeNullability.Equals(
+                    bodyType,
+                    targetResult);
+        }
+
+        private static bool MethodGroupNeedsExactTarget(
+            IMethodSymbol method,
+            IMethodSymbol invoke)
+        {
+            if (method.Parameters.Length != invoke.Parameters.Length
+                || method.ReturnsVoid != invoke.ReturnsVoid)
+            {
+                return true;
+            }
+
+            for (int index = 0; index < method.Parameters.Length; index++)
+            {
+                IParameterSymbol methodParameter = method.Parameters[index];
+                IParameterSymbol invokeParameter = invoke.Parameters[index];
+                if (methodParameter.RefKind != invokeParameter.RefKind
+                    || !SymbolEqualityComparer.IncludeNullability.Equals(
+                        methodParameter.Type,
+                        invokeParameter.Type))
+                {
+                    return true;
+                }
+            }
+
+            return !method.ReturnsVoid
+                && !SymbolEqualityComparer.IncludeNullability.Equals(
+                    method.ReturnType,
+                    invoke.ReturnType);
+        }
+
+        private GExpression TranslateExactMethodGroupArgument(
+            ExpressionSyntax expression,
+            IMethodSymbol method,
+            IMethodSymbol invoke)
+        {
+            var parameters = new List<Parameter>(invoke.Parameters.Length);
+            var arguments = new List<GExpression>(invoke.Parameters.Length);
+            for (int index = 0; index < invoke.Parameters.Length; index++)
+            {
+                IParameterSymbol invokeParameter = invoke.Parameters[index];
+                Parameter mapped = this.MapParameter(
+                    invokeParameter,
+                    expression,
+                    promoteNullability: false);
+                string name = $"__arg{index}";
+                parameters.Add(new Parameter(
+                    name,
+                    mapped.Type,
+                    mapped.IsVariadic,
+                    mapped.RefKind));
+
+                GExpression forwarded = new IdentifierExpression(name);
+                if (invokeParameter.RefKind is RefKind.Ref or RefKind.Out)
+                {
+                    forwarded = new UnaryExpression("&", forwarded);
+                }
+
+                arguments.Add(forwarded);
+            }
+
+            GExpression target = this.TranslateMethodGroupInvocationTarget(
+                expression,
+                method);
+            IReadOnlyList<GTypeReference> typeArguments = method.IsGenericMethod
+                ? method.TypeArguments
+                    .Select(type => this.typeMapper.Map(
+                        type,
+                        this.context,
+                        expression.GetLocation()))
+                    .ToList()
+                : null;
+            var call = new InvocationExpression(target, arguments, typeArguments);
+            GTypeReference returnType = this.MapDelegateLikeReturnType(
+                invoke,
+                isAsync: false,
+                expression.GetLocation());
+            var statements = returnType == null
+                ? new GStatement[] { new ExpressionStatement(call) }
+                : new GStatement[] { new ReturnStatement(call) };
+            return new LambdaExpression(
+                parameters,
+                blockBody: new BlockStatement(statements),
+                returnType: returnType,
+                isFunctionLiteral: true);
+        }
+
+        private GExpression TranslateMethodGroupInvocationTarget(
+            ExpressionSyntax expression,
+            IMethodSymbol method)
+        {
+            if (method.IsStatic
+                && method.MethodKind != MethodKind.LocalFunction
+                && method.ContainingType is { IsImplicitlyDeclared: false } owner
+                && !SymbolEqualityComparer.Default.Equals(
+                    owner.OriginalDefinition,
+                    this.entryType?.OriginalDefinition))
+            {
+                return new MemberAccessExpression(
+                    this.StaticQualifierReceiver(owner, expression.GetLocation()),
+                    SanitizeIdentifier(method.Name));
+            }
+
+            if (expression is MemberAccessExpressionSyntax member
+                && !method.IsStatic
+                && !this.TryGetStaticExtensionHelper(method, out _, out _))
+            {
+                GExpression receiver = this.CaptureMethodGroupReceiver(
+                    this.TranslateReceiverWithNullForgiveness(member.Expression),
+                    member.Expression);
+                return new MemberAccessExpression(
+                    receiver,
+                    SanitizeIdentifier(member.Name.Identifier.ValueText));
+            }
+
+            return this.TranslateExpression(expression);
         }
 
         private bool IsXunitNullAssertionArgument(ArgumentSyntax argument)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -1283,8 +1283,7 @@ public sealed partial class CSharpToGSharpTranslator
             AnonymousFunctionExpressionSyntax lambda,
             IMethodSymbol invoke)
         {
-            if (lambda.Body is not ExpressionSyntax body
-                || invoke.ReturnsVoid)
+            if (invoke.ReturnsVoid)
             {
                 return false;
             }
@@ -1303,11 +1302,27 @@ public sealed partial class CSharpToGSharpTranslator
                 targetResult = task.TypeArguments[0];
             }
 
-            ITypeSymbol bodyType = this.context.GetTypeInfo(body).Type;
-            return bodyType != null
-                && !SymbolEqualityComparer.IncludeNullability.Equals(
-                    bodyType,
-                    targetResult);
+            IEnumerable<ExpressionSyntax> results = lambda.Body switch
+            {
+                ExpressionSyntax expression => new[] { expression },
+                BlockSyntax block => block
+                    .DescendantNodes(static node =>
+                        node is not AnonymousFunctionExpressionSyntax
+                            and not LocalFunctionStatementSyntax)
+                    .OfType<ReturnStatementSyntax>()
+                    .Where(statement => statement.Expression != null)
+                    .Select(statement => statement.Expression),
+                _ => Enumerable.Empty<ExpressionSyntax>(),
+            };
+
+            return results.Any(result =>
+            {
+                ITypeSymbol resultType = this.context.GetTypeInfo(result).Type;
+                return resultType != null
+                    && !SymbolEqualityComparer.IncludeNullability.Equals(
+                        resultType,
+                        targetResult);
+            });
         }
 
         private static bool MethodGroupNeedsExactTarget(

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
@@ -159,14 +159,16 @@ public sealed partial class CSharpToGSharpTranslator
 
                 if (lambda.Body is BlockSyntax block)
                 {
-                    // ADR-0128 / issue #1172: a block-bodied C# lambda renders as the
-                    // idiomatic G# arrow form `(params) -> { … }`. The arrow lambda's
-                    // statement-block body now reaches parity with func literals and
-                    // infers its return type, so no explicit return type is emitted.
+                    // ADR-0128 / issue #1172: block-bodied lambdas normally use the
+                    // idiomatic inferred arrow form. Issue #3414: when a direct
+                    // argument's return expressions need conversion to the target
+                    // delegate result, preserve that exact result on a func literal.
                     return new LambdaExpression(
                         parameters,
                         blockBody: this.WithParameterShadows(lambda, this.TranslateBlock(block)),
-                        isAsync: isAsync);
+                        isAsync: isAsync,
+                        returnType: exactReturnType,
+                        isFunctionLiteral: exactTargetInvoke != null);
                 }
 
                 // A void static-helper `?.` call needs a guarded statement, not

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
@@ -22,7 +22,9 @@ public sealed partial class CSharpToGSharpTranslator
 {
     private sealed partial class DeclarationVisitor
     {
-        private GExpression TranslateLambda(AnonymousFunctionExpressionSyntax lambda)
+        private GExpression TranslateLambda(
+            AnonymousFunctionExpressionSyntax lambda,
+            IMethodSymbol exactTargetInvoke = null)
         {
             var parameters = new List<Parameter>();
             ParameterListSyntax parameterList = lambda switch
@@ -78,6 +80,12 @@ public sealed partial class CSharpToGSharpTranslator
             bool isAsync = lambda.AsyncKeyword.IsKind(SyntaxKind.AsyncKeyword);
             IMethodSymbol lambdaSymbol = this.context.GetSymbolInfo(lambda).Symbol as IMethodSymbol
                 ?? (this.context.GetTypeInfo(lambda).ConvertedType as INamedTypeSymbol)?.DelegateInvokeMethod;
+            GTypeReference exactReturnType = exactTargetInvoke != null
+                ? this.MapDelegateLikeReturnType(
+                    exactTargetInvoke,
+                    isAsync,
+                    lambda.GetLocation())
+                : null;
             bool hasUnderscoreParameter = (lambda is SimpleLambdaExpressionSyntax simpleLambda
                 && simpleLambda.Parameter.Identifier.ValueText == "_")
                 || parameterList?.Parameters.Any(parameter => parameter.Identifier.ValueText == "_") == true;
@@ -232,11 +240,27 @@ public sealed partial class CSharpToGSharpTranslator
 
                 if (spillPrologue.Count == 0)
                 {
+                    if (exactTargetInvoke != null)
+                    {
+                        return new LambdaExpression(
+                            parameters,
+                            blockBody: new BlockStatement(
+                                new GStatement[] { new ReturnStatement(expressionBody) }),
+                            isAsync: isAsync,
+                            returnType: exactReturnType,
+                            isFunctionLiteral: true);
+                    }
+
                     return new LambdaExpression(parameters, expressionBody: expressionBody, isAsync: isAsync);
                 }
 
                 var bodyStatements = new List<GStatement>(spillPrologue) { new ReturnStatement(expressionBody) };
-                return new LambdaExpression(parameters, blockBody: new BlockStatement(bodyStatements), isAsync: isAsync);
+                return new LambdaExpression(
+                    parameters,
+                    blockBody: new BlockStatement(bodyStatements),
+                    isAsync: isAsync,
+                    returnType: exactReturnType,
+                    isFunctionLiteral: exactTargetInvoke != null);
             }
             finally
             {

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -323,17 +323,8 @@ public sealed class CSharpTypeMapper
         TranslationContext context,
         Location location)
     {
-        bool previous = this.qualifyMetadataImportCollisions;
-        this.qualifyMetadataImportCollisions = true;
-        GTypeReference mapped;
-        try
-        {
-            mapped = this.Map(type, context, location);
-        }
-        finally
-        {
-            this.qualifyMetadataImportCollisions = previous;
-        }
+        GTypeReference mapped = this.WithMetadataImportCollisionQualification(
+            () => this.Map(type, context, location));
 
         if (!mapped.IsNullable)
         {
@@ -416,6 +407,27 @@ public sealed class CSharpTypeMapper
     /// <returns>A reference to the synthesized (or already-cached) data class.</returns>
     public NamedTypeReference GetOrCreateAnonymousDataClass(INamedTypeSymbol anonymousType, TranslationContext context, Location location) =>
         this.GetOrCreateAnonymousDataClassShape(anonymousType, context, location).Type;
+
+    /// <summary>
+    /// Maps an exact inferred contract while qualifying metadata homonyms
+    /// reachable through the current file's imports.
+    /// </summary>
+    /// <typeparam name="T">The mapped result type.</typeparam>
+    /// <param name="map">Mapping operation to run under collision qualification.</param>
+    /// <returns>The mapped result.</returns>
+    internal T WithMetadataImportCollisionQualification<T>(Func<T> map)
+    {
+        bool previous = this.qualifyMetadataImportCollisions;
+        this.qualifyMetadataImportCollisions = true;
+        try
+        {
+            return map();
+        }
+        finally
+        {
+            this.qualifyMetadataImportCollisions = previous;
+        }
+    }
 
     internal (NamedTypeReference Type, IReadOnlyList<IPropertySymbol> Properties) GetOrCreateAnonymousDataClassShape(
         INamedTypeSymbol anonymousType,


### PR DESCRIPTION
## Summary

Fixes #3414.

- preserve Roslyn's exact converted delegate parameter and return contracts for direct lambda and method-group arguments
- emit exact function-literal adapters only when natural callable shape differs, including metadata type-name collisions
- restore `ReplScreen.Status` to `SelectMany(...).Count(predicate)`
- remove migrated-Core callback locals/block wrappers now covered by direct argument typing

## Validation

- cs2gs focused delegate tests: 20 passed
- Core spill/multi-assignment tests: 50 passed
- compiler spill emit tests: 17 passed
- `dotnet build src/Repl/Repl.csproj -c Release --no-restore`: passed, 0 warnings/errors
- `cs2gs migrate --diagnostic-run --corpus src/Repl`: translate/compile/ILVerify/test-parity passed
- `python3 build/nullable_hygiene.py --base origin/main`: passed
- `git diff --check`: passed

Full `src/Core` diagnostic migration remains stopped before compile by the same eight pre-existing translation gaps reproduced on untouched main `6478b8c5`; generated callback sites now carry exact `func (...) BoundExpression` signatures.
