### PR TITLE
[cs2gs] Preserve nullable AsyncLocal state without sentinels

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundScope.cs
@@ -54,8 +54,6 @@ public sealed class BoundScope
     // Issue #2342: the ambient "current declaring package" (see
     // SetCurrentDeclaringPackage), lazily set/cleared only on the root scope
     // of the chain, exactly like anonymousTypeCache above.
-    // Empty string is the AsyncLocal storage sentinel for null; setter and
-    // getter normalize null <-> empty so save/restore preserves the contract.
     private AsyncLocal<string?> currentDeclaringPackageName = new AsyncLocal<string?>();
 
     // Issue #2456 (per-file import scoping / #2395 follow-up): the ambient
@@ -64,8 +62,8 @@ public sealed class BoundScope
     // single member body, mirroring currentDeclaringPackageName exactly.
     // Import enumeration consults this to expose only imports declared in the
     // same file as the reference being resolved, plus implicit imports.
-    private AsyncLocal<object?> currentReferencingSyntaxTree =
-        new AsyncLocal<object?>();
+    private AsyncLocal<GSharp.Core.CodeAnalysis.Syntax.SyntaxTree?> currentReferencingSyntaxTree =
+        new AsyncLocal<GSharp.Core.CodeAnalysis.Syntax.SyntaxTree?>();
 
     // Issue #2455: the ambient "qualified construction package hint" (see
     // SetQualifiedConstructionPackageHint), set only while re-binding the
@@ -1440,9 +1438,8 @@ public sealed class BoundScope
             return Parent.SetCurrentDeclaringPackage(packageName);
         }
 
-        var stored = currentDeclaringPackageName.Value;
-        var previous = string.IsNullOrEmpty(stored) ? null : stored;
-        currentDeclaringPackageName.Value = packageName ?? string.Empty;
+        var previous = currentDeclaringPackageName.Value;
+        currentDeclaringPackageName.Value = packageName;
         return previous;
     }
 
@@ -1470,8 +1467,8 @@ public sealed class BoundScope
             return Parent.SetCurrentReferencingSyntaxTree(tree);
         }
 
-        var previous = (currentReferencingSyntaxTree.Value as ReferencingSyntaxTreeState)?.Tree;
-        currentReferencingSyntaxTree.Value = new ReferencingSyntaxTreeState(tree);
+        var previous = currentReferencingSyntaxTree.Value;
+        currentReferencingSyntaxTree.Value = tree;
         return previous;
     }
 
@@ -1518,9 +1515,8 @@ public sealed class BoundScope
             return Parent.SetQualifiedConstructionPackageHint(packageName);
         }
 
-        var stored = qualifiedConstructionPackageHint.Value;
-        var previous = string.IsNullOrEmpty(stored) ? null : stored;
-        qualifiedConstructionPackageHint.Value = packageName ?? string.Empty;
+        var previous = qualifiedConstructionPackageHint.Value;
+        qualifiedConstructionPackageHint.Value = packageName;
         return previous;
     }
 
@@ -1530,15 +1526,7 @@ public sealed class BoundScope
     /// none is set.
     /// </summary>
     private string? GetCurrentDeclaringPackage()
-    {
-        if (Parent != null)
-        {
-            return Parent.GetCurrentDeclaringPackage();
-        }
-
-        var packageName = currentDeclaringPackageName.Value;
-        return string.IsNullOrEmpty(packageName) ? null : packageName;
-    }
+        => Parent != null ? Parent.GetCurrentDeclaringPackage() : currentDeclaringPackageName.Value;
 
     /// <summary>
     /// Issue #2456: gets the ambient "current referencing syntax tree" set by
@@ -1547,9 +1535,7 @@ public sealed class BoundScope
     /// import-based disambiguation this fix adds simply does not fire).
     /// </summary>
     private GSharp.Core.CodeAnalysis.Syntax.SyntaxTree? GetCurrentReferencingSyntaxTree()
