### PR TITLE
[cs2gs] Preserve attribute namespace imports

### DIFF
--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Attributes.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Attributes.cs
@@ -374,37 +374,53 @@ internal sealed partial class DeclarationBinder
             simpleName = name.Substring(dotIndex + 1);
         }
 
-        // The `Attribute`-suffix retry only ever applies to a simple
-        // (non-dotted) name, same as `ResolveAttributeType` — a dotted name's
-        // last segment is resolved by `bindTypeClause` itself via the
-        // reference-assembly path, which does its own suffix-free lookup.
-        var directExists = dotIndex < 0
-            && !string.IsNullOrEmpty(simpleName)
-            && scope.TryLookupTypeAlias(simpleName, arity, out _);
-
-        string? suffixedName = null;
-        var suffixedExists = false;
-        if (dotIndex < 0 && !string.IsNullOrEmpty(simpleName) && !simpleName.EndsWith("Attribute", StringComparison.Ordinal))
+        TypeSymbol? direct = null;
+        if (dotIndex < 0)
         {
-            suffixedName = simpleName + "Attribute";
-            suffixedExists = scope.TryLookupTypeAlias(suffixedName, arity, out _);
+            scope.TryLookupTypeAlias(simpleName, arity, out direct);
+        }
+        else
+        {
+            direct = ResolveNestedAttributeName(name, arity);
         }
 
-        if (directExists && suffixedExists)
+        TypeSymbol? suffixed = null;
+        string? suffixedName = null;
+        if (!string.IsNullOrEmpty(simpleName) && !simpleName.EndsWith("Attribute", StringComparison.Ordinal))
+        {
+            suffixedName = dotIndex >= 0
+                ? string.Concat(name.Substring(0, dotIndex + 1), simpleName, "Attribute")
+                : simpleName + "Attribute";
+            if (dotIndex < 0)
+            {
+                scope.TryLookupTypeAlias(suffixedName, arity, out suffixed);
+            }
+            else
+            {
+                suffixed = ResolveNestedAttributeName(suffixedName, arity);
+            }
+        }
+
+        if (IsAttributeType(direct) && IsAttributeType(suffixed))
         {
             Diagnostics.ReportAmbiguousAttributeName(nameLocation, name);
         }
 
         string resolvedLastSegment;
-        if (directExists)
+        if (IsAttributeType(direct))
         {
             nameIsExact = true;
             resolvedLastSegment = simpleName;
         }
-        else if (suffixedExists)
+        else if (suffixed != null)
         {
             nameIsExact = false;
-            resolvedLastSegment = Invariant.Required(suffixedName, "a detected suffixed attribute name is assigned before lookup");
+            resolvedLastSegment = simpleName + "Attribute";
+        }
+        else if (direct != null)
+        {
+            nameIsExact = true;
+            resolvedLastSegment = simpleName;
         }
         else if (dotIndex < 0)
         {
@@ -549,12 +565,129 @@ internal sealed partial class DeclarationBinder
             return resolved;
         }
 
-        if (name.IndexOf('.') >= 0 && scope.References.TryResolveType(name, out var clrType) && clrType != null)
+        if (name.IndexOf('.') >= 0)
         {
-            return TypeSymbol.FromClrType(clrType);
+            resolved = ResolveNestedAttributeName(name);
+            if (resolved != null)
+            {
+                return resolved;
+            }
+
+            if (scope.References.TryResolveType(name, out var clrType) && clrType != null)
+            {
+                return TypeSymbol.FromClrType(clrType);
+            }
         }
 
         return null;
