### PR TITLE
Preserve else-if branches in cs2gs pattern guard hoists

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue3418PatternGuardBranchTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3418PatternGuardBranchTranslationTests.cs
@@ -113,6 +113,59 @@ public sealed class Issue3418PatternGuardBranchTranslationTests
             "20");
     }
 
+    [Fact]
+    public void PatternGuardHoists_WithFilteredCatch_DoNotReportControlFlowMismatch()
+    {
+        string printed = Translate(
+            """
+            namespace Demo
+            {
+                public static class C
+                {
+                    public static int Select(object value, bool useFilter)
+                    {
+                        if (value is int number && number > 0)
+                        {
+                            number += 1;
+                            return number;
+                        }
+                        else if (value is string text && text.Length > 0)
+                        {
+                            text += "!";
+                            return text.Length;
+                        }
+                        else
+                        {
+                        }
+
+                        try
+                        {
+                            throw new System.InvalidOperationException();
+                        }
+                        catch (System.InvalidOperationException) when (useFilter)
+                        {
+                            return 30;
+                        }
+                        catch (System.Exception)
+                        {
+                            return 40;
+                        }
+                    }
+                }
+            }
+            """);
+
+        LocalFunctionHoistTranslationTests.CompileAndRun(
+            printed,
+            """
+            Console.WriteLine(C.Select(2, false))
+            Console.WriteLine(C.Select("text", false))
+            Console.WriteLine(C.Select(Object(), true))
+            Console.WriteLine(C.Select(Object(), false))
+            """,
+            string.Join(Environment.NewLine, "3", "5", "30", "40"));
+    }
+
     private static string Translate(string source, bool allowPositionalPatternDiagnostic = false)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3418PatternGuardBranchTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3418PatternGuardBranchTranslationTests.cs
