### PR TITLE
compiler+cs2gs: native yield break, iterator exit labels retired (#3501 A1)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Blocks.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Blocks.cs
@@ -1122,11 +1122,24 @@ internal sealed partial class StatementBinder
             return new BoundExpressionStatement(syntax, new BoundErrorExpression(null));
         }
 
+        // Issue #3501: `yield break` terminates the iterator. Bind it as the
+        // bare return the iterator MoveNext builders already lower to a jump
+        // to the shared end label (state = -1, return false) — both the sync
+        // rewriter and the async-iterator rewriter document exactly this
+        // meaning for an expressionless return inside an iterator body.
+        if (syntax.BreakKeyword != null)
+        {
+            return new BoundReturnStatement(syntax, expression: null);
+        }
+
         var elementType = GetIteratorElementType(function.Type);
-        var expression = bindExpression(syntax.Expression);
+        ExpressionSyntax expressionSyntax = Invariant.Required(
+            syntax.Expression,
+            "a yield statement without a break keyword carries an expression");
+        var expression = bindExpression(expressionSyntax);
         if (expression.Type != null && elementType != null && expression.Type != elementType)
         {
-            expression = conversions.BindConversion(syntax.Expression.Location, expression, elementType);
+            expression = conversions.BindConversion(expressionSyntax.Location, expression, elementType);
         }
 
         return new BoundYieldStatement(syntax, expression);

--- a/src/Core/CodeAnalysis/Syntax/Parser.Statements.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.Statements.cs
@@ -1455,6 +1455,15 @@ public partial class Parser
         // ADR-0040: `yield <expr>` statement. The `yield` token is a contextual
         // identifier (not a reserved keyword) to preserve source compatibility.
         var yieldToken = MatchToken(SyntaxKind.IdentifierToken);
+
+        // Issue #3501: `yield break` terminates the iterator from any nesting
+        // depth (C# alignment); plain `break` keeps its loop binding.
+        if (Current.Kind == SyntaxKind.BreakKeyword)
+        {
+            var breakToken = MatchToken(SyntaxKind.BreakKeyword);
+            return new YieldStatementSyntax(syntaxTree, yieldToken, expression: null, breakToken);
+        }
+
         var expression = ParseExpression();
         return new YieldStatementSyntax(syntaxTree, yieldToken, expression);
     }

--- a/src/Core/CodeAnalysis/Syntax/YieldStatementSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/YieldStatementSyntax.cs
@@ -5,7 +5,10 @@
 namespace GSharp.Core.CodeAnalysis.Syntax;
 
 /// <summary>
-/// Represents a <c>yield &lt;expr&gt;</c> statement in an iterator function (ADR-0040).
+/// Represents a <c>yield &lt;expr&gt;</c> statement in an iterator function
+/// (ADR-0040), or the iteration-terminating <c>yield break</c> statement
+/// (issue #3501: C#-aligned early exit from any nesting depth — `break`
+/// keeps its loop binding).
 /// </summary>
 public sealed class YieldStatementSyntax : StatementSyntax
 {
@@ -14,12 +17,14 @@ public sealed class YieldStatementSyntax : StatementSyntax
     /// </summary>
     /// <param name="syntaxTree">The parent syntax tree.</param>
     /// <param name="yieldKeyword">The contextual <c>yield</c> keyword token.</param>
-    /// <param name="expression">The expression to yield.</param>
-    public YieldStatementSyntax(SyntaxTree syntaxTree, SyntaxToken yieldKeyword, ExpressionSyntax expression)
+    /// <param name="expression">The expression to yield, or <see langword="null"/> for <c>yield break</c>.</param>
+    /// <param name="breakKeyword">The <c>break</c> keyword token for <c>yield break</c>, or <see langword="null"/>.</param>
+    public YieldStatementSyntax(SyntaxTree syntaxTree, SyntaxToken yieldKeyword, ExpressionSyntax? expression, SyntaxToken? breakKeyword = null)
         : base(syntaxTree)
     {
         YieldKeyword = yieldKeyword;
         Expression = expression;
+        BreakKeyword = breakKeyword;
     }
 
     /// <inheritdoc/>
@@ -28,6 +33,9 @@ public sealed class YieldStatementSyntax : StatementSyntax
     /// <summary>Gets the contextual <c>yield</c> keyword token.</summary>
     public SyntaxToken YieldKeyword { get; }
 
-    /// <summary>Gets the expression being yielded.</summary>
-    public ExpressionSyntax Expression { get; }
+    /// <summary>Gets the expression being yielded, or <see langword="null"/> for <c>yield break</c>.</summary>
+    public ExpressionSyntax? Expression { get; }
+
+    /// <summary>Gets the <c>break</c> keyword for <c>yield break</c>, or <see langword="null"/>.</summary>
+    public SyntaxToken? BreakKeyword { get; }
 }

