### PR TITLE
cs2gs: readable, edit-stable synthesized names (labels, lifted locals, discards)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/BlockLambdaArrowTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/BlockLambdaArrowTranslationTests.cs
@@ -166,7 +166,7 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("__local_F_Fact_", printed);
+        Assert.Contains("__local_F_Fact", printed);
         Assert.DoesNotContain("let Fact = func", printed);
         Assert.DoesNotContain("(n int32) -> {", printed);
     }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3467SyntheticNameTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3467SyntheticNameTests.cs
@@ -1,0 +1,240 @@
+// <copyright file="Issue3467SyntheticNameTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using GSharp.Tests;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Cs2Gs.Tests
+{
+    // Issue #3467: synthesized control-flow labels and lifted local-function
+    // names used to embed the syntax node's SpanStart (`__switchExit36386`,
+    // `__local_ProjectRegions..._20145`), which reads as garbage and shifts on
+    // any upstream edit; C# `_` lambda parameters became `__underscore`. Names
+    // are now allocated per function body in first-use order, lifted helpers
+    // suffix only on genuine collision, and unreferenced `_` parameters keep
+    // the discard spelling.
+    public sealed class Issue3467SyntheticNameTests
+    {
+        [Fact]
+        public void SyntheticNames_DoNotEmbedSourcePositions()
+        {
+            string printed = Translate("""
+                using System.Collections.Generic;
+
+                public class C
+                {
+                    private bool stop;
+
+                    public IEnumerable<int> Items()
+                    {
+                        if (stop)
+                        {
+                            yield break;
+                        }
+
+                        yield return 1;
+                    }
+
+                    public string Label(int value)
+                    {
+                        int ordinal = 0;
+                        return NewLabel("end", ref ordinal) + value;
+
+                        static string NewLabel(string prefix, ref int i)
+                        {
+                            i++;
+                            return prefix + i;
+                        }
+                    }
+                }
+                """);
+
+            Assert.Contains("__iteratorExit", printed, StringComparison.Ordinal);
+            Assert.Contains("__local_Label_NewLabel", printed, StringComparison.Ordinal);
+            Assert.DoesNotMatch(new Regex(@"__iteratorExit\d"), printed);
+            Assert.DoesNotMatch(new Regex(@"__local_Label_NewLabel_?\d"), printed);
+            TranslationTestValidation.AssertBinds(printed);
+        }
+
+        [Fact]
+        public void SyntheticNames_AreStableUnderUpstreamEdits()
+        {
+            const string body = """
+                using System.Collections.Generic;
+
+                public class C
+                {
+                    private bool stop;
+
+                    public IEnumerable<int> Items()
+                    {
+                        if (stop)
+                        {
+                            yield break;
+                        }
+
+                        yield return 1;
+                    }
+
+                    public string Label(int value)
+                    {
+                        int ordinal = 0;
+                        return NewLabel("end", ref ordinal) + value;
+
+                        static string NewLabel(string prefix, ref int i)
+                        {
+                            i++;
+                            return prefix + i;
+                        }
+                    }
+                }
+                """;
+
+            string original = Translate(body);
+            string shifted = Translate(
+                "// A long leading comment that shifts every span downstream." +
+                Environment.NewLine + Environment.NewLine + body);
+
+            Assert.Equal(original, shifted);
+        }
+
+        [Fact]
+        public void GotoCaseLabels_UseOrdinalsPerMethod()
+        {
+            string printed = Translate("""
+                public class C
+                {
+                    public static int Route(int value)
+                    {
+                        switch (value)
+                        {
+                            case 1:
+                                return 10;
+                            case 2:
+                                goto case 1;
+                            default:
+                                goto case 2;
+                        }
+                    }
+                }
+                """);
+
+            Assert.Contains("__gotoCase", printed, StringComparison.Ordinal);
+            Assert.DoesNotMatch(new Regex(@"__gotoCase\d{3,}"), printed);
+            TranslationTestValidation.AssertBinds(printed);
+        }
+
+        [Fact]
+        public void LiftedLocalFunctions_SuffixOnlyOnCollision()
+        {
+            string printed = Translate("""
+                public class C
+                {
+                    public string Run(int value)
+                    {
+                        int i = 0;
+                        return Helper(ref i) + value;
+
+                        static string Helper(ref int n)
+                        {
+                            n++;
+                            return "a" + n;
+                        }
+                    }
+
+                    public string Run(string value)
+                    {
+                        int i = 0;
+                        return Helper(ref i) + value;
+
+                        static string Helper(ref int n)
+                        {
+                            n++;
+                            return "b" + n;
+                        }
+                    }
+                }
+                """);
+
+            Assert.Contains("__local_Run_Helper", printed, StringComparison.Ordinal);
+            Assert.Contains("__local_Run_Helper_2", printed, StringComparison.Ordinal);
+            Assert.DoesNotContain("__local_Run_Helper_3", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+        }
+
+        [Fact]
+        public void UnreferencedUnderscoreLambdaParameter_KeepsDiscardSpelling()
+        {
+            string printed = Translate("""
+                using System;
+
+                public class C
+                {
+                    public static int Apply(Func<string, int> f) => f("x");
+
+                    public static int Run() => Apply(_ => 7);
+                }
+                """);
+
+            Assert.Contains("(_ string)", printed, StringComparison.Ordinal);
+            Assert.DoesNotContain("__underscore", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+        }
+
+        [Fact]
+        public void ReferencedUnderscoreLambdaParameter_StillRenames()
+        {
+            string printed = Translate("""
+                using System;
+
+                public class C
+                {
+                    public static int Apply(Func<int, int> f) => f(3);
+
+                    public static int Run() => Apply(_ => _ + 1);
+                }
+                """);
+
+            Assert.Contains("__underscore", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+        }
+
+        private static string Translate(
+            string source,
+            params MetadataReference[] additionalReferences)
+        {
+            IReadOnlyList<MetadataReference> references = additionalReferences.Length == 0
+                ? null
+                : CSharpProjectLoader.RuntimeReferences()
+                    .Concat(additionalReferences)
+                    .GroupBy(reference => reference.Display, StringComparer.Ordinal)
+                    .Select(group => group.First())
+                    .ToList();
+            LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+                new[] { ("Snippet.cs", source) },
+                references);
+            Assert.True(
+                project.BoundWithoutErrors,
+                "Snippet should bind with no C# errors: "
+                    + string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+            LoadedDocument document = Assert.Single(project.Documents);
+            var context = new TranslationContext(
+                project.Compilation,
+                document.SemanticModel,
+                document.FilePath);
+            CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+            return GSharpPrinter.Print(unit);
+        }
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/LocalFunctionHoistTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/LocalFunctionHoistTranslationTests.cs
@@ -229,8 +229,8 @@ namespace Demo
 
     Assert.DoesNotContain("let A", printed, StringComparison.Ordinal);
     Assert.DoesNotContain("let B", printed, StringComparison.Ordinal);
-    Assert.Contains("__local_M_A_", printed, StringComparison.Ordinal);
-    Assert.Contains("__local_M_B_", printed, StringComparison.Ordinal);
+    Assert.Contains("__local_M_A", printed, StringComparison.Ordinal);
+    Assert.Contains("__local_M_B", printed, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -267,7 +267,7 @@ namespace Demo
     // Issue #3399 hybrid: a capturing recursive local lowers to G#'s
     // nullable function-typed local, not a synthesized capture-passing helper.
     Assert.DoesNotContain("let Add", printed, StringComparison.Ordinal);
-    Assert.DoesNotContain("__local_Run_Add_", printed, StringComparison.Ordinal);
+    Assert.DoesNotContain("__local_Run_Add", printed, StringComparison.Ordinal);
     Assert.Contains("var Add", printed, StringComparison.Ordinal);
     Assert.Contains("Add = func", printed, StringComparison.Ordinal);
     Assert.Contains("Add!!(", printed, StringComparison.Ordinal);
@@ -321,8 +321,8 @@ namespace Demo
     // nullable function-typed locals, not synthesized capture-passing helpers.
     Assert.DoesNotContain("let AddEven", printed, StringComparison.Ordinal);
     Assert.DoesNotContain("let AddOdd", printed, StringComparison.Ordinal);
-    Assert.DoesNotContain("__local_Run_AddEven_", printed, StringComparison.Ordinal);
-    Assert.DoesNotContain("__local_Run_AddOdd_", printed, StringComparison.Ordinal);
+    Assert.DoesNotContain("__local_Run_AddEven", printed, StringComparison.Ordinal);
+    Assert.DoesNotContain("__local_Run_AddOdd", printed, StringComparison.Ordinal);
     Assert.Contains("var AddEven", printed, StringComparison.Ordinal);
     Assert.Contains("var AddOdd", printed, StringComparison.Ordinal);
     Assert.Contains("AddEven!!(", printed, StringComparison.Ordinal);
@@ -362,7 +362,7 @@ namespace Demo
 }");
 
     Assert.DoesNotContain("let Read", printed, StringComparison.Ordinal);
-    Assert.Contains("__local_Run_Read_", printed, StringComparison.Ordinal);
+    Assert.Contains("__local_Run_Read", printed, StringComparison.Ordinal);
     Assert.Contains("out doubled int32", printed, StringComparison.Ordinal);
     CompileAndRun(
         printed,
@@ -439,8 +439,8 @@ namespace Demo
 
         Assert.DoesNotContain("let Visit", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("let IsBaseCase", printed, StringComparison.Ordinal);
-        Assert.Contains("__local_Factorial_Visit_", printed, StringComparison.Ordinal);
-        Assert.Contains("__local_Factorial_IsBaseCase_", printed, StringComparison.Ordinal);
+        Assert.Contains("__local_Factorial_Visit", printed, StringComparison.Ordinal);
+        Assert.Contains("__local_Factorial_IsBaseCase", printed, StringComparison.Ordinal);
         CompileAndRun(
             printed,
             "Console.WriteLine(C().Factorial(5))",

--- a/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
@@ -386,9 +386,12 @@ namespace Demo
             })
             .ToArray();
 
+        // Issue #3467: exit labels no longer embed SpanStart, so the getter's
+        // label and the local function's label share the readable spelling
+        // `__iteratorExit` — each lives in its own G# function scope, where
+        // duplicate label names are legal.
         Assert.Equal(4, exits.Length);
-        Assert.Equal(2, exits.Distinct().Count());
-        Assert.All(exits.Distinct(), exit => Assert.Equal(2, exits.Count(candidate => candidate == exit)));
+        Assert.All(exits, exit => Assert.Equal("__iteratorExit", exit));
         Assert.DoesNotContain("yield break", printed);
     }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
@@ -898,10 +898,33 @@ public sealed partial class CSharpToGSharpTranslator
                 return this.EmittedName(symbol, symbol.Name);
             }
 
+            // Issue #3467: gsc accepts `_` as a (repeatable) discard parameter
+            // name, so an unreferenced C# `_` parameter keeps its spelling. A
+            // single `_` parameter that the body actually READS (legal C#: `_`
+            // is only a discard when it cannot bind) still needs a real
+            // identifier, since G# `_` is a true blank; only that case renames
+            // to `__underscore` (paired with the identifier-reference rewrite
+            // in TranslateIdentifierName).
             int underscoreCount = underscoreParameter.Parent is ParameterListSyntax parameterList
                 ? parameterList.Parameters.Count(p => p.Identifier.ValueText == "_")
                 : 1;
-            return underscoreCount == 1 ? "__underscore" : "_";
+            if (underscoreCount > 1)
+            {
+                return "_";
+            }
+
+            SyntaxNode body = underscoreParameter.Ancestors().FirstOrDefault(ancestor =>
+                ancestor is AnonymousFunctionExpressionSyntax
+                    or LocalFunctionStatementSyntax
+                    or BaseMethodDeclarationSyntax);
+            bool referenced = body != null
+                && body.DescendantNodes()
+                    .OfType<IdentifierNameSyntax>()
+                    .Any(identifier => identifier.Identifier.ValueText == "_"
+                        && SymbolEqualityComparer.Default.Equals(
+                            this.context.GetSymbolInfo(identifier).Symbol,
+                            symbol));
+            return referenced ? "__underscore" : "_";
         }
 
         /// <summary>
@@ -1384,7 +1407,7 @@ public sealed partial class CSharpToGSharpTranslator
             {
                 BlockStatement body = this.TranslateBodyCore(bodyOwner, description);
                 body = this.WithParameterShadows(bodyOwner, body);
-                return AddIteratorExitLabel(bodyOwner, body);
+                return this.AddIteratorExitLabel(bodyOwner, body);
             }
             finally
             {
@@ -1527,7 +1550,25 @@ public sealed partial class CSharpToGSharpTranslator
             }
         }
 
-        private static BlockStatement AddIteratorExitLabel(SyntaxNode bodyOwner, BlockStatement body)
+        // Issue #3467: lifted local-function helper names used to embed the
+        // local function's SpanStart, producing 50+ character identifiers that
+        // shift on any upstream edit. The name is now just
+        // `__local_{owner}_{name}`; only a genuine collision (an overload of
+        // the enclosing member declaring a same-named local function, or
+        // same-named locals in sibling scopes) takes an ordinal suffix.
+        private string AllocateLiftedLocalFunctionName(string ownerName, string localName)
+        {
+            string baseName = $"__local_{ownerName}_{localName}";
+            string candidate = baseName;
+            for (int suffix = 2; !this.state.UsedLiftedLocalFunctionNames.Add(candidate); suffix++)
+            {
+                candidate = $"{baseName}_{suffix}";
+            }
+
+            return candidate;
+        }
+
+        private BlockStatement AddIteratorExitLabel(SyntaxNode bodyOwner, BlockStatement body)
         {
             if (!HasYieldBreak(bodyOwner))
             {
@@ -1536,7 +1577,7 @@ public sealed partial class CSharpToGSharpTranslator
 
             var statements = body.Statements.ToList();
             statements.Add(new LabeledStatement(
-                IteratorExitLabelName(bodyOwner),
+                this.IteratorExitLabelName(bodyOwner),
                 new BlockStatement(new List<GStatement>())));
             return new BlockStatement(statements, body.IsUnsafe);
         }
@@ -1915,7 +1956,7 @@ public sealed partial class CSharpToGSharpTranslator
                     pair.Symbol.ContainingSymbol?.Name ?? "scope");
                 string localName = this.EmittedName(pair.Symbol, pair.Syntax.Identifier.ValueText);
                 this.state.LiftedStaticLocalFunctions[pair.Symbol] =
-                    $"__local_{ownerName}_{localName}_{pair.Syntax.SpanStart}";
+                    this.AllocateLiftedLocalFunctionName(ownerName, localName);
             }
 
             var capturingLocals = localFunctions
@@ -2024,7 +2065,7 @@ public sealed partial class CSharpToGSharpTranslator
                 string localName = this.EmittedName(pair.Symbol, pair.Syntax.Identifier.ValueText);
                 this.state.LiftedRecursiveLocalFunctions[pair.Symbol] =
                     new LiftedRecursiveLocalFunction(
-                        $"__local_{ownerName}_{localName}_{pair.Syntax.SpanStart}",
+                        this.AllocateLiftedLocalFunctionName(ownerName, localName),
                         containingMethod?.IsStatic != false,
                         captures);
             }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.ControlFlow.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.ControlFlow.cs
