### PR TITLE
cs2gs: emit bare sibling static references inside their declaring type

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue1072NullCheckedAsNullableTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1072NullCheckedAsNullableTranslationTests.cs
@@ -187,7 +187,7 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("return C.Echo(value)!!", printed);
+        Assert.Contains("return Echo(value)!!", printed);
         Assert.DoesNotContain("s string?", printed);
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1281RedundantNumericArgumentWrapTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1281RedundantNumericArgumentWrapTests.cs
@@ -123,7 +123,7 @@ namespace Demo
         }
     }
 }");
-        Assert.Contains("uint32(C.Five)", printed);
+        Assert.Contains("uint32(Five)", printed);
     }
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1723ValuePositionAssignmentTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1723ValuePositionAssignmentTranslationTests.cs
@@ -82,8 +82,8 @@ namespace Demo
     }
 }");
 
-        Assert.Equal(1, CountOccurrences(printed, "= C.F()"));
-        Assert.Contains("if (x = C.F()) > 0 {", printed);
+        Assert.Equal(1, CountOccurrences(printed, "= F()"));
+        Assert.Contains("if (x = F()) > 0 {", printed);
         Assert.Contains("Console.WriteLine(x)", printed);
     }
 
@@ -112,8 +112,8 @@ namespace Demo
     }
 }");
 
-        Assert.Equal(1, CountOccurrences(printed, "= C.F()"));
-        Assert.Contains("if (x = C.F()) {", printed);
+        Assert.Equal(1, CountOccurrences(printed, "= F()"));
+        Assert.Contains("if (x = F()) {", printed);
     }
 
     /// <summary>
@@ -196,8 +196,8 @@ namespace Demo
     }
 }");
 
-        Assert.Equal(1, CountOccurrences(printed, "= C.F()"));
-        Assert.Contains("return (x = C.F())", printed);
+        Assert.Equal(1, CountOccurrences(printed, "= F()"));
+        Assert.Contains("return (x = F())", printed);
     }
 
     /// <summary>
@@ -251,8 +251,8 @@ namespace Demo
             context.Diagnostics,
             diagnostic => diagnostic.Severity == TranslationSeverity.Unsupported);
         Assert.DoesNotContain("__spill", printed, StringComparison.Ordinal);
-        Assert.Contains("(map_[key] = C.Next())", printed, StringComparison.Ordinal);
-        Assert.Equal(1, CountOccurrences(printed, "C.Next()"));
+        Assert.Contains("(map_[key] = Next())", printed, StringComparison.Ordinal);
+        Assert.Equal(1, CountOccurrences(printed, "= Next()"));
 
         Assert.Equal("1,1,42,42,42", CompileAndRun(printed, "C.Run()").Trim());
     }
@@ -374,8 +374,8 @@ namespace Demo
             }
             """);
 
-        Assert.Equal(1, CountOccurrences(printed, "C.Receiver()"));
-        Assert.Equal(1, CountOccurrences(printed, "C.Next()"));
+        Assert.Equal(2, CountOccurrences(printed, "Receiver()"));
+        Assert.Equal(2, CountOccurrences(printed, "Next()"));
         Assert.Equal("1,1,1,13,13", CompileAndRun(printed, "C.Run()").Trim());
     }
 
@@ -437,7 +437,7 @@ namespace Demo
             }
             """);
 
-        Assert.Equal(2, CountOccurrences(printed, "C.Next()"));
+        Assert.Equal(3, CountOccurrences(printed, "Next()"));
         Assert.Equal("2,2,13,25,25", CompileAndRun(printed, "C.Run()").Trim());
     }
 
@@ -511,9 +511,9 @@ namespace Demo
             }
             """);
 
-        Assert.Equal(1, CountOccurrences(printed, "C.Receiver()"));
-        Assert.Equal(1, CountOccurrences(printed, "C.NextIndex()"));
-        Assert.Equal(1, CountOccurrences(printed, "C.NextValue()"));
+        Assert.Equal(2, CountOccurrences(printed, "Receiver()"));
+        Assert.Equal(2, CountOccurrences(printed, "NextIndex()"));
+        Assert.Equal(2, CountOccurrences(printed, "NextValue()"));
         Assert.Equal("RIV,1,1,1,1,42,42", CompileAndRun(printed, "C.Run()").Trim());
     }
 
@@ -1070,8 +1070,8 @@ namespace Demo
     }
 }");
 
-        int aAssign = printed.IndexOf("a = C.F()", StringComparison.Ordinal);
-        int bAssign = printed.IndexOf("b = C.G()", StringComparison.Ordinal);
+        int aAssign = printed.IndexOf("a = F()", StringComparison.Ordinal);
+        int bAssign = printed.IndexOf("b = G()", StringComparison.Ordinal);
         Assert.True(aAssign >= 0 && bAssign >= 0 && aAssign < bAssign, printed);
 
         int pAssign = printed.IndexOf("p = 1", StringComparison.Ordinal);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1729StaticCtorFoldTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1729StaticCtorFoldTranslationTests.cs
@@ -181,7 +181,7 @@ namespace Demo
 
         Assert.DoesNotContain(context.Diagnostics, d => d.IsUnsupported);
         Assert.Contains("init {", printed);
-        Assert.Contains("C.A = C.B * 2", printed);
+        Assert.Contains("A = B * 2", printed);
         Assert.DoesNotContain("var A int32 = B * 2", printed);
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1731DoubleEvaluationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1731DoubleEvaluationTranslationTests.cs
@@ -359,7 +359,7 @@ namespace Demo
         // Issue #1896: no helper needed — the native range-index form
         // already embeds `Next()` exactly once.
         Assert.Equal(2, CountOccurrences(printed, "Next()")); // 1 declaration + 1 call-site use
-        Assert.Contains("Data[C.Next()..2]", printed);
+        Assert.Contains("Data[Next()..2]", printed);
         Assert.DoesNotContain(".Slice(", printed);
         Assert.DoesNotContain("__init0(", printed);
         Assert.DoesNotContain(
@@ -424,7 +424,7 @@ namespace Demo
         // the `this(...)` argument list, and the native range-index form
         // already embeds `Next()` exactly once.
         Assert.Equal(2, CountOccurrences(printed, "Next()")); // 1 declaration + 1 call-site use
-        Assert.Contains("init(s[C.Next()..j])", printed);
+        Assert.Contains("init(s[Next()..j])", printed);
         Assert.DoesNotContain(".Slice(", printed);
         Assert.DoesNotContain("__init0(", printed);
         Assert.DoesNotContain(

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1732LoopLoweringTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1732LoopLoweringTranslationTests.cs
@@ -81,9 +81,9 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("} while (n = C.Probe()) < 0", printed);
+        Assert.Contains("} while (n = Probe()) < 0", printed);
         Assert.True(printed.IndexOf("bodyRuns++", StringComparison.Ordinal) <
-            printed.IndexOf("n = C.Probe()", StringComparison.Ordinal));
+            printed.IndexOf("n = Probe()", StringComparison.Ordinal));
 
         // Behavioral check: body ran once, Probe was called exactly once, AFTER
         // the body (a bug that hoisted the condition BEFORE the body would

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1839PatternDesignatorAndEnumExtensionTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1839PatternDesignatorAndEnumExtensionTests.cs
@@ -239,7 +239,7 @@ namespace Corpus.Issue3357
 ");
 
         Assert.Contains("func extension (color Color) Describe()", rendered, StringComparison.Ordinal);
-        Assert.Contains("C.Pick()?.Describe()", rendered, StringComparison.Ordinal);
+        Assert.Contains("Pick()?.Describe()", rendered, StringComparison.Ordinal);
         Assert.DoesNotContain("__spill", rendered, StringComparison.Ordinal);
         Assert.DoesNotContain("ColorExtensions.Describe", rendered, StringComparison.Ordinal);
         AssertRoundTripParses(rendered);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1845ChainedAssignmentReadBackTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1845ChainedAssignmentReadBackTests.cs
@@ -53,8 +53,8 @@ namespace Demo
 
         Assert.Equal(1, CountOccurrences(printed, "\"get\""));
         Assert.DoesNotContain("__spill", printed);
-        Assert.Contains("a = (obj.P = C.SideEffect())", printed);
-        Assert.Equal(1, CountOccurrences(printed, "C.SideEffect()"));
+        Assert.Contains("a = (obj.P = SideEffect())", printed);
+        Assert.Equal(1, CountOccurrences(printed, "= SideEffect()"));
     }
 
     [Fact]
@@ -76,9 +76,9 @@ namespace Demo
     }
 }");
 
-        Assert.Equal(1, CountOccurrences(printed, "C.Next()"));
+        Assert.Equal(1, CountOccurrences(printed, "= Next()"));
         Assert.DoesNotContain("__spill", printed);
-        Assert.Contains("a = (b = (c = C.Next()))", printed);
+        Assert.Contains("a = (b = (c = Next()))", printed);
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1849NullSeamHelperLoweringTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1849NullSeamHelperLoweringTests.cs
@@ -44,7 +44,7 @@ public class Issue3355NullSeamBlockExpressionLoweringTests
             """);
 
         Assert.Equal(2, CountOccurrences(printed, "GetA()"));
-        Assert.Contains("private var flag bool = C.GetA() is { X: 1, Y: 2 }", printed, StringComparison.Ordinal);
+        Assert.Contains("private var flag bool = GetA() is { X: 1, Y: 2 }", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("__spill", printed, StringComparison.Ordinal);
         AssertNoHelperOrGap(printed, context);
     }