-        => Parent != null
-            ? Parent.GetCurrentReferencingSyntaxTree()
-            : (currentReferencingSyntaxTree.Value as ReferencingSyntaxTreeState)?.Tree;
+        => Parent != null ? Parent.GetCurrentReferencingSyntaxTree() : currentReferencingSyntaxTree.Value;
 
     /// <summary>
     /// Issue #2455: gets the ambient qualified-construction package hint set
@@ -1557,15 +1543,7 @@ public sealed class BoundScope
     /// <see langword="null"/> when none is set.
     /// </summary>
     private string? GetQualifiedConstructionPackageHint()
-    {
-        if (Parent != null)
-        {
-            return Parent.GetQualifiedConstructionPackageHint();
-        }
-
-        var packageName = qualifiedConstructionPackageHint.Value;
-        return string.IsNullOrEmpty(packageName) ? null : packageName;
-    }
+        => Parent != null ? Parent.GetQualifiedConstructionPackageHint() : qualifiedConstructionPackageHint.Value;
 
     /// <summary>
     /// Issue #2455: tries to resolve (<paramref name="name"/>, <paramref name="arity"/>)
@@ -2845,14 +2823,4 @@ public sealed class BoundScope
         EnumSymbol e => e.Accessibility == Accessibility.Private,
         _ => false,
     };
-
-    private sealed class ReferencingSyntaxTreeState
-    {
-        public ReferencingSyntaxTreeState(GSharp.Core.CodeAnalysis.Syntax.SyntaxTree? tree)
-        {
-            Tree = tree;
-        }
-
-        public GSharp.Core.CodeAnalysis.Syntax.SyntaxTree? Tree { get; }
-    }
 }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
@@ -597,11 +597,9 @@ internal sealed partial class ExpressionBinder
                         // surfaces as `ICollection[K]` (a generic shape
                         // containing the in-scope `K`) instead of the
                         // type-erased `ICollection<object>`.
-                        var receiverOverride = ResolveInstancePropertyTypeFromReceiver(clrInstanceReceiverType, prop);
-                        var propType = receiverOverride
-                            ?? (prop.PropertyType.IsByRef
-                                ? MapClrMemberType(prop.PropertyType)
-                                : ClrNullability.GetPropertyTypeSymbol(prop));
+                        var propType = prop.PropertyType.IsByRef
+                            ? MapClrMemberType(prop.PropertyType)
+                            : MemberLookup.GetClrPropertyTypeSymbol(clrInstanceReceiverType, prop);
                         propType = NormalizeImportedSemanticAggregate(propType, prop);
                         return ConversionClassifier.AutoDereferenceRefReturn(new BoundClrPropertyAccessExpression(null, receiver!, prop, propType));
                     }
@@ -2469,123 +2467,6 @@ internal sealed partial class ExpressionBinder
                 || TypeSymbol.IsSameCompilationUserTypeTopLevel(mapped)
                 || openMemberType.IsGenericParameter
                 || openMemberType.IsGenericType
