### PR TITLE
Add safe JsonElement property readers

### DIFF
--- a/src/Sdk/Gsharp.Extensions/Json/JsonElementExtensions.gs
+++ b/src/Sdk/Gsharp.Extensions/Json/JsonElementExtensions.gs
@@ -1,0 +1,324 @@
+package Gsharp.Extensions.Json
+
+import System
+import System.Text.Json
+
+/// Returns the named JSON string property when it is present and valid.
+///
+/// The receiver must be an object and `name` must identify a string value.
+/// A non-object receiver, missing property, JSON `null`, or different value
+/// kind returns `nil`.
+///
+/// ```gs
+/// let name = root.GetStringOrNil("name")
+/// ```
+///
+/// See also [GetGuidOrNil](cref:Gsharp.Extensions.Json.GetGuidOrNil),
+/// [GetDateTimeOffsetOrNil](cref:Gsharp.Extensions.Json.GetDateTimeOffsetOrNil).
+///
+/// @param name the case-sensitive property name to read.
+/// @returns the decoded string value, or `nil` when the property is unavailable or invalid.
+func(element JsonElement) GetStringOrNil(name string) string? {
+  if element.ValueKind != JsonValueKind.Object {
+    return nil
+  }
+  if !element.TryGetProperty(name, out var value) {
+    return nil
+  }
+  if value.ValueKind != JsonValueKind.String {
+    return nil
+  }
+  return value.GetString()
+}
+
+/// Returns the named JSON string property parsed as a `Guid`.
+///
+/// The receiver must be an object and `name` must identify a string accepted
+/// by `JsonElement.TryGetGuid`. Missing, non-string, and malformed values
+/// return `nil`.
+///
+/// ```gs
+/// let id = root.GetGuidOrNil("id")
+/// ```
+///
+/// See also [GetStringOrNil](cref:Gsharp.Extensions.Json.GetStringOrNil).
+///
+/// @param name the case-sensitive property name to read.
+/// @returns the parsed `Guid`, or `nil` when the property is unavailable or invalid.
+func(element JsonElement) GetGuidOrNil(name string) Guid? {
+  if element.ValueKind != JsonValueKind.Object {
+    return nil
+  }
+  if !element.TryGetProperty(name, out var value) {
+    return nil
+  }
+  if value.ValueKind != JsonValueKind.String {
+    return nil
+  }
+  if !value.TryGetGuid(out var guid) {
+    return nil
+  }
+  return guid
+}
+
+/// Returns the named JSON string property parsed as a `DateTimeOffset`.
+///
+/// The receiver must be an object and `name` must identify a timestamp string
+/// accepted by `JsonElement.TryGetDateTimeOffset`. Missing, non-string, and
+/// malformed values return `nil`.
+///
+/// ```gs
+/// let createdAt = root.GetDateTimeOffsetOrNil("createdAt")
+/// ```
+///
+/// See also [GetStringOrNil](cref:Gsharp.Extensions.Json.GetStringOrNil).
+///
+/// @param name the case-sensitive property name to read.
+/// @returns the parsed timestamp with its offset, or `nil` when unavailable or invalid.
+func(element JsonElement) GetDateTimeOffsetOrNil(name string) DateTimeOffset? {
+  if element.ValueKind != JsonValueKind.Object {
+    return nil
+  }
+  if !element.TryGetProperty(name, out var value) {
+    return nil
+  }
+  if value.ValueKind != JsonValueKind.String {
+    return nil
+  }
+  if !value.TryGetDateTimeOffset(out var timestamp) {
+    return nil
+  }
+  return timestamp
+}
+
+/// Returns the named JSON string property decoded from Base64.
+///
+/// The receiver must be an object and `name` must identify a completely valid
+/// Base64 string. Missing, non-string, and malformed values return `nil`.
+///
+/// ```gs
+/// let payload = root.GetBytesFromBase64OrNil("payload")
+/// ```
+///
+/// See also [GetStringOrNil](cref:Gsharp.Extensions.Json.GetStringOrNil).
+///
+/// @param name the case-sensitive property name to read.
+/// @returns the decoded byte slice, or `nil` when the property is unavailable or invalid.
+func(element JsonElement) GetBytesFromBase64OrNil(name string) []?uint8 {
+  if element.ValueKind != JsonValueKind.Object {
+    return nil
+  }
+  if !element.TryGetProperty(name, out var value) {
+    return nil
+  }
+  if value.ValueKind != JsonValueKind.String {
+    return nil
+  }
+  if !value.TryGetBytesFromBase64(out var bytes) {
+    return nil
+  }
+  return bytes
+}
+
+/// Returns the named JSON number property as an `int32`.
+///
+/// The value must be an integer within the signed 32-bit range. Missing,
+/// non-number, fractional, and out-of-range values return `nil`.
+///
+/// ```gs
+/// let count = root.GetInt32OrNil("count")
+/// ```
+///
+/// See also [GetInt64OrNil](cref:Gsharp.Extensions.Json.GetInt64OrNil),
+/// [GetFloat64OrNil](cref:Gsharp.Extensions.Json.GetFloat64OrNil).
+///
+/// @param name the case-sensitive property name to read.
+/// @returns the `int32` value, or `nil` when the property is unavailable or invalid.
+func(element JsonElement) GetInt32OrNil(name string) int32? {
+  if element.ValueKind != JsonValueKind.Object {
+    return nil
+  }
+  if !element.TryGetProperty(name, out var value) {
+    return nil
+  }
+  if value.ValueKind != JsonValueKind.Number {
+    return nil
+  }
+  if !value.TryGetInt32(out var number) {
+    return nil
+  }
+  return number
+}
+
+/// Returns the named JSON number property as an `int64`.
+///
+/// The value must be an integer within the signed 64-bit range. Missing,
+/// non-number, fractional, and out-of-range values return `nil`.
+///
+/// ```gs
+/// let total = root.GetInt64OrNil("total")
+/// ```
+///
+/// See also [GetInt32OrNil](cref:Gsharp.Extensions.Json.GetInt32OrNil),
+/// [GetDecimalOrNil](cref:Gsharp.Extensions.Json.GetDecimalOrNil).
+///
+/// @param name the case-sensitive property name to read.
+/// @returns the `int64` value, or `nil` when the property is unavailable or invalid.
+func(element JsonElement) GetInt64OrNil(name string) int64? {
+  if element.ValueKind != JsonValueKind.Object {
+    return nil
+  }
+  if !element.TryGetProperty(name, out var value) {
+    return nil
+  }
+  if value.ValueKind != JsonValueKind.Number {
+    return nil
+  }
+  if !value.TryGetInt64(out var number) {
+    return nil
+  }
+  return number
+}
+
+/// Returns the named JSON number property as a finite `float64`.
+///
+/// Missing and non-number values return `nil`. Values that fail conversion or
+/// produce `NaN` or positive or negative infinity are also rejected.
+///
+/// ```gs
+/// let ratio = root.GetFloat64OrNil("ratio")
+/// ```
+///
+/// See also [GetDecimalOrNil](cref:Gsharp.Extensions.Json.GetDecimalOrNil),
+/// [GetInt64OrNil](cref:Gsharp.Extensions.Json.GetInt64OrNil).
+///
+/// @param name the case-sensitive property name to read.
+/// @returns the finite `float64` value, or `nil` when unavailable or invalid.
+func(element JsonElement) GetFloat64OrNil(name string) float64? {
+  if element.ValueKind != JsonValueKind.Object {
+    return nil
+  }
+  if !element.TryGetProperty(name, out var value) {
+    return nil
+  }
+  if value.ValueKind != JsonValueKind.Number {
+    return nil
+  }
+  if !value.TryGetDouble(out var number) {
+    return nil
+  }
+  if !float64.IsFinite(number) {
+    return nil
+  }
+  return number
+}
+
+/// Returns the named JSON number property as a `decimal`.
+///
+/// Use this helper when base-10 precision matters. Missing, non-number, and
+/// values outside the `decimal` range return `nil`.
+///
+/// ```gs
+/// let price = root.GetDecimalOrNil("price")
+/// ```
+///
+/// See also [GetFloat64OrNil](cref:Gsharp.Extensions.Json.GetFloat64OrNil),
+/// [GetInt64OrNil](cref:Gsharp.Extensions.Json.GetInt64OrNil).
+///
+/// @param name the case-sensitive property name to read.
+/// @returns the `decimal` value, or `nil` when the property is unavailable or invalid.
+func(element JsonElement) GetDecimalOrNil(name string) decimal? {
+  if element.ValueKind != JsonValueKind.Object {
+    return nil
+  }
+  if !element.TryGetProperty(name, out var value) {
+    return nil
+  }
+  if value.ValueKind != JsonValueKind.Number {
+    return nil
+  }
+  if !value.TryGetDecimal(out var number) {
+    return nil
+  }
+  return number
+}
+
+/// Returns the named JSON Boolean property.
+///
+/// Both JSON `true` and JSON `false` are valid results. A non-object receiver,
+/// missing property, JSON `null`, or different value kind returns `nil`.
+///
+/// ```gs
+/// let enabled = root.GetBoolOrNil("enabled")
+/// ```
+///
+/// See also [GetStringOrNil](cref:Gsharp.Extensions.Json.GetStringOrNil).
+///
+/// @param name the case-sensitive property name to read.
+/// @returns the Boolean value, or `nil` when the property is unavailable or invalid.
+func(element JsonElement) GetBoolOrNil(name string) bool? {
+  if element.ValueKind != JsonValueKind.Object {
+    return nil
+  }
+  if !element.TryGetProperty(name, out var value) {
+    return nil
+  }
+  if value.ValueKind != JsonValueKind.True && value.ValueKind != JsonValueKind.False {
+    return nil
+  }
+  return value.GetBoolean()
+}
+
+/// Returns the named JSON array property as a `JsonElement`.
+///
+/// A non-object receiver, missing property, JSON `null`, or different value
+/// kind returns `nil`. The returned element remains backed by the receiver's
+/// parent `JsonDocument` and must not outlive it.
+///
+/// ```gs
+/// let items = root.GetArrayOrNil("items")
+/// ```
+///
+/// See also [GetObjectOrNil](cref:Gsharp.Extensions.Json.GetObjectOrNil).
+///
+/// @param name the case-sensitive property name to read.
+/// @returns the array element, or `nil` when the property is unavailable or invalid.
+func(element JsonElement) GetArrayOrNil(name string) JsonElement? {
+  if element.ValueKind != JsonValueKind.Object {
+    return nil
+  }
+  if !element.TryGetProperty(name, out var value) {
+    return nil
+  }
+  if value.ValueKind != JsonValueKind.Array {
+    return nil
+  }
+  return value
+}
+
+/// Returns the named nested JSON object property as a `JsonElement`.
+///
+/// A non-object receiver, missing property, JSON `null`, or different value
+/// kind returns `nil`. The returned element remains backed by the receiver's
+/// parent `JsonDocument` and must not outlive it.
+///
+/// ```gs
+/// let config = root.GetObjectOrNil("config")
+/// ```
+///
+/// See also [GetArrayOrNil](cref:Gsharp.Extensions.Json.GetArrayOrNil).
+///
+/// @param name the case-sensitive property name to read.
+/// @returns the nested object, or `nil` when the property is unavailable or invalid.
+func(element JsonElement) GetObjectOrNil(name string) JsonElement? {
+  if element.ValueKind != JsonValueKind.Object {
+    return nil
+  }
+  if !element.TryGetProperty(name, out var value) {
+    return nil
+  }
+  if value.ValueKind != JsonValueKind.Object {
+    return nil
+  }
+  return value
+}