@@ -1,0 +1,161 @@
+// <copyright file="Issue3418PatternGuardBranchTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3418: legacy pattern-guard hoists must preserve each else-if branch
+/// exactly once.
+/// </summary>
+public sealed class Issue3418PatternGuardBranchTranslationTests
+{
+    [Fact]
+    public void MutableValuePatternGuard_PreservesElseIfWhenTypeTestFails()
+    {
+        string printed = Translate(
+            """
+            namespace Demo
+            {
+                public static class C
+                {
+                    private static bool TryRead(int value, out int extra)
+                    {
+                        extra = 2;
+                        return value > 0;
+                    }
+
+                    public static int Select(object value)
+                    {
+                        if (value is int number && TryRead(number, out var extra))
+                        {
+                            number += 1;
+                            return number + extra;
+                        }
+                        else if (value is string)
+                        {
+                            return 20;
+                        }
+                        else
+                        {
+                            throw new System.InvalidOperationException();
+                        }
+                    }
+                }
+            }
+            """);
+
+        Assert.Equal(1, CountOccurrences(printed, "return 20"));
+        Assert.Equal(1, CountOccurrences(printed, "throw InvalidOperationException()"));
+        LocalFunctionHoistTranslationTests.CompileAndRun(
+            printed,
+            "Console.WriteLine(C.Select(\"text\"))\nConsole.WriteLine(C.Select(42))",
+            "20" + Environment.NewLine + "45");
+    }
+
+    [Fact]
+    public void PositionalIfLetGuard_EmitsElseIfBranchOnce()
+    {
+        string printed = Translate(
+            """
+            namespace Demo
+            {
+                public sealed class Node
+                {
+                    public Node(int value)
+                    {
+                        Value = value;
+                    }
+
+                    public int Value;
+
+                    public void Deconstruct(out int value)
+                    {
+                        value = Value;
+                    }
+                }
+
+                public static class C
+                {
+                    private static object Get(object value) => value;
+
+                    public static int Select(object value)
+                    {
+                        if (value != null && Get(value) is Node(1) node && node.Value > 0)
+                        {
+                            return 10;
+                        }
+                        else if (value is string)
+                        {
+                            return 20;
+                        }
+                        else
+                        {
+                            throw new System.InvalidOperationException();
+                        }
+                    }
+                }
+            }
+            """,
+            allowPositionalPatternDiagnostic: true);
+
+        Assert.Equal(1, CountOccurrences(printed, "return 20"));
+        Assert.Equal(1, CountOccurrences(printed, "throw InvalidOperationException()"));
+        LocalFunctionHoistTranslationTests.CompileAndRun(
+            printed,
+            "Console.WriteLine(C.Select(\"text\"))",
+            "20");
+    }
+
+    private static string Translate(string source, bool allowPositionalPatternDiagnostic = false)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(
+            project.Compilation,
+            document.SemanticModel,
+            document.FilePath);
+        string printed = GSharpPrinter.Print(
+            new CSharpToGSharpTranslator().TranslateDocument(document, context));
+        if (allowPositionalPatternDiagnostic)
+        {
+            Assert.All(
+                context.Diagnostics,
+                diagnostic => Assert.True(
+                    diagnostic.Severity == TranslationSeverity.Info
+                        || diagnostic.ConstructKind == "Subpattern",
+                    diagnostic.ToString()));
+        }
+        else
+        {
+            Assert.DoesNotContain(context.Diagnostics, diagnostic => diagnostic.Severity != TranslationSeverity.Info);
+        }
+
+        TranslationTestValidation.AssertBinds(printed);
+        return printed;
+    }
+
+    private static int CountOccurrences(string text, string value)
+    {
+        int count = 0;
+        int index = 0;
+        while ((index = text.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += value.Length;
+        }
+
+        return count;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
@@ -1236,148 +1236,148 @@ public sealed partial class CSharpToGSharpTranslator
         private BlockStatement TranslateBody(SyntaxNode bodyOwner, string description)
         {
             SyntaxNode previousScope = this.state.CurrentBodyScope;
-            bool previousLegacyPatternGuardHoist = this.state.CurrentBodyUsesLegacyPatternGuardHoist;
             this.state.CurrentBodyScope = bodyOwner;
-            this.state.CurrentBodyUsesLegacyPatternGuardHoist = false;
             try
             {
                 BlockStatement body = this.TranslateBodyCore(bodyOwner, description);
                 body = this.WithParameterShadows(bodyOwner, body);
-                body = AddIteratorExitLabel(bodyOwner, body);
-                if (this.state.CurrentBodyUsesLegacyPatternGuardHoist)
-                {
-                    this.ReportPatternGuardControlTransferMismatch(bodyOwner, description, body);
-                }
-
-                return body;
+                return AddIteratorExitLabel(bodyOwner, body);
             }
             finally
             {
                 this.state.CurrentBodyScope = previousScope;
-                this.state.CurrentBodyUsesLegacyPatternGuardHoist = previousLegacyPatternGuardHoist;
             }
         }
 
         private void ReportPatternGuardControlTransferMismatch(
-            SyntaxNode bodyOwner,
-            string description,
-            BlockStatement body)
+            IfStatementSyntax ifStatement,
+            IReadOnlyList<GStatement> emittedHoist,
+            IReadOnlyList<GStatement> translatedBranches)
         {
-            BlockSyntax sourceBody = bodyOwner switch
+            // Compare the translated branch nodes by identity before and after
+            // hoist assembly. Unrelated method statements cannot affect this
+            // invariant, while intentional shared nodes such as filtered-catch
+            // rethrows retain their original multiplicity.
+            var branchTransfers = new Dictionary<GStatement, int>(
+                System.Collections.Generic.ReferenceEqualityComparer.Instance);
+            foreach (GStatement branch in translatedBranches)
             {
-                BaseMethodDeclarationSyntax method => method.Body,
-                AccessorDeclarationSyntax accessor => accessor.Body,
-                LocalFunctionStatementSyntax localFunction => localFunction.Body,
-                _ => null,
-            };
-            if (sourceBody == null)
+                CountTranslatedControlTransferReferences(branch, branchTransfers);
+            }
+
+            if (branchTransfers.Count == 0)
             {
                 return;
             }
 
-            int sourceReturns = sourceBody.DescendantNodesAndSelf(
-                    descendIntoChildren: node =>
-                        node is not (AnonymousFunctionExpressionSyntax or LocalFunctionStatementSyntax))
-                .OfType<ReturnStatementSyntax>()
-                .Count();
-            int sourceThrows = sourceBody.DescendantNodesAndSelf(
-                    descendIntoChildren: node =>
-                        node is not (AnonymousFunctionExpressionSyntax or LocalFunctionStatementSyntax))
-                .OfType<ThrowStatementSyntax>()
-                .Count();
-            int translatedReturns = 0;
-            int translatedThrows = 0;
-            CountTranslatedControlTransfers(body, ref translatedReturns, ref translatedThrows);
+            var emittedTransfers = new Dictionary<GStatement, int>(
+                System.Collections.Generic.ReferenceEqualityComparer.Instance);
+            foreach (GStatement statement in emittedHoist)
+            {
+                CountTranslatedControlTransferReferences(statement, emittedTransfers);
+            }
 
-            if (sourceReturns == translatedReturns && sourceThrows == translatedThrows)
+            if (branchTransfers.All(expected =>
+                    emittedTransfers.TryGetValue(expected.Key, out int actual)
+                    && actual == expected.Value))
             {
                 return;
             }
 
+            int branchReturns = branchTransfers
+                .Where(pair => pair.Key is ReturnStatement)
+                .Sum(pair => pair.Value);
+            int branchThrows = branchTransfers
+                .Where(pair => pair.Key is ThrowStatement)
+                .Sum(pair => pair.Value);
+            int emittedReturns = branchTransfers
+                .Where(pair => pair.Key is ReturnStatement)
+                .Sum(pair => emittedTransfers.TryGetValue(pair.Key, out int count) ? count : 0);
+            int emittedThrows = branchTransfers
+                .Where(pair => pair.Key is ThrowStatement)
+                .Sum(pair => emittedTransfers.TryGetValue(pair.Key, out int count) ? count : 0);
             string message =
-                $"legacy pattern-guard lowering changed control-transfer structure in {description}: " +
-                $"C# has {sourceReturns} return statement(s) and {sourceThrows} throw statement(s), " +
-                $"but emitted G# has {translatedReturns} return statement(s) and {translatedThrows} throw statement(s) " +
+                "legacy pattern-guard lowering changed translated branch control-transfer structure: " +
+                $"branches contain {branchReturns} return occurrence(s) and {branchThrows} throw occurrence(s), " +
+                $"but emitted hoist preserves {emittedReturns} return occurrence(s) and {emittedThrows} throw occurrence(s) " +
                 "(issue #3418).";
             this.context.Report(new TranslationDiagnostic(
                 "PatternGuardControlFlow",
                 message,
-                bodyOwner.GetLocation(),
+                ifStatement.GetLocation(),
                 TranslationSeverity.Unsupported));
         }
 
