### PR TITLE
gsc + cs2gs: function-literal parity — self-reference and ref/out/in (#3501 A2)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -355,7 +355,11 @@ public sealed class Binder
             {
                 return Lambdas.BindGenericLocalFunctionDeclaration(syntax);
             },
-            checkNonGenericLocalFunctionEnclosingTypeParameterReference: (location, name, literal) => Lambdas.CheckNonGenericLocalFunctionEnclosingTypeParameterReference(location, name, literal));
+            checkNonGenericLocalFunctionEnclosingTypeParameterReference: (location, name, literal) => Lambdas.CheckNonGenericLocalFunctionEnclosingTypeParameterReference(location, name, literal),
+            bindFunctionLiteralWithSelfDeclaration: (literalSyntax, onSignatureBound) =>
+            {
+                return Lambdas.BindFunctionLiteralExpression(literalSyntax, explicitName: null, onSignatureBound: onSignatureBound);
+            });
         BoundExpression BindTypeOfExpressionForDeclarations(TypeOfExpressionSyntax syntax) =>
             Expressions.BindTypeOfExpression(syntax);
         BoundExpression BindExpressionForDeclarations(ExpressionSyntax syntax) =>

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -1557,7 +1557,11 @@ public sealed class Binder
             diagnostics = diagnostics.InsertRange(0, previous.Diagnostics);
         }
 
-        var delegates = binder.scope.GetDeclaredDelegates();
+        // Issue #3501 A2: synthesized ref-kind delegates (see
+        // SynthesizedRefDelegateCache) join the declared named delegates so
+        // the emitter stamps their TypeDefs through the same ADR-0059 path.
+        var delegates = binder.scope.GetDeclaredDelegates()
+            .AddRange(binder.scope.GetSynthesizedRefDelegateCache().Symbols);
 
         var result = new BoundGlobalScope(previous, entryPointPackage, packagesInOrder.ToImmutable(), diagnostics, imports, functions, variables, typeAliases, structs, interfaces, enums, delegates, entryPoint, statements.ToImmutable());
         result.PreprocessorSymbols = preprocessorSymbols ?? ImmutableHashSet<string>.Empty;
@@ -1582,6 +1586,12 @@ public sealed class Binder
         // bodies against a freshly-derived scope chain) can rehydrate it and
         // bind literals appearing inside those bodies.
         result.RichAnonymousClassMap = binder.scope.GetRichAnonymousClassMap();
+
+        // Issue #3501 A2: carry the ref-kind delegate cache itself (not just
+        // a snapshot) so BindProgram can install it on its freshly-derived
+        // scope chain — a type clause bound in this pass and a literal bound
+        // in a method body must unify to the SAME synthesized delegate.
+        result.RefDelegateCache = binder.scope.GetSynthesizedRefDelegateCache();
 
         // Issue #1929/#1953: collect producer-declared friend assemblies
         // (`@assembly:InternalsVisibleTo("...")`) so the emitter can write
@@ -1620,6 +1630,7 @@ public sealed class Binder
                 ModuleAttributes = result.ModuleAttributes,
                 AnonymousTypes = result.AnonymousTypes,
                 RichAnonymousClassMap = result.RichAnonymousClassMap,
+                RefDelegateCache = result.RefDelegateCache,
             };
         }
 
@@ -1835,6 +1846,15 @@ public sealed class Binder
     public static BoundProgram BindProgram(BoundGlobalScope globalScope, ReferenceResolver? references, BoundBodyCache? cache, ImmutableHashSet<SyntaxTree>? dirtyTrees)
     {
         var parentScope = CreateParentScope(globalScope, references, preprocessorSymbols: globalScope?.PreprocessorSymbols, preserveLatestImportSyntaxTrees: true);
+
+        // Issue #3501 A2: reuse the global-scope pass's ref-kind delegate
+        // cache on this pass's scope chain, so a shape spelled in a
+        // declaration's type clause and the same shape appearing inside a
+        // method body resolve to ONE synthesized delegate symbol.
+        if (globalScope?.RefDelegateCache != null)
+        {
+            parentScope.InstallSynthesizedRefDelegateCache(globalScope.RefDelegateCache);
+        }
 
         // ADR-0146 / issue #2243: rehydrate the rich anonymous-object literal →
         // synthesized-class map onto this pass's scope chain so a literal
@@ -2336,7 +2356,16 @@ public sealed class Binder
         // the empty synthetic block unanchored — there is nothing to point at.
         SyntaxAnchoringWalker.Anchor(statement, statement.Statements.FirstOrDefault(s => s.Syntax is not null)?.Syntax);
 
-        return new BoundProgram(globalScope.Package, globalScope.Packages, diagnostics.ToImmutable(), functionBodies.ToImmutable(), globalScope.EntryPoint, statement, allStructs, globalScope.Interfaces, globalScope.Enums, globals, globalScope.Delegates)
+        // Issue #3501 A2: union the ref-kind delegates synthesized while
+        // binding top-level statements (already in globalScope.Delegates via
+        // BindGlobalScope) with those synthesized while binding
+        // function/method bodies just above (parentScope's own cache — a
+        // fresh scope chain, mirroring the anonymous-type union above).
+        var allDelegates = globalScope.Delegates
+            .AddRange(parentScope.GetSynthesizedRefDelegateCache().Symbols
+                .Where(d => !globalScope.Delegates.Contains(d)));
+
+        return new BoundProgram(globalScope.Package, globalScope.Packages, diagnostics.ToImmutable(), functionBodies.ToImmutable(), globalScope.EntryPoint, statement, allStructs, globalScope.Interfaces, globalScope.Enums, globals, allDelegates)
         {
             Imports = globalScope.GetCumulativeImports(),
             FriendAssemblies = globalScope.FriendAssemblies,
@@ -3476,6 +3505,44 @@ public sealed class Binder
                         ret = lambdas.WrapAsTask(ret);
                     }
                 }
+            }
+
+            // Issue #3501 A2: a parameter slot may carry the ADR-0060
+            // `ref`/`out`/`in` modifier — `(ref int32) -> void`. Func/Action
+            // cannot represent by-ref type arguments, so such a shape binds
+            // to a compiler-synthesized delegate (cached per shape, emitted
+            // through the ADR-0059 named-delegate path) instead of a
+            // FunctionTypeSymbol.
+            if (!syntax.FunctionParameterRefKindTokens.IsDefaultOrEmpty
+                && syntax.FunctionParameterRefKindTokens.Any(token => token != null))
+            {
+                var boundParamTypes = paramTypes.MoveToImmutable();
+                var refParameters = ImmutableArray.CreateBuilder<ParameterSymbol>(boundParamTypes.Length);
+                for (var i = 0; i < boundParamTypes.Length; i++)
+                {
+                    var refKindToken = syntax.FunctionParameterRefKindToken(i);
+                    var refKind = refKindToken?.Text switch
+                    {
+                        "ref" => RefKind.Ref,
+                        "out" => RefKind.Out,
+                        "in" => RefKind.In,
+                        _ => RefKind.None,
+                    };
+                    if (refKind != RefKind.None && syntax.IsParameterVariadic(i))
+                    {
+                        // ADR-0060 §8: a variadic slot cannot also carry a
+                        // ref-kind modifier — same rule as declared parameters.
+                        Diagnostics.ReportRefKindOnVariadicParameter(fnParameterTypes[i].Location, $"<arg{i}>");
+                        refKind = RefKind.None;
+                    }
+
+                    refParameters.Add(new ParameterSymbol($"arg{i}", boundParamTypes[i], refKind: refKind));
+                }
+
+                return scope.GetSynthesizedRefDelegateCache().GetOrCreate(
+                    refParameters.MoveToImmutable(),
+                    ret ?? TypeSymbol.Void,
+                    scope.GetCurrentDeclaringPackageName());
             }
 
             var variadicFlags = anyVariadic ? variadicFlagsBuilder.MoveToImmutable() : default;