@@ -78,7 +78,7 @@ public class Issue3355NullSeamBlockExpressionLoweringTests
             """);
 
         Assert.Equal(2, CountOccurrences(printed, "GetA()"));
-        Assert.Contains("C.GetA() is { X: > 0 }", printed, StringComparison.Ordinal);
+        Assert.Contains("GetA() is { X: > 0 }", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("__spill", printed, StringComparison.Ordinal);
         AssertNoHelperOrGap(printed, context);
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1875CompoundLinkReadBackTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1875CompoundLinkReadBackTests.cs
@@ -205,8 +205,8 @@ namespace Demo
 
         // The receiver-producing call (`GetHolder()`) is evaluated exactly
         // once, spilled into a temp, and that temp's `.P` is what the
-        // compound link reads/writes.
-        Assert.Equal(1, CountOccurrences(printed, "C.GetHolder()"));
+        // compound link reads/writes. (1 func declaration + 1 call site.)
+        Assert.Equal(2, CountOccurrences(printed, "GetHolder()"));
     }
 
     [Fact]
@@ -256,9 +256,9 @@ namespace Demo
     }
 }");
 
-        Assert.Equal(1, CountOccurrences(printed, "C.Next()"));
+        Assert.Equal(1, CountOccurrences(printed, "= Next()"));
         Assert.DoesNotContain("__spill", printed);
-        Assert.Contains("a = (b = (c = C.Next()))", printed);
+        Assert.Contains("a = (b = (c = Next()))", printed);
     }
 
     private static int CountOccurrences(string haystack, string needle)

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1901LambdaDefaultsTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1901LambdaDefaultsTranslationTests.cs
@@ -173,8 +173,8 @@ namespace Corpus.Issue1901
 ");
 
         Assert.Contains("func Total(values List[int32]) int32", rendered, StringComparison.Ordinal);
-        Assert.Contains("let zero = ParamsCollections.Total(List[int32]())", rendered, StringComparison.Ordinal);
-        Assert.Contains("let three = ParamsCollections.Total(List[int32]{ 1, 2, 3 })", rendered, StringComparison.Ordinal);
+        Assert.Contains("let zero = Total(List[int32]())", rendered, StringComparison.Ordinal);
+        Assert.Contains("let three = Total(List[int32]{ 1, 2, 3 })", rendered, StringComparison.Ordinal);
         AssertRoundTripParses(rendered);
     }
 
@@ -207,7 +207,7 @@ namespace Corpus.Issue1901
 }
 ");
 
-        Assert.Contains("let sum = ParamsCollections.Total(lst)", rendered, StringComparison.Ordinal);
+        Assert.Contains("let sum = Total(lst)", rendered, StringComparison.Ordinal);
         Assert.DoesNotContain("List[int32]{ lst }", rendered, StringComparison.Ordinal);
         AssertRoundTripParses(rendered);
     }
@@ -237,7 +237,7 @@ namespace Corpus.Issue1901
 
         Assert.Contains("func JoinParts(parts IEnumerable[string]) string", rendered, StringComparison.Ordinal);
         Assert.Contains(
-            "let joined = ParamsCollections.JoinParts(cast[IEnumerable[string]](List[string]{ \"a\", \"b\", \"c\" }))",
+            "let joined = JoinParts(cast[IEnumerable[string]](List[string]{ \"a\", \"b\", \"c\" }))",
             rendered,
             StringComparison.Ordinal);
         AssertRoundTripParses(rendered);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2009ExtensionBlockFollowUpTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2009ExtensionBlockFollowUpTranslationTests.cs
@@ -98,7 +98,9 @@ namespace Corpus.Caller
         // `CSharpTypeMapper.QualifiedTypeName` entirely — now correctly
         // qualifies a NESTED owner through its containing-type chain when its
         // simple name collides with another source type, exactly like the
-        // nested-type reference fix in issue #1174. `Holder` is declared twice:
+        // nested-type reference fix in issue #1174 — but issue #3471's
+        // same-type policy now supersedes it at sites lexically inside the
+        // declaring type, where the reference stays bare. `Holder` is declared twice:
         // once as an unrelated top-level class, and once nested inside
         // `Outer`, where the actual sibling static method being called lives.
         string rendered = Render(@"
@@ -129,14 +131,17 @@ namespace Corpus.Sibling
 }
 ");
 
-        // The bare sibling call is rewritten to the FULLY qualified nested
-        // owner...
-        Assert.Contains("Outer.Holder.Read()", rendered, StringComparison.Ordinal);
+        // The sibling call site is lexically inside the declaring nested type
+        // itself, so the same-type policy (issue #3471) keeps it BARE — the
+        // homonym collision is on the OWNER's simple name, not the member's,
+        // and never forces qualification at a same-type site.
+        Assert.Contains("return Read() + Read()", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("Outer.Holder.Read()", rendered, StringComparison.Ordinal);
 
         AssertRoundTripParses(rendered);
 
-        // Binding the printed G# end to end proves the qualified reference
-        // resolves against the NESTED type — the top-level homonym does not
+        // Binding the printed G# end to end proves the bare reference resolves
+        // against the enclosing NESTED type — the top-level homonym does not
         // declare `Read` at all and would fail member lookup (GS0158) if the
         // bare simple name had bound to it instead.
         var diagnostics = BindDiagnostics(rendered);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2164LazySingletonNullForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2164LazySingletonNullForgivenessTranslationTests.cs
@@ -55,7 +55,7 @@ namespace Demo
 }");
 
         Assert.Contains("private var instance Service?", printed);
-        Assert.Contains("return Service.instance!!", printed);
+        Assert.Contains("return instance!!", printed);
     }
 
     [Fact]
@@ -83,7 +83,7 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("return Service.instance!!", printed);
+        Assert.Contains("return instance!!", printed);
     }
 
     [Fact]
@@ -108,7 +108,7 @@ namespace Demo
 }");
 
         Assert.Contains("!!", printed);
-        Assert.Contains("return Service.instance!!", printed);
+        Assert.Contains("return instance!!", printed);
     }
 
     [Fact]
@@ -141,7 +141,7 @@ namespace Demo
 }");
 
         Assert.Contains("private var instance T?", printed);
-        Assert.Contains("return Singleton[T].instance!!", printed);
+        Assert.Contains("return instance!!", printed);
     }
 
     [Fact]
@@ -171,7 +171,7 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("Service.instance!!.ToString()", printed);
+        Assert.Contains("instance!!.ToString()", printed);
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2233NegatedBracePatternTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2233NegatedBracePatternTranslationTests.cs
@@ -74,7 +74,7 @@ namespace Demo
         // ADR-0166 / issue #3409: native `!(x is { } at)` guard; no hoisted
         // `let at DateTimeOffset? = promptShownAt` / `if at == nil`.
         Assert.Contains("if !(promptShownAt is { } at) {", printed);
-        Assert.Contains("clock() - at <= C.ExitWindow", printed);
+        Assert.Contains("clock() - at <= ExitWindow", printed);
         Assert.DoesNotContain("let at", printed);
         Assert.DoesNotContain("== nil", printed);
         Assert.DoesNotContain("as DateTimeOffset", printed);
@@ -231,7 +231,7 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("if promptShownAt is { } at && now - at <= C.ExitWindow {", printed);
+        Assert.Contains("if promptShownAt is { } at && now - at <= ExitWindow {", printed);
         Assert.DoesNotContain("if let", printed);
         Assert.DoesNotContain("promptShownAt!!", printed);
         Assert.DoesNotContain("__spill", printed);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2506PromotedCallReceiverForgivenessPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2506PromotedCallReceiverForgivenessPipelineTests.cs
@@ -57,12 +57,12 @@ public sealed class Issue2506PromotedCallReceiverForgivenessPipelineTests
             Directory.GetFiles(appRunDir, "*.gs", SearchOption.AllDirectories)
                 .Select(File.ReadAllText));
 
-        Assert.Contains("Repro.Find(false)!!.Name", emitted, StringComparison.Ordinal);
+        Assert.Contains("Find(false)!!.Name", emitted, StringComparison.Ordinal);
         Assert.Contains(
             "region.FromCountryCode()!!.Domain",
             emitted,
             StringComparison.Ordinal);
-        Assert.Contains("Repro.FindFactory()!!().Name", emitted, StringComparison.Ordinal);
+        Assert.Contains("FindFactory()!!().Name", emitted, StringComparison.Ordinal);
         Assert.True(
             appResult.Succeeded,
             "Expected default --via-sdk/gsc compilation to accept promoted same-project call receivers. Stages: " +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2506PromotedCallReceiverForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2506PromotedCallReceiverForgivenessTranslationTests.cs
@@ -91,26 +91,26 @@ public sealed class Issue2506PromotedCallReceiverForgivenessTranslationTests
             }
             """);
 
-        Assert.Contains("Repro.Find()!!.Name", printed, StringComparison.Ordinal);
-        Assert.Contains("Repro.Find()!!.Read()", printed, StringComparison.Ordinal);
-        Assert.Contains("Repro.Find()!![0]", printed, StringComparison.Ordinal);
-        Assert.Contains("Repro.Find().ExtensionName()", printed, StringComparison.Ordinal);
-        Assert.DoesNotContain("Repro.Find()!!.ExtensionName()", printed, StringComparison.Ordinal);
-        Assert.Contains("Repro.Find().NextExtension()!!.Name", printed, StringComparison.Ordinal);
-        Assert.Contains("Repro.Find()!!.Next()!!.Name", printed, StringComparison.Ordinal);
-        Assert.Contains("Repro.GetHolder().Child!!.Name", printed, StringComparison.Ordinal);
-        Assert.Contains("Repro.GetHolder()[0]!!.Name", printed, StringComparison.Ordinal);
+        Assert.Contains("Find()!!.Name", printed, StringComparison.Ordinal);
+        Assert.Contains("Find()!!.Read()", printed, StringComparison.Ordinal);
+        Assert.Contains("Find()!![0]", printed, StringComparison.Ordinal);
+        Assert.Contains("Find().ExtensionName()", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("Find()!!.ExtensionName()", printed, StringComparison.Ordinal);
+        Assert.Contains("Find().NextExtension()!!.Name", printed, StringComparison.Ordinal);
+        Assert.Contains("Find()!!.Next()!!.Name", printed, StringComparison.Ordinal);
+        Assert.Contains("GetHolder().Child!!.Name", printed, StringComparison.Ordinal);
+        Assert.Contains("GetHolder()[0]!!.Name", printed, StringComparison.Ordinal);
         Assert.Contains("FindGeneric[Item]()!!.Name", printed, StringComparison.Ordinal);
-        Assert.Equal(2, CountOccurrences(printed, "Repro.FindFactory()!!().Name"));
-        Assert.Contains("(Repro.Find())!!.Name", printed, StringComparison.Ordinal);
-        Assert.Contains("cast[Item](Repro.Find())", printed, StringComparison.Ordinal);
+        Assert.Equal(2, CountOccurrences(printed, "FindFactory()!!().Name"));
+        Assert.Contains("(Find())!!.Name", printed, StringComparison.Ordinal);
+        Assert.Contains("cast[Item](Find())", printed, StringComparison.Ordinal);
         Assert.DoesNotContain(" as Item", printed, StringComparison.Ordinal);
         Assert.Contains(
-            "(if condition { Repro.Find() } else { Repro.Always() })!!.Name",
+            "(if condition { Find() } else { Always() })!!.Name",
             printed,
             StringComparison.Ordinal);
         Assert.Contains("LocalFind()!!.Name", printed, StringComparison.Ordinal);
-        Assert.Contains("for item in Repro.FindMany()!!", printed, StringComparison.Ordinal);
+        Assert.Contains("for item in FindMany()!!", printed, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -132,8 +132,8 @@ public sealed class Issue2506PromotedCallReceiverForgivenessTranslationTests
             }
             """);
 
-        Assert.Contains("Repro.Find()!!.Name", printed, StringComparison.Ordinal);
-        Assert.Equal(1, CountOccurrences(printed, "Repro.Find()"));
+        Assert.Contains("Find()!!.Name", printed, StringComparison.Ordinal);
+        Assert.Equal(1, CountOccurrences(printed, "Find()!!"));
     }
 
     [Fact]
@@ -184,9 +184,9 @@ public sealed class Issue2506PromotedCallReceiverForgivenessTranslationTests
             }
             """);
 
-        Assert.Contains("(await Repro.FindAsync())!!.Name", printed, StringComparison.Ordinal);
-        Assert.Contains("Repro.FindAsync().ToString()", printed, StringComparison.Ordinal);
-        Assert.DoesNotContain("Repro.FindAsync()!!.ToString()", printed, StringComparison.Ordinal);
+        Assert.Contains("(await FindAsync())!!.Name", printed, StringComparison.Ordinal);
+        Assert.Contains("FindAsync().ToString()", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("FindAsync()!!.ToString()", printed, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -216,9 +216,9 @@ public sealed class Issue2506PromotedCallReceiverForgivenessTranslationTests
             """,
             "G# currently rejects nullable disposable resources even though C# using is null-tolerant.");
 
-        Assert.Contains("using let _ = Repro.Open()", printed, StringComparison.Ordinal);
+        Assert.Contains("using let _ = Open()", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("__using", printed, StringComparison.Ordinal);
-        Assert.DoesNotContain("Repro.Open()!!", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("Open()!!", printed, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -245,10 +245,10 @@ public sealed class Issue2506PromotedCallReceiverForgivenessTranslationTests
             """,
             "Expression-tree fixtures intentionally omit runtime assertions that G# requires for ordinary delegates.");
 
-        Assert.Contains("Repro.Find()?.Name", oblivious, StringComparison.Ordinal);
-        Assert.DoesNotContain("Repro.Find()!!?.Name", oblivious, StringComparison.Ordinal);
-        Assert.Contains("Repro.Find().Name", oblivious, StringComparison.Ordinal);
-        Assert.DoesNotContain("() -> Repro.Find()!!.Name", oblivious, StringComparison.Ordinal);
+        Assert.Contains("Find()?.Name", oblivious, StringComparison.Ordinal);
+        Assert.DoesNotContain("Find()!!?.Name", oblivious, StringComparison.Ordinal);
+        Assert.Contains("Find().Name", oblivious, StringComparison.Ordinal);
+        Assert.DoesNotContain("() -> Find()!!.Name", oblivious, StringComparison.Ordinal);
 
         string enabled = Translate("""
             #nullable enable
@@ -278,10 +278,10 @@ public sealed class Issue2506PromotedCallReceiverForgivenessTranslationTests
             }
             """);
 
-        Assert.Equal(2, CountOccurrences(enabled, "Repro.ExplicitMaybe()!!.Name"));
-        Assert.DoesNotContain("Repro.ExplicitMaybe().Name", enabled, StringComparison.Ordinal);
-        Assert.Contains("Repro.Always().Name", enabled, StringComparison.Ordinal);
-        Assert.DoesNotContain("Repro.Always()!!.Name", enabled, StringComparison.Ordinal);
+        Assert.Equal(2, CountOccurrences(enabled, "ExplicitMaybe()!!.Name"));
+        Assert.DoesNotContain("ExplicitMaybe().Name", enabled, StringComparison.Ordinal);
+        Assert.Contains("Always().Name", enabled, StringComparison.Ordinal);
+        Assert.DoesNotContain("Always()!!.Name", enabled, StringComparison.Ordinal);
         Assert.Contains("return item.Name", enabled, StringComparison.Ordinal);
         Assert.DoesNotContain("item!!.Name", enabled, StringComparison.Ordinal);
     }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2511NullableIndexArgumentForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2511NullableIndexArgumentForgivenessTranslationTests.cs
@@ -60,10 +60,10 @@ public sealed class Issue2511NullableIndexArgumentForgivenessTranslationTests
         Assert.Contains("let value = items[key!!]", printed, StringComparison.Ordinal);
         Assert.Contains("counts[key!!] += 1", printed, StringComparison.Ordinal);
         Assert.Contains("counts[key!!]++", printed, StringComparison.Ordinal);
-        Assert.Contains("items[Repro.FindKey()!!] ??= value", printed, StringComparison.Ordinal);
+        Assert.Contains("items[FindKey()!!] ??= value", printed, StringComparison.Ordinal);
         Assert.Contains("[key!!] = value", printed, StringComparison.Ordinal);
         Assert.Contains("return items[key!!]", printed, StringComparison.Ordinal);
-        Assert.Equal(1, CountOccurrences(printed, "items[Repro.FindKey()!!]"));
+        Assert.Equal(1, CountOccurrences(printed, "items[FindKey()!!]"));
     }
 
     [Fact]