--- a/test/Core.Tests/CodeAnalysis/Issue3501YieldBreakTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Issue3501YieldBreakTests.cs
@@ -1,0 +1,140 @@
+// <copyright file="Issue3501YieldBreakTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis;
+
+/// <summary>
+/// Issue #3501 Track A1: <c>yield break</c> terminates an iterator from any
+/// nesting depth (C# alignment). Plain <c>break</c> keeps its loop binding;
+/// the iterator MoveNext builders already lowered an expressionless return
+/// to the shared end label, so <c>yield break</c> binds to exactly that.
+/// </summary>
+public class Issue3501YieldBreakTests
+{
+    [Fact]
+    public void YieldBreak_AtBodyLevel_StopsIteration()
+    {
+        var source = @"
+func Items(stop bool) sequence[int32] {
+    yield 1
+    if stop {
+        yield break
+    }
+    yield 2
+}
+
+var total = 0
+for _, v in Items(true) {
+    total += v
+}
+for _, v in Items(false) {
+    total += v
+}
+total
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(4, result.Value);
+    }
+
+    [Fact]
+    public void YieldBreak_InsideLoop_TerminatesWholeIterator()
+    {
+        var source = @"
+func Items(limit int32) sequence[int32] {
+    for var i = 0; i < 10; i += 1 {
+        if i >= limit {
+            yield break
+        }
+        yield i
+    }
+    yield 99
+}
+
+var total = 0
+for _, v in Items(3) {
+    total += v
+}
+total
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(3, result.Value);
+    }
+
+    [Fact]
+    public void PlainBreak_InsideLoop_KeepsLoopBinding()
+    {
+        var source = @"
+func Items(limit int32) sequence[int32] {
+    for var i = 0; i < 10; i += 1 {
+        if i >= limit {
+            break
+        }
+        yield i
+    }
+    yield 99
+}
+
+var total = 0
+for _, v in Items(3) {
+    total += v
+}
+total
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(102, result.Value);
+    }
+
+    [Fact]
+    public void YieldBreak_InsideTryFinally_RunsFinally()
+    {
+        var source = @"
+class Probe {
+    shared {
+        var Cleaned bool = false
+    }
+}
+
+func Items() sequence[int32] {
+    try {
+        yield 1
+        yield break
+    } finally {
+        Probe.Cleaned = true
+    }
+}
+
+var total = 0
+for _, v in Items() {
+    total += v
+}
+if Probe.Cleaned {
+    total += 10
+}
+total
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(11, result.Value);
+    }
+
+    [Fact]
+    public void YieldBreak_OutsideIterator_ReportsDiagnostic()
+    {
+        var source = @"
+func NotIterator() int32 {
+    yield break
+    return 1
+}
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.IsError);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GStatement.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GStatement.cs
@@ -741,14 +741,16 @@ public sealed class SwitchStatement : GStatement
 /// A <c>yield</c> statement inside an iterator <c>func</c> whose return type is
 /// <c>sequence[T]</c> (spec §Iterators; sample <c>TupleSequenceIterators.gs</c>).
 /// When <see cref="Expression"/> is non-<see langword="null"/> the statement is
-/// <c>yield &lt;expr&gt;</c> (C# <c>yield return</c>).
+/// <c>yield &lt;expr&gt;</c> (C# <c>yield return</c>), or the
+/// iteration-terminating <c>yield break</c> when <see cref="Expression"/> is
+/// <see langword="null"/> (issue #3501).
 /// </summary>
 public sealed class YieldStatement : GStatement
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="YieldStatement"/> class.
     /// </summary>
-    /// <param name="expression">The yielded value.</param>
+    /// <param name="expression">The yielded value, or <see langword="null"/> for <c>yield break</c>.</param>
     public YieldStatement(GExpression expression)
     {
         Expression = expression;

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -1255,7 +1255,9 @@ public static class GSharpPrinter
                 return $"{pad}{raw.Text}";
 
             case YieldStatement yield:
-                return $"{pad}yield {RenderExpression(yield.Expression, indent)}";
+                return yield.Expression == null
+                    ? $"{pad}yield break"
+                    : $"{pad}yield {RenderExpression(yield.Expression, indent)}";
 
             case SwitchStatement switchStatement:
                 return RenderSwitchStatement(switchStatement, indent);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2552NestedBreakTargetTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2552NestedBreakTargetTests.cs
@@ -164,12 +164,18 @@ namespace Demo
     }
 
     [Fact]
-    public void Translator_LowersYieldBreakToNearestIteratorExit()
+    public void Translator_EmitsNativeYieldBreak()
     {
+        // Issue #3501 A1: `yield break` translates to G#'s native
+        // `yield break`, which exits the iterator from any nesting depth —
+        // including from inside the switch inside the while here. The loop's
+        // own `break` keeps its loop binding (the third "break" match below
+        // is the loop's).
         string printed = TranslateAndValidate(IteratorSource);
 
-        Assert.Equal(2, CountOccurrences(printed, "goto __iteratorExit"));
-        Assert.Equal(1, CountOccurrences(printed, "break"));
+        Assert.Equal(2, CountOccurrences(printed, "yield break"));
+        Assert.Equal(3, CountOccurrences(printed, "break"));
+        Assert.DoesNotContain("__iteratorExit", printed, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3467SyntheticNameTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3467SyntheticNameTests.cs
@@ -59,9 +59,11 @@ namespace Cs2Gs.Tests
                 }
                 """);
 
-            Assert.Contains("__iteratorExit", printed, StringComparison.Ordinal);
+            // Issue #3501 A1: `yield break` now translates to G#'s native
+            // `yield break` — no synthesized iterator-exit label at all.
+            Assert.Contains("yield break", printed, StringComparison.Ordinal);
+            Assert.DoesNotContain("__iteratorExit", printed, StringComparison.Ordinal);
             Assert.Contains("__local_Label_NewLabel", printed, StringComparison.Ordinal);
-            Assert.DoesNotMatch(new Regex(@"__iteratorExit\d"), printed);
             Assert.DoesNotMatch(new Regex(@"__local_Label_NewLabel_?\d"), printed);
             TranslationTestValidation.AssertBinds(printed);
         }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3501YieldBreakTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3501YieldBreakTranslationTests.cs
@@ -1,0 +1,97 @@
+// <copyright file="Issue3501YieldBreakTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using GSharp.Tests;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Cs2Gs.Tests
+{
+    // Issue #3501 Track A1: C# `yield break` now translates to G#'s native
+    // `yield break` statement instead of a synthesized `goto __iteratorExit`
+    // plus a trailing label.
+    public sealed class Issue3501YieldBreakTranslationTests
+    {
+        [Fact]
+        public void YieldBreak_TranslatesNativelyAndRuns()
+        {
+            string printed = Translate("""
+                using System.Collections.Generic;
+
+                public static class Obj
+                {
+                    public static IEnumerable<int> Items(int limit)
+                    {
+                        foreach (var i in new[] { 1, 2, 3, 4 })
+                        {
+                            if (i > limit)
+                            {
+                                yield break;
+                            }
+
+                            yield return i;
+                        }
+
+                        yield return 99;
+                    }
+
+                    public static int Run()
+                    {
+                        int total = 0;
+                        foreach (var v in Items(2))
+                        {
+                            total += v;
+                        }
+
+                        return total;
+                    }
+                }
+                """);
+
+            Assert.Contains("yield break", printed, StringComparison.Ordinal);
+            Assert.DoesNotContain("__iteratorExit", printed, StringComparison.Ordinal);
+            Assert.DoesNotContain("goto", printed, StringComparison.Ordinal);
+            EmittedOracleResult result = EmittedOracle.Evaluate(
+                printed + Environment.NewLine + "Obj.Run()");
+            Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+            Assert.Null(result.UnhandledException);
+            Assert.Equal(3, result.Value);
+        }
+
+        private static string Translate(
+            string source,
+            params MetadataReference[] additionalReferences)
+        {
+            IReadOnlyList<MetadataReference> references = additionalReferences.Length == 0
+                ? null
+                : CSharpProjectLoader.RuntimeReferences()
+                    .Concat(additionalReferences)
+                    .GroupBy(reference => reference.Display, StringComparer.Ordinal)
+                    .Select(group => group.First())
+                    .ToList();
+            LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+                new[] { ("Snippet.cs", source) },
+                references);
+            Assert.True(
+                project.BoundWithoutErrors,
+                "Snippet should bind with no C# errors: "
+                    + string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+            LoadedDocument document = Assert.Single(project.Documents);
+            var context = new TranslationContext(
+                project.Compilation,
+                document.SemanticModel,
+                document.FilePath);
+            CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+            return GSharpPrinter.Print(unit);
+        }
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
@@ -298,11 +298,11 @@ namespace Demo
     }
 
     /// <summary>
-    /// <c>yield break</c> maps to the nearest iterator exit label because G#
-    /// has no <c>yield break</c> (ADR-0115 §B).
+    /// <c>yield break</c> maps to G#'s native <c>yield break</c> statement
+    /// (issue #3501 A1), which terminates the iterator from any depth.
     /// </summary>
     [Fact]
-    public void YieldBreak_MappedToIteratorExit()
+    public void YieldBreak_TranslatesNatively()
     {
         string printed = TranslateUnit(@"
 namespace Demo
@@ -321,9 +321,9 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("goto __iteratorExit", printed);
-        Assert.Contains("__iteratorExit", printed);
-        Assert.DoesNotContain("yield break", printed);
+        Assert.Contains("yield break", printed);
+        Assert.DoesNotContain("__iteratorExit", printed);
+        Assert.DoesNotContain("goto", printed);
         Assert.DoesNotContain("unsupported", printed);
     }
 
@@ -386,13 +386,10 @@ namespace Demo
             })
             .ToArray();
 
-        // Issue #3467: exit labels no longer embed SpanStart, so the getter's
-        // label and the local function's label share the readable spelling
-        // `__iteratorExit` — each lives in its own G# function scope, where
-        // duplicate label names are legal.
-        Assert.Equal(4, exits.Length);
-        Assert.All(exits, exit => Assert.Equal("__iteratorExit", exit));
-        Assert.DoesNotContain("yield break", printed);
+        // Issue #3501 A1: `yield break` translates to G#'s native
+        // `yield break` — no synthesized exit labels remain.
+        Assert.Empty(exits);
+        Assert.Equal(2, printed.Split('\n').Count(line => line.TrimEnd().EndsWith("yield break", StringComparison.Ordinal)));
     }
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
@@ -1171,12 +1171,6 @@ public sealed partial class CSharpToGSharpTranslator
                 .Any();
         }
 
-        private static bool HasYieldBreak(SyntaxNode bodyOwner)
-            => bodyOwner.DescendantNodes(
-                    n => ReferenceEquals(n, bodyOwner) || n is not LocalFunctionStatementSyntax)
-                .OfType<YieldStatementSyntax>()
-                .Any(y => y.Expression == null);
-
         private List<AttributeUse> MapAttributes(IEnumerable<AttributeListSyntax> attributeLists)
         {
             var attributes = new List<AttributeUse>();
@@ -1477,7 +1471,7 @@ public sealed partial class CSharpToGSharpTranslator
             {
                 BlockStatement body = this.TranslateBodyCore(bodyOwner, description);
                 body = this.WithParameterShadows(bodyOwner, body);
-                return this.AddIteratorExitLabel(bodyOwner, body);
+                return body;
             }
             finally
             {
@@ -1636,20 +1630,6 @@ public sealed partial class CSharpToGSharpTranslator
             }
 
             return candidate;
-        }
-
-        private BlockStatement AddIteratorExitLabel(SyntaxNode bodyOwner, BlockStatement body)
-        {
-            if (!HasYieldBreak(bodyOwner))
-            {
-                return body;
-            }
-
-            var statements = body.Statements.ToList();
-            statements.Add(new LabeledStatement(
-                this.IteratorExitLabelName(bodyOwner),
-                new BlockStatement(new List<GStatement>())));
-            return new BlockStatement(statements, body.IsUnsafe);
         }
 
         // Issue #1278 / ADR-0131: a C# expression-bodied member (`=> expr`)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
@@ -1654,7 +1654,6 @@ public sealed partial class CSharpToGSharpTranslator
                 if (localFunction.Body != null)
                 {
                     BlockStatement innerBody = this.WithParameterShadows(localFunction, this.TranslateBlock(localFunction.Body));
-                    innerBody = this.AddIteratorExitLabel(localFunction, innerBody);
                     lambda = isAsyncVoidHandler
                         ? new LambdaExpression(parameters, blockBody: this.BuildAsyncVoidHandlerWrapperBody(parameters, innerBody, localFunction.GetLocation()), isAsync: false, returnType: null, isFunctionLiteral: true)
                         : new LambdaExpression(parameters, blockBody: innerBody, isAsync: isAsync, returnType: returnType, isFunctionLiteral: true);

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
@@ -1191,12 +1191,12 @@ public sealed partial class CSharpToGSharpTranslator
         {
             // `yield return x` maps to the G# iterator `yield x` (sample
             // TupleSequenceIterators.gs); the enclosing func's return type is
-            // rewritten to `sequence[T]`. G# has no `yield break`, so jump to
-            // the end of the nearest iterator body regardless of nested loops.
+            // rewritten to `sequence[T]`. `yield break` maps to G#'s native
+            // `yield break` (issue #3501), which terminates the iterator from
+            // any nesting depth.
             if (node.Expression == null)
             {
-                SyntaxNode target = this.state.CurrentBodyScope ?? GetBreakTarget(node);
-                return new[] { (GStatement)new GotoStatement(this.IteratorExitLabelName(target)) };
+                return new[] { (GStatement)new YieldStatement(null) };
             }
 
             GExpression value = this.TranslateValueWithNullForgiveness(node.Expression);
@@ -1221,9 +1221,6 @@ public sealed partial class CSharpToGSharpTranslator
             => node.Ancestors().FirstOrDefault(
                 n => n is BaseMethodDeclarationSyntax or AccessorDeclarationSyntax or LocalFunctionStatementSyntax)
                 ?? node;
-
-        private string IteratorExitLabelName(SyntaxNode node)
-            => this.SyntheticLabelName("iteratorExit", node);
 
         private GStatement TranslateForEachVariable(ForEachVariableStatementSyntax node)
         {


### PR DESCRIPTION
## Summary
- `yield break` is now a G# statement (C# alignment): terminates the iterator from any nesting depth; plain `break` keeps its loop binding
- minimal surface: the contextual-`yield` statement lookahead already routed `yield break`; the syntax node gains an optional `BreakKeyword`, and the binder emits the expressionless return both iterator MoveNext builders (sync + async) already lower to the shared end label — so both engines, try/finally `leave` semantics, and async iterators came for free
- cs2gs translates `yield break` natively and the `__iteratorExit` goto+label machinery is deleted outright

## Validation
- new `Issue3501YieldBreakTests` (Core.Tests): body-level and in-loop termination, the `break` vs `yield break` semantic split (102 vs 3), try/finally runs on exit, outside-iterator diagnostic — all through the emitted oracle
- new `Issue3501YieldBreakTranslationTests` (Cs2Gs.Tests): native emission + execution parity; three prior label-asserting tests flipped
- full `Core.Tests`: **8,019 passed, 0 failed**; full `Cs2Gs.Tests`: green (three flips verified individually after the run; one unrelated environmental miss needed local Release nupkgs)
- follow-up on merge: tighten `syntheticLabelCeiling` in the #3502 baseline

Part of #3501 (Track A1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)