### PR TITLE
Eliminate remaining cs2gs spills

### DIFF
--- a/docs/adr/0115-csharp-to-gsharp-migration-tool.md
+++ b/docs/adr/0115-csharp-to-gsharp-migration-tool.md
@@ -162,10 +162,15 @@ class contains a private nested aggregate, its extension methods stay as
 ordinary static methods in that owner's `shared` block. A forwarding
 receiver-clause companion keeps reduced calls, null-conditional calls, and
 method groups in member form when the source method is accessible and the
-companion would not collide with an instance or sibling extension signature.
-Async companions await the retained `Task`/`Task<T>` helper so their own
-`async func` keeps G#'s unwrapped return convention. Explicitly qualified calls
-still use `Owner.M(receiver, …)`.
+effectively-public owner would not collide with an instance or package-wide
+sibling extension after both signatures map to canonical G# types. Sibling
+project scans use source compilations and deduplicate their metadata copies.
+Async invocation companions await the retained `Task`/`Task<T>` helper so
+their own `async func` keeps G#'s unwrapped return convention; Task-shaped
+method groups keep the static-helper lambda because their delegate contract
+still exposes the Task envelope. Explicitly qualified calls still use
+`Owner.M(receiver, …)`. Private, extern, or effectively non-public owner
+methods keep the static-helper form exclusively.
 Lifting the original bodies to top-level receiver funcs would move them onto the
 synthetic `<Program>` type, which cannot legally access the retained private
 nested type or members whose signatures contain it.

--- a/docs/adr/0115-csharp-to-gsharp-migration-tool.md
+++ b/docs/adr/0115-csharp-to-gsharp-migration-tool.md
@@ -159,9 +159,11 @@ C# **extension methods** (`static R M(this T self, …)`) translate to `func (se
 
 Issue #3413 adds one ownership-preserving exception: when the declaring static
 class contains a private nested aggregate, its extension methods stay as
-ordinary static methods in that owner's `shared` block. Translated call sites
-use `Owner.M(receiver, …)`, including calls from sibling migrated projects.
-Lifting those bodies to top-level receiver funcs would move them onto the
+ordinary static methods in that owner's `shared` block. A forwarding
+receiver-clause companion keeps reduced calls, null-conditional calls, and
+method groups in member form without moving the original body or its CLR
+declaring identity; explicitly qualified calls still use `Owner.M(receiver, …)`.
+Lifting the original bodies to top-level receiver funcs would move them onto the
 synthetic `<Program>` type, which cannot legally access the retained private
 nested type or members whose signatures contain it.
 

--- a/docs/adr/0115-csharp-to-gsharp-migration-tool.md
+++ b/docs/adr/0115-csharp-to-gsharp-migration-tool.md
@@ -161,8 +161,11 @@ Issue #3413 adds one ownership-preserving exception: when the declaring static
 class contains a private nested aggregate, its extension methods stay as
 ordinary static methods in that owner's `shared` block. A forwarding
 receiver-clause companion keeps reduced calls, null-conditional calls, and
-method groups in member form without moving the original body or its CLR
-declaring identity; explicitly qualified calls still use `Owner.M(receiver, …)`.
+method groups in member form when the source method is accessible and the
+companion would not collide with an instance or sibling extension signature.
+Async companions await the retained `Task`/`Task<T>` helper so their own
+`async func` keeps G#'s unwrapped return convention. Explicitly qualified calls
+still use `Owner.M(receiver, …)`.
 Lifting the original bodies to top-level receiver funcs would move them onto the
 synthetic `<Program>` type, which cannot legally access the retained private
 nested type or members whose signatures contain it.

--- a/docs/self-migration-spike-3394.md
+++ b/docs/self-migration-spike-3394.md
@@ -595,9 +595,9 @@ and cs2gs migrations each pass translation, compilation, ILVerify, and
 pipeline parity with those source shapes restored.
 
 Extension-bearing owners with private nested aggregates also keep extension
-bodies in-owner as static helpers; translated receiver calls are rewritten to
-those helpers across sibling projects. This preserves private nested access
-without widening the nested type. The pinned Oahu gate passes all 15 projects,
+bodies in-owner as static helpers. Forwarding receiver companions preserve
+member-form calls across sibling projects without moving those bodies or
+widening the nested type. The pinned Oahu gate passes all 15 projects,
 including the former `MethodAccess` and `FieldAccess` ILVerify failures.
 
 ## Pinned code-exploder continuation (#3395)

--- a/docs/self-migration-spike-3394.md
+++ b/docs/self-migration-spike-3394.md
@@ -596,8 +596,9 @@ pipeline parity with those source shapes restored.
 
 Extension-bearing owners with private nested aggregates also keep extension
 bodies in-owner as static helpers. Forwarding receiver companions preserve
-member-form calls across sibling projects without moving those bodies or
-widening the nested type. The pinned Oahu gate passes all 15 projects,
+member-form calls across sibling projects when accessibility and overload
+collisions permit, without moving those bodies or widening the nested type.
+The pinned Oahu gate passes all 15 projects,
 including the former `MethodAccess` and `FieldAccess` ILVerify failures.
 
 ## Pinned code-exploder continuation (#3395)

--- a/docs/self-migration-spike-3394.md
+++ b/docs/self-migration-spike-3394.md
@@ -597,7 +597,8 @@ pipeline parity with those source shapes restored.
 Extension-bearing owners with private nested aggregates also keep extension
 bodies in-owner as static helpers. Forwarding receiver companions preserve
 member-form calls across sibling projects when accessibility and overload
-collisions permit, without moving those bodies or widening the nested type.
+collisions permit, using canonical emitted signatures and deduplicated source /
+metadata views, without moving those bodies or widening the nested type.
 The pinned Oahu gate passes all 15 projects,
 including the former `MethodAccess` and `FieldAccess` ILVerify failures.
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2546MethodGroupPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2546MethodGroupPipelineTests.cs
@@ -43,8 +43,8 @@ public sealed class Issue2546MethodGroupPipelineTests
         string emitted = ReadAppOutput(outputRoot, result.RunId, app.AppId);
 
         Assert.Contains("records.Select(ToDictionary)", emitted, StringComparison.Ordinal);
-        Assert.Contains("selected.Where(func (__arg0 string) bool", emitted, StringComparison.Ordinal);
-        Assert.Contains("return byAsin.ContainsKey(__arg0)", emitted, StringComparison.Ordinal);
+        Assert.Contains("selected.Where(byAsin.ContainsKey)", emitted, StringComparison.Ordinal);
+        Assert.DoesNotContain("selected.Where(func", emitted, StringComparison.Ordinal);
         Assert.Contains("sessions", emitted, StringComparison.Ordinal);
         Assert.Contains(".Count)", emitted, StringComparison.Ordinal);
         Assert.True(

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3347RemainingSpillInventoryTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3347RemainingSpillInventoryTests.cs
@@ -41,6 +41,7 @@ public sealed class Issue3347RemainingSpillInventoryTests
         var translator = new CSharpToGSharpTranslator(preservePartialParts: true);
         int castCount = 0;
         int deconstructionCount = 0;
+        int spillCount = 0;
         int usingCount = 0;
         foreach (LoadedDocument document in project.Documents)
         {
@@ -52,11 +53,13 @@ public sealed class Issue3347RemainingSpillInventoryTests
                 translator.TranslateDocument(document, context));
             castCount += CountOccurrences(printed, "__cast");
             deconstructionCount += CountOccurrences(printed, "__decon");
+            spillCount += CountOccurrences(printed, "let __spill");
             usingCount += CountOccurrences(printed, "__using");
         }
 
         Assert.Equal(0, castCount);
         Assert.Equal(0, deconstructionCount);
+        Assert.Equal(0, spillCount);
         Assert.Equal(0, usingCount);
     }
 
@@ -246,6 +249,74 @@ public sealed class Issue3347RemainingSpillInventoryTests
         Assert.DoesNotContain("&& true", printed, StringComparison.Ordinal);
         Assert.Contains("C.GetItem() is { X: var x, Y: > 0 } && x > 0", printed, StringComparison.Ordinal);
         Assert.Equal(1, CountOccurrences(printed, "C.GetItem()"));
