### PR TITLE
compiler+cs2gs: variant method groups under generic inference (#3501 A5)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -2036,7 +2036,7 @@ internal sealed partial class ExpressionBinder
         Func<TypeSymbol, Type?> projectType,
         int argumentOffset = 0)
     {
-        if (arguments == null || !arguments.Any(ClrOverloadResolution.IsUnresolvedMethodGroupArgument))
+        if (arguments == null || !arguments.Any(ClrOverloadResolution.IsMethodGroupArgument))
         {
             return null;
         }
@@ -2057,7 +2057,7 @@ internal sealed partial class ExpressionBinder
         IReadOnlyList<BoundExpression> arguments,
         int argumentOffset = 0)
     {
-        if (arguments == null || !arguments.Any(ClrOverloadResolution.IsUnresolvedMethodGroupArgument))
+        if (arguments == null || !arguments.Any(ClrOverloadResolution.IsMethodGroupArgument))
         {
             return null;
         }
@@ -2067,7 +2067,7 @@ internal sealed partial class ExpressionBinder
             var sourceIndex = argumentIndex - argumentOffset;
             return sourceIndex >= 0
                 && sourceIndex < arguments.Count
-                && ClrOverloadResolution.IsUnresolvedMethodGroupArgument(arguments[sourceIndex]);
+                && ClrOverloadResolution.IsMethodGroupArgument(arguments[sourceIndex]);
         };
     }
 
@@ -2076,7 +2076,7 @@ internal sealed partial class ExpressionBinder
         IReadOnlyList<Type> delegateParameterTypes,
         Func<TypeSymbol, Type?> projectType)
     {
-        if (argument is BoundClrMethodGroupExpression { ResolvedMethod: null } clrGroup)
+        if (argument is BoundClrMethodGroupExpression clrGroup)
         {
             var receiver = clrGroup.Receiver;
             var closesExtensionReceiver = receiver != null;
@@ -2122,7 +2122,7 @@ internal sealed partial class ExpressionBinder
             return (signatureParameters, method.ReturnType);
         }
 
-        if (argument is not BoundMethodGroupExpression { FunctionType: null } userGroup)
+        if (argument is not BoundMethodGroupExpression userGroup)
         {
             return null;
         }
@@ -2158,6 +2158,11 @@ internal sealed partial class ExpressionBinder
                     break;
                 }
 
+                // The method must ACCEPT what the delegate provides:
+                // ClassifyImplicit(target, source) with the METHOD parameter
+                // as the target admits contravariant groups
+                // (`Stringify(object?)` satisfies a `(string) -> string`
+                // slot; issue #3501 A5).
                 conversions[i] = ClrOverloadResolution.ClassifyImplicit(projected, delegateParameterTypes[i]);
                 if (conversions[i] == ClrOverloadResolution.ImplicitConversionKind.None)
                 {

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/ClrOverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/ClrOverloadResolution.cs
@@ -790,6 +790,18 @@ internal static class ClrOverloadResolution
             || argument is BoundClrMethodGroupExpression { ResolvedMethod: null };
 
     /// <summary>
+    /// Issue #3501 A5: whether <paramref name="argument"/> is ANY method-group
+    /// argument — resolved single-candidate groups included. Method groups
+    /// contribute only output-type inference, so even a group with a natural
+    /// function type must route through the method-group inference callback
+    /// instead of hard-unifying its natural type against the delegate slots.
+    /// </summary>
+    /// <param name="argument">The bound argument to inspect.</param>
+    /// <returns>Whether the argument is a method group.</returns>
+    public static bool IsMethodGroupArgument(BoundExpression argument) =>
+        argument is BoundMethodGroupExpression or BoundClrMethodGroupExpression;
+
+    /// <summary>
     /// Issue #506: returns <see langword="true"/> when <paramref name="parameter"/>
     /// is the trailing <c>params T[]</c> parameter — i.e. carries the
     /// <see cref="ParamArrayAttribute"/> marker and is a single-dimensional
@@ -1482,13 +1494,33 @@ internal static class ClrOverloadResolution
         {
             if (!UnifyForInference(delegateParameters[i], signature.Value.Parameters[i], inferred))
             {
-                return false;
+                // Issue #3501 A5: a VARIANT method group is a valid delegate
+                // conversion — the method may take a broader parameter type
+                // than the delegate (contravariance). When the delegate
+                // parameter closes to a concrete type the method parameter
+                // can accept, the position simply contributes no inference
+                // bounds; the later conversion check enforces the real
+                // compatibility (explicit type arguments already accepted
+                // exactly these method groups).
+                if (!TryCloseInferredType(delegateParameters[i], inferred, out var closedParameter)
+                    || closedParameter is null
+                    || !IsVariantAssignable(target: signature.Value.Parameters[i], source: closedParameter))
+                {
+                    return false;
+                }
             }
         }
 
         if (!UnifyForInference(delegateReturn, signature.Value.Return, inferred))
         {
-            return false;
+            // Covariant return: the method may return a narrower reference
+            // type than the delegate expects.
+            if (!TryCloseInferredType(delegateReturn, inferred, out var closedReturn)
+                || closedReturn is null
+                || !IsVariantAssignable(target: closedReturn, source: signature.Value.Return))
+            {
+                return false;
+            }
         }
 
         bounds.Clear();
@@ -2459,6 +2491,32 @@ internal static class ClrOverloadResolution
                     }
 
                     inferenceArgTypes = deferred;
