### PR TITLE
cs2gs: wrap-pass v2 and comment coverage extensions (#3501 B2+B3)

### DIFF
--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GNode.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GNode.cs
@@ -22,4 +22,12 @@ public abstract class GNode
     /// case — synthesized nodes never carry any).
     /// </summary>
     public System.Collections.Generic.IReadOnlyList<string> AttachedComments { get; set; }
+
+    /// <summary>
+    /// Gets or sets the author comment that followed the source construct on
+    /// the same line (issue #3501 B3), carrying its own <c>//</c> marker;
+    /// the printer appends it after the rendered node. <see langword="null"/>
+    /// when there is none.
+    /// </summary>
+    public string TrailingComment { get; set; }
 }

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -485,7 +485,15 @@ public static class GSharpPrinter
     private static string RenderWrappable(GExpression expression, int indent, int prefixWidth)
     {
         string single = RenderExpression(expression, indent);
-        if (single.IndexOf('\n') >= 0 || prefixWidth + single.Length <= MaxLineWidth)
+
+        // Issue #3501 B2: the budget applies to the FIRST line — an
+        // expression whose one-line head is over budget wraps even when a
+        // block-bodied lambda argument already made the render multi-line
+        // (previously any embedded newline bailed the whole statement out,
+        // which accounted for most residual >300-char lines).
+        int firstLineEnd = single.IndexOf('\n');
+        int firstLineLength = firstLineEnd < 0 ? single.Length : firstLineEnd;
+        if (prefixWidth + firstLineLength <= MaxLineWidth)
         {
             return single;
         }
@@ -528,6 +536,24 @@ public static class GSharpPrinter
                     : text;
             });
             return string.Join($" {chainRoot.Operator}\n{continuation}", parts);
+        }
+
+        // Issue #3501 B2: a long postfix chain (`a.B(x).C().D`) breaks
+        // before each dot — gsc parses leading-dot continuations — which
+        // reads better than exploding one link's argument list. Only plain
+        // `.` links participate (never `->` pointer access), and only when
+        // the chain has at least two links.
+        if (TryFlattenAccessChain(expression, out GExpression chainHead, out List<string> chainLinks)
+            && chainLinks.Count >= 2)
+        {
+            string headText = RenderExpression(chainHead, indent);
+            var chain = new StringBuilder(headText);
+            foreach (string link in chainLinks)
+            {
+                chain.Append('\n').Append(continuation).Append(link);
+            }
+
+            return chain.ToString();
         }
 
         if (expression is InvocationExpression { Arguments.Count: > 0 } invocation)
@@ -1134,9 +1160,59 @@ public static class GSharpPrinter
         return char.IsLetterOrDigit(first) || first == '_';
     }
 
+    private static bool TryFlattenAccessChain(
+        GExpression expression,
+        out GExpression head,
+        out List<string> links)
+    {
+        head = expression;
+        links = new List<string>();
+        var reversed = new List<string>();
+        GExpression current = expression;
+        while (true)
+        {
+            if (current is InvocationExpression { Target: MemberAccessExpression { IsArrow: false } call } chainCall)
+            {
+                string typeArgs = chainCall.TypeArguments.Count == 0
+                    ? string.Empty
+                    : $"[{string.Join(", ", chainCall.TypeArguments.Select(RenderType))}]";
+                string args = string.Join(
+                    ", ",
+                    chainCall.Arguments.Select(a => RenderExpression(a, 0)));
+                reversed.Add($".{call.MemberName}{typeArgs}({args})");
+                current = call.Target;
+                continue;
+            }
+
+            if (current is MemberAccessExpression { IsArrow: false } access)
+            {
+                reversed.Add($".{access.MemberName}");
+                current = access.Target;
+                continue;
+            }
+
+            break;
+        }
+
+        if (reversed.Count < 2)
+        {
+            return false;
+        }
+
+        head = current;
+        reversed.Reverse();
+        links = reversed;
+        return true;
+    }
+
     private static string RenderStatement(GStatement statement, int indent)
     {
         string core = RenderStatementCore(statement, indent);
+        if (statement.TrailingComment != null)
+        {
+            core = $"{core} {statement.TrailingComment}";
+        }
+
         return PrependAttachedComments(statement, core, indent);
     }
 
@@ -1963,9 +2039,31 @@ public static class GSharpPrinter
 
         sb.Append(method.Name);
         sb.Append(RenderTypeParameterList(method.TypeParameters));
