### PR TITLE
Eliminate redundant null forgiveness in cs2gs

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2427ObliviousExternalAssignmentForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2427ObliviousExternalAssignmentForgivenessTranslationTests.cs
@@ -62,12 +62,32 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("path = (pathStub + ext)!!.AsUncIfLong()!!", printed);
+        Assert.Contains("path = (pathStub + ext).AsUncIfLong()!!", printed);
+        Assert.DoesNotContain("(pathStub + ext)!!", printed);
 
         // Parity: the assignment absorbs the SAME single forgiveness a
         // direct return would need — the later `return path` must not need
         // (or get) a second one.
         Assert.DoesNotContain("return path!!", printed);
+    }
+
+    [Fact]
+    public void CheckedCastOfObliviousExternalResult_PreservesNull()
+    {
+        string printed = TranslateObliviousWithObliviousLibrary(@"
+namespace Demo
+{
+    public class C
+    {
+        public string Cast(ExtLib ext)
+        {
+            return (string)ext.Combine(""hello"");
+        }
+    }
+}");
+
+        Assert.Contains("cast[string](ext.Combine(\"hello\"))", printed);
+        Assert.DoesNotContain("ext.Combine(\"hello\")!!", printed);
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2427ObliviousExternalAssignmentForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2427ObliviousExternalAssignmentForgivenessTranslationTests.cs
@@ -72,7 +72,7 @@ namespace Demo
     }
 
     [Fact]
-    public void CheckedCastOfObliviousExternalResult_PreservesNull()
+    public void Issue3422_CheckedCastOfObliviousExternalResult_PreservesNull()
     {
         string printed = TranslateObliviousWithObliviousLibrary(@"
 namespace Demo
@@ -88,6 +88,13 @@ namespace Demo
 
         Assert.Contains("cast[string](ext.Combine(\"hello\"))", printed);
         Assert.DoesNotContain("ext.Combine(\"hello\")!!", printed);
+        TranslationTestValidation.AssertBinds(
+            printed,
+            """
+            class ExtLib {
+                func Combine(separator string) string -> separator
+            }
+            """);
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3422RedundantNullForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3422RedundantNullForgivenessTranslationTests.cs
@@ -36,6 +36,7 @@ public sealed class Issue3422RedundantNullForgivenessTranslationTests
         var translator = new CSharpToGSharpTranslator(preservePartialParts: true);
         int doubledAssertions = 0;
         int assertedParenthesizedReceivers = 0;
+        int assertions = 0;
         foreach (LoadedDocument document in project.Documents)
         {
             var context = new TranslationContext(
@@ -46,10 +47,256 @@ public sealed class Issue3422RedundantNullForgivenessTranslationTests
                 translator.TranslateDocument(document, context));
             doubledAssertions += CountOccurrences(printed, "!!!!");
             assertedParenthesizedReceivers += CountOccurrences(printed, ")!!.");
+            assertions += CountOccurrences(printed, "!!");
         }
 
         Assert.Equal(0, doubledAssertions);
-        Assert.Equal(9, assertedParenthesizedReceivers);
+        Assert.InRange(assertedParenthesizedReceivers, 0, 8);
+        Assert.InRange(assertions, 0, 6079);
+    }
+
+    [Fact]
+    public void InferredNonNullBindings_DoNotGainAssertions()
+    {
+        string printed = Translate(
+            """
+            #nullable enable
+
+            using System.Collections.Generic;
+
+            public static class C
+            {
+                private static void Consume(List<string> values, string text)
+                {
+                }
+
+                public static int Measure(string? input, object value, bool flag)
+                {
+                    var fresh = new List<string>();
+                    var fallback = input ?? "fallback";
+                    var concatenated = "prefix:" + fallback;
+                    var selected = flag ? concatenated : "other";
+                    var narrowed = (string)value;
+
+                    fresh.Add(fallback);
+                    Consume(fresh, concatenated);
+                    return fresh.Count
+                        + fallback.Length
+                        + concatenated.Length
+                        + selected.Length
+                        + narrowed.Length;
+                }
+            }
+            """);
+
+        Assert.DoesNotContain("fresh!!", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("fallback!!", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("concatenated!!", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("selected!!", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("narrowed!!", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("(\"prefix:\" + fallback)!!", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("cast[string](value)!!", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NonIteratorForEachElements_DoNotGainAssertions()
+    {
+        string printed = Translate(
+            """
+            #nullable enable
+
+            using System.Collections.Generic;
+
+            public static class C
+            {
+                public static int Measure(IEnumerable<string> values)
+                {
+                    var total = 0;
+                    foreach (var value in values)
+                    {
+                        total += value.Length;
+                    }
+
+                    return total;
+                }
+            }
+            """);
+
+        Assert.Contains("for value in values", printed, StringComparison.Ordinal);
+        Assert.Contains("total += value.Length", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("value!!", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void StaticExtensionMethodGroup_KeepsCapturedNonNullReceiver()
+    {
+        string printed = Translate(
+            """
+            #nullable enable
+
+            using System.Collections.Generic;
+            using System.Linq;
+
+            public sealed class Item
+            {
+            }
+
+            public static class C
+            {
+                public static int Remove(List<Item> values)
+                {
+                    var removed = values.ToArray();
+                    return values.RemoveAll(removed.Contains);
+                }
+            }
+            """);
+
+        Assert.Contains(
+            "Enumerable.Contains[Item](removed, __arg0)",
+            printed,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "Enumerable.Contains[Item](__arg0)",
+            printed,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FlowProvenCheckedCast_ForgivesNullableOperandNotCastResult()
+    {
+        string printed = Translate(
+            """
+            #nullable enable
+
+            using System;
+            using System.Diagnostics.CodeAnalysis;
+            using System.Reflection;
+
+            public static class C
+            {
+                private static bool TryResolve([NotNullWhen(true)] out MethodInfo? method)
+                {
+                    method = typeof(string).GetMethod("ToString", Type.EmptyTypes);
+                    return method is not null;
+                }
+
+                public static MethodBase Resolve()
+                {
+                    if (!TryResolve(out var method))
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    return (MethodBase)method;
+                }
+            }
+            """);
+
+        Assert.Contains("cast[MethodBase](method!!)", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("cast[MethodBase](method)!!", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LoopCarriedNullableLocal_KeepsRequiredAssertions()
+    {
+        string printed = Translate(
+            """
+            #nullable enable
+
+            using System;
+
+            public static class C
+            {
+                private static void Consume(Type type)
+                {
+                }
+
+                public static void Walk(Type? type, int count)
+                {
+                    if (type is null)
+                    {
+                        return;
+                    }
+
+                    while (count-- > 0)
+                    {
+                        Consume(type);
+                        type = type.BaseType ?? typeof(object);
+                    }
+                }
+            }
+            """);
+
+        Assert.Contains("C.Consume(type_!!)", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void IteratorForeachAndYield_KeepRequiredGenericTypeAssertions()
+    {
+        string printed = Translate(
+            """
+            #nullable enable
+
+            using System.Collections.Generic;
+
+            public static class C
+            {
+                public static IEnumerable<string> NonNullValues(IEnumerable<string?>? values)
+                {
+                    if (values is null)
+                    {
+                        yield break;
+                    }
+
+                    foreach (var value in values)
+                    {
+                        if (value is not null)
+                        {
+                            yield return value;
+                        }
+                    }
+                }
+            }
+            """);
+
+        Assert.Contains("for value in values!!", printed, StringComparison.Ordinal);
+        Assert.Contains("yield value!!", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SyntheticAssertionRatchet_PreservesOnlyRequiredNullableForgiveness()
+    {
+        string printed = Translate(
+            """
+            #nullable enable
+
+            using System.Collections.Generic;
+
+            public static class C
+            {
+                private static string? Maybe() => null;
+
+                public static int Measure(bool clear)
+                {
+                    string? explicitlyNullable = "text";
+                    List<string>? mutable = new List<string>();
+                    if (clear)
+                    {
+                        mutable = null;
+                    }
+
+                    return Maybe()!.Length
+                        + explicitlyNullable!.Length
+                        + mutable!.Count;
+                }
+            }
+            """);
+
+        Assert.Equal(1, CountOccurrences(printed, ")!!."));
+        Assert.Equal(0, CountOccurrences(printed, "!!!!"));
+        Assert.Contains("C.Maybe()!!.Length", printed, StringComparison.Ordinal);
+        Assert.Contains("explicitlyNullable!!.Length", printed, StringComparison.Ordinal);
+        Assert.Contains("mutable!!.Count", printed, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3422RedundantNullForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3422RedundantNullForgivenessTranslationTests.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Cs2Gs.CodeModel.Ast;
 using Cs2Gs.CodeModel.Printing;
@@ -154,6 +155,68 @@ public sealed class Issue3422RedundantNullForgivenessTranslationTests
         Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
         Assert.Null(result.UnhandledException);
         Assert.Equal(12, result.Value);
+    }
+
+    [Fact]
+    public void CrossNamespaceExactExtensionMethodGroup_GlobalUsingSynthesizesImport()
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[]
+            {
+                ("Extensions.cs", """
+                    #nullable enable
+                    namespace Acme.Extensions;
+
+                    public static class Ext
+                    {
+                        public static int Measure(this string? value, int delta) =>
+                            (value?.Length ?? 10) + delta;
+                    }
+                    """),
+                ("GlobalUsings.cs", "global using Acme.Extensions;"),
+                ("Consumer.cs", """
+                    #nullable enable
+                    using System;
+                    namespace Demo;
+
+                    public static class C
+                    {
+                        private static int Apply(Func<int, int> measure) => measure(2);
+
+                        public static int Run()
+                        {
+                            string? value = null;
+                            return Apply(value.Measure);
+                        }
+                    }
+                    """),
+            });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: "
+                + string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        var translator = new CSharpToGSharpTranslator();
+        string TranslateDocument(string fileName)
+        {
+            LoadedDocument document = project.Documents.Single(candidate =>
+                Path.GetFileName(candidate.FilePath) == fileName);
+            var context = new TranslationContext(
+                project.Compilation,
+                document.SemanticModel,
+                document.FilePath);
+            string printed = GSharpPrinter.Print(
+                translator.TranslateDocument(document, context));
+            Assert.DoesNotContain(
+                context.Diagnostics,
+                diagnostic => diagnostic.Severity == TranslationSeverity.Unsupported);
+            return printed;
+        }
+
+        string extensions = TranslateDocument("Extensions.cs");
+        string consumer = TranslateDocument("Consumer.cs");
+        Assert.Contains("import Acme.Extensions", consumer, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(extensions, consumer);
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3422RedundantNullForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3422RedundantNullForgivenessTranslationTests.cs
@@ -11,6 +11,7 @@ using Cs2Gs.CodeModel.RoundTrip;
 using Cs2Gs.Pipeline;
 using Cs2Gs.Translator;
 using Cs2Gs.Translator.Loading;
+using GSharp.Tests;
 using Xunit;
 
 namespace Cs2Gs.Tests;
@@ -36,7 +37,6 @@ public sealed class Issue3422RedundantNullForgivenessTranslationTests
         var translator = new CSharpToGSharpTranslator(preservePartialParts: true);
         int doubledAssertions = 0;
         int assertedParenthesizedReceivers = 0;
-        int assertions = 0;
         foreach (LoadedDocument document in project.Documents)
         {
             var context = new TranslationContext(
@@ -47,12 +47,10 @@ public sealed class Issue3422RedundantNullForgivenessTranslationTests
                 translator.TranslateDocument(document, context));
             doubledAssertions += CountOccurrences(printed, "!!!!");
             assertedParenthesizedReceivers += CountOccurrences(printed, ")!!.");
-            assertions += CountOccurrences(printed, "!!");
         }
 
         Assert.Equal(0, doubledAssertions);
         Assert.InRange(assertedParenthesizedReceivers, 0, 8);
-        Assert.InRange(assertions, 0, 6079);
     }
 
     [Fact]
@@ -96,6 +94,146 @@ public sealed class Issue3422RedundantNullForgivenessTranslationTests
         Assert.DoesNotContain("narrowed!!", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("(\"prefix:\" + fallback)!!", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("cast[string](value)!!", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NullableAssignmentInitializer_KeepsRequiredLocalAssertion()
+    {
+        string printed = Translate(
+            """
+            #nullable enable
+
+            public static class C
+            {
+                public static int Measure()
+                {
+                    string? sink = null;
+                    var inferred = (sink = "text");
+                    return inferred.Length;
+                }
+            }
+            """);
+
+        Assert.Contains("return inferred!!.Length", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SourceNullableExtensionMethodGroup_UsesReducedReceiverAtRuntime()
+    {
+        string printed = Translate(
+            """
+            #nullable enable
+
+            using System;
+
+            public static class Ext
+            {
+                public static int Measure(this string? value, int delta) =>
+                    (value?.Length ?? 10) + delta;
+            }
+
+            public static class C
+            {
+                private static int Apply(Func<int, int> measure) => measure(2);
+
+                public static int Run()
+                {
+                    string? value = null;
+                    return Apply(value.Measure);
+                }
+            }
+            """);
+
+        Assert.Contains("return value.Measure(__arg0)", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("Ext.Measure", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("value!!", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("value.Measure(value", printed, StringComparison.Ordinal);
+
+        EmittedOracleResult result = EmittedOracle.Evaluate(
+            printed + Environment.NewLine + "C.Run()");
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(12, result.Value);
+    }
+
+    [Fact]
+    public void SourceNonNullableExtensionMethodGroup_UsesNormalReceiverLowering()
+    {
+        string printed = Translate(
+            """
+            #nullable enable
+
+            using System;
+
+            public static class Ext
+            {
+                public static int Measure(this string value, int delta) =>
+                    value.Length + delta;
+            }
+
+            public static class C
+            {
+                private static int Apply(Func<int, int> measure) => measure(2);
+
+                private static int Bind(string? value) => Apply(value.Measure);
+
+                public static int Run() => Bind("abc");
+            }
+            """);
+
+        Assert.Contains("let __spill0 = value!!", printed, StringComparison.Ordinal);
+        Assert.Contains("return __spill0.Measure(__arg0)", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("Ext.Measure", printed, StringComparison.Ordinal);
+
+        EmittedOracleResult result = EmittedOracle.Evaluate(
+            printed + Environment.NewLine + "C.Run()");
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(5, result.Value);
+    }
+
+    [Fact]
+    public void EntryPointExtensionMethodGroup_DoesNotDuplicateReceiverAtRuntime()
+    {
+        string printed = Translate(
+            """
+            #nullable enable
+
+            using System;
+
+            public static class Program
+            {
+                public static bool Matches(this string value, string expected) =>
+                    value == expected;
+
+                private static bool Apply(Func<string, bool> matches) =>
+                    matches("match");
+
+                public static bool Run()
+                {
+                    string receiver = "match";
+                    return Apply(receiver.Matches);
+                }
+
+                public static void Main()
+                {
+                    Console.WriteLine(Run());
+                }
+            }
+            """);
+
+        Assert.Contains("return receiver.Matches(__arg0)", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "receiver.Matches(receiver, __arg0)",
+            printed,
+            StringComparison.Ordinal);
+
+        EmittedOracleResult result = EmittedOracle.Evaluate(printed);
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(
+            $"True{Environment.NewLine}",
+            result.Output.ReplaceLineEndings(Environment.NewLine));
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -623,17 +623,21 @@ public sealed partial class CSharpToGSharpTranslator
         private GExpression TranslateReceiverWithNullForgiveness(ExpressionSyntax recv)
         {
             GExpression translated = this.TranslateExpression(recv);
+            bool iteratorForeachReceiverRequiresAssertion =
+                this.IteratorForeachReceiverRequiresAssertion(recv);
 
-            if (this.GSharpExpressionIsStaticallyNonNull(recv, translated))
+            if (!iteratorForeachReceiverRequiresAssertion
+                && this.GSharpExpressionIsStaticallyNonNull(recv, translated))
             {
                 return ParenthesizeIfBareNumericLiteral(translated);
             }
 
-            if (!this.IsActivePatternBinding(recv)
+            if (iteratorForeachReceiverRequiresAssertion
+                || (!this.IsActivePatternBinding(recv)
                 && !this.IsWithinExpressionTreeLambda(recv)
                 && (this.ReceiverNeedsNullForgiveness(recv, isDereferenceReceiver: true)
                     || this.ReceiverIsNullableReferenceFieldOrProperty(recv)
-                    || this.NullableReferenceValueMayBeNull(recv)))
+                    || this.NullableReferenceValueMayBeNull(recv))))
             {
                 translated = EnsureNonNullAssertion(translated);
             }
@@ -656,6 +660,38 @@ public sealed partial class CSharpToGSharpTranslator
             }
 
             return ParenthesizeIfBareNumericLiteral(translated);
+        }
+
+        private bool IteratorForeachReceiverRequiresAssertion(ExpressionSyntax recv)
+        {
+            ExpressionSyntax unwrapped = recv;
+            while (unwrapped is ParenthesizedExpressionSyntax parenthesized)
+            {
+                unwrapped = parenthesized.Expression;
+            }
+
+            if (unwrapped is not IdentifierNameSyntax
+                || this.context.GetSymbolInfo(unwrapped).Symbol is not
+                    (ILocalSymbol or IParameterSymbol)
+                || this.GetDeclaredValueType(unwrapped) is not { IsReferenceType: true, NullableAnnotation: NullableAnnotation.Annotated }
+                || !this.IsGSharpFlowNarrowedLocal(unwrapped))
+            {
+                return false;
+            }
+
+            ForEachStatementSyntax forEach = unwrapped.Ancestors()
+                .OfType<ForEachStatementSyntax>()
+                .FirstOrDefault(loop => loop.Expression.Span.Contains(unwrapped.Span));
+            SyntaxNode body = this.state.CurrentBodyScope
+                ?? unwrapped.Ancestors().FirstOrDefault(node =>
+                    node is BaseMethodDeclarationSyntax
+                        or AccessorDeclarationSyntax
+                        or LocalFunctionStatementSyntax);
+
+            // G# iterator lowering needs the local smart-cast made explicit at
+            // the foreach source so the generated generic enumerator stays typed.
+            return forEach != null
+                && body?.DescendantNodes().OfType<YieldStatementSyntax>().Any() == true;
         }
 
         // ADR-0160: true when `recv` names a local whose declaration initializer is a
@@ -956,13 +992,8 @@ public sealed partial class CSharpToGSharpTranslator
                 return translated;
             }
 
-            TypeInfo valueTypeInfo = this.context.GetTypeInfo(value);
-            ITypeSymbol declaredValueType = this.GetDeclaredValueType(value);
             bool flowNarrowedAnnotatedValue =
-                valueTypeInfo.Nullability.FlowState == NullableFlowState.NotNull
-                && (valueTypeInfo.Nullability.Annotation == NullableAnnotation.Annotated
-                    || valueTypeInfo.Type?.NullableAnnotation == NullableAnnotation.Annotated
-                    || declaredValueType?.NullableAnnotation == NullableAnnotation.Annotated);
+                this.IsFlowNarrowedAnnotatedReference(value);
             bool flowRequiresAssertion = this.ReceiverNeedsNullForgiveness(value)
                 || flowNarrowedAnnotatedValue;
             if (!flowRequiresAssertion
@@ -1033,9 +1064,34 @@ public sealed partial class CSharpToGSharpTranslator
 
             switch (unwrapped)
             {
+                case LiteralExpressionSyntax literal:
+                    return !literal.IsKind(SyntaxKind.NullLiteralExpression)
+                        && !literal.IsKind(SyntaxKind.DefaultLiteralExpression);
+
+                case ObjectCreationExpressionSyntax:
+                case ImplicitObjectCreationExpressionSyntax:
+                case ArrayCreationExpressionSyntax:
+                case ImplicitArrayCreationExpressionSyntax:
+                case AnonymousObjectCreationExpressionSyntax:
+                case InterpolatedStringExpressionSyntax:
+                case TypeOfExpressionSyntax:
+                case ThrowExpressionSyntax:
+                    return true;
+
                 case PostfixUnaryExpressionSyntax suppression
                     when suppression.IsKind(SyntaxKind.SuppressNullableWarningExpression):
                     return !IsNullOrSuppressedNull(suppression.Operand);
+
+                case BinaryExpressionSyntax concatenation
+                    when concatenation.IsKind(SyntaxKind.AddExpression)
+                        && this.context.GetTypeInfo(concatenation).Type?.SpecialType
+                            == SpecialType.System_String:
+                    return true;
+
+                case CastExpressionSyntax cast
+                    when cast.Type is not NullableTypeSyntax
+                        && this.CastUsesCheckedReferenceConversion(cast):
+                    return true;
 
                 case ConditionalExpressionSyntax conditional:
                     GExpression conditionalValue = UnwrapTranslatedValue(translated);
@@ -1102,6 +1158,13 @@ public sealed partial class CSharpToGSharpTranslator
             }
 
             ISymbol symbol = this.context.GetSymbolInfo(expression).Symbol;
+            if (symbol is ILocalSymbol inferredLocal
+                && (this.LocalBindingInfersStaticallyNonNullInitializer(inferredLocal)
+                    || this.ForEachBindingInfersNonNullElement(inferredLocal)))
+            {
+                return true;
+            }
+
             ITypeSymbol type = symbol switch
             {
                 IFieldSymbol field => field.Type,
@@ -1121,6 +1184,76 @@ public sealed partial class CSharpToGSharpTranslator
                 && !this.IsImportedObliviousNullableMember(symbol)
                 && !this.LocalInitializedFromImportedObliviousNullable(symbol)
                 && (symbol == null || !this.ShouldPromoteToNullableReference(symbol));
+        }
+
+        private bool LocalBindingInfersStaticallyNonNullInitializer(ILocalSymbol local)
+        {
+            if (this.IsLocalReassigned(local)
+                || local.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax()
+                    is not VariableDeclaratorSyntax
+                    {
+                        Initializer.Value: { } initializer,
+                        Parent: VariableDeclarationSyntax declaration,
+                    })
+            {
+                return false;
+            }
+
+            if (declaration.Type.IsVar)
+            {
+                if (this.ShouldPromoteToNullableReference(local)
+                    || (IsAnnotatedNullableReference(local.Type)
+                        && this.IsUsedAsNullable(local, this.GetNullabilityScope(local))))
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                ITypeSymbol naturalType = this.context.GetTypeInfo(initializer).Type;
+                if (IsAnnotatedNullableReference(local.Type)
+                    || naturalType == null
+                    || !SymbolEqualityComparer.Default.Equals(local.Type, naturalType)
+                    || this.ShouldPromoteToNullableReference(local))
+                {
+                    return false;
+                }
+            }
+
+            return this.GSharpExpressionIsStaticallyNonNull(initializer);
+        }
+
+        private bool ForEachBindingInfersNonNullElement(ILocalSymbol local)
+        {
+            SyntaxNode body = this.state.CurrentBodyScope;
+
+            // Iterator lowering preserves the source collection's nullable
+            // element annotation, so yield seams handle their own proof here.
+            if (body?.DescendantNodes().OfType<YieldStatementSyntax>().Any() == true)
+            {
+                return false;
+            }
+
+            foreach (SyntaxReference reference in local.DeclaringSyntaxReferences)
+            {
+                if (reference.GetSyntax() is not ForEachStatementSyntax forEach
+                    || !SymbolEqualityComparer.Default.Equals(
+                        this.context.GetDeclaredSymbol(forEach),
+                        local))
+                {
+                    continue;
+                }
+
+                ITypeSymbol elementType = this.context.SemanticModel
+                    .GetForEachStatementInfo(forEach)
+                    .ElementType;
+                return elementType is { IsValueType: true }
+                    ? elementType.OriginalDefinition?.SpecialType
+                        != SpecialType.System_Nullable_T
+                    : elementType is { IsReferenceType: true, NullableAnnotation: NullableAnnotation.NotAnnotated };
+            }
+
+            return false;
         }
 
         private bool PatternLocalUsesNullableStorage(ExpressionSyntax expression)
@@ -1225,7 +1358,8 @@ public sealed partial class CSharpToGSharpTranslator
                             whenTrue,
                             includeWhenClauseRegion: false)
                         .Any(region => region.Span.Contains(expression.Span))
-                    || this.SymbolIsWrittenBetween(symbol, isPattern, expression, scope))
+                    || this.SymbolIsWrittenBetween(symbol, isPattern, expression, scope)
+                    || this.HasLoopCarriedWrite(expression, symbol, scope, isPattern))
                 {
                     continue;
                 }
@@ -1248,12 +1382,42 @@ public sealed partial class CSharpToGSharpTranslator
                             whenTrue,
                             includeWhenClauseRegion: false)
                         .Any(region => region.Span.Contains(expression.Span))
-                    || this.SymbolIsWrittenBetween(symbol, nullCheck, expression, scope))
+                    || this.SymbolIsWrittenBetween(symbol, nullCheck, expression, scope)
+                    || this.HasLoopCarriedWrite(expression, symbol, scope, nullCheck))
                 {
                     continue;
                 }
 
                 return true;
+            }
+
+            return false;
+        }
+
+        private bool HasLoopCarriedWrite(
+            ExpressionSyntax use,
+            ISymbol symbol,
+            SyntaxNode scope,
+            SyntaxNode narrowingGuard)
+        {
+            for (SyntaxNode node = use.Parent; node != null && node != scope; node = node.Parent)
+            {
+                if (node is WhileStatementSyntax
+                    or DoStatementSyntax
+                    or ForStatementSyntax
+                    or ForEachStatementSyntax
+                    or ForEachVariableStatementSyntax)
+                {
+                    // A guard outside a loop is not re-evaluated after a write in
+                    // the loop body, so it cannot prove later iterations non-null.
+                    bool hasWrite = node.DescendantNodes().Any(candidate =>
+                        !ReferenceEquals(candidate, use)
+                        && this.SyntaxNodeWritesSymbol(candidate, symbol));
+                    if (hasWrite && !node.Span.Contains(narrowingGuard.Span))
+                    {
+                        return true;
+                    }
+                }
             }
 
             return false;
@@ -1304,6 +1468,16 @@ public sealed partial class CSharpToGSharpTranslator
                 IPropertySymbol property => property.Type,
                 _ => null,
             };
+
+        private bool IsFlowNarrowedAnnotatedReference(ExpressionSyntax value)
+        {
+            TypeInfo typeInfo = this.context.GetTypeInfo(value);
+            ITypeSymbol declaredType = this.GetDeclaredValueType(value);
+            return typeInfo.Nullability.FlowState == NullableFlowState.NotNull
+                && (typeInfo.Nullability.Annotation == NullableAnnotation.Annotated
+                    || typeInfo.Type?.NullableAnnotation == NullableAnnotation.Annotated
+                    || declaredType?.NullableAnnotation == NullableAnnotation.Annotated);
+        }
 
         private bool NullableReferenceValueMayBeNull(ExpressionSyntax value)
         {
@@ -1512,7 +1686,8 @@ public sealed partial class CSharpToGSharpTranslator
             ExpressionSyntax recv,
             bool isDereferenceReceiver = false)
         {
-            if (this.IsActivePatternBinding(recv)
+            if (this.GSharpExpressionIsStaticallyNonNull(recv)
+                || this.IsActivePatternBinding(recv)
                 || this.IsGSharpFlowNarrowedLocal(recv))
             {
                 return false;

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -1141,7 +1141,7 @@ public sealed partial class CSharpToGSharpTranslator
                         : this.GSharpExpressionIsStaticallyNonNull(binary.Right);
 
                 case AssignmentExpressionSyntax assignment:
-                    if (this.PatternLocalUsesNullableStorage(assignment.Left))
+                    if (!this.AssignmentResultHasNonNullStaticType(assignment))
                     {
                         return false;
                     }
@@ -1158,11 +1158,19 @@ public sealed partial class CSharpToGSharpTranslator
             }
 
             ISymbol symbol = this.context.GetSymbolInfo(expression).Symbol;
-            if (symbol is ILocalSymbol inferredLocal
-                && (this.LocalBindingInfersStaticallyNonNullInitializer(inferredLocal)
-                    || this.ForEachBindingInfersNonNullElement(inferredLocal)))
+            if (symbol is ILocalSymbol inferredLocal)
             {
-                return true;
+                if (this.TryGetInferredLocalStaticNonNull(
+                    inferredLocal,
+                    out bool initializerIsNonNull))
+                {
+                    return initializerIsNonNull;
+                }
+
+                if (this.ForEachBindingInfersNonNullElement(inferredLocal))
+                {
+                    return true;
+                }
             }
 
             ITypeSymbol type = symbol switch
@@ -1186,10 +1194,12 @@ public sealed partial class CSharpToGSharpTranslator
                 && (symbol == null || !this.ShouldPromoteToNullableReference(symbol));
         }
 
-        private bool LocalBindingInfersStaticallyNonNullInitializer(ILocalSymbol local)
+        private bool TryGetInferredLocalStaticNonNull(
+            ILocalSymbol local,
+            out bool isNonNull)
         {
-            if (this.IsLocalReassigned(local)
-                || local.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax()
+            isNonNull = false;
+            if (local.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax()
                     is not VariableDeclaratorSyntax
                     {
                         Initializer.Value: { } initializer,
@@ -1220,7 +1230,8 @@ public sealed partial class CSharpToGSharpTranslator
                 }
             }
 
-            return this.GSharpExpressionIsStaticallyNonNull(initializer);
+            isNonNull = this.GSharpExpressionIsStaticallyNonNull(initializer);
+            return true;
         }
 
         private bool ForEachBindingInfersNonNullElement(ILocalSymbol local)
@@ -1392,6 +1403,35 @@ public sealed partial class CSharpToGSharpTranslator
             }
 
             return false;
+        }
+
+        private bool AssignmentResultHasNonNullStaticType(
+            AssignmentExpressionSyntax assignment)
+        {
+            if (this.PatternLocalUsesNullableStorage(assignment.Left))
+            {
+                return false;
+            }
+
+            ISymbol target = this.context.GetSymbolInfo(assignment.Left).Symbol;
+            ITypeSymbol targetType = target switch
+            {
+                ILocalSymbol local => local.Type,
+                IParameterSymbol parameter => parameter.Type,
+                IFieldSymbol field => field.Type,
+                IPropertySymbol property => property.Type,
+                _ => this.context.GetTypeInfo(assignment.Left).Type,
+            };
+            if (targetType is { IsReferenceType: true })
+            {
+                return this.TargetWillRemainNonNullableReference(
+                    targetType,
+                    target);
+            }
+
+            return targetType != null
+                && targetType.OriginalDefinition?.SpecialType
+                    != SpecialType.System_Nullable_T;
         }
 
         private bool HasLoopCarriedWrite(

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -1393,7 +1393,18 @@ public sealed partial class CSharpToGSharpTranslator
             IMethodSymbol invoke)
         {
             var parameters = new List<Parameter>(invoke.Parameters.Length);
-            var arguments = new List<GExpression>(invoke.Parameters.Length);
+            var arguments = new List<GExpression>(invoke.Parameters.Length + 1);
+            if (expression is MemberAccessExpressionSyntax extensionMember
+                && method.IsStatic
+                && method.IsExtensionMethod
+                && method.Parameters.Length == invoke.Parameters.Length + 1)
+            {
+                GExpression receiver = this.CaptureMethodGroupReceiver(
+                    this.TranslateReceiverWithNullForgiveness(extensionMember.Expression),
+                    extensionMember.Expression);
+                arguments.Add(PassStaticExtensionHelperReceiver(receiver, method));
+            }
+
             for (int index = 0; index < invoke.Parameters.Length; index++)
             {
                 IParameterSymbol invokeParameter = invoke.Parameters[index];
@@ -2788,6 +2799,13 @@ public sealed partial class CSharpToGSharpTranslator
                 sourceSymbol == null || targetSymbol == null
                     ? default
                     : this.context.Compilation.ClassifyConversion(sourceSymbol, targetSymbol);
+            if (cast.Type is not NullableTypeSyntax
+                && this.CastUsesCheckedReferenceConversion(cast)
+                && this.IsFlowNarrowedAnnotatedReference(cast.Expression))
+            {
+                operand = EnsureNonNullAssertion(operand);
+            }
+
             if (conversion.IsBoxing)
             {
                 GTypeReference boxingTargetType = cast.Type is NullableTypeSyntax
@@ -2822,19 +2840,29 @@ public sealed partial class CSharpToGSharpTranslator
                 && !targetType.IsNullable
                     ? MakeNullable(targetType)
                     : targetType;
-            bool isCheckedReferenceCast = conversion.IsReference
-                || (conversion.IsIdentity
-                    && sourceSymbol is { IsReferenceType: true }
-                    && targetSymbol is { IsReferenceType: true })
-                || (conversion.IsExplicit
-                    && sourceSymbol is ITypeParameterSymbol
-                    && targetSymbol is { TypeKind: TypeKind.Interface })
-                || (sourceSymbol is { TypeKind: TypeKind.Dynamic }
-                    && targetSymbol is { IsReferenceType: true });
             return new ConversionExpression(
                 conversionTargetType,
                 operand,
-                isCheckedReferenceCast);
+                this.CastUsesCheckedReferenceConversion(cast));
+        }
+
+        private bool CastUsesCheckedReferenceConversion(CastExpressionSyntax cast)
+        {
+            ITypeSymbol target = this.context.GetTypeInfo(cast.Type).Type;
+            ITypeSymbol source = this.context.GetTypeInfo(cast.Expression).Type;
+            Microsoft.CodeAnalysis.CSharp.Conversion conversion =
+                source == null || target == null
+                    ? default
+                    : this.context.Compilation.ClassifyConversion(source, target);
+            return conversion.IsReference
+                || (conversion.IsIdentity
+                    && source is { IsReferenceType: true }
+                    && target is { IsReferenceType: true })
+                || (conversion.IsExplicit
+                    && source is ITypeParameterSymbol
+                    && target is { TypeKind: TypeKind.Interface })
+                || (source is { TypeKind: TypeKind.Dynamic }
+                    && target is { IsReferenceType: true });
         }
 
         private GExpression TranslateWith(WithExpressionSyntax with)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -1396,6 +1396,11 @@ public sealed partial class CSharpToGSharpTranslator
             var arguments = new List<GExpression>(invoke.Parameters.Length + 1);
             GExpression target = null;
             IMethodSymbol original = method.ReducedFrom ?? method;
+            if (original.IsExtensionMethod)
+            {
+                this.typeMapper.TrackExtensionMethodNamespace(original);
+            }
+
             if (expression is MemberAccessExpressionSyntax extensionMember
                 && original.IsExtensionMethod
                 && this.context.GetSymbolInfo(extensionMember.Expression).Symbol

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -1394,15 +1394,62 @@ public sealed partial class CSharpToGSharpTranslator
         {
             var parameters = new List<Parameter>(invoke.Parameters.Length);
             var arguments = new List<GExpression>(invoke.Parameters.Length + 1);
+            GExpression target = null;
+            IMethodSymbol original = method.ReducedFrom ?? method;
             if (expression is MemberAccessExpressionSyntax extensionMember
-                && method.IsStatic
-                && method.IsExtensionMethod
-                && method.Parameters.Length == invoke.Parameters.Length + 1)
+                && original.IsExtensionMethod
+                && this.context.GetSymbolInfo(extensionMember.Expression).Symbol
+                    is not INamedTypeSymbol
+                && (method.MethodKind == MethodKind.ReducedExtension
+                    || original.Parameters.Length == invoke.Parameters.Length + 1))
             {
-                GExpression receiver = this.CaptureMethodGroupReceiver(
-                    this.TranslateReceiverWithNullForgiveness(extensionMember.Expression),
-                    extensionMember.Expression);
-                arguments.Add(PassStaticExtensionHelperReceiver(receiver, method));
+                // Target the emitted G# shape: migrated source extensions use
+                // receiver syntax unless only a static helper survives.
+                bool sourceDefined = !original.DeclaringSyntaxReferences.IsDefaultOrEmpty
+                    || this.KnownCompilations().Any(compilation =>
+                        SameAssembly(
+                            compilation.Assembly,
+                            original.ContainingAssembly));
+                bool useStaticHelper = this.TryGetStaticExtensionHelper(
+                    original,
+                    out string helperOwner,
+                    out string helperName)
+                    || !sourceDefined;
+                GExpression receiver;
+                if (useStaticHelper)
+                {
+                    receiver = this.ForgiveNullableReferenceValue(
+                        extensionMember.Expression,
+                        this.TranslateExpression(extensionMember.Expression),
+                        original.Parameters[0].Type,
+                        original.Parameters[0],
+                        includePromotedValue: true);
+                    receiver = this.CaptureMethodGroupReceiver(
+                        receiver,
+                        extensionMember.Expression);
+                    arguments.Add(PassStaticExtensionHelperReceiver(receiver, original));
+                    target = new MemberAccessExpression(
+                        helperOwner != null
+                            ? new IdentifierExpression(helperOwner)
+                            : this.StaticQualifierReceiver(
+                                original.ContainingType,
+                                expression.GetLocation()),
+                        helperName ?? SanitizeIdentifier(original.Name));
+                }
+                else
+                {
+                    GExpression translatedReceiver =
+                        this.MemberBindsToNullableThisExtension(extensionMember)
+                            ? this.TranslateExpression(extensionMember.Expression)
+                            : this.TranslateReceiverWithNullForgiveness(
+                                extensionMember.Expression);
+                    receiver = this.CaptureMethodGroupReceiver(
+                        translatedReceiver,
+                        extensionMember.Expression);
+                    target = new MemberAccessExpression(
+                        receiver,
+                        SanitizeIdentifier(original.Name));
+                }
             }
 
             for (int index = 0; index < invoke.Parameters.Length; index++)
@@ -1428,7 +1475,7 @@ public sealed partial class CSharpToGSharpTranslator
                 arguments.Add(forwarded);
             }
 
-            GExpression target = this.TranslateMethodGroupInvocationTarget(
+            target ??= this.TranslateMethodGroupInvocationTarget(
                 expression,
                 method);
             IReadOnlyList<GTypeReference> typeArguments = method.IsGenericMethod

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
@@ -1138,7 +1138,22 @@ public sealed partial class CSharpToGSharpTranslator
                 return new[] { (GStatement)new GotoStatement(IteratorExitLabelName(target)) };
             }
 
-            return new[] { (GStatement)new YieldStatement(this.TranslateValueWithNullForgiveness(node.Expression)) };
+            GExpression value = this.TranslateValueWithNullForgiveness(node.Expression);
+            TypeInfo typeInfo = this.context.GetTypeInfo(node.Expression);
+            ITypeSymbol declaredType = this.GetDeclaredValueType(node.Expression);
+            if (declaredType is { IsReferenceType: true, NullableAnnotation: NullableAnnotation.Annotated }
+                && typeInfo.ConvertedType is { IsReferenceType: true, NullableAnnotation: not NullableAnnotation.Annotated }
+                && this.context.GetSymbolInfo(node.Expression).Symbol is ILocalSymbol yieldedLocal
+                && yieldedLocal.DeclaringSyntaxReferences.Any(reference =>
+                    reference.GetSyntax() is ForEachStatementSyntax)
+                && typeInfo.Nullability.FlowState == NullableFlowState.NotNull)
+            {
+                // Preserve the non-null iterator element type through lowering;
+                // ordinary locals need no assertion at this seam.
+                value = EnsureNonNullAssertion(value);
+            }
+
+            return new[] { (GStatement)new YieldStatement(value) };
         }
 
         private static SyntaxNode GetBreakTarget(YieldStatementSyntax node)


### PR DESCRIPTION
## Summary
- recognize G#-statically-non-null constructions, concatenations, coalesces, conditionals, checked casts, inferred locals, and non-iterator foreach elements
- classify assignment-result nullability from emitted target/local types instead of nullable RHS flow
- emit exact extension method groups through their real receiver-companion or static-helper shape, including nullable receivers and erased entry-point owners
- preserve nullable casts, loop-carried writes, iterator ABI assertions, and source-authored forgiveness
- add focused bind/runtime coverage plus honest shape-specific Core and synthetic ratchets

## Core measurement
- `!!!!`: 0 -> 0
- `)!!.`: 9 -> 8
- total `!!` (measurement only, no raw-count test cap): 25,137 -> 5,313 across validated Core output (19,824 removed, 78.9%)

## Validation
- Issue3422 filter: 20 passed
- full `Cs2Gs.Tests`: 2,161 passed
- `dotnet build GSharp.sln -c Release -graph --no-restore --nologo`: passed, 0 warnings/errors
- Core diagnostic migration: translate PASS, compile PASS, ILVerify PASS, test parity PASS

Closes #3422