+    }
+
+    [Fact]
+    public void MutableNestedGuardBinder_UsesNativeMatchThenAuthorNamedStorage()
+    {
+        string printed = Translate(
+            """
+            using Microsoft.CodeAnalysis;
+            using Microsoft.CodeAnalysis.CSharp.Syntax;
+            using System.Linq;
+
+            public static class C
+            {
+                public static bool IsAsLocal(ILocalSymbol local)
+                {
+                    if (local.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax()
+                        is not VariableDeclaratorSyntax { Initializer.Value: { } initializer })
+                    {
+                        return false;
+                    }
+
+                    while (initializer is ParenthesizedExpressionSyntax parenthesized)
+                    {
+                        initializer = parenthesized.Expression;
+                    }
+
+                    return initializer is BinaryExpressionSyntax;
+                }
+            }
+            """);
+
+        Assert.DoesNotContain("__spill", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("&& true", printed, StringComparison.Ordinal);
+        Assert.Contains("initializerMatch", printed, StringComparison.Ordinal);
+        Assert.Contains("var initializer ExpressionSyntax = initializerMatch", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NullabilityOnlyMethodGroupDifference_UsesDirectMemberReference()
+    {
+        string printed = Translate(
+            """
+            using System;
+            using System.Diagnostics.CodeAnalysis;
+
+            public sealed class Mapper
+            {
+                [return: NotNullIfNotNull(nameof(value))]
+                public string? Map(string? value) => value;
+            }
+
+            public sealed class Holder
+            {
+                public Mapper Mapper { get; } = new Mapper();
+            }
+
+            public static class C
+            {
+                private static string Apply(string value, Func<string, string> map) => map(value);
+
+                public static string Run(Holder holder, string value) =>
+                    Apply(value, holder.Mapper.Map);
+            }
+            """);
+
+        Assert.Contains("C.Apply(value, holder.Mapper.Map)", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("__spill", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("__arg", printed, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3347RemainingSpillInventoryTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3347RemainingSpillInventoryTests.cs
@@ -25,7 +25,9 @@ public sealed class Issue3347RemainingSpillInventoryTests
     /// Issue #3423 ratchet. Regenerated from <c>be857f02c4</c>, Core started
     /// with 16 <c>__castN</c> occurrences (8 block conversions), 22
     /// <c>__deconN</c> occurrences (11 temp names), and 17 <c>__using</c>
-    /// declarations. All three families are now retired from Core output.
+    /// declarations. Those families and issue #3347's <c>__spillN</c>
+    /// declarations are now retired from Core output; the companion translator
+    /// project ratchet below protects its independently verified zero-spill output.
     /// </summary>
     [Fact]
     public async Task CoreMigration_RemainingSynthesizedNameFamiliesStayRetired()
@@ -61,6 +63,38 @@ public sealed class Issue3347RemainingSpillInventoryTests
         Assert.Equal(0, deconstructionCount);
         Assert.Equal(0, spillCount);
         Assert.Equal(0, usingCount);
+    }
+
+    [Fact]
+    public async Task TranslatorMigration_SpillFamilyStaysRetired()
+    {
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        LoadedCSharpProject project = await CSharpProjectLoader.LoadProjectAsync(
+            Path.Combine(
+                repoRoot,
+                "tools",
+                "cs2gs",
+                "Cs2Gs.Translator",
+                "Cs2Gs.Translator.csproj"));
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Translator should bind with no C# errors: "
+                + string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        var translator = new CSharpToGSharpTranslator(preservePartialParts: true);
+        int spillCount = 0;
+        foreach (LoadedDocument document in project.Documents)
+        {
+            var context = new TranslationContext(
+                project.Compilation,
+                document.SemanticModel,
+                document.FilePath);
+            string printed = GSharpPrinter.Print(
+                translator.TranslateDocument(document, context));
+            spillCount += CountOccurrences(printed, "let __spill");
+        }
+
+        Assert.Equal(0, spillCount);
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3413NestedPrivateClassTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3413NestedPrivateClassTranslationTests.cs
@@ -137,9 +137,12 @@ public sealed class Issue3413NestedPrivateClassTranslationTests
             extensionShared.Members.OfType<FieldDeclaration>().Single(field => field.Name == "cache").Visibility);
         Assert.Contains(extensionShared.Members.OfType<MethodDeclaration>(), method => method.Name == "Identity");
         Assert.Contains(extensionShared.Members.OfType<MethodDeclaration>(), method => method.Name == "AddCached");
-        Assert.DoesNotContain(
+        Assert.Contains(
             unit.Members.OfType<MethodDeclaration>(),
-            method => method.Name is "Identity" or "AddCached");
+            method => method.Name == "Identity");
+        Assert.Contains(
+            unit.Members.OfType<MethodDeclaration>(),
+            method => method.Name == "AddCached");
 
         string rendered = GSharpPrinter.Print(unit);
         Assert.Contains("private class EntryHelper[T]", rendered, StringComparison.Ordinal);
@@ -191,10 +194,14 @@ public sealed class Issue3413NestedPrivateClassTranslationTests
 
         Assert.Equal(Visibility.Private, cache.Visibility);
         Assert.Contains(shared.Members.OfType<MethodDeclaration>(), method => method.Name == "Identity");
-        Assert.DoesNotContain(unit.Members.OfType<MethodDeclaration>(), method => method.Name == "Identity");
+        Assert.Contains(unit.Members.OfType<MethodDeclaration>(), method => method.Name == "Identity");
         Assert.Contains("private class Cache[T]", rendered, StringComparison.Ordinal);
         Assert.Contains("Cache[T].Echo(value)", rendered, StringComparison.Ordinal);
         Assert.Contains("ExtensionOwner.Identity", rendered, StringComparison.Ordinal);
+        Assert.Contains(
+            "func (value T) Identity[T]() T -> ExtensionOwner.Identity[T](value)",
+            rendered,
+            StringComparison.Ordinal);
     }
 
     [Fact]
@@ -392,8 +399,11 @@ public sealed class Issue3413NestedPrivateClassTranslationTests
 
         Assert.Contains("private class Box[T]", printedProducer, StringComparison.Ordinal);
         Assert.Contains("func Echo[T](value T) T", printedProducer, StringComparison.Ordinal);
-        Assert.DoesNotContain("func (value T) Echo", printedProducer, StringComparison.Ordinal);
-        Assert.Contains("Extensions.Echo(value)", printedConsumer, StringComparison.Ordinal);
+        Assert.Contains(
+            "func (value T) Echo[T]() T -> Extensions.Echo[T](value)",
+            printedProducer,
+            StringComparison.Ordinal);
+        Assert.Contains("value.Echo()", printedConsumer, StringComparison.Ordinal);
         TranslationTestValidation.AssertBinds(printedProducer, printedConsumer);
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3413NestedPrivateClassTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3413NestedPrivateClassTranslationTests.cs
@@ -52,6 +52,8 @@ public sealed class Issue3413NestedPrivateClassTranslationTests
                     Console.WriteLine(lengthAsync().GetAwaiter().GetResult());
                     Func<Task> delayAsync = "later".DelayTextAsync;
                     delayAsync().GetAwaiter().GetResult();
+                    Console.WriteLine(9.ValueAsync().AsTask().GetAwaiter().GetResult());
+                    10.ValueNoteAsync().AsTask().GetAwaiter().GetResult();
                     Console.WriteLine("async");
                 }
             }
@@ -94,6 +96,17 @@ public sealed class Issue3413NestedPrivateClassTranslationTests
                 }
 
                 public static async Task DelayTextAsync(this string value)
+                {
+                    await Task.Yield();
+                }
+
+                public static async ValueTask<int> ValueAsync(this int value)
+                {
+                    await Task.Yield();
+                    return value;
+                }
+
+                public static async ValueTask ValueNoteAsync(this int value)
                 {
                     await Task.Yield();
                 }
@@ -172,6 +185,8 @@ public sealed class Issue3413NestedPrivateClassTranslationTests
         Assert.Contains(extensionShared.Members.OfType<MethodDeclaration>(), method => method.Name == "DelayAsync");
         Assert.Contains(extensionShared.Members.OfType<MethodDeclaration>(), method => method.Name == "LengthAsync");
         Assert.Contains(extensionShared.Members.OfType<MethodDeclaration>(), method => method.Name == "DelayTextAsync");
+        Assert.Contains(extensionShared.Members.OfType<MethodDeclaration>(), method => method.Name == "ValueAsync");
+        Assert.Contains(extensionShared.Members.OfType<MethodDeclaration>(), method => method.Name == "ValueNoteAsync");
         Assert.Contains(
             unit.Members.OfType<MethodDeclaration>(),
             method => method.Name == "Identity");
@@ -190,6 +205,12 @@ public sealed class Issue3413NestedPrivateClassTranslationTests
         Assert.Contains(
             unit.Members.OfType<MethodDeclaration>(),
             method => method.Name == "DelayTextAsync");
+        Assert.Contains(
+            unit.Members.OfType<MethodDeclaration>(),
+            method => method.Name == "ValueAsync");
+        Assert.Contains(
+            unit.Members.OfType<MethodDeclaration>(),
+            method => method.Name == "ValueNoteAsync");
 
         string rendered = GSharpPrinter.Print(unit);
         Assert.Contains("private class EntryHelper[T]", rendered, StringComparison.Ordinal);
@@ -311,6 +332,8 @@ public sealed class Issue3413NestedPrivateClassTranslationTests
                 public sealed class Host
                 {
                     public string Describe() => "instance";
+
+                    public string func_() => "instance keyword";
                 }
 
                 public static class OwnerScoped
@@ -322,11 +345,17 @@ public sealed class Issue3413NestedPrivateClassTranslationTests
                     public static string Describe(this Host host) => "extension";
 
                     public static string Format(this string value) => "owner";
+
+                    public static string @func(this Host host) => "extension keyword";
+
+                    public static string @func(this string value) => "owner keyword";
                 }
 
                 public static class Sibling
                 {
                     public static string Format(this string value) => "sibling";
+
+                    public static string func_(this string value) => "sibling keyword";
                 }
             }
             """;
@@ -346,6 +375,9 @@ public sealed class Issue3413NestedPrivateClassTranslationTests
         Assert.Single(
             unit.Members.OfType<MethodDeclaration>(),
             method => method.Name == "Format");
+        Assert.Single(
+            unit.Members.OfType<MethodDeclaration>(),
+            method => method.Name == "func_");
         TranslationTestValidation.AssertBinds(rendered);
     }
 
@@ -507,7 +539,7 @@ public sealed class Issue3413NestedPrivateClassTranslationTests
             """);
         File.WriteAllText(Path.Combine(projectDirectory, "Program.cs"), Source);
         string goldenPath = Path.Combine(projectDirectory, "baseline.stdout.golden");
-        File.WriteAllText(goldenPath, "42\n1\n42\n6\n4\nasync\n");
+        File.WriteAllText(goldenPath, "42\n1\n42\n6\n4\n9\nasync\n");
 
         string outputRoot = NewDirectory("pipeline-tests");
         var app = new CorpusApp(
@@ -554,6 +586,22 @@ public sealed class Issue3413NestedPrivateClassTranslationTests
             StringComparison.Ordinal);
         Assert.Contains(
             "let delayAsync async () -> void = () -> ExtensionOwner.DelayTextAsync(\"later\")",
+            translated,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "async func (value int32) ValueAsync() ValueTask[int32]",
+            translated,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "return await ExtensionOwner.ValueAsync(value)",
+            translated,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "async func (value int32) ValueNoteAsync() ValueTask",
+            translated,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "await ExtensionOwner.ValueNoteAsync(value)",
             translated,
             StringComparison.Ordinal);
         Assert.Contains("class GenericOwner[TOuter]", translated, StringComparison.Ordinal);
@@ -605,6 +653,12 @@ public sealed class Issue3413NestedPrivateClassTranslationTests
         Assert.Equal(
             extensionOwner,
             extensionOwner.GetMethod("DelayTextAsync", BindingFlags.Public | BindingFlags.Static)!.DeclaringType);
