### PR TITLE
Fix cs2gs discarded expression statements

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/BodyTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/BodyTranslationTests.cs
@@ -127,15 +127,13 @@ public class BodyTranslationTests
         Assert.Contains("for var i = 1; i <= 3; i++ {", body);
     }
 
-    /// <summary>C# statement-level discard <c>_ = expr;</c> has no G# discard target
-    /// (<c>_ = e</c> → GS0125), so it lowers to a bare expression statement of the
-    /// RHS (issue #914).</summary>
+    /// <summary>C# statement-level discard <c>_ = expr;</c> has no G# assignment
+    /// target. Effectful RHS values use G#'s native discard declaration.</summary>
     [Fact]
-    public void DiscardAssignment_EmitsBareRightHandSide()
+    public void DiscardAssignment_UsesNativeDiscardDeclaration()
     {
         string body = GetMethodBody("_ = n.ToString();");
-        Assert.Contains("n.ToString()", body);
-        Assert.DoesNotContain("_ =", body);
+        Assert.Contains("let _ = n.ToString()", body);
     }
 
     /// <summary>A C-style <c>for</c> with multiple declarators/initializers or

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1741SilentDivergenceTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1741SilentDivergenceTests.cs
@@ -184,8 +184,7 @@ namespace Demo
 
     /// <summary>
     /// A genuine C# discard (<c>_ = e;</c> with no <c>_</c> variable in scope)
-    /// must still drop the assignment and keep only the RHS, exactly as
-    /// before (issue #914).
+    /// must still drop the assignment target and preserve RHS evaluation.
     /// </summary>
     [Fact]
     public void TrueDiscard_StillDropsAssignment()
@@ -204,8 +203,7 @@ namespace Demo
     }
 }");
         string printed = GSharpPrinter.Print(unit);
-        Assert.DoesNotContain("_ =", printed, StringComparison.Ordinal);
-        Assert.Contains("Next()", printed, StringComparison.Ordinal);
+        Assert.Contains("let _ = Next()", printed, StringComparison.Ordinal);
     }
 
     private static (CompilationUnit Unit, TranslationContext Context) Translate(string source)

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3462DiscardAssignmentTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3462DiscardAssignmentTranslationTests.cs
@@ -177,6 +177,251 @@ public sealed class Issue3462DiscardAssignmentTranslationTests
     }
 
     [Fact]