-                ? mapped
-                : null;
-        }
-        catch (System.Reflection.AmbiguousMatchException)
-        {
-            return null;
-        }
-    }
-
-    /// <summary>
-    /// Issue #794: substitute the receiver's symbolic type arguments back
-    /// through a CLR property's open declaring type. The closed `clrReceiverType`
-    /// is the type-erased shape (#313 / #671), so reflection's
-    /// <see cref="PropertyInfo.PropertyType"/> reports the property's open type
-    /// closed over `object` — e.g. `Dictionary[K, V].Keys` surfaces as
-    /// `ICollection&lt;object&gt;`. Walk the open property on the receiver's
-    /// <see cref="ImportedTypeSymbol.OpenDefinition"/> and project its property
-    /// type using the receiver's <see cref="ImportedTypeSymbol.TypeArguments"/>.
-    /// Returns <see langword="null"/> when no substitution applies.
-    /// </summary>
-    private static TypeSymbol? ResolveInstancePropertyTypeFromReceiver(TypeSymbol receiverType, PropertyInfo closedProperty)
-    {
-        if (receiverType is not ImportedTypeSymbol imp
-            || imp.OpenDefinition == null
-            || imp.TypeArguments.IsDefaultOrEmpty
-            || closedProperty == null)
-        {
-            return null;
-        }
-
-        try
-        {
-            // Match by name + indexer arity to find the open counterpart.
-            // Properties on closed generic instances carry stable
-            // metadata-name overlap with their open declaration; an exact
-            // name lookup on the open type with the same instance-binding
-            // flags is sufficient for the single-name, non-indexer
-            // properties that surface real receiver-type generics.
-            var openType = imp.OpenDefinition;
-            if (closedProperty.DeclaringType != imp.ClrType
-                && closedProperty.DeclaringType?.IsGenericType == true)
-            {
-                foreach (var candidateInterface in imp.OpenDefinition.GetInterfaces())
-                {
-                    if (candidateInterface.IsGenericType
-                        && candidateInterface.GetGenericTypeDefinition()
-                            == closedProperty.DeclaringType.GetGenericTypeDefinition())
-                    {
-                        openType = candidateInterface;
-                        break;
-                    }
-                }
-            }
-
-            var openProperty = ClrTypeUtilities.SafeGetProperty(
-                openType,
-                closedProperty.Name,
-                BindingFlags.Public | BindingFlags.Instance);
-            if (openProperty == null || openProperty.GetIndexParameters().Length != 0)
-            {
-                return null;
-            }
-
-            var openPropType = openProperty.PropertyType;
-            if (openPropType == null)
-            {
-                return null;
-            }
-
-            var mapped = MemberLookup.MapOpenClrTypeToSymbolic(openPropType, imp.OpenDefinition, imp.TypeArguments);
-
-            // Issue #794 surfaced this projection for in-scope type parameters
-            // (e.g. `Dictionary[K, V].Keys` -> `ICollection[K]`). Issue #1304
-            // extends it to same-compilation user-defined type arguments: a
-            // member whose open type is a generic parameter — e.g.
-            // `IEnumerator[Ch].Current` -> `Ch` — must keep the user element
-            // `Ch` instead of erasing to `object`. A user-defined `Ch` has a
-            // null `ClrType` during binding, so the closed reflection property
-            // reports the erased `object`; surface the symbolic projection.
-            //
-            // Issue #1418 generalizes the #1304/#1328/#1344 progression: surface
-            // the symbolic projection whenever it carries a same-compilation
-            // user type ANYWHERE — whether the member is the user type itself
-            // (`IEnumerator[Ch].Current` -> `Ch`, #1304), a constructed generic
-            // that is an enumerable collection (`Dictionary[K, V].Values` ->
-            // `ValueCollection[K, V]`, #1328), a channel reader/writer
-            // (`Channel[Entry].Reader` -> `ChannelReader[Entry]`, #1344), or any
-            // OTHER constructed CLR generic over a user element
-            // (`TaskCompletionSource[Entry].Task` -> `Task[Entry]`,
-            // `Lazy[Entry]`, `IReadOnlyList[Entry]`, …). In every case the
-            // mapped type keeps the type-erased closed `ClrType` (e.g.
-            // `Task<object>`) for member/extension lookup — which resolves
-            // against the erased shape exactly as before (proven by #1088) —
-            // while its symbolic `[Entry]` argument keeps the element type from
-            // collapsing to `object` for downstream projections (`await`,
-            // `await for`, `.Result`, the `for … in` surface, LINQ terminals).
-            //
-            // The earlier #1305 worry — that surfacing a constructed generic
-            // over a user element would regress method lookup — does not
-            // materialize precisely because lookup reads `ClrType`, not the
-            // symbolic arguments; #1328 and #1344 already proved this for the
-            // collection and channel shapes, and `ContainsSameCompilationUserType`
-            // simply removes the type-specific allow-list.
-            //
-            // When the OPEN property type is itself a bare generic parameter
-            // (e.g. `KeyValuePair[K, V].Key` -> `K`, `.Value` -> `V`), the
-            // receiver's closed `ClrType` may have erased *every* type argument
-            // to `object` because a SIBLING argument is a same-compilation user
-            // type (a constructed generic over a user element erases the whole
-            // closed shape — so `KeyValuePair[uint32, E]` closes to
-            // `KeyValuePair<object, object>`, erasing the concrete `uint32`
-            // too). The symbolic projection is then authoritative, so prefer it
-            // via the `openPropType.IsGenericParameter` arm even when the mapped
-            // result no longer mentions the user type.
-            return TypeSymbol.ContainsTypeParameter(mapped)
-                || TypeSymbol.ContainsSameCompilationUserType(mapped)
-                || openPropType.IsGenericParameter
                 ? mapped
                 : null;
         }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
@@ -599,7 +599,10 @@ internal sealed partial class ExpressionBinder
                         // type-erased `ICollection<object>`.
                         var propType = prop.PropertyType.IsByRef
                             ? MapClrMemberType(prop.PropertyType)
-                            : MemberLookup.GetClrPropertyTypeSymbol(clrInstanceReceiverType, prop);
+                            : MemberLookup.GetClrPropertyTypeSymbol(
+                                clrInstanceReceiverType,
+                                prop,
+                                projectOnlyWhenSymbolicallyRequired: true);
                         propType = NormalizeImportedSemanticAggregate(propType, prop);
                         return ConversionClassifier.AutoDereferenceRefReturn(new BoundClrPropertyAccessExpression(null, receiver!, prop, propType));
                     }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -514,7 +514,7 @@ internal sealed partial class ExpressionBinder
                 return null;
             }
 
