### PR TITLE
Fix imported CLR object initializer lowering

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -797,18 +797,13 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
-        if (propRead.Type is NullableTypeSymbol nullableMember
-            && Conversion.IsReferenceLikeTarget(nullableMember.UnderlyingType))
-        {
-            var nullAssertion = BoundUnaryOperator.Bind(
-                SyntaxKind.BangBangToken,
-                nullableMember);
-            propRead = new BoundUnaryExpression(
-                braced,
-                Invariant.Required(nullAssertion, "a null assertion always binds"),
-                propRead);
-        }
-
+        // Reference nullability is metadata-only here. Keep the runtime value
+        // unchecked so assignment/Add arguments run before callvirt observes a
+        // null receiver, matching C# evaluation order.
+        TypeSymbol memberLocalType = propRead.Type is NullableTypeSymbol nullableMember
+            && Conversion.IsReferenceLikeTarget(nullableMember.UnderlyingType)
+                ? nullableMember.UnderlyingType
+                : propRead.Type;
         var nestedObjectAssignments = ImmutableArray.CreateBuilder<AssignmentExpressionSyntax?>(braced.Elements.Count);
         var hasNonIndexedElement = false;
         var hasSpreadElement = false;
@@ -825,14 +820,14 @@ internal sealed partial class ExpressionBinder
 
         var isNestedObjectInitializer = allElementsAreAssignments;
         if (!isNestedObjectInitializer &&
-            ((hasNonIndexedElement && !HasCollectionAdd(propRead.Type)) ||
-             (hasSpreadElement && !HasUnaryCollectionAdd(propRead.Type))))
+            ((hasNonIndexedElement && !HasCollectionAdd(memberLocalType)) ||
+             (hasSpreadElement && !HasUnaryCollectionAdd(memberLocalType))))
         {
             return false;
         }
 
         var tempName = "$collinit" + System.Threading.Interlocked.Increment(ref binderCtx.SyntheticLocalCounter).ToString(System.Globalization.CultureInfo.InvariantCulture);
-        var memberLocal = new LocalVariableSymbol(tempName, isReadOnly: false, propRead.Type);
+        var memberLocal = new LocalVariableSymbol(tempName, isReadOnly: false, memberLocalType);
         scope.TryDeclareVariable(memberLocal);
         statements.Add(new BoundVariableDeclaration(braced, memberLocal, propRead));
 
@@ -848,7 +843,7 @@ internal sealed partial class ExpressionBinder
                     nonNullAssignment.IdentifierToken,
                     nonNullAssignment.EqualsToken,
                     nonNullAssignment.Expression);
-                var boundAssignment = BindObjectInitializerAssignment(memberLocal, propRead.Type, initializer);
+                var boundAssignment = BindObjectInitializerAssignment(memberLocal, memberLocalType, initializer);
                 if (boundAssignment != null)
                 {
                     statements.Add(new BoundExpressionStatement(initializer, boundAssignment));

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -797,6 +797,18 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
+        if (propRead.Type is NullableTypeSymbol nullableMember
+            && Conversion.IsReferenceLikeTarget(nullableMember.UnderlyingType))
+        {
+            var nullAssertion = BoundUnaryOperator.Bind(
+                SyntaxKind.BangBangToken,
+                nullableMember);
+            propRead = new BoundUnaryExpression(
+                braced,
+                Invariant.Required(nullAssertion, "a null assertion always binds"),
+                propRead);
+        }
+
         var nestedObjectAssignments = ImmutableArray.CreateBuilder<AssignmentExpressionSyntax?>(braced.Elements.Count);
         var hasNonIndexedElement = false;
         var hasSpreadElement = false;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -1351,7 +1351,17 @@ internal sealed partial class ExpressionBinder
 
         var seenFieldNames = new HashSet<string>();
         var inits = ImmutableArray.CreateBuilder<BoundFieldInitializer>();
-        List<(string Name, TypeSymbol MemberType, CollectionInitializerExpressionSyntax Braced, SyntaxToken Anchor)>? bracedCollectionMembers = null;
+        List<(
+            FieldInitializerSyntax Syntax,
+            TypeSymbol MemberType,
+            CollectionInitializerExpressionSyntax? Braced,
+            FieldSymbol? Field,
+            StructSymbol? FieldDeclaringType,
+            PropertySymbol? Property)>? orderedInitializers =
+            syntax.Initializers.Any(initializer =>
+                initializer.Value is CollectionInitializerExpressionSyntax { Target: null })
+                ? new()
+                : null;
         foreach (var initSyntax in syntax.Initializers)
         {
             var fieldName = initSyntax.FieldIdentifier.Text;
@@ -1396,6 +1406,10 @@ internal sealed partial class ExpressionBinder
                     memberAccessibility);
             }
 
+            var memberType = hasField
+                ? Invariant.Required(field, "a resolved field has a type").Type
+                : Invariant.Required(property, "a resolved property has a type").Type;
+
             // Issue #1567: a braced member value `Member: { a, b }` populates the
             // collection member by lowering to `.Add(...)` calls on the
             // constructed receiver's `Member` (the C# collection-initializer-in-
@@ -1412,14 +1426,13 @@ internal sealed partial class ExpressionBinder
                     continue;
                 }
 
-                bracedCollectionMembers ??= new List<(string, TypeSymbol, CollectionInitializerExpressionSyntax, SyntaxToken)>();
-                bracedCollectionMembers.Add((
-                    fieldName,
-                    hasField
-                        ? Invariant.Required(field, "a resolved field has a type").Type
-                        : Invariant.Required(property, "a resolved property has a type").Type,
+                orderedInitializers!.Add((
+                    initSyntax,
+                    memberType,
                     bracedMemberInit,
-                    initSyntax.FieldIdentifier));
+                    field,
+                    fieldDeclaringType,
+                    property));
                 continue;
             }
 
@@ -1437,9 +1450,18 @@ internal sealed partial class ExpressionBinder
                 continue;
             }
 
-            var memberType = hasField
-                ? Invariant.Required(field, "a resolved field has a type").Type
-                : Invariant.Required(property, "a resolved property has a type").Type;
+            if (orderedInitializers != null)
+            {
+                orderedInitializers.Add((
+                    initSyntax,
+                    memberType,
+                    Braced: null,
+                    field,
+                    fieldDeclaringType,
+                    property));
+                continue;
+            }
+
             var valueExpr = BindExpression(initSyntax.Value);
             valueExpr = conversions.BindConversion(initSyntax.Value.Location, valueExpr, memberType);
             inits.Add(hasField
@@ -1475,32 +1497,66 @@ internal sealed partial class ExpressionBinder
         }
 
         var structLiteral = new BoundStructLiteralExpression(null, structSymbol, inits.ToImmutable());
-        if (bracedCollectionMembers == null)
+        if (orderedInitializers == null)
         {
             return structLiteral;
         }
 
-        // Issue #1567: one or more members were populated with a braced
-        // collection initializer (`Member: { a, b }`). Construct the literal into
-        // a synthetic local, then lower each such member to `.Add(...)` calls on
-        // `local.Member`. Because the collection member is a reference type, the
-        // Adds mutate the same collection the literal already holds, so yielding
-        // the local returns the populated instance. Mirrors the imported-class
-        // and standalone collection-initializer lowerings (block + temp local).
+        // A braced member forces statement lowering for every explicit
+        // initializer so scalar assignments stay interleaved with nested
+        // object/collection population in C# textual evaluation order.
         var litTempName = "$implit" + System.Threading.Interlocked.Increment(ref binderCtx.SyntheticLocalCounter).ToString(System.Globalization.CultureInfo.InvariantCulture);
         var litTemp = new LocalVariableSymbol(litTempName, isReadOnly: true, structSymbol);
         scope.TryDeclareVariable(litTemp);
 
         var bracedStatements = ImmutableArray.CreateBuilder<BoundStatement>();
         bracedStatements.Add(new BoundVariableDeclaration(syntax, litTemp, structLiteral));
-        foreach (var (name, memberType, braced, anchor) in bracedCollectionMembers)
+        foreach (var initializer in orderedInitializers)
         {
-            var litReceiver = new BoundVariableExpression(anchor, litTemp);
-            if (!TryEmitMemberCollectionInitializer(litReceiver, name, anchor, braced, bracedStatements))
+            if (initializer.Braced != null)
             {
-                Diagnostics.ReportTypeNotCollectionInitializable(anchor.Location, memberType);
-                BindCollectionElementsForDiagnostics(braced);
+                var litReceiver = new BoundVariableExpression(initializer.Syntax, litTemp);
+                if (!TryEmitMemberCollectionInitializer(
+                    litReceiver,
+                    initializer.Syntax.FieldIdentifier.Text,
+                    initializer.Syntax.FieldIdentifier,
+                    initializer.Braced,
+                    bracedStatements))
+                {
+                    Diagnostics.ReportTypeNotCollectionInitializable(
+                        initializer.Syntax.FieldIdentifier.Location,
+                        initializer.MemberType);
+                    BindCollectionElementsForDiagnostics(initializer.Braced);
+                }
+
+                continue;
             }
+
+            var value = BindExpression(initializer.Syntax.Value);
+            var converted = conversions.BindConversion(
+                initializer.Syntax.Value.Location,
+                value,
+                initializer.MemberType);
+            BoundExpression assignment = initializer.Field != null
+                ? new BoundFieldAssignmentExpression(
+                    initializer.Syntax,
+                    litTemp,
+                    Invariant.Required(
+                        initializer.FieldDeclaringType,
+                        "a resolved field has a declaring type"),
+                    initializer.Field,
+                    converted)
+                : new BoundPropertyAssignmentExpression(
+                    initializer.Syntax,
+                    new BoundVariableExpression(initializer.Syntax, litTemp),
+                    structSymbol,
+                    Invariant.Required(
+                        initializer.Property,
+                        "a resolved property initializer has a property"),
+                    converted);
+            bracedStatements.Add(new BoundExpressionStatement(
+                initializer.Syntax,
+                assignment));
         }
 
         var litResult = new BoundVariableExpression(syntax, litTemp);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1728ObjectInitializerWithCtorArgsTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1728ObjectInitializerWithCtorArgsTranslationTests.cs
