### PR TITLE
compiler: synthesize static receivers for bare shared member stores

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -811,6 +811,35 @@ internal sealed partial class ExpressionBinder
                 implicitPropReceiver.StructType,
                 implicitPropReceiver.Property);
         }
+        else if (variable is ImplicitStaticFieldVariableSymbol implicitStaticFieldReceiver)
+        {
+            // Issue #3489: the STATIC counterparts of the two cases above. A
+            // bare `shared` field/property name used as the receiver of a
+            // member write (`Instance.flush = v`, `Instance.Flag = v`)
+            // resolves to the implicit-static variable symbols, which have no
+            // local slot either — the emitter threw the same GS9998 the
+            // instance shapes did before #689/#1446. Synthesize the static
+            // access the read path (BindNameAccessReceiver) already uses.
+            implicitFieldReceiverExpr = implicitStaticFieldReceiver.InterfaceType != null
+                ? new BoundFieldAccessExpression(
+                    null,
+                    implicitStaticFieldReceiver.Field,
+                    implicitStaticFieldReceiver.InterfaceType)
+                : new BoundFieldAccessExpression(
+                    null,
+                    receiver: null,
+                    implicitStaticFieldReceiver.StructType,
+                    implicitStaticFieldReceiver.Field);
+        }
+        else if (variable is ImplicitStaticPropertyVariableSymbol implicitStaticPropReceiver
+            && implicitStaticPropReceiver.Property.HasGetter)
+        {
+            implicitFieldReceiverExpr = new BoundPropertyAccessExpression(
+                null,
+                receiver: null,
+                implicitStaticPropReceiver.StructType,
+                implicitStaticPropReceiver.Property);
+        }
 
         // Issue #2488: classify and bind the write through the same narrowed
         // receiver view used by reads. The symbol retains its declared nullable

--- a/test/Core.Tests/CodeAnalysis/Issue3489StaticStoreReceiverTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Issue3489StaticStoreReceiverTests.cs
@@ -1,0 +1,157 @@
+// <copyright file="Issue3489StaticStoreReceiverTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis;
+
+/// <summary>
+/// Issue #3489: a bare <c>shared</c> field or property used as the base
+/// receiver of a member STORE (<c>Instance.flush = value</c>) crashed the
+/// emitter with GS9998 ("no local slot or parameter index") — the implicit
+/// static variable symbols never got the expression-receiver synthesis the
+/// instance shapes received in #689/#1446, while reads, call receivers, and
+/// direct writes to the member itself all emitted fine.
+/// </summary>
+public class Issue3489StaticStoreReceiverTests
+{
+    [Fact]
+    public void SharedFieldReceiver_MemberFieldStore_EmitsAndRuns()
+    {
+        var source = @"
+class Logging {
+    var flush bool
+
+    shared {
+        var Instance Logging = Logging{}
+
+        func SetFlush(value bool) {
+            Instance.flush = value
+        }
+
+        func Read() bool -> Instance.flush
+    }
+}
+
+Logging.SetFlush(true)
+Logging.Read()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(true, result.Value);
+    }
+
+    [Fact]
+    public void SharedFieldReceiver_MemberPropertyStore_EmitsAndRuns()
+    {
+        var source = @"
+class Logging {
+    var flush bool
+
+    prop Flag bool {
+        get -> this.flush
+        set {
+            this.flush = value
+        }
+    }
+
+    shared {
+        var Instance Logging = Logging{}
+
+        func PropStore(v bool) {
+            Instance.Flag = v
+        }
+
+        func Read() bool -> Instance.flush
+    }
+}
+
+Logging.PropStore(true)
+Logging.Read()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(true, result.Value);
+    }
+
+    [Fact]
+    public void SharedFieldReceiver_InSetAccessor_EmitsAndRuns()
+    {
+        var source = @"
+class Logging {
+    var flush bool
+
+    shared {
+        var Instance Logging = Logging{}
+
+        prop InstantFlush bool {
+            get -> Instance.flush
+            set -> Instance.flush = value
+        }
+    }
+}
+
+Logging.InstantFlush = true
+Logging.InstantFlush
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(true, result.Value);
+    }
+
+    [Fact]
+    public void SharedPropertyReceiver_MemberStore_EmitsAndRuns()
+    {
+        var source = @"
+class Logging {
+    var count int32
+
+    shared {
+        var backing Logging = Logging{}
+
+        prop Instance Logging {
+            get -> backing
+        }
+
+        func Bump() int32 {
+            Instance.count = Instance.count + 1
+            return Instance.count
+        }
+    }
+}
+
+Logging.Bump()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(1, result.Value);
+    }
+
+    [Fact]
+    public void SharedFieldReceiver_CompoundMemberStore_EmitsAndRuns()
+    {
+        var source = @"
+class Counter {
+    var total int32
+
+    shared {
+        var Instance Counter = Counter{}
+
+        func Add(v int32) int32 {
+            Instance.total += v
+            return Instance.total
+        }
+    }
+}
+
+Counter.Add(21)
+Counter.Add(21)
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(42, result.Value);
+    }
+}


### PR DESCRIPTION
## Summary
- `BindFieldAssignmentExpression`'s implicit-receiver synthesis (#689/#1446) covered bare instance field/property receivers of member writes but never the static counterparts, so `Instance.flush = value` through a bare `shared` member crashed the emitter with GS9998
- `ImplicitStaticFieldVariableSymbol` / `ImplicitStaticPropertyVariableSymbol` receivers now synthesize the same static access shapes the read path already uses (including the interface-owned static field form from #1030)

## Validation
- new `Issue3489StaticStoreReceiverTests`: 5 emitted-oracle regressions — field and property member stores through shared field and shared property receivers, arrow and block `set` accessors, and compound assignment
- full `Core.Tests`: **8,004 passed, 0 failed**
- once merged, cs2gs's `IsStoreReceiverPosition` carve-out (PR #3488) can be retired in a follow-up

Fixes #3489

🤖 Generated with [Claude Code](https://claude.com/claude-code)