-        private static void CountTranslatedControlTransfers(
+        private static void CountTranslatedControlTransferReferences(
             GStatement statement,
-            ref int returns,
-            ref int throws)
+            IDictionary<GStatement, int> counts)
         {
             switch (statement)
             {
                 case null:
                     return;
                 case ReturnStatement:
-                    returns++;
-                    return;
                 case ThrowStatement:
-                    throws++;
+                    counts.TryGetValue(statement, out int count);
+                    counts[statement] = count + 1;
                     return;
                 case BlockStatement block:
                     foreach (GStatement child in block.Statements)
                     {
-                        CountTranslatedControlTransfers(child, ref returns, ref throws);
+                        CountTranslatedControlTransferReferences(child, counts);
                     }
 
                     return;
                 case IfStatement conditional:
-                    CountTranslatedControlTransfers(conditional.Then, ref returns, ref throws);
-                    CountTranslatedControlTransfers(conditional.ElseBranch, ref returns, ref throws);
+                    CountTranslatedControlTransferReferences(conditional.Then, counts);
+                    CountTranslatedControlTransferReferences(conditional.ElseBranch, counts);
                     return;
                 case IfLetStatement ifLet:
-                    CountTranslatedControlTransfers(ifLet.Then, ref returns, ref throws);
-                    CountTranslatedControlTransfers(ifLet.Else, ref returns, ref throws);
+                    CountTranslatedControlTransferReferences(ifLet.Then, counts);
+                    CountTranslatedControlTransferReferences(ifLet.Else, counts);
                     return;
                 case WhileStatement loop:
-                    CountTranslatedControlTransfers(loop.Body, ref returns, ref throws);
+                    CountTranslatedControlTransferReferences(loop.Body, counts);
                     return;
                 case WhileLetStatement loop:
-                    CountTranslatedControlTransfers(loop.Body, ref returns, ref throws);
+                    CountTranslatedControlTransferReferences(loop.Body, counts);
                     return;
                 case DoWhileStatement loop:
-                    CountTranslatedControlTransfers(loop.Body, ref returns, ref throws);
+                    CountTranslatedControlTransferReferences(loop.Body, counts);
                     return;
                 case ForStatement loop:
-                    CountTranslatedControlTransfers(loop.Body, ref returns, ref throws);
+                    CountTranslatedControlTransferReferences(loop.Body, counts);
                     return;
                 case ForInStatement loop:
-                    CountTranslatedControlTransfers(loop.Body, ref returns, ref throws);
+                    CountTranslatedControlTransferReferences(loop.Body, counts);
                     return;
                 case ForTupleInStatement loop:
-                    CountTranslatedControlTransfers(loop.Body, ref returns, ref throws);
+                    CountTranslatedControlTransferReferences(loop.Body, counts);
                     return;
                 case LockStatement locked:
-                    CountTranslatedControlTransfers(locked.Body, ref returns, ref throws);
+                    CountTranslatedControlTransferReferences(locked.Body, counts);
                     return;
                 case FixedStatement fixedStatement:
-                    CountTranslatedControlTransfers(fixedStatement.Body, ref returns, ref throws);
+                    CountTranslatedControlTransferReferences(fixedStatement.Body, counts);
                     return;
                 case TryStatement tryStatement:
-                    CountTranslatedControlTransfers(tryStatement.TryBlock, ref returns, ref throws);
+                    CountTranslatedControlTransferReferences(tryStatement.TryBlock, counts);
                     foreach (CatchClause catchClause in tryStatement.CatchClauses)
                     {
-                        CountTranslatedControlTransfers(catchClause.Body, ref returns, ref throws);
+                        CountTranslatedControlTransferReferences(catchClause.Body, counts);
                     }
 
-                    CountTranslatedControlTransfers(tryStatement.FinallyBlock, ref returns, ref throws);
+                    CountTranslatedControlTransferReferences(tryStatement.FinallyBlock, counts);
                     return;
                 case SwitchStatement switchStatement:
                     foreach (SwitchStatementCase switchCase in switchStatement.Cases)
                     {
-                        CountTranslatedControlTransfers(switchCase.Body, ref returns, ref throws);
+                        CountTranslatedControlTransferReferences(switchCase.Body, counts);
                     }
 
                     return;
                 case LabeledStatement labeled:
-                    CountTranslatedControlTransfers(labeled.Statement, ref returns, ref throws);
+                    CountTranslatedControlTransferReferences(labeled.Statement, counts);
                     return;
                 default:
                     return;

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
@@ -1236,16 +1236,151 @@ public sealed partial class CSharpToGSharpTranslator
         private BlockStatement TranslateBody(SyntaxNode bodyOwner, string description)
         {
             SyntaxNode previousScope = this.state.CurrentBodyScope;
+            bool previousLegacyPatternGuardHoist = this.state.CurrentBodyUsesLegacyPatternGuardHoist;
             this.state.CurrentBodyScope = bodyOwner;
+            this.state.CurrentBodyUsesLegacyPatternGuardHoist = false;
             try
             {
                 BlockStatement body = this.TranslateBodyCore(bodyOwner, description);
                 body = this.WithParameterShadows(bodyOwner, body);
-                return AddIteratorExitLabel(bodyOwner, body);
+                body = AddIteratorExitLabel(bodyOwner, body);
+                if (this.state.CurrentBodyUsesLegacyPatternGuardHoist)
+                {
+                    this.ReportPatternGuardControlTransferMismatch(bodyOwner, description, body);
+                }
+
+                return body;
             }
             finally
             {
                 this.state.CurrentBodyScope = previousScope;
+                this.state.CurrentBodyUsesLegacyPatternGuardHoist = previousLegacyPatternGuardHoist;
+            }
+        }
+
+        private void ReportPatternGuardControlTransferMismatch(
+            SyntaxNode bodyOwner,
+            string description,
+            BlockStatement body)
+        {
+            BlockSyntax sourceBody = bodyOwner switch
+            {
+                BaseMethodDeclarationSyntax method => method.Body,
+                AccessorDeclarationSyntax accessor => accessor.Body,
+                LocalFunctionStatementSyntax localFunction => localFunction.Body,
+                _ => null,
+            };
+            if (sourceBody == null)
+            {
+                return;
+            }
+
+            int sourceReturns = sourceBody.DescendantNodesAndSelf(
+                    descendIntoChildren: node =>
+                        node is not (AnonymousFunctionExpressionSyntax or LocalFunctionStatementSyntax))
+                .OfType<ReturnStatementSyntax>()
+                .Count();
+            int sourceThrows = sourceBody.DescendantNodesAndSelf(
+                    descendIntoChildren: node =>
+                        node is not (AnonymousFunctionExpressionSyntax or LocalFunctionStatementSyntax))
+                .OfType<ThrowStatementSyntax>()
+                .Count();
+            int translatedReturns = 0;
+            int translatedThrows = 0;
+            CountTranslatedControlTransfers(body, ref translatedReturns, ref translatedThrows);
+
+            if (sourceReturns == translatedReturns && sourceThrows == translatedThrows)
+            {
+                return;
+            }
+
+            string message =
+                $"legacy pattern-guard lowering changed control-transfer structure in {description}: " +
+                $"C# has {sourceReturns} return statement(s) and {sourceThrows} throw statement(s), " +
+                $"but emitted G# has {translatedReturns} return statement(s) and {translatedThrows} throw statement(s) " +
+                "(issue #3418).";
+            this.context.Report(new TranslationDiagnostic(
+                "PatternGuardControlFlow",
+                message,
+                bodyOwner.GetLocation(),
+                TranslationSeverity.Unsupported));
+        }
+
+        private static void CountTranslatedControlTransfers(
+            GStatement statement,
+            ref int returns,
+            ref int throws)
+        {
+            switch (statement)
+            {
+                case null:
+                    return;
+                case ReturnStatement:
+                    returns++;
+                    return;
+                case ThrowStatement:
+                    throws++;
+                    return;
+                case BlockStatement block:
+                    foreach (GStatement child in block.Statements)
+                    {
+                        CountTranslatedControlTransfers(child, ref returns, ref throws);
+                    }
+
+                    return;
+                case IfStatement conditional:
+                    CountTranslatedControlTransfers(conditional.Then, ref returns, ref throws);
+                    CountTranslatedControlTransfers(conditional.ElseBranch, ref returns, ref throws);
+                    return;
+                case IfLetStatement ifLet:
+                    CountTranslatedControlTransfers(ifLet.Then, ref returns, ref throws);
+                    CountTranslatedControlTransfers(ifLet.Else, ref returns, ref throws);
+                    return;
+                case WhileStatement loop:
+                    CountTranslatedControlTransfers(loop.Body, ref returns, ref throws);
+                    return;
+                case WhileLetStatement loop:
+                    CountTranslatedControlTransfers(loop.Body, ref returns, ref throws);
+                    return;
+                case DoWhileStatement loop:
+                    CountTranslatedControlTransfers(loop.Body, ref returns, ref throws);
+                    return;
+                case ForStatement loop:
+                    CountTranslatedControlTransfers(loop.Body, ref returns, ref throws);
+                    return;
+                case ForInStatement loop:
+                    CountTranslatedControlTransfers(loop.Body, ref returns, ref throws);
+                    return;
+                case ForTupleInStatement loop:
+                    CountTranslatedControlTransfers(loop.Body, ref returns, ref throws);
+                    return;
+                case LockStatement locked:
+                    CountTranslatedControlTransfers(locked.Body, ref returns, ref throws);
+                    return;
+                case FixedStatement fixedStatement:
+                    CountTranslatedControlTransfers(fixedStatement.Body, ref returns, ref throws);
+                    return;
+                case TryStatement tryStatement:
+                    CountTranslatedControlTransfers(tryStatement.TryBlock, ref returns, ref throws);
+                    foreach (CatchClause catchClause in tryStatement.CatchClauses)
+                    {
+                        CountTranslatedControlTransfers(catchClause.Body, ref returns, ref throws);
+                    }
+
+                    CountTranslatedControlTransfers(tryStatement.FinallyBlock, ref returns, ref throws);
+                    return;
+                case SwitchStatement switchStatement:
+                    foreach (SwitchStatementCase switchCase in switchStatement.Cases)
+                    {
+                        CountTranslatedControlTransfers(switchCase.Body, ref returns, ref throws);
+                    }
+
+                    return;
+                case LabeledStatement labeled:
+                    CountTranslatedControlTransfers(labeled.Statement, ref returns, ref throws);
+                    return;
+                default:
+                    return;
             }
         }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.ControlFlow.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.ControlFlow.cs
@@ -536,6 +536,7 @@ public sealed partial class CSharpToGSharpTranslator
             // and translates nothing when it declines.
             if (this.TryBuildIfLetGuard(ifStatement, out IReadOnlyList<GStatement> ifLetHoisted))
             {
+                this.state.CurrentBodyUsesLegacyPatternGuardHoist |= ifStatement.Else != null;
                 return ifLetHoisted;
             }
 
@@ -546,6 +547,7 @@ public sealed partial class CSharpToGSharpTranslator
 
             if (this.TryBuildPositiveGuardHoist(ifStatement, out IReadOnlyList<GStatement> positiveHoisted))
             {
+                this.state.CurrentBodyUsesLegacyPatternGuardHoist |= ifStatement.Else != null;
                 return positiveHoisted;
             }
 
@@ -737,7 +739,7 @@ public sealed partial class CSharpToGSharpTranslator
             {
                 thenStatements.AddRange(body.Statements);
             }
-            else
+            else if (elseBranch == null)
             {
                 GExpression guardExpression = null;
                 foreach (ExpressionSyntax guardClause in guards)
@@ -749,6 +751,40 @@ public sealed partial class CSharpToGSharpTranslator
                 }
 
                 thenStatements.Add(new IfStatement(guardExpression, body, elseBranch));
+            }
+            else
+            {
+                GExpression guardExpression = null;
+                foreach (ExpressionSyntax guardClause in guards)
+                {
+                    GExpression translated = this.TranslateExpression(guardClause);
+                    guardExpression = guardExpression == null
+                        ? translated
+                        : new BinaryExpression(guardExpression, "&&", translated);
+                }
+
+                string endLabel = $"__patternGuardEnd{ifStatement.SpanStart}";
+                List<GStatement> matchedBody = body.Statements.ToList();
+                matchedBody.Add(new GotoStatement(endLabel));
+                thenStatements.Add(new IfStatement(
+                    guardExpression,
+                    new BlockStatement(matchedBody)));
+
+                var guardedStatements = new List<GStatement>();
+                if (hoist != null)
+                {
+                    guardedStatements.Add(hoist);
+                }
+
+                guardedStatements.Add(binder);
+                guardedStatements.Add(new IfStatement(
+                    guard,
+                    new BlockStatement(thenStatements)));
+                guardedStatements.Add(elseBranch);
+                guardedStatements.Add(new LabeledStatement(
+                    endLabel,
+                    new BlockStatement(new List<GStatement>())));
+                return guardedStatements;
             }
 
             var statements = new List<GStatement>();

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.ControlFlow.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.ControlFlow.cs
@@ -536,7 +536,6 @@ public sealed partial class CSharpToGSharpTranslator
             // and translates nothing when it declines.
             if (this.TryBuildIfLetGuard(ifStatement, out IReadOnlyList<GStatement> ifLetHoisted))
             {
-                this.state.CurrentBodyUsesLegacyPatternGuardHoist |= ifStatement.Else != null;
                 return ifLetHoisted;
             }
 
@@ -547,7 +546,6 @@ public sealed partial class CSharpToGSharpTranslator
 
             if (this.TryBuildPositiveGuardHoist(ifStatement, out IReadOnlyList<GStatement> positiveHoisted))
             {
-                this.state.CurrentBodyUsesLegacyPatternGuardHoist |= ifStatement.Else != null;
                 return positiveHoisted;
             }
 
@@ -680,6 +678,14 @@ public sealed partial class CSharpToGSharpTranslator
             }
 
             result = new GStatement[] { hoist, new IfStatement(guard, then, elseBranch) };
