### PR TITLE
Fix cs2gs reserved identifier sanitization

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
@@ -3146,7 +3146,7 @@ internal sealed partial class ExpressionBinder
         const System.Reflection.BindingFlags flags = System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public;
         foreach (var m in ClrTypeUtilities.SafeGetMethods(type, flags))
         {
-            if (string.Equals(m.Name, name, System.StringComparison.Ordinal))
+            if (ClrTypeUtilities.EmittedMemberNameMatches(m, name))
             {
                 return true;
             }
@@ -3154,7 +3154,7 @@ internal sealed partial class ExpressionBinder
 
         foreach (var p in ClrTypeUtilities.SafeGetProperties(type, flags))
         {
-            if (string.Equals(p.Name, name, System.StringComparison.Ordinal))
+            if (ClrTypeUtilities.EmittedMemberNameMatches(p, name))
             {
                 return true;
             }
@@ -3162,7 +3162,7 @@ internal sealed partial class ExpressionBinder
 
         foreach (var f in ClrTypeUtilities.SafeGetFields(type, flags))
         {
-            if (string.Equals(f.Name, name, System.StringComparison.Ordinal))
+            if (ClrTypeUtilities.EmittedMemberNameMatches(f, name))
             {
                 return true;
             }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -152,7 +152,7 @@ internal sealed partial class ExpressionBinder
             foreach (var method in classType.GetMethods(
                          BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance))
             {
-                if (method.Name == methodName
+                if (ClrTypeUtilities.EmittedMemberNameMatches(method, methodName)
                     && method.IsGenericMethodDefinition
                     && method.GetGenericArguments().Length == explicitTypeArgs.Length)
                 {

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -1476,20 +1476,14 @@ internal sealed partial class ExpressionBinder
             {
                 string? parameterName = parameters[parameterIndex].Name;
                 string argumentName = named.NameToken.Text;
-                if (string.Equals(
-                        parameterName,
+                if (parameterName is not null
+                    && string.Equals(
+                        SyntaxFacts.GetEmittedIdentifier(
+                            parameterName,
+                            IdentifierNameContext.Parameter,
+                            parameters.Select(parameter => parameter.Name ?? string.Empty)),
                         argumentName,
-                        StringComparison.Ordinal) ||
-
-                    // parameterName: a real (non-synthetic) method parameter
-                    // always has a name; GetKeywordKind would already have
-                    // thrown on a null reflection Name before this change.
-                    (SyntaxFacts.GetKeywordKind(parameterName!) !=
-                        SyntaxKind.IdentifierToken &&
-                        string.Equals(
-                            parameterName + "_",
-                            argumentName,
-                            StringComparison.Ordinal)))
+                        StringComparison.Ordinal))
                 {
                     return parameterIndex;
                 }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -2582,7 +2582,7 @@ internal sealed partial class ExpressionBinder
         // method group for delegate conversions / member access.
         foreach (var method in ClrTypeUtilities.SafeGetMethodsIncludingInterfaces(declaringType, flags))
         {
-            if (!string.Equals(method.Name, name, StringComparison.Ordinal))
+            if (!ClrTypeUtilities.EmittedMemberNameMatches(method, name))
             {
                 continue;
             }

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -294,7 +294,7 @@ internal sealed class MemberLookup
             var result = new List<MethodInfo>();
             foreach (var m in selfMethods)
             {
-                if (string.Equals(m.Name, n, StringComparison.Ordinal))
+                if (ClrTypeUtilities.EmittedMemberNameMatches(m, n))
                 {
                     result.Add(m);
                 }
@@ -309,7 +309,7 @@ internal sealed class MemberLookup
                     current,
                     BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
                 {
-                    if (string.Equals(m.Name, n, StringComparison.Ordinal)
+                    if (ClrTypeUtilities.EmittedMemberNameMatches(m, n)
                         && !IsMethodHiddenByExisting(result, m))
                     {
                         result.Add(m);
@@ -323,7 +323,7 @@ internal sealed class MemberLookup
                     clrType.GetGenericTypeDefinition(),
                     BindingFlags.Public | BindingFlags.Instance))
                 {
-                    if (!string.Equals(openMethod.Name, n, StringComparison.Ordinal))
+                    if (!ClrTypeUtilities.EmittedMemberNameMatches(openMethod, n))
                     {
                         continue;
                     }
@@ -349,7 +349,7 @@ internal sealed class MemberLookup
             {
                 foreach (var m in ClrTypeUtilities.SafeGetMethods(iface, BindingFlags.Public | BindingFlags.Instance))
                 {
-                    if (!string.Equals(m.Name, n, StringComparison.Ordinal))
+                    if (!ClrTypeUtilities.EmittedMemberNameMatches(m, n))
                     {
                         continue;
                     }
@@ -2669,7 +2669,7 @@ internal sealed class MemberLookup
 
         foreach (var method in methods)
         {
-            if (!string.Equals(method.Name, methodName, StringComparison.Ordinal))
+            if (!ClrTypeUtilities.EmittedMemberNameMatches(method, methodName))
             {
                 continue;
             }
@@ -3485,7 +3485,7 @@ internal sealed class MemberLookup
                          staticClassType,
                          BindingFlags.Static | BindingFlags.Public))
             {
-                if (string.Equals(method.Name, methodName, StringComparison.Ordinal))
+                if (ClrTypeUtilities.EmittedMemberNameMatches(method, methodName))
                 {
                     statics.Add(method);
                 }
@@ -3550,7 +3550,7 @@ internal sealed class MemberLookup
 
             foreach (var method in methods)
             {
-                if (!string.Equals(method.Name, methodName, StringComparison.Ordinal))
+                if (!ClrTypeUtilities.EmittedMemberNameMatches(method, methodName))
                 {
                     continue;
                 }

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/ClrOverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/ClrOverloadResolution.cs
@@ -3133,11 +3133,16 @@ internal static class ClrOverloadResolution
 
     private static bool ParameterNameMatches(
         string? parameterName,
-        string argumentName) =>
-        string.Equals(parameterName, argumentName, StringComparison.Ordinal) ||
-        (parameterName is not null
-            && SyntaxFacts.GetKeywordKind(parameterName) != SyntaxKind.IdentifierToken &&
-            string.Equals(parameterName + "_", argumentName, StringComparison.Ordinal));
+        string argumentName,
+        ParameterInfo[] parameters) =>
+        parameterName is not null
+        && string.Equals(
+            SyntaxFacts.GetEmittedIdentifier(
+                parameterName,
+                IdentifierNameContext.Parameter,
+                parameters.Select(parameter => parameter.Name ?? string.Empty)),
+            argumentName,
+            StringComparison.Ordinal);
 
     /// <summary>
     /// Issue #343: returns the index of the parameter whose name matches
@@ -3148,7 +3153,7 @@ internal static class ClrOverloadResolution
     {
         for (var i = 0; i < parameters.Length; i++)
         {
-            if (ParameterNameMatches(parameters[i].Name, name))
+            if (ParameterNameMatches(parameters[i].Name, name, parameters))
             {
                 return i;
             }

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Arguments.cs
@@ -1107,9 +1107,10 @@ internal sealed partial class OverloadResolver
 
     private static bool ContainsClrParameterName(IEnumerable<string> parameterNames, string name)
     {
-        foreach (var parameterName in parameterNames)
+        string[] names = parameterNames.ToArray();
+        foreach (var parameterName in names)
         {
-            if (ClrParameterNameMatches(parameterName, name))
+            if (ClrParameterNameMatches(parameterName, name, names))
             {
                 return true;
             }
@@ -1120,10 +1121,15 @@ internal sealed partial class OverloadResolver
 
     private static bool ClrParameterNameMatches(
         string parameterName,
-        string argumentName) =>
-        string.Equals(parameterName, argumentName, StringComparison.Ordinal) ||
-        (SyntaxFacts.GetKeywordKind(parameterName) != SyntaxKind.IdentifierToken &&
-            string.Equals(parameterName + "_", argumentName, StringComparison.Ordinal));
+        string argumentName,
+        IEnumerable<string> parameterNames) =>
+        string.Equals(
+            SyntaxFacts.GetEmittedIdentifier(
+                parameterName,
+                IdentifierNameContext.Parameter,
+                parameterNames),
+            argumentName,
+            StringComparison.Ordinal);
 
     public void ValidateRefArguments(
         ImmutableArray<BoundExpression> arguments,

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
@@ -36,7 +36,7 @@ internal sealed partial class OverloadResolver
 
         foreach (var m in ClrTypeUtilities.SafeGetMethods(type, System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public))
         {
-            if (string.Equals(m.Name, name, System.StringComparison.Ordinal))
+            if (ClrTypeUtilities.EmittedMemberNameMatches(m, name))
             {
                 return true;
             }

--- a/src/Core/CodeAnalysis/Emit/CustomAttributeEncoder.cs
+++ b/src/Core/CodeAnalysis/Emit/CustomAttributeEncoder.cs
@@ -9,11 +9,13 @@
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using GSharp.Core.CodeAnalysis.Binding;
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Emit;
 
@@ -1268,7 +1270,25 @@ internal sealed class CustomAttributeEncoder
 
     private void WriteCustomAttributeNamedArg(BlobBuilder bb, Type attributeType, BoundAttributeArgument arg)
     {
-        var name = Invariant.Required(arg.Name, "a named attribute argument always has a member name");
+        string emittedName = Invariant.Required(
+            arg.Name,
+            "a named attribute argument always has a member name");
+        MemberInfo[] members = attributeType
+            .GetMembers(BindingFlags.Public | BindingFlags.Instance)
+            .ToArray();
+        string[] memberNames = members
+            .Select(member => member.Name)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        string name = members
+            .Where(member => member is PropertyInfo or FieldInfo)
+            .Select(member => member.Name)
+            .FirstOrDefault(candidate =>
+                SyntaxFacts.GetEmittedIdentifier(
+                    candidate,
+                    IdentifierNameContext.General,
+                    memberNames) == emittedName)
+            ?? emittedName;
         var prop = attributeType.GetProperty(name, BindingFlags.Public | BindingFlags.Instance);
         var field = prop == null
             ? attributeType.GetField(name, BindingFlags.Public | BindingFlags.Instance)
@@ -1293,7 +1313,7 @@ internal sealed class CustomAttributeEncoder
 
         bb.WriteByte(kindTag);
         WriteCustomAttributeFieldOrPropertyType(bb, memberType);
-        bb.WriteSerializedString(arg.Name);
+        bb.WriteSerializedString(name);
         WriteCustomAttributeFixedArg(bb, memberType, arg.Value);
     }
 

--- a/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
+++ b/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Symbols;
 
@@ -588,6 +589,44 @@ public static class ClrTypeUtilities
     /// <returns>The methods whose signatures load cleanly.</returns>
     public static MethodInfo[] SafeGetMethods(Type type, BindingFlags flags)
         => SafeEnumerate<MethodInfo>(type, flags, t => t.GetMethods(flags));
+
+    /// <summary>
+    /// Matches a G# emitted member spelling to its original CLR metadata name.
+    /// Exact CLR names win; sanitized names use the same collision-aware
+    /// normalization as cs2gs.
+    /// </summary>
+    /// <param name="member">The CLR member candidate.</param>
+    /// <param name="emittedName">The G# source spelling.</param>
+    /// <returns><c>true</c> when the names identify the same member.</returns>
+    public static bool EmittedMemberNameMatches(MemberInfo member, string emittedName)
+    {
+        if (string.Equals(member.Name, emittedName, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        Type? declaringType = member.DeclaringType;
+        if (declaringType is null)
+        {
+            return false;
+        }
+
+        const BindingFlags allMembers =
+            BindingFlags.Public | BindingFlags.NonPublic |
+            BindingFlags.Static | BindingFlags.Instance;
+        IEnumerable<string> scopeNames =
+            SafeGetProperties(declaringType, allMembers).Select(candidate => candidate.Name)
+                .Concat(SafeGetFields(declaringType, allMembers).Select(candidate => candidate.Name))
+                .Concat(SafeGetEvents(declaringType, allMembers).Select(candidate => candidate.Name))
+                .Concat(SafeGetMethods(declaringType, allMembers).Select(candidate => candidate.Name));
+        return string.Equals(
+            SyntaxFacts.GetEmittedIdentifier(
+                member.Name,
+                IdentifierNameContext.General,
+                scopeNames),
+            emittedName,
+            StringComparison.Ordinal);
+    }
 
     /// <summary>
     /// Looks up a single property by name tolerantly (issue #338). When the
@@ -1511,10 +1550,45 @@ public static class ClrTypeUtilities
             return null;
         }
 
+        TMember? FindCanonical()
+        {
+            for (Type? declaringType = type; declaringType != null; declaringType = declaringType.BaseType)
+            {
+                TMember? match = null;
+                foreach (TMember candidate in safeEnumerate(type, flags))
+                {
+                    if (!EmittedMemberNameMatches(candidate, name)
+                        || !AreSame(candidate.DeclaringType, declaringType))
+                    {
+                        continue;
+                    }
+
+                    if (match != null)
+                    {
+                        return null;
+                    }
+
+                    match = candidate;
+                }
+
+                if (match != null)
+                {
+                    return match;
+                }
+            }
+
+            return null;
+        }
+
         try
         {
             var member = directLookup(type, flags);
-            return member != null && CanLoadSignature(member) ? member : null;
+            if (member != null && CanLoadSignature(member))
+            {
+                return member;
+            }
+
+            return FindCanonical();
         }
         catch (AmbiguousMatchException)
         {
@@ -1523,7 +1597,7 @@ public static class ClrTypeUtilities
                 TMember? match = null;
                 foreach (var member in safeEnumerate(type, flags))
                 {
-                    if (!string.Equals(member.Name, name, StringComparison.Ordinal)
+                    if (!EmittedMemberNameMatches(member, name)
                         || !AreSame(member.DeclaringType, declaringType))
                     {
                         continue;
@@ -1550,15 +1624,7 @@ public static class ClrTypeUtilities
             // The direct lookup was poisoned by an unloadable member (the target
             // or a sibling reflected over during the search). Recover via the
             // guarded enumeration, which skips only the offending members.
-            foreach (var member in safeEnumerate(type, flags))
-            {
-                if (string.Equals(member.Name, name, StringComparison.Ordinal))
-                {
-                    return member;
-                }
-            }
-
-            return null;
+            return FindCanonical();
         }
     }
 

--- a/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
+++ b/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
@@ -18,6 +18,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.Loader;
 using GSharp.Core.CodeAnalysis.Binding;
 using GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Symbols;
 
@@ -1190,6 +1191,18 @@ public sealed class ReferenceResolver : IDisposable
                 return true;
             }
 
+            if (TryFindRawTypeName(
+                    fullName,
+                    warmNameIndex.Keys,
+                    out string? rawWarmName)
+                && warmNameIndex.TryGetValue(rawWarmName, out assemblyIndex)
+                && TryMaterializeWarmType(rawWarmName, assemblyIndex, out warm))
+            {
+                resolveCache.TryAdd(fullName, warm);
+                type = warm;
+                return true;
+            }
+
             resolveCache.TryAdd(fullName, MissTypeSentinel);
             return false;
         }
@@ -1201,8 +1214,161 @@ public sealed class ReferenceResolver : IDisposable
             return true;
         }
 
+        if (TryFindRawTypeName(
+                fullName,
+                typeNameIndex.Value.Keys,
+                out string? rawName)
+            && typeNameIndex.Value.TryGetValue(rawName, out indexed))
+        {
+            resolveCache.TryAdd(fullName, indexed);
+            type = indexed;
+            return true;
+        }
+
         resolveCache.TryAdd(fullName, MissTypeSentinel);
         return false;
+    }
+
+    private static bool TryFindRawTypeName(
+        string emittedName,
+        IEnumerable<string> rawNames,
+        [NotNullWhen(true)] out string? rawName)
+    {
+        string[] names = rawNames.ToArray();
+        Dictionary<string, HashSet<string>> scopes = BuildTypeNameScopes(names);
+        foreach (string candidate in names)
+        {
+            string canonical = CanonicalTypeName(candidate, scopes);
+            if (string.Equals(canonical, emittedName, StringComparison.Ordinal)
+                || string.Equals(
+                    canonical.Replace('+', '.'),
+                    emittedName,
+                    StringComparison.Ordinal))
+            {
+                rawName = candidate;
+                return true;
+            }
+        }
+
+        rawName = null;
+        return false;
+    }
+
+    private static Dictionary<string, HashSet<string>> BuildTypeNameScopes(
+        IEnumerable<string> rawNames)
+    {
+        var scopes = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+        foreach (string fullName in rawNames)
+        {
+            SplitRawTypeName(
+                fullName,
+                out string[] namespaceParts,
+                out string[] typeParts);
+            string parent = "namespace:";
+            foreach (string part in namespaceParts)
+            {
+                Add(parent, StripArity(part));
+                parent += "." + part;
+            }
+
+            parent = "type:" + string.Join(".", namespaceParts);
+            foreach (string part in typeParts)
+            {
+                Add(parent, StripArity(part));
+                parent += "+" + part;
+            }
+        }
+
+        return scopes;
+
+        void Add(string scope, string name)
+        {
+            if (!scopes.TryGetValue(scope, out HashSet<string>? names))
+            {
+                names = new HashSet<string>(StringComparer.Ordinal);
+                scopes[scope] = names;
+            }
+
+            names.Add(name);
+        }
+    }
+
+    private static string CanonicalTypeName(
+        string rawName,
+        IReadOnlyDictionary<string, HashSet<string>> scopes)
+    {
+        SplitRawTypeName(
+            rawName,
+            out string[] namespaceParts,
+            out string[] typeParts);
+        var canonicalNamespace = new List<string>(namespaceParts.Length);
+        string parent = "namespace:";
+        foreach (string part in namespaceParts)
+        {
+            string sourceName = StripArity(part);
+            scopes.TryGetValue(parent, out HashSet<string>? siblingNames);
+            canonicalNamespace.Add(SyntaxFacts.GetEmittedIdentifier(
+                sourceName,
+                IdentifierNameContext.General,
+                siblingNames));
+            parent += "." + part;
+        }
+
+        var canonicalTypes = new List<string>(typeParts.Length);
+        parent = "type:" + string.Join(".", namespaceParts);
+        foreach (string part in typeParts)
+        {
+            int arityIndex = part.IndexOf('`');
+            string sourceName = arityIndex >= 0
+                ? part.Substring(0, arityIndex)
+                : part;
+            string arity = arityIndex >= 0
+                ? part.Substring(arityIndex)
+                : string.Empty;
+            scopes.TryGetValue(parent, out HashSet<string>? siblingNames);
+            canonicalTypes.Add(
+                SyntaxFacts.GetEmittedIdentifier(
+                    sourceName,
+                    IdentifierNameContext.Type,
+                    siblingNames)
+                + arity);
+            parent += "+" + part;
+        }
+
+        string typeName = string.Join("+", canonicalTypes);
+        return canonicalNamespace.Count == 0
+            ? typeName
+            : string.Join(".", canonicalNamespace) + "." + typeName;
+    }
+
+    private static void SplitRawTypeName(
+        string fullName,
+        out string[] namespaceParts,
+        out string[] typeParts)
+    {
+        int nestedIndex = fullName.IndexOf('+');
+        string topLevel = nestedIndex >= 0
+            ? fullName.Substring(0, nestedIndex)
+            : fullName;
+        int namespaceEnd = topLevel.LastIndexOf('.');
+        namespaceParts = namespaceEnd >= 0
+            ? topLevel.Substring(0, namespaceEnd).Split('.')
+            : Array.Empty<string>();
+        string topType = namespaceEnd >= 0
+            ? topLevel.Substring(namespaceEnd + 1)
+            : topLevel;
+        string nestedTypes = nestedIndex >= 0
+            ? fullName.Substring(nestedIndex + 1)
+            : string.Empty;
+        typeParts = string.IsNullOrEmpty(nestedTypes)
+            ? new[] { topType }
+            : new[] { topType }.Concat(nestedTypes.Split('+')).ToArray();
+    }
+
+    private static string StripArity(string name)
+    {
+        int arityIndex = name.IndexOf('`');
+        return arityIndex >= 0 ? name.Substring(0, arityIndex) : name;
     }
 
     // Issue: an `internal` (non-externally-visible) type declared by a

--- a/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
+++ b/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
@@ -127,6 +127,7 @@ public sealed class ReferenceResolver : IDisposable
     // suffix for open generics — exactly the spellings Assembly.GetType accepts
     // and the binder already constructs (e.g. "Ns.Type`1").
     private readonly Lazy<Dictionary<string, Type>> typeNameIndex;
+    private readonly Lazy<Dictionary<string, string>> emittedTypeNameIndex;
 
     // ADR-0107 (cold-start cache): an optional, externally-supplied
     // full-name -> declaring-assembly-index map that stands in for the eager
@@ -185,6 +186,12 @@ public sealed class ReferenceResolver : IDisposable
         this.runtimeContext = runtimeContext;
         this.missingTransitiveReferences = missingTransitiveReferences;
         this.typeNameIndex = typeNameIndex ?? CreateTypeNameIndex(assemblies);
+        this.emittedTypeNameIndex = new Lazy<Dictionary<string, string>>(
+            () => BuildEmittedTypeNameIndex(
+                this.warmNameIndex is { } warm
+                    ? (IEnumerable<string>)warm.Keys
+                    : this.typeNameIndex.Value.Keys),
+            LazyThreadSafetyMode.ExecutionAndPublication);
     }
 
     private sealed class NotFoundSentinel
@@ -1193,7 +1200,6 @@ public sealed class ReferenceResolver : IDisposable
 
             if (TryFindRawTypeName(
                     fullName,
-                    warmNameIndex.Keys,
                     out string? rawWarmName)
                 && warmNameIndex.TryGetValue(rawWarmName, out assemblyIndex)
                 && TryMaterializeWarmType(rawWarmName, assemblyIndex, out warm))
@@ -1216,7 +1222,6 @@ public sealed class ReferenceResolver : IDisposable
 
         if (TryFindRawTypeName(
                 fullName,
-                typeNameIndex.Value.Keys,
                 out string? rawName)
             && typeNameIndex.Value.TryGetValue(rawName, out indexed))
         {
@@ -1229,29 +1234,29 @@ public sealed class ReferenceResolver : IDisposable
         return false;
     }
 
-    private static bool TryFindRawTypeName(
+    private bool TryFindRawTypeName(
         string emittedName,
-        IEnumerable<string> rawNames,
         [NotNullWhen(true)] out string? rawName)
+    {
+        return this.emittedTypeNameIndex.Value.TryGetValue(
+            emittedName,
+            out rawName);
+    }
+
+    private static Dictionary<string, string> BuildEmittedTypeNameIndex(
+        IEnumerable<string> rawNames)
     {
         string[] names = rawNames.ToArray();
         Dictionary<string, HashSet<string>> scopes = BuildTypeNameScopes(names);
+        var index = new Dictionary<string, string>(StringComparer.Ordinal);
         foreach (string candidate in names)
         {
             string canonical = CanonicalTypeName(candidate, scopes);
-            if (string.Equals(canonical, emittedName, StringComparison.Ordinal)
-                || string.Equals(
-                    canonical.Replace('+', '.'),
-                    emittedName,
-                    StringComparison.Ordinal))
-            {
-                rawName = candidate;
-                return true;
-            }
+            index.TryAdd(canonical, candidate);
+            index.TryAdd(canonical.Replace('+', '.'), candidate);
         }
 
-        rawName = null;
-        return false;
+        return index;
     }
 
     private static Dictionary<string, HashSet<string>> BuildTypeNameScopes(

--- a/src/Core/CodeAnalysis/Syntax/IdentifierNameContext.cs
+++ b/src/Core/CodeAnalysis/Syntax/IdentifierNameContext.cs
@@ -1,0 +1,39 @@
+// <copyright file="IdentifierNameContext.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+
+namespace GSharp.Core.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Identifies grammar positions where contextual G# spellings can consume an
+/// otherwise ordinary identifier.
+/// </summary>
+[Flags]
+public enum IdentifierNameContext
+{
+    /// <summary>Ordinary identifier position.</summary>
+    General = 0,
+
+    /// <summary>Function, constructor, receiver, or lambda parameter.</summary>
+    Parameter = 1 << 0,
+
+    /// <summary>Local declaration following <c>let</c>, <c>var</c>, or <c>const</c>.</summary>
+    Local = 1 << 1,
+
+    /// <summary>Generic type-parameter declaration.</summary>
+    TypeParameter = 1 << 2,
+
+    /// <summary>Bare invocation target.</summary>
+    Invocation = 1 << 3,
+
+    /// <summary>Pattern designation.</summary>
+    Pattern = 1 << 4,
+
+    /// <summary>Type-clause position.</summary>
+    Type = 1 << 5,
+
+    /// <summary>Bare index-expression receiver.</summary>
+    Index = 1 << 6,
+}

--- a/src/Core/CodeAnalysis/Syntax/Parser.Expressions.Creation.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.Expressions.Creation.cs
@@ -672,10 +672,13 @@ public partial class Parser
         return false;
     }
 
-    private ExpressionSyntax ParseNameOrCallExpression(bool stopBeforeIndirectInvocation = false)
+    private ExpressionSyntax ParseNameOrCallExpression(
+        bool stopBeforeIndirectInvocation = false,
+        bool allowContextualOperators = true)
     {
         ExpressionSyntax current;
-        if (Current.Kind == SyntaxKind.IdentifierToken
+        if (allowContextualOperators
+            && Current.Kind == SyntaxKind.IdentifierToken
             && Current.Text == "make"
             && Peek(1).Kind == SyntaxKind.OpenParenthesisToken
             && Peek(2).Kind == SyntaxKind.ChanKeyword)
@@ -683,21 +686,24 @@ public partial class Parser
             // Phase 5.4 / ADR-0022: contextual `make(chan T)` / `make(chan T, capacity)`.
             current = ParseMakeChannelExpression();
         }
-        else if (Current.Kind == SyntaxKind.IdentifierToken
+        else if (allowContextualOperators
+            && Current.Kind == SyntaxKind.IdentifierToken
             && Current.Text == "typeof"
             && Peek(1).Kind == SyntaxKind.OpenParenthesisToken)
         {
             // Issue #143: contextual `typeof(T)` — argument is a type clause.
             current = ParseTypeOfExpression();
         }
-        else if (Current.Kind == SyntaxKind.IdentifierToken
+        else if (allowContextualOperators
+            && Current.Kind == SyntaxKind.IdentifierToken
             && Current.Text == "sizeof"
             && Peek(1).Kind == SyntaxKind.OpenParenthesisToken)
         {
             // Issue #1336: contextual `sizeof(T)` — argument is a type clause.
             current = ParseSizeOfExpression();
         }
-        else if (Current.Kind == SyntaxKind.IdentifierToken
+        else if (allowContextualOperators
+            && Current.Kind == SyntaxKind.IdentifierToken
             && (Current.Text == "checked" || Current.Text == "unchecked")
             && Peek(1).Kind == SyntaxKind.OpenParenthesisToken)
         {
@@ -705,7 +711,8 @@ public partial class Parser
             // argument is an arithmetic expression, not a type clause.
             current = ParseCheckedExpression();
         }
-        else if (Current.Kind == SyntaxKind.IdentifierToken
+        else if (allowContextualOperators
+            && Current.Kind == SyntaxKind.IdentifierToken
             && Current.Text == "nameof"
             && Peek(1).Kind == SyntaxKind.OpenParenthesisToken)
         {

--- a/src/Core/CodeAnalysis/Syntax/Parser.Expressions.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.Expressions.cs
@@ -895,6 +895,22 @@ public partial class Parser
     {
         if (!IsTupleElementSelectorToken(Current, includesDot: false))
         {
+            // Contextual operators (`nameof`, `typeof`, `checked`, ...) are only
+            // operators at expression roots. After `.`/`?.` they are ordinary
+            // CLR/source member names and must not steal the call grammar.
+            if (Current.Kind == SyntaxKind.IdentifierToken
+                && Peek(1).Kind == SyntaxKind.OpenParenthesisToken)
+            {
+                return ParseCallExpression();
+            }
+
+            if (Current.Kind == SyntaxKind.IdentifierToken
+                && Peek(1).Kind == SyntaxKind.OpenSquareBracketToken
+                && LooksLikeGenericCallSite(1))
+            {
+                return ParseGenericCallExpression();
+            }
+
             return ParseNameOrCallExpression(stopBeforeIndirectInvocation: true);
         }
 

--- a/src/Core/CodeAnalysis/Syntax/Parser.Expressions.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.Expressions.cs
@@ -898,20 +898,9 @@ public partial class Parser
             // Contextual operators (`nameof`, `typeof`, `checked`, ...) are only
             // operators at expression roots. After `.`/`?.` they are ordinary
             // CLR/source member names and must not steal the call grammar.
-            if (Current.Kind == SyntaxKind.IdentifierToken
-                && Peek(1).Kind == SyntaxKind.OpenParenthesisToken)
-            {
-                return ParseCallExpression();
-            }
-
-            if (Current.Kind == SyntaxKind.IdentifierToken
-                && Peek(1).Kind == SyntaxKind.OpenSquareBracketToken
-                && LooksLikeGenericCallSite(1))
-            {
-                return ParseGenericCallExpression();
-            }
-
-            return ParseNameOrCallExpression(stopBeforeIndirectInvocation: true);
+            return ParseNameOrCallExpression(
+                stopBeforeIndirectInvocation: true,
+                allowContextualOperators: false);
         }
 
         var selectorToken = NextToken();

--- a/src/Core/CodeAnalysis/Syntax/Parser.Members.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.Members.cs
@@ -1945,7 +1945,7 @@ public partial class Parser
         // skipping the keyword and continuing to parse the rest as a regular
         // parameter. This stops the user from hitting a cryptic "expected
         // identifier" error and points them at the canonical spelling.
-        if (Current.Kind == SyntaxKind.IdentifierToken && Current.Text == "params"
+        if (Current.Kind == SyntaxKind.IdentifierToken && SyntaxFacts.IsParamsKeyword(Current.Text)
             && Peek(1).Kind == SyntaxKind.IdentifierToken)
         {
             var paramsToken = NextToken();

--- a/src/Core/CodeAnalysis/Syntax/SyntaxFacts.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxFacts.cs
@@ -242,13 +242,96 @@ public static class SyntaxFacts
     }
 
     /// <summary>
-    /// Determines whether a spelling cannot be emitted safely as an identifier
-    /// in every G# declaration position.
+    /// Determines whether a spelling is a hard G# keyword.
     /// </summary>
     /// <param name="text">The identifier spelling to inspect.</param>
-    /// <returns><c>true</c> for hard keywords and parser-reserved declaration spellings.</returns>
+    /// <returns><c>true</c> for hard keywords.</returns>
     public static bool IsReservedIdentifier(string text) =>
-        GetKeywordKind(text) != SyntaxKind.IdentifierToken || IsParamsKeyword(text);
+        IsReservedIdentifier(text, IdentifierNameContext.General);
+
+    /// <summary>
+    /// Determines whether a spelling is consumed by the grammar in a specific
+    /// identifier context.
+    /// </summary>
+    /// <param name="text">The identifier spelling to inspect.</param>
+    /// <param name="context">The emitted grammar contexts where the name is used.</param>
+    /// <returns><c>true</c> when the spelling must be changed.</returns>
+    public static bool IsReservedIdentifier(string text, IdentifierNameContext context)
+    {
+        if (GetKeywordKind(text) != SyntaxKind.IdentifierToken)
+        {
+            return true;
+        }
+
+        if ((context & IdentifierNameContext.Parameter) != 0
+            && text is "params" or "scoped" or "ref" or "out" or "in")
+        {
+            return true;
+        }
+
+        if ((context & IdentifierNameContext.Local) != 0
+            && text is "scoped" or "ref")
+        {
+            return true;
+        }
+
+        if ((context & IdentifierNameContext.TypeParameter) != 0
+            && text is "in" or "out")
+        {
+            return true;
+        }
+
+        if ((context & IdentifierNameContext.Invocation) != 0
+            && text is "make" or "typeof" or "sizeof" or "checked" or "unchecked" or "nameof" or "init")
+        {
+            return true;
+        }
+
+        if ((context & IdentifierNameContext.Pattern) != 0
+            && text is "and" or "or" or "when")
+        {
+            return true;
+        }
+
+        if ((context & IdentifierNameContext.Index) != 0
+            && text is "stackalloc" or "base")
+        {
+            return true;
+        }
+
+        return (context & IdentifierNameContext.Type) != 0
+            && text is "event" or "prop" or "init" or "convenience" or "shared" or "delegate" or "unmanaged";
+    }
+
+    /// <summary>
+    /// Produces a grammar-safe emitted spelling while preserving every legal
+    /// source name in the same scope.
+    /// </summary>
+    /// <param name="name">The source identifier value.</param>
+    /// <param name="context">The emitted grammar contexts where the name is used.</param>
+    /// <param name="scopeNames">Source names occupying the same emitted scope.</param>
+    /// <returns>The unchanged legal name, or a collision-free suffixed spelling.</returns>
+    public static string GetEmittedIdentifier(
+        string name,
+        IdentifierNameContext context,
+        IEnumerable<string>? scopeNames = null)
+    {
+        if (string.IsNullOrEmpty(name) || !IsReservedIdentifier(name, context))
+        {
+            return name;
+        }
+
+        HashSet<string>? occupied = scopeNames is null
+            ? null
+            : new HashSet<string>(scopeNames, StringComparer.Ordinal);
+        string candidate = name + "_";
+        while (occupied?.Contains(candidate) == true)
+        {
+            candidate += "_";
+        }
+
+        return candidate;
+    }
 
     /// <summary>
     /// Determines whether a spelling is the unsupported C# variadic modifier.

--- a/src/Core/CodeAnalysis/Syntax/SyntaxFacts.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxFacts.cs
@@ -242,6 +242,22 @@ public static class SyntaxFacts
     }
 
     /// <summary>
+    /// Determines whether a spelling cannot be emitted safely as an identifier
+    /// in every G# declaration position.
+    /// </summary>
+    /// <param name="text">The identifier spelling to inspect.</param>
+    /// <returns><c>true</c> for hard keywords and parser-reserved declaration spellings.</returns>
+    public static bool IsReservedIdentifier(string text) =>
+        GetKeywordKind(text) != SyntaxKind.IdentifierToken || IsParamsKeyword(text);
+
+    /// <summary>
+    /// Determines whether a spelling is the unsupported C# variadic modifier.
+    /// </summary>
+    /// <param name="text">The token spelling to inspect.</param>
+    /// <returns><c>true</c> for <c>params</c>.</returns>
+    public static bool IsParamsKeyword(string text) => text == "params";
+
+    /// <summary>
     /// Provides a list o all supported unary operators.
     /// </summary>
     /// <returns>An enumeration of sytax kinds that represent unary operators.</returns>

--- a/src/Core/CodeAnalysis/Syntax/SyntaxFacts.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxFacts.cs
@@ -282,7 +282,7 @@ public static class SyntaxFacts
         }
 
         if ((context & IdentifierNameContext.Invocation) != 0
-            && text is "make" or "typeof" or "sizeof" or "checked" or "unchecked" or "nameof" or "init")
+            && text is "typeof" or "sizeof" or "checked" or "unchecked" or "nameof" or "init")
         {
             return true;
         }

--- a/test/Compiler.Tests/Emit/Issue2962ConstrainedStaticPropertyChainTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2962ConstrainedStaticPropertyChainTests.cs
@@ -251,7 +251,7 @@ public class Issue2962ConstrainedStaticPropertyChainTests
 
             Assert.Equal(1, exitCode);
             Assert.Contains(
-                "error GS0333: Constrained static access 'sizeof(int32)' on type parameter 'T' must name a static-virtual member declared by an interface constraint (ADR-0089).",
+                "error GS0333: Constrained static access 'sizeof' on type parameter 'T' must name a static-virtual member declared by an interface constraint (ADR-0089).",
                 output,
                 StringComparison.Ordinal);
             Assert.DoesNotContain("GS9999", output, StringComparison.Ordinal);

--- a/test/Core.Tests/CodeAnalysis/Binding/NamedArgumentTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/NamedArgumentTests.cs
@@ -331,6 +331,42 @@ KeywordNamedParameterFixture.Combine(type_: ""cat"", value: 2)
     }
 
     [Fact]
+    public void ImportedClrParamsParameter_CollisionUsesCanonicalNames()
+    {
+        using var resolver = ReferenceResolver.WithReferences(
+            new[] { typeof(KeywordNamedParameterFixture).Assembly.Location });
+        var tree = SyntaxTree.Parse(SourceText.From(@"
+import GSharp.Core.Tests.CodeAnalysis.Binding
+
+KeywordNamedParameterFixture.CombineParams(params__: ""left"", params_: ""right"")
+"));
+        var compilation = new Compilation(resolver, tree);
+        var diagnostics = compilation.GlobalScope.Diagnostics
+            .Concat(compilation.BoundProgram.Diagnostics)
+            .ToImmutableArray();
+
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.IsError);
+    }
+
+    [Fact]
+    public void ImportedClrConstructorParamsParameter_CollisionUsesCanonicalNames()
+    {
+        using var resolver = ReferenceResolver.WithReferences(
+            new[] { typeof(KeywordNamedParameterFixture).Assembly.Location });
+        var tree = SyntaxTree.Parse(SourceText.From(@"
+import GSharp.Core.Tests.CodeAnalysis.Binding
+
+KeywordNamedConstructorFixture(params__: ""left"", params_: ""right"")
+"));
+        var compilation = new Compilation(resolver, tree);
+        var diagnostics = compilation.GlobalScope.Diagnostics
+            .Concat(compilation.BoundProgram.Diagnostics)
+            .ToImmutableArray();
+
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.IsError);
+    }
+
+    [Fact]
     public void ImportedClrGenericMethod_NamedLambdaArguments_InferAndBind()
     {
         using var resolver = ReferenceResolver.WithReferences(
@@ -393,6 +429,19 @@ public static class KeywordNamedParameterFixture
 {
     /// <summary>Combines the supplied values.</summary>
     public static string Combine(string type, int value) => $"{type}:{value}";
+
+    /// <summary>Combines colliding source parameter names.</summary>
+    public static string CombineParams(string @params, string params_) =>
+        @params + params_;
+}
+
+/// <summary>CLR constructor fixture with colliding source parameter names.</summary>
+public sealed class KeywordNamedConstructorFixture
+{
+    /// <summary>Initializes a new instance.</summary>
+    public KeywordNamedConstructorFixture(string @params, string params_)
+    {
+    }
 }
 
 /// <summary>CLR builder fixture for generic named-lambda calls.</summary>

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue3461IdentifierAttributeEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue3461IdentifierAttributeEmitTests.cs
@@ -1,0 +1,71 @@
+// <copyright file="Issue3461IdentifierAttributeEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Core.Tests.Fixtures;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>Issue #3461: emitted attribute names map back to CLR metadata names.</summary>
+public sealed class Issue3461IdentifierAttributeEmitTests
+{
+    [Fact]
+    public void ImportedReservedNamedArguments_RoundTripThroughMetadata()
+    {
+        string fixtureAssembly = typeof(ImportedReservedNamedAttribute).Assembly.Location;
+        using var resolver = ReferenceResolver.WithReferences(new[] { fixtureAssembly });
+        var compilation = new Compilation(
+            resolver,
+            SyntaxTree.Parse(SourceText.From(
+                """
+                import GSharp.Core.Tests.Fixtures
+
+                @ImportedReservedNamed("a", "b", type__: "c", type_: "d")
+                class Tagged {
+                }
+                """)));
+
+        using var stream = new MemoryStream();
+        var emit = compilation.Emit(stream);
+        Assert.True(
+            emit.Success,
+            string.Join("; ", emit.Diagnostics.Select(diagnostic => diagnostic.Message)));
+        stream.Position = 0;
+
+        var loadContext = new AssemblyLoadContext(
+            nameof(ImportedReservedNamedArguments_RoundTripThroughMetadata),
+            isCollectible: true);
+        try
+        {
+            loadContext.Resolving += (_, name) =>
+                name.Name == typeof(ImportedReservedNamedAttribute).Assembly.GetName().Name
+                    ? typeof(ImportedReservedNamedAttribute).Assembly
+                    : null;
+            Assembly assembly = loadContext.LoadFromStream(stream);
+            Type tagged = assembly.GetTypes().Single(type => type.Name == "Tagged");
+            CustomAttributeData attribute = tagged.GetCustomAttributesData()
+                .Single(candidate =>
+                    candidate.AttributeType == typeof(ImportedReservedNamedAttribute));
+
+            Assert.Equal(
+                new[] { "a", "b" },
+                attribute.ConstructorArguments.Select(argument => argument.Value).ToArray());
+            Assert.Equal(
+                new[] { "type", "type_" },
+                attribute.NamedArguments.Select(argument => argument.MemberName).ToArray());
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue3461ContextualIdentifierParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue3461ContextualIdentifierParserTests.cs
@@ -1,0 +1,55 @@
+// <copyright file="Issue3461ContextualIdentifierParserTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+/// <summary>Issue #3461: contextual operators stay contextual only at grammar roots.</summary>
+public sealed class Issue3461ContextualIdentifierParserTests
+{
+    [Theory]
+    [InlineData("nameof")]
+    [InlineData("checked")]
+    [InlineData("unchecked")]
+    [InlineData("typeof")]
+    [InlineData("sizeof")]
+    [InlineData("make")]
+    [InlineData("init")]
+    public void ContextualOperatorName_AfterMemberAccess_ParsesAsCall(string name)
+    {
+        SyntaxTree tree = SyntaxTree.Parse(SourceText.From(
+            $$"""
+            class C {
+                func Run(c C) {
+                    c.{{name}}()
+                }
+            }
+            """));
+
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void AllocatedParameterLambdaTypeParameterAndPatternNames_Parse()
+    {
+        SyntaxTree tree = SyntaxTree.Parse(SourceText.From(
+            """
+            class C[in_ any, out_ any] {
+                func Run(params_ int32, scoped_ int32, ref_ int32, out_ int32, in_ int32) int32 {
+                    let f (int32) -> int32 = (params_ int32) -> params_
+                    if params_ is int32 when_ {
+                        return f(when_)
+                    }
+
+                    return 0
+                }
+            }
+            """));
+
+        Assert.Empty(tree.Diagnostics);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Syntax/SyntaxFactsTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/SyntaxFactsTests.cs
@@ -22,11 +22,66 @@ public class SyntaxFactsTests
 
     [Theory]
     [InlineData("class", true)]
-    [InlineData("params", true)]
+    [InlineData("params", false)]
     [InlineData("scoped", false)]
     public void IsReservedIdentifier_ReturnsExpected(string text, bool expected)
     {
         Assert.Equal(expected, SyntaxFacts.IsReservedIdentifier(text));
+    }
+
+    [Theory]
+    [InlineData("params", IdentifierNameContext.Parameter)]
+    [InlineData("scoped", IdentifierNameContext.Parameter)]
+    [InlineData("ref", IdentifierNameContext.Parameter)]
+    [InlineData("out", IdentifierNameContext.Parameter)]
+    [InlineData("in", IdentifierNameContext.Parameter)]
+    [InlineData("scoped", IdentifierNameContext.Local)]
+    [InlineData("ref", IdentifierNameContext.Local)]
+    [InlineData("in", IdentifierNameContext.TypeParameter)]
+    [InlineData("out", IdentifierNameContext.TypeParameter)]
+    [InlineData("nameof", IdentifierNameContext.Invocation)]
+    [InlineData("checked", IdentifierNameContext.Invocation)]
+    [InlineData("unchecked", IdentifierNameContext.Invocation)]
+    [InlineData("typeof", IdentifierNameContext.Invocation)]
+    [InlineData("sizeof", IdentifierNameContext.Invocation)]
+    [InlineData("make", IdentifierNameContext.Invocation)]
+    [InlineData("init", IdentifierNameContext.Invocation)]
+    [InlineData("when", IdentifierNameContext.Pattern)]
+    [InlineData("and", IdentifierNameContext.Pattern)]
+    [InlineData("or", IdentifierNameContext.Pattern)]
+    [InlineData("event", IdentifierNameContext.Type)]
+    [InlineData("prop", IdentifierNameContext.Type)]
+    [InlineData("init", IdentifierNameContext.Type)]
+    [InlineData("convenience", IdentifierNameContext.Type)]
+    [InlineData("shared", IdentifierNameContext.Type)]
+    [InlineData("delegate", IdentifierNameContext.Type)]
+    [InlineData("unmanaged", IdentifierNameContext.Type)]
+    [InlineData("stackalloc", IdentifierNameContext.Index)]
+    [InlineData("base", IdentifierNameContext.Index)]
+    public void IsReservedIdentifier_ContextualSpellings_ReturnTrue(
+        string text,
+        IdentifierNameContext context)
+    {
+        Assert.True(SyntaxFacts.IsReservedIdentifier(text, context));
+    }
+
+    [Fact]
+    public void GetEmittedIdentifier_ReservesLegalSourceNamesBeforeSuffixing()
+    {
+        string[] names = { "params", "params_" };
+
+        Assert.Equal(
+            "params__",
+            SyntaxFacts.GetEmittedIdentifier(
+                "params",
+                IdentifierNameContext.Parameter,
+                names));
+        Assert.Equal(
+            "params_",
+            SyntaxFacts.GetEmittedIdentifier(
+                "params_",
+                IdentifierNameContext.Parameter,
+                names));
     }
 
     [Theory]

--- a/test/Core.Tests/CodeAnalysis/Syntax/SyntaxFactsTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/SyntaxFactsTests.cs
@@ -44,7 +44,6 @@ public class SyntaxFactsTests
     [InlineData("unchecked", IdentifierNameContext.Invocation)]
     [InlineData("typeof", IdentifierNameContext.Invocation)]
     [InlineData("sizeof", IdentifierNameContext.Invocation)]
-    [InlineData("make", IdentifierNameContext.Invocation)]
     [InlineData("init", IdentifierNameContext.Invocation)]
     [InlineData("when", IdentifierNameContext.Pattern)]
     [InlineData("and", IdentifierNameContext.Pattern)]

--- a/test/Core.Tests/CodeAnalysis/Syntax/SyntaxFactsTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/SyntaxFactsTests.cs
@@ -21,6 +21,15 @@ public class SyntaxFactsTests
     }
 
     [Theory]
+    [InlineData("class", true)]
+    [InlineData("params", true)]
+    [InlineData("scoped", false)]
+    public void IsReservedIdentifier_ReturnsExpected(string text, bool expected)
+    {
+        Assert.Equal(expected, SyntaxFacts.IsReservedIdentifier(text));
+    }
+
+    [Theory]
     [InlineData(SyntaxKind.PlusToken, "+")]
     [InlineData(SyntaxKind.FuncKeyword, "func")]
     [InlineData(SyntaxKind.ColonEqualsToken, ":=")]

--- a/test/Core.Tests/Fixtures/ImportedAttributeFixtures.cs
+++ b/test/Core.Tests/Fixtures/ImportedAttributeFixtures.cs
@@ -62,6 +62,22 @@ public sealed class ImportedEnumArgAttribute : Attribute
     public ImportedAttributeMode Mode { get; set; }
 }
 
+/// <summary>Attribute fixture with reserved and colliding CLR identifier names.</summary>
+[AttributeUsage(AttributeTargets.All)]
+public sealed class ImportedReservedNamedAttribute : Attribute
+{
+    /// <summary>Initializes a new instance.</summary>
+    public ImportedReservedNamedAttribute(string @params, string params_)
+    {
+    }
+
+    /// <summary>Gets or sets reserved-name data.</summary>
+    public string @type { get; set; }
+
+    /// <summary>Gets or sets colliding legal-name data.</summary>
+    public string type_ { get; set; }
+}
+
 /// <summary>
 /// A plain reference-assembly class used to verify that imports of non-System
 /// namespaces resolve inside function and method bodies — not just in top-level

--- a/test/Interpreter.Tests/Issue2962ConstrainedStaticPropertyChainEmittedOracleTests.cs
+++ b/test/Interpreter.Tests/Issue2962ConstrainedStaticPropertyChainEmittedOracleTests.cs
@@ -64,7 +64,7 @@ public class Issue2962ConstrainedStaticPropertyChainEmittedOracleTests
 
         var output = RunSubmission(Source);
         Assert.Contains(
-            "error GS0333: Constrained static access 'sizeof(int32)' on type parameter 'T' must name a static-virtual member declared by an interface constraint (ADR-0089).",
+            "error GS0333: Constrained static access 'sizeof' on type parameter 'T' must name a static-virtual member declared by an interface constraint (ADR-0089).",
             output,
             StringComparison.Ordinal);
         Assert.DoesNotContain("GS9999", output, StringComparison.Ordinal);

--- a/tools/cs2gs/Cs2Gs.Tests/ForEachNullForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/ForEachNullForgivenessTranslationTests.cs
@@ -127,10 +127,10 @@ namespace Demo
     }
 }");
 
-        // `nameof` requires a name reference; `nameof(text!!)` would be rejected
-        // (GS0190), so the null-forgiveness pass must skip nameof arguments.
-        Assert.Contains("nameof(text)", printed);
-        Assert.DoesNotContain("nameof(text!!)", printed);
+        // cs2gs constant-folds C# nameof before identifier allocation or
+        // null-forgiveness can change its source-level string value.
+        Assert.Contains("\"text\"", printed);
+        Assert.DoesNotContain("nameof(", printed);
     }
 
     private static string TranslateUnit(string source)

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1884GotoLabelTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1884GotoLabelTranslationTests.cs
@@ -142,7 +142,7 @@ namespace Corpus.Issue1884
 }
 ");
 
-        // `goto` is a G# reserved word (see GSharpReservedWords), so the C#
+        // `goto` is a G# reserved word (see SyntaxFacts), so the C#
         // verbatim label `@goto` must be suffixed to a valid G# identifier at
         // both its declaration and every reference.
         Assert.Contains("goto_:", rendered, StringComparison.Ordinal);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3413NestedPrivateClassTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3413NestedPrivateClassTranslationTests.cs
@@ -398,9 +398,18 @@ public sealed class Issue3413NestedPrivateClassTranslationTests
         Assert.Single(
             unit.Members.OfType<MethodDeclaration>(),
             method => method.Name == "Format");
+        Assert.Equal(
+            2,
+            unit.Members.OfType<MethodDeclaration>().Count(method => method.Name == "func_"));
         Assert.Single(
             unit.Members.OfType<MethodDeclaration>(),
-            method => method.Name == "func_");
+            method => method.Name == "func__");
+        Assert.Equal(
+            2,
+            shared.Members.OfType<MethodDeclaration>().Count(method => method.Name == "func_"));
+        Assert.DoesNotContain(
+            shared.Members.OfType<MethodDeclaration>(),
+            method => method.Name == "func__");
         TranslationTestValidation.AssertBinds(rendered);
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3413NestedPrivateClassTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3413NestedPrivateClassTranslationTests.cs
@@ -398,10 +398,10 @@ public sealed class Issue3413NestedPrivateClassTranslationTests
         Assert.Single(
             unit.Members.OfType<MethodDeclaration>(),
             method => method.Name == "Format");
-        Assert.Equal(
-            2,
-            unit.Members.OfType<MethodDeclaration>().Count(method => method.Name == "func_"));
         Assert.Single(
+            unit.Members.OfType<MethodDeclaration>(),
+            method => method.Name == "func_");
+        Assert.DoesNotContain(
             unit.Members.OfType<MethodDeclaration>(),
             method => method.Name == "func__");
         Assert.Equal(

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3461FriendAssemblyIdentifierTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3461FriendAssemblyIdentifierTests.cs
@@ -1,0 +1,143 @@
+// <copyright file="Issue3461FriendAssemblyIdentifierTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+using GSharpCompilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
+using GSharpReferenceResolver = GSharp.Core.CodeAnalysis.Symbols.ReferenceResolver;
+using GSharpSourceText = GSharp.Core.CodeAnalysis.Text.SourceText;
+using GSharpSyntaxTree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>Issue #3461: friend-visible inherited members reserve emitted names.</summary>
+public sealed class Issue3461FriendAssemblyIdentifierTests
+{
+    [Fact]
+    public void FriendInternalInheritedName_ReservesDerivedAllocationAtRuntime()
+    {
+        string directory = Path.Combine(
+            AppContext.BaseDirectory,
+            nameof(Issue3461FriendAssemblyIdentifierTests));
+        Directory.CreateDirectory(directory);
+        string libraryPath = Path.Combine(directory, "Friend.Library.dll");
+        CSharpCompilation library = CSharpCompilation.Create(
+            "Friend.Library",
+            new[]
+            {
+                CSharpSyntaxTree.ParseText(
+                    """
+                    using System.Runtime.CompilerServices;
+
+                    [assembly: InternalsVisibleTo("Friend.Consumer")]
+
+                    namespace FriendLib;
+
+                    public class Base
+                    {
+                        internal int type_() => 100;
+                    }
+                    """),
+            },
+            CSharpProjectLoader.RuntimeReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        using (FileStream stream = File.Create(libraryPath))
+        {
+            var emit = library.Emit(stream);
+            Assert.True(
+                emit.Success,
+                string.Join(Environment.NewLine, emit.Diagnostics));
+        }
+
+        var references = CSharpProjectLoader.RuntimeReferences()
+            .Append(MetadataReference.CreateFromFile(libraryPath))
+            .ToArray();
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[]
+            {
+                ("Consumer.cs", """
+                    using FriendLib;
+
+                    public sealed class Derived : Base
+                    {
+                        public int @type() => 7;
+
+                        public int Run() => @type();
+                    }
+
+                    public static class Holder
+                    {
+                        public static int Run() => new Derived().Run();
+                    }
+                    """),
+            },
+            references,
+            assemblyName: "Friend.Consumer");
+        Assert.True(
+            project.BoundWithoutErrors,
+            string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(
+            project.Compilation,
+            document.SemanticModel,
+            document.FilePath);
+        string rendered = GSharpPrinter.Print(
+            new CSharpToGSharpTranslator().TranslateDocument(document, context));
+        Assert.Contains("func type__()", rendered, StringComparison.Ordinal);
+        Assert.Contains("func Run() int32 -> type__()", rendered, StringComparison.Ordinal);
+
+        using var resolver = GSharpReferenceResolver.WithReferences(
+            new[] { libraryPath });
+        resolver.CurrentAssemblyName = "Friend.Consumer";
+        TranslationTestValidation.AssertBinds(resolver, rendered);
+        var compilation = new GSharpCompilation(
+            resolver,
+            GSharpSyntaxTree.Parse(GSharpSourceText.From(rendered)))
+        {
+            IsLibrary = true,
+        };
+        using var image = new MemoryStream();
+        var result = compilation.Emit(
+            image,
+            pdbStream: null,
+            refStream: null,
+            assemblyName: "Friend.Consumer");
+        Assert.True(
+            result.Success,
+            string.Join(Environment.NewLine, result.Diagnostics));
+        image.Position = 0;
+
+        var loadContext = new AssemblyLoadContext(
+            nameof(FriendInternalInheritedName_ReservesDerivedAllocationAtRuntime),
+            isCollectible: true);
+        try
+        {
+            loadContext.Resolving += (_, name) =>
+                name.Name == "Friend.Library"
+                    ? loadContext.LoadFromAssemblyPath(libraryPath)
+                    : null;
+            Assembly assembly = loadContext.LoadFromStream(image);
+            Type holder = assembly.GetTypes().Single(type => type.Name == "Holder");
+            MethodInfo run = holder.GetMethod(
+                "Run",
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(run);
+            Assert.Equal(7, run.Invoke(null, null));
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3461IdentifierSanitizationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3461IdentifierSanitizationTests.cs
@@ -537,6 +537,103 @@ public sealed class Issue3461IdentifierSanitizationTests
     }
 
     [Fact]
+    public void MethodTypeParameters_ReserveSameNamespaceTypes()
+    {
+        string rendered = Render(
+            """
+            namespace Demo;
+
+            public sealed class type_ { }
+
+            public sealed class C
+            {
+                public @type Echo<@type>(type_ outer, @type inner) => inner;
+            }
+
+            public static class Holder
+            {
+                public static string Run() =>
+                    new C().Echo<string>(new type_(), "ok");
+            }
+            """);
+
+        Assert.Contains("class type_", rendered, StringComparison.Ordinal);
+        Assert.Contains("Echo[type__](outer type_, inner type__)", rendered, StringComparison.Ordinal);
+        Assert.Contains("Echo[string](type_(), \"ok\")", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+
+        var result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Holder.Run()");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("ok", result.Value);
+    }
+
+    [Fact]
+    public void MethodTypeParameters_ReserveUsingAliases()
+    {
+        string rendered = Render(
+            """
+            using type_ = System.String;
+
+            public sealed class C
+            {
+                public @type Echo<@type>(type_ outer, @type inner) => inner;
+            }
+
+            public static class Holder
+            {
+                public static string Run() =>
+                    new C().Echo<string>("outer", "ok");
+            }
+            """);
+
+        Assert.Contains("Echo[type__](outer string, inner type__)", rendered, StringComparison.Ordinal);
+        Assert.Contains("Echo[string](\"outer\", \"ok\")", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+
+        var result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Holder.Run()");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("ok", result.Value);
+    }
+
+    [Fact]
+    public void MethodTypeParameters_ReserveImportedNamespaceTypes()
+    {
+        string fixtureAssembly = typeof(ImportedVisible.type_).Assembly.Location;
+        IReadOnlyList<MetadataReference> references = CSharpProjectLoader.RuntimeReferences()
+            .Append(MetadataReference.CreateFromFile(fixtureAssembly))
+            .ToArray();
+        string rendered = Render(
+            """
+            using ImportedVisible;
+
+            public sealed class C
+            {
+                public @type Echo<@type>(type_ outer, @type inner) => inner;
+            }
+
+            public static class Holder
+            {
+                public static string Run() =>
+                    new C().Echo<string>(new type_(), "ok");
+            }
+            """,
+            references);
+
+        Assert.Contains("Echo[type__](outer type_, inner type__)", rendered, StringComparison.Ordinal);
+        Assert.Contains("Echo[string](type_(), \"ok\")", rendered, StringComparison.Ordinal);
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { fixtureAssembly });
+        TranslationTestValidation.AssertBinds(resolver, rendered);
+        var result = EmittedOracle.Evaluate(
+            new[] { rendered + Environment.NewLine + "Holder.Run()" },
+            new EmittedOracleOptions { References = new[] { fixtureAssembly } });
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("ok", result.Value);
+    }
+
+    [Fact]
     public void ConsumerBeforeRecord_UsesPrecomputedPrimaryParameterName()
     {
         IReadOnlyDictionary<string, string> rendered = RenderFiles(

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3461IdentifierSanitizationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3461IdentifierSanitizationTests.cs
@@ -340,6 +340,102 @@ public sealed class Issue3461IdentifierSanitizationTests
     }
 
     [Fact]
+    public void InheritedLegalName_ReservesDerivedIllegalAllocationAtRuntime()
+    {
+        string rendered = Render(
+            """
+            public class Base
+            {
+                public int type_() => 100;
+            }
+
+            public sealed class Derived : Base
+            {
+                public int @type() => 7;
+            }
+
+            public static class Holder
+            {
+                public static int Run()
+                {
+                    var value = new Derived();
+                    return value.@type() + value.type_();
+                }
+            }
+            """);
+
+        Assert.Contains("func type__()", rendered, StringComparison.Ordinal);
+        Assert.Contains("func type_()", rendered, StringComparison.Ordinal);
+        Assert.Contains("value.type__()", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+
+        var result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Holder.Run()");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(107, result.Value);
+    }
+
+    [Fact]
+    public void RecordPrimaryParameter_SharesTypeMemberCollisionScope()
+    {
+        string rendered = Render(
+            """
+            public record R(int @params)
+            {
+                public int params_ => 100;
+            }
+
+            public static class Holder
+            {
+                public static int Run()
+                {
+                    var value = new R(7);
+                    return value.@params + value.params_;
+                }
+            }
+            """);
+
+        Assert.Contains("data class R(params__ int32)", rendered, StringComparison.Ordinal);
+        Assert.Contains("prop params_", rendered, StringComparison.Ordinal);
+        Assert.Contains("value.params__", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+
+        var result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Holder.Run()");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(107, result.Value);
+    }
+
+    [Fact]
+    public void ClassPrimaryParameter_SharesTypeMemberCollisionScope()
+    {
+        string rendered = Render(
+            """
+            public class C(int @params)
+            {
+                public int params_ => 100;
+
+                public int Read() => @params + params_;
+            }
+
+            public static class Holder
+            {
+                public static int Run() => new C(7).Read();
+            }
+            """);
+
+        Assert.Contains("class C(params__ int32)", rendered, StringComparison.Ordinal);
+        Assert.Contains("prop params_", rendered, StringComparison.Ordinal);
+        Assert.Contains("params__ + params_", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+
+        var result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Holder.Run()");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(107, result.Value);
+    }
+
+    [Fact]
     public void ConsumerBeforeRecord_UsesPrecomputedPrimaryParameterName()
     {
         IReadOnlyDictionary<string, string> rendered = RenderFiles(
@@ -466,6 +562,72 @@ public sealed class Issue3461IdentifierSanitizationTests
             new EmittedOracleOptions { References = new[] { fixtureAssembly } });
         Assert.Empty(result.Diagnostics);
         Assert.Equal(54, result.Value);
+    }
+
+    [Fact]
+    public void ImportedStaticContextualCalls_AreQualifiedAndRun()
+    {
+        string fixtureAssembly = typeof(ImportedContextualStatics).Assembly.Location;
+        IReadOnlyList<MetadataReference> references = CSharpProjectLoader.RuntimeReferences()
+            .Append(MetadataReference.CreateFromFile(fixtureAssembly))
+            .ToArray();
+        string rendered = Render(
+            """
+            using static Cs2Gs.Tests.ImportedContextualStatics;
+
+            public static class Holder
+            {
+                public static int Run() =>
+                    @nameof() + @typeof() + @sizeof() + @checked() + @unchecked();
+            }
+            """,
+            references);
+
+        Assert.Contains("ImportedContextualStatics.nameof()", rendered, StringComparison.Ordinal);
+        Assert.Contains("ImportedContextualStatics.typeof()", rendered, StringComparison.Ordinal);
+        Assert.Contains("ImportedContextualStatics.sizeof()", rendered, StringComparison.Ordinal);
+        Assert.Contains("ImportedContextualStatics.checked()", rendered, StringComparison.Ordinal);
+        Assert.Contains("ImportedContextualStatics.unchecked()", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("func nameof", rendered, StringComparison.Ordinal);
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { fixtureAssembly });
+        TranslationTestValidation.AssertBinds(resolver, rendered);
+        var result = EmittedOracle.Evaluate(
+            new[] { rendered + Environment.NewLine + "Holder.Run()" },
+            new EmittedOracleOptions { References = new[] { fixtureAssembly } });
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(31, result.Value);
+    }
+
+    [Fact]
+    public void ImportedReservedNamespaceAndTypes_ResolveCanonicalMetadataNames()
+    {
+        string fixtureAssembly = typeof(@class.@type).Assembly.Location;
+        IReadOnlyList<MetadataReference> references = CSharpProjectLoader.RuntimeReferences()
+            .Append(MetadataReference.CreateFromFile(fixtureAssembly))
+            .ToArray();
+        string rendered = Render(
+            """
+            using @class;
+
+            public static class Holder
+            {
+                public static int Run() => new @type().Value + new type_().Value;
+            }
+            """,
+            references);
+
+        Assert.Contains("import class__", rendered, StringComparison.Ordinal);
+        Assert.Contains("type__()", rendered, StringComparison.Ordinal);
+        Assert.Contains("type_()", rendered, StringComparison.Ordinal);
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { fixtureAssembly });
+        TranslationTestValidation.AssertBinds(resolver, rendered);
+        var result = EmittedOracle.Evaluate(
+            new[] { rendered + Environment.NewLine + "Holder.Run()" },
+            new EmittedOracleOptions { References = new[] { fixtureAssembly } });
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
     }
 
     [Fact]
@@ -828,4 +990,23 @@ public sealed class ImportedIdentifierMethods
 
     /// <summary>Contextual method name legal after member access.</summary>
     public int @make() => 0;
+}
+
+/// <summary>Imported static contextual method fixture.</summary>
+public static class ImportedContextualStatics
+{
+    /// <summary>Returns one.</summary>
+    public static int @nameof() => 1;
+
+    /// <summary>Returns two.</summary>
+    public static int @typeof() => 2;
+
+    /// <summary>Returns four.</summary>
+    public static int @sizeof() => 4;
+
+    /// <summary>Returns eight.</summary>
+    public static int @checked() => 8;
+
+    /// <summary>Returns sixteen.</summary>
+    public static int @unchecked() => 16;
 }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3461IdentifierSanitizationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3461IdentifierSanitizationTests.cs
@@ -507,6 +507,36 @@ public sealed class Issue3461IdentifierSanitizationTests
     }
 
     [Fact]
+    public void MethodTypeParameters_ReserveVisibleNestedTypes()
+    {
+        string rendered = Render(
+            """
+            public sealed class C
+            {
+                public sealed class type_ { }
+
+                public @type Echo<@type>(type_ outer, @type inner) => inner;
+            }
+
+            public static class Holder
+            {
+                public static string Run() =>
+                    new C().Echo<string>(new C.type_(), "ok");
+            }
+            """);
+
+        Assert.Contains("class type_", rendered, StringComparison.Ordinal);
+        Assert.Contains("Echo[type__](outer type_, inner type__)", rendered, StringComparison.Ordinal);
+        Assert.Contains("Echo[string](C.type_(), \"ok\")", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+
+        var result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Holder.Run()");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("ok", result.Value);
+    }
+
+    [Fact]
     public void ConsumerBeforeRecord_UsesPrecomputedPrimaryParameterName()
     {
         IReadOnlyDictionary<string, string> rendered = RenderFiles(
@@ -672,6 +702,68 @@ public sealed class Issue3461IdentifierSanitizationTests
             new EmittedOracleOptions { References = new[] { fixtureAssembly } });
         Assert.Empty(result.Diagnostics);
         Assert.Equal(38, result.Value);
+    }
+
+    [Fact]
+    public void ImportedStaticContextualFields_AreQualifiedAndRun()
+    {
+        string fixtureAssembly = typeof(ImportedContextualStaticFields).Assembly.Location;
+        IReadOnlyList<MetadataReference> references = CSharpProjectLoader.RuntimeReferences()
+            .Append(MetadataReference.CreateFromFile(fixtureAssembly))
+            .ToArray();
+        string rendered = Render(
+            """
+            using static Cs2Gs.Tests.ImportedContextualStaticFields;
+
+            public static class Holder
+            {
+                public static int Run() => @base[0] + @stackalloc[0] + @nameof();
+            }
+            """,
+            references);
+
+        Assert.Contains("ImportedContextualStaticFields.base!![0]", rendered, StringComparison.Ordinal);
+        Assert.Contains("ImportedContextualStaticFields.stackalloc!![0]", rendered, StringComparison.Ordinal);
+        Assert.Contains("ImportedContextualStaticFields.nameof!!()", rendered, StringComparison.Ordinal);
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { fixtureAssembly });
+        TranslationTestValidation.AssertBinds(resolver, rendered);
+        var result = EmittedOracle.Evaluate(
+            new[] { rendered + Environment.NewLine + "Holder.Run()" },
+            new EmittedOracleOptions { References = new[] { fixtureAssembly } });
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(15, result.Value);
+    }
+
+    [Fact]
+    public void ImportedStaticContextualProperties_AreQualifiedAndRun()
+    {
+        string fixtureAssembly = typeof(ImportedContextualStaticProperties).Assembly.Location;
+        IReadOnlyList<MetadataReference> references = CSharpProjectLoader.RuntimeReferences()
+            .Append(MetadataReference.CreateFromFile(fixtureAssembly))
+            .ToArray();
+        string rendered = Render(
+            """
+            using static Cs2Gs.Tests.ImportedContextualStaticProperties;
+
+            public static class Holder
+            {
+                public static int Run() => @base[0] + @stackalloc[0] + @nameof();
+            }
+            """,
+            references);
+
+        Assert.Contains("ImportedContextualStaticProperties.base!![0]", rendered, StringComparison.Ordinal);
+        Assert.Contains("ImportedContextualStaticProperties.stackalloc!![0]", rendered, StringComparison.Ordinal);
+        Assert.Contains("ImportedContextualStaticProperties.nameof!!()", rendered, StringComparison.Ordinal);
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { fixtureAssembly });
+        TranslationTestValidation.AssertBinds(resolver, rendered);
+        var result = EmittedOracle.Evaluate(
+            new[] { rendered + Environment.NewLine + "Holder.Run()" },
+            new EmittedOracleOptions { References = new[] { fixtureAssembly } });
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(18, result.Value);
     }
 
     [Fact]
@@ -1093,4 +1185,30 @@ public static class ImportedContextualStatics
 
     /// <summary>Returns generic value.</summary>
     public static T @nameof<T>(T value) => value;
+}
+
+/// <summary>Imported contextual static field fixture.</summary>
+public static class ImportedContextualStaticFields
+{
+    /// <summary>Reserved index-prefix field.</summary>
+    public static readonly int[] @base = { 3 };
+
+    /// <summary>Reserved index-prefix field.</summary>
+    public static readonly int[] @stackalloc = { 5 };
+
+    /// <summary>Reserved invocation field.</summary>
+    public static readonly Func<int> @nameof = () => 7;
+}
+
+/// <summary>Imported contextual static property fixture.</summary>
+public static class ImportedContextualStaticProperties
+{
+    /// <summary>Reserved index-prefix property.</summary>
+    public static int[] @base { get; } = new[] { 4 };
+
+    /// <summary>Reserved index-prefix property.</summary>
+    public static int[] @stackalloc { get; } = new[] { 6 };
+
+    /// <summary>Reserved invocation property.</summary>
+    public static Func<int> @nameof { get; } = () => 8;
 }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3461IdentifierSanitizationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3461IdentifierSanitizationTests.cs
@@ -1,0 +1,201 @@
+// <copyright file="Issue3461IdentifierSanitizationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+using GSharpSyntaxFacts = GSharp.Core.CodeAnalysis.Syntax.SyntaxFacts;
+using GSharpSyntaxKind = GSharp.Core.CodeAnalysis.Syntax.SyntaxKind;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>Issue #3461: every emitted identifier must avoid G# reserved spellings without collisions.</summary>
+public sealed class Issue3461IdentifierSanitizationTests
+{
+    [Fact]
+    public void LanguageServerParamsParameter_DeclarationAndReference_Bind()
+    {
+        string rendered = Render(
+            """
+            using System.Text.Json;
+
+            public static class LspServer
+            {
+                public static void Initialized(JsonElement @params)
+                {
+                    _ = @params;
+                }
+            }
+            """);
+
+        Assert.Contains("Initialized(params_ JsonElement)", rendered, StringComparison.Ordinal);
+        AssertNoStandaloneIdentifier(rendered, "params");
+        TranslationTestValidation.AssertBinds(
+            rendered,
+            """
+            package System.Text.Json
+
+            struct JsonElement { }
+            """);
+    }
+
+    [Fact]
+    public void ReservedAndSuffixIdentifiers_RemainDistinctAcrossSurfaces()
+    {
+        string rendered = Render(
+            """
+            using @import = System.Text.StringBuilder;
+            using import_ = System.Text.StringBuilder;
+
+            namespace Corpus.Issue3461
+            {
+                public class @type
+                {
+                    public int Value;
+                }
+
+                public class type_
+                {
+                    public int Value;
+                }
+
+                public class Holder
+                {
+                    private @import @scope = new @import();
+                    private import_ scope_ = new import_();
+
+                    public int @select(int @params, int params_, object value)
+                    {
+                        int @range = @params + this.@scope.Length;
+                        int range_ = params_ + this.scope_.Length;
+                        if (value is int @guard)
+                        {
+                            int guard_ = @guard + @range;
+                            if (guard_ > 0)
+                            {
+                                goto @goto;
+                            }
+                        }
+
+                        goto goto_;
+
+                    @goto:
+                        return @range;
+
+                    goto_:
+                        return range_;
+                    }
+
+                    public int select_(int @params, int params_, object value) =>
+                        @select(@params, params_, value);
+
+                    public @type MakeKeywordType() => new @type();
+
+                    public type_ MakeSuffixType() => new type_();
+                }
+            }
+            """);
+
+        Assert.Contains("import import_ = System.Text.StringBuilder", rendered, StringComparison.Ordinal);
+        Assert.Contains("import import__ = System.Text.StringBuilder", rendered, StringComparison.Ordinal);
+        Assert.Contains("class type_", rendered, StringComparison.Ordinal);
+        Assert.Contains("class type__", rendered, StringComparison.Ordinal);
+        Assert.Contains("select_(params_ int32, params__ int32", rendered, StringComparison.Ordinal);
+        Assert.Contains("select__(params_ int32, params__ int32", rendered, StringComparison.Ordinal);
+        Assert.Contains("range_", rendered, StringComparison.Ordinal);
+        Assert.Contains("range__", rendered, StringComparison.Ordinal);
+        Assert.Contains("guard_", rendered, StringComparison.Ordinal);
+        Assert.Contains("guard__", rendered, StringComparison.Ordinal);
+        Assert.Contains("goto goto_", rendered, StringComparison.Ordinal);
+        Assert.Contains("goto goto__", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+
+    [Fact]
+    public void AnonymousGeneratedMembers_PreserveReservedNameCollisions()
+    {
+        string rendered = Render(
+            """
+            public static class Holder
+            {
+                public static int Sum()
+                {
+                    var value = new { @params = 1, params_ = 2 };
+                    return value.@params + value.params_;
+                }
+            }
+            """);
+
+        Assert.Contains("params_ int32", rendered, StringComparison.Ordinal);
+        Assert.Contains("params__ int32", rendered, StringComparison.Ordinal);
+        Assert.Contains(".params_", rendered, StringComparison.Ordinal);
+        Assert.Contains(".params__", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+
+    [Fact]
+    public void LexerAndParserReservedWordAudit_AllNamesAreSanitized()
+    {
+        string[] reserved = Enum.GetValues<GSharpSyntaxKind>()
+            .Select(GSharpSyntaxFacts.GetText)
+            .Where(text => text != null && GSharpSyntaxFacts.GetKeywordKind(text) != GSharpSyntaxKind.IdentifierToken)
+            .Append("params")
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(text => text, StringComparer.Ordinal)
+            .ToArray();
+        string declarations = string.Join(
+            Environment.NewLine,
+            reserved.Select(word => $"    public int @{word};"));
+        string references = string.Join(" + ", reserved.Select(word => $"this.@{word}"));
+        string rendered = Render(
+            $$"""
+            public class ReservedAudit
+            {
+            {{declarations}}
+
+                public int Sum() => {{references}};
+            }
+            """);
+
+        foreach (string word in reserved)
+        {
+            Assert.Contains(word + "_", rendered, StringComparison.Ordinal);
+            Assert.DoesNotContain($"var {word} ", rendered, StringComparison.Ordinal);
+            Assert.DoesNotMatch(
+                $@"\.{Regex.Escape(word)}(?![A-Za-z0-9_])",
+                rendered);
+        }
+
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+
+    private static void AssertNoStandaloneIdentifier(string rendered, string identifier)
+    {
+        Match match = Regex.Match(
+            rendered,
+            $@"(?<![A-Za-z0-9_]){Regex.Escape(identifier)}(?![A-Za-z0-9_])");
+        Assert.False(match.Success, $"raw identifier '{identifier}' leaked into translated G#:\n{rendered}");
+    }
+
+    private static string Render(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Issue3461.cs", source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3461IdentifierSanitizationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3461IdentifierSanitizationTests.cs
@@ -3,12 +3,16 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Cs2Gs.CodeModel.Ast;
 using Cs2Gs.CodeModel.Printing;
 using Cs2Gs.Translator;
 using Cs2Gs.Translator.Loading;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Tests;
+using Microsoft.CodeAnalysis;
 using Xunit;
 using GSharpSyntaxFacts = GSharp.Core.CodeAnalysis.Syntax.SyntaxFacts;
 using GSharpSyntaxKind = GSharp.Core.CodeAnalysis.Syntax.SyntaxKind;
@@ -106,8 +110,8 @@ public sealed class Issue3461IdentifierSanitizationTests
         Assert.Contains("import import__ = System.Text.StringBuilder", rendered, StringComparison.Ordinal);
         Assert.Contains("class type_", rendered, StringComparison.Ordinal);
         Assert.Contains("class type__", rendered, StringComparison.Ordinal);
-        Assert.Contains("select_(params_ int32, params__ int32", rendered, StringComparison.Ordinal);
-        Assert.Contains("select__(params_ int32, params__ int32", rendered, StringComparison.Ordinal);
+        Assert.Contains("select_(params__ int32, params_ int32", rendered, StringComparison.Ordinal);
+        Assert.Contains("select__(params__ int32, params_ int32", rendered, StringComparison.Ordinal);
         Assert.Contains("range_", rendered, StringComparison.Ordinal);
         Assert.Contains("range__", rendered, StringComparison.Ordinal);
         Assert.Contains("guard_", rendered, StringComparison.Ordinal);
@@ -145,7 +149,6 @@ public sealed class Issue3461IdentifierSanitizationTests
         string[] reserved = Enum.GetValues<GSharpSyntaxKind>()
             .Select(GSharpSyntaxFacts.GetText)
             .Where(text => text != null && GSharpSyntaxFacts.GetKeywordKind(text) != GSharpSyntaxKind.IdentifierToken)
-            .Append("params")
             .Distinct(StringComparer.Ordinal)
             .OrderBy(text => text, StringComparer.Ordinal)
             .ToArray();
@@ -175,6 +178,352 @@ public sealed class Issue3461IdentifierSanitizationTests
         TranslationTestValidation.AssertBinds(rendered);
     }
 
+    [Fact]
+    public void ContextualGrammarNames_AreRenamedOnlyInUnsafeContexts()
+    {
+        string rendered = Render(
+            """
+            using System;
+
+            public class @event { }
+
+            public class MemberNames
+            {
+                public int @nameof() => 1;
+
+                public int @checked() => 2;
+
+                public int @typeof() => 3;
+
+                public int @sizeof() => 4;
+
+                public int @unchecked() => 5;
+
+                public int @make() => 6;
+
+                public int @init() => 7;
+            }
+
+            public class Holder<@in, @out>
+            {
+                private static int @checked() => 2;
+
+                private static int @typeof() => 3;
+
+                private static int @sizeof() => 4;
+
+                private static int @unchecked() => 5;
+
+                private static int @init() => 6;
+
+                private static int @make() => 7;
+
+                public int Run(int @params, int @scoped, int @ref, int @out, int @in)
+                {
+                    Func<int, int> lambda = (int @params) => @params;
+                    int paramsLocal = @params;
+                    return @checked() + @typeof() + @sizeof() + @unchecked() +
+                        @init() + @make() + lambda(paramsLocal);
+                }
+
+                public int MemberCalls(MemberNames names) =>
+                    names.@nameof() + names.@checked() + names.@typeof() +
+                    names.@sizeof() + names.@unchecked() + names.@make() + names.@init();
+
+                public @event Echo(@event value) => value;
+            }
+            """);
+
+        Assert.Contains("class event_", rendered, StringComparison.Ordinal);
+        Assert.Contains("class Holder[in_, out_]", rendered, StringComparison.Ordinal);
+        Assert.Contains(
+            "Run(params_ int32, scoped_ int32, ref_ int32, out_ int32, in_ int32)",
+            rendered,
+            StringComparison.Ordinal);
+        Assert.True(
+            rendered.Split("params_ int32", StringSplitOptions.None).Length >= 3,
+            rendered);
+        Assert.Contains("func checked_()", rendered, StringComparison.Ordinal);
+        Assert.Contains("func typeof_()", rendered, StringComparison.Ordinal);
+        Assert.Contains("func sizeof_()", rendered, StringComparison.Ordinal);
+        Assert.Contains("func unchecked_()", rendered, StringComparison.Ordinal);
+        Assert.Contains("func init_()", rendered, StringComparison.Ordinal);
+        Assert.Contains("func make_()", rendered, StringComparison.Ordinal);
+        Assert.Contains("names.nameof()", rendered, StringComparison.Ordinal);
+        Assert.Contains("names.checked()", rendered, StringComparison.Ordinal);
+        Assert.Contains("names.typeof()", rendered, StringComparison.Ordinal);
+        Assert.Contains("names.sizeof()", rendered, StringComparison.Ordinal);
+        Assert.Contains("names.unchecked()", rendered, StringComparison.Ordinal);
+        Assert.Contains("names.make()", rendered, StringComparison.Ordinal);
+        Assert.Contains("names.init_()", rendered, StringComparison.Ordinal);
+        Assert.Contains("func init_()", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("func nameof_()", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+
+    [Fact]
+    public void BareIndexContextualNames_AreAllocated()
+    {
+        string rendered = Render(
+            """
+            public static class Holder
+            {
+                public static int Read(int[] @stackalloc, int[] @base)
+                {
+                    return @stackalloc[0] + @base[0];
+                }
+            }
+            """);
+
+        Assert.Contains("Read(stackalloc_ []int32, base_ []int32)", rendered, StringComparison.Ordinal);
+        Assert.Contains("stackalloc_[0]", rendered, StringComparison.Ordinal);
+        Assert.Contains("base_[0]", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+
+    [Fact]
+    public void LegalPublicSuffixedNames_RemainUnchanged()
+    {
+        string rendered = Render(
+            """
+            namespace type_;
+
+            public class type_ { }
+
+            public class Holder
+            {
+                public int type_;
+
+                public type_ Echo(type_ type_)
+                {
+                    this.type_ = 1;
+                    return type_;
+                }
+            }
+            """);
+
+        Assert.Contains("package type_", rendered, StringComparison.Ordinal);
+        Assert.Contains("class type_ {", rendered, StringComparison.Ordinal);
+        Assert.Contains("var type_ int32", rendered, StringComparison.Ordinal);
+        Assert.Contains("Echo(type_ type_) type_", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("type__", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+
+    [Fact]
+    public void TypeContextualNames_AreAllocatedInTypeClausesAndConstruction()
+    {
+        string rendered = Render(
+            """
+            public class @event { }
+            public class @prop { }
+            public class @init { }
+            public class @convenience { }
+            public class @shared { }
+            public class @delegate { }
+            public class @unmanaged { }
+
+            public static class Holder
+            {
+                public static @event Event() => new @event();
+                public static @prop Prop() => new @prop();
+                public static @init Init() => new @init();
+                public static @convenience Convenience() => new @convenience();
+                public static @shared Shared() => new @shared();
+                public static @delegate Delegate() => new @delegate();
+                public static @unmanaged Unmanaged() => new @unmanaged();
+            }
+            """);
+
+        foreach ((string method, string name) in new[]
+                 {
+                     ("Event", "event_"),
+                     ("Prop", "prop_"),
+                     ("Init", "init_"),
+                     ("Convenience", "convenience_"),
+                     ("Shared", "shared_"),
+                     ("Delegate", "delegate_"),
+                     ("Unmanaged", "unmanaged_"),
+                 })
+        {
+            Assert.Contains($"class {name}", rendered, StringComparison.Ordinal);
+            Assert.Contains($"func {method}() {name} -> {name}()", rendered, StringComparison.Ordinal);
+        }
+
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+
+    [Fact]
+    public void PatternContextualNames_DeclarationAndReferencesBind()
+    {
+        string rendered = Render(
+            """
+            public static class Holder
+            {
+                public static int When(object value)
+                {
+                    if (value is int @when)
+                    {
+                        return @when;
+                    }
+
+                    return 0;
+                }
+
+                public static int And(object value)
+                {
+                    if (value is int @and)
+                    {
+                        return @and;
+                    }
+
+                    return 0;
+                }
+
+                public static int Or(object value)
+                {
+                    if (value is int @or)
+                    {
+                        return @or;
+                    }
+
+                    return 0;
+                }
+            }
+            """);
+
+        Assert.Contains("int32 when_", rendered, StringComparison.Ordinal);
+        Assert.Contains("int32 and_", rendered, StringComparison.Ordinal);
+        Assert.Contains("int32 or_", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+
+    [Fact]
+    public void UnicodeEscapedIdentifiers_UseValueTextAndBind()
+    {
+        string rendered = Render(
+            """
+            public class cl\u0061ss
+            {
+                public int p\u0061rams;
+
+                public int Read(int p\u0061rams)
+                {
+                    int ordin\u0061ry = p\u0061rams;
+                    this.p\u0061rams = ordin\u0061ry;
+                    return this.p\u0061rams;
+                }
+            }
+            """);
+
+        Assert.Contains("class class_", rendered, StringComparison.Ordinal);
+        Assert.Contains("var params int32", rendered, StringComparison.Ordinal);
+        Assert.Contains("Read(params_ int32)", rendered, StringComparison.Ordinal);
+        Assert.Contains("let ordinary", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain(@"\u", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+
+    [Fact]
+    public void NameofReservedParameter_PreservesSourceStringAtRuntime()
+    {
+        string rendered = Render(
+            """
+            public static class Holder
+            {
+                public static string Read(int @params) => nameof(@params);
+            }
+            """);
+
+        Assert.Contains("Read(params_ int32)", rendered, StringComparison.Ordinal);
+        Assert.Contains("\"params\"", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("nameof(", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+
+        var result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Holder.Read(1)");
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal("params", result.Value);
+    }
+
+    [Fact]
+    public void SourceNamespaceSegments_AliasesAndQualifiedReferencesBind()
+    {
+        IReadOnlyDictionary<string, string> rendered = RenderFiles(
+            ("Producer.cs", """
+                namespace @class;
+
+                public class Widget { }
+                """),
+            ("Consumer.cs", """
+                using @import = @class.Widget;
+
+                namespace Consumer;
+
+                public class Holder
+                {
+                    public @class.Widget Direct() => new @class.Widget();
+
+                    public @import Aliased() => new @import();
+                }
+                """));
+
+        Assert.Contains("package class_", rendered["Producer.cs"], StringComparison.Ordinal);
+        Assert.Contains(
+            "import import_ = class_.Widget",
+            rendered["Consumer.cs"],
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("@class", rendered["Consumer.cs"], StringComparison.Ordinal);
+        Assert.DoesNotContain("@import", rendered["Consumer.cs"], StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered.Values.ToArray());
+    }
+
+    [Fact]
+    public void ImportedAttributeNamedArguments_UseAllocatedNames()
+    {
+        string fixtureAssembly = typeof(ReservedNamedAttribute).Assembly.Location;
+        IReadOnlyList<MetadataReference> references = CSharpProjectLoader.RuntimeReferences()
+            .Append(MetadataReference.CreateFromFile(fixtureAssembly))
+            .ToArray();
+        string rendered = Render(
+            """
+            using Cs2Gs.Tests;
+
+            [ReservedNamed("a", "b", @type = "c", type_ = "d")]
+            public class Holder { }
+            """,
+            references);
+
+        Assert.Contains(
+            "@ReservedNamed(\"a\", \"b\", type__: \"c\", type_: \"d\")",
+            rendered,
+            StringComparison.Ordinal);
+        using var resolver = ReferenceResolver.WithReferences(new[] { fixtureAssembly });
+        TranslationTestValidation.AssertBinds(resolver, rendered);
+    }
+
+    [Fact]
+    public void EscapedReservedSourceAttributeName_DeclarationAndUseBind()
+    {
+        string rendered = Render(
+            """
+            using System;
+
+            public sealed class @class : Attribute
+            {
+                public @class(string value) { }
+            }
+
+            [@class("ok")]
+            public sealed class Holder { }
+            """);
+
+        Assert.Contains("class class_", rendered, StringComparison.Ordinal);
+        Assert.Contains("@class_(\"ok\")", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+
     private static void AssertNoStandaloneIdentifier(string rendered, string identifier)
     {
         Match match = Regex.Match(
@@ -183,10 +532,13 @@ public sealed class Issue3461IdentifierSanitizationTests
         Assert.False(match.Success, $"raw identifier '{identifier}' leaked into translated G#:\n{rendered}");
     }
 
-    private static string Render(string source)
+    private static string Render(
+        string source,
+        IReadOnlyList<MetadataReference> references = null)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
-            new[] { ("Issue3461.cs", source) });
+            new[] { ("Issue3461.cs", source) },
+            references);
 
         Assert.True(
             project.BoundWithoutErrors,
@@ -198,4 +550,42 @@ public sealed class Issue3461IdentifierSanitizationTests
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
         return GSharpPrinter.Print(unit);
     }
+
+    private static IReadOnlyDictionary<string, string> RenderFiles(
+        params (string FileName, string Source)[] sources)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(sources);
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        var translator = new CSharpToGSharpTranslator();
+        return project.Documents.ToDictionary(
+            document => document.FilePath,
+            document =>
+            {
+                var context = new TranslationContext(
+                    project.Compilation,
+                    document.SemanticModel,
+                    document.FilePath);
+                return GSharpPrinter.Print(translator.TranslateDocument(document, context));
+            },
+            StringComparer.Ordinal);
+    }
+}
+
+/// <summary>Imported attribute fixture with reserved and colliding CLR names.</summary>
+public sealed class ReservedNamedAttribute : Attribute
+{
+    /// <summary>Initializes a new instance.</summary>
+    public ReservedNamedAttribute(string @params, string params_)
+    {
+    }
+
+    /// <summary>Gets or sets reserved-name data.</summary>
+    public string @type { get; set; }
+
+    /// <summary>Gets or sets colliding legal-name data.</summary>
+    public string type_ { get; set; }
 }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3461IdentifierSanitizationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3461IdentifierSanitizationTests.cs
@@ -248,7 +248,7 @@ public sealed class Issue3461IdentifierSanitizationTests
         Assert.Contains("func sizeof_()", rendered, StringComparison.Ordinal);
         Assert.Contains("func unchecked_()", rendered, StringComparison.Ordinal);
         Assert.Contains("func init_()", rendered, StringComparison.Ordinal);
-        Assert.Contains("func make_()", rendered, StringComparison.Ordinal);
+        Assert.Contains("func make()", rendered, StringComparison.Ordinal);
         Assert.Contains("names.nameof()", rendered, StringComparison.Ordinal);
         Assert.Contains("names.checked()", rendered, StringComparison.Ordinal);
         Assert.Contains("names.typeof()", rendered, StringComparison.Ordinal);
@@ -259,6 +259,213 @@ public sealed class Issue3461IdentifierSanitizationTests
         Assert.Contains("func init_()", rendered, StringComparison.Ordinal);
         Assert.DoesNotContain("func nameof_()", rendered, StringComparison.Ordinal);
         TranslationTestValidation.AssertBinds(rendered);
+    }
+
+    [Fact]
+    public void InterfaceContract_CollisionUsesOneAllocatedNameAtRuntime()
+    {
+        string rendered = Render(
+            """
+            public interface IValue
+            {
+                int @type();
+            }
+
+            public sealed class Value : IValue
+            {
+                public int type_() => 100;
+
+                public int @type() => 7;
+            }
+
+            public static class Holder
+            {
+                public static int Run()
+                {
+                    IValue value = new Value();
+                    return value.@type() + new Value().type_();
+                }
+            }
+            """);
+
+        Assert.Equal(
+            2,
+            rendered.Split("func type__()", StringSplitOptions.None).Length - 1);
+        Assert.Contains("func type_()", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+
+        var result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Holder.Run()");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(107, result.Value);
+    }
+
+    [Fact]
+    public void OverrideContract_CollisionUsesOneAllocatedNameAtRuntime()
+    {
+        string rendered = Render(
+            """
+            public class Base
+            {
+                public virtual int @type() => 1;
+            }
+
+            public sealed class Derived : Base
+            {
+                public int type_() => 200;
+
+                public override int @type() => 9;
+            }
+
+            public static class Holder
+            {
+                public static int Run()
+                {
+                    Base value = new Derived();
+                    return value.@type() + new Derived().type_();
+                }
+            }
+            """);
+
+        Assert.Equal(
+            2,
+            rendered.Split("func type__()", StringSplitOptions.None).Length - 1);
+        Assert.Contains("func type_()", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+
+        var result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Holder.Run()");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(209, result.Value);
+    }
+
+    [Fact]
+    public void ConsumerBeforeRecord_UsesPrecomputedPrimaryParameterName()
+    {
+        IReadOnlyDictionary<string, string> rendered = RenderFiles(
+            ("Consumer.cs", """
+                public static class Holder
+                {
+                    public static int Read(R value) => value.@params;
+                }
+                """),
+            ("Record.cs", """
+                public record R
+                {
+                    public int @params { get; set; } = 7;
+                }
+                """));
+
+        Assert.Contains(".params_", rendered["Consumer.cs"], StringComparison.Ordinal);
+        Assert.Contains("data class R(params_", rendered["Record.cs"], StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered.Values.ToArray());
+    }
+
+    [Fact]
+    public void GenericBaseAndStackallocNames_AreAllocated()
+    {
+        string rendered = Render(
+            """
+            public class @base<T> { }
+            public class @stackalloc<T> { }
+
+            public static class CallHolder
+            {
+                private static T @base<T>(T value) => value;
+                private static T @stackalloc<T>(T value) => value;
+
+                public static int Run()
+                {
+                    return @base<int>(1) + @stackalloc<int>(2);
+                }
+            }
+
+            public static class CreateHolder
+            {
+                public static void Run()
+                {
+                    _ = new @base<int>();
+                    _ = new @stackalloc<int>();
+                }
+            }
+            """);
+
+        Assert.Contains("class base_", rendered, StringComparison.Ordinal);
+        Assert.Contains("class stackalloc_", rendered, StringComparison.Ordinal);
+        Assert.Contains("func base_[T]", rendered, StringComparison.Ordinal);
+        Assert.Contains("func stackalloc_[T]", rendered, StringComparison.Ordinal);
+        Assert.Contains("base_[int32](1)", rendered, StringComparison.Ordinal);
+        Assert.Contains("stackalloc_[int32](2)", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+
+    [Fact]
+    public void SourceExtensionNamespace_UsesAllocatedImport()
+    {
+        IReadOnlyDictionary<string, string> rendered = RenderFiles(
+            ("GlobalUsings.cs", "global using @class;"),
+            ("Extensions.cs", """
+                namespace @class;
+
+                public static class Extensions
+                {
+                    public static int CountLetters(this string value) => value.Length;
+                }
+                """),
+            ("Consumer.cs", """
+                namespace Consumer;
+
+                public static class Holder
+                {
+                    public static int Run() => "abc".CountLetters();
+                }
+                """));
+
+        Assert.Contains("package class_", rendered["Extensions.cs"], StringComparison.Ordinal);
+        Assert.Contains("import class_", rendered["Consumer.cs"], StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered.Values.ToArray());
+    }
+
+    [Fact]
+    public void ImportedClrMemberCollisionsAndMake_PreserveMetadataIdentityAtRuntime()
+    {
+        string fixtureAssembly = typeof(ImportedIdentifierFields).Assembly.Location;
+        IReadOnlyList<MetadataReference> references = CSharpProjectLoader.RuntimeReferences()
+            .Append(MetadataReference.CreateFromFile(fixtureAssembly))
+            .ToArray();
+        string rendered = Render(
+            """
+            using Cs2Gs.Tests;
+
+            public static class Holder
+            {
+                public static int Run()
+                {
+                    var fields = new ImportedIdentifierFields();
+                    var properties = new ImportedIdentifierProperties();
+                    var methods = new ImportedIdentifierMethods();
+                    return fields.@type + fields.type_ +
+                        properties.@type + properties.type_ +
+                        methods.@type() + methods.type_() + methods.@make();
+                }
+            }
+            """,
+            references);
+
+        Assert.Contains("fields.type__", rendered, StringComparison.Ordinal);
+        Assert.Contains("fields.type_", rendered, StringComparison.Ordinal);
+        Assert.Contains("properties.type__", rendered, StringComparison.Ordinal);
+        Assert.Contains("methods.type__()", rendered, StringComparison.Ordinal);
+        Assert.Contains("methods.make()", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("methods.make_()", rendered, StringComparison.Ordinal);
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { fixtureAssembly });
+        TranslationTestValidation.AssertBinds(resolver, rendered);
+        var result = EmittedOracle.Evaluate(
+            new[] { rendered + Environment.NewLine + "Holder.Run()" },
+            new EmittedOracleOptions { References = new[] { fixtureAssembly } });
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(54, result.Value);
     }
 
     [Fact]
@@ -588,4 +795,37 @@ public sealed class ReservedNamedAttribute : Attribute
 
     /// <summary>Gets or sets colliding legal-name data.</summary>
     public string type_ { get; set; }
+}
+
+/// <summary>Imported CLR field fixture with colliding names.</summary>
+public sealed class ImportedIdentifierFields
+{
+    /// <summary>Reserved-name field.</summary>
+    public int @type = 3;
+
+    /// <summary>Legal colliding field.</summary>
+    public int type_ = 5;
+}
+
+/// <summary>Imported CLR property fixture with colliding names.</summary>
+public sealed class ImportedIdentifierProperties
+{
+    /// <summary>Reserved-name property.</summary>
+    public int @type => 7;
+
+    /// <summary>Legal colliding property.</summary>
+    public int type_ => 11;
+}
+
+/// <summary>Imported CLR method fixture with colliding and contextual names.</summary>
+public sealed class ImportedIdentifierMethods
+{
+    /// <summary>Reserved-name method.</summary>
+    public int @type() => 13;
+
+    /// <summary>Legal colliding method.</summary>
+    public int type_() => 15;
+
+    /// <summary>Contextual method name legal after member access.</summary>
+    public int @make() => 0;
 }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3461IdentifierSanitizationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3461IdentifierSanitizationTests.cs
@@ -436,6 +436,77 @@ public sealed class Issue3461IdentifierSanitizationTests
     }
 
     [Fact]
+    public void LexicalNames_ReserveVisibleInstanceAndStaticMembers()
+    {
+        string rendered = Render(
+            """
+            public sealed class InstanceNames
+            {
+                public int params_ = 100;
+
+                public int type_ => 200;
+
+                public int Run(int @params)
+                {
+                    int @type = 7;
+                    return @params + this.params_ + @type + this.type_;
+                }
+            }
+
+            public static class StaticNames
+            {
+                public static int params_ = 1000;
+
+                public static int Run(int @params) => @params + params_;
+            }
+
+            public static class Holder
+            {
+                public static int Run() =>
+                    new InstanceNames().Run(3) + StaticNames.Run(5);
+            }
+            """);
+
+        Assert.Contains("Run(params__ int32)", rendered, StringComparison.Ordinal);
+        Assert.Contains("let type__ = 7", rendered, StringComparison.Ordinal);
+        Assert.Contains("params__ + this.params_", rendered, StringComparison.Ordinal);
+        Assert.Contains("type__ + this.type_", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+
+        var result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Holder.Run()");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(1315, result.Value);
+    }
+
+    [Fact]
+    public void MethodTypeParameters_ReserveContainingTypeParameters()
+    {
+        string rendered = Render(
+            """
+            public sealed class C<type_>
+            {
+                public @type Echo<@type>(type_ outer, @type inner) => inner;
+            }
+
+            public static class Holder
+            {
+                public static string Run() => new C<int>().Echo<string>(1, "ok");
+            }
+            """);
+
+        Assert.Contains("class C[type_]", rendered, StringComparison.Ordinal);
+        Assert.Contains("Echo[type__](outer type_, inner type__)", rendered, StringComparison.Ordinal);
+        Assert.Contains("Echo[string](1, \"ok\")", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+
+        var result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Holder.Run()");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("ok", result.Value);
+    }
+
+    [Fact]
     public void ConsumerBeforeRecord_UsesPrecomputedPrimaryParameterName()
     {
         IReadOnlyDictionary<string, string> rendered = RenderFiles(
@@ -578,7 +649,8 @@ public sealed class Issue3461IdentifierSanitizationTests
             public static class Holder
             {
                 public static int Run() =>
-                    @nameof() + @typeof() + @sizeof() + @checked() + @unchecked();
+                    @nameof() + @typeof() + @sizeof() + @checked() + @unchecked() +
+                    @base<int>(1) + @stackalloc<int>(2) + @nameof<int>(4);
             }
             """,
             references);
@@ -588,6 +660,9 @@ public sealed class Issue3461IdentifierSanitizationTests
         Assert.Contains("ImportedContextualStatics.sizeof()", rendered, StringComparison.Ordinal);
         Assert.Contains("ImportedContextualStatics.checked()", rendered, StringComparison.Ordinal);
         Assert.Contains("ImportedContextualStatics.unchecked()", rendered, StringComparison.Ordinal);
+        Assert.Contains("ImportedContextualStatics.base[int32](1)", rendered, StringComparison.Ordinal);
+        Assert.Contains("ImportedContextualStatics.stackalloc[int32](2)", rendered, StringComparison.Ordinal);
+        Assert.Contains("ImportedContextualStatics.nameof[int32](4)", rendered, StringComparison.Ordinal);
         Assert.DoesNotContain("func nameof", rendered, StringComparison.Ordinal);
 
         using var resolver = ReferenceResolver.WithReferences(new[] { fixtureAssembly });
@@ -596,7 +671,7 @@ public sealed class Issue3461IdentifierSanitizationTests
             new[] { rendered + Environment.NewLine + "Holder.Run()" },
             new EmittedOracleOptions { References = new[] { fixtureAssembly } });
         Assert.Empty(result.Diagnostics);
-        Assert.Equal(31, result.Value);
+        Assert.Equal(38, result.Value);
     }
 
     [Fact]
@@ -1009,4 +1084,13 @@ public static class ImportedContextualStatics
 
     /// <summary>Returns sixteen.</summary>
     public static int @unchecked() => 16;
+
+    /// <summary>Returns generic value.</summary>
+    public static T @base<T>(T value) => value;
+
+    /// <summary>Returns generic value.</summary>
+    public static T @stackalloc<T>(T value) => value;
+
+    /// <summary>Returns generic value.</summary>
+    public static T @nameof<T>(T value) => value;
 }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3461ReservedMetadataFixtures.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3461ReservedMetadataFixtures.cs
@@ -1,0 +1,28 @@
+// <copyright file="Issue3461ReservedMetadataFixtures.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace @class
+{
+    /// <summary>Imported reserved-name type.</summary>
+    public sealed class @type
+    {
+        /// <summary>Gets fixture value.</summary>
+        public int Value => 19;
+    }
+
+    /// <summary>Imported legal colliding type.</summary>
+    public sealed class type_
+    {
+        /// <summary>Gets fixture value.</summary>
+        public int Value => 23;
+    }
+}
+
+namespace class_
+{
+    /// <summary>Legal colliding namespace marker.</summary>
+    public sealed class Marker
+    {
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3461ReservedMetadataFixtures.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3461ReservedMetadataFixtures.cs
@@ -26,3 +26,11 @@ namespace class_
     {
     }
 }
+
+namespace ImportedVisible
+{
+    /// <summary>Imported namespace-visible type used by generic scope tests.</summary>
+    public sealed class type_
+    {
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/TranslationTestValidation.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/TranslationTestValidation.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using Cs2Gs.CodeModel.RoundTrip;
 using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
 using Xunit;
@@ -24,6 +25,17 @@ internal static class TranslationTestValidation
     /// <param name="sources">One or more emitted G# source files.</param>
     /// <returns>The first source's round-trip result for callers that retain detailed parse assertions.</returns>
     public static RoundTripResult AssertBinds(params string[] sources)
+        => AssertBinds(references: null, sources);
+
+    /// <summary>
+    /// Asserts that emitted G# parses and binds against explicit CLR references.
+    /// </summary>
+    /// <param name="references">CLR references available to binding.</param>
+    /// <param name="sources">One or more emitted G# source files.</param>
+    /// <returns>The first source's round-trip result.</returns>
+    public static RoundTripResult AssertBinds(
+        ReferenceResolver references,
+        params string[] sources)
     {
         Assert.NotNull(sources);
         Assert.NotEmpty(sources);
@@ -40,7 +52,10 @@ internal static class TranslationTestValidation
             return SyntaxTree.Parse(SourceText.From(source));
         }).ToImmutableArray();
 
-        BoundGlobalScope scope = Binder.BindGlobalScope(previous: null, trees);
+        BoundGlobalScope scope = Binder.BindGlobalScope(
+            previous: null,
+            trees,
+            references);
         var errors = scope.Diagnostics
             .Concat(Binder.BindProgram(scope).Diagnostics)
             .Where(diagnostic => diagnostic.IsError)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
@@ -15,6 +15,8 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Text;
+using GSharpIdentifierNameContext = GSharp.Core.CodeAnalysis.Syntax.IdentifierNameContext;
+using GSharpSyntaxFacts = GSharp.Core.CodeAnalysis.Syntax.SyntaxFacts;
 
 namespace Cs2Gs.Translator;
 
@@ -397,7 +399,7 @@ public sealed partial class CSharpToGSharpTranslator
                 IParameterSymbol parameter = argument.NameColon == null
                     ? constructor.Parameters[i]
                     : constructor.Parameters.FirstOrDefault(candidate =>
-                        candidate.Name == argument.NameColon.Name.Identifier.Text);
+                        candidate.Name == argument.NameColon.Name.Identifier.ValueText);
                 if (parameter == null || !explicitArguments.TryAdd(parameter.Ordinal, argument))
                 {
                     this.context.ReportUnsupported(
@@ -723,7 +725,7 @@ public sealed partial class CSharpToGSharpTranslator
                 _ => Variance.None,
             };
 
-            return new TypeParameter(SanitizeIdentifier(tp.Name), legacy, flags, variance);
+            return new TypeParameter(this.EmittedName(tp, tp.Name), legacy, flags, variance);
         }
 
         // Issue #1909: `TypeDeclarationSyntax.ParameterList` carries a primary
@@ -889,11 +891,11 @@ public sealed partial class CSharpToGSharpTranslator
             return new Parameter(MapParameterName(symbol, fallbackNode), type, variadic, refKind, defaultValue, attributes);
         }
 
-        private static string MapParameterName(IParameterSymbol symbol, SyntaxNode fallbackNode)
+        private string MapParameterName(IParameterSymbol symbol, SyntaxNode fallbackNode)
         {
             if (symbol.Name != "_" || fallbackNode is not ParameterSyntax underscoreParameter)
             {
-                return SanitizeIdentifier(symbol.Name);
+                return this.EmittedName(symbol, symbol.Name);
             }
 
             int underscoreCount = underscoreParameter.Parent is ParameterListSyntax parameterList
@@ -1091,19 +1093,28 @@ public sealed partial class CSharpToGSharpTranslator
                 foreach (AttributeSyntax attribute in list.Attributes)
                 {
                     using IDisposable modelScope = this.context.UseSemanticModelFor(attribute.SyntaxTree);
+                    this.ResolveAttributeType(
+                        attribute,
+                        out INamedTypeSymbol attributeType,
+                        out IAliasSymbol sourceAlias);
+                    this.typeMapper.TrackAttributeType(attributeType, sourceAlias);
                     var arguments = new List<AttributeArgument>();
                     if (attribute.ArgumentList != null)
                     {
                         foreach (AttributeArgumentSyntax argument in attribute.ArgumentList.Arguments)
                         {
                             GExpression value = this.MapAttributeArgumentValue(argument);
-                            string name = argument.NameEquals?.Name.Identifier.Text
-                                ?? argument.NameColon?.Name.Identifier.Text;
+                            string name = this.TranslateAttributeArgumentName(
+                                argument,
+                                attributeType);
                             arguments.Add(new AttributeArgument(value, name));
                         }
                     }
 
-                    string attributeName = this.TranslateAttributeName(attribute);
+                    string attributeName = this.TranslateAttributeName(
+                        attribute,
+                        attributeType,
+                        sourceAlias);
 
                     attributes.Add(new AttributeUse(attributeName, arguments, target));
                 }
@@ -1115,56 +1126,160 @@ public sealed partial class CSharpToGSharpTranslator
         // Issue #3445: resolve attributes semantically so their containing
         // namespaces and aliases participate in synthesized imports, while
         // retaining source qualification and Attribute-suffix spelling.
-        private string TranslateAttributeName(AttributeSyntax attribute)
+        private void ResolveAttributeType(
+            AttributeSyntax attribute,
+            out INamedTypeSymbol attributeType,
+            out IAliasSymbol sourceAlias)
         {
             ISymbol symbol = this.context.GetSymbolInfo(attribute).Symbol
                 ?? this.context.GetSymbolInfo(attribute.Name).Symbol;
-            INamedTypeSymbol attributeType = symbol switch
+            attributeType = symbol switch
             {
                 IMethodSymbol constructor => constructor.ContainingType,
                 INamedTypeSymbol namedType => namedType,
                 IAliasSymbol aliasSymbol => aliasSymbol.Target as INamedTypeSymbol,
                 _ => null,
             };
-            IAliasSymbol sourceAlias = attribute.Name
+            sourceAlias = attribute.Name
                 .DescendantNodesAndSelf()
                 .OfType<IdentifierNameSyntax>()
                 .Select(identifier => this.context.SemanticModel.GetAliasInfo(identifier))
                 .FirstOrDefault(candidate => candidate != null);
-            this.typeMapper.TrackAttributeType(attributeType, sourceAlias);
-            return this.TranslateUnresolvedAttributeName(attribute.Name);
         }
 
-        // Issue #1913: convert C# generic attribute angle brackets to G# square
-        // brackets while retaining the source name and qualification.
-        private string TranslateUnresolvedAttributeName(NameSyntax nameSyntax)
+        private string TranslateAttributeName(
+            AttributeSyntax attribute,
+            INamedTypeSymbol attributeType,
+            IAliasSymbol sourceAlias) =>
+            this.TranslateAttributeNameSyntax(
+                attribute.Name,
+                attributeType,
+                sourceAlias,
+                isRightmost: true);
+
+        private string TranslateAttributeNameSyntax(
+            NameSyntax nameSyntax,
+            INamedTypeSymbol attributeType,
+            IAliasSymbol sourceAlias,
+            bool isRightmost)
         {
-            string attributeName = nameSyntax.ToString();
-            int aliasSeparator = attributeName.IndexOf("::", System.StringComparison.Ordinal);
-            if (aliasSeparator >= 0)
+            switch (nameSyntax)
             {
-                // Strip a `global::` (or extern-alias) qualifier; G# has no
-                // alias-qualified name syntax.
-                attributeName = attributeName.Substring(aliasSeparator + 2);
+                case QualifiedNameSyntax qualified:
+                    return this.TranslateAttributeNameSyntax(
+                            qualified.Left,
+                            attributeType,
+                            sourceAlias,
+                            isRightmost: false)
+                        + "."
+                        + this.TranslateAttributeNameSyntax(
+                            qualified.Right,
+                            attributeType,
+                            sourceAlias,
+                            isRightmost);
+
+                case AliasQualifiedNameSyntax aliasQualified:
+                    string alias = aliasQualified.Alias.Identifier.ValueText == "global"
+                        ? null
+                        : this.EmittedName(
+                            sourceAlias,
+                            aliasQualified.Alias.Identifier.ValueText,
+                            GSharpIdentifierNameContext.Type);
+                    string aliasedName = this.TranslateAttributeNameSyntax(
+                        aliasQualified.Name,
+                        attributeType,
+                        sourceAlias,
+                        isRightmost);
+                    return alias is null ? aliasedName : alias + "." + aliasedName;
+
+                case GenericNameSyntax generic:
+                    string genericName = this.TranslateAttributeSimpleName(
+                        generic.Identifier,
+                        generic,
+                        attributeType,
+                        sourceAlias,
+                        isRightmost);
+                    IReadOnlyList<GTypeReference> typeArguments = this.MapTypeArguments(generic);
+                    return $"{genericName}[{string.Join(", ", typeArguments.Select(GSharpPrinter.RenderTypeReference))}]";
+
+                case IdentifierNameSyntax identifier:
+                    return this.TranslateAttributeSimpleName(
+                        identifier.Identifier,
+                        identifier,
+                        attributeType,
+                        sourceAlias,
+                        isRightmost);
+
+                default:
+                    return nameSyntax.ToString();
+            }
+        }
+
+        private string TranslateAttributeSimpleName(
+            SyntaxToken identifier,
+            SimpleNameSyntax syntax,
+            INamedTypeSymbol attributeType,
+            IAliasSymbol sourceAlias,
+            bool isRightmost)
+        {
+            string sourceName = identifier.ValueText;
+            IAliasSymbol alias = this.context.SemanticModel.GetAliasInfo(syntax);
+            if (alias != null)
+            {
+                return this.EmittedName(
+                    alias,
+                    sourceName,
+                    GSharpIdentifierNameContext.Type);
             }
 
-            GenericNameSyntax generic = nameSyntax switch
+            if (isRightmost
+                && attributeType != null
+                && attributeType.Name == sourceName + "Attribute"
+                && !GSharpSyntaxFacts.IsReservedIdentifier(
+                    sourceName,
+                    GSharpIdentifierNameContext.Type))
             {
-                GenericNameSyntax g => g,
-                QualifiedNameSyntax { Right: GenericNameSyntax g } => g,
-                AliasQualifiedNameSyntax { Name: GenericNameSyntax g } => g,
-                _ => null,
-            };
-
-            if (generic == null)
-            {
-                return attributeName;
+                return sourceName;
             }
 
-            IReadOnlyList<GTypeReference> typeArguments = this.MapTypeArguments(generic);
-            string baseName = attributeName.Substring(0, attributeName.IndexOf('<'));
-            string typeArgumentList = string.Join(", ", typeArguments.Select(GSharpPrinter.RenderTypeReference));
-            return $"{baseName}[{typeArgumentList}]";
+            ISymbol symbol = this.context.GetSymbolInfo(syntax).Symbol;
+            if (isRightmost && attributeType != null)
+            {
+                symbol = attributeType;
+            }
+
+            return this.EmittedName(
+                symbol ?? sourceAlias,
+                sourceName,
+                GSharpIdentifierNameContext.Type);
+        }
+
+        private string TranslateAttributeArgumentName(
+            AttributeArgumentSyntax argument,
+            INamedTypeSymbol attributeType)
+        {
+            SimpleNameSyntax nameSyntax = argument.NameEquals?.Name
+                ?? argument.NameColon?.Name;
+            if (nameSyntax == null)
+            {
+                return null;
+            }
+
+            string sourceName = nameSyntax.Identifier.ValueText;
+            ISymbol symbol = this.context.GetSymbolInfo(nameSyntax).Symbol;
+            GSharpIdentifierNameContext nameContext = argument.NameColon != null
+                ? GSharpIdentifierNameContext.Parameter
+                : GSharpIdentifierNameContext.General;
+            if (symbol == null && attributeType != null)
+            {
+                symbol = argument.NameColon != null
+                    ? attributeType.InstanceConstructors
+                        .SelectMany(constructor => constructor.Parameters)
+                        .FirstOrDefault(parameter => parameter.Name == sourceName)
+                    : attributeType.GetMembers(sourceName).FirstOrDefault();
+            }
+
+            return this.EmittedName(symbol, sourceName, nameContext);
         }
 
         // Issue #1731 N1: attribute-argument expressions here can never be an
@@ -1784,8 +1899,10 @@ public sealed partial class CSharpToGSharpTranslator
                     continue;
                 }
 
-                string ownerName = SanitizeIdentifier(pair.Symbol.ContainingSymbol?.Name ?? "scope");
-                string localName = SanitizeIdentifier(pair.Syntax.Identifier.Text);
+                string ownerName = this.EmittedName(
+                    pair.Symbol.ContainingSymbol,
+                    pair.Symbol.ContainingSymbol?.Name ?? "scope");
+                string localName = this.EmittedName(pair.Symbol, pair.Syntax.Identifier.ValueText);
                 this.state.LiftedStaticLocalFunctions[pair.Symbol] =
                     $"__local_{ownerName}_{localName}_{pair.Syntax.SpanStart}";
             }
@@ -1890,8 +2007,10 @@ public sealed partial class CSharpToGSharpTranslator
                     containingMethod = containingMethod.ContainingSymbol as IMethodSymbol;
                 }
 
-                string ownerName = SanitizeIdentifier(pair.Symbol.ContainingSymbol?.Name ?? "scope");
-                string localName = SanitizeIdentifier(pair.Syntax.Identifier.Text);
+                string ownerName = this.EmittedName(
+                    pair.Symbol.ContainingSymbol,
+                    pair.Symbol.ContainingSymbol?.Name ?? "scope");
+                string localName = this.EmittedName(pair.Symbol, pair.Syntax.Identifier.ValueText);
                 this.state.LiftedRecursiveLocalFunctions[pair.Symbol] =
                     new LiftedRecursiveLocalFunction(
                         $"__local_{ownerName}_{localName}_{pair.Syntax.SpanStart}",
@@ -2077,7 +2196,7 @@ public sealed partial class CSharpToGSharpTranslator
                         }
                     }
 
-                    string name = SanitizeIdentifier(syntax.Identifier.Text);
+                    string name = this.EmittedName(symbol, syntax.Identifier.ValueText);
                     members.Add(symbol);
                     names.Add(name);
                     declarations.Add(new LocalDeclarationStatement(
@@ -2192,7 +2311,7 @@ public sealed partial class CSharpToGSharpTranslator
                     bool usedHere = statements[i]
                         .DescendantNodes()
                         .OfType<IdentifierNameSyntax>()
-                        .Any(id => id.Identifier.Text == localFunction.Identifier.Text
+                        .Any(id => id.Identifier.ValueText == localFunction.Identifier.ValueText
                             && SymbolEqualityComparer.Default.Equals(
                                 this.context.GetSymbolInfo(id).Symbol, funcSymbol));
                     if (usedHere)
@@ -2326,7 +2445,7 @@ public sealed partial class CSharpToGSharpTranslator
                 body = new BlockStatement(new GStatement[]
                 {
                     new FixedStatement(
-                        SanitizeIdentifier(declarator.Identifier.Text),
+                        this.EmittedName(declarator, declarator.Identifier),
                         pointerType,
                         source,
                         body),
@@ -2548,7 +2667,9 @@ public sealed partial class CSharpToGSharpTranslator
                     // lowers to G#'s async-iteration form `await for x in seq`
                     // (spec AwaitForRangeStmt). Without it, iterating an
                     // `IAsyncEnumerable<T>` with a plain `for` is rejected (GS0116).
-                    string loopIdentifier = SanitizeIdentifier(forEach.Identifier.Text);
+                    string loopIdentifier = this.EmittedName(
+                        this.context.GetDeclaredSymbol(forEach),
+                        forEach.Identifier.ValueText);
                     BlockStatement loopBody = this.TranslateStatementAsBlock(forEach.Statement);
                     Conversion elementConversion = this.context.SemanticModel
                         .GetForEachStatementInfo(forEach)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.ControlFlow.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.ControlFlow.cs
@@ -375,7 +375,7 @@ public sealed partial class CSharpToGSharpTranslator
             // synthetic name is used.
             ILocalSymbol mainBinder = this.FindMainPatternBinder(isPattern.Pattern);
             string hoistName = mainBinder != null
-                ? SanitizeIdentifier(mainBinder.Name)
+                ? this.EmittedName(mainBinder, mainBinder.Name)
                 : $"__scrutinee{this.state.LoopHoistCounter++}";
 
             BindingKind binding = mainBinder != null && this.IsLocalReassigned(mainBinder)
@@ -614,7 +614,7 @@ public sealed partial class CSharpToGSharpTranslator
             }
 
             GTypeReference targetType = this.MapTypeSyntax(typeSyntax);
-            string localName = SanitizeIdentifier(single.Identifier.Text);
+            string localName = this.EmittedName(single, single.Identifier);
             GExpression receiver = this.TranslateExpression(isPattern.Expression);
 
             if (targetSymbol.IsValueType)
@@ -956,7 +956,7 @@ public sealed partial class CSharpToGSharpTranslator
                 return false;
             }
 
-            string localName = SanitizeIdentifier(single.Identifier.Text);
+            string localName = this.EmittedName(single, single.Identifier);
             GExpression receiver = this.TranslateExpression(isPattern.Expression);
             GExpression hoistInitializer;
             GTypeReference targetType;
@@ -1171,7 +1171,7 @@ public sealed partial class CSharpToGSharpTranslator
                 && binder.Type is { TypeKind: not TypeKind.Error, IsRefLikeType: false }
                 && !CSharpTypeMapper.IsSystemIndexOrRange(binder.Type))
             {
-                string mutableName = SanitizeIdentifier(designation.Identifier.Text);
+                string mutableName = this.EmittedName(designation, designation.Identifier);
                 string matchName = FreshPatternMatchName(
                     mutableName,
                     this.state.CurrentBodyScope ?? ifStatement);
@@ -1256,7 +1256,7 @@ public sealed partial class CSharpToGSharpTranslator
                 return false;
             }
 
-            string localName = SanitizeIdentifier(designation.Identifier.Text);
+            string localName = this.EmittedName(designation, designation.Identifier);
             GTypeReference localType = MakeNullable(
                 this.typeMapper.Map(
                     binder.Type,
@@ -1314,7 +1314,7 @@ public sealed partial class CSharpToGSharpTranslator
                     return false;
                 }
 
-                string localName = SanitizeIdentifier(single.Identifier.Text);
+                string localName = this.EmittedName(single, single.Identifier);
                 GExpression receiver = this.TranslateExpression(isPattern.Expression);
                 GExpression initializer;
                 GTypeReference targetType;

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Declarations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Declarations.cs
@@ -15,7 +15,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Text;
-using GSharpSyntaxFacts = GSharp.Core.CodeAnalysis.Syntax.SyntaxFacts;
+using GSharpIdentifierNameContext = GSharp.Core.CodeAnalysis.Syntax.IdentifierNameContext;
 
 namespace Cs2Gs.Translator;
 
@@ -69,6 +69,7 @@ public sealed partial class CSharpToGSharpTranslator
             int nextOrdinal = 0;
             foreach (EnumMemberDeclarationSyntax member in node.Members)
             {
+                ISymbol memberSymbol = this.context.GetDeclaredSymbol(member);
                 int? explicitValue = null;
                 if (this.context.GetDeclaredSymbol(member) is IFieldSymbol { HasConstantValue: true } fieldSymbol)
                 {
@@ -102,7 +103,8 @@ public sealed partial class CSharpToGSharpTranslator
                             member.GetLocation(),
                             TranslationSeverity.Info));
                         nextOrdinal++;
-                        cases.Add(new EnumCase(SanitizeIdentifier(member.Identifier.Text)));
+                        cases.Add(new EnumCase(
+                            this.EmittedName(memberSymbol, member.Identifier.ValueText)));
                         continue;
                     }
 
@@ -119,11 +121,13 @@ public sealed partial class CSharpToGSharpTranslator
                     nextOrdinal++;
                 }
 
-                cases.Add(new EnumCase(SanitizeIdentifier(member.Identifier.Text), explicitValue: explicitValue));
+                cases.Add(new EnumCase(
+                    this.EmittedName(memberSymbol, member.Identifier.ValueText),
+                    explicitValue: explicitValue));
             }
 
             return new EnumDeclaration(
-                SanitizeIdentifier(node.Identifier.Text),
+                this.EmittedName(symbol, node.Identifier.ValueText),
                 cases,
                 MapVisibility(symbol, this.context, node, preserveStaticClassPrivate: true),
                 attributes: this.MapAttributes(node.AttributeLists));
@@ -302,11 +306,7 @@ public sealed partial class CSharpToGSharpTranslator
 
         // G# keywords and parser-reserved declaration spellings come from the
         // compiler's canonical SyntaxFacts source.
-        // Internal (not private) so the outer <see cref="CSharpToGSharpTranslator"/>
-        // forwarding method can expose it to <see cref="CSharpTypeMapper"/>, which
-        // routes type-name references through this exact sanitizer too (issue
-        // #1734).
-        internal static string SanitizeIdentifier(string name)
+        private string SanitizeIdentifier(string name)
         {
             if (string.IsNullOrEmpty(name))
             {
@@ -322,9 +322,25 @@ public sealed partial class CSharpToGSharpTranslator
                 name = name.Substring(1);
             }
 
-            string unsuffixed = name.TrimEnd('_');
-            return GSharpSyntaxFacts.IsReservedIdentifier(unsuffixed) ? name + "_" : name;
+            return this.nameAllocator.GetName(name);
         }
+
+        private string EmittedName(
+            ISymbol symbol,
+            string fallbackName,
+            GSharpIdentifierNameContext context = GSharpIdentifierNameContext.General) =>
+            symbol is null
+                ? this.nameAllocator.GetName(fallbackName, context)
+                : this.nameAllocator.GetName(symbol, context);
+
+        private string EmittedName(
+            SyntaxNode node,
+            SyntaxToken token,
+            GSharpIdentifierNameContext context = GSharpIdentifierNameContext.General) =>
+            this.EmittedName(
+                this.context.GetDeclaredSymbol(node) ?? this.context.GetSymbolInfo(node).Symbol,
+                token.ValueText,
+                context);
 
         // Issue #2382: whether `localFunction` — declared among the top-level
         // statements — captures NOTHING from its top-level-statement siblings
@@ -407,7 +423,7 @@ public sealed partial class CSharpToGSharpTranslator
             // canonical form" gap (issue #1900) that still applies to a
             // captured/non-hoisted local function.
             return new MethodDeclaration(
-                SanitizeIdentifier(localFunction.Identifier.Text),
+                this.EmittedName(symbol, localFunction.Identifier.ValueText),
                 parameters,
                 returnType,
                 body,
@@ -737,7 +753,7 @@ public sealed partial class CSharpToGSharpTranslator
                 }
 
                 result.Add((
-                    SanitizeIdentifier(prop.Identifier.Text),
+                    this.EmittedName(symbol, prop.Identifier.ValueText),
                     this.TranslateNullSeamExpression(prop.Initializer.Value)));
             }
 
@@ -882,7 +898,7 @@ public sealed partial class CSharpToGSharpTranslator
 
             string enumTypeName = this.typeMapper.Map(namedEnum, this.context, node?.GetLocation()) is NamedTypeReference typeRef
                 ? typeRef.Name
-                : SanitizeIdentifier(namedEnum.Name);
+                : this.EmittedName(namedEnum, namedEnum.Name);
 
             // Issue #1733 N2: comparing/decomposing the constant as `long` throws
             // `OverflowException` (crashing the translator on otherwise-valid input)
@@ -906,7 +922,9 @@ public sealed partial class CSharpToGSharpTranslator
             {
                 if (ToEnumBitPattern(member.ConstantValue, underlyingType) == target)
                 {
-                    return new MemberAccessExpression(new IdentifierExpression(enumTypeName), SanitizeIdentifier(member.Name));
+                    return new MemberAccessExpression(
+                        new IdentifierExpression(enumTypeName),
+                        this.EmittedName(member, member.Name));
                 }
             }
 
@@ -925,7 +943,9 @@ public sealed partial class CSharpToGSharpTranslator
                         continue;
                     }
 
-                    GExpression memberExpr = new MemberAccessExpression(new IdentifierExpression(enumTypeName), SanitizeIdentifier(member.Name));
+                    GExpression memberExpr = new MemberAccessExpression(
+                        new IdentifierExpression(enumTypeName),
+                        this.EmittedName(member, member.Name));
                     combined = combined == null ? memberExpr : new BinaryExpression(combined, "|", memberExpr);
                     remaining &= ~memberValue;
                 }
@@ -1378,7 +1398,7 @@ public sealed partial class CSharpToGSharpTranslator
 
             return new TypeDeclaration(
                 kind.Value,
-                SanitizeIdentifier(node.Identifier.Text),
+                this.EmittedName(symbol, node.Identifier.ValueText),
                 typeParameters: typeParameters,
                 primaryConstructorParameters: primaryCtor,
                 baseType: baseType,
@@ -1518,7 +1538,13 @@ public sealed partial class CSharpToGSharpTranslator
                     ? this.TranslateExpression(prop.Initializer.Value)
                     : new DefaultValueExpression(type);
 
-                primaryParameters.Add(new Parameter(SanitizeIdentifier(prop.Identifier.Text), type, defaultValue: defaultValue));
+                primaryParameters.Add(new Parameter(
+                    this.EmittedName(
+                        propSymbol,
+                        prop.Identifier.ValueText,
+                        GSharpIdentifierNameContext.Parameter),
+                    type,
+                    defaultValue: defaultValue));
                 propertiesAsParams.Add(propSymbol);
             }
 
@@ -1774,7 +1800,15 @@ public sealed partial class CSharpToGSharpTranslator
                 type = this.PromoteIfUsedAsNullable(type, param);
                 type = this.PromoteDelegateParameterInvokedWithNull(type, param);
                 GExpression liftedDefault = this.BuildOptionalParameterDefault(param, type, node);
-                primaryParameters.Add(new Parameter(SanitizeIdentifier(target.Name), type, defaultValue: liftedDefault));
+                ISymbol targetSymbol = target.Property
+                    ?? ctorSymbol.ContainingType.GetMembers(target.Name).FirstOrDefault();
+                primaryParameters.Add(new Parameter(
+                    this.EmittedName(
+                        targetSymbol,
+                        target.Name,
+                        GSharpIdentifierNameContext.Parameter),
+                    type,
+                    defaultValue: liftedDefault));
                 if (target.Property != null)
                 {
                     propertiesAsParams.Add(target.Property);

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Declarations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Declarations.cs
@@ -15,6 +15,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Text;
+using GSharpSyntaxFacts = GSharp.Core.CodeAnalysis.Syntax.SyntaxFacts;
 
 namespace Cs2Gs.Translator;
 
@@ -299,9 +300,8 @@ public sealed partial class CSharpToGSharpTranslator
             return (funcs, statements);
         }
 
-        // The set of hard G# keywords (Cs2Gs.Compiler SyntaxFacts.GetKeywordKind).
-        // A C# identifier that collides with one of these cannot be emitted bare; it
-        // is suffixed with `_` consistently at every declaration and reference site.
+        // G# keywords and parser-reserved declaration spellings come from the
+        // compiler's canonical SyntaxFacts source.
         // Internal (not private) so the outer <see cref="CSharpToGSharpTranslator"/>
         // forwarding method can expose it to <see cref="CSharpTypeMapper"/>, which
         // routes type-name references through this exact sanitizer too (issue
@@ -322,7 +322,8 @@ public sealed partial class CSharpToGSharpTranslator
                 name = name.Substring(1);
             }
 
-            return GSharpReservedWords.Contains(name) ? name + "_" : name;
+            string unsuffixed = name.TrimEnd('_');
+            return GSharpSyntaxFacts.IsReservedIdentifier(unsuffixed) ? name + "_" : name;
         }
 
         // Issue #2382: whether `localFunction` — declared among the top-level

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Declarations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Declarations.cs
@@ -328,10 +328,41 @@ public sealed partial class CSharpToGSharpTranslator
         private string EmittedName(
             ISymbol symbol,
             string fallbackName,
-            GSharpIdentifierNameContext context = GSharpIdentifierNameContext.General) =>
-            symbol is null
-                ? this.nameAllocator.GetName(fallbackName, context)
-                : this.nameAllocator.GetName(symbol, context);
+            GSharpIdentifierNameContext context = GSharpIdentifierNameContext.General)
+        {
+            if (symbol is null)
+            {
+                return this.nameAllocator.GetName(fallbackName, context);
+            }
+
+            if (symbol is IDiscardSymbol)
+            {
+                return fallbackName;
+            }
+
+            bool isExplicitInterfaceMember = symbol switch
+            {
+                IMethodSymbol method => !method.ExplicitInterfaceImplementations.IsDefaultOrEmpty,
+                IPropertySymbol property => !property.ExplicitInterfaceImplementations.IsDefaultOrEmpty,
+                IEventSymbol @event => !@event.ExplicitInterfaceImplementations.IsDefaultOrEmpty,
+                _ => false,
+            };
+            if (!isExplicitInterfaceMember)
+            {
+                return this.nameAllocator.GetName(symbol, context);
+            }
+
+            IEnumerable<string> siblingNames = symbol.ContainingType?
+                .GetMembers()
+                .Select(member =>
+                {
+                    int separator = member.Name.LastIndexOf('.');
+                    return separator >= 0
+                        ? member.Name.Substring(separator + 1)
+                        : member.Name;
+                });
+            return this.nameAllocator.GetName(fallbackName, context, siblingNames);
+        }
 
         private string EmittedName(
             SyntaxNode node,

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Declarations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Declarations.cs
@@ -340,28 +340,7 @@ public sealed partial class CSharpToGSharpTranslator
                 return fallbackName;
             }
 
-            bool isExplicitInterfaceMember = symbol switch
-            {
-                IMethodSymbol method => !method.ExplicitInterfaceImplementations.IsDefaultOrEmpty,
-                IPropertySymbol property => !property.ExplicitInterfaceImplementations.IsDefaultOrEmpty,
-                IEventSymbol @event => !@event.ExplicitInterfaceImplementations.IsDefaultOrEmpty,
-                _ => false,
-            };
-            if (!isExplicitInterfaceMember)
-            {
-                return this.nameAllocator.GetName(symbol, context);
-            }
-
-            IEnumerable<string> siblingNames = symbol.ContainingType?
-                .GetMembers()
-                .Select(member =>
-                {
-                    int separator = member.Name.LastIndexOf('.');
-                    return separator >= 0
-                        ? member.Name.Substring(separator + 1)
-                        : member.Name;
-                });
-            return this.nameAllocator.GetName(fallbackName, context, siblingNames);
+            return this.nameAllocator.GetName(symbol, context);
         }
 
         private string EmittedName(

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
@@ -711,7 +711,7 @@ public sealed partial class CSharpToGSharpTranslator
                         continue;
                     }
 
-                    string name = SanitizeIdentifier(single.Identifier.Text);
+                    string name = this.EmittedName(single, single.Identifier);
                     if (name == "_")
                     {
                         targets.Add(new IdentifierExpression(name));
@@ -935,7 +935,7 @@ public sealed partial class CSharpToGSharpTranslator
             if (designation is SingleVariableDesignationSyntax single)
             {
                 this.ReportIfIndexOrRangeTypedDesignation(single);
-                string name = SanitizeIdentifier(single.Identifier.Text);
+                string name = this.EmittedName(single, single.Identifier);
                 ILocalSymbol local = this.context.GetDeclaredSymbol(single) as ILocalSymbol;
                 statements.Add(new LocalDeclarationStatement(
                     local != null && this.IsLocalReassigned(local)
@@ -992,7 +992,7 @@ public sealed partial class CSharpToGSharpTranslator
                 {
                     collected.Add(designation switch
                     {
-                        SingleVariableDesignationSyntax single => SanitizeIdentifier(single.Identifier.Text),
+                        SingleVariableDesignationSyntax single => this.EmittedName(single, single.Identifier),
                         _ => "_",
                     });
 
@@ -1023,7 +1023,7 @@ public sealed partial class CSharpToGSharpTranslator
                     var declaration = (DeclarationExpressionSyntax)argument.Expression;
                     collected.Add(declaration.Designation switch
                     {
-                        SingleVariableDesignationSyntax single => SanitizeIdentifier(single.Identifier.Text),
+                        SingleVariableDesignationSyntax single => this.EmittedName(single, single.Identifier),
                         _ => "_",
                     });
 
@@ -1189,7 +1189,7 @@ public sealed partial class CSharpToGSharpTranslator
             GExpression value;
             if (argument.RefKindKeyword.Kind() is SyntaxKind.RefKeyword or SyntaxKind.OutKeyword
                 && argument.Expression is not DeclarationExpressionSyntax
-                && argument.Expression is not IdentifierNameSyntax { Identifier.Text: "_" })
+                && argument.Expression is not IdentifierNameSyntax { Identifier.ValueText: "_" })
             {
                 // Keep address-of outermost so gsc's ref/out call binder sees
                 // the expected argument shape: `&{ spills; lvalue }`.
@@ -1207,7 +1207,9 @@ public sealed partial class CSharpToGSharpTranslator
             return argument.NameColon == null || !preserveName
                 ? value
                 : new NamedArgumentExpression(
-                    SanitizeIdentifier(argument.NameColon.Name.Identifier.Text),
+                    this.EmittedName(
+                        this.context.GetSymbolInfo(argument.NameColon.Name).Symbol,
+                        argument.NameColon.Name.Identifier.ValueText),
                     value);
         }
 
@@ -1363,7 +1365,7 @@ public sealed partial class CSharpToGSharpTranslator
                     }
 
                     liftedParameters.Add(new Parameter(
-                        SanitizeIdentifier(capture.Symbol.Name),
+                        this.EmittedName(capture.Symbol, capture.Symbol.Name),
                         this.typeMapper.Map(
                             captureType,
                             this.context,
@@ -1554,7 +1556,7 @@ public sealed partial class CSharpToGSharpTranslator
             // function literal (which has no name to hang `[T]` off) — see
             // `let Name[T, U] = func (...) ... { ... }` in G#.
             var typeParameters = localFunction.TypeParameterList?.Parameters
-                .Select(tp => SanitizeIdentifier(tp.Identifier.Text))
+                .Select(tp => this.EmittedName(tp, tp.Identifier))
                 .ToList();
 
             // Issue #3399: this local participates in a recursive/mutually
@@ -1595,7 +1597,10 @@ public sealed partial class CSharpToGSharpTranslator
 
             return new GStatement[]
             {
-                new LocalFunctionStatement(SanitizeIdentifier(localFunction.Identifier.Text), lambda, typeParameters),
+                new LocalFunctionStatement(
+                    this.EmittedName(localSymbol, localFunction.Identifier.ValueText),
+                    lambda,
+                    typeParameters),
             };
         }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -105,7 +105,7 @@ public sealed partial class CSharpToGSharpTranslator
             {
                 return new MemberAccessExpression(
                     this.StaticQualifierReceiver(owner, identifier.GetLocation()),
-                    SanitizeIdentifier(identifier.Identifier.Text));
+                    this.EmittedName(staticMember, identifier.Identifier.ValueText));
             }
 
             // A bare type used as an expression receiver (Path.Combine,
@@ -124,7 +124,7 @@ public sealed partial class CSharpToGSharpTranslator
                 return new IdentifierExpression("__underscore");
             }
 
-            return new IdentifierExpression(SanitizeIdentifier(identifier.Identifier.Text));
+            return new IdentifierExpression(this.EmittedName(identifier, identifier.Identifier));
         }
 
         private static bool IsDirectWrite(IdentifierNameSyntax identifier) =>
@@ -449,7 +449,7 @@ public sealed partial class CSharpToGSharpTranslator
                     // source type elsewhere in the compilation.
                     return new MemberAccessExpression(
                         this.StaticQualifierReceiver(extOwner, member.GetLocation()),
-                        SanitizeIdentifier(member.Name.Identifier.Text));
+                        this.EmittedName(extSymbol, member.Name.Identifier.ValueText));
                 }
 
                 if (extSymbol is IPropertySymbol)
@@ -467,7 +467,7 @@ public sealed partial class CSharpToGSharpTranslator
                     {
                         return new MemberAccessExpression(
                             this.TranslateExpression(member.Expression),
-                            SanitizeIdentifier(member.Name.Identifier.Text));
+                            this.EmittedName(extSymbol, member.Name.Identifier.ValueText));
                     }
 
                     // An instance extension property has no receiver-clause form
@@ -476,7 +476,9 @@ public sealed partial class CSharpToGSharpTranslator
                     // a bare property read becomes a zero-argument call.
                     GExpression extReceiver = this.TranslateReceiverWithNullForgiveness(member.Expression);
                     return new InvocationExpression(
-                        new MemberAccessExpression(extReceiver, SanitizeIdentifier(member.Name.Identifier.Text)),
+                        new MemberAccessExpression(
+                            extReceiver,
+                            this.EmittedName(extSymbol, member.Name.Identifier.ValueText)),
                         new List<GExpression>(),
                         null);
                 }
@@ -557,7 +559,8 @@ public sealed partial class CSharpToGSharpTranslator
                     : this.TranslateReceiverWithNullForgiveness(member.Expression);
             }
 
-            string memberName = member.Name.Identifier.Text;
+            string memberName = member.Name.Identifier.ValueText;
+            ISymbol memberSymbol = this.context.GetSymbolInfo(member).Symbol;
 
             // Issue #1905: C# pointer member access (`p->X`) and plain member
             // access (`p.X`) both parse as MemberAccessExpressionSyntax,
@@ -581,7 +584,7 @@ public sealed partial class CSharpToGSharpTranslator
             // positional and carry no element names (ADR-0115 §B.4). The default
             // `.ItemN` access already resolves; only named-element access needs the
             // rewrite, detected via the bound tuple-element field symbol.
-            if (this.context.GetSymbolInfo(member).Symbol is IFieldSymbol field &&
+            if (memberSymbol is IFieldSymbol field &&
                 field.ContainingType is { IsTupleType: true })
             {
                 IFieldSymbol positional = field.CorrespondingTupleField ?? field;
@@ -593,7 +596,10 @@ public sealed partial class CSharpToGSharpTranslator
             // synthesized `data class` whose primary-constructor parameters
             // preserve real member names — no rewrite needed; `x.A` stays
             // `x.A` on the G# side, exactly like the C# anonymous-type property.
-            return new MemberAccessExpression(target, SanitizeIdentifier(memberName), isArrow);
+            return new MemberAccessExpression(
+                target,
+                this.EmittedName(memberSymbol, memberName),
+                isArrow);
         }
 
         /// <summary>

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -112,6 +112,11 @@ public sealed partial class CSharpToGSharpTranslator
             // Task.FromResult, Console.WriteLine, ...) does not pass through
             // type-syntax translation. Map it here so SDK implicit/global
             // usings still contribute the namespace import required by G#.
+            if (this.context.SemanticModel.GetAliasInfo(identifier) is IAliasSymbol alias)
+            {
+                return new IdentifierExpression(this.EmittedName(alias, alias.Name));
+            }
+
             if (this.context.SemanticModel.GetAliasInfo(identifier) is null &&
                 this.context.GetSymbolInfo(identifier).Symbol is INamedTypeSymbol type)
             {
@@ -550,7 +555,8 @@ public sealed partial class CSharpToGSharpTranslator
                 this.context.GetTypeInfo(member.Expression).Type is { IsAnonymousType: true };
 
             GExpression target;
-            if (this.context.GetSymbolInfo(member.Expression).Symbol is INamedTypeSymbol
+            if (this.context.SemanticModel.GetAliasInfo(member.Expression) is null
+                && this.context.GetSymbolInfo(member.Expression).Symbol is INamedTypeSymbol
                 { IsGenericType: true } receiverNamedType)
             {
                 // A qualified generic type is a MemberAccessExpressionSyntax;

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -124,6 +124,12 @@ public sealed partial class CSharpToGSharpTranslator
                 return new IdentifierExpression("__underscore");
             }
 
+            if (identifier.Identifier.ValueText == "_"
+                && this.context.GetSymbolInfo(identifier).Symbol is null)
+            {
+                return new IdentifierExpression("_");
+            }
+
             return new IdentifierExpression(this.EmittedName(identifier, identifier.Identifier));
         }
 
@@ -589,6 +595,7 @@ public sealed partial class CSharpToGSharpTranslator
             {
                 IFieldSymbol positional = field.CorrespondingTupleField ?? field;
                 memberName = positional.Name;
+                memberSymbol = positional;
             }
 
             // Issue #2282 (was #2224): an anonymous-typed value (`new { A = 1,

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -100,7 +100,10 @@ public sealed partial class CSharpToGSharpTranslator
                     { IsStatic: true, Kind: SymbolKind.Field or SymbolKind.Property } staticMember &&
                 staticMember.ContainingType is { TypeKind: TypeKind.Class or TypeKind.Struct } owner &&
                 !owner.IsImplicitlyDeclared &&
-                !this.IsStaticUsingTarget(owner) &&
+                (!this.IsStaticUsingTarget(owner)
+                    || RequiresQualifiedImportedContextualValue(
+                        staticMember,
+                        identifier)) &&
                 !SymbolEqualityComparer.Default.Equals(owner.OriginalDefinition, this.entryType?.OriginalDefinition))
             {
                 return new MemberAccessExpression(
@@ -136,6 +139,34 @@ public sealed partial class CSharpToGSharpTranslator
             }
 
             return new IdentifierExpression(this.EmittedName(identifier, identifier.Identifier));
+        }
+
+        private static bool RequiresQualifiedImportedContextualValue(
+            ISymbol member,
+            IdentifierNameSyntax identifier)
+        {
+            if (!member.DeclaringSyntaxReferences.IsDefaultOrEmpty)
+            {
+                return false;
+            }
+
+            var context =
+                GSharp.Core.CodeAnalysis.Syntax.IdentifierNameContext.General;
+            if (identifier.Parent is ElementAccessExpressionSyntax elementAccess
+                && elementAccess.Expression == identifier)
+            {
+                context |= GSharp.Core.CodeAnalysis.Syntax.IdentifierNameContext.Index;
+            }
+
+            if (identifier.Parent is InvocationExpressionSyntax invocation
+                && invocation.Expression == identifier)
+            {
+                context |= GSharp.Core.CodeAnalysis.Syntax.IdentifierNameContext.Invocation;
+            }
+
+            return GSharp.Core.CodeAnalysis.Syntax.SyntaxFacts.IsReservedIdentifier(
+                member.Name,
+                context);
         }
 
         private static bool IsDirectWrite(IdentifierNameSyntax identifier) =>

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.IfLet.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.IfLet.cs
@@ -120,7 +120,7 @@ public sealed partial class CSharpToGSharpTranslator
                 return false;
             }
 
-            string name = SanitizeIdentifier(designation.Identifier.Text);
+            string name = this.EmittedName(designation, designation.Identifier);
             GExpression residualGuard = null;
             if (residualPattern != null
                 && !this.TryTranslateIfLetResidualPattern(residualPattern, name, out residualGuard))
@@ -358,7 +358,7 @@ public sealed partial class CSharpToGSharpTranslator
                 return false;
             }
 
-            string name = SanitizeIdentifier(designation.Identifier.Text);
+            string name = this.EmittedName(designation, designation.Identifier);
             GExpression residualGuard = null;
             if (residualPattern != null
                 && !this.TryTranslateIfLetResidualPattern(residualPattern, name, out residualGuard))
@@ -588,7 +588,7 @@ public sealed partial class CSharpToGSharpTranslator
                 return false;
             }
 
-            string name = SanitizeIdentifier(designation.Identifier.Text);
+            string name = this.EmittedName(designation, designation.Identifier);
             GExpression residualGuard = null;
             if (residualPattern != null
                 && !this.TryTranslateIfLetResidualPattern(residualPattern, name, out residualGuard))
@@ -704,7 +704,7 @@ public sealed partial class CSharpToGSharpTranslator
                 }
             }
 
-            string name = SanitizeIdentifier(designation.Identifier.Text);
+            string name = this.EmittedName(designation, designation.Identifier);
             GExpression residualGuard = null;
             if (residualPattern != null
                 && !this.TryTranslateIfLetResidualPattern(residualPattern, name, out residualGuard))

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -280,9 +280,28 @@ public sealed partial class CSharpToGSharpTranslator
             }
             else if (invocation.Expression is GenericNameSyntax generic)
             {
-                target = new IdentifierExpression(this.EmittedName(
-                    this.context.GetSymbolInfo(invocation).Symbol,
-                    generic.Identifier.ValueText));
+                ISymbol genericSymbol = this.context.GetSymbolInfo(invocation).Symbol;
+                if (genericSymbol is IMethodSymbol
+                    { IsStatic: true, ContainingType: { TypeKind: TypeKind.Class or TypeKind.Struct } genericOwner } genericMethod
+                    && RequiresQualifiedImportedContextualCall(
+                        genericMethod,
+                        includeGenericPrefix: true))
+                {
+                    target = new MemberAccessExpression(
+                        this.StaticQualifierReceiver(
+                            genericOwner,
+                            generic.GetLocation()),
+                        this.EmittedName(
+                            genericMethod,
+                            generic.Identifier.ValueText));
+                }
+                else
+                {
+                    target = new IdentifierExpression(this.EmittedName(
+                        genericSymbol,
+                        generic.Identifier.ValueText));
+                }
+
                 typeArguments = this.MapTypeArguments(generic);
             }
             else if (invocation.Expression is MemberAccessExpressionSyntax member
@@ -362,11 +381,25 @@ public sealed partial class CSharpToGSharpTranslator
         }
 
         private static bool RequiresQualifiedImportedContextualCall(
-            IMethodSymbol method) =>
-            method.DeclaringSyntaxReferences.IsDefaultOrEmpty
-            && GSharp.Core.CodeAnalysis.Syntax.SyntaxFacts.IsReservedIdentifier(
+            IMethodSymbol method,
+            bool includeGenericPrefix = false)
+        {
+            if (!method.DeclaringSyntaxReferences.IsDefaultOrEmpty)
+            {
+                return false;
+            }
+
+            var context =
+                GSharp.Core.CodeAnalysis.Syntax.IdentifierNameContext.Invocation;
+            if (includeGenericPrefix)
+            {
+                context |= GSharp.Core.CodeAnalysis.Syntax.IdentifierNameContext.Index;
+            }
+
+            return GSharp.Core.CodeAnalysis.Syntax.SyntaxFacts.IsReservedIdentifier(
                 method.Name,
-                GSharp.Core.CodeAnalysis.Syntax.IdentifierNameContext.Invocation);
+                context);
+        }
 
         private static bool TryGetExplicitExtensionReceiverArgument(
             IInvocationOperation invocation,

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -313,7 +313,8 @@ public sealed partial class CSharpToGSharpTranslator
                 this.context.GetSymbolInfo(bareName).Symbol is IMethodSymbol { IsStatic: true, MethodKind: not MethodKind.LocalFunction } staticMethod &&
                 staticMethod.ContainingType is { TypeKind: TypeKind.Class or TypeKind.Struct } owner &&
                 !owner.IsImplicitlyDeclared &&
-                !this.IsStaticUsingTarget(owner) &&
+                (!this.IsStaticUsingTarget(owner)
+                    || RequiresQualifiedImportedContextualCall(staticMethod)) &&
                 !SymbolEqualityComparer.Default.Equals(owner.OriginalDefinition, this.entryType?.OriginalDefinition))
             {
                 // A C# bare sibling static call (`Round(value, 2)`) carries an
@@ -359,6 +360,13 @@ public sealed partial class CSharpToGSharpTranslator
 
             return new InvocationExpression(target, arguments, typeArguments);
         }
+
+        private static bool RequiresQualifiedImportedContextualCall(
+            IMethodSymbol method) =>
+            method.DeclaringSyntaxReferences.IsDefaultOrEmpty
+            && GSharp.Core.CodeAnalysis.Syntax.SyntaxFacts.IsReservedIdentifier(
+                method.Name,
+                GSharp.Core.CodeAnalysis.Syntax.IdentifierNameContext.Invocation);
 
         private static bool TryGetExplicitExtensionReceiverArgument(
             IInvocationOperation invocation,

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -24,6 +24,12 @@ public sealed partial class CSharpToGSharpTranslator
     {
         private GExpression TranslateInvocation(InvocationExpressionSyntax invocation)
         {
+            if (invocation.Expression is IdentifierNameSyntax { Identifier.ValueText: "nameof" }
+                && this.context.SemanticModel.GetConstantValue(invocation) is { HasValue: true, Value: string name })
+            {
+                return LiteralExpression.String(name);
+            }
+
             GExpression target;
             IReadOnlyList<GTypeReference> typeArguments = null;
 
@@ -67,7 +73,8 @@ public sealed partial class CSharpToGSharpTranslator
                 foreach (LiftedLocalFunctionCapture capture in recursiveLift.Captures)
                 {
                     GExpression captureArgument =
-                        new IdentifierExpression(SanitizeIdentifier(capture.Symbol.Name));
+                        new IdentifierExpression(
+                            this.EmittedName(capture.Symbol, capture.Symbol.Name));
                     recursiveArguments.Add(capture.IsByRef
                         ? new UnaryExpression("&", captureArgument)
                         : captureArgument);
@@ -185,7 +192,9 @@ public sealed partial class CSharpToGSharpTranslator
                 return new InvocationExpression(
                     new MemberAccessExpression(
                         staticExtReceiver,
-                        SanitizeIdentifier((staticExt.ReducedFrom ?? staticExt).Name)),
+                        this.EmittedName(
+                            staticExt.ReducedFrom ?? staticExt,
+                            (staticExt.ReducedFrom ?? staticExt).Name)),
                     staticExtRest,
                     staticExtTypeArgs);
             }
@@ -226,7 +235,9 @@ public sealed partial class CSharpToGSharpTranslator
                 return new InvocationExpression(
                     new MemberAccessExpression(
                         bareExtReceiver,
-                        SanitizeIdentifier((bareExt.ReducedFrom ?? bareExt).Name)),
+                        this.EmittedName(
+                            bareExt.ReducedFrom ?? bareExt,
+                            (bareExt.ReducedFrom ?? bareExt).Name)),
                     bareExtRest,
                     bareExtTypeArgs);
             }
@@ -261,7 +272,9 @@ public sealed partial class CSharpToGSharpTranslator
             }
             else if (invocation.Expression is GenericNameSyntax generic)
             {
-                target = new IdentifierExpression(SanitizeIdentifier(generic.Identifier.Text));
+                target = new IdentifierExpression(this.EmittedName(
+                    this.context.GetSymbolInfo(invocation).Symbol,
+                    generic.Identifier.ValueText));
                 typeArguments = this.MapTypeArguments(generic);
             }
             else if (invocation.Expression is MemberAccessExpressionSyntax member
@@ -269,7 +282,9 @@ public sealed partial class CSharpToGSharpTranslator
             {
                 target = new MemberAccessExpression(
                     this.TranslateExpression(member.Expression),
-                    SanitizeIdentifier(memberGeneric.Identifier.Text));
+                    this.EmittedName(
+                        this.context.GetSymbolInfo(invocation).Symbol,
+                        memberGeneric.Identifier.ValueText));
                 typeArguments = this.MapTypeArguments(memberGeneric);
             }
             else if (invocation.Expression is MemberBindingExpressionSyntax memberBinding
@@ -281,7 +296,9 @@ public sealed partial class CSharpToGSharpTranslator
                 // bracket-type-argument form so the chained call keeps `[T...]`.
                 target = new MemberAccessExpression(
                     new ConditionalReceiverExpression(),
-                    SanitizeIdentifier(memberBindingGeneric.Identifier.Text));
+                    this.EmittedName(
+                        this.context.GetSymbolInfo(invocation).Symbol,
+                        memberBindingGeneric.Identifier.ValueText));
                 typeArguments = this.MapTypeArguments(memberBindingGeneric);
             }
             else if (invocation.Expression is IdentifierNameSyntax bareName &&
@@ -306,7 +323,7 @@ public sealed partial class CSharpToGSharpTranslator
                 // via `MethodKind: not MethodKind.LocalFunction`.
                 target = new MemberAccessExpression(
                     this.StaticQualifierReceiver(owner, bareName.GetLocation()),
-                    staticMethod.Name);
+                    this.EmittedName(staticMethod, staticMethod.Name));
             }
             else
             {
@@ -407,7 +424,7 @@ public sealed partial class CSharpToGSharpTranslator
             switch (callee)
             {
                 case MemberAccessExpressionSyntax member
-                    when member.Name.Identifier.Text == "Invoke":
+                    when member.Name.Identifier.ValueText == "Invoke":
                     // A nullable delegate/event receiver spelled `field.Invoke(...)`
                     // needs the same `!!` the direct-call spelling `field(...)` gets
                     // below (#1598): route through the shared receiver-forgiveness
@@ -417,7 +434,7 @@ public sealed partial class CSharpToGSharpTranslator
                     receiver = this.TranslateReceiverWithNullForgiveness(member.Expression);
                     return true;
                 case MemberBindingExpressionSyntax binding
-                    when binding.Name.Identifier.Text == "Invoke":
+                    when binding.Name.Identifier.ValueText == "Invoke":
                     receiver = new ConditionalReceiverExpression();
                     return true;
 
@@ -740,8 +757,10 @@ public sealed partial class CSharpToGSharpTranslator
             }
 
             IMethodSymbol original = method.ReducedFrom ?? method;
-            ownerName = original.ContainingType?.Name is { } containingName ? SanitizeIdentifier(containingName) : null;
-            methodName = SanitizeIdentifier(original.Name);
+            ownerName = original.ContainingType is { } containingType
+                ? this.EmittedName(containingType, containingType.Name)
+                : null;
+            methodName = this.EmittedName(original, original.Name);
             return ownerName != null;
         }
 
@@ -771,10 +790,10 @@ public sealed partial class CSharpToGSharpTranslator
                 return false;
             }
 
-            ownerName = original.ContainingType?.Name is { } containingName
-                ? SanitizeIdentifier(containingName)
+            ownerName = original.ContainingType is { } containingType
+                ? this.EmittedName(containingType, containingType.Name)
                 : null;
-            methodName = SanitizeIdentifier(original.Name);
+            methodName = this.EmittedName(original, original.Name);
             return ownerName != null;
         }
 
@@ -1227,7 +1246,9 @@ public sealed partial class CSharpToGSharpTranslator
             return argument.NameColon == null
                 ? value
                 : new NamedArgumentExpression(
-                    SanitizeIdentifier(argument.NameColon.Name.Identifier.Text),
+                    this.EmittedName(
+                        this.context.GetSymbolInfo(argument.NameColon.Name).Symbol,
+                        argument.NameColon.Name.Identifier.ValueText),
                     value);
         }
 
@@ -1246,7 +1267,7 @@ public sealed partial class CSharpToGSharpTranslator
                     };
                 }
 
-                if (argument.Expression is IdentifierNameSyntax { Identifier.Text: "_" })
+                if (argument.Expression is IdentifierNameSyntax { Identifier.ValueText: "_" })
                 {
                     return new OutArgumentExpression("out", "_");
                 }
@@ -1523,7 +1544,7 @@ public sealed partial class CSharpToGSharpTranslator
                             : this.StaticQualifierReceiver(
                                 original.ContainingType,
                                 expression.GetLocation()),
-                        helperName ?? SanitizeIdentifier(original.Name));
+                        helperName ?? this.EmittedName(original, original.Name));
                 }
                 else
                 {
@@ -1537,7 +1558,7 @@ public sealed partial class CSharpToGSharpTranslator
                         extensionMember.Expression);
                     target = new MemberAccessExpression(
                         receiver,
-                        SanitizeIdentifier(original.Name));
+                        this.EmittedName(original, original.Name));
                 }
             }
 
@@ -1603,7 +1624,7 @@ public sealed partial class CSharpToGSharpTranslator
             {
                 return new MemberAccessExpression(
                     this.StaticQualifierReceiver(owner, expression.GetLocation()),
-                    SanitizeIdentifier(method.Name));
+                    this.EmittedName(method, method.Name));
             }
 
             if (expression is MemberAccessExpressionSyntax member
@@ -1615,7 +1636,7 @@ public sealed partial class CSharpToGSharpTranslator
                     member.Expression);
                 return new MemberAccessExpression(
                     receiver,
-                    SanitizeIdentifier(member.Name.Identifier.ValueText));
+                    this.EmittedName(method, member.Name.Identifier.ValueText));
             }
 
             return this.TranslateExpression(expression);
@@ -1778,7 +1799,7 @@ public sealed partial class CSharpToGSharpTranslator
         {
             return argument.Parent?.Parent is InvocationExpressionSyntax
             {
-                Expression: IdentifierNameSyntax { Identifier.Text: "nameof" },
+                Expression: IdentifierNameSyntax { Identifier.ValueText: "nameof" },
             };
         }
 
@@ -2379,7 +2400,7 @@ public sealed partial class CSharpToGSharpTranslator
                         if (memberElements != null)
                         {
                             fieldInitializers.Add(new FieldInitializer(
-                                SanitizeIdentifier(name.Identifier.Text),
+                                this.EmittedName(name, name.Identifier),
                                 new CollectionInitializerExpression(target: null, memberElements)));
                             continue;
                         }
@@ -2387,7 +2408,7 @@ public sealed partial class CSharpToGSharpTranslator
 
                     GExpression value = this.TranslateExpression(assignment.Right);
                     fieldInitializers.Add(new FieldInitializer(
-                        SanitizeIdentifier(name.Identifier.Text),
+                        this.EmittedName(name, name.Identifier),
                         this.ForgiveObjectInitializerValue(assignment, value)));
                 }
                 else
@@ -2435,7 +2456,7 @@ public sealed partial class CSharpToGSharpTranslator
                         if (memberElements != null)
                         {
                             memberInitializers.Add(new FieldInitializer(
-                                SanitizeIdentifier(name.Identifier.Text),
+                                this.EmittedName(name, name.Identifier),
                                 new CollectionInitializerExpression(target: null, memberElements)));
                             continue;
                         }
@@ -2448,14 +2469,14 @@ public sealed partial class CSharpToGSharpTranslator
                         if (memberElements != null)
                         {
                             memberInitializers.Add(new FieldInitializer(
-                                SanitizeIdentifier(name.Identifier.Text),
+                                this.EmittedName(name, name.Identifier),
                                 new CollectionInitializerExpression(target: null, memberElements)));
                             continue;
                         }
                     }
 
                     memberInitializers.Add(new FieldInitializer(
-                        SanitizeIdentifier(name.Identifier.Text),
+                        this.EmittedName(name, name.Identifier),
                         this.ForgiveObjectInitializerValue(
                             assignment,
                             this.TranslateExpression(assignment.Right))));
@@ -2525,7 +2546,7 @@ public sealed partial class CSharpToGSharpTranslator
                 if (element is AssignmentExpressionSyntax { Left: IdentifierNameSyntax memberName } memberAssignment)
                 {
                     elements.Add(new CollectionInitializerElement(
-                        SanitizeIdentifier(memberName.Identifier.Text),
+                        this.EmittedName(memberName, memberName.Identifier),
                         this.TranslateExpression(memberAssignment.Right)));
                 }
                 else if (element is AssignmentExpressionSyntax { Left: ImplicitElementAccessSyntax indexAccess } indexedAssignment)
@@ -2938,7 +2959,9 @@ public sealed partial class CSharpToGSharpTranslator
                 }
 
                 fieldInitializers.Add(new FieldInitializer(
-                    SanitizeIdentifier(initialization.MemberName),
+                    this.EmittedName(
+                        plan.Constructor.ContainingType.GetMembers(initialization.MemberName).FirstOrDefault(),
+                        initialization.MemberName),
                     argumentValue));
             }
 
@@ -2962,7 +2985,9 @@ public sealed partial class CSharpToGSharpTranslator
                 using IDisposable modelScope = this.context.UseSemanticModelFor(fixedExpression.SyntaxTree);
                 GExpression value = this.TranslateExpression(fixedExpression);
                 fieldInitializers.Add(new FieldInitializer(
-                    SanitizeIdentifier(initialization.MemberName),
+                    this.EmittedName(
+                        plan.Constructor.ContainingType.GetMembers(initialization.MemberName).FirstOrDefault(),
+                        initialization.MemberName),
                     value));
             }
 
@@ -3088,7 +3113,7 @@ public sealed partial class CSharpToGSharpTranslator
                     assignment.Left is IdentifierNameSyntax name)
                 {
                     updates.Add(new FieldInitializer(
-                        SanitizeIdentifier(name.Identifier.Text),
+                        this.EmittedName(name, name.Identifier),
                         this.TranslateExpression(assignment.Right)));
                 }
                 else

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
@@ -159,7 +159,7 @@ public sealed partial class CSharpToGSharpTranslator
                         yield return (
                             new FieldDeclaration(
                                 BindingKind.Let,
-                                SanitizeIdentifier(property.Identifier.Text),
+                                this.EmittedName(propertySymbol, property.Identifier.ValueText),
                                 bodyFieldType,
                                 bodyFieldInit,
                                 Visibility.Public),
@@ -400,7 +400,8 @@ public sealed partial class CSharpToGSharpTranslator
                 constructionArguments.Add(matchTimeout);
             }
 
-            string cacheName = "__generatedRegex_" + SanitizeIdentifier(node.Identifier.Text);
+            string emittedMethodName = this.EmittedName(symbol, node.Identifier.ValueText);
+            string cacheName = "__generatedRegex_" + emittedMethodName;
             var occupiedNames = new HashSet<string>(
                 symbol.ContainingType.GetMembers().Select(member => member.Name),
                 StringComparer.Ordinal);
@@ -420,7 +421,7 @@ public sealed partial class CSharpToGSharpTranslator
                 .Where(mapped => !IsGeneratedRegexAttributeName(mapped.Name))
                 .ToList();
             method = new MethodDeclaration(
-                SanitizeIdentifier(node.Identifier.Text),
+                emittedMethodName,
                 returnType: regexType,
                 visibility: MapVisibility(symbol, this.context, node),
                 attributes: attributes,
@@ -688,7 +689,7 @@ public sealed partial class CSharpToGSharpTranslator
             // `s` as the receiver for its instance members (and may still declare
             // static members that simply ignore it).
             bool hasNamedReceiver = receiverParameter != null && !receiverParameter.Identifier.IsMissing
-                && receiverParameter.Identifier.Text.Length > 0;
+                && receiverParameter.Identifier.ValueText.Length > 0;
 
             Receiver receiver = null;
             if (hasNamedReceiver)
@@ -699,7 +700,7 @@ public sealed partial class CSharpToGSharpTranslator
                     : this.MapTypeSyntax(receiverParameter.Type);
 
                 receiver = new Receiver(
-                    SanitizeIdentifier(receiverParameter.Identifier.Text),
+                    this.EmittedName(receiverSymbol, receiverParameter.Identifier.ValueText),
                     receiverType,
                     isExplicitExtension: RequiresExplicitExtensionReceiver(
                         receiverSymbol?.Type,
@@ -799,7 +800,7 @@ public sealed partial class CSharpToGSharpTranslator
                 : null;
 
             var method = new MethodDeclaration(
-                SanitizeIdentifier(node.Identifier.Text),
+                this.EmittedName(symbol, node.Identifier.ValueText),
                 new List<Parameter>(),
                 returnType,
                 body,
@@ -829,7 +830,7 @@ public sealed partial class CSharpToGSharpTranslator
                     : this.MapTypeSyntax(node.Declaration.Type);
 
                 var declaration = new EventDeclaration(
-                    SanitizeIdentifier(declarator.Identifier.Text),
+                    this.EmittedName(symbol, declarator.Identifier.ValueText),
                     type,
                     MapVisibility(symbol, this.context, node),
                     this.MapAttributes(node.AttributeLists),
@@ -946,7 +947,7 @@ public sealed partial class CSharpToGSharpTranslator
                 : MapVisibility(symbol, this.context, node);
 
             var declaration = new EventDeclaration(
-                SanitizeIdentifier(node.Identifier.Text),
+                this.EmittedName(symbol, node.Identifier.ValueText),
                 type,
                 eventVisibility,
                 this.MapAttributes(node.AttributeLists),
@@ -976,8 +977,8 @@ public sealed partial class CSharpToGSharpTranslator
             List<TypeParameter> typeParameters = this.MapTypeParameters(symbol);
             bool isNested = symbol?.ContainingType != null;
             string name = isNested
-                ? CSharpTypeMapper.LiftedNestedDelegateName(symbol)
-                : SanitizeIdentifier(node.Identifier.Text);
+                ? this.typeMapper.LiftedNestedDelegateName(symbol, this.context)
+                : this.EmittedName(symbol, node.Identifier.ValueText);
             Visibility visibility = MapVisibility(symbol, this.context, node);
             if (isNested)
             {
@@ -1045,7 +1046,7 @@ public sealed partial class CSharpToGSharpTranslator
 
                 // T2: a field that became a primary-constructor parameter is no
                 // longer a standalone member (the parameter declares the field).
-                if (lift.FieldsAsPrimaryParameters.Contains(declarator.Identifier.Text))
+                if (lift.FieldsAsPrimaryParameters.Contains(declarator.Identifier.ValueText))
                 {
                     continue;
                 }
@@ -1084,7 +1085,7 @@ public sealed partial class CSharpToGSharpTranslator
                 // constructor assignment independent of the constructor parameters
                 // (lifted out of the dropped `init`) or from a C# field initializer.
                 GExpression initializer = null;
-                if (lift.FieldInitializers.TryGetValue(declarator.Identifier.Text, out GExpression lifted))
+                if (lift.FieldInitializers.TryGetValue(declarator.Identifier.ValueText, out GExpression lifted))
                 {
                     initializer = lifted;
                 }
@@ -1137,7 +1138,7 @@ public sealed partial class CSharpToGSharpTranslator
 
                 var declaration = new FieldDeclaration(
                     binding,
-                    SanitizeIdentifier(declarator.Identifier.Text),
+                    this.EmittedName(symbol, declarator.Identifier.ValueText),
                     type,
                     initializer: initializer,
                     visibility: MapVisibility(symbol, this.context, field),
@@ -1322,7 +1323,7 @@ public sealed partial class CSharpToGSharpTranslator
                     GTypeReference receiverType = this.typeMapper.Map(self.Type, this.context, node.GetLocation());
                     receiverType = this.PromoteIfUsedAsNullable(receiverType, self);
                     receiver = new Receiver(
-                        SanitizeIdentifier(self.Name),
+                        this.EmittedName(self, self.Name),
                         receiverType,
                         isExplicitExtension: RequiresExplicitExtensionReceiver(symbol));
                     skipFirstParameter = true;
@@ -1359,7 +1360,7 @@ public sealed partial class CSharpToGSharpTranslator
                 {
                     new LocalDeclarationStatement(
                         BindingKind.Var,
-                        SanitizeIdentifier(ownedExtensionSelf.Name),
+                        this.EmittedName(ownedExtensionSelf, ownedExtensionSelf.Name),
                         initializer: new ThisExpression()),
                 };
                 statements.AddRange(body.Statements);
@@ -1401,7 +1402,7 @@ public sealed partial class CSharpToGSharpTranslator
                 string instanceBodyName = null;
                 if (!symbol.IsStatic && symbol.ContainingType.TypeKind == TypeKind.Class)
                 {
-                    instanceBodyName = "__asyncVoid_" + SanitizeIdentifier(symbol.Name);
+                    instanceBodyName = "__asyncVoid_" + this.EmittedName(symbol, symbol.Name);
                     while (symbol.ContainingType.GetMembers(instanceBodyName).Length > 0)
                     {
                         instanceBodyName += "_";
@@ -1471,7 +1472,7 @@ public sealed partial class CSharpToGSharpTranslator
                 : MapVisibility(symbol, this.context, node);
 
             var method = new MethodDeclaration(
-                SanitizeIdentifier(node.Identifier.Text),
+                this.EmittedName(symbol, node.Identifier.ValueText),
                 parameters: parameters,
                 returnType: returnType,
                 body: body,
@@ -1514,14 +1515,14 @@ public sealed partial class CSharpToGSharpTranslator
             IReadOnlyList<GTypeReference> typeArguments = original.TypeParameters
                 .Select(parameter =>
                     (GTypeReference)new NamedTypeReference(
-                        SanitizeIdentifier(parameter.Name)))
+                        this.EmittedName(parameter, parameter.Name)))
                 .ToList();
 
             var call = new InvocationExpression(
                 new MemberAccessExpression(
                     new IdentifierExpression(
-                        SanitizeIdentifier(original.ContainingType.Name)),
-                    SanitizeIdentifier(original.Name)),
+                        this.EmittedName(original.ContainingType, original.ContainingType.Name)),
+                    this.EmittedName(original, original.Name)),
                 arguments,
                 typeArguments);
             INamedTypeSymbol asyncEnvelope = original.IsAsync
@@ -1633,13 +1634,13 @@ public sealed partial class CSharpToGSharpTranslator
         {
             string extensionSignature =
                 this.CanonicalReducedSignature(extension, parameterOffset: 1);
-            string emittedName = SanitizeIdentifier(extension.Name);
+            string emittedName = this.EmittedName(extension, extension.Name);
             for (INamedTypeSymbol current = receiver; current != null; current = current.BaseType)
             {
                 foreach (IMethodSymbol method in current.GetMembers().OfType<IMethodSymbol>())
                 {
                     if (!method.IsStatic
-                        && SanitizeIdentifier(method.Name) == emittedName
+                        && this.EmittedName(method, method.Name) == emittedName
                         && this.CanonicalReducedSignature(method, parameterOffset: 0)
                             == extensionSignature)
                     {
@@ -1656,7 +1657,7 @@ public sealed partial class CSharpToGSharpTranslator
         {
             string namespaceName = method.ContainingNamespace?.ToDisplayString()
                 ?? string.Empty;
-            string emittedName = SanitizeIdentifier(method.Name);
+            string emittedName = this.EmittedName(method, method.Name);
             var seen = new HashSet<string>(StringComparer.Ordinal);
 
             foreach (INamedTypeSymbol type in method.ContainingNamespace.GetTypeMembers())
@@ -1664,7 +1665,7 @@ public sealed partial class CSharpToGSharpTranslator
                 foreach (IMethodSymbol candidate in type.GetMembers().OfType<IMethodSymbol>())
                 {
                     if (candidate.IsExtensionMethod
-                        && SanitizeIdentifier(candidate.Name) == emittedName
+                        && this.EmittedName(candidate, candidate.Name) == emittedName
                         && seen.Add(ExtensionMethodIdentity(candidate)))
                     {
                         yield return candidate;
@@ -1689,7 +1690,7 @@ public sealed partial class CSharpToGSharpTranslator
                         .OfType<IMethodSymbol>())
                     {
                         if (candidate.IsExtensionMethod
-                            && SanitizeIdentifier(candidate.Name) == emittedName
+                            && this.EmittedName(candidate, candidate.Name) == emittedName
                             && seen.Add(ExtensionMethodIdentity(candidate)))
                         {
                             yield return candidate;
@@ -1758,7 +1759,7 @@ public sealed partial class CSharpToGSharpTranslator
         {
             var parts = new List<string>
             {
-                SanitizeIdentifier(method.Name),
+                this.EmittedName(method, method.Name),
                 method.TypeParameters.Length.ToString(CultureInfo.InvariantCulture),
             };
             for (int index = parameterOffset; index < method.Parameters.Length; index++)
@@ -1787,7 +1788,8 @@ public sealed partial class CSharpToGSharpTranslator
                 this.context.SiblingCompilations,
                 this.context.RepositoryCompilations);
             var signatureMapper = new CSharpTypeMapper(
-                new AnonymousTypeRegistry());
+                new AnonymousTypeRegistry(),
+                this.nameAllocator);
             GTypeReference mapped = signatureMapper.Map(
                 type,
                 signatureContext,
@@ -1796,7 +1798,7 @@ public sealed partial class CSharpToGSharpTranslator
                 .Replace("?", string.Empty, StringComparison.Ordinal);
             foreach (ITypeParameterSymbol parameter in method.TypeParameters)
             {
-                string name = Regex.Escape(SanitizeIdentifier(parameter.Name));
+                string name = Regex.Escape(this.EmittedName(parameter, parameter.Name));
                 rendered = Regex.Replace(
                     rendered,
                     $@"(?<![\p{{L}}\p{{N}}_]){name}(?![\p{{L}}\p{{N}}_])",
@@ -2469,7 +2471,7 @@ public sealed partial class CSharpToGSharpTranslator
             }
 
             property = new PropertyDeclaration(
-                SanitizeIdentifier(node.Identifier.Text),
+                this.EmittedName(symbol, node.Identifier.ValueText),
                 type,
                 propertyAccessors,
                 visibility: MapVisibility(symbol, this.context, node),
@@ -2650,7 +2652,7 @@ public sealed partial class CSharpToGSharpTranslator
                 : MapVisibility(symbol, this.context, node);
 
             var property = new PropertyDeclaration(
-                SanitizeIdentifier(node.Identifier.Text),
+                this.EmittedName(symbol, node.Identifier.ValueText),
                 type,
                 accessors: accessors,
                 visibility: explicitInterfacePropertyVisibility,

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.PatternVariables.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.PatternVariables.cs
@@ -501,7 +501,7 @@ public sealed partial class CSharpToGSharpTranslator
                             if (sub.NameColon != null)
                             {
                                 directRoots.Add(this.EmittedName(
-                                    this.context.GetSymbolInfo(sub.NameColon.Name).Symbol,
+                                    this.GetPatternMemberSymbol(sub.NameColon.Name),
                                     this.GetSubpatternMemberName(sub)));
                                 continue;
                             }
@@ -705,7 +705,7 @@ public sealed partial class CSharpToGSharpTranslator
                 {
                     fields.Add(new PropertyPatternField(
                         this.EmittedName(
-                            this.context.GetSymbolInfo(sub.NameColon.Name).Symbol,
+                            this.GetPatternMemberSymbol(sub.NameColon.Name),
                             this.GetSubpatternMemberName(sub)),
                         this.BuildNativePattern(sub.Pattern, binders)));
                     continue;

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.PatternVariables.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.PatternVariables.cs
@@ -47,7 +47,8 @@ public sealed partial class CSharpToGSharpTranslator
             GPattern native = this.BuildNativePattern(pattern, binders);
             foreach (ILocalSymbol binder in binders)
             {
-                this.state.PatternBindings[binder] = new IdentifierExpression(SanitizeIdentifier(binder.Name));
+                this.state.PatternBindings[binder] =
+                    new IdentifierExpression(this.EmittedName(binder, binder.Name));
                 this.state.NativePatternVariables.Add(binder);
             }
 
@@ -169,7 +170,7 @@ public sealed partial class CSharpToGSharpTranslator
 
                 foreach (IdentifierNameSyntax identifier in scope.DescendantNodes().OfType<IdentifierNameSyntax>())
                 {
-                    if (identifier.Identifier.Text != local.Name
+                    if (identifier.Identifier.ValueText != local.Name
                         || !SymbolEqualityComparer.Default.Equals(this.context.GetSymbolInfo(identifier).Symbol, local))
                     {
                         continue;
@@ -499,7 +500,9 @@ public sealed partial class CSharpToGSharpTranslator
 
                             if (sub.NameColon != null)
                             {
-                                directRoots.Add(SanitizeIdentifier(this.GetSubpatternMemberName(sub)));
+                                directRoots.Add(this.EmittedName(
+                                    this.context.GetSymbolInfo(sub.NameColon.Name).Symbol,
+                                    this.GetSubpatternMemberName(sub)));
                                 continue;
                             }
 
@@ -509,7 +512,7 @@ public sealed partial class CSharpToGSharpTranslator
                             }
 
                             List<string> names = SplitMemberPath(sub.ExpressionColon.Expression);
-                            string rootName = SanitizeIdentifier(names[0]);
+                            string rootName = names[0];
                             extendedRoots.Add(rootName);
                             if (!extendedTrees.TryGetValue(rootName, out ExtendedPropertyFieldTree tree))
                             {
@@ -701,13 +704,15 @@ public sealed partial class CSharpToGSharpTranslator
                 if (sub.NameColon != null)
                 {
                     fields.Add(new PropertyPatternField(
-                        SanitizeIdentifier(this.GetSubpatternMemberName(sub)),
+                        this.EmittedName(
+                            this.context.GetSymbolInfo(sub.NameColon.Name).Symbol,
+                            this.GetSubpatternMemberName(sub)),
                         this.BuildNativePattern(sub.Pattern, binders)));
                     continue;
                 }
 
                 List<string> names = SplitMemberPath(sub.ExpressionColon.Expression);
-                string rootName = SanitizeIdentifier(names[0]);
+                string rootName = names[0];
                 if (!extendedTrees.TryGetValue(rootName, out ExtendedPropertyFieldTree tree))
                 {
                     tree = new ExtendedPropertyFieldTree();
@@ -739,7 +744,7 @@ public sealed partial class CSharpToGSharpTranslator
                 binders.Add(local);
                 return this.state.NativePatternVariableAliases.TryGetValue(local, out string alias)
                     ? alias
-                    : SanitizeIdentifier(single.Identifier.Text);
+                    : this.EmittedName(single, single.Identifier);
             }
 
             return "_";

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -1336,7 +1336,9 @@ public sealed partial class CSharpToGSharpTranslator
 
                     ISymbol memberSymbol = sub.NameColon != null
                         ? this.GetPatternMemberSymbol(sub.NameColon.Name)
-                        : (this.context.GetTypeInfo(recursive.Type).Type as INamedTypeSymbol)?
+                        : (recursive.Type != null
+                            ? this.context.GetTypeInfo(recursive.Type).Type as INamedTypeSymbol
+                            : receiverType as INamedTypeSymbol)?
                             .GetMembers(memberName)
                             .FirstOrDefault();
                     GExpression memberAccess = new MemberAccessExpression(

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -284,9 +284,9 @@ public sealed partial class CSharpToGSharpTranslator
                     // — a silent-wrong `?.` read.
                     string bindingMemberName = this.GetPatternMemberName(memberBinding.Name);
                     string emittedBindingMemberName = this.EmittedName(
-                        this.context.GetSymbolInfo(memberBinding).Symbol,
+                        this.GetPatternMemberSymbol(memberBinding),
                         bindingMemberName);
-                    if (this.context.GetSymbolInfo(memberBinding).Symbol is IPropertySymbol extBindingProperty
+                    if (this.GetPatternMemberSymbol(memberBinding) is IPropertySymbol extBindingProperty
                         && !extBindingProperty.IsStatic
                         && TryGetExtensionBlockOwner(extBindingProperty, out _))
                     {
@@ -1287,7 +1287,7 @@ public sealed partial class CSharpToGSharpTranslator
                         GExpression memberAccess = new MemberAccessExpression(
                             memberReceiver,
                             this.EmittedName(
-                                this.context.GetSymbolInfo(sub.NameColon.Name).Symbol,
+                                this.GetPatternMemberSymbol(sub.NameColon.Name),
                                 memberName));
                         ITypeSymbol memberType = this.TryGetSubpatternMemberType(sub);
                         memberTest = this.TranslatePatternTest(memberAccess, sub.Pattern, memberType, isNestedPatternMember: true);
@@ -1335,7 +1335,7 @@ public sealed partial class CSharpToGSharpTranslator
                     }
 
                     ISymbol memberSymbol = sub.NameColon != null
-                        ? this.context.GetSymbolInfo(sub.NameColon.Name).Symbol
+                        ? this.GetPatternMemberSymbol(sub.NameColon.Name)
                         : (this.context.GetTypeInfo(recursive.Type).Type as INamedTypeSymbol)?
                             .GetMembers(memberName)
                             .FirstOrDefault();
@@ -1427,6 +1427,14 @@ public sealed partial class CSharpToGSharpTranslator
             return name.Identifier.ValueText;
         }
 
+        private ISymbol GetPatternMemberSymbol(SyntaxNode node)
+        {
+            ISymbol symbol = this.context.GetSymbolInfo(node).Symbol;
+            return symbol is IFieldSymbol { ContainingType.IsTupleType: true } tupleField
+                ? tupleField.CorrespondingTupleField ?? tupleField
+                : symbol;
+        }
+
         // Splits an extended property subpattern's dotted member path
         // (`Start.X`, `A.B.C`, ...) into its leaf-to-root identifier chain
         // (`["Start", "X"]`, `["A", "B", "C"]`), using each bound member's
@@ -1440,14 +1448,14 @@ public sealed partial class CSharpToGSharpTranslator
             while (current is MemberAccessExpressionSyntax memberAccess)
             {
                 names.Insert(0, this.EmittedName(
-                    this.context.GetSymbolInfo(memberAccess).Symbol,
+                    this.GetPatternMemberSymbol(memberAccess),
                     this.GetPatternMemberName(memberAccess.Name)));
                 current = memberAccess.Expression;
             }
 
             string rootName = current is SimpleNameSyntax simpleName
                 ? this.EmittedName(
-                    this.context.GetSymbolInfo(simpleName).Symbol,
+                    this.GetPatternMemberSymbol(simpleName),
                     this.GetPatternMemberName(simpleName))
                 : current.ToString();
             names.Insert(0, rootName);

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -52,7 +52,9 @@ public sealed partial class CSharpToGSharpTranslator
                         return new TypeExpression(typeRef);
                     }
 
-                    return new IdentifierExpression(SanitizeIdentifier(generic.Identifier.Text));
+                    return new IdentifierExpression(this.EmittedName(
+                        this.context.GetSymbolInfo(generic).Symbol,
+                        generic.Identifier.ValueText));
 
                 case ThisExpressionSyntax:
                     return new ThisExpression();
@@ -281,6 +283,9 @@ public sealed partial class CSharpToGSharpTranslator
                     // print emits a bare property-style access on a func member
                     // — a silent-wrong `?.` read.
                     string bindingMemberName = this.GetPatternMemberName(memberBinding.Name);
+                    string emittedBindingMemberName = this.EmittedName(
+                        this.context.GetSymbolInfo(memberBinding).Symbol,
+                        bindingMemberName);
                     if (this.context.GetSymbolInfo(memberBinding).Symbol is IPropertySymbol extBindingProperty
                         && !extBindingProperty.IsStatic
                         && TryGetExtensionBlockOwner(extBindingProperty, out _))
@@ -289,7 +294,7 @@ public sealed partial class CSharpToGSharpTranslator
                             new MemberAccessExpression(
                                 this.state.ConditionalReceiverReplacement ??
                                     new ConditionalReceiverExpression(),
-                                SanitizeIdentifier(bindingMemberName)),
+                                emittedBindingMemberName),
                             new List<GExpression>(),
                             null);
                     }
@@ -300,7 +305,7 @@ public sealed partial class CSharpToGSharpTranslator
                     return new MemberAccessExpression(
                         this.state.ConditionalReceiverReplacement ??
                             new ConditionalReceiverExpression(),
-                        SanitizeIdentifier(bindingMemberName));
+                        emittedBindingMemberName);
 
                 case ElementBindingExpressionSyntax elementBinding:
                     GExpression bindingReceiver =
@@ -345,7 +350,9 @@ public sealed partial class CSharpToGSharpTranslator
 
                 case AliasQualifiedNameSyntax aliasQualified:
                     // `global::System` → drop the `global::` alias and keep the name.
-                    return new IdentifierExpression(aliasQualified.Name.Identifier.Text);
+                    return new IdentifierExpression(this.EmittedName(
+                        aliasQualified.Name,
+                        aliasQualified.Name.Identifier));
 
                 case AssignmentExpressionSyntax nestedAssignment:
                     // A value-position deconstruction assignment may already have
@@ -700,7 +707,7 @@ public sealed partial class CSharpToGSharpTranslator
                     storageType = MakeNullable(storageType);
                 }
 
-                string name = SanitizeIdentifier(binder.Name);
+                string name = this.EmittedName(binder, binder.Name);
                 var local = new IdentifierExpression(name);
                 declarations.Add(new LocalDeclarationStatement(
                     BindingKind.Var,
@@ -1277,7 +1284,11 @@ public sealed partial class CSharpToGSharpTranslator
                     if (sub.NameColon != null)
                     {
                         string memberName = this.GetSubpatternMemberName(sub);
-                        GExpression memberAccess = new MemberAccessExpression(memberReceiver, SanitizeIdentifier(memberName));
+                        GExpression memberAccess = new MemberAccessExpression(
+                            memberReceiver,
+                            this.EmittedName(
+                                this.context.GetSymbolInfo(sub.NameColon.Name).Symbol,
+                                memberName));
                         ITypeSymbol memberType = this.TryGetSubpatternMemberType(sub);
                         memberTest = this.TranslatePatternTest(memberAccess, sub.Pattern, memberType, isNestedPatternMember: true);
                     }
@@ -1316,14 +1327,21 @@ public sealed partial class CSharpToGSharpTranslator
                         continue;
                     }
 
-                    string memberName = sub.NameColon?.Name.Identifier.Text ?? memberNames?[i];
+                    string memberName = sub.NameColon?.Name.Identifier.ValueText ?? memberNames?[i];
                     if (memberName == null)
                     {
                         this.context.ReportUnsupported(sub, "positional subpattern has no canonical G# form yet (ADR-0115 §B).");
                         continue;
                     }
 
-                    GExpression memberAccess = new MemberAccessExpression(memberReceiver, SanitizeIdentifier(memberName));
+                    ISymbol memberSymbol = sub.NameColon != null
+                        ? this.context.GetSymbolInfo(sub.NameColon.Name).Symbol
+                        : (this.context.GetTypeInfo(recursive.Type).Type as INamedTypeSymbol)?
+                            .GetMembers(memberName)
+                            .FirstOrDefault();
+                    GExpression memberAccess = new MemberAccessExpression(
+                        memberReceiver,
+                        this.EmittedName(memberSymbol, memberName));
                     GExpression memberTest = this.TranslatePatternTest(memberAccess, sub.Pattern, isNestedPatternMember: true);
                     test = test == null ? memberTest : new BinaryExpression(test, "&&", memberTest);
                 }
@@ -1406,12 +1424,13 @@ public sealed partial class CSharpToGSharpTranslator
                 return (tupleField.CorrespondingTupleField ?? tupleField).Name;
             }
 
-            return name.Identifier.Text;
+            return name.Identifier.ValueText;
         }
 
         // Splits an extended property subpattern's dotted member path
         // (`Start.X`, `A.B.C`, ...) into its leaf-to-root identifier chain
-        // (`["Start", "X"]`, `["A", "B", "C"]`), unsanitized. Shared by the
+        // (`["Start", "X"]`, `["A", "B", "C"]`), using each bound member's
+        // allocated emitted name. Shared by the
         // is-form guard builder (<see cref="TranslateExtendedPropertyMemberTest"/>)
         // and the switch-arm nested-field builder (<see cref="ExtendedPropertyFieldTree"/>).
         private List<string> SplitMemberPath(ExpressionSyntax memberPath)
@@ -1420,12 +1439,16 @@ public sealed partial class CSharpToGSharpTranslator
             ExpressionSyntax current = memberPath;
             while (current is MemberAccessExpressionSyntax memberAccess)
             {
-                names.Insert(0, this.GetPatternMemberName(memberAccess.Name));
+                names.Insert(0, this.EmittedName(
+                    this.context.GetSymbolInfo(memberAccess).Symbol,
+                    this.GetPatternMemberName(memberAccess.Name)));
                 current = memberAccess.Expression;
             }
 
             string rootName = current is SimpleNameSyntax simpleName
-                ? this.GetPatternMemberName(simpleName)
+                ? this.EmittedName(
+                    this.context.GetSymbolInfo(simpleName).Symbol,
+                    this.GetPatternMemberName(simpleName))
                 : current.ToString();
             names.Insert(0, rootName);
             return names;
@@ -1475,7 +1498,7 @@ public sealed partial class CSharpToGSharpTranslator
             GExpression guard = null;
             for (int i = 0; i < names.Count - 1; i++)
             {
-                memberReceiver = new MemberAccessExpression(memberReceiver, SanitizeIdentifier(names[i]));
+                memberReceiver = new MemberAccessExpression(memberReceiver, names[i]);
 
                 ITypeSymbol declaredType = this.ResolveDeclaredReceiverType(
                     this.context.GetTypeInfo(intermediateExprs[i]).Type, intermediateExprs[i]);
@@ -1486,7 +1509,7 @@ public sealed partial class CSharpToGSharpTranslator
                 }
             }
 
-            string leafName = SanitizeIdentifier(names[^1]);
+            string leafName = names[^1];
             GExpression finalMemberAccess = new MemberAccessExpression(memberReceiver, leafName);
             ITypeSymbol leafType = this.context.GetTypeInfo(memberPath).Type;
             GExpression leafTest = this.TranslatePatternTest(finalMemberAccess, leafPattern, leafType, isNestedPatternMember: true);

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
@@ -217,7 +217,7 @@ public sealed partial class CSharpToGSharpTranslator
 
                 results.Add(new LocalDeclarationStatement(
                     binding,
-                    SanitizeIdentifier(declarator.Identifier.Text),
+                    this.EmittedName(declarator, declarator.Identifier),
                     type,
                     initializer,
                     isUsing: isUsing,
@@ -249,7 +249,7 @@ public sealed partial class CSharpToGSharpTranslator
                     continue;
                 }
 
-                string name = SanitizeIdentifier(declarator.Identifier.Text);
+                string name = this.EmittedName(localSymbol, declarator.Identifier.ValueText);
 
                 GExpression initializer = declarator.Initializer?.Value is RefExpressionSyntax refInit
                     ? this.TranslateRefExpression(refInit)
@@ -892,7 +892,9 @@ public sealed partial class CSharpToGSharpTranslator
         private GExpression TranslateOutVarDesignation(SingleVariableDesignationSyntax single)
         {
             this.ReportIfIndexOrRangeTypedDesignation(single);
-            return new OutArgumentExpression("out var", SanitizeIdentifier(single.Identifier.Text));
+            return new OutArgumentExpression(
+                "out var",
+                this.EmittedName(single, single.Identifier));
         }
 
         // Issue #1967: an Index/Range-typed LINQ query range variable
@@ -1391,7 +1393,7 @@ public sealed partial class CSharpToGSharpTranslator
             // prologue); the label is attached to the FIRST emitted statement
             // only — C# source has no way to target a position mid-expansion,
             // so this is a faithful mapping.
-            string label = SanitizeIdentifier(labeledStatement.Identifier.Text);
+            string label = this.EmittedName(labeledStatement, labeledStatement.Identifier);
             List<GStatement> inner = this.TranslateStatement(labeledStatement.Statement).ToList();
             if (inner.Count == 0)
             {
@@ -1428,7 +1430,8 @@ public sealed partial class CSharpToGSharpTranslator
                 default:
                     // Plain `goto label;` — Expression is the label name as an
                     // IdentifierNameSyntax (verified against Roslyn 4.14).
-                    string label = SanitizeIdentifier(((IdentifierNameSyntax)gotoStatement.Expression).Identifier.Text);
+                    var labelName = (IdentifierNameSyntax)gotoStatement.Expression;
+                    string label = this.EmittedName(labelName, labelName.Identifier);
                     return new[] { (GStatement)new GotoStatement(label) };
             }
         }
@@ -1571,7 +1574,9 @@ public sealed partial class CSharpToGSharpTranslator
                     exceptionType = typeSymbol != null
                         ? this.typeMapper.Map(typeSymbol, this.context, catchClause.Declaration.Type.GetLocation())
                         : new NamedTypeReference(catchClause.Declaration.Type.ToString());
-                    variableName = SanitizeIdentifier(catchClause.Declaration.Identifier.Text);
+                    variableName = this.EmittedName(
+                        catchClause.Declaration,
+                        catchClause.Declaration.Identifier);
                     if (string.IsNullOrEmpty(variableName))
                     {
                         // `catch (Exception)` with no binding: synthesize one so the
@@ -1681,8 +1686,8 @@ public sealed partial class CSharpToGSharpTranslator
                 GTypeReference clauseType = typeSymbol != null
                     ? this.typeMapper.Map(typeSymbol, this.context, clause.GetLocation())
                     : new NamedTypeReference("Exception");
-                string originalName = clause.Declaration != null && !string.IsNullOrEmpty(clause.Declaration.Identifier.Text)
-                    ? SanitizeIdentifier(clause.Declaration.Identifier.Text)
+                string originalName = clause.Declaration != null && !string.IsNullOrEmpty(clause.Declaration.Identifier.ValueText)
+                    ? this.EmittedName(clause.Declaration, clause.Declaration.Identifier)
                     : sharedBinder;
 
                 string previousCatch = this.state.CurrentCatchVariable;
@@ -2036,7 +2041,8 @@ public sealed partial class CSharpToGSharpTranslator
                     receiverSymbol.Kind is SymbolKind.Property or SymbolKind.Field)
                 {
                     GExpression qualifiedReceiver = new MemberAccessExpression(
-                        new ThisExpression(), SanitizeIdentifier(receiverId.Identifier.Text));
+                        new ThisExpression(),
+                        this.EmittedName(receiverId, receiverId.Identifier));
 
                     if (this.ReceiverNeedsNullForgiveness(receiverId, isDereferenceReceiver: true) ||
                         this.ReceiverIsNullableReferenceFieldOrProperty(receiverId))
@@ -2045,7 +2051,8 @@ public sealed partial class CSharpToGSharpTranslator
                     }
 
                     return new MemberAccessExpression(
-                        qualifiedReceiver, SanitizeIdentifier(member.Name.Identifier.Text));
+                        qualifiedReceiver,
+                        this.EmittedName(member, member.Name.Identifier));
                 }
 
                 if (this.ReceiverNeedsNullForgiveness(member.Expression, isDereferenceReceiver: true) ||
@@ -2056,7 +2063,7 @@ public sealed partial class CSharpToGSharpTranslator
                 {
                     return new MemberAccessExpression(
                         EnsureNonNullAssertion(this.TranslateExpression(member.Expression)),
-                        SanitizeIdentifier(member.Name.Identifier.Text));
+                        this.EmittedName(member, member.Name.Identifier));
                 }
             }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
@@ -1607,7 +1607,7 @@ public sealed partial class CSharpToGSharpTranslator
                         {
                             string rawFieldName = this.GetSubpatternMemberName(sub);
                             string fieldName = this.EmittedName(
-                                this.context.GetSymbolInfo(sub.NameColon.Name).Symbol,
+                                this.GetPatternMemberSymbol(sub.NameColon.Name),
                                 rawFieldName);
                             fields.Add(new PropertyPatternField(
                                 fieldName,
@@ -1729,7 +1729,7 @@ public sealed partial class CSharpToGSharpTranslator
                         }
 
                         ISymbol memberSymbol = sub.NameColon != null
-                            ? this.context.GetSymbolInfo(sub.NameColon.Name).Symbol
+                            ? this.GetPatternMemberSymbol(sub.NameColon.Name)
                             : (this.context.GetTypeInfo(recursive.Type).Type as INamedTypeSymbol)?
                                 .GetMembers(memberName)
                                 .FirstOrDefault();
@@ -1779,7 +1779,7 @@ public sealed partial class CSharpToGSharpTranslator
                         ? new List<string>
                         {
                             this.EmittedName(
-                                this.context.GetSymbolInfo(sub.NameColon.Name).Symbol,
+                                this.GetPatternMemberSymbol(sub.NameColon.Name),
                                 this.GetSubpatternMemberName(sub)),
                         }
                         : sub.ExpressionColon != null
@@ -1854,7 +1854,7 @@ public sealed partial class CSharpToGSharpTranslator
                     }
 
                     ISymbol memberSymbol = sub.NameColon != null
-                        ? this.context.GetSymbolInfo(sub.NameColon.Name).Symbol
+                        ? this.GetPatternMemberSymbol(sub.NameColon.Name)
                         : (this.context.GetTypeInfo(recursive.Type).Type as INamedTypeSymbol)?
                             .GetMembers(memberName)
                             .FirstOrDefault();

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
@@ -15,6 +15,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Text;
+using GSharpIdentifierNameContext = GSharp.Core.CodeAnalysis.Syntax.IdentifierNameContext;
 
 namespace Cs2Gs.Translator;
 
@@ -334,7 +335,12 @@ public sealed partial class CSharpToGSharpTranslator
             GTypeReference type = parameter.Type != null
                 ? this.MapTypeSyntax(parameter.Type)
                 : new NamedTypeReference(CSharpTypeMapper.UnsupportedPlaceholderType);
-            return new Parameter(SanitizeIdentifier(parameter.Identifier.Text), type);
+            return new Parameter(
+                this.EmittedName(
+                    parameter,
+                    parameter.Identifier,
+                    GSharpIdentifierNameContext.Parameter),
+                type);
         }
 
         // `typeof(IEnumerable<>)` over an unbound generic has no bound symbol for
@@ -383,13 +389,13 @@ public sealed partial class CSharpToGSharpTranslator
             {
                 case GenericNameSyntax simple:
                     generic = simple;
-                    name = simple.Identifier.Text;
+                    name = simple.Identifier.ValueText;
                     break;
                 case QualifiedNameSyntax { Right: GenericNameSyntax right } qualified:
                     generic = right;
                     name = qualified.Left.ToString().Replace("global::", string.Empty, StringComparison.Ordinal)
                         + "."
-                        + right.Identifier.Text;
+                        + right.Identifier.ValueText;
                     break;
                 default:
                     return false;
@@ -661,7 +667,7 @@ public sealed partial class CSharpToGSharpTranslator
             foreach ((ILocalSymbol symbol, _) in mutableBindings)
             {
                 this.state.PatternBindings[symbol] =
-                    new IdentifierExpression(SanitizeIdentifier(symbol.Name));
+                    new IdentifierExpression(this.EmittedName(symbol, symbol.Name));
             }
         }
 
@@ -702,7 +708,7 @@ public sealed partial class CSharpToGSharpTranslator
             {
                 declarations.Add(new LocalDeclarationStatement(
                     BindingKind.Var,
-                    SanitizeIdentifier(symbol.Name),
+                    this.EmittedName(symbol, symbol.Name),
                     this.typeMapper.Map(symbol.Type, this.context, pattern.GetLocation()),
                     initializer: matchedValue));
             }
@@ -1218,7 +1224,7 @@ public sealed partial class CSharpToGSharpTranslator
             return new RawStatement("// unsupported: foreach variable deconstruction");
         }
 
-        private static void CollectForEachVariableNames(ExpressionSyntax variable, List<string> names)
+        private void CollectForEachVariableNames(ExpressionSyntax variable, List<string> names)
         {
             switch (variable)
             {
@@ -1235,17 +1241,17 @@ public sealed partial class CSharpToGSharpTranslator
                     break;
 
                 case IdentifierNameSyntax identifier:
-                    names.Add(SanitizeIdentifier(identifier.Identifier.Text));
+                    names.Add(this.EmittedName(identifier, identifier.Identifier));
                     break;
             }
         }
 
-        private static void CollectDesignationNames(VariableDesignationSyntax designation, List<string> names)
+        private void CollectDesignationNames(VariableDesignationSyntax designation, List<string> names)
         {
             switch (designation)
             {
                 case SingleVariableDesignationSyntax single:
-                    names.Add(SanitizeIdentifier(single.Identifier.Text));
+                    names.Add(this.EmittedName(single, single.Identifier));
                     break;
 
                 case DiscardDesignationSyntax:
@@ -1319,7 +1325,7 @@ public sealed partial class CSharpToGSharpTranslator
                 case DeclarationPatternSyntax declaration
                     when declaration.Designation is SingleVariableDesignationSyntax variable:
                     return new TypePattern(
-                        SanitizeIdentifier(variable.Identifier.Text),
+                        this.EmittedName(variable, variable.Identifier),
                         this.MapTypeSyntax(declaration.Type));
 
                 case DeclarationPatternSyntax declaration
@@ -1360,7 +1366,7 @@ public sealed partial class CSharpToGSharpTranslator
 
                     return new VarPattern(
                         varPattern.Designation is SingleVariableDesignationSyntax varVariable
-                            ? SanitizeIdentifier(varVariable.Identifier.Text)
+                            ? this.EmittedName(varVariable, varVariable.Identifier)
                             : "_");
 
                 case RecursivePatternSyntax { Type: { } type } recursive
@@ -1443,7 +1449,7 @@ public sealed partial class CSharpToGSharpTranslator
                     {
                         bindings.Add((
                             binder,
-                            new IdentifierExpression(SanitizeIdentifier(binder.Name))));
+                            new IdentifierExpression(this.EmittedName(binder, binder.Name))));
                     }
 
                     return native;
@@ -1547,7 +1553,7 @@ public sealed partial class CSharpToGSharpTranslator
                         return new SlicePattern(captureName);
                     }
 
-                    return new SlicePattern(SanitizeIdentifier(variable.Identifier.Text));
+                    return new SlicePattern(this.EmittedName(variable, variable.Identifier));
 
                 case VarPatternSyntax { Designation: DiscardDesignationSyntax }:
                     return new SlicePattern(designator: null);
@@ -1560,7 +1566,7 @@ public sealed partial class CSharpToGSharpTranslator
                     // G#'s slice capture designator is always typed as the
                     // slice's own `[]T`, so the (redundant) C# declared type is
                     // dropped — same bind-only treatment as the `var` capture above.
-                    return new SlicePattern(SanitizeIdentifier(declVariable.Identifier.Text));
+                    return new SlicePattern(this.EmittedName(declVariable, declVariable.Identifier));
 
                 default:
                     GExpression sliceValue = BuildSliceExpression(receiver, prefixCount, suffixCount);
@@ -1599,7 +1605,10 @@ public sealed partial class CSharpToGSharpTranslator
                     {
                         if (sub.NameColon != null)
                         {
-                            string fieldName = SanitizeIdentifier(this.GetSubpatternMemberName(sub));
+                            string rawFieldName = this.GetSubpatternMemberName(sub);
+                            string fieldName = this.EmittedName(
+                                this.context.GetSymbolInfo(sub.NameColon.Name).Symbol,
+                                rawFieldName);
                             fields.Add(new PropertyPatternField(
                                 fieldName,
                                 this.TranslatePattern(
@@ -1633,7 +1642,7 @@ public sealed partial class CSharpToGSharpTranslator
                             // root's position at its FIRST occurrence so field
                             // order still matches the source.
                             List<string> names = SplitMemberPath(sub.ExpressionColon.Expression);
-                            string rootName = SanitizeIdentifier(names[0]);
+                            string rootName = names[0];
                             if (!extendedFieldTrees.TryGetValue(rootName, out ExtendedPropertyFieldTree tree))
                             {
                                 tree = new ExtendedPropertyFieldTree();
@@ -1712,18 +1721,24 @@ public sealed partial class CSharpToGSharpTranslator
                             continue;
                         }
 
-                        string memberName = sub.NameColon?.Name.Identifier.Text ?? memberNames?[i];
+                        string memberName = sub.NameColon?.Name.Identifier.ValueText ?? memberNames?[i];
                         if (memberName == null)
                         {
                             this.context.ReportUnsupported(sub, "positional subpattern has no canonical G# form yet (ADR-0115 §B).");
                             continue;
                         }
 
+                        ISymbol memberSymbol = sub.NameColon != null
+                            ? this.context.GetSymbolInfo(sub.NameColon.Name).Symbol
+                            : (this.context.GetTypeInfo(recursive.Type).Type as INamedTypeSymbol)?
+                                .GetMembers(memberName)
+                                .FirstOrDefault();
+                        string emittedMemberName = this.EmittedName(memberSymbol, memberName);
                         fields.Add(new PropertyPatternField(
-                            SanitizeIdentifier(memberName),
+                            emittedMemberName,
                             this.TranslatePattern(
                                 sub.Pattern,
-                                new MemberAccessExpression(receiver, SanitizeIdentifier(memberName)),
+                                new MemberAccessExpression(receiver, emittedMemberName),
                                 bindings,
                                 usedDesignators,
                                 guards,
@@ -1744,7 +1759,7 @@ public sealed partial class CSharpToGSharpTranslator
             // name so a keyword-colliding designator agrees with its references
             // (issue #1734).
             string designator = recursive.Designation is SingleVariableDesignationSyntax named
-                ? SanitizeIdentifier(named.Identifier.Text)
+                ? this.EmittedName(named, named.Identifier)
                 : SanitizeIdentifier(LowerCamel(GetRightmostTypeName(recursive.Type)));
 
             // Issue #1839 (N3): two typed recursive subpatterns within the SAME
@@ -1761,7 +1776,12 @@ public sealed partial class CSharpToGSharpTranslator
                 foreach (SubpatternSyntax sub in recursive.PropertyPatternClause.Subpatterns)
                 {
                     List<string> memberPath = sub.NameColon != null
-                        ? new List<string> { this.GetSubpatternMemberName(sub) }
+                        ? new List<string>
+                        {
+                            this.EmittedName(
+                                this.context.GetSymbolInfo(sub.NameColon.Name).Symbol,
+                                this.GetSubpatternMemberName(sub)),
+                        }
                         : sub.ExpressionColon != null
                             ? SplitMemberPath(sub.ExpressionColon.Expression)
                             : null;
@@ -1778,7 +1798,7 @@ public sealed partial class CSharpToGSharpTranslator
                     {
                         memberAccess = new MemberAccessExpression(
                             memberAccess,
-                            SanitizeIdentifier(memberName));
+                            memberName);
                     }
 
                     this.AddTypedSubpatternTest(
@@ -1824,7 +1844,7 @@ public sealed partial class CSharpToGSharpTranslator
                         continue;
                     }
 
-                    string memberName = sub.NameColon?.Name.Identifier.Text ?? memberNames?[i];
+                    string memberName = sub.NameColon?.Name.Identifier.ValueText ?? memberNames?[i];
                     if (memberName == null)
                     {
                         this.context.ReportUnsupported(
@@ -1833,8 +1853,14 @@ public sealed partial class CSharpToGSharpTranslator
                         continue;
                     }
 
+                    ISymbol memberSymbol = sub.NameColon != null
+                        ? this.context.GetSymbolInfo(sub.NameColon.Name).Symbol
+                        : (this.context.GetTypeInfo(recursive.Type).Type as INamedTypeSymbol)?
+                            .GetMembers(memberName)
+                            .FirstOrDefault();
                     GExpression memberAccess = new MemberAccessExpression(
-                        new IdentifierExpression(designator), SanitizeIdentifier(memberName));
+                        new IdentifierExpression(designator),
+                        this.EmittedName(memberSymbol, memberName));
                     this.AddTypedSubpatternTest(
                         sub.Pattern,
                         memberAccess,
@@ -1939,7 +1965,7 @@ public sealed partial class CSharpToGSharpTranslator
                 || rootPattern.DescendantNodesAndSelf()
                     .OfType<SingleVariableDesignationSyntax>()
                     .Any(designation =>
-                        SanitizeIdentifier(designation.Identifier.Text) == candidate));
+                        this.EmittedName(designation, designation.Identifier) == candidate));
 
             usedDesignators.Add(candidate);
             return candidate;
@@ -1971,7 +1997,7 @@ public sealed partial class CSharpToGSharpTranslator
                 case AliasQualifiedNameSyntax aliasQualified:
                     return GetRightmostTypeName(aliasQualified.Name);
                 case SimpleNameSyntax simple:
-                    return simple.Identifier.Text;
+                    return simple.Identifier.ValueText;
                 case PredefinedTypeSyntax predefined:
                     ITypeSymbol predefinedSymbol = this.context.GetTypeInfo(predefined).Type;
                     return predefinedSymbol?.Name ?? predefined.Keyword.Text;
@@ -2007,7 +2033,10 @@ public sealed partial class CSharpToGSharpTranslator
             // grows it. G# has no anonymous types to carry more than one variable
             // through a lambda, so scope.Count > 1 is threaded as a positional
             // tuple (see <see cref="BuildScopeParameter"/>).
-            var scope = new List<(string Name, GTypeReference Type)> { (from.Identifier.Text, rangeType) };
+            var scope = new List<(string Name, GTypeReference Type, ISymbol Symbol)>
+            {
+                (from.Identifier.ValueText, rangeType, this.context.GetDeclaredSymbol(from)),
+            };
 
             // Issue #1998: track the enclosing query node so a scope that grows
             // past G#'s tuple arity cap (see <see cref="BuildScopeParameter"/>)
@@ -2071,7 +2100,7 @@ public sealed partial class CSharpToGSharpTranslator
 
         private GExpression LowerQueryBody(
             QueryBodySyntax body,
-            List<(string Name, GTypeReference Type)> scope,
+            List<(string Name, GTypeReference Type, ISymbol Symbol)> scope,
             GExpression current)
         {
             foreach (QueryClauseSyntax clause in body.Clauses)
@@ -2139,7 +2168,7 @@ public sealed partial class CSharpToGSharpTranslator
                     // An identity projection (`select n`) after another clause is a
                     // no-op the C# compiler elides; keep it only when it transforms.
                     if (scope.Count == 1 && select.Expression is IdentifierNameSyntax id
-                        && id.Identifier.Text == scope[0].Name && body.Clauses.Count > 0)
+                        && id.Identifier.ValueText == scope[0].Name && body.Clauses.Count > 0)
                     {
                         break;
                     }
@@ -2171,9 +2200,12 @@ public sealed partial class CSharpToGSharpTranslator
             if (body.Continuation != null)
             {
                 this.ReportIfIndexOrRangeTypedRangeVariable(body.Continuation, body.Continuation.Identifier, resultTypeSymbol);
-                var continuationScope = new List<(string Name, GTypeReference Type)>
+                var continuationScope = new List<(string Name, GTypeReference Type, ISymbol Symbol)>
                 {
-                    (SanitizeIdentifier(body.Continuation.Identifier.Text), resultType),
+                    (
+                        body.Continuation.Identifier.ValueText,
+                        resultType,
+                        this.context.GetDeclaredSymbol(body.Continuation)),
                 };
                 current = this.LowerQueryBody(body.Continuation.Body, continuationScope, current);
             }
@@ -2187,7 +2219,7 @@ public sealed partial class CSharpToGSharpTranslator
         // positional tuple carries the widened scope forward.
         private GExpression LowerLetClause(
             LetClauseSyntax let,
-            List<(string Name, GTypeReference Type)> scope,
+            List<(string Name, GTypeReference Type, ISymbol Symbol)> scope,
             GExpression current)
         {
             var prologue = new List<GStatement>();
@@ -2203,7 +2235,8 @@ public sealed partial class CSharpToGSharpTranslator
                 : new NamedTypeReference(CSharpTypeMapper.UnsupportedPlaceholderType);
 
             List<GExpression> elements = scope
-                .Select(v => (GExpression)new IdentifierExpression(SanitizeIdentifier(v.Name)))
+                .Select(v => (GExpression)new IdentifierExpression(
+                    this.EmittedName(v.Symbol, v.Name)))
                 .ToList();
             elements.Add(letValue);
             prologue.Add(new ReturnStatement(new TupleLiteralExpression(elements)));
@@ -2213,7 +2246,10 @@ public sealed partial class CSharpToGSharpTranslator
                 new MemberAccessExpression(current, "Select"),
                 new List<GExpression> { lambda });
 
-            scope.Add((let.Identifier.Text, letType));
+            scope.Add((
+                let.Identifier.ValueText,
+                letType,
+                this.context.GetDeclaredSymbol(let)));
             return current;
         }
 
@@ -2224,13 +2260,16 @@ public sealed partial class CSharpToGSharpTranslator
         // as `let` above.
         private GExpression LowerAdditionalFromClause(
             FromClauseSyntax from,
-            List<(string Name, GTypeReference Type)> scope,
+            List<(string Name, GTypeReference Type, ISymbol Symbol)> scope,
             GExpression current)
         {
             LambdaExpression collectionSelector = this.BuildScopeLambda(scope, from.Expression);
             this.ReportIfIndexOrRangeTypedRangeVariable(from, from.Identifier, from.Type, from.Expression);
             GTypeReference newVarType = this.ResolveRangeVariableType(from.Type, from.Expression, from);
-            (string Name, GTypeReference Type) newVar = (from.Identifier.Text, newVarType);
+            (string Name, GTypeReference Type, ISymbol Symbol) newVar = (
+                from.Identifier.ValueText,
+                newVarType,
+                this.context.GetDeclaredSymbol(from));
             LambdaExpression resultSelector = this.BuildTransparentResultSelector(scope, newVar);
 
             current = new InvocationExpression(
@@ -2247,17 +2286,21 @@ public sealed partial class CSharpToGSharpTranslator
         // scope by `g : IEnumerable<TInner>` instead of the bare inner variable.
         private GExpression LowerJoinClause(
             JoinClauseSyntax join,
-            List<(string Name, GTypeReference Type)> scope,
+            List<(string Name, GTypeReference Type, ISymbol Symbol)> scope,
             GExpression current)
         {
             GExpression inner = this.TranslateExpression(join.InExpression);
             this.ReportIfIndexOrRangeTypedRangeVariable(join, join.Identifier, join.Type, join.InExpression);
             GTypeReference innerVarType = this.ResolveRangeVariableType(join.Type, join.InExpression, join);
-            var innerVar = (Name: join.Identifier.Text, Type: innerVarType);
+            var innerVar = (
+                Name: join.Identifier.ValueText,
+                Type: innerVarType,
+                Symbol: this.context.GetDeclaredSymbol(join));
 
             LambdaExpression outerKeySelector = this.BuildScopeLambda(scope, join.LeftExpression);
             LambdaExpression innerKeySelector = this.BuildScopeLambda(
-                new List<(string Name, GTypeReference Type)> { innerVar }, join.RightExpression);
+                new List<(string Name, GTypeReference Type, ISymbol Symbol)> { innerVar },
+                join.RightExpression);
 
             if (join.Into == null)
             {
@@ -2277,8 +2320,9 @@ public sealed partial class CSharpToGSharpTranslator
             // `into g` is always `IEnumerable<TInner>` (spec §12.19.3.8) — never
             // Index/Range itself — so no loud-gap check applies here.
             var groupVar = (
-                Name: join.Into.Identifier.Text,
-                Type: (GTypeReference)new NamedTypeReference("sequence", new List<GTypeReference> { innerVarType }));
+                Name: join.Into.Identifier.ValueText,
+                Type: (GTypeReference)new NamedTypeReference("sequence", new List<GTypeReference> { innerVarType }),
+                Symbol: this.context.GetDeclaredSymbol(join.Into));
             LambdaExpression groupResultSelector = this.BuildTransparentResultSelector(scope, groupVar);
             current = new InvocationExpression(
                 new MemberAccessExpression(current, "GroupJoin"),
@@ -2294,7 +2338,7 @@ public sealed partial class CSharpToGSharpTranslator
         // element type becomes `IGrouping<TKey, TElement>`.
         private GExpression LowerGroupClause(
             GroupClauseSyntax group,
-            List<(string Name, GTypeReference Type)> scope,
+            List<(string Name, GTypeReference Type, ISymbol Symbol)> scope,
             GExpression current,
             out GTypeReference resultType)
         {
@@ -2305,7 +2349,7 @@ public sealed partial class CSharpToGSharpTranslator
 
             bool isIdentity = scope.Count == 1
                 && group.GroupExpression is IdentifierNameSyntax id
-                && id.Identifier.Text == scope[0].Name;
+                && id.Identifier.ValueText == scope[0].Name;
 
             var args = new List<GExpression> { keySelector };
             GTypeReference elementType;
@@ -2329,7 +2373,7 @@ public sealed partial class CSharpToGSharpTranslator
         private GExpression QueryCall(
             GExpression receiver,
             string method,
-            List<(string Name, GTypeReference Type)> scope,
+            List<(string Name, GTypeReference Type, ISymbol Symbol)> scope,
             ExpressionSyntax lambdaBody)
         {
             LambdaExpression lambda = this.BuildScopeLambda(scope, lambdaBody);
@@ -2344,7 +2388,7 @@ public sealed partial class CSharpToGSharpTranslator
         // back into the individual range-variable names `body` refers to (see
         // <see cref="BuildScopeParameter"/>).
         private LambdaExpression BuildScopeLambda(
-            List<(string Name, GTypeReference Type)> scope,
+            List<(string Name, GTypeReference Type, ISymbol Symbol)> scope,
             ExpressionSyntax lambdaBody)
         {
             var prologue = new List<GStatement>();
@@ -2383,17 +2427,21 @@ public sealed partial class CSharpToGSharpTranslator
         // the left-hand (current) scope, one for the newly introduced variable,
         // returning the widened scope as a positional tuple.
         private LambdaExpression BuildTransparentResultSelector(
-            List<(string Name, GTypeReference Type)> leftScope,
-            (string Name, GTypeReference Type) rightVar)
+            List<(string Name, GTypeReference Type, ISymbol Symbol)> leftScope,
+            (string Name, GTypeReference Type, ISymbol Symbol) rightVar)
         {
             var prologue = new List<GStatement>();
             Parameter leftParam = this.BuildScopeParameter(leftScope, prologue);
-            var rightParam = new Parameter(SanitizeIdentifier(rightVar.Name), rightVar.Type);
+            var rightParam = new Parameter(
+                this.EmittedName(rightVar.Symbol, rightVar.Name),
+                rightVar.Type);
 
             List<GExpression> elements = leftScope
-                .Select(v => (GExpression)new IdentifierExpression(SanitizeIdentifier(v.Name)))
+                .Select(v => (GExpression)new IdentifierExpression(
+                    this.EmittedName(v.Symbol, v.Name)))
                 .ToList();
-            elements.Add(new IdentifierExpression(SanitizeIdentifier(rightVar.Name)));
+            elements.Add(new IdentifierExpression(
+                this.EmittedName(rightVar.Symbol, rightVar.Name)));
             prologue.Add(new ReturnStatement(new TupleLiteralExpression(elements)));
 
             return new LambdaExpression(
@@ -2408,12 +2456,14 @@ public sealed partial class CSharpToGSharpTranslator
         // still refer to each range variable by its own name (issue #1902 — G#
         // has no anonymous types to bind the C# spec's transparent identifier to).
         private Parameter BuildScopeParameter(
-            List<(string Name, GTypeReference Type)> scope,
+            List<(string Name, GTypeReference Type, ISymbol Symbol)> scope,
             List<GStatement> prologue)
         {
             if (scope.Count == 1)
             {
-                return new Parameter(SanitizeIdentifier(scope[0].Name), scope[0].Type);
+                return new Parameter(
+                    this.EmittedName(scope[0].Symbol, scope[0].Name),
+                    scope[0].Type);
             }
 
             // Issue #1998: G#'s tuple family (mirroring the BCL's `ValueTuple`)
@@ -2453,7 +2503,7 @@ public sealed partial class CSharpToGSharpTranslator
 
             prologue.Add(new TupleDeconstructionStatement(
                 BindingKind.Let,
-                scope.Select(v => SanitizeIdentifier(v.Name)).ToList(),
+                scope.Select(v => this.EmittedName(v.Symbol, v.Name)).ToList(),
                 new IdentifierExpression(tupleParamName)));
             return new Parameter(tupleParamName, new TupleTypeReference(scope.Select(v => v.Type).ToList()));
         }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
@@ -1730,7 +1730,9 @@ public sealed partial class CSharpToGSharpTranslator
 
                         ISymbol memberSymbol = sub.NameColon != null
                             ? this.GetPatternMemberSymbol(sub.NameColon.Name)
-                            : (this.context.GetTypeInfo(recursive.Type).Type as INamedTypeSymbol)?
+                            : (recursive.Type != null
+                                ? this.context.GetTypeInfo(recursive.Type).Type as INamedTypeSymbol
+                                : null)?
                                 .GetMembers(memberName)
                                 .FirstOrDefault();
                         string emittedMemberName = this.EmittedName(memberSymbol, memberName);
@@ -1855,7 +1857,9 @@ public sealed partial class CSharpToGSharpTranslator
 
                     ISymbol memberSymbol = sub.NameColon != null
                         ? this.GetPatternMemberSymbol(sub.NameColon.Name)
-                        : (this.context.GetTypeInfo(recursive.Type).Type as INamedTypeSymbol)?
+                        : (recursive.Type != null
+                            ? this.context.GetTypeInfo(recursive.Type).Type as INamedTypeSymbol
+                            : null)?
                             .GetMembers(memberName)
                             .FirstOrDefault();
                     GExpression memberAccess = new MemberAccessExpression(

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -1094,7 +1094,9 @@ public sealed partial class CSharpToGSharpTranslator
                 continue;
             }
 
-            string alias = directive.Alias?.Name.Identifier.Text;
+            string alias = directive.Alias is null
+                ? null
+                : SanitizeIdentifier(directive.Alias.Name.Identifier.Text);
 
             if (namespaceOrType is not NameSyntax)
             {
@@ -1236,20 +1238,6 @@ public sealed partial class CSharpToGSharpTranslator
         // UNQUALIFIED (gsc resolves it through `import X`), unlike a sibling
         // static, which is qualified through its owning type.
         private readonly HashSet<INamedTypeSymbol> staticUsingTargets;
-
-        // The set of hard G# keywords (Cs2Gs.Compiler SyntaxFacts.GetKeywordKind).
-        // A C# identifier that collides with one of these cannot be emitted bare; it
-        // is suffixed with `_` consistently at every declaration and reference site.
-        private static readonly HashSet<string> GSharpReservedWords = new HashSet<string>(System.StringComparer.Ordinal)
-        {
-            "as", "async", "await", "break", "case", "catch", "chan", "class", "const",
-            "continue", "default", "defer", "do", "else", "enum", "false", "fallthrough",
-            "finally", "for", "func", "go", "goto", "guard", "if", "import", "interface",
-            "internal", "is", "let", "lock", "map", "nil", "open", "operator", "override",
-            "package", "private", "protected", "public", "range", "return", "scope",
-            "sealed", "select", "sequence", "struct", "switch", "throw", "true", "try",
-            "type", "using", "var", "while",
-        };
 
         // gsc's ADR-0044 implicit numeric widening lattice (mirrors
         // Conversion.NumericWideningTargets), keyed on the C# SpecialType of the

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -15,6 +15,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Text;
+using IdentifierNameContext = GSharp.Core.CodeAnalysis.Syntax.IdentifierNameContext;
 
 namespace Cs2Gs.Translator;
 
@@ -209,7 +210,10 @@ public sealed partial class CSharpToGSharpTranslator
         OwnedExtensionRegistry ownedExtensions =
             GetOrCollectOwnedExtensions(context.Compilation).Filter(this.retainedFilePaths);
 
-        string package = this.packageFilter ?? this.ResolvePackage(root, context);
+        EmittedNameAllocator nameAllocator = EmittedNameAllocator.For(context.Compilation);
+        string package = this.packageFilter is null
+            ? this.ResolvePackage(root, context, nameAllocator)
+            : this.ResolvePackageName(this.packageFilter, context, nameAllocator);
 
         // T3 (ADR-0115 §B.1/§B.11): the C# program entry point and its enclosing
         // static class normally become top-level G#. When the entry class owns a
@@ -243,7 +247,11 @@ public sealed partial class CSharpToGSharpTranslator
             contributingTrees
                 .Where(tree => tree != root.SyntaxTree)
                 .OrderBy(tree => tree.FilePath, StringComparer.Ordinal);
-        IReadOnlyList<ImportDirective> imports = this.TranslateImports(root, extraUsingTrees, context);
+        IReadOnlyList<ImportDirective> imports = this.TranslateImports(
+            root,
+            extraUsingTrees,
+            context,
+            nameAllocator);
 
         HashSet<INamedTypeSymbol> openBases = GetOrCollectSubclassedBaseTypes(context.Compilation);
         HashSet<INamedTypeSymbol> staticUsingTargets = CollectStaticUsingTargets(root, context);
@@ -265,7 +273,7 @@ public sealed partial class CSharpToGSharpTranslator
             this.anonymousTypeRegistriesByPackage[registryKey] = anonymousTypeRegistry;
         }
 
-        var typeMapper = new CSharpTypeMapper(anonymousTypeRegistry);
+        var typeMapper = new CSharpTypeMapper(anonymousTypeRegistry, nameAllocator);
         typeMapper.ReserveImportAliases(imports);
         var visitor = new DeclarationVisitor(
             context,
@@ -275,6 +283,7 @@ public sealed partial class CSharpToGSharpTranslator
             preserveEntryType ? null : entryPoint,
             partialTypeParts,
             ownedExtensions,
+            nameAllocator,
             this.preservePartialParts,
             this.markMergedTypePartial,
             this.widenObliviousReferenceFields);
@@ -409,14 +418,6 @@ public sealed partial class CSharpToGSharpTranslator
             .Select(symbol => symbol.ContainingNamespace.ToDisplayString())
             .Distinct(StringComparer.Ordinal)
             .ToList();
-
-    // Forwards to the canonical identifier sanitizer implemented on the nested
-    // declaration visitor, so callers outside the visitor (e.g.
-    // <see cref="CSharpTypeMapper"/>) can route type-name references through the
-    // exact same sanitizer used at every declaration and reference site inside
-    // the visitor, keeping declared and referenced names in agreement (issue
-    // #1734).
-    internal static string SanitizeIdentifier(string name) => DeclarationVisitor.SanitizeIdentifier(name);
 
     private static IEnumerable<MemberDeclarationSyntax> EnumerateTopLevelDeclarations(CompilationUnitSyntax root)
     {
@@ -1032,7 +1033,10 @@ public sealed partial class CSharpToGSharpTranslator
         }
     }
 
-    private string ResolvePackage(CompilationUnitSyntax root, TranslationContext context)
+    private string ResolvePackage(
+        CompilationUnitSyntax root,
+        TranslationContext context,
+        EmittedNameAllocator nameAllocator)
     {
         List<(string Name, Location Location)> namespaces = EnumerateTopLevelDeclarations(root)
             .Select(member => (
@@ -1040,7 +1044,7 @@ public sealed partial class CSharpToGSharpTranslator
                 Location: member.GetLocation()))
             .Where(item => item.Symbol?.ContainingNamespace is { IsGlobalNamespace: false })
             .Select(item => (
-                item.Symbol.ContainingNamespace.ToDisplayString(),
+                nameAllocator.GetNamespaceName(item.Symbol.ContainingNamespace),
                 item.Location))
             .ToList();
 
@@ -1063,10 +1067,30 @@ public sealed partial class CSharpToGSharpTranslator
         return dominant;
     }
 
+    private string ResolvePackageName(
+        string packageName,
+        TranslationContext context,
+        EmittedNameAllocator nameAllocator)
+    {
+        INamespaceSymbol current = context.Compilation.GlobalNamespace;
+        foreach (string segment in packageName.Split('.'))
+        {
+            current = current.GetNamespaceMembers()
+                .FirstOrDefault(candidate => candidate.Name == segment);
+            if (current == null)
+            {
+                return packageName;
+            }
+        }
+
+        return nameAllocator.GetNamespaceName(current);
+    }
+
     private IReadOnlyList<ImportDirective> TranslateImports(
         CompilationUnitSyntax root,
         IEnumerable<Microsoft.CodeAnalysis.SyntaxTree> extraUsingTrees,
-        TranslationContext context)
+        TranslationContext context,
+        EmittedNameAllocator nameAllocator)
     {
         var imports = new List<ImportDirective>();
         var seen = new HashSet<(string Name, string Alias)>();
@@ -1082,6 +1106,8 @@ public sealed partial class CSharpToGSharpTranslator
 
         foreach (UsingDirectiveSyntax directive in usings)
         {
+            using IDisposable modelScope = context.UseSemanticModelFor(directive.SyntaxTree);
+
             // C# 12 alias-any-type directives (`using X = (int, string);`,
             // arrays, pointers, nullable value types, ...) put a non-name
             // TypeSyntax where a plain dotted name used to be the only option;
@@ -1096,7 +1122,12 @@ public sealed partial class CSharpToGSharpTranslator
 
             string alias = directive.Alias is null
                 ? null
-                : SanitizeIdentifier(directive.Alias.Name.Identifier.Text);
+                : nameAllocator.GetName(
+                    context.GetDeclaredSymbol(directive),
+                    IdentifierNameContext.Type)
+                    ?? nameAllocator.GetName(
+                        directive.Alias.Name.Identifier.ValueText,
+                        IdentifierNameContext.Type);
 
             if (namespaceOrType is not NameSyntax)
             {
@@ -1128,7 +1159,7 @@ public sealed partial class CSharpToGSharpTranslator
             // become `import Foo.Bar`, not the unparseable `import
             // global::Foo.Bar` (G#'s import syntax has no alias-qualifier
             // form).
-            string name = CSharpTypeMapper.StripGlobalPrefix(namespaceOrType.ToString());
+            string name = this.TranslateImportName(namespaceOrType, context, nameAllocator);
 
             if (!directive.StaticKeyword.IsKind(SyntaxKind.None))
             {
@@ -1158,6 +1189,38 @@ public sealed partial class CSharpToGSharpTranslator
         }
 
         return imports;
+    }
+
+    private string TranslateImportName(
+        TypeSyntax namespaceOrType,
+        TranslationContext context,
+        EmittedNameAllocator nameAllocator)
+    {
+        ISymbol symbol = context.GetSymbolInfo(namespaceOrType).Symbol;
+        return symbol switch
+        {
+            INamespaceSymbol ns => nameAllocator.GetNamespaceName(ns),
+            INamedTypeSymbol type => this.QualifiedImportTypeName(type, nameAllocator),
+            _ => CSharpTypeMapper.StripGlobalPrefix(namespaceOrType.ToString()),
+        };
+    }
+
+    private string QualifiedImportTypeName(
+        INamedTypeSymbol type,
+        EmittedNameAllocator nameAllocator)
+    {
+        var typeParts = new Stack<string>();
+        INamedTypeSymbol outermost = type;
+        for (INamedTypeSymbol current = type; current != null; current = current.ContainingType)
+        {
+            typeParts.Push(nameAllocator.GetName(current));
+            outermost = current;
+        }
+
+        string typeName = string.Join(".", typeParts);
+        return outermost.ContainingNamespace is { IsGlobalNamespace: false } ns
+            ? $"{nameAllocator.GetNamespaceName(ns)}.{typeName}"
+            : typeName;
     }
 
     /// <summary>
@@ -1219,6 +1282,7 @@ public sealed partial class CSharpToGSharpTranslator
         // Issue #2821: same-package source extension methods are emitted as
         // members of their owned receiver type, not as top-level receiver funcs.
         private readonly OwnedExtensionRegistry ownedExtensions;
+        private readonly EmittedNameAllocator nameAllocator;
 
         // ADR-0145 (§C/§D): when true, `partial` parts are NOT merged — every
         // part is emitted as its own standalone G# `partial` declaration (using
@@ -1285,6 +1349,7 @@ public sealed partial class CSharpToGSharpTranslator
             IMethodSymbol entryPoint,
             Dictionary<INamedTypeSymbol, List<TypeDeclarationSyntax>> partialTypeParts,
             OwnedExtensionRegistry ownedExtensions,
+            EmittedNameAllocator nameAllocator,
             bool preservePartialParts = false,
             bool markMergedTypePartial = false,
             bool widenObliviousReferenceFields = false)
@@ -1295,6 +1360,7 @@ public sealed partial class CSharpToGSharpTranslator
             this.staticUsingTargets = staticUsingTargets ?? new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
             this.partialTypeParts = partialTypeParts ?? new Dictionary<INamedTypeSymbol, List<TypeDeclarationSyntax>>(SymbolEqualityComparer.Default);
             this.ownedExtensions = ownedExtensions ?? new OwnedExtensionRegistry(context.Compilation.Assembly);
+            this.nameAllocator = nameAllocator ?? EmittedNameAllocator.For(context.Compilation);
             this.preservePartialParts = preservePartialParts;
             this.markMergedTypePartial = markMergedTypePartial;
             this.widenObliviousReferenceFields = widenObliviousReferenceFields;

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -254,7 +254,8 @@ public sealed class CSharpTypeMapper
             return;
         }
 
-        this.shortenedNamespaces.Add(ns.ToDisplayString());
+        this.shortenedNamespaces.Add(
+            this.nameAllocator?.GetNamespaceName(ns) ?? ns.ToDisplayString());
     }
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -73,6 +73,7 @@ public sealed class CSharpTypeMapper
     /// </para>
     /// </summary>
     private readonly AnonymousTypeRegistry anonymousTypeRegistry;
+    private readonly EmittedNameAllocator nameAllocator;
 
     /// <summary>
     /// Issue #2282: the synthesized anonymous-type <c>data class</c>
@@ -148,8 +149,16 @@ public sealed class CSharpTypeMapper
     /// The package-scoped registry of already-synthesized anonymous-type shapes.
     /// </param>
     public CSharpTypeMapper(AnonymousTypeRegistry anonymousTypeRegistry)
+        : this(anonymousTypeRegistry, nameAllocator: null)
+    {
+    }
+
+    internal CSharpTypeMapper(
+        AnonymousTypeRegistry anonymousTypeRegistry,
+        EmittedNameAllocator nameAllocator)
     {
         this.anonymousTypeRegistry = anonymousTypeRegistry ?? new AnonymousTypeRegistry();
+        this.nameAllocator = nameAllocator;
     }
 
     /// <summary>
@@ -187,14 +196,18 @@ public sealed class CSharpTypeMapper
 
         string aliasTarget = alias?.Target switch
         {
-            INamespaceSymbol ns when !ns.IsGlobalNamespace => ns.ToDisplayString(),
-            INamedTypeSymbol type => StripGlobalPrefix(
-                type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)),
+            INamespaceSymbol ns when !ns.IsGlobalNamespace =>
+                this.nameAllocator?.GetNamespaceName(ns) ?? ns.ToDisplayString(),
+            INamedTypeSymbol type => this.QualifiedAliasTarget(type),
             _ => null,
         };
         if (!string.IsNullOrEmpty(aliasTarget))
         {
-            this.synthesizedTypeAliases[CSharpToGSharpTranslator.SanitizeIdentifier(alias.Name)] = aliasTarget;
+            string aliasName = this.nameAllocator?.GetName(alias)
+                ?? GSharp.Core.CodeAnalysis.Syntax.SyntaxFacts.GetEmittedIdentifier(
+                    alias.Name,
+                    GSharp.Core.CodeAnalysis.Syntax.IdentifierNameContext.Type);
+            this.synthesizedTypeAliases[aliasName] = aliasTarget;
         }
     }
 
@@ -493,9 +506,9 @@ public sealed class CSharpTypeMapper
         INamedTypeSymbol named,
         TranslationContext context)
     {
-        string simpleName = CSharpToGSharpTranslator.SanitizeIdentifier(named.Name);
+        string simpleName = this.Names(context).GetName(named);
         string target = named.ContainingNamespace is { IsGlobalNamespace: false } ns
-            ? $"{ns.ToDisplayString()}.{simpleName}"
+            ? $"{this.Names(context).GetNamespaceName(ns)}.{simpleName}"
             : simpleName;
         foreach (var existing in this.synthesizedTypeAliases)
         {
@@ -552,7 +565,11 @@ public sealed class CSharpTypeMapper
 
         string syntheticName = AnonymousTypeRegistry.SyntheticName(shapeKey, properties.Count);
         var parameters = properties
-            .Select(p => new Cs2Gs.CodeModel.Ast.Parameter(CSharpToGSharpTranslator.SanitizeIdentifier(p.Name), this.Map(p.Type, context, location)))
+            .Select(p => new Cs2Gs.CodeModel.Ast.Parameter(
+                this.Names(context).GetName(
+                    p,
+                    GSharp.Core.CodeAnalysis.Syntax.IdentifierNameContext.Parameter),
+                this.Map(p.Type, context, location)))
             .ToList();
 
         context.Report(new TranslationDiagnostic(
@@ -584,12 +601,14 @@ public sealed class CSharpTypeMapper
         type is INamedTypeSymbol { ContainingNamespace.Name: "System", ContainingNamespace.ContainingNamespace.IsGlobalNamespace: true } named
             && (named.Name == "Index" || named.Name == "Range");
 
-    internal static string LiftedNestedDelegateName(INamedTypeSymbol named)
+    internal string LiftedNestedDelegateName(
+        INamedTypeSymbol named,
+        TranslationContext context)
     {
         var parts = new List<string>();
         for (INamedTypeSymbol current = named; current != null; current = current.ContainingType)
         {
-            parts.Insert(0, CSharpToGSharpTranslator.SanitizeIdentifier(current.Name));
+            parts.Insert(0, this.Names(context).GetName(current));
         }
 
         return string.Join("_", parts);
@@ -628,6 +647,31 @@ public sealed class CSharpTypeMapper
                 type.TypeArguments.Select(argument => this.Map(argument, context, location)).ToList())
             : new NamedTypeReference(this.DelegateTypeName(type, context, location));
     }
+
+    private string QualifiedAliasTarget(INamedTypeSymbol type)
+    {
+        if (this.nameAllocator is null)
+        {
+            return StripGlobalPrefix(
+                type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
+        }
+
+        var parts = new Stack<string>();
+        INamedTypeSymbol outermost = type;
+        for (INamedTypeSymbol current = type; current != null; current = current.ContainingType)
+        {
+            parts.Push(this.nameAllocator.GetName(current));
+            outermost = current;
+        }
+
+        string typeName = string.Join(".", parts);
+        return outermost.ContainingNamespace is { IsGlobalNamespace: false } ns
+            ? $"{this.nameAllocator.GetNamespaceName(ns)}.{typeName}"
+            : typeName;
+    }
+
+    private EmittedNameAllocator Names(TranslationContext context) =>
+        this.nameAllocator ?? EmittedNameAllocator.For(context.Compilation);
 
     /// <summary>
     /// Issue #1906: maps a C# function-pointer type (<c>delegate*&lt;...&gt;</c>)
@@ -802,7 +846,7 @@ public sealed class CSharpTypeMapper
 
         if (type is ITypeParameterSymbol typeParameter)
         {
-            return new NamedTypeReference(CSharpToGSharpTranslator.SanitizeIdentifier(typeParameter.Name));
+            return new NamedTypeReference(this.Names(context).GetName(typeParameter));
         }
 
         if (type is INamedTypeSymbol named)
@@ -898,12 +942,12 @@ public sealed class CSharpTypeMapper
                     && IsWithinContainingType(named, context, location))
                 {
                     return new NamedTypeReference(
-                        CSharpToGSharpTranslator.SanitizeIdentifier(named.Name),
+                        this.Names(context).GetName(named),
                         mappedOwnTypeArguments);
                 }
 
                 return new NamedTypeReference(
-                    CSharpToGSharpTranslator.SanitizeIdentifier(named.Name),
+                    this.Names(context).GetName(named),
                     mappedOwnTypeArguments,
                     this.Map(named.ContainingType, context, location));
             }
@@ -919,7 +963,7 @@ public sealed class CSharpTypeMapper
             return new NamedTypeReference(this.QualifiedTypeName(named, context, location));
         }
 
-        return new NamedTypeReference(CSharpToGSharpTranslator.SanitizeIdentifier(type.Name));
+        return new NamedTypeReference(this.Names(context).GetName(type));
     }
 
     private string DelegateTypeName(
@@ -928,7 +972,7 @@ public sealed class CSharpTypeMapper
         Location location)
     {
         return IsSourceDeclaredDelegate(named) && named.ContainingType != null
-            ? LiftedNestedDelegateName(named)
+            ? this.LiftedNestedDelegateName(named, context)
             : this.QualifiedTypeName(named, context, location);
     }
 
@@ -969,7 +1013,7 @@ public sealed class CSharpTypeMapper
         if (named.ContainingType == null)
         {
             this.TrackShortenedNamespace(named);
-            string simpleName = CSharpToGSharpTranslator.SanitizeIdentifier(named.Name);
+            string simpleName = this.Names(context).GetName(named);
             if (IsDeclaredInContainingNamespace(named, context, location))
             {
                 return simpleName;
@@ -1011,7 +1055,7 @@ public sealed class CSharpTypeMapper
             }
 
             return named.ContainingNamespace is { IsGlobalNamespace: false } containingNs
-                ? $"{containingNs.ToDisplayString()}.{simpleName}"
+                ? $"{this.Names(context).GetNamespaceName(containingNs)}.{simpleName}"
                 : simpleName;
         }
 
@@ -1022,14 +1066,14 @@ public sealed class CSharpTypeMapper
             && !this.HasSourceHomonym(named, context)
             && IsWithinContainingType(named, context, location))
         {
-            return CSharpToGSharpTranslator.SanitizeIdentifier(named.Name);
+            return this.Names(context).GetName(named);
         }
 
         var parts = new List<string>();
         INamedTypeSymbol outermost = named;
         for (INamedTypeSymbol current = named; current != null; current = current.ContainingType)
         {
-            parts.Insert(0, CSharpToGSharpTranslator.SanitizeIdentifier(current.Name));
+            parts.Insert(0, this.Names(context).GetName(current));
             outermost = current;
         }
 
@@ -1041,7 +1085,7 @@ public sealed class CSharpTypeMapper
             || (scanOutermostImports && this.HasImportedNamespaceHomonym(outermost, context));
         return outermostAmbiguous
             && outermost.ContainingNamespace is { IsGlobalNamespace: false } outerNamespace
-                ? $"{outerNamespace.ToDisplayString()}.{nestedName}"
+                ? $"{this.Names(context).GetNamespaceName(outerNamespace)}.{nestedName}"
                 : nestedName;
     }
 
@@ -1100,7 +1144,8 @@ public sealed class CSharpTypeMapper
     {
         if (outermostType.ContainingNamespace is { IsGlobalNamespace: false } ns)
         {
-            this.shortenedNamespaces.Add(ns.ToDisplayString());
+            this.shortenedNamespaces.Add(
+                this.nameAllocator?.GetNamespaceName(ns) ?? ns.ToDisplayString());
         }
     }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -194,7 +194,7 @@ public sealed class CSharpTypeMapper
         };
         if (!string.IsNullOrEmpty(aliasTarget))
         {
-            this.synthesizedTypeAliases[alias.Name] = aliasTarget;
+            this.synthesizedTypeAliases[CSharpToGSharpTranslator.SanitizeIdentifier(alias.Name)] = aliasTarget;
         }
     }
 

--- a/tools/cs2gs/Cs2Gs.Translator/EmittedNameAllocator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/EmittedNameAllocator.cs
@@ -106,9 +106,7 @@ internal sealed class EmittedNameAllocator
              current != null && !current.IsGlobalNamespace;
              current = current.ContainingNamespace)
         {
-            parts.Push(current.Locations.Any(location => location.IsInSource)
-                ? this.GetName(current)
-                : current.Name);
+            parts.Push(this.GetName(current));
         }
 
         return string.Join(".", parts);
@@ -173,7 +171,16 @@ internal sealed class EmittedNameAllocator
         {
             case IParameterSymbol parameter
                 when parameter.ContainingSymbol is IMethodSymbol method:
-                return method.Parameters.Select(candidate => candidate.Name).ToArray();
+                IEnumerable<string> parameterNames =
+                    method.Parameters.Select(candidate => candidate.Name);
+                if (IsPrimaryConstructorParameter(parameter)
+                    && parameter.ContainingType is { } primaryType)
+                {
+                    parameterNames = parameterNames.Concat(
+                        this.GetVisibleTypeMemberNames(primaryType));
+                }
+
+                return parameterNames.Distinct(StringComparer.Ordinal).ToArray();
 
             case ITypeParameterSymbol typeParameter
                 when typeParameter.ContainingSymbol is IMethodSymbol method:
@@ -200,15 +207,68 @@ internal sealed class EmittedNameAllocator
                     ?? Array.Empty<string>();
 
             default:
-                return symbol.ContainingType?.GetMembers()
-                    .Select(SourceName)
-                    .ToArray()
-                    ?? symbol.ContainingNamespace?.GetMembers()
+                return symbol.ContainingType is { } containingType
+                    ? this.GetVisibleTypeMemberNames(containingType)
+                    : symbol.ContainingNamespace?.GetMembers()
                         .Select(SourceName)
                         .ToArray()
                     ?? Array.Empty<string>();
         }
     }
+
+    private IReadOnlyCollection<string> GetVisibleTypeMemberNames(
+        INamedTypeSymbol type)
+    {
+        var names = new HashSet<string>(
+            type.GetMembers().Select(SourceName),
+            StringComparer.Ordinal);
+        for (INamedTypeSymbol current = type.BaseType;
+             current != null;
+             current = current.BaseType)
+        {
+            foreach (ISymbol member in current.GetMembers())
+            {
+                if (IsVisibleInheritedMember(member, type))
+                {
+                    names.Add(SourceName(member));
+                }
+            }
+        }
+
+        foreach (INamedTypeSymbol iface in type.AllInterfaces)
+        {
+            foreach (ISymbol member in iface.GetMembers())
+            {
+                names.Add(SourceName(member));
+            }
+        }
+
+        return names.ToArray();
+    }
+
+    private static bool IsVisibleInheritedMember(
+        ISymbol member,
+        INamedTypeSymbol derivedType) =>
+        member.DeclaredAccessibility switch
+        {
+            Accessibility.Public or Accessibility.Protected
+                or Accessibility.ProtectedOrInternal => true,
+            Accessibility.Internal or Accessibility.ProtectedAndInternal =>
+                SymbolEqualityComparer.Default.Equals(
+                    member.ContainingAssembly,
+                    derivedType.ContainingAssembly),
+            _ => false,
+        };
+
+    private static bool IsPrimaryConstructorParameter(IParameterSymbol parameter) =>
+        parameter.DeclaringSyntaxReferences.Any(reference =>
+            reference.GetSyntax() is ParameterSyntax
+            {
+                Parent: ParameterListSyntax
+                {
+                    Parent: TypeDeclarationSyntax,
+                },
+            });
 
     private IReadOnlyCollection<string> GetAliasScopeNames(IAliasSymbol alias)
     {
@@ -319,6 +379,19 @@ internal sealed class EmittedNameAllocator
         {
             foreach (ISymbol member in type.GetMembers())
             {
+                if (member is IPropertySymbol propertyMember)
+                {
+                    foreach (SyntaxReference reference in propertyMember.DeclaringSyntaxReferences)
+                    {
+                        if (reference.GetSyntax() is ParameterSyntax parameterSyntax
+                            && this.compilation.GetSemanticModel(reference.SyntaxTree)
+                                .GetDeclaredSymbol(parameterSyntax) is IParameterSymbol parameter)
+                        {
+                            Union(propertyMember, parameter);
+                        }
+                    }
+                }
+
                 ISymbol overridden = member switch
                 {
                     IMethodSymbol method => method.OverriddenMethod,

--- a/tools/cs2gs/Cs2Gs.Translator/EmittedNameAllocator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/EmittedNameAllocator.cs
@@ -1,0 +1,327 @@
+// <copyright file="EmittedNameAllocator.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using GSharpIdentifierNameContext = GSharp.Core.CodeAnalysis.Syntax.IdentifierNameContext;
+using GSharpSyntaxFacts = GSharp.Core.CodeAnalysis.Syntax.SyntaxFacts;
+
+namespace Cs2Gs.Translator;
+
+/// <summary>Allocates stable, grammar-safe G# names for bound C# symbols.</summary>
+internal sealed class EmittedNameAllocator
+{
+    private static readonly ConditionalWeakTable<Compilation, EmittedNameAllocator> Cache = new();
+
+    private readonly Compilation compilation;
+
+    private readonly object gate = new();
+
+    private readonly Dictionary<ISymbol, string> emittedNames =
+        new(SymbolEqualityComparer.Default);
+
+    private readonly Dictionary<ISymbol, GSharpIdentifierNameContext> additionalContexts =
+        new(SymbolEqualityComparer.Default);
+
+    private readonly Dictionary<ISymbol, IReadOnlyCollection<string>> methodScopeNames =
+        new(SymbolEqualityComparer.Default);
+
+    private readonly HashSet<ISymbol> invocationSensitive =
+        new(SymbolEqualityComparer.Default);
+
+    private EmittedNameAllocator(Compilation compilation)
+    {
+        this.compilation = compilation;
+        this.CollectInvocationSensitiveSymbols();
+    }
+
+    public static EmittedNameAllocator For(Compilation compilation) =>
+        Cache.GetValue(compilation, static value => new EmittedNameAllocator(value));
+
+    public string GetName(
+        ISymbol symbol,
+        GSharpIdentifierNameContext additionalContext = GSharpIdentifierNameContext.General)
+    {
+        if (symbol is null)
+        {
+            return null;
+        }
+
+        lock (this.gate)
+        {
+            symbol = Canonical(symbol);
+            if (additionalContext != GSharpIdentifierNameContext.General)
+            {
+                this.additionalContexts.TryGetValue(
+                    symbol,
+                    out GSharpIdentifierNameContext registered);
+                this.additionalContexts[symbol] = registered | additionalContext;
+            }
+
+            if (this.emittedNames.TryGetValue(symbol, out string existing)
+                && additionalContext == GSharpIdentifierNameContext.General)
+            {
+                return existing;
+            }
+
+            this.additionalContexts.TryGetValue(
+                symbol,
+                out GSharpIdentifierNameContext registeredContext);
+            GSharpIdentifierNameContext context =
+                this.GetContext(symbol) | registeredContext | additionalContext;
+            string emitted = GSharpSyntaxFacts.GetEmittedIdentifier(
+                symbol.Name,
+                context,
+                this.GetScopeNames(symbol));
+            this.emittedNames[symbol] = emitted;
+
+            return emitted;
+        }
+    }
+
+    public string GetName(
+        string name,
+        GSharpIdentifierNameContext context = GSharpIdentifierNameContext.General,
+        IEnumerable<string> scopeNames = null) =>
+        GSharpSyntaxFacts.GetEmittedIdentifier(name, context, scopeNames);
+
+    public string GetNamespaceName(INamespaceSymbol namespaceSymbol)
+    {
+        if (namespaceSymbol is null || namespaceSymbol.IsGlobalNamespace)
+        {
+            return null;
+        }
+
+        var parts = new Stack<string>();
+        for (INamespaceSymbol current = namespaceSymbol;
+             current != null && !current.IsGlobalNamespace;
+             current = current.ContainingNamespace)
+        {
+            parts.Push(current.Locations.Any(location => location.IsInSource)
+                ? this.GetName(current)
+                : current.Name);
+        }
+
+        return string.Join(".", parts);
+    }
+
+    private static ISymbol Canonical(ISymbol symbol) =>
+        symbol switch
+        {
+            IMethodSymbol method => method.OriginalDefinition,
+            INamedTypeSymbol type => type.OriginalDefinition,
+            _ => symbol,
+        };
+
+    private GSharpIdentifierNameContext GetContext(ISymbol symbol)
+    {
+        GSharpIdentifierNameContext context = symbol switch
+        {
+            IParameterSymbol => GSharpIdentifierNameContext.Parameter,
+            IRangeVariableSymbol =>
+                GSharpIdentifierNameContext.Parameter | GSharpIdentifierNameContext.Local,
+            ITypeParameterSymbol => GSharpIdentifierNameContext.TypeParameter | GSharpIdentifierNameContext.Type,
+            INamedTypeSymbol => GSharpIdentifierNameContext.Type,
+            IAliasSymbol => GSharpIdentifierNameContext.Type,
+            IPropertySymbol { ContainingType.IsAnonymousType: true } =>
+                GSharpIdentifierNameContext.Parameter,
+            IPropertySymbol property when property.DeclaringSyntaxReferences
+                .Any(reference => reference.GetSyntax() is ParameterSyntax) =>
+                GSharpIdentifierNameContext.Parameter,
+            IMethodSymbol method when method.Name == "init"
+                && !method.DeclaringSyntaxReferences.IsDefaultOrEmpty =>
+                GSharpIdentifierNameContext.Invocation,
+            IMethodSymbol { MethodKind: MethodKind.LocalFunction } => GSharpIdentifierNameContext.Local,
+            ILocalSymbol local when local.DeclaringSyntaxReferences
+                .Any(reference => reference.GetSyntax() is SingleVariableDesignationSyntax) =>
+                GSharpIdentifierNameContext.Pattern,
+            ILocalSymbol => GSharpIdentifierNameContext.Local,
+            _ => GSharpIdentifierNameContext.General,
+        };
+
+        if (this.invocationSensitive.Contains(symbol))
+        {
+            context |= GSharpIdentifierNameContext.Invocation;
+        }
+
+        return context;
+    }
+
+    private IReadOnlyCollection<string> GetScopeNames(ISymbol symbol)
+    {
+        switch (symbol)
+        {
+            case IParameterSymbol parameter
+                when parameter.ContainingSymbol is IMethodSymbol method:
+                return method.Parameters.Select(candidate => candidate.Name).ToArray();
+
+            case ITypeParameterSymbol typeParameter
+                when typeParameter.ContainingSymbol is IMethodSymbol method:
+                return method.TypeParameters.Select(candidate => candidate.Name).ToArray();
+
+            case ITypeParameterSymbol typeParameter
+                when typeParameter.ContainingSymbol is INamedTypeSymbol type:
+                return type.TypeParameters.Select(candidate => candidate.Name).ToArray();
+
+            case ILocalSymbol:
+            case IRangeVariableSymbol:
+            case ILabelSymbol:
+            case IMethodSymbol { MethodKind: MethodKind.LocalFunction }:
+                return this.GetMethodScopeNames(symbol.ContainingSymbol);
+
+            case IAliasSymbol alias:
+                return this.GetAliasScopeNames(alias);
+
+            case INamespaceSymbol namespaceSymbol:
+                return namespaceSymbol.ContainingNamespace?
+                    .GetMembers()
+                    .Select(candidate => candidate.Name)
+                    .ToArray()
+                    ?? Array.Empty<string>();
+
+            default:
+                return symbol.ContainingType?.GetMembers()
+                    .Select(candidate => candidate.Name)
+                    .ToArray()
+                    ?? symbol.ContainingNamespace?.GetMembers()
+                        .Select(candidate => candidate.Name)
+                        .ToArray()
+                    ?? Array.Empty<string>();
+        }
+    }
+
+    private IReadOnlyCollection<string> GetAliasScopeNames(IAliasSymbol alias)
+    {
+        SyntaxReference reference = alias.DeclaringSyntaxReferences.FirstOrDefault();
+        if (reference is null)
+        {
+            return Array.Empty<string>();
+        }
+
+        return reference.SyntaxTree.GetRoot()
+            .DescendantNodes()
+            .OfType<UsingDirectiveSyntax>()
+            .Where(directive => directive.Alias != null)
+            .Select(directive => directive.Alias.Name.Identifier.ValueText)
+            .ToArray();
+    }
+
+    private IReadOnlyCollection<string> GetMethodScopeNames(ISymbol containingSymbol)
+    {
+        if (containingSymbol is not IMethodSymbol method)
+        {
+            return Array.Empty<string>();
+        }
+
+        method = method.OriginalDefinition;
+        if (this.methodScopeNames.TryGetValue(method, out IReadOnlyCollection<string> existing))
+        {
+            return existing;
+        }
+
+        var names = new HashSet<string>(
+            method.Parameters.Select(parameter => parameter.Name),
+            StringComparer.Ordinal);
+        foreach (SyntaxReference reference in method.DeclaringSyntaxReferences)
+        {
+            Microsoft.CodeAnalysis.SyntaxNode root = reference.GetSyntax();
+            SemanticModel model = this.compilation.GetSemanticModel(reference.SyntaxTree);
+            foreach (Microsoft.CodeAnalysis.SyntaxNode node in root.DescendantNodesAndSelf())
+            {
+                ISymbol declared = model.GetDeclaredSymbol(node);
+                if (declared is ILocalSymbol or IRangeVariableSymbol or ILabelSymbol
+                    || declared is IMethodSymbol { MethodKind: MethodKind.LocalFunction })
+                {
+                    if (SymbolEqualityComparer.Default.Equals(
+                        Canonical(declared.ContainingSymbol),
+                        method))
+                    {
+                        names.Add(declared.Name);
+                    }
+                }
+            }
+        }
+
+        string[] result = names.ToArray();
+        this.methodScopeNames[method] = result;
+        return result;
+    }
+
+    private void CollectInvocationSensitiveSymbols()
+    {
+        foreach (Microsoft.CodeAnalysis.SyntaxTree tree in this.compilation.SyntaxTrees)
+        {
+            SemanticModel model = this.compilation.GetSemanticModel(tree);
+            Microsoft.CodeAnalysis.SyntaxNode root = tree.GetRoot();
+            foreach (InvocationExpressionSyntax invocation in root.DescendantNodes().OfType<InvocationExpressionSyntax>())
+            {
+                if (invocation.Expression is not SimpleNameSyntax simple
+                    || !GSharpSyntaxFacts.IsReservedIdentifier(
+                        simple.Identifier.ValueText,
+                        GSharpIdentifierNameContext.Invocation))
+                {
+                    continue;
+                }
+
+                ISymbol symbol = model.GetSymbolInfo(simple).Symbol;
+                if (symbol != null)
+                {
+                    this.invocationSensitive.Add(Canonical(symbol));
+                }
+            }
+
+            foreach (ObjectCreationExpressionSyntax creation in root.DescendantNodes().OfType<ObjectCreationExpressionSyntax>())
+            {
+                if (!GSharpSyntaxFacts.IsReservedIdentifier(
+                    RightmostIdentifier(creation.Type),
+                    GSharpIdentifierNameContext.Invocation))
+                {
+                    continue;
+                }
+
+                if (model.GetSymbolInfo(creation).Symbol is IMethodSymbol constructor)
+                {
+                    this.invocationSensitive.Add(Canonical(constructor.ContainingType));
+                }
+            }
+
+            foreach (ImplicitObjectCreationExpressionSyntax creation in root.DescendantNodes().OfType<ImplicitObjectCreationExpressionSyntax>())
+            {
+                if (model.GetTypeInfo(creation).Type is INamedTypeSymbol type
+                    && GSharpSyntaxFacts.IsReservedIdentifier(
+                        type.Name,
+                        GSharpIdentifierNameContext.Invocation))
+                {
+                    this.invocationSensitive.Add(Canonical(type));
+                }
+            }
+
+            foreach (ElementAccessExpressionSyntax access in root.DescendantNodes().OfType<ElementAccessExpressionSyntax>())
+            {
+                if (access.Expression is IdentifierNameSyntax identifier
+                    && GSharpSyntaxFacts.IsReservedIdentifier(
+                        identifier.Identifier.ValueText,
+                        GSharpIdentifierNameContext.Index)
+                    && model.GetSymbolInfo(identifier).Symbol is { } symbol)
+                {
+                    this.additionalContexts[Canonical(symbol)] =
+                        GSharpIdentifierNameContext.Index;
+                }
+            }
+        }
+    }
+
+    private static string RightmostIdentifier(TypeSyntax type) =>
+        type switch
+        {
+            SimpleNameSyntax simple => simple.Identifier.ValueText,
+            QualifiedNameSyntax qualified => qualified.Right.Identifier.ValueText,
+            AliasQualifiedNameSyntax alias => alias.Name.Identifier.ValueText,
+            _ => type.ToString(),
+        };
+}

--- a/tools/cs2gs/Cs2Gs.Translator/EmittedNameAllocator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/EmittedNameAllocator.cs
@@ -277,7 +277,33 @@ internal sealed class EmittedNameAllocator
                 case INamedTypeSymbol type:
                     names.UnionWith(
                         type.TypeParameters.Select(parameter => parameter.Name));
+                    names.UnionWith(this.GetVisibleNestedTypeNames(type));
                     break;
+            }
+        }
+
+        return names;
+    }
+
+    private IEnumerable<string> GetVisibleNestedTypeNames(INamedTypeSymbol type)
+    {
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        for (INamedTypeSymbol current = type;
+             current != null;
+             current = current.ContainingType)
+        {
+            names.UnionWith(current.GetTypeMembers().Select(SourceName));
+            for (INamedTypeSymbol baseType = current.BaseType;
+                 baseType != null;
+                 baseType = baseType.BaseType)
+            {
+                foreach (INamedTypeSymbol nested in baseType.GetTypeMembers())
+                {
+                    if (IsVisibleInheritedMember(nested, current))
+                    {
+                        names.Add(SourceName(nested));
+                    }
+                }
             }
         }
 
@@ -742,7 +768,8 @@ internal sealed class EmittedNameAllocator
                     && GSharpSyntaxFacts.IsReservedIdentifier(
                         identifier.Identifier.ValueText,
                         GSharpIdentifierNameContext.Index)
-                    && model.GetSymbolInfo(identifier).Symbol is { } symbol)
+                    && model.GetSymbolInfo(identifier).Symbol is { } symbol
+                    && !symbol.DeclaringSyntaxReferences.IsDefaultOrEmpty)
                 {
                     this.AddPrecomputedContext(
                         symbol,

--- a/tools/cs2gs/Cs2Gs.Translator/EmittedNameAllocator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/EmittedNameAllocator.cs
@@ -183,11 +183,17 @@ internal sealed class EmittedNameAllocator
 
             case ITypeParameterSymbol typeParameter
                 when typeParameter.ContainingSymbol is IMethodSymbol method:
-                return this.GetVisibleTypeParameterNames(method).ToArray();
+                return this.GetVisibleTypeParameterNames(method)
+                    .Concat(this.GetLexicallyVisibleTypeNames(typeParameter))
+                    .Distinct(StringComparer.Ordinal)
+                    .ToArray();
 
             case ITypeParameterSymbol typeParameter
                 when typeParameter.ContainingSymbol is INamedTypeSymbol type:
-                return this.GetVisibleTypeParameterNames(type).ToArray();
+                return this.GetVisibleTypeParameterNames(type)
+                    .Concat(this.GetLexicallyVisibleTypeNames(typeParameter))
+                    .Distinct(StringComparer.Ordinal)
+                    .ToArray();
 
             case ILocalSymbol:
             case IRangeVariableSymbol:
@@ -303,6 +309,32 @@ internal sealed class EmittedNameAllocator
                     {
                         names.Add(SourceName(nested));
                     }
+                }
+            }
+        }
+
+        return names;
+    }
+
+    private IEnumerable<string> GetLexicallyVisibleTypeNames(
+        ITypeParameterSymbol typeParameter)
+    {
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        foreach (SyntaxReference reference in typeParameter.DeclaringSyntaxReferences)
+        {
+            SemanticModel model = this.compilation.GetSemanticModel(reference.SyntaxTree);
+            foreach (ISymbol symbol in model.LookupNamespacesAndTypes(
+                reference.Span.Start))
+            {
+                switch (symbol)
+                {
+                    case INamedTypeSymbol type:
+                        names.Add(SourceName(type));
+                        break;
+                    case IAliasSymbol alias
+                        when alias.Target is INamedTypeSymbol:
+                        names.Add(alias.Name);
+                        break;
                 }
             }
         }

--- a/tools/cs2gs/Cs2Gs.Translator/EmittedNameAllocator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/EmittedNameAllocator.cs
@@ -25,7 +25,10 @@ internal sealed class EmittedNameAllocator
     private readonly Dictionary<ISymbol, string> emittedNames =
         new(SymbolEqualityComparer.Default);
 
-    private readonly Dictionary<ISymbol, GSharpIdentifierNameContext> additionalContexts =
+    private readonly Dictionary<ISymbol, GSharpIdentifierNameContext> precomputedContexts =
+        new(SymbolEqualityComparer.Default);
+
+    private readonly Dictionary<ISymbol, IReadOnlyCollection<ISymbol>> contractGroups =
         new(SymbolEqualityComparer.Default);
 
     private readonly Dictionary<ISymbol, IReadOnlyCollection<string>> methodScopeNames =
@@ -37,7 +40,9 @@ internal sealed class EmittedNameAllocator
     private EmittedNameAllocator(Compilation compilation)
     {
         this.compilation = compilation;
+        this.CollectContractGroups();
         this.CollectInvocationSensitiveSymbols();
+        this.CollectPrimaryParameterContexts();
     }
 
     public static EmittedNameAllocator For(Compilation compilation) =>
@@ -55,30 +60,29 @@ internal sealed class EmittedNameAllocator
         lock (this.gate)
         {
             symbol = Canonical(symbol);
-            if (additionalContext != GSharpIdentifierNameContext.General)
-            {
-                this.additionalContexts.TryGetValue(
-                    symbol,
-                    out GSharpIdentifierNameContext registered);
-                this.additionalContexts[symbol] = registered | additionalContext;
-            }
-
-            if (this.emittedNames.TryGetValue(symbol, out string existing)
-                && additionalContext == GSharpIdentifierNameContext.General)
+            if (this.emittedNames.TryGetValue(symbol, out string existing))
             {
                 return existing;
             }
 
-            this.additionalContexts.TryGetValue(
-                symbol,
-                out GSharpIdentifierNameContext registeredContext);
-            GSharpIdentifierNameContext context =
-                this.GetContext(symbol) | registeredContext | additionalContext;
+            IReadOnlyCollection<ISymbol> contract = this.GetContractGroup(symbol);
+            GSharpIdentifierNameContext context = additionalContext;
+            foreach (ISymbol member in contract)
+            {
+                this.precomputedContexts.TryGetValue(
+                    member,
+                    out GSharpIdentifierNameContext precomputed);
+                context |= this.GetContext(member) | precomputed;
+            }
+
             string emitted = GSharpSyntaxFacts.GetEmittedIdentifier(
-                symbol.Name,
+                SourceName(symbol),
                 context,
-                this.GetScopeNames(symbol));
-            this.emittedNames[symbol] = emitted;
+                contract.SelectMany(this.GetScopeNames).Distinct(StringComparer.Ordinal));
+            foreach (ISymbol member in contract)
+            {
+                this.emittedNames[member] = emitted;
+            }
 
             return emitted;
         }
@@ -114,9 +118,19 @@ internal sealed class EmittedNameAllocator
         symbol switch
         {
             IMethodSymbol method => method.OriginalDefinition,
+            IPropertySymbol property => property.OriginalDefinition,
+            IEventSymbol @event => @event.OriginalDefinition,
             INamedTypeSymbol type => type.OriginalDefinition,
             _ => symbol,
         };
+
+    private static string SourceName(ISymbol symbol)
+    {
+        int separator = symbol.Name.LastIndexOf('.');
+        return separator >= 0
+            ? symbol.Name.Substring(separator + 1)
+            : symbol.Name;
+    }
 
     private GSharpIdentifierNameContext GetContext(ISymbol symbol)
     {
@@ -144,7 +158,8 @@ internal sealed class EmittedNameAllocator
             _ => GSharpIdentifierNameContext.General,
         };
 
-        if (this.invocationSensitive.Contains(symbol))
+        if (!symbol.DeclaringSyntaxReferences.IsDefaultOrEmpty
+            && this.invocationSensitive.Contains(symbol))
         {
             context |= GSharpIdentifierNameContext.Invocation;
         }
@@ -180,16 +195,16 @@ internal sealed class EmittedNameAllocator
             case INamespaceSymbol namespaceSymbol:
                 return namespaceSymbol.ContainingNamespace?
                     .GetMembers()
-                    .Select(candidate => candidate.Name)
+                    .Select(SourceName)
                     .ToArray()
                     ?? Array.Empty<string>();
 
             default:
                 return symbol.ContainingType?.GetMembers()
-                    .Select(candidate => candidate.Name)
+                    .Select(SourceName)
                     .ToArray()
                     ?? symbol.ContainingNamespace?.GetMembers()
-                        .Select(candidate => candidate.Name)
+                        .Select(SourceName)
                         .ToArray()
                     ?? Array.Empty<string>();
         }
@@ -252,6 +267,302 @@ internal sealed class EmittedNameAllocator
         return result;
     }
 
+    private IReadOnlyCollection<ISymbol> GetContractGroup(ISymbol symbol) =>
+        this.contractGroups.TryGetValue(symbol, out IReadOnlyCollection<ISymbol> group)
+            ? group
+            : new[] { symbol };
+
+    private void AddPrecomputedContext(
+        ISymbol symbol,
+        GSharpIdentifierNameContext context)
+    {
+        symbol = Canonical(symbol);
+        this.precomputedContexts.TryGetValue(
+            symbol,
+            out GSharpIdentifierNameContext existing);
+        this.precomputedContexts[symbol] = existing | context;
+    }
+
+    private void CollectContractGroups()
+    {
+        var parent = new Dictionary<ISymbol, ISymbol>(SymbolEqualityComparer.Default);
+
+        ISymbol Find(ISymbol symbol)
+        {
+            symbol = Canonical(symbol);
+            if (!parent.TryGetValue(symbol, out ISymbol current))
+            {
+                parent[symbol] = symbol;
+                return symbol;
+            }
+
+            if (!SymbolEqualityComparer.Default.Equals(current, symbol))
+            {
+                parent[symbol] = Find(current);
+            }
+
+            return parent[symbol];
+        }
+
+        void Union(ISymbol left, ISymbol right)
+        {
+            ISymbol leftRoot = Find(left);
+            ISymbol rightRoot = Find(right);
+            if (!SymbolEqualityComparer.Default.Equals(leftRoot, rightRoot))
+            {
+                parent[rightRoot] = leftRoot;
+            }
+        }
+
+        foreach (INamedTypeSymbol type in EnumerateSourceTypes(
+            this.compilation.Assembly.GlobalNamespace))
+        {
+            foreach (ISymbol member in type.GetMembers())
+            {
+                ISymbol overridden = member switch
+                {
+                    IMethodSymbol method => method.OverriddenMethod,
+                    IPropertySymbol property => property.OverriddenProperty,
+                    IEventSymbol @event => @event.OverriddenEvent,
+                    _ => null,
+                };
+                if (overridden != null)
+                {
+                    Union(member, overridden);
+                }
+
+                IEnumerable<ISymbol> explicitImplementations = member switch
+                {
+                    IMethodSymbol method => method.ExplicitInterfaceImplementations,
+                    IPropertySymbol property => property.ExplicitInterfaceImplementations,
+                    IEventSymbol @event => @event.ExplicitInterfaceImplementations,
+                    _ => Array.Empty<ISymbol>(),
+                };
+                foreach (ISymbol implemented in explicitImplementations)
+                {
+                    Union(member, implemented);
+                }
+            }
+
+            foreach (INamedTypeSymbol iface in type.AllInterfaces)
+            {
+                foreach (ISymbol interfaceMember in iface.GetMembers())
+                {
+                    ISymbol implementation =
+                        type.FindImplementationForInterfaceMember(interfaceMember);
+                    if (implementation != null)
+                    {
+                        Union(implementation, interfaceMember);
+                    }
+                }
+            }
+        }
+
+        var groups = new Dictionary<ISymbol, List<ISymbol>>(
+            SymbolEqualityComparer.Default);
+        foreach (ISymbol symbol in parent.Keys.ToArray())
+        {
+            ISymbol root = Find(symbol);
+            if (!groups.TryGetValue(root, out List<ISymbol> group))
+            {
+                group = new List<ISymbol>();
+                groups[root] = group;
+            }
+
+            group.Add(symbol);
+        }
+
+        foreach (List<ISymbol> group in groups.Values)
+        {
+            ISymbol[] members = group.ToArray();
+            foreach (ISymbol member in members)
+            {
+                this.contractGroups[member] = members;
+            }
+        }
+    }
+
+    private void CollectPrimaryParameterContexts()
+    {
+        foreach (Microsoft.CodeAnalysis.SyntaxTree tree in this.compilation.SyntaxTrees)
+        {
+            SemanticModel model = this.compilation.GetSemanticModel(tree);
+            foreach (RecordDeclarationSyntax record in tree.GetRoot()
+                .DescendantNodes()
+                .OfType<RecordDeclarationSyntax>())
+            {
+                if (record.ParameterList != null)
+                {
+                    continue;
+                }
+
+                List<ConstructorDeclarationSyntax> instanceConstructors = record.Members
+                    .OfType<ConstructorDeclarationSyntax>()
+                    .Where(constructor =>
+                        !constructor.Modifiers.Any(
+                            Microsoft.CodeAnalysis.CSharp.SyntaxKind.StaticKeyword))
+                    .ToList();
+                if (instanceConstructors.Count > 0)
+                {
+                    if (instanceConstructors.Count == 1
+                        && model.GetDeclaredSymbol(record) is INamedTypeSymbol
+                            { IsValueType: true } recordStruct)
+                    {
+                        this.CollectRecordStructConstructorContexts(
+                            instanceConstructors[0],
+                            recordStruct,
+                            model);
+                    }
+
+                    continue;
+                }
+
+                var candidates = record.Members
+                    .OfType<PropertyDeclarationSyntax>()
+                    .Where(property =>
+                        !property.Modifiers.Any(
+                            Microsoft.CodeAnalysis.CSharp.SyntaxKind.StaticKeyword)
+                        && property.ExpressionBody == null
+                        && property.AccessorList != null
+                        && property.AccessorList.Accessors.All(accessor =>
+                            accessor.Body == null && accessor.ExpressionBody == null)
+                        && property.AccessorList.Accessors.Any(accessor =>
+                            accessor.IsKind(
+                                Microsoft.CodeAnalysis.CSharp.SyntaxKind.GetAccessorDeclaration)))
+                    .Select(property => (
+                        Syntax: property,
+                        Symbol: model.GetDeclaredSymbol(property) as IPropertySymbol))
+                    .Where(candidate => candidate.Symbol != null)
+                    .ToList();
+                if (candidates.Count == 0
+                    || candidates.Any(candidate =>
+                        this.GetContractGroup(Canonical(candidate.Symbol)).Count > 1))
+                {
+                    continue;
+                }
+
+                bool abort = false;
+                var parameters = new List<IPropertySymbol>();
+                foreach (var candidate in candidates)
+                {
+                    IPropertySymbol property = candidate.Symbol;
+                    if (property.IsRequired || property.SetMethod?.IsInitOnly == true)
+                    {
+                        continue;
+                    }
+
+                    bool nonConstantInitializer = candidate.Syntax.Initializer != null
+                        && !model.GetConstantValue(candidate.Syntax.Initializer.Value).HasValue;
+                    if (nonConstantInitializer)
+                    {
+                        if (property.ContainingType.IsValueType)
+                        {
+                            abort = true;
+                            break;
+                        }
+
+                        continue;
+                    }
+
+                    parameters.Add(property);
+                }
+
+                if (!abort)
+                {
+                    foreach (IPropertySymbol property in parameters)
+                    {
+                        this.AddPrecomputedContext(
+                            property,
+                            GSharpIdentifierNameContext.Parameter);
+                    }
+                }
+            }
+        }
+    }
+
+    private void CollectRecordStructConstructorContexts(
+        ConstructorDeclarationSyntax constructor,
+        INamedTypeSymbol containingType,
+        SemanticModel model)
+    {
+        if (constructor.Body == null
+            || constructor.Initializer != null
+            || model.GetDeclaredSymbol(constructor) is not IMethodSymbol constructorSymbol)
+        {
+            return;
+        }
+
+        var targets = new Dictionary<IParameterSymbol, ISymbol>(
+            SymbolEqualityComparer.Default);
+        foreach (StatementSyntax statement in constructor.Body.Statements)
+        {
+            if (statement is not ExpressionStatementSyntax { Expression: AssignmentExpressionSyntax assignment }
+                || !assignment.OperatorToken.IsKind(
+                    Microsoft.CodeAnalysis.CSharp.SyntaxKind.EqualsToken)
+                || model.GetSymbolInfo(assignment.Left).Symbol is not ISymbol target
+                || target is not IFieldSymbol and not IPropertySymbol
+                || target.IsStatic
+                || !SymbolEqualityComparer.Default.Equals(
+                    target.ContainingType,
+                    containingType)
+                || assignment.Right is not IdentifierNameSyntax right
+                || model.GetSymbolInfo(right).Symbol is not IParameterSymbol parameter
+                || !SymbolEqualityComparer.Default.Equals(
+                    parameter.ContainingSymbol,
+                    constructorSymbol)
+                || !targets.TryAdd(parameter, target))
+            {
+                return;
+            }
+        }
+
+        if (constructorSymbol.Parameters.Any(parameter => !targets.ContainsKey(parameter)))
+        {
+            return;
+        }
+
+        foreach (ISymbol target in targets.Values)
+        {
+            this.AddPrecomputedContext(
+                target,
+                GSharpIdentifierNameContext.Parameter);
+        }
+    }
+
+    private static IEnumerable<INamedTypeSymbol> EnumerateSourceTypes(
+        INamespaceSymbol namespaceSymbol)
+    {
+        foreach (INamedTypeSymbol type in namespaceSymbol.GetTypeMembers())
+        {
+            yield return type;
+            foreach (INamedTypeSymbol nested in EnumerateNestedTypes(type))
+            {
+                yield return nested;
+            }
+        }
+
+        foreach (INamespaceSymbol child in namespaceSymbol.GetNamespaceMembers())
+        {
+            foreach (INamedTypeSymbol type in EnumerateSourceTypes(child))
+            {
+                yield return type;
+            }
+        }
+    }
+
+    private static IEnumerable<INamedTypeSymbol> EnumerateNestedTypes(
+        INamedTypeSymbol type)
+    {
+        foreach (INamedTypeSymbol nested in type.GetTypeMembers())
+        {
+            yield return nested;
+            foreach (INamedTypeSymbol deeper in EnumerateNestedTypes(nested))
+            {
+                yield return deeper;
+            }
+        }
+    }
+
     private void CollectInvocationSensitiveSymbols()
     {
         foreach (Microsoft.CodeAnalysis.SyntaxTree tree in this.compilation.SyntaxTrees)
@@ -261,32 +572,52 @@ internal sealed class EmittedNameAllocator
             foreach (InvocationExpressionSyntax invocation in root.DescendantNodes().OfType<InvocationExpressionSyntax>())
             {
                 if (invocation.Expression is not SimpleNameSyntax simple
-                    || !GSharpSyntaxFacts.IsReservedIdentifier(
-                        simple.Identifier.ValueText,
-                        GSharpIdentifierNameContext.Invocation))
+                    || model.GetSymbolInfo(simple).Symbol is not { } symbol)
                 {
                     continue;
                 }
 
-                ISymbol symbol = model.GetSymbolInfo(simple).Symbol;
-                if (symbol != null)
+                if (GSharpSyntaxFacts.IsReservedIdentifier(
+                    simple.Identifier.ValueText,
+                    GSharpIdentifierNameContext.Invocation))
                 {
                     this.invocationSensitive.Add(Canonical(symbol));
+                }
+
+                if (simple is GenericNameSyntax
+                    && GSharpSyntaxFacts.IsReservedIdentifier(
+                        simple.Identifier.ValueText,
+                        GSharpIdentifierNameContext.Index))
+                {
+                    this.AddPrecomputedContext(
+                        symbol,
+                        GSharpIdentifierNameContext.Index);
                 }
             }
 
             foreach (ObjectCreationExpressionSyntax creation in root.DescendantNodes().OfType<ObjectCreationExpressionSyntax>())
             {
-                if (!GSharpSyntaxFacts.IsReservedIdentifier(
-                    RightmostIdentifier(creation.Type),
-                    GSharpIdentifierNameContext.Invocation))
+                if (model.GetSymbolInfo(creation).Symbol is not IMethodSymbol constructor)
                 {
                     continue;
                 }
 
-                if (model.GetSymbolInfo(creation).Symbol is IMethodSymbol constructor)
+                string name = RightmostIdentifier(creation.Type);
+                if (GSharpSyntaxFacts.IsReservedIdentifier(
+                    name,
+                    GSharpIdentifierNameContext.Invocation))
                 {
                     this.invocationSensitive.Add(Canonical(constructor.ContainingType));
+                }
+
+                if (HasGenericRightmostName(creation.Type)
+                    && GSharpSyntaxFacts.IsReservedIdentifier(
+                        name,
+                        GSharpIdentifierNameContext.Index))
+                {
+                    this.AddPrecomputedContext(
+                        constructor.ContainingType,
+                        GSharpIdentifierNameContext.Index);
                 }
             }
 
@@ -299,6 +630,17 @@ internal sealed class EmittedNameAllocator
                 {
                     this.invocationSensitive.Add(Canonical(type));
                 }
+
+                if (model.GetTypeInfo(creation).Type is INamedTypeSymbol
+                        { IsGenericType: true } genericType
+                    && GSharpSyntaxFacts.IsReservedIdentifier(
+                        genericType.Name,
+                        GSharpIdentifierNameContext.Index))
+                {
+                    this.AddPrecomputedContext(
+                        genericType,
+                        GSharpIdentifierNameContext.Index);
+                }
             }
 
             foreach (ElementAccessExpressionSyntax access in root.DescendantNodes().OfType<ElementAccessExpressionSyntax>())
@@ -309,8 +651,9 @@ internal sealed class EmittedNameAllocator
                         GSharpIdentifierNameContext.Index)
                     && model.GetSymbolInfo(identifier).Symbol is { } symbol)
                 {
-                    this.additionalContexts[Canonical(symbol)] =
-                        GSharpIdentifierNameContext.Index;
+                    this.AddPrecomputedContext(
+                        symbol,
+                        GSharpIdentifierNameContext.Index);
                 }
             }
         }
@@ -323,5 +666,14 @@ internal sealed class EmittedNameAllocator
             QualifiedNameSyntax qualified => qualified.Right.Identifier.ValueText,
             AliasQualifiedNameSyntax alias => alias.Name.Identifier.ValueText,
             _ => type.ToString(),
+        };
+
+    private static bool HasGenericRightmostName(TypeSyntax type) =>
+        type switch
+        {
+            GenericNameSyntax => true,
+            QualifiedNameSyntax qualified => qualified.Right is GenericNameSyntax,
+            AliasQualifiedNameSyntax alias => alias.Name is GenericNameSyntax,
+            _ => false,
         };
 }

--- a/tools/cs2gs/Cs2Gs.Translator/EmittedNameAllocator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/EmittedNameAllocator.cs
@@ -173,22 +173,21 @@ internal sealed class EmittedNameAllocator
                 when parameter.ContainingSymbol is IMethodSymbol method:
                 IEnumerable<string> parameterNames =
                     method.Parameters.Select(candidate => candidate.Name);
-                if (IsPrimaryConstructorParameter(parameter)
-                    && parameter.ContainingType is { } primaryType)
+                if (parameter.ContainingType is { } parameterType)
                 {
                     parameterNames = parameterNames.Concat(
-                        this.GetVisibleTypeMemberNames(primaryType));
+                        this.GetVisibleTypeMemberNames(parameterType));
                 }
 
                 return parameterNames.Distinct(StringComparer.Ordinal).ToArray();
 
             case ITypeParameterSymbol typeParameter
                 when typeParameter.ContainingSymbol is IMethodSymbol method:
-                return method.TypeParameters.Select(candidate => candidate.Name).ToArray();
+                return this.GetVisibleTypeParameterNames(method).ToArray();
 
             case ITypeParameterSymbol typeParameter
                 when typeParameter.ContainingSymbol is INamedTypeSymbol type:
-                return type.TypeParameters.Select(candidate => candidate.Name).ToArray();
+                return this.GetVisibleTypeParameterNames(type).ToArray();
 
             case ILocalSymbol:
             case IRangeVariableSymbol:
@@ -256,19 +255,34 @@ internal sealed class EmittedNameAllocator
             Accessibility.Internal or Accessibility.ProtectedAndInternal =>
                 SymbolEqualityComparer.Default.Equals(
                     member.ContainingAssembly,
-                    derivedType.ContainingAssembly),
+                    derivedType.ContainingAssembly)
+                || member.ContainingAssembly?.GivesAccessTo(
+                    derivedType.ContainingAssembly) == true,
             _ => false,
         };
 
-    private static bool IsPrimaryConstructorParameter(IParameterSymbol parameter) =>
-        parameter.DeclaringSyntaxReferences.Any(reference =>
-            reference.GetSyntax() is ParameterSyntax
+    private IEnumerable<string> GetVisibleTypeParameterNames(ISymbol symbol)
+    {
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        for (ISymbol current = symbol;
+             current != null;
+             current = current.ContainingSymbol)
+        {
+            switch (current)
             {
-                Parent: ParameterListSyntax
-                {
-                    Parent: TypeDeclarationSyntax,
-                },
-            });
+                case IMethodSymbol method:
+                    names.UnionWith(
+                        method.TypeParameters.Select(parameter => parameter.Name));
+                    break;
+                case INamedTypeSymbol type:
+                    names.UnionWith(
+                        type.TypeParameters.Select(parameter => parameter.Name));
+                    break;
+            }
+        }
+
+        return names;
+    }
 
     private IReadOnlyCollection<string> GetAliasScopeNames(IAliasSymbol alias)
     {
@@ -302,6 +316,11 @@ internal sealed class EmittedNameAllocator
         var names = new HashSet<string>(
             method.Parameters.Select(parameter => parameter.Name),
             StringComparer.Ordinal);
+        if (method.ContainingType is { } containingType)
+        {
+            names.UnionWith(this.GetVisibleTypeMemberNames(containingType));
+        }
+
         foreach (SyntaxReference reference in method.DeclaringSyntaxReferences)
         {
             Microsoft.CodeAnalysis.SyntaxNode root = reference.GetSyntax();
@@ -658,6 +677,7 @@ internal sealed class EmittedNameAllocator
                 }
 
                 if (simple is GenericNameSyntax
+                    && !symbol.DeclaringSyntaxReferences.IsDefaultOrEmpty
                     && GSharpSyntaxFacts.IsReservedIdentifier(
                         simple.Identifier.ValueText,
                         GSharpIdentifierNameContext.Index))


### PR DESCRIPTION
## Summary
- canonicalize G# identifier allocation across contracts, inheritance, lexical scopes, primary constructors, enclosing generic scopes, visible nested types, and C#-visible namespace/import/alias types
- preserve CLR metadata identities through canonical member/type/namespace resolution
- qualify imported contextual static methods, fields, properties, and delegate values
- honor InternalsVisibleTo when inherited members reserve emitted names
- retain prior Unicode, alias, attribute, `nameof`, extension namespace, and collision fixes

## Validation
- focused Issue3461/alias/nested-type runtime and binding tests: 38 passed
- PR CI: 33 passed, 0 failed, 3 skipped

Closes #3461