-            if (!TryGetWritableClrMember(instanceMember, out _, out var instTargetSymbol, out _))
+            if (!TryGetWritableClrMember(instanceMember, receiverType, out _, out var instTargetSymbol, out _))
             {
                 Diagnostics.ReportCannotAssign(initSyntax.EqualsToken.Location, propertyName);
                 _ = BindExpression(initSyntax.Value);
@@ -826,7 +826,7 @@ internal sealed partial class ExpressionBinder
                 return new BoundErrorExpression(null);
             }
 
-            if (!TryGetWritableClrMember(instanceMember, out var instTargetType, out var instTargetSymbol, out var instWritable))
+            if (!TryGetWritableClrMember(instanceMember, assignmentReceiverType, out var instTargetType, out var instTargetSymbol, out var instWritable))
             {
                 Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, fieldName);
                 return new BoundErrorExpression(null);
@@ -1664,7 +1664,7 @@ internal sealed partial class ExpressionBinder
             return null;
         }
 
-        if (!TryGetWritableClrMember(instanceMember, out _, out var targetSymbol, out _))
+        if (!TryGetWritableClrMember(instanceMember, boundReceiver.Type, out _, out var targetSymbol, out _))
         {
             Diagnostics.ReportCannotAssign(syntax.OperatorToken.Location, memberName);
             return new BoundErrorExpression(null);
@@ -2533,7 +2533,7 @@ internal sealed partial class ExpressionBinder
                 return new BoundErrorExpression(null);
             }
 
-            if (!TryGetWritableClrMember(instanceMember, out var instTargetType, out var instTargetSymbol, out var instWritable))
+            if (!TryGetWritableClrMember(instanceMember, receiverType, out var instTargetType, out var instTargetSymbol, out var instWritable))
             {
                 Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, fieldName);
                 return new BoundErrorExpression(null);
@@ -3015,7 +3015,7 @@ internal sealed partial class ExpressionBinder
             return true;
         }
 
-        if (!TryGetWritableClrMember(instanceMember, out _, out var targetSymbol, out _))
+        if (!TryGetWritableClrMember(instanceMember, globalType, out _, out var targetSymbol, out _))
         {
             Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, memberName);
             result = new BoundErrorExpression(null);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -1784,7 +1784,7 @@ internal sealed partial class ExpressionBinder
                 continue;
             }
 
-            if (!TryGetWritableClrMember(member, out _, out var targetSymbol, out _))
+            if (!TryGetWritableClrMember(member, tempVar.Type, out _, out var targetSymbol, out _))
             {
                 Diagnostics.ReportCannotAssign(initSyntax.FieldIdentifier.Location, memberName);
                 _ = BindExpression(initSyntax.Value);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -1214,12 +1214,22 @@ internal sealed partial class ExpressionBinder
     }
 
     private static bool TryGetWritableClrMember(MemberInfo? member, [NotNullWhen(true)] out Type? targetType, [NotNullWhen(true)] out TypeSymbol? targetTypeSymbol, out bool writable)