+            if (elseBranch != null)
+            {
+                this.ReportPatternGuardControlTransferMismatch(
+                    ifStatement,
+                    result,
+                    new GStatement[] { then, elseBranch });
+            }
+
             return true;
         }
 
@@ -784,6 +790,10 @@ public sealed partial class CSharpToGSharpTranslator
                 guardedStatements.Add(new LabeledStatement(
                     endLabel,
                     new BlockStatement(new List<GStatement>())));
+                this.ReportPatternGuardControlTransferMismatch(
+                    ifStatement,
+                    guardedStatements,
+                    new GStatement[] { body, elseBranch });
                 return guardedStatements;
             }
 
@@ -798,6 +808,14 @@ public sealed partial class CSharpToGSharpTranslator
                 guard,
                 new BlockStatement(thenStatements),
                 guards.Count == 0 ? elseBranch : null));
+            if (elseBranch != null)
+            {
+                this.ReportPatternGuardControlTransferMismatch(
+                    ifStatement,
+                    statements,
+                    new GStatement[] { body, elseBranch });
+            }
+
             return statements;
         }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.IfLet.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.IfLet.cs
@@ -322,6 +322,17 @@ public sealed partial class CSharpToGSharpTranslator
                 return false;
             }
 
+            // A statement-form `if let` has no guard clause. Nesting a residual
+            // or conjoined guard would require attaching the same C# else branch
+            // to both binding failure and guard failure; a leading prefix would
+            // add a third copy. Let the general pattern lowering keep one branch.
+            if (ifStatement.Else != null
+                && (prefix.Count > 0
+                    || (!directBinding && (residualPattern != null || guards.Count > 0))))
+            {
+                return false;
+            }
+
             // A guard that itself hoists a spill would need a statement seam
             // ahead of the `if`, but the spill may read the binding — which is
             // only in scope inside the `if let`. Leave those to the general path.

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.IfLet.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.IfLet.cs
@@ -421,6 +421,7 @@ public sealed partial class CSharpToGSharpTranslator
                 elseBranch = this.TranslateElseStatement(ifStatement.Else.Statement);
             }
 