@@ -140,12 +140,12 @@ public sealed class Issue2511NullableIndexArgumentForgivenessTranslationTests
             }
             """);
 
-        Assert.Contains("items[Repro.Field!!] = \"field\"", printed, StringComparison.Ordinal);
-        Assert.Contains("items[Repro.Property!!] = \"property\"", printed, StringComparison.Ordinal);
-        Assert.Contains("items[Repro.FindKey()!!] = \"method\"", printed, StringComparison.Ordinal);
+        Assert.Contains("items[Field!!] = \"field\"", printed, StringComparison.Ordinal);
+        Assert.Contains("items[Property!!] = \"property\"", printed, StringComparison.Ordinal);
+        Assert.Contains("items[FindKey()!!] = \"method\"", printed, StringComparison.Ordinal);
         Assert.Contains("items[parameter!!] = \"parameter\"", printed, StringComparison.Ordinal);
-        Assert.Contains("if choose { Repro.Field } else { Repro.Property }", printed, StringComparison.Ordinal);
-        Assert.Contains("Repro.Property })!!] = \"conditional\"", printed, StringComparison.Ordinal);
+        Assert.Contains("if choose { Field } else { Property }", printed, StringComparison.Ordinal);
+        Assert.Contains("Property })!!] = \"conditional\"", printed, StringComparison.Ordinal);
         Assert.Contains("items[(holder?.Key)!!] = \"conditional-access\"", printed, StringComparison.Ordinal);
         Assert.Contains(
             "items[Environment.GetEnvironmentVariable(\"DIRECT\")!!] = \"external\"",

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2516SliceCovariancePipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2516SliceCovariancePipelineTests.cs
@@ -73,7 +73,7 @@ public sealed class Issue2516SliceCovariancePipelineTests
 
         // Compiler-level slice/interface covariance makes the natural
         // translation valid; cs2gs must not manufacture an `as` escape hatch.
-        Assert.Contains("Repro.Accept(values)", emitted, StringComparison.Ordinal);
+        Assert.Contains("Accept(values)", emitted, StringComparison.Ordinal);
         Assert.DoesNotContain("values as IEnumerable[IPerson]", emitted, StringComparison.Ordinal);
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2538ConvenienceInitializerTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2538ConvenienceInitializerTests.cs
@@ -78,7 +78,7 @@ public sealed class Issue2538ConvenienceInitializerTests
                 });
 
         int delegation = printed.IndexOf(
-            "init(Routed.Trace(seed), Routed.Trace(seed + 1))",
+            "init(Trace(seed), Trace(seed + 1))",
             StringComparison.Ordinal);
         int parameterShadow = printed.IndexOf("var seed = seed", StringComparison.Ordinal);
         Assert.True(delegation >= 0 && parameterShadow > delegation, printed);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2579NullableReferenceFidelityPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2579NullableReferenceFidelityPipelineTests.cs
@@ -49,8 +49,8 @@ public sealed class Issue2579NullableReferenceFidelityPipelineTests
         Assert.Contains("model.GetChild()!!.Name", emitted, StringComparison.Ordinal);
         Assert.Contains("model.Name!!.Echo()", emitted, StringComparison.Ordinal);
         Assert.Contains("let local = model.Name!!", emitted, StringComparison.Ordinal);
-        Assert.Contains("Repro.Required = model.Name!!", emitted, StringComparison.Ordinal);
-        Assert.Contains("Repro.Consume(model.Name!!)", emitted, StringComparison.Ordinal);
+        Assert.Contains("Required = model.Name!!", emitted, StringComparison.Ordinal);
+        Assert.Contains("Consume(model.Name!!)", emitted, StringComparison.Ordinal);
         Assert.Contains("Holder(model.Name!!)", emitted, StringComparison.Ordinal);
         Assert.Contains("model.Children!![0]", emitted, StringComparison.Ordinal);
         Assert.Contains("for child in model.Children!!", emitted, StringComparison.Ordinal);
@@ -95,8 +95,8 @@ public sealed class Issue2579NullableReferenceFidelityPipelineTests
 
         Assert.Contains("Factory.GetItem()!!.Next!!.Name", emitted, StringComparison.Ordinal);
         Assert.Contains("Factory.GetItem()!!.Label()", emitted, StringComparison.Ordinal);
-        Assert.Contains("Repro.Consume(Factory.GetItem()!!)", emitted, StringComparison.Ordinal);
-        Assert.Contains("Repro.Required = Factory.GetItem()!!", emitted, StringComparison.Ordinal);
+        Assert.Contains("Consume(Factory.GetItem()!!)", emitted, StringComparison.Ordinal);
+        Assert.Contains("Required = Factory.GetItem()!!", emitted, StringComparison.Ordinal);
         Assert.Contains("Factory.GetMap()!![Factory.GetKey()!!]", emitted, StringComparison.Ordinal);
         Assert.Contains("for item in Factory.GetItems()!!", emitted, StringComparison.Ordinal);
         Assert.Contains("yield line!!", emitted, StringComparison.Ordinal);
@@ -150,8 +150,8 @@ public sealed class Issue2579NullableReferenceFidelityPipelineTests
         Assert.Contains("for current in items!!", emitted, StringComparison.Ordinal);
         Assert.Contains("var required = key!!", emitted, StringComparison.Ordinal);
         Assert.Contains("required = key!!", emitted, StringComparison.Ordinal);
-        Assert.Contains("Repro.Required = key!!", emitted, StringComparison.Ordinal);
-        Assert.Contains("Repro.Consume(key!!)", emitted, StringComparison.Ordinal);
+        Assert.Contains("Required = key!!", emitted, StringComparison.Ordinal);
+        Assert.Contains("Consume(key!!)", emitted, StringComparison.Ordinal);
         Assert.Contains("map_[key!!]", emitted, StringComparison.Ordinal);
         Assert.True(
             app.Succeeded,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2579NullableReferenceFidelityTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2579NullableReferenceFidelityTranslationTests.cs
@@ -75,8 +75,8 @@ public sealed class Issue2579NullableReferenceFidelityTranslationTests
         Assert.Contains("for current in items!!", printed, StringComparison.Ordinal);
         Assert.Contains("var required = key!!", printed, StringComparison.Ordinal);
         Assert.Contains("required = key!!", printed, StringComparison.Ordinal);
-        Assert.Contains("Repro.Required = key!!", printed, StringComparison.Ordinal);
-        Assert.Contains("Repro.Consume(key!!)", printed, StringComparison.Ordinal);
+        Assert.Contains("Required = key!!", printed, StringComparison.Ordinal);
+        Assert.Contains("Consume(key!!)", printed, StringComparison.Ordinal);
         Assert.Contains("map_[key!!]", printed, StringComparison.Ordinal);
         Assert.Contains("let optional string? = key", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("optional string? = key!!", printed, StringComparison.Ordinal);
@@ -115,7 +115,7 @@ public sealed class Issue2579NullableReferenceFidelityTranslationTests
             }
             """);
 
-        Assert.Contains("Repro.Length(value!!)", printed, StringComparison.Ordinal);
+        Assert.Contains("Length(value!!)", printed, StringComparison.Ordinal);
         Assert.Contains("@NotNullWhen(true)", printed, StringComparison.Ordinal);
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2635ConstantContextNullabilityTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2635ConstantContextNullabilityTranslationTests.cs
@@ -33,7 +33,7 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("const Settings string = \"appsettings\" + C.Extension", printed);
+        Assert.Contains("const Settings string = \"appsettings\" + Extension", printed);
         Assert.Contains("const value = \"Mozilla/5.0 \" + \"AppleWebKit/537.36\"", printed);
         Assert.DoesNotContain("!!", printed);
     }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2821OwnedExtensionMemberTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2821OwnedExtensionMemberTranslationTests.cs
@@ -559,8 +559,8 @@ public static class User
 
         string user = Compact(printed["User.cs"]);
 
-        Assert.Equal(1, CountOccurrences(user, "User.GetHost()"));
-        Assert.Contains("() -> User.GetHost()?.Touch()", user);
+        Assert.Equal(1, CountOccurrences(user, "GetHost()?"));
+        Assert.Contains("() -> GetHost()?.Touch()", user);
         Assert.DoesNotContain("__spill", user);
         Assert.DoesNotContain("FirstExtensions.Touch", user);
         Assert.DoesNotContain("default(void", user);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2821OwnedExtensionMemberTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2821OwnedExtensionMemberTranslationTests.cs
@@ -457,11 +457,11 @@ public static class User
 
         string user = Compact(printed["User.cs"]);
 
-        Assert.Equal(1, CountOccurrences(user, "User.GetHost()"));
-        Assert.Contains("User.GetHost()?.Describe()", user);
+        Assert.Equal(1, CountOccurrences(user, "GetHost()?"));
+        Assert.Contains("GetHost()?.Describe()", user);
         Assert.DoesNotContain("__spill", user);
         Assert.DoesNotContain("FirstExtensions.Describe", user);
-        Assert.DoesNotContain("if User.GetHost() != nil", user);
+        Assert.DoesNotContain("if GetHost() != nil", user);
 
         ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> diagnostics =
             BindDiagnostics(printed.Values);
@@ -685,8 +685,8 @@ public static class User
 
         string user = Compact(printed["User.cs"]);
 
-        Assert.Equal(1, CountOccurrences(user, "User.GetConfig()"));
-        Assert.Contains("User.GetConfig()?.Options.Describe()", user);
+        Assert.Equal(1, CountOccurrences(user, "GetConfig()?"));
+        Assert.Contains("GetConfig()?.Options.Describe()", user);
         Assert.DoesNotContain("__spill", user);
         Assert.DoesNotContain("FirstExtensions.Describe", user);
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3090AwaitInvocationArgumentTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3090AwaitInvocationArgumentTests.cs
@@ -106,10 +106,10 @@ public sealed class Issue3090AwaitInvocationArgumentTests
         AssertInOrder(
             printed,
             "GetReceiver().ReceiveAsync(",
-            "after: Scenario.After(3)",
+            "after: After(3)",
             "label: \"named\"",
-            "value: await Scenario.InnerAsync(2)",
-            "before: Scenario.Before(1)");
+            "value: await InnerAsync(2)",
+            "before: Before(1)");
         Assert.DoesNotContain("__spill", printed, StringComparison.Ordinal);
         AssertRoundTrip(printed);
     }
@@ -167,19 +167,19 @@ public sealed class Issue3090AwaitInvocationArgumentTests
             """);
 
         Assert.Contains(
-            "receiver?.ReceiveAsync(value: await Scenario.InnerAsync())",
+            "receiver?.ReceiveAsync(value: await InnerAsync())",
             printed,
             StringComparison.Ordinal);
         Assert.Contains(
-            "receiver?.Next!!.ReceiveAsync(value: await Scenario.InnerAsync())",
+            "receiver?.Next!!.ReceiveAsync(value: await InnerAsync())",
             printed,
             StringComparison.Ordinal);
         Assert.Contains(
-            "Scenario.SetRefAsync(&a, value: await Scenario.InnerAsync())",
+            "SetRefAsync(&a, value: await InnerAsync())",
             printed,
             StringComparison.Ordinal);
         Assert.Contains(
-            "Scenario.SetOutAsync(out b, value: await Scenario.InnerAsync())",
+            "SetOutAsync(out b, value: await InnerAsync())",
             printed,
             StringComparison.Ordinal);
         Assert.DoesNotContain("__spill", printed, StringComparison.Ordinal);
@@ -381,12 +381,12 @@ public sealed class Issue3090AwaitInvocationArgumentTests
                     SearchOption.AllDirectories)
                 .Select(File.ReadAllText));
 
-        Assert.Contains("after: AwaitExpressionFixture.Trace(", emitted, StringComparison.Ordinal);
+        Assert.Contains("after: Trace(", emitted, StringComparison.Ordinal);
         Assert.Contains(
-            "value: await AwaitExpressionFixture.TraceAsync(",
+            "value: await TraceAsync(",
             emitted,
             StringComparison.Ordinal);
-        Assert.Contains("before: AwaitExpressionFixture.Trace(", emitted, StringComparison.Ordinal);
+        Assert.Contains("before: Trace(", emitted, StringComparison.Ordinal);
         Assert.DoesNotContain("__spill", emitted, StringComparison.Ordinal);
         Assert.Equal(1, CountOccurrences(emitted, "TraceReceiver(\"static-extension\")"));
         Assert.Equal(1, CountOccurrences(emitted, "CreateReceiver(\"bare-extension\")"));

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3092NullConditionalRangeSliceTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3092NullConditionalRangeSliceTests.cs
@@ -103,7 +103,7 @@ public sealed class Issue3092NullConditionalRangeSliceTests
 
         Assert.Contains("hash?[..12]", printed, StringComparison.Ordinal);
         Assert.Contains(
-            "Program.Receiver(\"abcdef\")?[Program.Start()..Program.End()]",
+            "Receiver(\"abcdef\")?[Start()..End()]",
             printed,
             StringComparison.Ordinal);
         Assert.Contains("numbers?[1..3]", printed, StringComparison.Ordinal);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3096CollectionSpreadPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3096CollectionSpreadPipelineTests.cs
@@ -176,7 +176,7 @@ public sealed class Issue3096CollectionSpreadPipelineTests
         Assert.Contains("List[string](){", translated, StringComparison.Ordinal);
         Assert.Contains("[]float64{1", translated, StringComparison.Ordinal);
         Assert.Contains("List[float64](){", translated, StringComparison.Ordinal);
-        Assert.Contains("...Holder.Temperatures", translated, StringComparison.Ordinal);
+        Assert.Contains("...Temperatures", translated, StringComparison.Ordinal);
         Assert.Contains("Property = []string{\"property-head\", ...", translated, StringComparison.Ordinal);
         Assert.DoesNotContain("__spread", translated, StringComparison.Ordinal);
         Assert.DoesNotContain(".AddRange(", translated, StringComparison.Ordinal);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3347RemainingSpillInventoryTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3347RemainingSpillInventoryTests.cs
@@ -165,7 +165,7 @@ public sealed class Issue3347RemainingSpillInventoryTests
             """);
 
         Assert.DoesNotContain("__spill", printed, StringComparison.Ordinal);
-        Assert.Contains("C.Get() is string and { Length: > 0 } or int32", printed, StringComparison.Ordinal);
+        Assert.Contains("Get() is string and { Length: > 0 } or int32", printed, StringComparison.Ordinal);
         Assert.Contains("node.Value != nil", printed, StringComparison.Ordinal);
     }
 
@@ -202,10 +202,10 @@ public sealed class Issue3347RemainingSpillInventoryTests
 
         Assert.DoesNotContain("__spill", printed, StringComparison.Ordinal);
         Assert.Contains(
-            "if C.Get() is string { Length: > 0 } text && text[0] == 'a' { text.Length } else { 0 }",
+            "if Get() is string { Length: > 0 } text && text[0] == 'a' { text.Length } else { 0 }",
             printed,
             StringComparison.Ordinal);
