### PR TITLE
Eliminate residual checked-cast noise

### DIFF
--- a/docs/adr/0167-checked-reference-conversion-calls.md
+++ b/docs/adr/0167-checked-reference-conversion-calls.md
@@ -51,8 +51,9 @@ cannot resolve to a constructor. `T?(value)` remains unambiguously a nullable
 conversion target.
 
 cs2gs maps every C# explicit reference cast `(T)value` to `cast[T](value)` or
-`cast[T?](value)`. Numeric/value casts keep `T(value)` / `T?(value)`. C# `as`
-expressions continue to map to G# `as`.
+`cast[T?](value)`. Explicit boxing casts to non-`object` reference targets use
+the same constructor-independent spelling. Numeric/value casts keep
+`T(value)` / `T?(value)`. C# `as` expressions continue to map to G# `as`.
 
 ## Consequences
 

--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -254,6 +254,16 @@ public sealed class Conversion
             return Conversion.Implicit;
         }
 
+        // Issue #3421 review follow-up: C# permits an explicit conversion from
+        // any type parameter to any interface. The runtime boxes the generic
+        // value, then checks the boxed reference against the interface. The
+        // constraint-proven implicit case returned above; this arm covers the
+        // otherwise-unconstrained checked cast.
+        if (from is TypeParameterSymbol && IsInterfaceLikeType(to))
+        {
+            return Conversion.Explicit;
+        }
+
         // Issue #1540: a generic type parameter `T` is ALWAYS implicitly
         // convertible to a GENUINE `object` slot — a boxing conversion for a
         // value `T`, a reference conversion for a reference `T`, and `box !!T`

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
@@ -479,12 +479,28 @@ internal sealed partial class MethodBodyEmitter
         // null reference for the missing-value case). `GetElementTypeToken`
         // already selects the right token for the nullable wrapper in either
         // constraint case, so we box the wrapper symbol directly.
-        if ((from is TypeParameterSymbol
-                || (from is NullableTypeSymbol fromNullableTp && fromNullableTp.UnderlyingType is TypeParameterSymbol))
+        var genericBoxSource = from as TypeParameterSymbol
+            ?? (from as NullableTypeSymbol)?.UnderlyingType as TypeParameterSymbol;
+        if (genericBoxSource != null
             && (to.ClrType?.IsSameAs(typeof(object)) == true || IsInterfaceTargetType(to)))
         {
             this.il.OpCode(ILOpCode.Box);
             this.il.Token(this.outer.memberRefs.GetElementTypeToken(from));
+
+            // Issue #3421 review follow-up: an unconstrained `T -> I`
+            // explicit cast is `box !!T; castclass I`. The castclass is what
+            // rejects incompatible reference and value instantiations.
+            // Constraint-proven implicit `T -> I` conversions remain box-only.
+            var interfaceTarget = to is NullableTypeSymbol nullableInterfaceTarget
+                ? nullableInterfaceTarget.UnderlyingType
+                : to;
+            if (IsInterfaceTargetType(interfaceTarget)
+                && !Conversion.Classify(genericBoxSource, interfaceTarget).IsImplicit)
+            {
+                this.il.OpCode(ILOpCode.Castclass);
+                this.il.Token(this.outer.memberRefs.GetElementTypeToken(interfaceTarget));
+            }
+
             return;
         }
 

--- a/src/Core/Resx/ResxDesignerGenerator.cs
+++ b/src/Core/Resx/ResxDesignerGenerator.cs
@@ -118,11 +118,11 @@ public static class ResxDesignerGenerator
         string gsType = ResxTypeNameMapper.Map(entry.TypeName);
         sb.Append("        prop ").Append(identifier).Append(' ').Append(gsType).AppendLine(" {");
         sb.AppendLine("            get {");
-        sb.Append("                return (ResourceManager.GetObject(\"")
-            .Append(entry.Name)
-            .Append("\", resourceCulture) as ")
+        sb.Append("                return cast[")
             .Append(gsType)
-            .AppendLine(")!!");
+            .Append("](ResourceManager.GetObject(\"")
+            .Append(entry.Name)
+            .AppendLine("\", resourceCulture))");
         sb.AppendLine("            }");
         sb.AppendLine("        }");
     }

