### PR TITLE
Fix non-binding property patterns on member receivers

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue3424NonBindingPropertyPatternTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3424NonBindingPropertyPatternTranslationTests.cs
@@ -1,0 +1,125 @@
+// <copyright file="Issue3424NonBindingPropertyPatternTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3424: non-binding property patterns over implicit property or field
+/// receivers must use native G# patterns because gsc does not smart-cast members.
+/// </summary>
+public sealed class Issue3424NonBindingPropertyPatternTranslationTests
+{
+    private const string Symbols = """
+        namespace Demo
+        {
+            public abstract class BoundPattern
+            {
+            }
+
+            public sealed class BoundTypePattern : BoundPattern
+            {
+                public object? PropertyPattern { get; init; }
+                public bool HasBinding { get; init; }
+            }
+        """;
+
+    [Fact]
+    public void ImplicitPropertyReceiver_UsesNativePatternAndEvaluatesOnce()
+    {
+        string printed = Translate(
+            Symbols + """
+            public sealed class C
+            {
+                private readonly BoundPattern pattern =
+                    new BoundTypePattern { PropertyPattern = null, HasBinding = false };
+                private int reads;
+
+                private BoundPattern Pattern
+                {
+                    get
+                    {
+                        reads++;
+                        return pattern;
+                    }
+                }
+
+                public int Run()
+                {
+                    bool matched = Pattern is BoundTypePattern
+                    {
+                        PropertyPattern: null,
+                        HasBinding: false,
+                    };
+                    return matched ? reads : -1;
+                }
+                }
+            }
+            """);
+
+        Assert.Contains(
+            "Pattern is BoundTypePattern and { PropertyPattern: nil, HasBinding: false }",
+            printed,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("Pattern.PropertyPattern", printed, StringComparison.Ordinal);
+        LocalFunctionHoistTranslationTests.CompileAndRun(
+            printed,
+            "Console.WriteLine(C().Run())",
+            "1");
+    }
+
+    [Fact]
+    public void ImplicitFieldReceiver_UsesNativePatternAndBinds()
+    {
+        string printed = Translate(
+            Symbols + """
+            public sealed class C
+            {
+                private readonly BoundPattern pattern =
+                    new BoundTypePattern { PropertyPattern = null, HasBinding = false };
+
+                public bool IsSimple =>
+                    pattern is BoundTypePattern
+                    {
+                        PropertyPattern: null,
+                        HasBinding: false,
+                    };
+                }
+            }
+            """);
+
+        Assert.Contains(
+            "pattern is BoundTypePattern and { PropertyPattern: nil, HasBinding: false }",
+            printed,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("pattern.PropertyPattern", printed, StringComparison.Ordinal);
+    }
+
+    private static string Translate(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(
+            project.Compilation,
+            document.SemanticModel,
+            document.FilePath);
+        string printed = GSharpPrinter.Print(
+            new CSharpToGSharpTranslator().TranslateDocument(document, context));
+        Assert.DoesNotContain(
+            context.Diagnostics,
+            diagnostic => diagnostic.Severity != TranslationSeverity.Info);
+        TranslationTestValidation.AssertBinds(printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue914NumericCoercionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914NumericCoercionTranslationTests.cs
@@ -545,13 +545,12 @@ namespace Demo
     }
 
     /// <summary>
-    /// A C# constant `or` pattern on a nullable numeric (`b is 11 or 12`) lowers to
-    /// equality tests whose literals are retyped to the receiver's numeric type, so
-    /// the result type-checks under G#'s no-implicit-promotion rule (a bare
-    /// `b == 11` of `uint8?` vs `int32` is GS0129).
+    /// A C# constant <c>or</c> pattern on a nullable numeric property uses a
+    /// native G# pattern. The pattern binder types its constants against the
+    /// subject and evaluates the property once.
     /// </summary>
     [Fact]
-    public void ConstantOrPattern_NullableNumericReceiver_RetypesLiterals()
+    public void ConstantOrPattern_NullableNumericPropertyReceiver_UsesNativePattern()
     {
         string printed = TranslateUnit(@"
 #nullable enable
@@ -563,8 +562,8 @@ namespace Demo
         public bool M() => Mode is 11 or 12 or 13;
     }
 }");
-        Assert.Contains("Mode == (11 as uint8?)", printed);
-        Assert.Contains("Mode == (12 as uint8?)", printed);
+        Assert.Contains("Mode is 11 or 12 or 13", printed);
+        Assert.DoesNotContain("Mode ==", printed);
     }
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -574,13 +574,14 @@ public sealed partial class CSharpToGSharpTranslator
             GExpression receiver = this.TranslateExpression(isPattern.Expression);
             ITypeSymbol receiverType = this.context.GetTypeInfo(isPattern.Expression).Type;
 
-            // ADR-0162 / issue #3347: G# evaluates a native boolean pattern
-            // subject exactly once. Emit that form whenever C# introduces no
-            // pattern local; the old hand-expanded member-test tree was the
-            // dominant source of avoidable __spillN locals.
+            // ADR-0162 / issues #3347/#3424: G# evaluates a native boolean
+            // pattern subject exactly once. Use that form when C# introduces no
+            // pattern local and gsc cannot smart-cast the original scrutinee.
+            // An implicit property/field can translate to a bare identifier, but
+            // only bare locals and parameters are smart-castable (ADR-0069).
             if (!PatternIntroducesBinding(isPattern.Pattern)
                 && !PatternReadsScrutineeAtMostOnce(isPattern.Pattern)
-                && !IsTrivialOperand(receiver))
+                && !this.IsSmartCastableScrutinee(isPattern.Expression))
             {
                 var bindings = new List<(ISymbol Symbol, GExpression Replacement)>();
                 var guards = new List<GExpression>();


### PR DESCRIPTION
## Summary
- choose native non-binding multi-read patterns from Roslyn scrutinee smart-castability, not emitted operand triviality
- keep local/parameter hand-expansion while fixing implicit property and field receivers
- verify native binding plus property getter evaluation exactly once
- update nullable numeric property-pattern coverage for native constant-pattern typing

## Validation
- `dotnet build GSharp.sln --configuration Release --no-restore -graph` (0 warnings, 0 errors)
- full `cs2gs-remainder` shard: 1,250 passed
- 42 related cs2gs pattern tests passed in Release
- 2 Core translation corpus ratchets passed
- G04 pattern corpus pipeline: translate, compile, ILVerify, and stdout parity all passed

## Test discrimination
Before the product fix, both new `TranslationTestValidation.AssertBinds` regressions failed with GS0158 member lookup errors from hand-expanded receiver tests. Native lowering makes both bind; runtime coverage confirms the property getter runs once.

Fixes #3424