-        Assert.Contains("if C.Get() is string { Length: > 0 } text {", printed, StringComparison.Ordinal);
+        Assert.Contains("if Get() is string { Length: > 0 } text {", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("if let", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("as string", printed, StringComparison.Ordinal);
     }
@@ -300,7 +300,7 @@ public sealed class Issue3347RemainingSpillInventoryTests
             """);
 
         Assert.DoesNotContain("__spill", printed, StringComparison.Ordinal);
-        Assert.Contains("a = (b = C.Echo((holder.P = 5)))", printed, StringComparison.Ordinal);
+        Assert.Contains("a = (b = Echo((holder.P = 5)))", printed, StringComparison.Ordinal);
         Assert.Contains("return (holder[0] = a + b)", printed, StringComparison.Ordinal);
     }
 
@@ -328,8 +328,8 @@ public sealed class Issue3347RemainingSpillInventoryTests
 
         Assert.DoesNotContain("__spill", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("&& true", printed, StringComparison.Ordinal);
-        Assert.Contains("C.GetItem() is { X: var x, Y: > 0 } && x > 0", printed, StringComparison.Ordinal);
-        Assert.Equal(1, CountOccurrences(printed, "C.GetItem()"));
+        Assert.Contains("GetItem() is { X: var x, Y: > 0 } && x > 0", printed, StringComparison.Ordinal);
+        Assert.Equal(1, CountOccurrences(printed, "GetItem() is"));
     }
 
     [Fact]
@@ -395,7 +395,7 @@ public sealed class Issue3347RemainingSpillInventoryTests
             }
             """);
 
-        Assert.Contains("C.Apply(value, holder.Mapper.Map)", printed, StringComparison.Ordinal);
+        Assert.Contains("Apply(value, holder.Mapper.Map)", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("__spill", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("__arg", printed, StringComparison.Ordinal);
     }
@@ -422,7 +422,7 @@ public sealed class Issue3347RemainingSpillInventoryTests
             """);
 
         Assert.Contains("__spill", printed, StringComparison.Ordinal);
-        Assert.Equal(1, CountOccurrences(printed, "C.GetItem()"));
+        Assert.Equal(1, CountOccurrences(printed, "= GetItem()"));
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3352WhileLetTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3352WhileLetTranslationTests.cs
@@ -65,7 +65,7 @@ public sealed class Issue3352WhileLetTranslationTests
             """);
 
         // ADR-0166 / issue #3409: native pattern variable instead of `while let`.