-        sb.Append('(');
-        sb.Append(RenderParameterList(method.Parameters));
-        sb.Append(')');
+        string parameterList = RenderParameterList(method.Parameters);
+
+        // Issue #3501 B2: a signature whose one-line form exceeds the budget
+        // wraps its parameter list after `(` and each comma — the same
+        // continuation shapes gsc parses in call positions.
+        int signatureLineStart = sb.ToString().LastIndexOf('\n') + 1;
+        int signatureLineLength = sb.Length - signatureLineStart;
+        if (method.Parameters.Count > 1
+            && signatureLineLength + parameterList.Length + 2 > MaxLineWidth)
+        {
+            string parameterPad = Indent(indent + 1);
+            sb.Append("(\n");
+            sb.Append(parameterPad);
+            sb.Append(string.Join(
+                ",\n" + parameterPad,
+                method.Parameters.Select(RenderParameter)));
+            sb.Append(')');
+        }
+        else
+        {
+            sb.Append('(');
+            sb.Append(parameterList);
+            sb.Append(')');
+        }
+
         if (method.ReturnType != null)
         {
             sb.Append(' ');
@@ -2007,9 +2105,14 @@ public static class GSharpPrinter
         switch (statement)
         {
             case ReturnStatement ret:
-                return ret.Expression == null ? string.Empty : RenderExpression(ret.Expression, indent);
+                // Issue #3501 B2: arrow bodies participate in the wrap pass —
+                // a long value expression breaks the same way a `return`
+                // statement's would (gsc parses the continuations after `->`).
+                return ret.Expression == null
+                    ? string.Empty
+                    : RenderWrappable(ret.Expression, indent, Indent(indent).Length + 8);
             case ExpressionStatement expr:
-                return RenderExpression(expr.Expression, indent);
+                return RenderWrappable(expr.Expression, indent, Indent(indent).Length + 8);
             case AssignmentStatement assignment:
                 return $"{RenderExpression(assignment.Target, indent)} {assignment.Operator} {RenderExpression(assignment.Value, indent)}";
             default:

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1902LinqQueryTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1902LinqQueryTranslationTests.cs
@@ -170,7 +170,7 @@ namespace Corpus.Issue1902
 ");
 
         Assert.Contains(
-            "owners.GroupJoin(pets, (o Owner) -> o.Id, (p Pet) -> p.OwnerId, (o Owner, petGroup sequence[Pet]) -> {",
+            ".GroupJoin(pets, (o Owner) -> o.Id, (p Pet) -> p.OwnerId, (o Owner, petGroup sequence[Pet]) -> {",
             rendered,
             StringComparison.Ordinal);
         Assert.Contains("petGroup.Count()", rendered, StringComparison.Ordinal);
@@ -226,7 +226,7 @@ namespace Corpus.Issue1902
 }
 ");
 
-        Assert.Contains("words.GroupBy((w string) -> w.Length)", rendered, StringComparison.Ordinal);
+        Assert.Contains(".GroupBy((w string) -> w.Length)", rendered, StringComparison.Ordinal);
         Assert.Contains(".Where((g", rendered, StringComparison.Ordinal);
         Assert.Contains("g.Key > 3", rendered, StringComparison.Ordinal);
         AssertRoundTripParses(rendered);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1998LinqFollowUpTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1998LinqFollowUpTests.cs
@@ -187,7 +187,7 @@ namespace Corpus.Issue1998
 }
 ");
 
-        Assert.Contains("sales.GroupBy((s Sale) -> s.RegionId, (s Sale) -> s.Amount)", rendered, StringComparison.Ordinal);
+        Assert.Contains(".GroupBy((s Sale) -> s.RegionId, (s Sale) -> s.Amount)", rendered, StringComparison.Ordinal);
         Assert.Contains(".Join(regions,", rendered, StringComparison.Ordinal);
         Assert.Contains("g.Sum()", rendered, StringComparison.Ordinal);
         AssertRoundTripParses(rendered);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3083WithLambdaRoundTripTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3083WithLambdaRoundTripTests.cs
@@ -88,7 +88,7 @@ public sealed class Issue3083WithLambdaRoundTripTests
             ".Select((s ArchScenario) -> (s with { Steps = ",
             printed,
             StringComparison.Ordinal);