@@ -762,7 +762,7 @@ public sealed partial class CSharpToGSharpTranslator
                         : new BinaryExpression(guardExpression, "&&", translated);
                 }
 
-                string endLabel = $"__patternGuardEnd{ifStatement.SpanStart}";
+                string endLabel = this.SyntheticLabelName("patternGuardEnd", ifStatement);
                 List<GStatement> matchedBody = body.Statements.ToList();
                 matchedBody.Add(new GotoStatement(endLabel));
                 thenStatements.Add(new IfStatement(

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
@@ -1654,7 +1654,7 @@ public sealed partial class CSharpToGSharpTranslator
                 if (localFunction.Body != null)
                 {
                     BlockStatement innerBody = this.WithParameterShadows(localFunction, this.TranslateBlock(localFunction.Body));
-                    innerBody = AddIteratorExitLabel(localFunction, innerBody);
+                    innerBody = this.AddIteratorExitLabel(localFunction, innerBody);
                     lambda = isAsyncVoidHandler
                         ? new LambdaExpression(parameters, blockBody: this.BuildAsyncVoidHandlerWrapperBody(parameters, innerBody, localFunction.GetLocation()), isAsync: false, returnType: null, isFunctionLiteral: true)
                         : new LambdaExpression(parameters, blockBody: innerBody, isAsync: isAsync, returnType: returnType, isFunctionLiteral: true);

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
@@ -1455,7 +1455,7 @@ public sealed partial class CSharpToGSharpTranslator
                         return new[] { (GStatement)new RawStatement($"// unsupported: {gotoStatement.Kind()}") };
                     }
 
-                    return new[] { (GStatement)new GotoStatement(GotoCaseOrDefaultLabelName(target)) };
+                    return new[] { (GStatement)new GotoStatement(this.GotoCaseOrDefaultLabelName(target)) };
 
                 default:
                     // Plain `goto label;` — Expression is the label name as an
@@ -1517,16 +1517,16 @@ public sealed partial class CSharpToGSharpTranslator
         /// <summary>
         /// The synthesized G# label name for a <c>goto case</c>/<c>goto
         /// default</c> target (issue #1884). Keyed by the target label's own
-        /// source position (<see cref="SyntaxNode.SpanStart"/>), which is
-        /// unique within the file and stable across the two independent call
-        /// sites that must agree on the name: the arm that defines the label
+        /// syntax node, which keeps the two independent call sites that must
+        /// agree on the name — the arm that defines the label
         /// (<see cref="TranslateSwitchStatement"/>) and the <c>goto</c> that
-        /// targets it (<see cref="ResolveGotoCaseOrDefaultTarget"/> callers).
+        /// targets it (<see cref="ResolveGotoCaseOrDefaultTarget"/> callers) —
+        /// consistent through the per-scope ordinal allocation (issue #3467).
         /// </summary>
-        private static string GotoCaseOrDefaultLabelName(SwitchLabelSyntax label)
-            => label is DefaultSwitchLabelSyntax
-                ? $"__gotoDefault{label.SpanStart}"
-                : $"__gotoCase{label.SpanStart}";
+        private string GotoCaseOrDefaultLabelName(SwitchLabelSyntax label)
+            => this.SyntheticLabelName(
+                label is DefaultSwitchLabelSyntax ? "gotoDefault" : "gotoCase",
+                label);
 
         private GStatement TranslateThrow(ThrowStatementSyntax throwStatement)
         {

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
@@ -958,7 +958,7 @@ public sealed partial class CSharpToGSharpTranslator
                                 new ConstantPattern(this.TranslateExpression(valueLabel.Value)),
                                 this.TranslateSwitchSectionBody(
                                     section,
-                                    gotoTargets.Contains(valueLabel) ? GotoCaseOrDefaultLabelName(valueLabel) : null)));
+                                    gotoTargets.Contains(valueLabel) ? this.GotoCaseOrDefaultLabelName(valueLabel) : null)));
                             break;
 
                         case DefaultSwitchLabelSyntax defaultLabel:
@@ -966,7 +966,7 @@ public sealed partial class CSharpToGSharpTranslator
                                 null,
                                 this.TranslateSwitchSectionBody(
                                     section,
-                                    gotoTargets.Contains(defaultLabel) ? GotoCaseOrDefaultLabelName(defaultLabel) : null)));
+                                    gotoTargets.Contains(defaultLabel) ? this.GotoCaseOrDefaultLabelName(defaultLabel) : null)));
                             break;
 
                         default:
@@ -997,7 +997,7 @@ public sealed partial class CSharpToGSharpTranslator
             if (needsExitLabel)
             {
                 yield return new LabeledStatement(
-                    SwitchExitLabelName(node),
+                    this.SwitchExitLabelName(node),
                     new BlockStatement(new List<GStatement>()));
             }
         }
@@ -1111,7 +1111,7 @@ public sealed partial class CSharpToGSharpTranslator
                     return System.Array.Empty<GStatement>();
                 }
 
-                return new[] { (GStatement)new GotoStatement(SwitchExitLabelName(targetSwitch)) };
+                return new[] { (GStatement)new GotoStatement(this.SwitchExitLabelName(targetSwitch)) };
             }
 
             return new[] { (GStatement)new BreakStatement() };
@@ -1154,8 +1154,38 @@ public sealed partial class CSharpToGSharpTranslator
             return false;
         }
 