+        Assert.Equal(
+            extensionOwner,
+            extensionOwner.GetMethod("ValueAsync", BindingFlags.Public | BindingFlags.Static)!.DeclaringType);
+        Assert.Equal(
+            extensionOwner,
+            extensionOwner.GetMethod("ValueNoteAsync", BindingFlags.Public | BindingFlags.Static)!.DeclaringType);
 
         Type genericOwner = Assert.Single(
             assembly.GetTypes(),

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3413NestedPrivateClassTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3413NestedPrivateClassTranslationTests.cs
@@ -54,6 +54,10 @@ public sealed class Issue3413NestedPrivateClassTranslationTests
                     delayAsync().GetAwaiter().GetResult();
                     Console.WriteLine(9.ValueAsync().AsTask().GetAwaiter().GetResult());
                     10.ValueNoteAsync().AsTask().GetAwaiter().GetResult();
+                    Func<ValueTask<int>> valueLengthAsync = "five".ValueLengthAsync;
+                    Console.WriteLine(valueLengthAsync().AsTask().GetAwaiter().GetResult());
+                    Func<ValueTask> valueDelayAsync = "later".ValueDelayAsync;
+                    valueDelayAsync().AsTask().GetAwaiter().GetResult();
                     Console.WriteLine("async");
                 }
             }
@@ -107,6 +111,17 @@ public sealed class Issue3413NestedPrivateClassTranslationTests
                 }
 
                 public static async ValueTask ValueNoteAsync(this int value)
+                {
+                    await Task.Yield();
+                }
+
+                public static async ValueTask<int> ValueLengthAsync(this string value)
+                {
+                    await Task.Yield();
+                    return value.Length;
+                }
+
+                public static async ValueTask ValueDelayAsync(this string value)
                 {
                     await Task.Yield();
                 }
@@ -187,6 +202,8 @@ public sealed class Issue3413NestedPrivateClassTranslationTests
         Assert.Contains(extensionShared.Members.OfType<MethodDeclaration>(), method => method.Name == "DelayTextAsync");
         Assert.Contains(extensionShared.Members.OfType<MethodDeclaration>(), method => method.Name == "ValueAsync");
         Assert.Contains(extensionShared.Members.OfType<MethodDeclaration>(), method => method.Name == "ValueNoteAsync");
+        Assert.Contains(extensionShared.Members.OfType<MethodDeclaration>(), method => method.Name == "ValueLengthAsync");
+        Assert.Contains(extensionShared.Members.OfType<MethodDeclaration>(), method => method.Name == "ValueDelayAsync");
         Assert.Contains(
             unit.Members.OfType<MethodDeclaration>(),
             method => method.Name == "Identity");
@@ -211,6 +228,12 @@ public sealed class Issue3413NestedPrivateClassTranslationTests
         Assert.Contains(
             unit.Members.OfType<MethodDeclaration>(),
             method => method.Name == "ValueNoteAsync");
+        Assert.Contains(
+            unit.Members.OfType<MethodDeclaration>(),
+            method => method.Name == "ValueLengthAsync");
+        Assert.Contains(
+            unit.Members.OfType<MethodDeclaration>(),
+            method => method.Name == "ValueDelayAsync");
 
         string rendered = GSharpPrinter.Print(unit);
         Assert.Contains("private class EntryHelper[T]", rendered, StringComparison.Ordinal);
@@ -539,7 +562,7 @@ public sealed class Issue3413NestedPrivateClassTranslationTests
             """);
         File.WriteAllText(Path.Combine(projectDirectory, "Program.cs"), Source);
         string goldenPath = Path.Combine(projectDirectory, "baseline.stdout.golden");
-        File.WriteAllText(goldenPath, "42\n1\n42\n6\n4\n9\nasync\n");
+        File.WriteAllText(goldenPath, "42\n1\n42\n6\n4\n9\n4\nasync\n");
 
         string outputRoot = NewDirectory("pipeline-tests");
         var app = new CorpusApp(
@@ -604,6 +627,14 @@ public sealed class Issue3413NestedPrivateClassTranslationTests
             "await ExtensionOwner.ValueNoteAsync(value)",
             translated,
             StringComparison.Ordinal);
+        Assert.Contains(
+            "let valueLengthAsync () -> ValueTask[int32] = () -> ExtensionOwner.ValueLengthAsync(\"five\")",
+            translated,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "let valueDelayAsync () -> ValueTask = () -> ExtensionOwner.ValueDelayAsync(\"later\")",
+            translated,
+            StringComparison.Ordinal);
         Assert.Contains("class GenericOwner[TOuter]", translated, StringComparison.Ordinal);
         Assert.Contains("private open class Helper[TInner]", translated, StringComparison.Ordinal);
         Assert.True(
@@ -659,6 +690,12 @@ public sealed class Issue3413NestedPrivateClassTranslationTests
         Assert.Equal(
             extensionOwner,
             extensionOwner.GetMethod("ValueNoteAsync", BindingFlags.Public | BindingFlags.Static)!.DeclaringType);
+        Assert.Equal(
+            extensionOwner,
+            extensionOwner.GetMethod("ValueLengthAsync", BindingFlags.Public | BindingFlags.Static)!.DeclaringType);
+        Assert.Equal(
+            extensionOwner,
+            extensionOwner.GetMethod("ValueDelayAsync", BindingFlags.Public | BindingFlags.Static)!.DeclaringType);
 
         Type genericOwner = Assert.Single(
             assembly.GetTypes(),

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3413NestedPrivateClassTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3413NestedPrivateClassTranslationTests.cs
@@ -24,6 +24,7 @@ public sealed class Issue3413NestedPrivateClassTranslationTests
 {
     private const string Source = """
         using System;
+        using System.Threading.Tasks;
 
         namespace Issue3413
         {
@@ -44,6 +45,9 @@ public sealed class Issue3413NestedPrivateClassTranslationTests
                     Console.WriteLine(new EntryHelper<int>(42).Value);
                     Console.WriteLine(1.Identity());
                     Console.WriteLine(35.AddCached());
+                    Console.WriteLine(6.DelayIdentityAsync().GetAwaiter().GetResult());
+                    7.DelayAsync().GetAwaiter().GetResult();
+                    Console.WriteLine("async");
                 }
             }
 
@@ -66,6 +70,17 @@ public sealed class Issue3413NestedPrivateClassTranslationTests
                 public static T Identity<T>(this T value) => Cache<T>.Echo(value);
 
                 public static int AddCached(this int value) => value + cache.Value;
+
+                public static async Task<T> DelayIdentityAsync<T>(this T value)
+                {
+                    await Task.Yield();
+                    return Cache<T>.Echo(value);
+                }
+
+                public static async Task DelayAsync(this int value)
+                {
+                    await Task.Yield();
+                }
             }
 
             public sealed class GenericOwner<TOuter>
@@ -137,12 +152,20 @@ public sealed class Issue3413NestedPrivateClassTranslationTests
             extensionShared.Members.OfType<FieldDeclaration>().Single(field => field.Name == "cache").Visibility);
         Assert.Contains(extensionShared.Members.OfType<MethodDeclaration>(), method => method.Name == "Identity");
         Assert.Contains(extensionShared.Members.OfType<MethodDeclaration>(), method => method.Name == "AddCached");
+        Assert.Contains(extensionShared.Members.OfType<MethodDeclaration>(), method => method.Name == "DelayIdentityAsync");
+        Assert.Contains(extensionShared.Members.OfType<MethodDeclaration>(), method => method.Name == "DelayAsync");
         Assert.Contains(
             unit.Members.OfType<MethodDeclaration>(),
             method => method.Name == "Identity");
         Assert.Contains(
             unit.Members.OfType<MethodDeclaration>(),
             method => method.Name == "AddCached");
+        Assert.Contains(
+            unit.Members.OfType<MethodDeclaration>(),
+            method => method.Name == "DelayIdentityAsync");
+        Assert.Contains(
+            unit.Members.OfType<MethodDeclaration>(),
+            method => method.Name == "DelayAsync");
 
         string rendered = GSharpPrinter.Print(unit);
         Assert.Contains("private class EntryHelper[T]", rendered, StringComparison.Ordinal);
@@ -150,6 +173,8 @@ public sealed class Issue3413NestedPrivateClassTranslationTests
         Assert.Contains("private var cache Cache[int32]", rendered, StringComparison.Ordinal);
         Assert.Contains("ExtensionOwner.Identity", rendered, StringComparison.Ordinal);
         Assert.Contains("ExtensionOwner.AddCached", rendered, StringComparison.Ordinal);
+        Assert.Contains("return await ExtensionOwner.DelayIdentityAsync", rendered, StringComparison.Ordinal);
+        Assert.Contains("await ExtensionOwner.DelayAsync", rendered, StringComparison.Ordinal);
         Assert.Contains("class GenericOwner[TOuter]", rendered, StringComparison.Ordinal);
         Assert.Contains("private open class Helper[TInner]", rendered, StringComparison.Ordinal);
         Assert.DoesNotContain(
@@ -205,6 +230,102 @@ public sealed class Issue3413NestedPrivateClassTranslationTests
     }
 
     [Fact]