+                }
+
+                // Issue #3501 A5: a method-group argument contributes only
+                // OUTPUT-type inference (C# §12.6.3): its natural function
+                // type must not hard-unify the delegate's parameter slots —
+                // `paths.Select(Stringify)` with `Stringify(object?)` infers
+                // TSource from the receiver (string) and TResult from the
+                // group's return given those inputs, with the contravariant
+                // parameter satisfied by conversion, not unification. Null
+                // the slot so TryInferMethodGroupArgument handles it.
+                if (methodGroupInference != null && methodGroupArgumentCheck != null)
+                {
+                    Type?[]? groupCleared = null;
+                    for (var i = 0; i < inferenceArgTypes.Count; i++)
+                    {
+                        if (inferenceArgTypes[i] != null && methodGroupArgumentCheck(i))
+                        {
+                            groupCleared ??= inferenceArgTypes.ToArray();
+                            groupCleared[i] = null;
+                        }
+                    }
+
+                    if (groupCleared != null)
+                    {
+                        inferenceArgTypes = groupCleared;
+                    }
                 }
 
                 var inferenceMethodGroup = methodGroupInference;
@@ -5043,6 +5101,35 @@ internal static class ClrOverloadResolution
 
         var underlying = target.GetGenericArguments()[0];
         return ClrTypeUtilities.AreSame(underlying, source);
+    }
+
+    /// <summary>
+    /// Issue #3501 A5: whether <paramref name="source"/> converts to
+    /// <paramref name="target"/> by identity or implicit reference
+    /// conversion — the variance C# permits between a method group's
+    /// signature and the target delegate's. Value types only convert by
+    /// identity (no boxing variance in delegate signatures).
+    /// </summary>
+    private static bool IsVariantAssignable(Type target, Type source)
+    {
+        if (ClrTypeUtilities.IsSameAs(target, source))
+        {
+            return true;
+        }
+
+        if (source.IsValueType || target.IsValueType)
+        {
+            return false;
+        }
+
+        try
+        {
+            return target.IsAssignableFrom(source);
+        }
+        catch (NotSupportedException)
+        {
+            return false;
+        }
     }
 
     private static bool UnifyForInference(Type? parameterType, Type? argumentType, Dictionary<string, Type> bounds)

