### PR TITLE
compiler: fix contextual lambda diagnostic ownership

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Arguments.cs
@@ -374,20 +374,6 @@ internal sealed partial class OverloadResolver
             return false;
         }
 
-        // Error return also represents valid target-dependent void blocks.
-        // Only body diagnostics prove this eager bind must not run again.
-        if (lambda != null
-            && tryGetFunctionLiteral(argument, out var erroneousLiteral)
-            && erroneousLiteral.FunctionType.ReturnType == TypeSymbol.Error
-            && Diagnostics.Any(diagnostic =>
-                diagnostic.Severity == DiagnosticSeverity.Error
-                && ReferenceEquals(diagnostic.Location.Text, lambda.Body.Location.Text)
-                && diagnostic.Location.Span.Start >= lambda.Body.Location.Span.Start
-                && diagnostic.Location.Span.End <= lambda.Body.Location.Span.End))
-        {
-            return false;
-        }
-
         if (lambda != null
             && !IsLambdaReturnShapeCompatible(argument, expectedType, lambda))
         {
@@ -400,6 +386,7 @@ internal sealed partial class OverloadResolver
             return true;
         }
 
+        using var diagnosticTransaction = Diagnostics.BeginTransaction();
         BoundExpression candidate;
         if (lambda != null && bindLambdaWithTarget != null)
         {
@@ -428,6 +415,7 @@ internal sealed partial class OverloadResolver
             return false;
         }
 
+        diagnosticTransaction.Commit();
         result = converted;
         return true;
     }

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -20,6 +20,7 @@ public sealed partial class DiagnosticBag : IEnumerable<Diagnostic>
 {
     private readonly ImmutableArray<Diagnostic>.Builder diagnostics = ImmutableArray.CreateBuilder<Diagnostic>();
     private readonly Stack<List<Diagnostic>> duplicateSuppressions = new();
+    private readonly Stack<List<Diagnostic>> transactions = new();
 
     /// <summary>
     /// Gets the number of diagnostics currently held in the bag. Used together
@@ -134,6 +135,13 @@ public sealed partial class DiagnosticBag : IEnumerable<Diagnostic>
         }
     }
 
+    internal Transaction BeginTransaction()
+    {
+        var added = new List<Diagnostic>();
+        transactions.Push(added);
+        return new Transaction(this, added);
+    }
+
     private void Add(Diagnostic diagnostic)
     {
         if (duplicateSuppressions.TryPeek(out var existing))
@@ -149,6 +157,30 @@ public sealed partial class DiagnosticBag : IEnumerable<Diagnostic>
         }
 
         diagnostics.Add(diagnostic);
+        foreach (var transaction in transactions)
+        {
+            transaction.Add(diagnostic);
+        }
+    }
+
+    private void CompleteTransaction(List<Diagnostic> added, bool commit)
+    {
+        if (!ReferenceEquals(transactions.Pop(), added) || commit)
+        {
+            return;
+        }
+
+        for (var addedIndex = added.Count - 1; addedIndex >= 0; addedIndex--)
+        {
+            for (var diagnosticIndex = diagnostics.Count - 1; diagnosticIndex >= 0; diagnosticIndex--)
+            {
+                if (ReferenceEquals(diagnostics[diagnosticIndex], added[addedIndex]))
+                {
+                    diagnostics.RemoveAt(diagnosticIndex);
+                    break;
+                }
+            }
+        }
     }
 
     private static bool AreEquivalent(Diagnostic left, Diagnostic right)
@@ -190,5 +222,39 @@ public sealed partial class DiagnosticBag : IEnumerable<Diagnostic>
         var message = string.Format(descriptor.MessageFormat, messageArguments);
         var diagnostic = new Diagnostic(location, descriptor.Id, severity, message);
         Add(diagnostic);
+    }
+
+    internal sealed class Transaction : IDisposable
+    {
+        private readonly DiagnosticBag owner;
+        private readonly List<Diagnostic> added;
+        private bool completed;
+
+        internal Transaction(DiagnosticBag owner, List<Diagnostic> added)
+        {
+            this.owner = owner;
+            this.added = added;
+        }
+
+        public void Dispose()
+        {
+            Complete(commit: false);
+        }
+
+        internal void Commit()
+        {
+            Complete(commit: true);
+        }
+
+        private void Complete(bool commit)
+        {
+            if (completed)
+            {
+                return;
+            }
+
+            completed = true;
+            owner.CompleteTransaction(added, commit);
+        }
     }
 }

--- a/test/Core.Tests/CodeAnalysis/DiagnosticBagTests.cs
+++ b/test/Core.Tests/CodeAnalysis/DiagnosticBagTests.cs
@@ -65,6 +65,23 @@ public class DiagnosticBagTests
     }
 
     [Fact]
+    public void Transaction_RollbackRemovesOnlyDiagnosticsAddedByTransaction()
+    {
+        var location = MakeLocation("source");
+        var existing = new Diagnostic(location, "GS0001", DiagnosticSeverity.Warning, "existing");
+        var rolledBack = new Diagnostic(location, "GS0002", DiagnosticSeverity.Error, "rolled back");
+        var bag = new DiagnosticBag();
+        bag.Report(existing);
+
+        using (bag.BeginTransaction())
+        {
+            bag.Report(rolledBack);
+        }
+
+        Assert.Equal(new[] { existing }, bag);
+    }
+
+    [Fact]
     public void Diagnostic_ToString_Returns_Message()
     {
         var location = MakeLocation("x");


### PR DESCRIPTION
Follow-up to #3483.

Contextual lambda conversion now owns speculative rebind diagnostics transactionally. Failed rebinds roll back only diagnostics emitted by that attempt, while successful rebinds preserve contextual diagnostics and suppress exact natural-bind duplicates. This removes duplicate GS0523/GS0130 reports without return-error guards or diagnostic-order assumptions.

Tests cover warning-only, mixed error/warning, typed error, invocation, constructor, static/instance/accessor, nested delegate, void/value, emit, and cs2gs paths.