### PR TITLE
Polish the landing README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,161 +1,86 @@
+<div align="center">
+
+<img src="assets/gsharp-icon.svg?raw=true" alt="G# logo" width="160" />
+
 # G#
 
-A modern, simple, and accessible programming language for .NET.
+**A modern, simple, and accessible programming language for .NET.**
 
-G# brings Go-, Kotlin-, and Swift-style ergonomics to the CLR. The
-syntax stays small and predictable; the runtime is the same .NET you
-already know, so every BCL type, NuGet package, and `dotnet` tool works
-out of the box.
+Kotlin- and Swift-style semantics, Go- and Python-inspired syntax — on the CLR you already know.
 
 [![build](https://github.com/DavidObando/gsharp/actions/workflows/build.yml/badge.svg)](https://github.com/DavidObando/gsharp/actions/workflows/build.yml)
 [![quality dashboard](https://github.com/DavidObando/gsharp/actions/workflows/pages.yml/badge.svg)](https://davidobando.github.io/gsharp/docs/next/project/quality-dashboard)
+[![NuGet](https://img.shields.io/nuget/v/Gsharp.NET.Sdk.svg?label=Gsharp.NET.Sdk)](https://www.nuget.org/packages/Gsharp.NET.Sdk/)
+[![VS Marketplace](https://img.shields.io/visual-studio-marketplace/v/gsharplang.vscode-gsharp?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=gsharplang.vscode-gsharp)
+[![license: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-📖 **Documentation:** https://davidobando.github.io/gsharp/ — language
-tour, tutorials, specification, and tooling reference. The site source
-lives in [`website/`](website/).
+[Documentation](https://davidobando.github.io/gsharp/) ·
+[A Tour of G#](https://davidobando.github.io/gsharp/docs/tour/) ·
+[Getting started](#getting-started) ·
+[Editor support](#editor-support) ·
+[Contributing](#contributing)
 
-![](assets/gsharp-icon.svg?raw=true)
+</div>
 
-## A taste of G#
-
-A short tour of v0.2 idioms — the same ones the documentation site uses.
-
-### Data classes with `with`-copy and deconstruction
+---
 
 ```gsharp
-package GSharp.Tour.DataClass
+package hello
 
 import System
 
-data class Person(Name string, Age int32)
+data class Point(X int32, Y int32)
 
-let alice = Person("Alice", 30)
-let older = alice with { Age = 31 }
-let (n, a) = older
-
-Console.WriteLine("$n is $a")           // Alice is 31
-Console.WriteLine(alice == older)       // False — different Age
-Console.WriteLine(alice == Person("Alice", 30))  // True — structural equality
-```
-
-`data struct` is the value-typed counterpart, with the same synthesized
-equality, `with`-copy, and deconstruction.
-
-### `if let` for nullable handling
-
-```gsharp
-package GSharp.Tour.IfLet
-
-import System
-
-func Greet(name string?) {
-    if let n = name {
-        Console.WriteLine("hi $n")
-    } else {
-        Console.WriteLine("hi stranger")
+func describe(p Point?) string {
+    if let q = p {
+        return "point at (${q.X}, ${q.Y})"
     }
+    return "nowhere"
 }
 
-Greet("Ada")
-Greet(nil)
+let origin = Point(0, 0)
+let moved = origin with { X = 3 }
+
+Console.WriteLine(describe(moved))       // point at (3, 0)
+Console.WriteLine(moved == Point(3, 0))  // True — structural equality
+Console.WriteLine(describe(nil))         // nowhere
 ```
 
-`guard let v = expr else { return }` is the partner form: it binds `v` for
-the remainder of the enclosing block when the value is non-nil, and the
-`else` branch must unconditionally exit.
+Every sample in this README compiles and runs with the current compiler.
 
-`while let v = Next() { ... }` is the loop form: `Next()` is re-evaluated
-before each iteration, `v` is non-null inside the body, and the loop ends when
-the initializer returns `nil`.
+## Why G#?
 
-### Sequences from `Gsharp.Extensions.Sequences`
-
-```gsharp
-package GSharp.Tour.Sequences
-
-import System
-import Gsharp.Extensions.Sequences
-
-for pair in Sequences.Range(1, 5).Indexed() {
-    Console.WriteLine("${pair.Item1}: ${pair.Item2}")
-}
-
-for trio in Sequences.Range(1, 6).Windowed(3) {
-    Console.WriteLine(String.Join(",", trio))
-}
-```
-
-`Sequences` ships builders (`Range`, `RangeStep`, `Iterate`, `Repeat`,
-`Of`, `Empty`), transformers (`Indexed`, `Windowed`, `Chunked`,
-`Pairwise`, `Interleave`), safe terminals (`FirstOrNil`, `LastOrNil`,
-`SingleOrNil`), and G#-shaped collectors (`ToSlice`, `ToMap`).
-
-### Optional helpers — `Map`, `OrElse`, `Filter`
-
-```gsharp
-package GSharp.Tour.Optional
-
-import System
-import Gsharp.Extensions.Optional
-
-let name string? = "ada"
-
-let upper = name.Map((s string) -> s.ToUpper())
-Console.WriteLine(upper ?? "<absent>")           // ADA
-
-let absent string? = nil
-Console.WriteLine(absent.OrElse("default"))      // default
-
-let short = name.Filter((s string) -> s.Length <= 2)
-Console.WriteLine(short ?? "<filtered out>")     // <filtered out>
-```
-
-### `scope` + `async` / `await`
-
-```gsharp
-package GSharp.Tour.AsyncScope
-
-import System
-import System.Threading.Tasks
-
-async func compute(n int32) int32 {
-    await Task.Delay(5)
-    return n * 2
-}
-
-async func runAll() {
-    let a = await compute(3)
-    let b = await compute(4)
-    Console.WriteLine("a = $a, b = $b")
-}
-
-scope {
-    runAll().Wait()
-}
-
-Console.WriteLine("done")
-```
-
-`scope { ... }` is the structured-concurrency block: child work
-registered inside the scope is joined before control leaves it, and
-failures are observed instead of silently lost.
+- **Small, predictable syntax.** Type-after-name declarations, no semicolons,
+  no ceremony. Top-level statements are the entry point; a one-file program is
+  a real program.
+- **Null safety by design.** `T?` is a distinct type. `if let`, `guard let`,
+  `while let`, `?.`, and `??` make the absent case explicit — the compiler
+  won't let you forget it.
+- **Data modeling that pulls its weight.** `data class` / `data struct` give
+  you structural equality, `with`-copy, and deconstruction from a single line.
+- **Structured concurrency.** `chan`, `go`, and `scope { }` blocks bring
+  Go-style channels and goroutine-shaped tasks to .NET, with child work joined
+  and failures observed before control leaves the scope.
+- **The whole .NET ecosystem.** Every BCL type, every NuGet package, LINQ,
+  P/Invoke, events — callable directly, no bindings or wrappers. G# assemblies
+  are ordinary .NET assemblies consumable from C# and F#.
+- **First-class tooling.** An MSBuild SDK (`dotnet build`/`run`/`pack` just
+  work), a language server with VS Code and Visual Studio extensions, a REPL,
+  code analyzers, and a C#→G# migration tool.
 
 ## Getting started
 
-G# ships an MSBuild SDK ([`Gsharp.NET.Sdk`](https://www.nuget.org/packages/Gsharp.NET.Sdk/))
-and a `dotnet new` template package ([`Gsharp.Templates`](https://www.nuget.org/packages/Gsharp.Templates/)),
-both available on NuGet, so a `.gsproj` is just a regular .NET project
-that happens to compile `.gs` files. After installing the template
-package, you can scaffold and run a console app in three commands:
+You need the [.NET 10 SDK](https://dotnet.microsoft.com/download). Then:
 
 ```sh
 dotnet new install Gsharp.Templates
 dotnet new gsharp-console -n MyApp
-cd MyApp && dotnet build && dotnet run
-# -> Hello from GSharp!
+cd MyApp && dotnet run
+# Hello from GSharp!
 ```
 
-A minimal `.gsproj` looks like any other modern .NET project:
+A `.gsproj` is a regular SDK-style .NET project that happens to compile
+`.gs` files:
 
 ```xml
 <Project Sdk="Gsharp.NET.Sdk">
@@ -167,38 +92,48 @@ A minimal `.gsproj` looks like any other modern .NET project:
 </Project>
 ```
 
-The SDK is validated against `net8.0` and `net10.0`; adding additional
-target frameworks is a one-line change in
-[`e2etests/multitarget-e2e.sh`](e2etests/multitarget-e2e.sh).
+Templates for libraries, xUnit test projects, and web apps ship in the same
+package: `gsharp-lib`, `gsharp-xunit`, `gsharp-web`.
 
-## Editor support
+## A taste of G#
 
-The **G# VS Code extension** is published on the
-[Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=gsharplang.vscode-gsharp).
-It provides syntax highlighting, language-server features (completion,
-hover, diagnostics, formatting, and more), build/run commands, and
-debugger configuration for `.gs` and `.gsproj` files. Install it from
-within VS Code (search for "G#") or from the command line:
-
-```sh
-code --install-extension gsharplang.vscode-gsharp
-```
-
-The repository also builds a
-[G# extension for Visual Studio 2022 and Visual Studio 2026](src/vs-gsharp/README.md).
-It provides the same language server and editor assets plus native CPS
-projects, NuGet, managed debugging, Test Explorer, project/item templates,
-snippets, and all six G# themes.
-
-## Interoperating with .NET
-
-Every .NET type — your packages, third-party NuGet packages, the BCL —
-is callable from G# with the syntax you already know. CLR generics use
-G#'s bracket spelling, and method calls, properties, indexers, and
-`for in` over `IEnumerable[T]` all just work:
+### Channels and structured concurrency
 
 ```gsharp
-package GSharp.Tour.Interop
+package pipeline
+
+import System
+import Gsharp.Extensions.Go
+
+func produce(ch chan int32) int32 {
+    for var n = 1; n <= 3; n = n + 1 {
+        ch <- n * 10
+    }
+    return 0
+}
+
+let ch = make(chan int32, 3)
+
+scope {
+    go produce(ch)
+
+    for var i = 0; i < 3; i = i + 1 {
+        Console.WriteLine("got ${<-ch}")
+    }
+}
+
+Console.WriteLine("pipeline drained")
+```
+
+`scope { }` guarantees the goroutines it spawns finish (and surface their
+failures) before the block exits. See the
+[concurrency guide](https://davidobando.github.io/gsharp/docs/extensions/go-concurrency)
+for `select`-style patterns, buffered channels, and `close` semantics.
+
+### Seamless .NET interop
+
+```gsharp
+package interop
 
 import System
 import System.Collections.Generic
@@ -208,88 +143,92 @@ let nums = List[int32]()
 nums.Add(1)
 nums.Add(2)
 nums.Add(3)
-nums.Add(4)
 
-let evens = nums.Where((x int32) -> x % 2 == 0)
-for v in evens {
-    Console.WriteLine(v)
-}
-
-Console.WriteLine(nums.Sum())
+let doubled = nums.Select((x int32) -> x * 2).Sum()
+Console.WriteLine("sum of doubles: $doubled")   // 12
 ```
 
-G# also speaks the unmanaged boundary directly. A `func` declaration
-whose body is `;` and that carries `@DllImport` or `@LibraryImport`
-binds as a P/Invoke stub — no `extern` keyword needed:
-
-```gsharp
-package GSharp.Tour.PInvoke
-
-import System
-import System.Runtime.InteropServices
-
-@DllImport("libc", EntryPoint: "strlen", CharSet: CharSet.Ansi)
-func StrLen(text string) nint;
-
-Console.WriteLine(StrLen("Hello, world!"))   // 13
-```
-
-The full interop story — events, delegates, ref/out parameters,
-function pointers, struct marshalling — is documented in the
+CLR generics use G#'s bracket spelling (`List[int32]`), lambdas flow into
+LINQ, and `@DllImport` functions bind as P/Invoke stubs. The full story —
+events, delegates, ref/out, function pointers, struct marshalling — is in the
 [CLR interop reference](https://davidobando.github.io/gsharp/docs/ref/clr-interop).
+
+Want more? The [Tour of G#](https://davidobando.github.io/gsharp/docs/tour/)
+walks through pattern matching, interfaces, extension functions, error
+handling, generics, and the rest of the language.
+
+## Editor support
+
+<table>
+<tr><td><b>VS Code</b></td><td>
+
+[`gsharplang.vscode-gsharp`](https://marketplace.visualstudio.com/items?itemName=gsharplang.vscode-gsharp)
+— syntax highlighting, completion, hover, diagnostics, formatting, build/run
+commands, and debugging. `code --install-extension gsharplang.vscode-gsharp`
+
+</td></tr>
+<tr><td><b>Visual&nbsp;Studio</b></td><td>
+
+The [G# extension for Visual Studio 2022/2026](src/vs-gsharp/README.md) adds
+native projects, NuGet, managed debugging, Test Explorer, templates, and six
+G# themes on top of the same language server.
+
+</td></tr>
+<tr><td><b>REPL</b></td><td>
+
+`dotnet tool install --global Gsharp.Repl` gives you `gsi`, an interactive
+REPL and `.gs` file runner.
+
+</td></tr>
+</table>
+
+## Tooling
+
+| Tool | What it does |
+| --- | --- |
+| [`Gsharp.NET.Sdk`](https://www.nuget.org/packages/Gsharp.NET.Sdk/) | MSBuild SDK — `dotnet build`, `run`, `test`, and `pack` for `.gsproj` projects, including Roslyn source-generator hosting and code analyzers. |
+| [`Gsharp.Templates`](https://www.nuget.org/packages/Gsharp.Templates/) | `dotnet new` templates: console, library, xUnit, web. |
+| [`Gsharp.Repl`](https://www.nuget.org/packages/Gsharp.Repl/) | `gsi` — interactive REPL and file runner. |
+| [`Gsharp.Cs2Gs`](https://www.nuget.org/packages/Gsharp.Cs2Gs/) | `cs2gs` — migrates C# projects to G#, including Roslyn analyzers and their tests. |
+
+`cs2gs` doubles as the compiler's quality gate: every C# syntax construct is
+classified in a machine-checked coverage inventory, a per-construct
+conformance corpus is translated, compiled, IL-verified, and byte-compared
+against its C# baseline on every PR, and newly discovered gaps are
+automatically filed as issues (see [`tools/cs2gs/README.md`](tools/cs2gs/README.md)).
 
 ## Documentation
 
-| Topic | Where |
-| --- | --- |
-| Live documentation site | https://davidobando.github.io/gsharp/ |
-| A Tour of G# (start here) | [`website/docs/tour/`](website/docs/tour/) |
-| Tutorials | [`website/docs/tutorials/`](website/docs/tutorials/) |
-| Language guide | [`website/docs/guide/`](website/docs/guide/) |
-| Language specification | [`website/docs/ref/spec.md`](website/docs/ref/spec.md) |
-| Architecture Decision Records | [`docs/adr/`](docs/adr/) |
-| MSBuild SDK + templates | [`docs/sdk-usage.md`](docs/sdk-usage.md) |
-| Compiler architecture | [`docs/emit-pipeline.md`](docs/emit-pipeline.md) |
-
-## .NET tools
-
-The REPL and the C#→G# migrator ship as global .NET tools (requires a .NET 10 runtime):
-
-```sh
-dotnet tool install --global Gsharp.Repl    # `gsi` — interactive REPL / file runner
-dotnet tool install --global Gsharp.Cs2Gs   # `cs2gs` — C# to G# migration tool
-```
-
-`cs2gs` doubles as the compiler's quality gate: every C# syntax construct is
-classified in a machine-checked coverage inventory
-([`docs/cs2gs-coverage-matrix.md`](docs/cs2gs-coverage-matrix.md)), a
-per-construct conformance corpus is translated, compiled, IL-verified, and
-byte-compared against its C# baseline on every PR, and newly discovered
-compiler gaps are automatically filed as issues from a fingerprinted gap
-ledger (see [`tools/cs2gs/README.md`](tools/cs2gs/README.md) and ADR-0138).
+The [documentation site](https://davidobando.github.io/gsharp/) hosts the
+language tour, tutorials, the language guide, the specification, and the
+tooling reference; its source lives in [`website/`](website/). Design history
+is recorded as [Architecture Decision Records](docs/adr/).
 
 ## Repository layout
 
 ```
 src/
-  Core/               # Shared front-end: syntax, binder, lowering, symbols, emit
-  Compiler/           # gsc.dll command-line driver
-  Repl/               # gsi.dll modern Spectre.Console TUI (REPL + language tests)
+  Core/               # Compiler front-end: syntax, binder, lowering, symbols, emit
+  Compiler/           # gsc — command-line compiler driver
+  Repl/               # gsi — interactive REPL
   LanguageServer/     # LSP server backing the editor experience
-  Sdk/
-    Gsharp.NET.Sdk/   # MSBuild SDK that wires .gsproj into dotnet build
-    Gsharp.Templates/ # dotnet new template package (gsharp-console)
-  Gsharp.Extensions/  # Opt-in idiomatic helpers (Optional, Sequences, Go)
-samples/              # End-user fixtures referenced by docs and tests
-e2etests/             # End-to-end smoke scripts: sdk-e2e, templates-e2e, multitarget-e2e
-test/                 # xUnit projects covering Core, Compiler, Interpreter, LSP
-website/              # Docusaurus site (source for the docs above)
+  Sdk/                # MSBuild SDK, templates, and Gsharp.Extensions
+  vs-gsharp/          # Visual Studio extension
+tools/cs2gs/          # C# → G# migration tool and conformance corpus
+e2etests/             # End-to-end smoke tests
+test/                 # xUnit suites covering the compiler, SDK, and tooling
+website/              # Docusaurus documentation site
 ```
 
 ## Contributing
 
-Contributions are welcome. Read [`CONTRIBUTING.md`](CONTRIBUTING.md) for build,
-test, ADR, golden-file, and pull-request guidance. Compatibility commitments
-are documented in
-[`docs/compatibility-and-stability.md`](docs/compatibility-and-stability.md);
-report vulnerabilities privately through [`SECURITY.md`](SECURITY.md).
+Contributions are welcome — read [`CONTRIBUTING.md`](CONTRIBUTING.md) for
+build, test, and pull-request guidance. Compatibility commitments are
+documented in
+[`docs/compatibility-and-stability.md`](docs/compatibility-and-stability.md),
+and vulnerabilities can be reported privately through
+[`SECURITY.md`](SECURITY.md).
+
+## License
+
+G# is open source under the [MIT license](LICENSE).


### PR DESCRIPTION
## Summary

Modernizes the repository landing page, replacing the v0.2-era tour with a polished layout modeled on popular open-source project READMEs:

- **Centered hero**: the G# SVG logo (retained — on brand), name, tagline ("Kotlin- and Swift-style semantics, Go- and Python-inspired syntax — on the CLR you already know"), a five-badge row (build, quality dashboard, NuGet `Gsharp.NET.Sdk` version, VS Marketplace version, MIT license), and quick links.
- **Verified hero sample**: `data class` + `with`-copy + `if let` over a nullable — compiled and run with the current `gsc`; outputs shown as comments are the actual program output.
- **Why G#** feature bullets: syntax, null safety, data modeling, structured concurrency, .NET ecosystem, tooling.
- **Quickstart** trimmed to the three-command template flow, plus the minimal `.gsproj` and the other template short names (`gsharp-lib`, `gsharp-xunit`, `gsharp-web` — verified against the template package).
- **Two more verified samples**: a channels/`go`/`scope` pipeline (run against `Gsharp.Extensions`) and a LINQ interop snippet — both executed successfully before inclusion.
- **Editor support** table (VS Code, Visual Studio, REPL), **tooling** table for the four NuGet packages, docs pointers, compact repo layout, contributing + license footer.

All documentation-site links were checked against `website/versioned_docs/version-0.4/` (the published latest), so `/docs/tour/`, `/docs/extensions/go-concurrency`, and `/docs/ref/clr-interop` all resolve.

## Verification

Every code sample in the README was compiled and executed with `gsc` built from this branch's merge base; captured outputs match the inline comments. No code changes — README.md only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)