### PR TITLE
cs2gs: XML doc comments convert to the ADR-0057 Markdown surface (#3501 B1)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue3469CommentPreservationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3469CommentPreservationTests.cs
@@ -67,9 +67,11 @@ namespace Cs2Gs.Tests
                 }
                 """);
 
-            Assert.Contains("/// <summary>", printed, StringComparison.Ordinal);
+            // Issue #3501 B1: doc comments render in the ADR-0057 Markdown
+            // surface, not verbatim XML.
             Assert.Contains("/// Computes the widget's mass in grams.", printed, StringComparison.Ordinal);
-            Assert.Contains("/// <returns>The mass.</returns>", printed, StringComparison.Ordinal);
+            Assert.Contains("/// @returns The mass.", printed, StringComparison.Ordinal);
+            Assert.DoesNotContain("<summary>", printed, StringComparison.Ordinal);
             Assert.Contains("// A plain member comment.", printed, StringComparison.Ordinal);
             TranslationTestValidation.AssertBinds(printed);
         }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3501DocMarkdownTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3501DocMarkdownTests.cs
@@ -1,0 +1,172 @@
+// <copyright file="Issue3501DocMarkdownTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using GSharp.Tests;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Cs2Gs.Tests
+{
+    // Issue #3501 Track B1: C# XML doc comments convert to G#'s ADR-0057
+    // Markdown authoring surface instead of passing XML tags through
+    // verbatim. Constructs outside the bijective subset splice into the
+    // ```xmldoc escape hatch; malformed XML passes through untouched.
+    public sealed class Issue3501DocMarkdownTests
+    {
+        [Fact]
+        public void SummaryParamsReturnsException_ConvertToBlockTags()
+        {
+            string printed = Translate("""
+                public class Widget
+                {
+                    /// <summary>
+                    /// Computes the widget's mass in grams.
+                    /// </summary>
+                    /// <param name="scale">The scale factor applied to the raw mass.</param>
+                    /// <typeparam name="T">Unused, documented anyway.</typeparam>
+                    /// <returns>The scaled mass.</returns>
+                    /// <exception cref="System.ArgumentException">When scale is negative.</exception>
+                    public int Mass<T>(int scale) => 42 * scale;
+                }
+                """);
+
+            Assert.Contains("/// Computes the widget's mass in grams.", printed, StringComparison.Ordinal);
+            Assert.Contains("/// @param scale The scale factor applied to the raw mass.", printed, StringComparison.Ordinal);
+            Assert.Contains("/// @typeparam T Unused, documented anyway.", printed, StringComparison.Ordinal);
+            Assert.Contains("/// @returns The scaled mass.", printed, StringComparison.Ordinal);
+            Assert.Contains("/// @exception System.ArgumentException When scale is negative.", printed, StringComparison.Ordinal);
+            Assert.DoesNotContain("<summary>", printed, StringComparison.Ordinal);
+            Assert.DoesNotContain("<param", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+        }
+
+        [Fact]
+        public void InlineElements_ConvertToMarkdownSpellings()
+        {
+            string printed = Translate("""
+                public class Widget
+                {
+                    /// <summary>
+                    /// Uses <c>raw</c> mode; see <see cref="Widget"/> and
+                    /// <see cref="Other">the other one</see>, or read
+                    /// <see href="https://example.test/docs">the docs</see>.
+                    /// Passing <paramref name="mode"/> as <see langword="null"/> resets.
+                    /// </summary>
+                    public int Run(string mode) => mode.Length;
+                }
+
+                public class Other
+                {
+                }
+                """);
+
+            Assert.Contains("`raw` mode; see (cref:Widget) and", printed, StringComparison.Ordinal);
+            Assert.Contains("[the other one](cref:Other)", printed, StringComparison.Ordinal);
+            Assert.Contains("[the docs](https://example.test/docs)", printed, StringComparison.Ordinal);
+            Assert.Contains("[`mode`](paramref) as `null` resets.", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+        }
+
+        [Fact]
+        public void ParasListsAndCode_ConvertToMarkdownBlocks()
+        {
+            string printed = Translate("""
+                public class Widget
+                {
+                    /// <summary>
+                    /// First paragraph.
+                    /// <para>Second paragraph.</para>
+                    /// <list type="bullet">
+                    /// <item><description>alpha</description></item>
+                    /// <item><description>beta</description></item>
+                    /// </list>
+                    /// <code>
+                    /// var w = Widget()
+                    /// </code>
+                    /// </summary>
+                    public int Run() => 1;
+                }
+                """);
+
+            Assert.Contains("/// First paragraph.", printed, StringComparison.Ordinal);
+            Assert.Contains("/// Second paragraph.", printed, StringComparison.Ordinal);
+            Assert.Contains("/// - alpha", printed, StringComparison.Ordinal);
+            Assert.Contains("/// - beta", printed, StringComparison.Ordinal);
+            Assert.Contains("/// ```", printed, StringComparison.Ordinal);
+            Assert.Contains("/// var w = Widget()", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+        }
+
+        [Fact]
+        public void UnmappedConstructs_UseXmldocEscapeHatch()
+        {
+            string printed = Translate("""
+                public class Widget
+                {
+                    /// <summary>Documented.</summary>
+                    /// <list type="table">
+                    /// <listheader><term>Name</term><description>Meaning</description></listheader>
+                    /// <item><term>Width</term><description>extent in X</description></item>
+                    /// </list>
+                    public int Run() => 1;
+                }
+                """);
+
+            Assert.Contains("/// ```xmldoc", printed, StringComparison.Ordinal);
+            Assert.Contains("<listheader><term>Name</term>", printed, StringComparison.Ordinal);
+            Assert.Contains("/// Documented.", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+        }
+
+        [Fact]
+        public void MalformedXml_PassesThroughVerbatim()
+        {
+            string printed = Translate("""
+                public class Widget
+                {
+                    /// Raw prose with a stray < angle bracket, no tags.
+                    public int Run() => 1;
+                }
+                """);
+
+            Assert.Contains("/// Raw prose with a stray < angle bracket, no tags.", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+        }
+
+        private static string Translate(
+            string source,
+            params MetadataReference[] additionalReferences)
+        {
+            IReadOnlyList<MetadataReference> references = additionalReferences.Length == 0
+                ? null
+                : CSharpProjectLoader.RuntimeReferences()
+                    .Concat(additionalReferences)
+                    .GroupBy(reference => reference.Display, StringComparer.Ordinal)
+                    .Select(group => group.First())
+                    .ToList();
+            LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+                new[] { ("Snippet.cs", source) },
+                references);
+            Assert.True(
+                project.BoundWithoutErrors,
+                "Snippet should bind with no C# errors: "
+                    + string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+            LoadedDocument document = Assert.Single(project.Documents);
+            var context = new TranslationContext(
+                project.Compilation,
+                document.SemanticModel,
+                document.FilePath);
+            CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+            return GSharpPrinter.Print(unit);
+        }
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
@@ -65,19 +65,16 @@ public sealed partial class CSharpToGSharpTranslator
                         break;
 
                     case SyntaxKind.SingleLineDocumentationCommentTrivia:
-                        foreach (string raw in trivia.ToFullString()
-                            .Split('\n', StringSplitOptions.RemoveEmptyEntries))
+                        // Issue #3501 B1: XML doc comments convert to the
+                        // ADR-0057 Markdown authoring surface (`@param`,
+                        // backticks, `(cref:X)`, …) with the ```xmldoc
+                        // escape hatch for constructs outside the bijective
+                        // subset; malformed XML passes through verbatim.
+                        IReadOnlyList<string> converted =
+                            XmlDocMarkdownConverter.Convert(trivia.ToFullString());
+                        if (converted != null)
                         {
-                            string text = raw.Trim();
-                            if (text.Length == 0)
-                            {
-                                continue;
-                            }
-
-                            (lines ??= new List<string>()).Add(
-                                text.StartsWith("///", StringComparison.Ordinal)
-                                    ? text
-                                    : $"/// {text}");
+                            (lines ??= new List<string>()).AddRange(converted);
                         }
 
                         break;

--- a/tools/cs2gs/Cs2Gs.Translator/XmlDocMarkdownConverter.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/XmlDocMarkdownConverter.cs
@@ -1,0 +1,359 @@
+// <copyright file="XmlDocMarkdownConverter.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+
+namespace Cs2Gs.Translator;
+
+/// <summary>
+/// Issue #3501 Track B1: converts a C# XML documentation comment into G#'s
+/// ADR-0057 Markdown authoring surface. The mapping is the ADR's bijective
+/// subset applied in reverse — <c>&lt;summary&gt;</c> becomes leading prose,
+/// the structured elements become <c>@param</c>/<c>@typeparam</c>/
+/// <c>@returns</c>/<c>@remarks</c>/<c>@value</c>/<c>@exception</c>/
+/// <c>@seealso</c> block tags, and inline elements become their Markdown
+/// spellings (<c>&lt;c&gt;</c> → backticks, <c>&lt;see cref&gt;</c> →
+/// <c>(cref:X)</c> / <c>[text](cref:X)</c>, <c>&lt;paramref&gt;</c> →
+/// <c>[`name`](paramref)</c>, <c>&lt;para&gt;</c> → blank lines, bullet and
+/// number lists → Markdown lists, <c>&lt;code&gt;</c> → fenced blocks).
+/// Anything outside the subset is spliced verbatim into the ADR's
+/// <c>```xmldoc</c> fenced escape hatch so no construct is lost, and a
+/// comment that does not parse as XML at all passes through unchanged.
+/// </summary>
+internal static class XmlDocMarkdownConverter
+{
+    /// <summary>
+    /// Converts one raw documentation-comment trivia string (the `///`-prefixed
+    /// lines) into ADR-0057 Markdown doc-comment lines, each already carrying
+    /// the <c>///</c> marker.
+    /// </summary>
+    /// <param name="rawTrivia">The full text of the documentation trivia.</param>
+    /// <returns>The converted lines, or <see langword="null"/> when the input
+    /// has no content.</returns>
+    public static IReadOnlyList<string> Convert(string rawTrivia)
+    {
+        List<string> sourceLines = rawTrivia
+            .Split('\n')
+            .Select(line => line.Trim())
+            .Where(line => line.Length > 0)
+            .Select(line => line.StartsWith("///", StringComparison.Ordinal)
+                ? line.Substring(3).TrimStart()
+                : line)
+            .ToList();
+        if (sourceLines.Count == 0)
+        {
+            return null;
+        }
+
+        XElement root;
+        try
+        {
+            root = XElement.Parse(
+                "<gsdoc>" + string.Join("\n", sourceLines) + "</gsdoc>",
+                LoadOptions.PreserveWhitespace);
+        }
+        catch (System.Xml.XmlException)
+        {
+            // Not well-formed XML (e.g. prose with a stray '<'): pass the
+            // original lines through untouched — never lose author content.
+            return sourceLines.Select(line => line.Length == 0 ? "///" : $"/// {line}").ToList();
+        }
+
+        var output = new List<string>();
+        var sections = new List<(string Tag, XElement Element)>();
+        var summaryParts = new List<XNode>();
+        var unmapped = new List<XNode>();
+        foreach (XNode node in root.Nodes())
+        {
+            if (node is XElement element)
+            {
+                switch (element.Name.LocalName)
+                {
+                    case "summary":
+                        summaryParts.AddRange(element.Nodes());
+                        continue;
+                    case "param":
+                    case "typeparam":
+                    case "returns":
+                    case "remarks":
+                    case "value":
+                    case "exception":
+                    case "seealso":
+                        sections.Add((element.Name.LocalName, element));
+                        continue;
+                    default:
+                        unmapped.Add(node);
+                        continue;
+                }
+            }
+
+            // Loose prose outside <summary> joins the summary.
+            summaryParts.Add(node);
+        }
+
+        AppendBlockContent(output, summaryParts);
+        foreach ((string tag, XElement element) in sections)
+        {
+            string head = tag switch
+            {
+                "param" => $"@param {element.Attribute("name")?.Value}",
+                "typeparam" => $"@typeparam {element.Attribute("name")?.Value}",
+                "returns" => "@returns",
+                "remarks" => "@remarks",
+                "value" => "@value",
+                "exception" => $"@exception {element.Attribute("cref")?.Value}",
+                "seealso" => element.Attribute("cref") is { } cref
+                    ? $"@seealso {cref.Value}"
+                    : $"@seealso {element.Attribute("href")?.Value}",
+                _ => null,
+            };
+            List<string> body = RenderBlockLines(element.Nodes());
+            if (body.Count == 0)
+            {
+                output.Add(head);
+            }
+            else
+            {
+                output.Add($"{head} {body[0]}".TrimEnd());
+                output.AddRange(body.Skip(1));
+            }
+        }
+
+        foreach (XNode node in unmapped)
+        {
+            // The ADR-0057 escape hatch: splice any construct the subset
+            // omits (<inheritdoc/>, <list type="table">, custom elements)
+            // verbatim so it round-trips losslessly.
+            output.Add("```xmldoc");
+            output.AddRange(node.ToString().Split('\n').Select(line => line.TrimEnd()));
+            output.Add("```");
+        }
+
+        while (output.Count > 0 && string.IsNullOrWhiteSpace(output[^1]))
+        {
+            output.RemoveAt(output.Count - 1);
+        }
+
+        while (output.Count > 0 && string.IsNullOrWhiteSpace(output[0]))
+        {
+            output.RemoveAt(0);
+        }
+
+        if (output.Count == 0)
+        {
+            return null;
+        }
+
+        return output
+            .Select(line => string.IsNullOrWhiteSpace(line) ? "///" : $"/// {line}")
+            .ToList();
+    }
+
+    private static void AppendBlockContent(List<string> output, IEnumerable<XNode> nodes)
+    {
+        List<string> lines = RenderBlockLines(nodes);
+        output.AddRange(lines);
+    }
+
+    /// <summary>
+    /// Renders mixed block content (paragraphs, lists, code fences, inline
+    /// runs) into Markdown lines without any comment marker.
+    /// </summary>
+    private static List<string> RenderBlockLines(IEnumerable<XNode> nodes)
+    {
+        var lines = new List<string>();
+        var inline = new StringBuilder();
+
+        void FlushInline()
+        {
+            string text = NormalizeInlineWhitespace(inline.ToString());
+            inline.Clear();
+            if (text.Length > 0)
+            {
+                lines.Add(text);
+            }
+        }
+
+        void BlankSeparator()
+        {
+            if (lines.Count > 0 && !string.IsNullOrWhiteSpace(lines[^1]))
+            {
+                lines.Add(string.Empty);
+            }
+        }
+
+        foreach (XNode node in nodes)
+        {
+            switch (node)
+            {
+                case XText text:
+                    inline.Append(text.Value);
+                    break;
+
+                case XElement { Name.LocalName: "para" } para:
+                    FlushInline();
+                    BlankSeparator();
+                    lines.AddRange(RenderBlockLines(para.Nodes()));
+                    lines.Add(string.Empty);
+                    break;
+
+                case XElement { Name.LocalName: "code" } code:
+                    FlushInline();
+                    string lang = code.Attribute("lang")?.Value
+                        ?? code.Attribute("language")?.Value
+                        ?? string.Empty;
+                    lines.Add($"```{lang}");
+                    lines.AddRange(TrimCodeBlock(code.Value));
+                    lines.Add("```");
+                    break;
+
+                case XElement { Name.LocalName: "list" } list:
+                    FlushInline();
+                    string type = list.Attribute("type")?.Value;
+                    if (type is "bullet" or "number")
+                    {
+                        int ordinal = 1;
+                        foreach (XElement item in list.Elements("item"))
+                        {
+                            IEnumerable<XNode> itemNodes = item.Element("description") is { } description
+                                ? description.Nodes()
+                                : item.Nodes();
+                            string itemText = NormalizeInlineWhitespace(RenderInline(itemNodes));
+                            lines.Add(type == "bullet" ? $"- {itemText}" : $"{ordinal}. {itemText}");
+                            ordinal++;
+                        }
+                    }
+                    else
+                    {
+                        // Table (and any other) list shapes are outside the
+                        // bijective subset — escape-hatch them verbatim.
+                        lines.Add("```xmldoc");
+                        lines.AddRange(list.ToString().Split('\n').Select(l => l.TrimEnd()));
+                        lines.Add("```");
+                    }
+
+                    break;
+
+                default:
+                    inline.Append(RenderInline(new[] { node }));
+                    break;
+            }
+        }
+
+        FlushInline();
+        while (lines.Count > 0 && string.IsNullOrWhiteSpace(lines[^1]))
+        {
+            lines.RemoveAt(lines.Count - 1);
+        }
+
+        return lines;
+    }
+
+    private static string RenderInline(IEnumerable<XNode> nodes)
+    {
+        var sb = new StringBuilder();
+        foreach (XNode node in nodes)
+        {
+            switch (node)
+            {
+                case XText text:
+                    sb.Append(text.Value);
+                    break;
+
+                case XElement { Name.LocalName: "c" } code:
+                    sb.Append('`').Append(code.Value).Append('`');
+                    break;
+
+                case XElement { Name.LocalName: "see" } see:
+                    if (see.Attribute("cref") is { } cref)
+                    {
+                        string target = StripDocIdPrefix(cref.Value);
+                        sb.Append(string.IsNullOrEmpty(see.Value)
+                            ? $"(cref:{target})"
+                            : $"[{see.Value}](cref:{target})");
+                    }
+                    else if (see.Attribute("href") is { } href)
+                    {
+                        sb.Append('[')
+                            .Append(string.IsNullOrEmpty(see.Value) ? href.Value : see.Value)
+                            .Append("](")
+                            .Append(href.Value)
+                            .Append(')');
+                    }
+                    else if (see.Attribute("langword") is { } langword)
+                    {
+                        // `<see langword="null"/>` has no subset spelling;
+                        // backticks read identically and keep the doc inline.
+                        sb.Append('`').Append(langword.Value).Append('`');
+                    }
+
+                    break;
+
+                case XElement { Name.LocalName: "paramref" } paramref:
+                    sb.Append("[`").Append(paramref.Attribute("name")?.Value).Append("`](paramref)");
+                    break;
+
+                case XElement { Name.LocalName: "typeparamref" } typeparamref:
+                    // Outside the subset; backticks are the readable stand-in.
+                    sb.Append('`').Append(typeparamref.Attribute("name")?.Value).Append('`');
+                    break;
+
+                default:
+                    sb.Append(node.ToString());
+                    break;
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private static string NormalizeInlineWhitespace(string text)
+    {
+        var sb = new StringBuilder(text.Length);
+        bool pendingSpace = false;
+        foreach (char c in text)
+        {
+            if (char.IsWhiteSpace(c))
+            {
+                pendingSpace = sb.Length > 0;
+            }
+            else
+            {
+                if (pendingSpace)
+                {
+                    sb.Append(' ');
+                    pendingSpace = false;
+                }
+
+                sb.Append(c);
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private static IEnumerable<string> TrimCodeBlock(string value)
+    {
+        string[] raw = value.Split('\n');
+        var kept = raw
+            .SkipWhile(string.IsNullOrWhiteSpace)
+            .Reverse()
+            .SkipWhile(string.IsNullOrWhiteSpace)
+            .Reverse()
+            .ToList();
+        int indent = kept
+            .Where(line => line.TrimEnd().Length > 0)
+            .Select(line => line.Length - line.TrimStart().Length)
+            .DefaultIfEmpty(0)
+            .Min();
+        return kept.Select(line => line.Length >= indent ? line.Substring(indent).TrimEnd() : line.TrimEnd());
+    }
+
+    private static string StripDocIdPrefix(string cref) =>
+        cref.Length > 2 && cref[1] == ':' ? cref.Substring(2) : cref;
+}


### PR DESCRIPTION
## Summary
- `XmlDocMarkdownConverter` maps C# XML doc comments onto G#'s KDoc-style Markdown authoring surface (ADR-0057), applying the bijective subset in reverse: leading-prose summary, `@param`/`@typeparam`/`@returns`/`@remarks`/`@value`/`@exception`/`@seealso` block tags, backticks/fences/`(cref:X)`/`[text](cref:X)`/`[`name`](paramref)`/paragraphs/lists inline
- constructs outside the subset splice verbatim into the ` ```xmldoc ` escape hatch (lossless); malformed XML passes through untouched
- `<see langword>` / `<typeparamref>` render as backticks — readability over strict bijection, noted in code

## Validation
- new `Issue3501DocMarkdownTests`: 5 regressions (block tags, inline spellings, paragraph/list/code blocks, escape hatch, malformed fallthrough), each bind-validated
- `Issue3469CommentPreservationTests` flipped to Markdown expectations
- full `Cs2Gs.Tests`: **2,348 passed**, 1 environment-only miss (needs local Release nupkgs; green after packing — unrelated to this change)

Part of #3501 (Track B1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)