### PR TITLE
Support string and char concatenation

### DIFF
--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.InterfaceVerification.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.InterfaceVerification.cs
@@ -2357,6 +2357,17 @@ internal sealed partial class DeclarationBinder
             case BoundConversionExpression conv:
                 return TryEvaluateConstant(conv.Expression, out value);
 
+            case BoundImportedCallExpression call
+                when call.Function.Method.DeclaringType?.IsSameAs(typeof(System.Convert)) == true
+                && call.Function.Method.Name == nameof(System.Convert.ToString)
+                && call.Function.Method.GetParameters() is [{ ParameterType: var parameterType }]
+                && parameterType.IsSameAs(typeof(char))
+                && call.Arguments is [{ } argument]
+                && TryEvaluateConstant(argument, out var charValue)
+                && charValue is char ch:
+                value = ch.ToString();
+                return true;
+
             case BoundFieldAccessExpression fieldAccess
                 when fieldAccess.Field.IsConst
                 && fieldAccess.Field.ConstantValue != null:

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -2294,6 +2294,25 @@ internal sealed partial class ExpressionBinder
     {
         var boundOperator = BoundBinaryOperator.Bind(operatorKind, boundLeft.Type, boundRight.Type);
 
+        // Issue #3463: C# defines string concatenation with char operands in
+        // either order. Keep char-to-string adaptation local to `+` rather
+        // than introducing a general implicit char -> string conversion.
+        if (boundOperator == null && operatorKind == SyntaxKind.PlusToken)
+        {
+            if (GetNullableUnderlying(boundLeft.Type) == TypeSymbol.String
+                && boundRight.Type == TypeSymbol.Char)
+            {
+                boundRight = ConvertStringConcatCharOperand(boundRight, rightLocation);
+                boundOperator = BoundBinaryOperator.Bind(operatorKind, boundLeft.Type, boundRight.Type);
+            }
+            else if (boundLeft.Type == TypeSymbol.Char
+                && GetNullableUnderlying(boundRight.Type) == TypeSymbol.String)
+            {
+                boundLeft = ConvertStringConcatCharOperand(boundLeft, leftLocation);
+                boundOperator = BoundBinaryOperator.Bind(operatorKind, boundLeft.Type, boundRight.Type);
+            }
+        }
+
         if (operatorKind is SyntaxKind.ShiftLeftToken or SyntaxKind.ShiftRightToken or SyntaxKind.UnsignedShiftRightToken
             && (GetNullableUnderlying(boundLeft.Type) == TypeSymbol.Char
                 || GetNullableUnderlying(boundRight.Type) == TypeSymbol.Char))
@@ -2593,6 +2612,16 @@ internal sealed partial class ExpressionBinder
         }
 
         return boundOperator;
+    }
+
+    private BoundExpression ConvertStringConcatCharOperand(BoundExpression expression, TextLocation location)
+    {
+        return expression switch
+        {
+            BoundLiteralExpression { Value: char value } =>
+                new BoundLiteralExpression(expression.Syntax, value.ToString()),
+            _ => ConvertToString(expression, location),
+        };
     }
 
     private static bool TryGetPromotedCharUnaryType(SyntaxKind operatorKind, TypeSymbol operandType, out TypeSymbol? promotedType)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3463StringCharConcatTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3463StringCharConcatTests.cs
