### PR TITLE
ci: ratcheting repo self-migration nightly gate (#3501 Track C)

### DIFF
--- a/.github/workflows/cs2gs-selfmig-nightly.yml
+++ b/.github/workflows/cs2gs-selfmig-nightly.yml
@@ -1,0 +1,59 @@
+name: cs2gs-selfmig-nightly
+
+# Issue #3501 Track C: the repo self-migration gate. Migrates the entire
+# GSharp repository C# → G# nightly and enforces the ratcheting baseline in
+# tools/cs2gs/selfmig-baseline.json — a green-count floor plus readability
+# ceilings (synthetic labels, __local_ lifts, >300-char lines) over the
+# migrated output. Track A/B improvements tighten the baseline in the same
+# PR, so the migration goal ratchets instead of drifting.
+#
+# Too expensive for the PR gates (~40+ minutes: 55 projects through
+# translate + SDK compile + ilverify + parity); scheduled clear of
+# cs2gs-nightly (07:17), windows-nightly (09:23), macos-nightly (11:23).
+
+on:
+  schedule:
+    - cron: '23 13 * * *'
+  workflow_dispatch:
+
+env:
+  # See build.yml: parallel MSBuild nodes corrupt $GITHUB_ENV via
+  # Nerdbank.GitVersioning's GitBuildVersion* emission.
+  NBGV_SetCloudBuildVersionVars: false
+
+jobs:
+  selfmig:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v5
+        with:
+          global-json-file: global.json
+
+      - name: Restore
+        run: dotnet restore GSharp.sln --locked-mode
+
+      - name: Restore .NET local tools
+        run: dotnet tool restore
+
+      - name: Build cs2gs (Release)
+        run: dotnet build tools/cs2gs/Cs2Gs.Cli/Cs2Gs.Cli.csproj --configuration Release --no-restore -graph
+
+      - name: Run self-migration gate
+        run: ./build/run-cs2gs-selfmig.sh
+
+      - name: Upload run artifacts
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: cs2gs-selfmig-run
+          path: |
+            /tmp/gsharp-cs2gs-selfmig/migrate.log
+            /tmp/gsharp-cs2gs-selfmig/runs/**/run.json
+            /tmp/gsharp-cs2gs-selfmig/runs/**/report.html

--- a/build/run-cs2gs-selfmig.sh
+++ b/build/run-cs2gs-selfmig.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Issue #3501 Track C: the repo self-migration gate. Migrates the ENTIRE
+# GSharp repository from C# to G# (translate + compile + ilverify + parity
+# per project) and enforces the ratcheting baseline in
+# tools/cs2gs/selfmig-baseline.json:
+#
+#   - greenFloor:            minimum fully-green apps (run fails below it)
+#   - syntheticLabelCeiling: max __switchExit/__iteratorExit/__gotoCase/
+#                            __patternGuardEnd occurrences in migrated output
+#   - liftedLocalCeiling:    max __local_ lifted-helper occurrences
+#   - longLineCeiling:       max lines longer than 300 characters
+#
+# The ceilings cap readability regressions; the floor caps functional ones.
+# When a Track A/B improvement lands, tighten the corresponding number in the
+# baseline within the same PR so progress ratchets.
+#
+# E2E fixtures that are not migration targets are excluded via --exclude.
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+baseline="$repo_root/tools/cs2gs/selfmig-baseline.json"
+work_root=${SELFMIG_GATE_ROOT:-"${TMPDIR:-/tmp}/gsharp-cs2gs-selfmig"}
+
+case "$work_root" in
+  ""|"/"|"$repo_root")
+    echo "Refusing unsafe self-migration gate root: '$work_root'" >&2
+    exit 2
+    ;;
+esac
+
+rm -rf "$work_root"
+mkdir -p "$work_root"
+work_root=$(cd "$work_root" && pwd -P)
+migrated_dir="$work_root/migrated"
+runs_dir="$work_root/runs"
+
+set +e
+dotnet "$repo_root/out/bin/Release/Cs2Gs.Cli/cs2gs.dll" migrate \
+  --corpus "$repo_root" \
+  --out "$migrated_dir" \
+  --artifacts "$runs_dir" \
+  --config Release \
+  --exclude samples/ProjectRef/CSharpApp \
+  --exclude samples/PropertyRef/CSharpApp \
+  | tee "$work_root/migrate.log"
+migrate_exit=${PIPESTATUS[0]}
+set -e
+
+run_json=$(find "$runs_dir" -maxdepth 2 -name run.json | sort | tail -1)
+if [[ -z "$run_json" ]]; then
+  echo "self-migration gate: no run.json produced (migrate exit $migrate_exit)." >&2
+  exit 1
+fi
+
+green=$(jq '[.apps[] | select(.succeeded)] | length' "$run_json")
+total=$(jq '.apps | length' "$run_json")
+
+labels=$(grep -rhoE '__(switchExit|iteratorExit|gotoCase|gotoDefault|patternGuardEnd)' "$migrated_dir" --include='*.gs' 2>/dev/null | wc -l | tr -d ' ')
+lifts=$(grep -rho '__local_' "$migrated_dir" --include='*.gs' 2>/dev/null | wc -l | tr -d ' ')
+long_lines=$(find "$migrated_dir" -name '*.gs' -exec awk 'length($0)>300' {} + 2>/dev/null | wc -l | tr -d ' ')
+
+green_floor=$(jq -r '.greenFloor' "$baseline")
+label_ceiling=$(jq -r '.syntheticLabelCeiling' "$baseline")
+lift_ceiling=$(jq -r '.liftedLocalCeiling' "$baseline")
+long_ceiling=$(jq -r '.longLineCeiling' "$baseline")
+
+summary="self-migration: $green/$total green (floor $green_floor); labels=$labels (ceiling $label_ceiling); __local_=$lifts (ceiling $lift_ceiling); lines>300=$long_lines (ceiling $long_ceiling)"
+echo "$summary"
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  {
+    echo "### cs2gs self-migration gate"
+    echo ''
+    echo "| metric | value | baseline |"
+    echo "|---|---|---|"
+    echo "| green apps | $green/$total | floor $green_floor |"
+    echo "| synthetic labels | $labels | ceiling $label_ceiling |"
+    echo "| \`__local_\` lifts | $lifts | ceiling $lift_ceiling |"
+    echo "| lines >300 chars | $long_lines | ceiling $long_ceiling |"
+  } >> "$GITHUB_STEP_SUMMARY"
+fi
+
+status=0
+if (( green < green_floor )); then
+  echo "GATE: green count $green fell below floor $green_floor." >&2
+  status=1
+fi
+if (( labels > label_ceiling )); then
+  echo "GATE: synthetic label count $labels exceeded ceiling $label_ceiling." >&2
+  status=1
+fi
+if (( lifts > lift_ceiling )); then
+  echo "GATE: __local_ count $lifts exceeded ceiling $lift_ceiling." >&2
+  status=1
+fi
+if (( long_lines > long_ceiling )); then
+  echo "GATE: >300-char line count $long_lines exceeded ceiling $long_ceiling." >&2
+  status=1
+fi
+
+if (( status == 0 )); then
+  echo "Self-migration gate PASSED."
+fi
+exit "$status"

