### PR TITLE
cs2gs: render method-group wrappers as readable arrow lambdas

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue3414DelegateArgumentInferenceTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3414DelegateArgumentInferenceTests.cs
@@ -203,10 +203,10 @@ public sealed class Issue3414DelegateArgumentInferenceTests
         Assert.Contains("DiagnosticsOf", consumer, StringComparison.Ordinal);
         Assert.Contains("IsError", consumer, StringComparison.Ordinal);
         Assert.Contains(
-            "ApplyDescription(cell, func (__arg0 Cell) object",
+            "ApplyDescription(cell, func (value Cell) object",
             consumer,
             StringComparison.Ordinal);
-        Assert.Contains("return Program.Describe(__arg0)", consumer, StringComparison.Ordinal);
+        Assert.Contains("return Program.Describe(value)", consumer, StringComparison.Ordinal);
         Assert.Contains(
             "Rebuilder(func (value Cell) object",
             consumer,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3422RedundantNullForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3422RedundantNullForgivenessTranslationTests.cs
@@ -145,7 +145,7 @@ public sealed class Issue3422RedundantNullForgivenessTranslationTests
             }
             """);
 
-        Assert.Contains("return value.Measure(__arg0)", printed, StringComparison.Ordinal);
+        Assert.Contains("(delta int32) -> value.Measure(delta)", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("Ext.Measure", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("value!!", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("value.Measure(value", printed, StringComparison.Ordinal);
@@ -245,7 +245,7 @@ public sealed class Issue3422RedundantNullForgivenessTranslationTests
             """);
 
         Assert.Contains("let __spill0 = value!!", printed, StringComparison.Ordinal);
-        Assert.Contains("return __spill0.Measure(__arg0)", printed, StringComparison.Ordinal);
+        Assert.Contains("(delta int32) -> __spill0.Measure(delta)", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("Ext.Measure", printed, StringComparison.Ordinal);
 
         EmittedOracleResult result = EmittedOracle.Evaluate(
@@ -285,9 +285,9 @@ public sealed class Issue3422RedundantNullForgivenessTranslationTests
             }
             """);
 
-        Assert.Contains("return receiver.Matches(__arg0)", printed, StringComparison.Ordinal);
+        Assert.Contains("(expected string) -> receiver.Matches(expected)", printed, StringComparison.Ordinal);
         Assert.DoesNotContain(
-            "receiver.Matches(receiver, __arg0)",
+            "receiver.Matches(receiver, expected)",
             printed,
             StringComparison.Ordinal);
 
@@ -353,11 +353,11 @@ public sealed class Issue3422RedundantNullForgivenessTranslationTests
             """);
 
         Assert.Contains(
-            "Enumerable.Contains[Item](removed, __arg0)",
+            "Enumerable.Contains[Item](removed, value)",
             printed,
             StringComparison.Ordinal);
         Assert.DoesNotContain(
-            "Enumerable.Contains[Item](__arg0)",
+            "Enumerable.Contains[Item](value)",
             printed,
             StringComparison.Ordinal);
     }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3468MethodGroupWrapperTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3468MethodGroupWrapperTests.cs