+        => TryGetWritableClrMember(member, receiverType: null, out targetType, out targetTypeSymbol, out writable);
+
+    private static bool TryGetWritableClrMember(
+        MemberInfo? member,
+        TypeSymbol? receiverType,
+        [NotNullWhen(true)] out Type? targetType,
+        [NotNullWhen(true)] out TypeSymbol? targetTypeSymbol,
+        out bool writable)
     {
         switch (member)
         {
             case PropertyInfo p:
                 targetType = p.PropertyType;
-                targetTypeSymbol = ClrNullability.GetPropertyTypeSymbol(p);
+                targetTypeSymbol = receiverType == null
+                    ? ClrNullability.GetPropertyTypeSymbol(p)
+                    : MemberLookup.GetClrPropertyTypeSymbol(receiverType, p);
                 writable = p.CanWrite && p.GetSetMethod(nonPublic: false) != null;
                 return writable;
             case FieldInfo f:

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -1229,7 +1229,10 @@ internal sealed partial class ExpressionBinder
                 targetType = p.PropertyType;
                 targetTypeSymbol = receiverType == null
                     ? ClrNullability.GetPropertyTypeSymbol(p)
-                    : MemberLookup.GetClrPropertyTypeSymbol(receiverType, p);
+                    : MemberLookup.GetClrPropertyTypeSymbol(
+                        receiverType,
+                        p,
+                        projectOnlyWhenSymbolicallyRequired: true);
                 writable = p.CanWrite && p.GetSetMethod(nonPublic: false) != null;
                 return writable;
             case FieldInfo f:

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -3755,8 +3755,15 @@ internal sealed class MemberLookup
     /// </summary>
     /// <param name="targetType">The symbolic imported receiver type.</param>
     /// <param name="closedProperty">The reflected property selected from the erased receiver.</param>
+    /// <param name="projectOnlyWhenSymbolicallyRequired">
+    /// Whether to use closed-property nullability unless receiver substitution carries
+    /// information that CLR metadata cannot represent.
+    /// </param>
     /// <returns>The property type after symbolic receiver substitution.</returns>
-    internal static TypeSymbol GetClrPropertyTypeSymbol(TypeSymbol targetType, PropertyInfo closedProperty)
+    internal static TypeSymbol GetClrPropertyTypeSymbol(
+        TypeSymbol targetType,
+        PropertyInfo closedProperty,
+        bool projectOnlyWhenSymbolicallyRequired = false)
     {
         if (GetImportedTypeSymbol(targetType) is ImportedTypeSymbol imported
             && TryGetSymbolicDeclaringContext(
@@ -3778,8 +3785,10 @@ internal sealed class MemberLookup
                 // constructed receiver such as AsyncLocal<string?>. Keep the
                 // receiver-projected property type when CLR metadata cannot
                 // represent its symbolic shape.
-                if (TypeSymbol.RequiresSymbolicProjection(mapped)
-                    || openProperty.PropertyType.IsGenericParameter)
+                if (!projectOnlyWhenSymbolicallyRequired
+                    || openProperty.PropertyType.IsGenericParameter
+                    || (openProperty.PropertyType.ContainsGenericParameters
+                        && TypeSymbol.RequiresSymbolicProjection(mapped)))
                 {
                     return mapped;
                 }

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -3769,10 +3769,20 @@ internal sealed class MemberLookup
             var openProperty = FindOpenIndexerDefinition(openDefinition, closedProperty);
             if (openProperty != null)
             {
-                return MapOpenClrTypeToSymbolic(
+                var mapped = MapOpenClrTypeToSymbolic(
                     openProperty.PropertyType,
                     openDefinition,
                     declaringTypeArguments);
+
+                // Issue #3415: reflection erases reference nullability from a
+                // constructed receiver such as AsyncLocal<string?>. Keep the
+                // receiver-projected property type when CLR metadata cannot
+                // represent its symbolic shape.
+                if (TypeSymbol.RequiresSymbolicProjection(mapped)
+                    || openProperty.PropertyType.IsGenericParameter)
+                {
+                    return mapped;
+                }
             }
         }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3415NullableAsyncLocalTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3415NullableAsyncLocalTests.cs
@@ -1,0 +1,111 @@
+// <copyright file="Issue3415NullableAsyncLocalTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+public sealed class Issue3415NullableAsyncLocalTests
+{
+    [Fact]
+    public void NullableReferenceTypeArgument_ProjectsThroughClrPropertySetter()
+    {
+        var result = EmittedOracle.Evaluate("""
+            import System.Threading
+
+            let state = AsyncLocal[string?]()
+            state.Value = nil
+            state.Value == nil
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(true, result.Value);
+    }
+
+    [Fact]
+    public void NullableState_NestedExecutionContextsAndConcurrentTasks_RestoreIndependently()
+    {
+        var result = EmittedOracle.Evaluate("""
+            import System.Threading
+            import System.Threading.Tasks
+
+            func Run() int32 {
+                let state = AsyncLocal[string?]()
+                state.Value = nil
+                let nullContext = ExecutionContext.Capture()
+                if nullContext == nil {
+                    return -1
+                }
+
+                state.Value = "outer"
+                let outerContext = ExecutionContext.Capture()
+                if outerContext == nil {
+                    return -2
+                }
+
+                state.Value = "root"
+                var score = 0
+                ExecutionContext.Run(outerContext, (ignored object?) -> {
+                    if state.Value == "outer" {
+                        score++
+                    }
+
+                    state.Value = "inner-parent"
+                    ExecutionContext.Run(nullContext, (nestedIgnored object?) -> {
+                        if state.Value == nil {
+                            score++
+                        }
+
+                        state.Value = "inner-child"
+                    }, nil)
+
+                    if state.Value == "inner-parent" {
+                        score++
+                    }
+                }, nil)
+
+                if state.Value == "root" {
+                    score++
+                }
+
+                let barrier = Barrier(2)
+                state.Value = "left"
+                let left = Task.Run(() -> {
+                    let inherited = state.Value == "left"
+                    state.Value = nil
+                    barrier.SignalAndWait()
+                    return inherited && state.Value == nil
+                })
+
+                state.Value = "right"
+                let right = Task.Run(() -> {
+                    let inherited = state.Value == "right"
+                    state.Value = "right-child"
+                    barrier.SignalAndWait()
+                    return inherited && state.Value == "right-child"
+                })
+
+                if left.Result {
+                    score++
+                }
+
+                if right.Result {
+                    score++
+                }
+
+                if state.Value == "right" {
+                    score++
+                }
+
+                return score
+            }
+
+            Run()
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(7, result.Value);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3415NullableAsyncLocalTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3415NullableAsyncLocalTranslationTests.cs
@@ -1,0 +1,158 @@
+// <copyright file="Issue3415NullableAsyncLocalTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using GSharp.Tests;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+public sealed class Issue3415NullableAsyncLocalTranslationTests
+{
+    private const string Source = """
+        #nullable enable
+        using System.Threading;
+        using System.Threading.Tasks;
+
+        namespace Demo;
+
+        public sealed class Probe
+        {
+            private readonly AsyncLocal<string?> state = new AsyncLocal<string?>();
+
+            public int Run()
+            {
+                state.Value = null;
+                ExecutionContext? nullContext = ExecutionContext.Capture();
+                if (nullContext == null)
+                {
+                    return -1;
+                }
+
+                state.Value = "outer";
+                ExecutionContext? outerContext = ExecutionContext.Capture();
+                if (outerContext == null)
+                {
+                    return -2;
+                }
+
+                state.Value = "root";
+                int score = 0;
+                ExecutionContext.Run(outerContext, _ =>
+                {
+                    if (state.Value == "outer")
+                    {
+                        score++;
+                    }
+
+                    state.Value = "inner-parent";
+                    ExecutionContext.Run(nullContext, _ =>
+                    {
+                        if (state.Value == null)
+                        {
+                            score++;
+                        }
+
+                        state.Value = "inner-child";
+                    }, null);
+
+                    if (state.Value == "inner-parent")
+                    {
+                        score++;
+                    }
+                }, null);
+
+                if (state.Value == "root")
+                {
+                    score++;
+                }
+
+                var barrier = new Barrier(2);
+                state.Value = "left";
+                Task<bool> left = Task.Run(() =>
+                {
+                    bool inherited = state.Value == "left";
+                    state.Value = null;
+                    barrier.SignalAndWait();
+                    return inherited && state.Value == null;
+                });
+
+                state.Value = "right";
+                Task<bool> right = Task.Run(() =>
+                {
+                    bool inherited = state.Value == "right";
+                    state.Value = "right-child";
+                    barrier.SignalAndWait();
+                    return inherited && state.Value == "right-child";
+                });
+
+                if (left.Result)
+                {
+                    score++;
+                }
+
+                if (right.Result)
+                {
+                    score++;
+                }
+
+                if (state.Value == "right")
+                {
+                    score++;
+                }
+
+                return score;
+            }
+        }
+        """;
+
+    [Fact]
+    public void NullableAsyncLocal_TranslatesDirectStorageAndRunsWithExecutionContextIsolation()
+    {
+        string printed = Translate(Source);
+
+        Assert.Contains("AsyncLocal[string?]", printed, StringComparison.Ordinal);
+        Assert.Contains("state.Value = nil", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("?? \"\"", printed, StringComparison.Ordinal);
+
+        var result = EmittedOracle.Evaluate(printed + Environment.NewLine + "Probe().Run()");
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(7, result.Value);
+    }
+
+    private static string Translate(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(
+            project.Compilation,
+            document.SemanticModel,
+            document.FilePath);
+        CompilationUnit unit =
+            new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.DoesNotContain(
+            context.Diagnostics,
+            diagnostic => diagnostic.Severity == TranslationSeverity.Unsupported);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult roundTrip = TranslationTestValidation.AssertBinds(printed);
+        Assert.True(
+            roundTrip.Success,
+            string.Join(Environment.NewLine, roundTrip.Errors) +
+                Environment.NewLine +
+                printed);
+        return printed;
+    }
+}


### PR DESCRIPTION
Closes #3415.

## Root cause

`AsyncLocal<T>.Value` writes were target-typed from the reflected closed property. CLR reflection erases nullable-reference annotations, so an `AsyncLocal<string?>` receiver exposed a setter target of `string`. The read path separately projected generic property types from the symbolic receiver, leaving getter and setter contracts inconsistent and rejecting `nil`/`null` writes.

## Fix

- reuse one receiver-aware CLR property projection for reads and writes
- retain symbolic property types when CLR metadata cannot represent nullable references, type parameters, or same-compilation user types
- thread symbolic receiver types through imported instance-property assignment and object-initializer paths
- keep ordinary property-level CLR nullability and imported-constraint contracts unchanged when receiver substitution is not required

## Workaround reversal

`BoundScope` now stores nullable package names directly in `AsyncLocal<string?>`, with no empty-string normalization. Referencing syntax trees also return to direct `AsyncLocal<SyntaxTree?>` storage; the object wrapper and stale sentinel invariant comments are removed.

## Tests

- direct `AsyncLocal<string?>` null assignment/read in emitted G#
- nested `ExecutionContext.Run` save/restore across null and non-null states
- concurrent `Task.Run` context isolation with synchronized overlap
- cs2gs translation round-trip, direct `state.Value = nil` shape, compilation, and runtime execution
- related nullable generic/property regressions: 11/11 pass
- imported interface-constraint property regressions: 10/10 pass
- focused Core regressions: 2/2 issue tests and 97/97 related tests pass
- `python3 build/nullable_hygiene.py --base origin/main`: pass

A diagnostic translation of actual `src/Core` emits `AsyncLocal[string?]`, `AsyncLocal[SyntaxTree?]`, and direct nullable `Value` assignments in `BoundScope.gs`. The whole diagnostic run stops before compile on eight unrelated translation diagnostics in unchanged files (seven #2821 conditional-access gaps plus one `KnownAttributes` round-trip gap).