-        Assert.Contains("})).Where((s ArchScenario) ->", printed, StringComparison.Ordinal);
+        Assert.Contains(".Where((s ArchScenario) ->", printed, StringComparison.Ordinal);
         AssertRoundTrip(printed);
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3501WrapAndCommentCoverageTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3501WrapAndCommentCoverageTests.cs
@@ -1,0 +1,173 @@
+// <copyright file="Issue3501WrapAndCommentCoverageTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using GSharp.Tests;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Cs2Gs.Tests
+{
+    // Issue #3501 B2+B3: the wrap pass extends to invocations whose
+    // arguments are multi-line lambdas (first-line budget), long postfix
+    // chains (leading-dot continuations), and long declaration signatures;
+    // comment coverage extends to trailing same-line comments and comments
+    // dangling before a block's closing brace.
+    public sealed class Issue3501WrapAndCommentCoverageTests
+    {
+        [Fact]
+        public void MultiLineLambdaArgument_StillWrapsLongHead()
+        {
+            string printed = Translate("""
+                using System;
+
+                public static class Obj
+                {
+                    private static int Configure(
+                        string firstConfigurationComponentName,
+                        string secondConfigurationComponentName,
+                        string thirdConfigurationComponentName,
+                        Func<int, int> transformCallback) => transformCallback(1);
+
+                    public static int Run()
+                    {
+                        return Configure("first-component-value-with-length", "second-component-value-with-length", "third-component-value-with-length", value =>
+                        {
+                            int doubled = value * 2;
+                            return doubled + 40;
+                        });
+                    }
+                }
+                """);
+
+            Assert.Contains("Configure(\n", printed, StringComparison.Ordinal);
+            Assert.All(
+                printed.Split('\n').Where(line => !line.Contains("func ", StringComparison.Ordinal)),
+                line => Assert.True(line.Length <= 160, $"line still too long: {line}"));
+            EmittedOracleResult result = EmittedOracle.Evaluate(
+                printed + Environment.NewLine + "Obj.Run()");
+            Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+            Assert.Null(result.UnhandledException);
+            Assert.Equal(42, result.Value);
+        }
+
+        [Fact]
+        public void LongPostfixChain_BreaksBeforeDots_AndRuns()
+        {
+            string printed = Translate("""
+                public static class Obj
+                {
+                    public static int Run(string candidateInputValueForProcessing)
+                    {
+                        return candidateInputValueForProcessing.Trim().Replace("aaaa", "bb").Replace("cccc", "dd").Replace("eeee", "ff").Replace("gggg", "hh").ToUpperInvariant().Length;
+                    }
+                }
+                """);
+
+            Assert.Contains(".Trim()\n", printed, StringComparison.Ordinal);
+            Assert.Contains(".Replace(\"aaaa\", \"bb\")", printed, StringComparison.Ordinal);
+            EmittedOracleResult result = EmittedOracle.Evaluate(
+                printed + Environment.NewLine + "Obj.Run(\"  aaaacccceeeegggg  \")");
+            Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+            Assert.Null(result.UnhandledException);
+            Assert.Equal(8, result.Value);
+        }
+
+        [Fact]
+        public void LongDeclarationSignature_WrapsParameterList_AndBinds()
+        {
+            string printed = Translate("""
+                public static class Obj
+                {
+                    public static string Combine(string firstComponentValueName, string secondComponentValueName, string thirdComponentValueName, string fourthComponentValueName, int repetitionCountValue)
+                        => firstComponentValueName + secondComponentValueName + thirdComponentValueName + fourthComponentValueName + repetitionCountValue;
+                }
+                """);
+
+            Assert.Contains("Combine(\n", printed, StringComparison.Ordinal);
+            Assert.Contains("firstComponentValueName string,\n", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+        }
+
+        [Fact]
+        public void TrailingAndDanglingComments_Survive()
+        {
+            string printed = Translate("""
+                public static class Obj
+                {
+                    public static int Run()
+                    {
+                        var seed = 41; // seed chosen for the calibration branch
+                        seed += 1;
+                        return seed;
+                        // dangling: kept for the audit trail
+                    }
+                }
+                """);
+
+            Assert.Contains("// seed chosen for the calibration branch", printed, StringComparison.Ordinal);
+            Assert.Contains("// dangling: kept for the audit trail", printed, StringComparison.Ordinal);
+            int trailing = printed.IndexOf("// seed chosen", StringComparison.Ordinal);
+            int seedLine = printed.IndexOf("var seed", StringComparison.Ordinal);
+            Assert.True(
+                printed.Substring(seedLine, trailing - seedLine).IndexOf('\n') < 0,
+                "trailing comment stays on the statement's line");
+            EmittedOracleResult result = EmittedOracle.Evaluate(
+                printed + Environment.NewLine + "Obj.Run()");
+            Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+            Assert.Equal(42, result.Value);
+        }
+
+        [Fact]
+        public void ShortSignaturesAndChains_KeepOneLineForm()
+        {
+            string printed = Translate("""
+                public static class Obj
+                {
+                    public static int Add(int x, int y) => x + y;
+
+                    public static int Run(string s) => s.Trim().Length + Add(1, 2);
+                }
+                """);
+
+            Assert.Contains("Add(x int32, y int32)", printed, StringComparison.Ordinal);
+            Assert.Contains("s.Trim().Length", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+        }
+
+        private static string Translate(
+            string source,
+            params MetadataReference[] additionalReferences)
+        {
+            IReadOnlyList<MetadataReference> references = additionalReferences.Length == 0
+                ? null
+                : CSharpProjectLoader.RuntimeReferences()
+                    .Concat(additionalReferences)
+                    .GroupBy(reference => reference.Display, StringComparer.Ordinal)
+                    .Select(group => group.First())
+                    .ToList();
+            LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+                new[] { ("Snippet.cs", source) },
+                references);
+            Assert.True(
+                project.BoundWithoutErrors,
+                "Snippet should bind with no C# errors: "
+                    + string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+            LoadedDocument document = Assert.Single(project.Documents);
+            var context = new TranslationContext(
+                project.Compilation,
+                document.SemanticModel,
+                document.FilePath);
+            CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+            return GSharpPrinter.Print(unit);
+        }
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
@@ -1902,6 +1902,7 @@ public sealed partial class CSharpToGSharpTranslator
                 statements.AddRange(this.TranslateStatement(statement));
             }
 
+            this.AppendDanglingComments(statements, block.CloseBraceToken);
             return new BlockStatement(statements);
         }
 
@@ -2595,6 +2596,60 @@ public sealed partial class CSharpToGSharpTranslator
         // emitted immediately ahead of `statement`'s own output, then the ambient
         // seam is restored — so a nested statement (e.g. a block's own children)
         // always gets its own independent seam rather than sharing this one.
+        // Issue #3501 B3: a comment on the SAME line after the statement
+        // rides as the emitted statement's trailing comment.
+        private static void AttachTrailingComment(GNode node, SyntaxNode source)
+        {
+            if (node == null || source == null || node.TrailingComment != null)
+            {
+                return;
+            }
+
+            foreach (SyntaxTrivia trivia in source.GetTrailingTrivia())
+            {
+                if (trivia.IsKind(SyntaxKind.EndOfLineTrivia))
+                {
+                    break;
+                }
+
+                if (trivia.IsKind(SyntaxKind.SingleLineCommentTrivia))
+                {
+                    node.TrailingComment = trivia.ToString().TrimEnd();
+                    break;
+                }
+            }
+        }
+
+        // Issue #3501 B3: comments between a block's last statement and its
+        // closing brace have no following statement to ride on; emit them as
+        // standalone comment lines so they survive.
+        private void AppendDanglingComments(List<GStatement> statements, SyntaxToken closeBrace)
+        {
+            foreach (SyntaxTrivia trivia in closeBrace.LeadingTrivia)
+            {
+                switch (trivia.Kind())
+                {
+                    case SyntaxKind.SingleLineCommentTrivia:
+                        statements.Add(new RawStatement(trivia.ToString().TrimEnd()));
+                        break;
+
+                    case SyntaxKind.MultiLineCommentTrivia:
+                        string block = trivia.ToString();
+                        block = block.StartsWith("/*", StringComparison.Ordinal) ? block.Substring(2) : block;
+                        block = block.EndsWith("*/", StringComparison.Ordinal)
+                            ? block.Substring(0, block.Length - 2)
+                            : block;
+                        foreach (string raw in block.Split('\n'))
+                        {
+                            string text = raw.Trim().TrimStart('*').TrimStart();
+                            statements.Add(new RawStatement(text.Length == 0 ? "//" : $"// {text}"));
+                        }
+
+                        break;
+                }
+            }
+        }
+
         private IEnumerable<GStatement> TranslateStatement(StatementSyntax statement)
         {
             List<GStatement> outerSpillPrologue = this.state.PendingSpillPrologue;
@@ -2606,12 +2661,14 @@ public sealed partial class CSharpToGSharpTranslator
                 if (spillPrologue.Count == 0)
                 {
                     AttachSourceComments(core.FirstOrDefault(), statement);
+                    AttachTrailingComment(core.LastOrDefault(), statement);
                     return core;
                 }
 
                 var combined = new List<GStatement>(spillPrologue);
                 combined.AddRange(core);
                 AttachSourceComments(combined[0], statement);
+                AttachTrailingComment(combined[^1], statement);
                 return combined;
             }
             finally


### PR DESCRIPTION
## Summary
- **Wrap v2**: first-line budget (multi-line lambda arguments no longer bail the statement out of wrapping), leading-dot chain breaking for long postfix chains (probe-verified gsc continuations — LINQ pipelines render one link per line), declaration-signature parameter-list wrapping, and arrow bodies participating like `return` statements
- **Comment coverage**: trailing same-line comments ride on the emitted statement; comments dangling before a block's closing brace emit as standalone lines

## Validation
- new `Issue3501WrapAndCommentCoverageTests`: 5 regressions — multi-line-lambda head wrap + oracle, chain break + oracle, signature wrap + bind, trailing/dangling comments + oracle, and the short-form one-line guarantee
- 4 LINQ/round-trip needles updated to the wrapped chain spellings (the wrapped output is the intended readable form)
- full `Cs2Gs.Tests`: **2,344 passed**; the 4 needle updates and the known environmental nupkg miss verified green individually after the run
- follow-up on merge: tighten `longLineCeiling` in the #3502 baseline

Part of #3501 (Tracks B2+B3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)