-        private static string SwitchExitLabelName(SwitchStatementSyntax node)
-            => $"__switchExit{node.SpanStart}";
+        // Issue #3467: synthesized labels used to embed the syntax node's
+        // SpanStart (`__switchExit36386`) — unreadable, and unstable because
+        // any upstream edit shifts every label in the file. Labels are instead
+        // numbered per enclosing function body in first-use order: the first
+        // label of a prefix is bare (`__switchExit`), later ones take an
+        // ordinal (`__switchExit2`). Function literals and local functions are
+        // their own G# function scopes, so each restarts the numbering.
+        private string SyntheticLabelName(string prefix, SyntaxNode node)
+        {
+            if (this.state.SyntheticLabelNames.TryGetValue(node, out string existing))
+            {
+                return existing;
+            }
+
+            SyntaxNode scope = node.AncestorsAndSelf().FirstOrDefault(ancestor =>
+                ancestor is BaseMethodDeclarationSyntax
+                    or AccessorDeclarationSyntax
+                    or LocalFunctionStatementSyntax
+                    or AnonymousFunctionExpressionSyntax
+                    or CompilationUnitSyntax)
+                ?? node;
+            (SyntaxNode Scope, string Prefix) key = (scope, prefix);
+            this.state.SyntheticLabelCounters.TryGetValue(key, out int ordinal);
+            ordinal++;
+            this.state.SyntheticLabelCounters[key] = ordinal;
+            string name = ordinal == 1 ? $"__{prefix}" : $"__{prefix}{ordinal}";
+            this.state.SyntheticLabelNames[node] = name;
+            return name;
+        }
+
+        private string SwitchExitLabelName(SwitchStatementSyntax node)
+            => this.SyntheticLabelName("switchExit", node);
 
         private IEnumerable<GStatement> TranslateYieldStatement(YieldStatementSyntax node)
         {
@@ -1166,7 +1196,7 @@ public sealed partial class CSharpToGSharpTranslator
             if (node.Expression == null)
             {
                 SyntaxNode target = this.state.CurrentBodyScope ?? GetBreakTarget(node);
-                return new[] { (GStatement)new GotoStatement(IteratorExitLabelName(target)) };
+                return new[] { (GStatement)new GotoStatement(this.IteratorExitLabelName(target)) };
             }
 
             GExpression value = this.TranslateValueWithNullForgiveness(node.Expression);
@@ -1192,8 +1222,8 @@ public sealed partial class CSharpToGSharpTranslator
                 n => n is BaseMethodDeclarationSyntax or AccessorDeclarationSyntax or LocalFunctionStatementSyntax)
                 ?? node;
 