--- a/src/Core/CodeAnalysis/Binding/BoundGlobalScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundGlobalScope.cs
@@ -340,6 +340,14 @@ public sealed class BoundGlobalScope
         = new Dictionary<GSharp.Core.CodeAnalysis.Syntax.AnonymousClassExpressionSyntax, StructSymbol>();
 
     /// <summary>
+    /// Gets or sets the ref-kind delegate cache (issue #3501 A2) shared with
+    /// <c>BindProgram</c>'s body-binding pass so a function-type shape with
+    /// <c>ref</c>/<c>out</c>/<c>in</c> slots resolves to one synthesized
+    /// delegate symbol across both passes.
+    /// </summary>
+    internal SynthesizedRefDelegateCache? RefDelegateCache { get; set; }
+
+    /// <summary>
     /// Returns every import visible across the whole <see cref="Previous"/>
     /// chain, oldest submission first (issue #2101). This is the cumulative
     /// view that <see cref="Imports"/> itself used to provide directly —

--- a/src/Core/CodeAnalysis/Binding/BoundScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundScope.cs
@@ -51,6 +51,10 @@ public sealed class BoundScope
     // per-compilation anonymous-type cache.
     private AnonymousTypeCache? anonymousTypeCache;
 
+    // Issue #3501 A2: synthesized ref-kind delegate cache, held at the root
+    // of the chain, exactly like anonymousTypeCache above.
+    private SynthesizedRefDelegateCache? synthesizedRefDelegateCache;
+
     // Issue #2342: the ambient "current declaring package" (see
     // SetCurrentDeclaringPackage), lazily set/cleared only on the root scope
     // of the chain, exactly like anonymousTypeCache above.
@@ -1562,6 +1566,42 @@ public sealed class BoundScope
     /// <returns>The shared <see cref="AnonymousTypeCache"/> for this scope's chain.</returns>
     internal AnonymousTypeCache GetAnonymousTypeCache()
         => Parent != null ? Parent.GetAnonymousTypeCache() : anonymousTypeCache ??= new AnonymousTypeCache();
+
+    /// <summary>
+    /// Issue #3501 A2: gets the per-compile-pass synthesized ref-kind
+    /// delegate cache (see <see cref="SynthesizedRefDelegateCache"/>), walking
+    /// to the root of this scope's chain so every scope in one bind pass
+    /// shares the same cache instance — mirrors <see cref="GetAnonymousTypeCache"/>.
+    /// </summary>
+    /// <returns>The shared <see cref="SynthesizedRefDelegateCache"/> for this scope's chain.</returns>
+    internal SynthesizedRefDelegateCache GetSynthesizedRefDelegateCache()
+        => Parent != null ? Parent.GetSynthesizedRefDelegateCache() : synthesizedRefDelegateCache ??= new SynthesizedRefDelegateCache();
+
+    /// <summary>
+    /// Issue #3501 A2: installs an existing ref-kind delegate cache on this
+    /// chain's root — used by <c>BindProgram</c> to continue the global-scope
+    /// pass's cache so shapes unify across the two binding passes.
+    /// </summary>
+    /// <param name="cache">The cache to share.</param>
+    internal void InstallSynthesizedRefDelegateCache(SynthesizedRefDelegateCache cache)
+    {
+        if (Parent != null)
+        {
+            Parent.InstallSynthesizedRefDelegateCache(cache);
+            return;
+        }
+
+        synthesizedRefDelegateCache = cache;
+    }
+
+    /// <summary>
+    /// Issue #3501 A2: gets the ambient declaring package name set by
+    /// <see cref="SetCurrentDeclaringPackage"/>, used to place synthesized
+    /// ref-kind delegates in the package whose declaration is being bound.
+    /// </summary>
+    /// <returns>The ambient package name, or <see langword="null"/>.</returns>
+    internal string? GetCurrentDeclaringPackageName()
+        => Parent != null ? Parent.GetCurrentDeclaringPackageName() : currentDeclaringPackageName.Value;
 
     /// <summary>
     /// Issue #2342: sets the package name of the top-level (or nested) type or

--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -233,10 +233,19 @@ internal sealed class LambdaBinder
     /// local-function declaration) instead of the default
     /// <c>&lt;lambdaN&gt;</c> synthetic name, so scope-based name lookup
     /// (<see cref="BoundScope.TryDeclareFunction"/>) can find it.</param>
+    /// <param name="onSignatureBound">Issue #3501 A2: when non-null, invoked
+    /// once the literal's signature (parameters + return type) is bound —
+    /// with the synthetic <see cref="FunctionSymbol"/> and the literal's
+    /// natural <see cref="FunctionTypeSymbol"/> — BEFORE the body-binding
+    /// scope is pushed. A named-binding caller (<c>let f = func ...</c>)
+    /// uses this to declare <c>f</c> into the enclosing scope so the body
+    /// can reference itself (recursion through the captured variable, the
+    /// G# local-function idiom).</param>
     /// <returns>The bound function-literal expression.</returns>
     public BoundExpression BindFunctionLiteralExpression(
         FunctionLiteralExpressionSyntax syntax,
-        string? explicitName = null)
+        string? explicitName = null,
+        Action<FunctionSymbol, FunctionTypeSymbol>? onSignatureBound = null)
     {
         // Phase 4.7: function literal `[async] func(p1 T1, p2 T2) R { body }`.
         // Bind parameters, push a new scope chained to the current scope so
@@ -338,6 +347,11 @@ internal sealed class LambdaBinder
             parameterSymbols.ToImmutable(),
             returnType);
         synthetic.IsAsync = isAsync;
+
+        // Issue #3501 A2: give a named-binding caller the chance to declare
+        // the literal's own name into the (still-current) enclosing scope
+        // before the body binds, so `let f = func ...` bodies can call `f`.
+        onSignatureBound?.Invoke(synthetic, fnType);
 
         // Snapshot current binder state, then push a child scope and bind
         // the body as if we were inside this synthetic function.
@@ -546,8 +560,20 @@ internal sealed class LambdaBinder
                 binderCtx.CurrentTypeParameters[tp.Name] = tp;
             }
 
-            var literal = (BoundFunctionLiteralExpression)BindFunctionLiteralExpression(literalSyntax, explicitName: name);
-            literal.Function.TypeParameters = typeParameters;
+            // Issue #3501 A2: declare the function (with its type parameters
+            // already attached, so generic call resolution sees them) into the
+            // enclosing scope BEFORE the body binds — a generic local function
+            // can then call itself (`fact[T](n - 1)`), matching C# local
+            // functions.
+            var declaredEarly = false;
+            var literal = (BoundFunctionLiteralExpression)BindFunctionLiteralExpression(
+                literalSyntax,
+                explicitName: name,
+                onSignatureBound: (fn, _) =>
+                {
+                    fn.TypeParameters = typeParameters;
+                    declaredEarly = Scope.TryDeclareFunction(fn);
+                });
 
             if (literal.CapturedVariables.Length > 0)
             {
@@ -576,7 +602,7 @@ internal sealed class LambdaBinder
                 }
             }
 
-            if (!Scope.TryDeclareFunction(literal.Function))
+            if (!declaredEarly)
             {
                 Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, name);
             }

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
@@ -1294,6 +1294,15 @@ internal sealed partial class StatementBinder
         var type = syntax.TypeClause is { } typeClause
             ? bindTypeClause(typeClause)
             : null;
+        var accessibility = resolveAccessibility(syntax.AccessibilityModifier);
+
+        // Issue #3501 A2: when the initializer is a function literal, the
+        // variable is declared BEFORE the literal's body binds (from the
+        // literal's own signature, or the explicit type clause when present)
+        // so the body can reference the binding it is being assigned to —
+        // `let fact = func(n int32) int32 { ... fact(n - 1) ... }` is the G#
+        // local-function recursion idiom.
+        VariableSymbol? preDeclaredSelf = null;
 
         BoundExpression convertedInitializer;
         TypeSymbol variableType;