--- a/test/Core.Tests/CodeAnalysis/Issue3501VariantMethodGroupTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Issue3501VariantMethodGroupTests.cs
@@ -1,0 +1,143 @@
+// <copyright file="Issue3501VariantMethodGroupTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis;
+
+/// <summary>
+/// Issue #3501 Track A5: generic inference accepts VARIANT method-group
+/// candidates — a method may take a broader parameter type than the target
+/// delegate (contravariance) and return a narrower one (covariance), exactly
+/// as C# method-group conversions permit. Method-group arguments contribute
+/// only output-type inference: their natural function type no longer
+/// hard-unifies the delegate's parameter slots. Explicit type arguments
+/// already accepted these groups; inference now matches.
+/// </summary>
+public class Issue3501VariantMethodGroupTests
+{
+    [Fact]
+    public void ContravariantParameter_UnderInference_BindsAndRuns()
+    {
+        var source = @"
+import System.Collections.Generic
+import System.Linq
+
+class W {
+    shared {
+        func Stringify(value object?) string -> value?.ToString() ?? ""<nil>""
+
+        func Run() string {
+            let paths = List[string]{ ""a"", ""b"" }
+            return string.Join("","", paths.Select(Stringify))
+        }
+    }
+}
+
+W.Run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal("a,b", result.Value);
+    }
+
+    [Fact]
+    public void ContravariantParameter_InPredicateSlot_BindsAndRuns()
+    {
+        var source = @"
+import System.Collections.Generic
+import System.Linq
+
+class W {
+    shared {
+        func IsShort(value object?) bool -> value?.ToString()?.Length < 2
+
+        func Run() int32 {
+            let paths = List[string]{ ""a"", ""bb"", ""c"" }
+            return paths.Where(IsShort).Count()
+        }
+    }
+}
+
+W.Run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(2, result.Value);
+    }
+
+    [Fact]
+    public void CovariantReturn_IntoFixedDelegateSlot_BindsAndRuns()
+    {
+        var source = @"
+class W {
+    shared {
+        func Twice(s string) string -> s + s
+
+        func Apply(f (string) -> object) object -> f(""q"")
+
+        func Run() string -> Apply(Twice).ToString() ?? """"
+    }
+}
+
+W.Run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal("qq", result.Value);
+    }
+
+    [Fact]
+    public void ExactCandidate_StillPreferredOverVariant()
+    {
+        var source = @"
+import System.Collections.Generic
+import System.Linq
+
+class W {
+    shared {
+        func Mark(value object?) string -> ""object""
+
+        func Mark(value string) string -> ""string""
+
+        func Run() string {
+            let paths = List[string]{ ""a"" }
+            return paths.Select(Mark).First()
+        }
+    }
+}
+
+W.Run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal("string", result.Value);
+    }
+
+    [Fact]
+    public void IncompatibleGroup_StillReportsResolutionFailure()
+    {
+        var source = @"
+import System.Collections.Generic
+import System.Linq
+
+class W {
+    shared {
+        func Weigh(value int32) string -> value.ToString()
+
+        func Run() string {
+            let paths = List[string]{ ""a"" }
+            return paths.Select(Weigh).First()
+        }
+    }
+}
+
+W.Run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.IsError);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3468MethodGroupWrapperTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3468MethodGroupWrapperTests.cs
@@ -50,8 +50,11 @@ namespace Cs2Gs.Tests
             TranslationTestValidation.AssertBinds(printed);
         }
 
+        // An EXPLICIT C# delegate creation renders as a G# construction,
+        // whose operand cannot be a variant group — so the cast shape keeps
+        // its arrow wrapper even after #3501 A5.
         [Fact]
-        public void ParameterContravariantWrapper_UsesArrowFormWithDerivedName()
+        public void ContravariantCastMethodGroup_KeepsArrowWrapper()
         {
             string printed = Translate("""
                 using System;
@@ -73,8 +76,9 @@ namespace Cs2Gs.Tests
             TranslationTestValidation.AssertBinds(printed);
         }
 
+        // Issue #3501 A5: covariant-return groups pass direct.
         [Fact]
-        public void ReturnCovariantWrapper_KeepsTypedFunctionLiteralWithDerivedName()
+        public void ReturnCovariantMethodGroup_PassesDirect()
         {
             string printed = Translate("""
                 using System.Collections.Generic;
@@ -89,8 +93,8 @@ namespace Cs2Gs.Tests
                 }
                 """);
 
-            Assert.Contains("func (s string) object", printed, StringComparison.Ordinal);
-            Assert.Contains("W.Twice(s)", printed, StringComparison.Ordinal);
+            Assert.Contains("Select[string, object](Twice)", printed, StringComparison.Ordinal);
+            Assert.DoesNotContain("func (s string) object", printed, StringComparison.Ordinal);
             Assert.DoesNotContain("__arg", printed, StringComparison.Ordinal);
             TranslationTestValidation.AssertBinds(printed);
         }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -1497,8 +1497,9 @@ public sealed partial class CSharpToGSharpTranslator
             if (this.TryGetMethodGroupArgument(
                     argument,
                     out IMethodSymbol method,
-                    out IMethodSymbol methodGroupInvoke)
-                && MethodGroupNeedsExactTarget(method, methodGroupInvoke))
+                    out IMethodSymbol methodGroupInvoke,
+                    out bool isImplicitGroupConversion)
+                && MethodGroupNeedsExactTarget(method, methodGroupInvoke, isImplicitGroupConversion))
             {
                 return this.typeMapper.WithMetadataImportCollisionQualification(
                     () => this.TranslateExactMethodGroupArgument(
@@ -1513,10 +1514,12 @@ public sealed partial class CSharpToGSharpTranslator
         private bool TryGetMethodGroupArgument(
             ArgumentSyntax argument,
             out IMethodSymbol method,
-            out IMethodSymbol invoke)
+            out IMethodSymbol invoke,
+            out bool isImplicitConversion)
         {
             method = null;
             invoke = null;
+            isImplicitConversion = false;
             if (this.context.SemanticModel.GetOperation(argument) is not IArgumentOperation argumentOperation
                 || argumentOperation.Value is not IDelegateCreationOperation delegateCreation
                 || delegateCreation.Target is not IMethodReferenceOperation methodReference
@@ -1524,6 +1527,18 @@ public sealed partial class CSharpToGSharpTranslator
             {
                 return false;
             }
+
+            // Issue #3501 A5: variance-direct emission is safe only when the
+            // CALLEE is imported CLR — its delegate slots are real CLR
+            // delegate types, where gsc creates variant method-group
+            // delegates correctly (proven end-to-end). A source-defined
+            // callee's slot translates to a NATIVE function type, whose
+            // erased-delegate semantics do not support variant groups yet
+            // (gsc emits NotSupported or unsound IL) — those keep wrappers.
+            ISymbol targetMethod = argumentOperation.Parameter?.ContainingSymbol;
+            bool calleeIsImported = targetMethod != null
+                && targetMethod.DeclaringSyntaxReferences.IsDefaultOrEmpty;
+            isImplicitConversion = delegateCreation.IsImplicit && calleeIsImported;
 
             method = methodReference.Method;
             invoke = delegateType.DelegateInvokeMethod;
@@ -1587,7 +1602,8 @@ public sealed partial class CSharpToGSharpTranslator
 
         private static bool MethodGroupNeedsExactTarget(
             IMethodSymbol method,
-            IMethodSymbol invoke)
+            IMethodSymbol invoke,
+            bool isImplicitConversion = true)
         {
             if (method.Parameters.Length != invoke.Parameters.Length
                 || method.ReturnsVoid != invoke.ReturnsVoid)
@@ -1595,14 +1611,52 @@ public sealed partial class CSharpToGSharpTranslator
                 return true;
             }
 
+            // Issue #3501 A5: gsc now accepts VARIANT method groups at
+            // IMPLICIT conversion sites — a contravariant reference
+            // parameter or covariant reference return converts directly,
+            // under inference and against fixed delegate slots alike — so a
+            // pure reference-variance mismatch no longer forces a wrapper
+            // lambda there. An EXPLICIT C# delegate creation
+            // (`(Func<...>)Group`, `new Func<...>(Group)`) still renders as
+            // a G# construction, whose operand cannot be a variant group,
+            // so those keep the wrapper. Ref-kind differences and
+            // non-reference (identity-only) type changes always do.
+            if (!isImplicitConversion)
+            {
+                for (int index = 0; index < method.Parameters.Length; index++)
+                {
+                    IParameterSymbol methodParameter = method.Parameters[index];
+                    IParameterSymbol invokeParameter = invoke.Parameters[index];
+                    if (methodParameter.RefKind != invokeParameter.RefKind
+                        || !SymbolEqualityComparer.Default.Equals(
+                            methodParameter.Type,
+                            invokeParameter.Type))
+                    {
+                        return true;
+                    }
+                }
+
+                return !method.ReturnsVoid
+                    && !SymbolEqualityComparer.Default.Equals(
+                        method.ReturnType,
+                        invoke.ReturnType);
+            }
+
             for (int index = 0; index < method.Parameters.Length; index++)
             {
                 IParameterSymbol methodParameter = method.Parameters[index];
                 IParameterSymbol invokeParameter = invoke.Parameters[index];
-                if (methodParameter.RefKind != invokeParameter.RefKind
-                    || !SymbolEqualityComparer.Default.Equals(
+                if (methodParameter.RefKind != invokeParameter.RefKind)
+                {
+                    return true;
+                }
+
+                if (!SymbolEqualityComparer.Default.Equals(
                         methodParameter.Type,
-                        invokeParameter.Type))
+                        invokeParameter.Type)
+                    && !IsReferenceVariantCompatible(
+                        target: methodParameter.Type,
+                        source: invokeParameter.Type))
                 {
                     return true;
                 }
@@ -1611,7 +1665,34 @@ public sealed partial class CSharpToGSharpTranslator
             return !method.ReturnsVoid
                 && !SymbolEqualityComparer.Default.Equals(
                     method.ReturnType,
-                    invoke.ReturnType);
+                    invoke.ReturnType)
+                && !IsReferenceVariantCompatible(
+                    target: invoke.ReturnType,
+                    source: method.ReturnType);
+        }
+
+        // Issue #3501 A5: whether `source` converts to `target` by implicit
+        // reference conversion — the variance C# permits between a method
+        // group's signature and the target delegate's, mirrored by gsc since
+        // its variant method-group support landed.
+        private static bool IsReferenceVariantCompatible(ITypeSymbol target, ITypeSymbol source)
+        {
+            if (target == null || source == null
+                || target.IsValueType || source.IsValueType)
+            {
+                return false;
+            }
+
+            for (ITypeSymbol current = source; current != null; current = (current as INamedTypeSymbol)?.BaseType)
+            {
+                if (SymbolEqualityComparer.Default.Equals(current, target))
+                {
+                    return true;
+                }
+            }
+
+            return source.AllInterfaces.Any(candidate =>
+                SymbolEqualityComparer.Default.Equals(candidate, target));
         }
 
         // Issue #3468: a synthesized method-group wrapper parameter takes its


### PR DESCRIPTION
## Summary
- **gsc**: method-group arguments contribute only output-type inference (C# §12.6.3) — the group predicates widen to resolved groups, inference nulls their slots, and `TryInferMethodGroupArgument` accepts reference-variant positions without contributing bounds (`IsVariantAssignable`: identity or implicit reference conversion; value-type variance excluded). `paths.Select(Stringify)` with contravariant `Stringify(object?)` now compiles and runs; exact candidates still beat variant ones.
- **cs2gs**: direct method references replace wrapper lambdas for implicit conversions at **imported-CLR callees** (runtime-verified end-to-end). Source-defined callees translate to native function-type slots where gsc's emitter can't yet express variant groups — filed as #3505 with both repros (NotSupported for contravariant params; a pre-existing unsound value-type variance that compiles then NREs) — so those keep their arrow wrappers, as do explicit delegate creations.

## Validation
- new `Issue3501VariantMethodGroupTests` (Core.Tests): 5 emitted-oracle regressions — contravariant `Select`/`Where` under inference, covariant return into a fixed CLR slot, exact-beats-variant betterness, genuine-mismatch diagnostic
- full `Core.Tests`: **8,019 passed, 0 failed**; full `Cs2Gs.Tests`: **2,344 passed, 0 failed** (includes the `ReplShape` full-pipeline run and all wrapper-shape classes)

Part of #3501 (Track A5). Once #3505 is fixed, the imported-callee restriction in `MethodGroupNeedsExactTarget` can lift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)