+    }
+
+    private TypeSymbol? ResolveNestedAttributeName(string name, int preferredArity = -1)
+    {
+        string[] segments = name.Split('.');
+        if (segments.Length < 2)
+        {
+            return null;
+        }
+
+        for (int outerIndex = 0; outerIndex < segments.Length - 1; outerIndex++)
+        {
+            TypeSymbol? current = lookupType(segments[outerIndex]);
+            if (current == null || !QualifierMatchesContainingNamespace(current, segments, outerIndex))
+            {
+                continue;
+            }
+
+            bool resolved = true;
+            for (int i = outerIndex + 1; i < segments.Length; i++)
+            {
+                int arity = i == segments.Length - 1 ? preferredArity : -1;
+                if (scope.TryLookupNestedTypeAlias(current, segments[i], arity, out var nested))
+                {
+                    current = nested;
+                    continue;
+                }
+
+                if (current is StructSymbol container
+                    && scope.TryLookupNestedTypeAliasIncludingInherited(
+                        container,
+                        segments[i],
+                        arity,
+                        out nested,
+                        out _))
+                {
+                    current = nested;
+                    continue;
+                }
+
+                Type? containingType = current.ClrType;
+                Type? nestedClrType = null;
+                if (containingType != null && arity > 0)
+                {
+                    scope.References.TryResolveNestedType(
+                        containingType,
+                        segments[i] + "`" + arity,
+                        out nestedClrType);
+                }
+
+                if (containingType == null
+                    || (nestedClrType == null
+                        && !scope.References.TryResolveNestedType(
+                            containingType,
+                            segments[i],
+                            out nestedClrType)))
+                {
+                    resolved = false;
+                    break;
+                }
+
+                current = TypeSymbol.FromClrType(nestedClrType);
+            }
+
+            if (resolved)
+            {
+                return current;
+            }
+        }
+
+        return null;
+    }
+
+    private bool QualifierMatchesContainingNamespace(TypeSymbol type, string[] segments, int typeIndex)
+    {
+        if (typeIndex == 0)
+        {
+            return true;
+        }
+
+        string? containingNamespace = type switch
+        {
+            StructSymbol structure => structure.PackageName,
+            EnumSymbol @enum => @enum.PackageName,
+            InterfaceSymbol @interface => @interface.PackageName,
+            DelegateTypeSymbol @delegate => @delegate.PackageName,
+            _ => type.ClrType?.Namespace,
+        };
+        if (containingNamespace == null)
+        {
+            return false;
+        }
+
+        string qualifier = string.Join(".", segments, 0, typeIndex);
+        if (string.Equals(qualifier, containingNamespace, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        if (!scope.TryLookupImport(segments[0], out var import) || !import.IsAlias)
+        {
+            return false;
+        }
+
+        string expandedQualifier = typeIndex == 1
+            ? import.Target
+            : import.Target + "." + string.Join(".", segments, 1, typeIndex - 1);
+        return string.Equals(expandedQualifier, containingNamespace, StringComparison.Ordinal);
     }
 
     private bool IsAttributeType(TypeSymbol? typeSymbol)

--- a/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
+++ b/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
@@ -776,6 +776,22 @@ public sealed class ReferenceResolver : IDisposable
 
         if (requireExternalVisibility && !IsExternallyResolvable(resolved))
         {
+            // Issue #3445 follow-through: dependency assemblies can carry
+            // internal compatibility shims with the same full name as a public
+            // framework type. The raw index intentionally keeps first-writer
+            // precedence for infrastructure lookups, but user-written names
+            // must skip an inaccessible shim and continue to an accessible
+            // duplicate, matching C# reference resolution.
+            foreach (Assembly assembly in this.assemblies)
+            {
+                Type? candidate = SafeGetType(assembly, fullName);
+                if (candidate != null && IsExternallyResolvable(candidate))
+                {
+                    type = candidate;
+                    return true;
+                }
+            }
+
             return false;
         }
 

--- a/src/Repl/Program.cs
+++ b/src/Repl/Program.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using GSharp.Core.CodeAnalysis.Compilation;
@@ -205,10 +206,9 @@ public static class Program
     /// Parses gsc-style reference switches: <c>/r:&lt;file&gt;</c> or
     /// <c>/reference:&lt;file&gt;</c> (also accepted with a leading dash).
     /// </summary>
-    // Oats #3445: keep the out slot non-null until cs2gs preserves NotNullWhen's namespace import.
-    private static bool TryParseReferenceSwitch(string arg, out string referencePath)
+    private static bool TryParseReferenceSwitch(string arg, [NotNullWhen(true)] out string? referencePath)
     {
-        referencePath = string.Empty;
+        referencePath = null;
         if (arg.Length < 2 || (arg[0] != '/' && arg[0] != '-'))
         {
             return false;

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1206QualifiedAttributeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1206QualifiedAttributeTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
 using Xunit;
@@ -58,6 +59,57 @@ public class Issue1206QualifiedAttributeTests
         var attr = Assert.Single(helper.Attributes);
         Assert.Equal("System.ObsoleteAttribute", attr.AttributeType.Name);
         Assert.DoesNotContain(GetBinderDiagnostics(globalScope), d => d.Id == "GS0198");
+    }
+
+    [Fact]
+    public void Nested_UserAttribute_UsesContainerAndSuffix()
+    {
+        var globalScope = BindSource(
+            """
+            class NestedAttribute : Attribute {
+            }
+
+            class GenericAttribute[T] : Attribute {
+            }
+
+            class Holder {
+                class Nested {
+                }
+
+                class NestedAttribute : Attribute {
+                }
+
+                class Generic[T] {
+                }
+
+                class GenericAttribute[T] : Attribute {
+                }
+            }
+
+            @Holder.Nested
+            class Consumer {
+            }
+
+            @Holder.Generic[int32]
+            class GenericConsumer {
+            }
+            """);
+        var consumer = globalScope.Structs.Single(type => type.Name == "Consumer");
+        var genericConsumer = globalScope.Structs.Single(type => type.Name == "GenericConsumer");
+
+        var attribute = Assert.Single(consumer.Attributes);
+        var attributeType = Assert.IsType<StructSymbol>(attribute.AttributeType);
+        Assert.Equal("NestedAttribute", attributeType.Name);
+        Assert.Equal("Holder", attributeType.ContainingType?.Name);
+
+        var genericAttribute = Assert.Single(genericConsumer.Attributes);
+        var genericAttributeType = Assert.IsType<StructSymbol>(genericAttribute.AttributeType);
+        Assert.Equal("GenericAttribute", genericAttributeType.Name);
+        Assert.Equal(
+            "Holder",
+            (genericAttributeType.Definition ?? genericAttributeType).ContainingType?.Name);
+        Assert.Equal(TypeSymbol.Int32, Assert.Single(genericAttributeType.TypeArguments));
+        Assert.Empty(GetBinderDiagnostics(globalScope));
     }
 
     [Fact]

--- a/test/Core.Tests/CodeAnalysis/Symbols/ReferenceResolverTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/ReferenceResolverTests.cs
@@ -3,9 +3,12 @@
 // </copyright>
 
 using System;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using GSharp.Core.CodeAnalysis.Symbols;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Symbols;
@@ -132,6 +135,49 @@ public class ReferenceResolverTests
             typeof(System.Diagnostics.DiagnosticSource).FullName,
             requireExternalVisibility: false,
             out _));
+    }
+
+    [Fact]
+    public void TryResolveType_SkipsInternalDuplicateForPublicType()
+    {
+        string directory = Path.Combine(
+            AppContext.BaseDirectory,
+            "reference-resolver-3445",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+
+        try
+        {
+            string internalPath = EmitCollisionAssembly(
+                directory,
+                "InternalAttributeShim",
+                "internal");
+            string publicPath = EmitCollisionAssembly(
+                directory,
+                "PublicFrameworkType",
+                "public");
+            using var resolver = ReferenceResolver.WithReferences(new[]
+            {
+                internalPath,
+                publicPath,
+            });
+
+            Assert.True(resolver.TryResolveType(
+                "ResolverCollision3445.MarkerAttribute",
+                requireExternalVisibility: false,
+                out var raw));
+            Assert.Equal("InternalAttributeShim", raw.Assembly.GetName().Name);
+
+            Assert.True(resolver.TryResolveType(
+                "ResolverCollision3445.MarkerAttribute",
+                out var resolved));
+            Assert.True(resolved.IsPublic);
+            Assert.Equal("PublicFrameworkType", resolved.Assembly.GetName().Name);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
     }
 
     [Fact]
@@ -347,6 +393,32 @@ public class ReferenceResolverTests
         // cross-context identity mismatches the resolver exists to prevent).
         Assert.NotSame(typeof(string), stringType);
         Assert.NotSame(typeof(System.Console), consoleType);
+    }
+
+    private static string EmitCollisionAssembly(
+        string directory,
+        string assemblyName,
+        string accessibility)
+    {
+        string path = Path.Combine(directory, assemblyName + ".dll");
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            assemblyName,
+            new[]
+            {
+                CSharpSyntaxTree.ParseText(
+                    $"namespace ResolverCollision3445; {accessibility} sealed class MarkerAttribute {{ }}"),
+            },
+            new[]
+            {
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            },
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        using FileStream stream = File.Create(path);
+        Microsoft.CodeAnalysis.Emit.EmitResult result = compilation.Emit(stream);
+        Assert.True(
+            result.Success,
+            string.Join(Environment.NewLine, result.Diagnostics));
+        return path;
     }
 
     private static ReferenceResolver BuildMetadataLoadContextResolver()

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3445AttributeImportTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3445AttributeImportTranslationTests.cs
@@ -75,7 +75,6 @@ public sealed class Issue3445AttributeImportTranslationTests
                 [Marker]
                 [MarkerAttribute]
                 [AttributeAlias]
-                [global::External.Attributes.Marker]
                 [Generic<int>]
                 public sealed class Consumer
                 {
@@ -93,11 +92,34 @@ public sealed class Issue3445AttributeImportTranslationTests
             1,
             consumer.Split('\n').Count(line => line == "import External.Attributes"));
         Assert.Contains("@assembly:Marker", consumer, StringComparison.Ordinal);
-        Assert.Contains("@MarkerAttribute", consumer, StringComparison.Ordinal);
+        Assert.Contains(
+            "import AttributeAlias = External.Attributes.MarkerAttribute",
+            consumer,
+            StringComparison.Ordinal);
+        Assert.Contains("@AttributeAlias", consumer, StringComparison.Ordinal);
         Assert.Contains("@Generic[int32]", consumer, StringComparison.Ordinal);
         Assert.Contains("@return:Marker", consumer, StringComparison.Ordinal);
         Assert.Contains("@Marker value string", consumer, StringComparison.Ordinal);
         TranslationTestValidation.AssertBinds(translated.Values.ToArray());
+    }
+
+    [Fact]
+    public void QualifiedAttribute_PreservesNameAndSynthesizesImport()
+    {
+        IReadOnlyDictionary<string, string> translated = Translate(
+            ("Consumer.cs", """
+                namespace Demo;
+
+                [global::System.Obsolete]
+                public sealed class Consumer
+                {
+                }
+                """));
+
+        string consumer = translated["Consumer.cs"];
+        Assert.Contains("import System", consumer, StringComparison.Ordinal);
+        Assert.Contains("@System.Obsolete", consumer, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(consumer);
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3445AttributeImportTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3445AttributeImportTranslationTests.cs
@@ -1,0 +1,185 @@
+// <copyright file="Issue3445AttributeImportTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+public sealed class Issue3445AttributeImportTranslationTests
+{
+    [Fact]
+    public void NotNullWhen_FromGlobalUsing_SynthesizesImportAndBinds()
+    {
+        IReadOnlyDictionary<string, string> translated = Translate(
+            ("GlobalUsings.cs", "global using System.Diagnostics.CodeAnalysis;"),
+            ("Consumer.cs", """
+                #nullable enable
+
+                namespace Demo;
+
+                public static class Parser
+                {
+                    public static bool TryParse(
+                        string input,
+                        [NotNullWhen(true)] out string? value)
+                    {
+                        value = input.Length > 0 ? input : null;
+                        return value is not null;
+                    }
+                }
+                """));
+
+        string consumer = translated["Consumer.cs"];
+        Assert.Contains("import System.Diagnostics.CodeAnalysis", consumer, StringComparison.Ordinal);
+        Assert.Contains("@NotNullWhen(true) out value string?", consumer, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(translated.Values.ToArray());
+    }
+
+    [Fact]
+    public void AttributeTypes_UseSemanticNamesAndOneContainingNamespaceImport()
+    {
+        IReadOnlyDictionary<string, string> translated = Translate(
+            ("GlobalUsings.cs", """
+                global using External.Attributes;
+                global using AttributeAlias = External.Attributes.MarkerAttribute;
+                """),
+            ("Attributes.cs", """
+                using System;
+
+                namespace External.Attributes;
+
+                [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+                public sealed class MarkerAttribute : Attribute
+                {
+                }
+
+                public sealed class GenericAttribute<T> : Attribute
+                {
+                }
+
+                """),
+            ("Consumer.cs", """
+                [assembly: Marker]
+
+                namespace Demo;
+
+                [Marker]
+                [MarkerAttribute]
+                [AttributeAlias]
+                [global::External.Attributes.Marker]
+                [Generic<int>]
+                public sealed class Consumer
+                {
+                    [Marker]
+                    public string Value { get; } = "";
+
+                    [return: Marker]
+                    [Marker]
+                    public string Echo([Marker] string value) => value;
+                }
+                """));
+
+        string consumer = translated["Consumer.cs"];
+        Assert.Equal(
+            1,
+            consumer.Split('\n').Count(line => line == "import External.Attributes"));
+        Assert.Contains("@assembly:Marker", consumer, StringComparison.Ordinal);
+        Assert.Contains("@MarkerAttribute", consumer, StringComparison.Ordinal);
+        Assert.Contains("@Generic[int32]", consumer, StringComparison.Ordinal);
+        Assert.Contains("@return:Marker", consumer, StringComparison.Ordinal);
+        Assert.Contains("@Marker value string", consumer, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(translated.Values.ToArray());
+    }
+
+    [Fact]
+    public void NestedAttribute_TracksContainingNamespaceAndMappedName()
+    {
+        IReadOnlyDictionary<string, string> translated = Translate(
+            ("GlobalUsings.cs", "global using External.Attributes;"),
+            ("Attributes.cs", """
+                using System;
+
+                namespace External.Attributes;
+
+                public static class Holder
+                {
+                    public sealed class NestedAttribute : Attribute
+                    {
+                    }
+                }
+                """),
+            ("Consumer.cs", """
+                namespace Demo;
+
+                [Holder.Nested]
+                public sealed class Consumer
+                {
+                }
+                """));
+
+        string consumer = translated["Consumer.cs"];
+        Assert.Contains("import External.Attributes", consumer, StringComparison.Ordinal);
+        Assert.Contains("@Holder.Nested", consumer, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GlobalNamespaceAttribute_DoesNotSynthesizeImportAndBinds()
+    {
+        IReadOnlyDictionary<string, string> translated = Translate(
+            ("Attributes.cs", """
+                using System;
+
+                public sealed class MarkerAttribute : Attribute
+                {
+                }
+                """),
+            ("Consumer.cs", """
+                [Marker]
+                public sealed class Consumer
+                {
+                }
+                """));
+
+        string consumer = translated["Consumer.cs"];
+        Assert.DoesNotContain("import ", consumer, StringComparison.Ordinal);
+        Assert.Contains("@Marker", consumer, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(translated.Values.ToArray());
+    }
+
+    private static IReadOnlyDictionary<string, string> Translate(
+        params (string FileName, string Source)[] sources)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(sources);
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippets should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        var translator = new CSharpToGSharpTranslator();
+        var translated = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (LoadedDocument document in project.Documents.Where(document =>
+            Path.GetFileName(document.FilePath) != "GlobalUsings.cs"))
+        {
+            var context = new TranslationContext(
+                project.Compilation,
+                document.SemanticModel,
+                document.FilePath);
+            CompilationUnit unit = translator.TranslateDocument(document, context);
+            Assert.DoesNotContain(
+                context.Diagnostics,
+                diagnostic => diagnostic.Severity == TranslationSeverity.Unsupported);
+            translated.Add(Path.GetFileName(document.FilePath), GSharpPrinter.Print(unit));
+        }
+
+        return translated;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3445AttributeImportTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3445AttributeImportTranslationTests.cs
@@ -126,15 +126,38 @@ public sealed class Issue3445AttributeImportTranslationTests
     public void NestedAttribute_TracksContainingNamespaceAndMappedName()
     {
         IReadOnlyDictionary<string, string> translated = Translate(
-            ("GlobalUsings.cs", "global using External.Attributes;"),
+            ("GlobalUsings.cs", """
+                global using External.Attributes;
+                global using AttributeNamespace = External.Attributes;
+                """),
             ("Attributes.cs", """
                 using System;
 
                 namespace External.Attributes;
 
+                public sealed class NestedAttribute : Attribute
+                {
+                }
+
+                public sealed class GenericAttribute<T> : Attribute
+                {
+                }
+
                 public static class Holder
                 {
+                    public sealed class Nested
+                    {
+                    }
+
                     public sealed class NestedAttribute : Attribute
+                    {
+                    }
+
+                    public sealed class Generic<T>
+                    {
+                    }
+
+                    public sealed class GenericAttribute<T> : Attribute
                     {
                     }
                 }
@@ -146,11 +169,40 @@ public sealed class Issue3445AttributeImportTranslationTests
                 public sealed class Consumer
                 {
                 }
+
+                [Holder.NestedAttribute]
+                public sealed class ExplicitConsumer
+                {
+                }
+
+                [Holder.Generic<int>]
+                public sealed class GenericConsumer
+                {
+                }
+
+                [global::External.Attributes.Holder.Nested]
+                public sealed class QualifiedConsumer
+                {
+                }
+
+                [AttributeNamespace.Holder.Nested]
+                public sealed class AliasQualifiedConsumer
+                {
+                }
                 """));
 
         string consumer = translated["Consumer.cs"];
         Assert.Contains("import External.Attributes", consumer, StringComparison.Ordinal);
         Assert.Contains("@Holder.Nested", consumer, StringComparison.Ordinal);
+        Assert.Contains("@Holder.NestedAttribute", consumer, StringComparison.Ordinal);
+        Assert.Contains("@Holder.Generic[int32]", consumer, StringComparison.Ordinal);
+        Assert.Contains("@External.Attributes.Holder.Nested", consumer, StringComparison.Ordinal);
+        Assert.Contains("@AttributeNamespace.Holder.Nested", consumer, StringComparison.Ordinal);
+        Assert.Contains(
+            "import AttributeNamespace = External.Attributes",
+            consumer,
+            StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(translated.Values.ToArray());
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
@@ -1112,10 +1112,9 @@ public sealed partial class CSharpToGSharpTranslator
             return attributes;
         }
 
-        // Issue #3445: resolve attributes through the ordinary type mapper so
-        // their containing namespaces participate in synthesized imports and
-        // alias/qualified names expand to a bindable semantic type name. This
-        // also reuses the mapper's nested/generic naming and collision rules.
+        // Issue #3445: resolve attributes semantically so their containing
+        // namespaces and aliases participate in synthesized imports, while
+        // retaining source qualification and Attribute-suffix spelling.
         private string TranslateAttributeName(AttributeSyntax attribute)
         {
             ISymbol symbol = this.context.GetSymbolInfo(attribute).Symbol
@@ -1124,50 +1123,20 @@ public sealed partial class CSharpToGSharpTranslator
             {
                 IMethodSymbol constructor => constructor.ContainingType,
                 INamedTypeSymbol namedType => namedType,
-                IAliasSymbol alias => alias.Target as INamedTypeSymbol,
+                IAliasSymbol aliasSymbol => aliasSymbol.Target as INamedTypeSymbol,
                 _ => null,
             };
-            if (attributeType == null)
-            {
-                return this.TranslateUnresolvedAttributeName(attribute.Name);
-            }
-
-            GTypeReference mappedType = this.typeMapper.Map(
-                attributeType,
-                this.context,
-                attribute.GetLocation());
-            if (mappedType is NamedTypeReference named
-                && AttributeSuffixWasElided(attribute.Name, attributeType)
-                && named.Name.EndsWith("Attribute", System.StringComparison.Ordinal))
-            {
-                mappedType = new NamedTypeReference(
-                    named.Name.Substring(0, named.Name.Length - "Attribute".Length),
-                    named.TypeArguments,
-                    named.ContainingType);
-            }
-
-            return GSharpPrinter.RenderTypeReference(mappedType);
+            IAliasSymbol sourceAlias = attribute.Name
+                .DescendantNodesAndSelf()
+                .OfType<IdentifierNameSyntax>()
+                .Select(identifier => this.context.SemanticModel.GetAliasInfo(identifier))
+                .FirstOrDefault(candidate => candidate != null);
+            this.typeMapper.TrackAttributeType(attributeType, sourceAlias);
+            return this.TranslateUnresolvedAttributeName(attribute.Name);
         }
 
-        private static bool AttributeSuffixWasElided(
-            NameSyntax nameSyntax,
-            INamedTypeSymbol attributeType)
-        {
-            SimpleNameSyntax simpleName = nameSyntax switch
-            {
-                SimpleNameSyntax simple => simple,
-                QualifiedNameSyntax qualified => qualified.Right,
-                AliasQualifiedNameSyntax aliasQualified => aliasQualified.Name,
-                _ => null,
-            };
-
-            return simpleName != null
-                && attributeType.Name == simpleName.Identifier.ValueText + "Attribute";
-        }
-
-        // Issue #1913 fallback for an unresolved C# 11 generic attribute:
-        // convert angle-bracket type arguments to G# square brackets while
-        // retaining the source name for diagnostic-tolerant translation.
+        // Issue #1913: convert C# generic attribute angle brackets to G# square
+        // brackets while retaining the source name and qualification.
         private string TranslateUnresolvedAttributeName(NameSyntax nameSyntax)
         {
             string attributeName = nameSyntax.ToString();

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
@@ -1090,6 +1090,7 @@ public sealed partial class CSharpToGSharpTranslator
                 string target = list.Target?.Identifier.Text;
                 foreach (AttributeSyntax attribute in list.Attributes)
                 {
+                    using IDisposable modelScope = this.context.UseSemanticModelFor(attribute.SyntaxTree);
                     var arguments = new List<AttributeArgument>();
                     if (attribute.ArgumentList != null)
                     {
@@ -1102,7 +1103,7 @@ public sealed partial class CSharpToGSharpTranslator
                         }
                     }
 
-                    string attributeName = this.TranslateAttributeName(attribute.Name);
+                    string attributeName = this.TranslateAttributeName(attribute);
 
                     attributes.Add(new AttributeUse(attributeName, arguments, target));
                 }
@@ -1111,16 +1112,63 @@ public sealed partial class CSharpToGSharpTranslator
             return attributes;
         }
 
-        // Issue #1913: a C# 11 generic attribute (`[Tag<int>]`) parses its type
-        // arguments in ANGLE brackets, so `nameSyntax.ToString()` carries them as
-        // `Tag<int>` verbatim. G# has no angle-bracket syntax at all (ADR-0020) —
-        // every generic construct, including a generic attribute, spells its
-        // type-argument list in SQUARE brackets. Reuse the same
-        // <see cref="MapTypeArguments"/>/<see cref="GSharpPrinter.RenderTypeReference"/>
-        // path a generic type reference or generic call already routes through,
-        // rather than hand-rolling the bracket text, so an unsupported/unresolvable
-        // type argument still gets the placeholder the type mapper already emits.
-        private string TranslateAttributeName(NameSyntax nameSyntax)
+        // Issue #3445: resolve attributes through the ordinary type mapper so
+        // their containing namespaces participate in synthesized imports and
+        // alias/qualified names expand to a bindable semantic type name. This
+        // also reuses the mapper's nested/generic naming and collision rules.
+        private string TranslateAttributeName(AttributeSyntax attribute)
+        {
+            ISymbol symbol = this.context.GetSymbolInfo(attribute).Symbol
+                ?? this.context.GetSymbolInfo(attribute.Name).Symbol;
+            INamedTypeSymbol attributeType = symbol switch
+            {
+                IMethodSymbol constructor => constructor.ContainingType,
+                INamedTypeSymbol namedType => namedType,
+                IAliasSymbol alias => alias.Target as INamedTypeSymbol,
+                _ => null,
+            };
+            if (attributeType == null)
+            {
+                return this.TranslateUnresolvedAttributeName(attribute.Name);
+            }
+
+            GTypeReference mappedType = this.typeMapper.Map(
+                attributeType,
+                this.context,
+                attribute.GetLocation());
+            if (mappedType is NamedTypeReference named
+                && AttributeSuffixWasElided(attribute.Name, attributeType)
+                && named.Name.EndsWith("Attribute", System.StringComparison.Ordinal))
+            {
+                mappedType = new NamedTypeReference(
+                    named.Name.Substring(0, named.Name.Length - "Attribute".Length),
+                    named.TypeArguments,
+                    named.ContainingType);
+            }
+
+            return GSharpPrinter.RenderTypeReference(mappedType);
+        }
+
+        private static bool AttributeSuffixWasElided(
+            NameSyntax nameSyntax,
+            INamedTypeSymbol attributeType)
+        {
+            SimpleNameSyntax simpleName = nameSyntax switch
+            {
+                SimpleNameSyntax simple => simple,
+                QualifiedNameSyntax qualified => qualified.Right,
+                AliasQualifiedNameSyntax aliasQualified => aliasQualified.Name,
+                _ => null,
+            };
+
+            return simpleName != null
+                && attributeType.Name == simpleName.Identifier.ValueText + "Attribute";
+        }
+
+        // Issue #1913 fallback for an unresolved C# 11 generic attribute:
+        // convert angle-bracket type arguments to G# square brackets while
+        // retaining the source name for diagnostic-tolerant translation.
+        private string TranslateUnresolvedAttributeName(NameSyntax nameSyntax)
         {
             string attributeName = nameSyntax.ToString();
             int aliasSeparator = attributeName.IndexOf("::", System.StringComparison.Ordinal);

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -383,7 +383,8 @@ public sealed partial class CSharpToGSharpTranslator
             }
         }
 
-        var alreadyImported = new HashSet<string>(allImports.Select(i => i.Name));
+        var alreadyImported = new HashSet<string>(
+            allImports.Where(import => import.Alias == null).Select(import => import.Name));
         foreach (string ns in typeMapper.ShortenedNamespaces.OrderBy(n => n, System.StringComparer.Ordinal))
         {
             if (ns != package && alreadyImported.Add(ns))

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -169,6 +169,33 @@ public sealed class CSharpTypeMapper
     public IReadOnlyList<TypeDeclaration> PendingAnonymousDataClasses => this.pendingAnonymousDataClasses;
 
     /// <summary>
+    /// Records a translated attribute type's containing namespace and any
+    /// source alias so the compilation-unit import synthesis can resolve the
+    /// attribute without changing its source spelling.
+    /// </summary>
+    /// <param name="attributeType">The semantically resolved attribute type.</param>
+    /// <param name="alias">The alias used by the attribute name, if any.</param>
+    public void TrackAttributeType(INamedTypeSymbol attributeType, IAliasSymbol alias)
+    {
+        if (attributeType != null)
+        {
+            this.TrackShortenedNamespace(attributeType);
+        }
+
+        string aliasTarget = alias?.Target switch
+        {
+            INamespaceSymbol ns when !ns.IsGlobalNamespace => ns.ToDisplayString(),
+            INamedTypeSymbol type => StripGlobalPrefix(
+                type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)),
+            _ => null,
+        };
+        if (!string.IsNullOrEmpty(aliasTarget))
+        {
+            this.synthesizedTypeAliases[alias.Name] = aliasTarget;
+        }
+    }
+
+    /// <summary>
     /// Records the declaring namespace of a resolved extension-method
     /// invocation or method-group reference into the same shortened-namespace
     /// tracking set used for type imports (see <see cref="shortenedNamespaces"/>),


### PR DESCRIPTION
## Summary

- resolve translated attributes semantically so containing namespaces and aliases flow into synthesized imports while preserving source qualification, `Attribute` suffix spelling, generic arguments, and declaration targets
- resolve source and CLR nested attribute types through their containing-type chains, including suffix elision, generic nested attributes, namespace/type aliases, fully-qualified names, inherited containers, and same-name collision safety
- treat aliased imports separately from bare namespace imports so alias synthesis cannot suppress an import required by an unaliased attribute spelling
- restore `Repl.Program.TryParseReferenceSwitch` to its nullable `[NotNullWhen(true)]` contract
- skip inaccessible compatibility shims when a later referenced assembly exposes the public type with the same full name; migrated gsi needs this because MessagePack.Annotations precedes the framework reference with an internal `NotNullWhenAttribute` shim
- add focused translation/binding and reference-resolution regressions

## Validation

- attribute/binder/resolver focused suites — **93 passed**
- cs2gs attribute/import focused suites — **28 passed**
- `python3 build/nullable_hygiene.py` — PASS
- `dotnet build GSharp.sln -c Release --no-restore -warnaserror` — 0 warnings, 0 errors
- targeted gsi migration run `2026-08-18T21-39-14Z_37ef00` — translate, compile, ILVerify, and test parity PASS; generated `Program.gs` contains `import System.Diagnostics.CodeAnalysis` and `@NotNullWhen(true) out referencePath string?`; all classes and methods in target `gsi.dll` verified

Nullable-hygiene guard review: new attribute-binder branches select exact versus `Attribute`-suffixed candidates and stop only when a qualifier/type segment is absent or belongs to another namespace. They extend previously failing nested-name resolution; existing simple and CLR-qualified success paths remain unchanged. Resolver fallback guard still only skips assemblies that do not define an accessible colliding type.

Fixes #3445