--- a/test/Compiler.Tests/Emit/Issue3421GenericInterfaceCastEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3421GenericInterfaceCastEmitTests.cs
@@ -1,0 +1,202 @@
+// <copyright file="Issue3421GenericInterfaceCastEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection.Emit;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #3421: an unconstrained generic explicit cast to an interface emits
+/// <c>box T; castclass I</c>. Constraint-proven implicit conversions stay
+/// box-only.
+/// </summary>
+public sealed class Issue3421GenericInterfaceCastEmitTests
+{
+    [Fact]
+    public async Task GenericInterfaceCast_CompilesVerifiesAndPreservesRuntimeChecks()
+    {
+        const string source = """
+            import System
+
+            interface IValue3421 {
+                func Read() int32;
+            }
+
+            struct CompatibleValue3421 : IValue3421 {
+                func Read() int32 -> 7
+            }
+
+            struct IncompatibleValue3421 {}
+            class IncompatibleReference3421 {}
+
+            func CheckedCast3421[T](value T) IValue3421 -> cast[IValue3421](value)
+            func ImplicitCast3421[T IValue3421](value T) IValue3421 -> value
+
+            Console.WriteLine(CheckedCast3421[CompatibleValue3421](CompatibleValue3421{}).Read())
+
+            try {
+                CheckedCast3421[IncompatibleReference3421](IncompatibleReference3421())
+                Console.WriteLine("missing reference failure")
+            } catch (e InvalidCastException) {
+                Console.WriteLine("reference failure")
+            }
+
+            try {
+                CheckedCast3421[IncompatibleValue3421](IncompatibleValue3421{})
+                Console.WriteLine("missing value failure")
+            } catch (e InvalidCastException) {
+                Console.WriteLine("value failure")
+            }
+
+            Console.WriteLine(ImplicitCast3421[CompatibleValue3421](CompatibleValue3421{}).Read())
+            """;
+
+        var result = await CompileInspectAndRun(
+            source,
+            "CheckedCast3421",
+            "ImplicitCast3421");
+
+        Assert.Equal(
+            string.Join(
+                Environment.NewLine,
+                "7",
+                "reference failure",
+                "value failure",
+                "7") + Environment.NewLine,
+            result.Output);
+
+        var checkedInstructions = IlInstructionReader.Read(result.MethodIl["CheckedCast3421"]);
+        Assert.Contains(checkedInstructions, instruction => instruction.OpCode == OpCodes.Box);
+        Assert.Contains(checkedInstructions, instruction => instruction.OpCode == OpCodes.Castclass);
+
+        var implicitInstructions = IlInstructionReader.Read(result.MethodIl["ImplicitCast3421"]);
+        Assert.Contains(implicitInstructions, instruction => instruction.OpCode == OpCodes.Box);
+        Assert.DoesNotContain(implicitInstructions, instruction => instruction.OpCode == OpCodes.Castclass);
+    }
+
+    private static async Task<(string Output, IReadOnlyDictionary<string, byte[]> MethodIl)> CompileInspectAndRun(
+        string source,
+        params string[] methods)
+    {
+        string outputDirectory = Path.Combine(
+            AppContext.BaseDirectory,
+            nameof(Issue3421GenericInterfaceCastEmitTests),
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(outputDirectory);
+        try
+        {
+            string sourcePath = Path.Combine(outputDirectory, "Program.gs");
+            string outputPath = Path.Combine(outputDirectory, "Issue3421.dll");
+            File.WriteAllText(sourcePath, source);
+
+            using var standardOut = new StringWriter();
+            using var standardError = new StringWriter();
+            TextWriter previousOut = Console.Out;
+            TextWriter previousError = Console.Error;
+            Console.SetOut(standardOut);
+            Console.SetError(standardError);
+            int exitCode;
+            try
+            {
+                exitCode = Program.Main(new[]
+                {
+                    "/out:" + outputPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    sourcePath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+                Console.SetError(previousError);
+            }
+
+            Assert.True(
+                exitCode == 0,
+                $"gsc failed (exit {exitCode}):\nstdout:\n{standardOut}\nstderr:\n{standardError}");
+
+            var methodIl = methods.ToDictionary(
+                method => method,
+                method => ReadMethodIl(outputPath, method));
+
+            IlVerifier.Verify(outputPath);
+
+            var startInfo = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = outputDirectory,
+            };
+            startInfo.ArgumentList.Add("exec");
+            startInfo.ArgumentList.Add("--runtimeconfig");
+            startInfo.ArgumentList.Add(Path.ChangeExtension(outputPath, ".runtimeconfig.json"));
+            startInfo.ArgumentList.Add(outputPath);
+
+            using var process = Process.Start(startInfo)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec.");
+            Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync();
+            Task<string> stderrTask = process.StandardError.ReadToEndAsync();
+            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            try
+            {
+                await process.WaitForExitAsync(timeout.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                process.Kill(entireProcessTree: true);
+                Assert.Fail("dotnet exec timed out.");
+            }
+
+            string stdout = await stdoutTask;
+            string stderr = await stderrTask;
+            Assert.True(
+                process.ExitCode == 0,
+                $"sample exited {process.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return (stdout.ReplaceLineEndings(Environment.NewLine), methodIl);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(outputDirectory, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    private static byte[] ReadMethodIl(string assemblyPath, string methodName)
+    {
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+        MetadataReader metadata = peReader.GetMetadataReader();
+        foreach (MethodDefinitionHandle methodHandle in metadata.MethodDefinitions)
+        {
+            MethodDefinition method = metadata.GetMethodDefinition(methodHandle);
+            if (metadata.GetString(method.Name) != methodName || method.RelativeVirtualAddress == 0)
+            {
+                continue;
+            }
+
+            return peReader.GetMethodBody(method.RelativeVirtualAddress).GetILBytes()
+                ?? Array.Empty<byte>();
+        }
+
+        throw new InvalidOperationException($"Method '{methodName}' was not found in '{assemblyPath}'.");
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3421CheckedReferenceCastTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3421CheckedReferenceCastTests.cs
@@ -175,6 +175,37 @@ public sealed class Issue3421CheckedReferenceCastTests
     }
 
     [Fact]
+    public void UnambiguousCastBoxesValueTypesToInterfaces()
+    {
+        var result = EmittedOracle.Evaluate("""
+            import System
+
+            interface IValue3421 {
+                func Read() int32;
+            }
+
+            struct Value3421 : IValue3421 {
+                func Read() int32 -> 7
+            }
+
+            Console.WriteLine(cast[IValue3421](Value3421{}).Read())
+            Console.WriteLine(cast[IValue3421?](Value3421{})!!.Read())
+            Console.WriteLine(cast[IValue3421](default(Value3421?)) == nil)
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(
+            string.Join(
+                Environment.NewLine,
+                "7",
+                "7",
+                "True") + Environment.NewLine,
+            result.Output);
+        Assert.Equal(string.Empty, result.ErrorOutput);
+        Assert.Equal(0, result.ExitCode);
+    }
+
+    [Fact]
     public void FailedClrConstructorFallbackBindsCaptureArgumentOnce()
     {
         var tree = SyntaxTree.Parse(SourceText.From("""

--- a/test/Core.Tests/Resx/ResxDesignerGeneratorTests.cs
+++ b/test/Core.Tests/Resx/ResxDesignerGeneratorTests.cs
@@ -91,7 +91,7 @@ public class ResxDesignerGeneratorTests
     }
 
     [Fact]
-    public void Generate_TypedResource_UsesGetObjectWithAsCast()
+    public void Generate_TypedResource_UsesCheckedCast()
     {
         var document = ResxDocument.Parse(SampleResx);
         var options = new ResxDesignerOptions("Oahu.Core.Properties", "Resources", "Oahu.Core.Properties.Resources", isPublic: false);
@@ -99,7 +99,9 @@ public class ResxDesignerGeneratorTests
         string source = ResxDesignerGenerator.Generate(document, options);
 
         Assert.Contains("prop SampleBytes []uint8 {", source);
-        Assert.Contains("ResourceManager.GetObject(\"SampleBytes\", resourceCulture) as []uint8", source);
+        Assert.Contains(
+            "cast[[]uint8](ResourceManager.GetObject(\"SampleBytes\", resourceCulture))",
+            source);
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3347RemainingSpillInventoryTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3347RemainingSpillInventoryTests.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -12,6 +13,15 @@ using Cs2Gs.CodeModel.RoundTrip;
 using Cs2Gs.Pipeline;
 using Cs2Gs.Translator;
 using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using GSharpAsExpressionSyntax = GSharp.Core.CodeAnalysis.Syntax.AsExpressionSyntax;
+using GSharpExpressionSyntax = GSharp.Core.CodeAnalysis.Syntax.ExpressionSyntax;
+using GSharpParenthesizedExpressionSyntax = GSharp.Core.CodeAnalysis.Syntax.ParenthesizedExpressionSyntax;
+using GSharpSyntaxKind = GSharp.Core.CodeAnalysis.Syntax.SyntaxKind;
+using GSharpSyntaxNode = GSharp.Core.CodeAnalysis.Syntax.SyntaxNode;
+using GSharpSyntaxTree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree;
+using GSharpUnaryExpressionSyntax = GSharp.Core.CodeAnalysis.Syntax.UnaryExpressionSyntax;
 using Xunit;
 
 namespace Cs2Gs.Tests;
@@ -30,7 +40,7 @@ public sealed class Issue3347RemainingSpillInventoryTests
     /// project ratchet below protects its independently verified zero-spill output.
     /// </summary>
     [Fact]
-    public async Task CoreMigration_RemainingSynthesizedNameFamiliesStayRetired()
+    public async Task CoreMigration_Issue3421CheckedCastNoiseAndSynthesizedNameFamiliesStayRetired()
     {
         string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
         LoadedCSharpProject project = await CSharpProjectLoader.LoadProjectAsync(
@@ -45,6 +55,8 @@ public sealed class Issue3347RemainingSpillInventoryTests
         int deconstructionCount = 0;
         int spillCount = 0;
         int usingCount = 0;
+        int sourceAssertedAsConversions = 0;
+        int translatedAssertedAsConversions = 0;
         foreach (LoadedDocument document in project.Documents)
         {
             var context = new TranslationContext(
@@ -57,12 +69,15 @@ public sealed class Issue3347RemainingSpillInventoryTests
             deconstructionCount += CountOccurrences(printed, "__decon");
             spillCount += CountOccurrences(printed, "let __spill");
             usingCount += CountOccurrences(printed, "__using");
+            sourceAssertedAsConversions += CountSourceAssertedAsConversions(document);
+            translatedAssertedAsConversions += CountTranslatedAssertedAsConversions(printed);
         }
 
         Assert.Equal(0, castCount);
         Assert.Equal(0, deconstructionCount);
         Assert.Equal(0, spillCount);
         Assert.Equal(0, usingCount);
+        Assert.Equal(sourceAssertedAsConversions, translatedAssertedAsConversions);
     }
 
     [Fact]
@@ -95,6 +110,38 @@ public sealed class Issue3347RemainingSpillInventoryTests
         }
 
         Assert.Equal(0, spillCount);
+    }
+
+    [Fact]
+    public void Issue3421AssertedAsInventory_AllowsExplicitSourceSuppression()
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[]
+            {
+                (
+                    "Snippet.cs",
+                    """
+                    public static class C
+                    {
+                        public static int Length(object value) => (value as string)!.Length;
+                    }
+                    """),
+            });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: "
+                + string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(
+            project.Compilation,
+            document.SemanticModel,
+            document.FilePath);
+        string printed = GSharpPrinter.Print(
+            new CSharpToGSharpTranslator().TranslateDocument(document, context));
+
+        Assert.Equal(1, CountSourceAssertedAsConversions(document));
+        Assert.Equal(1, CountTranslatedAssertedAsConversions(printed));
     }
 
     [Fact]
@@ -466,6 +513,63 @@ public sealed class Issue3347RemainingSpillInventoryTests
         }
 
         return count;
+    }
+
+    private static int CountSourceAssertedAsConversions(LoadedDocument document)
+        => document.GetRoot()
+            .DescendantNodes()
+            .OfType<PostfixUnaryExpressionSyntax>()
+            .Count(postfix =>
+                postfix.RawKind == (int)SyntaxKind.SuppressNullableWarningExpression
+                && UnwrapCSharpParentheses(postfix.Operand) is BinaryExpressionSyntax binary
+                && binary.RawKind == (int)SyntaxKind.AsExpression);
+
+    private static int CountTranslatedAssertedAsConversions(string printed)
+    {
+        var tree = GSharpSyntaxTree.Parse(printed);
+        Assert.Empty(tree.Diagnostics);
+        return Descendants(tree.Root)
+            .OfType<GSharpUnaryExpressionSyntax>()
+            .Count(IsAssertedAsConversion);
+    }
+
+    private static Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax UnwrapCSharpParentheses(
+        Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax expression)
+    {
+        while (expression is Microsoft.CodeAnalysis.CSharp.Syntax.ParenthesizedExpressionSyntax parenthesized)
+        {
+            expression = parenthesized.Expression;
+        }
+
+        return expression;
+    }
+
+    private static bool IsAssertedAsConversion(GSharpUnaryExpressionSyntax unary)
+    {
+        if (unary.OperatorToken.Kind != GSharpSyntaxKind.BangBangToken)
+        {
+            return false;
+        }
+
+        GSharpExpressionSyntax operand = unary.Operand;
+        while (operand is GSharpParenthesizedExpressionSyntax parenthesized)
+        {
+            operand = parenthesized.Expression;
+        }
+
+        return operand is GSharpAsExpressionSyntax;
+    }
+
+    private static IEnumerable<GSharpSyntaxNode> Descendants(GSharpSyntaxNode node)
+    {
+        yield return node;
+        foreach (GSharpSyntaxNode child in node.GetChildren())
+        {
+            foreach (GSharpSyntaxNode descendant in Descendants(child))
+            {
+                yield return descendant;
+            }
+        }
     }
 
     private static string Translate(string source)

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3394BoxingCastTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3394BoxingCastTranslationTests.cs
@@ -171,7 +171,7 @@ namespace Demo
     }
 
     [Fact]
-    public void ImmutableArrayToReadOnlyList_UsesNativeInterfaceProjection()
+    public void ImmutableArrayToReadOnlyList_UsesUnambiguousInterfaceCast()
     {
         const string source = @"
 using System.Collections.Generic;
@@ -190,9 +190,9 @@ namespace Demo
 
         string rendered = Translate(source);
 
-        Assert.Contains("(values as IReadOnlyList[string])!!", rendered, StringComparison.Ordinal);
+        Assert.Contains("cast[IReadOnlyList[string]](values)", rendered, StringComparison.Ordinal);
         Assert.DoesNotContain("__cast", rendered, StringComparison.Ordinal);
-        Assert.DoesNotContain("IReadOnlyList[string](values)", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("values as IReadOnlyList[string]", rendered, StringComparison.Ordinal);
         TranslationTestValidation.AssertBinds(rendered);
     }
 
@@ -226,8 +226,9 @@ namespace Demo
 
         string rendered = Translate(source);
 
-        Assert.Contains("let boxed = (value as IValue)!!", rendered, StringComparison.Ordinal);
+        Assert.Contains("let boxed = cast[IValue](value)", rendered, StringComparison.Ordinal);
         Assert.DoesNotContain("__cast", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("value as IValue", rendered, StringComparison.Ordinal);
         TranslationTestValidation.AssertBinds(rendered);
 
         var result = EmittedOracle.Evaluate(rendered + Environment.NewLine + "C().Run()");
@@ -255,8 +256,8 @@ namespace Demo
 
         string rendered = Translate(source);
 
-        Assert.Contains("value as IValue?", rendered, StringComparison.Ordinal);
-        Assert.DoesNotContain("(value as IValue?)!!", rendered, StringComparison.Ordinal);
+        Assert.Contains("cast[IValue?](value)", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("value as IValue?", rendered, StringComparison.Ordinal);
         Assert.DoesNotContain("__cast", rendered, StringComparison.Ordinal);
         TranslationTestValidation.AssertBinds(rendered);
     }
@@ -293,8 +294,8 @@ namespace Demo
 
         string rendered = Translate(source);
 
-        Assert.Contains("cast[IValue](value as IValue)", rendered, StringComparison.Ordinal);
-        Assert.DoesNotContain("(value as IValue)!!", rendered, StringComparison.Ordinal);
+        Assert.Contains("cast[IValue](value)", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("value as IValue", rendered, StringComparison.Ordinal);
         Assert.DoesNotContain("__cast", rendered, StringComparison.Ordinal);
         TranslationTestValidation.AssertBinds(rendered);
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3421CheckedReferenceCastTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3421CheckedReferenceCastTranslationTests.cs
@@ -3,10 +3,16 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 using Cs2Gs.CodeModel.Ast;
 using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Pipeline;
 using Cs2Gs.Translator;
 using Cs2Gs.Translator.Loading;
+using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Tests;
 using Xunit;
 
@@ -22,6 +28,39 @@ namespace Cs2Gs.Tests;
 /// </summary>
 public class Issue3421CheckedReferenceCastTranslationTests
 {
+    [Fact]
+    public async Task CoreMigration_HasNoAssertedAsConversions()
+    {
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        Assert.False(string.IsNullOrEmpty(repoRoot));
+
+        LoadedCSharpProject project = await CSharpProjectLoader.LoadProjectAsync(
+            Path.Combine(repoRoot, "src", "Core", "Core.csproj"));
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Core should bind with no C# errors: "
+                + string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        var translator = new CSharpToGSharpTranslator(preservePartialParts: true);
+        int assertedAsConversions = 0;
+        foreach (LoadedDocument document in project.Documents)
+        {
+            var context = new TranslationContext(
+                project.Compilation,
+                document.SemanticModel,
+                document.FilePath);
+            string printed = GSharpPrinter.Print(
+                translator.TranslateDocument(document, context));
+            var tree = SyntaxTree.Parse(printed);
+            Assert.Empty(tree.Diagnostics);
+            assertedAsConversions += Descendants(tree.Root)
+                .OfType<UnaryExpressionSyntax>()
+                .Count(IsAssertedAsConversion);
+        }
+
+        Assert.Equal(0, assertedAsConversions);
+    }
+
     [Fact]
     public void NonNullableTargetCast_UsedAsReceiver_UsesConversionCall()
     {
@@ -295,5 +334,33 @@ public static class C
         var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
         return GSharpPrinter.Print(unit);
+    }
+
+    private static bool IsAssertedAsConversion(UnaryExpressionSyntax unary)
+    {
+        if (unary.OperatorToken.Kind != SyntaxKind.BangBangToken)
+        {
+            return false;
+        }
+
+        ExpressionSyntax operand = unary.Operand;
+        while (operand is ParenthesizedExpressionSyntax parenthesized)
+        {
+            operand = parenthesized.Expression;
+        }
+
+        return operand is AsExpressionSyntax;
+    }
+
+    private static IEnumerable<SyntaxNode> Descendants(SyntaxNode node)
+    {
+        yield return node;
+        foreach (SyntaxNode child in node.GetChildren())
+        {
+            foreach (SyntaxNode descendant in Descendants(child))
+            {
+                yield return descendant;
+            }
+        }
     }
 }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3421CheckedReferenceCastTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3421CheckedReferenceCastTranslationTests.cs
@@ -3,16 +3,10 @@
 // </copyright>
 
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 using Cs2Gs.CodeModel.Ast;
 using Cs2Gs.CodeModel.Printing;
-using Cs2Gs.Pipeline;
 using Cs2Gs.Translator;
 using Cs2Gs.Translator.Loading;
-using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Tests;
 using Xunit;
 
@@ -28,39 +22,6 @@ namespace Cs2Gs.Tests;
 /// </summary>
 public class Issue3421CheckedReferenceCastTranslationTests
 {
-    [Fact]
-    public async Task CoreMigration_HasNoAssertedAsConversions()
-    {
-        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
-        Assert.False(string.IsNullOrEmpty(repoRoot));
-
-        LoadedCSharpProject project = await CSharpProjectLoader.LoadProjectAsync(
-            Path.Combine(repoRoot, "src", "Core", "Core.csproj"));
-        Assert.True(
-            project.BoundWithoutErrors,
-            "Core should bind with no C# errors: "
-                + string.Join(Environment.NewLine, project.ErrorDiagnostics));
-
-        var translator = new CSharpToGSharpTranslator(preservePartialParts: true);
-        int assertedAsConversions = 0;
-        foreach (LoadedDocument document in project.Documents)
-        {
-            var context = new TranslationContext(
-                project.Compilation,
-                document.SemanticModel,
-                document.FilePath);
-            string printed = GSharpPrinter.Print(
-                translator.TranslateDocument(document, context));
-            var tree = SyntaxTree.Parse(printed);
-            Assert.Empty(tree.Diagnostics);
-            assertedAsConversions += Descendants(tree.Root)
-                .OfType<UnaryExpressionSyntax>()
-                .Count(IsAssertedAsConversion);
-        }
-
-        Assert.Equal(0, assertedAsConversions);
-    }
-
     [Fact]
     public void NonNullableTargetCast_UsedAsReceiver_UsesConversionCall()
     {
@@ -213,6 +174,25 @@ public static class C
     }
 
     [Fact]
+    public void UnconstrainedGenericInterfaceCast_UsesCheckedCast()
+    {
+        string printed = Translate(@"
+public interface IValue
+{
+    int Read();
+}
+
+public static class C
+{
+    public static IValue Cast<T>(T value) => (IValue)value;
+}");
+
+        Assert.Contains("cast[IValue](value)", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("value as IValue", printed, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(printed);
+    }
+
+    [Fact]
     public void GenericAndDynamicReferenceCasts_UseConversionCalls()
     {
         string printed = Translate(@"
@@ -334,33 +314,5 @@ public static class C
         var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
         return GSharpPrinter.Print(unit);
-    }
-
-    private static bool IsAssertedAsConversion(UnaryExpressionSyntax unary)
-    {
-        if (unary.OperatorToken.Kind != SyntaxKind.BangBangToken)
-        {
-            return false;
-        }
-
-        ExpressionSyntax operand = unary.Operand;
-        while (operand is ParenthesizedExpressionSyntax parenthesized)
-        {
-            operand = parenthesized.Expression;
-        }
-
-        return operand is AsExpressionSyntax;
-    }
-
-    private static IEnumerable<SyntaxNode> Descendants(SyntaxNode node)
-    {
-        yield return node;
-        foreach (SyntaxNode child in node.GetChildren())
-        {
-            foreach (SyntaxNode descendant in Descendants(child))
-            {
-                yield return descendant;
-            }
-        }
     }
 }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3421CheckedReferenceCastTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3421CheckedReferenceCastTranslationTests.cs
@@ -136,6 +136,44 @@ public sealed class C
     }
 
     [Fact]
+    public void ExplicitAsNullForgiveness_RemainsTestingConversion()
+    {
+        string printed = Translate(@"
+public sealed class C
+{
+    public int Length(object value) => (value as string)!.Length;
+}");
+
+        Assert.Contains("(value as string)!!.Length", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("cast[string](value)", printed, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(printed);
+    }
+
+    [Fact]
+    public void ConditionalInterfaceBoxingCast_UsesUnambiguousCast()
+    {
+        string printed = Translate(@"
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+public static class C
+{
+    public static IReadOnlyList<string>? Names(ImmutableArray<string> argumentNames) =>
+        argumentNames.IsDefault ? null : (IReadOnlyList<string>)argumentNames;
+}");
+
+        Assert.Contains(
+            "if argumentNames.IsDefault { default(IReadOnlyList[string]?) } else { cast[IReadOnlyList[string]](argumentNames) }",
+            printed,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "(argumentNames as IReadOnlyList[string])!!",
+            printed,
+            StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(printed);
+    }
+
+    [Fact]
     public void GenericAndDynamicReferenceCasts_UseConversionCalls()
     {
         string printed = Translate(@"

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3422RedundantNullForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3422RedundantNullForgivenessTranslationTests.cs
@@ -3,7 +3,9 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Cs2Gs.CodeModel.Ast;
 using Cs2Gs.CodeModel.Printing;
@@ -11,6 +13,7 @@ using Cs2Gs.CodeModel.RoundTrip;
 using Cs2Gs.Pipeline;
 using Cs2Gs.Translator;
 using Cs2Gs.Translator.Loading;
+using GSharp.Core.CodeAnalysis.Syntax;
 using Xunit;
 
 namespace Cs2Gs.Tests;
@@ -36,6 +39,7 @@ public sealed class Issue3422RedundantNullForgivenessTranslationTests
         var translator = new CSharpToGSharpTranslator(preservePartialParts: true);
         int doubledAssertions = 0;
         int assertedParenthesizedReceivers = 0;
+        int assertedAsConversions = 0;
         foreach (LoadedDocument document in project.Documents)
         {
             var context = new TranslationContext(
@@ -46,10 +50,16 @@ public sealed class Issue3422RedundantNullForgivenessTranslationTests
                 translator.TranslateDocument(document, context));
             doubledAssertions += CountOccurrences(printed, "!!!!");
             assertedParenthesizedReceivers += CountOccurrences(printed, ")!!.");
+            var tree = SyntaxTree.Parse(printed);
+            Assert.Empty(tree.Diagnostics);
+            assertedAsConversions += Descendants(tree.Root)
+                .OfType<UnaryExpressionSyntax>()
+                .Count(IsAssertedAsConversion);
         }
 
         Assert.Equal(0, doubledAssertions);
         Assert.Equal(9, assertedParenthesizedReceivers);
+        Assert.Equal(0, assertedAsConversions);
     }
 
     [Fact]
@@ -318,5 +328,33 @@ public sealed class Issue3422RedundantNullForgivenessTranslationTests
         }
 
         return count;
+    }
+
+    private static bool IsAssertedAsConversion(UnaryExpressionSyntax unary)
+    {
+        if (unary.OperatorToken.Kind != SyntaxKind.BangBangToken)
+        {
+            return false;
+        }
+
+        ExpressionSyntax operand = unary.Operand;
+        while (operand is ParenthesizedExpressionSyntax parenthesized)
+        {
+            operand = parenthesized.Expression;
+        }
+
+        return operand is AsExpressionSyntax;
+    }
+
+    private static IEnumerable<SyntaxNode> Descendants(SyntaxNode node)
+    {
+        yield return node;
+        foreach (SyntaxNode child in node.GetChildren())
+        {
+            foreach (SyntaxNode descendant in Descendants(child))
+            {
+                yield return descendant;
+            }
+        }
     }
 }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3422RedundantNullForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3422RedundantNullForgivenessTranslationTests.cs
@@ -3,9 +3,7 @@
 // </copyright>
 
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using Cs2Gs.CodeModel.Ast;
 using Cs2Gs.CodeModel.Printing;
@@ -13,7 +11,6 @@ using Cs2Gs.CodeModel.RoundTrip;
 using Cs2Gs.Pipeline;
 using Cs2Gs.Translator;
 using Cs2Gs.Translator.Loading;
-using GSharp.Core.CodeAnalysis.Syntax;
 using Xunit;
 
 namespace Cs2Gs.Tests;
@@ -39,7 +36,6 @@ public sealed class Issue3422RedundantNullForgivenessTranslationTests
         var translator = new CSharpToGSharpTranslator(preservePartialParts: true);
         int doubledAssertions = 0;
         int assertedParenthesizedReceivers = 0;
-        int assertedAsConversions = 0;
         foreach (LoadedDocument document in project.Documents)
         {
             var context = new TranslationContext(
@@ -50,16 +46,10 @@ public sealed class Issue3422RedundantNullForgivenessTranslationTests
                 translator.TranslateDocument(document, context));
             doubledAssertions += CountOccurrences(printed, "!!!!");
             assertedParenthesizedReceivers += CountOccurrences(printed, ")!!.");
-            var tree = SyntaxTree.Parse(printed);
-            Assert.Empty(tree.Diagnostics);
-            assertedAsConversions += Descendants(tree.Root)
-                .OfType<UnaryExpressionSyntax>()
-                .Count(IsAssertedAsConversion);
         }
 
         Assert.Equal(0, doubledAssertions);
         Assert.Equal(9, assertedParenthesizedReceivers);
-        Assert.Equal(0, assertedAsConversions);
     }
 
     [Fact]
@@ -328,33 +318,5 @@ public sealed class Issue3422RedundantNullForgivenessTranslationTests
         }
 
         return count;
-    }
-
-    private static bool IsAssertedAsConversion(UnaryExpressionSyntax unary)
-    {
-        if (unary.OperatorToken.Kind != SyntaxKind.BangBangToken)
-        {
-            return false;
-        }
-
-        ExpressionSyntax operand = unary.Operand;
-        while (operand is ParenthesizedExpressionSyntax parenthesized)
-        {
-            operand = parenthesized.Expression;
-        }
-
-        return operand is AsExpressionSyntax;
-    }
-
-    private static IEnumerable<SyntaxNode> Descendants(SyntaxNode node)
-    {
-        yield return node;
-        foreach (SyntaxNode child in node.GetChildren())
-        {
-            foreach (SyntaxNode descendant in Descendants(child))
-            {
-                yield return descendant;
-            }
-        }
     }
 }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -2794,37 +2794,12 @@ public sealed partial class CSharpToGSharpTranslator
                     && !targetType.IsNullable
                         ? MakeNullable(targetType)
                         : targetType;
-                if (targetSymbol is { SpecialType: SpecialType.System_Object })
-                {
-                    return new ConversionExpression(boxingTargetType, operand);
-                }
-
-                // Preserve the explicit interface result type without a
-                // synthetic typed slot. `as` supplies the interface projection;
-                // a non-null target then restores the cast's static contract.
-                var projection = new BinaryExpression(
+                bool useUnambiguousCast =
+                    targetSymbol is not { SpecialType: SpecialType.System_Object };
+                return new ConversionExpression(
+                    boxingTargetType,
                     operand,
-                    "as",
-                    new TypeExpression(boxingTargetType));
-                bool sourceIsNullableValueType =
-                    sourceSymbol is INamedTypeSymbol
-                    {
-                        OriginalDefinition.SpecialType: SpecialType.System_Nullable_T,
-                    };
-
-                // Boxing Nullable<T> with HasValue=false yields null; asserting
-                // here would turn a valid C# null result into a throw.
-                if (boxingTargetType.IsNullable)
-                {
-                    return projection;
-                }
-
-                return sourceIsNullableValueType
-                    ? new ConversionExpression(
-                        boxingTargetType,
-                        projection,
-                        isCheckedReferenceCast: true)
-                    : new NonNullAssertionExpression(projection);
+                    useUnambiguousCast);
             }
 
             // Preserve explicit class/interface-to-object casts when they

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -2826,6 +2826,9 @@ public sealed partial class CSharpToGSharpTranslator
                 || (conversion.IsIdentity
                     && sourceSymbol is { IsReferenceType: true }
                     && targetSymbol is { IsReferenceType: true })
+                || (conversion.IsExplicit
+                    && sourceSymbol is ITypeParameterSymbol
+                    && targetSymbol is { TypeKind: TypeKind.Interface })
                 || (sourceSymbol is { TypeKind: TypeKind.Dynamic }
                     && targetSymbol is { IsReferenceType: true });
             return new ConversionExpression(


### PR DESCRIPTION
Closes #3421

## Summary
- route explicit boxing casts to non-`object` reference targets through existing `cast[T](value)` / `cast[T?](value)` mechanism instead of `(value as T)!!`
- support unconstrained generic `T -> interface` checked casts end to end: binder explicit conversion, cs2gs `cast[I](value)`, emitter `box T; castclass I`; constraint-proven implicit casts remain box-only
- use checked-cast spelling in generated typed resource accessors
- integrate checked-cast noise into existing Core migration inventory: translated asserted-`as` count must equal genuine source `(value as T)!` count, so synthetic residual count remains zero without rejecting legitimate source suppression

## Validation
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release --no-restore --nologo --verbosity:minimal --filter 'FullyQualifiedName~Issue3421'` — 13 passed
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release --no-restore --nologo --verbosity:minimal --filter 'FullyQualifiedName~Issue3421'` — 1 passed; compiles, IL-verifies, inspects `box`/`castclass`, and runs compatible/incompatible generic instantiations
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --no-restore --nologo --verbosity:minimal --filter 'FullyQualifiedName~Issue3421'` — 16 passed
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release --no-build --no-restore --nologo --verbosity:minimal` — 7,695 passed
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release --no-build --no-restore --nologo --verbosity:minimal` — 4,409 passed
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --no-build --no-restore --nologo --verbosity:minimal` — 2,148 passed
- `dotnet build GSharp.sln -c Release --no-restore --nologo --verbosity:minimal` — succeeded, 0 warnings/errors