@@ -1399,7 +1408,25 @@ internal sealed partial class StatementBinder
             }
             else
             {
-                var initializer = bindExpression(syntax.Initializer);
+                BoundExpression initializer;
+                if (syntax.Initializer is FunctionLiteralExpressionSyntax literalInitializer
+                    && bindFunctionLiteralWithSelfDeclaration != null)
+                {
+                    // Issue #3501 A2: bind the literal with a signature hook
+                    // that declares the variable into the current scope before
+                    // the body binds. The variable's type is the explicit type
+                    // clause when present, else the literal's natural type.
+                    initializer = bindFunctionLiteralWithSelfDeclaration(literalInitializer, (_, fnType) =>
+                    {
+                        preDeclaredSelf = bindLocalVariableWithAccessibility(
+                            syntax.Identifier, isReadOnly, type ?? fnType, accessibility);
+                    });
+                }
+                else
+                {
+                    initializer = bindExpression(syntax.Initializer);
+                }
+
                 variableType = type ?? initializer.Type;
                 convertedInitializer = conversions.BindConversion(syntax.Initializer.Location, initializer, variableType);
 
@@ -1426,8 +1453,8 @@ internal sealed partial class StatementBinder
             }
         }
 
-        var accessibility = resolveAccessibility(syntax.AccessibilityModifier);
-        var variable = bindLocalVariableWithAccessibility(syntax.Identifier, isReadOnly, variableType, accessibility);
+        var variable = preDeclaredSelf
+            ?? bindLocalVariableWithAccessibility(syntax.Identifier, isReadOnly, variableType, accessibility);
 
         // Issue #3316 (ADR-0159 follow-up (a)): a bare `chan T` slot without an
         // initializer is only a declaration-site error (GS0520) for a GLOBAL —

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
@@ -1265,6 +1265,26 @@ internal sealed partial class StatementBinder
         => syntax is BinaryExpressionSyntax binary
             && binary.OperatorToken.Kind == SyntaxKind.QuestionQuestionToken;
 
+    /// <summary>
+    /// Issue #3501 A2: when the literal declares at least one
+    /// <c>ref</c>/<c>out</c>/<c>in</c> parameter, returns the synthesized
+    /// delegate type backing its shape (Func/Action cannot carry by-ref type
+    /// arguments); <see langword="null"/> for a by-value-only literal, which
+    /// keeps its <see cref="FunctionTypeSymbol"/> natural type.
+    /// </summary>
+    private TypeSymbol? SynthesizeRefDelegateForLiteral(FunctionSymbol function, FunctionTypeSymbol functionType)
+    {
+        if (!function.Parameters.Any(p => p.RefKind != RefKind.None))
+        {
+            return null;
+        }
+
+        return scope.GetSynthesizedRefDelegateCache().GetOrCreate(
+            function.Parameters,
+            functionType.ReturnType,
+            scope.GetCurrentDeclaringPackageName());
+    }
+
     private BoundStatement BindVariableDeclaration(VariableDeclarationSyntax syntax)
     {
         // Issue #491 (ADR-0060 follow-up): a `let ref` / `var ref` declaration introduces a
@@ -1416,10 +1436,17 @@ internal sealed partial class StatementBinder
                     // that declares the variable into the current scope before
                     // the body binds. The variable's type is the explicit type
                     // clause when present, else the literal's natural type.
-                    initializer = bindFunctionLiteralWithSelfDeclaration(literalInitializer, (_, fnType) =>
+                    initializer = bindFunctionLiteralWithSelfDeclaration(literalInitializer, (fn, fnType) =>
                     {
+                        // Issue #3501 A2: a literal with `ref`/`out`/`in`
+                        // parameters cannot live in a Func/Action-backed
+                        // FunctionTypeSymbol — its inferred type is the
+                        // synthesized ref-kind delegate for its shape.
+                        var selfType = type
+                            ?? SynthesizeRefDelegateForLiteral(fn, fnType)
+                            ?? (TypeSymbol)fnType;
                         preDeclaredSelf = bindLocalVariableWithAccessibility(
-                            syntax.Identifier, isReadOnly, type ?? fnType, accessibility);
+                            syntax.Identifier, isReadOnly, selfType, accessibility);
                     });
                 }
                 else
@@ -1427,7 +1454,7 @@ internal sealed partial class StatementBinder
                     initializer = bindExpression(syntax.Initializer);
                 }
 
-                variableType = type ?? initializer.Type;
+                variableType = type ?? preDeclaredSelf?.Type ?? initializer.Type;
                 convertedInitializer = conversions.BindConversion(syntax.Initializer.Location, initializer, variableType);
 
                 // Issue #2016: a NON-generic named local function (`let`/`var`/`const

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.cs
@@ -89,6 +89,16 @@ internal sealed partial class StatementBinder
     private readonly BindVariableDeclarationAttributesDelegate bindVariableDeclarationAttributes;
     private readonly Func<FunctionSymbol?> getCurrentFunction;
     private readonly Func<LambdaExpressionSyntax, FunctionTypeSymbol, BoundExpression>? bindLambdaWithTargetType;
+
+    /// <summary>
+    /// Issue #3501 A2: binds a function-literal initializer with a hook that
+    /// fires after the literal's signature binds (and before its body does),
+    /// letting <c>BindVariableDeclaration</c> declare the variable first so
+    /// the body can self-reference. See
+    /// <c>LambdaBinder.BindFunctionLiteralExpression</c>'s
+    /// <c>onSignatureBound</c> parameter.
+    /// </summary>
+    private readonly Func<FunctionLiteralExpressionSyntax, Action<FunctionSymbol, FunctionTypeSymbol>, BoundExpression>? bindFunctionLiteralWithSelfDeclaration;
     private readonly Func<VariableDeclarationSyntax, BoundStatement>? bindGenericLocalFunctionDeclaration;
     private readonly Action<TextLocation, string, BoundFunctionLiteralExpression>? checkNonGenericLocalFunctionEnclosingTypeParameterReference;
     private readonly Stack<SyntaxNode> exceptionHandlerRegions = new();
@@ -117,7 +127,8 @@ internal sealed partial class StatementBinder
         Func<FunctionSymbol?> getCurrentFunction,
         Func<LambdaExpressionSyntax, FunctionTypeSymbol, BoundExpression>? bindLambdaWithTargetType = null,
         Func<VariableDeclarationSyntax, BoundStatement>? bindGenericLocalFunctionDeclaration = null,
-        Action<TextLocation, string, BoundFunctionLiteralExpression>? checkNonGenericLocalFunctionEnclosingTypeParameterReference = null)
+        Action<TextLocation, string, BoundFunctionLiteralExpression>? checkNonGenericLocalFunctionEnclosingTypeParameterReference = null,
+        Func<FunctionLiteralExpressionSyntax, Action<FunctionSymbol, FunctionTypeSymbol>, BoundExpression>? bindFunctionLiteralWithSelfDeclaration = null)
     {
         this.binderCtx = binderCtx ?? throw new ArgumentNullException(nameof(binderCtx));
         this.conversions = conversions ?? throw new ArgumentNullException(nameof(conversions));
@@ -138,6 +149,7 @@ internal sealed partial class StatementBinder
         this.bindLambdaWithTargetType = bindLambdaWithTargetType;
         this.bindGenericLocalFunctionDeclaration = bindGenericLocalFunctionDeclaration;
         this.checkNonGenericLocalFunctionEnclosingTypeParameterReference = checkNonGenericLocalFunctionEnclosingTypeParameterReference;
+        this.bindFunctionLiteralWithSelfDeclaration = bindFunctionLiteralWithSelfDeclaration;
     }
 
     private DiagnosticBag Diagnostics => binderCtx.Diagnostics;