+    public void NestedDeconstruction_PreservesEarlierCallArgumentOrder()
+    {
+        string rendered = Render("""
+            public sealed class Probe
+            {
+                private int trace;
+
+                private int Mark(int value)
+                {
+                    trace = (trace * 10) + value;
+                    return value;
+                }
+
+                private (int, int) Pair()
+                {
+                    trace = (trace * 10) + 2;
+                    return (2, 3);
+                }
+
+                private int Observe(int first, (int, int) pair)
+                {
+                    trace = (trace * 10) + 5;
+                    return first + pair.Item1;
+                }
+
+                public int Run()
+                {
+                    int a = 0;
+                    int b = 0;
+                    _ = Observe(Mark(1), ((a, b) = Pair()));
+                    return trace;
+                }
+            }
+            """);
+
+        TranslationTestValidation.AssertBinds(rendered);
+        EmittedOracleResult result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Probe().Run()");
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(125, result.Value);
+    }
+
+    [Fact]
+    public void ConditionalAndSwitchArmNestedDeconstruction_PreserveArgumentOrder()
+    {
+        string rendered = Render("""
+            public sealed class Probe
+            {
+                private int trace;
+
+                private int Mark(int value)
+                {
+                    trace = (trace * 10) + value;
+                    return value;
+                }
+
+                private (int, int) Pair()
+                {
+                    trace = (trace * 10) + 2;
+                    return (2, 3);
+                }
+
+                private int Observe(int first, (int, int) pair)
+                {
+                    trace = (trace * 10) + 5;
+                    return first + pair.Item1;
+                }
+
+                public int Run()
+                {
+                    int a = 0;
+                    int b = 0;
+                    _ = 0 switch
+                    {
+                        0 => Observe(Mark(1), ((a, b) = Pair())),
+                        _ => 0,
+                    };
+                    _ = true
+                        ? Observe(Mark(3), ((a, b) = Pair()))
+                        : 0;
+                    return trace;
+                }
+            }
+            """);
+
+        TranslationTestValidation.AssertBinds(rendered);
+        EmittedOracleResult result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Probe().Run()");
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(125325, result.Value);
+    }
+
+    [Fact]
+    public void NestedDeconstruction_PreservesReceiverBeforeArguments()
+    {
+        string rendered = Render("""
+            public sealed class Probe
+            {
+                private int trace;
+
+                private Probe Receiver()
+                {
+                    trace = (trace * 10) + 1;
+                    return this;
+                }
+
+                private (int, int) Pair()
+                {
+                    trace = (trace * 10) + 2;
+                    return (2, 3);
+                }
+
+                private int Observe((int, int) pair)
+                {
+                    trace = (trace * 10) + 5;
+                    return pair.Item1;
+                }
+
+                public int Run()
+                {
+                    int a = 0;
+                    int b = 0;
+                    _ = Receiver().Observe(((a, b) = Pair()));
+                    return trace;
+                }
+            }
+            """);
+
+        TranslationTestValidation.AssertBinds(rendered);
+        EmittedOracleResult result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Probe().Run()");
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(125, result.Value);
+    }
+
+    [Fact]
+    public void NestedDeconstruction_PreservesConstructorAndIndexerArgumentOrder()
+    {
+        string rendered = Render("""
+            public sealed class Probe
+            {
+                private int trace;
+
+                public Probe()
+                {
+                }
+
+                private Probe(int first, (int, int) pair, Probe owner)
+                {
+                    owner.trace = (owner.trace * 10) + 5;
+                }
+
+                private int this[int value]
+                {
+                    get
+                    {
+                        trace = (trace * 10) + 5;
+                        return value;
+                    }
+                }
+
+                private int Mark(int value)
+                {
+                    trace = (trace * 10) + value;
+                    return value;
+                }
+
+                private (int, int) Pair()
+                {
+                    trace = (trace * 10) + 2;
+                    return (2, 3);
+                }
+
+                public int Run()
+                {
+                    int a = 0;
+                    int b = 0;
+                    _ = new Probe(Mark(1), ((a, b) = Pair()), this);
+                    int constructorTrace = trace;
+                    trace = 0;
+                    _ = this[Mark(1) + ((a, b) = Pair()).Item1];
+                    return (constructorTrace * 1000) + trace;
+                }
+            }
+            """);
+
+        TranslationTestValidation.AssertBinds(rendered);
+        EmittedOracleResult result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Probe().Run()");
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(125125, result.Value);
+    }
+
+    [Fact]
+    public void EarlierThrow_PreventsNestedDeconstructionEvaluation()
+    {
+        string rendered = Render("""
+            public sealed class Probe
+            {
+                private int trace;
+
+                private int ThrowFirst()
+                {
+                    trace = (trace * 10) + 1;
+                    throw new System.InvalidOperationException();
+                }
+
+                private (int, int) Pair()
+                {
+                    trace = (trace * 10) + 2;
+                    return (2, 3);
+                }
+
+                private static int Observe(int first, (int, int) pair) => first;
+
+                public int Run()
+                {
+                    int a = 0;
+                    int b = 0;
+                    try
+                    {
+                        _ = Observe(ThrowFirst(), ((a, b) = Pair()));
+                    }
+                    catch (System.InvalidOperationException)
+                    {
+                    }
+
+                    return trace;
+                }
+            }
+            """);
+
+        TranslationTestValidation.AssertBinds(rendered);
+        EmittedOracleResult result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Probe().Run()");
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(1, result.Value);
+    }
+
+    [Fact]
     public void ConditionalPostfix_DiscardExecutesOnlySelectedBranch()
     {
         string rendered = Render("""

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3462DiscardAssignmentTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3462DiscardAssignmentTranslationTests.cs
@@ -99,6 +99,84 @@ public sealed class Issue3462DiscardAssignmentTranslationTests
     }
 
     [Fact]
+    public void ParenthesizedDeconstructionAssignment_WritesTargetsAndEvaluatesOnce()
+    {
+        string rendered = Render("""
+            public sealed class Probe
+            {
+                private int calls;
+
+                private (int, int) Get()
+                {
+                    calls++;
+                    return (1, 2);
+                }
+
+                public int Run()
+                {
+                    int a = 0;
+                    int b = 0;
+                    _ = ((a, b) = Get());
+                    return (calls * 100) + (a * 10) + b;
+                }
+            }
+            """);
+
+        TranslationTestValidation.AssertBinds(rendered);
+        EmittedOracleResult result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Probe().Run()");
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(112, result.Value);
+    }
+
+    [Fact]
+    public void NestedAssignmentShapes_PreserveBranchesValuesAndOrder()
+    {
+        string rendered = Render("""
+            public sealed class Probe
+            {
+                private int trace;
+
+                private (int, int) Next(int marker)
+                {
+                    trace = (trace * 10) + marker;
+                    return (marker, marker + 1);
+                }
+
+                private int Observe((int, int) value)
+                {
+                    trace = (trace * 10) + value.Item1;
+                    return value.Item2;
+                }
+
+                public int Run()
+                {
+                    int a = 0;
+                    int b = 0;
+                    _ = Observe(((a, b) = Next(2)));
+                    _ = true ? ((a, b) = Next(3)) : ((a, b) = Next(8));
+                    _ = 0 switch
+                    {
+                        0 => ((a, b) = Next(4)),
+                        _ => ((a, b) = Next(9)),
+                    };
+                    _ = (a = 6);
+                    _ = (a += 1);
+                    return (trace * 100) + (a * 10) + b;
+                }
+            }
+            """);
+
+        TranslationTestValidation.AssertBinds(rendered);
+        EmittedOracleResult result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Probe().Run()");
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(223475, result.Value);
+    }
+
+    [Fact]
     public void ThrowingGetter_IsStillEvaluated()
     {
         string rendered = Render("""

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3462DiscardAssignmentTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3462DiscardAssignmentTranslationTests.cs
@@ -604,6 +604,115 @@ public sealed class Issue3462DiscardAssignmentTranslationTests
     }
 
     [Fact]
+    public void VoidConditionalInstanceCall_HostsDeconstructionInsideGuardedStatement()
+    {
+        string rendered = Render("""
+            public sealed class Probe
+            {
+                private int trace;
+
+                private Probe? Receiver(bool present)
+                {
+                    trace = (trace * 10) + 9;
+                    return present ? this : null;
+                }
+
+                private (int, int) Pair(int value)
+                {
+                    trace = (trace * 10) + value;
+                    return (value, value);
+                }
+
+                private (int, int) ThrowingPair()
+                {
+                    trace = (trace * 10) + 7;
+                    throw new System.InvalidOperationException();
+                }
+
+                private void Accept((int, int) pair)
+                {
+                    trace = (trace * 10) + 5;
+                }
+
+                public int Run()
+                {
+                    int a = 0;
+                    int b = 0;
+                    Receiver(false)?.Accept(((a, b) = Pair(1)));
+                    Receiver(true)?.Accept(((a, b) = Pair(2)));
+                    Receiver(false)?.Accept(((a, b) = ThrowingPair()));
+                    try
+                    {
+                        Receiver(true)?.Accept(((a, b) = ThrowingPair()));
+                    }
+                    catch (System.InvalidOperationException)
+                    {
+                    }
+
+                    return (trace * 100) + (a * 10) + b;
+                }
+            }
+            """);
+
+        TranslationTestValidation.AssertBinds(rendered);
+        EmittedOracleResult result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Probe().Run()");
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(992599722, result.Value);
+    }
+
+    [Fact]
+    public void VoidConditionalExtensionCall_HostsDeconstructionInsideGuardedStatement()
+    {
+        string rendered = Render("""
+            public static class ProbeExtensions
+            {
+                public static void Accept(this Probe probe, (int, int) pair) =>
+                    probe.Record();
+            }
+
+            public sealed class Probe
+            {
+                private int trace;
+
+                private Probe? Receiver(bool present)
+                {
+                    trace = (trace * 10) + 9;
+                    return present ? this : null;
+                }
+
+                private (int, int) Pair(int value)
+                {
+                    trace = (trace * 10) + value;
+                    return (value, value);
+                }
+
+                public void Record()
+                {
+                    trace = (trace * 10) + 5;
+                }
+
+                public int Run()
+                {
+                    int a = 0;
+                    int b = 0;
+                    Receiver(false)?.Accept(((a, b) = Pair(1)));
+                    Receiver(true)?.Accept(((a, b) = Pair(2)));
+                    return (trace * 100) + (a * 10) + b;
+                }
+            }
+            """);
+
+        TranslationTestValidation.AssertBinds(rendered);
+        EmittedOracleResult result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Probe().Run()");
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(992522, result.Value);
+    }
+
+    [Fact]
     public void ConditionalPostfix_DiscardExecutesOnlySelectedBranch()
     {
         string rendered = Render("""

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3462DiscardAssignmentTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3462DiscardAssignmentTranslationTests.cs
@@ -1,0 +1,245 @@
+// <copyright file="Issue3462DiscardAssignmentTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using GSharp.Tests;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>Issue #3462: statement-level discards remove only inert RHS values.</summary>
+public sealed class Issue3462DiscardAssignmentTranslationTests
+{
+    [Fact]
+    public void MethodBody_InertValuesAreRemoved_AndReservedParameterStaysSanitized()
+    {
+        string rendered = Render("""
+            public static class Server
+            {
+                public static void Initialized(object @params)
+                {
+                    int local = 1;
+                    _ = @params;
+                    _ = local;
+                    _ = 42;
+                    _ = (local, @params);
+                }
+            }
+            """);
+
+        Assert.Contains("Initialized(params_ object)", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("let _ =", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("\n        params_\n", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+
+    [Fact]
+    public void MethodBody_EffectfulValuesUseNativeDiscard_AndRunInOrder()
+    {
+        string rendered = Render("""
+            public sealed class Probe
+            {
+                private int state;
+                private int Value
+                {
+                    get
+                    {
+                        state = (state * 10) + 2;
+                        return state;
+                    }
+                }
+
+                private int this[int value]
+                {
+                    get
+                    {
+                        state = (state * 10) + value;
+                        return state;
+                    }
+                }
+
+                private int Touch(int value)
+                {
+                    state = (state * 10) + value;
+                    return state;
+                }
+
+                public int Run()
+                {
+                    int local = 0;
+                    _ = true ? Touch(9) : Touch(8);
+                    _ = Touch(1);
+                    _ = Value;
+                    _ = this[3];
+                    _ = local = 4;
+                    _ = local++;
+                    return (state * 10) + local;
+                }
+            }
+            """);
+
+        Assert.Contains("let _ = Touch(1)", rendered, StringComparison.Ordinal);
+        Assert.Contains("let _ = if true { Touch(9) } else { Touch(8) }", rendered, StringComparison.Ordinal);
+        Assert.Contains("let _ = Value", rendered, StringComparison.Ordinal);
+        Assert.Contains("let _ = this[3]", rendered, StringComparison.Ordinal);
+        Assert.Contains("local = 4", rendered, StringComparison.Ordinal);
+        Assert.Contains("local++", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+
+        EmittedOracleResult result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Probe().Run()");
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(91235, result.Value);
+    }
+
+    [Fact]
+    public void ThrowingGetter_IsStillEvaluated()
+    {
+        string rendered = Render("""
+            public sealed class Probe
+            {
+                private int Value => throw new System.InvalidOperationException("discarded");
+
+                public int Run()
+                {
+                    _ = Value;
+                    return 1;
+                }
+            }
+            """);
+
+        TranslationTestValidation.AssertBinds(rendered);
+        EmittedOracleResult result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Probe().Run()");
+        Assert.IsType<InvalidOperationException>(result.UnhandledException);
+    }
+
+    [Fact]
+    public void NullableForgiveness_DoesNotSuppressRuntimeEvaluation()
+    {
+        string rendered = Render("""
+            #nullable enable
+
+            public static class Probe
+            {
+                public static int Run(string? value)
+                {
+                    _ = value!.Length;
+                    return 1;
+                }
+            }
+            """);
+
+        Assert.Contains("let _ = value!!.Length", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+        EmittedOracleResult result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Probe.Run(nil)");
+        Assert.IsType<NullReferenceException>(result.UnhandledException);
+    }
+
+    [Fact]
+    public void LambdaBodies_ReuseStatementDiscardTranslation()
+    {
+        string rendered = Render("""
+            using System;
+
+            public sealed class Probe
+            {
+                private int state;
+
+                private int Touch(int value)
+                {
+                    state = (state * 10) + value;
+                    return state;
+                }
+
+                public int Run()
+                {
+                    Action expressionBody = () => _ = Touch(4);
+                    Action blockBody = () => { _ = Touch(5); };
+                    expressionBody();
+                    blockBody();
+                    return state;
+                }
+            }
+            """);
+
+        Assert.Contains("Touch(4)", rendered, StringComparison.Ordinal);
+        Assert.Contains("let _ = Touch(5)", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+        EmittedOracleResult result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Probe().Run()");
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(45, result.Value);
+    }
+
+    [Fact]
+    public void AsyncMethod_DiscardedAwaitRemainsAwaited()
+    {
+        string rendered = Render("""
+            using System.Threading.Tasks;
+
+            public static class Probe
+            {
+                public static async Task<int> Run()
+                {
+                    _ = await Task.FromResult(7);
+                    return 1;
+                }
+            }
+            """);
+
+        Assert.Contains("let _ = await Task.FromResult(7)", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+
+    [Fact]
+    public void IteratorBody_DiscardedCallRemainsEvaluated()
+    {
+        string rendered = Render("""
+            using System.Collections.Generic;
+
+            public sealed class Probe
+            {
+                private int state;
+
+                private int Touch(int value)
+                {
+                    state = value;
+                    return state;
+                }
+
+                public IEnumerable<int> Run()
+                {
+                    _ = Touch(7);
+                    yield return state;
+                }
+            }
+            """);
+
+        Assert.Contains("let _ = Touch(7)", rendered, StringComparison.Ordinal);
+        Assert.Contains("yield state", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+
+    private static string Render(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3462DiscardAssignmentTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3462DiscardAssignmentTranslationTests.cs
@@ -177,6 +177,134 @@ public sealed class Issue3462DiscardAssignmentTranslationTests
     }
 
     [Fact]
+    public void ConditionalPostfix_DiscardExecutesOnlySelectedBranch()
+    {
+        string rendered = Render("""
+            public static class Probe
+            {
+                public static int Run()
+                {
+                    int i = 0;
+                    int j = 0;
+                    bool pickFirst = true;
+                    _ = pickFirst ? i++ : j++;
+                    return (i * 10) + j;
+                }
+            }
+            """);
+
+        TranslationTestValidation.AssertBinds(rendered);
+        EmittedOracleResult result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Probe.Run()");
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(10, result.Value);
+    }
+
+    [Fact]
+    public void DeconstructionRhsPostfix_ExecutesExactlyOnce()
+    {
+        string rendered = Render("""
+            public sealed class Probe
+            {
+                private int calls;
+
+                private (int, int) Next(int marker)
+                {
+                    calls++;
+                    return (marker + 1, marker + 2);
+                }
+
+                private static int Observe((int, int) value) => value.Item1;
+
+                public int Run()
+                {
+                    int i = 0;
+                    int a = 0;
+                    int b = 0;
+                    _ = Observe(((a, b) = Next(i++)));
+                    return (calls * 1000) + (i * 100) + (a * 10) + b;
+                }
+            }
+            """);
+
+        TranslationTestValidation.AssertBinds(rendered);
+        EmittedOracleResult result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Probe().Run()");
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(1112, result.Value);
+    }
+
+    [Fact]
+    public void SwitchArmIncrement_DiscardKeepsEffectsBranchLocal()
+    {
+        string rendered = Render("""
+            public static class Probe
+            {
+                public static int Run()
+                {
+                    int i = 0;
+                    int j = 0;
+                    int k = 0;
+                    int l = 0;
+                    _ = 0 switch
+                    {
+                        0 => i++,
+                        _ => j++,
+                    };
+                    _ = 0 switch
+                    {
+                        0 => ++k,
+                        _ => ++l,
+                    };
+                    return (i * 1000) + (j * 100) + (k * 10) + l;
+                }
+            }
+            """);
+
+        TranslationTestValidation.AssertBinds(rendered);
+        EmittedOracleResult result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Probe.Run()");
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(1010, result.Value);
+    }
+
+    [Fact]
+    public void ShortCircuitedPostfix_DiscardRunsOnlyEvaluatedOperands()
+    {
+        string rendered = Render("""
+            #nullable enable
+
+            public sealed class Probe
+            {
+                private int Observe(int value) => value;
+
+                public static int Run()
+                {
+                    int i = 0;
+                    int j = 0;
+                    int? present = 1;
+                    int? missing = null;
+                    Probe? absent = null;
+                    _ = present ?? i++;
+                    _ = missing ?? j++;
+                    _ = absent?.Observe(i++);
+                    return (i * 10) + j;
+                }
+            }
+            """);
+
+        TranslationTestValidation.AssertBinds(rendered);
+        EmittedOracleResult result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Probe.Run()");
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(1, result.Value);
+    }
+
+    [Fact]
     public void ThrowingGetter_IsStillEvaluated()
     {
         string rendered = Render("""

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3462DiscardAssignmentTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3462DiscardAssignmentTranslationTests.cs
@@ -866,6 +866,88 @@ public sealed class Issue3462DiscardAssignmentTranslationTests
     }
 
     [Fact]
+    public void VoidConditionalInstanceCall_CapturesRefLocalAliasBeforeArguments()
+    {
+        string rendered = Render("""
+            public sealed class Probe
+            {
+                private int trace;
+                private Probe? current;
+
+                private (int, int) Pair()
+                {
+                    trace = (trace * 10) + 1;
+                    current = null;
+                    return (1, 1);
+                }
+
+                private void Accept((int, int) pair)
+                {
+                    trace = (trace * 10) + 5;
+                }
+
+                public int Run()
+                {
+                    int a = 0;
+                    int b = 0;
+                    current = this;
+                    ref Probe? alias = ref current;
+                    alias?.Accept(((a, b) = Pair()));
+                    return trace;
+                }
+            }
+            """);
+
+        TranslationTestValidation.AssertBinds(rendered);
+        EmittedOracleResult result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Probe().Run()");
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(15, result.Value);
+    }
+
+    [Fact]
+    public void VoidConditionalInstanceCall_CapturesRefReadonlyAliasBeforeArguments()
+    {
+        string rendered = Render("""
+            public sealed class Probe
+            {
+                private int trace;
+                private Probe? current;
+
+                private (int, int) Pair()
+                {
+                    trace = (trace * 10) + 1;
+                    current = null;
+                    return (1, 1);
+                }
+
+                private void Accept((int, int) pair)
+                {
+                    trace = (trace * 10) + 5;
+                }
+
+                public int Run()
+                {
+                    int a = 0;
+                    int b = 0;
+                    current = this;
+                    ref readonly Probe? alias = ref current;
+                    alias?.Accept(((a, b) = Pair()));
+                    return trace;
+                }
+            }
+            """);
+
+        TranslationTestValidation.AssertBinds(rendered);
+        EmittedOracleResult result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Probe().Run()");
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(15, result.Value);
+    }
+
+    [Fact]
     public void ConditionalPostfix_DiscardExecutesOnlySelectedBranch()
     {
         string rendered = Render("""

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3462DiscardAssignmentTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3462DiscardAssignmentTranslationTests.cs
@@ -422,6 +422,188 @@ public sealed class Issue3462DiscardAssignmentTranslationTests
     }
 
     [Fact]
+    public void ShortCircuitBooleanOperands_HostDeconstructionOnlyWhenEvaluated()
+    {
+        string rendered = Render("""
+            public sealed class Probe
+            {
+                private int trace;
+
+                private (int, int) Pair(int value)
+                {
+                    trace = (trace * 10) + value;
+                    return (value, value);
+                }
+
+                private (int, int) ThrowingPair()
+                {
+                    trace = (trace * 10) + 5;
+                    throw new System.InvalidOperationException();
+                }
+
+                public int Run()
+                {
+                    int a = 0;
+                    int b = 0;
+                    _ = false && ((a, b) = Pair(1)).Item1 > 0;
+                    _ = true && ((a, b) = Pair(2)).Item1 > 0;
+                    _ = true || ((a, b) = Pair(3)).Item1 > 0;
+                    bool consumed = false || ((a, b) = Pair(4)).Item1 > 0;
+                    _ = false && ((a, b) = ThrowingPair()).Item1 > 0;
+                    try
+                    {
+                        _ = true && ((a, b) = ThrowingPair()).Item1 > 0;
+                    }
+                    catch (System.InvalidOperationException)
+                    {
+                    }
+
+                    return (trace * 100) + (a * 10) + b + (consumed ? 0 : 10000);
+                }
+            }
+            """);
+
+        TranslationTestValidation.AssertBinds(rendered);
+        EmittedOracleResult result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Probe().Run()");
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(24544, result.Value);
+    }
+
+    [Fact]
+    public void CoalesceOperand_HostsDeconstructionForDiscardAndConsumedValues()
+    {
+        string rendered = Render("""
+            public sealed class Probe
+            {
+                private int trace;
+
+                private (int, int) Pair(int value)
+                {
+                    trace = (trace * 10) + value;
+                    return (value, value + 1);
+                }
+
+                public int Run()
+                {
+                    int a = 0;
+                    int b = 0;
+                    int? present = 7;
+                    int? absent = null;
+                    int first = present ?? ((a, b) = Pair(1)).Item1;
+                    int second = absent ?? ((a, b) = Pair(2)).Item1;
+                    _ = absent ?? ((a, b) = Pair(3)).Item1;
+                    return (trace * 10000) + (first * 1000) + (second * 100) + (a * 10) + b;
+                }
+            }
+            """);
+
+        TranslationTestValidation.AssertBinds(rendered);
+        EmittedOracleResult result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Probe().Run()");
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(237234, result.Value);
+    }
+
+    [Fact]
+    public void ConditionalAccessOperands_HostDeconstructionOnlyForNonNullReceivers()
+    {
+        string rendered = Render("""
+            public sealed class Probe
+            {
+                private int trace;
+
+                private (int, int) Pair(int value)
+                {
+                    trace = (trace * 10) + value;
+                    return (value, value);
+                }
+
+                private int Observe(int value)
+                {
+                    trace = (trace * 10) + 5;
+                    return value;
+                }
+
+                private Probe? Receiver(bool present)
+                {
+                    trace = (trace * 10) + 9;
+                    return present ? this : null;
+                }
+
+                public int Run()
+                {
+                    int a = 0;
+                    int b = 0;
+                    _ = Receiver(false)?.Observe(((a, b) = Pair(1)).Item1);
+                    int? observed = Receiver(true)?.Observe(((a, b) = Pair(2)).Item1);
+                    int[]? missingValues = null;
+                    int[] values = new[] { 0, 1, 2, 3 };
+                    _ = missingValues?[((a, b) = Pair(3)).Item1];
+                    int? indexed = values?[((a, b) = Pair(1)).Item1];
+                    return (trace * 1000) + (a * 100) + (b * 10) +
+                        (observed ?? 0) + (indexed ?? 0);
+                }
+            }
+            """);
+
+        TranslationTestValidation.AssertBinds(rendered);
+        EmittedOracleResult result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Probe().Run()");
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(99251113, result.Value);
+    }
+
+    [Fact]
+    public void ConditionalExtensionCall_HostsDeconstructionInsideGuardedCall()
+    {
+        string rendered = Render("""
+            public static class ProbeExtensions
+            {
+                public static int Observe(this Probe probe, int value) => probe.Record(value);
+            }
+
+            public sealed class Probe
+            {
+                private int trace;
+
+                private (int, int) Pair(int value)
+                {
+                    trace = (trace * 10) + value;
+                    return (value, value);
+                }
+
+                public int Record(int value)
+                {
+                    trace = (trace * 10) + 5;
+                    return value;
+                }
+
+                public int Run()
+                {
+                    int a = 0;
+                    int b = 0;
+                    Probe? missing = null;
+                    Probe? present = this;
+                    _ = missing?.Observe(((a, b) = Pair(1)).Item1);
+                    int? observed = present?.Observe(((a, b) = Pair(2)).Item1);
+                    return (trace * 100) + (a * 10) + b + (observed ?? 0);
+                }
+            }
+            """);
+
+        TranslationTestValidation.AssertBinds(rendered);
+        EmittedOracleResult result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Probe().Run()");
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(2524, result.Value);
+    }
+
+    [Fact]
     public void ConditionalPostfix_DiscardExecutesOnlySelectedBranch()
     {
         string rendered = Render("""

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3462DiscardAssignmentTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3462DiscardAssignmentTranslationTests.cs
@@ -272,6 +272,72 @@ public sealed class Issue3462DiscardAssignmentTranslationTests
     }
 
     [Fact]
+    public void SwitchArmPostfixCall_PreservesOldValueAndOperandOrder()
+    {
+        string rendered = Render("""
+            public static class Probe
+            {
+                private static int observed;
+
+                private static int Observe(int before, int after)
+                {
+                    observed = ((before + 1) * 10) + after;
+                    return observed;
+                }
+
+                public static int Run()
+                {
+                    int i = 0;
+                    _ = 0 switch
+                    {
+                        0 => Observe(i++, i),
+                        _ => 0,
+                    };
+                    return observed;
+                }
+            }
+            """);
+
+        TranslationTestValidation.AssertBinds(rendered);
+        EmittedOracleResult result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Probe.Run()");
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(11, result.Value);
+    }
+
+    [Fact]
+    public void ConditionalPostfixCall_PreservesOldValueAndOperandOrder()
+    {
+        string rendered = Render("""
+            public static class Probe
+            {
+                private static int observed;
+
+                private static int Observe(int before, int after)
+                {
+                    observed = ((before + 1) * 10) + after;
+                    return observed;
+                }
+
+                public static int Run()
+                {
+                    int i = 0;
+                    _ = true ? Observe(i++, i) : 0;
+                    return observed;
+                }
+            }
+            """);
+
+        TranslationTestValidation.AssertBinds(rendered);
+        EmittedOracleResult result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Probe.Run()");
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(11, result.Value);
+    }
+
+    [Fact]
     public void ShortCircuitedPostfix_DiscardRunsOnlyEvaluatedOperands()
     {
         string rendered = Render("""

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3462DiscardAssignmentTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3462DiscardAssignmentTranslationTests.cs
@@ -569,6 +569,17 @@ public sealed class Issue3462DiscardAssignmentTranslationTests
             public sealed class Probe
             {
                 private int trace;
+                private int reads;
+
+                private Probe? Current
+                {
+                    get
+                    {
+                        trace = (trace * 10) + 9;
+                        reads++;
+                        return reads == 2 ? this : null;
+                    }
+                }
 
                 private (int, int) Pair(int value)
                 {
@@ -586,10 +597,8 @@ public sealed class Issue3462DiscardAssignmentTranslationTests
                 {
                     int a = 0;
                     int b = 0;
-                    Probe? missing = null;
-                    Probe? present = this;
-                    _ = missing?.Observe(((a, b) = Pair(1)).Item1);
-                    int? observed = present?.Observe(((a, b) = Pair(2)).Item1);
+                    _ = Current?.Observe(((a, b) = Pair(1)).Item1);
+                    int? observed = Current?.Observe(((a, b) = Pair(2)).Item1);
                     return (trace * 100) + (a * 10) + b + (observed ?? 0);
                 }
             }
@@ -600,7 +609,7 @@ public sealed class Issue3462DiscardAssignmentTranslationTests
             rendered + Environment.NewLine + "Probe().Run()");
         Assert.Empty(result.Diagnostics);
         Assert.Null(result.UnhandledException);
-        Assert.Equal(2524, result.Value);
+        Assert.Equal(992524, result.Value);
     }
 
     [Fact]
@@ -710,6 +719,150 @@ public sealed class Issue3462DiscardAssignmentTranslationTests
         Assert.Empty(result.Diagnostics);
         Assert.Null(result.UnhandledException);
         Assert.Equal(992522, result.Value);
+    }
+
+    [Fact]
+    public void VoidConditionalInstanceCall_CapturesChangingPropertyReceiverOnce()
+    {
+        string rendered = Render("""
+            public sealed class Probe
+            {
+                private int trace;
+                private int reads;
+
+                private Probe? Current
+                {
+                    get
+                    {
+                        trace = (trace * 10) + 9;
+                        reads++;
+                        return reads == 1 ? this : null;
+                    }
+                }
+
+                private (int, int) Pair(int value)
+                {
+                    trace = (trace * 10) + value;
+                    return (value, value);
+                }
+
+                private void Accept((int, int) pair)
+                {
+                    trace = (trace * 10) + 5;
+                }
+
+                public int Run()
+                {
+                    int a = 0;
+                    int b = 0;
+                    Current?.Accept(((a, b) = Pair(1)));
+                    Current?.Accept(((a, b) = Pair(2)));
+                    return (trace * 100) + (a * 10) + b;
+                }
+            }
+            """);
+
+        TranslationTestValidation.AssertBinds(rendered);
+        EmittedOracleResult result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Probe().Run()");
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(915911, result.Value);
+    }
+
+    [Fact]
+    public void VoidConditionalExtensionCall_CapturesChangingPropertyReceiverOnce()
+    {
+        string rendered = Render("""
+            public static class ProbeExtensions
+            {
+                public static void Accept(this Probe probe, (int, int) pair) =>
+                    probe.Record();
+            }
+
+            public sealed class Probe
+            {
+                private int trace;
+                private int reads;
+
+                private Probe? Current
+                {
+                    get
+                    {
+                        trace = (trace * 10) + 9;
+                        reads++;
+                        return reads == 1 ? this : null;
+                    }
+                }
+
+                private (int, int) Pair(int value)
+                {
+                    trace = (trace * 10) + value;
+                    return (value, value);
+                }
+
+                public void Record()
+                {
+                    trace = (trace * 10) + 5;
+                }
+
+                public int Run()
+                {
+                    int a = 0;
+                    int b = 0;
+                    Current?.Accept(((a, b) = Pair(1)));
+                    Current?.Accept(((a, b) = Pair(2)));
+                    return (trace * 100) + (a * 10) + b;
+                }
+            }
+            """);
+
+        TranslationTestValidation.AssertBinds(rendered);
+        EmittedOracleResult result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Probe().Run()");
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(915911, result.Value);
+    }
+
+    [Fact]
+    public void VoidConditionalInstanceCall_CapturesMutableFieldBeforeArguments()
+    {
+        string rendered = Render("""
+            public sealed class Probe
+            {
+                private int trace;
+                private Probe? current;
+
+                private (int, int) Pair()
+                {
+                    trace = (trace * 10) + 1;
+                    current = null;
+                    return (1, 1);
+                }
+
+                private void Accept((int, int) pair)
+                {
+                    trace = (trace * 10) + 5;
+                }
+
+                public int Run()
+                {
+                    int a = 0;
+                    int b = 0;
+                    current = this;
+                    current?.Accept(((a, b) = Pair()));
+                    return (trace * 100) + (a * 10) + b;
+                }
+            }
+            """);
+
+        TranslationTestValidation.AssertBinds(rendered);
+        EmittedOracleResult result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Probe().Run()");
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(1511, result.Value);
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
@@ -2606,17 +2606,13 @@ public sealed partial class CSharpToGSharpTranslator
                     // Only a value-position deconstruction assignment needs a
                     // return prologue; ordinary assignments remain inline.
                     var returnPrologue = new List<GStatement>();
+                    var replacements = new List<ExpressionSyntax>();
                     List<AssignmentExpressionSyntax> returnEmbedded =
-                        this.CollectEmbeddedAssignments(ret.Expression, includeSelf: true);
-                    foreach (AssignmentExpressionSyntax node in returnEmbedded)
-                    {
-                        returnPrologue.AddRange(this.FlattenChainedAssignment(node));
-                    }
-
-                    foreach (AssignmentExpressionSyntax node in returnEmbedded)
-                    {
-                        this.state.SuppressedAssignments.Add(node);
-                    }
+                        this.HoistAssignmentsInOrder(
+                            ret.Expression,
+                            includeSelf: true,
+                            returnPrologue,
+                            replacements);
 
                     GExpression returnValue;
                     try
@@ -2625,10 +2621,9 @@ public sealed partial class CSharpToGSharpTranslator
                     }
                     finally
                     {
-                        foreach (AssignmentExpressionSyntax node in returnEmbedded)
-                        {
-                            this.state.SuppressedAssignments.Remove(node);
-                        }
+                        this.ReleaseHoistedAssignments(
+                            returnEmbedded,
+                            replacements);
                     }
 
                     returnPrologue.Add(new ReturnStatement(

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.ControlFlow.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.ControlFlow.cs
@@ -330,21 +330,17 @@ public sealed partial class CSharpToGSharpTranslator
         {
             if (clause is not IsPatternExpressionSyntax isPattern)
             {
-                List<AssignmentExpressionSyntax> embedded = this.CollectEmbeddedAssignments(clause, includeSelf: true);
+                var replacements = new List<ExpressionSyntax>();
+                List<AssignmentExpressionSyntax> embedded =
+                    this.HoistAssignmentsInOrder(
+                        clause,
+                        includeSelf: true,
+                        into,
+                        replacements);
                 if (embedded.Count == 0)
                 {
                     into.Add(BreakIf(Negate(this.TranslateExpression(clause))));
                     return;
-                }
-
-                foreach (AssignmentExpressionSyntax node in embedded)
-                {
-                    into.AddRange(this.FlattenChainedAssignment(node));
-                }
-
-                foreach (AssignmentExpressionSyntax node in embedded)
-                {
-                    this.state.SuppressedAssignments.Add(node);
                 }
 
                 try
@@ -353,10 +349,7 @@ public sealed partial class CSharpToGSharpTranslator
                 }
                 finally
                 {
-                    foreach (AssignmentExpressionSyntax node in embedded)
-                    {
-                        this.state.SuppressedAssignments.Remove(node);
-                    }
+                    this.ReleaseHoistedAssignments(embedded, replacements);
                 }
 
                 return;

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
@@ -341,13 +341,14 @@ public sealed partial class CSharpToGSharpTranslator
 
         private static List<PostfixUnaryExpressionSyntax> CollectEmbeddedPostfix(ExpressionSyntax expression)
         {
-            // Collect `i++` / `i--` nodes nested inside `expression` (in document
-            // order), excluding any that live inside a nested lambda / local
-            // function (those belong to that body's own statement seam).
+            // Collect eagerly evaluated `i++` / `i--` nodes in document order.
+            // Conditional/short-circuited operands keep G#'s native inline form.
             return expression.DescendantNodes(descendIntoChildren: node =>
                     node is not (AnonymousFunctionExpressionSyntax or LocalFunctionStatementSyntax))
                 .OfType<PostfixUnaryExpressionSyntax>()
                 .Where(p => p.IsKind(SyntaxKind.PostIncrementExpression) || p.IsKind(SyntaxKind.PostDecrementExpression))
+                .Where(p => !IsInsideConditionalValueBranch(p, expression))
+                .Where(p => !IsInShortCircuitedSubexpression(p, expression))
                 .ToList();
         }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
@@ -93,6 +93,37 @@ public sealed partial class CSharpToGSharpTranslator
             }
         }
 
+        private bool RequiresLocalAssignmentSeam(ExpressionSyntax expression) =>
+            this.CollectEmbeddedAssignments(expression, includeSelf: true).Count > 0;
+
+        private GExpression TranslateWithLocalAssignmentSeam(
+            ExpressionSyntax expression,
+            Func<GExpression> translate)
+        {
+            List<GStatement> outerSpillPrologue = this.state.PendingSpillPrologue;
+            var statements = new List<GStatement>();
+            var replacements = new List<ExpressionSyntax>();
+            this.state.PendingSpillPrologue = statements;
+            List<AssignmentExpressionSyntax> embedded =
+                this.HoistAssignmentsInOrder(
+                    expression,
+                    includeSelf: true,
+                    statements,
+                    replacements);
+            try
+            {
+                GExpression value = translate();
+                return statements.Count == 0
+                    ? value
+                    : new BlockExpression(statements, value);
+            }
+            finally
+            {
+                this.ReleaseHoistedAssignments(embedded, replacements);
+                this.state.PendingSpillPrologue = outerSpillPrologue;
+            }
+        }
+
         private void HoistPrecedingEvaluationOperands(
             ExpressionSyntax root,
             AssignmentExpressionSyntax assignment,
@@ -238,9 +269,8 @@ public sealed partial class CSharpToGSharpTranslator
         /// excluding ones inside a nested lambda/local function (their own
         /// statement seam). Assignments inside a conditional
         /// (`?:`) arm are left for that arm's native G# block-expression seam.
-        /// Assignments hidden inside any other short-circuited operand would change
-        /// evaluation COUNT/order if hoisted, so they are flagged unsupported
-        /// instead (issue #1723).
+        /// Assignments inside any other short-circuited operand are left for that
+        /// operand's local block-expression seam.
         /// </summary>
         private List<AssignmentExpressionSyntax> CollectEmbeddedAssignments(ExpressionSyntax expression, bool includeSelf)
         {
@@ -355,16 +385,9 @@ public sealed partial class CSharpToGSharpTranslator
 
                 if (IsInShortCircuitedSubexpression(candidate, expression))
                 {
-                    // ADR-0161 / issue #3350: a short-circuited operand's write must
-                    // run only when that operand is evaluated, so it cannot be
-                    // hoisted into a preceding statement — but it does not need to
-                    // be. G# assignment is a value-yielding expression, so
-                    // `TranslateAssignmentAsExpression` emits it in place, exactly
-                    // where C# put it. Skipping it here leaves it to that path.
-                    //
-                    // This previously reported Unsupported and then DROPPED the
-                    // write entirely (issue #1723), on the mistaken premise that G#
-                    // assignment was statement-only.
+                    // Scalar assignments remain native G# value expressions.
+                    // Deconstruction is hosted by the nested short-circuit
+                    // operand's own block-expression seam.
                     continue;
                 }
 
@@ -426,8 +449,7 @@ public sealed partial class CSharpToGSharpTranslator
         // True when `node` is reached only through a not-always-evaluated operand
         // inside `root`: the right operand of `&&`/`||`/`??`, or the "when not
         // null" side of a `?.`/`?[...]` conditional-access chain (including any
-        // member/element access further chained off it). Unlike a `?:` arm, these
-        // positions have no native statement-hosting expression seam.
+        // member/element access further chained off it).
         private static bool IsInShortCircuitedSubexpression(SyntaxNode node, ExpressionSyntax root)
         {
             for (SyntaxNode current = node; current != null && current != root; current = current.Parent)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
@@ -32,38 +32,162 @@ public sealed partial class CSharpToGSharpTranslator
             bool includeSelf,
             Func<List<GStatement>> buildMain)
         {
-            List<AssignmentExpressionSyntax> embedded = this.CollectEmbeddedAssignments(expression, includeSelf);
-            if (embedded.Count == 0)
+            var hoisted = new List<GStatement>();
+            var replacements = new List<ExpressionSyntax>();
+            List<AssignmentExpressionSyntax> suppressed =
+                this.HoistAssignmentsInOrder(
+                    expression,
+                    includeSelf,
+                    hoisted,
+                    replacements);
+            if (suppressed.Count == 0)
             {
                 return buildMain();
             }
 
-            var hoisted = new List<GStatement>();
-            foreach (AssignmentExpressionSyntax node in embedded)
-            {
-                hoisted.AddRange(this.FlattenChainedAssignment(node));
-            }
-
-            foreach (AssignmentExpressionSyntax node in embedded)
-            {
-                this.state.SuppressedAssignments.Add(node);
-            }
-
-            List<GStatement> main;
             try
             {
-                main = buildMain();
+                hoisted.AddRange(buildMain());
+                return hoisted;
             }
             finally
             {
-                foreach (AssignmentExpressionSyntax node in embedded)
-                {
-                    this.state.SuppressedAssignments.Remove(node);
-                }
+                this.ReleaseHoistedAssignments(suppressed, replacements);
+            }
+        }
+
+        private List<AssignmentExpressionSyntax> HoistAssignmentsInOrder(
+            ExpressionSyntax expression,
+            bool includeSelf,
+            List<GStatement> statements,
+            List<ExpressionSyntax> replacements)
+        {
+            List<AssignmentExpressionSyntax> embedded =
+                this.CollectEmbeddedAssignments(expression, includeSelf);
+            foreach (AssignmentExpressionSyntax node in embedded)
+            {
+                this.HoistPrecedingEvaluationOperands(
+                    expression,
+                    node,
+                    statements,
+                    replacements);
+                statements.AddRange(this.FlattenChainedAssignment(node));
+                this.state.SuppressedAssignments.Add(node);
             }
 
-            hoisted.AddRange(main);
-            return hoisted;
+            return embedded;
+        }
+
+        private void ReleaseHoistedAssignments(
+            IEnumerable<AssignmentExpressionSyntax> suppressed,
+            IEnumerable<ExpressionSyntax> replacements)
+        {
+            foreach (AssignmentExpressionSyntax node in suppressed)
+            {
+                this.state.SuppressedAssignments.Remove(node);
+            }
+
+            foreach (ExpressionSyntax replacement in replacements)
+            {
+                this.state.HoistedExpressionValues.Remove(replacement);
+            }
+        }
+
+        private void HoistPrecedingEvaluationOperands(
+            ExpressionSyntax root,
+            AssignmentExpressionSyntax assignment,
+            List<GStatement> statements,
+            List<ExpressionSyntax> replacements)
+        {
+            IOperation current = this.context.SemanticModel.GetOperation(assignment);
+            if (current == null)
+            {
+                return;
+            }
+
+            var groups = new List<List<ExpressionSyntax>>();
+            while (current.Parent is IOperation parent && current.Syntax != root)
+            {
+                var preceding = new List<ExpressionSyntax>();
+                foreach (IOperation child in parent.ChildOperations)
+                {
+                    if (ReferenceEquals(child, current))
+                    {
+                        break;
+                    }
+
+                    ExpressionSyntax expression = OperationExpression(child);
+                    if (expression != null
+                        && root.Span.Contains(expression.Span)
+                        && expression != root)
+                    {
+                        preceding.Add(expression);
+                    }
+                }
+
+                if (preceding.Count > 0)
+                {
+                    groups.Insert(0, preceding);
+                }
+
+                current = parent;
+            }
+
+            foreach (ExpressionSyntax preceding in groups.SelectMany(group => group))
+            {
+                if (this.state.HoistedExpressionValues.ContainsKey(preceding)
+                    || preceding is LiteralExpressionSyntax
+                        or ThisExpressionSyntax
+                        or BaseExpressionSyntax
+                        or DefaultExpressionSyntax
+                        or TypeOfExpressionSyntax)
+                {
+                    continue;
+                }
+
+                List<GStatement> outerSpillPrologue = this.state.PendingSpillPrologue;
+                this.state.PendingSpillPrologue = statements;
+                GExpression value;
+                try
+                {
+                    value = this.TranslateExpression(preceding);
+                }
+                finally
+                {
+                    this.state.PendingSpillPrologue = outerSpillPrologue;
+                }
+
+                string temp = $"__spill{this.state.SpillCounter++}";
+                statements.Add(new LocalDeclarationStatement(
+                    BindingKind.Let,
+                    temp,
+                    type: null,
+                    initializer: value));
+                this.state.HoistedExpressionValues[preceding] =
+                    new IdentifierExpression(temp);
+                replacements.Add(preceding);
+            }
+        }
+
+        private static ExpressionSyntax OperationExpression(IOperation operation)
+        {
+            if (operation is IInstanceReferenceOperation { IsImplicit: true }
+                or IMethodReferenceOperation)
+            {
+                return null;
+            }
+
+            if (operation is IArgumentOperation argument)
+            {
+                return argument.Value.Syntax as ExpressionSyntax;
+            }
+
+            while (operation.IsImplicit && operation.ChildOperations.Count() == 1)
+            {
+                operation = operation.ChildOperations.Single();
+            }
+
+            return operation.Syntax as ExpressionSyntax;
         }
 
         /// <summary>
@@ -91,32 +215,20 @@ public sealed partial class CSharpToGSharpTranslator
 
         private GExpression TranslateConditionWithHoistCore(ExpressionSyntax expression, List<GStatement> prologue)
         {
-            List<AssignmentExpressionSyntax> embedded = this.CollectEmbeddedAssignments(expression, includeSelf: true);
-            if (embedded.Count == 0)
-            {
-                return this.TranslateExpression(expression);
-            }
-
-            foreach (AssignmentExpressionSyntax node in embedded)
-            {
-                prologue.AddRange(this.FlattenChainedAssignment(node));
-            }
-
-            foreach (AssignmentExpressionSyntax node in embedded)
-            {
-                this.state.SuppressedAssignments.Add(node);
-            }
-
+            var replacements = new List<ExpressionSyntax>();
+            List<AssignmentExpressionSyntax> embedded =
+                this.HoistAssignmentsInOrder(
+                    expression,
+                    includeSelf: true,
+                    prologue,
+                    replacements);
             try
             {
                 return this.TranslateExpression(expression);
             }
             finally
             {
-                foreach (AssignmentExpressionSyntax node in embedded)
-                {
-                    this.state.SuppressedAssignments.Remove(node);
-                }
+                this.ReleaseHoistedAssignments(embedded, replacements);
             }
         }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
@@ -236,7 +236,7 @@ public sealed partial class CSharpToGSharpTranslator
             var safe = new List<AssignmentExpressionSyntax>();
             foreach (AssignmentExpressionSyntax candidate in candidates)
             {
-                if (IsInsideConditionalExpressionBranch(candidate, expression))
+                if (IsInsideConditionalValueBranch(candidate, expression))
                 {
                     continue;
                 }
@@ -288,16 +288,21 @@ public sealed partial class CSharpToGSharpTranslator
             }
         }
 
-        // A `?:` arm owns a native G# block-expression seam. An enclosing seam
-        // must not hoist the arm's assignment unconditionally; it leaves the node
-        // for TranslateConditionalBranch to lower inside the selected arm.
-        private static bool IsInsideConditionalExpressionBranch(SyntaxNode node, ExpressionSyntax root)
+        // Conditional and switch-expression arms own block-expression seams. An
+        // enclosing seam must leave each assignment inside its selected arm.
+        private static bool IsInsideConditionalValueBranch(SyntaxNode node, ExpressionSyntax root)
         {
             for (SyntaxNode current = node; current != null && current != root; current = current.Parent)
             {
                 SyntaxNode parent = current.Parent;
                 if (parent is ConditionalExpressionSyntax conditional &&
                     (current == conditional.WhenTrue || current == conditional.WhenFalse))
+                {
+                    return true;
+                }
+
+                if (parent is SwitchExpressionArmSyntax switchArm &&
+                    current == switchArm.Expression)
                 {
                     return true;
                 }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.IfLet.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.IfLet.cs
@@ -801,7 +801,7 @@ public sealed partial class CSharpToGSharpTranslator
                      !initializer.IsKind(SyntaxKind.WithInitializerExpression)))
                 .Any(assignment =>
                     AssignmentRequiresStatementLowering(assignment)
-                    && !IsInsideConditionalExpressionBranch(assignment, branch));
+                    && !IsInsideConditionalValueBranch(assignment, branch));
         }
 
         /// <summary>

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -701,9 +701,10 @@ public sealed partial class CSharpToGSharpTranslator
             out GExpression call,
             bool hostLocalAssignmentSeam)
         {
-            GExpression receiver = this.SpillOperand(
+            GExpression receiver = this.CaptureReceiverOnce(
                 this.TranslateExpression(conditionalAccess.Expression),
-                conditionalAccess.Expression);
+                conditionalAccess.Expression,
+                "a conditional-access helper call here has no enclosing evaluation seam to capture its receiver once.");
             GExpression helperReceiver = new NonNullAssertionExpression(receiver);
             if (chainedReceiver != null)
             {
@@ -943,7 +944,16 @@ public sealed partial class CSharpToGSharpTranslator
 
         private GExpression CaptureMethodGroupReceiver(
             GExpression receiver,
-            ExpressionSyntax receiverSyntax)
+            ExpressionSyntax receiverSyntax) =>
+            this.CaptureReceiverOnce(
+                receiver,
+                receiverSyntax,
+                "a static-helper extension method group here has no enclosing evaluation seam to capture its receiver once.");
+
+        private GExpression CaptureReceiverOnce(
+            GExpression receiver,
+            ExpressionSyntax receiverSyntax,
+            string unsupportedMessage)
         {
             // Issue #3357/#3360: a trivial, stable receiver needs no temp. A
             // mutable/reassigned local still spills because C# captures the
@@ -965,7 +975,7 @@ public sealed partial class CSharpToGSharpTranslator
 
             this.context.ReportUnsupported(
                 receiverSyntax,
-                "a static-helper extension method group here has no enclosing evaluation seam to capture its receiver once.");
+                unsupportedMessage);
             return receiver;
         }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -557,7 +557,8 @@ public sealed partial class CSharpToGSharpTranslator
                 helperName,
                 chainedReceiver,
                 out GExpression guard,
-                out GExpression call);
+                out GExpression call,
+                hostLocalAssignmentSeam: true);
 
             GTypeReference nullableType = this.typeMapper.Map(
                 conditionalType,
@@ -614,19 +615,38 @@ public sealed partial class CSharpToGSharpTranslator
                 return true;
             }
 
-            this.BuildNullConditionalStaticExtensionHelper(
-                conditionalAccess,
-                invocation,
-                owner,
-                name,
-                helperName,
-                chainedReceiver,
-                out GExpression guard,
-                out GExpression call);
+            var localStatements = new List<GStatement>();
+            var replacements = new List<ExpressionSyntax>();
+            List<AssignmentExpressionSyntax> embedded =
+                this.HoistAssignmentsInOrder(
+                    conditionalAccess.WhenNotNull,
+                    includeSelf: true,
+                    localStatements,
+                    replacements);
+            GExpression guard;
+            GExpression call;
+            try
+            {
+                this.BuildNullConditionalStaticExtensionHelper(
+                    conditionalAccess,
+                    invocation,
+                    owner,
+                    name,
+                    helperName,
+                    chainedReceiver,
+                    out guard,
+                    out call,
+                    hostLocalAssignmentSeam: false);
+            }
+            finally
+            {
+                this.ReleaseHoistedAssignments(embedded, replacements);
+            }
 
+            localStatements.Add(new ExpressionStatement(call));
             result = new IfStatement(
                 guard,
-                new BlockStatement(new GStatement[] { new ExpressionStatement(call) }));
+                new BlockStatement(localStatements));
             return true;
         }
 
@@ -678,7 +698,8 @@ public sealed partial class CSharpToGSharpTranslator
             SimpleNameSyntax helperName,
             ExpressionSyntax chainedReceiver,
             out GExpression guard,
-            out GExpression call)
+            out GExpression call,
+            bool hostLocalAssignmentSeam)
         {
             GExpression receiver = this.SpillOperand(
                 this.TranslateExpression(conditionalAccess.Expression),
@@ -705,7 +726,8 @@ public sealed partial class CSharpToGSharpTranslator
                     callTypeArgs);
             }
 
-            call = this.RequiresLocalAssignmentSeam(conditionalAccess.WhenNotNull)
+            call = hostLocalAssignmentSeam
+                && this.RequiresLocalAssignmentSeam(conditionalAccess.WhenNotNull)
                 ? this.TranslateWithLocalAssignmentSeam(
                     conditionalAccess.WhenNotNull,
                     TranslateCall)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -1003,7 +1003,8 @@ public sealed partial class CSharpToGSharpTranslator
                 return false;
             }
 
-            if (symbol is IParameterSymbol { RefKind: not RefKind.None })
+            if (symbol is ILocalSymbol { RefKind: not RefKind.None }
+                or IParameterSymbol { RefKind: not RefKind.None })
             {
                 return false;
             }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -691,16 +691,25 @@ public sealed partial class CSharpToGSharpTranslator
                     helperReceiver);
             }
 
-            var callArgs = new List<GExpression> { helperReceiver };
-            callArgs.AddRange(this.TranslateArguments(invocation.ArgumentList.Arguments));
             IReadOnlyList<GTypeReference> callTypeArgs = helperName is GenericNameSyntax generic
                 ? this.MapTypeArguments(generic)
                 : null;
 
-            call = new InvocationExpression(
-                new MemberAccessExpression(new IdentifierExpression(owner), name),
-                callArgs,
-                callTypeArgs);
+            GExpression TranslateCall()
+            {
+                var callArgs = new List<GExpression> { helperReceiver };
+                callArgs.AddRange(this.TranslateArguments(invocation.ArgumentList.Arguments));
+                return new InvocationExpression(
+                    new MemberAccessExpression(new IdentifierExpression(owner), name),
+                    callArgs,
+                    callTypeArgs);
+            }
+
+            call = this.RequiresLocalAssignmentSeam(conditionalAccess.WhenNotNull)
+                ? this.TranslateWithLocalAssignmentSeam(
+                    conditionalAccess.WhenNotNull,
+                    TranslateCall)
+                : TranslateCall();
             guard = new BinaryExpression(receiver, "!=", LiteralExpression.Null());
         }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -281,6 +281,12 @@ public sealed partial class CSharpToGSharpTranslator
                         return enumExtResult;
                     }
 
+                    if (this.RequiresLocalAssignmentSeam(conditionalAccess.WhenNotNull))
+                    {
+                        return this.TranslateConditionalAccessWithLocalAssignmentSeam(
+                            conditionalAccess);
+                    }
+
                     if (DependsOnEnclosingConditionalReceiver(conditionalAccess.Expression)
                         && FindLeadingElementBinding(conditionalAccess.WhenNotNull)
                             is ElementBindingExpressionSyntax conditionalIndexBinding
@@ -517,6 +523,44 @@ public sealed partial class CSharpToGSharpTranslator
                     FindLeadingElementBinding(elementAccess.Expression),
                 _ => null,
             };
+
+        private GExpression TranslateConditionalAccessWithLocalAssignmentSeam(
+            ConditionalAccessExpressionSyntax conditionalAccess)
+        {
+            GExpression receiver = this.SpillOperand(
+                this.TranslateExpression(conditionalAccess.Expression),
+                conditionalAccess.Expression);
+            GExpression previousReceiver = this.state.ConditionalReceiverReplacement;
+            this.state.ConditionalReceiverReplacement =
+                new NonNullAssertionExpression(receiver);
+            GExpression whenNotNull;
+            try
+            {
+                whenNotNull = this.TranslateWithLocalAssignmentSeam(
+                    conditionalAccess.WhenNotNull,
+                    () => this.TranslateExpression(conditionalAccess.WhenNotNull));
+            }
+            finally
+            {
+                this.state.ConditionalReceiverReplacement = previousReceiver;
+            }
+
+            ITypeSymbol conditionalType = this.context.GetTypeInfo(conditionalAccess).Type;
+            GTypeReference nullableType = this.typeMapper.Map(
+                conditionalType,
+                this.context,
+                conditionalAccess.GetLocation());
+            if (!nullableType.IsNullable)
+            {
+                nullableType = MakeNullable(nullableType);
+            }
+
+            return new ParenthesizedExpression(
+                new IfExpression(
+                    new BinaryExpression(receiver, "!=", LiteralExpression.Null()),
+                    whenNotNull,
+                    new DefaultValueExpression(nullableType)));
+        }
 
         private GExpression TranslateNonNullableConditionalIndex(
             ExpressionSyntax continuation,

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -24,6 +24,11 @@ public sealed partial class CSharpToGSharpTranslator
     {
         private GExpression TranslateExpression(ExpressionSyntax expression)
         {
+            if (this.state.HoistedExpressionValues.TryGetValue(expression, out GExpression hoistedValue))
+            {
+                return hoistedValue;
+            }
+
             switch (expression)
             {
                 case LiteralExpressionSyntax literal:

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -527,9 +527,10 @@ public sealed partial class CSharpToGSharpTranslator
         private GExpression TranslateConditionalAccessWithLocalAssignmentSeam(
             ConditionalAccessExpressionSyntax conditionalAccess)
         {
-            GExpression receiver = this.SpillOperand(
+            GExpression receiver = this.CaptureReceiverOnce(
                 this.TranslateExpression(conditionalAccess.Expression),
-                conditionalAccess.Expression);
+                conditionalAccess.Expression,
+                "a conditional-access expression here has no enclosing evaluation seam to capture its receiver once.");
             GExpression previousReceiver = this.state.ConditionalReceiverReplacement;
             this.state.ConditionalReceiverReplacement =
                 new NonNullAssertionExpression(receiver);

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
@@ -438,32 +438,28 @@ public sealed partial class CSharpToGSharpTranslator
         private GExpression TranslateBinaryRightOperand(BinaryExpressionSyntax binary)
         {
             // A fallback pattern in a right operand may spill its scrutinee.
-            // Host that spill in the operand itself so `&&`/`||`/`??` still
-            // decide whether the scrutinee runs.
+            // A deconstruction assignment also needs statements. Host either in
+            // the operand itself so `&&`/`||`/`??` still decide whether it runs.
             if (!IsShortCircuitOperator(binary)
-                || this.state.PendingSpillPrologue == null
-                || !this.ContainsFallbackPatternSpill(binary.Right))
+                || (!this.RequiresLocalAssignmentSeam(binary.Right)
+                    && (this.state.PendingSpillPrologue == null
+                        || !this.ContainsFallbackPatternSpill(binary.Right))))
             {
                 return this.TranslateExpression(binary.Right);
             }
 
-            List<GStatement> outerSpillPrologue = this.state.PendingSpillPrologue;
             List<GStatement> previousDeclarations = this.state.ShortCircuitSpillDeclarations;
             SyntaxNode previousScope = this.state.ShortCircuitSpillScope;
-            var statements = new List<GStatement>();
-            this.state.PendingSpillPrologue = statements;
-            this.state.ShortCircuitSpillDeclarations ??= outerSpillPrologue;
+            this.state.ShortCircuitSpillDeclarations ??= this.state.PendingSpillPrologue;
             this.state.ShortCircuitSpillScope ??= binary.Right;
             try
             {
-                GExpression value = this.TranslateExpression(binary.Right);
-                return statements.Count == 0
-                    ? value
-                    : new BlockExpression(statements, value);
+                return this.TranslateWithLocalAssignmentSeam(
+                    binary.Right,
+                    () => this.TranslateExpression(binary.Right));
             }
             finally
             {
-                this.state.PendingSpillPrologue = outerSpillPrologue;
                 this.state.ShortCircuitSpillDeclarations = previousDeclarations;
                 this.state.ShortCircuitSpillScope = previousScope;
             }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
@@ -2141,7 +2141,9 @@ public sealed partial class CSharpToGSharpTranslator
         /// statements: tuple declaration/deconstruction forms may expand, while
         /// ordinary chained assignments remain native nested expressions.
         /// </summary>
-        private IEnumerable<GStatement> TranslateExpressionStatements(ExpressionSyntax expression)
+        private IEnumerable<GStatement> TranslateExpressionStatements(
+            ExpressionSyntax expression,
+            bool hoistPostfix = true)
         {
             if (expression is AssignmentExpressionSyntax assignment &&
                 assignment.IsKind(SyntaxKind.SimpleAssignmentExpression))
@@ -2232,9 +2234,11 @@ public sealed partial class CSharpToGSharpTranslator
             return this.WithHoistedAssignments(
                 expression,
                 includeSelf: false,
-                () => this.WithHoistedPostfix(
-                    expression,
-                    () => new[] { this.TranslateExpressionStatement(expression) }).ToList());
+                () => hoistPostfix
+                    ? this.WithHoistedPostfix(
+                        expression,
+                        () => new[] { this.TranslateExpressionStatement(expression) }).ToList()
+                    : new List<GStatement> { this.TranslateExpressionStatement(expression) });
         }
 
         // Strips parentheses so chain/assignment detection is parenthesis-transparent.

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
@@ -2102,6 +2102,37 @@ public sealed partial class CSharpToGSharpTranslator
             return symbol is IDiscardSymbol or null;
         }
 
+        private bool CanDropDiscardedExpression(ExpressionSyntax expression)
+        {
+            expression = Unwrap(expression);
+            switch (expression)
+            {
+                case LiteralExpressionSyntax:
+                case ThisExpressionSyntax:
+                case BaseExpressionSyntax:
+                case DefaultExpressionSyntax:
+                case TypeOfExpressionSyntax:
+                    return true;
+
+                case IdentifierNameSyntax identifier:
+                    return this.context.GetSymbolInfo(identifier).Symbol
+                        is ILocalSymbol { RefKind: RefKind.None }
+                        or IParameterSymbol { RefKind: RefKind.None }
+                        or IRangeVariableSymbol;
+
+                case PostfixUnaryExpressionSyntax suppressed
+                    when suppressed.IsKind(SyntaxKind.SuppressNullableWarningExpression):
+                    return this.CanDropDiscardedExpression(suppressed.Operand);
+
+                case TupleExpressionSyntax tuple:
+                    return tuple.Arguments.All(argument =>
+                        this.CanDropDiscardedExpression(argument.Expression));
+
+                default:
+                    return false;
+            }
+        }
+
         /// <summary>
         /// Translates an expression-statement that may expand into several G#
         /// statements: tuple declaration/deconstruction forms may expand, while
@@ -2117,10 +2148,32 @@ public sealed partial class CSharpToGSharpTranslator
                 {
                     // C# statement-level discard `_ = e` (Roslyn parses the `_`
                     // target as an IdentifierNameSyntax). G# has no discard target
-                    // (`_ = e` → GS0125), so drop the assignment and emit just the
-                    // RHS as statement(s); `_ = a = b`, `_ = x ?? throw E`, and
-                    // `_ = await ...` flow through the RHS translation (issue #914).
-                    return this.TranslateExpressionStatements(assignment.Right);
+                    // (`_ = e` → GS0125). Drop only reads that cannot run code or
+                    // throw; otherwise G#'s native discard declaration evaluates
+                    // the RHS exactly once while keeping its value unbound.
+                    if (this.CanDropDiscardedExpression(assignment.Right))
+                    {
+                        return System.Array.Empty<GStatement>();
+                    }
+
+                    if ((assignment.Right is AssignmentExpressionSyntax or SwitchExpressionSyntax)
+                        || (assignment.Right is PrefixUnaryExpressionSyntax prefix
+                            && (prefix.IsKind(SyntaxKind.PreIncrementExpression)
+                                || prefix.IsKind(SyntaxKind.PreDecrementExpression)))
+                        || (assignment.Right is PostfixUnaryExpressionSyntax postfix
+                            && (postfix.IsKind(SyntaxKind.PostIncrementExpression)
+                                || postfix.IsKind(SyntaxKind.PostDecrementExpression))))
+                    {
+                        return this.TranslateExpressionStatements(assignment.Right);
+                    }
+
+                    return new[]
+                    {
+                        (GStatement)new LocalDeclarationStatement(
+                            BindingKind.Let,
+                            "_",
+                            initializer: this.TranslateExpression(assignment.Right)),
+                    };
                 }
 
                 if (this.TryGetDeconstructionTargets(assignment.Left, out BindingKind binding, out IReadOnlyList<string> names))

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
@@ -1980,9 +1980,10 @@ public sealed partial class CSharpToGSharpTranslator
         private GStatement TranslateVoidConditionalAccessWithLocalAssignmentSeam(
             ConditionalAccessExpressionSyntax conditionalAccess)
         {
-            GExpression receiver = this.SpillOperand(
+            GExpression receiver = this.CaptureReceiverOnce(
                 this.TranslateExpression(conditionalAccess.Expression),
-                conditionalAccess.Expression);
+                conditionalAccess.Expression,
+                "a void conditional-access statement here has no enclosing evaluation seam to capture its receiver once.");
             GExpression previousReceiver = this.state.ConditionalReceiverReplacement;
             List<GStatement> outerSpillPrologue = this.state.PendingSpillPrologue;
             var statements = new List<GStatement>();

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
@@ -1903,6 +1903,16 @@ public sealed partial class CSharpToGSharpTranslator
                 return conditionalHelperStatement;
             }
 
+            if (expression is ConditionalAccessExpressionSyntax voidConditionalAccess
+                && this.context.GetTypeInfo(voidConditionalAccess).Type
+                    is { SpecialType: SpecialType.System_Void }
+                && this.RequiresLocalAssignmentSeam(
+                    voidConditionalAccess.WhenNotNull))
+            {
+                return this.TranslateVoidConditionalAccessWithLocalAssignmentSeam(
+                    voidConditionalAccess);
+            }
+
             switch (expression)
             {
                 case AssignmentExpressionSyntax assignment when this.IsDelegateMulticastCombine(assignment, out string combineOp):
@@ -1965,6 +1975,42 @@ public sealed partial class CSharpToGSharpTranslator
                 default:
                     return new ExpressionStatement(this.TranslateExpression(expression));
             }
+        }
+
+        private GStatement TranslateVoidConditionalAccessWithLocalAssignmentSeam(
+            ConditionalAccessExpressionSyntax conditionalAccess)
+        {
+            GExpression receiver = this.SpillOperand(
+                this.TranslateExpression(conditionalAccess.Expression),
+                conditionalAccess.Expression);
+            GExpression previousReceiver = this.state.ConditionalReceiverReplacement;
+            List<GStatement> outerSpillPrologue = this.state.PendingSpillPrologue;
+            var statements = new List<GStatement>();
+            var replacements = new List<ExpressionSyntax>();
+            this.state.ConditionalReceiverReplacement =
+                new NonNullAssertionExpression(receiver);
+            this.state.PendingSpillPrologue = statements;
+            List<AssignmentExpressionSyntax> embedded =
+                this.HoistAssignmentsInOrder(
+                    conditionalAccess.WhenNotNull,
+                    includeSelf: true,
+                    statements,
+                    replacements);
+            try
+            {
+                statements.Add(new ExpressionStatement(
+                    this.TranslateExpression(conditionalAccess.WhenNotNull)));
+            }
+            finally
+            {
+                this.ReleaseHoistedAssignments(embedded, replacements);
+                this.state.PendingSpillPrologue = outerSpillPrologue;
+                this.state.ConditionalReceiverReplacement = previousReceiver;
+            }
+
+            return new IfStatement(
+                new BinaryExpression(receiver, "!=", LiteralExpression.Null()),
+                new BlockStatement(statements));
         }
 
         private GExpression TranslateAssignmentValue(AssignmentExpressionSyntax assignment)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
@@ -47,17 +47,13 @@ public sealed partial class CSharpToGSharpTranslator
                 {
                     // Value-position deconstruction assignments still need a
                     // statement seam; ordinary assignments remain inline.
+                    var replacements = new List<ExpressionSyntax>();
                     List<AssignmentExpressionSyntax> initializerEmbedded =
-                        this.CollectEmbeddedAssignments(declarator.Initializer.Value, includeSelf: true);
-                    foreach (AssignmentExpressionSyntax node in initializerEmbedded)
-                    {
-                        results.AddRange(this.FlattenChainedAssignment(node));
-                    }
-
-                    foreach (AssignmentExpressionSyntax node in initializerEmbedded)
-                    {
-                        this.state.SuppressedAssignments.Add(node);
-                    }
+                        this.HoistAssignmentsInOrder(
+                            declarator.Initializer.Value,
+                            includeSelf: true,
+                            results,
+                            replacements);
 
                     try
                     {
@@ -69,10 +65,9 @@ public sealed partial class CSharpToGSharpTranslator
                     }
                     finally
                     {
-                        foreach (AssignmentExpressionSyntax node in initializerEmbedded)
-                        {
-                            this.state.SuppressedAssignments.Remove(node);
-                        }
+                        this.ReleaseHoistedAssignments(
+                            initializerEmbedded,
+                            replacements);
                     }
                 }
 
@@ -1094,17 +1089,13 @@ public sealed partial class CSharpToGSharpTranslator
             this.state.PendingSpillPrologue = statements;
             try
             {
+                var replacements = new List<ExpressionSyntax>();
                 List<AssignmentExpressionSyntax> embedded =
-                    this.CollectEmbeddedAssignments(branch, includeSelf: true);
-                foreach (AssignmentExpressionSyntax node in embedded)
-                {
-                    statements.AddRange(this.FlattenChainedAssignment(node));
-                }
-
-                foreach (AssignmentExpressionSyntax node in embedded)
-                {
-                    this.state.SuppressedAssignments.Add(node);
-                }
+                    this.HoistAssignmentsInOrder(
+                        branch,
+                        includeSelf: true,
+                        statements,
+                        replacements);
 
                 try
                 {
@@ -1115,10 +1106,7 @@ public sealed partial class CSharpToGSharpTranslator
                 }
                 finally
                 {
-                    foreach (AssignmentExpressionSyntax node in embedded)
-                    {
-                        this.state.SuppressedAssignments.Remove(node);
-                    }
+                    this.ReleaseHoistedAssignments(embedded, replacements);
                 }
             }
             finally

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
@@ -1071,9 +1071,9 @@ public sealed partial class CSharpToGSharpTranslator
 
             GExpression condition = this.TranslateExpression(conditional.Condition);
             (GExpression whenTrue, List<GStatement> thenStatements) =
-                this.TranslateConditionalBranch(conditional.WhenTrue);
+                this.TranslateConditionalValueBranch(conditional.WhenTrue);
             (GExpression whenFalse, List<GStatement> elseStatements) =
-                this.TranslateConditionalBranch(conditional.WhenFalse);
+                this.TranslateConditionalValueBranch(conditional.WhenFalse);
             (whenTrue, whenFalse) = this.CoerceConditionalArms(conditional, whenTrue, whenFalse);
             return new IfExpression(
                 condition,
@@ -1083,11 +1083,11 @@ public sealed partial class CSharpToGSharpTranslator
                 elseStatements);
         }
 
-        // A G# if-expression arm is a block expression: it can run statements,
-        // then yield its trailing expression. Keep every arm-local spill/write in
-        // that block so only the selected C# arm executes it (issue #1723).
-        private (GExpression Value, List<GStatement> Statements) TranslateConditionalBranch(
-            ExpressionSyntax branch)
+        // G# conditional/switch arms can use block expressions: run arm-local
+        // spills/writes there so only the selected C# arm executes them.
+        private (GExpression Value, List<GStatement> Statements) TranslateConditionalValueBranch(
+            ExpressionSyntax branch,
+            Func<GExpression> translateValue = null)
         {
             List<GStatement> outerSpillPrologue = this.state.PendingSpillPrologue;
             var statements = new List<GStatement>();
@@ -1108,7 +1108,10 @@ public sealed partial class CSharpToGSharpTranslator
 
                 try
                 {
-                    return (this.TranslateValueWithNullForgiveness(branch), statements);
+                    GExpression value = translateValue != null
+                        ? translateValue()
+                        : this.TranslateValueWithNullForgiveness(branch);
+                    return (value, statements);
                 }
                 finally
                 {
@@ -2156,24 +2159,30 @@ public sealed partial class CSharpToGSharpTranslator
                         return System.Array.Empty<GStatement>();
                     }
 
-                    if ((assignment.Right is AssignmentExpressionSyntax or SwitchExpressionSyntax)
-                        || (assignment.Right is PrefixUnaryExpressionSyntax prefix
+                    ExpressionSyntax discardedValue = Unwrap(assignment.Right);
+                    if ((discardedValue is AssignmentExpressionSyntax or SwitchExpressionSyntax)
+                        || (discardedValue is PrefixUnaryExpressionSyntax prefix
                             && (prefix.IsKind(SyntaxKind.PreIncrementExpression)
                                 || prefix.IsKind(SyntaxKind.PreDecrementExpression)))
-                        || (assignment.Right is PostfixUnaryExpressionSyntax postfix
+                        || (discardedValue is PostfixUnaryExpressionSyntax postfix
                             && (postfix.IsKind(SyntaxKind.PostIncrementExpression)
                                 || postfix.IsKind(SyntaxKind.PostDecrementExpression))))
                     {
-                        return this.TranslateExpressionStatements(assignment.Right);
+                        return this.TranslateExpressionStatements(discardedValue);
                     }
 
-                    return new[]
-                    {
-                        (GStatement)new LocalDeclarationStatement(
-                            BindingKind.Let,
-                            "_",
-                            initializer: this.TranslateExpression(assignment.Right)),
-                    };
+                    return this.WithHoistedAssignments(
+                        assignment.Right,
+                        includeSelf: true,
+                        () => this.WithHoistedPostfix(
+                            assignment.Right,
+                            () => new[]
+                            {
+                                (GStatement)new LocalDeclarationStatement(
+                                    BindingKind.Let,
+                                    "_",
+                                    initializer: this.TranslateExpression(assignment.Right)),
+                            }).ToList());
                 }
 
                 if (this.TryGetDeconstructionTargets(assignment.Left, out BindingKind binding, out IReadOnlyList<string> names))

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
@@ -2174,15 +2174,13 @@ public sealed partial class CSharpToGSharpTranslator
                     return this.WithHoistedAssignments(
                         assignment.Right,
                         includeSelf: true,
-                        () => this.WithHoistedPostfix(
-                            assignment.Right,
-                            () => new[]
-                            {
-                                (GStatement)new LocalDeclarationStatement(
-                                    BindingKind.Let,
-                                    "_",
-                                    initializer: this.TranslateExpression(assignment.Right)),
-                            }).ToList());
+                        () => new List<GStatement>
+                        {
+                            new LocalDeclarationStatement(
+                                BindingKind.Let,
+                                "_",
+                                initializer: this.TranslateExpression(assignment.Right)),
+                        });
                 }
 
                 if (this.TryGetDeconstructionTargets(assignment.Left, out BindingKind binding, out IReadOnlyList<string> names))

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
@@ -828,7 +828,7 @@ public sealed partial class CSharpToGSharpTranslator
                     };
                 }
 
-                return this.TranslateExpressionStatements(expression).ToList();
+                return this.TranslateExpressionStatements(expression, hoistPostfix: false).ToList();
             }).ToList());
         }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
@@ -630,9 +630,15 @@ public sealed partial class CSharpToGSharpTranslator
             ExpressionSyntax expression,
             GTypeReference nullableResultType)
         {
-            return nullableResultType != null && IsNullOrDefaultLiteral(expression)
-                ? new DefaultValueExpression(nullableResultType)
-                : this.TranslateValueWithNullForgiveness(expression);
+            (GExpression value, List<GStatement> statements) =
+                this.TranslateConditionalValueBranch(
+                    expression,
+                    () => nullableResultType != null && IsNullOrDefaultLiteral(expression)
+                        ? new DefaultValueExpression(nullableResultType)
+                        : this.TranslateValueWithNullForgiveness(expression));
+            return statements.Count == 0
+                ? value
+                : new BlockExpression(statements, value);
         }
 
         private GExpression TranslateSwitchPatternGuard(
@@ -756,7 +762,7 @@ public sealed partial class CSharpToGSharpTranslator
                 }
 
                 GExpression guard;
-                GStatement body;
+                BlockStatement body;
                 try
                 {
                     guard = this.TranslateSwitchPatternGuard(
@@ -764,7 +770,7 @@ public sealed partial class CSharpToGSharpTranslator
                         guards,
                         mutableBindings);
                     this.UseMutableSwitchPatternLocals(mutableBindings);
-                    body = this.TranslateSwitchArmExpressionAsStatement(arm.Expression);
+                    body = this.TranslateSwitchArmExpressionAsBlock(arm.Expression);
                 }
                 finally
                 {
@@ -780,7 +786,7 @@ public sealed partial class CSharpToGSharpTranslator
                 }
 
                 BlockStatement armBody = this.MaterializeMutableSwitchPatternLocals(
-                    new BlockStatement(new[] { body }),
+                    body,
                     mutableBindings,
                     arm.Pattern);
                 cases.Add(new SwitchStatementCase(pattern, armBody, guard));
@@ -808,18 +814,22 @@ public sealed partial class CSharpToGSharpTranslator
             return new SwitchStatement(subject, cases);
         }
 
-        // Renders a switch-expression arm's value expression as a single G#
-        // statement for the discarded switch-statement lowering above. A `throw`
-        // arm becomes a throw statement; every other expression is emitted as an
-        // expression statement (its value is discarded).
-        private GStatement TranslateSwitchArmExpressionAsStatement(ExpressionSyntax expression)
+        // Renders a switch-expression arm through the shared statement seam so
+        // assignment/deconstruction side effects stay inside the selected arm.
+        private BlockStatement TranslateSwitchArmExpressionAsBlock(ExpressionSyntax expression)
         {
-            if (expression is ThrowExpressionSyntax throwExpression)
+            return new BlockStatement(this.WithSpillSeam(() =>
             {
-                return new ThrowStatement(this.TranslateExpression(throwExpression.Expression));
-            }
+                if (expression is ThrowExpressionSyntax throwExpression)
+                {
+                    return new[]
+                    {
+                        (GStatement)new ThrowStatement(this.TranslateExpression(throwExpression.Expression)),
+                    };
+                }
 
-            return new ExpressionStatement(this.TranslateExpression(expression));
+                return this.TranslateExpressionStatements(expression).ToList();
+            }).ToList());
         }
 
         private IEnumerable<GStatement> TranslateSwitchStatement(SwitchStatementSyntax node)

--- a/tools/cs2gs/Cs2Gs.Translator/DocumentTranslationState.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/DocumentTranslationState.cs
@@ -108,6 +108,12 @@ internal sealed class DocumentTranslationState
     public Dictionary<TupleExpressionSyntax, GExpression> TupleAssignmentValues { get; } =
         new Dictionary<TupleExpressionSyntax, GExpression>();
 
+    // Values captured before a nested deconstruction assignment is hoisted.
+    // TranslateExpression substitutes these temps at their original positions
+    // so C# left-to-right operand evaluation remains intact.
+    public Dictionary<ExpressionSyntax, GExpression> HoistedExpressionValues { get; } =
+        new Dictionary<ExpressionSyntax, GExpression>();
+
     // Static-field initializers lifted out of a `static` constructor body
     // (`static T() { Field = value; }`). G# has no static constructor, so a
     // simple static ctor is folded into the corresponding `shared { }` field


### PR DESCRIPTION
## Summary
- remove statement-level discards only for inert, non-throwing values
- evaluate effectful or potentially throwing values through G# native discard declarations while reusing existing assignment/increment/switch statement lowering
- cover methods, lambdas, iterators, async/await, nested expressions, exceptions, nullable behavior, evaluation order, and reserved identifier sanitation

## Focused validation
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj --no-restore --filter 'FullyQualifiedName~Issue3462DiscardAssignmentTranslationTests|FullyQualifiedName~Issue3461IdentifierSanitizationTests.LanguageServerParamsParameter_DeclarationAndReference_Bind|FullyQualifiedName~Issue1741SilentDivergenceTests|FullyQualifiedName~Issue914DiscardedSwitchExpressionTranslationTests|FullyQualifiedName~CodeExploderTranslationTests.VoidDelegateDiscardAssignment_EmitsRhsStatement|FullyQualifiedName~CodeExploderTranslationTests.BlockLambdaSingleUnderscoreParameter_IsRenamed|FullyQualifiedName~BodyTranslationTests.DiscardAssignment_UsesNativeDiscardDeclaration' --verbosity minimal`\n- 21 passed\n\nCloses #3462