-        Assert.Contains("while C.Next() is string text {", printed, StringComparison.Ordinal);
+        Assert.Contains("while Next() is string text {", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("while let", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("as string", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("__scrutinee", printed, StringComparison.Ordinal);
@@ -108,9 +108,9 @@ public sealed class Issue3352WhileLetTranslationTests
 
         // ADR-0166 / issue #3409: the bare non-null pattern is a native
         // pattern variable over the receiver itself — no `as`, no `while let`.
-        Assert.Contains("while C.Next() is { } text {", printed, StringComparison.Ordinal);
+        Assert.Contains("while Next() is { } text {", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("while let", printed, StringComparison.Ordinal);
-        Assert.DoesNotContain("C.Next() as", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("Next() as", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("__scrutinee", printed, StringComparison.Ordinal);
         Assert.Equal("value|2", CompileAndRun(printed, "C.Run()").Trim());
     }
@@ -153,7 +153,7 @@ public sealed class Issue3352WhileLetTranslationTests
         // ADR-0166 / issue #3409: the conjoined guard reads the native pattern
         // variable in the `&&` right operand — it stays in the loop condition
         // instead of becoming an `if !(guard) { break }` prologue.
-        Assert.Contains("while C.Next() is string text && text.Length > 0 {", printed, StringComparison.Ordinal);
+        Assert.Contains("while Next() is string text && text.Length > 0 {", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("while let", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("break", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("__scrutinee", printed, StringComparison.Ordinal);
@@ -195,7 +195,7 @@ public sealed class Issue3352WhileLetTranslationTests
 
         // ADR-0166 / issue #3409: the value-type binder is a native pattern
         // variable of the tested type — no `as int32?` layer to strip.
-        Assert.Contains("while C.Next() is int32 value {", printed, StringComparison.Ordinal);
+        Assert.Contains("while Next() is int32 value {", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("while let", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("as int32?", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("__scrutinee", printed, StringComparison.Ordinal);
@@ -242,7 +242,7 @@ public sealed class Issue3352WhileLetTranslationTests
 
         // ADR-0166 / issue #3409: the native pattern loop owns re-evaluation,
         // so `continue` and `break` route exactly as in the C# source.
-        Assert.Contains("while C.Next() is string text {", printed, StringComparison.Ordinal);
+        Assert.Contains("while Next() is string text {", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("while let", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("__scrutinee", printed, StringComparison.Ordinal);
         Assert.Equal("keepstop|3", CompileAndRun(printed, "C.Run()").Trim());
@@ -288,7 +288,7 @@ public sealed class Issue3352WhileLetTranslationTests
 
         // ADR-0166 / issue #3409: the nested loop is a native pattern loop;
         // its `continue` still targets it, not the outer loop.
-        Assert.Contains("while C.Next() is string text {", printed, StringComparison.Ordinal);
+        Assert.Contains("while Next() is string text {", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("while let", printed, StringComparison.Ordinal);
         Assert.Equal("2|1|2", CompileAndRun(printed, "C.Run()").Trim());
     }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3358NativeMultiAssignmentTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3358NativeMultiAssignmentTranslationTests.cs
@@ -146,7 +146,7 @@ public sealed class C
     }
 }");
 
-        Assert.Contains("a, b = C.Pair()", printed, StringComparison.Ordinal);
+        Assert.Contains("a, b = Pair()", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("__decon", printed, StringComparison.Ordinal);
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3360SpillTrivialityGuardTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3360SpillTrivialityGuardTests.cs
@@ -78,7 +78,7 @@ public sealed class C
 }");
 
         Assert.DoesNotContain("__spill", printed, StringComparison.Ordinal);
-        Assert.Contains("if C.Get() is int32 i {", printed, StringComparison.Ordinal);
+        Assert.Contains("if Get() is int32 i {", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("if let", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("as int32?", printed, StringComparison.Ordinal);
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3394NegatedPatternGuardTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3394NegatedPatternGuardTranslationTests.cs
@@ -185,7 +185,7 @@ namespace Demo
 
         Assert.Contains("var candidate Candidate? = value as Candidate", rendered, StringComparison.Ordinal);
         Assert.Contains("if candidate == nil {", rendered, StringComparison.Ordinal);
-        Assert.Contains("candidate = C.Normalize(candidate)", rendered, StringComparison.Ordinal);
+        Assert.Contains("candidate = Normalize(candidate)", rendered, StringComparison.Ordinal);
         Assert.Contains("return candidate.Value", rendered, StringComparison.Ordinal);
         Assert.DoesNotContain("is Candidate candidate", rendered, StringComparison.Ordinal);
         TranslationTestValidation.AssertBinds(rendered);
@@ -282,7 +282,7 @@ namespace Demo
             new CSharpToGSharpTranslator().TranslateDocument(document, context));
 
         Assert.Contains("var candidate Candidate?", rendered, StringComparison.Ordinal);
-        Assert.Contains("candidate = C.Normalize(candidate)", rendered, StringComparison.Ordinal);
+        Assert.Contains("candidate = Normalize(candidate)", rendered, StringComparison.Ordinal);
         TranslationTestValidation.AssertBinds(rendered);
     }
 
@@ -469,9 +469,9 @@ namespace Demo
         // ADR-0166 / issue #3409: `skip` is still tested before `Get(value)` is
         // called, and the else-branch sees the when-false pattern variable.
         int prefixGuard = rendered.IndexOf("if skip ||", StringComparison.Ordinal);
-        int patternTest = rendered.IndexOf("!(C.Get(value) is Candidate candidate)", StringComparison.Ordinal);
+        int patternTest = rendered.IndexOf("!(Get(value) is Candidate candidate)", StringComparison.Ordinal);
         Assert.True(prefixGuard >= 0 && patternTest > prefixGuard, rendered);
-        Assert.Contains("if skip || !(C.Get(value) is Candidate candidate) {", rendered, StringComparison.Ordinal);
+        Assert.Contains("if skip || !(Get(value) is Candidate candidate) {", rendered, StringComparison.Ordinal);
         Assert.Contains("} else {", rendered, StringComparison.Ordinal);
         Assert.Contains("return candidate.Value", rendered, StringComparison.Ordinal);
         Assert.DoesNotContain("let candidate", rendered, StringComparison.Ordinal);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3394NestedGenericTypeTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3394NestedGenericTypeTranslationTests.cs
@@ -269,10 +269,10 @@ namespace Demo
         string rendered = GSharpPrinter.Print(
             new CSharpToGSharpTranslator().TranslateDocument(document, context));
 
-        Assert.Contains("var (left, right) = C.Pair()", rendered, StringComparison.Ordinal);
+        Assert.Contains("var (left, right) = Pair()", rendered, StringComparison.Ordinal);
         Assert.DoesNotContain("let (left, right)", rendered, StringComparison.Ordinal);
-        Assert.Contains("C.Touch(&left)", rendered, StringComparison.Ordinal);
-        Assert.Contains("C.Touch(&right)", rendered, StringComparison.Ordinal);
+        Assert.Contains("Touch(&left)", rendered, StringComparison.Ordinal);
+        Assert.Contains("Touch(&right)", rendered, StringComparison.Ordinal);
         TranslationTestValidation.AssertBinds(rendered);
     }
 
@@ -314,7 +314,7 @@ namespace Demo
         string rendered = GSharpPrinter.Print(
             new CSharpToGSharpTranslator().TranslateDocument(document, context));
 
-        Assert.Contains("var (left, right) = C.Pair()", rendered, StringComparison.Ordinal);
+        Assert.Contains("var (left, right) = Pair()", rendered, StringComparison.Ordinal);
         Assert.DoesNotContain("let (left, right)", rendered, StringComparison.Ordinal);
         TranslationTestValidation.AssertBinds(rendered);
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3402ShortCircuitPatternBinderTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3402ShortCircuitPatternBinderTranslationTests.cs
@@ -72,7 +72,7 @@ public class Issue3402ShortCircuitPatternBinderTranslationTests
         // ADR-0166 / issue #3409: native pattern variable; `candidate` and the
         // later `out var extra` both stay visible through the chain and the body.
         Assert.Contains(
-            "if Get(value) is Candidate candidate && candidate.Value > 0 && TryRead(out var extra) && extra > 0 {",
+            "if Get(value) is Candidate candidate && candidate.Value > 0 && C.TryRead(out var extra) && extra > 0 {",
             rendered,
             StringComparison.Ordinal);
         Assert.Contains("return candidate.Value + extra", rendered, StringComparison.Ordinal);
@@ -132,7 +132,7 @@ public class Issue3402ShortCircuitPatternBinderTranslationTests
         // ADR-0166 / issue #3409: the `out var` prefix and the native pattern
         // variable share one condition; no nested `if let` for the binder.
         Assert.Contains(
-            "if TryGet(input, out var value) && value is Candidate candidate && candidate.Value > 0 {",
+            "if C.TryGet(input, out var value) && value is Candidate candidate && candidate.Value > 0 {",
             rendered,
             StringComparison.Ordinal);
         Assert.Contains("return candidate.Value", rendered, StringComparison.Ordinal);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3402ShortCircuitPatternBinderTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3402ShortCircuitPatternBinderTranslationTests.cs
@@ -72,7 +72,7 @@ public class Issue3402ShortCircuitPatternBinderTranslationTests
         // ADR-0166 / issue #3409: native pattern variable; `candidate` and the
         // later `out var extra` both stay visible through the chain and the body.
         Assert.Contains(
-            "if C.Get(value) is Candidate candidate && candidate.Value > 0 && C.TryRead(out var extra) && extra > 0 {",
+            "if Get(value) is Candidate candidate && candidate.Value > 0 && TryRead(out var extra) && extra > 0 {",
             rendered,
             StringComparison.Ordinal);
         Assert.Contains("return candidate.Value + extra", rendered, StringComparison.Ordinal);
@@ -132,7 +132,7 @@ public class Issue3402ShortCircuitPatternBinderTranslationTests
         // ADR-0166 / issue #3409: the `out var` prefix and the native pattern
         // variable share one condition; no nested `if let` for the binder.
         Assert.Contains(
-            "if C.TryGet(input, out var value) && value is Candidate candidate && candidate.Value > 0 {",
+            "if TryGet(input, out var value) && value is Candidate candidate && candidate.Value > 0 {",
             rendered,
             StringComparison.Ordinal);
         Assert.Contains("return candidate.Value", rendered, StringComparison.Ordinal);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3402ShortCircuitPatternBinderTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3402ShortCircuitPatternBinderTranslationTests.cs
@@ -72,7 +72,7 @@ public class Issue3402ShortCircuitPatternBinderTranslationTests
         // ADR-0166 / issue #3409: native pattern variable; `candidate` and the
         // later `out var extra` both stay visible through the chain and the body.
         Assert.Contains(
-            "if Get(value) is Candidate candidate && candidate.Value > 0 && C.TryRead(out var extra) && extra > 0 {",
+            "if Get(value) is Candidate candidate && candidate.Value > 0 && TryRead(out var extra) && extra > 0 {",
             rendered,
             StringComparison.Ordinal);
         Assert.Contains("return candidate.Value + extra", rendered, StringComparison.Ordinal);
@@ -132,7 +132,7 @@ public class Issue3402ShortCircuitPatternBinderTranslationTests
         // ADR-0166 / issue #3409: the `out var` prefix and the native pattern
         // variable share one condition; no nested `if let` for the binder.
         Assert.Contains(
-            "if C.TryGet(input, out var value) && value is Candidate candidate && candidate.Value > 0 {",
+            "if TryGet(input, out var value) && value is Candidate candidate && candidate.Value > 0 {",
             rendered,
             StringComparison.Ordinal);
         Assert.Contains("return candidate.Value", rendered, StringComparison.Ordinal);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3409NativePatternVariableTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3409NativePatternVariableTranslationTests.cs
@@ -89,7 +89,7 @@ public class Issue3409NativePatternVariableTranslationTests
             }
             """);
 
-        Assert.Contains("if C.Get(value) is Candidate candidate && candidate.Value > 0 {", printed, StringComparison.Ordinal);
+        Assert.Contains("if Get(value) is Candidate candidate && candidate.Value > 0 {", printed, StringComparison.Ordinal);
         Assert.Contains("return candidate.Value", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("if let", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("__spill", printed, StringComparison.Ordinal);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3422RedundantNullForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3422RedundantNullForgivenessTranslationTests.cs
@@ -428,7 +428,7 @@ public sealed class Issue3422RedundantNullForgivenessTranslationTests
             }
             """);
 
-        Assert.Contains("C.Consume(type_!!)", printed, StringComparison.Ordinal);
+        Assert.Contains("Consume(type_!!)", printed, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -495,7 +495,7 @@ public sealed class Issue3422RedundantNullForgivenessTranslationTests
 
         Assert.Equal(1, CountOccurrences(printed, ")!!."));
         Assert.Equal(0, CountOccurrences(printed, "!!!!"));
-        Assert.Contains("C.Maybe()!!.Length", printed, StringComparison.Ordinal);
+        Assert.Contains("Maybe()!!.Length", printed, StringComparison.Ordinal);
         Assert.Contains("explicitlyNullable!!.Length", printed, StringComparison.Ordinal);
         Assert.Contains("mutable!!.Count", printed, StringComparison.Ordinal);
     }
@@ -542,7 +542,7 @@ public sealed class Issue3422RedundantNullForgivenessTranslationTests
             "case Wrapper { Child: Leaf leaf } wrapper",
             printed,
             StringComparison.Ordinal);
-        Assert.Contains("return C.Consume(leaf) + wrapper.GetHashCode()", printed, StringComparison.Ordinal);
+        Assert.Contains("return Consume(leaf) + wrapper.GetHashCode()", printed, StringComparison.Ordinal);
         Assert.DoesNotContain(" as Leaf", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("!!!!", printed, StringComparison.Ordinal);
         Assert.DoesNotContain(")!!.", printed, StringComparison.Ordinal);
@@ -631,7 +631,7 @@ public sealed class Issue3422RedundantNullForgivenessTranslationTests
 
         Assert.DoesNotContain("})!!", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("(left ?? right)!!", printed, StringComparison.Ordinal);
-        Assert.Contains("C.Maybe()!!.Length", printed, StringComparison.Ordinal);
+        Assert.Contains("Maybe()!!.Length", printed, StringComparison.Ordinal);
         Assert.Contains("(value as string)!!.Length", printed, StringComparison.Ordinal);
         Assert.Contains("return (first ?? second)!!", printed, StringComparison.Ordinal);
         Assert.Contains("value!!", printed, StringComparison.Ordinal);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3460TranslatorTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3460TranslatorTests.cs
@@ -683,11 +683,11 @@ namespace Cs2Gs.Tests
                 MetadataReference.CreateFromFile(typeof(Fixtures.Issue3460ImportedOptions).Assembly.Location));
 
             Assert.Contains(
-                "Issue3460ImportedOptions(Obj.MarkArgument())",
+                "Issue3460ImportedOptions(MarkArgument())",
                 printed,
                 StringComparison.Ordinal);
-            Assert.Contains("Required = Obj.MarkText(\"ok\", 3)", printed, StringComparison.Ordinal);
-            Assert.Contains("InitOnly = Obj.Mark(4)", printed, StringComparison.Ordinal);
+            Assert.Contains("Required = MarkText(\"ok\", 3)", printed, StringComparison.Ordinal);
+            Assert.Contains("InitOnly = Mark(4)", printed, StringComparison.Ordinal);
             TranslationTestValidation.AssertBinds(printed);
 
             EmittedOracleResult result = EmittedOracle.Evaluate(
@@ -753,8 +753,8 @@ namespace Cs2Gs.Tests
                 MetadataReference.CreateFromFile(typeof(Fixtures.Issue3460NestedOptions).Assembly.Location));
 
             Assert.Contains("Nested: { Value = 5 }", printed, StringComparison.Ordinal);
-            Assert.Contains("Nested: { Value = Obj.Mark(1) }", printed, StringComparison.Ordinal);
-            Assert.Contains("Values: { Obj.Mark(2) }", printed, StringComparison.Ordinal);
+            Assert.Contains("Nested: { Value = Mark(1) }", printed, StringComparison.Ordinal);
+            Assert.Contains("Values: { Mark(2) }", printed, StringComparison.Ordinal);
             TranslationTestValidation.AssertBinds(printed);
 
             EmittedOracleResult result = EmittedOracle.Evaluate(

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3466NestedHomonymAliasTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3466NestedHomonymAliasTests.cs
@@ -132,15 +132,15 @@ public sealed class Issue3466NestedHomonymAliasTests
             printed,
             StringComparison.Ordinal);
         Assert.Contains(
-            "Holder.Total(GenericList[int32]{ 1, 2, 3 })",
+            "Total(GenericList[int32]{ 1, 2, 3 })",
             printed,
             StringComparison.Ordinal);
         Assert.Contains(
-            "Holder.Total(GenericList[int32]{ 4, 5 })",
+            "Total(GenericList[int32]{ 4, 5 })",
             printed,
             StringComparison.Ordinal);
         Assert.Contains(
-            "Holder.TotalInterface(cast[IEnumerable[int32]](GenericList[int32]{ 6, 7 }))",
+            "TotalInterface(cast[IEnumerable[int32]](GenericList[int32]{ 6, 7 }))",
             printed,
             StringComparison.Ordinal);
 
@@ -261,8 +261,12 @@ public sealed class Issue3466NestedHomonymAliasTests
             "Invoked source values keep their emitted name while the generated type alias moves.");
     }
 
+    // Issue #3471: sibling static member references now print bare inside
+    // their declaring aggregate, and a file-scope import alias would shadow
+    // them, so the readable-alias allocator must step aside to a suffixed
+    // alias whenever a source static member claims the readable name.
     [Fact]
-    public void ReadableAlias_DoesNotAvoidQualifiedMemberValues()
+    public void ReadableAlias_AvoidsBareSiblingMemberValues()
     {
         string printed = Translate("""
             using System;
@@ -298,20 +302,25 @@ public sealed class Issue3466NestedHomonymAliasTests
             """);
 
         Assert.Contains(
-            "import TextStringBuilder = System.Text.StringBuilder",
-            printed,
-            StringComparison.Ordinal);
-        Assert.DoesNotContain(
             "import TextStringBuilder_2 = System.Text.StringBuilder",
             printed,
             StringComparison.Ordinal);
-        Assert.Equal(2, CountOccurrences(printed, "TextStringBuilder(\""));
-        Assert.Contains("FieldCase.TextStringBuilder()", printed, StringComparison.Ordinal);
-        Assert.Contains("PropertyCase.TextStringBuilder()", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "import TextStringBuilder = System.Text.StringBuilder",
+            printed,
+            StringComparison.Ordinal);
+        Assert.Equal(2, CountOccurrences(printed, "TextStringBuilder_2(\""));
+        Assert.DoesNotContain("FieldCase.TextStringBuilder()", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("PropertyCase.TextStringBuilder()", printed, StringComparison.Ordinal);
+        Assert.Contains("TextStringBuilder()", printed, StringComparison.Ordinal);
     }
 
+    // Issue #3471: uninvoked sibling static value reads also print bare, so
+    // the readable alias steps aside for them too; a same-named LOCAL alone
+    // would not move the alias (locals stay lexically scoped), but the static
+    // field/property cases in this snippet force the suffixed alias.
     [Fact]
-    public void ReadableAlias_DoesNotAvoidUninvokedValueNames()
+    public void ReadableAlias_AvoidsUninvokedSiblingValueNames()
     {
         string printed = Translate("""
             namespace Demo
@@ -355,14 +364,14 @@ public sealed class Issue3466NestedHomonymAliasTests
             """);
 
         Assert.Contains(
-            "import TextStringBuilder = System.Text.StringBuilder",
-            printed,
-            StringComparison.Ordinal);
-        Assert.DoesNotContain(
             "import TextStringBuilder_2 = System.Text.StringBuilder",
             printed,
             StringComparison.Ordinal);
-        Assert.Equal(3, CountOccurrences(printed, "TextStringBuilder(\""));
+        Assert.DoesNotContain(
+            "import TextStringBuilder = System.Text.StringBuilder",
+            printed,
+            StringComparison.Ordinal);
+        Assert.Equal(3, CountOccurrences(printed, "TextStringBuilder_2(\""));
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3471SiblingStaticQualificationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3471SiblingStaticQualificationTests.cs
@@ -200,12 +200,11 @@ namespace Cs2Gs.Tests
             TranslationTestValidation.AssertBinds(printed);
         }
 
-        // gsc resolves bare sibling statics from lambda bodies inside INSTANCE
-        // members but reports GS0130 for lambda bodies inside `shared` member
-        // bodies (issue #3487), so a lambda site in a static member keeps the
-        // qualifier while a lambda site in an instance member goes bare.
+        // gsc issue #3487 (fixed): bare sibling statics resolve from lambda
+        // bodies inside shared members just as they do in instance members,
+        // so both lambda sites go bare.
         [Fact]
-        public void LambdaBody_InStaticMember_StaysQualified()
+        public void LambdaBody_InStaticMember_EmitsBare()
         {
             string printed = Translate("""
                 using System;
@@ -224,8 +223,9 @@ namespace Cs2Gs.Tests
                 }
                 """);
 
-            Assert.Contains("Events.Hidden()", printed, StringComparison.Ordinal);
-            Assert.Contains("Events.Shown()", printed, StringComparison.Ordinal);
+            Assert.DoesNotContain("Events.Hidden()", printed, StringComparison.Ordinal);
+            Assert.DoesNotContain("Events.Shown()", printed, StringComparison.Ordinal);
+            Assert.Contains("Hidden() + Shown()", printed, StringComparison.Ordinal);
             TranslationTestValidation.AssertBinds(printed);
         }
 
@@ -251,11 +251,11 @@ namespace Cs2Gs.Tests
             TranslationTestValidation.AssertBinds(printed);
         }
 
-        // gsc's emitter throws GS9998 when a bare shared member is the base
-        // receiver of a member STORE, while reads and call receivers emit
-        // fine — so only the store-receiver position keeps its qualifier.
+        // gsc issue #3489 (fixed): a bare shared member works as the base
+        // receiver of a member STORE, so store positions go bare like every
+        // other sibling static reference.
         [Fact]
-        public void SiblingStaticStoreReceiver_StaysQualified()
+        public void SiblingStaticStoreReceiver_EmitsBare()
         {
             string printed = Translate("""
                 public class Logging
@@ -286,10 +286,10 @@ namespace Cs2Gs.Tests
                 }
                 """);
 
-            Assert.Contains("Logging.Instance.flush = value", printed, StringComparison.Ordinal);
+            Assert.Contains("set -> Instance.flush = value", printed, StringComparison.Ordinal);
             Assert.Contains("get -> Instance.flush", printed, StringComparison.Ordinal);
             Assert.Contains("Instance.Set(value)", printed, StringComparison.Ordinal);
-            Assert.DoesNotContain("Logging.Instance.Set", printed, StringComparison.Ordinal);
+            Assert.DoesNotContain("Logging.Instance", printed, StringComparison.Ordinal);
             EmittedOracleResult result = EmittedOracle.Evaluate(
                 printed + Environment.NewLine + "Logging.Run()");
             Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
@@ -297,12 +297,11 @@ namespace Cs2Gs.Tests
             Assert.Equal(1, result.Value);
         }
 
-        // gsc double-binds the arguments of a BARE sibling call when an
-        // argument subtree carries an inline `out var` declaration (issue
-        // #3490: GS9002 + GS0102 for the same declaration), so such calls
-        // keep the qualifier.
+        // gsc issue #3490 (fixed): a bare sibling call whose argument
+        // subtree carries an inline `out var` declaration binds cleanly, so
+        // it goes bare like every other sibling static call.
         [Fact]
-        public void SiblingStaticCall_WithOutVarArgument_StaysQualified()
+        public void SiblingStaticCall_WithOutVarArgument_EmitsBare()
         {
             string printed = Translate("""
                 using System.Collections.Generic;
@@ -321,7 +320,8 @@ namespace Cs2Gs.Tests
                 }
                 """);
 
-            Assert.Contains("Writer.Format(if row.TryGetValue(k, out var v)", printed, StringComparison.Ordinal);
+            Assert.Contains("Format(if row.TryGetValue(k, out var v)", printed, StringComparison.Ordinal);
+            Assert.DoesNotContain("Writer.Format(", printed, StringComparison.Ordinal);
             Assert.Contains("string -> Format(value)", printed, StringComparison.Ordinal);
             TranslationTestValidation.AssertBinds(printed);
         }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3471SiblingStaticQualificationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3471SiblingStaticQualificationTests.cs
@@ -1,0 +1,282 @@
+// <copyright file="Issue3471SiblingStaticQualificationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using GSharp.Tests;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Cs2Gs.Tests
+{
+    // Issue #3471: a bare C# reference to a sibling static member used to be
+    // re-qualified through the owning type on every line (`Agent.IsEnabled(...)`
+    // inside `Agent`). gsc resolves bare sibling `shared` references from
+    // anywhere inside the declaring aggregate's body, so the qualifier is only
+    // required where the emitted body leaves the type scope (lifted extension
+    // funcs), or where gsc genuinely cannot see the member bare (nested type →
+    // outer statics, derived type → inherited statics).
+    public sealed class Issue3471SiblingStaticQualificationTests
+    {
+        [Fact]
+        public void InstanceMethod_SiblingSharedMembers_EmitBare()
+        {
+            string printed = Translate("""
+                public class Agent
+                {
+                    public static int Count { get; set; }
+
+                    public string Name = "x";
+
+                    public string Describe()
+                    {
+                        if (IsEnabled("1"))
+                        {
+                            Count = Count + 1;
+                            return Name + Count;
+                        }
+
+                        return Name;
+                    }
+
+                    private static bool IsEnabled(string value) => value == "1";
+                }
+                """);
+
+            Assert.DoesNotContain("Agent.IsEnabled", printed, StringComparison.Ordinal);
+            Assert.DoesNotContain("Agent.Count", printed, StringComparison.Ordinal);
+            Assert.Contains("IsEnabled(\"1\")", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+        }
+
+        [Fact]
+        public void SharedMethod_SiblingSharedFieldAndCall_Evaluate()
+        {
+            string printed = Translate("""
+                public static class Obj
+                {
+                    private static int seed = 40;
+
+                    public static int Run()
+                    {
+                        Bump(2);
+                        return seed;
+                    }
+
+                    private static int Bump(int by) => seed += by;
+                }
+                """);
+
+            Assert.DoesNotContain("Obj.Bump", printed, StringComparison.Ordinal);
+            Assert.DoesNotContain("Obj.seed", printed, StringComparison.Ordinal);
+            EmittedOracleResult result = EmittedOracle.Evaluate(
+                printed + Environment.NewLine + "Obj.Run()");
+            Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+            Assert.Null(result.UnhandledException);
+            Assert.Equal(42, result.Value);
+        }
+
+        [Fact]
+        public void NestedType_OuterSharedMember_StaysQualified()
+        {
+            string printed = Translate("""
+                public class Outer
+                {
+                    public static string Tag() => "outer";
+
+                    public class Inner
+                    {
+                        public string From() => Tag();
+                    }
+                }
+                """);
+
+            Assert.Contains("Outer.Tag()", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+        }
+
+        [Fact]
+        public void DerivedType_InheritedSharedMember_StaysQualified()
+        {
+            string printed = Translate("""
+                public class BaseCls
+                {
+                    public static string BaseTag() => "base";
+                }
+
+                public class DerivedCls : BaseCls
+                {
+                    public string From() => BaseTag();
+                }
+                """);
+
+            Assert.Contains("BaseCls.BaseTag()", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+        }
+
+        [Fact]
+        public void LiftedExtensionBody_SiblingStatic_StaysQualified()
+        {
+            string printed = Translate("""
+                public static class Ext
+                {
+                    public static int Twice(this int value) => Add(value, value);
+
+                    public static int Add(int a, int b) => a + b;
+                }
+                """);
+
+            Assert.Contains("Ext.Add(", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+        }
+
+        [Fact]
+        public void LiftedStaticLocalFunction_SameTypeCall_EmitsBare()
+        {
+            string printed = Translate("""
+                public class Labels
+                {
+                    public string Make()
+                    {
+                        int ordinal = 0;
+                        return NewLabel("switchEnd", ref ordinal);
+
+                        static string NewLabel(string prefix, ref int i)
+                        {
+                            i++;
+                            return prefix + i;
+                        }
+                    }
+                }
+                """);
+
+            Assert.Contains("__local_", printed, StringComparison.Ordinal);
+            Assert.DoesNotContain("Labels.__local_", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+        }
+
+        [Fact]
+        public void GenericOwner_SiblingSharedMember_EmitsBare()
+        {
+            string printed = Translate("""
+                public class Box<T>
+                {
+                    public static int Total { get; set; }
+
+                    public int Touch()
+                    {
+                        Total = Total + 1;
+                        return Total;
+                    }
+                }
+                """);
+
+            Assert.DoesNotContain("Box[T].Total", printed, StringComparison.Ordinal);
+            Assert.DoesNotContain("Box.Total", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+        }
+
+        [Fact]
+        public void StructOwner_SiblingSharedMember_EmitsBare()
+        {
+            string printed = Translate("""
+                public struct Pt
+                {
+                    public static int Zero => 0;
+
+                    public int X;
+
+                    public int Shift() => X + Zero;
+                }
+                """);
+
+            Assert.DoesNotContain("Pt.Zero", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+        }
+
+        // gsc resolves bare sibling statics from lambda bodies inside INSTANCE
+        // members but reports GS0130 for lambda bodies inside `shared` member
+        // bodies (issue #3487), so a lambda site in a static member keeps the
+        // qualifier while a lambda site in an instance member goes bare.
+        [Fact]
+        public void LambdaBody_InStaticMember_StaysQualified()
+        {
+            string printed = Translate("""
+                using System;
+
+                public class Events
+                {
+                    private static int Hidden() => 3;
+
+                    public static int Shown() => 4;
+
+                    public static int Run()
+                    {
+                        Func<int> mixed = () => Hidden() + Shown();
+                        return mixed();
+                    }
+                }
+                """);
+
+            Assert.Contains("Events.Hidden()", printed, StringComparison.Ordinal);
+            Assert.Contains("Events.Shown()", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+        }
+
+        [Fact]
+        public void LambdaBody_InInstanceMember_EmitsBare()
+        {
+            string printed = Translate("""
+                using System;
+
+                public class Events
+                {
+                    private static int Hidden() => 3;
+
+                    public int Run()
+                    {
+                        Func<int> f = () => Hidden();
+                        return f();
+                    }
+                }
+                """);
+
+            Assert.DoesNotContain("Events.Hidden()", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+        }
+
+        private static string Translate(
+            string source,
+            params MetadataReference[] additionalReferences)
+        {
+            IReadOnlyList<MetadataReference> references = additionalReferences.Length == 0
+                ? null
+                : CSharpProjectLoader.RuntimeReferences()
+                    .Concat(additionalReferences)
+                    .GroupBy(reference => reference.Display, StringComparer.Ordinal)
+                    .Select(group => group.First())
+                    .ToList();
+            LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+                new[] { ("Snippet.cs", source) },
+                references);
+            Assert.True(
+                project.BoundWithoutErrors,
+                "Snippet should bind with no C# errors: "
+                    + string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+            LoadedDocument document = Assert.Single(project.Documents);
+            var context = new TranslationContext(
+                project.Compilation,
+                document.SemanticModel,
+                document.FilePath);
+            CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+            return GSharpPrinter.Print(unit);
+        }
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3471SiblingStaticQualificationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3471SiblingStaticQualificationTests.cs
@@ -251,6 +251,81 @@ namespace Cs2Gs.Tests
             TranslationTestValidation.AssertBinds(printed);
         }
 
+        // gsc's emitter throws GS9998 when a bare shared member is the base
+        // receiver of a member STORE, while reads and call receivers emit
+        // fine — so only the store-receiver position keeps its qualifier.
+        [Fact]
+        public void SiblingStaticStoreReceiver_StaysQualified()
+        {
+            string printed = Translate("""
+                public class Logging
+                {
+                    private bool flush;
+
+                    private static Logging Instance = new Logging();
+
+                    public static bool InstantFlush
+                    {
+                        get => Instance.flush;
+                        set => Instance.flush = value;
+                    }
+
+                    public static void Apply(bool value)
+                    {
+                        Instance.Set(value);
+                    }
+
+                    public static int Run()
+                    {
+                        InstantFlush = true;
+                        Apply(true);
+                        return InstantFlush ? 1 : 0;
+                    }
+
+                    private void Set(bool value) => this.flush = value;
+                }
+                """);
+
+            Assert.Contains("Logging.Instance.flush = value", printed, StringComparison.Ordinal);
+            Assert.Contains("get -> Instance.flush", printed, StringComparison.Ordinal);
+            Assert.Contains("Instance.Set(value)", printed, StringComparison.Ordinal);
+            Assert.DoesNotContain("Logging.Instance.Set", printed, StringComparison.Ordinal);
+            EmittedOracleResult result = EmittedOracle.Evaluate(
+                printed + Environment.NewLine + "Logging.Run()");
+            Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+            Assert.Null(result.UnhandledException);
+            Assert.Equal(1, result.Value);
+        }
+
+        // gsc double-binds the arguments of a BARE sibling call when an
+        // argument subtree carries an inline `out var` declaration (issue
+        // #3490: GS9002 + GS0102 for the same declaration), so such calls
+        // keep the qualifier.
+        [Fact]
+        public void SiblingStaticCall_WithOutVarArgument_StaysQualified()
+        {
+            string printed = Translate("""
+                using System.Collections.Generic;
+                using System.Linq;
+
+                public class Writer
+                {
+                    public string Row(IReadOnlyDictionary<string, object?> row, List<string> keys)
+                    {
+                        return string.Join(",", keys.Select(k => Format(row.TryGetValue(k, out var v) ? v : null)));
+                    }
+
+                    public static string Plain(object? value) => Format(value);
+
+                    private static string Format(object? value) => value?.ToString() ?? "";
+                }
+                """);
+
+            Assert.Contains("Writer.Format(if row.TryGetValue(k, out var v)", printed, StringComparison.Ordinal);
+            Assert.Contains("string -> Format(value)", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+        }
+
         private static string Translate(
             string source,
             params MetadataReference[] additionalReferences)

--- a/tools/cs2gs/Cs2Gs.Tests/L2TranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/L2TranslationTests.cs
@@ -141,13 +141,14 @@ namespace Demo
     }
 
     /// <summary>
-    /// ADR-0115 §B.18: a C# bare sibling static call inside a non-entry static
-    /// class (<c>Round(value, 2)</c>) is qualified through its owning type
-    /// (<c>RoundHost.Round(value, 2)</c>), because a G# <c>shared</c> method body
-    /// has no implicit type scope.
+    /// ADR-0115 §B.18 / issue #3471: a C# bare sibling static call inside its
+    /// own declaring type (<c>Two(value, 2)</c>) stays bare, because gsc
+    /// resolves bare sibling <c>shared</c> references from anywhere inside the
+    /// declaring aggregate's body; only sites that leave the type scope keep
+    /// the owning-type qualifier.
     /// </summary>
     [Fact]
-    public void SiblingStaticCall_IsQualifiedByOwningType()
+    public void SiblingStaticCall_EmitsBareInsideOwningType()
     {
         string printed = TranslateUnit(@"
 namespace Demo
@@ -160,7 +161,8 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("RoundHost.Two(value, 2)", printed);
+        Assert.Contains("Two(value, 2)", printed);
+        Assert.DoesNotContain("RoundHost.Two(value, 2)", printed);
     }
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Tests/StaticMemberQualificationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/StaticMemberQualificationTranslationTests.cs
@@ -64,11 +64,14 @@ namespace Corpus.StaticMember
 ";
 
     [Fact]
-    public void StaticFieldReferenced_FromSiblingSharedMethod_IsQualified()
+    public void StaticFieldReferenced_FromSiblingSharedMethod_EmitsBare()
     {
+        // Issue #3471: gsc resolves a bare sibling `shared` member reference
+        // from inside the declaring aggregate, so the qualifier is dropped.
         string rendered = TranslateAndPrint(SiblingSource);
 
-        Assert.Contains("Holder.Tab", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("Holder.Tab", rendered, StringComparison.Ordinal);
+        Assert.Contains("return Tab", rendered, StringComparison.Ordinal);
     }
 
     private const string GenericSiblingSource = @"
@@ -94,17 +97,18 @@ namespace Corpus.StaticMember
 ";
 
     [Fact]
-    public void StaticMemberReferenced_FromGenericSibling_IsQualifiedWithTypeArguments()
+    public void StaticMemberReferenced_FromGenericSibling_EmitsBare()
     {
-        // A generic owner (`Box<T>`) that lives beside a non-generic type of the
-        // same simple name (`static class Box`) must be qualified with its type
-        // arguments (`Box[T].Tab` / `Box[T].Read()`), not the bare arity-0 name —
-        // otherwise gsc binds the wrong (non-generic) type and reports GS0158.
+        // Issue #3471: even a generic owner beside a non-generic type of the
+        // same simple name (`static class Box` / `class Box<T>`) references its
+        // own shared members bare — no qualifier means the old wrong-arity
+        // hazard (binding arity-0 `Box` and reporting GS0158) cannot arise.
         string rendered = TranslateAndPrint(GenericSiblingSource);
 
-        Assert.Contains("Box[T].Tab", rendered, StringComparison.Ordinal);
-        Assert.Contains("Box[T].Read()", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("Box[T].Tab", rendered, StringComparison.Ordinal);
         Assert.DoesNotContain("Box.Tab", rendered, StringComparison.Ordinal);
+        Assert.Contains("return Tab", rendered, StringComparison.Ordinal);
+        Assert.Contains("Read().ToString()", rendered, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -50,9 +50,13 @@ public sealed partial class CSharpToGSharpTranslator
                 && this.state.LiftedStaticLocalFunctions.TryGetValue(localFunction, out string liftedName)
                 && localFunction.ContainingType is { } containingType)
             {
-                return new MemberAccessExpression(
-                    this.StaticQualifierReceiver(containingType, identifier.GetLocation()),
-                    liftedName);
+                // Issue #3471: the lifted helper lands in the containing
+                // aggregate's `shared` block, so a same-type site names it bare.
+                return this.IsBareSiblingStaticScope(containingType, liftedName, identifier)
+                    ? new IdentifierExpression(liftedName)
+                    : new MemberAccessExpression(
+                        this.StaticQualifierReceiver(containingType, identifier.GetLocation()),
+                        liftedName);
             }
 
             // Issue #3399: a member of a recursive/mutually recursive SCC of
@@ -104,7 +108,11 @@ public sealed partial class CSharpToGSharpTranslator
                     || RequiresQualifiedImportedContextualValue(
                         staticMember,
                         identifier)) &&
-                !SymbolEqualityComparer.Default.Equals(owner.OriginalDefinition, this.entryType?.OriginalDefinition))
+                !SymbolEqualityComparer.Default.Equals(owner.OriginalDefinition, this.entryType?.OriginalDefinition) &&
+                !this.IsBareSiblingStaticScope(
+                    owner,
+                    this.EmittedName(staticMember, identifier.Identifier.ValueText),
+                    identifier))
             {
                 return new MemberAccessExpression(
                     this.StaticQualifierReceiver(owner, identifier.GetLocation()),
@@ -184,6 +192,99 @@ public sealed partial class CSharpToGSharpTranslator
                          argument.RefKindKeyword.Kind() is SyntaxKind.RefKeyword or SyntaxKind.OutKeyword => true,
                 _ => false,
             };
+
+        // Issue #3471: gsc resolves a bare reference to a sibling `shared`
+        // member (func, var, let — reads, writes, and calls) from anywhere
+        // lexically inside the declaring aggregate's emitted body: instance
+        // methods, `shared` methods, generic owners, and structs alike. The
+        // implicit-type-qualifier rule (ADR-0115 §B.18) therefore only applies
+        // where the emitted body actually LEAVES the type scope. Bare emission
+        // requires the reference site's nearest enclosing type declaration to
+        // be the owner itself: a NESTED type does not see its outer type's
+        // shared members bare (GS0130), and a derived type does not see
+        // inherited ones, so both stay qualified. A classic extension method's
+        // body may be lifted to a top-level receiver-clause `func` (file
+        // scope), so any site inside one keeps the qualifier as well — even
+        // owner-scoped (#3413) extension bodies, conservatively. The member's
+        // emitted name must not be claimed by any file-scope import alias,
+        // imported type, or source type name — those shadow class members in
+        // gsc scope resolution, so a colliding member reference keeps the
+        // qualifier (the readable-alias allocator reciprocally avoids sibling
+        // static member names when synthesizing new aliases). Finally, gsc
+        // resolves bare sibling statics from lambda bodies inside INSTANCE
+        // members, but reports GS0130 for a lambda body inside a `shared`
+        // member body (issue #3487) — while the qualified spelling binds in
+        // both — so a site that is inside an emitted function literal AND
+        // inside a static member context keeps the qualifier. A non-lifted C#
+        // local function counts as a function literal (cs2gs lowers it to a
+        // `let` func binding); a LIFTED static local function instead becomes
+        // a real `shared` helper method, which is a static member context of
+        // its own regardless of the containing C# member.
+        private bool IsBareSiblingStaticScope(
+            INamedTypeSymbol owner,
+            string memberName,
+            SyntaxNode site)
+        {
+            if (this.typeMapper.ClaimsDocumentScopeName(memberName, this.context))
+            {
+                return false;
+            }
+
+            bool emittedLambdaContext = false;
+            bool staticMemberContext = false;
+            for (SyntaxNode node = site; node != null; node = node.Parent)
+            {
+                if (node is AnonymousFunctionExpressionSyntax)
+                {
+                    emittedLambdaContext = true;
+                }
+
+                if (node is LocalFunctionStatementSyntax localFunction)
+                {
+                    IMethodSymbol localSymbol =
+                        this.context.GetDeclaredSymbol(localFunction) as IMethodSymbol;
+                    bool liftedStatic = localSymbol != null
+                        && this.state.LiftedStaticLocalFunctions.ContainsKey(localSymbol);
+                    bool liftedRecursive = localSymbol != null
+                        && this.state.LiftedRecursiveLocalFunctions.ContainsKey(localSymbol);
+                    if (liftedStatic
+                        || (liftedRecursive
+                            && this.state.LiftedRecursiveLocalFunctions[localSymbol].IsStatic))
+                    {
+                        staticMemberContext = true;
+                    }
+                    else if (!liftedRecursive)
+                    {
+                        emittedLambdaContext = true;
+                    }
+                }
+
+                if (node is MethodDeclarationSyntax method
+                    && this.context.GetDeclaredSymbol(method) is IMethodSymbol
+                        { IsExtensionMethod: true })
+                {
+                    return false;
+                }
+
+                if (node is TypeDeclarationSyntax typeDeclaration)
+                {
+                    return !(emittedLambdaContext && staticMemberContext)
+                        && this.context.GetDeclaredSymbol(typeDeclaration) is INamedTypeSymbol siteType
+                        && SymbolEqualityComparer.Default.Equals(
+                            siteType.OriginalDefinition,
+                            owner.OriginalDefinition);
+                }
+
+                if (node is MemberDeclarationSyntax member
+                    && node is not BaseTypeDeclarationSyntax
+                    && member.Modifiers.Any(SyntaxKind.StaticKeyword))
+                {
+                    staticMemberContext = true;
+                }
+            }
+
+            return false;
+        }
 
         // Builds the receiver expression used to qualify a bare sibling static
         // member reference through its owning type. For a non-generic owner this is

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -109,10 +109,11 @@ public sealed partial class CSharpToGSharpTranslator
                         staticMember,
                         identifier)) &&
                 !SymbolEqualityComparer.Default.Equals(owner.OriginalDefinition, this.entryType?.OriginalDefinition) &&
-                !this.IsBareSiblingStaticScope(
-                    owner,
-                    this.EmittedName(staticMember, identifier.Identifier.ValueText),
-                    identifier))
+                !(this.IsBareSiblingStaticScope(
+                        owner,
+                        this.EmittedName(staticMember, identifier.Identifier.ValueText),
+                        identifier)
+                    && !IsStoreReceiverPosition(identifier)))
             {
                 return new MemberAccessExpression(
                     this.StaticQualifierReceiver(owner, identifier.GetLocation()),
@@ -220,6 +221,46 @@ public sealed partial class CSharpToGSharpTranslator
         // `let` func binding); a LIFTED static local function instead becomes
         // a real `shared` helper method, which is a static member context of
         // its own regardless of the containing C# member.
+        // Issue #3471: gsc's emitter throws GS9998 ("Variable 'X' has no
+        // local slot or parameter index") when a BARE shared member is the
+        // base receiver of a member STORE (`Instance.flush = value`,
+        // `Instance.Flag = v`, compound assignments, ref/out arguments) in any
+        // member body — while reads (`Instance.flush`), call receivers
+        // (`Instance.Apply(v)`), and direct writes to the member itself
+        // (`Count = Count + 1`) all emit fine. Until that is fixed, a sibling
+        // static referenced in store-receiver position keeps its qualifier.
+        private static bool IsStoreReceiverPosition(IdentifierNameSyntax identifier)
+        {
+            SyntaxNode current = identifier;
+            while ((current.Parent is MemberAccessExpressionSyntax memberAccess
+                        && memberAccess.Expression == current)
+                || (current.Parent is ElementAccessExpressionSyntax elementAccess
+                        && elementAccess.Expression == current))
+            {
+                current = current.Parent;
+            }
+
+            if (ReferenceEquals(current, identifier))
+            {
+                return false;
+            }
+
+            return current.Parent switch
+            {
+                AssignmentExpressionSyntax assignment when assignment.Left == current => true,
+                PrefixUnaryExpressionSyntax prefix
+                    when prefix.Operand == current &&
+                         prefix.Kind() is SyntaxKind.PreIncrementExpression or SyntaxKind.PreDecrementExpression => true,
+                PostfixUnaryExpressionSyntax postfix
+                    when postfix.Operand == current &&
+                         postfix.Kind() is SyntaxKind.PostIncrementExpression or SyntaxKind.PostDecrementExpression => true,
+                ArgumentSyntax argument
+                    when argument.Expression == current &&
+                         argument.RefKindKeyword.Kind() is SyntaxKind.RefKeyword or SyntaxKind.OutKeyword => true,
+                _ => false,
+            };
+        }
+
         private bool IsBareSiblingStaticScope(
             INamedTypeSymbol owner,
             string memberName,

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -109,11 +109,10 @@ public sealed partial class CSharpToGSharpTranslator
                         staticMember,
                         identifier)) &&
                 !SymbolEqualityComparer.Default.Equals(owner.OriginalDefinition, this.entryType?.OriginalDefinition) &&
-                !(this.IsBareSiblingStaticScope(
-                        owner,
-                        this.EmittedName(staticMember, identifier.Identifier.ValueText),
-                        identifier)
-                    && !IsStoreReceiverPosition(identifier)))
+                !this.IsBareSiblingStaticScope(
+                    owner,
+                    this.EmittedName(staticMember, identifier.Identifier.ValueText),
+                    identifier))
             {
                 return new MemberAccessExpression(
                     this.StaticQualifierReceiver(owner, identifier.GetLocation()),
@@ -211,56 +210,10 @@ public sealed partial class CSharpToGSharpTranslator
         // imported type, or source type name — those shadow class members in
         // gsc scope resolution, so a colliding member reference keeps the
         // qualifier (the readable-alias allocator reciprocally avoids sibling
-        // static member names when synthesizing new aliases). Finally, gsc
-        // resolves bare sibling statics from lambda bodies inside INSTANCE
-        // members, but reports GS0130 for a lambda body inside a `shared`
-        // member body (issue #3487) — while the qualified spelling binds in
-        // both — so a site that is inside an emitted function literal AND
-        // inside a static member context keeps the qualifier. A non-lifted C#
-        // local function counts as a function literal (cs2gs lowers it to a
-        // `let` func binding); a LIFTED static local function instead becomes
-        // a real `shared` helper method, which is a static member context of
-        // its own regardless of the containing C# member.
-        // Issue #3471: gsc's emitter throws GS9998 ("Variable 'X' has no
-        // local slot or parameter index") when a BARE shared member is the
-        // base receiver of a member STORE (`Instance.flush = value`,
-        // `Instance.Flag = v`, compound assignments, ref/out arguments) in any
-        // member body — while reads (`Instance.flush`), call receivers
-        // (`Instance.Apply(v)`), and direct writes to the member itself
-        // (`Count = Count + 1`) all emit fine. Until that is fixed, a sibling
-        // static referenced in store-receiver position keeps its qualifier.
-        private static bool IsStoreReceiverPosition(IdentifierNameSyntax identifier)
-        {
-            SyntaxNode current = identifier;
-            while ((current.Parent is MemberAccessExpressionSyntax memberAccess
-                        && memberAccess.Expression == current)
-                || (current.Parent is ElementAccessExpressionSyntax elementAccess
-                        && elementAccess.Expression == current))
-            {
-                current = current.Parent;
-            }
-
-            if (ReferenceEquals(current, identifier))
-            {
-                return false;
-            }
-
-            return current.Parent switch
-            {
-                AssignmentExpressionSyntax assignment when assignment.Left == current => true,
-                PrefixUnaryExpressionSyntax prefix
-                    when prefix.Operand == current &&
-                         prefix.Kind() is SyntaxKind.PreIncrementExpression or SyntaxKind.PreDecrementExpression => true,
-                PostfixUnaryExpressionSyntax postfix
-                    when postfix.Operand == current &&
-                         postfix.Kind() is SyntaxKind.PostIncrementExpression or SyntaxKind.PostDecrementExpression => true,
-                ArgumentSyntax argument
-                    when argument.Expression == current &&
-                         argument.RefKindKeyword.Kind() is SyntaxKind.RefKeyword or SyntaxKind.OutKeyword => true,
-                _ => false,
-            };
-        }
-
+        // static member names when synthesizing new aliases). Function-literal
+        // bodies need no special casing: since gsc issue #3487 was fixed,
+        // bare sibling statics resolve from lambdas in shared members exactly
+        // as they do in instance members.
         private bool IsBareSiblingStaticScope(
             INamedTypeSymbol owner,
             string memberName,
@@ -271,35 +224,8 @@ public sealed partial class CSharpToGSharpTranslator
                 return false;
             }
 
-            bool emittedLambdaContext = false;
-            bool staticMemberContext = false;
             for (SyntaxNode node = site; node != null; node = node.Parent)
             {
-                if (node is AnonymousFunctionExpressionSyntax)
-                {
-                    emittedLambdaContext = true;
-                }
-
-                if (node is LocalFunctionStatementSyntax localFunction)
-                {
-                    IMethodSymbol localSymbol =
-                        this.context.GetDeclaredSymbol(localFunction) as IMethodSymbol;
-                    bool liftedStatic = localSymbol != null
-                        && this.state.LiftedStaticLocalFunctions.ContainsKey(localSymbol);
-                    bool liftedRecursive = localSymbol != null
-                        && this.state.LiftedRecursiveLocalFunctions.ContainsKey(localSymbol);
-                    if (liftedStatic
-                        || (liftedRecursive
-                            && this.state.LiftedRecursiveLocalFunctions[localSymbol].IsStatic))
-                    {
-                        staticMemberContext = true;
-                    }
-                    else if (!liftedRecursive)
-                    {
-                        emittedLambdaContext = true;
-                    }
-                }
-
                 if (node is MethodDeclarationSyntax method
                     && this.context.GetDeclaredSymbol(method) is IMethodSymbol
                         { IsExtensionMethod: true })
@@ -309,18 +235,10 @@ public sealed partial class CSharpToGSharpTranslator
 
                 if (node is TypeDeclarationSyntax typeDeclaration)
                 {
-                    return !(emittedLambdaContext && staticMemberContext)
-                        && this.context.GetDeclaredSymbol(typeDeclaration) is INamedTypeSymbol siteType
+                    return this.context.GetDeclaredSymbol(typeDeclaration) is INamedTypeSymbol siteType
                         && SymbolEqualityComparer.Default.Equals(
                             siteType.OriginalDefinition,
                             owner.OriginalDefinition);
-                }
-
-                if (node is MemberDeclarationSyntax member
-                    && node is not BaseTypeDeclarationSyntax
-                    && member.Modifiers.Any(SyntaxKind.StaticKeyword))
-                {
-                    staticMemberContext = true;
                 }
             }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -341,20 +341,10 @@ public sealed partial class CSharpToGSharpTranslator
                 (!this.IsStaticUsingTarget(owner)
                     || RequiresQualifiedImportedContextualCall(staticMethod)) &&
                 !SymbolEqualityComparer.Default.Equals(owner.OriginalDefinition, this.entryType?.OriginalDefinition) &&
-                !(this.IsBareSiblingStaticScope(
-                        owner,
-                        this.EmittedName(staticMethod, staticMethod.Name),
-                        bareName)
-
-                    // Issue #3490: gsc double-binds arguments of a BARE
-                    // sibling call when the argument subtree carries an inline
-                    // `out var` declaration (GS9002 + GS0102 for the same
-                    // declaration), while the qualified spelling compiles —
-                    // so such calls keep the qualifier.
-                    && !invocation.ArgumentList.Arguments.Any(argument =>
-                        argument.DescendantNodesAndSelf()
-                            .OfType<DeclarationExpressionSyntax>()
-                            .Any())))
+                !this.IsBareSiblingStaticScope(
+                    owner,
+                    this.EmittedName(staticMethod, staticMethod.Name),
+                    bareName))
             {
                 // A C# bare sibling static call (`Round(value, 2)`) carries an
                 // implicit type qualifier only where the emitted body leaves the

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -341,10 +341,20 @@ public sealed partial class CSharpToGSharpTranslator
                 (!this.IsStaticUsingTarget(owner)
                     || RequiresQualifiedImportedContextualCall(staticMethod)) &&
                 !SymbolEqualityComparer.Default.Equals(owner.OriginalDefinition, this.entryType?.OriginalDefinition) &&
-                !this.IsBareSiblingStaticScope(
-                    owner,
-                    this.EmittedName(staticMethod, staticMethod.Name),
-                    bareName))
+                !(this.IsBareSiblingStaticScope(
+                        owner,
+                        this.EmittedName(staticMethod, staticMethod.Name),
+                        bareName)
+
+                    // Issue #3490: gsc double-binds arguments of a BARE
+                    // sibling call when the argument subtree carries an inline
+                    // `out var` declaration (GS9002 + GS0102 for the same
+                    // declaration), while the qualified spelling compiles —
+                    // so such calls keep the qualifier.
+                    && !invocation.ArgumentList.Arguments.Any(argument =>
+                        argument.DescendantNodesAndSelf()
+                            .OfType<DeclarationExpressionSyntax>()
+                            .Any())))
             {
                 // A C# bare sibling static call (`Round(value, 2)`) carries an
                 // implicit type qualifier only where the emitted body leaves the

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -90,6 +90,8 @@ public sealed partial class CSharpToGSharpTranslator
 
                 GExpression recursiveTarget = recursiveLift.IsStatic
                     && recursiveLocal.ContainingType is { } recursiveContainingType
+                    && !this.IsBareSiblingStaticScope(
+                        recursiveContainingType, recursiveLift.Name, invocation)
                         ? new MemberAccessExpression(
                             this.StaticQualifierReceiver(recursiveContainingType, invocation.GetLocation()),
                             recursiveLift.Name)
@@ -257,9 +259,13 @@ public sealed partial class CSharpToGSharpTranslator
                 && this.state.LiftedStaticLocalFunctions.TryGetValue(localFunction, out string liftedName)
                 && localFunction.ContainingType is { } containingType)
             {
-                target = new MemberAccessExpression(
-                    this.StaticQualifierReceiver(containingType, invocation.GetLocation()),
-                    liftedName);
+                // Issue #3471: same-type call sites name the lifted `shared`
+                // helper bare; only cross-type sites qualify through the owner.
+                target = this.IsBareSiblingStaticScope(containingType, liftedName, invocation)
+                    ? new IdentifierExpression(liftedName)
+                    : new MemberAccessExpression(
+                        this.StaticQualifierReceiver(containingType, invocation.GetLocation()),
+                        liftedName);
                 if (invocation.Expression is GenericNameSyntax liftedGeneric)
                 {
                     typeArguments = this.MapTypeArguments(liftedGeneric);
@@ -334,11 +340,16 @@ public sealed partial class CSharpToGSharpTranslator
                 !owner.IsImplicitlyDeclared &&
                 (!this.IsStaticUsingTarget(owner)
                     || RequiresQualifiedImportedContextualCall(staticMethod)) &&
-                !SymbolEqualityComparer.Default.Equals(owner.OriginalDefinition, this.entryType?.OriginalDefinition))
+                !SymbolEqualityComparer.Default.Equals(owner.OriginalDefinition, this.entryType?.OriginalDefinition) &&
+                !this.IsBareSiblingStaticScope(
+                    owner,
+                    this.EmittedName(staticMethod, staticMethod.Name),
+                    bareName))
             {
                 // A C# bare sibling static call (`Round(value, 2)`) carries an
-                // implicit type qualifier. A G# `shared` method body has no
-                // implicit type scope, so the call must be qualified through the
+                // implicit type qualifier only where the emitted body leaves the
+                // owner's type scope (issue #3471) — e.g. a lifted extension
+                // `func` at file scope — and must then be qualified through the
                 // owning type (`Geometry.Round(value, 2)`); see ADR-0115 §B.18.
                 // A bare call to a `using static` member is the exception
                 // (ADR-0134): gsc brings it into scope through `import Owner`,

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -120,6 +120,14 @@ public sealed class CSharpTypeMapper
     private readonly HashSet<string> reservedInvokedLocalNames =
         new(System.StringComparer.Ordinal);
 
+    // Issue #3471: static member simple names declared by source aggregates in
+    // the contributing trees. Sibling static references print bare inside
+    // their declaring aggregate, and a file-scope import alias shadows class
+    // members in gsc scope resolution, so a synthesized readable alias must
+    // never take one of these names.
+    private readonly HashSet<string> reservedSiblingStaticMemberNames =
+        new(System.StringComparer.Ordinal);
+
     /// <summary>
     /// Issue #1174: cached per-compilation census of source-declared top-level
     /// type simple names (built lazily on first use), used to decide whether a
@@ -707,6 +715,21 @@ public sealed class CSharpTypeMapper
                     this.reservedTypeParameterNames.Add(names.GetName(typeParameterSymbol));
                 }
 
+                if (node is TypeDeclarationSyntax memberCensusDeclaration
+                    && semanticModel.GetDeclaredSymbol(memberCensusDeclaration) is INamedTypeSymbol
+                        { TypeKind: TypeKind.Class or TypeKind.Struct } declaredAggregate)
+                {
+                    foreach (ISymbol member in declaredAggregate.GetMembers())
+                    {
+                        if (member.IsStatic
+                            && member is IFieldSymbol or IPropertySymbol
+                                or IMethodSymbol { MethodKind: MethodKind.Ordinary })
+                        {
+                            this.reservedSiblingStaticMemberNames.Add(names.GetName(member));
+                        }
+                    }
+                }
+
                 if (node is InvocationExpressionSyntax { Expression: SimpleNameSyntax invokedName })
                 {
                     ISymbol invokedSymbol = semanticModel.GetSymbolInfo(invokedName).Symbol;
@@ -814,6 +837,28 @@ public sealed class CSharpTypeMapper
                 this.reservedImportedTypeNames.Add(names.GetName(type));
             }
         }
+    }
+
+    /// <summary>
+    /// Issue #3471: whether a bare identifier at file scope would bind to an
+    /// import alias, an imported type, a synthesized type alias, or a
+    /// source-declared top-level type of the same name. All of these shadow a
+    /// sibling static member reference inside its declaring aggregate (imports
+    /// and type names win over members in gsc scope resolution), so such
+    /// members keep their type qualifier instead of printing bare.
+    /// </summary>
+    /// <param name="name">The emitted member simple name to probe.</param>
+    /// <param name="context">The active translation context.</param>
+    /// <returns><see langword="true"/> when the name is claimed at file scope.</returns>
+    internal bool ClaimsDocumentScopeName(string name, TranslationContext context)
+    {
+        this.sourceDeclaredTypeNames ??= BuildSourceDeclaredTypeNames(
+            context.Compilation,
+            this.Names(context));
+        return this.reservedTypeAliases.ContainsKey(name)
+            || this.reservedImportedTypeNames.Contains(name)
+            || this.synthesizedTypeAliases.ContainsKey(name)
+            || this.sourceDeclaredTypeNames.Contains(name);
     }
 
     /// <summary>
@@ -935,6 +980,7 @@ public sealed class CSharpTypeMapper
         reserved.UnionWith(this.reservedTypeParameterNames);
         reserved.UnionWith(this.reservedInvokedLocalNames);
         reserved.UnionWith(this.sourceDeclaredTypeNames);
+        reserved.UnionWith(this.reservedSiblingStaticMemberNames);
 
         string namespaceQualifier = namespaceName?.Split('.').Last() ?? "Global";
         string baseAlias = $"{namespaceQualifier}{simpleName}";


### PR DESCRIPTION
## Summary
- drop the type qualifier on bare C# sibling static references (calls, reads, writes) when the site is lexically inside the declaring type — gsc resolves them bare from instance methods, shared methods, generic owners, structs, and `shared init` blocks (all probe-verified against the current compiler)
- keep the qualifier exactly where bare emission cannot bind: nested type → outer statics and derived type → inherited statics (GS0130), classic extension-method bodies (lifted to file scope), name collisions with file-scope import aliases / imported types / source type names, and function-literal bodies inside static member contexts (gsc lambda scope gap, filed as #3487 with minimal repro)
- lifted static local-function helpers (`__local_...`) called from their own type also go bare
- reciprocal allocator guard: readable import aliases (#3466) now reserve source static member names, so a synthesized alias can never shadow a member that prints bare (`TextStringBuilder` → `TextStringBuilder_2` when a sibling member claims the name)
- refresh ~90 stale qualified spellings across 40 suite files; rewrite the old-policy tests (StaticMemberQualificationTranslationTests, L2TranslationTests, Issue3466 readable-alias pair) to the new invariants

## Validation
- new `Issue3471SiblingStaticQualificationTests`: 10 regressions covering bare emission, all four keep-qualified exceptions, the lambda static/instance split, and an execution-parity oracle — each round-trips through gsc binding
- full `Cs2Gs.Tests`: **2,324 passed, 0 failed**
- gsc semantics established by direct compiler probes (same-class shared calls/reads/writes from instance/shared/generic/struct contexts; nested, inherited, private-in-lambda, and annotated-lambda counterexamples)

Fixes #3471

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Corpus follow-up (`97f143b7`)
The pinned Oahu gate caught two gsc defects that bare emission walks into; both shapes keep the qualifier until the compiler is fixed:
- **#3489** — gsc's emitter throws GS9998 when a bare shared member is the base receiver of a member store (`Instance.flush = value`); reads, call receivers, and direct member writes are fine. Carve-out: `IsStoreReceiverPosition`, with an end-to-end emitted-assembly oracle regression.
- **#3490** — gsc double-binds the arguments of a bare sibling call whose argument subtree carries an inline `out var` declaration (GS9002 + GS0102 for the same declaration); the qualified spelling compiles. Carve-out on the bare-call path, with a binder round-trip regression.

Validation: pinned Oahu gate **15/15 locally**; full `Cs2Gs.Tests` **2,326 passed, 0 failed**.


## Carve-out retirement (`9248194a` + `7af5b70e`)
All three gsc defects the corpus follow-up worked around are now fixed on main (#3498 for #3487, #3499 for #3489, #3500 for #3490), so after merging main in, the workaround qualifiers are gone:
- `IsBareSiblingStaticScope` drops the function-literal × static-member-context restriction (lambdas in shared members now emit bare sibling statics)
- `IsStoreReceiverPosition` removed (bare shared members emit as member-store receivers: `Instance.flush = value`)
- the `out var` argument check on the bare-call path removed

The bare sibling static policy now applies as fully as gsc's semantics allow; the only remaining qualified positions are the semantic ones (nested → outer statics, derived → inherited statics, lifted extension bodies, file-scope name collisions). The affected regressions flip to assert the bare spellings through the bind round-trip and emitted-assembly oracles.

### Validation after retirement
- full `Cs2Gs.Tests`: **2,344 passed, 0 failed**
- pinned Oahu gate: **15/15 apps green** locally — including the Logging.gs store line and the Oahu.Cli out-var lambdas that previously needed the qualifiers
