### PR TITLE
cs2gs: preserve author comments and doc comments through translation

### DIFF
--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GNode.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GNode.cs
@@ -11,4 +11,15 @@ namespace Cs2Gs.CodeModel.Ast;
 /// </summary>
 public abstract class GNode
 {
+    /// <summary>
+    /// Gets or sets the author comment lines captured from the source C#
+    /// node's leading trivia (issue #3469). Each entry is a complete comment
+    /// line carrying its own marker (<c>// …</c> or <c>/// …</c>); the
+    /// printer emits them, indented, immediately above the node. Block
+    /// comments are normalized to <c>//</c> lines at capture time so the
+    /// emitted G# stays in the canonical single-line form. <see langword="null"/>
+    /// when the node has no attached comments (the overwhelmingly common
+    /// case — synthesized nodes never carry any).
+    /// </summary>
+    public System.Collections.Generic.IReadOnlyList<string> AttachedComments { get; set; }
 }

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -1060,6 +1060,32 @@ public static class GSharpPrinter
 
     private static string RenderStatement(GStatement statement, int indent)
     {
+        string core = RenderStatementCore(statement, indent);
+        return PrependAttachedComments(statement, core, indent);
+    }
+
+    // Issue #3469: author comments captured from the source C# node's leading
+    // trivia print, indented, immediately above the node they rode in on.
+    private static string PrependAttachedComments(GNode node, string rendered, int indent)
+    {
+        if (node?.AttachedComments is not { Count: > 0 } comments)
+        {
+            return rendered;
+        }
+
+        var pad = Indent(indent);
+        var sb = new StringBuilder();
+        foreach (string comment in comments)
+        {
+            sb.Append(pad).Append(comment).Append('\n');
+        }
+
+        sb.Append(rendered);
+        return sb.ToString();
+    }
+
+    private static string RenderStatementCore(GStatement statement, int indent)
+    {
         var pad = Indent(indent);
         switch (statement)
         {
@@ -1235,8 +1261,9 @@ public static class GSharpPrinter
     private static string RenderSimpleStatement(GStatement statement, int indent)
     {
         // A "simple" statement (init/incr clause of a C-style for) is rendered
-        // inline with no leading indentation.
-        return RenderStatement(statement, indent).TrimStart();
+        // inline with no leading indentation — and no leading comments, which
+        // would corrupt the single-line clause (issue #3469).
+        return RenderStatementCore(statement, indent).TrimStart();
     }
 
     private static string RenderIfLet(IfLetStatement ifLet, int indent)
@@ -1476,6 +1503,11 @@ public static class GSharpPrinter
     }
 
     private static string RenderMember(GMember member, int indent)
+    {
+        return PrependAttachedComments(member, RenderMemberCore(member, indent), indent);
+    }
+
+    private static string RenderMemberCore(GMember member, int indent)
     {
         switch (member)
         {
@@ -1901,7 +1933,7 @@ public static class GSharpPrinter
             case AssignmentStatement assignment:
                 return $"{RenderExpression(assignment.Target, indent)} {assignment.Operator} {RenderExpression(assignment.Value, indent)}";
             default:
-                return RenderStatement(statement, 0).TrimStart();
+                return RenderStatementCore(statement, 0).TrimStart();
         }
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3347RemainingSpillInventoryTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3347RemainingSpillInventoryTests.cs
@@ -67,7 +67,10 @@ public sealed class Issue3347RemainingSpillInventoryTests
                 translator.TranslateDocument(document, context));
             castCount += CountOccurrences(printed, "__cast");
             deconstructionCount += CountOccurrences(printed, "__decon");
-            spillCount += CountOccurrences(printed, "let __spill");
+            // Issue #3469: author comments now flow into the emitted G#,
+            // and Translator-source comments mention the very patterns this
+            // inventory counts — count code lines only.
+            spillCount += CountOccurrences(StripCommentLines(printed), "let __spill");
             usingCount += CountOccurrences(printed, "__using");
             sourceAssertedAsConversions += CountSourceAssertedAsConversions(document);
             translatedAssertedAsConversions += CountTranslatedAssertedAsConversions(printed);
@@ -106,7 +109,10 @@ public sealed class Issue3347RemainingSpillInventoryTests
                 document.FilePath);
             string printed = GSharpPrinter.Print(
                 translator.TranslateDocument(document, context));