--- a/src/Core/CodeAnalysis/Binding/SynthesizedRefDelegateCache.cs
+++ b/src/Core/CodeAnalysis/Binding/SynthesizedRefDelegateCache.cs
@@ -1,0 +1,86 @@
+// <copyright file="SynthesizedRefDelegateCache.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Text;
+using GSharp.Core.CodeAnalysis.Symbols;
+
+namespace GSharp.Core.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #3501 A2: per-compile-pass cache of compiler-synthesized delegate
+/// types backing native function types with <c>ref</c>/<c>out</c>/<c>in</c>
+/// parameters. <c>System.Func</c>/<c>System.Action</c> cannot carry by-ref
+/// type arguments, so a function type spelled <c>(ref int32) -&gt; void</c>
+/// (or the natural type of a literal <c>func(ref n int32) { … }</c>) lowers
+/// to a sealed <c>MulticastDelegate</c> TypeDef with the matching by-ref
+/// <c>Invoke</c> signature — the exact shape ADR-0059 named delegates
+/// already emit and every call/conversion path already supports. Two
+/// spellings of the same shape (same ref kinds, parameter types, and return
+/// type) unify to the SAME synthesized symbol within one compile pass,
+/// mirroring <see cref="AnonymousTypeCache"/>.
+/// </summary>
+internal sealed class SynthesizedRefDelegateCache
+{
+    private readonly Dictionary<string, DelegateTypeSymbol> byShape = new();
+    private readonly List<DelegateTypeSymbol> symbols = new();
+    private int counter;
+
+    /// <summary>Gets every distinct synthesized delegate created so far in this cache, in creation order.</summary>
+    public IReadOnlyList<DelegateTypeSymbol> Symbols => symbols;
+
+    /// <summary>
+    /// Returns the cached synthesized delegate for the given signature,
+    /// creating and caching a new one on first use. At least one parameter
+    /// is expected to carry a non-<see cref="RefKind.None"/> ref kind —
+    /// by-value-only shapes stay on <see cref="FunctionTypeSymbol"/>.
+    /// </summary>
+    /// <param name="parameters">The parameter symbols (names, types, and ref kinds preserved for emit).</param>
+    /// <param name="returnType">The delegate's return type (<see cref="TypeSymbol.Void"/> for none).</param>
+    /// <param name="packageName">The package (CLR namespace) the synthesized TypeDef is emitted into.</param>
+    /// <returns>The (cached) synthesized <see cref="DelegateTypeSymbol"/>.</returns>
+    public DelegateTypeSymbol GetOrCreate(
+        ImmutableArray<ParameterSymbol> parameters,
+        TypeSymbol returnType,
+        string? packageName)
+    {
+        var key = BuildKey(parameters, returnType);
+        if (byShape.TryGetValue(key, out var existing))
+        {
+            return existing;
+        }
+
+        // Roslyn synthesizes `<>A{…}`/`<>F{…}` for ref-kind lambdas; the
+        // angle-bracket prefix keeps the name unspeakable in source while
+        // remaining a valid CLR TypeDef name.
+        var symbol = new DelegateTypeSymbol(
+            $"<>RefFunc{counter++}",
+            packageName ?? string.Empty,
+            Accessibility.Internal,
+            ImmutableArray<ParameterSymbol>.Empty,
+            TypeSymbol.Void,
+            declaration: null!);
+        symbol.SetSignature(parameters, returnType);
+
+        byShape[key] = symbol;
+        symbols.Add(symbol);
+        return symbol;
+    }
+
+    private static string BuildKey(ImmutableArray<ParameterSymbol> parameters, TypeSymbol returnType)
+    {
+        var sb = new StringBuilder();
+        foreach (var parameter in parameters)
+        {
+            sb.Append((int)parameter.RefKind).Append(':');
+            FunctionTypeSymbol.AppendIdentityKey(sb, parameter.Type);
+            sb.Append(';');
+        }
+
+        sb.Append("->");
+        FunctionTypeSymbol.AppendIdentityKey(sb, returnType);
+        return sb.ToString();
+    }
+}

--- a/src/Core/CodeAnalysis/Syntax/Parser.TypeClauses.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.TypeClauses.cs
@@ -634,10 +634,24 @@ public partial class Parser
         var openParen = MatchToken(SyntaxKind.OpenParenthesisToken);
         var nodesAndSeparators = ImmutableArray.CreateBuilder<SyntaxNode>();
         var ellipsisTokens = ImmutableArray.CreateBuilder<SyntaxToken?>();
