### PR TITLE
Avoid redundant null assertions in cs2gs

### DIFF
--- a/docs/adr/0115-csharp-to-gsharp-migration-tool.md
+++ b/docs/adr/0115-csharp-to-gsharp-migration-tool.md
@@ -560,10 +560,12 @@ empirically (gsc **0.2.137+31ced6cfb7**) before adoption.
   has **no range operator** (gsc gap, §G OD-1); a `RangeExpression` index over a
   `Span`/`Memory`/`ReadOnlySpan` lowers to a `.Slice` call: `s[i..j]` →
   `s.Slice(i, j - i)`, `s[i..]` → `s.Slice(i)`, `s[..j]` → `s.Slice(0, j)`.
-- **Null-forgiving `expr!` → non-null assertion `expr!!`.** G#'s postfix `!!`
-  asserts non-null (spec: "Postfix `!!` asserts non-null"), the direct analogue
-  of the C# null-forgiving operator, so the `SuppressNullableWarningExpression`
-  operand is preserved with `!!` rather than dropped.
+- **Null-forgiving `expr!` → non-null assertion `expr!!` when still needed.**
+  G#'s postfix `!!` asserts non-null (spec: "Postfix `!!` asserts non-null"),
+  but cs2gs omits it when native pattern bindings, G# smart-cast flow, or
+  non-null conditional/coalesce arms already give the translated value a
+  non-null type. Assertion insertion is idempotent, so an existing `!!` is
+  never wrapped in another one.
 - **Post/pre-increment/decrement as an expression.** G# now models `++`/`--`
   both as statements *and* as value-producing expressions (issue #1027). A
   `PostIncrementExpression`/`PostDecrementExpression` used as a **value** in a

--- a/tools/cs2gs/Cs2Gs.Tests/CodeExploderTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/CodeExploderTranslationTests.cs
@@ -19,7 +19,7 @@ namespace Cs2Gs.Tests;
 public class CodeExploderTranslationTests
 {
     [Fact]
-    public void FlowNarrowedCollectionElement_IsAsserted()
+    public void FlowNarrowedCollectionElement_UsesGSharpSmartCast()
     {
         string printed = TranslateUnit("""
             #nullable enable
@@ -40,8 +40,9 @@ public class CodeExploderTranslationTests
             """);
 
         Assert.True(
-            printed.Contains("""[]string{"--branch", gitRef!!}""", StringComparison.Ordinal),
+            printed.Contains("""[]string{"--branch", gitRef}""", StringComparison.Ordinal),
             printed);
+        Assert.DoesNotContain("gitRef!!", printed, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1072NullCheckedAsNullableTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1072NullCheckedAsNullableTranslationTests.cs
@@ -133,7 +133,7 @@ namespace Demo
     }
 
     [Fact]
-    public void FlowNarrowedNullableValue_IsAssertedAtNonNullSinks()
+    public void FlowNarrowedNullableValue_UsesGSharpSmartCastsAtNonNullSinks()
     {
         string printed = TranslateUnit(@"
 #nullable enable
@@ -158,9 +158,11 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("Use(next!!)", printed);
-        Assert.Contains("current = next!!", printed);
+        Assert.Contains("Use(next)", printed);
+        Assert.Contains("current = next", printed);
         Assert.Contains("values[0] = next!!", printed);
+        Assert.DoesNotContain("Use(next!!)", printed);
+        Assert.DoesNotContain("current = next!!", printed);
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1730SwitchPatternBindingTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1730SwitchPatternBindingTests.cs
@@ -25,9 +25,8 @@ namespace Cs2Gs.Tests;
 /// (`Circle { Radius: var r } when r > 0 => ...`) resolved it while still out
 /// of scope.
 ///
-/// Both are fixed by installing each pattern's bindings before translating
-/// anything that can reference them (guard and body alike), scoped per
-/// case/arm exactly like the existing `TranslateIf` condition-binding scope.
+/// Native G# property-pattern bindings now preserve those names directly in
+/// the switch pattern, guard, and body, scoped per case/arm.
 /// </summary>
 public class Issue1730SwitchPatternBindingTests
 {
@@ -44,12 +43,10 @@ namespace Demo
 
     /// <summary>
     /// A switch-statement pattern label's `var` property binding must be
-    /// installed before the case body is translated, so a body reference to
-    /// the bound variable resolves to the rewritten member access instead of a
-    /// bare, undeclared name.
+    /// preserved in the native G# pattern so the body reads the bound name.
     /// </summary>
     [Fact]
-    public void SwitchStatement_RecursivePatternVarBinding_UsedInBody_ResolvesToMemberAccess()
+    public void SwitchStatement_RecursivePatternVarBinding_UsedInBody_UsesNativeBinding()
     {
         string printed = TranslateUnit(ShapesPrelude + @"
     public static class Shapes
@@ -67,8 +64,9 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("circle.Radius", printed);
-        Assert.DoesNotContain("return r", printed);
+        Assert.Contains("case Circle { Radius: var r }", printed);
+        Assert.Contains("return r", printed);
+        Assert.DoesNotContain("circle.Radius", printed);
     }
 
     /// <summary>
@@ -77,7 +75,7 @@ namespace Demo
     /// installed scope).
     /// </summary>
     [Fact]
-    public void SwitchStatement_RecursivePatternVarBinding_UsedInGuard_ResolvesToMemberAccess()
+    public void SwitchStatement_RecursivePatternVarBinding_UsedInGuard_UsesNativeBinding()
     {
         string printed = TranslateUnit(ShapesPrelude + @"
     public static class Shapes
@@ -95,10 +93,9 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("when circle.Radius > 0", printed);
-        Assert.Contains("circle.Radius", printed);
-        Assert.DoesNotContain("when r > 0", printed);
-        Assert.DoesNotContain("return r", printed);
+        Assert.Contains("case Circle { Radius: var r } when r > 0", printed);
+        Assert.Contains("return r", printed);
+        Assert.DoesNotContain("circle.Radius", printed);
     }
 
     /// <summary>
@@ -121,10 +118,8 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("when circle.Radius > 0", printed);
-        Assert.Contains("circle.Radius", printed);
-        Assert.DoesNotContain("when r > 0", printed);
-        Assert.DoesNotContain("=> r,", printed);
+        Assert.Contains("case Circle { Radius: var r } when r > 0: r", printed);
+        Assert.DoesNotContain("circle.Radius", printed);
     }
 
     /// <summary>
@@ -158,9 +153,11 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("circle.Radius", printed);
-        Assert.Contains("square.Side", printed);
-        Assert.DoesNotContain("return r", printed);
+        Assert.Contains("case Circle { Radius: var r }", printed);
+        Assert.Contains("case Square { Side: var r }", printed);
+        Assert.Contains("return r", printed);
+        Assert.DoesNotContain("circle.Radius", printed);
+        Assert.DoesNotContain("square.Side", printed);
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1734DeclarationSiteSanitizationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1734DeclarationSiteSanitizationTests.cs
@@ -201,11 +201,8 @@ namespace Corpus.Issue1734
     }
 
     [Fact]
-    public void RecursivePatternSynthesizedDesignator_QualifiedGenericType_UsesRightmostSimpleName()
+    public void RecursivePatternBinding_QualifiedGenericType_UsesNativePattern()
     {
-        // The synthesized designator must be derived from the right-most simple
-        // identifier of the type ('List', not the invalid 'list<int>' that
-        // 'Type.ToString()' would yield for a generic type).
         string rendered = Render(@"
 using System.Collections.Generic;
 
@@ -228,7 +225,8 @@ namespace Corpus.Issue1734
 ");
 
         Assert.DoesNotContain("list<int>", rendered, StringComparison.Ordinal);
-        Assert.Contains("list", rendered, StringComparison.Ordinal);
+        Assert.Contains("List[int32] { Count: var c }", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("list.Count", rendered, StringComparison.Ordinal);
         AssertRoundTripParses(rendered);
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2434DelegateNullableInterfaceWideningTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2434DelegateNullableInterfaceWideningTranslationTests.cs
@@ -373,7 +373,7 @@ namespace Demo
     }
 
     [Fact]
-    public void EarlyReturnNullGuard_LocalPassedToNonNullConstructor_AssertsNonNull()
+    public void EarlyReturnNullGuard_LocalPassedToNonNullConstructor_UsesSmartCast()
     {
         string printed = TranslateNullableEnabled(@"
 #nullable enable
@@ -395,7 +395,8 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("return Holder(item!!)", printed);
+        Assert.Contains("return Holder(item)", printed);
+        Assert.DoesNotContain("item!!", printed);
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2506PromotedCallReceiverForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2506PromotedCallReceiverForgivenessTranslationTests.cs
@@ -281,7 +281,8 @@ public sealed class Issue2506PromotedCallReceiverForgivenessTranslationTests
         Assert.DoesNotContain("Repro.ExplicitMaybe().Name", enabled, StringComparison.Ordinal);
         Assert.Contains("Repro.Always().Name", enabled, StringComparison.Ordinal);
         Assert.DoesNotContain("Repro.Always()!!.Name", enabled, StringComparison.Ordinal);
-        Assert.Contains("item!!.Name", enabled, StringComparison.Ordinal);
+        Assert.Contains("return item.Name", enabled, StringComparison.Ordinal);
+        Assert.DoesNotContain("item!!.Name", enabled, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2511NullableIndexArgumentForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2511NullableIndexArgumentForgivenessTranslationTests.cs
@@ -218,7 +218,8 @@ public sealed class Issue2511NullableIndexArgumentForgivenessTranslationTests
             """,
             NullableContextOptions.Enable);
 
-        Assert.Contains("return items[key!!]", enabled, StringComparison.Ordinal);
+        Assert.Contains("return items[key]", enabled, StringComparison.Ordinal);
+        Assert.DoesNotContain("key!!", enabled, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2842CrossProjectObliviousLocalPromotionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2842CrossProjectObliviousLocalPromotionTranslationTests.cs
@@ -158,7 +158,8 @@ namespace App
 
         string compactApp = Compact(printedApp);
         Assert.Contains("func Read(conversion Conversion?)", compactApp);
-        Assert.Contains("let reason = conversion!!.FailureReason!!", compactApp);
+        Assert.Contains("let reason = conversion.FailureReason!!", compactApp);
+        Assert.DoesNotContain("conversion!!", compactApp);
         Assert.DoesNotContain("return reason!!", compactApp);
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3412IteratorPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3412IteratorPipelineTests.cs
@@ -143,7 +143,8 @@ public sealed class Issue3412IteratorPipelineTests
         Assert.Contains("sequence[KeyValuePair[string, Node]]", translated, StringComparison.Ordinal);
         Assert.Contains("sequence[Type]", translated, StringComparison.Ordinal);
         Assert.Contains("yield KeyValuePair[string, Node]", translated, StringComparison.Ordinal);
-        Assert.Contains("yield current!!", translated, StringComparison.Ordinal);
+        Assert.Contains("yield current", translated, StringComparison.Ordinal);
+        Assert.DoesNotContain("yield current!!", translated, StringComparison.Ordinal);
         Assert.DoesNotContain("List[KeyValuePair[string, Node]]()", translated, StringComparison.Ordinal);
         Assert.True(
             appResult.Succeeded,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3422RedundantNullForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3422RedundantNullForgivenessTranslationTests.cs
@@ -1,0 +1,268 @@
+// <copyright file="Issue3422RedundantNullForgivenessTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Pipeline;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Regression coverage for issue #3422's redundant null-forgiveness classes.
+/// </summary>
+public sealed class Issue3422RedundantNullForgivenessTranslationTests
+{
+    [Fact]
+    public async Task CoreMigration_RedundantAssertionInventoryDoesNotRegress()
+    {
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        Assert.False(string.IsNullOrEmpty(repoRoot));
+
+        LoadedCSharpProject project = await CSharpProjectLoader.LoadProjectAsync(
+            Path.Combine(repoRoot, "src", "Core", "Core.csproj"));
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Core should bind with no C# errors: "
+                + string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        var translator = new CSharpToGSharpTranslator(preservePartialParts: true);
+        int doubledAssertions = 0;
+        int assertedParenthesizedReceivers = 0;
+        foreach (LoadedDocument document in project.Documents)
+        {
+            var context = new TranslationContext(
+                project.Compilation,
+                document.SemanticModel,
+                document.FilePath);
+            string printed = GSharpPrinter.Print(
+                translator.TranslateDocument(document, context));
+            doubledAssertions += CountOccurrences(printed, "!!!!");
+            assertedParenthesizedReceivers += CountOccurrences(printed, ")!!.");
+        }
+
+        Assert.Equal(0, doubledAssertions);
+        Assert.Equal(9, assertedParenthesizedReceivers);
+    }
+
+    [Fact]
+    public void SwitchPropertyPatternBindings_UseNativeNonNullableDesignators()
+    {
+        string printed = Translate(
+            """
+            #nullable enable
+
+            public abstract class Node
+            {
+            }
+
+            public sealed class Leaf : Node
+            {
+                public string Text { get; init; } = "";
+            }
+
+            public sealed class Wrapper : Node
+            {
+                public Node? Child { get; init; }
+            }
+
+            public static class C
+            {
+                private static int Consume(Leaf leaf) => leaf.Text.Length;
+
+                public static int Measure(Node node)
+                {
+                    switch (node)
+                    {
+                        case Wrapper { Child: Leaf leaf } wrapper:
+                            return Consume(leaf) + wrapper.GetHashCode();
+                        default:
+                            return 0;
+                    }
+                }
+            }
+            """);
+
+        Assert.Contains(
+            "case Wrapper { Child: Leaf leaf } wrapper",
+            printed,
+            StringComparison.Ordinal);
+        Assert.Contains("return C.Consume(leaf) + wrapper.GetHashCode()", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain(" as Leaf", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("!!!!", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain(")!!.", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NativePatternBindingsAndSmartCastLocals_DoNotGainAssertions()
+    {
+        string printed = Translate(
+            """
+            #nullable enable
+
+            public abstract class Node
+            {
+            }
+
+            public sealed class Leaf : Node
+            {
+            }
+
+            public sealed class Wrapper : Node
+            {
+                public Node? Child { get; init; }
+            }
+
+            public static class C
+            {
+                private static int Consume(Node node) => node.GetHashCode();
+
+                public static bool InCondition(Node? node) =>
+                    node is Wrapper wrapper
+                    && Consume(wrapper) > 0
+                    && node.GetHashCode() > 0;
+
+                public static int AfterExitingIf(Node? node)
+                {
+                    if (node is not Wrapper { Child: Leaf leaf } wrapper)
+                    {
+                        return 0;
+                    }
+
+                    return Consume(leaf) + Consume(wrapper) + node.GetHashCode();
+                }
+            }
+            """);
+
+        Assert.DoesNotContain("wrapper!!", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("leaf!!", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("node!!", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ProvenNonNullSuppressions_AreElidedAndRequiredAssertionsRemain()
+    {
+        string printed = Translate(
+            """
+            #nullable enable
+
+            public static class C
+            {
+                private static string? Maybe() => null;
+
+                public static string Choose(bool flag, string left, string right) =>
+                    (flag ? left : right)!;
+
+                public static string Coalesce(string? left, string right) =>
+                    (left ?? right)!;
+
+                public static string RequiredCoalesce(string? first, string? second)
+                {
+                    if (first is null && second is null)
+                    {
+                        return "";
+                    }
+
+                    return (first ?? second)!;
+                }
+
+                public static int Required(object value) =>
+                    Maybe()!.Length + (value as string)!.Length;
+
+                public static int NullableValue(int? value) =>
+                    value!.Value;
+            }
+            """);
+
+        Assert.DoesNotContain("})!!", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("(left ?? right)!!", printed, StringComparison.Ordinal);
+        Assert.Contains("C.Maybe()!!.Length", printed, StringComparison.Ordinal);
+        Assert.Contains("(value as string)!!.Length", printed, StringComparison.Ordinal);
+        Assert.Contains("return (first ?? second)!!", printed, StringComparison.Ordinal);
+        Assert.Contains("value!!", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("!!!!", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ValuePositionIf_UsesTranslatedArmNullability()
+    {
+        string printed = Translate(
+            """
+            #nullable enable
+
+            public static class C
+            {
+                public static string Narrowed(string? value) =>
+                    value is not null ? value : "fallback";
+
+                public static string Required(bool flag, string? value) =>
+                    (flag ? value : "fallback")!;
+            }
+            """);
+
+        Assert.Contains(
+            "if value != nil { value } else { \"fallback\" }",
+            printed,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "(if value != nil { value } else { \"fallback\" })!!",
+            printed,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "(if flag { value } else { \"fallback\" })!!",
+            printed,
+            StringComparison.Ordinal);
+    }
+
+    private static string Translate(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Snippet.cs", "using System;\n\nnamespace Demo\n{\n" + source + "\n}\n") });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: "
+                + string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(
+            project.Compilation,
+            document.SemanticModel,
+            document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(
+            document,
+            context);
+        string printed = GSharpPrinter.Print(unit);
+
+        Assert.DoesNotContain(
+            context.Diagnostics,
+            diagnostic => diagnostic.Severity == TranslationSeverity.Unsupported);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must bind. Errors:\n"
+                + string.Join("\n", result.Errors)
+                + "\n\nPrinted:\n"
+                + printed);
+        return printed;
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        int count = 0;
+        for (int index = haystack.IndexOf(needle, StringComparison.Ordinal);
+            index >= 0;
+            index = haystack.IndexOf(needle, index + needle.Length, StringComparison.Ordinal))
+        {
+            count++;
+        }
+
+        return count;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3422RedundantNullForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3422RedundantNullForgivenessTranslationTests.cs
@@ -221,6 +221,34 @@ public sealed class Issue3422RedundantNullForgivenessTranslationTests
             StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void TupleDeconstructionBetweenGuardAndUse_InvalidatesSmartCastNarrowing()
+    {
+        string printed = Translate(
+            """
+            #nullable enable
+
+            public static class C
+            {
+                private static string? replacement;
+
+                public static int TupleWrite(string? value)
+                {
+                    if (value is null || replacement is null)
+                    {
+                        return 0;
+                    }
+
+                    int marker = 0;
+                    (value, marker) = (replacement, 1);
+                    return value.Length;
+                }
+            }
+            """);
+
+        Assert.Contains("return value!!.Length", printed, StringComparison.Ordinal);
+    }
+
     private static string Translate(string source)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3422RedundantNullForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3422RedundantNullForgivenessTranslationTests.cs
@@ -249,6 +249,32 @@ public sealed class Issue3422RedundantNullForgivenessTranslationTests
         Assert.Contains("return value!!.Length", printed, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void SwitchWhenNullGuard_DoesNotNarrowSectionBody()
+    {
+        string printed = Translate(
+            """
+            #nullable enable
+
+            public static class C
+            {
+                public static int Measure(int kind, string? value)
+                {
+                    switch (kind)
+                    {
+                        case 1 when value is not null:
+                            return value.Length;
+                        default:
+                            return 0;
+                    }
+                }
+            }
+            """);
+
+        Assert.Contains("case 1 when value != nil", printed, StringComparison.Ordinal);
+        Assert.Contains("return value!!.Length", printed, StringComparison.Ordinal);
+    }
+
     private static string Translate(string source)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(

--- a/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
@@ -934,14 +934,11 @@ namespace Demo
     }
 
     /// <summary>
-    /// A tuple literal element is a value position: a declared-nullable
-    /// (<c>T?</c>) operand flow-proven non-null by a preceding guard must be
-    /// emitted with the G# non-null assertion (<c>x!!</c>), because G# does not
-    /// smart-cast across the tuple boundary and would otherwise reject the
-    /// nullable element against the non-null tuple slot (issue #914).
+    /// A tuple literal element keeps the bare local when G#'s own flow analysis
+    /// carries the preceding non-null guard into the tuple value.
     /// </summary>
     [Fact]
-    public void TupleLiteralElement_GuardedNullable_RendersNonNullAssertion()
+    public void TupleLiteralElement_GuardedNullable_UsesGSharpSmartCast()
     {
         string printed = TranslateUnit(@"
 #nullable enable
@@ -959,7 +956,8 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("return (a!!,", printed);
+        Assert.Contains("return (a,", printed);
+        Assert.DoesNotContain("a!!", printed);
     }
 
     private static string TranslateUnit(string source, string roundTripOnlyReason = null)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.ControlFlow.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.ControlFlow.cs
@@ -1941,6 +1941,33 @@ public sealed partial class CSharpToGSharpTranslator
             return false;
         }
 
+        // Shared by declaration mutability and smart-cast invalidation so tuple,
+        // ref/out, address-of, and ref-alias writes cannot drift apart.
+        private bool SyntaxNodeWritesSymbol(SyntaxNode node, ISymbol symbol) =>
+            node switch
+            {
+                AssignmentExpressionSyntax assignment
+                    when this.BindsTo(assignment.Left, symbol) => true,
+                AssignmentExpressionSyntax { Left: TupleExpressionSyntax leftTuple }
+                    when this.TupleAssignmentTargetsInclude(leftTuple, symbol) => true,
+                PostfixUnaryExpressionSyntax postfix
+                    when (postfix.IsKind(SyntaxKind.PostIncrementExpression)
+                            || postfix.IsKind(SyntaxKind.PostDecrementExpression))
+                        && this.BindsTo(postfix.Operand, symbol) => true,
+                PrefixUnaryExpressionSyntax prefix
+                    when (prefix.IsKind(SyntaxKind.PreIncrementExpression)
+                            || prefix.IsKind(SyntaxKind.PreDecrementExpression)
+                            || prefix.IsKind(SyntaxKind.AddressOfExpression))
+                        && this.BindsTo(prefix.Operand, symbol) => true,
+                ArgumentSyntax argument
+                    when !argument.RefOrOutKeyword.IsKind(SyntaxKind.None)
+                        && this.BindsTo(argument.Expression, symbol) => true,
+                RefExpressionSyntax refOf
+                    when refOf.Expression is IdentifierNameSyntax
+                        && this.BindsTo(refOf.Expression, symbol) => true,
+                _ => false,
+            };
+
         // Returns true when <paramref name="symbol"/> is assigned, incremented,
         // decremented, or passed by ref/out anywhere in <paramref name="scope"/>.
         // Generalises <see cref="IsLocalReassigned"/> to any symbol (used for
@@ -1967,62 +1994,9 @@ public sealed partial class CSharpToGSharpTranslator
         {
             foreach (SyntaxNode node in scope.DescendantNodes())
             {
-                switch (node)
+                if (this.SyntaxNodeWritesSymbol(node, symbol))
                 {
-                    case AssignmentExpressionSyntax assignment
-                        when this.BindsTo(assignment.Left, symbol):
-                        return true;
-
-                    // `(x, y) = (y, x)` deconstruction-ASSIGNMENT: `assignment.Left`
-                    // is the whole tuple, not `symbol` itself, so the plain
-                    // `BindsTo` case above never matches — without this, an
-                    // existing local written only via deconstruction-assignment
-                    // was (mis-)classified as never-reassigned and bound `let`,
-                    // then the element-wise write-back lowering (see
-                    // `LowerTupleAssignment`) failed gsc GS0127 "read-only"
-                    // (issue #1895). A tuple element that is itself a
-                    // declaration (`var y` in the mixed `(x, var y) = ...` form)
-                    // introduces a NEW binding, not a write to `symbol`, so it is
-                    // deliberately excluded by `TupleAssignmentTargetsInclude`.
-                    case AssignmentExpressionSyntax tupleAssignment
-                        when tupleAssignment.Left is TupleExpressionSyntax leftTuple
-                            && this.TupleAssignmentTargetsInclude(leftTuple, symbol):
-                        return true;
-
-                    case PostfixUnaryExpressionSyntax postfix
-                        when (postfix.IsKind(SyntaxKind.PostIncrementExpression)
-                                || postfix.IsKind(SyntaxKind.PostDecrementExpression))
-                            && this.BindsTo(postfix.Operand, symbol):
-                        return true;
-
-                    case PrefixUnaryExpressionSyntax prefix
-                        when (prefix.IsKind(SyntaxKind.PreIncrementExpression)
-                                || prefix.IsKind(SyntaxKind.PreDecrementExpression))
-                            && this.BindsTo(prefix.Operand, symbol):
-                        return true;
-
-                    case ArgumentSyntax argument
-                        when !argument.RefOrOutKeyword.IsKind(SyntaxKind.None)
-                            && this.BindsTo(argument.Expression, symbol):
-                        return true;
-
-                    case PrefixUnaryExpressionSyntax addressOf
-                        when addressOf.IsKind(SyntaxKind.AddressOfExpression)
-                            && this.BindsTo(addressOf.Operand, symbol):
-                        return true;
-
-                    // Issue #1900: `ref int alias = ref v;` aliases `v`'s storage
-                    // through G#'s native ref-local (`let/var ref alias T = v`,
-                    // no address-of operator on the RHS — see
-                    // TranslateRefExpression). gsc's ref-alias binder rejects
-                    // aliasing a `let`-bound (read-only) variable
-                    // (GS9005-equivalent "cannot take address of constant"), so
-                    // `v` must be forced to `var` here exactly like a variable
-                    // whose address is taken with the unsafe `&` operator above.
-                    case RefExpressionSyntax refOf
-                        when refOf.Expression is IdentifierNameSyntax
-                            && this.BindsTo(refOf.Expression, symbol):
-                        return true;
+                    return true;
                 }
             }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -1207,7 +1207,10 @@ public sealed partial class CSharpToGSharpTranslator
                     || !TryGetPatternNonNullPolarity(isPattern.Pattern, out bool whenTrue)
                     || (PatternUsesNativeVariableSyntax(isPattern.Pattern)
                         && !this.ConditionUsesNativePatternVariables(GetConditionRoot(isPattern)))
-                    || !ComputePatternFlowRegions(isPattern, whenTrue)
+                    || !ComputePatternFlowRegions(
+                            isPattern,
+                            whenTrue,
+                            includeWhenClauseRegion: false)
                         .Any(region => region.Span.Contains(expression.Span))
                     || this.SymbolIsWrittenBetween(symbol, isPattern, expression, scope))
                 {
@@ -1227,7 +1230,10 @@ public sealed partial class CSharpToGSharpTranslator
                         nullCheck,
                         symbol,
                         out bool whenTrue)
-                    || !ComputeBooleanFlowRegions(nullCheck, whenTrue)
+                    || !ComputeBooleanFlowRegions(
+                            nullCheck,
+                            whenTrue,
+                            includeWhenClauseRegion: false)
                         .Any(region => region.Span.Contains(expression.Span))
                     || this.SymbolIsWrittenBetween(symbol, nullCheck, expression, scope))
                 {

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -511,7 +511,7 @@ public sealed partial class CSharpToGSharpTranslator
                         GExpression nullableValue = this.TranslateExpression(member.Expression);
                         return this.IsWithinExpressionTreeLambda(member.Expression)
                             ? new MemberAccessExpression(nullableValue, "Value")
-                            : new NonNullAssertionExpression(nullableValue);
+                            : EnsureNonNullAssertion(nullableValue);
                     case "HasValue":
                         // Parenthesize the null test so it composes correctly
                         // under any surrounding operator. C# `!x.HasValue` would
@@ -617,13 +617,18 @@ public sealed partial class CSharpToGSharpTranslator
         {
             GExpression translated = this.TranslateExpression(recv);
 
+            if (this.GSharpExpressionIsStaticallyNonNull(recv, translated))
+            {
+                return ParenthesizeIfBareNumericLiteral(translated);
+            }
+
             if (!this.IsActivePatternBinding(recv)
                 && !this.IsWithinExpressionTreeLambda(recv)
                 && (this.ReceiverNeedsNullForgiveness(recv, isDereferenceReceiver: true)
                     || this.ReceiverIsNullableReferenceFieldOrProperty(recv)
                     || this.NullableReferenceValueMayBeNull(recv)))
             {
-                translated = new NonNullAssertionExpression(translated);
+                translated = EnsureNonNullAssertion(translated);
             }
             else if (!this.IsWithinExpressionTreeLambda(recv) && this.IsLocalBoundFromAsExpression(recv))
             {
@@ -640,7 +645,7 @@ public sealed partial class CSharpToGSharpTranslator
                 // move the throw earlier and break the guarded shape
                 // (`var p = o as T; if (p != null) …`), which Roslyn DOES flag and
                 // which the predicates above already handle correctly.
-                translated = new NonNullAssertionExpression(translated);
+                translated = EnsureNonNullAssertion(translated);
             }
 
             return ParenthesizeIfBareNumericLiteral(translated);
@@ -873,21 +878,23 @@ public sealed partial class CSharpToGSharpTranslator
 
         // Issue #1354: a value-position read (a `return` expression or a
         // conditional-expression arm) of a declared-`T?`/promoted-to-`T?` symbol
-        // that Roslyn's flow analysis has narrowed to non-null needs a `!!`
-        // assertion to satisfy a non-null target. G# does not smart-cast
-        // property/field chains, so unlike the receiver pass this also covers
-        // bare reads consumed as values (`return Continuation` /
-        // `cond ? a : Continuation`). The shared <see cref="ReceiverNeedsNullForgiveness"/>
-        // predicate already excludes null-comparison operands (flow there is not
-        // NotNull), `?.` receivers, `this`/`base`, and literals.
+        // that Roslyn's flow analysis has narrowed to non-null may need a `!!`
+        // assertion to satisfy a non-null target. G# smart-casts stable locals
+        // under native guards, but property/field chains and other nullable
+        // values still need the bridge.
         private GExpression TranslateValueWithNullForgiveness(ExpressionSyntax value)
         {
             GExpression translated = this.TranslateExpression(value);
 
+            if (this.GSharpExpressionIsStaticallyNonNull(value, translated))
+            {
+                return translated;
+            }
+
             if (!this.IsActivePatternBinding(value)
                 && this.ReceiverNeedsNullForgiveness(value))
             {
-                return new NonNullAssertionExpression(translated);
+                return EnsureNonNullAssertion(translated);
             }
 
             (ITypeSymbol targetType, ISymbol targetSymbol) = this.FindContextualValueTarget(value);
@@ -913,7 +920,7 @@ public sealed partial class CSharpToGSharpTranslator
             ISymbol targetSymbol,
             bool includePromotedValue = false)
         {
-            if (this.IsActivePatternBinding(value))
+            if (this.GSharpExpressionIsStaticallyNonNull(value, translated))
             {
                 return translated;
             }
@@ -966,7 +973,7 @@ public sealed partial class CSharpToGSharpTranslator
                 or ConditionalAccessExpressionSyntax
                     ? new ParenthesizedExpression(translated)
                     : translated;
-            return new NonNullAssertionExpression(operand);
+            return EnsureNonNullAssertion(operand);
         }
 
         private GExpression AssertFlowNarrowedNullableReference(
@@ -975,15 +982,302 @@ public sealed partial class CSharpToGSharpTranslator
             GTypeReference targetType)
         {
             ITypeSymbol declaredValueType = this.GetDeclaredValueType(value);
-            if (translated is not NonNullAssertionExpression
+            if (!this.GSharpExpressionIsStaticallyNonNull(value, translated)
                 && targetType is { IsNullable: false }
                 && declaredValueType is { IsReferenceType: true, NullableAnnotation: NullableAnnotation.Annotated }
                 && this.context.GetTypeInfo(value).Nullability.FlowState == NullableFlowState.NotNull)
             {
-                return new NonNullAssertionExpression(translated);
+                return EnsureNonNullAssertion(translated);
             }
 
             return translated;
+        }
+
+        private static GExpression EnsureNonNullAssertion(GExpression expression) =>
+            TranslatedExpressionIsStaticallyNonNull(expression)
+                ? expression
+                : new NonNullAssertionExpression(expression);
+
+        private bool GSharpExpressionIsStaticallyNonNull(
+            ExpressionSyntax expression,
+            GExpression translated = null)
+        {
+            if (translated != null && TranslatedExpressionIsStaticallyNonNull(translated))
+            {
+                return true;
+            }
+
+            if (this.PatternLocalUsesNullableStorage(expression))
+            {
+                return false;
+            }
+
+            if (this.IsActivePatternBinding(expression)
+                || this.IsGSharpFlowNarrowedLocal(expression))
+            {
+                return true;
+            }
+
+            ExpressionSyntax unwrapped = expression;
+            while (unwrapped is ParenthesizedExpressionSyntax parenthesized)
+            {
+                unwrapped = parenthesized.Expression;
+            }
+
+            switch (unwrapped)
+            {
+                case PostfixUnaryExpressionSyntax suppression
+                    when suppression.IsKind(SyntaxKind.SuppressNullableWarningExpression):
+                    return !IsNullOrSuppressedNull(suppression.Operand);
+
+                case ConditionalExpressionSyntax conditional:
+                    GExpression conditionalValue = UnwrapTranslatedValue(translated);
+                    if (conditionalValue is IfExpression ifExpression)
+                    {
+                        return this.GSharpExpressionIsStaticallyNonNull(
+                                conditional.WhenTrue,
+                                ifExpression.ThenExpression)
+                            && this.GSharpExpressionIsStaticallyNonNull(
+                                conditional.WhenFalse,
+                                ifExpression.ElseExpression);
+                    }
+
+                    if (conditionalValue is IfLetExpression ifLet)
+                    {
+                        return this.GSharpExpressionIsStaticallyNonNull(
+                                conditional.WhenTrue,
+                                ifLet.ThenExpression)
+                            && this.GSharpExpressionIsStaticallyNonNull(
+                                conditional.WhenFalse,
+                                ifLet.ElseExpression);
+                    }
+
+                    return this.GSharpExpressionIsStaticallyNonNull(conditional.WhenTrue)
+                        && this.GSharpExpressionIsStaticallyNonNull(conditional.WhenFalse);
+
+                case SwitchExpressionSyntax switchExpression:
+                    if (UnwrapTranslatedValue(translated) is SwitchExpression translatedSwitch
+                        && translatedSwitch.Arms.Count == switchExpression.Arms.Count)
+                    {
+                        return switchExpression.Arms
+                            .Select((arm, index) => (arm, index))
+                            .All(pair => this.GSharpExpressionIsStaticallyNonNull(
+                                pair.arm.Expression,
+                                translatedSwitch.Arms[pair.index].Body));
+                    }
+
+                    return switchExpression.Arms.All(arm =>
+                        this.GSharpExpressionIsStaticallyNonNull(arm.Expression));
+
+                case BinaryExpressionSyntax binary when binary.IsKind(SyntaxKind.CoalesceExpression):
+                    return UnwrapTranslatedValue(translated) is BinaryExpression
+                            { Operator: "??" } translatedBinary
+                        ? this.GSharpExpressionIsStaticallyNonNull(
+                            binary.Right,
+                            translatedBinary.Right)
+                        : this.GSharpExpressionIsStaticallyNonNull(binary.Right);
+
+                case AssignmentExpressionSyntax assignment:
+                    if (this.PatternLocalUsesNullableStorage(assignment.Left))
+                    {
+                        return false;
+                    }
+
+                    return UnwrapTranslatedValue(translated) is AssignmentExpression translatedAssignment
+                        ? this.GSharpExpressionIsStaticallyNonNull(
+                            assignment.Right,
+                            translatedAssignment.Value)
+                        : this.GSharpExpressionIsStaticallyNonNull(assignment.Right);
+
+                case BinaryExpressionSyntax binary when binary.IsKind(SyntaxKind.AsExpression):
+                case ConditionalAccessExpressionSyntax:
+                    return false;
+            }
+
+            ISymbol symbol = this.context.GetSymbolInfo(expression).Symbol;
+            ITypeSymbol type = symbol switch
+            {
+                IFieldSymbol field => field.Type,
+                ILocalSymbol local => local.Type,
+                IParameterSymbol parameter => parameter.Type,
+                IPropertySymbol property => property.Type,
+                IMethodSymbol { MethodKind: not MethodKind.Constructor } method => method.ReturnType,
+                _ => this.context.GetTypeInfo(expression).Type,
+            };
+
+            if (type is { IsValueType: true })
+            {
+                return type.OriginalDefinition?.SpecialType != SpecialType.System_Nullable_T;
+            }
+
+            return type is { IsReferenceType: true, NullableAnnotation: NullableAnnotation.NotAnnotated }
+                && !this.IsImportedObliviousNullableMember(symbol)
+                && !this.LocalInitializedFromImportedObliviousNullable(symbol)
+                && (symbol == null || !this.ShouldPromoteToNullableReference(symbol));
+        }
+
+        private bool PatternLocalUsesNullableStorage(ExpressionSyntax expression)
+        {
+            ISymbol symbol = this.context.GetSymbolInfo(expression).Symbol;
+            if (symbol is not ILocalSymbol { Type.IsReferenceType: true } local)
+            {
+                return false;
+            }
+
+            if (this.state.HoistedNullableGuardLocals.Contains(local))
+            {
+                return true;
+            }
+
+            bool isPatternLocal = local.DeclaringSyntaxReferences.Any(reference =>
+                reference.GetSyntax() is SingleVariableDesignationSyntax);
+            SyntaxNode scope = this.state.CurrentBodyScope ?? expression.SyntaxTree.GetRoot();
+            return isPatternLocal && this.IsSymbolReassigned(local, scope);
+        }
+
+        private static GExpression UnwrapTranslatedValue(GExpression expression)
+        {
+            while (expression is ParenthesizedExpression parenthesized)
+            {
+                expression = parenthesized.Inner;
+            }
+
+            return expression is BlockExpression block
+                ? UnwrapTranslatedValue(block.Value)
+                : expression;
+        }
+
+        private static bool TranslatedExpressionIsStaticallyNonNull(GExpression expression) =>
+            expression switch
+            {
+                NonNullAssertionExpression => true,
+                ParenthesizedExpression parenthesized =>
+                    TranslatedExpressionIsStaticallyNonNull(parenthesized.Inner),
+                BlockExpression block =>
+                    TranslatedExpressionIsStaticallyNonNull(block.Value),
+                IfExpression ifExpression =>
+                    TranslatedExpressionIsStaticallyNonNull(ifExpression.ThenExpression)
+                        && TranslatedExpressionIsStaticallyNonNull(ifExpression.ElseExpression),
+                IfLetExpression ifLet =>
+                    TranslatedExpressionIsStaticallyNonNull(ifLet.ThenExpression)
+                        && TranslatedExpressionIsStaticallyNonNull(ifLet.ElseExpression),
+                SwitchExpression switchExpression =>
+                    switchExpression.Arms.Count > 0
+                        && switchExpression.Arms.All(arm =>
+                            TranslatedExpressionIsStaticallyNonNull(arm.Body)),
+                BinaryExpression binary when binary.Operator == "??" =>
+                    TranslatedExpressionIsStaticallyNonNull(binary.Right),
+                _ => false,
+            };
+
+        private bool IsGSharpFlowNarrowedLocal(ExpressionSyntax expression)
+        {
+            while (expression is ParenthesizedExpressionSyntax parenthesized)
+            {
+                expression = parenthesized.Expression;
+            }
+
+            ISymbol symbol = this.context.GetSymbolInfo(expression).Symbol;
+            if (expression is not IdentifierNameSyntax
+                || symbol is not (ILocalSymbol or IParameterSymbol)
+                || this.context.GetTypeInfo(expression).Nullability.FlowState != NullableFlowState.NotNull)
+            {
+                return false;
+            }
+
+            SyntaxNode scope = this.state.CurrentBodyScope
+                ?? expression.Ancestors().FirstOrDefault(node =>
+                    node is BaseMethodDeclarationSyntax
+                        or AccessorDeclarationSyntax
+                        or LocalFunctionStatementSyntax
+                        or AnonymousFunctionExpressionSyntax);
+            if (scope == null)
+            {
+                return false;
+            }
+
+            foreach (IsPatternExpressionSyntax isPattern in scope
+                .DescendantNodes(node =>
+                    node is not (LocalFunctionStatementSyntax or AnonymousFunctionExpressionSyntax))
+                .OfType<IsPatternExpressionSyntax>())
+            {
+                if (isPattern.SpanStart >= expression.SpanStart
+                    || !this.BindsToGuardSymbol(isPattern.Expression, symbol)
+                    || !IsNativelyExpressiblePattern(isPattern.Pattern, topLevel: true)
+                    || !TryGetPatternNonNullPolarity(isPattern.Pattern, out bool whenTrue)
+                    || (PatternUsesNativeVariableSyntax(isPattern.Pattern)
+                        && !this.ConditionUsesNativePatternVariables(GetConditionRoot(isPattern)))
+                    || !ComputePatternFlowRegions(isPattern, whenTrue)
+                        .Any(region => region.Span.Contains(expression.Span))
+                    || this.SymbolIsWrittenBetween(symbol, isPattern, expression, scope))
+                {
+                    continue;
+                }
+
+                return true;
+            }
+
+            foreach (BinaryExpressionSyntax nullCheck in scope
+                .DescendantNodes(node =>
+                    node is not (LocalFunctionStatementSyntax or AnonymousFunctionExpressionSyntax))
+                .OfType<BinaryExpressionSyntax>())
+            {
+                if (nullCheck.SpanStart >= expression.SpanStart
+                    || !this.TryGetNullComparisonNonNullPolarity(
+                        nullCheck,
+                        symbol,
+                        out bool whenTrue)
+                    || !ComputeBooleanFlowRegions(nullCheck, whenTrue)
+                        .Any(region => region.Span.Contains(expression.Span))
+                    || this.SymbolIsWrittenBetween(symbol, nullCheck, expression, scope))
+                {
+                    continue;
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool TryGetNullComparisonNonNullPolarity(
+            BinaryExpressionSyntax comparison,
+            ISymbol symbol,
+            out bool whenTrue)
+        {
+            if (!comparison.IsKind(SyntaxKind.EqualsExpression)
+                && !comparison.IsKind(SyntaxKind.NotEqualsExpression))
+            {
+                whenTrue = false;
+                return false;
+            }
+
+            bool comparesSymbolToNull =
+                (IsNullLiteral(comparison.Left)
+                    && this.BindsToGuardSymbol(comparison.Right, symbol))
+                || (IsNullLiteral(comparison.Right)
+                    && this.BindsToGuardSymbol(comparison.Left, symbol));
+            whenTrue = comparison.IsKind(SyntaxKind.NotEqualsExpression);
+            return comparesSymbolToNull;
+        }
+
+        private bool SymbolIsWrittenBetween(
+            ISymbol symbol,
+            SyntaxNode start,
+            SyntaxNode use,
+            SyntaxNode scope)
+        {
+            return scope
+                .DescendantNodes(node =>
+                    node is not (LocalFunctionStatementSyntax or AnonymousFunctionExpressionSyntax))
+                .OfType<IdentifierNameSyntax>()
+                .Any(identifier =>
+                    identifier.SpanStart > start.Span.End
+                    && identifier.SpanStart < use.SpanStart
+                    && IsDirectWrite(identifier)
+                    && SymbolEqualityComparer.Default.Equals(
+                        this.context.GetSymbolInfo(identifier).Symbol,
+                        symbol));
         }
 
         private ITypeSymbol GetDeclaredValueType(ExpressionSyntax value) =>
@@ -998,7 +1292,8 @@ public sealed partial class CSharpToGSharpTranslator
 
         private bool NullableReferenceValueMayBeNull(ExpressionSyntax value)
         {
-            if (value is PostfixUnaryExpressionSyntax
+            if (this.GSharpExpressionIsStaticallyNonNull(value)
+                || value is PostfixUnaryExpressionSyntax
                     { RawKind: (int)SyntaxKind.SuppressNullableWarningExpression }
                 || this.IsWithinExpressionTreeLambda(value)
                 || this.IsCallableValueExpression(value))
@@ -1037,6 +1332,8 @@ public sealed partial class CSharpToGSharpTranslator
                 BinaryExpressionSyntax coalesce
                     when coalesce.IsKind(SyntaxKind.CoalesceExpression) =>
                         this.NullableReferenceValueMayBeNull(coalesce.Right),
+                AssignmentExpressionSyntax assignment =>
+                    this.PatternLocalUsesNullableStorage(assignment.Left),
                 _ => false,
             };
 
@@ -1118,7 +1415,7 @@ public sealed partial class CSharpToGSharpTranslator
                 or ConditionalAccessExpressionSyntax
                     ? new ParenthesizedExpression(translated)
                     : translated;
-            return new NonNullAssertionExpression(assertionOperand);
+            return EnsureNonNullAssertion(assertionOperand);
         }
 
         private bool IndexArgumentValueNeedsNullForgiveness(ExpressionSyntax value)
@@ -1200,6 +1497,12 @@ public sealed partial class CSharpToGSharpTranslator
             ExpressionSyntax recv,
             bool isDereferenceReceiver = false)
         {
+            if (this.IsActivePatternBinding(recv)
+                || this.IsGSharpFlowNarrowedLocal(recv))
+            {
+                return false;
+            }
+
             // `expr!` already lowers to a `NonNullAssertionExpression`; never
             // double-assert. `this`/`base`, a null literal, and a `?.` conditional
             // access receiver are handled by their own paths and are not

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -1270,14 +1270,10 @@ public sealed partial class CSharpToGSharpTranslator
             return scope
                 .DescendantNodes(node =>
                     node is not (LocalFunctionStatementSyntax or AnonymousFunctionExpressionSyntax))
-                .OfType<IdentifierNameSyntax>()
-                .Any(identifier =>
-                    identifier.SpanStart > start.Span.End
-                    && identifier.SpanStart < use.SpanStart
-                    && IsDirectWrite(identifier)
-                    && SymbolEqualityComparer.Default.Equals(
-                        this.context.GetSymbolInfo(identifier).Symbol,
-                        symbol));
+                .Any(node =>
+                    node.SpanStart > start.Span.End
+                    && node.Span.End <= use.SpanStart
+                    && this.SyntaxNodeWritesSymbol(node, symbol));
         }
 
         private ITypeSymbol GetDeclaredValueType(ExpressionSyntax value) =>

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -1183,7 +1183,7 @@ public sealed partial class CSharpToGSharpTranslator
                 && !isFlowNarrowedLocal
                 && this.ReceiverNeedsNullForgiveness(argument.Expression))
             {
-                return new NonNullAssertionExpression(this.TranslateExpression(argument.Expression));
+                return EnsureNonNullAssertion(this.TranslateExpression(argument.Expression));
             }
 
             // A C# argument whose declared numeric type differs from the type C#
@@ -2028,7 +2028,7 @@ public sealed partial class CSharpToGSharpTranslator
             return (this.NullableReferenceValueMayBeNull(valueExpression)
                     || (this.IsObliviousCompilation()
                         && this.IsNullablePromotedValue(valueExpression)))
-                ? new NonNullAssertionExpression(translatedValue)
+                ? EnsureNonNullAssertion(translatedValue)
                 : translatedValue;
         }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.PatternVariables.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.PatternVariables.cs
@@ -196,12 +196,22 @@ public sealed partial class CSharpToGSharpTranslator
         /// </summary>
         private static List<SyntaxNode> ComputeNativePatternVariableRegions(IsPatternExpressionSyntax isPattern)
         {
-            var regions = new List<SyntaxNode>();
-            SyntaxNode node = isPattern;
-
             // `x is not T t` assigns `t` when the whole test is FALSE.
             StripTopLevelNegation(isPattern.Pattern, out bool negated);
-            bool whenTrue = !negated;
+            return ComputePatternFlowRegions(isPattern, whenTrue: !negated);
+        }
+
+        private static List<SyntaxNode> ComputePatternFlowRegions(
+            IsPatternExpressionSyntax isPattern,
+            bool whenTrue) =>
+            ComputeBooleanFlowRegions(isPattern, whenTrue);
+
+        private static List<SyntaxNode> ComputeBooleanFlowRegions(
+            ExpressionSyntax condition,
+            bool whenTrue)
+        {
+            var regions = new List<SyntaxNode>();
+            SyntaxNode node = condition;
 
             while (true)
             {
@@ -306,6 +316,84 @@ public sealed partial class CSharpToGSharpTranslator
                         return regions;
                 }
             }
+        }
+
+        private static bool TryGetPatternNonNullPolarity(
+            PatternSyntax pattern,
+            out bool whenTrue)
+        {
+            switch (pattern)
+            {
+                case ParenthesizedPatternSyntax parenthesized:
+                    return TryGetPatternNonNullPolarity(parenthesized.Pattern, out whenTrue);
+
+                case UnaryPatternSyntax unary when unary.OperatorToken.IsKind(SyntaxKind.NotKeyword):
+                    if (TryGetPatternNonNullPolarity(unary.Pattern, out whenTrue))
+                    {
+                        whenTrue = !whenTrue;
+                        return true;
+                    }
+
+                    break;
+
+                case ConstantPatternSyntax constant when IsNullLiteral(constant.Expression):
+                    whenTrue = false;
+                    return true;
+
+                case BinaryPatternSyntax binary when binary.OperatorToken.IsKind(SyntaxKind.AndKeyword):
+                    {
+                        bool leftKnown = TryGetPatternNonNullPolarity(binary.Left, out bool leftWhenTrue);
+                        bool rightKnown = TryGetPatternNonNullPolarity(binary.Right, out bool rightWhenTrue);
+                        if ((leftKnown && leftWhenTrue) || (rightKnown && rightWhenTrue))
+                        {
+                            whenTrue = true;
+                            return true;
+                        }
+
+                        if (leftKnown && rightKnown && !leftWhenTrue && !rightWhenTrue)
+                        {
+                            whenTrue = false;
+                            return true;
+                        }
+
+                        break;
+                    }
+
+                case BinaryPatternSyntax binary when binary.OperatorToken.IsKind(SyntaxKind.OrKeyword):
+                    {
+                        bool leftKnown = TryGetPatternNonNullPolarity(binary.Left, out bool leftWhenTrue);
+                        bool rightKnown = TryGetPatternNonNullPolarity(binary.Right, out bool rightWhenTrue);
+                        if ((leftKnown && !leftWhenTrue) || (rightKnown && !rightWhenTrue))
+                        {
+                            whenTrue = false;
+                            return true;
+                        }
+
+                        if (leftKnown && rightKnown && leftWhenTrue && rightWhenTrue)
+                        {
+                            whenTrue = true;
+                            return true;
+                        }
+
+                        break;
+                    }
+
+                case VarPatternSyntax:
+                case DiscardPatternSyntax:
+                    break;
+
+                case ConstantPatternSyntax:
+                case RelationalPatternSyntax:
+                case TypePatternSyntax:
+                case DeclarationPatternSyntax:
+                case RecursivePatternSyntax:
+                case ListPatternSyntax:
+                    whenTrue = true;
+                    return true;
+            }
+
+            whenTrue = false;
+            return false;
         }
 
         // Peels parentheses and top-level `not` layers off a pattern, reporting

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.PatternVariables.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.PatternVariables.cs
@@ -203,12 +203,14 @@ public sealed partial class CSharpToGSharpTranslator
 
         private static List<SyntaxNode> ComputePatternFlowRegions(
             IsPatternExpressionSyntax isPattern,
-            bool whenTrue) =>
-            ComputeBooleanFlowRegions(isPattern, whenTrue);
+            bool whenTrue,
+            bool includeWhenClauseRegion = true) =>
+            ComputeBooleanFlowRegions(isPattern, whenTrue, includeWhenClauseRegion);
 
         private static List<SyntaxNode> ComputeBooleanFlowRegions(
             ExpressionSyntax condition,
-            bool whenTrue)
+            bool whenTrue,
+            bool includeWhenClauseRegion = true)
         {
             var regions = new List<SyntaxNode>();
             SyntaxNode node = condition;
@@ -298,7 +300,7 @@ public sealed partial class CSharpToGSharpTranslator
                         return regions;
 
                     case WhenClauseSyntax whenClause:
-                        if (whenTrue)
+                        if (whenTrue && includeWhenClauseRegion)
                         {
                             if (whenClause.Parent is CasePatternSwitchLabelSyntax { Parent: SwitchSectionSyntax section })
                             {

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -416,8 +416,8 @@ public sealed partial class CSharpToGSharpTranslator
                 case PostfixUnaryExpressionSyntax suppressNullable
                     when suppressNullable.IsKind(SyntaxKind.SuppressNullableWarningExpression):
                     // The C# null-forgiving operator `expr!` maps to G#'s postfix
-                    // non-null assertion `expr!!` (spec: "Postfix `!!` asserts
-                    // non-null"), preserving the assertion (ADR-0115 §B).
+                    // non-null assertion `expr!!` when the translated operand
+                    // still has a nullable static type (ADR-0115 §B).
                     // A null literal is never forgivable: preserve `nil` so its
                     // target type accepts nullable sinks and rejects non-null ones.
                     if (IsNullOrSuppressedNull(suppressNullable.Operand))
@@ -425,8 +425,12 @@ public sealed partial class CSharpToGSharpTranslator
                         return this.TranslateExpression(suppressNullable.Operand);
                     }
 
-                    return new NonNullAssertionExpression(
-                        this.TranslateExpression(suppressNullable.Operand));
+                    GExpression suppressed = this.TranslateExpression(suppressNullable.Operand);
+                    return this.GSharpExpressionIsStaticallyNonNull(
+                        suppressNullable.Operand,
+                        suppressed)
+                            ? suppressed
+                            : EnsureNonNullAssertion(suppressed);
 
                 case PostfixUnaryExpressionSyntax postfixValue
                     when postfixValue.IsKind(SyntaxKind.PostIncrementExpression)
@@ -1898,7 +1902,7 @@ public sealed partial class CSharpToGSharpTranslator
             return sourceType is { IsReferenceType: true }
                 && (sourceType.NullableAnnotation == NullableAnnotation.Annotated
                     || this.ShouldPromoteToNullableReference(symbol))
-                ? new NonNullAssertionExpression(translated)
+                ? EnsureNonNullAssertion(translated)
                 : translated;
         }
 
@@ -2014,7 +2018,7 @@ public sealed partial class CSharpToGSharpTranslator
                     out GExpression replacement)
                 && replacement is NonNullAssertionExpression)
             {
-                result = new NonNullAssertionExpression(result);
+                result = EnsureNonNullAssertion(result);
             }
 
             return result;
@@ -2038,7 +2042,7 @@ public sealed partial class CSharpToGSharpTranslator
             GExpression result =
                 this.context.GetTypeInfo(assignment).Nullability.FlowState == NullableFlowState.NotNull
                 || !this.NullableReferenceValueMayBeNull(assignment.Right)
-                ? new NonNullAssertionExpression(value)
+                ? EnsureNonNullAssertion(value)
                 : value;
             return statements.Count == 0
                 ? result

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
@@ -576,7 +576,7 @@ public sealed partial class CSharpToGSharpTranslator
             }
 
             return this.IsNullablePromotedValue(assignment.Right)
-                ? new NonNullAssertionExpression(translatedRhs)
+                ? EnsureNonNullAssertion(translatedRhs)
                 : translatedRhs;
         }
 
@@ -623,7 +623,7 @@ public sealed partial class CSharpToGSharpTranslator
                 return translatedRhs;
             }
 
-            return new NonNullAssertionExpression(translatedRhs);
+            return EnsureNonNullAssertion(translatedRhs);
         }
 
         // Issue #2427 (oblivious sink): a plain REASSIGNMENT (`path = (pathStub +
@@ -673,7 +673,7 @@ public sealed partial class CSharpToGSharpTranslator
                 return translatedRhs;
             }
 
-            return new NonNullAssertionExpression(translatedRhs);
+            return EnsureNonNullAssertion(translatedRhs);
         }
 
         // For a compound numeric assignment `x OP= y` (`+= -= *= /= %= &= |= ^=`),
@@ -2041,7 +2041,7 @@ public sealed partial class CSharpToGSharpTranslator
                     if (this.ReceiverNeedsNullForgiveness(receiverId, isDereferenceReceiver: true) ||
                         this.ReceiverIsNullableReferenceFieldOrProperty(receiverId))
                     {
-                        qualifiedReceiver = new NonNullAssertionExpression(qualifiedReceiver);
+                        qualifiedReceiver = EnsureNonNullAssertion(qualifiedReceiver);
                     }
 
                     return new MemberAccessExpression(
@@ -2055,7 +2055,7 @@ public sealed partial class CSharpToGSharpTranslator
                      this.state.HoistedNullableGuardLocals.Contains(hoistedSymbol)))
                 {
                     return new MemberAccessExpression(
-                        new NonNullAssertionExpression(this.TranslateExpression(member.Expression)),
+                        EnsureNonNullAssertion(this.TranslateExpression(member.Expression)),
                         SanitizeIdentifier(member.Name.Identifier.Text));
                 }
             }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
@@ -500,7 +500,7 @@ public sealed partial class CSharpToGSharpTranslator
                 // pattern designation, not a declarator — check the whole arm
                 // pattern tree here.
                 this.ReportIndexOrRangeDesignationsInPattern(arm.Pattern);
-                GPattern pattern = this.TranslatePattern(
+                GPattern pattern = this.TranslateSwitchPattern(
                     arm.Pattern,
                     subject,
                     bindings,
@@ -731,7 +731,7 @@ public sealed partial class CSharpToGSharpTranslator
                 var mutableBindings = new List<(ILocalSymbol Symbol, GExpression MatchedValue)>();
 
                 this.ReportIndexOrRangeDesignationsInPattern(arm.Pattern);
-                GPattern pattern = this.TranslatePattern(
+                GPattern pattern = this.TranslateSwitchPattern(
                     arm.Pattern,
                     subject,
                     bindings,
@@ -863,7 +863,7 @@ public sealed partial class CSharpToGSharpTranslator
                             // Issue #1967: same guard as the switch-expression arm
                             // path above, for the switch-statement `case` form.
                             this.ReportIndexOrRangeDesignationsInPattern(patternLabel.Pattern);
-                            GPattern pattern = this.TranslatePattern(
+                            GPattern pattern = this.TranslateSwitchPattern(
                                 patternLabel.Pattern,
                                 subject,
                                 bindings,
@@ -1399,6 +1399,49 @@ public sealed partial class CSharpToGSharpTranslator
                         $"pattern '{pattern.Kind()}' has no canonical G# form yet (ADR-0115 §B).");
                     return new DiscardPattern();
             }
+        }
+
+        private GPattern TranslateSwitchPattern(
+            PatternSyntax pattern,
+            GExpression receiver,
+            List<(ISymbol Symbol, GExpression Replacement)> bindings,
+            HashSet<string> usedDesignators,
+            List<GExpression> guards,
+            List<(ILocalSymbol Symbol, GExpression MatchedValue)> mutableBindings)
+        {
+            if (pattern is RecursivePatternSyntax { Type: not null, PropertyPatternClause: not null }
+                && PatternIntroducesBinding(pattern)
+                && this.IsNativelyExpressiblePattern(pattern, topLevel: true))
+            {
+                SyntaxNode scope = this.state.CurrentBodyScope ?? pattern.SyntaxTree.GetRoot();
+                List<ILocalSymbol> locals = pattern
+                    .DescendantNodesAndSelf()
+                    .OfType<SingleVariableDesignationSyntax>()
+                    .Select(this.context.GetDeclaredSymbol)
+                    .OfType<ILocalSymbol>()
+                    .ToList();
+                if (locals.All(local => !this.IsSymbolReassigned(local, scope)))
+                {
+                    var nativeBinders = new List<ILocalSymbol>();
+                    GPattern native = this.BuildNativePattern(pattern, nativeBinders);
+                    foreach (ILocalSymbol binder in nativeBinders)
+                    {
+                        bindings.Add((
+                            binder,
+                            new IdentifierExpression(SanitizeIdentifier(binder.Name))));
+                    }
+
+                    return native;
+                }
+            }
+
+            return this.TranslatePattern(
+                pattern,
+                receiver,
+                bindings,
+                usedDesignators,
+                guards,
+                mutableBindings);
         }
 
         // Issue #1889: G# has a native list pattern (spec §Pattern matching,


### PR DESCRIPTION
## Summary
- make null-forgiveness insertion idempotent and skip values already non-null in G#
- preserve native switch pattern binders and recognize smart-cast flow, including exiting guards
- decide value-position conditional/coalesce nullability from translated arms
- add focused regressions and Core migration ratchets (`!!!!`: 0, `)!!.`: 9)

## Validation
- 109 changed-test regressions passed
- 515 null/pattern/conditional regressions passed
- Core migration inventory passed

Fixes #3422