-            spillCount += CountOccurrences(printed, "let __spill");
+            // Issue #3469: author comments now flow into the emitted G#,
+            // and Translator-source comments mention the very patterns this
+            // inventory counts — count code lines only.
+            spillCount += CountOccurrences(StripCommentLines(printed), "let __spill");
         }
 
         Assert.Equal(0, spillCount);
@@ -501,6 +507,16 @@ public sealed class Issue3347RemainingSpillInventoryTests
             StringComparison.Ordinal);
         Assert.DoesNotContain("__spill", printed, StringComparison.Ordinal);
     }
+
+
+    private static string StripCommentLines(string printed) =>
+        string.Join(
+            "\n",
+            printed.Split('\n').Where(line =>
+            {
+                string trimmed = line.TrimStart();
+                return !trimmed.StartsWith("//", StringComparison.Ordinal);
+            }));
 
     private static int CountOccurrences(string haystack, string needle)
     {

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3422RedundantNullForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3422RedundantNullForgivenessTranslationTests.cs
@@ -46,8 +46,12 @@ public sealed class Issue3422RedundantNullForgivenessTranslationTests
                 document.FilePath);
             string printed = GSharpPrinter.Print(
                 translator.TranslateDocument(document, context));
-            doubledAssertions += CountOccurrences(printed, "!!!!");
-            assertedParenthesizedReceivers += CountOccurrences(printed, ")!!.");
+            // Issue #3469: author comments now flow into the emitted G#,
+            // and Core-source comments mention the very patterns this
+            // inventory counts — count code lines only.
+            string code = StripCommentLines(printed);
+            doubledAssertions += CountOccurrences(code, "!!!!");
+            assertedParenthesizedReceivers += CountOccurrences(code, ")!!.");
         }
 
         Assert.Equal(0, doubledAssertions);
@@ -754,6 +758,16 @@ public sealed class Issue3422RedundantNullForgivenessTranslationTests
                 + printed);
         return printed;
     }
