### PR TITLE
Support inline out declarations in constructors

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -1850,7 +1850,8 @@ internal sealed partial class ExpressionBinder
         {
             // ADR-0060 §1: `out var n [T]` / `out let n [T]` / `out _ [T]`.
             // Only legal when the modifier is `out` AND the parameter (if known) is `out`.
-            if (!string.Equals(syntax.RefKindModifier.Text, "out", System.StringComparison.Ordinal))
+            if (!string.Equals(syntax.RefKindModifier.Text, "out", System.StringComparison.Ordinal)
+                || (parameter != null && parameter.RefKind != RefKind.Out))
             {
                 Diagnostics.ReportOutDeclarationOutsideOutArgument(syntax.Location);
                 return new BoundErrorExpression(null);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -1860,7 +1860,7 @@ internal sealed partial class ExpressionBinder
             TypeSymbol? declaredType = null;
             if (syntax.DeclaredType != null)
             {
-                declaredType = bindTypeClause(syntax.DeclaredType);
+                declaredType = bindTypeClause(syntax.DeclaredType) ?? TypeSymbol.Error;
             }
 
             if (declaredType == null && parameter != null)

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -1696,6 +1696,36 @@ internal sealed partial class ExpressionBinder
                 || (canAccessInternalConstructors
                     && (constructor.IsAssembly || constructor.IsFamilyOrAssembly)))
             .ToArray();
+
+        var inlineOutArguments = GetInlineOutArgumentIndices(syntax);
+        if (inlineOutArguments.Count > 0)
+        {
+            var invalidInlineOutArguments = inlineOutArguments
+                .Where(index => !ctors.Any(constructor => ConstructorSupportsInlineOutArgument(
+                    constructor,
+                    argumentNames,
+                    index)))
+                .ToArray();
+            if (invalidInlineOutArguments.Length > 0)
+            {
+                foreach (var index in invalidInlineOutArguments)
+                {
+                    Diagnostics.ReportOutDeclarationOutsideOutArgument(
+                        OverloadResolver.UnwrapNamedArgumentValue(syntax.Arguments[index]).Location);
+                }
+
+                result = new BoundErrorExpression(syntax);
+                return true;
+            }
+
+            ctors = ctors
+                .Where(constructor => ConstructorSupportsInlineOutArguments(
+                    constructor,
+                    argumentNames,
+                    inlineOutArguments))
+                .ToArray();
+        }
+
         var ctorParameterLists = new List<ParameterInfo[]>(ctors.Length);
         foreach (var constructor in ctors)
         {
@@ -1742,13 +1772,20 @@ internal sealed partial class ExpressionBinder
                 continue;
             }
 
-            boundArguments.Add(BindCallArgumentWithDelegateTargetTyping(
-                syntax.Arguments[i],
-                ctorParameterLists,
-                sourceArgumentCount: syntax.Arguments.Count,
-                sourceArgIndex: i,
-                argName: argName,
-                paramOffset: 0));
+            if (inner is RefArgumentExpressionSyntax refArgument)
+            {
+                boundArguments.Add(BindRefArgumentExpression(refArgument, parameter: null));
+            }
+            else
+            {
+                boundArguments.Add(BindCallArgumentWithDelegateTargetTyping(
+                    syntax.Arguments[i],
+                    ctorParameterLists,
+                    sourceArgumentCount: syntax.Arguments.Count,
+                    sourceArgIndex: i,
+                    argName: argName,
+                    paramOffset: 0));
+            }
         }
 
         // Phase A (overload resolution): pick a constructor via the shared
@@ -1760,6 +1797,12 @@ internal sealed partial class ExpressionBinder
         var hasUserClassArg = false;
         for (var i = 0; i < boundArguments.Count; i++)
         {
+            if (TryGetInlineOutVarArgument(syntax, i, out _))
+            {
+                argTypes[i] = ClrOverloadResolution.InlineOutVarArgumentType;
+                continue;
+            }
+
             // Issue #530: use GetEffectiveArgumentClrType (see instance method path).
             // Issue #533: allow null (nil literal) to flow through; overload
             // resolution now handles null source as compatible with reference
@@ -1851,7 +1894,8 @@ internal sealed partial class ExpressionBinder
                     break;
                 case ClrOverloadResolution.ResolutionOutcome.Ambiguous:
                     Diagnostics.ReportAmbiguousOverload(syntax.Location, clrType.Name, resolution.Ambiguous.Length, resolution.Ambiguous.Select(ClrOverloadResolution.FormatMethodSignature));
-                    return false;
+                    result = new BoundErrorExpression(syntax);
+                    return true;
                 default:
                     break;
             }
@@ -1902,8 +1946,14 @@ internal sealed partial class ExpressionBinder
         }
 
         var ctorParameters = bestCtor.GetParameters();
+        var ctorRawArgs = RebindInlineOutConstructorArguments(
+            syntax,
+            boundArguments.MoveToImmutable(),
+            bestCtor,
+            ctorMapping,
+            openGenericDefinition,
+            symbolicTypeArgs);
         var ctorRefKinds = ComputeArgumentRefKinds(ctorParameters);
-        var ctorRawArgs = boundArguments.MoveToImmutable();
         var ctorExpandedArgs = ctorIsExpanded
             ? overloads.ExpandParamsArguments(ctorRawArgs, ctorParameters, syntax, parameterMapping: ctorMapping)
             : ctorRawArgs;
@@ -1978,6 +2028,146 @@ internal sealed partial class ExpressionBinder
             ctorRefKinds);
         result = WrapWithHandlerPrelude(ctorCall, ctorHandlerPrelude, syntax);
         return true;