@@ -27,7 +27,7 @@ namespace Cs2Gs.Tests;
 public class Issue1728ObjectInitializerWithCtorArgsTranslationTests
 {
     [Fact]
-    public void ReferenceClassNoArgsObjectInitializer_EmitsConstructionSuffix()
+    public void ImportedReferenceClassNoArgsObjectInitializer_EmitsCompositeLiteral()
     {
         string printed = TranslateUnit(@"
 using System.Text;
@@ -39,9 +39,8 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("StringBuilder()", printed);
-        Assert.Contains("Capacity = 2", printed);
-        Assert.DoesNotContain("StringBuilder{Capacity:", printed);
+        Assert.Contains("StringBuilder{Capacity: 2}", printed);
+        Assert.DoesNotContain("StringBuilder(){", printed);
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1901LambdaDefaultsTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1901LambdaDefaultsTranslationTests.cs
@@ -237,7 +237,7 @@ namespace Corpus.Issue1901
 
         Assert.Contains("func JoinParts(parts IEnumerable[string]) string", rendered, StringComparison.Ordinal);
         Assert.Contains(
-            "let joined = ParamsCollections.JoinParts(List[string]{ \"a\", \"b\", \"c\" })",
+            "let joined = ParamsCollections.JoinParts(cast[IEnumerable[string]](List[string]{ \"a\", \"b\", \"c\" }))",
             rendered,
             StringComparison.Ordinal);
         AssertRoundTripParses(rendered);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2412CrossProjectObliviousNullabilityTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2412CrossProjectObliviousNullabilityTranslationTests.cs
@@ -607,7 +607,7 @@ namespace App
     }
 
     [Fact]
-    public void CrossProject_MigratedSiblingObjectInitializer_UsesConstructorSuffix()
+    public void CrossProject_MigratedSiblingObjectInitializer_UsesCompositeLiteral()
     {
         const string library = @"
 namespace Library
@@ -644,7 +644,7 @@ namespace App
         string printed = GSharpPrinter.Print(
             new CSharpToGSharpTranslator().TranslateDocument(document, context));
 
-        Assert.Contains("Widget(){Enabled = true}", Compact(printed));
+        Assert.Contains("Widget{Enabled: true}", Compact(printed));
     }
 
     // ---- Transitive (three-project) chain: the real Oahu shape -------------

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3460TranslatorTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3460TranslatorTests.cs
@@ -281,6 +281,95 @@ namespace Cs2Gs.Tests
         }
 
         [Fact]
+        public void SystemObjectAlias_ReservesPartialSiblingImports()
+        {
+            string printed = TranslateFile(
+                "A.Primary.cs",
+                preservePartialParts: false,
+                ("A.Primary.cs", """
+                    namespace Demo;
+
+                    public partial class PartialOwner
+                    {
+                        public static string Run() =>
+                            new object { }.GetType().FullName!;
+                    }
+                    """),
+                ("B.Partial.cs", """
+                    using __cs2gs_System_Object = System.Text.StringBuilder;
+
+                    namespace Demo;
+
+                    public partial class PartialOwner
+                    {
+                        public int Value;
+                    }
+                    """));
+
+            Assert.Contains(
+                "import __cs2gs_System_Object = System.Text.StringBuilder",
+                printed,
+                StringComparison.Ordinal);
+            Assert.Contains(
+                "import __cs2gs_System_Object_2 = System.Object",
+                printed,
+                StringComparison.Ordinal);
+            Assert.Contains("__cs2gs_System_Object_2()", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+
+            EmittedOracleResult result = EmittedOracle.Evaluate(
+                printed + Environment.NewLine + "Demo.PartialOwner.Run()");
+            Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+            Assert.Null(result.UnhandledException);
+            Assert.Equal("System.Object", result.Value);
+        }
+
+        [Fact]
+        public void SystemObjectAlias_ReservesOwnedExtensionImports()
+        {
+            string printed = TranslateFile(
+                "A.Host.cs",
+                preservePartialParts: true,
+                ("A.Host.cs", """
+                    namespace Demo;
+
+                    public sealed class Host
+                    {
+                        public static string Run() =>
+                            new object { }.GetType().FullName!;
+                    }
+                    """),
+                ("B.Extensions.cs", """
+                    using __cs2gs_System_Object = System.Text.StringBuilder;
+
+                    namespace Demo;
+
+                    public static class HostExtensions
+                    {
+                        public static int Measure(this Host host) => 1;
+                    }
+                    """));
+
+            Assert.Contains(
+                "import __cs2gs_System_Object = System.Text.StringBuilder",
+                printed,
+                StringComparison.Ordinal);
+            Assert.Contains(
+                "import __cs2gs_System_Object_2 = System.Object",
+                printed,
+                StringComparison.Ordinal);
+            Assert.Contains("__cs2gs_System_Object_2()", printed, StringComparison.Ordinal);
+            Assert.Contains("func Measure()", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+
+            EmittedOracleResult result = EmittedOracle.Evaluate(
+                printed + Environment.NewLine + "Demo.Host.Run()");
+            Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+            Assert.Null(result.UnhandledException);
+            Assert.Equal("System.Object", result.Value);
+        }
+
+        [Fact]
         public void ImportedParameterlessInitializer_PreservesOrderedMembersNestedInitializersAndRuntime()
         {
             string printed = Translate("""
@@ -798,6 +887,29 @@ namespace Cs2Gs.Tests
                 document.FilePath);
             CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
             return (GSharpPrinter.Print(unit), context);
+        }
+
+        private static string TranslateFile(
+            string targetPath,
+            bool preservePartialParts,
+            params (string Path, string Source)[] sources)
+        {
+            LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(sources);
+            Assert.True(
+                project.BoundWithoutErrors,
+                "Snippets should bind with no C# errors: "
+                    + string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+            LoadedDocument document = project.Documents.Single(candidate =>
+                candidate.FilePath.EndsWith(targetPath, StringComparison.Ordinal));
+            var context = new TranslationContext(
+                project.Compilation,
+                document.SemanticModel,
+                document.FilePath);
+            CompilationUnit unit = new CSharpToGSharpTranslator(
+                preservePartialParts: preservePartialParts)
+                .TranslateDocument(document, context);
+            return GSharpPrinter.Print(unit);
         }
     }
 }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3460TranslatorTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3460TranslatorTests.cs
@@ -426,6 +426,57 @@ namespace Cs2Gs.Tests
         }
 
         [Fact]
+        public void ContributingDeclarationGraph_DoesNotFollowUnrelatedSameTreeExtensions()
+        {
+            string printed = TranslateFile(
+                "A.Primary.cs",
+                preservePartialParts: false,
+                ("A.Primary.cs", """
+                    namespace Demo;
+
+                    public partial class Root
+                    {
+                        public static string Run() =>
+                            typeof(System.Threading.Timer).FullName!;
+                    }
+                    """),
+                ("B.PartialAndUnrelated.cs", """
+                    namespace Demo;
+
+                    public partial class Root
+                    {
+                        public int Value;
+                    }
+
+                    public sealed class Unrelated
+                    {
+                    }
+                    """),
+                ("C.UnrelatedExtensions.cs", """
+                    using System.Timers;
+
+                    namespace Demo;
+
+                    public static class UnrelatedExtensions
+                    {
+                        public static int Measure(this Unrelated value) => 1;
+                    }
+                    """));
+
+            Assert.Contains("import System.Threading", printed, StringComparison.Ordinal);
+            Assert.DoesNotContain("import System.Timers", printed, StringComparison.Ordinal);
+            Assert.Contains("typeof(Timer)", printed, StringComparison.Ordinal);
+            Assert.DoesNotContain("func Measure()", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+
+            EmittedOracleResult result = EmittedOracle.Evaluate(
+                printed + Environment.NewLine + "Demo.Root.Run()");
+            Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+            Assert.Null(result.UnhandledException);
+            Assert.Equal("System.Threading.Timer", result.Value);
+        }
+
+        [Fact]
         public void ImportedParameterlessInitializer_PreservesOrderedMembersNestedInitializersAndRuntime()
         {
             string printed = Translate("""

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3460TranslatorTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3460TranslatorTests.cs
@@ -370,6 +370,62 @@ namespace Cs2Gs.Tests
         }
 
         [Fact]
+        public void SystemObjectAlias_ReservesTransitivePartialOwnedExtensionImports()
+        {
+            string printed = TranslateFile(
+                "A.Primary.cs",
+                preservePartialParts: false,
+                ("A.Primary.cs", """
+                    namespace Demo;
+
+                    public partial class Outer
+                    {
+                        public static string Run() =>
+                            new object { }.GetType().FullName!;
+                    }
+                    """),
+                ("B.Partial.cs", """
+                    namespace Demo;
+
+                    public partial class Outer
+                    {
+                        public sealed class Nested
+                        {
+                        }
+                    }
+                    """),
+                ("C.Extensions.cs", """
+                    using __cs2gs_System_Object = System.Text.StringBuilder;
+
+                    namespace Demo;
+
+                    public static class NestedExtensions
+                    {
+                        public static int Measure(this Outer.Nested value) => 1;
+                    }
+                    """));
+
+            Assert.Contains(
+                "import __cs2gs_System_Object = System.Text.StringBuilder",
+                printed,
+                StringComparison.Ordinal);
+            Assert.Contains(
+                "import __cs2gs_System_Object_2 = System.Object",
+                printed,
+                StringComparison.Ordinal);
+            Assert.Contains("__cs2gs_System_Object_2()", printed, StringComparison.Ordinal);
+            Assert.Contains("class Nested", printed, StringComparison.Ordinal);
+            Assert.Contains("func Measure()", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+
+            EmittedOracleResult result = EmittedOracle.Evaluate(
+                printed + Environment.NewLine + "Demo.Outer.Run()");
+            Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+            Assert.Null(result.UnhandledException);
+            Assert.Equal("System.Object", result.Value);
+        }
+
+        [Fact]
         public void ImportedParameterlessInitializer_PreservesOrderedMembersNestedInitializersAndRuntime()
         {
             string printed = Translate("""

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3460TranslatorTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3460TranslatorTests.cs
@@ -477,6 +477,60 @@ namespace Cs2Gs.Tests
         }
 
         [Fact]
+        public void ContributingDeclarationGraph_SkipsNonPrimaryPartialSeeds()
+        {
+            string printed = TranslateFile(
+                "B.RootAndNonPrimary.cs",
+                preservePartialParts: false,
+                ("A.CarrierPrimary.cs", """
+                    namespace Demo;
+
+                    public partial class Carrier
+                    {
+                    }
+                    """),
+                ("B.RootAndNonPrimary.cs", """
+                    namespace Demo;
+
+                    public sealed class Root
+                    {
+                        public static string Run() =>
+                            typeof(System.Threading.Timer).FullName!;
+                    }
+
+                    public partial class Carrier
+                    {
+                        public sealed class Nested
+                        {
+                        }
+                    }
+                    """),
+                ("C.NestedExtensions.cs", """
+                    using System.Timers;
+
+                    namespace Demo;
+
+                    public static class NestedExtensions
+                    {
+                        public static int Measure(this Carrier.Nested value) => 1;
+                    }
+                    """));
+
+            Assert.Contains("import System.Threading", printed, StringComparison.Ordinal);
+            Assert.DoesNotContain("import System.Timers", printed, StringComparison.Ordinal);
+            Assert.Contains("class Root", printed, StringComparison.Ordinal);
+            Assert.DoesNotContain("class Carrier", printed, StringComparison.Ordinal);
+            Assert.DoesNotContain("func Measure()", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+
+            EmittedOracleResult result = EmittedOracle.Evaluate(
+                printed + Environment.NewLine + "Demo.Root.Run()");
+            Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+            Assert.Null(result.UnhandledException);
+            Assert.Equal("System.Threading.Timer", result.Value);
+        }
+
+        [Fact]
         public void ImportedParameterlessInitializer_PreservesOrderedMembersNestedInitializersAndRuntime()
         {
             string printed = Translate("""

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3460TranslatorTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3460TranslatorTests.cs
@@ -103,6 +103,28 @@ namespace Cs2Gs.Tests.Fixtures
         public int Value { get; init; }
     }
 
+    public sealed class Issue3460ParamsInterfaceOverloadOptions
+    {
+        public Issue3460ParamsInterfaceOverloadOptions(
+            params IEnumerable<int> values)
+        {
+            Selected = 1;
+            Count = values.Count();
+        }
+
+        public Issue3460ParamsInterfaceOverloadOptions(List<int> values)
+        {
+            Selected = 2;
+            Count = values.Count;
+        }
+
+        public int Selected { get; }
+
+        public int Count { get; }
+
+        public int Value { get; init; }
+    }
+
     public sealed class Issue3460SpanParamsOptions
     {
         public Issue3460SpanParamsOptions(params ReadOnlySpan<int> values)
@@ -223,9 +245,11 @@ namespace Cs2Gs.Tests
         public void SystemObjectEmptyInitializer_RemainsClrObjectConstruction()
         {
             string printed = Translate("""
+                using __cs2gs_System_Object = System.Text.StringBuilder;
+
                 namespace Demo
                 {
-                    public sealed class Object
+                    public sealed class __cs2gs_System_Object_2
                     {
                     }
 
@@ -238,10 +262,14 @@ namespace Cs2Gs.Tests
                 """);
 
             Assert.Contains(
-                "import __cs2gs_System_Object = System.Object",
+                "import __cs2gs_System_Object = System.Text.StringBuilder",
                 printed,
                 StringComparison.Ordinal);
-            Assert.Contains("__cs2gs_System_Object()", printed, StringComparison.Ordinal);
+            Assert.Contains(
+                "import __cs2gs_System_Object_3 = System.Object",
+                printed,
+                StringComparison.Ordinal);
+            Assert.Contains("__cs2gs_System_Object_3()", printed, StringComparison.Ordinal);
             Assert.DoesNotContain("object{}", printed, StringComparison.Ordinal);
             TranslationTestValidation.AssertBinds(printed);
 
@@ -620,6 +648,39 @@ namespace Cs2Gs.Tests
         }
 
         [Fact]
+        public void ImportedParamsInterfaceCollection_CoercesToSelectedParameterType()
+        {
+            string printed = Translate("""
+                using Cs2Gs.Tests.Fixtures;
+
+                public static class Obj
+                {
+                    public static int Run()
+                    {
+                        var options = new Issue3460ParamsInterfaceOverloadOptions { Value = 3 };
+                        return (options.Selected * 100)
+                            + (options.Count * 10)
+                            + options.Value;
+                    }
+                }
+                """,
+                MetadataReference.CreateFromFile(typeof(Fixtures.Issue3460ParamsInterfaceOverloadOptions).Assembly.Location));
+
+            Assert.Contains(
+                "Issue3460ParamsInterfaceOverloadOptions(cast[IEnumerable[int32]](List[int32]())){Value = 3}",
+                printed,
+                StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+
+            EmittedOracleResult result = EmittedOracle.Evaluate(
+                printed + Environment.NewLine + "Obj.Run()",
+                new[] { typeof(Fixtures.Issue3460ParamsInterfaceOverloadOptions).Assembly.Location });
+            Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+            Assert.Null(result.UnhandledException);
+            Assert.Equal(103, result.Value);
+        }
+
+        [Fact]
         public void ImportedSpanParamsCollection_ExpandedObjectCreationUsesArrayConversion()
         {
             string printed = Translate("""
@@ -637,7 +698,7 @@ namespace Cs2Gs.Tests
                 MetadataReference.CreateFromFile(typeof(Fixtures.Issue3460SpanParamsOptions).Assembly.Location));
 
             Assert.Contains(
-                "Issue3460SpanParamsOptions([]int32{1, 2}){Value = 3}",
+                "Issue3460SpanParamsOptions(ReadOnlySpan[int32]([]int32{1, 2})){Value = 3}",
                 printed,
                 StringComparison.Ordinal);
             TranslationTestValidation.AssertBinds(printed);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3460TranslatorTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3460TranslatorTests.cs
@@ -86,6 +86,68 @@ namespace Cs2Gs.Tests.Fixtures
         public int Value { get; init; }
     }
 
+    public sealed class Issue3460OptionalParamsCollectionOptions
+    {
+        public Issue3460OptionalParamsCollectionOptions(
+            int marker = 7,
+            params List<int> values)
+        {
+            Marker = marker;
+            Count = values.Count;
+        }
+
+        public int Marker { get; }
+
+        public int Count { get; }
+
+        public int Value { get; init; }
+    }
+
+    public sealed class Issue3460SpanParamsOptions
+    {
+        public Issue3460SpanParamsOptions(params ReadOnlySpan<int> values)
+        {
+            Count = values.Length;
+        }
+
+        public int Count { get; }
+
+        public int Value { get; init; }
+    }
+
+    public sealed class Issue3460UnsupportedParamsOptions
+    {
+        public Issue3460UnsupportedParamsOptions(params HashSet<int> values)
+        {
+            Count = values.Count;
+        }
+
+        public int Count { get; }
+
+        public int Value { get; init; }
+    }
+
+    public sealed class Issue3460StringDefaultOptions
+    {
+        public Issue3460StringDefaultOptions(string marker = "selected")
+        {
+            Selected = 1;
+            Marker = marker;
+        }
+
+        public Issue3460StringDefaultOptions(object marker)
+        {
+            Selected = 2;
+            Marker = marker.ToString();
+        }
+
+        public int Selected { get; }
+
+        public string Marker { get; }
+
+        public int Value { get; init; }
+    }
+
     public sealed class Issue3460NonNullNestedHolder
     {
         public Issue3460NestedOptions Nested { get; } = new();
@@ -94,6 +156,11 @@ namespace Cs2Gs.Tests.Fixtures
     public sealed class Issue3460NullNestedHolder
     {
         public Issue3460NestedOptions Nested { get; }
+    }
+
+    public sealed class Issue3460NullCollectionHolder
+    {
+        public List<int> Values { get; }
     }
 }
 
@@ -158,6 +225,10 @@ namespace Cs2Gs.Tests
             string printed = Translate("""
                 namespace Demo
                 {
+                    public sealed class Object
+                    {
+                    }
+
                     public static class Obj
                     {
                         public static string Run() =>
@@ -166,7 +237,11 @@ namespace Cs2Gs.Tests
                 }
                 """);
 
-            Assert.Contains("Object()", printed, StringComparison.Ordinal);
+            Assert.Contains(
+                "import __cs2gs_System_Object = System.Object",
+                printed,
+                StringComparison.Ordinal);
+            Assert.Contains("__cs2gs_System_Object()", printed, StringComparison.Ordinal);
             Assert.DoesNotContain("object{}", printed, StringComparison.Ordinal);
             TranslationTestValidation.AssertBinds(printed);
 
@@ -304,8 +379,17 @@ namespace Cs2Gs.Tests
 
                 public static class Obj
                 {
+                    private static int trace;
+
+                    private static int Mark(int digit)
+                    {
+                        trace = (trace * 10) + digit;
+                        return digit;
+                    }
+
                     public static int Run()
                     {
+                        trace = 0;
                         var initialized = new Issue3460NonNullNestedHolder
                         {
                             Nested = { Value = 5 },
@@ -315,13 +399,25 @@ namespace Cs2Gs.Tests
                         {
                             _ = new Issue3460NullNestedHolder
                             {
-                                Nested = { Value = 7 },
+                                Nested = { Value = Mark(1) },
                             };
                             return -1;
                         }
                         catch (NullReferenceException)
                         {
-                            return initialized.Nested!.Value;
+                        }
+
+                        try
+                        {
+                            _ = new Issue3460NullCollectionHolder
+                            {
+                                Values = { Mark(2) },
+                            };
+                            return -2;
+                        }
+                        catch (NullReferenceException)
+                        {
+                            return trace + initialized.Nested!.Value;
                         }
                     }
                 }
@@ -329,7 +425,8 @@ namespace Cs2Gs.Tests
                 MetadataReference.CreateFromFile(typeof(Fixtures.Issue3460NestedOptions).Assembly.Location));
 
             Assert.Contains("Nested: { Value = 5 }", printed, StringComparison.Ordinal);
-            Assert.Contains("Nested: { Value = 7 }", printed, StringComparison.Ordinal);
+            Assert.Contains("Nested: { Value = Obj.Mark(1) }", printed, StringComparison.Ordinal);
+            Assert.Contains("Values: { Obj.Mark(2) }", printed, StringComparison.Ordinal);
             TranslationTestValidation.AssertBinds(printed);
 
             EmittedOracleResult result = EmittedOracle.Evaluate(
@@ -337,7 +434,7 @@ namespace Cs2Gs.Tests
                 new[] { typeof(Fixtures.Issue3460NestedOptions).Assembly.Location });
             Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
             Assert.Null(result.UnhandledException);
-            Assert.Equal(5, result.Value);
+            Assert.Equal(17, result.Value);
         }
 
         [Fact]
@@ -491,7 +588,130 @@ namespace Cs2Gs.Tests
             Assert.Equal(3, result.Value);
         }
 
+        [Fact]
+        public void ImportedOptionalBeforeParamsCollection_MaterializesEveryOperationSlot()
+        {
+            string printed = Translate("""
+                using Cs2Gs.Tests.Fixtures;
+
+                public static class Obj
+                {
+                    public static int Run()
+                    {
+                        var options = new Issue3460OptionalParamsCollectionOptions { Value = 3 };
+                        return (options.Marker * 100) + (options.Count * 10) + options.Value;
+                    }
+                }
+                """,
+                MetadataReference.CreateFromFile(typeof(Fixtures.Issue3460OptionalParamsCollectionOptions).Assembly.Location));
+
+            Assert.Contains(
+                "Issue3460OptionalParamsCollectionOptions(int32(7), List[int32]()){Value = 3}",
+                printed,
+                StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+
+            EmittedOracleResult result = EmittedOracle.Evaluate(
+                printed + Environment.NewLine + "Obj.Run()",
+                new[] { typeof(Fixtures.Issue3460OptionalParamsCollectionOptions).Assembly.Location });
+            Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+            Assert.Null(result.UnhandledException);
+            Assert.Equal(703, result.Value);
+        }
+
+        [Fact]
+        public void ImportedSpanParamsCollection_ExpandedObjectCreationUsesArrayConversion()
+        {
+            string printed = Translate("""
+                using Cs2Gs.Tests.Fixtures;
+
+                public static class Obj
+                {
+                    public static int Run()
+                    {
+                        var options = new Issue3460SpanParamsOptions(1, 2) { Value = 3 };
+                        return (options.Count * 10) + options.Value;
+                    }
+                }
+                """,
+                MetadataReference.CreateFromFile(typeof(Fixtures.Issue3460SpanParamsOptions).Assembly.Location));
+
+            Assert.Contains(
+                "Issue3460SpanParamsOptions([]int32{1, 2}){Value = 3}",
+                printed,
+                StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+
+            EmittedOracleResult result = EmittedOracle.Evaluate(
+                printed + Environment.NewLine + "Obj.Run()",
+                new[] { typeof(Fixtures.Issue3460SpanParamsOptions).Assembly.Location });
+            Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+            Assert.Null(result.UnhandledException);
+            Assert.Equal(23, result.Value);
+        }
+
+        [Fact]
+        public void ImportedUnsupportedParamsCollection_NonemptyExpansionReportsDiagnostic()
+        {
+            (_, TranslationContext context) = TranslateWithContext("""
+                using Cs2Gs.Tests.Fixtures;
+
+                public static class Obj
+                {
+                    public static object Run() =>
+                        new Issue3460UnsupportedParamsOptions(1, 2) { Value = 3 };
+                }
+                """,
+                MetadataReference.CreateFromFile(typeof(Fixtures.Issue3460UnsupportedParamsOptions).Assembly.Location));
+
+            Assert.Contains(
+                context.Diagnostics,
+                diagnostic => diagnostic.Severity == TranslationSeverity.Unsupported
+                    && diagnostic.Message.Contains("HashSet", StringComparison.Ordinal));
+        }
+
+        [Fact]
+        public void ImportedStringOptionalDefault_PreservesSelectedReferenceOverload()
+        {
+            string printed = Translate("""
+                using Cs2Gs.Tests.Fixtures;
+
+                public static class Obj
+                {
+                    public static int Run()
+                    {
+                        var options = new Issue3460StringDefaultOptions { Value = 3 };
+                        return (options.Selected * 100)
+                            + (options.Marker.Length * 10)
+                            + options.Value;
+                    }
+                }
+                """,
+                MetadataReference.CreateFromFile(typeof(Fixtures.Issue3460StringDefaultOptions).Assembly.Location));
+
+            Assert.Contains(
+                "Issue3460StringDefaultOptions(\"selected\"){Value = 3}",
+                printed,
+                StringComparison.Ordinal);
+            Assert.DoesNotContain("\"selected\" as string", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+
+            EmittedOracleResult result = EmittedOracle.Evaluate(
+                printed + Environment.NewLine + "Obj.Run()",
+                new[] { typeof(Fixtures.Issue3460StringDefaultOptions).Assembly.Location });
+            Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+            Assert.Null(result.UnhandledException);
+            Assert.Equal(183, result.Value);
+        }
+
         private static string Translate(
+            string source,
+            params MetadataReference[] additionalReferences)
+        {
+            return TranslateWithContext(source, additionalReferences).Printed;
+        }
+
+        private static (string Printed, TranslationContext Context) TranslateWithContext(
             string source,
             params MetadataReference[] additionalReferences)
         {
@@ -516,7 +736,7 @@ namespace Cs2Gs.Tests
                 document.SemanticModel,
                 document.FilePath);
             CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
-            return GSharpPrinter.Print(unit);
+            return (GSharpPrinter.Print(unit), context);
         }
     }
 }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3460TranslatorTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3460TranslatorTests.cs
@@ -56,6 +56,45 @@ namespace Cs2Gs.Tests.Fixtures
 
         public int Value { get; init; }
     }
+
+    public sealed class Issue3460OverloadedOptionalOptions
+    {
+        public Issue3460OverloadedOptionalOptions(short marker = 7)
+        {
+            Selected = 1;
+        }
+
+        public Issue3460OverloadedOptionalOptions(int marker)
+        {
+            Selected = 2;
+        }
+
+        public int Selected { get; }
+
+        public int Value { get; init; }
+    }
+
+    public sealed class Issue3460ParamsCollectionOptions
+    {
+        public Issue3460ParamsCollectionOptions(params List<int> values)
+        {
+            Count = values.Count;
+        }
+
+        public int Count { get; }
+
+        public int Value { get; init; }
+    }
+
+    public sealed class Issue3460NonNullNestedHolder
+    {
+        public Issue3460NestedOptions Nested { get; } = new();
+    }
+
+    public sealed class Issue3460NullNestedHolder
+    {
+        public Issue3460NestedOptions Nested { get; }
+    }
 }
 
 namespace Cs2Gs.Tests
@@ -111,6 +150,31 @@ namespace Cs2Gs.Tests
                 StringComparison.Ordinal);
             Assert.DoesNotContain("ParallelOptions(){", printed, StringComparison.Ordinal);
             TranslationTestValidation.AssertBinds(printed);
+        }
+
+        [Fact]
+        public void SystemObjectEmptyInitializer_RemainsClrObjectConstruction()
+        {
+            string printed = Translate("""
+                namespace Demo
+                {
+                    public static class Obj
+                    {
+                        public static string Run() =>
+                            new object { }.GetType().FullName!;
+                    }
+                }
+                """);
+
+            Assert.Contains("Object()", printed, StringComparison.Ordinal);
+            Assert.DoesNotContain("object{}", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+
+            EmittedOracleResult result = EmittedOracle.Evaluate(
+                printed + Environment.NewLine + "Demo.Obj.Run()");
+            Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+            Assert.Null(result.UnhandledException);
+            Assert.Equal("System.Object", result.Value);
         }
 
         [Fact]
@@ -232,6 +296,108 @@ namespace Cs2Gs.Tests
         }
 
         [Fact]
+        public void ImportedNestedMemberInitializer_UnwrapsNullableReceiverAndPreservesNullThrow()
+        {
+            string printed = Translate("""
+                using System;
+                using Cs2Gs.Tests.Fixtures;
+
+                public static class Obj
+                {
+                    public static int Run()
+                    {
+                        var initialized = new Issue3460NonNullNestedHolder
+                        {
+                            Nested = { Value = 5 },
+                        };
+
+                        try
+                        {
+                            _ = new Issue3460NullNestedHolder
+                            {
+                                Nested = { Value = 7 },
+                            };
+                            return -1;
+                        }
+                        catch (NullReferenceException)
+                        {
+                            return initialized.Nested!.Value;
+                        }
+                    }
+                }
+                """,
+                MetadataReference.CreateFromFile(typeof(Fixtures.Issue3460NestedOptions).Assembly.Location));
+
+            Assert.Contains("Nested: { Value = 5 }", printed, StringComparison.Ordinal);
+            Assert.Contains("Nested: { Value = 7 }", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+
+            EmittedOracleResult result = EmittedOracle.Evaluate(
+                printed + Environment.NewLine + "Obj.Run()",
+                new[] { typeof(Fixtures.Issue3460NestedOptions).Assembly.Location });
+            Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+            Assert.Null(result.UnhandledException);
+            Assert.Equal(5, result.Value);
+        }
+
+        [Fact]
+        public void SourceCompositeInitializer_BracedMembersPreserveTextualEvaluationOrder()
+        {
+            string printed = Translate("""
+                using System.Collections.Generic;
+
+                public sealed class Nested
+                {
+                    public int Value { get; set; }
+                }
+
+                public sealed class Options
+                {
+                    public int First { get; set; }
+                    public Nested Nested { get; } = new();
+                    public int Middle { get; set; }
+                    public List<int> Values { get; } = new();
+                    public int Last { get; set; }
+                }
+
+                public static class Obj
+                {
+                    private static int trace;
+
+                    private static int Mark(int digit)
+                    {
+                        trace = (trace * 10) + digit;
+                        return digit;
+                    }
+
+                    public static int Run()
+                    {
+                        trace = 0;
+                        _ = new Options
+                        {
+                            First = Mark(1),
+                            Nested = { Value = Mark(2) },
+                            Middle = Mark(3),
+                            Values = { Mark(4) },
+                            Last = Mark(5),
+                        };
+                        return trace;
+                    }
+                }
+                """);
+
+            Assert.Contains("Options{", printed, StringComparison.Ordinal);
+            Assert.DoesNotContain("Options(){", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+
+            EmittedOracleResult result = EmittedOracle.Evaluate(
+                printed + Environment.NewLine + "Obj.Run()");
+            Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+            Assert.Null(result.UnhandledException);
+            Assert.Equal(12345, result.Value);
+        }
+
+        [Fact]
         public void ImportedOptionalConstructor_DefaultIsMaterializedBeforeInitializer()
         {
             string printed = Translate("""
@@ -249,7 +415,7 @@ namespace Cs2Gs.Tests
                 MetadataReference.CreateFromFile(typeof(Fixtures.Issue3460OptionalOptions).Assembly.Location));
 
             Assert.Contains(
-                "Issue3460OptionalOptions(7){Value = 3}",
+                "Issue3460OptionalOptions(int32(7)){Value = 3}",
                 printed,
                 StringComparison.Ordinal);
             Assert.DoesNotContain("Issue3460OptionalOptions(){", printed, StringComparison.Ordinal);
@@ -261,6 +427,68 @@ namespace Cs2Gs.Tests
             Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
             Assert.Null(result.UnhandledException);
             Assert.Equal(73, result.Value);
+        }
+
+        [Fact]
+        public void ImportedOptionalConstructor_DefaultKeepsSelectedNarrowOverload()
+        {
+            string printed = Translate("""
+                using Cs2Gs.Tests.Fixtures;
+
+                public static class Obj
+                {
+                    public static int Run()
+                    {
+                        var options = new Issue3460OverloadedOptionalOptions { Value = 3 };
+                        return (options.Selected * 10) + options.Value;
+                    }
+                }
+                """,
+                MetadataReference.CreateFromFile(typeof(Fixtures.Issue3460OverloadedOptionalOptions).Assembly.Location));
+
+            Assert.Contains(
+                "Issue3460OverloadedOptionalOptions(int16(7)){Value = 3}",
+                printed,
+                StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+
+            EmittedOracleResult result = EmittedOracle.Evaluate(
+                printed + Environment.NewLine + "Obj.Run()",
+                new[] { typeof(Fixtures.Issue3460OverloadedOptionalOptions).Assembly.Location });
+            Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+            Assert.Null(result.UnhandledException);
+            Assert.Equal(13, result.Value);
+        }
+
+        [Fact]
+        public void ImportedParamsCollectionConstructor_NoParenthesesBuildsEmptyListArgument()
+        {
+            string printed = Translate("""
+                using Cs2Gs.Tests.Fixtures;
+
+                public static class Obj
+                {
+                    public static int Run()
+                    {
+                        var options = new Issue3460ParamsCollectionOptions { Value = 3 };
+                        return (options.Count * 10) + options.Value;
+                    }
+                }
+                """,
+                MetadataReference.CreateFromFile(typeof(Fixtures.Issue3460ParamsCollectionOptions).Assembly.Location));
+
+            Assert.Contains(
+                "Issue3460ParamsCollectionOptions(List[int32]()){Value = 3}",
+                printed,
+                StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+
+            EmittedOracleResult result = EmittedOracle.Evaluate(
+                printed + Environment.NewLine + "Obj.Run()",
+                new[] { typeof(Fixtures.Issue3460ParamsCollectionOptions).Assembly.Location });
+            Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+            Assert.Null(result.UnhandledException);
+            Assert.Equal(3, result.Value);
         }
 
         private static string Translate(

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3460TranslatorTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3460TranslatorTests.cs
@@ -464,7 +464,9 @@ namespace Cs2Gs.Tests
                     """));
 
             Assert.Contains("import System.Threading", printed, StringComparison.Ordinal);
-            Assert.DoesNotContain("import System.Timers", printed, StringComparison.Ordinal);
+            Assert.True(
+                !printed.Contains("import System.Timers", StringComparison.Ordinal),
+                printed);
             Assert.Contains("typeof(Timer)", printed, StringComparison.Ordinal);
             Assert.DoesNotContain("func Measure()", printed, StringComparison.Ordinal);
             TranslationTestValidation.AssertBinds(printed);
@@ -517,7 +519,9 @@ namespace Cs2Gs.Tests
                     """));
 
             Assert.Contains("import System.Threading", printed, StringComparison.Ordinal);
-            Assert.DoesNotContain("import System.Timers", printed, StringComparison.Ordinal);
+            Assert.True(
+                !printed.Contains("import System.Timers", StringComparison.Ordinal),
+                printed);
             Assert.Contains("class Root", printed, StringComparison.Ordinal);
             Assert.DoesNotContain("class Carrier", printed, StringComparison.Ordinal);
             Assert.DoesNotContain("func Measure()", printed, StringComparison.Ordinal);
@@ -525,6 +529,52 @@ namespace Cs2Gs.Tests
 
             EmittedOracleResult result = EmittedOracle.Evaluate(
                 printed + Environment.NewLine + "Demo.Root.Run()");
+            Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+            Assert.Null(result.UnhandledException);
+            Assert.Equal("System.Threading.Timer", result.Value);
+        }
+
+        [Fact]
+        public void ContributingDeclarationGraph_FlattenedEntrySkipsPartialSiblings()
+        {
+            string printed = TranslateEntryFile(
+                "A.Entry.cs",
+                ("A.Entry.cs", """
+                    using System.Threading;
+
+                    namespace Demo;
+
+                    public static partial class Program
+                    {
+                        public static string Probe() => typeof(Timer).FullName!;
+
+                        public static void Main()
+                        {
+                        }
+                    }
+                    """),
+                ("B.EntrySibling.cs", """
+                    using System.Timers;
+
+                    namespace Demo;
+
+                    public static partial class Program
+                    {
+                        public static int Unemitted() => 1;
+                    }
+                    """));
+
+            Assert.Contains("import System.Threading", printed, StringComparison.Ordinal);
+            Assert.True(
+                !printed.Contains("import System.Timers", StringComparison.Ordinal),
+                printed);
+            Assert.Contains("func Probe()", printed, StringComparison.Ordinal);
+            Assert.DoesNotContain("func Unemitted()", printed, StringComparison.Ordinal);
+            Assert.DoesNotContain("class Program", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+
+            EmittedOracleResult result = EmittedOracle.Evaluate(
+                printed + Environment.NewLine + "Probe()");
             Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
             Assert.Null(result.UnhandledException);
             Assert.Equal("System.Threading.Timer", result.Value);
@@ -1055,7 +1105,33 @@ namespace Cs2Gs.Tests
             bool preservePartialParts,
             params (string Path, string Source)[] sources)
         {
-            LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(sources);
+            return TranslateFileCore(
+                targetPath,
+                preservePartialParts,
+                OutputKind.DynamicallyLinkedLibrary,
+                sources);
+        }
+
+        private static string TranslateEntryFile(
+            string targetPath,
+            params (string Path, string Source)[] sources)
+        {
+            return TranslateFileCore(
+                targetPath,
+                preservePartialParts: false,
+                OutputKind.ConsoleApplication,
+                sources);
+        }
+
+        private static string TranslateFileCore(
+            string targetPath,
+            bool preservePartialParts,
+            OutputKind outputKind,
+            params (string Path, string Source)[] sources)
+        {
+            LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+                sources,
+                outputKind: outputKind);
             Assert.True(
                 project.BoundWithoutErrors,
                 "Snippets should bind with no C# errors: "

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3460TranslatorTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3460TranslatorTests.cs
@@ -1,0 +1,294 @@
+// <copyright file="Issue3460TranslatorTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using GSharp.Tests;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Cs2Gs.Tests.Fixtures
+{
+    public sealed class Issue3460ImportedOptions
+    {
+        public Issue3460ImportedOptions()
+        {
+            Trace = (Trace * 10) + 1;
+        }
+
+        public Issue3460ImportedOptions(int marker)
+        {
+            Trace = (Trace * 10) + marker;
+        }
+
+        public static int Trace { get; set; }
+
+        public required string Required { get; init; }
+
+        public int InitOnly { get; init; }
+
+        public int Value { get; set; }
+
+        public Issue3460NestedOptions Nested { get; set; } = new();
+
+        public List<int> Values { get; } = new();
+    }
+
+    public sealed class Issue3460NestedOptions
+    {
+        public int Value { get; set; }
+    }
+
+    public sealed class Issue3460OptionalOptions
+    {
+        public Issue3460OptionalOptions(int marker = 7)
+        {
+            Marker = marker;
+        }
+
+        public int Marker { get; }
+
+        public int Value { get; init; }
+    }
+}
+
+namespace Cs2Gs.Tests
+{
+    public sealed class Issue3460TranslatorTests
+    {
+        [Fact]
+        public void ImportedClrObjectInitializer_UsesCanonicalCompositeLiteralAndBinds()
+        {
+            string printed = Translate("""
+                using System.Text.Json;
+                using System.Text.Json.Serialization;
+
+                public static class Obj
+                {
+                    public static JsonSerializerOptions Make() =>
+                        new JsonSerializerOptions
+                        {
+                            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+                        };
+                }
+                """,
+                MetadataReference.CreateFromFile(
+                    typeof(System.Text.Json.JsonSerializerOptions).Assembly.Location));
+
+            Assert.Contains(
+                "JsonSerializerOptions{DefaultIgnoreCondition: JsonIgnoreCondition.WhenWritingNull}",
+                printed,
+                StringComparison.Ordinal);
+            Assert.DoesNotContain("JsonSerializerOptions(){", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+        }
+
+        [Fact]
+        public void ImportedClrObjectInitializer_InArgumentPosition_Binds()
+        {
+            string printed = Translate("""
+                using System.Threading.Tasks;
+
+                public static class Obj
+                {
+                    private static int Read(ParallelOptions options) =>
+                        options.MaxDegreeOfParallelism;
+
+                    public static int Make() =>
+                        Read(new ParallelOptions { MaxDegreeOfParallelism = 4 });
+                }
+                """);
+
+            Assert.Contains(
+                "Read(ParallelOptions{MaxDegreeOfParallelism: 4})",
+                printed,
+                StringComparison.Ordinal);
+            Assert.DoesNotContain("ParallelOptions(){", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+        }
+
+        [Fact]
+        public void ImportedParameterlessInitializer_PreservesOrderedMembersNestedInitializersAndRuntime()
+        {
+            string printed = Translate("""
+                using Cs2Gs.Tests.Fixtures;
+
+                public static class Obj
+                {
+                    private static Issue3460ImportedOptions Capture(
+                        Issue3460ImportedOptions options) => options;
+
+                    private static int Mark(int digit)
+                    {
+                        Issue3460ImportedOptions.Trace =
+                            (Issue3460ImportedOptions.Trace * 10) + digit;
+                        return digit;
+                    }
+
+                    private static string MarkText(string value, int digit)
+                    {
+                        Mark(digit);
+                        return value;
+                    }
+
+                    public static int Run()
+                    {
+                        Issue3460ImportedOptions.Trace = 0;
+                        var options = Capture(
+                            new Issue3460ImportedOptions
+                            {
+                                Required = MarkText("ok", 2),
+                                InitOnly = Mark(3),
+                                Value = Mark(4),
+                                Nested = new Issue3460NestedOptions { Value = Mark(5) },
+                                Values = { Mark(6), Mark(7) },
+                            });
+                        return Issue3460ImportedOptions.Trace
+                            + options.Required.Length
+                            + options.InitOnly
+                            + options.Value
+                            + options.Nested.Value
+                            + options.Values[0]
+                            + options.Values[1];
+                    }
+                }
+                """,
+                MetadataReference.CreateFromFile(typeof(Fixtures.Issue3460ImportedOptions).Assembly.Location));
+
+            Assert.Contains("Issue3460ImportedOptions{", printed, StringComparison.Ordinal);
+            Assert.DoesNotContain("Issue3460ImportedOptions(){", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+
+            EmittedOracleResult result = EmittedOracle.Evaluate(
+                printed + Environment.NewLine + "Obj.Run()",
+                new[] { typeof(Fixtures.Issue3460ImportedOptions).Assembly.Location });
+            Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+            Assert.Null(result.UnhandledException);
+            Assert.Equal(1234594, result.Value);
+        }
+
+        [Fact]
+        public void ImportedConstructorArguments_RunBeforeOrderedMemberAssignments()
+        {
+            string printed = Translate("""
+                using Cs2Gs.Tests.Fixtures;
+
+                public static class Obj
+                {
+                    private static int MarkArgument()
+                    {
+                        Issue3460ImportedOptions.Trace =
+                            (Issue3460ImportedOptions.Trace * 10) + 1;
+                        return 2;
+                    }
+
+                    private static int Mark(int digit)
+                    {
+                        Issue3460ImportedOptions.Trace =
+                            (Issue3460ImportedOptions.Trace * 10) + digit;
+                        return digit;
+                    }
+
+                    private static string MarkText(string value, int digit)
+                    {
+                        Mark(digit);
+                        return value;
+                    }
+
+                    public static int Run()
+                    {
+                        Issue3460ImportedOptions.Trace = 0;
+                        var options = new Issue3460ImportedOptions(MarkArgument())
+                        {
+                            Required = MarkText("ok", 3),
+                            InitOnly = Mark(4),
+                        };
+                        return Issue3460ImportedOptions.Trace + options.Required.Length;
+                    }
+                }
+                """,
+                MetadataReference.CreateFromFile(typeof(Fixtures.Issue3460ImportedOptions).Assembly.Location));
+
+            Assert.Contains(
+                "Issue3460ImportedOptions(Obj.MarkArgument())",
+                printed,
+                StringComparison.Ordinal);
+            Assert.Contains("Required = Obj.MarkText(\"ok\", 3)", printed, StringComparison.Ordinal);
+            Assert.Contains("InitOnly = Obj.Mark(4)", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+
+            EmittedOracleResult result = EmittedOracle.Evaluate(
+                printed + Environment.NewLine + "Obj.Run()",
+                new[] { typeof(Fixtures.Issue3460ImportedOptions).Assembly.Location });
+            Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+            Assert.Null(result.UnhandledException);
+            Assert.Equal(1236, result.Value);
+        }
+
+        [Fact]
+        public void ImportedOptionalConstructor_DefaultIsMaterializedBeforeInitializer()
+        {
+            string printed = Translate("""
+                using Cs2Gs.Tests.Fixtures;
+
+                public static class Obj
+                {
+                    public static int Run()
+                    {
+                        var options = new Issue3460OptionalOptions { Value = 3 };
+                        return (options.Marker * 10) + options.Value;
+                    }
+                }
+                """,
+                MetadataReference.CreateFromFile(typeof(Fixtures.Issue3460OptionalOptions).Assembly.Location));
+
+            Assert.Contains(
+                "Issue3460OptionalOptions(7){Value = 3}",
+                printed,
+                StringComparison.Ordinal);
+            Assert.DoesNotContain("Issue3460OptionalOptions(){", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+
+            EmittedOracleResult result = EmittedOracle.Evaluate(
+                printed + Environment.NewLine + "Obj.Run()",
+                new[] { typeof(Fixtures.Issue3460OptionalOptions).Assembly.Location });
+            Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+            Assert.Null(result.UnhandledException);
+            Assert.Equal(73, result.Value);
+        }
+
+        private static string Translate(
+            string source,
+            params MetadataReference[] additionalReferences)
+        {
+            IReadOnlyList<MetadataReference> references = additionalReferences.Length == 0
+                ? null
+                : CSharpProjectLoader.RuntimeReferences()
+                    .Concat(additionalReferences)
+                    .GroupBy(reference => reference.Display, StringComparer.Ordinal)
+                    .Select(group => group.First())
+                    .ToList();
+            LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+                new[] { ("Snippet.cs", source) },
+                references);
+            Assert.True(
+                project.BoundWithoutErrors,
+                "Snippet should bind with no C# errors: "
+                    + string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+            LoadedDocument document = Assert.Single(project.Documents);
+            var context = new TranslationContext(
+                project.Compilation,
+                document.SemanticModel,
+                document.FilePath);
+            CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+            return GSharpPrinter.Print(unit);
+        }
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -1083,7 +1083,9 @@ public sealed partial class CSharpToGSharpTranslator
                 .ToList();
             if (spanObjectCreation)
             {
-                translatedArguments.Add(new ArrayLiteralExpression(elementType, paramsValues));
+                translatedArguments.Add(this.CoerceMaterializedArgument(
+                    new ArrayLiteralExpression(elementType, paramsValues),
+                    paramsCollectionArg.Parameter.Type));
                 return translatedArguments;
             }
 
@@ -1098,9 +1100,18 @@ public sealed partial class CSharpToGSharpTranslator
             // element (an empty `{ }` fails to bind, GS0157); the bare
             // construction call (`List[int32]()`) is the canonical empty form
             // (mirrors the C# `[]`-collection-expression lowering above).
-            translatedArguments.Add(collectionElements.Count == 0
+            GExpression collectionArgument = collectionElements.Count == 0
                 ? construction
-                : new CollectionInitializerExpression(construction, collectionElements));
+                : new CollectionInitializerExpression(construction, collectionElements);
+            bool exactListParameter = paramsCollectionArg.Parameter.Type
+                is INamedTypeSymbol { Name: "List" } listParameter
+                && listParameter.ContainingNamespace?.ToDisplayString()
+                    == "System.Collections.Generic";
+            translatedArguments.Add(exactListParameter
+                ? collectionArgument
+                : this.CoerceMaterializedArgument(
+                    collectionArgument,
+                    paramsCollectionArg.Parameter.Type));
             return translatedArguments;
         }
 
@@ -1204,7 +1215,7 @@ public sealed partial class CSharpToGSharpTranslator
             }
 
             return coerceToParameterType
-                ? this.CoerceMaterializedDefault(
+                ? this.CoerceMaterializedArgument(
                     defaultValue,
                     argumentOperation.Parameter.Type)
                 : defaultValue;
@@ -1828,7 +1839,9 @@ public sealed partial class CSharpToGSharpTranslator
             if (typeSymbol is INamedTypeSymbol { SpecialType: SpecialType.System_Object } systemObject)
             {
                 type = new NamedTypeReference(
-                    this.typeMapper.GetOrCreateMetadataTypeAlias(systemObject));
+                    this.typeMapper.GetOrCreateMetadataTypeAlias(
+                        systemObject,
+                        this.context));
             }
 
             bool hasCtorArgs = arguments.Count > 0;
@@ -1998,7 +2011,7 @@ public sealed partial class CSharpToGSharpTranslator
                     return arguments;
                 }
 
-                materialized.Add(this.CoerceMaterializedDefault(
+                materialized.Add(this.CoerceMaterializedArgument(
                     defaultValue,
                     parameter.Type));
             }
@@ -2006,34 +2019,34 @@ public sealed partial class CSharpToGSharpTranslator
             return materialized;
         }
 
-        private GExpression CoerceMaterializedDefault(
-            GExpression defaultValue,
+        private GExpression CoerceMaterializedArgument(
+            GExpression value,
             ITypeSymbol parameterType)
         {
             if (!parameterType.IsReferenceType)
             {
-                return this.CoerceOperandTo(defaultValue, parameterType);
+                return this.CoerceOperandTo(value, parameterType);
             }
 
             GTypeReference mappedType = this.typeMapper.Map(
                 parameterType,
                 this.context,
                 Location.None);
-            if (defaultValue is LiteralExpression { Kind: LiteralKind.Null }
-                || defaultValue is IdentifierExpression { Name: "nil" })
+            if (value is LiteralExpression { Kind: LiteralKind.Null }
+                || value is IdentifierExpression { Name: "nil" })
             {
                 return new DefaultValueExpression(mappedType);
             }
 
             if (parameterType.SpecialType == SpecialType.System_String
-                && defaultValue is LiteralExpression { Kind: LiteralKind.String })
+                && value is LiteralExpression { Kind: LiteralKind.String })
             {
-                return defaultValue;
+                return value;
             }
 
             return new ConversionExpression(
                 mappedType,
-                defaultValue,
+                value,
                 isCheckedReferenceCast: true);
         }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -1825,8 +1825,8 @@ public sealed partial class CSharpToGSharpTranslator
                 // §B.11).
                 if (!hasCtorArgs
                     && (typeSymbol is ITypeParameterSymbol
-                        || (typeSymbol is INamedTypeSymbol initializedType
-                            && ShouldUseCompositeObjectInitializer(initializedType, initializer))))
+                        || (typeSymbol is INamedTypeSymbol
+                            && this.InvokesParameterlessConstructor(creationNode))))
                 {
                     return this.BuildObjectInitializerLiteral(initializer, type);
                 }
@@ -1842,7 +1842,10 @@ public sealed partial class CSharpToGSharpTranslator
                 // this: it lowers to a synthetic local, the assignments, then a
                 // trailing value, so it composes at any expression position —
                 // no hoisted-temp workaround is needed.
-                return this.BuildConstructionWithInitializerSuffix(initializer, type, arguments);
+                return this.BuildConstructionWithInitializerSuffix(
+                    initializer,
+                    type,
+                    this.MaterializeOmittedConstructorArguments(creationNode, arguments));
             }
 
             // A source-defined value aggregate (`struct` / `data struct`) has no
@@ -1865,32 +1868,54 @@ public sealed partial class CSharpToGSharpTranslator
             return BuildConstruction(type, arguments);
         }
 
-        private bool ShouldUseCompositeObjectInitializer(
-            INamedTypeSymbol initializedType,
-            InitializerExpressionSyntax initializer)
+        private bool InvokesParameterlessConstructor(
+            BaseObjectCreationExpressionSyntax creationNode)
         {
-            string assemblyName = initializedType.ContainingAssembly?.Name;
-            if (!initializedType.IsValueType
-                && assemblyName != null
-                && assemblyName != this.context.Compilation.AssemblyName
-                && this.context.RepositoryCompilations?.Any(
-                    compilation => compilation.AssemblyName == assemblyName) == true)
+            return this.context.GetSymbolInfo(creationNode).Symbol
+                is IMethodSymbol { Parameters.Length: 0 };
+        }
+
+        private IReadOnlyList<GExpression> MaterializeOmittedConstructorArguments(
+            BaseObjectCreationExpressionSyntax creationNode,
+            IReadOnlyList<GExpression> arguments)
+        {
+            if (arguments.Count != 0
+                || this.context.GetSymbolInfo(creationNode).Symbol is not IMethodSymbol constructor
+                || constructor.Parameters.Length == 0)
             {
-                return false;
+                return arguments;
             }
 
-            if (initializedType.IsValueType
-                || initializedType.Locations.Any(location => location.IsInSource)
-                || initializer.Expressions.OfType<AssignmentExpressionSyntax>()
-                    .Any(assignment => assignment.Right is InitializerExpressionSyntax))
+            var materialized = new List<GExpression>(constructor.Parameters.Length);
+            foreach (IParameterSymbol parameter in constructor.Parameters)
             {
-                return true;
+                if (parameter.IsParams && parameter.Type is IArrayTypeSymbol paramsArray)
+                {
+                    materialized.Add(new ArrayLiteralExpression(
+                        this.typeMapper.Map(
+                            paramsArray.ElementType,
+                            this.context,
+                            creationNode.GetLocation())));
+                    continue;
+                }
+
+                GTypeReference parameterType = this.typeMapper.Map(
+                    parameter.Type,
+                    this.context,
+                    creationNode.GetLocation());
+                GExpression defaultValue = this.BuildOptionalParameterDefault(
+                    parameter,
+                    parameterType,
+                    creationNode);
+                if (defaultValue == null)
+                {
+                    return arguments;
+                }
+
+                materialized.Add(defaultValue);
             }
 
-            return assemblyName != null
-                && assemblyName != "System.Private.CoreLib"
-                && !assemblyName.StartsWith("System.", StringComparison.Ordinal)
-                && !assemblyName.StartsWith("Microsoft.", StringComparison.Ordinal);
+            return materialized;
         }
 
         private bool TryBuildSourceStructConstructorFields(

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -1040,11 +1040,14 @@ public sealed partial class CSharpToGSharpTranslator
                 // gaps that same declaration (issue #1901 follow-up), and a half-
                 // translated callee with no working caller is what we're guarding
                 // against here — so both sides need to stay consistent. A callee from
-                // a REFERENCED assembly (e.g. BCL `Task.WhenAll(params ReadOnlySpan<Task>)`)
-                // is never translated as a declaration in the first place, so there is
-                // nothing to stay consistent with; fall back to the pre-#1901 ordinary
-                // argument translation silently, exactly as it worked before this PR.
-                if (targetMethod?.DeclaringSyntaxReferences.IsEmpty == false)
+                // a REFERENCED method (e.g. BCL
+                // `Task.WhenAll(params ReadOnlySpan<Task>)`) is never translated
+                // as a declaration, so ordinary calls retain the pre-#1901
+                // fallback. Object creation must still gap: dropping its implicit
+                // params-collection argument invents a nonexistent zero-arg
+                // constructor.
+                if (targetMethod?.DeclaringSyntaxReferences.IsEmpty == false
+                    || callSyntax is BaseObjectCreationExpressionSyntax)
                 {
                     this.context.ReportUnsupported(
                         callSyntax,
@@ -1056,6 +1059,10 @@ public sealed partial class CSharpToGSharpTranslator
 
             var translatedArguments = arguments.Take(paramsOrdinal).Select(a => this.TranslateArgument(a)).ToList();
 
+            _ = this.typeMapper.Map(
+                paramsCollectionArg.Parameter.Type,
+                this.context,
+                callSyntax.GetLocation());
             ITypeSymbol paramsElementType = ((INamedTypeSymbol)paramsCollectionArg.Parameter.Type).TypeArguments[0];
             GTypeReference elementType = this.typeMapper.Map(paramsElementType, this.context, callSyntax.GetLocation());
 
@@ -1705,9 +1712,9 @@ public sealed partial class CSharpToGSharpTranslator
                 ? this.typeMapper.Map(typeSymbol, this.context, creation.GetLocation())
                 : new NamedTypeReference(creation.Type.ToString());
 
-            var arguments = creation.ArgumentList == null
-                ? new List<GExpression>()
-                : this.TranslateCallArguments(creation, creation.ArgumentList.Arguments);
+            var arguments = this.TranslateCallArguments(
+                creation,
+                creation.ArgumentList?.Arguments ?? default);
 
             // A C# delegate creation `new SomeDelegate(target)` wraps a method
             // group, lambda, or another delegate in a named delegate type. G# has
@@ -1819,6 +1826,12 @@ public sealed partial class CSharpToGSharpTranslator
 
             if (initializer != null && initializer.IsKind(SyntaxKind.ObjectInitializerExpression))
             {
+                if (typeSymbol?.SpecialType == SpecialType.System_Object
+                    && initializer.Expressions.Count == 0)
+                {
+                    return BuildConstruction(type, arguments);
+                }
+
                 // An object initializer `new T { Field = value, ... }` with NO
                 // constructor argument list maps to the canonical G# struct
                 // literal `T{Field: value, ...}` (spec §Struct literals; ADR-0115
@@ -1826,6 +1839,7 @@ public sealed partial class CSharpToGSharpTranslator
                 if (!hasCtorArgs
                     && (typeSymbol is ITypeParameterSymbol
                         || (typeSymbol is INamedTypeSymbol
+                            && typeSymbol.SpecialType != SpecialType.System_Object
                             && this.InvokesParameterlessConstructor(creationNode))))
                 {
                     return this.BuildObjectInitializerLiteral(initializer, type);
@@ -1912,7 +1926,7 @@ public sealed partial class CSharpToGSharpTranslator
                     return arguments;
                 }
 
-                materialized.Add(defaultValue);
+                materialized.Add(this.CoerceOperandTo(defaultValue, parameter.Type));
             }
 
             return materialized;
@@ -2184,13 +2198,14 @@ public sealed partial class CSharpToGSharpTranslator
         /// (<c>new object()</c>, <c>new string(' ', n)</c>, target-typed <c>new()</c>)
         /// must spell a callable CLR type name instead — otherwise gsc reports
         /// GS0130 ("Function 'string' doesn't exist"). Most aliases use a
-        /// qualified name; <c>string</c> uses imported <c>String</c> because
-        /// namespace-qualified constructor expressions are not bindable.
+        /// qualified name; <c>object</c>/<c>string</c> use imported
+        /// <c>Object</c>/<c>String</c> because namespace-qualified constructor
+        /// expressions are not bindable.
         /// Non-keyword type names are returned unchanged.
         /// </summary>
         private static string ConstructionCalleeName(string typeName) => typeName switch
         {
-            "object" => "System.Object",
+            "object" => "Object",
             "string" => "String",
             "bool" => "System.Boolean",
             "char" => "System.Char",

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -1047,7 +1047,8 @@ public sealed partial class CSharpToGSharpTranslator
                 // params-collection argument invents a nonexistent zero-arg
                 // constructor.
                 if (targetMethod?.DeclaringSyntaxReferences.IsEmpty == false
-                    || callSyntax is BaseObjectCreationExpressionSyntax)
+                    || (callSyntax is BaseObjectCreationExpressionSyntax
+                        && arguments.Count == 0))
                 {
                     this.context.ReportUnsupported(
                         callSyntax,

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -952,10 +952,11 @@ public sealed partial class CSharpToGSharpTranslator
         /// constructor to reach for): the concrete <c>List&lt;T&gt;</c> class itself,
         /// plus the interfaces it already implements. Matched structurally (single
         /// type argument) rather than by shape, per issue #1901 follow-up — a
-        /// <c>ReadOnlySpan&lt;T&gt;</c>/<c>Span&lt;T&gt;</c> (C#13's PREFERRED params-collection
-        /// overload), a <c>HashSet&lt;T&gt;</c>, or any user <c>[CollectionBuilder]</c> type
-        /// has no gsc construction form and must gap instead of silently mismatching
-        /// the declared parameter type.
+        /// <c>HashSet&lt;T&gt;</c> or any user <c>[CollectionBuilder]</c> type has no
+        /// gsc construction form and must gap instead of silently mismatching the
+        /// declared parameter type. Object creation additionally lowers
+        /// <c>Span&lt;T&gt;</c>/<c>ReadOnlySpan&lt;T&gt;</c> through an array argument,
+        /// reusing gsc's existing array-to-span implicit conversion.
         /// </summary>
         private static bool IsSupportedParamsCollectionType(ITypeSymbol type)
         {
@@ -976,6 +977,11 @@ public sealed partial class CSharpToGSharpTranslator
                 SpecialType.System_Collections_Generic_IReadOnlyList_T or
                 SpecialType.System_Collections_Generic_IReadOnlyCollection_T;
         }
+
+        private static bool IsSpanParamsCollectionType(ITypeSymbol type) =>
+            type is INamedTypeSymbol { TypeArguments: [ITypeSymbol] } named
+            && named.ContainingNamespace?.ToDisplayString() == "System"
+            && named.Name is "Span" or "ReadOnlySpan";
 
         private List<GExpression> TranslateCallArguments(SyntaxNode callSyntax, SeparatedSyntaxList<ArgumentSyntax> arguments)
         {
@@ -1025,16 +1031,17 @@ public sealed partial class CSharpToGSharpTranslator
                 return this.TranslateArguments(arguments);
             }
 
-            int paramsOrdinal = paramsCollectionArg.Parameter.Ordinal;
-
-            if (!IsSupportedParamsCollectionType(paramsCollectionArg.Parameter.Type))
+            bool spanObjectCreation = callSyntax is BaseObjectCreationExpressionSyntax
+                && IsSpanParamsCollectionType(paramsCollectionArg.Parameter.Type);
+            if (!IsSupportedParamsCollectionType(paramsCollectionArg.Parameter.Type)
+                && !spanObjectCreation)
             {
                 // gsc can only construct a List[T]{...} literal at the call site
                 // (BuildConstruction below has no other collection constructor to
-                // reach for). Anything else — params Span<T>/ReadOnlySpan<T> (the
-                // PREFERRED C#13 overload), HashSet<T>, a [CollectionBuilder] type,
-                // or a collection type with other than one type argument — has no
-                // gsc construction form.
+                // reach for). Anything else — HashSet<T>, a
+                // [CollectionBuilder] type, or a collection type with other than
+                // one type argument — has no gsc construction form. Object
+                // creation's Span<T>/ReadOnlySpan<T> case was handled above.
                 //
                 // Only gap when the callee itself is declared IN SOURCE: MapParameter
                 // gaps that same declaration (issue #1901 follow-up), and a half-
@@ -1047,8 +1054,7 @@ public sealed partial class CSharpToGSharpTranslator
                 // params-collection argument invents a nonexistent zero-arg
                 // constructor.
                 if (targetMethod?.DeclaringSyntaxReferences.IsEmpty == false
-                    || (callSyntax is BaseObjectCreationExpressionSyntax
-                        && arguments.Count == 0))
+                    || callSyntax is BaseObjectCreationExpressionSyntax)
                 {
                     this.context.ReportUnsupported(
                         callSyntax,
@@ -1058,7 +1064,12 @@ public sealed partial class CSharpToGSharpTranslator
                 return this.TranslateArguments(arguments);
             }
 
-            var translatedArguments = arguments.Take(paramsOrdinal).Select(a => this.TranslateArgument(a)).ToList();
+            var translatedArguments = this.TranslateArgumentsBeforeParamsCollection(
+                callSyntax,
+                arguments,
+                operationArguments,
+                paramsCollectionArg,
+                out int consumedSyntaxArguments);
 
             _ = this.typeMapper.Map(
                 paramsCollectionArg.Parameter.Type,
@@ -1067,8 +1078,17 @@ public sealed partial class CSharpToGSharpTranslator
             ITypeSymbol paramsElementType = ((INamedTypeSymbol)paramsCollectionArg.Parameter.Type).TypeArguments[0];
             GTypeReference elementType = this.typeMapper.Map(paramsElementType, this.context, callSyntax.GetLocation());
 
-            var collectionElements = arguments.Skip(paramsOrdinal)
-                .Select(a => new CollectionInitializerElement(this.TranslateArgument(a)))
+            var paramsValues = arguments.Skip(consumedSyntaxArguments)
+                .Select(a => this.TranslateArgument(a))
+                .ToList();
+            if (spanObjectCreation)
+            {
+                translatedArguments.Add(new ArrayLiteralExpression(elementType, paramsValues));
+                return translatedArguments;
+            }
+
+            var collectionElements = paramsValues
+                .Select(value => new CollectionInitializerElement(value))
                 .ToList();
             var listType = new NamedTypeReference("List", new List<GTypeReference> { elementType });
             GExpression construction = BuildConstruction(listType, new List<GExpression>());
@@ -1082,6 +1102,39 @@ public sealed partial class CSharpToGSharpTranslator
                 ? construction
                 : new CollectionInitializerExpression(construction, collectionElements));
             return translatedArguments;
+        }
+
+        private List<GExpression> TranslateArgumentsBeforeParamsCollection(
+            SyntaxNode callSyntax,
+            SeparatedSyntaxList<ArgumentSyntax> arguments,
+            ImmutableArray<IArgumentOperation> operationArguments,
+            IArgumentOperation paramsCollectionArgument,
+            out int consumedSyntaxArguments)
+        {
+            var result = new List<GExpression>(paramsCollectionArgument.Parameter.Ordinal);
+            consumedSyntaxArguments = 0;
+            foreach (IArgumentOperation operationArgument in operationArguments)
+            {
+                if (operationArgument.ArgumentKind == ArgumentKind.ParamCollection)
+                {
+                    break;
+                }
+
+                if (operationArgument.ArgumentKind == ArgumentKind.DefaultValue)
+                {
+                    result.Add(this.TranslateOperationDefaultArgument(
+                        callSyntax,
+                        operationArgument,
+                        "parameter",
+                        coerceToParameterType: true));
+                    continue;
+                }
+
+                result.Add(this.TranslateArgument(arguments[consumedSyntaxArguments]));
+                consumedSyntaxArguments++;
+            }
+
+            return result;
         }
 
         /// <summary>
@@ -1108,33 +1161,11 @@ public sealed partial class CSharpToGSharpTranslator
             {
                 if (argumentOperation.ArgumentKind == ArgumentKind.DefaultValue)
                 {
-                    Optional<object> constant = argumentOperation.Value.ConstantValue;
-                    GExpression defaultValue = constant.HasValue
-                        ? this.MapConstantValue(
-                            constant.Value,
-                            argumentOperation.Parameter.Type,
-                            callSyntax,
-                            $"parameter '{argumentOperation.Parameter.Name}''s default value")
-                        : null;
-                    if (defaultValue == null)
-                    {
-                        // `nil` is the CORRECT mapping for a legitimate null/default
-                        // constant (constant.Value == null); anything else that
-                        // failed to map (decimal, default(struct), or no constant
-                        // at all) has no gsc literal form — `nil` there would
-                        // silently substitute the wrong value AND type. Gap loudly.
-                        bool legitimateNull = constant.HasValue && constant.Value == null;
-                        if (!legitimateNull)
-                        {
-                            this.context.ReportUnsupported(
-                                callSyntax,
-                                $"lambda default value of type '{argumentOperation.Parameter.Type}' has no gsc constant form.");
-                        }
-
-                        defaultValue = new IdentifierExpression("nil");
-                    }
-
-                    result.Add(defaultValue);
+                    result.Add(this.TranslateOperationDefaultArgument(
+                        callSyntax,
+                        argumentOperation,
+                        "lambda parameter",
+                        coerceToParameterType: false));
                     continue;
                 }
 
@@ -1143,6 +1174,40 @@ public sealed partial class CSharpToGSharpTranslator
             }
 
             return result;
+        }
+
+        private GExpression TranslateOperationDefaultArgument(
+            SyntaxNode callSyntax,
+            IArgumentOperation argumentOperation,
+            string parameterKind,
+            bool coerceToParameterType)
+        {
+            Optional<object> constant = argumentOperation.Value.ConstantValue;
+            GExpression defaultValue = constant.HasValue
+                ? this.MapConstantValue(
+                    constant.Value,
+                    argumentOperation.Parameter.Type,
+                    callSyntax,
+                    $"parameter '{argumentOperation.Parameter.Name}''s default value")
+                : null;
+            if (defaultValue == null)
+            {
+                bool legitimateNull = constant.HasValue && constant.Value == null;
+                if (!legitimateNull)
+                {
+                    this.context.ReportUnsupported(
+                        callSyntax,
+                        $"{parameterKind} default value of type '{argumentOperation.Parameter.Type}' has no gsc constant form.");
+                }
+
+                defaultValue = new IdentifierExpression("nil");
+            }
+
+            return coerceToParameterType
+                ? this.CoerceMaterializedDefault(
+                    defaultValue,
+                    argumentOperation.Parameter.Type)
+                : defaultValue;
         }
 
         private GExpression TranslateArgument(ArgumentSyntax argument)
@@ -1760,6 +1825,12 @@ public sealed partial class CSharpToGSharpTranslator
             IReadOnlyList<GExpression> arguments,
             InitializerExpressionSyntax initializer)
         {
+            if (typeSymbol is INamedTypeSymbol { SpecialType: SpecialType.System_Object } systemObject)
+            {
+                type = new NamedTypeReference(
+                    this.typeMapper.GetOrCreateMetadataTypeAlias(systemObject));
+            }
+
             bool hasCtorArgs = arguments.Count > 0;
 
             // A C# collection initializer maps to the canonical G# collection
@@ -1927,10 +1998,43 @@ public sealed partial class CSharpToGSharpTranslator
                     return arguments;
                 }
 
-                materialized.Add(this.CoerceOperandTo(defaultValue, parameter.Type));
+                materialized.Add(this.CoerceMaterializedDefault(
+                    defaultValue,
+                    parameter.Type));
             }
 
             return materialized;
+        }
+
+        private GExpression CoerceMaterializedDefault(
+            GExpression defaultValue,
+            ITypeSymbol parameterType)
+        {
+            if (!parameterType.IsReferenceType)
+            {
+                return this.CoerceOperandTo(defaultValue, parameterType);
+            }
+
+            GTypeReference mappedType = this.typeMapper.Map(
+                parameterType,
+                this.context,
+                Location.None);
+            if (defaultValue is LiteralExpression { Kind: LiteralKind.Null }
+                || defaultValue is IdentifierExpression { Name: "nil" })
+            {
+                return new DefaultValueExpression(mappedType);
+            }
+
+            if (parameterType.SpecialType == SpecialType.System_String
+                && defaultValue is LiteralExpression { Kind: LiteralKind.String })
+            {
+                return defaultValue;
+            }
+
+            return new ConversionExpression(
+                mappedType,
+                defaultValue,
+                isCheckedReferenceCast: true);
         }
 
         private bool TryBuildSourceStructConstructorFields(

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
@@ -470,9 +470,9 @@ public sealed partial class CSharpToGSharpTranslator
                 ? this.typeMapper.Map(typeSymbol, this.context, creation.GetLocation())
                 : new NamedTypeReference(CSharpTypeMapper.UnsupportedPlaceholderType);
 
-            var arguments = creation.ArgumentList == null
-                ? new List<GExpression>()
-                : this.TranslateCallArguments(creation, creation.ArgumentList.Arguments);
+            var arguments = this.TranslateCallArguments(
+                creation,
+                creation.ArgumentList?.Arguments ?? default);
 
             return this.BuildObjectCreationCore(creation, typeSymbol, type, arguments, creation.Initializer);
         }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -211,6 +211,14 @@ public sealed partial class CSharpToGSharpTranslator
 
         string package = this.packageFilter ?? this.ResolvePackage(root, context);
 
+        // T3 (ADR-0115 §B.1/§B.11): the C# program entry point and its enclosing
+        // static class normally become top-level G#. When the entry class owns a
+        // nested aggregate type, keep the class intact instead.
+        IMethodSymbol entryPoint = context.Compilation.GetEntryPoint(default);
+        INamedTypeSymbol entryType = entryPoint?.ContainingType;
+        bool preserveEntryType = entryType?.GetTypeMembers()
+            .Any(type => type.TypeKind != TypeKind.Delegate) == true;
+
         // Issue #1910 (gap 3): a merged-in member from a non-primary partial
         // part (see `VisitAggregateCore`) is translated using ITS OWN file's
         // semantic model (`TranslationContext.UseSemanticModelFor`), so a short
@@ -229,7 +237,8 @@ public sealed partial class CSharpToGSharpTranslator
                 partialTypeParts,
                 ownedExtensions,
                 this.preservePartialParts,
-                this.packageFilter);
+                this.packageFilter,
+                preserveEntryType ? null : entryType);
         IEnumerable<Microsoft.CodeAnalysis.SyntaxTree> extraUsingTrees =
             contributingTrees
                 .Where(tree => tree != root.SyntaxTree)
@@ -238,19 +247,6 @@ public sealed partial class CSharpToGSharpTranslator
 
         HashSet<INamedTypeSymbol> openBases = GetOrCollectSubclassedBaseTypes(context.Compilation);
         HashSet<INamedTypeSymbol> staticUsingTargets = CollectStaticUsingTargets(root, context);
-
-        // T3 (ADR-0115 §B.1/§B.11): the C# program entry point and its enclosing
-        // static class normally become top-level G#. When the entry class owns a
-        // nested aggregate type, keep the class intact instead: G# supports class-scoped
-        // static Main, and flattening would discard the nested type's owner and
-        // private accessibility.
-        //
-        // Computed once here and threaded through so the visitor does not
-        // recompute it (`Compilation.GetEntryPoint` re-walks the compilation).
-        IMethodSymbol entryPoint = context.Compilation.GetEntryPoint(default);
-        INamedTypeSymbol entryType = entryPoint?.ContainingType;
-        bool preserveEntryType = entryType?.GetTypeMembers()
-            .Any(type => type.TypeKind != TypeKind.Delegate) == true;
 
         // Share the anonymous-type registry with every other
         // document already translated (by this same translator instance)
@@ -891,7 +887,8 @@ public sealed partial class CSharpToGSharpTranslator
         Dictionary<INamedTypeSymbol, List<TypeDeclarationSyntax>> partialTypeParts,
         OwnedExtensionRegistry ownedExtensions,
         bool preservePartialParts,
-        string packageFilter)
+        string packageFilter,
+        INamedTypeSymbol flattenedEntryType)
     {
         var trees = new HashSet<Microsoft.CodeAnalysis.SyntaxTree>
         {
@@ -937,6 +934,15 @@ public sealed partial class CSharpToGSharpTranslator
             SemanticModel model = context.Compilation.GetSemanticModel(
                 declaration.SyntaxTree);
             INamedTypeSymbol type = model.GetDeclaredSymbol(declaration);
+            bool isFlattenedEntry = type != null
+                && SymbolEqualityComparer.Default.Equals(
+                    type.OriginalDefinition,
+                    flattenedEntryType?.OriginalDefinition);
+            if (isFlattenedEntry)
+            {
+                continue;
+            }
+
             bool attachOwnedExtensions = true;
             if (type != null
                 && partialTypeParts.TryGetValue(

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -897,14 +897,33 @@ public sealed partial class CSharpToGSharpTranslator
         {
             root.SyntaxTree,
         };
-        var pending = new Queue<TypeDeclarationSyntax>(
-            EnumerateTopLevelDeclarations(root)
-                .OfType<TypeDeclarationSyntax>()
-                .Where(declaration => packageFilter is null
-                    || context.Compilation.GetSemanticModel(declaration.SyntaxTree)
-                        .GetDeclaredSymbol(declaration)?
-                        .ContainingNamespace?
-                        .ToDisplayString() == packageFilter));
+        var pending = new Queue<TypeDeclarationSyntax>();
+        SemanticModel rootModel = context.Compilation.GetSemanticModel(
+            root.SyntaxTree);
+        foreach (TypeDeclarationSyntax declaration in EnumerateTopLevelDeclarations(root)
+            .OfType<TypeDeclarationSyntax>())
+        {
+            INamedTypeSymbol type = rootModel.GetDeclaredSymbol(declaration);
+            if (packageFilter != null
+                && type?.ContainingNamespace?.ToDisplayString() != packageFilter)
+            {
+                continue;
+            }
+
+            if (!preservePartialParts
+                && type != null
+                && partialTypeParts.TryGetValue(
+                    type,
+                    out List<TypeDeclarationSyntax> parts)
+                && (parts[0].SyntaxTree != declaration.SyntaxTree
+                    || parts[0].Span != declaration.Span))
+            {
+                continue;
+            }
+
+            pending.Enqueue(declaration);
+        }
+
         var seen = new HashSet<TypeDeclarationSyntax>();
         while (pending.Count > 0)
         {

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -222,12 +222,17 @@ public sealed partial class CSharpToGSharpTranslator
         // ADR-0145 preserve mode: each part is a standalone declaration, so it
         // must NOT pull in sibling parts' `using` directives — its own imports
         // are all it needs (there is no cross-part member merge to resolve).
+        HashSet<Microsoft.CodeAnalysis.SyntaxTree> contributingTrees =
+            CollectContributingTrees(
+                root,
+                context,
+                partialTypeParts,
+                ownedExtensions,
+                this.preservePartialParts);
         IEnumerable<Microsoft.CodeAnalysis.SyntaxTree> extraUsingTrees =
-            this.preservePartialParts
-                ? Enumerable.Empty<Microsoft.CodeAnalysis.SyntaxTree>()
-                : CollectExtraUsingTrees(root, partialTypeParts);
-        extraUsingTrees = extraUsingTrees.Concat(
-            CollectOwnedExtensionUsingTrees(root, context, ownedExtensions));
+            contributingTrees
+                .Where(tree => tree != root.SyntaxTree)
+                .OrderBy(tree => tree.FilePath, StringComparer.Ordinal);
         IReadOnlyList<ImportDirective> imports = this.TranslateImports(root, extraUsingTrees, context);
 
         HashSet<INamedTypeSymbol> openBases = GetOrCollectSubclassedBaseTypes(context.Compilation);
@@ -873,55 +878,64 @@ public sealed partial class CSharpToGSharpTranslator
         return result;
     }
 
-    // Issue #1910 (gap 3): for every partial type whose PRIMARY part lives in
-    // `root`, collect the distinct `SyntaxTree`s of its OTHER (non-primary)
-    // parts. Those trees' `using` directives are unioned into `root`'s import
-    // block by `TranslateImports`, because merged-in member bodies from those
-    // parts are translated under their own file's semantic model and may rely
-    // on a `using` that only exists there.
-    private static HashSet<Microsoft.CodeAnalysis.SyntaxTree> CollectExtraUsingTrees(
-        CompilationUnitSyntax root,
-        Dictionary<INamedTypeSymbol, List<TypeDeclarationSyntax>> partialTypeParts)
-    {
-        var trees = new HashSet<Microsoft.CodeAnalysis.SyntaxTree>();
-        foreach (List<TypeDeclarationSyntax> parts in partialTypeParts.Values)
-        {
-            if (parts[0].SyntaxTree != root.SyntaxTree)
-            {
-                continue;
-            }
-
-            foreach (TypeDeclarationSyntax part in parts.Skip(1))
-            {
-                if (part.SyntaxTree != root.SyntaxTree)
-                {
-                    trees.Add(part.SyntaxTree);
-                }
-            }
-        }
-
-        return trees;
-    }
-
-    private static HashSet<Microsoft.CodeAnalysis.SyntaxTree> CollectOwnedExtensionUsingTrees(
+    // Builds the cycle-safe closure of source trees whose declarations or
+    // owned extension methods are emitted into the root document. Imports and
+    // alias reservation consume this same set.
+    private static HashSet<Microsoft.CodeAnalysis.SyntaxTree> CollectContributingTrees(
         CompilationUnitSyntax root,
         TranslationContext context,
-        OwnedExtensionRegistry ownedExtensions)
+        Dictionary<INamedTypeSymbol, List<TypeDeclarationSyntax>> partialTypeParts,
+        OwnedExtensionRegistry ownedExtensions,
+        bool preservePartialParts)
     {
-        var trees = new HashSet<Microsoft.CodeAnalysis.SyntaxTree>();
-        foreach (TypeDeclarationSyntax declaration in root.DescendantNodes().OfType<TypeDeclarationSyntax>())
+        var trees = new HashSet<Microsoft.CodeAnalysis.SyntaxTree>
         {
-            if (context.GetDeclaredSymbol(declaration) is not INamedTypeSymbol type ||
-                !ownedExtensions.TryGetMethods(type, out IReadOnlyList<MethodDeclarationSyntax> methods))
+            root.SyntaxTree,
+        };
+        var pending = new Queue<Microsoft.CodeAnalysis.SyntaxTree>();
+        pending.Enqueue(root.SyntaxTree);
+        while (pending.Count > 0)
+        {
+            Microsoft.CodeAnalysis.SyntaxTree tree = pending.Dequeue();
+            if (!preservePartialParts)
             {
-                continue;
+                foreach (List<TypeDeclarationSyntax> parts in partialTypeParts.Values)
+                {
+                    if (parts[0].SyntaxTree != tree)
+                    {
+                        continue;
+                    }
+
+                    foreach (TypeDeclarationSyntax part in parts.Skip(1))
+                    {
+                        if (trees.Add(part.SyntaxTree))
+                        {
+                            pending.Enqueue(part.SyntaxTree);
+                        }
+                    }
+                }
             }
 
-            foreach (MethodDeclarationSyntax method in methods)
+            CompilationUnitSyntax treeRoot = (CompilationUnitSyntax)tree.GetRoot();
+            SemanticModel model = context.Compilation.GetSemanticModel(tree);
+            foreach (TypeDeclarationSyntax declaration in treeRoot
+                .DescendantNodes()
+                .OfType<TypeDeclarationSyntax>())
             {
-                if (method.SyntaxTree != root.SyntaxTree)
+                if (model.GetDeclaredSymbol(declaration) is not INamedTypeSymbol type
+                    || !ownedExtensions.TryGetMethods(
+                        type,
+                        out IReadOnlyList<MethodDeclarationSyntax> methods))
                 {
-                    trees.Add(method.SyntaxTree);
+                    continue;
+                }
+
+                foreach (MethodDeclarationSyntax method in methods)
+                {
+                    if (trees.Add(method.SyntaxTree))
+                    {
+                        pending.Enqueue(method.SyntaxTree);
+                    }
                 }
             }
         }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -223,12 +223,13 @@ public sealed partial class CSharpToGSharpTranslator
         // must NOT pull in sibling parts' `using` directives — its own imports
         // are all it needs (there is no cross-part member merge to resolve).
         HashSet<Microsoft.CodeAnalysis.SyntaxTree> contributingTrees =
-            CollectContributingTrees(
+            CollectContributingDeclarationTrees(
                 root,
                 context,
                 partialTypeParts,
                 ownedExtensions,
-                this.preservePartialParts);
+                this.preservePartialParts,
+                this.packageFilter);
         IEnumerable<Microsoft.CodeAnalysis.SyntaxTree> extraUsingTrees =
             contributingTrees
                 .Where(tree => tree != root.SyntaxTree)
@@ -878,64 +879,78 @@ public sealed partial class CSharpToGSharpTranslator
         return result;
     }
 
-    // Builds the cycle-safe closure of source trees whose declarations or
-    // owned extension methods are emitted into the root document. Imports and
-    // alias reservation consume this same set.
-    private static HashSet<Microsoft.CodeAnalysis.SyntaxTree> CollectContributingTrees(
+    // Builds the cycle-safe closure of declarations actually emitted into the
+    // root document: root aggregates, their merged partial declarations, their
+    // nested aggregates, and owned extension methods absorbed by those exact
+    // aggregate symbols. Imports and alias reservation consume the resulting
+    // tree set; unrelated declarations sharing one of those trees are never
+    // traversed.
+    private static HashSet<Microsoft.CodeAnalysis.SyntaxTree> CollectContributingDeclarationTrees(
         CompilationUnitSyntax root,
         TranslationContext context,
         Dictionary<INamedTypeSymbol, List<TypeDeclarationSyntax>> partialTypeParts,
         OwnedExtensionRegistry ownedExtensions,
-        bool preservePartialParts)
+        bool preservePartialParts,
+        string packageFilter)
     {
         var trees = new HashSet<Microsoft.CodeAnalysis.SyntaxTree>
         {
             root.SyntaxTree,
         };
-        var pending = new Queue<Microsoft.CodeAnalysis.SyntaxTree>();
-        pending.Enqueue(root.SyntaxTree);
+        var pending = new Queue<TypeDeclarationSyntax>(
+            EnumerateTopLevelDeclarations(root)
+                .OfType<TypeDeclarationSyntax>()
+                .Where(declaration => packageFilter is null
+                    || context.Compilation.GetSemanticModel(declaration.SyntaxTree)
+                        .GetDeclaredSymbol(declaration)?
+                        .ContainingNamespace?
+                        .ToDisplayString() == packageFilter));
+        var seen = new HashSet<TypeDeclarationSyntax>();
         while (pending.Count > 0)
         {
-            Microsoft.CodeAnalysis.SyntaxTree tree = pending.Dequeue();
-            if (!preservePartialParts)
+            TypeDeclarationSyntax declaration = pending.Dequeue();
+            if (!seen.Add(declaration))
             {
-                foreach (List<TypeDeclarationSyntax> parts in partialTypeParts.Values)
-                {
-                    if (parts[0].SyntaxTree != tree)
-                    {
-                        continue;
-                    }
+                continue;
+            }
 
+            trees.Add(declaration.SyntaxTree);
+            SemanticModel model = context.Compilation.GetSemanticModel(
+                declaration.SyntaxTree);
+            INamedTypeSymbol type = model.GetDeclaredSymbol(declaration);
+            bool attachOwnedExtensions = true;
+            if (type != null
+                && partialTypeParts.TryGetValue(
+                    type,
+                    out List<TypeDeclarationSyntax> parts))
+            {
+                bool isPrimary = parts[0].SyntaxTree == declaration.SyntaxTree
+                    && parts[0].Span == declaration.Span;
+                attachOwnedExtensions = isPrimary;
+                if (!preservePartialParts && isPrimary)
+                {
                     foreach (TypeDeclarationSyntax part in parts.Skip(1))
                     {
-                        if (trees.Add(part.SyntaxTree))
-                        {
-                            pending.Enqueue(part.SyntaxTree);
-                        }
+                        pending.Enqueue(part);
                     }
                 }
             }
 
-            CompilationUnitSyntax treeRoot = (CompilationUnitSyntax)tree.GetRoot();
-            SemanticModel model = context.Compilation.GetSemanticModel(tree);
-            foreach (TypeDeclarationSyntax declaration in treeRoot
-                .DescendantNodes()
+            foreach (TypeDeclarationSyntax nested in declaration.Members
                 .OfType<TypeDeclarationSyntax>())
             {
-                if (model.GetDeclaredSymbol(declaration) is not INamedTypeSymbol type
-                    || !ownedExtensions.TryGetMethods(
-                        type,
-                        out IReadOnlyList<MethodDeclarationSyntax> methods))
-                {
-                    continue;
-                }
+                pending.Enqueue(nested);
+            }
 
+            if (attachOwnedExtensions
+                && type != null
+                && ownedExtensions.TryGetMethods(
+                    type,
+                    out IReadOnlyList<MethodDeclarationSyntax> methods))
+            {
                 foreach (MethodDeclarationSyntax method in methods)
                 {
-                    if (trees.Add(method.SyntaxTree))
-                    {
-                        pending.Enqueue(method.SyntaxTree);
-                    }
+                    trees.Add(method.SyntaxTree);
                 }
             }
         }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -264,6 +264,7 @@ public sealed partial class CSharpToGSharpTranslator
         }
 
         var typeMapper = new CSharpTypeMapper(anonymousTypeRegistry);
+        typeMapper.ReserveImportAliases(imports);
         var visitor = new DeclarationVisitor(
             context,
             typeMapper,

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -463,6 +463,17 @@ public sealed class CSharpTypeMapper
         }
     }
 
+    internal string GetOrCreateMetadataTypeAlias(INamedTypeSymbol named)
+    {
+        string simpleName = CSharpToGSharpTranslator.SanitizeIdentifier(named.Name);
+        string target = named.ContainingNamespace is { IsGlobalNamespace: false } ns
+            ? $"{ns.ToDisplayString()}.{simpleName}"
+            : simpleName;
+        string alias = $"__cs2gs_{target.Replace('.', '_')}";
+        this.synthesizedTypeAliases[alias] = target;
+        return alias;
+    }
+
     internal (NamedTypeReference Type, IReadOnlyList<IPropertySymbol> Properties) GetOrCreateAnonymousDataClassShape(
         INamedTypeSymbol anonymousType,
         TranslationContext context,
@@ -933,16 +944,12 @@ public sealed class CSharpTypeMapper
             if (!named.Locations.Any(candidate => candidate.IsInSource)
                 && named.Name == "List"
                 && named.ContainingNamespace?.ToDisplayString()
-                    == "System.Collections.Generic"
-                && named.ContainingNamespace is { IsGlobalNamespace: false } aliasNamespace)
+                    == "System.Collections.Generic")
             {
-                // ponytail: Core only needs the List<T> collision. Generalize
-                // when imported CLR type aliases bind reliably in type and
-                // constructor positions for arbitrary metadata types.
-                string target = $"{aliasNamespace.ToDisplayString()}.{simpleName}";
-                string alias = $"__cs2gs_{target.Replace('.', '_')}";
-                this.synthesizedTypeAliases[alias] = target;
-                return alias;
+                // ponytail: ordinary metadata collision qualification only
+                // needs List<T>; constructor paths request aliases explicitly
+                // when a qualified CLR constructor cannot bind.
+                return this.GetOrCreateMetadataTypeAlias(named);
             }
 
             return named.ContainingNamespace is { IsGlobalNamespace: false } containingNs

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -463,14 +463,42 @@ public sealed class CSharpTypeMapper
         }
     }
 
-    internal string GetOrCreateMetadataTypeAlias(INamedTypeSymbol named)
+    internal string GetOrCreateMetadataTypeAlias(
+        INamedTypeSymbol named,
+        TranslationContext context)
     {
         string simpleName = CSharpToGSharpTranslator.SanitizeIdentifier(named.Name);
         string target = named.ContainingNamespace is { IsGlobalNamespace: false } ns
             ? $"{ns.ToDisplayString()}.{simpleName}"
             : simpleName;
-        string alias = $"__cs2gs_{target.Replace('.', '_')}";
-        this.synthesizedTypeAliases[alias] = target;
+        foreach (var existing in this.synthesizedTypeAliases)
+        {
+            if (existing.Value == target)
+            {
+                return existing.Key;
+            }
+        }
+
+        this.sourceSimpleNameCounts ??= BuildSourceSimpleNameCounts(context.Compilation);
+        var reserved = new HashSet<string>(
+            this.synthesizedTypeAliases.Keys,
+            System.StringComparer.Ordinal);
+        reserved.UnionWith(this.sourceSimpleNameCounts.Keys);
+        reserved.UnionWith(
+            context.SemanticModel.SyntaxTree.GetRoot()
+                .DescendantNodes()
+                .OfType<UsingDirectiveSyntax>()
+                .Where(directive => directive.Alias != null)
+                .Select(directive => directive.Alias.Name.Identifier.ValueText));
+
+        string baseAlias = $"__cs2gs_{target.Replace('.', '_')}";
+        string alias = baseAlias;
+        for (var suffix = 2; reserved.Contains(alias); suffix++)
+        {
+            alias = $"{baseAlias}_{suffix}";
+        }
+
+        this.synthesizedTypeAliases.Add(alias, target);
         return alias;
     }
 
@@ -949,7 +977,7 @@ public sealed class CSharpTypeMapper
                 // ponytail: ordinary metadata collision qualification only
                 // needs List<T>; constructor paths request aliases explicitly
                 // when a qualified CLR constructor cannot bind.
-                return this.GetOrCreateMetadataTypeAlias(named);
+                return this.GetOrCreateMetadataTypeAlias(named, context);
             }
 
             return named.ContainingNamespace is { IsGlobalNamespace: false } containingNs

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -99,6 +99,9 @@ public sealed class CSharpTypeMapper
     private readonly Dictionary<string, string> synthesizedTypeAliases =
         new(System.StringComparer.Ordinal);
 
+    private readonly Dictionary<string, HashSet<string>> reservedTypeAliases =
+        new(System.StringComparer.Ordinal);
+
     /// <summary>
     /// Issue #1174: cached per-compilation census of source-declared type simple
     /// names (built lazily on first use), used to decide whether a source nested
@@ -443,6 +446,29 @@ public sealed class CSharpTypeMapper
         this.GetOrCreateAnonymousDataClassShape(anonymousType, context, location).Type;
 
     /// <summary>
+    /// Reserves aliases already present in the final translated import set.
+    /// </summary>
+    /// <param name="imports">Imports collected from the active and merged source trees.</param>
+    internal void ReserveImportAliases(IEnumerable<ImportDirective> imports)
+    {
+        foreach (ImportDirective import in imports)
+        {
+            if (import.Alias == null)
+            {
+                continue;
+            }
+
+            if (!this.reservedTypeAliases.TryGetValue(import.Alias, out var targets))
+            {
+                targets = new HashSet<string>(System.StringComparer.Ordinal);
+                this.reservedTypeAliases.Add(import.Alias, targets);
+            }
+
+            targets.Add(import.Name);
+        }
+    }
+
+    /// <summary>
     /// Maps an exact inferred contract while qualifying metadata homonyms
     /// reachable through the current file's imports.
     /// </summary>
@@ -479,17 +505,21 @@ public sealed class CSharpTypeMapper
             }
         }
 
+        foreach (var reservedAlias in this.reservedTypeAliases)
+        {
+            if (reservedAlias.Value.Count == 1
+                && reservedAlias.Value.Contains(target))
+            {
+                return reservedAlias.Key;
+            }
+        }
+
         this.sourceSimpleNameCounts ??= BuildSourceSimpleNameCounts(context.Compilation);
         var reserved = new HashSet<string>(
             this.synthesizedTypeAliases.Keys,
             System.StringComparer.Ordinal);
+        reserved.UnionWith(this.reservedTypeAliases.Keys);
         reserved.UnionWith(this.sourceSimpleNameCounts.Keys);
-        reserved.UnionWith(
-            context.SemanticModel.SyntaxTree.GetRoot()
-                .DescendantNodes()
-                .OfType<UsingDirectiveSyntax>()
-                .Where(directive => directive.Alias != null)
-                .Select(directive => directive.Alias.Name.Identifier.ValueText));
 
         string baseAlias = $"__cs2gs_{target.Replace('.', '_')}";
         string alias = baseAlias;


### PR DESCRIPTION
Closes #3460

## Summary
- emit canonical composite literals for parameterless source and metadata object initializers
- preserve non-parameterless constructor semantics by materializing omitted optional/params arguments before initializer suffixes
- cover binding, expression position, constructor/member evaluation order, required/init-only setters, nested object/collection initializers, and runtime parity

## Validation
- targeted initializer tests: 17 passed
- full Cs2Gs.Tests: 2,166 passed
- `dotnet build GSharp.sln --no-restore --nologo`: passed, 0 warnings/errors
- full self-migration: invalid `()\{...=...\}` sites under `src/**/*.gs` reduced from 36 to 0
- Core migration passes all stages; existing unrelated LanguageServer round-trip gaps remain unchanged

## Review follow-up
- fixed System.Object construction, nullable nested-member receivers, textual initializer ordering, optional-default coercion, and no-parentheses params collections
- focused local validation: Issue3460 (10), nearest translator initializer tests (47), nearest binder/parser tests (25), focused project build
- full PR CI green, including cs2gs corpus, Oahu, and code-exploder migrations

## Second review follow-up
- completed expanded params diagnostics/lowering, operation-slot defaults, deferred nullable-member failure, collision-proof System.Object construction, and reference-default coercion
- focused local validation: Issue3460 + Issue1901 (25), nearest translator tests (52), nearest binder/parser tests (25), focused project build
- full PR CI green, including corpus, Oahu, and code-exploder migrations

## Final narrow follow-up
- allocate synthesized CLR aliases uniquely across source aliases/type names
- coerce synthesized params collections to selected parameter types to prevent overload drift
- focused local validation: Issue3460 + Issue1901 (26), nearest alias/initializer tests (49), focused project build
- full PR CI green

## Fourth narrow follow-up
- reserve synthesized aliases from complete translated import set, including partial-merge and owned-extension trees
- focused local validation: Issue3460 (17), nearest import aggregation tests (34), focused project build
- full PR CI green

## Fifth narrow follow-up
- build cycle-safe transitive closure across partial merges and recursively owned extension trees
- reuse closure for merged import translation and alias reservation
- focused local validation: Issue3460 (18), nearest import aggregation tests (34), focused project build
- full PR CI green

## Sixth narrow follow-up
- replace tree-wide import closure with cycle-safe graph of declarations actually emitted through root, partial merges, nested types, and absorbed owned extensions
- prevent unrelated same-tree extension imports from shadowing required Timer imports
- focused local validation: Issue3460 (19), nearest declaration/import tests (34), focused project build
- full PR CI green

## Seventh narrow follow-up
- seed merge-mode import closure only from top-level declarations that actually emit: non-partials or selected primary partials
- preserve recursive sibling-part, nested-type, and owned-extension traversal from emitted primaries
- focused local validation: Issue3460 (20), nearest partial/extension tests (28), focused project build
- full PR CI green

## Eighth narrow follow-up
- exclude flattened entry classes from merged partial sibling import traversal
- preserve normal partial merge closure and current-part entry owned/nested contributions
- focused local validation: Issue3460 (21), nearest entry/partial tests (27), focused project build
- full PR CI green