### PR TITLE
Preserve fallback pattern evaluation order

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue3419FallbackPatternHoistTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3419FallbackPatternHoistTranslationTests.cs
@@ -140,6 +140,197 @@ public sealed class Issue3419FallbackPatternHoistTranslationTests
     }
 
     [Fact]
+    public void TranslatedNonTrivialIdentifierScrutinees_StayBehindShortCircuitOperators()
+    {
+        string printed = Translate(
+            """
+            namespace Demo
+            {
+                public sealed class Payload
+                {
+                    public int Value;
+                }
+
+                public sealed class Container
+                {
+                    private readonly Payload child = new Payload { Value = 7 };
+
+                    public bool ThrowOnRead;
+                    public int Reads;
+
+                    public Payload Child
+                    {
+                        get
+                        {
+                            Reads++;
+                            if (ThrowOnRead)
+                            {
+                                throw new System.InvalidOperationException();
+                            }
+
+                            return child;
+                        }
+                    }
+                }
+
+                public class Base
+                {
+                    private static readonly Payload current = new Payload { Value = 7 };
+
+                    protected static bool ThrowOnRead;
+                    protected static int Reads;
+
+                    protected static Payload Current
+                    {
+                        get
+                        {
+                            Reads++;
+                            if (ThrowOnRead)
+                            {
+                                throw new System.InvalidOperationException();
+                            }
+
+                            return current;
+                        }
+                    }
+
+                    protected static void Reset(bool shouldThrow)
+                    {
+                        ThrowOnRead = shouldThrow;
+                        Reads = 0;
+                    }
+                }
+
+                public sealed class Derived : Base
+                {
+                    private static bool And(bool guard, bool shouldThrow)
+                    {
+                        Reset(shouldThrow);
+                        return guard
+                            && Current is { Value: var value }
+                            && value > 0;
+                    }
+
+                    private static bool Or(bool guard, bool shouldThrow)
+                    {
+                        Reset(shouldThrow);
+                        return guard
+                            || (Current is { Value: var value }
+                                && value > 0);
+                    }
+
+                    private static bool Coalesce(bool? preferred, bool shouldThrow)
+                    {
+                        Reset(shouldThrow);
+                        return preferred
+                            ?? (Current is { Value: var value }
+                                && value > 0);
+                    }
+
+                    private static bool Nested(bool guard, Container container) =>
+                        guard
+                        && container is { Child: var child }
+                        && child is { Value: var value }
+                        && value > 0;
+
+                    public static string Run()
+                    {
+                        bool andFalse = And(false, true);
+                        string andFalseResult = andFalse + ":" + Reads;
+                        bool andTrue = And(true, false);
+                        string andTrueResult = andTrue + ":" + Reads;
+                        bool orTrue = Or(true, true);
+                        string orTrueResult = orTrue + ":" + Reads;
+                        bool orFalse = Or(false, false);
+                        string orFalseResult = orFalse + ":" + Reads;
+                        bool coalesceTrue = Coalesce(true, true);
+                        string coalesceTrueResult = coalesceTrue + ":" + Reads;
+                        bool coalesceNull = Coalesce(null, false);
+                        string coalesceNullResult = coalesceNull + ":" + Reads;
+
+                        var container = new Container { ThrowOnRead = true };
+                        bool nestedFalse = Nested(false, container);
+                        string nestedFalseResult = nestedFalse + ":" + container.Reads;
+                        container.ThrowOnRead = false;
+                        bool nestedTrue = Nested(true, container);
+                        string nestedTrueResult = nestedTrue + ":" + container.Reads;
+
+                        return andFalseResult + "," + andTrueResult
+                            + "," + orTrueResult + "," + orFalseResult
+                            + "," + coalesceTrueResult + "," + coalesceNullResult
+                            + "," + nestedFalseResult + "," + nestedTrueResult;
+                    }
+                }
+            }
+            """);
+
+        LocalFunctionHoistTranslationTests.CompileAndRun(
+            printed,
+            "Console.WriteLine(Derived.Run())",
+            "False:0,True:1,True:0,True:1,True:0,True:1,False:0,True:1");
+    }
+
+    [Fact]
+    public void NonNullableStructScrutinee_UsesBindingDeferredSpillStorage()
+    {
+        string printed = Translate(
+            """
+            namespace Demo
+            {
+                public struct Measurement
+                {
+                    public int Value;
+                }
+
+                public sealed class Holder
+                {
+                    public bool ThrowOnRead;
+                    public int Reads;
+
+                    public Measurement Current
+                    {
+                        get
+                        {
+                            Reads++;
+                            if (ThrowOnRead)
+                            {
+                                throw new System.InvalidOperationException();
+                            }
+
+                            return new Measurement { Value = 7 };
+                        }
+                    }
+                }
+
+                public static class C
+                {
+                    private static bool Check(bool guard, Holder holder) =>
+                        guard
+                        && holder.Current is { Value: var value }
+                        && value > 0;
+
+                    public static string Run()
+                    {
+                        var holder = new Holder { ThrowOnRead = true };
+                        bool skipped = Check(false, holder);
+                        int skippedReads = holder.Reads;
+                        holder.ThrowOnRead = false;
+                        bool evaluated = Check(true, holder);
+                        return skipped + "," + skippedReads
+                            + "," + evaluated + "," + holder.Reads;
+                    }
+                }
+            }
+            """);
+
+        Assert.Matches("var __spill[0-9]+ Measurement", printed);
+        LocalFunctionHoistTranslationTests.CompileAndRun(
+            printed,
+            "Console.WriteLine(C.Run())",
+            "False,0,True,1");
+    }
+
+    [Fact]
     public void ReassignedReferenceBinder_IsDeclaredMutableAndRemainsNonNullInBody()
     {
         string printed = Translate(

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3419FallbackPatternHoistTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3419FallbackPatternHoistTranslationTests.cs
@@ -1,0 +1,287 @@
+// <copyright file="Issue3419FallbackPatternHoistTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3419: fallback pattern spills preserve short-circuit order, and
+/// reassigned pattern binders have mutable storage.
+/// </summary>
+public sealed class Issue3419FallbackPatternHoistTranslationTests
+{
+    [Fact]
+    public void ShortCircuitedFallbackScrutinees_StayBehindGuardsAcrossSurfaces()
+    {
+        string printed = Translate(
+            """
+            namespace Demo
+            {
+                public sealed class Payload
+                {
+                    public int Value;
+                }
+
+                public sealed class Holder
+                {
+                    private readonly Payload payload = new Payload { Value = 7 };
+
+                    public int Reads;
+
+                    public Payload Payload
+                    {
+                        get
+                        {
+                            Reads++;
+                            return payload;
+                        }
+                    }
+                }
+
+                public static class C
+                {
+                    private static int calls;
+
+                    private static Payload Read(bool shouldThrow)
+                    {
+                        calls++;
+                        if (shouldThrow)
+                        {
+                            throw new System.InvalidOperationException();
+                        }
+
+                        return new Payload { Value = 7 };
+                    }
+
+                    private static object ReadObject(bool shouldThrow) =>
+                        Read(shouldThrow);
+
+                    private static int Statement(bool guard, bool shouldThrow)
+                    {
+                        if (guard
+                            && Read(shouldThrow) is { Value: var value }
+                            && value > 0)
+                        {
+                            return value;
+                        }
+
+                        return 0;
+                    }
+
+                    private static bool Boolean(bool guard, bool shouldThrow) =>
+                        guard
+                        && Read(shouldThrow) is { Value: var value }
+                        && value > 0;
+
+                    private static int Conditional(bool guard, bool shouldThrow) =>
+                        guard
+                        && Read(shouldThrow) is { Value: var value }
+                            ? value
+                            : 0;
+
+                    private static int NullableReceiver(Holder? holder)
+                    {
+                        if (holder != null
+                            && holder.Payload is { Value: var value }
+                            && value > 0)
+                        {
+                            return value;
+                        }
+
+                        return 0;
+                    }
+
+                    private static int MutableTypedBinder(bool guard, bool shouldThrow)
+                    {
+                        if (guard
+                            && ReadObject(shouldThrow) is Payload payload
+                            && payload.Value > 0)
+                        {
+                            payload = new Payload { Value = payload.Value + 1 };
+                            return payload.Value;
+                        }
+
+                        return 0;
+                    }
+
+                    public static string Run()
+                    {
+                        calls = 0;
+                        int statementFalse = Statement(false, true);
+                        bool booleanFalse = Boolean(false, true);
+                        int conditionalFalse = Conditional(false, true);
+                        int statementTrue = Statement(true, false);
+                        bool booleanTrue = Boolean(true, false);
+                        int conditionalTrue = Conditional(true, false);
+                        int nullableFalse = NullableReceiver(null);
+                        var holder = new Holder();
+                        int nullableTrue = NullableReceiver(holder);
+                        int mutableFalse = MutableTypedBinder(false, true);
+                        int mutableTrue = MutableTypedBinder(true, false);
+                        return statementFalse + "," + booleanFalse + "," + conditionalFalse
+                            + "," + statementTrue + "," + booleanTrue + "," + conditionalTrue
+                            + "," + nullableFalse + "," + nullableTrue + "," + holder.Reads
+                            + "," + mutableFalse + "," + mutableTrue + "," + calls;
+                    }
+                }
+            }
+            """);
+
+        LocalFunctionHoistTranslationTests.CompileAndRun(
+            printed,
+            "Console.WriteLine(C.Run())",
+            "0,False,0,7,True,7,0,7,1,0,8,4");
+    }
+
+    [Fact]
+    public void ReassignedReferenceBinder_IsDeclaredMutableAndRemainsNonNullInBody()
+    {
+        string printed = Translate(
+            """
+            #nullable enable
+
+            namespace Demo
+            {
+                public sealed class Node
+                {
+                    public string? StartTag;
+                }
+
+                public static class C
+                {
+                    public static string Read(Node node)
+                    {
+                        if (node.StartTag is { } startTag)
+                        {
+                            startTag = startTag + "!";
+                            return startTag;
+                        }
+
+                        return "none";
+                    }
+
+                    public static string ReadAfterGuard(Node node)
+                    {
+                        if (node.StartTag is { } startTag)
+                        {
+                        }
+                        else
+                        {
+                            return "none";
+                        }
+
+                        startTag = startTag + "!";
+                        return startTag;
+                    }
+
+                    public static string Conditional(Node node) =>
+                        node.StartTag is { } startTag
+                            ? startTag = startTag + "!"
+                            : "none";
+
+                    public static string Negated(object value) =>
+                        value is not string text
+                            ? "none"
+                            : text = text + "!";
+                }
+            }
+            """);
+
+        Assert.Contains("var startTag string?", printed, StringComparison.Ordinal);
+        Assert.Contains("startTag =", printed, StringComparison.Ordinal);
+        Assert.Contains("+ \"!\"", printed, StringComparison.Ordinal);
+        LocalFunctionHoistTranslationTests.CompileAndRun(
+            printed,
+            """
+            let node = Node()
+            node.StartTag = "open"
+            Console.WriteLine(C.Read(node))
+            Console.WriteLine(C.Read(Node()))
+            Console.WriteLine(C.ReadAfterGuard(node))
+            Console.WriteLine(C.ReadAfterGuard(Node()))
+            Console.WriteLine(C.Conditional(node))
+            Console.WriteLine(C.Conditional(Node()))
+            Console.WriteLine(C.Negated("open"))
+            Console.WriteLine(C.Negated(1))
+            """,
+            string.Join(
+                Environment.NewLine,
+                "open!",
+                "none",
+                "open!",
+                "none",
+                "open!",
+                "none",
+                "open!",
+                "none"));
+    }
+
+    [Fact]
+    public void ReassignedValueBinder_UsesNonNullableMutableStorage()
+    {
+        string printed = Translate(
+            """
+            namespace Demo
+            {
+                public sealed class Node
+                {
+                    public int? Value;
+                }
+
+                public static class C
+                {
+                    public static int Read(Node node)
+                    {
+                        if (node.Value is { } value)
+                        {
+                            value += 1;
+                            return value;
+                        }
+
+                        return -1;
+                    }
+                }
+            }
+            """);
+
+        Assert.Contains("var value int32", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("var value int32?", printed, StringComparison.Ordinal);
+        LocalFunctionHoistTranslationTests.CompileAndRun(
+            printed,
+            """
+            let node = Node()
+            node.Value = 5
+            Console.WriteLine(C.Read(node))
+            Console.WriteLine(C.Read(Node()))
+            """,
+            "6" + Environment.NewLine + "-1");
+    }
+
+    private static string Translate(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(
+            project.Compilation,
+            document.SemanticModel,
+            document.FilePath);
+        string printed = GSharpPrinter.Print(
+            new CSharpToGSharpTranslator().TranslateDocument(document, context));
+        Assert.DoesNotContain(
+            context.Diagnostics,
+            diagnostic => diagnostic.Severity != TranslationSeverity.Info);
+        TranslationTestValidation.AssertBinds(printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.ControlFlow.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.ControlFlow.cs
@@ -549,7 +549,7 @@ public sealed partial class CSharpToGSharpTranslator
                 return positiveHoisted;
             }
 
-            return new[] { this.TranslateIf(ifStatement) };
+            return this.TranslateIfWithConditionPrologue(ifStatement);
         }
 
         private GStatement TranslateElseStatement(StatementSyntax statement)
@@ -1484,6 +1484,16 @@ public sealed partial class CSharpToGSharpTranslator
 
         private GStatement TranslateIf(IfStatementSyntax ifStatement)
         {
+            IReadOnlyList<GStatement> translated =
+                this.TranslateIfWithConditionPrologue(ifStatement);
+            return translated.Count == 1
+                ? translated[0]
+                : new BlockStatement(translated);
+        }
+
+        private IReadOnlyList<GStatement> TranslateIfWithConditionPrologue(
+            IfStatementSyntax ifStatement)
+        {
             // Translate the condition first so any `x is T t` declaration pattern
             // registers its Kotlin-style smart-cast binding before the guarded
             // block is translated; the binding is scoped to the then-block only.
@@ -1510,14 +1520,8 @@ public sealed partial class CSharpToGSharpTranslator
                 elseBranch = this.TranslateElseStatement(ifStatement.Else.Statement);
             }
 
-            GStatement result = new IfStatement(condition, then, elseBranch);
-            if (conditionPrologue.Count > 0)
-            {
-                conditionPrologue.Add(result);
-                result = new BlockStatement(conditionPrologue);
-            }
-
-            return result;
+            conditionPrologue.Add(new IfStatement(condition, then, elseBranch));
+            return conditionPrologue;
         }
 
         private GStatement TranslateForStatement(ForStatementSyntax forStatement)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
@@ -1031,7 +1031,17 @@ public sealed partial class CSharpToGSharpTranslator
         // native block-expression seam.
         private GExpression SpillOperand(GExpression operand, SyntaxNode operandSyntaxForDiagnostic)
         {
-            if (this.state.PendingSpillPrologue != null || IsTrivialOperand(operand))
+            if (IsTrivialOperand(operand))
+            {
+                return operand;
+            }
+
+            if (this.CanAssignShortCircuitSpill(operandSyntaxForDiagnostic))
+            {
+                return this.AssignShortCircuitSpill(operand, operandSyntaxForDiagnostic);
+            }
+
+            if (this.state.PendingSpillPrologue != null)
             {
                 return this.SpillOperand(operand);
             }
@@ -1041,6 +1051,66 @@ public sealed partial class CSharpToGSharpTranslator
                 "a native block-expression spill seam; emitting it would evaluate it more than once.";
             this.context.ReportUnsupported(operandSyntaxForDiagnostic, message);
             return operand;
+        }
+
+        private bool CanAssignShortCircuitSpill(SyntaxNode operandSyntax)
+        {
+            if (this.state.ShortCircuitSpillDeclarations == null
+                || this.state.PendingSpillPrologue == null
+                || this.state.ShortCircuitSpillScope == null)
+            {
+                return false;
+            }
+
+            for (SyntaxNode current = operandSyntax; current != null; current = current.Parent)
+            {
+                if (current == this.state.ShortCircuitSpillScope)
+                {
+                    return true;
+                }
+
+                if (current is AnonymousFunctionExpressionSyntax or LocalFunctionStatementSyntax)
+                {
+                    return false;
+                }
+            }
+
+            return false;
+        }
+
+        private GExpression AssignShortCircuitSpill(
+            GExpression operand,
+            SyntaxNode operandSyntax)
+        {
+            TypeInfo typeInfo = this.context.GetTypeInfo(operandSyntax);
+            ITypeSymbol operandType = typeInfo.Type ?? typeInfo.ConvertedType;
+            if (operandType == null || operandType.TypeKind == TypeKind.Error)
+            {
+                this.context.ReportUnsupported(
+                    operandSyntax,
+                    "a short-circuited fallback pattern scrutinee has no resolvable type for its deferred spill local (issue #3419).");
+                return this.SpillOperand(operand);
+            }
+
+            GTypeReference spillType = this.typeMapper.Map(
+                operandType,
+                this.context,
+                operandSyntax.GetLocation());
+            if (operandType.IsReferenceType)
+            {
+                spillType = MakeNullable(spillType);
+            }
+
+            string temp = $"__spill{this.state.SpillCounter++}";
+            var reference = new IdentifierExpression(temp);
+            this.state.ShortCircuitSpillDeclarations.Add(
+                new LocalDeclarationStatement(
+                    BindingKind.Var,
+                    temp,
+                    spillType));
+            this.state.PendingSpillPrologue.Add(
+                new AssignmentStatement(reference, operand));
+            return reference;
         }
 
         // Issue #3355: field/property initializers and constructor-initializer

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -624,7 +624,140 @@ public sealed partial class CSharpToGSharpTranslator
                 receiver = this.SpillOperand(receiver, isPattern.Expression);
             }
 
-            return this.TranslatePatternTest(receiver, isPattern.Pattern, receiverType, isPattern.Expression);
+            GExpression test = this.TranslatePatternTest(
+                receiver,
+                isPattern.Pattern,
+                receiverType,
+                isPattern.Expression);
+            return this.MaterializeFallbackPatternBindings(isPattern, receiver, test);
+        }
+
+        private GExpression MaterializeFallbackPatternBindings(
+            IsPatternExpressionSyntax isPattern,
+            GExpression receiver,
+            GExpression test)
+        {
+            // Reassigned binders need real writable locals. Bindings whose
+            // scrutinee moved into a short-circuit block need the same treatment
+            // so later conjuncts and selected branches do not reference a
+            // block-local spill.
+            bool crossesShortCircuitBoundary =
+                this.state.ShortCircuitSpillDeclarations != null;
+            List<ILocalSymbol> materializedBinders = this.EnumeratePatternBinders(isPattern.Pattern)
+                .Where(binder =>
+                    crossesShortCircuitBoundary
+                    || this.IsLocalReassigned(binder))
+                .ToList();
+            if (materializedBinders.Count == 0)
+            {
+                return test;
+            }
+
+            List<GStatement> declarations =
+                this.state.ShortCircuitSpillDeclarations
+                ?? this.state.PendingSpillPrologue;
+            if (declarations == null)
+            {
+                this.context.ReportUnsupported(
+                    isPattern,
+                    "a fallback pattern binder requiring materialized storage reached an expression without a declaration seam (issue #3419).");
+                return test;
+            }
+
+            StripTopLevelNegation(isPattern.Pattern, out bool negated);
+            var assignments = new List<GStatement>(materializedBinders.Count);
+            foreach (ILocalSymbol binder in materializedBinders)
+            {
+                if (!this.state.PatternBindings.TryGetValue(
+                        binder,
+                        out GExpression replacement))
+                {
+                    this.context.ReportUnsupported(
+                        isPattern.Pattern,
+                        $"fallback pattern binder '{binder.Name}' has no translated matched-value expression for materialized storage (issue #3419).");
+                    continue;
+                }
+
+                if (negated)
+                {
+                    replacement = this.BuildNegatedPatternBindingValue(
+                        binder,
+                        receiver,
+                        isPattern.Expression);
+                }
+
+                GTypeReference storageType = this.typeMapper.Map(
+                    binder.Type,
+                    this.context,
+                    isPattern.Pattern.GetLocation());
+                if (binder.Type.IsReferenceType)
+                {
+                    storageType = MakeNullable(storageType);
+                }
+
+                string name = SanitizeIdentifier(binder.Name);
+                var local = new IdentifierExpression(name);
+                declarations.Add(new LocalDeclarationStatement(
+                    BindingKind.Var,
+                    name,
+                    storageType));
+                assignments.Add(new AssignmentStatement(local, replacement));
+                this.state.PatternBindings[binder] =
+                    binder.Type.IsReferenceType
+                        && binder.NullableAnnotation != NullableAnnotation.Annotated
+                            ? new NonNullAssertionExpression(local)
+                            : local;
+            }
+
+            if (assignments.Count == 0)
+            {
+                return test;
+            }
+
+            return new BinaryExpression(
+                test,
+                negated ? "||" : "&&",
+                new BlockExpression(
+                    assignments,
+                    LiteralExpression.Bool(!negated)));
+        }
+
+        private GExpression BuildNegatedPatternBindingValue(
+            ILocalSymbol binder,
+            GExpression receiver,
+            ExpressionSyntax receiverSyntax)
+        {
+            GTypeReference targetType = this.typeMapper.Map(
+                binder.Type,
+                this.context,
+                receiverSyntax.GetLocation());
+            if (binder.Type.IsValueType)
+            {
+                ITypeSymbol receiverType = this.context.GetTypeInfo(receiverSyntax).Type;
+                if (receiverType is INamedTypeSymbol nullableReceiver
+                    && nullableReceiver.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T
+                    && nullableReceiver.TypeArguments.Length == 1
+                    && SymbolEqualityComparer.Default.Equals(
+                        nullableReceiver.TypeArguments[0],
+                        binder.Type))
+                {
+                    return new NonNullAssertionExpression(receiver);
+                }
+
+                return targetType is NamedTypeReference namedTarget
+                    ? new InvocationExpression(
+                        new IdentifierExpression(namedTarget.Name),
+                        new[] { receiver },
+                        namedTarget.TypeArguments)
+                    : new NonNullAssertionExpression(receiver);
+            }
+
+            return new NonNullAssertionExpression(
+                new ParenthesizedExpression(
+                    new BinaryExpression(
+                        receiver,
+                        "as",
+                        new TypeExpression(targetType))));
         }
 
         // See <see cref="TranslateIsPattern"/>: true when translating `pattern`
@@ -1866,10 +1999,25 @@ public sealed partial class CSharpToGSharpTranslator
                 return this.TranslateCoalescingAssignmentAsExpression(assignment);
             }
 