--- a/tools/cs2gs/Cs2Gs.Cli/Program.cs
+++ b/tools/cs2gs/Cs2Gs.Cli/Program.cs
@@ -187,6 +187,15 @@ internal static class Program
 
             options.ArtifactRoot ??= Path.GetFullPath(options.OutputRoot) + ".cs2gs-runs";
             apps = RepositoryDiscovery.Discover(corpus);
+            if (options.ExcludeAppIdPrefixes.Count > 0)
+            {
+                int before = apps.Count;
+                apps = apps
+                    .Where(app => !options.ExcludeAppIdPrefixes.Any(prefix =>
+                        app.Id.StartsWith(prefix, StringComparison.Ordinal)))
+                    .ToList();
+                Console.WriteLine($"cs2gs: excluded {before - apps.Count} project(s) via --exclude.");
+            }
         }
         else if (appIds.Count > 0)
         {
@@ -462,6 +471,10 @@ internal static class Program
                     case "--config":
                         options.Config = NextValue(args, ref i, arg);
                         break;
+                    case "--exclude":
+                        options.ExcludeAppIdPrefixes.Add(
+                            NextValue(args, ref i, arg).Replace('\\', '/').TrimEnd('/'));
+                        break;
                     case "--baseline":
                         baselinePath = NextValue(args, ref i, arg);
                         break;
@@ -626,6 +639,8 @@ internal static class Program
         Console.WriteLine("  --gsgen <path>    Override gsgen.dll (default: out/bin/<Config>/Gsgen.Cli/gsgen.dll); issue #2215.");
         Console.WriteLine("                    With --diagnostic-run, --out is the runs root.");
         Console.WriteLine("  --config <name>   Build config used to find gsc (default: Release).");
+        Console.WriteLine("  --exclude <path>  Repository migration only: exclude apps whose repo-relative id");
+        Console.WriteLine("                    starts with <path> (repeatable; e2e fixtures, non-app projects).");
         Console.WriteLine("  --baseline <file> Gate on the gap ledger (tools/cs2gs/triage/gaps.json): fail only on");
         Console.WriteLine("                    NEW or REGRESSED fingerprints; known-open gaps are tolerated.");
         Console.WriteLine("  --baseline-strict Also fail on STALE ledger entries (nightly mode).");

--- a/tools/cs2gs/Cs2Gs.Pipeline/PipelineOptions.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/PipelineOptions.cs
@@ -62,6 +62,15 @@ public sealed class PipelineOptions
     public string SourceRoot { get; set; }
 
     /// <summary>
+    /// Gets repository-relative app-id prefixes excluded from repository
+    /// migration (issue #3501 corpus hygiene: e2e fixtures such as
+    /// <c>samples/ProjectRef/CSharpApp</c> are not migration targets).
+    /// Matched with an ordinal prefix comparison against the discovered
+    /// app id.
+    /// </summary>
+    public List<string> ExcludeAppIdPrefixes { get; } = new List<string>();
+
+    /// <summary>
     /// Gets or sets the build configuration used to locate the default compiler
     /// (<c>Release</c> by default).
     /// </summary>

--- a/tools/cs2gs/selfmig-baseline.json
+++ b/tools/cs2gs/selfmig-baseline.json
@@ -1,0 +1,7 @@
+{
+  "comment": "Issue #3501 Track C: ratcheting baseline for the repo self-migration gate (build/run-cs2gs-selfmig.sh). greenFloor is the minimum number of fully-green apps (translate+compile+ilverify+parity); the *Ceiling metrics cap readability regressions in the migrated output. Calibrated 2026-08-23 against the full 55-project corpus (25 green; 255 synthetic labels; 111 __local_ lifts; 3766 lines >300 chars). Improve a metric, then tighten the corresponding number in the same PR.",
+  "greenFloor": 25,
+  "syntheticLabelCeiling": 260,
+  "liftedLocalCeiling": 115,
+  "longLineCeiling": 3800
+}


### PR DESCRIPTION
## Summary
- new `cs2gs-selfmig-nightly` workflow + `build/run-cs2gs-selfmig.sh`: migrates the entire repository C# → G# nightly and enforces `tools/cs2gs/selfmig-baseline.json` — a green-count floor (25) plus readability ceilings over the migrated output (synthetic labels 260, `__local_` lifts 115, >300-char lines 3800, calibrated 2026-08-23 against the full 55-project corpus)
- Track A/B improvements tighten the baseline in the same PR, so the #3501 goal ratchets: green count can only go up, synthetic noise and long lines can only go down
- `cs2gs migrate` gains repeatable `--exclude <path-prefix>` (repository layout only) for corpus hygiene; the two e2e fixture apps are excluded

## Validation
- full local gate run: **25/55 green** (floor holds), metrics table emitted, both gate outcomes exercised (floor pass + ceiling fail-loud before calibration)
- `--exclude` verified live (2 projects excluded)
- workflow YAML validated; script `bash -n` clean; scheduled 13:23 UTC clear of the other three nightlies

Part of #3501 (Track C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)