+            BlockStatement translatedThen = then;
             GStatement inner;
             if (directBinding)
             {
@@ -459,6 +460,14 @@ public sealed partial class CSharpToGSharpTranslator
             if (prefix.Count == 0)
             {
                 result = new[] { inner };
+                if (elseBranch != null)
+                {
+                    this.ReportPatternGuardControlTransferMismatch(
+                        ifStatement,
+                        result,
+                        new GStatement[] { translatedThen, elseBranch });
+                }
+
                 return true;
             }
 
@@ -478,6 +487,14 @@ public sealed partial class CSharpToGSharpTranslator
                     new BlockStatement(new[] { inner }),
                     elseBranch),
             };
+            if (elseBranch != null)
+            {
+                this.ReportPatternGuardControlTransferMismatch(
+                    ifStatement,
+                    result,
+                    new GStatement[] { translatedThen, elseBranch });
+            }
+
             return true;
         }
 

--- a/tools/cs2gs/Cs2Gs.Translator/DocumentTranslationState.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/DocumentTranslationState.cs
@@ -53,6 +53,10 @@ internal sealed class DocumentTranslationState
     public HashSet<ISymbol> NativePatternVariables { get; } =
         new HashSet<ISymbol>(SymbolEqualityComparer.Default);
 
+    // Enables the per-body return/throw count guard only for branch-sensitive
+    // legacy pattern hoists; other lowerings can intentionally synthesize exits.
+    public bool CurrentBodyUsesLegacyPatternGuardHoist { get; set; }
+
     // Pattern variables (`x is T t`) that <see cref="TryBuildPositiveGuardHoist"/>
     // materialised as a *nullable* G# local (`var t T? = scrutinee as T`). gsc
     // flow-narrows such a local for reads inside the `if t != nil { … }` guard,