-            return new AssignmentExpression(
+            GExpression result = new AssignmentExpression(
                 this.TranslateAssignmentTarget(assignment.Left),
                 this.TranslateAssignmentValue(assignment),
                 assignment.OperatorToken.Text);
+
+            // A materialized non-null reference binder uses nullable storage
+            // because its declaration precedes the guard. Its assignment result
+            // still has the binder's non-null C# type.
+            if (assignment.Left is IdentifierNameSyntax identifier
+                && this.context.GetSymbolInfo(identifier).Symbol is { } symbol
+                && this.state.PatternBindings.TryGetValue(
+                    symbol,
+                    out GExpression replacement)
+                && replacement is NonNullAssertionExpression)
+            {
+                result = new NonNullAssertionExpression(result);
+            }
+
+            return result;
         }
 
         private GExpression TranslateCoalescingAssignmentAsExpression(

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
@@ -302,7 +302,7 @@ public sealed partial class CSharpToGSharpTranslator
 
             GExpression left = this.TranslateExpression(binary.Left);
             string op = binary.OperatorToken.Text;
-            GExpression right = this.TranslateExpression(binary.Right);
+            GExpression right = this.TranslateBinaryRightOperand(binary);
 
             // C# string concatenation `a + b`: when the `+` operator binds to
             // `string`, C# implicitly converts each non-string operand to a string
@@ -423,6 +423,64 @@ public sealed partial class CSharpToGSharpTranslator
             }
 
             return new BinaryExpression(left, op, right);