--- a/test/Extensions.Tests/JsonElementExtensionsTests.cs
+++ b/test/Extensions.Tests/JsonElementExtensionsTests.cs
@@ -1,0 +1,259 @@
+using System.Text.Json;
+using Gsharp.Extensions.Json;
+using Xunit;
+
+namespace GSharp.Extensions.Tests;
+
+public class JsonElementExtensionsTests
+{
+    [Fact]
+    public void GetStringOrNil_StringProperty_ReturnsValue()
+    {
+        using var document = JsonDocument.Parse("{\"name\":\"alpha\"}");
+
+        Assert.Equal(
+            "alpha",
+            document.RootElement.GetStringOrNil("name"));
+    }
+
+    [Theory]
+    [InlineData("[]")]
+    [InlineData("{}")]
+    [InlineData("{\"name\":42}")]
+    public void GetStringOrNil_InvalidShape_ReturnsNull(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+
+        Assert.Null(document.RootElement.GetStringOrNil("name"));
+    }
+
+    [Fact]
+    public void GetGuidOrNil_GuidProperty_ReturnsValue()
+    {
+        using var document = JsonDocument.Parse(
+            "{\"id\":\"d85b1407-351d-4694-9392-03acc5870eb1\"}");
+
+        Assert.Equal(
+            Guid.Parse("d85b1407-351d-4694-9392-03acc5870eb1"),
+            document.RootElement.GetGuidOrNil("id"));
+    }
+
+    [Theory]
+    [InlineData("[]")]
+    [InlineData("{}")]
+    [InlineData("{\"id\":42}")]
+    [InlineData("{\"id\":\"not-a-guid\"}")]
+    public void GetGuidOrNil_InvalidInput_ReturnsNull(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+
+        Assert.Null(document.RootElement.GetGuidOrNil("id"));
+    }
+
+    [Fact]
+    public void GetDateTimeOffsetOrNil_TimestampProperty_ReturnsValue()
+    {
+        using var document = JsonDocument.Parse(
+            "{\"createdAt\":\"2026-08-23T12:34:56-04:00\"}");
+
+        Assert.Equal(
+            new DateTimeOffset(
+                2026, 8, 23, 12, 34, 56,
+                TimeSpan.FromHours(-4)),
+            document.RootElement.GetDateTimeOffsetOrNil("createdAt"));
+    }
+
+    [Theory]
+    [InlineData("[]")]
+    [InlineData("{}")]
+    [InlineData("{\"createdAt\":42}")]
+    [InlineData("{\"createdAt\":\"not-a-timestamp\"}")]
+    public void GetDateTimeOffsetOrNil_InvalidInput_ReturnsNull(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+
+        Assert.Null(document.RootElement.GetDateTimeOffsetOrNil("createdAt"));
+    }
+
+    [Fact]
+    public void GetBytesFromBase64OrNil_Base64Property_ReturnsValue()
+    {
+        using var document = JsonDocument.Parse("{\"payload\":\"AQID\"}");
+
+        Assert.Equal(
+            new byte[] { 1, 2, 3 },
+            document.RootElement.GetBytesFromBase64OrNil("payload"));
+    }
+
+    [Theory]
+    [InlineData("[]")]
+    [InlineData("{}")]
+    [InlineData("{\"payload\":42}")]
+    [InlineData("{\"payload\":\"not-base64***\"}")]
+    public void GetBytesFromBase64OrNil_InvalidInput_ReturnsNull(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+
+        Assert.Null(document.RootElement.GetBytesFromBase64OrNil("payload"));
+    }
+
+    [Fact]
+    public void GetInt32OrNil_IntegerProperty_ReturnsValue()
+    {
+        using var document = JsonDocument.Parse("{\"count\":42}");
+
+        Assert.Equal(
+            42,
+            document.RootElement.GetInt32OrNil("count"));
+    }
+
+    [Theory]
+    [InlineData("[]")]
+    [InlineData("{}")]
+    [InlineData("{\"count\":\"42\"}")]
+    [InlineData("{\"count\":1.5}")]
+    public void GetInt32OrNil_InvalidShape_ReturnsNull(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+
+        Assert.Null(document.RootElement.GetInt32OrNil("count"));
+    }
+
+    [Fact]
+    public void GetInt64OrNil_LargeIntegerProperty_ReturnsValue()
+    {
+        using var document = JsonDocument.Parse(
+            "{\"count\":5000000000}");
+
+        Assert.Equal(
+            5_000_000_000L,
+            document.RootElement.GetInt64OrNil("count"));
+    }
+
+    [Theory]
+    [InlineData("[]")]
+    [InlineData("{}")]
+    [InlineData("{\"count\":\"5000000000\"}")]
+    [InlineData("{\"count\":9223372036854775808}")]
+    public void GetInt64OrNil_InvalidInput_ReturnsNull(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+
+        Assert.Null(document.RootElement.GetInt64OrNil("count"));
+    }
+
+    [Fact]
+    public void GetFloat64OrNil_FractionalProperty_ReturnsValue()
+    {
+        using var document = JsonDocument.Parse(
+            "{\"ratio\":12.5}");
+
+        Assert.Equal(
+            12.5,
+            document.RootElement.GetFloat64OrNil("ratio"));
+    }
+
+    [Theory]
+    [InlineData("[]")]
+    [InlineData("{}")]
+    [InlineData("{\"ratio\":\"12.5\"}")]
+    [InlineData("{\"ratio\":1e400}")]
+    public void GetFloat64OrNil_InvalidInput_ReturnsNull(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+
+        Assert.Null(document.RootElement.GetFloat64OrNil("ratio"));
+    }
+
+    [Fact]
+    public void GetDecimalOrNil_DecimalProperty_ReturnsValue()
+    {
+        using var document = JsonDocument.Parse("{\"price\":12.50}");
+
+        Assert.Equal(
+            12.50m,
+            document.RootElement.GetDecimalOrNil("price"));
+    }
+
+    [Theory]
+    [InlineData("[]")]
+    [InlineData("{}")]
+    [InlineData("{\"price\":\"12.50\"}")]
+    [InlineData("{\"price\":1e400}")]
+    public void GetDecimalOrNil_InvalidInput_ReturnsNull(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+
+        Assert.Null(document.RootElement.GetDecimalOrNil("price"));
+    }
+
+    [Theory]
+    [InlineData("{\"enabled\":true}", true)]
+    [InlineData("{\"enabled\":false}", false)]
+    public void GetBoolOrNil_BooleanProperty_ReturnsValue(string json, bool expected)
+    {
+        using var document = JsonDocument.Parse(json);
+
+        Assert.Equal(
+            expected,
+            document.RootElement.GetBoolOrNil("enabled"));
+    }
+
+    [Theory]
+    [InlineData("[]")]
+    [InlineData("{}")]
+    [InlineData("{\"enabled\":1}")]
+    public void GetBoolOrNil_InvalidShape_ReturnsNull(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+
+        Assert.Null(document.RootElement.GetBoolOrNil("enabled"));
+    }
+
+    [Fact]
+    public void GetArrayOrNil_ArrayProperty_ReturnsValue()
+    {
+        using var document = JsonDocument.Parse("{\"items\":[1,2]}");
+
+        var array = document.RootElement.GetArrayOrNil("items");
+
+        Assert.True(array.HasValue);
+        Assert.Equal(2, array.Value.GetArrayLength());
+    }
+
+    [Theory]
+    [InlineData("[]")]
+    [InlineData("{}")]
+    [InlineData("{\"items\":{}}")]
+    public void GetArrayOrNil_InvalidShape_ReturnsNull(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+
+        Assert.Null(document.RootElement.GetArrayOrNil("items"));
+    }
+
+    [Fact]
+    public void GetObjectOrNil_ObjectProperty_ReturnsValue()
+    {
+        using var document = JsonDocument.Parse(
+            "{\"config\":{\"name\":\"alpha\"}}");
+
+        var value = document.RootElement.GetObjectOrNil("config");
+
+        Assert.True(value.HasValue);
+        Assert.Equal(
+            "alpha",
+            value.Value.GetProperty("name").GetString());
+    }
+
+    [Theory]
+    [InlineData("[]")]
+    [InlineData("{}")]
+    [InlineData("{\"config\":[]}")]
+    public void GetObjectOrNil_InvalidShape_ReturnsNull(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+
+        Assert.Null(document.RootElement.GetObjectOrNil("config"));
+    }
+}


### PR DESCRIPTION
Fixes #3493

## Summary

- Add safe JsonElement property readers under Gsharp.Extensions.Json.
- Return nil for missing properties, incompatible kinds, and failed conversions.
- Add focused success and invalid-input tests.

## Verification

- Release solution build: 0 warnings, 0 errors.
- Extensions.Tests: 173 passed, 0 failed.
- e2etests/sdk-e2e.sh: passed and produced a runnable HelloWorld assembly from the packed SDK.
- ADR-0154 witness: on origin/main at cddd9f5b, adding only JsonElementExtensionsTests.cs failed with CS0234 because Gsharp.Extensions.Json did not exist. Adding JsonElementExtensions.gs made the suite pass 173/173.

## Checklist

- [x] Behavioral tests carry a witness of discrimination (ADR-0154).
- [x] Self-review verdict: MERGEABLE. No residual issues.