--- a/tools/cs2gs/Cs2Gs.Translator/DocumentTranslationState.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/DocumentTranslationState.cs
@@ -53,10 +53,6 @@ internal sealed class DocumentTranslationState
     public HashSet<ISymbol> NativePatternVariables { get; } =
         new HashSet<ISymbol>(SymbolEqualityComparer.Default);
 
-    // Enables the per-body return/throw count guard only for branch-sensitive
-    // legacy pattern hoists; other lowerings can intentionally synthesize exits.
-    public bool CurrentBodyUsesLegacyPatternGuardHoist { get; set; }
-
     // Pattern variables (`x is T t`) that <see cref="TryBuildPositiveGuardHoist"/>
     // materialised as a *nullable* G# local (`var t T? = scrutinee as T`). gsc
     // flow-narrows such a local for reads inside the `if t != nil { … }` guard,


### PR DESCRIPTION
Fixes #3418.

## Summary

- Preserve value-pattern fallback `else if` chains on both type-test and conjoined-guard failure, without moving guard-declared locals out of scope.
- Route guarded/prefixed statement `if let` shapes with an `else` through the non-duplicating general pattern lowering.
- Add a scoped per-body return/throw structural check that reports an unsupported diagnostic if a branch-sensitive legacy hoist changes control-transfer counts.
- Add runtime regressions for the dropped value-pattern branch and structural regressions for duplicated positional `if let` branches.

## Verification

- `dotnet build GSharp.sln -c Release --no-restore -graph --nologo` — 0 warnings, 0 errors.
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --no-restore --filter FullyQualifiedName~Issue3418PatternGuardBranchTranslationTests --logger 'console;verbosity=minimal'` — 2/2 passed.
- Related pattern filters (`Issue3418|Issue3409|Issue3394|Issue3360|Issue3359|Issue3347|Issue2646`) — 63/63 passed.
- Cs2Gs.Tests non-pipeline (`FullyQualifiedName!~Pipeline`) — 2028/2028 passed.
- `OAHU_GATE_ROOT="$PWD/.issue3418-oahu" ./build/run-cs2gs-oahu.sh` — source tests passed; migrated G# gate 15/15 apps green.