+        }
+
+        private GExpression TranslateBinaryRightOperand(BinaryExpressionSyntax binary)
+        {
+            // A fallback pattern in a right operand may spill its scrutinee.
+            // Host that spill in the operand itself so `&&`/`||`/`??` still
+            // decide whether the scrutinee runs.
+            if (!IsShortCircuitOperator(binary)
+                || this.state.PendingSpillPrologue == null
+                || !this.ContainsFallbackPatternSpill(binary.Right))
+            {
+                return this.TranslateExpression(binary.Right);
+            }
+
+            List<GStatement> outerSpillPrologue = this.state.PendingSpillPrologue;
+            List<GStatement> previousDeclarations = this.state.ShortCircuitSpillDeclarations;
+            SyntaxNode previousScope = this.state.ShortCircuitSpillScope;
+            var statements = new List<GStatement>();
+            this.state.PendingSpillPrologue = statements;
+            this.state.ShortCircuitSpillDeclarations ??= outerSpillPrologue;
+            this.state.ShortCircuitSpillScope ??= binary.Right;
+            try
+            {
+                GExpression value = this.TranslateExpression(binary.Right);
+                return statements.Count == 0
+                    ? value
+                    : new BlockExpression(statements, value);
+            }
+            finally
+            {
+                this.state.PendingSpillPrologue = outerSpillPrologue;
+                this.state.ShortCircuitSpillDeclarations = previousDeclarations;
+                this.state.ShortCircuitSpillScope = previousScope;
+            }
+        }
+
+        private static bool IsShortCircuitOperator(BinaryExpressionSyntax binary) =>
+            binary.IsKind(SyntaxKind.LogicalAndExpression)
+            || binary.IsKind(SyntaxKind.LogicalOrExpression)
+            || binary.IsKind(SyntaxKind.CoalesceExpression);
+
+        private bool ContainsFallbackPatternSpill(ExpressionSyntax expression)
+        {
+            foreach (IsPatternExpressionSyntax isPattern in expression
+                .DescendantNodesAndSelf(
+                    descendIntoChildren: node =>
+                        node is not (AnonymousFunctionExpressionSyntax or LocalFunctionStatementSyntax))
+                .OfType<IsPatternExpressionSyntax>())
+            {
+                if (!PatternReadsScrutineeAtMostOnce(isPattern.Pattern)
+                    && !IsTrivialPatternReceiver(isPattern.Expression)
+                    && !this.ConditionUsesNativePatternVariables(GetConditionRoot(isPattern)))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         // For a string-concatenation `+` operand: if the operand's C# type is not

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
@@ -473,7 +473,7 @@ public sealed partial class CSharpToGSharpTranslator
                 .OfType<IsPatternExpressionSyntax>())
             {
                 if (!PatternReadsScrutineeAtMostOnce(isPattern.Pattern)
-                    && !IsTrivialPatternReceiver(isPattern.Expression)
+                    && !this.PatternReceiverTranslatesToTrivialOperand(isPattern.Expression)
                     && !this.ConditionUsesNativePatternVariables(GetConditionRoot(isPattern)))
                 {
                     return true;
@@ -481,6 +481,19 @@ public sealed partial class CSharpToGSharpTranslator
             }
 
             return false;
+        }
+
+        private bool PatternReceiverTranslatesToTrivialOperand(ExpressionSyntax expression)
+        {
+            if (!IsTrivialPatternReceiver(expression))
+            {
+                return false;
+            }
+
+            // A bare identifier may become a member access through pattern-binding
+            // substitution or implicit static qualification. Classify the emitted
+            // shape so its spill stays behind earlier short-circuit guards.
+            return IsTrivialOperand(this.TranslateExpression(Unparenthesize(expression)));
         }
 
         // For a string-concatenation `+` operand: if the operand's C# type is not

--- a/tools/cs2gs/Cs2Gs.Translator/DocumentTranslationState.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/DocumentTranslationState.cs
@@ -175,6 +175,17 @@ internal sealed class DocumentTranslationState
     // unrelated enclosing scope.
     public List<GStatement> PendingSpillPrologue { get; set; }
 
+    // A fallback pattern spill inside a conditionally evaluated short-circuit
+    // operand declares its reusable temp in the enclosing expression's seam,
+    // then assigns it inside the operand's block expression. This keeps the temp
+    // visible to later pattern-variable reads without evaluating the scrutinee
+    // before the guards that protect it.
+    public List<GStatement> ShortCircuitSpillDeclarations { get; set; }
+
+    // Outermost short-circuit operand currently redirecting fallback pattern
+    // spills. Nested lambdas/local functions must not reuse its declaration seam.
+    public SyntaxNode ShortCircuitSpillScope { get; set; }
+
     // Monotonic counter for synthesizing spill temporaries (issue #1731).
     public int SpillCounter { get; set; }
 


### PR DESCRIPTION
Fixes #3419.

## Summary

- Keep fallback pattern scrutinee spills inside conditionally evaluated `&&`/`||`/`??` operands while declaring reusable typed storage in the enclosing seam.
- Classify syntactically bare pattern scrutinees by their translated G# shape, so nested binder substitutions and inherited/qualified static getters remain behind earlier short-circuit guards.
- Materialize fallback pattern binders when reassigned or when their scrutinee crosses a short-circuit block, preserving later-conjunct, branch, body, and post-guard scope.
- Preserve nullable reference storage, non-nullable value/struct storage, assignment-expression result types, ADR-0166 native paths, and #3418 branch handling.
- Add binding and compile/run regressions for false/null protected paths, exact-once evaluation, statement/boolean/conditional surfaces, `&&`/`||`/`??`, nested binder scrutinees, inherited static getters, non-nullable struct spills, typed and `var` fallback patterns, mutable reference/value binders, post-guard scope, and negated bindings.

## Verification

- Issue #3419 regressions — 5/5 passed.
- Related pattern translation tests — 122/122 passed.
- Broad cs2gs non-pipeline suite — 2034/2034 passed.
- Release solution build — 0 warnings, 0 errors.
- Oahu self-host gate — source tests 342 + 2 + 5 passed; 15/15 translated applications passed translation, compilation, IL verification, and test parity.