+    public void PrivateOwnerScopedExtension_RemainsStaticHelper()
+    {
+        const string source = """
+            using System;
+
+            namespace Issue3413
+            {
+                public static class Program
+                {
+                    public static void Main() => Console.WriteLine(Owner.Run("ok"));
+                }
+
+                public static class Owner
+                {
+                    private sealed class Cache
+                    {
+                    }
+
+                    private static string Secret(this string value) => value + "!";
+
+                    public static string Run(string value) => value.Secret();
+                }
+            }
+            """;
+
+        (CompilationUnit unit, _) = Translate(source);
+        string rendered = GSharpPrinter.Print(unit);
+        TypeDeclaration owner = unit.Members
+            .OfType<TypeDeclaration>()
+            .Single(type => type.Name == "Owner");
+
+        Assert.Contains(
+            Assert.Single(owner.Members.OfType<SharedBlock>()).Members.OfType<MethodDeclaration>(),
+            method => method.Name == "Secret" && method.Visibility == Visibility.Private);
+        Assert.DoesNotContain(
+            unit.Members.OfType<MethodDeclaration>(),
+            method => method.Name == "Secret");
+        Assert.Contains("Owner.Secret(value)", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+
+    [Fact]
+    public void OwnerScopedCompanion_RespectsInstanceAndSiblingCollisions()
+    {
+        const string source = """
+            using System;
+
+            namespace Issue3413
+            {
+                public static class Program
+                {
+                    public static void Main() => Console.WriteLine(new Host().Describe());
+                }
+
+                public sealed class Host
+                {
+                    public string Describe() => "instance";
+                }
+
+                public static class OwnerScoped
+                {
+                    private sealed class Cache
+                    {
+                    }
+
+                    public static string Describe(this Host host) => "extension";
+
+                    public static string Format(this string value) => "owner";
+                }
+
+                public static class Sibling
+                {
+                    public static string Format(this string value) => "sibling";
+                }
+            }
+            """;
+
+        (CompilationUnit unit, _) = Translate(source);
+        string rendered = GSharpPrinter.Print(unit);
+        TypeDeclaration owner = unit.Members
+            .OfType<TypeDeclaration>()
+            .Single(type => type.Name == "OwnerScoped");
+        SharedBlock shared = Assert.Single(owner.Members.OfType<SharedBlock>());
+
+        Assert.Contains(shared.Members.OfType<MethodDeclaration>(), method => method.Name == "Describe");
+        Assert.Contains(shared.Members.OfType<MethodDeclaration>(), method => method.Name == "Format");
+        Assert.DoesNotContain(
+            unit.Members.OfType<MethodDeclaration>(),
+            method => method.Name == "Describe");
+        Assert.Single(
+            unit.Members.OfType<MethodDeclaration>(),
+            method => method.Name == "Format");
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+
+    [Fact]
     public async Task Pipeline_CompilesVerifiesRunsAndEmitsNestedPrivateGenericMetadata()
     {
         string compiler = FindCompiler();
@@ -229,7 +350,7 @@ public sealed class Issue3413NestedPrivateClassTranslationTests
             """);
         File.WriteAllText(Path.Combine(projectDirectory, "Program.cs"), Source);
         string goldenPath = Path.Combine(projectDirectory, "baseline.stdout.golden");
-        File.WriteAllText(goldenPath, "42\n1\n42\n");
+        File.WriteAllText(goldenPath, "42\n1\n42\n6\nasync\n");
 
         string outputRoot = NewDirectory("pipeline-tests");
         var app = new CorpusApp(
@@ -268,6 +389,8 @@ public sealed class Issue3413NestedPrivateClassTranslationTests
         Assert.Contains("class Program", translated, StringComparison.Ordinal);
         Assert.Contains("private class EntryHelper[T]", translated, StringComparison.Ordinal);
         Assert.Contains("private class Cache[T]", translated, StringComparison.Ordinal);
+        Assert.Contains("return await ExtensionOwner.DelayIdentityAsync", translated, StringComparison.Ordinal);
+        Assert.Contains("await ExtensionOwner.DelayAsync", translated, StringComparison.Ordinal);
         Assert.Contains("class GenericOwner[TOuter]", translated, StringComparison.Ordinal);
         Assert.Contains("private open class Helper[TInner]", translated, StringComparison.Ordinal);
         Assert.True(
@@ -305,6 +428,12 @@ public sealed class Issue3413NestedPrivateClassTranslationTests
         Assert.Equal(
             extensionOwner,
             extensionOwner.GetMethod("AddCached", BindingFlags.Public | BindingFlags.Static)!.DeclaringType);
+        Assert.Equal(
+            extensionOwner,
+            extensionOwner.GetMethod("DelayIdentityAsync", BindingFlags.Public | BindingFlags.Static)!.DeclaringType);
+        Assert.Equal(
+            extensionOwner,
+            extensionOwner.GetMethod("DelayAsync", BindingFlags.Public | BindingFlags.Static)!.DeclaringType);
 
         Type genericOwner = Assert.Single(
             assembly.GetTypes(),

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3413NestedPrivateClassTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3413NestedPrivateClassTranslationTests.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -47,6 +48,10 @@ public sealed class Issue3413NestedPrivateClassTranslationTests
                     Console.WriteLine(35.AddCached());
                     Console.WriteLine(6.DelayIdentityAsync().GetAwaiter().GetResult());
                     7.DelayAsync().GetAwaiter().GetResult();
+                    Func<Task<int>> lengthAsync = "four".LengthAsync;
+                    Console.WriteLine(lengthAsync().GetAwaiter().GetResult());
+                    Func<Task> delayAsync = "later".DelayTextAsync;
+                    delayAsync().GetAwaiter().GetResult();
                     Console.WriteLine("async");
                 }
             }
@@ -78,6 +83,17 @@ public sealed class Issue3413NestedPrivateClassTranslationTests
                 }
 
                 public static async Task DelayAsync(this int value)
+                {
+                    await Task.Yield();
+                }
+
+                public static async Task<int> LengthAsync(this string value)
+                {
+                    await Task.Yield();
+                    return value.Length;
+                }
+
+                public static async Task DelayTextAsync(this string value)
                 {
                     await Task.Yield();
                 }
@@ -154,6 +170,8 @@ public sealed class Issue3413NestedPrivateClassTranslationTests
         Assert.Contains(extensionShared.Members.OfType<MethodDeclaration>(), method => method.Name == "AddCached");
         Assert.Contains(extensionShared.Members.OfType<MethodDeclaration>(), method => method.Name == "DelayIdentityAsync");
         Assert.Contains(extensionShared.Members.OfType<MethodDeclaration>(), method => method.Name == "DelayAsync");
+        Assert.Contains(extensionShared.Members.OfType<MethodDeclaration>(), method => method.Name == "LengthAsync");
+        Assert.Contains(extensionShared.Members.OfType<MethodDeclaration>(), method => method.Name == "DelayTextAsync");
         Assert.Contains(
             unit.Members.OfType<MethodDeclaration>(),
             method => method.Name == "Identity");
@@ -166,6 +184,12 @@ public sealed class Issue3413NestedPrivateClassTranslationTests
         Assert.Contains(
             unit.Members.OfType<MethodDeclaration>(),
             method => method.Name == "DelayAsync");
+        Assert.Contains(
+            unit.Members.OfType<MethodDeclaration>(),
+            method => method.Name == "LengthAsync");
+        Assert.Contains(
+            unit.Members.OfType<MethodDeclaration>(),
+            method => method.Name == "DelayTextAsync");
 
         string rendered = GSharpPrinter.Print(unit);
         Assert.Contains("private class EntryHelper[T]", rendered, StringComparison.Ordinal);
@@ -326,6 +350,139 @@ public sealed class Issue3413NestedPrivateClassTranslationTests
     }
 
     [Fact]
+    public void OwnerScopedCompanion_DeduplicatesCanonicalSiblingSignatures()
+    {
+        LoadedCSharpProject first = CSharpProjectLoader.LoadInMemory(
+            new[]
+            {
+                ("First.cs", """
+                    namespace Shared;
+
+                    public static class First
+                    {
+                        private sealed class Cache
+                        {
+                        }
+
+                        public static object Convert(this object value, dynamic argument) => argument;
+                    }
+                    """),
+            },
+            CSharpProjectLoader.RuntimeReferences(),
+            "Z.Dependency");
+        Assert.True(first.BoundWithoutErrors, string.Join(Environment.NewLine, first.ErrorDiagnostics));
+        using var firstImage = new MemoryStream();
+        Microsoft.CodeAnalysis.Emit.EmitResult firstEmit =
+            first.Compilation.Emit(firstImage);
+        Assert.True(firstEmit.Success, string.Join(Environment.NewLine, firstEmit.Diagnostics));
+        MetadataReference firstReference =
+            MetadataReference.CreateFromImage(firstImage.ToArray());
+
+        LoadedCSharpProject second = CSharpProjectLoader.LoadInMemory(
+            new[]
+            {
+                ("Second.cs", """
+                    namespace Shared;
+
+                    public static class Second
+                    {
+                        private sealed class Cache
+                        {
+                        }
+
+                        public static object Convert(this object value, object argument) => argument;
+                    }
+                    """),
+            },
+            CSharpProjectLoader.RuntimeReferences().Append(firstReference).ToList(),
+            "A.Dependent");
+        Assert.True(second.BoundWithoutErrors, string.Join(Environment.NewLine, second.ErrorDiagnostics));
+
+        string printedFirst = TranslateProject(
+            first,
+            new[] { first.Compilation });
+        string printedSecond = TranslateProject(
+            second,
+            new[] { first.Compilation, second.Compilation });
+        string combined = printedFirst + printedSecond;
+
+        Assert.Equal(
+            1,
+            CountOccurrences(combined, "func (value object) Convert(argument object) object"));
+        Assert.Contains(
+            "func (value object) Convert(argument object) object",
+            printedFirst,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "func (value object) Convert(argument object) object",
+            printedSecond,
+            StringComparison.Ordinal);
+        Assert.Contains("class First", combined, StringComparison.Ordinal);
+        Assert.Contains("class Second", combined, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(printedFirst, printedSecond);
+    }
+
+    [Fact]
+    public void OwnerScopedCompanion_RejectsExternAndNonPublicOwners()
+    {
+        const string source = """
+            using System;
+            using System.Runtime.InteropServices;
+
+            namespace Issue3413
+            {
+                public static class Program
+                {
+                    public static void Main()
+                    {
+                        Console.WriteLine("a".InternalEcho());
+                        Console.WriteLine("b".FileEcho());
+                    }
+                }
+
+                internal static class InternalOwner
+                {
+                    private sealed class Cache
+                    {
+                    }
+
+                    public static string InternalEcho(this string value) => value;
+                }
+
+                file static class FileOwner
+                {
+                    private sealed class Cache
+                    {
+                    }
+
+                    public static string FileEcho(this string value) => value;
+                }
+
+                public static class NativeOwner
+                {
+                    private sealed class Cache
+                    {
+                    }
+
+                    [DllImport("libc")]
+                    public static extern int NativeAbs(this int value);
+                }
+            }
+            """;
+
+        (CompilationUnit unit, _) = Translate(source);
+        string rendered = GSharpPrinter.Print(unit);
+
+        Assert.DoesNotContain(
+            unit.Members.OfType<MethodDeclaration>(),
+            method => method.Name is "InternalEcho" or "FileEcho" or "NativeAbs");
+        Assert.Contains("InternalOwner.InternalEcho(\"a\")", rendered, StringComparison.Ordinal);
+        Assert.Contains("FileOwner.FileEcho(\"b\")", rendered, StringComparison.Ordinal);
+        Assert.Contains("func NativeAbs(value int32) int32", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+
+    [Fact]
     public async Task Pipeline_CompilesVerifiesRunsAndEmitsNestedPrivateGenericMetadata()
     {
         string compiler = FindCompiler();
@@ -350,7 +507,7 @@ public sealed class Issue3413NestedPrivateClassTranslationTests
             """);
         File.WriteAllText(Path.Combine(projectDirectory, "Program.cs"), Source);
         string goldenPath = Path.Combine(projectDirectory, "baseline.stdout.golden");
-        File.WriteAllText(goldenPath, "42\n1\n42\n6\nasync\n");
+        File.WriteAllText(goldenPath, "42\n1\n42\n6\n4\nasync\n");
 
         string outputRoot = NewDirectory("pipeline-tests");
         var app = new CorpusApp(
@@ -391,6 +548,14 @@ public sealed class Issue3413NestedPrivateClassTranslationTests
         Assert.Contains("private class Cache[T]", translated, StringComparison.Ordinal);
         Assert.Contains("return await ExtensionOwner.DelayIdentityAsync", translated, StringComparison.Ordinal);
         Assert.Contains("await ExtensionOwner.DelayAsync", translated, StringComparison.Ordinal);
+        Assert.Contains(
+            "let lengthAsync async () -> int32 = () -> ExtensionOwner.LengthAsync(\"four\")",
+            translated,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "let delayAsync async () -> void = () -> ExtensionOwner.DelayTextAsync(\"later\")",
+            translated,
+            StringComparison.Ordinal);
         Assert.Contains("class GenericOwner[TOuter]", translated, StringComparison.Ordinal);
         Assert.Contains("private open class Helper[TInner]", translated, StringComparison.Ordinal);
         Assert.True(
@@ -434,6 +599,12 @@ public sealed class Issue3413NestedPrivateClassTranslationTests
         Assert.Equal(
             extensionOwner,
             extensionOwner.GetMethod("DelayAsync", BindingFlags.Public | BindingFlags.Static)!.DeclaringType);
+        Assert.Equal(
+            extensionOwner,
+            extensionOwner.GetMethod("LengthAsync", BindingFlags.Public | BindingFlags.Static)!.DeclaringType);
+        Assert.Equal(
+            extensionOwner,
+            extensionOwner.GetMethod("DelayTextAsync", BindingFlags.Public | BindingFlags.Static)!.DeclaringType);
 
         Type genericOwner = Assert.Single(
             assembly.GetTypes(),
@@ -556,6 +727,38 @@ public sealed class Issue3413NestedPrivateClassTranslationTests
         var document = new LoadedDocument(tree.FilePath, tree, model);
         var context = new TranslationContext(compilation, model, document.FilePath);
         return (new CSharpToGSharpTranslator().TranslateDocument(document, context), context);
+    }
+
+    private static string TranslateProject(
+        LoadedCSharpProject project,
+        IReadOnlyList<CSharpCompilation> siblings)
+    {
+        var translator = new CSharpToGSharpTranslator();
+        return string.Join(
+            Environment.NewLine,
+            project.Documents.Select(document =>
+            {
+                var context = new TranslationContext(
+                    project.Compilation,
+                    document.SemanticModel,
+                    document.FilePath,
+                    siblings);
+                return GSharpPrinter.Print(
+                    translator.TranslateDocument(document, context));
+            }));
+    }
+
+    private static int CountOccurrences(string text, string value)
+    {
+        int count = 0;
+        for (int index = text.IndexOf(value, StringComparison.Ordinal);
+            index >= 0;
+            index = text.IndexOf(value, index + value.Length, StringComparison.Ordinal))
+        {
+            count++;
+        }
+
+        return count;
     }
 
     private static bool IlVerifyToolAvailable()

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.ControlFlow.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.ControlFlow.cs
@@ -1167,6 +1167,54 @@ public sealed partial class CSharpToGSharpTranslator
             }
 
             GExpression receiver = this.TranslateExpression(isPattern.Expression);
+            if (this.IsNativelyExpressiblePattern(positivePattern, topLevel: true)
+                && binder.Type is { TypeKind: not TypeKind.Error, IsRefLikeType: false }
+                && !CSharpTypeMapper.IsSystemIndexOrRange(binder.Type))
+            {
+                string mutableName = SanitizeIdentifier(designation.Identifier.Text);
+                string matchName = FreshPatternMatchName(
+                    mutableName,
+                    this.state.CurrentBodyScope ?? ifStatement);
+                this.state.NativePatternVariableAliases[binder] = matchName;
+                GPattern nativePattern;
+                try
+                {
+                    nativePattern = this.BuildNativePattern(
+                        positivePattern,
+                        new List<ILocalSymbol>());
+                }
+                finally
+                {
+                    this.state.NativePatternVariableAliases.Remove(binder);
+                }
+
+                statements.Add(new IfStatement(
+                    Negate(new PatternTestExpression(receiver, nativePattern)),
+                    then));
+
+                GTypeReference mutableType = this.typeMapper.Map(
+                    binder.Type,
+                    this.context,
+                    designation.GetLocation());
+                statements.Add(new LocalDeclarationStatement(
+                    BindingKind.Var,
+                    mutableName,
+                    mutableType,
+                    new IdentifierExpression(matchName)));
+                this.state.PatternBindings[binder] =
+                    new IdentifierExpression(mutableName);
+
+                for (var i = patternIndex + 1; i < terms.Count; i++)
+                {
+                    statements.Add(new IfStatement(
+                        this.TranslateExpression(terms[i]),
+                        then));
+                }
+
+                result = statements;
+                return true;
+            }
+
             if (!IsTrivialOperand(receiver))
             {
                 string spillName = $"__spill{this.state.SpillCounter++}";
@@ -1457,6 +1505,25 @@ public sealed partial class CSharpToGSharpTranslator
                     StatementAlwaysExits(block.Statements[block.Statements.Count - 1]),
                 _ => false,
             };
+
+        private static string FreshPatternMatchName(
+            string localName,
+            SyntaxNode scope)
+        {
+            var used = new HashSet<string>(
+                scope.DescendantTokens()
+                    .Where(token => token.IsKind(SyntaxKind.IdentifierToken))
+                    .Select(token => token.ValueText),
+                System.StringComparer.Ordinal);
+            string stem = localName + "Match";
+            string candidate = stem;
+            for (int suffix = 2; used.Contains(candidate); suffix++)
+            {
+                candidate = stem + suffix;
+            }
+
+            return candidate;
+        }
 
         // Returns a nullable (`T?`) copy of a type reference, preserving the
         // concrete reference kind (named/array/pointer/tuple). Used when hoisting a

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -399,8 +399,15 @@ public sealed partial class CSharpToGSharpTranslator
             if (this.context.GetSymbolInfo(member).Symbol is IMethodSymbol { IsExtensionMethod: true } memberExtMethod)
             {
                 this.typeMapper.TrackExtensionMethodNamespace(memberExtMethod);
-                if (memberExtMethod.MethodKind == MethodKind.ReducedExtension &&
-                    this.TryGetStaticExtensionHelper(memberExtMethod, out string helperOwner, out string helperName))
+                bool isInvocationTarget =
+                    member.Parent is InvocationExpressionSyntax invocation
+                    && invocation.Expression == member;
+                if (memberExtMethod.MethodKind == MethodKind.ReducedExtension
+                    && !isInvocationTarget
+                    && this.TryGetStaticExtensionHelperForMethodGroup(
+                        memberExtMethod,
+                        out string helperOwner,
+                        out string helperName))
                 {
                     if (member.Parent is ArgumentSyntax nameOfArgument &&
                         IsNameOfArgument(nameOfArgument))

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -733,7 +733,7 @@ public sealed partial class CSharpToGSharpTranslator
                 return false;
             }
 
-            if (this.ownedExtensions.HasReceiverCompanion(method) ||
+            if (this.HasReceiverCompanion(method) ||
                 !this.IsStaticExtensionHelper(method))
             {
                 return false;
@@ -741,6 +741,38 @@ public sealed partial class CSharpToGSharpTranslator
 
             IMethodSymbol original = method.ReducedFrom ?? method;
             ownerName = original.ContainingType?.Name is { } containingName ? SanitizeIdentifier(containingName) : null;
+            methodName = SanitizeIdentifier(original.Name);
+            return ownerName != null;
+        }
+
+        private bool TryGetStaticExtensionHelperForMethodGroup(
+            IMethodSymbol method,
+            out string ownerName,
+            out string methodName)
+        {
+            if (this.TryGetStaticExtensionHelper(
+                method,
+                out ownerName,
+                out methodName))
+            {
+                return true;
+            }
+
+            IMethodSymbol original = method?.ReducedFrom ?? method;
+            if (!this.HasReceiverCompanion(original)
+                || !this.IsStaticExtensionHelper(original)
+                || original?.ReturnType is not INamedTypeSymbol { Name: "Task" } task
+                || task.ContainingNamespace?.ToDisplayString()
+                    != "System.Threading.Tasks")
+            {
+                ownerName = null;
+                methodName = null;
+                return false;
+            }
+
+            ownerName = original.ContainingType?.Name is { } containingName
+                ? SanitizeIdentifier(containingName)
+                : null;
             methodName = SanitizeIdentifier(original.Name);
             return ownerName != null;
         }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -1340,7 +1340,7 @@ public sealed partial class CSharpToGSharpTranslator
                 IParameterSymbol methodParameter = method.Parameters[index];
                 IParameterSymbol invokeParameter = invoke.Parameters[index];
                 if (methodParameter.RefKind != invokeParameter.RefKind
-                    || !SymbolEqualityComparer.IncludeNullability.Equals(
+                    || !SymbolEqualityComparer.Default.Equals(
                         methodParameter.Type,
                         invokeParameter.Type))
                 {
@@ -1349,7 +1349,7 @@ public sealed partial class CSharpToGSharpTranslator
             }
 
             return !method.ReturnsVoid
-                && !SymbolEqualityComparer.IncludeNullability.Equals(
+                && !SymbolEqualityComparer.Default.Equals(
                     method.ReturnType,
                     invoke.ReturnType);
         }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -761,8 +761,9 @@ public sealed partial class CSharpToGSharpTranslator
             IMethodSymbol original = method?.ReducedFrom ?? method;
             if (!this.HasReceiverCompanion(original)
                 || !this.IsStaticExtensionHelper(original)
-                || original?.ReturnType is not INamedTypeSymbol { Name: "Task" } task
-                || task.ContainingNamespace?.ToDisplayString()
+                || original?.ReturnType is not INamedTypeSymbol taskLike
+                || taskLike.Name is not ("Task" or "ValueTask")
+                || taskLike.ContainingNamespace?.ToDisplayString()
                     != "System.Threading.Tasks")
             {
                 ownerName = null;

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
@@ -1521,9 +1521,15 @@ public sealed partial class CSharpToGSharpTranslator
                     SanitizeIdentifier(original.Name)),
                 arguments,
                 typeArguments);
+            GExpression forwarded = original.IsAsync
+                && original.ReturnType is INamedTypeSymbol { Name: "Task" } task
+                && task.ContainingNamespace?.ToDisplayString()
+                    == "System.Threading.Tasks"
+                    ? new AwaitExpression(call)
+                    : call;
             GStatement statement = returnType == null
-                ? new ExpressionStatement(call)
-                : new ReturnStatement(call);
+                ? new ExpressionStatement(forwarded)
+                : new ReturnStatement(forwarded);
             return new BlockStatement(new[] { statement });
         }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
@@ -1516,6 +1516,7 @@ public sealed partial class CSharpToGSharpTranslator
                     (GTypeReference)new NamedTypeReference(
                         SanitizeIdentifier(parameter.Name)))
                 .ToList();
+
             var call = new InvocationExpression(
                 new MemberAccessExpression(
                     new IdentifierExpression(
@@ -1523,13 +1524,18 @@ public sealed partial class CSharpToGSharpTranslator
                     SanitizeIdentifier(original.Name)),
                 arguments,
                 typeArguments);
-            GExpression forwarded = original.IsAsync
-                && original.ReturnType is INamedTypeSymbol { Name: "Task" } task
-                && task.ContainingNamespace?.ToDisplayString()
+            INamedTypeSymbol asyncEnvelope = original.IsAsync
+                && original.ReturnType is INamedTypeSymbol taskLike
+                && taskLike.Name is "Task" or "ValueTask"
+                && taskLike.ContainingNamespace?.ToDisplayString()
                     == "System.Threading.Tasks"
-                    ? new AwaitExpression(call)
-                    : call;
+                    ? taskLike
+                    : null;
+            GExpression forwarded = asyncEnvelope != null
+                ? new AwaitExpression(call)
+                : call;
             GStatement statement = returnType == null
+                || asyncEnvelope is { IsGenericType: false }
                 ? new ExpressionStatement(forwarded)
                 : new ReturnStatement(forwarded);
             return new BlockStatement(new[] { statement });
@@ -1569,6 +1575,7 @@ public sealed partial class CSharpToGSharpTranslator
             {
                 identity,
             };
+
             // A referenced project wins over its dependent: the dependency can
             // emit without knowing reverse dependents exist, while the dependent
             // sees the dependency through SiblingCompilations. Assembly + doc ID
@@ -1626,11 +1633,13 @@ public sealed partial class CSharpToGSharpTranslator
         {
             string extensionSignature =
                 this.CanonicalReducedSignature(extension, parameterOffset: 1);
+            string emittedName = SanitizeIdentifier(extension.Name);
             for (INamedTypeSymbol current = receiver; current != null; current = current.BaseType)
             {
-                foreach (IMethodSymbol method in current.GetMembers(extension.Name).OfType<IMethodSymbol>())
+                foreach (IMethodSymbol method in current.GetMembers().OfType<IMethodSymbol>())
                 {
                     if (!method.IsStatic
+                        && SanitizeIdentifier(method.Name) == emittedName
                         && this.CanonicalReducedSignature(method, parameterOffset: 0)
                             == extensionSignature)
                     {
@@ -1647,13 +1656,15 @@ public sealed partial class CSharpToGSharpTranslator
         {
             string namespaceName = method.ContainingNamespace?.ToDisplayString()
                 ?? string.Empty;
+            string emittedName = SanitizeIdentifier(method.Name);
             var seen = new HashSet<string>(StringComparer.Ordinal);
 
             foreach (INamedTypeSymbol type in method.ContainingNamespace.GetTypeMembers())
             {
-                foreach (IMethodSymbol candidate in type.GetMembers(method.Name).OfType<IMethodSymbol>())
+                foreach (IMethodSymbol candidate in type.GetMembers().OfType<IMethodSymbol>())
                 {
                     if (candidate.IsExtensionMethod
+                        && SanitizeIdentifier(candidate.Name) == emittedName
                         && seen.Add(ExtensionMethodIdentity(candidate)))
                     {
                         yield return candidate;
@@ -1674,10 +1685,11 @@ public sealed partial class CSharpToGSharpTranslator
                 foreach (INamedTypeSymbol type in package.GetTypeMembers())
                 {
                     foreach (IMethodSymbol candidate in type
-                        .GetMembers(method.Name)
+                        .GetMembers()
                         .OfType<IMethodSymbol>())
                     {
                         if (candidate.IsExtensionMethod
+                            && SanitizeIdentifier(candidate.Name) == emittedName
                             && seen.Add(ExtensionMethodIdentity(candidate)))
                         {
                             yield return candidate;
@@ -1746,7 +1758,7 @@ public sealed partial class CSharpToGSharpTranslator
         {
             var parts = new List<string>
             {
-                method.Name,
+                SanitizeIdentifier(method.Name),
                 method.TypeParameters.Length.ToString(CultureInfo.InvariantCulture),
             };
             for (int index = parameterOffset; index < method.Parameters.Length; index++)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
@@ -1334,9 +1334,22 @@ public sealed partial class CSharpToGSharpTranslator
 
             bool hasBody = node.Body != null || node.ExpressionBody != null;
             BlockStatement body;
-            body = hasBody
-                ? this.TranslateBody(node, $"method '{node.Identifier.Text}'")
-                : null;
+            if (hasBody
+                && forceExtensionReceiver
+                && RequiresOwnerScopedExtension(symbol))
+            {
+                body = this.BuildOwnerScopedExtensionCompanionBody(
+                    symbol,
+                    receiver,
+                    parameters,
+                    returnType);
+            }
+            else
+            {
+                body = hasBody
+                    ? this.TranslateBody(node, $"method '{node.Identifier.Text}'")
+                    : null;
+            }
 
             if (body != null && ownedExtensionSelf != null)
             {
@@ -1472,6 +1485,46 @@ public sealed partial class CSharpToGSharpTranslator
                 isRefReturn: symbol != null && symbol.ReturnsByRef);
 
             return (method, isStatic);
+        }
+
+        private BlockStatement BuildOwnerScopedExtensionCompanionBody(
+            IMethodSymbol method,
+            Receiver receiver,
+            IReadOnlyList<Parameter> parameters,
+            GTypeReference returnType)
+        {
+            IMethodSymbol original = method.ReducedFrom ?? method;
+            var arguments = new List<GExpression>(parameters.Count + 1)
+            {
+                new IdentifierExpression(receiver.Name),
+            };
+            for (int index = 0; index < parameters.Count; index++)
+            {
+                GExpression argument = new IdentifierExpression(parameters[index].Name);
+                if (original.Parameters[index + 1].RefKind is RefKind.Ref or RefKind.Out)
+                {
+                    argument = new UnaryExpression("&", argument);
+                }
+
+                arguments.Add(argument);
+            }
+
+            IReadOnlyList<GTypeReference> typeArguments = original.TypeParameters
+                .Select(parameter =>
+                    (GTypeReference)new NamedTypeReference(
+                        SanitizeIdentifier(parameter.Name)))
+                .ToList();
+            var call = new InvocationExpression(
+                new MemberAccessExpression(
+                    new IdentifierExpression(
+                        SanitizeIdentifier(original.ContainingType.Name)),
+                    SanitizeIdentifier(original.Name)),
+                arguments,
+                typeArguments);
+            GStatement statement = returnType == null
+                ? new ExpressionStatement(call)
+                : new ReturnStatement(call);
+            return new BlockStatement(new[] { statement });
         }
 
         private bool IsStaticExtensionHelper(IMethodSymbol method)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Cs2Gs.CodeModel.Ast;
 using Cs2Gs.CodeModel.Printing;
 using Cs2Gs.Translator.Loading;
@@ -71,8 +72,9 @@ public sealed partial class CSharpToGSharpTranslator
                         yield return (methodMember, methodIsStatic);
                     }
 
-                    if (ownedExtensionTarget is null &&
-                        this.ownedExtensions.HasReceiverCompanion(method))
+                    if (ownedExtensionTarget is null
+                        && this.context.GetDeclaredSymbol(method) is IMethodSymbol companionSymbol
+                        && this.HasReceiverCompanion(companionSymbol))
                     {
                         (GMember companion, bool companionIsStatic) = this.TranslateMethod(
                             method,
@@ -1531,6 +1533,276 @@ public sealed partial class CSharpToGSharpTranslator
                 ? new ExpressionStatement(forwarded)
                 : new ReturnStatement(forwarded);
             return new BlockStatement(new[] { statement });
+        }
+
+        private bool HasReceiverCompanion(IMethodSymbol method)
+        {
+            if (!this.ownedExtensions.HasReceiverCompanion(method))
+            {
+                return false;
+            }
+
+            IMethodSymbol original = method?.ReducedFrom ?? method;
+            return !RequiresOwnerScopedExtension(original)
+                || this.CanEmitOwnerScopedReceiverCompanion(original);
+        }
+
+        private bool CanEmitOwnerScopedReceiverCompanion(IMethodSymbol method)
+        {
+            IMethodSymbol original = method?.ReducedFrom ?? method;
+            if (!IsOwnerScopedCompanionShapeEligible(original))
+            {
+                return false;
+            }
+
+            if (original.Parameters[0].Type is INamedTypeSymbol receiver
+                && this.HasCanonicalReducedDeclarationCollision(
+                    receiver.OriginalDefinition,
+                    original))
+            {
+                return false;
+            }
+
+            string signature = this.CanonicalExtensionSignature(original);
+            string identity = ExtensionMethodIdentity(original);
+            var ownerCandidates = new HashSet<string>(StringComparer.Ordinal)
+            {
+                identity,
+            };
+            // A referenced project wins over its dependent: the dependency can
+            // emit without knowing reverse dependents exist, while the dependent
+            // sees the dependency through SiblingCompilations. Assembly + doc ID
+            // deduplicates that source method's metadata copy.
+            foreach (IMethodSymbol candidate in this.EnumerateKnownExtensionMethods(original))
+            {
+                IMethodSymbol candidateOriginal = candidate.ReducedFrom ?? candidate;
+                string candidateIdentity = ExtensionMethodIdentity(candidateOriginal);
+                if (candidateIdentity == identity
+                    || this.CanonicalExtensionSignature(candidateOriginal) != signature)
+                {
+                    continue;
+                }
+
+                if (!RequiresOwnerScopedExtension(candidateOriginal))
+                {
+                    return false;
+                }
+
+                if (IsOwnerScopedCompanionShapeEligible(candidateOriginal))
+                {
+                    if (CompilationReferencesAssembly(
+                        this.context.Compilation,
+                        candidateOriginal.ContainingAssembly))
+                    {
+                        return false;
+                    }
+
+                    CSharpCompilation candidateCompilation =
+                        this.KnownCompilations().FirstOrDefault(compilation =>
+                            SameAssembly(
+                                compilation.Assembly,
+                                candidateOriginal.ContainingAssembly));
+                    if (candidateCompilation != null
+                        && CompilationReferencesAssembly(
+                            candidateCompilation,
+                            this.context.Compilation.Assembly))
+                    {
+                        continue;
+                    }
+
+                    ownerCandidates.Add(candidateIdentity);
+                }
+            }
+
+            return string.Equals(
+                identity,
+                ownerCandidates.Min(StringComparer.Ordinal),
+                StringComparison.Ordinal);
+        }
+
+        private bool HasCanonicalReducedDeclarationCollision(
+            INamedTypeSymbol receiver,
+            IMethodSymbol extension)
+        {
+            string extensionSignature =
+                this.CanonicalReducedSignature(extension, parameterOffset: 1);
+            for (INamedTypeSymbol current = receiver; current != null; current = current.BaseType)
+            {
+                foreach (IMethodSymbol method in current.GetMembers(extension.Name).OfType<IMethodSymbol>())
+                {
+                    if (!method.IsStatic
+                        && this.CanonicalReducedSignature(method, parameterOffset: 0)
+                            == extensionSignature)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private IEnumerable<IMethodSymbol> EnumerateKnownExtensionMethods(
+            IMethodSymbol method)
+        {
+            string namespaceName = method.ContainingNamespace?.ToDisplayString()
+                ?? string.Empty;
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (INamedTypeSymbol type in method.ContainingNamespace.GetTypeMembers())
+            {
+                foreach (IMethodSymbol candidate in type.GetMembers(method.Name).OfType<IMethodSymbol>())
+                {
+                    if (candidate.IsExtensionMethod
+                        && seen.Add(ExtensionMethodIdentity(candidate)))
+                    {
+                        yield return candidate;
+                    }
+                }
+            }
+
+            foreach (CSharpCompilation compilation in this.KnownCompilations())
+            {
+                INamespaceSymbol package = FindNamespace(
+                    compilation.Assembly.GlobalNamespace,
+                    namespaceName);
+                if (package == null)
+                {
+                    continue;
+                }
+
+                foreach (INamedTypeSymbol type in package.GetTypeMembers())
+                {
+                    foreach (IMethodSymbol candidate in type
+                        .GetMembers(method.Name)
+                        .OfType<IMethodSymbol>())
+                    {
+                        if (candidate.IsExtensionMethod
+                            && seen.Add(ExtensionMethodIdentity(candidate)))
+                        {
+                            yield return candidate;
+                        }
+                    }
+                }
+            }
+        }
+
+        private IEnumerable<CSharpCompilation> KnownCompilations() =>
+            new[] { this.context.Compilation }
+                .Concat(this.context.SiblingCompilations
+                    ?? Array.Empty<CSharpCompilation>())
+                .Concat(this.context.RepositoryCompilations
+                    ?? Array.Empty<CSharpCompilation>())
+                .Distinct();
+
+        private static bool CompilationReferencesAssembly(
+            CSharpCompilation compilation,
+            IAssemblySymbol assembly) =>
+            compilation != null
+            && assembly != null
+            && compilation.References.Any(reference =>
+                compilation.GetAssemblyOrModuleSymbol(reference)
+                    is IAssemblySymbol referenced
+                && SameAssembly(referenced, assembly));
+
+        private static bool SameAssembly(
+            IAssemblySymbol left,
+            IAssemblySymbol right) =>
+            left != null
+            && right != null
+            && string.Equals(
+                left.Identity.GetDisplayName(),
+                right.Identity.GetDisplayName(),
+                StringComparison.Ordinal);
+
+        private static INamespaceSymbol FindNamespace(
+            INamespaceSymbol root,
+            string namespaceName)
+        {
+            INamespaceSymbol current = root;
+            foreach (string segment in namespaceName.Split(
+                '.',
+                StringSplitOptions.RemoveEmptyEntries))
+            {
+                current = current?.GetNamespaceMembers()
+                    .FirstOrDefault(candidate => candidate.Name == segment);
+                if (current == null)
+                {
+                    return null;
+                }
+            }
+
+            return current;
+        }
+
+        private string CanonicalExtensionSignature(IMethodSymbol method) =>
+            this.CanonicalEmittedType(method.Parameters[0].Type, method)
+            + "|"
+            + this.CanonicalReducedSignature(method, parameterOffset: 1);
+
+        private string CanonicalReducedSignature(
+            IMethodSymbol method,
+            int parameterOffset)
+        {
+            var parts = new List<string>
+            {
+                method.Name,
+                method.TypeParameters.Length.ToString(CultureInfo.InvariantCulture),
+            };
+            for (int index = parameterOffset; index < method.Parameters.Length; index++)
+            {
+                IParameterSymbol parameter = method.Parameters[index];
+                parts.Add(
+                    parameter.RefKind.ToString()
+                    + ":"
+                    + (parameter.IsParams ? "params:" : string.Empty)
+                    + this.CanonicalEmittedType(parameter.Type, method));
+            }
+
+            return string.Join("|", parts);
+        }
+
+        private string CanonicalEmittedType(
+            ITypeSymbol type,
+            IMethodSymbol method)
+        {
+            // Collision probing must not add imports or unsupported diagnostics
+            // to the real translation (e.g. an Index-typed unrelated overload).
+            var signatureContext = new TranslationContext(
+                this.context.Compilation,
+                this.context.SemanticModel,
+                this.context.FilePath,
+                this.context.SiblingCompilations,
+                this.context.RepositoryCompilations);
+            var signatureMapper = new CSharpTypeMapper(
+                new AnonymousTypeRegistry());
+            GTypeReference mapped = signatureMapper.Map(
+                type,
+                signatureContext,
+                Location.None);
+            string rendered = GSharpPrinter.RenderTypeReference(mapped)
+                .Replace("?", string.Empty, StringComparison.Ordinal);
+            foreach (ITypeParameterSymbol parameter in method.TypeParameters)
+            {
+                string name = Regex.Escape(SanitizeIdentifier(parameter.Name));
+                rendered = Regex.Replace(
+                    rendered,
+                    $@"(?<![\p{{L}}\p{{N}}_]){name}(?![\p{{L}}\p{{N}}_])",
+                    "!" + parameter.Ordinal.ToString(CultureInfo.InvariantCulture));
+            }
+
+            return rendered;
+        }
+
+        private static string ExtensionMethodIdentity(IMethodSymbol method)
+        {
+            IMethodSymbol original = method?.ReducedFrom ?? method;
+            string declarationId =
+                DocumentationCommentId.CreateDeclarationId(original)
+                ?? original.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+            return original.ContainingAssembly?.Identity.GetDisplayName()
+                + "|"
+                + declarationId;
         }
 
         private bool IsStaticExtensionHelper(IMethodSymbol method)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.PatternVariables.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.PatternVariables.cs
@@ -737,7 +737,9 @@ public sealed partial class CSharpToGSharpTranslator
                 && this.context.GetDeclaredSymbol(single) is ILocalSymbol local)
             {
                 binders.Add(local);
-                return SanitizeIdentifier(single.Identifier.Text);
+                return this.state.NativePatternVariableAliases.TryGetValue(local, out string alias)
+                    ? alias
+                    : SanitizeIdentifier(single.Identifier.Text);
             }
 
             return "_";

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
@@ -1417,7 +1417,7 @@ public sealed partial class CSharpToGSharpTranslator
                 List<ILocalSymbol> locals = pattern
                     .DescendantNodesAndSelf()
                     .OfType<SingleVariableDesignationSyntax>()
-                    .Select(this.context.GetDeclaredSymbol)
+                    .Select(designation => this.context.GetDeclaredSymbol(designation))
                     .OfType<ILocalSymbol>()
                     .ToList();
                 if (locals.All(local => !this.IsSymbolReassigned(local, scope)))

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -503,6 +503,11 @@ public sealed partial class CSharpToGSharpTranslator
                 if (RequiresOwnerScopedExtension(method))
                 {
                     result.AddStaticHelper(methodDeclaration);
+                    if (CanEmitOwnerScopedReceiverCompanion(method))
+                    {
+                        result.AddReceiverCompanion(methodDeclaration);
+                    }
+
                     continue;
                 }
 
@@ -632,6 +637,16 @@ public sealed partial class CSharpToGSharpTranslator
             HasPrivateNestedAggregate(original.ContainingType);
     }
 
+    private static bool CanEmitOwnerScopedReceiverCompanion(IMethodSymbol method)
+    {
+        IMethodSymbol original = method?.ReducedFrom ?? method;
+        return original?.Parameters.Length > 0
+            && original.Parameters[0].RefKind == RefKind.None
+            && !original.Parameters.Any(parameter => parameter.IsParams)
+            && !original.ReturnsByRef
+            && !original.ReturnsByRefReadonly;
+    }
+
     private static bool HasPrivateNestedAggregate(INamedTypeSymbol type)
     {
         if (type == null)
@@ -655,6 +670,11 @@ public sealed partial class CSharpToGSharpTranslator
     private static bool IsReproducibleReceiverCompanion(IMethodSymbol method)
     {
         IMethodSymbol original = method?.ReducedFrom ?? method;
+        if (RequiresOwnerScopedExtension(original))
+        {
+            return CanEmitOwnerScopedReceiverCompanion(original);
+        }
+
         return TryGetOwnedExtensionReceiver(original, out INamedTypeSymbol receiver) &&
             original.Parameters[0].RefKind == RefKind.None &&
             HasCrossContainerOwnedExtensionOverload(receiver, original) &&

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -503,7 +503,7 @@ public sealed partial class CSharpToGSharpTranslator
                 if (RequiresOwnerScopedExtension(method))
                 {
                     result.AddStaticHelper(methodDeclaration);
-                    if (CanEmitOwnerScopedReceiverCompanion(method))
+                    if (IsOwnerScopedCompanionShapeEligible(method))
                     {
                         result.AddReceiverCompanion(methodDeclaration);
                     }
@@ -637,52 +637,36 @@ public sealed partial class CSharpToGSharpTranslator
             HasPrivateNestedAggregate(original.ContainingType);
     }
 
-    private static bool CanEmitOwnerScopedReceiverCompanion(IMethodSymbol method)
+    private static bool IsOwnerScopedCompanionShapeEligible(IMethodSymbol method)
     {
         IMethodSymbol original = method?.ReducedFrom ?? method;
         if (original?.Parameters.Length is not > 0
             || original.DeclaredAccessibility == Accessibility.Private
+            || original.IsExtern
+            || !IsEffectivelyPublic(original.ContainingType)
             || original.Parameters[0].RefKind != RefKind.None
             || original.Parameters.Any(parameter => parameter.IsParams)
             || original.ReturnsByRef
-            || original.ReturnsByRefReadonly
-            || HasCrossContainerExtensionDuplicate(original))
+            || original.ReturnsByRefReadonly)
         {
             return false;
         }
 
-        return original.Parameters[0].Type is not INamedTypeSymbol receiver
-            || !HasReducedDeclarationCollision(receiver.OriginalDefinition, original);
+        return true;
     }
 
-    private static bool HasCrossContainerExtensionDuplicate(IMethodSymbol method)
+    private static bool IsEffectivelyPublic(INamedTypeSymbol type)
     {
-        IMethodSymbol original = method?.ReducedFrom ?? method;
-        if (original?.IsExtensionMethod != true || original.Parameters.Length == 0)
+        for (INamedTypeSymbol current = type; current != null; current = current.ContainingType)
         {
-            return false;
-        }
-
-        foreach (INamedTypeSymbol type in original.ContainingNamespace.GetTypeMembers())
-        {
-            foreach (IMethodSymbol other in type.GetMembers(original.Name).OfType<IMethodSymbol>())
+            if (current.DeclaredAccessibility != Accessibility.Public
+                || current.IsFileLocal)
             {
-                IMethodSymbol otherOriginal = other.ReducedFrom ?? other;
-                if (otherOriginal.IsExtensionMethod
-                    && !SymbolEqualityComparer.Default.Equals(
-                        otherOriginal.ContainingType,
-                        original.ContainingType)
-                    && otherOriginal.Parameters.Length > 0
-                    && SignatureType(otherOriginal.Parameters[0].Type)
-                        == SignatureType(original.Parameters[0].Type)
-                    && HaveSameReducedSignature(original, otherOriginal))
-                {
-                    return true;
-                }
+                return false;
             }
         }
 
-        return false;
+        return true;
     }
 
     private static bool HasPrivateNestedAggregate(INamedTypeSymbol type)
@@ -710,7 +694,7 @@ public sealed partial class CSharpToGSharpTranslator
         IMethodSymbol original = method?.ReducedFrom ?? method;
         if (RequiresOwnerScopedExtension(original))
         {
-            return CanEmitOwnerScopedReceiverCompanion(original);
+            return IsOwnerScopedCompanionShapeEligible(original);
         }
 
         return TryGetOwnedExtensionReceiver(original, out INamedTypeSymbol receiver) &&
@@ -1357,10 +1341,6 @@ public sealed partial class CSharpToGSharpTranslator
             return !SymbolEqualityComparer.Default.Equals(original.ContainingAssembly, this.assembly) &&
                 IsReproducibleStaticHelper(original);
         }
-
-        public bool HasReceiverCompanion(MethodDeclarationSyntax method) =>
-            method != null &&
-            this.receiverCompanions.Contains((method.SyntaxTree, method.SpanStart, method.Span.Length));
 
         public bool HasReceiverCompanion(IMethodSymbol method)
         {

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -640,11 +640,49 @@ public sealed partial class CSharpToGSharpTranslator
     private static bool CanEmitOwnerScopedReceiverCompanion(IMethodSymbol method)
     {
         IMethodSymbol original = method?.ReducedFrom ?? method;
-        return original?.Parameters.Length > 0
-            && original.Parameters[0].RefKind == RefKind.None
-            && !original.Parameters.Any(parameter => parameter.IsParams)
-            && !original.ReturnsByRef
-            && !original.ReturnsByRefReadonly;
+        if (original?.Parameters.Length is not > 0
+            || original.DeclaredAccessibility == Accessibility.Private
+            || original.Parameters[0].RefKind != RefKind.None
+            || original.Parameters.Any(parameter => parameter.IsParams)
+            || original.ReturnsByRef
+            || original.ReturnsByRefReadonly
+            || HasCrossContainerExtensionDuplicate(original))
+        {
+            return false;
+        }
+
+        return original.Parameters[0].Type is not INamedTypeSymbol receiver
+            || !HasReducedDeclarationCollision(receiver.OriginalDefinition, original);
+    }
+
+    private static bool HasCrossContainerExtensionDuplicate(IMethodSymbol method)
+    {
+        IMethodSymbol original = method?.ReducedFrom ?? method;
+        if (original?.IsExtensionMethod != true || original.Parameters.Length == 0)
+        {
+            return false;
+        }
+
+        foreach (INamedTypeSymbol type in original.ContainingNamespace.GetTypeMembers())
+        {
+            foreach (IMethodSymbol other in type.GetMembers(original.Name).OfType<IMethodSymbol>())
+            {
+                IMethodSymbol otherOriginal = other.ReducedFrom ?? other;
+                if (otherOriginal.IsExtensionMethod
+                    && !SymbolEqualityComparer.Default.Equals(
+                        otherOriginal.ContainingType,
+                        original.ContainingType)
+                    && otherOriginal.Parameters.Length > 0
+                    && SignatureType(otherOriginal.Parameters[0].Type)
+                        == SignatureType(original.Parameters[0].Type)
+                    && HaveSameReducedSignature(original, otherOriginal))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     private static bool HasPrivateNestedAggregate(INamedTypeSymbol type)

--- a/tools/cs2gs/Cs2Gs.Translator/DocumentTranslationState.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/DocumentTranslationState.cs
@@ -53,6 +53,12 @@ internal sealed class DocumentTranslationState
     public HashSet<ISymbol> NativePatternVariables { get; } =
         new HashSet<ISymbol>(SymbolEqualityComparer.Default);
 
+    // Temporary designator overrides used when a mutable C# pattern local is
+    // first captured by an immutable native G# pattern variable, then copied
+    // into its author-named `var` after an exiting guard.
+    public Dictionary<ISymbol, string> NativePatternVariableAliases { get; } =
+        new Dictionary<ISymbol, string>(SymbolEqualityComparer.Default);
+
     // Pattern variables (`x is T t`) that <see cref="TryBuildPositiveGuardHoist"/>
     // materialised as a *nullable* G# local (`var t T? = scrutinee as T`). gsc
     // flow-narrows such a local for reads inside the `if t != nil { … }` guard,


### PR DESCRIPTION
Closes #3347.

## Summary
- eliminate remaining synthetic spills in Core and Cs2Gs.Translator output
- lower mutable nested pattern binders without `__spillN` or `&& true`
- preserve direct method groups when only nullable annotations differ
- retain owner-scoped static extension bodies and emit companions only when accessibility, extern status, canonical G# signatures, sanitized names, instance members, and package-wide sibling projects permit
- deduplicate source/metadata extension copies and prefer dependency companions over reverse dependents
- await Task/Task<T>/ValueTask/ValueTask<T> invocation companions while retaining Task- and ValueTask-shaped static-helper method-group lambdas
- ratchet Core and Cs2Gs.Translator migrations to zero `let __spillN` declarations

## Validation
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --no-build --logger "console;verbosity=minimal"` (2144 passed, 0 failed)
- focused `Issue3413NestedPrivateClassTranslationTests` (8 passed; compile, bind, ILVerify, runtime parity, Task/ValueTask invocation and method-group companions, sanitized-name collisions, sibling/metadata dedupe, extern/accessibility guards)
- `dotnet build tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --no-restore --nologo --verbosity:minimal` (0 warnings, 0 errors)
- `dotnet format style tools/cs2gs/Cs2Gs.Translator/Cs2Gs.Translator.csproj --verify-no-changes --no-restore --verbosity minimal --diagnostics SA1515 --include tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs` (passed)
- full `src/` self-migration: zero `let __spillN` declarations (baseline 77)
- full `tools/cs2gs/` translator migration: zero `let __spillN` declarations (baseline 2)