+
+
+    private static string StripCommentLines(string printed) =>
+        string.Join(
+            "\n",
+            printed.Split('\n').Where(line =>
+            {
+                string trimmed = line.TrimStart();
+                return !trimmed.StartsWith("//", StringComparison.Ordinal);
+            }));
 
     private static int CountOccurrences(string haystack, string needle)
     {

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3469CommentPreservationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3469CommentPreservationTests.cs
@@ -1,0 +1,151 @@
+// <copyright file="Issue3469CommentPreservationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using GSharp.Tests;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Cs2Gs.Tests
+{
+    // Issue #3469: author comments (`//`, `/* */`) and `///` doc comments were
+    // dropped wholesale — ~70k comment lines in the self-migrated src/ became
+    // 78. Leading trivia now rides on the first G# node each statement, type
+    // member, and top-level type translates to, and the printer re-emits it
+    // above that node; `///` doc lines keep the doc-comment marker
+    // (ADR-0057), block comments normalize to `//` lines.
+    public sealed class Issue3469CommentPreservationTests
+    {
+        [Fact]
+        public void StatementComments_SurviveTranslation_AndBind()
+        {
+            string printed = Translate("""
+                public static class C
+                {
+                    public static int Run()
+                    {
+                        // The seed is deliberately non-zero: zero would skip
+                        // the calibration branch below.
+                        var seed = 41;
+
+                        /* block comment
+                           second line */
+                        seed = seed + 1;
+                        return seed;
+                    }
+                }
+                """);
+
+            Assert.Contains("// The seed is deliberately non-zero: zero would skip", printed, StringComparison.Ordinal);
+            Assert.Contains("// the calibration branch below.", printed, StringComparison.Ordinal);
+            Assert.Contains("// block comment", printed, StringComparison.Ordinal);
+            Assert.Contains("// second line", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+        }
+
+        [Fact]
+        public void MemberDocComments_KeepDocMarker_AndBind()
+        {
+            string printed = Translate("""
+                public class Widget
+                {
+                    /// <summary>
+                    /// Computes the widget's mass in grams.
+                    /// </summary>
+                    /// <returns>The mass.</returns>
+                    public int Mass() => 42;
+
+                    // A plain member comment.
+                    public int Tare() => 1;
+                }
+                """);
+
+            Assert.Contains("/// <summary>", printed, StringComparison.Ordinal);
+            Assert.Contains("/// Computes the widget's mass in grams.", printed, StringComparison.Ordinal);
+            Assert.Contains("/// <returns>The mass.</returns>", printed, StringComparison.Ordinal);
+            Assert.Contains("// A plain member comment.", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+        }
+
+        [Fact]
+        public void TypeComments_AndCommentPlacement_AreAboveTheirNodes()
+        {
+            string printed = Translate("""
+                // ADR-9999: this type is load-bearing.
+                public class Anchor
+                {
+                    public int Value()
+                    {
+                        // above the return
+                        return 3;
+                    }
+                }
+                """);
+
+            int typeComment = printed.IndexOf("// ADR-9999: this type is load-bearing.", StringComparison.Ordinal);
+            int typeDecl = printed.IndexOf("class Anchor", StringComparison.Ordinal);
+            int bodyComment = printed.IndexOf("// above the return", StringComparison.Ordinal);
+            int returnStmt = printed.IndexOf("return 3", StringComparison.Ordinal);
+            Assert.True(typeComment >= 0 && typeComment < typeDecl, printed);
+            Assert.True(bodyComment > typeDecl && bodyComment < returnStmt, printed);
+            TranslationTestValidation.AssertBinds(printed);
+        }
+
+        [Fact]
+        public void CommentedCode_StillExecutes()
+        {
+            string printed = Translate("""
+                public static class Obj
+                {
+                    /// <summary>Adds one, documented.</summary>
+                    public static int Run()
+                    {
+                        // returns 42
+                        return 41 + 1;
+                    }
+                }
+                """);
+
+            EmittedOracleResult result = EmittedOracle.Evaluate(
+                printed + Environment.NewLine + "Obj.Run()");
+            Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+            Assert.Null(result.UnhandledException);
+            Assert.Equal(42, result.Value);
+        }
+
+        private static string Translate(
+            string source,
+            params MetadataReference[] additionalReferences)
+        {
+            IReadOnlyList<MetadataReference> references = additionalReferences.Length == 0
+                ? null
+                : CSharpProjectLoader.RuntimeReferences()
+                    .Concat(additionalReferences)
+                    .GroupBy(reference => reference.Display, StringComparer.Ordinal)
+                    .Select(group => group.First())
+                    .ToList();
+            LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+                new[] { ("Snippet.cs", source) },
+                references);
+            Assert.True(
+                project.BoundWithoutErrors,
+                "Snippet should bind with no C# errors: "
+                    + string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+            LoadedDocument document = Assert.Single(project.Documents);
+            var context = new TranslationContext(
+                project.Compilation,
+                document.SemanticModel,
+                document.FilePath);
+            CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+            return GSharpPrinter.Print(unit);
+        }
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
@@ -24,6 +24,76 @@ public sealed partial class CSharpToGSharpTranslator
 {
     private sealed partial class DeclarationVisitor
     {
+        // Issue #3469: author comments (`//`, `/* */`, and `///` doc lines)
+        // from the C# node's leading trivia are carried onto the first G#
+        // node the construct translates to; the printer re-emits them above
+        // that node. Block comments normalize to `//` lines; doc-comment
+        // lines keep the `///` marker (G# doc comments, ADR-0057). Synthesized
+        // translator notes stay distinguishable because they are RawStatement
+        // text, never AttachedComments entries.
+        internal static void AttachSourceComments(GNode node, SyntaxNode source)
+        {
+            if (node == null || source == null)
+            {
+                return;
+            }
+
+            List<string> lines = null;
+            foreach (SyntaxTrivia trivia in source.GetLeadingTrivia())
+            {
+                switch (trivia.Kind())
+                {
+                    case SyntaxKind.SingleLineCommentTrivia:
+                        (lines ??= new List<string>()).Add(trivia.ToString().TrimEnd());
+                        break;
+
+                    case SyntaxKind.MultiLineCommentTrivia:
+                        string block = trivia.ToString();
+                        block = block.StartsWith("/*", StringComparison.Ordinal)
+                            ? block.Substring(2)
+                            : block;
+                        block = block.EndsWith("*/", StringComparison.Ordinal)
+                            ? block.Substring(0, block.Length - 2)
+                            : block;
+                        foreach (string raw in block.Split('\n'))
+                        {
+                            string text = raw.Trim().TrimStart('*').TrimStart();
+                            (lines ??= new List<string>()).Add(
+                                text.Length == 0 ? "//" : $"// {text}");
+                        }
+
+                        break;
+
+                    case SyntaxKind.SingleLineDocumentationCommentTrivia:
+                        foreach (string raw in trivia.ToFullString()
+                            .Split('\n', StringSplitOptions.RemoveEmptyEntries))
+                        {
+                            string text = raw.Trim();
+                            if (text.Length == 0)
+                            {
+                                continue;
+                            }
+
+                            (lines ??= new List<string>()).Add(
+                                text.StartsWith("///", StringComparison.Ordinal)
+                                    ? text
+                                    : $"/// {text}");
+                        }
+
+                        break;
+                }
+            }
+
+            if (lines == null)
+            {
+                return;
+            }
+
+            node.AttachedComments = node.AttachedComments is { Count: > 0 } existing
+                ? lines.Concat(existing).ToList()
+                : lines;
+        }
+
         private (GMember Member, bool IsStatic) TranslateIndexer(IndexerDeclarationSyntax node)
         {
             // ADR-0118 / issue #944: a C# indexer (`public T this[int i] => ...`)
@@ -2494,11 +2564,13 @@ public sealed partial class CSharpToGSharpTranslator
                 List<GStatement> core = this.TranslateStatementCore(statement).ToList();
                 if (spillPrologue.Count == 0)
                 {
+                    AttachSourceComments(core.FirstOrDefault(), statement);
                     return core;
                 }
 
                 var combined = new List<GStatement>(spillPrologue);
                 combined.AddRange(core);
+                AttachSourceComments(combined[0], statement);
                 return combined;
             }
             finally

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Declarations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Declarations.cs
@@ -1250,6 +1250,7 @@ public sealed partial class CSharpToGSharpTranslator
                 // in a different `SyntaxTree`; issue #2821 owned extension methods
                 // can as well. Resolve either through that tree's semantic model.
                 using IDisposable modelScope = this.context.UseSemanticModelFor(member.SyntaxTree);
+                bool attachedMemberComments = false;
                 foreach ((GMember translated, bool isStatic) in this.TranslateMember(
                     member,
                     kind.Value,
@@ -1259,6 +1260,15 @@ public sealed partial class CSharpToGSharpTranslator
                     callSiteLoweredStructConstructors,
                     ownedExtensionTarget))
                 {
+                    // Issue #3469: the member's leading comments ride on the
+                    // FIRST G# member it translates to, wherever that member
+                    // is placed (instance body, shared block, or top level).
+                    if (!attachedMemberComments && translated != null)
+                    {
+                        AttachSourceComments(translated, member);
+                        attachedMemberComments = true;
+                    }
+
                     // A C# operator overload translates to a receiver-clause
                     // `func (a T) operator <op>(...)`; like every receiver-clause
                     // func it only binds at top level, so it is lifted out as a

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -364,6 +364,10 @@ public sealed partial class CSharpToGSharpTranslator
             GMember translated = visitor.Visit(member);
             if (translated is not null)
             {
+                // Issue #3469: a top-level type's own leading comments (file
+                // headers, ADR references, type doc comments) ride on the
+                // translated declaration.
+                DeclarationVisitor.AttachSourceComments(translated, member);
                 members.Add(translated);
             }
 


### PR DESCRIPTION
## Summary
- every G# emit node can carry `AttachedComments`, captured from C# leading trivia at three funnels: the statement dispatcher, the type-member loop, and the top-level type walk — so comments survive wherever the translated node lands (instance body, shared block, lifted sibling, entry statements excepted)
- `//` comments pass through verbatim; `/* */` blocks normalize to `//` lines; `///` XML doc lines keep the doc marker (G# doc comments, ADR-0057) so gsc's `/doc` pipeline can consume them
- the printer emits attached comments indented immediately above their node; inline positions (for-clause init/increment) render comment-free so clauses cannot be corrupted; synthesized translator notes stay distinguishable (RawStatement text, never AttachedComments)
- the two repo-scale inventory tests now count code lines only, since real source comments mention the very patterns they count (`__spill`, `!!`)

## Validation
- new `Issue3469CommentPreservationTests`: 4 regressions — statement comments (line + block), member doc comments with markers, type-comment and in-body placement ordering, and an execution-parity oracle over commented code; each binds through gsc
- full `Cs2Gs.Tests`: **2,318 passed, 0 failed** (includes the Core- and Translator-wide migration inventories, which translate the real repo with comments flowing)
- CI's corpus gates (Oahu, code-exploder) exercise commented real-world sources end-to-end: translate → compile → ilverify → parity

Fixes #3469

🤖 Generated with [Claude Code](https://claude.com/claude-code)