-        private static string IteratorExitLabelName(SyntaxNode node)
-            => $"__iteratorExit{node.SpanStart}";
+        private string IteratorExitLabelName(SyntaxNode node)
+            => this.SyntheticLabelName("iteratorExit", node);
 
         private GStatement TranslateForEachVariable(ForEachVariableStatementSyntax node)
         {

--- a/tools/cs2gs/Cs2Gs.Translator/DocumentTranslationState.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/DocumentTranslationState.cs
@@ -244,6 +244,24 @@ internal sealed class DocumentTranslationState
     public Dictionary<IMethodSymbol, string> LiftedStaticLocalFunctions { get; } =
         new Dictionary<IMethodSymbol, string>(SymbolEqualityComparer.Default);
 
+    // Issue #3467: synthesized control-flow label names, allocated per
+    // enclosing function body in first-use order instead of embedding the
+    // syntax node's SpanStart. The node-keyed memo keeps the independent call
+    // sites that must agree on a label (its definition and its gotos)
+    // consistent; the counter map hands out the per-scope ordinals.
+    public Dictionary<SyntaxNode, string> SyntheticLabelNames { get; } =
+        new Dictionary<SyntaxNode, string>();
+
+    public Dictionary<(SyntaxNode Scope, string Prefix), int> SyntheticLabelCounters { get; } =
+        new Dictionary<(SyntaxNode Scope, string Prefix), int>();
+
+    // Issue #3467: lifted local-function helper names already allocated in
+    // this document, so a name collision (same enclosing member name + same
+    // local-function name) takes an ordinal suffix instead of embedding
+    // SpanStart.
+    public HashSet<string> UsedLiftedLocalFunctionNames { get; } =
+        new HashSet<string>(StringComparer.Ordinal);
+
     public Dictionary<IMethodSymbol, LiftedRecursiveLocalFunction> LiftedRecursiveLocalFunctions { get; } =
         new Dictionary<IMethodSymbol, LiftedRecursiveLocalFunction>(SymbolEqualityComparer.Default);
 


### PR DESCRIPTION
## Summary
- control-flow labels (`__switchExit`, `__iteratorExit`, `__gotoCase`/`__gotoDefault`, `__patternGuardEnd`) no longer embed SpanStart: they are allocated per enclosing function body in first-use order (first bare, then `__switchExit2`, …) via a node-keyed memo so label definitions and their gotos always agree; duplicate spellings across nested function literals are legal G# (probe-verified against gsc)
- lifted local-function helpers drop the SpanStart suffix: `__local_{owner}_{name}`, ordinal-suffixed only on genuine collision (e.g. same-named locals in overloads)
- C# `_` parameters print as the `_` discard (gsc accepts it, even repeated in one signature — probe-verified); only a `_` parameter the body actually reads still renames to `__underscore`
- names are now stable across upstream edits: shifting every source span (e.g. adding a comment) leaves the translation byte-identical, eliminating spurious re-migration diffs

## Validation
- new `Issue3467SyntheticNameTests`: 6 regressions — position-free spellings, per-method goto-case ordinals, collision suffixing, both discard cases, and the byte-identical stability property
- updated 5 existing tests that asserted the old span-suffixed spellings (exact names now assertable)
- full `Cs2Gs.Tests`: **2,320 passed, 0 failed**

Fixes #3467

🤖 Generated with [Claude Code](https://claude.com/claude-code)