@@ -1,0 +1,152 @@
+// <copyright file="Issue3463StringCharConcatTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>Issue #3463: native string and char concatenation.</summary>
+public class Issue3463StringCharConcatTests
+{
+    [Fact]
+    public void StringCharForms_BindWithoutDiagnostics()
+    {
+        const string source = """
+            func F(ns string?, ch char) {
+                var s = "text"
+                var a = s + ch
+                var b = ch + s
+                var c = ns + ch
+                var d = ch + ns
+                s += ch
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Theory]
+    [InlineData("\"left\" + '!'", "left!")]
+    [InlineData("'!' + \"right\"", "!right")]
+    [InlineData("var s string? = nil\ns + 'x'", "x")]
+    [InlineData("\"a\" + 'b' + 'c'", "abc")]
+    public void StringCharExpressions_EmitAndRun(string source, string expected)
+    {
+        var result = EmittedOracle.Evaluate(source);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(expected, result.Value);
+    }
+
+    [Fact]
+    public void DirectorySeparatorChar_CompoundAssignment_EmitsAndRuns()
+    {
+        var result = EmittedOracle.Evaluate(
+            """
+            import System.IO
+
+            var normalizedDirectory = "root"
+            normalizedDirectory += Path.DirectorySeparatorChar
+            normalizedDirectory
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("root" + Path.DirectorySeparatorChar, result.Value);
+    }
+
+    [Fact]
+    public void ConstantStringAndCharConcat_FoldsAndEmits()
+    {
+        var result = EmittedOracle.Evaluate(
+            """
+            class Values {
+                const Separator char = 'b'
+                const Text string = "a" + Separator
+            }
+
+            Values.Text
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("ab", result.Value);
+    }
+
+    [Fact]
+    public void PropertyCompoundAssignment_EvaluatesReceiverOnce()
+    {
+        var result = EmittedOracle.Evaluate(
+            """
+            class Box {
+                var value string = "a"
+                prop Text string { get { return value } set { this.value = value } }
+            }
+
+            func GetBox() Box {
+                calls += 1
+                return box
+            }
+
+            var calls = 0
+            let box = Box()
+            GetBox().Text += 'x'
+            "${box.Text}:$calls"
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("ax:1", result.Value);
+    }
+
+    [Fact]
+    public void IndexerCompoundAssignment_EvaluatesReceiverAndIndexOnce()
+    {
+        var result = EmittedOracle.Evaluate(
+            """
+            import System.Collections.Generic
+
+            func GetValues() Dictionary[int32, string] {
+                receiverCalls += 1
+                return values
+            }
+
+            func GetIndex() int32 {
+                indexCalls += 1
+                return 0
+            }
+
+            var receiverCalls = 0
+            var indexCalls = 0
+            let values = Dictionary[int32, string]()
+            values[0] = "a"
+            GetValues()[GetIndex()] += 'x'
+            "${values[0]}:$receiverCalls:$indexCalls"
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("ax:1:1", result.Value);
+    }
+
+    private static ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        if (tree.Diagnostics.Any())
+        {
+            return tree.Diagnostics;
+        }
+
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+        if (globalScope.Diagnostics.Any())
+        {
+            return globalScope.Diagnostics;
+        }
+
+        return Binder.BindProgram(globalScope).Diagnostics.ToImmutableArray();
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/StringConcatenationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/StringConcatenationTranslationTests.cs
@@ -14,14 +14,9 @@ namespace Cs2Gs.Tests;
 
 /// <summary>
 /// Translation tests for C# string concatenation (issue #914). C# `a + b`
-/// implicitly converts each non-<c>string</c> operand to a string via
-/// <c>String.Concat</c>/<c>ToString</c>, but G# has no implicit string
-/// conversion (spec: use interpolation or an explicit conversion), so a `+`
-/// whose operands are not both <c>string</c> is rejected with GS0129
-/// (<c>operator '+' is not defined for 'Indent' and 'string'</c>). The
-/// translator rewrites each non-<c>string</c> operand to an explicit
-/// <c>operand.ToString()</c> call so the concatenation type-checks while
-/// preserving C#'s displayed value.
+/// implicitly converts non-<c>string</c> operands through its predefined
+/// concatenation operators. G# handles <c>char</c> natively; remaining operand
+/// types are rewritten to explicit <c>ToString()</c> calls.
 /// </summary>
 public class StringConcatenationTranslationTests
 {
@@ -70,6 +65,28 @@ namespace Demo
 }");
 
         Assert.Contains("\"n=\" + n.ToString()", printed);
+    }
+
+    [Fact]
+    public void CharConcatenation_UsesNativeGSharpOperator()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public string F(char ch)
+        {
+            string value = ""root"";
+            value += ch;
+            return ch + value;
+        }
+    }
+}");
+
+        Assert.Contains("value += ch", printed);
+        Assert.Contains("return ch + value", printed);
+        Assert.DoesNotContain("ch.ToString()", printed);
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
@@ -314,13 +314,9 @@ public sealed partial class CSharpToGSharpTranslator
             string op = binary.OperatorToken.Text;
             GExpression right = this.TranslateBinaryRightOperand(binary);
 
-            // C# string concatenation `a + b`: when the `+` operator binds to
-            // `string`, C# implicitly converts each non-string operand to a string
-            // (via `String.Concat`/`ToString`). G# has no implicit conversion, so a
-            // `+` whose operands are not both `string` is GS0129 (`operator '+' is
-            // not defined for 'Indent' and 'string'`). Rewrite each non-string
-            // operand to an explicit `operand.ToString()` so the concatenation
-            // type-checks, matching C#'s displayed value.
+            // C# string concatenation `a + b`: gsc handles char operands
+            // natively. Other non-string operands still need an explicit
+            // `ToString()` because G# does not expose C#'s string + object arms.
             if (binary.IsKind(SyntaxKind.AddExpression)
                 && this.context.GetTypeInfo(binary).Type?.SpecialType == SpecialType.System_String)
             {
@@ -503,18 +499,14 @@ public sealed partial class CSharpToGSharpTranslator
         }
 
         // For a string-concatenation `+` operand: if the operand's C# type is not
-        // already `string`, wrap the translated operand in an explicit
-        // `operand.ToString()` call so G# (which has no implicit string conversion)
-        // type-checks the concatenation. A string operand (including a nested
-        // string `+` sub-expression, whose type is also `string`) is returned
-        // unchanged, as is a bare `null` literal (`null.ToString()` would throw;
-        // C# renders it as the empty string, and a translated `nil` keeps that
-        // intent while remaining assignable to a `string` slot). The operand is
-        // parenthesized when needed so member access binds to the whole operand.
+        // already `string` or `char`, wrap the translated operand in an explicit
+        // `operand.ToString()` call. G# handles char concatenation natively. A
+        // bare `null` literal is also unchanged (`null.ToString()` would throw).
         private GExpression CoerceConcatOperand(ExpressionSyntax operandSyntax, GExpression translated)
         {
             ITypeSymbol operandType = this.context.GetTypeInfo(operandSyntax).Type;
-            if (operandType?.SpecialType == SpecialType.System_String)
+            SpecialType specialType = operandType?.SpecialType ?? SpecialType.None;
+            if (specialType is SpecialType.System_String or SpecialType.System_Char)
             {
                 return translated;
             }


### PR DESCRIPTION
## Summary
- adapt `char` operands to string inside shared binary-operator binding, covering both operand orders and compound assignment
- preserve constant folding and nullable-string `String.Concat` behavior
- let cs2gs emit native G# char concatenation without translator-only rewrites
- verify imported `Path.DirectorySeparatorChar`, properties, and indexers with single evaluation

## Tests
- `dotnet test test/Core.Tests/Core.Tests.csproj --no-restore --filter 'FullyQualifiedName~Issue3463StringCharConcatTests|FullyQualifiedName~Issue1927VarianceConversionAndStringConcatTests|FullyQualifiedName~Issue1193ConstFolding' --nologo`
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj --no-restore --filter FullyQualifiedName~StringConcatenationTranslationTests --nologo`

Closes #3463