### PR TITLE
compiler: resolve bare shared siblings from lambdas in shared members

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
@@ -109,6 +109,24 @@ internal sealed partial class OverloadResolver
         return Scope.TryLookupSymbol("this") as ParameterSymbol;
     }
 
+    /// <summary>
+    /// Issue #3487: the lexical owner for implicit static-self dispatch. A
+    /// member body carries it as the function's own <c>StaticOwnerType</c>; a
+    /// function literal nested in that body has a synthetic symbol with no
+    /// <c>StaticOwnerType</c>, only the <c>LexicalEnclosingType</c> chained
+    /// through <c>LambdaBinder.ResolveLexicalEnclosingType</c> — falling back
+    /// to it makes bare sibling <c>shared</c> calls resolve identically in
+    /// both positions (they already did inside instance-method lambdas via
+    /// the effective-<c>this</c> path).
+    /// </summary>
+    private TypeSymbol? GetImplicitStaticSelfOwner()
+    {
+        var current = getCurrentFunction();
+        return current?.ThisParameter != null
+            ? null
+            : current?.StaticOwnerType ?? current?.LexicalEnclosingType;
+    }
+
     private StructSymbol? GetConstructorInitializerReceiverType()
     {
         return (getCurrentFunction()?.ReceiverType as StructSymbol)
@@ -278,7 +296,7 @@ internal sealed partial class OverloadResolver
         {
             // ADR-0089 / ADR-0090: implicit static-self dispatch inside a
             // static-virtual or private-static interface helper body.
-            if (getCurrentFunction()?.StaticOwnerType is InterfaceSymbol staticIface)
+            if (GetImplicitStaticSelfOwner() is InterfaceSymbol staticIface)
             {
                 if (!TypeMemberModel.GetMethods(staticIface, name, MemberQuery.Static(MemberKinds.Method)).IsDefaultOrEmpty
                     || staticIface.GetStaticPrivateMethods(name).Length > 0)
@@ -286,7 +304,7 @@ internal sealed partial class OverloadResolver
                     return true;
                 }
             }
-            else if (getCurrentFunction()?.StaticOwnerType is StructSymbol staticStruct)
+            else if (GetImplicitStaticSelfOwner() is StructSymbol staticStruct)
             {
                 // Issue #1585: implicit static-self dispatch inside a
                 // `shared` method body of a user struct/class.
@@ -834,8 +852,7 @@ internal sealed partial class OverloadResolver
             // <c>StaticOwnerType</c> set to the owning InterfaceSymbol. An
             // unqualified call resolves against the interface's static
             // (public + private) buckets.
-            if (getCurrentFunction()?.ThisParameter == null
-                && getCurrentFunction()?.StaticOwnerType is InterfaceSymbol implicitStaticIface)
+            if (GetImplicitStaticSelfOwner() is InterfaceSymbol implicitStaticIface)
             {
                 var implicitStaticOverloads = TypeMemberModel.GetMethods(implicitStaticIface, syntax.Identifier.Text, MemberQuery.Static(MemberKinds.Method));
                 var implicitStaticPrivateOverloads = implicitStaticIface.GetStaticPrivateMethods(syntax.Identifier.Text);
@@ -879,8 +896,7 @@ internal sealed partial class OverloadResolver
             // walks the same base-type chain as the qualified path. The method
             // group is fetched through the canonical member-resolution layer
             // (ADR-0112) so it holds under both reference resolvers.
-            if (getCurrentFunction()?.ThisParameter == null
-                && getCurrentFunction()?.StaticOwnerType is StructSymbol implicitStaticStruct
+            if (GetImplicitStaticSelfOwner() is StructSymbol implicitStaticStruct
                 && bindUserTypeStaticCall != null)
             {
                 var implicitStaticStructOverloads = TypeMemberModel.GetMethods(

--- a/test/Core.Tests/CodeAnalysis/Issue3487SharedLambdaScopeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Issue3487SharedLambdaScopeTests.cs
@@ -1,0 +1,157 @@
+// <copyright file="Issue3487SharedLambdaScopeTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis;
+
+/// <summary>
+/// Issue #3487: a bare reference to a sibling <c>shared</c> member from a
+/// lambda body inside a <c>shared</c> method failed name lookup (GS0130),
+/// while the identical reference bound fine from the shared method body
+/// itself, from instance-method lambdas, and via the qualified spelling.
+/// Implicit static-self dispatch now falls back to the lambda's
+/// <c>LexicalEnclosingType</c> when its synthetic symbol has no
+/// <c>StaticOwnerType</c>.
+/// </summary>
+public class Issue3487SharedLambdaScopeTests
+{
+    [Fact]
+    public void SharedMethodLambda_BareSiblingSharedCall_BindsAndRuns()
+    {
+        var source = @"
+class E {
+    shared {
+        func Shown() int32 -> 4
+
+        func FromShared() int32 {
+            let f = () -> Shown()
+            return f()
+        }
+    }
+}
+
+E.FromShared()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(4, result.Value);
+    }
+
+    [Fact]
+    public void SharedMethodLambda_BarePrivateSiblingSharedCall_BindsAndRuns()
+    {
+        var source = @"
+class E {
+    shared {
+        private func Hidden() int32 -> 3
+
+        func FromShared() int32 {
+            let f = () -> Hidden()
+            return f()
+        }
+    }
+}
+
+E.FromShared()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(3, result.Value);
+    }
+
+    [Fact]
+    public void SharedMethodLambda_TargetTypedBinding_BindsAndRuns()
+    {
+        var source = @"
+class E {
+    shared {
+        func Shown() int32 -> 4
+
+        func Run() int32 {
+            let g () -> int32 = () -> Shown()
+            return g()
+        }
+    }
+}
+
+E.Run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(4, result.Value);
+    }
+
+    [Fact]
+    public void SharedMethodNestedLambda_BareSiblingSharedCall_BindsAndRuns()
+    {
+        var source = @"
+class E {
+    shared {
+        func Shown() int32 -> 4
+
+        func Run() int32 {
+            let outer = () -> {
+                let inner = () -> Shown()
+                return inner()
+            }
+            return outer()
+        }
+    }
+}
+
+E.Run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(4, result.Value);
+    }
+
+    [Fact]
+    public void InstanceMethodLambda_BareSiblingSharedCall_StillBindsAndRuns()
+    {
+        var source = @"
+class E {
+    shared {
+        private func Hidden() int32 -> 3
+    }
+
+    func FromInstance() int32 {
+        let f = () -> Hidden()
+        return f()
+    }
+}
+
+var e = E{}
+e.FromInstance()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(3, result.Value);
+    }
+
+    [Fact]
+    public void StaticInterfaceHelperLambda_BareSiblingStaticCall_Binds()
+    {
+        var source = @"
+struct S {
+    shared {
+        func Pick() int32 -> 9
+
+        func Run() int32 {
+            let f = () -> Pick()
+            return f()
+        }
+    }
+}
+
+S.Run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(9, result.Value);
+    }
+}


### PR DESCRIPTION
## Summary
- implicit static-self dispatch consulted only `getCurrentFunction()?.StaticOwnerType`, which a lambda's synthetic function symbol never carries — inside a `shared` method's lambda, bare sibling `shared` calls died with GS0130 while the qualified spelling and instance-method lambdas (effective-`this` path, #1159) worked
- new `GetImplicitStaticSelfOwner` falls back to the lambda's `LexicalEnclosingType` (chained through nested literals by `LambdaBinder.ResolveLexicalEnclosingType`); the callable-candidate predicate and both dispatch sites (interface static helpers, struct/class shared methods) now use it

## Validation
- new `Issue3487SharedLambdaScopeTests`: 6 emitted-oracle regressions — public/private siblings, target-typed lambda bindings, nested literals, struct owners, and the already-working instance-lambda path
- full `Core.Tests`: **8,005 passed, 0 failed**
- once merged, cs2gs's lambda-context carve-out in `IsBareSiblingStaticScope` (PR #3488) can be retired in a follow-up

Fixes #3487

🤖 Generated with [Claude Code](https://claude.com/claude-code)