### PR TITLE
compiler: tolerate same-syntax out-var redeclaration on call re-bind

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -1981,6 +1981,23 @@ internal sealed partial class ExpressionBinder
 
                 if (!scope.TryDeclareVariable(local))
                 {
+                    // Issue #3490: an argument list can legally bind twice —
+                    // BindCallExpression pre-binds every argument for overload
+                    // probing, then the implicit static-self and using-static
+                    // finalizers re-bind the whole call from syntax. When the
+                    // colliding local was declared from THIS SAME syntax node,
+                    // this is that re-bind, not a genuine duplicate: reuse the
+                    // already-declared local (same parameter → same type)
+                    // instead of reporting GS0102 and cascading into GS9002 at
+                    // the out-parameter position.
+                    if (scope.TryLookupSymbol(localName) is LocalVariableSymbol existing
+                        && ReferenceEquals(existing.DeclaringSyntax, syntax))
+                    {
+                        return new BoundAddressOfExpression(
+                            null,
+                            new BoundVariableExpression(null, existing));
+                    }
+
                     Diagnostics.ReportSymbolAlreadyDeclared(resolvedDeclarationIdentifier.Location, localName);
                     return new BoundErrorExpression(null);
                 }

--- a/test/Core.Tests/CodeAnalysis/Issue3490OutVarRebindTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Issue3490OutVarRebindTests.cs
@@ -1,0 +1,105 @@
+// <copyright file="Issue3490OutVarRebindTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis;
+
+/// <summary>
+/// Issue #3490: a bare call to a sibling <c>shared</c> function whose
+/// argument subtree carries an inline <c>out var</c> declaration reported
+/// GS9002 + GS0102 for the same declaration — BindCallExpression pre-binds
+/// every argument for overload probing (declaring the out local), then the
+/// implicit static-self finalizer re-binds the whole call from syntax and
+/// the second declaration collided. A same-syntax collision now reuses the
+/// already-declared local; genuinely duplicate declarations (distinct
+/// syntax) still report GS0102.
+/// </summary>
+public class Issue3490OutVarRebindTests
+{
+    [Fact]
+    public void BareSiblingCall_OutVarInIfExpressionArgument_BindsAndRuns()
+    {
+        var source = @"
+class W {
+    shared {
+        private func Format(value int32) string -> ""v"" + value.ToString()
+
+        func Run() string {
+            return Format(if int.TryParse(""42"", out var v) { v } else { 0 })
+        }
+    }
+}
+
+W.Run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal("v42", result.Value);
+    }
+
+    [Fact]
+    public void BareSiblingCall_OutVarUsedAfterCall_BindsAndRuns()
+    {
+        var source = @"
+class W {
+    shared {
+        private func Touch(flag bool) bool -> flag
+
+        func Run() int32 {
+            if Touch(int.TryParse(""7"", out var v)) {
+                return v
+            }
+            return 0
+        }
+    }
+}
+
+W.Run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(7, result.Value);
+    }
+
+    [Fact]
+    public void GenuineDuplicateOutVar_StillReportsAlreadyDeclared()
+    {
+        var source = @"
+class W {
+    func Bad(text string) int32 {
+        if int.TryParse(text, out var v) && int.TryParse(text, out var v) {
+            return v
+        }
+        return 0
+    }
+}
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0102");
+    }
+
+    [Fact]
+    public void QualifiedSiblingCall_OutVarArgument_StillBindsAndRuns()
+    {
+        var source = @"
+class W {
+    shared {
+        private func Format(value int32) string -> ""v"" + value.ToString()
+
+        func Run() string {
+            return W.Format(if int.TryParse(""3"", out var v) { v } else { 0 })
+        }
+    }
+}
+
+W.Run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal("v3", result.Value);
+    }
+}


### PR DESCRIPTION
## Summary
- `BindCallExpression` pre-binds arguments for overload probing (declaring inline `out var` locals), then the implicit static-self / using-static finalizers re-bind the call from syntax — the second declaration collided (GS0102) and cascaded into GS9002 at the out-parameter position, so a bare sibling call with an out-var argument failed while the qualified spelling compiled
- `BindRefArgumentExpression` now recognizes the re-bind: a collision with a local whose `DeclaringSyntax` is the same `RefArgumentExpression` node reuses the already-declared local; genuine duplicates (distinct syntax) still report GS0102

## Validation
- new `Issue3490OutVarRebindTests`: 4 regressions — the bare-call if-expression shape from the issue, out-var reads after the call, the qualified spelling, and the genuine-duplicate diagnostic — through the emitted oracle
- full `Core.Tests`: **8,003 passed, 0 failed**
- once merged, cs2gs's out-var-argument carve-out on the bare-call path (PR #3488) can be retired in a follow-up

Fixes #3490

🤖 Generated with [Claude Code](https://claude.com/claude-code)