+        var refKindTokens = ImmutableArray.CreateBuilder<SyntaxToken?>();
 
         while (Current.Kind != SyntaxKind.CloseParenthesisToken &&
                Current.Kind != SyntaxKind.EndOfFileToken)
         {
+            // Issue #3501 A2: a parameter slot may lead with the ADR-0060
+            // contextual `ref`/`out`/`in` modifier — `(ref int32) -> void`.
+            // The modifier is consumed only when the next token can start a
+            // type clause, so a plain type named `ref`/`out`/`in` (followed
+            // by `,` or `)`) still binds as the slot's type.
+            SyntaxToken? refKind = null;
+            if (Current.Kind == SyntaxKind.IdentifierToken
+                && Current.Text is "ref" or "out" or "in"
+                && CanStartTypeClause(Peek(1)))
+            {
+                refKind = NextToken();
+            }
+
             SyntaxToken? ellipsis = null;
             if (Current.Kind == SyntaxKind.EllipsisToken)
             {
@@ -646,6 +660,7 @@ public partial class Parser
 
             nodesAndSeparators.Add(ParseTypeClause());
             ellipsisTokens.Add(ellipsis);
+            refKindTokens.Add(refKind);
             if (Current.Kind == SyntaxKind.CommaToken)
             {
                 nodesAndSeparators.Add(MatchToken(SyntaxKind.CommaToken));
@@ -660,9 +675,10 @@ public partial class Parser
         var arrow = MatchToken(SyntaxKind.RightArrowToken);
         var returnTypeClause = ParseTypeClause();
         var question = Current.Kind == SyntaxKind.QuestionToken ? MatchToken(SyntaxKind.QuestionToken) : null;
+        TypeClauseSyntax clause;
         if (asyncModifier != null)
         {
-            return TypeClauseSyntax.CreateAsyncArrowFunction(
+            clause = TypeClauseSyntax.CreateAsyncArrowFunction(
                 syntaxTree,
                 asyncModifier,
                 openParen,
@@ -673,16 +689,27 @@ public partial class Parser
                 returnTypeClause,
                 question);
         }
+        else
+        {
+            clause = TypeClauseSyntax.CreateArrowFunction(
+                syntaxTree,
+                openParen,
+                new SeparatedSyntaxList<TypeClauseSyntax>(nodesAndSeparators.ToImmutable()),
+                ellipsisTokens.ToImmutable(),
+                closeParen,
+                arrow,
+                returnTypeClause,
+                question);
+        }
 
-        return TypeClauseSyntax.CreateArrowFunction(
-            syntaxTree,
-            openParen,
-            new SeparatedSyntaxList<TypeClauseSyntax>(nodesAndSeparators.ToImmutable()),
-            ellipsisTokens.ToImmutable(),
-            closeParen,
-            arrow,
-            returnTypeClause,
-            question);
+        // Issue #3501 A2: attach the per-slot ref-kind modifier tokens when
+        // any slot carried one.
+        if (refKindTokens.Any(token => token != null))
+        {
+            clause.FunctionParameterRefKindTokens = refKindTokens.ToImmutable();
+        }
+
+        return clause;
     }
 
     private TypeClauseSyntax ParseParenthesizedArrowFunctionTypeClause(SyntaxToken? asyncModifier)
@@ -696,9 +723,10 @@ public partial class Parser
         _ = MatchToken(SyntaxKind.CloseParenthesisToken);
         var question = Current.Kind == SyntaxKind.QuestionToken ? MatchToken(SyntaxKind.QuestionToken) : null;
 
+        TypeClauseSyntax rebuilt;
         if (inner.AsyncModifier != null)
         {
-            return TypeClauseSyntax.CreateAsyncArrowFunction(
+            rebuilt = TypeClauseSyntax.CreateAsyncArrowFunction(
                 syntaxTree,
                 inner.AsyncModifier,
                 inner.OpenParenToken,
@@ -709,16 +737,23 @@ public partial class Parser
                 inner.ReturnTypeClause,
                 question);
         }
+        else
+        {
+            rebuilt = TypeClauseSyntax.CreateArrowFunction(
+                syntaxTree,
+                inner.OpenParenToken,
+                inner.FunctionParameterTypes,
+                inner.FunctionParameterEllipsisTokens,
+                inner.CloseParenToken,
+                inner.ArrowToken,
+                inner.ReturnTypeClause,
+                question);
+        }
 
-        return TypeClauseSyntax.CreateArrowFunction(
-            syntaxTree,
-            inner.OpenParenToken,
-            inner.FunctionParameterTypes,
-            inner.FunctionParameterEllipsisTokens,
-            inner.CloseParenToken,
-            inner.ArrowToken,
-            inner.ReturnTypeClause,
-            question);
+        // Issue #3501 A2: the rebuild must carry the inner clause's per-slot
+        // ref-kind modifiers — `((ref int32) -> void)?` keeps its ref slot.
+        rebuilt.FunctionParameterRefKindTokens = inner.FunctionParameterRefKindTokens;
+        return rebuilt;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Syntax/TypeClauseSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/TypeClauseSyntax.cs
@@ -621,6 +621,19 @@ public sealed class TypeClauseSyntax : SyntaxNode
     /// </summary>
     public ImmutableArray<SyntaxToken?> FunctionParameterEllipsisTokens { get; } = ImmutableArray<SyntaxToken?>.Empty;
 
+    /// <summary>
+    /// Gets the per-parameter <c>ref</c>/<c>out</c>/<c>in</c> contextual
+    /// modifier tokens of an arrow-form function-type clause (issue #3501
+    /// A2: <c>(ref int32) -&gt; void</c>). The array is parallel to
+    /// <see cref="FunctionParameterTypes"/> — entry <c>i</c> is the leading
+    /// modifier token of the i-th parameter slot, or <see langword="null"/>
+    /// when that slot is a plain by-value parameter. Always non-default;
+    /// <see cref="ImmutableArray{T}.Empty"/> when the clause is not a
+    /// function-type clause or carries no ref-kind modifiers. Assigned by
+    /// the parser after construction.
+    /// </summary>
+    public ImmutableArray<SyntaxToken?> FunctionParameterRefKindTokens { get; internal set; } = ImmutableArray<SyntaxToken?>.Empty;
+
     /// <summary>Gets the function return-type clause, or <c>null</c> when the type is void / not a function type.</summary>
     public TypeClauseSyntax? ReturnTypeClause { get; }
 
@@ -821,6 +834,18 @@ public sealed class TypeClauseSyntax : SyntaxNode
             && index >= 0
             && index < FunctionParameterEllipsisTokens.Length
             && FunctionParameterEllipsisTokens[index] != null;
+    }
+
+    /// <summary>Returns the parameter slot's leading <c>ref</c>/<c>out</c>/<c>in</c> modifier token, or <see langword="null"/> for a by-value slot (issue #3501 A2).</summary>
+    /// <param name="index">The parameter slot index.</param>
+    /// <returns>The modifier token, or <see langword="null"/>.</returns>
+    public SyntaxToken? FunctionParameterRefKindToken(int index)
+    {
+        return !FunctionParameterRefKindTokens.IsDefaultOrEmpty
+            && index >= 0
+            && index < FunctionParameterRefKindTokens.Length
+            ? FunctionParameterRefKindTokens[index]
+            : null;
     }
 
     /// <summary>

--- a/test/Core.Tests/CodeAnalysis/Issue3501FunctionLiteralSelfReferenceTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Issue3501FunctionLiteralSelfReferenceTests.cs
@@ -1,0 +1,173 @@
+// <copyright file="Issue3501FunctionLiteralSelfReferenceTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis;
+
+/// <summary>
+/// Issue #3501 Track A2: a <c>let</c>/<c>var</c>-bound function literal can
+/// reference its own name inside its body — the binding is declared from the
+/// literal's signature (or the explicit type clause) BEFORE the body binds,
+/// so recursion works through the captured variable. This is the G#
+/// local-function idiom; previously the body-site name lookup failed with
+/// GS0130.
+/// </summary>
+public class Issue3501FunctionLiteralSelfReferenceTests
+{
+    [Fact]
+    public void LetBoundLiteral_CanRecurse()
+    {
+        var source = @"
+func Run() int32 {
+    let fact = func(n int32) int32 {
+        if n <= 1 {
+            return 1
+        }
+        return n * fact(n - 1)
+    }
+    return fact(5)
+}
+
+Run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(120, result.Value);
+    }
+
+    [Fact]
+    public void ExplicitTypeClause_LetBoundLiteral_CanRecurse()
+    {
+        var source = @"
+func Run() int32 {
+    let fib ((int32) -> int32) = func(n int32) int32 {
+        if n <= 1 {
+            return n
+        }
+        return fib(n - 1) + fib(n - 2)
+    }
+    return fib(10)
+}
+
+Run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(55, result.Value);
+    }
+
+    [Fact]
+    public void TopLevelLetBoundLiteral_CanRecurse()
+    {
+        var source = @"
+let fib = func(n int32) int32 {
+    if n <= 1 {
+        return n
+    }
+    return fib(n - 1) + fib(n - 2)
+}
+
+fib(10)
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(55, result.Value);
+    }
+
+    [Fact]
+    public void VarBoundLiteral_RecursionFollowsReassignment()
+    {
+        // Recursion goes through the variable's cell, not a snapshot: after
+        // `f` is reassigned, the ORIGINAL literal's self-call observes the
+        // new value — the same semantics C# gives `Func<int,int> f = ...`
+        // built via the null-then-assign idiom.
+        var source = @"
+func Run() int32 {
+    var f = func(n int32) int32 {
+        if n <= 0 {
+            return 0
+        }
+        return f(n - 1)
+    }
+    let original = f
+    f = func(n int32) int32 {
+        return 100
+    }
+    return original(1)
+}
+
+Run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(100, result.Value);
+    }
+
+    [Fact]
+    public void Literal_CapturesOuterLocalAndSelf()
+    {
+        var source = @"
+func Run() int32 {
+    var offset = 10
+    let sum = func(n int32) int32 {
+        if n <= 0 {
+            return offset
+        }
+        return n + sum(n - 1)
+    }
+    return sum(3)
+}
+
+Run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(16, result.Value);
+    }
+
+    [Fact]
+    public void GenericLocalFunction_CanRecurse()
+    {
+        var source = @"
+func Run() int32 {
+    let depth[T] = func(v T, n int32) int32 {
+        if n <= 0 {
+            return 0
+        }
+        return depth[T](v, n - 1) + 1
+    }
+    return depth[string](""x"", 4)
+}
+
+Run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(4, result.Value);
+    }
+
+    [Fact]
+    public void AsyncLiteral_CanRecurse()
+    {
+        var source = @"
+func Run() int32 {
+    let depth = async func(n int32) int32 {
+        if n <= 0 {
+            return 0
+        }
+        return await depth(n - 1) + 1
+    }
+    return depth(5).Result
+}
+
+Run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(5, result.Value);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Issue3501RefKindFunctionLiteralTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Issue3501RefKindFunctionLiteralTests.cs
@@ -1,0 +1,213 @@
+// <copyright file="Issue3501RefKindFunctionLiteralTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis;
+
+/// <summary>
+/// Issue #3501 Track A2: function literals and native function types carry
+/// ADR-0060 <c>ref</c>/<c>out</c>/<c>in</c> parameters with the same
+/// semantics as declared functions. <c>System.Func</c>/<c>Action</c> cannot
+/// represent by-ref type arguments, so such shapes bind to a
+/// compiler-synthesized delegate (one per distinct shape, emitted through
+/// the ADR-0059 named-delegate path); previously a ref-kind literal without
+/// a named-delegate target failed with a same-display GS0155.
+/// </summary>
+public class Issue3501RefKindFunctionLiteralTests
+{
+    [Fact]
+    public void RefLiteral_InfersSynthesizedDelegate_AndMutatesThroughRef()
+    {
+        var source = @"
+func Run() int32 {
+    let bump = func(ref n int32) {
+        n = n + 1
+    }
+    var x = 41
+    bump(ref x)
+    return x
+}
+
+Run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void OutAndInLiterals_WorkThroughInferredTypes()
+    {
+        var source = @"
+func Run() int32 {
+    let tryGet = func(out v int32) bool {
+        v = 7
+        return true
+    }
+    var total = 0
+    if tryGet(out var got) {
+        total += got
+    }
+    let reader = func(in v int32) int32 {
+        return v * 2
+    }
+    var src = 21
+    total += reader(&src)
+    return total
+}
+
+Run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(49, result.Value);
+    }
+
+    [Fact]
+    public void RefFunctionTypeClause_InParameterPosition_AcceptsLiteralArgument()
+    {
+        var source = @"
+func apply(f (ref int32) -> void) int32 {
+    var x = 41
+    f(ref x)
+    return x
+}
+
+func Run() int32 {
+    return apply(func(ref n int32) {
+        n = n + 1
+    })
+}
+
+Run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void RefFunctionTypeClause_InReturnPosition_RoundTrips()
+    {
+        var source = @"
+func makeDouble() (ref int32) -> void {
+    return func(ref n int32) {
+        n = n * 2
+    }
+}
+
+func Run() int32 {
+    let f = makeDouble()
+    var x = 21
+    f(ref x)
+    return x
+}
+
+Run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void NullableRefFunctionType_AssignsAndInvokesWithAssertion()
+    {
+        var source = @"
+func Run() int32 {
+    var acc ((ref int32) -> void)? = nil
+    acc = func(ref n int32) {
+        n = n + 10
+    }
+    var y = 1
+    acc!!(ref y)
+    return y
+}
+
+Run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(11, result.Value);
+    }
+
+    [Fact]
+    public void SelfReferencingRefLiteral_Recurses()
+    {
+        var source = @"
+func Run() int32 {
+    let countdown = func(ref n int32) {
+        if n > 0 {
+            n = n - 1
+            countdown(ref n)
+        }
+    }
+    var x = 5
+    countdown(ref x)
+    return x
+}
+
+Run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(0, result.Value);
+    }
+
+    [Fact]
+    public void SameShape_UnifiesToOneSynthesizedDelegate()
+    {
+        // Two spellings of the same shape are the same symbol within one
+        // compile pass, so a literal bound through one clause assigns to a
+        // slot declared through the other.
+        var source = @"
+func apply(f (ref int32) -> void, seed int32) int32 {
+    var x = seed
+    f(ref x)
+    return x
+}
+
+func Run() int32 {
+    let g ((ref int32) -> void) = func(ref n int32) {
+        n = n + 1
+    }
+    return apply(g, 41)
+}
+
+Run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void NamedDelegateTarget_StillBindsDirectly()
+    {
+        // The delegate declaration is spelled AFTER `func Run` because a
+        // void-returning `delegate func(...)` greedily consumes a following
+        // `func` keyword as its return-type clause (pre-existing parse
+        // greediness, unrelated to this issue).
+        var source = @"
+func Run() int32 {
+    let bump BumpShape = func(ref n int32) {
+        n = n + 1
+    }
+    var x = 41
+    bump(ref x)
+    return x
+}
+
+Run()
+
+type BumpShape = delegate func(ref n int32)
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(42, result.Value);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/BlockLambdaArrowTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/BlockLambdaArrowTranslationTests.cs
@@ -166,8 +166,10 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("__local_F_Fact", printed);
-        Assert.DoesNotContain("let Fact = func", printed);
+        // Issue #3501 A2: direct self-recursion stays as an in-place `let`
+        // literal — gsc's self-reference support removed the lift.
+        Assert.DoesNotContain("__local_F_Fact", printed);
+        Assert.Contains("let Fact = func", printed);
         Assert.DoesNotContain("(n int32) -> {", printed);
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3399CapturingRecursiveLocalFunctionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3399CapturingRecursiveLocalFunctionTranslationTests.cs
@@ -53,13 +53,13 @@ namespace Demo
     }
 }");
 
-        // The recursive member must be a mutable function local, not a plain
-        // `let` binding, and the self-recursive call site inside the closure
-        // body must carry the postfix null assertion.
-        Assert.DoesNotContain("let Add", printed, StringComparison.Ordinal);
-        Assert.Contains("var Add", printed, StringComparison.Ordinal);
-        Assert.Contains("Add = func", printed, StringComparison.Ordinal);
-        Assert.Contains("Add!!(", printed, StringComparison.Ordinal);
+        // Issue #3501 A2: a DIRECT self-recursive capturing local now stays
+        // on the canonical `let Add = func …` path (gsc literals see their
+        // own binding) — the #3399 nullable-local scheme is reserved for
+        // MUTUAL recursion.
+        Assert.Contains("let Add = func", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("var Add", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("Add!!(", printed, StringComparison.Ordinal);
 
         LocalFunctionHoistTranslationTests.CompileAndRun(printed, "C().M()");
     }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3501DocMarkdownTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3501DocMarkdownTests.cs
@@ -141,6 +141,40 @@ namespace Cs2Gs.Tests
             TranslationTestValidation.AssertBinds(printed);
         }
 
+        [Fact]
+        public void LongSummaryProse_RewrapsInsteadOfEmittingOneLongLine()
+        {
+            // The converter's whitespace normalization joins the source's own
+            // `///` line breaks; without the re-wrap pass a multi-line C#
+            // summary became one arbitrarily long output line (the dominant
+            // source of >300-char lines in the repo self-migration).
+            string printed = Translate("""
+                public class Widget
+                {
+                    /// <summary>
+                    /// This summary is deliberately written as several source lines of moderately long prose so that
+                    /// the joined single-paragraph form comfortably exceeds any sane single-line budget and therefore
+                    /// exercises the word-wrap pass that splits emitted documentation prose at the configured width
+                    /// while never splitting an individual word in half.
+                    /// </summary>
+                    public int Mass() => 42;
+                }
+                """);
+
+            List<string> docLines = printed
+                .Split('\n')
+                .Select(line => line.TrimEnd())
+                .Where(line => line.TrimStart().StartsWith("///", StringComparison.Ordinal))
+                .ToList();
+            Assert.True(docLines.Count >= 3, "The long summary should span multiple wrapped lines:\n" + printed);
+            Assert.All(docLines, line => Assert.True(
+                line.TrimStart().Length <= 104,
+                "Every emitted doc line should respect the wrap width: " + line));
+            Assert.Contains("/// This summary is deliberately written", printed, StringComparison.Ordinal);
+            Assert.Contains("splitting an individual word in half.", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+        }
+
         private static string Translate(
             string source,
             params MetadataReference[] additionalReferences)

--- a/tools/cs2gs/Cs2Gs.Tests/LocalFunctionHoistTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/LocalFunctionHoistTranslationTests.cs
@@ -264,13 +264,12 @@ namespace Demo
     }
 }");
 
-    // Issue #3399 hybrid: a capturing recursive local lowers to G#'s
-    // nullable function-typed local, not a synthesized capture-passing helper.
-    Assert.DoesNotContain("let Add", printed, StringComparison.Ordinal);
+    // Issue #3501 A2: gsc `let`-bound literals can self-reference, so a
+    // DIRECT self-recursive capturing local stays on the canonical
+    // `let Add = func …` path — no lift, no #3399 nullable-local scheme.
     Assert.DoesNotContain("__local_Run_Add", printed, StringComparison.Ordinal);
-    Assert.Contains("var Add", printed, StringComparison.Ordinal);
-    Assert.Contains("Add = func", printed, StringComparison.Ordinal);
-    Assert.Contains("Add!!(", printed, StringComparison.Ordinal);
+    Assert.Contains("let Add = func", printed, StringComparison.Ordinal);
+    Assert.DoesNotContain("Add!!(", printed, StringComparison.Ordinal);
     CompileAndRun(
         printed,
         "C().Run(3)\nConsole.WriteLine(\"ok\")",
@@ -437,10 +436,14 @@ namespace Demo
     }
 }");
 
-        Assert.DoesNotContain("let Visit", printed, StringComparison.Ordinal);
-        Assert.DoesNotContain("let IsBaseCase", printed, StringComparison.Ordinal);
-        Assert.Contains("__local_Factorial_Visit", printed, StringComparison.Ordinal);
-        Assert.Contains("__local_Factorial_IsBaseCase", printed, StringComparison.Ordinal);
+        // Issue #3501 A2: direct self-recursion no longer forces the shared-
+        // helper lift — both statics stay as in-place `let` literals (Visit's
+        // self-call resolves through its own binding; IsBaseCase is declared
+        // before Visit, so the sibling call resolves lexically).
+        Assert.Contains("let Visit = func", printed, StringComparison.Ordinal);
+        Assert.Contains("let IsBaseCase = func", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("__local_Factorial_Visit", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("__local_Factorial_IsBaseCase", printed, StringComparison.Ordinal);
         CompileAndRun(
             printed,
             "Console.WriteLine(C().Factorial(5))",

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
@@ -1961,12 +1961,22 @@ public sealed partial class CSharpToGSharpTranslator
                             pair.Symbol)
                         && (identifier.Parent is not InvocationExpressionSyntax invocation
                             || !ReferenceEquals(invocation.Expression, identifier)));
+
+                // Issue #3501 A2: gsc `let`-bound function literals can now
+                // reference their own binding, so DIRECT self-recursion no
+                // longer forces a lift — only a cycle that passes through
+                // ANOTHER local function does (the partner would have to be
+                // forward-referenced before its `let` declaration).
+                bool recursiveThroughOthers = edges.TryGetValue(pair.Symbol, out HashSet<IMethodSymbol> ownDependencies)
+                    && ownDependencies.Any(dependency =>
+                        !SymbolEqualityComparer.Default.Equals(dependency, pair.Symbol)
+                        && IsRecursive(
+                            pair.Symbol,
+                            dependency,
+                            new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default) { dependency }));
                 if ((!usedAsMethodGroup
                         && pair.Symbol.Parameters.Any(parameter => parameter.RefKind != RefKind.None))
-                    || IsRecursive(
-                        pair.Symbol,
-                        pair.Symbol,
-                        new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default)))
+                    || recursiveThroughOthers)
                 {
                     toLift.Add(pair.Symbol);
                 }
@@ -2260,6 +2270,17 @@ public sealed partial class CSharpToGSharpTranslator
                 // visibility. SCCs with no capturing member therefore keep the
                 // canonical `let`/hoist path entirely.
                 if (!group.Any(f => this.CapturesOuterState(f.Syntax, f.Symbol)))
+                {
+                    continue;
+                }
+
+                // Issue #3501 A2: gsc `let`-bound literals now see their own
+                // binding, so a single-member SCC (direct self-recursion) works
+                // on the canonical `let name = func …` path even when it
+                // captures — no nullable-forward-declaration scheme needed.
+                // Only MUTUAL recursion still requires it (a partner would be
+                // referenced before its `let` declaration).
+                if (group.Count == 1)
                 {
                     continue;
                 }

--- a/tools/cs2gs/Cs2Gs.Translator/XmlDocMarkdownConverter.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/XmlDocMarkdownConverter.cs
@@ -28,6 +28,14 @@ namespace Cs2Gs.Translator;
 internal static class XmlDocMarkdownConverter
 {
     /// <summary>
+    /// Issue #3501 follow-up: maximum content width (excluding the
+    /// <c>/// </c> marker and indentation) of an emitted prose doc line.
+    /// Sized so a doc line at typical nesting stays within the printer's
+    /// 120-column budget.
+    /// </summary>
+    private const int MaxDocLineWidth = 100;
+
+    /// <summary>
     /// Converts one raw documentation-comment trivia string (the `///`-prefixed
     /// lines) into ADR-0057 Markdown doc-comment lines, each already carrying
     /// the <c>///</c> marker.
@@ -149,9 +157,141 @@ internal static class XmlDocMarkdownConverter
             return null;
         }
 
-        return output
+        // Issue #3501 follow-up: NormalizeInlineWhitespace collapses the
+        // source's own `///` line breaks, so a multi-line C# summary would
+        // otherwise become ONE arbitrarily long prose line (the top source
+        // of >300-char lines in the repo self-migration). Re-wrap prose at a
+        // readable width; fenced content (```…```) is untouched.
+        var wrapped = new List<string>(output.Count);
+        bool inFence = false;
+        foreach (string line in output)
+        {
+            if (line.TrimStart().StartsWith("```", StringComparison.Ordinal))
+            {
+                inFence = !inFence;
+                wrapped.Add(line);
+            }
+            else if (inFence)
+            {
+                wrapped.Add(line);
+            }
+            else
+            {
+                wrapped.AddRange(WrapProseLine(line));
+            }
+        }
+
+        return wrapped
             .Select(line => string.IsNullOrWhiteSpace(line) ? "///" : $"/// {line}")
             .ToList();
+    }
+
+    /// <summary>
+    /// Word-wraps one prose line to <see cref="MaxDocLineWidth"/> content
+    /// characters. List items and <c>@tag</c> heads simply continue on the
+    /// following line (Markdown treats the continuation as part of the same
+    /// block). Wrap points are only taken between "atoms": a Markdown link
+    /// (<c>[text](target)</c>) or backtick code span is never split even
+    /// when it contains spaces, and a single atom longer than the width
+    /// stays intact on its own line.
+    /// </summary>
+    private static IEnumerable<string> WrapProseLine(string line)
+    {
+        if (line.Length <= MaxDocLineWidth)
+        {
+            yield return line;
+            yield break;
+        }
+
+        var current = new StringBuilder();
+        foreach (string atom in SplitIntoAtoms(line))
+        {
+            if (current.Length > 0 && current.Length + 1 + atom.Length > MaxDocLineWidth)
+            {
+                yield return current.ToString();
+                current.Clear();
+            }
+
+            if (current.Length > 0)
+            {
+                current.Append(' ');
+            }
+
+            current.Append(atom);
+        }
+
+        if (current.Length > 0)
+        {
+            yield return current.ToString();
+        }
+    }
+
+    /// <summary>
+    /// Splits a prose line at spaces, re-merging any run of words that sits
+    /// inside an unclosed inline span — an odd number of backticks, an
+    /// unclosed <c>[</c>, or an unclosed link-target <c>](…</c> — so
+    /// Markdown links and code spans survive wrapping as single atoms.
+    /// </summary>
+    private static IEnumerable<string> SplitIntoAtoms(string line)
+    {
+        var atom = new StringBuilder();
+        foreach (string word in line.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (atom.Length > 0)
+            {
+                atom.Append(' ');
+            }
+
+            atom.Append(word);
+            if (!HasOpenInlineSpan(atom.ToString()))
+            {
+                yield return atom.ToString();
+                atom.Clear();
+            }
+        }
+
+        if (atom.Length > 0)
+        {
+            yield return atom.ToString();
+        }
+    }
+
+    private static bool HasOpenInlineSpan(string text)
+    {
+        int backticks = 0;
+        int bracketDepth = 0;
+        int linkParenDepth = 0;
+        for (int i = 0; i < text.Length; i++)
+        {
+            char c = text[i];
+            if (c == '`')
+            {
+                backticks++;
+            }
+            else if (c == '[')
+            {
+                bracketDepth++;
+            }
+            else if (c == ']')
+            {
+                if (bracketDepth > 0)
+                {
+                    bracketDepth--;
+                }
+
+                if (i + 1 < text.Length && text[i + 1] == '(')
+                {
+                    linkParenDepth++;
+                    i++;
+                }
+            }
+            else if (c == ')' && linkParenDepth > 0)
+            {
+                linkParenDepth--;
+            }
+        }
+
+        return (backticks % 2) != 0 || bracketDepth > 0 || linkParenDepth > 0;
     }
 
     private static void AppendBlockContent(List<string> output, IEnumerable<XNode> nodes)

--- a/tools/cs2gs/selfmig-baseline.json
+++ b/tools/cs2gs/selfmig-baseline.json
@@ -1,7 +1,7 @@
 {
-  "comment": "Issue #3501 Track C: ratcheting baseline for the repo self-migration gate (build/run-cs2gs-selfmig.sh). greenFloor is the minimum number of fully-green apps (translate+compile+ilverify+parity); the *Ceiling metrics cap readability regressions in the migrated output. Calibrated 2026-08-23 against the full 55-project corpus (25 green; 255 synthetic labels; 111 __local_ lifts; 3766 lines >300 chars). Improve a metric, then tighten the corresponding number in the same PR.",
+  "comment": "Issue #3501 Track C: ratcheting baseline for the repo self-migration gate (build/run-cs2gs-selfmig.sh). greenFloor is the minimum number of fully-green apps (translate+compile+ilverify+parity); the *Ceiling metrics cap readability regressions in the migrated output. Recalibrated 2026-08-23 after the #3503-#3507 merges plus the doc-line re-wrap fix (25 green; 84 synthetic labels; 111 __local_ lifts; 3627 lines >300 chars). Improve a metric, then tighten the corresponding number in the same PR.",
   "greenFloor": 25,
-  "syntheticLabelCeiling": 260,
+  "syntheticLabelCeiling": 100,
   "liftedLocalCeiling": 115,
-  "longLineCeiling": 3800
+  "longLineCeiling": 3700
 }

--- a/tools/cs2gs/selfmig-baseline.json
+++ b/tools/cs2gs/selfmig-baseline.json
@@ -1,7 +1,7 @@
 {
-  "comment": "Issue #3501 Track C: ratcheting baseline for the repo self-migration gate (build/run-cs2gs-selfmig.sh). greenFloor is the minimum number of fully-green apps (translate+compile+ilverify+parity); the *Ceiling metrics cap readability regressions in the migrated output. Recalibrated 2026-08-23 after the #3503-#3507 merges plus the doc-line re-wrap fix (25 green; 84 synthetic labels; 111 __local_ lifts; 3627 lines >300 chars). Improve a metric, then tighten the corresponding number in the same PR.",
+  "comment": "Issue #3501 Track C: ratcheting baseline for the repo self-migration gate (build/run-cs2gs-selfmig.sh). greenFloor is the minimum number of fully-green apps (translate+compile+ilverify+parity); the *Ceiling metrics cap readability regressions in the migrated output. Recalibrated 2026-08-23 after the #3503-#3507 merges plus the doc-line re-wrap fix (25 green; 84 synthetic labels; 77 __local_ lifts (A2 self-recursion retarget); 3625 lines >300 chars). Improve a metric, then tighten the corresponding number in the same PR.",
   "greenFloor": 25,
   "syntheticLabelCeiling": 100,
-  "liftedLocalCeiling": 115,
+  "liftedLocalCeiling": 85,
   "longLineCeiling": 3700
 }


### PR DESCRIPTION
## What this does

Track A2 of #3501, in two gsc capabilities plus the cs2gs retarget:

### 1. Self-reference: `let f = func …` bodies can call `f`

The literal's signature (parameters + return type) binds before its body, so `BindVariableDeclaration` now declares the binding at that point — from the explicit type clause when present, else the literal's natural type — and the body's name lookup finds it:

```gsharp
let fact = func(n int32) int32 {
    if n <= 1 { return 1 }
    return n * fact(n - 1)      // previously GS0130
}
```

Works for locals, top-level globals, explicit type clauses, `var` (recursion follows the cell, so rebinding is observed — C# `Func` semantics), captures alongside self, async literals, and generic local functions (`fact[T](n - 1)` — the FunctionSymbol is declared with its type parameters before the body binds). The existing closure/emit machinery needed **zero changes**; recursion is capture-of-own-binding.

### 2. `ref`/`out`/`in` parameters on literals and native function types

`Func`/`Action` cannot carry by-ref type arguments, so a byref shape now binds to a compiler-synthesized delegate (`<>RefFunc{n}`, one per distinct shape per compile pass, mirroring the anonymous-type cache) emitted through the ADR-0059 named-delegate path — the path that already produces correct by-ref `Invoke` metadata and supports every call form:

```gsharp
let bump = func(ref n int32) { n = n + 1 }   // natural type: synthesized delegate
bump(ref x)                                   // ref/out var/&x all work

func apply(f (ref int32) -> void) { … }       // ADR-0060 keyword spelling in type clauses
var acc ((ref int32) -> void)? = nil          // nullable form keeps its ref slots
```

The cache is shared across the global-scope and body-binding passes (`BoundGlobalScope.RefDelegateCache`) so one shape is one symbol; `BoundProgram.Delegates` unions the synthesized set for emit. Note per ADR-0060, `*T`/`&T` is deliberately not a parameter-type spelling (GS0238) — parity uses the keyword modifiers, `&x` stays the call-site primitive.

### 3. cs2gs retarget

- **Direct self-recursion no longer lifts**: a self-recursive local function stays an in-place `let Name = func …` instead of a `__local_` shared helper, and a self-recursive *capturing* local function drops the #3399 nullable-forward-declaration scheme (no more `var Add (…)? = nil` + `Add!!(…)`). Mutual recursion keeps the existing lowerings — a partner would still be forward-referenced before its `let`.
- Repo self-migration: **`__local_` lifts 111 → 77**; baseline ratcheted `liftedLocalCeiling` 115 → 85. Green count held at 25/55; labels 84; long lines 3625.

## Verification

- Core.Tests **8039/8039** green (15 new tests: `Issue3501FunctionLiteralSelfReferenceTests`, `Issue3501RefKindFunctionLiteralTests`).
- Cs2Gs.Tests **2355/2355** green (lift-expectation tests updated to the new shapes; `Issue2231MutualRecursionRemainsUnsupportedByGscLetBindings` still passes — forward-reference remains an error).
- LanguageServer + analyzers build clean.
- Full self-migration gate PASSED on this branch (includes the #3508 doc-wrap fix via merge).

## Notes

- Diagnostics can display a synthesized delegate as `<>RefFunc0` (C# similarly shows "anonymous delegate" for ref-kind lambda natural types); a friendlier display form is a possible follow-up.
- Pre-existing, unrelated: a **void**-returning `type X = delegate func(…)` greedily consumes a following `func`/identifier as its return-type clause — worth its own issue.
- The `hasRefParams` local-function lift trigger in cs2gs is deliberately untouched: synthesized-to-named delegate conversions don't exist, so lifting remains the safe translation there.

Closes the A2 track of #3501.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgrKRVPGaEm9zLaYvankA1