+    }
+
+    private static List<int> GetInlineOutArgumentIndices(CallExpressionSyntax syntax)
+    {
+        var result = new List<int>();
+        for (var i = 0; i < syntax.Arguments.Count; i++)
+        {
+            if (OverloadResolver.UnwrapNamedArgumentValue(syntax.Arguments[i])
+                is RefArgumentExpressionSyntax { IsInlineDeclaration: true })
+            {
+                result.Add(i);
+            }
+        }
+
+        return result;
+    }
+
+    private static bool ConstructorSupportsInlineOutArguments(
+        ConstructorInfo constructor,
+        ImmutableArray<string> argumentNames,
+        IReadOnlyList<int> inlineOutArguments)
+    {
+        foreach (var sourceIndex in inlineOutArguments)
+        {
+            if (!ConstructorSupportsInlineOutArgument(
+                    constructor,
+                    argumentNames,
+                    sourceIndex))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool ConstructorSupportsInlineOutArgument(
+        ConstructorInfo constructor,
+        ImmutableArray<string> argumentNames,
+        int sourceIndex)
+    {
+        var parameters = constructor.GetParameters();
+        var name = argumentNames.IsDefault ? null : argumentNames[sourceIndex];
+        var parameterIndex = name == null
+            ? sourceIndex
+            : FindClrParameterIndex(parameters, name);
+        return parameterIndex >= 0
+            && parameterIndex < parameters.Length
+            && parameters[parameterIndex].IsOut
+            && !parameters[parameterIndex].IsIn;
+    }
+
+    private static int FindClrParameterIndex(ParameterInfo[] parameters, string argumentName)
+    {
+        var parameterNames = parameters.Select(parameter => parameter.Name ?? string.Empty).ToArray();
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            if (OverloadResolver.ClrParameterNameMatches(
+                    parameters[i].Name ?? string.Empty,
+                    argumentName,
+                    parameterNames))
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private ImmutableArray<BoundExpression> RebindInlineOutConstructorArguments(
+        CallExpressionSyntax syntax,
+        ImmutableArray<BoundExpression> arguments,
+        ConstructorInfo constructor,
+        ImmutableArray<int> parameterMapping,
+        Type? openGenericDefinition,
+        ImmutableArray<TypeSymbol> symbolicTypeArguments)
+    {
+        ImmutableArray<BoundExpression>.Builder? rebuilt = null;
+        var parameters = constructor.GetParameters();
+        for (var i = 0; i < arguments.Length; i++)
+        {
+            if (!TryGetInlineOutVarArgument(syntax, i, out var refArgument))
+            {
+                continue;
+            }
+
+            var parameterIndex = parameterMapping.IsDefault ? i : parameterMapping[i];
+            var parameter = parameters[parameterIndex];
+            var pointeeType = ResolveConstructorParameterPointeeType(
+                constructor,
+                parameterIndex,
+                openGenericDefinition,
+                symbolicTypeArguments)
+                ?? TypeSymbol.FromClrType(parameter.ParameterType.GetElementType());
+            var syntheticParameter = new ParameterSymbol(
+                parameter.Name ?? "value",
+                pointeeType,
+                refKind: RefKind.Out);
+            rebuilt ??= arguments.ToBuilder();
+            rebuilt[i] = BindRefArgumentExpression(refArgument, syntheticParameter);
+        }
+
+        return rebuilt?.ToImmutable() ?? arguments;
+    }
+
+    private static TypeSymbol? ResolveConstructorParameterPointeeType(
+        ConstructorInfo constructor,
+        int parameterIndex,
+        Type? openGenericDefinition,
+        ImmutableArray<TypeSymbol> symbolicTypeArguments)
+    {
+        if (openGenericDefinition == null || symbolicTypeArguments.IsDefaultOrEmpty)
+        {
+            return null;
+        }
+
+        var openConstructor = ClrTypeUtilities.SafeGetConstructors(
+                openGenericDefinition,
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+            .FirstOrDefault(candidate =>
+                candidate.MetadataToken == constructor.MetadataToken
+                && candidate.Module == constructor.Module);
+        if (openConstructor == null)
+        {
+            return null;
+        }
+
+        var openParameters = openConstructor.GetParameters();
+        if (parameterIndex >= openParameters.Length)
+        {
+            return null;
+        }
+
+        var openPointee = openParameters[parameterIndex].ParameterType.GetElementType();
+        return openPointee == null
+            ? null
+            : MemberLookup.MapOpenClrTypeToSymbolic(
+                openPointee,
+                openGenericDefinition,
+                symbolicTypeArguments);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -1907,6 +1907,14 @@ internal sealed partial class ExpressionBinder
 
         if (bestCtor == null)
         {
+            var hasInvalidExplicitTypedInlineOut = inlineOutArguments.Any(index =>
+                OverloadResolver.UnwrapNamedArgumentValue(syntax.Arguments[index])
+                    is RefArgumentExpressionSyntax { DeclaredType: not null }
+                && boundArguments[index]
+                    is BoundAddressOfExpression { Operand.Type: var operandType }
+                && operandType == TypeSymbol.Error);
+            var hasErrorArgument =
+                boundArguments.Any(static argument => argument.Type == TypeSymbol.Error);
             if (TryReportClrConstructorInlineOutTypeMismatch(
                     syntax,
                     inlineOutArguments,
@@ -1914,7 +1922,14 @@ internal sealed partial class ExpressionBinder
                     argumentNames,
                     boundArguments,
                     openGenericDefinition,
-                    symbolicTypeArgs))
+                    symbolicTypeArgs)
+                || (!hasInvalidExplicitTypedInlineOut
+                    && !hasErrorArgument
+                    && TryReportClrConstructorArgumentTypeMismatch(
+                        syntax,
+                        ctors,
+                        argumentNames,
+                        boundArguments)))
             {
                 DeclareClrConstructorInlineOutLocals(
                     syntax,
@@ -1927,14 +1942,8 @@ internal sealed partial class ExpressionBinder
                 return true;
             }
 
-            var hasInvalidExplicitTypedInlineOut = inlineOutArguments.Any(index =>
-                OverloadResolver.UnwrapNamedArgumentValue(syntax.Arguments[index])
-                    is RefArgumentExpressionSyntax { DeclaredType: not null }
-                && boundArguments[index]
-                    is BoundAddressOfExpression { Operand.Type: var operandType }
-                && operandType == TypeSymbol.Error);
             if (hasInvalidExplicitTypedInlineOut
-                || boundArguments.Any(static argument => argument.Type == TypeSymbol.Error))
+                || hasErrorArgument)
             {
                 DeclareClrConstructorInlineOutLocals(
                     syntax,
@@ -1944,7 +1953,7 @@ internal sealed partial class ExpressionBinder
                     openGenericDefinition,
                     symbolicTypeArgs);
                 result = new BoundErrorExpression(syntax);
-                return hasInvalidExplicitTypedInlineOut;
+                return hasInvalidExplicitTypedInlineOut || inlineOutArguments.Count > 0;
             }
 
             // Issue #524: CLR value types always have an implicit zero-init
@@ -1974,6 +1983,20 @@ internal sealed partial class ExpressionBinder
             if (!argumentNames.IsDefault
                 && overloads.TryReportUnknownNamedArgumentForClrConstructor(clrType, syntax, argumentNames))
             {
+                DeclareClrConstructorInlineOutLocals(
+                    syntax,
+                    inlineOutArguments,
+                    ctors,
+                    argumentNames,
+                    openGenericDefinition,
+                    symbolicTypeArgs);
+                result = new BoundErrorExpression(syntax);
+                return true;
+            }
+
+            if (inlineOutArguments.Count > 0)
+            {
+                Diagnostics.ReportNoApplicableOverload(syntax.Identifier.Location, clrType.Name);
                 DeclareClrConstructorInlineOutLocals(
                     syntax,
                     inlineOutArguments,
@@ -2095,6 +2118,61 @@ internal sealed partial class ExpressionBinder
         }
 
         return result;
+    }
+
+    private bool TryReportClrConstructorArgumentTypeMismatch(
+        CallExpressionSyntax syntax,
+        IReadOnlyList<ConstructorInfo> constructors,
+        ImmutableArray<string> argumentNames,
+        ImmutableArray<BoundExpression>.Builder boundArguments)
+    {
+        var candidates = constructors
+            .Where(constructor => constructor.GetParameters().Length == syntax.Arguments.Count)
+            .Take(2)
+            .ToArray();
+        if (candidates.Length != 1)
+        {
+            return false;
+        }
+
+        var parameters = candidates[0].GetParameters();
+        for (var index = 0; index < boundArguments.Count; index++)
+        {
+            var name = argumentNames.IsDefault ? null : argumentNames[index];
+            var parameterIndex = name == null ? index : FindClrParameterIndex(parameters, name);
+            if (parameterIndex < 0 || parameterIndex >= parameters.Length)
+            {
+                return false;
+            }
+
+            var parameter = parameters[parameterIndex];
+            var expectedType = TypeSymbol.FromClrType(
+                parameter.ParameterType.IsByRef
+                    ? parameter.ParameterType.GetElementType()
+                    : parameter.ParameterType);
+            var actualType = boundArguments[index] is BoundAddressOfExpression address
+                ? address.Operand.Type
+                : boundArguments[index].Type;
+            if (actualType == TypeSymbol.Error)
+            {
+                continue;
+            }
+
+            var isCompatible = parameter.ParameterType.IsByRef
+                ? DeclarationBinder.TypeSignaturesEquivalent(expectedType, actualType)
+                : Conversion.Classify(actualType, expectedType).IsImplicit;
+            if (!isCompatible)
+            {
+                Diagnostics.ReportWrongArgumentType(
+                    syntax.Arguments[index].Location,
+                    parameter.Name ?? "value",
+                    expectedType,
+                    actualType);
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private bool TryReportClrConstructorInlineOutTypeMismatch(

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -1669,9 +1669,12 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
+        var inlineOutArguments = GetInlineOutArgumentIndices(syntax);
+
         // Issue #343: pre-validate named-argument layout for CLR constructor calls.
         if (!overloads.TryAnalyzeCallArgumentLayout(syntax.Arguments, out _, out var argumentNames))
         {
+            DeclareInvalidClrConstructorInlineOutLocals(syntax, inlineOutArguments);
             result = new BoundErrorExpression(syntax);
             return true;
         }
@@ -1697,7 +1700,6 @@ internal sealed partial class ExpressionBinder
                     && (constructor.IsAssembly || constructor.IsFamilyOrAssembly)))
             .ToArray();
 
-        var inlineOutArguments = GetInlineOutArgumentIndices(syntax);
         if (inlineOutArguments.Count > 0)
         {
             var invalidInlineOutArguments = inlineOutArguments
@@ -1714,6 +1716,7 @@ internal sealed partial class ExpressionBinder
                         OverloadResolver.UnwrapNamedArgumentValue(syntax.Arguments[index]).Location);
                 }
 
+                DeclareInvalidClrConstructorInlineOutLocals(syntax, inlineOutArguments);
                 result = new BoundErrorExpression(syntax);
                 return true;
             }
@@ -1894,6 +1897,7 @@ internal sealed partial class ExpressionBinder
                     break;
                 case ClrOverloadResolution.ResolutionOutcome.Ambiguous:
                     Diagnostics.ReportAmbiguousOverload(syntax.Location, clrType.Name, resolution.Ambiguous.Length, resolution.Ambiguous.Select(ClrOverloadResolution.FormatMethodSignature));
+                    DeclareInvalidClrConstructorInlineOutLocals(syntax, inlineOutArguments);
                     result = new BoundErrorExpression(syntax);
                     return true;
                 default:
@@ -1905,6 +1909,13 @@ internal sealed partial class ExpressionBinder
         {
             if (boundArguments.Any(static argument => argument.Type == TypeSymbol.Error))
             {
+                DeclareClrConstructorInlineOutLocals(
+                    syntax,
+                    inlineOutArguments,
+                    ctors,
+                    argumentNames,
+                    openGenericDefinition,
+                    symbolicTypeArgs);
                 result = new BoundErrorExpression(syntax);
                 return false;
             }
@@ -1936,10 +1947,24 @@ internal sealed partial class ExpressionBinder
             if (!argumentNames.IsDefault
                 && overloads.TryReportUnknownNamedArgumentForClrConstructor(clrType, syntax, argumentNames))
             {
+                DeclareClrConstructorInlineOutLocals(
+                    syntax,
+                    inlineOutArguments,
+                    ctors,
+                    argumentNames,
+                    openGenericDefinition,
+                    symbolicTypeArgs);
                 result = new BoundErrorExpression(syntax);
                 return true;
             }
 
+            DeclareClrConstructorInlineOutLocals(
+                syntax,
+                inlineOutArguments,
+                ctors,
+                argumentNames,
+                openGenericDefinition,
+                symbolicTypeArgs);
             noApplicableOverload = true;
             boundArgumentsOnFailure = boundArguments.MoveToImmutable();
             return false;
@@ -2043,6 +2068,87 @@ internal sealed partial class ExpressionBinder
         }
 
         return result;
+    }
+
+    private void DeclareInvalidClrConstructorInlineOutLocals(
+        CallExpressionSyntax syntax,
+        IReadOnlyList<int> inlineOutArguments)
+    {
+        var errorParameter = new ParameterSymbol("value", TypeSymbol.Error, refKind: RefKind.Out);
+        foreach (var index in inlineOutArguments)
+        {
+            var inlineOut = (RefArgumentExpressionSyntax)OverloadResolver.UnwrapNamedArgumentValue(
+                syntax.Arguments[index]);
+            if (!inlineOut.IsDiscard)
+            {
+                _ = BindRefArgumentExpression(inlineOut, errorParameter);
+            }
+        }
+    }
+
+    private void DeclareClrConstructorInlineOutLocals(
+        CallExpressionSyntax syntax,
+        IReadOnlyList<int> inlineOutArguments,
+        IReadOnlyList<ConstructorInfo> constructors,
+        ImmutableArray<string> argumentNames,
+        Type? openGenericDefinition,
+        ImmutableArray<TypeSymbol> symbolicTypeArguments)
+    {
+        foreach (var index in inlineOutArguments)
+        {
+            var inlineOut = (RefArgumentExpressionSyntax)OverloadResolver.UnwrapNamedArgumentValue(
+                syntax.Arguments[index]);
+            if (inlineOut.IsDiscard || inlineOut.DeclaredType != null)
+            {
+                continue;
+            }
+
+            var name = argumentNames.IsDefault ? null : argumentNames[index];
+            ConstructorInfo? matchingConstructor = null;
+            var matchingParameterIndex = -1;
+            foreach (var constructor in constructors)
+            {
+                var parameters = constructor.GetParameters();
+                var parameterIndex = name == null ? index : FindClrParameterIndex(parameters, name);
+                if (parameterIndex < 0
+                    || parameterIndex >= parameters.Length
+                    || !parameters[parameterIndex].IsOut
+                    || parameters[parameterIndex].IsIn)
+                {
+                    continue;
+                }
+
+                if (matchingConstructor != null)
+                {
+                    matchingConstructor = null;
+                    matchingParameterIndex = -1;
+                    break;
+                }
+
+                matchingConstructor = constructor;
+                matchingParameterIndex = parameterIndex;
+            }
+
+            if (matchingConstructor == null)
+            {
+                var errorParameter = new ParameterSymbol("value", TypeSymbol.Error, refKind: RefKind.Out);
+                _ = BindRefArgumentExpression(inlineOut, errorParameter);
+                continue;
+            }
+
+            var parameter = matchingConstructor.GetParameters()[matchingParameterIndex];
+            var pointeeType = ResolveConstructorParameterPointeeType(
+                matchingConstructor,
+                matchingParameterIndex,
+                openGenericDefinition,
+                symbolicTypeArguments)
+                ?? TypeSymbol.FromClrType(parameter.ParameterType.GetElementType());
+            var resolvedParameter = new ParameterSymbol(
+                parameter.Name ?? "value",
+                pointeeType,
+                refKind: RefKind.Out);
+            _ = BindRefArgumentExpression(inlineOut, resolvedParameter);
+        }
     }
 
     private static bool ConstructorSupportsInlineOutArguments(

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -1674,7 +1674,7 @@ internal sealed partial class ExpressionBinder
         // Issue #343: pre-validate named-argument layout for CLR constructor calls.
         if (!overloads.TryAnalyzeCallArgumentLayout(syntax.Arguments, out _, out var argumentNames))
         {
-            DeclareInvalidClrConstructorInlineOutLocals(syntax, inlineOutArguments);
+            DeclareInvalidClrConstructorInlineOutLocals(syntax, inlineOutArguments, bindExplicitTyped: true);
             result = new BoundErrorExpression(syntax);
             return true;
         }
@@ -1716,7 +1716,7 @@ internal sealed partial class ExpressionBinder
                         OverloadResolver.UnwrapNamedArgumentValue(syntax.Arguments[index]).Location);
                 }
 
-                DeclareInvalidClrConstructorInlineOutLocals(syntax, inlineOutArguments);
+                DeclareInvalidClrConstructorInlineOutLocals(syntax, inlineOutArguments, bindExplicitTyped: true);
                 result = new BoundErrorExpression(syntax);
                 return true;
             }
@@ -2072,14 +2072,16 @@ internal sealed partial class ExpressionBinder
 
     private void DeclareInvalidClrConstructorInlineOutLocals(
         CallExpressionSyntax syntax,
-        IReadOnlyList<int> inlineOutArguments)
+        IReadOnlyList<int> inlineOutArguments,
+        bool bindExplicitTyped = false)
     {
         var errorParameter = new ParameterSymbol("value", TypeSymbol.Error, refKind: RefKind.Out);
         foreach (var index in inlineOutArguments)
         {
             var inlineOut = (RefArgumentExpressionSyntax)OverloadResolver.UnwrapNamedArgumentValue(
                 syntax.Arguments[index]);
-            if (!inlineOut.IsDiscard && inlineOut.DeclaredType == null)
+            if (!inlineOut.IsDiscard
+                && (bindExplicitTyped || inlineOut.DeclaredType == null))
             {
                 _ = BindRefArgumentExpression(inlineOut, errorParameter);
             }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -1907,7 +1907,14 @@ internal sealed partial class ExpressionBinder
 
         if (bestCtor == null)
         {
-            if (boundArguments.Any(static argument => argument.Type == TypeSymbol.Error))
+            var hasInvalidExplicitTypedInlineOut = inlineOutArguments.Any(index =>
+                OverloadResolver.UnwrapNamedArgumentValue(syntax.Arguments[index])
+                    is RefArgumentExpressionSyntax { DeclaredType: not null }
+                && boundArguments[index]
+                    is BoundAddressOfExpression { Operand.Type: var operandType }
+                && operandType == TypeSymbol.Error);
+            if (hasInvalidExplicitTypedInlineOut
+                || boundArguments.Any(static argument => argument.Type == TypeSymbol.Error))
             {
                 DeclareClrConstructorInlineOutLocals(
                     syntax,
@@ -1917,7 +1924,7 @@ internal sealed partial class ExpressionBinder
                     openGenericDefinition,
                     symbolicTypeArgs);
                 result = new BoundErrorExpression(syntax);
-                return false;
+                return hasInvalidExplicitTypedInlineOut;
             }
 
             // Issue #524: CLR value types always have an implicit zero-init
@@ -2218,6 +2225,11 @@ internal sealed partial class ExpressionBinder
         for (var i = 0; i < arguments.Length; i++)
         {
             if (!TryGetInlineOutVarArgument(syntax, i, out var refArgument))
+            {
+                continue;
+            }
+
+            if (refArgument.DeclaredType != null)
             {
                 continue;
             }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -1925,6 +1925,7 @@ internal sealed partial class ExpressionBinder
                     symbolicTypeArgs)
                 || (!hasInvalidExplicitTypedInlineOut
                     && !hasErrorArgument
+                    && inlineOutArguments.Count > 0
                     && TryReportClrConstructorArgumentTypeMismatch(
                         syntax,
                         ctors,

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -1907,6 +1907,26 @@ internal sealed partial class ExpressionBinder
 
         if (bestCtor == null)
         {
+            if (TryReportClrConstructorInlineOutTypeMismatch(
+                    syntax,
+                    inlineOutArguments,
+                    ctors,
+                    argumentNames,
+                    boundArguments,
+                    openGenericDefinition,
+                    symbolicTypeArgs))
+            {
+                DeclareClrConstructorInlineOutLocals(
+                    syntax,
+                    inlineOutArguments,
+                    ctors,
+                    argumentNames,
+                    openGenericDefinition,
+                    symbolicTypeArgs);
+                result = new BoundErrorExpression(syntax);
+                return true;
+            }
+
             var hasInvalidExplicitTypedInlineOut = inlineOutArguments.Any(index =>
                 OverloadResolver.UnwrapNamedArgumentValue(syntax.Arguments[index])
                     is RefArgumentExpressionSyntax { DeclaredType: not null }
@@ -2075,6 +2095,74 @@ internal sealed partial class ExpressionBinder
         }
 
         return result;
+    }
+
+    private bool TryReportClrConstructorInlineOutTypeMismatch(
+        CallExpressionSyntax syntax,
+        IReadOnlyList<int> inlineOutArguments,
+        IReadOnlyList<ConstructorInfo> constructors,
+        ImmutableArray<string> argumentNames,
+        ImmutableArray<BoundExpression>.Builder boundArguments,
+        Type? openGenericDefinition,
+        ImmutableArray<TypeSymbol> symbolicTypeArguments)
+    {
+        foreach (var index in inlineOutArguments)
+        {
+            var inlineOut = (RefArgumentExpressionSyntax)OverloadResolver.UnwrapNamedArgumentValue(
+                syntax.Arguments[index]);
+            if (inlineOut.DeclaredType == null
+                || boundArguments[index]
+                    is not BoundAddressOfExpression { Operand.Type: var actualType }
+                || actualType == TypeSymbol.Error)
+            {
+                continue;
+            }
+
+            TypeSymbol? expectedType = null;
+            string? parameterName = null;
+            foreach (var constructor in constructors)
+            {
+                var parameters = constructor.GetParameters();
+                var name = argumentNames.IsDefault ? null : argumentNames[index];
+                var parameterIndex = name == null ? index : FindClrParameterIndex(parameters, name);
+                if (parameterIndex < 0
+                    || parameterIndex >= parameters.Length
+                    || !parameters[parameterIndex].IsOut
+                    || parameters[parameterIndex].IsIn)
+                {
+                    continue;
+                }
+
+                var candidateType = ResolveConstructorParameterPointeeType(
+                    constructor,
+                    parameterIndex,
+                    openGenericDefinition,
+                    symbolicTypeArguments)
+                    ?? TypeSymbol.FromClrType(parameters[parameterIndex].ParameterType.GetElementType());
+                if (expectedType != null
+                    && !DeclarationBinder.TypeSignaturesEquivalent(expectedType, candidateType))
+                {
+                    expectedType = null;
+                    break;
+                }
+
+                expectedType = candidateType;
+                parameterName = parameters[parameterIndex].Name ?? "value";
+            }
+
+            if (expectedType != null
+                && !DeclarationBinder.TypeSignaturesEquivalent(expectedType, actualType))
+            {
+                Diagnostics.ReportWrongArgumentType(
+                    inlineOut.Location,
+                    parameterName ?? "value",
+                    expectedType,
+                    actualType);
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private void DeclareInvalidClrConstructorInlineOutLocals(

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -2079,7 +2079,7 @@ internal sealed partial class ExpressionBinder
         {
             var inlineOut = (RefArgumentExpressionSyntax)OverloadResolver.UnwrapNamedArgumentValue(
                 syntax.Arguments[index]);
-            if (!inlineOut.IsDiscard)
+            if (!inlineOut.IsDiscard && inlineOut.DeclaredType == null)
             {
                 _ = BindRefArgumentExpression(inlineOut, errorParameter);
             }

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Arguments.cs
@@ -1119,7 +1119,7 @@ internal sealed partial class OverloadResolver
         return false;
     }
 
-    private static bool ClrParameterNameMatches(
+    internal static bool ClrParameterNameMatches(
         string parameterName,
         string argumentName,
         IEnumerable<string> parameterNames) =>

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
@@ -463,11 +463,14 @@ internal sealed partial class OverloadResolver
             var typeArgumentsMatchConversionTarget = syntax.TypeArgumentList == null
                 || (singleArgClass is { IsGenericDefinition: true }
                     && syntax.TypeArgumentList.Arguments.Count == singleArgClass.TypeParameters.Length);
+            var hasInlineOutArgument = UnwrapNamedArgumentValue(syntax.Arguments[0])
+                is RefArgumentExpressionSyntax { IsInlineDeclaration: true };
             if (singleArgClass != null
                 && singleArgClass.IsClass
                 && typeArgumentsMatchConversionTarget
                 && (syntax.NullableQuestionToken != null
-                    || !HasSingleArgumentConstructorShape(singleArgClass)))
+                    || (!hasInlineOutArgument
+                        && !HasSingleArgumentConstructorShape(singleArgClass))))
             {
                 reportObsoleteUseIfApplicable(
                     syntax.Identifier.Location,

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
@@ -433,8 +433,12 @@ internal sealed partial class OverloadResolver
         var conversionType = lookupTypeWithArity(
             syntax.Identifier.Text,
             ctorPreferredArity);
+        var hasSingleInlineOutArgument = syntax.Arguments.Count == 1
+            && UnwrapNamedArgumentValue(syntax.Arguments[0])
+                is RefArgumentExpressionSyntax { IsInlineDeclaration: true };
         if (!hasNonConstructorCallable
             && syntax.Arguments.Count == 1
+            && !hasSingleInlineOutArgument
             && conversionType is TypeSymbol)
         {
             var explicitConversionType = TryConstructConversionTarget(
@@ -463,14 +467,11 @@ internal sealed partial class OverloadResolver
             var typeArgumentsMatchConversionTarget = syntax.TypeArgumentList == null
                 || (singleArgClass is { IsGenericDefinition: true }
                     && syntax.TypeArgumentList.Arguments.Count == singleArgClass.TypeParameters.Length);
-            var hasInlineOutArgument = UnwrapNamedArgumentValue(syntax.Arguments[0])
-                is RefArgumentExpressionSyntax { IsInlineDeclaration: true };
             if (singleArgClass != null
                 && singleArgClass.IsClass
                 && typeArgumentsMatchConversionTarget
                 && (syntax.NullableQuestionToken != null
-                    || (!hasInlineOutArgument
-                        && !HasSingleArgumentConstructorShape(singleArgClass))))
+                    || !HasSingleArgumentConstructorShape(singleArgClass)))
             {
                 reportObsoleteUseIfApplicable(
                     syntax.Identifier.Location,

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
@@ -1664,7 +1664,13 @@ internal sealed partial class OverloadResolver
                         candidateFunction,
                         syntax.Arguments.Count,
                         argumentNames,
-                        inferenceBoundArguments))
+                        inferenceBoundArguments)
+                    || !ConstructorAcceptsTypedInlineOutArguments(
+                        syntax,
+                        candidateFunction,
+                        argumentNames,
+                        inlineOutArgumentIndices,
+                        inferenceArgumentTypes))
                 {
                     continue;
                 }
@@ -1739,6 +1745,40 @@ internal sealed partial class OverloadResolver
         }
 
         constructed = ConstructExplicitConstructorType(classType, tps, substitution);
+        return true;
+    }
+
+    private static bool ConstructorAcceptsTypedInlineOutArguments(
+        CallExpressionSyntax syntax,
+        FunctionSymbol constructor,
+        ImmutableArray<string> argumentNames,
+        ImmutableArray<int> inlineOutArgumentIndices,
+        IReadOnlyList<TypeSymbol?> argumentTypes)
+    {
+        foreach (var argumentIndex in inlineOutArgumentIndices)
+        {
+            var inlineOut = (RefArgumentExpressionSyntax)UnwrapNamedArgumentValue(
+                syntax.Arguments[argumentIndex]);
+            if (inlineOut.IsDiscard || inlineOut.DeclaredType == null)
+            {
+                continue;
+            }
+
+            var name = argumentNames.IsDefault ? null : argumentNames[argumentIndex];
+            var parameterIndex = name == null
+                ? argumentIndex
+                : FindParameterIndex(constructor.Parameters, name);
+            if (parameterIndex < 0
+                || parameterIndex >= constructor.Parameters.Length
+                || argumentTypes[argumentIndex] is not { } argumentType
+                || !DeclarationBinder.TypeSignaturesEquivalent(
+                    argumentType,
+                    constructor.Parameters[parameterIndex].Type))
+            {
+                return false;
+            }
+        }
+
         return true;
     }
 

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
@@ -1755,6 +1755,11 @@ internal sealed partial class OverloadResolver
         ImmutableArray<int> inlineOutArgumentIndices,
         IReadOnlyList<TypeSymbol?> argumentTypes)
     {
+        if (inlineOutArgumentIndices.IsDefaultOrEmpty)
+        {
+            return true;
+        }
+
         foreach (var argumentIndex in inlineOutArgumentIndices)
         {
             var inlineOut = (RefArgumentExpressionSyntax)UnwrapNamedArgumentValue(

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
@@ -769,6 +769,8 @@ internal sealed partial class OverloadResolver
     /// </summary>
     private BoundExpression BindExplicitConstructorCallExpression(CallExpressionSyntax syntax, StructSymbol classType)
     {
+        var inlineOutArgumentIndices = GetInlineOutArgumentIndices(syntax.Arguments);
+
         // Issue #1214: a generic class declaring an explicit `init(...)`
         // constructor is constructed at a closed type (`Box[int32](5, "x")`).
         // Resolve the type arguments — supplied explicitly or inferred from the
@@ -783,11 +785,10 @@ internal sealed partial class OverloadResolver
         {
             if (!TryCloseGenericExplicitConstructorType(syntax, classType, out classType))
             {
+                DeclareUnresolvedInlineOutLocals(syntax.Arguments, inlineOutArgumentIndices);
                 return new BoundErrorExpression(syntax);
             }
         }
-
-        var inlineOutArgumentIndices = GetInlineOutArgumentIndices(syntax.Arguments);
 
         // Issue #343: pre-validate named-argument layout (positional precedes
         // named, no duplicate names). Diagnostics are reported by the helper.
@@ -1150,14 +1151,6 @@ internal sealed partial class OverloadResolver
                     convertedArguments.Add(argument);
                     continue;
                 }
-
-                if (inlineOut.DeclaredType == null
-                    && argument is BoundAddressOfExpression { Operand.Type: var operandType }
-                    && operandType == TypeSymbol.Error)
-                {
-                    var rebindParameter = new ParameterSymbol(parameter.Name, paramType, refKind: RefKind.Out);
-                    boundArguments[i] = argument = bindRefArgumentExpression(inlineOut, rebindParameter);
-                }
             }
 
             // ADR-0055 Tier 4 (#369): re-lower an interpolated-string argument
@@ -1403,6 +1396,23 @@ internal sealed partial class OverloadResolver
 
     private void DeclareUnresolvedInlineOutLocals(
         SeparatedSyntaxList<ExpressionSyntax> arguments,
+        ImmutableArray<int> inlineOutArgumentIndices)
+    {
+        var errorOutParameter = new ParameterSymbol("value", TypeSymbol.Error, refKind: RefKind.Out);
+        foreach (var argumentIndex in inlineOutArgumentIndices)
+        {
+            var inlineOut = (RefArgumentExpressionSyntax)UnwrapNamedArgumentValue(arguments[argumentIndex]);
+            if (inlineOut.IsDiscard || inlineOut.DeclaredType != null)
+            {
+                continue;
+            }
+
+            _ = bindRefArgumentExpression(inlineOut, errorOutParameter);
+        }
+    }
+
+    private void DeclareUnresolvedInlineOutLocals(
+        SeparatedSyntaxList<ExpressionSyntax> arguments,
         ImmutableArray<int> inlineOutArgumentIndices,
         ImmutableArray<BoundExpression>.Builder boundArguments)
     {
@@ -1545,7 +1555,8 @@ internal sealed partial class OverloadResolver
 
             foreach (var tp in tps)
             {
-                if (!substitution.ContainsKey(tp))
+                if (!substitution.TryGetValue(tp, out var inferredType)
+                    || inferredType == TypeSymbol.Error)
                 {
                     Diagnostics.ReportTypeArgumentInferenceFailed(syntax.Identifier.Location, classType.Name, tp.Name);
                     return false;

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
@@ -793,7 +793,7 @@ internal sealed partial class OverloadResolver
         {
             if (!inlineOutArgumentIndices.IsDefaultOrEmpty)
             {
-                var openConstructors = classType.EffectiveExplicitConstructors;
+                var openConstructors = GetAccessibleExplicitConstructorsOrAll(classType);
                 var invalidInlineOutArgument = inlineOutArgumentIndices.FirstOrDefault(
                     index => !openConstructors.Any(ctor => ConstructorAcceptsInlineOutArgument(
                         ctor,
@@ -828,17 +828,7 @@ internal sealed partial class OverloadResolver
         // single-overload diagnostics (wrong arity) still fire below.
         // Issue #1214: for a closed generic construction, the constructor table
         // lives on the open definition (EffectiveExplicitConstructors).
-        var ctorOverloads = classType.EffectiveExplicitConstructors;
-        var accessibleCtorOverloads = ctorOverloads
-            .Where(ctor => AccessibilityChecker.IsAccessible(
-                ctor.Function.Accessibility,
-                ctor.DeclaringType ?? classType,
-                getCurrentFunction()))
-            .ToImmutableArray();
-        if (!accessibleCtorOverloads.IsDefaultOrEmpty)
-        {
-            ctorOverloads = accessibleCtorOverloads;
-        }
+        var ctorOverloads = GetAccessibleExplicitConstructorsOrAll(classType);
 
         if (!inlineOutArgumentIndices.IsDefaultOrEmpty)
         {
@@ -1652,18 +1642,7 @@ internal sealed partial class OverloadResolver
             var inferredCandidateCount = 0;
             TypeParameterSymbol? unresolvedTypeParameter = null;
             Dictionary<TypeParameterSymbol, TypeSymbol>? constraintFailureSubstitution = null;
-            var inferenceConstructors = classType.EffectiveExplicitConstructors;
-            var accessibleInferenceConstructors = inferenceConstructors
-                .Where(constructor => AccessibilityChecker.IsAccessible(
-                    constructor.Function.Accessibility,
-                    constructor.DeclaringType ?? classType,
-                    getCurrentFunction()))
-                .ToImmutableArray();
-            if (!accessibleInferenceConstructors.IsDefaultOrEmpty)
-            {
-                inferenceConstructors = accessibleInferenceConstructors;
-            }
-
+            var inferenceConstructors = GetAccessibleExplicitConstructorsOrAll(classType);
             foreach (var constructor in inferenceConstructors)
             {
                 if (!ConstructorAcceptsInlineOutArguments(
@@ -1957,6 +1936,21 @@ internal sealed partial class OverloadResolver
         }
 
         return bindExpression(argument).Type;
+    }
+
+    private ImmutableArray<ConstructorSymbol> GetAccessibleExplicitConstructorsOrAll(
+        StructSymbol classType)
+    {
+        var constructors = classType.EffectiveExplicitConstructors;
+        var accessibleConstructors = constructors
+            .Where(constructor => AccessibilityChecker.IsAccessible(
+                constructor.Function.Accessibility,
+                constructor.DeclaringType ?? classType,
+                getCurrentFunction()))
+            .ToImmutableArray();
+        return accessibleConstructors.IsDefaultOrEmpty
+            ? constructors
+            : accessibleConstructors;
     }
 
     private bool IsPartiallyApplicableExplicitConstructor(

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
@@ -889,6 +889,10 @@ internal sealed partial class OverloadResolver
             if (ctorOverloads.IsDefaultOrEmpty)
             {
                 Diagnostics.ReportNoApplicableOverload(syntax.Identifier.Location, classType.Name);
+                DeclareUnresolvedInlineOutLocals(
+                    syntax.Arguments,
+                    inlineOutArgumentIndices,
+                    boundArgumentsBuilder);
                 return new BoundErrorExpression(syntax);
             }
         }

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
@@ -1549,11 +1549,36 @@ internal sealed partial class OverloadResolver
                 ? ImmutableArray<ParameterSymbol>.Empty
                 : ctorOverloads[0].Parameters;
 
-            for (var i = 0; i < syntax.Arguments.Count && i < ctorParams.Length; i++)
+            for (var i = 0; i < syntax.Arguments.Count; i++)
             {
-                var argSyntax = UnwrapNamedArgumentValue(syntax.Arguments[i]);
+                var sourceArgument = syntax.Arguments[i];
+                var parameterIndex = sourceArgument is NamedArgumentExpressionSyntax named
+                    ? FindParameterIndex(ctorParams, named.NameToken.Text)
+                    : i;
+                if (parameterIndex < 0 || parameterIndex >= ctorParams.Length)
+                {
+                    continue;
+                }
+
+                var argSyntax = UnwrapNamedArgumentValue(sourceArgument);
+                if (argSyntax is RefArgumentExpressionSyntax { IsInlineDeclaration: true } inlineOut)
+                {
+                    if (inlineOut.DeclaredType == null)
+                    {
+                        continue;
+                    }
+
+                    var declaredType = bindTypeClause(inlineOut.DeclaredType);
+                    if (declaredType != null)
+                    {
+                        inferTypeArguments(ctorParams[parameterIndex].Type, declaredType, substitution);
+                    }
+
+                    continue;
+                }
+
                 var preBound = bindExpression(argSyntax);
-                inferTypeArguments(ctorParams[i].Type, preBound.Type, substitution);
+                inferTypeArguments(ctorParams[parameterIndex].Type, preBound.Type, substitution);
             }
 
             Diagnostics.TruncateTo(inferenceDiagMark);

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
@@ -817,20 +817,27 @@ internal sealed partial class OverloadResolver
 
         if (!inlineOutArgumentIndices.IsDefaultOrEmpty)
         {
+            var invalidInlineOutArgument = inlineOutArgumentIndices.FirstOrDefault(
+                index => !ctorOverloads.Any(ctor => ConstructorAcceptsInlineOutArgument(
+                    ctor,
+                    argumentNames,
+                    index)),
+                -1);
+            if (invalidInlineOutArgument >= 0)
+            {
+                var inlineOut = (RefArgumentExpressionSyntax)UnwrapNamedArgumentValue(
+                    syntax.Arguments[invalidInlineOutArgument]);
+                Diagnostics.ReportOutDeclarationOutsideOutArgument(inlineOut.Location);
+                DeclareInvalidInlineOutLocals(syntax.Arguments, inlineOutArgumentIndices);
+                return new BoundErrorExpression(syntax);
+            }
+
             ctorOverloads = ctorOverloads
                 .Where(ctor => ConstructorAcceptsInlineOutArguments(
                     ctor,
                     argumentNames,
                     inlineOutArgumentIndices))
                 .ToImmutableArray();
-            if (ctorOverloads.IsDefaultOrEmpty)
-            {
-                var firstInlineOut = (RefArgumentExpressionSyntax)UnwrapNamedArgumentValue(
-                    syntax.Arguments[inlineOutArgumentIndices[0]]);
-                Diagnostics.ReportOutDeclarationOutsideOutArgument(firstInlineOut.Location);
-                DeclareInvalidInlineOutLocals(syntax.Arguments, inlineOutArgumentIndices);
-                return new BoundErrorExpression(syntax);
-            }
         }
 
         var boundArgumentsBuilder = ImmutableArray.CreateBuilder<BoundExpression>(syntax.Arguments.Count);
@@ -1296,22 +1303,33 @@ internal sealed partial class OverloadResolver
         ImmutableArray<string> argumentNames,
         ImmutableArray<int> inlineOutArgumentIndices)
     {
-        var parameters = constructor.Parameters;
         foreach (var argumentIndex in inlineOutArgumentIndices)
         {
-            var name = argumentNames.IsDefault ? null : argumentNames[argumentIndex];
-            var parameterIndex = name == null
-                ? argumentIndex
-                : FindParameterIndex(parameters, name);
-            if (parameterIndex < 0
-                || parameterIndex >= parameters.Length
-                || parameters[parameterIndex].RefKind != RefKind.Out)
+            if (!ConstructorAcceptsInlineOutArgument(
+                    constructor,
+                    argumentNames,
+                    argumentIndex))
             {
                 return false;
             }
         }
 
         return true;
+    }
+
+    private static bool ConstructorAcceptsInlineOutArgument(
+        ConstructorSymbol constructor,
+        ImmutableArray<string> argumentNames,
+        int argumentIndex)
+    {
+        var parameters = constructor.Parameters;
+        var name = argumentNames.IsDefault ? null : argumentNames[argumentIndex];
+        var parameterIndex = name == null
+            ? argumentIndex
+            : FindParameterIndex(parameters, name);
+        return parameterIndex >= 0
+            && parameterIndex < parameters.Length
+            && parameters[parameterIndex].RefKind == RefKind.Out;
     }
 
     private static int FindParameterIndex(

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
@@ -812,6 +812,25 @@ internal sealed partial class OverloadResolver
             ctorOverloads = accessibleCtorOverloads;
         }
 
+        var inlineOutArgumentIndices = GetInlineOutArgumentIndices(syntax.Arguments);
+        if (!inlineOutArgumentIndices.IsDefaultOrEmpty)
+        {
+            ctorOverloads = ctorOverloads
+                .Where(ctor => ConstructorAcceptsInlineOutArguments(
+                    ctor,
+                    argumentNames,
+                    inlineOutArgumentIndices))
+                .ToImmutableArray();
+            if (ctorOverloads.IsDefaultOrEmpty)
+            {
+                var firstInlineOut = (RefArgumentExpressionSyntax)UnwrapNamedArgumentValue(
+                    syntax.Arguments[inlineOutArgumentIndices[0]]);
+                Diagnostics.ReportOutDeclarationOutsideOutArgument(firstInlineOut.Location);
+                DeclareInvalidInlineOutLocals(syntax.Arguments, inlineOutArgumentIndices);
+                return new BoundErrorExpression(syntax);
+            }
+        }
+
         var boundArgumentsBuilder = ImmutableArray.CreateBuilder<BoundExpression>(syntax.Arguments.Count);
         for (var ai = 0; ai < syntax.Arguments.Count; ai++)
         {
@@ -846,6 +865,23 @@ internal sealed partial class OverloadResolver
 
             boundArgument ??= BindOverloadArgumentValue(argument);
             boundArgumentsBuilder.Add(boundArgument);
+        }
+
+        if (!inlineOutArgumentIndices.IsDefaultOrEmpty && ctorOverloads.Length > 1)
+        {
+            ctorOverloads = ctorOverloads
+                .Where(ctor => ConstructorAcceptsTypedInlineOutArguments(
+                    ctor,
+                    classType,
+                    argumentNames,
+                    inlineOutArgumentIndices,
+                    boundArgumentsBuilder))
+                .ToImmutableArray();
+            if (ctorOverloads.IsDefaultOrEmpty)
+            {
+                Diagnostics.ReportNoApplicableOverload(syntax.Identifier.Location, classType.Name);
+                return new BoundErrorExpression(syntax);
+            }
         }
 
         ConstructorSymbol? selectedCtor;
@@ -1227,6 +1263,107 @@ internal sealed partial class OverloadResolver
             convertedArguments.ToImmutable(),
             parameterNameAt);
         return new BoundConstructorCallExpression(syntax, classType, finalArguments, selectedCtor);
+    }
+
+    private static ImmutableArray<int> GetInlineOutArgumentIndices(
+        SeparatedSyntaxList<ExpressionSyntax> arguments)
+    {
+        ImmutableArray<int>.Builder? indices = null;
+        for (var i = 0; i < arguments.Count; i++)
+        {
+            if (UnwrapNamedArgumentValue(arguments[i])
+                is RefArgumentExpressionSyntax { IsInlineDeclaration: true })
+            {
+                indices ??= ImmutableArray.CreateBuilder<int>();
+                indices.Add(i);
+            }
+        }
+
+        return indices?.ToImmutable() ?? default;
+    }
+
+    private static bool ConstructorAcceptsInlineOutArguments(
+        ConstructorSymbol constructor,
+        ImmutableArray<string> argumentNames,
+        ImmutableArray<int> inlineOutArgumentIndices)
+    {
+        var parameters = constructor.Parameters;
+        foreach (var argumentIndex in inlineOutArgumentIndices)
+        {
+            var name = argumentNames.IsDefault ? null : argumentNames[argumentIndex];
+            var parameterIndex = name == null
+                ? argumentIndex
+                : FindParameterIndex(parameters, name);
+            if (parameterIndex < 0
+                || parameterIndex >= parameters.Length
+                || parameters[parameterIndex].RefKind != RefKind.Out)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static int FindParameterIndex(
+        ImmutableArray<ParameterSymbol> parameters,
+        string name)
+    {
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            if (parameters[i].Name == name)
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private static bool ConstructorAcceptsTypedInlineOutArguments(
+        ConstructorSymbol constructor,
+        StructSymbol constructedType,
+        ImmutableArray<string> argumentNames,
+        ImmutableArray<int> inlineOutArgumentIndices,
+        ImmutableArray<BoundExpression>.Builder boundArguments)
+    {
+        var parameterTypes = constructedType.GetConstructorParameterTypesForConstruction(constructor);
+        foreach (var argumentIndex in inlineOutArgumentIndices)
+        {
+            if (boundArguments[argumentIndex]
+                    is not BoundAddressOfExpression { Operand.Type: var argumentType }
+                || argumentType == TypeSymbol.Error)
+            {
+                continue;
+            }
+
+            var name = argumentNames.IsDefault ? null : argumentNames[argumentIndex];
+            var parameterIndex = name == null
+                ? argumentIndex
+                : FindParameterIndex(constructor.Parameters, name);
+            if (parameterIndex < 0
+                || parameterIndex >= parameterTypes.Length
+                || !DeclarationBinder.TypeSignaturesEquivalent(
+                    argumentType,
+                    parameterTypes[parameterIndex]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private void DeclareInvalidInlineOutLocals(
+        SeparatedSyntaxList<ExpressionSyntax> arguments,
+        ImmutableArray<int> inlineOutArgumentIndices)
+    {
+        var errorOutParameter = new ParameterSymbol("value", TypeSymbol.Error, refKind: RefKind.Out);
+        foreach (var argumentIndex in inlineOutArgumentIndices)
+        {
+            var inlineOut = (RefArgumentExpressionSyntax)UnwrapNamedArgumentValue(arguments[argumentIndex]);
+            _ = bindRefArgumentExpression(inlineOut, errorOutParameter);
+        }
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
@@ -1398,6 +1398,11 @@ internal sealed partial class OverloadResolver
         SeparatedSyntaxList<ExpressionSyntax> arguments,
         ImmutableArray<int> inlineOutArgumentIndices)
     {
+        if (inlineOutArgumentIndices.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
         var errorOutParameter = new ParameterSymbol("value", TypeSymbol.Error, refKind: RefKind.Out);
         foreach (var argumentIndex in inlineOutArgumentIndices)
         {

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
@@ -932,6 +932,10 @@ internal sealed partial class OverloadResolver
                     Diagnostics.ReportNoApplicableOverload(syntax.Identifier.Location, classType.Name);
                 }
 
+                DeclareUnresolvedInlineOutLocals(
+                    syntax.Arguments,
+                    inlineOutArgumentIndices,
+                    boundArgumentsBuilder);
                 return new BoundErrorExpression(syntax);
             }
 
@@ -1390,6 +1394,28 @@ internal sealed partial class OverloadResolver
         {
             var inlineOut = (RefArgumentExpressionSyntax)UnwrapNamedArgumentValue(arguments[argumentIndex]);
             _ = bindRefArgumentExpression(inlineOut, errorOutParameter);
+        }
+    }
+
+    private void DeclareUnresolvedInlineOutLocals(
+        SeparatedSyntaxList<ExpressionSyntax> arguments,
+        ImmutableArray<int> inlineOutArgumentIndices,
+        ImmutableArray<BoundExpression>.Builder boundArguments)
+    {
+        var errorOutParameter = new ParameterSymbol("value", TypeSymbol.Error, refKind: RefKind.Out);
+        foreach (var argumentIndex in inlineOutArgumentIndices)
+        {
+            var inlineOut = (RefArgumentExpressionSyntax)UnwrapNamedArgumentValue(arguments[argumentIndex]);
+            if (inlineOut.IsDiscard
+                || inlineOut.DeclaredType != null
+                || boundArguments[argumentIndex]
+                    is not BoundAddressOfExpression { Operand.Type: var argumentType }
+                || argumentType != TypeSymbol.Error)
+            {
+                continue;
+            }
+
+            boundArguments[argumentIndex] = bindRefArgumentExpression(inlineOut, errorOutParameter);
         }
     }
 

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
@@ -909,6 +909,21 @@ internal sealed partial class OverloadResolver
 
         if (!inlineOutArgumentIndices.IsDefaultOrEmpty && ctorOverloads.Length > 1)
         {
+            var hasFailedExplicitInlineOutType = inlineOutArgumentIndices.Any(index =>
+                ((RefArgumentExpressionSyntax)UnwrapNamedArgumentValue(
+                    syntax.Arguments[index])).DeclaredType != null
+                && boundArgumentsBuilder[index]
+                    is BoundAddressOfExpression { Operand.Type: var argumentType }
+                && argumentType == TypeSymbol.Error);
+            if (hasFailedExplicitInlineOutType)
+            {
+                DeclareUnresolvedInlineOutLocals(
+                    syntax.Arguments,
+                    inlineOutArgumentIndices,
+                    boundArgumentsBuilder);
+                return new BoundErrorExpression(syntax);
+            }
+
             ctorOverloads = ctorOverloads
                 .Where(ctor => ConstructorAcceptsTypedInlineOutArguments(
                     ctor,
@@ -1659,7 +1674,16 @@ internal sealed partial class OverloadResolver
                     || inferredType == TypeSymbol.Error);
                 if (candidateUnresolvedTypeParameter != null)
                 {
-                    unresolvedTypeParameter ??= candidateUnresolvedTypeParameter;
+                    if (IsPartiallyApplicableExplicitConstructor(
+                            syntax,
+                            constructor,
+                            argumentNames,
+                            inferenceArgumentTypes,
+                            candidateSubstitution))
+                    {
+                        unresolvedTypeParameter ??= candidateUnresolvedTypeParameter;
+                    }
+
                     continue;
                 }
 
@@ -1921,6 +1945,53 @@ internal sealed partial class OverloadResolver
         }
 
         return bindExpression(argument).Type;
+    }
+
+    private static bool IsPartiallyApplicableExplicitConstructor(
+        CallExpressionSyntax syntax,
+        ConstructorSymbol constructor,
+        ImmutableArray<string> argumentNames,
+        IReadOnlyList<TypeSymbol?> argumentTypes,
+        Dictionary<TypeParameterSymbol, TypeSymbol> substitution)
+    {
+        if (constructor.Parameters.Length != syntax.Arguments.Count)
+        {
+            return false;
+        }
+
+        for (var argumentIndex = 0; argumentIndex < syntax.Arguments.Count; argumentIndex++)
+        {
+            var parameterIndex = argumentNames.IsDefault || argumentNames[argumentIndex] == null
+                ? argumentIndex
+                : FindParameterIndex(constructor.Parameters, argumentNames[argumentIndex]);
+            if (parameterIndex < 0 || parameterIndex >= constructor.Parameters.Length)
+            {
+                return false;
+            }
+
+            var argumentType = argumentTypes[argumentIndex];
+            if (argumentType == null || argumentType == TypeSymbol.Error)
+            {
+                continue;
+            }
+
+            var parameter = constructor.Parameters[parameterIndex];
+            var parameterType = Binder.SubstituteType(parameter.Type, substitution);
+            if (TypeSymbol.ContainsTypeParameter(parameterType))
+            {
+                continue;
+            }
+
+            var isCompatible = parameter.RefKind == RefKind.None
+                ? Conversion.Classify(argumentType, parameterType).IsImplicit
+                : DeclarationBinder.TypeSignaturesEquivalent(argumentType, parameterType);
+            if (!isCompatible)
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
@@ -863,6 +863,12 @@ internal sealed partial class OverloadResolver
                     argumentNames,
                     inlineOutArgumentIndices))
                 .ToImmutableArray();
+            if (ctorOverloads.IsDefaultOrEmpty)
+            {
+                Diagnostics.ReportNoApplicableOverload(syntax.Identifier.Location, classType.Name);
+                DeclareInvalidInlineOutLocals(syntax.Arguments, inlineOutArgumentIndices);
+                return new BoundErrorExpression(syntax);
+            }
         }
 
         var boundArgumentsBuilder = ImmutableArray.CreateBuilder<BoundExpression>(syntax.Arguments.Count);
@@ -1410,6 +1416,11 @@ internal sealed partial class OverloadResolver
         SeparatedSyntaxList<ExpressionSyntax> arguments,
         ImmutableArray<int> inlineOutArgumentIndices)
     {
+        if (inlineOutArgumentIndices.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
         var errorOutParameter = new ParameterSymbol("value", TypeSymbol.Error, refKind: RefKind.Out);
         foreach (var argumentIndex in inlineOutArgumentIndices)
         {
@@ -1445,6 +1456,11 @@ internal sealed partial class OverloadResolver
         ImmutableArray<int> inlineOutArgumentIndices,
         ImmutableArray<BoundExpression>.Builder boundArguments)
     {
+        if (inlineOutArgumentIndices.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
         var errorOutParameter = new ParameterSymbol("value", TypeSymbol.Error, refKind: RefKind.Out);
         foreach (var argumentIndex in inlineOutArgumentIndices)
         {
@@ -1619,6 +1635,7 @@ internal sealed partial class OverloadResolver
 
             var candidates = new List<(FunctionSymbol Function, Dictionary<TypeParameterSymbol, TypeSymbol> Substitution)>();
             var inferredCandidateCount = 0;
+            TypeParameterSymbol? unresolvedTypeParameter = null;
             Dictionary<TypeParameterSymbol, TypeSymbol>? constraintFailureSubstitution = null;
             foreach (var constructor in classType.EffectiveExplicitConstructors)
             {
@@ -1637,9 +1654,12 @@ internal sealed partial class OverloadResolver
                     argumentNames,
                     inferenceArgumentTypes,
                     candidateSubstitution);
-                if (tps.Any(tp => !candidateSubstitution.TryGetValue(tp, out var inferredType)
-                    || inferredType == TypeSymbol.Error))
+                var candidateUnresolvedTypeParameter = tps.FirstOrDefault(tp =>
+                    !candidateSubstitution.TryGetValue(tp, out var inferredType)
+                    || inferredType == TypeSymbol.Error);
+                if (candidateUnresolvedTypeParameter != null)
                 {
+                    unresolvedTypeParameter ??= candidateUnresolvedTypeParameter;
                     continue;
                 }
 
@@ -1691,7 +1711,19 @@ internal sealed partial class OverloadResolver
                 {
                     if (inferredCandidateCount == 0)
                     {
-                        Diagnostics.ReportTypeArgumentInferenceFailed(syntax.Identifier.Location, classType.Name, tps[0].Name);
+                        var hasFailedExplicitInlineOutType =
+                            !inlineOutArgumentIndices.IsDefaultOrEmpty
+                            && inlineOutArgumentIndices.Any(index =>
+                                ((RefArgumentExpressionSyntax)UnwrapNamedArgumentValue(
+                                    syntax.Arguments[index])).DeclaredType != null
+                                && inferenceArgumentTypes[index] == TypeSymbol.Error);
+                        if (!hasFailedExplicitInlineOutType)
+                        {
+                            Diagnostics.ReportTypeArgumentInferenceFailed(
+                                syntax.Identifier.Location,
+                                classType.Name,
+                                (unresolvedTypeParameter ?? tps[0]).Name);
+                        }
                     }
                     else
                     {
@@ -1885,7 +1917,7 @@ internal sealed partial class OverloadResolver
         {
             return inlineOut.DeclaredType == null
                 ? null
-                : bindTypeClause(inlineOut.DeclaredType);
+                : bindTypeClause(inlineOut.DeclaredType) ?? TypeSymbol.Error;
         }
 
         return bindExpression(argument).Type;

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
@@ -831,7 +831,7 @@ internal sealed partial class OverloadResolver
                 // The callback uses null to mean that overload resolution has
                 // not identified the ref parameter yet; its legacy non-null
                 // annotation predates that two-pass binding contract.
-                boundArgument = bindRefArgumentExpression(refArgument, parameterForArg!);
+                boundArgument = bindRefArgumentExpression(refArgument, null);
             }
 
             var lambdaArgument = argument as LambdaExpressionSyntax;
@@ -1077,6 +1077,28 @@ internal sealed partial class OverloadResolver
             // for a closed generic construction (equal to parameter.Type for a
             // non-generic/open type).
             var paramType = effectiveParamTypes[i];
+
+            var argumentSyntax = i < parameterSyntax.Length && parameterSyntax[i] != null
+                ? UnwrapNamedArgumentValue(parameterSyntax[i]!)
+                : null;
+            if (argumentSyntax is RefArgumentExpressionSyntax { IsInlineDeclaration: true } inlineOut)
+            {
+                if (parameter.RefKind != RefKind.Out)
+                {
+                    Diagnostics.ReportOutDeclarationOutsideOutArgument(inlineOut.Location);
+                    hasErrors = true;
+                    convertedArguments.Add(argument);
+                    continue;
+                }
+
+                if (inlineOut.DeclaredType == null
+                    && argument is BoundAddressOfExpression { Operand.Type: var operandType }
+                    && operandType == TypeSymbol.Error)
+                {
+                    var rebindParameter = new ParameterSymbol(parameter.Name, paramType, refKind: RefKind.Out);
+                    boundArguments[i] = argument = bindRefArgumentExpression(inlineOut, rebindParameter);
+                }
+            }
 
             // ADR-0055 Tier 4 (#369): re-lower an interpolated-string argument
             // targeting an IFormattable/FormattableString parameter.

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
@@ -1652,7 +1652,19 @@ internal sealed partial class OverloadResolver
             var inferredCandidateCount = 0;
             TypeParameterSymbol? unresolvedTypeParameter = null;
             Dictionary<TypeParameterSymbol, TypeSymbol>? constraintFailureSubstitution = null;
-            foreach (var constructor in classType.EffectiveExplicitConstructors)
+            var inferenceConstructors = classType.EffectiveExplicitConstructors;
+            var accessibleInferenceConstructors = inferenceConstructors
+                .Where(constructor => AccessibilityChecker.IsAccessible(
+                    constructor.Function.Accessibility,
+                    constructor.DeclaringType ?? classType,
+                    getCurrentFunction()))
+                .ToImmutableArray();
+            if (!accessibleInferenceConstructors.IsDefaultOrEmpty)
+            {
+                inferenceConstructors = accessibleInferenceConstructors;
+            }
+
+            foreach (var constructor in inferenceConstructors)
             {
                 if (!ConstructorAcceptsInlineOutArguments(
                         constructor,
@@ -1947,24 +1959,35 @@ internal sealed partial class OverloadResolver
         return bindExpression(argument).Type;
     }
 
-    private static bool IsPartiallyApplicableExplicitConstructor(
+    private bool IsPartiallyApplicableExplicitConstructor(
         CallExpressionSyntax syntax,
         ConstructorSymbol constructor,
         ImmutableArray<string> argumentNames,
         IReadOnlyList<TypeSymbol?> argumentTypes,
         Dictionary<TypeParameterSymbol, TypeSymbol> substitution)
     {
-        if (constructor.Parameters.Length != syntax.Arguments.Count)
+        if (!IsApplicableUserCallable(
+                constructor.Function,
+                syntax.Arguments.Count,
+                argumentNames))
         {
             return false;
         }
 
+        var parameters = constructor.Parameters;
+        var isVariadic = parameters.Length > 0 && parameters[parameters.Length - 1].IsVariadic;
+        var fixedParameterCount = isVariadic ? parameters.Length - 1 : parameters.Length;
+        var variadicArgumentCount = isVariadic
+            ? syntax.Arguments.Count - fixedParameterCount
+            : 0;
         for (var argumentIndex = 0; argumentIndex < syntax.Arguments.Count; argumentIndex++)
         {
             var parameterIndex = argumentNames.IsDefault || argumentNames[argumentIndex] == null
-                ? argumentIndex
-                : FindParameterIndex(constructor.Parameters, argumentNames[argumentIndex]);
-            if (parameterIndex < 0 || parameterIndex >= constructor.Parameters.Length)
+                ? isVariadic && argumentIndex >= fixedParameterCount
+                    ? parameters.Length - 1
+                    : argumentIndex
+                : FindParameterIndex(parameters, argumentNames[argumentIndex]);
+            if (parameterIndex < 0 || parameterIndex >= parameters.Length)
             {
                 return false;
             }
@@ -1975,8 +1998,16 @@ internal sealed partial class OverloadResolver
                 continue;
             }
 
-            var parameter = constructor.Parameters[parameterIndex];
+            var parameter = parameters[parameterIndex];
             var parameterType = Binder.SubstituteType(parameter.Type, substitution);
+            if (isVariadic
+                && parameterIndex == parameters.Length - 1
+                && parameterType is SliceTypeSymbol variadicSlice
+                && (variadicArgumentCount != 1 || argumentType is not SliceTypeSymbol))
+            {
+                parameterType = variadicSlice.ElementType;
+            }
+
             if (TypeSymbol.ContainsTypeParameter(parameterType))
             {
                 continue;

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
@@ -1086,7 +1086,7 @@ internal sealed partial class OverloadResolver
 
                 newSyntax[fixedCtorParamCount] = parameterSyntax.Length > fixedCtorParamCount
                     ? parameterSyntax[fixedCtorParamCount]
-                    : (syntax.Arguments.Count > 0 ? syntax.Arguments[syntax.Arguments.Count - 1] : null);
+                    : null;
                 parameterSyntax = newSyntax;
             }
         }
@@ -1548,37 +1548,66 @@ internal sealed partial class OverloadResolver
             var ctorParams = ctorOverloads.IsDefaultOrEmpty
                 ? ImmutableArray<ParameterSymbol>.Empty
                 : ctorOverloads[0].Parameters;
+            var ctorIsVariadic = ctorParams.Length > 0
+                && ctorParams[ctorParams.Length - 1].IsVariadic;
+            var fixedParameterCount = ctorIsVariadic ? ctorParams.Length - 1 : ctorParams.Length;
+            List<ExpressionSyntax>? variadicArguments = null;
 
             for (var i = 0; i < syntax.Arguments.Count; i++)
             {
                 var sourceArgument = syntax.Arguments[i];
                 var parameterIndex = sourceArgument is NamedArgumentExpressionSyntax named
                     ? FindParameterIndex(ctorParams, named.NameToken.Text)
-                    : i;
+                    : ctorIsVariadic && i >= fixedParameterCount
+                        ? ctorParams.Length - 1
+                        : i;
                 if (parameterIndex < 0 || parameterIndex >= ctorParams.Length)
                 {
                     continue;
                 }
 
                 var argSyntax = UnwrapNamedArgumentValue(sourceArgument);
-                if (argSyntax is RefArgumentExpressionSyntax { IsInlineDeclaration: true } inlineOut)
+                if (ctorIsVariadic && parameterIndex == ctorParams.Length - 1)
                 {
-                    if (inlineOut.DeclaredType == null)
-                    {
-                        continue;
-                    }
-
-                    var declaredType = bindTypeClause(inlineOut.DeclaredType);
-                    if (declaredType != null)
-                    {
-                        inferTypeArguments(ctorParams[parameterIndex].Type, declaredType, substitution);
-                    }
-
+                    variadicArguments ??= new List<ExpressionSyntax>();
+                    variadicArguments.Add(argSyntax);
                     continue;
                 }
 
-                var preBound = bindExpression(argSyntax);
-                inferTypeArguments(ctorParams[parameterIndex].Type, preBound.Type, substitution);
+                var argumentType = BindExplicitConstructorInferenceArgument(argSyntax);
+                if (argumentType != null)
+                {
+                    inferTypeArguments(ctorParams[parameterIndex].Type, argumentType, substitution);
+                }
+            }
+
+            if (ctorIsVariadic
+                && variadicArguments is { Count: > 0 }
+                && ctorParams[ctorParams.Length - 1].Type is SliceTypeSymbol variadicSlice)
+            {
+                if (variadicArguments.Count == 1)
+                {
+                    var argumentType = BindExplicitConstructorInferenceArgument(variadicArguments[0]);
+                    if (argumentType is SliceTypeSymbol)
+                    {
+                        inferTypeArguments(variadicSlice, argumentType, substitution);
+                    }
+                    else if (argumentType != null)
+                    {
+                        inferTypeArguments(variadicSlice.ElementType, argumentType, substitution);
+                    }
+                }
+                else
+                {
+                    foreach (var variadicArgument in variadicArguments)
+                    {
+                        var argumentType = BindExplicitConstructorInferenceArgument(variadicArgument);
+                        if (argumentType != null)
+                        {
+                            inferTypeArguments(variadicSlice.ElementType, argumentType, substitution);
+                        }
+                    }
+                }
             }
 
             Diagnostics.TruncateTo(inferenceDiagMark);
@@ -1617,6 +1646,18 @@ internal sealed partial class OverloadResolver
             ? StructSymbol.Construct(classType, typeArgs.MoveToImmutable(), mapClrType)
             : StructSymbol.Construct(classType, typeArgs.MoveToImmutable());
         return true;
+    }
+
+    private TypeSymbol? BindExplicitConstructorInferenceArgument(ExpressionSyntax argument)
+    {
+        if (argument is RefArgumentExpressionSyntax { IsInlineDeclaration: true } inlineOut)
+        {
+            return inlineOut.DeclaredType == null
+                ? null
+                : bindTypeClause(inlineOut.DeclaredType);
+        }
+
+        return bindExpression(argument).Type;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
@@ -930,9 +930,12 @@ internal sealed partial class OverloadResolver
         else
         {
             var ctorFunctions = ImmutableArray.CreateBuilder<FunctionSymbol>(ctorOverloads.Length);
+            var constructorByFunction = new Dictionary<FunctionSymbol, ConstructorSymbol>();
             foreach (var c in ctorOverloads)
             {
-                ctorFunctions.Add(c.Function);
+                var candidate = CreateConstructedConstructorCandidate(c, classType);
+                ctorFunctions.Add(candidate);
+                constructorByFunction.Add(candidate, c);
             }
 
             var selectedFn = SelectBestInstanceOverload(
@@ -968,15 +971,7 @@ internal sealed partial class OverloadResolver
                 return new BoundErrorExpression(syntax);
             }
 
-            selectedCtor = null;
-            foreach (var c in ctorOverloads)
-            {
-                if (ReferenceEquals(c.Function, selectedFn))
-                {
-                    selectedCtor = c;
-                    break;
-                }
-            }
+            selectedCtor = constructorByFunction[selectedFn];
         }
 
         selectedCtor = Invariant.Required(selectedCtor, "an applicable explicit constructor has a selected constructor symbol");
@@ -1436,7 +1431,7 @@ internal sealed partial class OverloadResolver
         foreach (var argumentIndex in inlineOutArgumentIndices)
         {
             var inlineOut = (RefArgumentExpressionSyntax)UnwrapNamedArgumentValue(arguments[argumentIndex]);
-            if (inlineOut.IsDiscard || inlineOut.DeclaredType != null)
+            if (inlineOut.IsDiscard)
             {
                 continue;
             }
@@ -1508,6 +1503,41 @@ internal sealed partial class OverloadResolver
         }
     }
 
+    private static FunctionSymbol CreateConstructedConstructorCandidate(
+        ConstructorSymbol constructor,
+        StructSymbol constructedType)
+    {
+        var effectiveTypes = constructedType.GetConstructorParameterTypesForConstruction(constructor);
+        var parameters = ImmutableArray.CreateBuilder<ParameterSymbol>(constructor.Parameters.Length);
+        for (var i = 0; i < constructor.Parameters.Length; i++)
+        {
+            var parameter = constructor.Parameters[i];
+            var candidateParameter = new ParameterSymbol(
+                parameter.Name,
+                effectiveTypes[i],
+                parameter.IsVariadic,
+                parameter.DeclaringSyntax,
+                parameter.IsScoped,
+                parameter.RefKind);
+            if (parameter.HasExplicitDefaultValue)
+            {
+                candidateParameter.SetExplicitDefaultValue(parameter.ExplicitDefaultValue);
+            }
+
+            parameters.Add(candidateParameter);
+        }
+
+        var function = constructor.Function;
+        return new FunctionSymbol(
+            function.Name,
+            parameters.MoveToImmutable(),
+            function.Type,
+            function.Declaration,
+            function.Package,
+            function.Accessibility,
+            constructedType);
+    }
+
     /// <summary>
     /// Issue #1214: closes a generic class that declares an explicit
     /// <c>init(...)</c> constructor for a construction call <c>Box[int32](args)</c>.
@@ -1564,99 +1594,134 @@ internal sealed partial class OverloadResolver
         }
         else
         {
-            // Infer the type arguments from the value arguments against the
-            // (first) explicit constructor's parameter list. The open-definition
-            // constructor parameter types reference the class type parameters,
-            // so binding each argument and unifying drives inference.
-            //
             // Issue #1629: this is a throwaway probe — BindExplicitConstructorCallExpression
             // re-binds the same argument syntax for real once the closed type is
             // known. Roll back any diagnostics the probe produced so they are
             // reported exactly once, by the real bind.
             var inferenceDiagMark = Diagnostics.Count;
-
-            var ctorOverloads = classType.EffectiveExplicitConstructors;
-            var inferenceConstructor = ctorOverloads.FirstOrDefault(
-                ctor => ConstructorAcceptsInlineOutArguments(
-                    ctor,
-                    argumentNames,
-                    inlineOutArgumentIndices));
-            var ctorParams = inferenceConstructor?.Parameters
-                ?? (ctorOverloads.IsDefaultOrEmpty
-                    ? ImmutableArray<ParameterSymbol>.Empty
-                    : ctorOverloads[0].Parameters);
-            var ctorIsVariadic = ctorParams.Length > 0
-                && ctorParams[ctorParams.Length - 1].IsVariadic;
-            var fixedParameterCount = ctorIsVariadic ? ctorParams.Length - 1 : ctorParams.Length;
-            List<ExpressionSyntax>? variadicArguments = null;
-
+            var inferenceArgumentTypes = new TypeSymbol?[syntax.Arguments.Count];
+            var inferenceBoundArguments = ImmutableArray.CreateBuilder<BoundExpression>(syntax.Arguments.Count);
             for (var i = 0; i < syntax.Arguments.Count; i++)
             {
-                var sourceArgument = syntax.Arguments[i];
-                var parameterIndex = sourceArgument is NamedArgumentExpressionSyntax named
-                    ? FindParameterIndex(ctorParams, named.NameToken.Text)
-                    : ctorIsVariadic && i >= fixedParameterCount
-                        ? ctorParams.Length - 1
-                        : i;
-                if (parameterIndex < 0 || parameterIndex >= ctorParams.Length)
+                var argument = UnwrapNamedArgumentValue(syntax.Arguments[i]);
+                if (argument is RefArgumentExpressionSyntax { IsInlineDeclaration: true })
                 {
+                    inferenceArgumentTypes[i] = BindExplicitConstructorInferenceArgument(argument);
+                    inferenceBoundArguments.Add(new BoundErrorExpression(argument));
                     continue;
                 }
 
-                var argSyntax = UnwrapNamedArgumentValue(sourceArgument);
-                if (ctorIsVariadic && parameterIndex == ctorParams.Length - 1)
-                {
-                    variadicArguments ??= new List<ExpressionSyntax>();
-                    variadicArguments.Add(argSyntax);
-                    continue;
-                }
-
-                var argumentType = BindExplicitConstructorInferenceArgument(argSyntax);
-                if (argumentType != null)
-                {
-                    inferTypeArguments(ctorParams[parameterIndex].Type, argumentType, substitution);
-                }
+                var boundArgument = bindExpression(argument);
+                inferenceArgumentTypes[i] = boundArgument.Type;
+                inferenceBoundArguments.Add(boundArgument);
             }
 
-            if (ctorIsVariadic
-                && variadicArguments is { Count: > 0 }
-                && ctorParams[ctorParams.Length - 1].Type is SliceTypeSymbol variadicSlice)
+            var candidates = new List<(FunctionSymbol Function, Dictionary<TypeParameterSymbol, TypeSymbol> Substitution)>();
+            var inferredCandidateCount = 0;
+            Dictionary<TypeParameterSymbol, TypeSymbol>? constraintFailureSubstitution = null;
+            foreach (var constructor in classType.EffectiveExplicitConstructors)
             {
-                if (variadicArguments.Count == 1)
+                if (!ConstructorAcceptsInlineOutArguments(
+                        constructor,
+                        argumentNames,
+                        inlineOutArgumentIndices))
                 {
-                    var argumentType = BindExplicitConstructorInferenceArgument(variadicArguments[0]);
-                    if (argumentType is SliceTypeSymbol)
-                    {
-                        inferTypeArguments(variadicSlice, argumentType, substitution);
-                    }
-                    else if (argumentType != null)
-                    {
-                        inferTypeArguments(variadicSlice.ElementType, argumentType, substitution);
-                    }
+                    continue;
                 }
-                else
+
+                var candidateSubstitution = new Dictionary<TypeParameterSymbol, TypeSymbol>();
+                InferExplicitConstructorTypeArguments(
+                    syntax,
+                    constructor,
+                    argumentNames,
+                    inferenceArgumentTypes,
+                    candidateSubstitution);
+                if (tps.Any(tp => !candidateSubstitution.TryGetValue(tp, out var inferredType)
+                    || inferredType == TypeSymbol.Error))
                 {
-                    foreach (var variadicArgument in variadicArguments)
-                    {
-                        var argumentType = BindExplicitConstructorInferenceArgument(variadicArgument);
-                        if (argumentType != null)
-                        {
-                            inferTypeArguments(variadicSlice.ElementType, argumentType, substitution);
-                        }
-                    }
+                    continue;
                 }
+
+                inferredCandidateCount++;
+                if (!tps.All(tp => satisfiesConstraint(candidateSubstitution[tp], tp)))
+                {
+                    constraintFailureSubstitution ??= candidateSubstitution;
+                    continue;
+                }
+
+                var candidateType = ConstructExplicitConstructorType(
+                    classType,
+                    tps,
+                    candidateSubstitution);
+                var candidateFunction = CreateConstructedConstructorCandidate(
+                    constructor,
+                    candidateType);
+                if (!IsApplicableUserCallable(
+                        candidateFunction,
+                        syntax.Arguments.Count,
+                        argumentNames)
+                    || !IsConvertibilityApplicable(
+                        candidateFunction,
+                        syntax.Arguments.Count,
+                        argumentNames,
+                        inferenceBoundArguments))
+                {
+                    continue;
+                }
+
+                candidates.Add((candidateFunction, candidateSubstitution));
             }
 
             Diagnostics.TruncateTo(inferenceDiagMark);
 
-            foreach (var tp in tps)
+            if (candidates.Count == 0)
             {
-                if (!substitution.TryGetValue(tp, out var inferredType)
-                    || inferredType == TypeSymbol.Error)
+                if (constraintFailureSubstitution != null)
                 {
-                    Diagnostics.ReportTypeArgumentInferenceFailed(syntax.Identifier.Location, classType.Name, tp.Name);
+                    substitution = constraintFailureSubstitution;
+                }
+                else
+                {
+                    if (inferredCandidateCount == 0)
+                    {
+                        Diagnostics.ReportTypeArgumentInferenceFailed(syntax.Identifier.Location, classType.Name, tps[0].Name);
+                    }
+                    else
+                    {
+                        Diagnostics.ReportNoApplicableOverload(syntax.Identifier.Location, classType.Name);
+                    }
+
                     return false;
                 }
+            }
+            else if (candidates.Count == 1)
+            {
+                substitution = candidates[0].Substitution;
+            }
+            else
+            {
+                var selected = SelectBestInstanceOverload(
+                    candidates.Select(candidate => candidate.Function).ToImmutableArray(),
+                    syntax.Arguments.Count,
+                    argumentNames,
+                    inferenceBoundArguments.ToImmutable(),
+                    out var ambiguous,
+                    out _);
+                if (selected == null)
+                {
+                    if (ambiguous)
+                    {
+                        Diagnostics.ReportAmbiguousOverloadResolution(syntax.Identifier.Location, classType.Name);
+                    }
+                    else
+                    {
+                        Diagnostics.ReportNoApplicableOverload(syntax.Identifier.Location, classType.Name);
+                    }
+
+                    return false;
+                }
+
+                substitution = candidates.First(candidate => ReferenceEquals(candidate.Function, selected)).Substitution;
             }
         }
 
@@ -1673,16 +1738,92 @@ internal sealed partial class OverloadResolver
             }
         }
 
-        var typeArgs = ImmutableArray.CreateBuilder<TypeSymbol>(tps.Length);
-        foreach (var tp in tps)
+        constructed = ConstructExplicitConstructorType(classType, tps, substitution);
+        return true;
+    }
+
+    private void InferExplicitConstructorTypeArguments(
+        CallExpressionSyntax syntax,
+        ConstructorSymbol constructor,
+        ImmutableArray<string> argumentNames,
+        IReadOnlyList<TypeSymbol?> argumentTypes,
+        Dictionary<TypeParameterSymbol, TypeSymbol> substitution)
+    {
+        var parameters = constructor.Parameters;
+        var isVariadic = parameters.Length > 0 && parameters[parameters.Length - 1].IsVariadic;
+        var fixedParameterCount = isVariadic ? parameters.Length - 1 : parameters.Length;
+        List<int>? variadicArgumentIndices = null;
+
+        for (var i = 0; i < syntax.Arguments.Count; i++)
         {
-            typeArgs.Add(substitution[tp]);
+            var parameterIndex = argumentNames.IsDefault || argumentNames[i] == null
+                ? isVariadic && i >= fixedParameterCount
+                    ? parameters.Length - 1
+                    : i
+                : FindParameterIndex(parameters, argumentNames[i]);
+            if (parameterIndex < 0 || parameterIndex >= parameters.Length)
+            {
+                continue;
+            }
+
+            if (isVariadic && parameterIndex == parameters.Length - 1)
+            {
+                variadicArgumentIndices ??= new List<int>();
+                variadicArgumentIndices.Add(i);
+                continue;
+            }
+
+            if (argumentTypes[i] is { } argumentType)
+            {
+                inferTypeArguments(parameters[parameterIndex].Type, argumentType, substitution);
+            }
         }
 
-        constructed = MapClrType is { } mapClrType
-            ? StructSymbol.Construct(classType, typeArgs.MoveToImmutable(), mapClrType)
-            : StructSymbol.Construct(classType, typeArgs.MoveToImmutable());
-        return true;
+        if (!isVariadic
+            || variadicArgumentIndices is not { Count: > 0 }
+            || parameters[parameters.Length - 1].Type is not SliceTypeSymbol variadicSlice)
+        {
+            return;
+        }
+
+        if (variadicArgumentIndices.Count == 1)
+        {
+            var argumentType = argumentTypes[variadicArgumentIndices[0]];
+            if (argumentType is SliceTypeSymbol)
+            {
+                inferTypeArguments(variadicSlice, argumentType, substitution);
+            }
+            else if (argumentType != null)
+            {
+                inferTypeArguments(variadicSlice.ElementType, argumentType, substitution);
+            }
+
+            return;
+        }
+
+        foreach (var argumentIndex in variadicArgumentIndices)
+        {
+            if (argumentTypes[argumentIndex] is { } argumentType)
+            {
+                inferTypeArguments(variadicSlice.ElementType, argumentType, substitution);
+            }
+        }
+    }
+
+    private StructSymbol ConstructExplicitConstructorType(
+        StructSymbol definition,
+        ImmutableArray<TypeParameterSymbol> typeParameters,
+        Dictionary<TypeParameterSymbol, TypeSymbol> substitution)
+    {
+        var typeArguments = ImmutableArray.CreateBuilder<TypeSymbol>(typeParameters.Length);
+        foreach (var typeParameter in typeParameters)
+        {
+            typeArguments.Add(substitution[typeParameter]);
+        }
+
+        return MapClrType is { } mapClrType
+            ? StructSymbol.Construct(definition, typeArguments.MoveToImmutable(), mapClrType)
+            : StructSymbol.Construct(definition, typeArguments.MoveToImmutable());
     }
 
     private TypeSymbol? BindExplicitConstructorInferenceArgument(ExpressionSyntax argument)

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
@@ -771,6 +771,14 @@ internal sealed partial class OverloadResolver
     {
         var inlineOutArgumentIndices = GetInlineOutArgumentIndices(syntax.Arguments);
 
+        // Issue #343: pre-validate named-argument layout (positional precedes
+        // named, no duplicate names). Diagnostics are reported by the helper.
+        if (!TryAnalyzeCallArgumentLayout(syntax.Arguments, out _, out var argumentNames))
+        {
+            DeclareInvalidInlineOutLocals(syntax.Arguments, inlineOutArgumentIndices);
+            return new BoundErrorExpression(syntax);
+        }
+
         // Issue #1214: a generic class declaring an explicit `init(...)`
         // constructor is constructed at a closed type (`Box[int32](5, "x")`).
         // Resolve the type arguments — supplied explicitly or inferred from the
@@ -783,19 +791,35 @@ internal sealed partial class OverloadResolver
         // TypeSpec (ResolveUserCtorTokenForExplicit).
         if (syntax.TypeArgumentList != null || classType.IsGenericDefinition)
         {
-            if (!TryCloseGenericExplicitConstructorType(syntax, classType, out classType))
+            if (!inlineOutArgumentIndices.IsDefaultOrEmpty)
+            {
+                var openConstructors = classType.EffectiveExplicitConstructors;
+                var invalidInlineOutArgument = inlineOutArgumentIndices.FirstOrDefault(
+                    index => !openConstructors.Any(ctor => ConstructorAcceptsInlineOutArgument(
+                        ctor,
+                        argumentNames,
+                        index)),
+                    -1);
+                if (invalidInlineOutArgument >= 0)
+                {
+                    var inlineOut = (RefArgumentExpressionSyntax)UnwrapNamedArgumentValue(
+                        syntax.Arguments[invalidInlineOutArgument]);
+                    Diagnostics.ReportOutDeclarationOutsideOutArgument(inlineOut.Location);
+                    DeclareInvalidInlineOutLocals(syntax.Arguments, inlineOutArgumentIndices);
+                    return new BoundErrorExpression(syntax);
+                }
+            }
+
+            if (!TryCloseGenericExplicitConstructorType(
+                    syntax,
+                    classType,
+                    argumentNames,
+                    inlineOutArgumentIndices,
+                    out classType))
             {
                 DeclareUnresolvedInlineOutLocals(syntax.Arguments, inlineOutArgumentIndices);
                 return new BoundErrorExpression(syntax);
             }
-        }
-
-        // Issue #343: pre-validate named-argument layout (positional precedes
-        // named, no duplicate names). Diagnostics are reported by the helper.
-        if (!TryAnalyzeCallArgumentLayout(syntax.Arguments, out _, out var argumentNames))
-        {
-            DeclareInvalidInlineOutLocals(syntax.Arguments, inlineOutArgumentIndices);
-            return new BoundErrorExpression(syntax);
         }
 
         // ADR-0063 §9: when the class declares multiple init(...) constructors,
@@ -1304,6 +1328,11 @@ internal sealed partial class OverloadResolver
         ImmutableArray<string> argumentNames,
         ImmutableArray<int> inlineOutArgumentIndices)
     {
+        if (inlineOutArgumentIndices.IsDefaultOrEmpty)
+        {
+            return true;
+        }
+
         foreach (var argumentIndex in inlineOutArgumentIndices)
         {
             if (!ConstructorAcceptsInlineOutArgument(
@@ -1493,6 +1522,8 @@ internal sealed partial class OverloadResolver
     private bool TryCloseGenericExplicitConstructorType(
         CallExpressionSyntax syntax,
         StructSymbol classType,
+        ImmutableArray<string> argumentNames,
+        ImmutableArray<int> inlineOutArgumentIndices,
         out StructSymbol constructed)
     {
         constructed = classType;
@@ -1545,9 +1576,15 @@ internal sealed partial class OverloadResolver
             var inferenceDiagMark = Diagnostics.Count;
 
             var ctorOverloads = classType.EffectiveExplicitConstructors;
-            var ctorParams = ctorOverloads.IsDefaultOrEmpty
-                ? ImmutableArray<ParameterSymbol>.Empty
-                : ctorOverloads[0].Parameters;
+            var inferenceConstructor = ctorOverloads.FirstOrDefault(
+                ctor => ConstructorAcceptsInlineOutArguments(
+                    ctor,
+                    argumentNames,
+                    inlineOutArgumentIndices));
+            var ctorParams = inferenceConstructor?.Parameters
+                ?? (ctorOverloads.IsDefaultOrEmpty
+                    ? ImmutableArray<ParameterSymbol>.Empty
+                    : ctorOverloads[0].Parameters);
             var ctorIsVariadic = ctorParams.Length > 0
                 && ctorParams[ctorParams.Length - 1].IsVariadic;
             var fixedParameterCount = ctorIsVariadic ? ctorParams.Length - 1 : ctorParams.Length;

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
@@ -1477,9 +1477,11 @@ internal sealed partial class OverloadResolver
 
         foreach (var argumentIndex in inlineOutArgumentIndices)
         {
+            var inlineOut = (RefArgumentExpressionSyntax)UnwrapNamedArgumentValue(arguments[argumentIndex]);
             if (boundArguments[argumentIndex]
                     is not BoundAddressOfExpression { Operand.Type: var argumentType }
-                || argumentType != TypeSymbol.Error)
+                || argumentType != TypeSymbol.Error
+                || inlineOut.DeclaredType != null)
             {
                 continue;
             }
@@ -1498,7 +1500,6 @@ internal sealed partial class OverloadResolver
                 parameter.Name,
                 parameterTypes[parameterIndex],
                 refKind: RefKind.Out);
-            var inlineOut = (RefArgumentExpressionSyntax)UnwrapNamedArgumentValue(arguments[argumentIndex]);
             boundArguments[argumentIndex] = bindRefArgumentExpression(inlineOut, reboundParameter);
         }
     }
@@ -1701,6 +1702,13 @@ internal sealed partial class OverloadResolver
                 }
             }
             else if (candidates.Count == 1)
+            {
+                substitution = candidates[0].Substitution;
+            }
+            else if (candidates.Skip(1).All(candidate =>
+                tps.All(tp => DeclarationBinder.TypeSignaturesEquivalent(
+                    candidate.Substitution[tp],
+                    candidates[0].Substitution[tp]))))
             {
                 substitution = candidates[0].Substitution;
             }

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
@@ -787,10 +787,13 @@ internal sealed partial class OverloadResolver
             }
         }
 
+        var inlineOutArgumentIndices = GetInlineOutArgumentIndices(syntax.Arguments);
+
         // Issue #343: pre-validate named-argument layout (positional precedes
         // named, no duplicate names). Diagnostics are reported by the helper.
         if (!TryAnalyzeCallArgumentLayout(syntax.Arguments, out _, out var argumentNames))
         {
+            DeclareInvalidInlineOutLocals(syntax.Arguments, inlineOutArgumentIndices);
             return new BoundErrorExpression(syntax);
         }
 
@@ -812,7 +815,6 @@ internal sealed partial class OverloadResolver
             ctorOverloads = accessibleCtorOverloads;
         }
 
-        var inlineOutArgumentIndices = GetInlineOutArgumentIndices(syntax.Arguments);
         if (!inlineOutArgumentIndices.IsDefaultOrEmpty)
         {
             ctorOverloads = ctorOverloads
@@ -947,6 +949,13 @@ internal sealed partial class OverloadResolver
         // per-position conversion below targets the concrete argument types.
         // For a non-generic or open type these equal the declared types.
         var effectiveParamTypes = classType.GetConstructorParameterTypesForConstruction(selectedCtor);
+        RebindSelectedConstructorInlineOutArguments(
+            syntax.Arguments,
+            argumentNames,
+            selectedCtor,
+            effectiveParamTypes,
+            inlineOutArgumentIndices,
+            boundArgumentsBuilder);
 
         // ADR-0101 follow-up / issue #812: a constructor's last parameter
         // may be variadic. The arity check accepts any count >= the fixed
@@ -1363,6 +1372,47 @@ internal sealed partial class OverloadResolver
         {
             var inlineOut = (RefArgumentExpressionSyntax)UnwrapNamedArgumentValue(arguments[argumentIndex]);
             _ = bindRefArgumentExpression(inlineOut, errorOutParameter);
+        }
+    }
+
+    private void RebindSelectedConstructorInlineOutArguments(
+        SeparatedSyntaxList<ExpressionSyntax> arguments,
+        ImmutableArray<string> argumentNames,
+        ConstructorSymbol constructor,
+        ImmutableArray<TypeSymbol> parameterTypes,
+        ImmutableArray<int> inlineOutArgumentIndices,
+        ImmutableArray<BoundExpression>.Builder boundArguments)
+    {
+        if (inlineOutArgumentIndices.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        foreach (var argumentIndex in inlineOutArgumentIndices)
+        {
+            if (boundArguments[argumentIndex]
+                    is not BoundAddressOfExpression { Operand.Type: var argumentType }
+                || argumentType != TypeSymbol.Error)
+            {
+                continue;
+            }
+
+            var name = argumentNames.IsDefault ? null : argumentNames[argumentIndex];
+            var parameterIndex = name == null
+                ? argumentIndex
+                : FindParameterIndex(constructor.Parameters, name);
+            if (parameterIndex < 0 || parameterIndex >= parameterTypes.Length)
+            {
+                continue;
+            }
+
+            var parameter = constructor.Parameters[parameterIndex];
+            var reboundParameter = new ParameterSymbol(
+                parameter.Name,
+                parameterTypes[parameterIndex],
+                refKind: RefKind.Out);
+            var inlineOut = (RefArgumentExpressionSyntax)UnwrapNamedArgumentValue(arguments[argumentIndex]);
+            boundArguments[argumentIndex] = bindRefArgumentExpression(inlineOut, reboundParameter);
         }
     }
 

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
@@ -2138,7 +2138,8 @@ internal sealed partial class MethodBodyEmitter
             // Issue #1613: same fix for byte/bool — ldind.u1 zero-extends.
             this.il.OpCode(ILOpCode.Ldind_u1);
         }
-        else if (ReflectionMetadataEmitter.IsValueTypeSymbol(pointeeType))
+        else if (pointeeType is TypeParameterSymbol
+            || ReflectionMetadataEmitter.IsValueTypeSymbol(pointeeType))
         {
             this.il.OpCode(ILOpCode.Ldobj);
             this.il.Token(this.outer.memberRefs.GetElementTypeToken(pointeeType));
@@ -2177,7 +2178,8 @@ internal sealed partial class MethodBodyEmitter
         {
             this.il.OpCode(ILOpCode.Stind_i1);
         }
-        else if (ReflectionMetadataEmitter.IsValueTypeSymbol(pointeeType))
+        else if (pointeeType is TypeParameterSymbol
+            || ReflectionMetadataEmitter.IsValueTypeSymbol(pointeeType))
         {
             this.il.OpCode(ILOpCode.Stobj);
             this.il.Token(this.outer.memberRefs.GetElementTypeToken(pointeeType));

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3464ConstructorInlineOutTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3464ConstructorInlineOutTests.cs
@@ -111,6 +111,48 @@ public sealed class Issue3464ConstructorInlineOutTests
     }
 
     [Fact]
+    public void ImportedMutex_MismatchedExplicitTypedOutReportsConstructorDiagnostic()
+    {
+        var result = Evaluate("""
+            import System.Threading
+
+            Mutex(false, nil, out var value int64)
+            value
+            """);
+
+        AssertImportedTypedOutMismatchWithoutCascades(result);
+    }
+
+    [Fact]
+    public void ImportedMutex_NamedMismatchedExplicitTypedOutReportsConstructorDiagnostic()
+    {
+        var result = Evaluate("""
+            import System.Threading
+
+            Mutex(
+                createdNew: out var value int64,
+                name: nil,
+                initiallyOwned: false)
+            value
+            """);
+
+        AssertImportedTypedOutMismatchWithoutCascades(result);
+    }
+
+    [Fact]
+    public void ImportedConstructor_MismatchedTypedOutDeclaresInferredSibling()
+    {
+        var result = EvaluateFixture("""
+            import GSharp.Core.Tests.CodeAnalysis.Binding
+
+            Issue3464TwoOutConstructor(out var invalid int64, out var sibling)
+            invalid + sibling
+            """);
+
+        AssertImportedTypedOutMismatchWithoutCascades(result);
+    }
+
+    [Fact]
     public void ImportedGenericConstructor_InfersOutVarType()
     {
         var result = EvaluateFixture("""
@@ -1580,6 +1622,14 @@ public sealed class Issue3464ConstructorInlineOutTests
             diagnostic => diagnostic.Id is "GS0125" or "GS0159" or "GS0285");
     }
 
+    private static void AssertImportedTypedOutMismatchWithoutCascades(EmittedOracleResult result)
+    {
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0154");
+        Assert.DoesNotContain(
+            result.Diagnostics,
+            diagnostic => diagnostic.Id is "GS0102" or "GS0125" or "GS0130");
+    }
+
     private static EmittedOracleResult Evaluate(string source) => EmittedOracle.Evaluate(source);
 
     private static EmittedOracleResult EvaluateFixture(string source) =>
@@ -1649,5 +1699,14 @@ public sealed class Issue3464FailureConstructor
     public Issue3464FailureConstructor(int prefix, out int value, int required)
     {
         value = prefix + required;
+    }
+}
+
+public sealed class Issue3464TwoOutConstructor
+{
+    public Issue3464TwoOutConstructor(out bool first, out int second)
+    {
+        first = true;
+        second = 42;
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3464ConstructorInlineOutTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3464ConstructorInlineOutTests.cs
@@ -629,6 +629,96 @@ public sealed class Issue3464ConstructorInlineOutTests
     }
 
     [Fact]
+    public void SourceGenericConstructor_ExplicitTypedOutFiltersInferredCandidates()
+    {
+        var result = Evaluate("""
+            class TypedGenericChoice[T] {
+                init(out value int32, seed T) {
+                    value = 40
+                }
+
+                init(out value string, seed T) {
+                    value = ""
+                }
+            }
+
+            TypedGenericChoice(out var value int32, 2)
+            value
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(40, result.Value);
+    }
+
+    [Fact]
+    public void SourceGenericConstructor_ExplicitTypedOutFiltersReversedCandidates()
+    {
+        var result = Evaluate("""
+            class ReversedTypedGenericChoice[T] {
+                init(out value string, seed T) {
+                    value = ""
+                }
+
+                init(out value int32, seed T) {
+                    value = 40
+                }
+            }
+
+            ReversedTypedGenericChoice(out var value int32, 2)
+            value
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(40, result.Value);
+    }
+
+    [Fact]
+    public void SourceGenericConstructor_NamedExplicitTypedOutFiltersMultipleTypeParameters()
+    {
+        var result = Evaluate("""
+            class NamedTypedGenericChoice[T,U] {
+                init(out value int32, first T, second U) {
+                    value = 42
+                }
+
+                init(out value string, first T, second U) {
+                    value = ""
+                }
+            }
+
+            NamedTypedGenericChoice(second: "x", value: out var value int32, first: 42)
+            value
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void SourceGenericConstructor_IncompatibleExplicitTypedOutReportsNoApplicable()
+    {
+        var result = Evaluate("""
+            class IncompatibleTypedGenericChoice[T] {
+                init(out value int32, seed T) {
+                    value = 0
+                }
+
+                init(out value string, seed T) {
+                    value = ""
+                }
+            }
+
+            IncompatibleTypedGenericChoice(out var value bool, 2)
+            value
+            """);
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0267");
+        Assert.DoesNotContain(
+            result.Diagnostics,
+            diagnostic => diagnostic.Id is "GS0102" or "GS0125");
+    }
+
+    [Fact]
     public void SourceClosedGenericConstructor_RanksSubstitutedParameterTypes()
     {
         var result = Evaluate("""

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3464ConstructorInlineOutTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3464ConstructorInlineOutTests.cs
@@ -1,0 +1,251 @@
+// <copyright file="Issue3464ConstructorInlineOutTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Linq;
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+public sealed class Issue3464ConstructorInlineOutTests
+{
+    [Fact]
+    public void ImportedMutex_MixedNamedAndPositionalOutVar_BindsAndRuns()
+    {
+        var result = Evaluate("""
+            import System.Threading
+
+            let guardName string? = nil
+            let processGuard = Mutex(initiallyOwned: false, guardName, out var createdNew)
+            processGuard.Dispose()
+            createdNew
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(true, result.Value);
+    }
+
+    [Fact]
+    public void ImportedMutex_ReorderedNamedOutLet_BindsAndRuns()
+    {
+        var result = Evaluate("""
+            import System.Threading
+
+            let processGuard = Mutex(
+                createdNew: out let createdNew,
+                name: nil,
+                initiallyOwned: false)
+            processGuard.Dispose()
+            createdNew
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(true, result.Value);
+    }
+
+    [Fact]
+    public void ImportedMutex_ExplicitlyTypedOutVar_BindsAndRuns()
+    {
+        var result = Evaluate("""
+            import System.Threading
+
+            let processGuard = Mutex(false, nil, out var createdNew bool)
+            processGuard.Dispose()
+            createdNew
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(true, result.Value);
+    }
+
+    [Fact]
+    public void ImportedMutex_OutDiscard_BindsAndPreservesResultType()
+    {
+        var result = Evaluate("""
+            import System.Threading
+
+            let processGuard = Mutex(false, nil, out _)
+            processGuard.Dispose()
+            42
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void ImportedGenericConstructor_InfersOutVarType()
+    {
+        var result = EvaluateFixture("""
+            import GSharp.Core.Tests.CodeAnalysis.Binding
+
+            let fixture = Issue3464GenericConstructor[int32](out var value)
+            value + fixture.Value
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(84, result.Value);
+    }
+
+    [Fact]
+    public void ImportedNestedConstructor_InfersOutVarType()
+    {
+        var result = EvaluateFixture("""
+            import GSharp.Core.Tests.CodeAnalysis.Binding
+
+            let fixture = Issue3464Outer.Nested(out var value)
+            value + fixture.Value
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(84, result.Value);
+    }
+
+    [Fact]
+    public void SourceConstructor_ReorderedNamedOutVar_IsVisibleAndAssigned()
+    {
+        var result = Evaluate("""
+            class Box {
+                var Value int32
+
+                init(prefix int32, out result int32) {
+                    result = prefix + 2
+                    Value = result
+                }
+            }
+
+            let box = Box(result: out var result, prefix: 40)
+            result + box.Value
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(84, result.Value);
+    }
+
+    [Fact]
+    public void ImportedConstructor_OutDeclarationAtValuePosition_ReportsOnlyGs0236()
+    {
+        var result = Evaluate("""
+            import System.Threading
+
+            Mutex(out var invalid, nil, out _)
+            """);
+
+        Assert.Equal(new[] { "GS0236" }, result.Diagnostics.Select(diagnostic => diagnostic.Id).Distinct());
+    }
+
+    [Fact]
+    public void ImportedConstructor_OutDeclarationAtRefPosition_ReportsGs0236()
+    {
+        var result = EvaluateFixture("""
+            import GSharp.Core.Tests.CodeAnalysis.Binding
+
+            Issue3464RefConstructor(out var value)
+            """);
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0236");
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Id == "GS0130");
+    }
+
+    [Fact]
+    public void ImportedConstructor_OutVarOverloads_RemainAmbiguous()
+    {
+        var result = EvaluateFixture("""
+            import GSharp.Core.Tests.CodeAnalysis.Binding
+
+            Issue3464AmbiguousConstructor(out var value)
+            """);
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0160");
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Id == "GS0236");
+    }
+
+    [Fact]
+    public void SourceConstructor_OutDeclarationAtValuePosition_ReportsGs0236()
+    {
+        var result = Evaluate("""
+            class ValueCtor {
+                init(value int32) {
+                }
+            }
+
+            ValueCtor(out var value)
+            """);
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0236");
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Id == "GS0130");
+    }
+
+    [Fact]
+    public void SourceConstructor_OutVarOverloads_RemainAmbiguous()
+    {
+        var result = Evaluate("""
+            class AmbiguousCtor {
+                init(out value int32) {
+                    value = 0
+                }
+
+                init(out value string) {
+                    value = ""
+                }
+            }
+
+            AmbiguousCtor(out var value)
+            """);
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0266");
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Id == "GS0236");
+    }
+
+    private static EmittedOracleResult Evaluate(string source) => EmittedOracle.Evaluate(source);
+
+    private static EmittedOracleResult EvaluateFixture(string source) =>
+        EmittedOracle.Evaluate(source, new[] { typeof(Issue3464GenericConstructor<>).Assembly.Location });
+}
+
+public sealed class Issue3464GenericConstructor<T>
+{
+    public Issue3464GenericConstructor(out T value)
+    {
+        value = (T)(object)42;
+        Value = value;
+    }
+
+    public T Value { get; }
+}
+
+public sealed class Issue3464RefConstructor
+{
+    public Issue3464RefConstructor(ref int value)
+    {
+    }
+}
+
+public sealed class Issue3464Outer
+{
+    public sealed class Nested
+    {
+        public Nested(out int value)
+        {
+            value = 42;
+            Value = value;
+        }
+
+        public int Value { get; }
+    }
+}
+
+public sealed class Issue3464AmbiguousConstructor
+{
+    public Issue3464AmbiguousConstructor(out int value)
+    {
+        value = 0;
+    }
+
+    public Issue3464AmbiguousConstructor(out string value)
+    {
+        value = string.Empty;
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3464ConstructorInlineOutTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3464ConstructorInlineOutTests.cs
@@ -574,6 +574,32 @@ public sealed class Issue3464ConstructorInlineOutTests
     }
 
     [Fact]
+    public void SourceConstructor_TypedFilterFailure_DeclaresSiblingInferredOutLocal()
+    {
+        var result = Evaluate("""
+            class TypedSiblingFailureCtor {
+                init(out first int32, out second int32) {
+                    first = 0
+                    second = 0
+                }
+
+                init(out first int32, out second string) {
+                    first = 0
+                    second = ""
+                }
+            }
+
+            TypedSiblingFailureCtor(out var first, out var second bool)
+            first
+            """);
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0267");
+        Assert.DoesNotContain(
+            result.Diagnostics,
+            diagnostic => diagnostic.Id is "GS0102" or "GS0125");
+    }
+
+    [Fact]
     public void SourceConstructor_MissingRequiredAfterOutVar_DeclaresLocal()
     {
         var result = Evaluate("""

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3464ConstructorInlineOutTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3464ConstructorInlineOutTests.cs
@@ -391,6 +391,130 @@ public sealed class Issue3464ConstructorInlineOutTests
         Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Id == "GS0236");
     }
 
+    [Fact]
+    public void SourceConstructor_MissingRequiredAfterOutVar_DeclaresLocal()
+    {
+        var result = Evaluate("""
+            class MissingRequiredCtor {
+                init(out value int32, other int32) {
+                    value = other
+                }
+            }
+
+            MissingRequiredCtor(out var value)
+            value + 1
+            """);
+
+        AssertPrimaryWithoutUndefined(result, "GS0144");
+    }
+
+    [Fact]
+    public void SourceConstructor_TooManyArgumentsAfterOutLet_DeclaresLocal()
+    {
+        var result = Evaluate("""
+            class TooManyCtor {
+                init(out value int32) {
+                    value = 0
+                }
+            }
+
+            TooManyCtor(out let value, 1)
+            value + 1
+            """);
+
+        AssertPrimaryWithoutUndefined(result, "GS0144");
+    }
+
+    [Fact]
+    public void SourceConstructor_InvalidNamedOrderAfterTypedOut_DeclaresLocal()
+    {
+        var result = Evaluate("""
+            class NamedOrderCtor {
+                init(other int32, out value int32) {
+                    value = other
+                }
+            }
+
+            NamedOrderCtor(value: out var value int32, 1)
+            value + 1
+            """);
+
+        AssertPrimaryWithoutUndefined(result, "GS0244");
+    }
+
+    [Fact]
+    public void SourceConstructor_DuplicateNamedArgumentWithOutVar_DeclaresErrorLocal()
+    {
+        var result = Evaluate("""
+            class DuplicateNamedCtor {
+                init(out value int32, other int32 = 0) {
+                    value = other
+                }
+            }
+
+            DuplicateNamedCtor(value: out var value, value: 1)
+            value
+            """);
+
+        AssertPrimaryWithoutUndefined(result, "GS0245");
+    }
+
+    [Fact]
+    public void SourceConstructor_UnknownNamedArgumentAfterOutVar_DeclaresLocal()
+    {
+        var result = Evaluate("""
+            class UnknownNamedCtor {
+                init(out value int32, other int32 = 0) {
+                    value = other
+                }
+            }
+
+            UnknownNamedCtor(value: out var value, missing: 1)
+            value
+            """);
+
+        AssertPrimaryWithoutUndefined(result, "GS0246");
+    }
+
+    [Fact]
+    public void SourceConstructor_VariadicMismatchAfterOutDiscard_PreservesPrimaryDiagnostic()
+    {
+        var result = Evaluate("""
+            class VariadicMismatchCtor {
+                init(out value int32, rest ...int32) {
+                    value = 0
+                }
+            }
+
+            VariadicMismatchCtor(out _, "bad")
+            """);
+
+        AssertPrimaryWithoutUndefined(result, "GS0154");
+    }
+
+    [Fact]
+    public void SourceConstructor_ConversionFailureAfterOutVar_DeclaresLocal()
+    {
+        var result = Evaluate("""
+            class ConversionFailureCtor {
+                init(out value int32, other int32) {
+                    value = other
+                }
+            }
+
+            ConversionFailureCtor(out var value, "bad")
+            value + 1
+            """);
+
+        AssertPrimaryWithoutUndefined(result, "GS0154");
+    }
+
+    private static void AssertPrimaryWithoutUndefined(EmittedOracleResult result, string primaryId)
+    {
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == primaryId);
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Id is "GS0125" or "GS0236");
+    }
+
     private static EmittedOracleResult Evaluate(string source) => EmittedOracle.Evaluate(source);
 
     private static EmittedOracleResult EvaluateFixture(string source) =>

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3464ConstructorInlineOutTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3464ConstructorInlineOutTests.cs
@@ -104,6 +104,93 @@ public sealed class Issue3464ConstructorInlineOutTests
     }
 
     [Fact]
+    public void SourceGenericConstructor_WrongTypeArgumentArity_DeclaresOutLocal()
+    {
+        var result = Evaluate("""
+            class WrongArityGenericOutBox[T] {
+                init(seed int32, out flag bool) {
+                    flag = seed > 0
+                }
+            }
+
+            WrongArityGenericOutBox[int32, int32](5, out var flag)
+            flag
+            """);
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0148");
+        Assert.DoesNotContain(
+            result.Diagnostics,
+            diagnostic => diagnostic.Id is "GS0102" or "GS0125");
+    }
+
+    [Fact]
+    public void SourceGenericConstructor_UnknownTypeArgument_DeclaresOutLocal()
+    {
+        var result = Evaluate("""
+            class UnknownTypeGenericOutBox[T] {
+                init(seed int32, out flag bool) {
+                    flag = seed > 0
+                }
+            }
+
+            UnknownTypeGenericOutBox[MissingIssue3464Type](5, out var flag)
+            flag
+            """);
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0113");
+        Assert.DoesNotContain(
+            result.Diagnostics,
+            diagnostic => diagnostic.Id is "GS0102" or "GS0125");
+    }
+
+    [Fact]
+    public void SourceGenericConstructor_UninferableOutDeclarations_DoNotDuplicateLocals()
+    {
+        var result = Evaluate("""
+            class UninferableVarGenericOutBox[T] {
+                init(out value T) { }
+            }
+
+            class UninferableLetGenericOutBox[T] {
+                init(out value T) { }
+            }
+
+            class UninferableDiscardGenericOutBox[T] {
+                init(out value T) { }
+            }
+
+            UninferableVarGenericOutBox(out var varValue)
+            varValue
+            UninferableLetGenericOutBox(out let letValue)
+            letValue
+            UninferableDiscardGenericOutBox(out _)
+            """);
+
+        Assert.Equal(3, result.Diagnostics.Count(diagnostic => diagnostic.Id == "GS0151"));
+        Assert.DoesNotContain(
+            result.Diagnostics,
+            diagnostic => diagnostic.Id is "GS0102" or "GS0125");
+    }
+
+    [Fact]
+    public void SourceGenericConstructor_ConcreteOutVar_BindsAndRuns()
+    {
+        var result = Evaluate("""
+            class ConcreteGenericOutBox[T] {
+                init(seed T, out value T) {
+                    value = seed
+                }
+            }
+
+            ConcreteGenericOutBox[int32](42, out var value)
+            value
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
     public void SourceConstructor_ReorderedNamedOutVar_IsVisibleAndAssigned()
     {
         var result = Evaluate("""

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3464ConstructorInlineOutTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3464ConstructorInlineOutTests.cs
@@ -282,6 +282,155 @@ public sealed class Issue3464ConstructorInlineOutTests
     }
 
     [Fact]
+    public void SourceGenericVariadicConstructor_LeadingOutVar_InfersFromPackedTail()
+    {
+        var result = Evaluate("""
+            class LeadingOutVariadicBox[T] {
+                init(out value T, items ...T) {
+                    value = items[0]
+                }
+            }
+
+            LeadingOutVariadicBox(out var value, 42)
+            value
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void SourceGenericVariadicConstructor_InfersFromMultiplePackedTailArguments()
+    {
+        var result = Evaluate("""
+            class MultiTailVariadicBox[T] {
+                init(out value T, items ...T) {
+                    value = items[2]
+                }
+            }
+
+            MultiTailVariadicBox(out var value, 40, 41, 42)
+            value
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void SourceGenericVariadicConstructor_InfersFromPassThroughSlice()
+    {
+        var result = Evaluate("""
+            class SliceTailVariadicBox[T] {
+                init(out value T, items ...T) {
+                    value = items[0]
+                }
+            }
+
+            let items = []int32{42}
+            SliceTailVariadicBox(out var value, items)
+            value
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void SourceGenericVariadicConstructor_TrailingOut_UsesFixedArgumentEvidence()
+    {
+        var result = Evaluate("""
+            class TrailingOutVariadicBox[T] {
+                init(seed T, out value T, items ...T) {
+                    value = seed
+                }
+            }
+
+            TrailingOutVariadicBox(42, out let value)
+            value
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void SourceGenericVariadicConstructor_MultipleTypeParameters_InferFixedAndTail()
+    {
+        var result = Evaluate("""
+            class MultipleTypeVariadicBox[T, U] {
+                init(out value T, marker U, items ...T) {
+                    value = items[0]
+                }
+            }
+
+            MultipleTypeVariadicBox(out var value, "marker", 42)
+            value
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void SourceGenericVariadicConstructor_ExplicitTypedOut_AllowsZeroTail()
+    {
+        var result = Evaluate("""
+            class TypedOutVariadicBox[T] {
+                init(out value T, items ...T) {
+                    value = default(T)
+                }
+            }
+
+            TypedOutVariadicBox(out var value int32)
+            value
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(0, result.Value);
+    }
+
+    [Fact]
+    public void SourceGenericVariadicConstructor_ZeroTailWithoutEvidence_ReportsInference()
+    {
+        var result = Evaluate("""
+            class NoEvidenceVariadicBox[T] {
+                init(out value T, items ...T) {
+                    value = default(T)
+                }
+            }
+
+            NoEvidenceVariadicBox(out var value)
+            value
+            """);
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0151");
+        Assert.DoesNotContain(
+            result.Diagnostics,
+            diagnostic => diagnostic.Id is "GS0102" or "GS0125");
+    }
+
+    [Fact]
+    public void SourceGenericVariadicConstructor_MixedNamedArguments_PreservePrimaryDiagnostic()
+    {
+        var result = Evaluate("""
+            class NamedVariadicInferenceBox[T] {
+                init(out value T, marker int32, items ...T) {
+                    value = items[0]
+                }
+            }
+
+            NamedVariadicInferenceBox(value: out var value, 0, 42)
+            value
+            """);
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0246");
+        Assert.DoesNotContain(
+            result.Diagnostics,
+            diagnostic => diagnostic.Id is "GS0102" or "GS0125" or "GS0151");
+    }
+
+    [Fact]
     public void SourceConstructor_ReorderedNamedOutVar_IsVisibleAndAssigned()
     {
         var result = Evaluate("""

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3464ConstructorInlineOutTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3464ConstructorInlineOutTests.cs
@@ -378,6 +378,194 @@ public sealed class Issue3464ConstructorInlineOutTests
     }
 
     [Fact]
+    public void SourceGenericConstructor_InferenceIgnoresInaccessibleCandidate()
+    {
+        var result = Evaluate("""
+            class AccessibilityInferenceChoice[T] {
+                init(value T, marker string) {
+                }
+
+                private init(value int32, marker T) {
+                }
+            }
+
+            AccessibilityInferenceChoice(42, "x")
+            42
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void SourceGenericConstructor_ReversedInferenceIgnoresInaccessibleCandidate()
+    {
+        var result = Evaluate("""
+            class ReversedAccessibilityInferenceChoice[T] {
+                private init(value int32, marker T) {
+                }
+
+                init(value T, marker string) {
+                }
+            }
+
+            ReversedAccessibilityInferenceChoice(42, "x")
+            42
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void SourceGenericConstructor_NamedInferenceIgnoresInaccessibleCandidate()
+    {
+        var result = Evaluate("""
+            class NamedAccessibilityInferenceChoice[T] {
+                init(value T, marker string) {
+                }
+
+                private init(value int32, marker T) {
+                }
+            }
+
+            NamedAccessibilityInferenceChoice(marker: "x", value: 42)
+            42
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void SourceGenericConstructor_InlineOutInferenceIgnoresInaccessibleCandidate()
+    {
+        var result = Evaluate("""
+            class InlineOutAccessibilityInferenceChoice[T] {
+                init(out value T, seed T, marker string) {
+                    value = seed
+                }
+
+                private init(out value int32, seed int32, marker T) {
+                    value = seed
+                }
+            }
+
+            InlineOutAccessibilityInferenceChoice(out var value, 42, "x")
+            value
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void SourceGenericConstructor_AllInaccessibleReportsAccessibility()
+    {
+        var result = Evaluate("""
+            class InaccessibleGenericConstructor[T] {
+                private init(value T) {
+                }
+            }
+
+            InaccessibleGenericConstructor(42)
+            """);
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0472");
+    }
+
+    [Fact]
+    public void SourceGenericConstructor_OptionalOmittedReportsActualUnresolvedTypeParameter()
+    {
+        var result = Evaluate("""
+            class OptionalPartialInference[T,U] {
+                init(value T, marker string = "x") {
+                }
+            }
+
+            OptionalPartialInference(42)
+            """);
+
+        AssertUnresolvedTypeParameter(result, "U");
+    }
+
+    [Fact]
+    public void SourceGenericConstructor_OptionalSuppliedReportsActualUnresolvedTypeParameter()
+    {
+        var result = Evaluate("""
+            class SuppliedOptionalPartialInference[T,U] {
+                init(value T, marker string = "x") {
+                }
+            }
+
+            SuppliedOptionalPartialInference(42, "y")
+            """);
+
+        AssertUnresolvedTypeParameter(result, "U");
+    }
+
+    [Fact]
+    public void SourceGenericConstructor_NamedOptionalReportsActualUnresolvedTypeParameter()
+    {
+        var result = Evaluate("""
+            class NamedOptionalPartialInference[T,U] {
+                init(value T, marker string = "x") {
+                }
+            }
+
+            NamedOptionalPartialInference(value: 42)
+            """);
+
+        AssertUnresolvedTypeParameter(result, "U");
+    }
+
+    [Fact]
+    public void SourceGenericConstructor_ZeroVariadicReportsActualUnresolvedTypeParameter()
+    {
+        var result = Evaluate("""
+            class ZeroVariadicPartialInference[T,U] {
+                init(value T, items ...string) {
+                }
+            }
+
+            ZeroVariadicPartialInference(42)
+            """);
+
+        AssertUnresolvedTypeParameter(result, "U");
+    }
+
+    [Fact]
+    public void SourceGenericConstructor_MultipleVariadicReportsActualUnresolvedTypeParameter()
+    {
+        var result = Evaluate("""
+            class MultipleVariadicPartialInference[T,U] {
+                init(value T, items ...string) {
+                }
+            }
+
+            MultipleVariadicPartialInference(42, "x", "y")
+            """);
+
+        AssertUnresolvedTypeParameter(result, "U");
+    }
+
+    [Fact]
+    public void SourceGenericConstructor_PassThroughVariadicReportsActualUnresolvedTypeParameter()
+    {
+        var result = Evaluate("""
+            class PassThroughVariadicPartialInference[T,U] {
+                init(value T, items ...string) {
+                }
+            }
+
+            let items = []string{"x", "y"}
+            PassThroughVariadicPartialInference(42, items)
+            """);
+
+        AssertUnresolvedTypeParameter(result, "U");
+    }
+
+    [Fact]
     public void SourceGenericConstructor_UninferableOutDeclarations_DoNotDuplicateLocals()
     {
         var result = Evaluate("""
@@ -1772,6 +1960,15 @@ public sealed class Issue3464ConstructorInlineOutTests
         Assert.DoesNotContain(
             result.Diagnostics,
             diagnostic => diagnostic.Id is "GS0102" or "GS0125" or "GS0130");
+    }
+
+    private static void AssertUnresolvedTypeParameter(
+        EmittedOracleResult result,
+        string typeParameter)
+    {
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal("GS0151", diagnostic.Id);
+        Assert.Contains($"'{typeParameter}'", diagnostic.Message, StringComparison.Ordinal);
     }
 
     private static EmittedOracleResult Evaluate(string source) => EmittedOracle.Evaluate(source);

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3464ConstructorInlineOutTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3464ConstructorInlineOutTests.cs
@@ -695,6 +695,28 @@ public sealed class Issue3464ConstructorInlineOutTests
     }
 
     [Fact]
+    public void SourceGenericConstructor_PositionalExplicitTypedOutFiltersMultipleTypeParameters()
+    {
+        var result = Evaluate("""
+            class PositionalTypedGenericChoice[T,U] {
+                init(out value int32, first T, second U) {
+                    value = 42
+                }
+
+                init(out value string, first T, second U) {
+                    value = ""
+                }
+            }
+
+            PositionalTypedGenericChoice(out var value int32, 2, "x")
+            value
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
     public void SourceGenericConstructor_IncompatibleExplicitTypedOutReportsNoApplicable()
     {
         var result = Evaluate("""
@@ -716,6 +738,38 @@ public sealed class Issue3464ConstructorInlineOutTests
         Assert.DoesNotContain(
             result.Diagnostics,
             diagnostic => diagnostic.Id is "GS0102" or "GS0125");
+    }
+
+    [Fact]
+    public void SourceConstructor_UnknownExplicitOutTypeReportsOnceAndDeclaresLocal()
+    {
+        var result = Evaluate("""
+            class UnknownExplicitOutTypeChoice {
+                init(out value int32) {
+                    value = 0
+                }
+            }
+
+            UnknownExplicitOutTypeChoice(out var value NoSuchIssue3464SourceType)
+            value
+            """);
+
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal("GS0113", diagnostic.Id);
+    }
+
+    [Fact]
+    public void ImportedConstructor_UnknownExplicitOutTypeReportsOnceAndDeclaresLocal()
+    {
+        var result = Evaluate("""
+            import System.Threading
+
+            Mutex(false, nil, out var value NoSuchIssue3464ImportedType)
+            value
+            """);
+
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal("GS0113", diagnostic.Id);
     }
 
     [Fact]

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3464ConstructorInlineOutTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3464ConstructorInlineOutTests.cs
@@ -431,6 +431,105 @@ public sealed class Issue3464ConstructorInlineOutTests
     }
 
     [Fact]
+    public void SourceGenericConstructor_InvalidOutPositions_ReportGs0236BeforeInference()
+    {
+        var result = Evaluate("""
+            class GenericValuePosition[T] {
+                init(value T) { }
+            }
+
+            class GenericTypedValuePosition[T] {
+                init(value T) { }
+            }
+
+            class GenericRefPosition[T] {
+                init(ref value T) { }
+            }
+
+            class GenericInPosition[T] {
+                init(in value T) { }
+            }
+
+            GenericValuePosition(out var value)
+            value
+            GenericTypedValuePosition(out var typedValue int32)
+            typedValue
+            GenericRefPosition(out let refValue)
+            refValue
+            GenericInPosition(out var inValue)
+            inValue
+            """);
+
+        Assert.Equal(4, result.Diagnostics.Count(diagnostic => diagnostic.Id == "GS0236"));
+        Assert.DoesNotContain(
+            result.Diagnostics,
+            diagnostic => diagnostic.Id is "GS0102" or "GS0125" or "GS0151");
+    }
+
+    [Fact]
+    public void SourceGenericConstructor_NamedInvalidOut_ReportsActualOffender()
+    {
+        var result = Evaluate("""
+            class NamedInvalidGenericOut[T] {
+                init(seed T, value T) { }
+            }
+
+            NamedInvalidGenericOut(value: out var invalid, seed: 42)
+            invalid
+            """);
+
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal("GS0236", diagnostic.Id);
+        Assert.Equal(
+            "out var invalid",
+            diagnostic.Location.Text.ToString(diagnostic.Location.Span));
+    }
+
+    [Fact]
+    public void SourceGenericConstructor_OpenOverloads_UseValidOutLayoutForInference()
+    {
+        var result = Evaluate("""
+            class GenericOpenOutChoice[T] {
+                init(value T, marker int32) { }
+
+                init(out value T, seed T) {
+                    value = seed
+                }
+            }
+
+            GenericOpenOutChoice(out var value, 42)
+            value
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void SourceGenericConstructor_ValidOutLayouts_RemainAmbiguous()
+    {
+        var result = Evaluate("""
+            class AmbiguousGenericOutChoice[T] {
+                init(out value T) {
+                    value = default(T)
+                }
+
+                init(out value int32) {
+                    value = 0
+                }
+            }
+
+            AmbiguousGenericOutChoice[int32](out var value)
+            value
+            """);
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0266");
+        Assert.DoesNotContain(
+            result.Diagnostics,
+            diagnostic => diagnostic.Id is "GS0125" or "GS0236");
+    }
+
+    [Fact]
     public void SourceConstructor_ReorderedNamedOutVar_IsVisibleAndAssigned()
     {
         var result = Evaluate("""

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3464ConstructorInlineOutTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3464ConstructorInlineOutTests.cs
@@ -208,6 +208,26 @@ public sealed class Issue3464ConstructorInlineOutTests
     }
 
     [Fact]
+    public void SourceGenericConstructor_PartialInferenceFailure_DeclaresExplicitTypedOutLocal()
+    {
+        var result = Evaluate("""
+            class PhantomBox[T, U] {
+                init(out value T) {
+                    value = default(T)
+                }
+            }
+
+            PhantomBox(out var made int32)
+            made
+            """);
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0151");
+        Assert.DoesNotContain(
+            result.Diagnostics,
+            diagnostic => diagnostic.Id is "GS0102" or "GS0125");
+    }
+
+    [Fact]
     public void SourceGenericConstructor_ConcreteOutVar_BindsAndRuns()
     {
         var result = Evaluate("""

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3464ConstructorInlineOutTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3464ConstructorInlineOutTests.cs
@@ -310,6 +310,22 @@ public sealed class Issue3464ConstructorInlineOutTests
     }
 
     [Fact]
+    public void ImportedConstructor_ExplicitTypedOutAmbiguity_DoesNotRedeclareLocal()
+    {
+        var result = EvaluateFixture("""
+            import GSharp.Core.Tests.CodeAnalysis.Binding
+
+            Issue3464AmbiguousTypedConstructor(out var value int32)
+            value
+            """);
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0160");
+        Assert.DoesNotContain(
+            result.Diagnostics,
+            diagnostic => diagnostic.Id is "GS0102" or "GS0125");
+    }
+
+    [Fact]
     public void ImportedConstructor_DuplicateNamedOutVar_DeclaresErrorLocal()
     {
         var result = EvaluateFixture("""
@@ -483,10 +499,78 @@ public sealed class Issue3464ConstructorInlineOutTests
             }
 
             AmbiguousCtor(out var value)
+            value
             """);
 
         Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0266");
-        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Id == "GS0236");
+        Assert.DoesNotContain(
+            result.Diagnostics,
+            diagnostic => diagnostic.Id is "GS0125" or "GS0236");
+    }
+
+    [Fact]
+    public void SourceConstructor_OutLetAmbiguity_DeclaresErrorLocal()
+    {
+        var result = Evaluate("""
+            class AmbiguousLetCtor {
+                init(out value int32) {
+                    value = 0
+                }
+
+                init(out value string) {
+                    value = ""
+                }
+            }
+
+            AmbiguousLetCtor(out let value)
+            value
+            """);
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0266");
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Id == "GS0125");
+    }
+
+    [Fact]
+    public void SourceConstructor_OutDiscardAmbiguity_PreservesPrimaryDiagnostic()
+    {
+        var result = Evaluate("""
+            class AmbiguousDiscardCtor {
+                init(out value int32) {
+                    value = 0
+                }
+
+                init(out value string) {
+                    value = ""
+                }
+            }
+
+            AmbiguousDiscardCtor(out _)
+            """);
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0266");
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Id == "GS0125");
+    }
+
+    [Fact]
+    public void SourceConstructor_NoApplicableOutVar_DeclaresErrorLocal()
+    {
+        var result = Evaluate("""
+            class NoApplicableOutCtor {
+                init(out value int32, first int32, second int32) {
+                    value = first + second
+                }
+
+                init(out value string, first string, second string, third string) {
+                    value = first + second + third
+                }
+            }
+
+            NoApplicableOutCtor(out var value, 1)
+            value
+            """);
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0267");
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Id == "GS0125");
     }
 
     [Fact]
@@ -671,6 +755,19 @@ public sealed class Issue3464AmbiguousConstructor
     public Issue3464AmbiguousConstructor(out string value)
     {
         value = string.Empty;
+    }
+}
+
+public sealed class Issue3464AmbiguousTypedConstructor
+{
+    public Issue3464AmbiguousTypedConstructor(out int value, string tag = null)
+    {
+        value = tag?.Length ?? 0;
+    }
+
+    public Issue3464AmbiguousTypedConstructor(out int value, Uri tag = null)
+    {
+        value = tag == null ? 0 : 1;
     }
 }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3464ConstructorInlineOutTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3464ConstructorInlineOutTests.cs
@@ -125,6 +125,154 @@ public sealed class Issue3464ConstructorInlineOutTests
     }
 
     [Fact]
+    public void SourceConstructor_OutVar_SelectsOutOverRefAndIn()
+    {
+        var result = Evaluate("""
+            class RefKindChoice {
+                var Tag int32
+
+                init(out value int32) {
+                    value = 41
+                    Tag = 1
+                }
+
+                init(ref value string) {
+                    Tag = 2
+                }
+
+                init(in value bool) {
+                    Tag = 3
+                }
+            }
+
+            let choice = RefKindChoice(out var value)
+            value + choice.Tag
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void SourceConstructor_ReorderedAndMixedNamedOutVar_SelectOutOverRefAndIn()
+    {
+        var result = Evaluate("""
+            class NamedRefKindChoice {
+                var Tag int32
+
+                init(prefix int32, out value int32) {
+                    value = prefix + 1
+                    Tag = 1
+                }
+
+                init(prefix int32, ref value string) {
+                    Tag = 2
+                }
+
+                init(prefix int32, in value bool) {
+                    Tag = 3
+                }
+            }
+
+            let reordered = NamedRefKindChoice(value: out var first, prefix: 40)
+            let mixed = NamedRefKindChoice(prefix: 20, out var second)
+            first + second + reordered.Tag + mixed.Tag
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(64, result.Value);
+    }
+
+    [Fact]
+    public void SourceConstructor_OutLetAndDiscard_SelectOutOverRefAndIn()
+    {
+        var result = Evaluate("""
+            class LetDiscardRefKindChoice {
+                var Tag int32
+
+                init(out value int32) {
+                    value = 20
+                    Tag = 1
+                }
+
+                init(ref value string) {
+                    Tag = 2
+                }
+
+                init(in value bool) {
+                    Tag = 3
+                }
+            }
+
+            let kept = LetDiscardRefKindChoice(out let value)
+            let discarded = LetDiscardRefKindChoice(out _)
+            value + kept.Tag + discarded.Tag
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(22, result.Value);
+    }
+
+    [Fact]
+    public void SourceConstructor_ExplicitTypedOut_SelectsMatchingOutOverRef()
+    {
+        var result = Evaluate("""
+            class TypedRefKindChoice {
+                var Tag int32
+
+                init(out value int32) {
+                    value = 40
+                    Tag = 2
+                }
+
+                init(out value string) {
+                    value = ""
+                    Tag = 3
+                }
+
+                init(ref value bool) {
+                    Tag = 4
+                }
+            }
+
+            let choice = TypedRefKindChoice(out var value int32)
+            value + choice.Tag
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void SourceConstructor_OrdinaryRefAndInCallsStillBind()
+    {
+        var result = Evaluate("""
+            class RefOnly {
+                init(ref value string) {
+                    value = value + "!"
+                }
+            }
+
+            class InOnly {
+                var Value bool
+
+                init(in value bool) {
+                    Value = value
+                }
+            }
+
+            var text = "ok"
+            RefOnly(&text)
+            let flag = true
+            let captured = InOnly(in flag)
+            text.Length + (captured.Value ? 1 : 0)
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(4, result.Value);
+    }
+
+    [Fact]
     public void ImportedConstructor_OutDeclarationAtValuePosition_ReportsOnlyGs0236()
     {
         var result = Evaluate("""
@@ -145,8 +293,7 @@ public sealed class Issue3464ConstructorInlineOutTests
             Issue3464RefConstructor(out var value)
             """);
 
-        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0236");
-        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Id == "GS0130");
+        Assert.Equal("GS0236", Assert.Single(result.Diagnostics).Id);
     }
 
     [Fact]
@@ -179,6 +326,45 @@ public sealed class Issue3464ConstructorInlineOutTests
     }
 
     [Fact]
+    public void SourceConstructor_NoOutOverload_ReportsOnlyGs0236AndDeclaresErrorLocal()
+    {
+        var result = Evaluate("""
+            class NoOutChoice {
+                init(value int32) {
+                }
+
+                init(ref value string) {
+                }
+
+                init(in value bool) {
+                }
+            }
+
+            NoOutChoice(out var value)
+            value
+            """);
+
+        Assert.Equal("GS0236", Assert.Single(result.Diagnostics).Id);
+    }
+
+    [Fact]
+    public void SourceConstructor_NamedInlineOutMappedToRef_ReportsOnlyGs0236()
+    {
+        var result = Evaluate("""
+            class NamedNoOutChoice {
+                init(out result int32, ref other string) {
+                    result = 0
+                }
+            }
+
+            NamedNoOutChoice(other: out var value, result: out _)
+            value
+            """);
+
+        Assert.Equal("GS0236", Assert.Single(result.Diagnostics).Id);
+    }
+
+    [Fact]
     public void SourceConstructor_OutVarOverloads_RemainAmbiguous()
     {
         var result = Evaluate("""
@@ -189,6 +375,12 @@ public sealed class Issue3464ConstructorInlineOutTests
 
                 init(out value string) {
                     value = ""
+                }
+
+                init(ref value bool) {
+                }
+
+                init(in value int64) {
                 }
             }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3464ConstructorInlineOutTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3464ConstructorInlineOutTests.cs
@@ -191,6 +191,97 @@ public sealed class Issue3464ConstructorInlineOutTests
     }
 
     [Fact]
+    public void SourceGenericConstructor_LeadingOutVar_InfersFromLaterArgument()
+    {
+        var result = Evaluate("""
+            class LeadingOutGenericBox[T] {
+                init(out value T, seed T) {
+                    value = seed
+                }
+            }
+
+            LeadingOutGenericBox(out var value, 42)
+            value
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void SourceGenericConstructor_TrailingOutLet_InfersFromEarlierArgument()
+    {
+        var result = Evaluate("""
+            class TrailingOutGenericBox[T] {
+                init(seed T, out value T) {
+                    value = seed
+                }
+            }
+
+            TrailingOutGenericBox(42, out let value)
+            value
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void SourceGenericConstructor_ReorderedNamedOutVar_InfersFromNamedArgument()
+    {
+        var result = Evaluate("""
+            class NamedOutGenericBox[T] {
+                init(out value T, seed T) {
+                    value = seed
+                }
+            }
+
+            NamedOutGenericBox(seed: 42, value: out var value)
+            value
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void SourceGenericConstructor_MultipleLeadingOuts_InferEachTypeParameter()
+    {
+        var result = Evaluate("""
+            class MultipleOutGenericBox[T, U] {
+                init(out first T, out second U, seed T, other U) {
+                    first = seed
+                    second = other
+                }
+            }
+
+            MultipleOutGenericBox(out var first, out let second, 40, 2)
+            first + second
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void SourceGenericConstructor_ExplicitTypedOut_IsInferenceEvidence()
+    {
+        var result = Evaluate("""
+            class TypedOutGenericBox[T] {
+                init(out value T) {
+                    value = default(T)
+                }
+            }
+
+            TypedOutGenericBox(out var value int32)
+            value
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(0, result.Value);
+    }
+
+    [Fact]
     public void SourceConstructor_ReorderedNamedOutVar_IsVisibleAndAssigned()
     {
         var result = Evaluate("""

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3464ConstructorInlineOutTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3464ConstructorInlineOutTests.cs
@@ -310,6 +310,84 @@ public sealed class Issue3464ConstructorInlineOutTests
     }
 
     [Fact]
+    public void ImportedConstructor_DuplicateNamedOutVar_DeclaresErrorLocal()
+    {
+        var result = EvaluateFixture("""
+            import GSharp.Core.Tests.CodeAnalysis.Binding
+
+            Issue3464FailureConstructor(value: out var value, value: 1)
+            value
+            """);
+
+        AssertImportedPrimaryWithoutCascades(result, "GS0245");
+    }
+
+    [Fact]
+    public void ImportedConstructor_OutVarAtNonOutPosition_DeclaresErrorLocal()
+    {
+        var result = EvaluateFixture("""
+            import GSharp.Core.Tests.CodeAnalysis.Binding
+
+            Issue3464FailureConstructor(out var value, 1)
+            value
+            """);
+
+        AssertImportedPrimaryWithoutCascades(result, "GS0236");
+    }
+
+    [Fact]
+    public void ImportedConstructor_ConversionFailure_DeclaresTypedOutLocal()
+    {
+        var result = EvaluateFixture("""
+            import GSharp.Core.Tests.CodeAnalysis.Binding
+
+            Issue3464FailureConstructor(1, out var value, "bad")
+            value + 1
+            """);
+
+        AssertImportedPrimaryWithoutCascades(result, "GS0130");
+    }
+
+    [Fact]
+    public void ImportedConstructor_MissingRequiredArgument_DeclaresTypedOutLocal()
+    {
+        var result = EvaluateFixture("""
+            import GSharp.Core.Tests.CodeAnalysis.Binding
+
+            Issue3464FailureConstructor(1, out var value)
+            value + 1
+            """);
+
+        AssertImportedPrimaryWithoutCascades(result, "GS0130");
+    }
+
+    [Fact]
+    public void ImportedConstructor_UnknownNamedArgument_DeclaresTypedOutLocal()
+    {
+        var result = EvaluateFixture("""
+            import GSharp.Core.Tests.CodeAnalysis.Binding
+
+            Issue3464FailureConstructor(1, value: out var value, missing: 2)
+            value + 1
+            """);
+
+        AssertImportedPrimaryWithoutCascades(result, "GS0246");
+    }
+
+    [Fact]
+    public void ImportedMutex_DuplicateNamedOutVar_DeclaresErrorLocal()
+    {
+        var result = Evaluate("""
+            import System.Threading
+
+            Mutex(false, createdNew: out var createdNew, createdNew: out _)
+            createdNew
+            """);
+
+        AssertImportedPrimaryWithoutCascades(result, "GS0245");
+    }
+
+    [Fact]
     public void SourceConstructor_OutDeclarationAtValuePosition_ReportsGs0236()
     {
         var result = Evaluate("""
@@ -362,6 +440,26 @@ public sealed class Issue3464ConstructorInlineOutTests
             """);
 
         Assert.Equal("GS0236", Assert.Single(result.Diagnostics).Id);
+    }
+
+    [Fact]
+    public void SourceConstructor_Gs0236PointsToActualInvalidInlineOutArgument()
+    {
+        var result = Evaluate("""
+            class LocatedNoOutChoice {
+                init(out result int32, ref other string) {
+                    result = 0
+                }
+            }
+
+            LocatedNoOutChoice(result: out _, other: out var invalid)
+            """);
+
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal("GS0236", diagnostic.Id);
+        Assert.Equal(
+            "out var invalid",
+            diagnostic.Location.Text.ToString(diagnostic.Location.Span));
     }
 
     [Fact]
@@ -515,6 +613,16 @@ public sealed class Issue3464ConstructorInlineOutTests
         Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Id is "GS0125" or "GS0236");
     }
 
+    private static void AssertImportedPrimaryWithoutCascades(
+        EmittedOracleResult result,
+        string primaryId)
+    {
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == primaryId);
+        Assert.DoesNotContain(
+            result.Diagnostics,
+            diagnostic => diagnostic.Id is "GS0125" or "GS0159" or "GS0285");
+    }
+
     private static EmittedOracleResult Evaluate(string source) => EmittedOracle.Evaluate(source);
 
     private static EmittedOracleResult EvaluateFixture(string source) =>
@@ -563,5 +671,13 @@ public sealed class Issue3464AmbiguousConstructor
     public Issue3464AmbiguousConstructor(out string value)
     {
         value = string.Empty;
+    }
+}
+
+public sealed class Issue3464FailureConstructor
+{
+    public Issue3464FailureConstructor(int prefix, out int value, int required)
+    {
+        value = prefix + required;
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3464ConstructorInlineOutTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3464ConstructorInlineOutTests.cs
@@ -153,6 +153,48 @@ public sealed class Issue3464ConstructorInlineOutTests
     }
 
     [Fact]
+    public void ImportedConstructor_ErrorArgumentConsumesConstructorFailureOnce()
+    {
+        var result = EvaluateFixture("""
+            import GSharp.Core.Tests.CodeAnalysis.Binding
+
+            Issue3464FailureConstructor(missing, out var value int32, 1)
+            value
+            """);
+
+        Assert.Equal(1, result.Diagnostics.Count(diagnostic => diagnostic.Id == "GS0125"));
+        Assert.DoesNotContain(
+            result.Diagnostics,
+            diagnostic => diagnostic.Id is "GS0102" or "GS0130");
+    }
+
+    [Fact]
+    public void ImportedConstructor_ConversionFailureConsumesConstructorFailureOnce()
+    {
+        var result = EvaluateFixture("""
+            import GSharp.Core.Tests.CodeAnalysis.Binding
+
+            Issue3464FailureConstructor(1, out var value int32, "bad")
+            value
+            """);
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0154");
+        Assert.DoesNotContain(
+            result.Diagnostics,
+            diagnostic => diagnostic.Id is "GS0102" or "GS0125" or "GS0130");
+    }
+
+    [Fact]
+    public void NonexistentCallableStillReportsFunctionNotFound()
+    {
+        var result = Evaluate("""
+            DefinitelyMissingIssue3464Callable(1)
+            """);
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0130");
+    }
+
+    [Fact]
     public void ImportedGenericConstructor_InfersOutVarType()
     {
         var result = EvaluateFixture("""
@@ -253,6 +295,86 @@ public sealed class Issue3464ConstructorInlineOutTests
         var diagnostic = Assert.Single(result.Diagnostics);
         Assert.Equal("GS0151", diagnostic.Id);
         Assert.Contains("'U'", diagnostic.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SourceGenericConstructor_InferenceIgnoresInapplicablePartialCandidate()
+    {
+        var result = Evaluate("""
+            class ApplicablePartialInference[T,U] {
+                init(value T, marker string) {
+                }
+
+                init(value int32, marker U) {
+                }
+            }
+
+            ApplicablePartialInference(42, true)
+            """);
+
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal("GS0151", diagnostic.Id);
+        Assert.Contains("'T'", diagnostic.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SourceGenericConstructor_ReversedInferenceIgnoresInapplicablePartialCandidate()
+    {
+        var result = Evaluate("""
+            class ReversedApplicablePartialInference[T,U] {
+                init(value int32, marker U) {
+                }
+
+                init(value T, marker string) {
+                }
+            }
+
+            ReversedApplicablePartialInference(42, true)
+            """);
+
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal("GS0151", diagnostic.Id);
+        Assert.Contains("'T'", diagnostic.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SourceGenericConstructor_NamedInferenceIgnoresInapplicablePartialCandidate()
+    {
+        var result = Evaluate("""
+            class NamedApplicablePartialInference[T,U] {
+                init(value T, marker string) {
+                }
+
+                init(value int32, marker U) {
+                }
+            }
+
+            NamedApplicablePartialInference(marker: true, value: 42)
+            """);
+
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal("GS0151", diagnostic.Id);
+        Assert.Contains("'T'", diagnostic.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SourceGenericConstructor_ExplicitArgumentsBypassPartialInference()
+    {
+        var result = Evaluate("""
+            class ExplicitApplicablePartialInference[T,U] {
+                init(value T, marker string) {
+                }
+
+                init(value int32, marker U) {
+                }
+            }
+
+            ExplicitApplicablePartialInference[int32,bool](42, true)
+            42
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
     }
 
     [Fact]
@@ -917,6 +1039,28 @@ public sealed class Issue3464ConstructorInlineOutTests
     }
 
     [Fact]
+    public void SourceConstructor_UnknownExplicitOutTypeStopsOverloadSelection()
+    {
+        var result = Evaluate("""
+            class UnknownExplicitOutOverloadChoice {
+                init(out value int32) {
+                    value = 0
+                }
+
+                init(out value string) {
+                    value = ""
+                }
+            }
+
+            UnknownExplicitOutOverloadChoice(out var value MissingIssue3464OutType)
+            value
+            """);
+
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal("GS0113", diagnostic.Id);
+    }
+
+    [Fact]
     public void ImportedConstructor_UnknownExplicitOutTypeReportsOnceAndDeclaresLocal()
     {
         var result = Evaluate("""
@@ -1250,7 +1394,7 @@ public sealed class Issue3464ConstructorInlineOutTests
             value + 1
             """);
 
-        AssertImportedPrimaryWithoutCascades(result, "GS0130");
+        AssertImportedPrimaryWithoutCascades(result, "GS0154");
     }
 
     [Fact]
@@ -1263,7 +1407,7 @@ public sealed class Issue3464ConstructorInlineOutTests
             value + 1
             """);
 
-        AssertImportedPrimaryWithoutCascades(result, "GS0130");
+        AssertImportedPrimaryWithoutCascades(result, "GS0267");
     }
 
     [Fact]

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3464ConstructorInlineOutTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3464ConstructorInlineOutTests.cs
@@ -475,6 +475,139 @@ public sealed class Issue3464ConstructorInlineOutTests
     }
 
     [Fact]
+    public void SourceGenericConstructor_InaccessibleOutDoesNotValidateLayout()
+    {
+        var result = Evaluate("""
+            class InaccessibleOutLayoutChoice[T] {
+                init(value T, marker T) {
+                }
+
+                private init(out value T, marker T) {
+                    value = marker
+                }
+            }
+
+            InaccessibleOutLayoutChoice(out var value, 42)
+            value
+            """);
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0236");
+        Assert.DoesNotContain(
+            result.Diagnostics,
+            diagnostic => diagnostic.Id is "GS0125" or "GS0151");
+    }
+
+    [Fact]
+    public void SourceGenericConstructor_ReversedInaccessibleOutDoesNotValidateLayout()
+    {
+        var result = Evaluate("""
+            class ReversedInaccessibleOutLayoutChoice[T] {
+                private init(out value T, marker T) {
+                    value = marker
+                }
+
+                init(value T, marker T) {
+                }
+            }
+
+            ReversedInaccessibleOutLayoutChoice(out var value, 42)
+            value
+            """);
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0236");
+        Assert.DoesNotContain(
+            result.Diagnostics,
+            diagnostic => diagnostic.Id is "GS0125" or "GS0151");
+    }
+
+    [Fact]
+    public void SourceGenericConstructor_NamedInaccessibleOutDoesNotValidateLayout()
+    {
+        var result = Evaluate("""
+            class NamedInaccessibleOutLayoutChoice[T] {
+                init(value T, marker T) {
+                }
+
+                private init(out value T, marker T) {
+                    value = marker
+                }
+            }
+
+            NamedInaccessibleOutLayoutChoice(marker: 42, value: out var value)
+            value
+            """);
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0236");
+        Assert.DoesNotContain(
+            result.Diagnostics,
+            diagnostic => diagnostic.Id is "GS0125" or "GS0151");
+    }
+
+    [Fact]
+    public void SourceGenericConstructor_ProtectedOutDoesNotValidateLayout()
+    {
+        var result = Evaluate("""
+            open class ProtectedOutLayoutChoice[T] {
+                init(value T, marker T) {
+                }
+
+                protected init(out value T, marker T) {
+                    value = marker
+                }
+            }
+
+            ProtectedOutLayoutChoice(out var value, 42)
+            value
+            """);
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0236");
+        Assert.DoesNotContain(
+            result.Diagnostics,
+            diagnostic => diagnostic.Id is "GS0125" or "GS0151");
+    }
+
+    [Fact]
+    public void SourceGenericConstructor_InternalOutRemainsAccessible()
+    {
+        var result = Evaluate("""
+            class InternalOutLayoutChoice[T] {
+                init(value T, marker T) {
+                }
+
+                internal init(out value T, marker T) {
+                    value = marker
+                }
+            }
+
+            InternalOutLayoutChoice(out var value, 42)
+            value
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void SourceGenericConstructor_AllPrivateOutPreservesAccessibilityDiagnostic()
+    {
+        var result = Evaluate("""
+            class AllPrivateOutLayoutChoice[T] {
+                private init(out value T, marker T) {
+                    value = marker
+                }
+            }
+
+            AllPrivateOutLayoutChoice(out var value, 42)
+            value
+            """);
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0472");
+        Assert.DoesNotContain(
+            result.Diagnostics,
+            diagnostic => diagnostic.Id is "GS0125" or "GS0151" or "GS0236");
+    }
+
+    [Fact]
     public void SourceGenericConstructor_OptionalOmittedReportsActualUnresolvedTypeParameter()
     {
         var result = Evaluate("""

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3464ConstructorInlineOutTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3464ConstructorInlineOutTests.cs
@@ -76,6 +76,41 @@ public sealed class Issue3464ConstructorInlineOutTests
     }
 
     [Fact]
+    public void ImportedMutex_InvalidExplicitTypedOut_DeclaresLocal()
+    {
+        var result = Evaluate("""
+            import System.Threading
+
+            Mutex(out var invalid bool, nil, out _)
+            invalid
+            """);
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0236");
+        Assert.DoesNotContain(
+            result.Diagnostics,
+            diagnostic => diagnostic.Id is "GS0102" or "GS0125");
+    }
+
+    [Fact]
+    public void ImportedMutex_NamedInvalidExplicitTypedOut_DeclaresLocal()
+    {
+        var result = Evaluate("""
+            import System.Threading
+
+            Mutex(
+                createdNew: out _,
+                name: nil,
+                initiallyOwned: out var invalid bool)
+            invalid
+            """);
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0236");
+        Assert.DoesNotContain(
+            result.Diagnostics,
+            diagnostic => diagnostic.Id is "GS0102" or "GS0125");
+    }
+
+    [Fact]
     public void ImportedGenericConstructor_InfersOutVarType()
     {
         var result = EvaluateFixture("""
@@ -527,6 +562,112 @@ public sealed class Issue3464ConstructorInlineOutTests
         Assert.DoesNotContain(
             result.Diagnostics,
             diagnostic => diagnostic.Id is "GS0125" or "GS0236");
+    }
+
+    [Fact]
+    public void SourceGenericConstructor_InferenceUsesApplicableOutLayoutCandidate()
+    {
+        var result = Evaluate("""
+            class CandidateSpecificGenericChoice[T] {
+                init(out value int32, seed string) {
+                    value = 0
+                }
+
+                init(out value T, seed T) {
+                    value = seed
+                }
+            }
+
+            CandidateSpecificGenericChoice(out var value, 42)
+            value
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void SourceGenericConstructor_NamedInferenceUsesApplicableOutLayoutCandidate()
+    {
+        var result = Evaluate("""
+            class NamedCandidateGenericChoice[T] {
+                init(out value int32, seed string) {
+                    value = 0
+                }
+
+                init(out value T, seed T) {
+                    value = seed
+                }
+            }
+
+            NamedCandidateGenericChoice(seed: 42, value: out var value)
+            value
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void SourceClosedGenericConstructor_RanksSubstitutedParameterTypes()
+    {
+        var result = Evaluate("""
+            class ClosedGenericChoice[T] {
+                init(out value T, seed T) {
+                    value = seed
+                }
+
+                init(out value int32, seed int64) {
+                    value = 0
+                }
+            }
+
+            ClosedGenericChoice[int32](out var value, 42)
+            value
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void SourceGenericConstructor_BadTypeArity_DeclaresExplicitTypedOutLocal()
+    {
+        var result = Evaluate("""
+            class ExplicitTypedRecoveryBox[T] {
+                init(out value T) {
+                    value = default(T)
+                }
+            }
+
+            ExplicitTypedRecoveryBox[int32, string](out var value int32)
+            value
+            """);
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0148");
+        Assert.DoesNotContain(
+            result.Diagnostics,
+            diagnostic => diagnostic.Id is "GS0102" or "GS0125");
+    }
+
+    [Fact]
+    public void SourceGenericConstructor_BadTypeArityNamedOut_DeclaresExplicitTypedLocal()
+    {
+        var result = Evaluate("""
+            class NamedExplicitTypedRecoveryBox[T] {
+                init(out value T) {
+                    value = default(T)
+                }
+            }
+
+            NamedExplicitTypedRecoveryBox[int32, string](value: out var value int32)
+            value
+            """);
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0148");
+        Assert.DoesNotContain(
+            result.Diagnostics,
+            diagnostic => diagnostic.Id is "GS0102" or "GS0125");
     }
 
     [Fact]

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3464ConstructorInlineOutTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3464ConstructorInlineOutTests.cs
@@ -179,6 +179,41 @@ public sealed class Issue3464ConstructorInlineOutTests
     }
 
     [Fact]
+    public void SourceGenericConstructor_UnknownExplicitOutTypeReportsOnceAndDeclaresLocal()
+    {
+        var result = Evaluate("""
+            class UnknownExplicitGenericOutType[T] {
+                init(out value T) {
+                    value = default(T)
+                }
+            }
+
+            UnknownExplicitGenericOutType(out var value NoSuchIssue3464GenericType)
+            value
+            """);
+
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal("GS0113", diagnostic.Id);
+    }
+
+    [Fact]
+    public void SourceGenericConstructor_InferenceReportsActualUnresolvedTypeParameter()
+    {
+        var result = Evaluate("""
+            class PartialGenericInference[T,U] {
+                init(value T) {
+                }
+            }
+
+            PartialGenericInference(42)
+            """);
+
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal("GS0151", diagnostic.Id);
+        Assert.Contains("'U'", diagnostic.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void SourceGenericConstructor_UninferableOutDeclarations_DoNotDuplicateLocals()
     {
         var result = Evaluate("""
@@ -738,6 +773,87 @@ public sealed class Issue3464ConstructorInlineOutTests
         Assert.DoesNotContain(
             result.Diagnostics,
             diagnostic => diagnostic.Id is "GS0102" or "GS0125");
+    }
+
+    [Fact]
+    public void SourceConstructor_SplitOutLayoutsReportNoApplicable()
+    {
+        var result = Evaluate("""
+            class SplitOutLayoutChoice {
+                init(out first int32, second int32) {
+                    first = second
+                }
+
+                init(first int32, out second int32) {
+                    second = first
+                }
+            }
+
+            SplitOutLayoutChoice(out var first, out var second)
+            first + second
+            """);
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0267");
+        Assert.DoesNotContain(
+            result.Diagnostics,
+            diagnostic => diagnostic.Id is "GS0102" or "GS0125" or "GS0236");
+    }
+
+    [Fact]
+    public void SourceConstructor_ReversedSplitOutLayoutsReportNoApplicable()
+    {
+        var result = Evaluate("""
+            class ReversedSplitOutLayoutChoice {
+                init(first int32, out second int32) {
+                    second = first
+                }
+
+                init(out first int32, second int32) {
+                    first = second
+                }
+            }
+
+            ReversedSplitOutLayoutChoice(out var first, out var second)
+            first + second
+            """);
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0267");
+        Assert.DoesNotContain(
+            result.Diagnostics,
+            diagnostic => diagnostic.Id is "GS0102" or "GS0125" or "GS0236");
+    }
+
+    [Fact]
+    public void SourceConstructor_DuplicateNamedArgumentsWithoutInlineOutDoesNotCrash()
+    {
+        var result = Evaluate("""
+            class DuplicateNamedWithoutOut {
+                init(first int32, second int32) {
+                }
+            }
+
+            DuplicateNamedWithoutOut(first: 1, first: 2)
+            """);
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0245");
+    }
+
+    [Fact]
+    public void SourceConstructor_NoApplicableOverloadWithoutInlineOutDoesNotCrash()
+    {
+        var result = Evaluate("""
+            class NoApplicableWithoutOut {
+                init(value int32) {
+                }
+
+                init(value string) {
+                }
+            }
+
+            NoApplicableWithoutOut(true)
+            """);
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id is "GS0266" or "GS0267");
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3464ConstructorInlineOutTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3464ConstructorInlineOutTranslationTests.cs
@@ -1,0 +1,62 @@
+// <copyright file="Issue3464ConstructorInlineOutTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Pipeline;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using GSharp.Tests;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+public sealed class Issue3464ConstructorInlineOutTranslationTests
+{
+    [Fact]
+    public void MutexConstructorInlineOutVar_TranslatesBindsAndRuns()
+    {
+        const string source = """
+            using System.Threading;
+
+            public static class GuardFactory
+            {
+                public static bool Create()
+                {
+                    string? guardName = null;
+                    var processGuard = new Mutex(initiallyOwned: false, guardName, out var createdNew);
+                    processGuard.Dispose();
+                    return createdNew;
+                }
+            }
+            """;
+
+        var rendered = Translate(source);
+
+        Assert.Contains(
+            "Mutex(initiallyOwned: false, guardName, out var createdNew)",
+            rendered,
+            StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+
+        var runtime = EmittedOracle.Evaluate(rendered + Environment.NewLine + "GuardFactory.Create()");
+        Assert.Empty(runtime.Diagnostics);
+        Assert.Equal(true, runtime.Value);
+    }
+
+    private static string Translate(string source)
+    {
+        var project = CSharpProjectLoader.LoadInMemory(new[] { ("GuardFactory.cs", source) });
+        Assert.True(project.BoundWithoutErrors, string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        var document = Assert.Single(project.Documents);
+        var context = new TranslationContext(
+            project.Compilation,
+            document.SemanticModel,
+            document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        return GSharpPrinter.Print(unit);
+    }
+}


### PR DESCRIPTION
Closes #3464

## Summary
- bind inline `out var`/`out let`/`out _` through imported CLR constructor overload resolution
- rebind inferred locals from selected constructor parameter types, including named, generic, and nested constructor paths
- enforce true `out` positions for imported and source constructors and suppress fallback diagnostic cascades
- add Core runtime/diagnostic coverage plus cs2gs original-repro regression

## Focused validation
- `dotnet test test/Core.Tests/Core.Tests.csproj --no-restore --nologo --filter "FullyQualifiedName~Issue3464ConstructorInlineOutTests|FullyQualifiedName~Issue1599EnumTryParseOutVarTests|FullyQualifiedName~Issue3311OpenMapMemberLookupEmitTests|FullyQualifiedName~RefKindParameterEmitTests|FullyQualifiedName~NamedArgumentTests" --verbosity:minimal` (77 passed)
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj --no-restore --nologo --filter FullyQualifiedName~Issue3464ConstructorInlineOutTranslationTests --verbosity:minimal` (1 passed)