@@ -1,0 +1,154 @@
+// <copyright file="Issue3468MethodGroupWrapperTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using GSharp.Tests;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Cs2Gs.Tests
+{
+    // Issue #3468: a method group whose signature already matches the target
+    // delegate passes through as a direct method reference; a wrapper that IS
+    // required renders as the concise arrow form with parameter names derived
+    // from the target method (`(value string) -> Stringify(value)`), keeping
+    // the block-bodied explicit-return-type function literal only where the
+    // delegate's result type must be pinned (return covariance) or parameters
+    // pass by reference.
+    public sealed class Issue3468MethodGroupWrapperTests
+    {
+        [Fact]
+        public void MatchingMethodGroups_PassThroughDirect()
+        {
+            string printed = Translate("""
+                using System.Collections.Generic;
+                using System.IO;
+                using System.Linq;
+
+                public class W
+                {
+                    public List<string> Full(List<string> paths)
+                        => paths.Select(Path.GetFullPath).ToList();
+
+                    public List<int> Lens(List<string> paths)
+                        => paths.Select(Len).ToList();
+
+                    private static int Len(string s) => s.Length;
+                }
+                """);
+
+            Assert.Contains("paths.Select(Path.GetFullPath)", printed, StringComparison.Ordinal);
+            Assert.Contains("Select(Len)", printed, StringComparison.Ordinal);
+            Assert.DoesNotContain("__arg", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+        }
+
+        [Fact]
+        public void ParameterContravariantWrapper_UsesArrowFormWithDerivedName()
+        {
+            string printed = Translate("""
+                using System;
+                using System.Collections.Generic;
+                using System.Linq;
+
+                public class W
+                {
+                    public List<string> Mixed(List<string> paths)
+                        => paths.Select((Func<string, string>)Stringify).ToList();
+
+                    private static string Stringify(object? value) => value?.ToString() ?? "";
+                }
+                """);
+
+            Assert.Contains("(value string) -> W.Stringify(value)", printed, StringComparison.Ordinal);
+            Assert.DoesNotContain("__arg", printed, StringComparison.Ordinal);
+            Assert.DoesNotContain("func (", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+        }
+
+        [Fact]
+        public void ReturnCovariantWrapper_KeepsTypedFunctionLiteralWithDerivedName()
+        {
+            string printed = Translate("""
+                using System.Collections.Generic;
+                using System.Linq;
+
+                public class W
+                {
+                    public List<object> Objs(List<string> paths)
+                        => paths.Select<string, object>(Twice).ToList();
+
+                    private static string Twice(string s) => s + s;
+                }
+                """);
+
+            Assert.Contains("func (s string) object", printed, StringComparison.Ordinal);
+            Assert.Contains("W.Twice(s)", printed, StringComparison.Ordinal);
+            Assert.DoesNotContain("__arg", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+        }
+
+        [Fact]
+        public void ArrowWrapper_ExecutesWithParity()
+        {
+            string printed = Translate("""
+                using System;
+                using System.Collections.Generic;
+                using System.Linq;
+
+                public static class Obj
+                {
+                    public static int Run()
+                    {
+                        var items = new List<string> { "a", "bb" };
+                        return items.Select((Func<string, int>)Weigh).Sum();
+                    }
+
+                    private static int Weigh(object? value) => (value as string)?.Length ?? 0;
+                }
+                """);
+
+            Assert.Contains("(value string) -> Obj.Weigh(value)", printed, StringComparison.Ordinal);
+            EmittedOracleResult result = EmittedOracle.Evaluate(
+                printed + Environment.NewLine + "Obj.Run()");
+            Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+            Assert.Null(result.UnhandledException);
+            Assert.Equal(3, result.Value);
+        }
+
+        private static string Translate(
+            string source,
+            params MetadataReference[] additionalReferences)
+        {
+            IReadOnlyList<MetadataReference> references = additionalReferences.Length == 0
+                ? null
+                : CSharpProjectLoader.RuntimeReferences()
+                    .Concat(additionalReferences)
+                    .GroupBy(reference => reference.Display, StringComparer.Ordinal)
+                    .Select(group => group.First())
+                    .ToList();
+            LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+                new[] { ("Snippet.cs", source) },
+                references);
+            Assert.True(
+                project.BoundWithoutErrors,
+                "Snippet should bind with no C# errors: "
+                    + string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+            LoadedDocument document = Assert.Single(project.Documents);
+            var context = new TranslationContext(
+                project.Compilation,
+                document.SemanticModel,
+                document.FilePath);
+            CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+            return GSharpPrinter.Print(unit);
+        }
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -898,13 +898,22 @@ public sealed partial class CSharpToGSharpTranslator
                 PassStaticExtensionHelperReceiver(receiver, method),
             };
 
+            var wrapperParameterNames = new HashSet<string>(StringComparer.Ordinal);
+            ReserveMethodGroupReceiverName(receiver, wrapperParameterNames);
+            ImmutableArray<IParameterSymbol> helperNameParameters =
+                invoke != null
+                    ? MethodGroupWrapperNameParameters(method, invoke)
+                    : method.Parameters;
             for (int i = 0; i < sourceParameters.Length; i++)
             {
                 Parameter mapped = this.MapParameter(
                     sourceParameters[i],
                     member,
                     promoteNullability: false);
-                string name = $"__arg{i}";
+                string name = MethodGroupWrapperParameterName(
+                    helperNameParameters,
+                    i,
+                    wrapperParameterNames);
                 parameters.Add(new Parameter(
                     name,
                     mapped.Type,
@@ -1594,11 +1603,75 @@ public sealed partial class CSharpToGSharpTranslator
                     invoke.ReturnType);
         }
 
+        // Issue #3468: a synthesized method-group wrapper parameter takes its
+        // name from the TARGET method's corresponding parameter (`path`,
+        // `value`) so the wrapper reads like the surrounding arrow lambdas;
+        // `__arg{i}` remains only the fallback for missing, discard, reserved,
+        // or colliding names. For extension-method groups the delegate's
+        // parameters align to the ORIGINAL method's parameters AFTER the
+        // receiver, so callers pass the receiver-stripped list, and the
+        // captured receiver identifier is pre-seeded into
+        // <paramref name="usedNames"/> so a derived name can never shadow it.
+        private static ImmutableArray<IParameterSymbol> MethodGroupWrapperNameParameters(
+            IMethodSymbol method,
+            IMethodSymbol invoke)
+        {
+            IMethodSymbol original = method.ReducedFrom ?? method;
+            if (method.MethodKind == MethodKind.ReducedExtension)
+            {
+                return method.Parameters;
+            }
+
+            return original.IsExtensionMethod
+                && original.Parameters.Length == invoke.Parameters.Length + 1
+                ? original.Parameters.RemoveAt(0)
+                : method.Parameters;
+        }
+
+        private static void ReserveMethodGroupReceiverName(
+            GExpression receiver,
+            HashSet<string> usedNames)
+        {
+            GExpression current = receiver;
+            while (current is MemberAccessExpression memberAccess)
+            {
+                current = memberAccess.Target;
+            }
+
+            if (current is IdentifierExpression identifier)
+            {
+                usedNames.Add(identifier.Name);
+            }
+        }
+
+        private static string MethodGroupWrapperParameterName(
+            ImmutableArray<IParameterSymbol> targetParameters,
+            int index,
+            HashSet<string> usedNames)
+        {
+            string candidate = index < targetParameters.Length
+                ? targetParameters[index].Name
+                : null;
+            if (string.IsNullOrEmpty(candidate)
+                || candidate == "_"
+                || GSharp.Core.CodeAnalysis.Syntax.SyntaxFacts.IsReservedIdentifier(
+                    candidate,
+                    GSharp.Core.CodeAnalysis.Syntax.IdentifierNameContext.Parameter)
+                || !usedNames.Add(candidate))
+            {
+                candidate = $"__arg{index}";
+                usedNames.Add(candidate);
+            }
+
+            return candidate;
+        }
+
         private GExpression TranslateExactMethodGroupArgument(
             ExpressionSyntax expression,
             IMethodSymbol method,
             IMethodSymbol invoke)
         {
+            var wrapperParameterNames = new HashSet<string>(StringComparer.Ordinal);
             var parameters = new List<Parameter>(invoke.Parameters.Length);
             var arguments = new List<GExpression>(invoke.Parameters.Length + 1);
             GExpression target = null;
@@ -1664,6 +1737,20 @@ public sealed partial class CSharpToGSharpTranslator
                 }
             }
 
+            target ??= this.TranslateMethodGroupInvocationTarget(
+                expression,
+                method);
+            ReserveMethodGroupReceiverName(target, wrapperParameterNames);
+
+            // At this point `arguments` holds only a captured receiver (the
+            // static-extension-helper shape); reserve its root identifier too.
+            foreach (GExpression receiverArgument in arguments)
+            {
+                ReserveMethodGroupReceiverName(receiverArgument, wrapperParameterNames);
+            }
+
+            ImmutableArray<IParameterSymbol> wrapperNameParameters =
+                MethodGroupWrapperNameParameters(method, invoke);
             for (int index = 0; index < invoke.Parameters.Length; index++)
             {
                 IParameterSymbol invokeParameter = invoke.Parameters[index];
@@ -1671,7 +1758,10 @@ public sealed partial class CSharpToGSharpTranslator
                     invokeParameter,
                     expression,
                     promoteNullability: false);
-                string name = $"__arg{index}";
+                string name = MethodGroupWrapperParameterName(
+                    wrapperNameParameters,
+                    index,
+                    wrapperParameterNames);
                 parameters.Add(new Parameter(
                     name,
                     mapped.Type,
@@ -1687,9 +1777,6 @@ public sealed partial class CSharpToGSharpTranslator
                 arguments.Add(forwarded);
             }
 
-            target ??= this.TranslateMethodGroupInvocationTarget(
-                expression,
-                method);
             IReadOnlyList<GTypeReference> typeArguments = method.IsGenericMethod
                 ? method.TypeArguments
                     .Select(type => this.typeMapper.Map(
@@ -1703,6 +1790,29 @@ public sealed partial class CSharpToGSharpTranslator
                 invoke,
                 isAsync: false,
                 expression.GetLocation());
+
+            // Issue #3468: the surrounding output uses arrow lambdas, so a
+            // wrapper whose result type needs no pinning renders as the
+            // concise arrow form `(path string) -> Target(path)`. Only two
+            // shapes still need a body that fixes the delegate's result type:
+            // a non-void delegate whose result differs from the method's
+            // return (the explicit-return-type function literal widens the
+            // returned value), and a void delegate wrapping a value-returning
+            // method (the block statement discards the value). By-ref
+            // parameters also keep the literal form.
+            bool hasByRefParameter = invoke.Parameters.Any(
+                parameter => parameter.RefKind is RefKind.Ref or RefKind.Out);
+            bool resultMatches = invoke.ReturnsVoid
+                ? method.ReturnsVoid
+                : !method.ReturnsVoid
+                    && SymbolEqualityComparer.Default.Equals(
+                        method.ReturnType,
+                        invoke.ReturnType);
+            if (!hasByRefParameter && resultMatches)
+            {
+                return new LambdaExpression(parameters, expressionBody: call);
+            }
+
             var statements = returnType == null
                 ? new GStatement[] { new ExpressionStatement(call) }
                 : new GStatement[] { new ReturnStatement(call) };


### PR DESCRIPTION
## Summary
- wrapper parameters take the target method's own parameter names (`path`, `value`, `delta`) instead of `__argN`, aligned past the receiver for extension-method groups, with the captured receiver identifier reserved so a derived name can never shadow it (`(delta int32) -> value.Measure(delta)`)
- wrappers whose result type needs no pinning render as concise arrow lambdas; the explicit-return-type function literal remains only for return covariance, value-discard into void delegates, and by-ref parameters
- signature-matching method groups keep passing through as direct references (`paths.Select(Path.GetFullPath)`, bare sibling `Select(Len)`) — probe-verified against gsc

## Validation
- new `Issue3468MethodGroupWrapperTests`: 4 regressions — direct pass-through, arrow wrapper with derived name, typed-literal return-covariance wrapper, and an execution-parity oracle
- 6 existing `__arg0` expectations updated to the new spellings (Issue3414, Issue3422)
- full `Cs2Gs.Tests`: **2,318 passed, 0 failed**

Fixes #3468

🤖 Generated with [Claude Code](https://claude.com/claude-code)