### PR TITLE
gsc + cs2gs: switch family — break-in-arm, comma arms, fallthrough (#3501 A3)

### DIFF
--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -89,6 +89,7 @@ EventSubscriptionExpression
 ExpressionCollectionElement
 ExpressionStatement
 FallthroughKeyword
+FallthroughStatement
 FalseKeyword
 FieldAccessExpression
 FieldAssignmentExpression

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -130,7 +130,7 @@ IDs may be given as `GS0001`, `0001`, or the bare integer `1`; all three forms a
 | GS0165 | Error | Top-level statements may appear in at most one package per compilation. | Two or more `package` declarations in a single compilation each contain top-level statements. |
 | GS0166 | Warning | Top-level statements conflict with an explicit `Main` function. | Both top-level statements and a `func Main()` are present; TLS wins and the explicit `Main` is shadowed. |
 | GS0167 | Error | Multi-assignment target/value count mismatch. | `a, b = 1, 2, 3` — three values for two targets. |
-| GS0168 | Error | `fallthrough` is not supported. | `fallthrough` keyword used in a `switch` case body. |
+| GS0168 | Error | `fallthrough` must be the last statement of a `switch` case body. | `fallthrough` followed by more statements in the same case body (issue #3501 A3: a trailing `fallthrough` is now legal Go-style control flow). |
 | GS0169 | Error | Duplicate `default` arm in `switch`. | Two `default:` arms inside one `switch` statement. |
 | GS0170 | Error | Switch case value is not a constant expression. | `case x:` where `x` is a mutable variable. |
 | GS0171 | Error | Switch case type is incompatible with the switch expression. | `switch (s) { case 42: }` where `s` is `string`. |
@@ -660,6 +660,18 @@ field initializers (`p with { x = 10 }`) parse on separate paths and are unaffec
 | ID | Severity | Message | Example |
 |---|---|---|---|
 | GS0531 | Error | `Constructor initializer arguments cannot reference instance member '<name>' before the delegated or base constructor has run.` | `init() : base({ let self = this 1 }) { }` |
+
+## `fallthrough` placement (GS0533–GS0534)
+
+Issue #3501 A3: `fallthrough` gained Go semantics — legal only as the LAST
+statement of a non-final `switch` arm, transferring into the next arm's body
+without evaluating its pattern or guard. GS0168 (above) reports a misplaced
+`fallthrough`; these report the two structural misuses.
+
+| ID | Severity | Message | Example |
+|---|---|---|---|
+| GS0533 | Error | `'fallthrough' cannot be used in the final arm of a 'switch' statement.` | `switch x { case 1 { fallthrough } }` |
+| GS0534 | Error | `'fallthrough' cannot target a 'switch' arm whose pattern declares bindings or that has a 'when' guard — the jump would skip their assignment.` | `case 1 { fallthrough } case string s { ... }` |
 
 ## Pattern variable outside its definitely-assigned region (GS0532)
 

--- a/src/Core/CodeAnalysis/Binding/BinderContext.cs
+++ b/src/Core/CodeAnalysis/Binding/BinderContext.cs
@@ -201,8 +201,39 @@ internal sealed class BinderContext
     /// labeled <c>break</c> / <c>continue</c> resolve their target by
     /// scanning this stack for a matching label name.
     /// </summary>
-    public Stack<(string? LabelName, BoundLabel BreakLabel, BoundLabel ContinueLabel)> LoopStack { get; }
-        = new Stack<(string? LabelName, BoundLabel BreakLabel, BoundLabel ContinueLabel)>();
+    /// <remarks>
+    /// Issue #3501 A3: a <c>switch</c> statement also pushes a frame so an
+    /// unlabeled <c>break</c> in an arm exits the switch (C#/Go alignment).
+    /// A switch frame has a <see langword="null"/> <c>ContinueLabel</c> and
+    /// a <see langword="null"/> <c>LabelName</c> — <c>continue</c> binding
+    /// skips such frames to reach the enclosing loop.
+    /// </remarks>
+    public Stack<(string? LabelName, BoundLabel BreakLabel, BoundLabel? ContinueLabel)> LoopStack { get; }
+        = new Stack<(string? LabelName, BoundLabel BreakLabel, BoundLabel? ContinueLabel)>();
+
+    /// <summary>
+    /// Gets the set of break labels that were actually targeted by a bound
+    /// <c>break</c> statement (issue #3501 A3) — a switch appends its
+    /// break-label statement only when someone jumped to it, so exhaustive
+    /// all-paths-return switches keep their exit shape.
+    /// </summary>
+    public HashSet<BoundLabel> UsedBreakLabels { get; } = new HashSet<BoundLabel>();
+
+    /// <summary>
+    /// Gets or sets the label a legal <c>fallthrough</c> in the CURRENT
+    /// switch arm jumps to — the next arm's body-entry label (issue #3501
+    /// A3). <see langword="null"/> when the current arm cannot fall through
+    /// (final arm, or no fallthrough present). Set by
+    /// <c>BindSwitchStatement</c> per arm; cleared by lambda nested frames.
+    /// </summary>
+    public BoundLabel? CurrentFallthroughTarget { get; set; }
+
+    /// <summary>
+    /// Gets or sets the one syntax node in the current switch arm where a
+    /// <c>fallthrough</c> is legal — the arm body's LAST statement (issue
+    /// #3501 A3). Any other <c>fallthrough</c> reports GS0168.
+    /// </summary>
+    public Syntax.StatementSyntax? CurrentFallthroughAnchor { get; set; }
 
     /// <summary>
     /// Gets the enclosing function's user-defined <c>goto</c> labels

--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -1614,6 +1614,8 @@ internal sealed class LambdaBinder
         binderCtx.DefinedUserLabels.Clear();
         binderCtx.UnresolvedGotoLabels.Clear();
         binderCtx.LoopStack.Clear();
+        binderCtx.CurrentFallthroughTarget = null;
+        binderCtx.CurrentFallthroughAnchor = null;
         return saved;
     }
 
@@ -1671,6 +1673,9 @@ internal sealed class LambdaBinder
         {
             binderCtx.LoopStack.Push(saved.LoopStack[i]);
         }
+
+        binderCtx.CurrentFallthroughTarget = saved.FallthroughTarget;
+        binderCtx.CurrentFallthroughAnchor = saved.FallthroughAnchor;
     }
 
     private static TypeSymbol? ResolveLexicalEnclosingType(FunctionSymbol? outerFunction)
@@ -2264,6 +2269,8 @@ internal sealed class LambdaBinder
             DefinedUserLabels = new HashSet<string>(ctx.DefinedUserLabels);
             UnresolvedGotoLabels = new Dictionary<string, TextLocation>(ctx.UnresolvedGotoLabels);
             LoopStack = ctx.LoopStack.ToArray();
+            FallthroughTarget = ctx.CurrentFallthroughTarget;
+            FallthroughAnchor = ctx.CurrentFallthroughAnchor;
         }
 
         public Dictionary<string, BoundLabel> UserLabels { get; }
@@ -2272,7 +2279,13 @@ internal sealed class LambdaBinder
 
         public Dictionary<string, TextLocation> UnresolvedGotoLabels { get; }
 
-        public (string? LabelName, BoundLabel BreakLabel, BoundLabel ContinueLabel)[] LoopStack { get; }
+        public (string? LabelName, BoundLabel BreakLabel, BoundLabel? ContinueLabel)[] LoopStack { get; }
+
+        // Issue #3501 A3: a lambda body inside a switch arm must not see the
+        // enclosing arm's fallthrough context — same isolation as LoopStack.
+        public BoundLabel? FallthroughTarget { get; }
+
+        public Syntax.StatementSyntax? FallthroughAnchor { get; }
     }
 
     // Issue #1451: collects the locals declared by inline `out var`/`out let`

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Blocks.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Blocks.cs
@@ -72,9 +72,18 @@ internal sealed partial class StatementBinder
                 : null;
             var endsInFallthrough = trailingStatement is FallthroughStatementSyntax;
             binderCtx.CurrentFallthroughAnchor = endsInFallthrough ? trailingStatement : null;
-            binderCtx.CurrentFallthroughTarget = endsInFallthrough && caseIndex < syntax.Cases.Length - 1
-                ? armEntryLabels[caseIndex + 1] ??= new BoundLabel($"switchArm{switchOrdinal}_{caseIndex + 1}")
-                : null;
+            binderCtx.CurrentFallthroughTarget = null;
+            if (endsInFallthrough && caseIndex < syntax.Cases.Length - 1)
+            {
+                var nextArmEntry = armEntryLabels[caseIndex + 1];
+                if (nextArmEntry == null)
+                {
+                    nextArmEntry = new BoundLabel($"switchArm{switchOrdinal}_{caseIndex + 1}");
+                    armEntryLabels[caseIndex + 1] = nextArmEntry;
+                }
+
+                binderCtx.CurrentFallthroughTarget = nextArmEntry;
+            }
 
             if (caseSyntax.IsDefault)
             {

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Blocks.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Blocks.cs
@@ -45,8 +45,37 @@ internal sealed partial class StatementBinder
         Dictionary<AccessPath, TypeSymbol>? mergedExitFrame = null;
         var mergeFailed = false;
 
-        foreach (var caseSyntax in syntax.Cases)
+        // Issue #3501 A3: (a) an unlabeled `break` inside an arm exits the
+        // switch — push a LoopStack frame whose ContinueLabel is null so
+        // `continue` still binds to the enclosing loop; (b) an arm whose
+        // body ENDS in `fallthrough` jumps to the NEXT arm's body-entry
+        // label, skipping that arm's pattern test and guard (Go semantics).
+        binderCtx.LabelCounter++;
+        var switchOrdinal = binderCtx.LabelCounter;
+        var switchBreakLabel = new BoundLabel($"switchBreak{switchOrdinal}");
+        var armEntryLabels = new BoundLabel?[syntax.Cases.Length];
+        var savedFallthroughTarget = binderCtx.CurrentFallthroughTarget;
+        var savedFallthroughAnchor = binderCtx.CurrentFallthroughAnchor;
+        binderCtx.LoopStack.Push((null, switchBreakLabel, null));
+        try
         {
+        for (var caseIndex = 0; caseIndex < syntax.Cases.Length; caseIndex++)
+        {
+            var caseSyntax = syntax.Cases[caseIndex];
+
+            // Issue #3501 A3: arm the fallthrough context for this arm. The
+            // one legal position is the body's last statement; a trailing
+            // fallthrough in a non-final arm targets the next arm's entry
+            // label (created on demand, prepended when that arm binds).
+            var trailingStatement = caseSyntax.Body.Statements.Length > 0
+                ? caseSyntax.Body.Statements[caseSyntax.Body.Statements.Length - 1]
+                : null;
+            var endsInFallthrough = trailingStatement is FallthroughStatementSyntax;
+            binderCtx.CurrentFallthroughAnchor = endsInFallthrough ? trailingStatement : null;
+            binderCtx.CurrentFallthroughTarget = endsInFallthrough && caseIndex < syntax.Cases.Length - 1
+                ? armEntryLabels[caseIndex + 1] ??= new BoundLabel($"switchArm{switchOrdinal}_{caseIndex + 1}")
+                : null;
+
             if (caseSyntax.IsDefault)
             {
                 if (hasDefault)
@@ -56,6 +85,7 @@ internal sealed partial class StatementBinder
 
                 hasDefault = true;
                 var defaultBody = BindBlockStatement(caseSyntax.Body);
+                defaultBody = PrependArmEntryLabel(defaultBody, armEntryLabels[caseIndex]);
                 arms.Add(new BoundPatternSwitchArm(null, pattern: null, guard: null, defaultBody));
 
                 if (!EndsInUnconditionalExit(defaultBody))
@@ -73,6 +103,18 @@ internal sealed partial class StatementBinder
             scope = new BoundScope(scope);
             var caseValue = Invariant.Required(caseSyntax.Value, "a non-default switch case has a pattern value");
             var pattern = patterns.BindPattern(caseValue, switchType);
+
+            // Issue #3501 A3: a fallthrough INTO this arm skips its pattern
+            // test — pattern bindings and guards would run unassigned/
+            // unevaluated, so such targets are rejected. Pattern-declared
+            // variables live in the arm scope just pushed above.
+            if (armEntryLabels[caseIndex] != null
+                && (scope.GetDeclaredVariables().Length > 0 || caseSyntax.Guard != null))
+            {
+                var previousCase = syntax.Cases[caseIndex - 1];
+                var fallthroughKeyword = previousCase.Body.Statements[previousCase.Body.Statements.Length - 1];
+                Diagnostics.ReportFallthroughTargetHasBindings(fallthroughKeyword.Location);
+            }
 
             // Issue #991: a guarded arm (`when <bool>`) can always fail at
             // runtime, so a guarded discard `case _ when …` does NOT act as a
@@ -111,6 +153,7 @@ internal sealed partial class StatementBinder
                 });
 
             scope = scope.Pop();
+            body = PrependArmEntryLabel(body, armEntryLabels[caseIndex]);
             arms.Add(new BoundPatternSwitchArm(null, pattern, guard, body));
 
             // Issue #991: a guarded arm may not actually run even when its
@@ -167,6 +210,13 @@ internal sealed partial class StatementBinder
                 mergedExitFrame = next;
             }
         }
+        }
+        finally
+        {
+            binderCtx.LoopStack.Pop();
+            binderCtx.CurrentFallthroughTarget = savedFallthroughTarget;
+            binderCtx.CurrentFallthroughAnchor = savedFallthroughAnchor;
+        }
 
         var boundArms = arms.ToImmutable();
         var isExhaustive = ExhaustivenessAnalyzer.AnalyzeSwitchStatement(
@@ -191,7 +241,36 @@ internal sealed partial class StatementBinder
             binderCtx.PendingSwitchExitFrames[result] = mergedExitFrame;
         }
 
+        // Issue #3501 A3: when an arm actually used `break`, its goto targets
+        // the statement position right after the switch — append the label
+        // there. Switches with no arm-level break keep their bare shape (so
+        // exhaustive all-arms-return switches still read as unconditional
+        // exits to the all-paths-return check).
+        if (binderCtx.UsedBreakLabels.Contains(switchBreakLabel))
+        {
+            return new BoundBlockStatement(
+                syntax,
+                ImmutableArray.Create<BoundStatement>(result, new BoundLabelStatement(null, switchBreakLabel)));
+        }
+
         return result;
+    }
+
+    /// <summary>
+    /// Issue #3501 A3: prepends the arm's body-entry label — the target a
+    /// <c>fallthrough</c> in the PREVIOUS arm jumps to — when one was
+    /// requested; returns the body unchanged otherwise.
+    /// </summary>
+    private static BoundStatement PrependArmEntryLabel(BoundStatement body, BoundLabel? entryLabel)
+    {
+        if (entryLabel == null)
+        {
+            return body;
+        }
+
+        return new BoundBlockStatement(
+            body.Syntax,
+            ImmutableArray.Create<BoundStatement>(new BoundLabelStatement(null, entryLabel), body));
     }
 
     /// <summary>
@@ -714,6 +793,15 @@ internal sealed partial class StatementBinder
 
         var bound = ImmutableArray.CreateBuilder<BoundSelectCase>();
         var sawDefault = false;
+
+        // Issue #3501 A3: Go alignment — an unlabeled `break` inside a select
+        // arm exits the SELECT (same frame shape as switch: null ContinueLabel
+        // keeps `continue` bound to the enclosing loop).
+        binderCtx.LabelCounter++;
+        var selectBreakLabel = new BoundLabel($"selectBreak{binderCtx.LabelCounter}");
+        binderCtx.LoopStack.Push((null, selectBreakLabel, null));
+        try
+        {
         foreach (var caseSyntax in syntax.Cases)
         {
             if (caseSyntax.CaseKind == SelectCaseKind.Default)
@@ -799,8 +887,21 @@ internal sealed partial class StatementBinder
 
             bound.Add(new BoundSelectCase(caseSyntax.CaseKind, channelExpr, valueExpr, variable, body));
         }
+        }
+        finally
+        {
+            binderCtx.LoopStack.Pop();
+        }
 
-        return new BoundSelectStatement(syntax, bound.ToImmutable());
+        var selectResult = new BoundSelectStatement(syntax, bound.ToImmutable());
+        if (binderCtx.UsedBreakLabels.Contains(selectBreakLabel))
+        {
+            return new BoundBlockStatement(
+                syntax,
+                ImmutableArray.Create<BoundStatement>(selectResult, new BoundLabelStatement(null, selectBreakLabel)));
+        }
+
+        return selectResult;
     }
 
     private BoundStatement BindScopeStatement(ScopeStatementSyntax syntax)

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Jumps.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Jumps.cs
@@ -280,8 +280,39 @@ internal sealed partial class StatementBinder
             return BindErrorStatement();
         }
 
+        // Issue #3501 A3: the top frame may be a switch (C#/Go alignment —
+        // an unlabeled `break` in a switch arm exits the switch, not the
+        // enclosing loop). Record the target so the switch appends its
+        // break-label statement only when actually jumped to.
         var breakLabel = binderCtx.LoopStack.Peek().BreakLabel;
+        binderCtx.UsedBreakLabels.Add(breakLabel);
         return new BoundGotoStatement(syntax, breakLabel);
+    }
+
+    /// <summary>
+    /// Issue #3501 A3: binds a <c>fallthrough</c> statement (Go semantics).
+    /// Legal only as the LAST statement of a non-final switch arm's body —
+    /// <c>BindSwitchStatement</c> arms the anchor/target context per arm —
+    /// and lowers to a goto targeting the next arm's body-entry label,
+    /// skipping that arm's pattern test and guard.
+    /// </summary>
+    private BoundStatement BindFallthroughStatement(FallthroughStatementSyntax syntax)
+    {
+        if (!ReferenceEquals(syntax, binderCtx.CurrentFallthroughAnchor))
+        {
+            Diagnostics.ReportFallthroughNotSupported(syntax.Keyword.Location);
+            return BindErrorStatement();
+        }
+
+        if (binderCtx.CurrentFallthroughTarget is not { } target)
+        {
+            // Well-placed, but this is the switch's final arm — there is no
+            // next body to fall into.
+            Diagnostics.ReportFallthroughInFinalArm(syntax.Keyword.Location);
+            return BindErrorStatement();
+        }
+
+        return new BoundGotoStatement(syntax, target);
     }
 
     private BoundStatement BindContinueStatement(ContinueStatementSyntax syntax)
@@ -297,9 +328,9 @@ internal sealed partial class StatementBinder
             var name = syntax.LabelIdentifier.Text;
             foreach (var frame in binderCtx.LoopStack)
             {
-                if (frame.LabelName == name)
+                if (frame.LabelName == name && frame.ContinueLabel is { } labeledContinue)
                 {
-                    return new BoundGotoStatement(syntax, frame.ContinueLabel);
+                    return new BoundGotoStatement(syntax, labeledContinue);
                 }
             }
 
@@ -307,8 +338,18 @@ internal sealed partial class StatementBinder
             return BindErrorStatement();
         }
 
-        var continueLabel = binderCtx.LoopStack.Peek().ContinueLabel;
-        return new BoundGotoStatement(syntax, continueLabel);
+        // Issue #3501 A3: skip switch frames (null ContinueLabel) — `continue`
+        // inside a switch arm still targets the enclosing loop, as in C#/Go.
+        foreach (var frame in binderCtx.LoopStack)
+        {
+            if (frame.ContinueLabel is { } continueLabel)
+            {
+                return new BoundGotoStatement(syntax, continueLabel);
+            }
+        }
+
+        Diagnostics.ReportInvalidBreakOrContinue(syntax.Keyword.Location, syntax.Keyword.Text);
+        return BindErrorStatement();
     }
 
     private BoundStatement BindReturnStatement(ReturnStatementSyntax syntax)

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.cs
@@ -213,6 +213,8 @@ internal sealed partial class StatementBinder
                 return BindBreakStatement((BreakStatementSyntax)syntax);
             case SyntaxKind.ContinueStatement:
                 return BindContinueStatement((ContinueStatementSyntax)syntax);
+            case SyntaxKind.FallthroughStatement:
+                return BindFallthroughStatement((FallthroughStatementSyntax)syntax);
             case SyntaxKind.ReturnStatement:
                 return BindReturnStatement((ReturnStatementSyntax)syntax);
             case SyntaxKind.ExpressionStatement:

--- a/src/Core/CodeAnalysis/DiagnosticBag.Reports.Statements.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.Reports.Statements.cs
@@ -294,12 +294,23 @@ public sealed partial class DiagnosticBag
     => Report(location, DiagnosticDescriptors.InvalidMultiAssignmentTarget);
 
     /// <summary>
-    /// Reports a use of the reserved <c>fallthrough</c> keyword (ADR-0013: GSharp
-    /// does not support Go-style implicit case fallthrough).
+    /// Reports a misplaced <c>fallthrough</c> statement (issue #3501 A3:
+    /// <c>fallthrough</c> is legal only as the LAST statement of a switch
+    /// case body).
     /// </summary>
     /// <param name="location">The text location where <c>fallthrough</c> was found.</param>
     public void ReportFallthroughNotSupported(TextLocation location)
     => Report(location, DiagnosticDescriptors.FallthroughNotSupported);
+
+    /// <summary>Reports a <c>fallthrough</c> in the final arm of a switch (issue #3501 A3).</summary>
+    /// <param name="location">The text location of the <c>fallthrough</c> keyword.</param>
+    public void ReportFallthroughInFinalArm(TextLocation location)
+    => Report(location, DiagnosticDescriptors.FallthroughInFinalArm);
+
+    /// <summary>Reports a <c>fallthrough</c> whose target arm declares pattern bindings or a guard (issue #3501 A3).</summary>
+    /// <param name="location">The text location of the <c>fallthrough</c> keyword.</param>
+    public void ReportFallthroughTargetHasBindings(TextLocation location)
+    => Report(location, DiagnosticDescriptors.FallthroughTargetHasBindings);
 
     /// <summary>
     /// Reports a duplicate <c>default</c> arm in a switch statement.

--- a/src/Core/CodeAnalysis/DiagnosticDescriptors.cs
+++ b/src/Core/CodeAnalysis/DiagnosticDescriptors.cs
@@ -84,7 +84,12 @@ internal static class DiagnosticDescriptors
     internal static readonly DiagnosticDescriptor MultipleTopLevelFiles = new("GS0165", DiagnosticSeverity.Error, "Top-level statements may appear in at most one package per compilation.");
     internal static readonly DiagnosticDescriptor TopLevelStatementsConflictWithMain = new("GS0166", DiagnosticSeverity.Warning, "The entry point of the program is global statements; ignoring the explicit Main function entry point.");
     internal static readonly DiagnosticDescriptor MultiAssignmentMismatch = new("GS0167", DiagnosticSeverity.Error, "Multi-assignment has {0} target(s) but {1} value(s).");
-    internal static readonly DiagnosticDescriptor FallthroughNotSupported = new("GS0168", DiagnosticSeverity.Error, "'fallthrough' is not supported (ADR-0013). GSharp 'switch' cases do not fall through.");
+
+    // Issue #3501 A3: `fallthrough` is now a real statement (Go semantics),
+    // so GS0168 became the placement error instead of a blanket rejection.
+    internal static readonly DiagnosticDescriptor FallthroughNotSupported = new("GS0168", DiagnosticSeverity.Error, "'fallthrough' must be the last statement of a 'switch' case body.");
+    internal static readonly DiagnosticDescriptor FallthroughInFinalArm = new("GS0533", DiagnosticSeverity.Error, "'fallthrough' cannot be used in the final arm of a 'switch' statement.");
+    internal static readonly DiagnosticDescriptor FallthroughTargetHasBindings = new("GS0534", DiagnosticSeverity.Error, "'fallthrough' cannot target a 'switch' arm whose pattern declares bindings or that has a 'when' guard — the jump would skip their assignment.");
     internal static readonly DiagnosticDescriptor DuplicateSwitchDefault = new("GS0169", DiagnosticSeverity.Error, "A 'switch' statement can only have one 'default' arm.");
     internal static readonly DiagnosticDescriptor SwitchCaseValueNotConstant = new("GS0170", DiagnosticSeverity.Error, "Switch case value must be a constant expression.");
     internal static readonly DiagnosticDescriptor SwitchCaseTypeMismatch = new("GS0171", DiagnosticSeverity.Error, "Switch case value of type '{0}' is incompatible with switch expression of type '{1}'.");

--- a/src/Core/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/Lowerer.cs
@@ -128,8 +128,13 @@ public sealed class Lowerer : BoundTreeRewriter
     {
         var discriminant = RewriteExpression(node.Discriminant);
         if (discriminant is not BoundLiteralExpression literal
-            || node.Arms.Any(arm => arm.Guard != null))
+            || node.Arms.Any(arm => arm.Guard != null)
+            || node.Arms.Any(HasFallthroughEntryLabel))
         {
+            // Issue #3501 A3: an arm carrying a fallthrough entry label is a
+            // goto target from the PREVIOUS arm — the constant fast path
+            // keeps only one arm's body, so the label (and the fallthrough
+            // chain) would vanish. Keep the full switch shape.
             return base.RewritePatternSwitchStatement(node);
         }
 
@@ -1700,6 +1705,15 @@ public sealed class Lowerer : BoundTreeRewriter
 
         return new BoundBlockStatement(null, builder.ToImmutable());
     }
+
+    /// <summary>
+    /// Issue #3501 A3: true when the arm's body starts with the synthesized
+    /// <c>switchArm…</c> body-entry label a <c>fallthrough</c> in the
+    /// previous arm jumps to (see <c>StatementBinder.BindSwitchStatement</c>).
+    /// </summary>
+    private static bool HasFallthroughEntryLabel(BoundPatternSwitchArm arm)
+        => arm.Body is BoundBlockStatement { Statements: [BoundLabelStatement { Label.Name: { } labelName }, ..] }
+            && labelName.StartsWith("switchArm", System.StringComparison.Ordinal);
 
     private BoundLabel GenerateLabel()
     {

--- a/src/Core/CodeAnalysis/Syntax/FallthroughStatementSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/FallthroughStatementSyntax.cs
@@ -1,0 +1,32 @@
+// <copyright file="FallthroughStatementSyntax.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Issue #3501 A3: the <c>fallthrough</c> statement (Go semantics). Legal
+/// only as the last statement of a non-final <c>switch</c> arm body;
+/// transfers control to the NEXT arm's body without evaluating that arm's
+/// pattern or guard. The binder enforces placement (GS0168 family) — the
+/// parser accepts the reserved keyword anywhere a statement can start.
+/// </summary>
+public sealed class FallthroughStatementSyntax : StatementSyntax
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FallthroughStatementSyntax"/> class.
+    /// </summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="keyword">The <c>fallthrough</c> keyword token.</param>
+    public FallthroughStatementSyntax(SyntaxTree syntaxTree, SyntaxToken keyword)
+        : base(syntaxTree)
+    {
+        Keyword = keyword;
+    }
+
+    /// <inheritdoc/>
+    public override SyntaxKind Kind => SyntaxKind.FallthroughStatement;
+
+    /// <summary>Gets the <c>fallthrough</c> keyword token.</summary>
+    public SyntaxToken Keyword { get; }
+}

--- a/src/Core/CodeAnalysis/Syntax/Parser.Patterns.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.Patterns.cs
@@ -61,6 +61,18 @@ public partial class Parser
 
         var caseKeyword = MatchToken(SyntaxKind.CaseKeyword);
         var value = ParsePattern(PatternParseContext.SwitchStatement);
+
+        // Issue #3501 A3: Go-style comma multi-pattern arms — `case 1, 2 { … }`.
+        // Each comma folds into the same disjunction node the `or` combinator
+        // produces (BindBinaryPattern treats any non-`and` operator as `or`),
+        // so downstream binding/emit need no changes.
+        while (Current.Kind == SyntaxKind.CommaToken)
+        {
+            var comma = NextToken();
+            var next = ParsePattern(PatternParseContext.SwitchStatement);
+            value = new BinaryPatternSyntax(syntaxTree, value, comma, next);
+        }
+
         var (whenKeyword, guard) = ParseOptionalWhenGuard(bodyFollows: true);
         var caseBody = ParseBlockStatement();
         return new SwitchCaseSyntax(syntaxTree, caseKeyword, value, whenKeyword, guard, caseBody);
@@ -639,11 +651,11 @@ public partial class Parser
 
     private StatementSyntax ParseFallthroughStatement()
     {
-        // ADR-0013: `fallthrough` is reserved but unsupported. Consume the token and
-        // emit a diagnostic so user code surfaces a clear error.
+        // Issue #3501 A3: `fallthrough` is now a real statement (Go
+        // semantics). The binder enforces placement — last statement of a
+        // non-final switch arm — and reports misuse.
         var keyword = MatchToken(SyntaxKind.FallthroughKeyword);
-        Diagnostics.ReportFallthroughNotSupported(keyword.Location);
-        return new ExpressionStatementSyntax(syntaxTree, new LiteralExpressionSyntax(syntaxTree, keyword, value: 0));
+        return new FallthroughStatementSyntax(syntaxTree, keyword);
     }
 
     private StatementSyntax ParseTryStatement()

--- a/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -207,6 +207,7 @@ public enum SyntaxKind
     GotoStatement,
     BreakStatement,
     ContinueStatement,
+    FallthroughStatement,
     ReturnStatement,
     MultiAssignmentStatement,
     MultiAssignmentDeclarationExpression,

--- a/test/Compiler.Tests/Emit/Issue2890SwitchSelectEscapingBranchEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2890SwitchSelectEscapingBranchEmitTests.cs
@@ -26,9 +26,9 @@ public class Issue2890SwitchSelectEscapingBranchEmitTests
             package Issue2890.EmitSwitchBreak
 
             func F(x int32) int32 {
-                for {
+                outer: for {
                     switch x {
-                        default { break }
+                        default { break outer }
                     }
                 }
             }
@@ -45,9 +45,9 @@ public class Issue2890SwitchSelectEscapingBranchEmitTests
             import Gsharp.Extensions.Go
 
             func F() int32 {
-                for {
+                outer: for {
                     select {
-                        default { break }
+                        default { break outer }
                     }
                 }
             }

--- a/test/Compiler.Tests/Emit/Issue2921LambdaBodyDefiniteReturnTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2921LambdaBodyDefiniteReturnTests.cs
@@ -26,9 +26,9 @@ public class Issue2921LambdaBodyDefiniteReturnTests
             func G(f (int32) -> int32) int32 { return f(1) }
             func F(x int32) int32 {
                 return G(func(v int32) int32 {
-                    for {
+                    outer: for {
                         switch v {
-                            case 1 { break }
+                            case 1 { break outer }
                             default { return 1 }
                         }
                     }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2890SwitchSelectEscapingBranchFlowTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2890SwitchSelectEscapingBranchFlowTests.cs
@@ -20,7 +20,7 @@ namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 public class Issue2890SwitchSelectEscapingBranchFlowTests
 {
     [Fact]
-    public void BreakOutOfPatternSwitchArm_ReportsGs0100()
+    public void BreakOutOfPatternSwitchArm_ExitsSwitchAndBindsClean()
     {
         const string Source = """
             package Issue2890.SwitchBreak
@@ -34,11 +34,11 @@ public class Issue2890SwitchSelectEscapingBranchFlowTests
             }
             """;
 
-        AssertOnlyGs0100(Source);
+        AssertBindsClean(Source);
     }
 
     [Fact]
-    public void BreakOutOfSelectDefaultArm_ReportsGs0100()
+    public void BreakOutOfSelectDefaultArm_ExitsSelectAndBindsClean()
     {
         const string Source = """
             package Issue2890.SelectBreak
@@ -53,11 +53,11 @@ public class Issue2890SwitchSelectEscapingBranchFlowTests
             }
             """;
 
-        AssertOnlyGs0100(Source);
+        AssertBindsClean(Source);
     }
 
     [Fact]
-    public void BreakOutOfRealSelectArm_ReportsGs0100()
+    public void BreakOutOfRealSelectArm_ExitsSelectAndBindsClean()
     {
         const string Source = """
             package Issue2890.SelectRealBreak
@@ -75,11 +75,11 @@ public class Issue2890SwitchSelectEscapingBranchFlowTests
             }
             """;
 
-        AssertOnlyGs0100(Source);
+        AssertBindsClean(Source);
     }
 
     [Fact]
-    public void BreakOutOfNestedPatternSwitchArm_ReportsGs0100()
+    public void BreakOutOfNestedPatternSwitchArm_ExitsInnerSwitchAndBindsClean()
     {
         const string Source = """
             package Issue2890.NestedSwitchBreak
@@ -98,7 +98,7 @@ public class Issue2890SwitchSelectEscapingBranchFlowTests
             }
             """;
 
-        AssertOnlyGs0100(Source);
+        AssertBindsClean(Source);
     }
 
     [Fact]
@@ -162,7 +162,7 @@ public class Issue2890SwitchSelectEscapingBranchFlowTests
     }
 
     [Fact]
-    public void PatternSwitchInsideFixedBreak_ReportsGs0100()
+    public void PatternSwitchInsideFixedBreak_ExitsSwitchAndBindsClean()
     {
         const string Source = """
             package Issue2890.SwitchFixedBreak
@@ -180,11 +180,11 @@ public class Issue2890SwitchSelectEscapingBranchFlowTests
             }
             """;
 
-        AssertOnlyGs0100(Source);
+        AssertBindsClean(Source);
     }
 
     [Fact]
-    public void PatternSwitchInsideScopeBreak_ReportsGs0100()
+    public void PatternSwitchInsideScopeBreak_ExitsSwitchAndBindsClean()
     {
         const string Source = """
             package Issue2890.SwitchScopeBreak
@@ -201,7 +201,7 @@ public class Issue2890SwitchSelectEscapingBranchFlowTests
             }
             """;
 
-        AssertOnlyGs0100(Source);
+        AssertBindsClean(Source);
     }
 
     [Fact]
@@ -240,7 +240,7 @@ public class Issue2890SwitchSelectEscapingBranchFlowTests
     }
 
     [Fact]
-    public void FalseGuardArmBreak_ReportsGs0100()
+    public void FalseGuardArmBreak_ExitsSwitchAndBindsClean()
     {
         const string Source = """
             package Issue2890.FalseGuardBreak
@@ -255,7 +255,7 @@ public class Issue2890SwitchSelectEscapingBranchFlowTests
             }
             """;
 
-        AssertOnlyGs0100(Source);
+        AssertBindsClean(Source);
     }
 
     [Fact]
@@ -395,7 +395,7 @@ public class Issue2890SwitchSelectEscapingBranchFlowTests
     }
 
     [Fact]
-    public void LiteralSwitchImpossibleEscapingArms_ReportsGs0100()
+    public void LiteralSwitchImpossibleEscapingArms_ExitSwitchAndBindClean()
     {
         const string Source = """
             package Issue2890.LiteralSwitch
@@ -411,7 +411,7 @@ public class Issue2890SwitchSelectEscapingBranchFlowTests
             }
             """;
 
-        AssertOnlyGs0100(Source);
+        AssertBindsClean(Source);
     }
 
     [Fact]
@@ -465,6 +465,19 @@ public class Issue2890SwitchSelectEscapingBranchFlowTests
             """;
 
         AssertNoErrors(Source);
+    }
+
+
+    // Issue #3501 A3: an unlabeled `break` inside a switch/select arm now
+    // exits the switch/select (Go/C# alignment), so the enclosing infinite
+    // `for` never terminates and the function binds clean — the shapes above
+    // stopped being GS0100 escapes. Labeled break still targets the loop and
+    // keeps its GS0100 coverage (see the Labeled* tests).
+    private static void AssertBindsClean(string source)
+    {
+        var (result, _) = Compile(source);
+        Assert.Empty(result.Diagnostics.Where(candidate => candidate.IsError));
+        Assert.True(result.Success);
     }
 
     private static void AssertOnlyGs0100(string source)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2891TryRegionFlowTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2891TryRegionFlowTests.cs
@@ -243,11 +243,11 @@ public class Issue2891TryRegionFlowTests
             """);
         yield return Case("TryInsideSwitchArmBreak", """
             func F(x int32) int32 {
-                for {
+                outer: for {
                     switch x {
                         default {
                             try {
-                                break
+                                break outer
                             } finally {
                             }
                         }
@@ -257,10 +257,10 @@ public class Issue2891TryRegionFlowTests
             """);
         yield return Case("SwitchInsideTryBreak", """
             func F(x int32) int32 {
-                for {
+                outer: for {
                     try {
                         switch x {
-                            default { break }
+                            default { break outer }
                         }
                     } finally {
                     }
@@ -270,11 +270,11 @@ public class Issue2891TryRegionFlowTests
         yield return Case("TryInsideSelectBreak", """
             import Gsharp.Extensions.Go
             func F() int32 {
-                for {
+                outer: for {
                     select {
                         default {
                             try {
-                                break
+                                break outer
                             } finally {
                             }
                         }
@@ -285,10 +285,10 @@ public class Issue2891TryRegionFlowTests
         yield return Case("SelectInsideTryBreak", """
             import Gsharp.Extensions.Go
             func F() int32 {
-                for {
+                outer: for {
                     try {
                         select {
-                            default { break }
+                            default { break outer }
                         }
                     } finally {
                     }

--- a/test/Core.Tests/CodeAnalysis/Binding/SwitchStatementTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/SwitchStatementTests.cs
@@ -104,8 +104,12 @@ public class SwitchStatementTests
     }
 
     [Fact]
-    public void Fallthrough_Reports_Error()
+    public void Fallthrough_ToPlainConstantArm_BindsClean()
     {
+        // Issue #3501 A3: `fallthrough` gained Go semantics — a trailing
+        // fallthrough into a binding-free arm is legal (the target's
+        // body-local declarations still run normally). Misuse coverage lives
+        // in Issue3501SwitchFamilyTests (GS0168/GS0533/GS0534).
         var src = @"func F() {
  var x = 1
  switch x {
@@ -114,8 +118,7 @@ public class SwitchStatementTests
  }
 }
 ";
-        var diagnostics = Bind(src);
-        Assert.Contains(diagnostics, d => d.Message.Contains("fallthrough", System.StringComparison.OrdinalIgnoreCase));
+        Assert.Empty(Bind(src));
     }
 
     [Fact]

--- a/test/Core.Tests/CodeAnalysis/Issue3501SwitchFamilyTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Issue3501SwitchFamilyTests.cs
@@ -1,0 +1,270 @@
+// <copyright file="Issue3501SwitchFamilyTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis;
+
+/// <summary>
+/// Issue #3501 Track A3: switch-family C#/Go alignment. An unlabeled
+/// <c>break</c> in an arm exits the switch (loops nested in an arm keep
+/// their own binding; <c>continue</c> still targets the enclosing loop);
+/// <c>case 1, 2 { … }</c> comma multi-pattern arms are sugar for the
+/// ADR-0166 <c>or</c> combinator; and <c>fallthrough</c> (previously
+/// reserved-and-rejected) gets Go semantics — last statement of a
+/// non-final arm, transfers into the next arm's body skipping its pattern
+/// test and guard.
+/// </summary>
+public class Issue3501SwitchFamilyTests
+{
+    [Fact]
+    public void BreakInArm_ExitsSwitch()
+    {
+        var source = @"
+func Run() string {
+    var log = """"
+    switch 1 {
+        case 1 {
+            log = log + ""a""
+            break
+            log = log + ""b""
+        }
+        default {
+            log = log + ""d""
+        }
+    }
+    return log + ""!""
+}
+
+Run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal("a!", result.Value);
+    }
+
+    [Fact]
+    public void BreakInLoopInsideArm_ExitsLoopNotSwitch()
+    {
+        var source = @"
+func Run() string {
+    var log = """"
+    switch 1 {
+        case 1 {
+            for var i = 0; i < 5; i += 1 {
+                if i == 2 {
+                    break
+                }
+                log = log + ""i""
+            }
+            log = log + ""post""
+        }
+        default {
+        }
+    }
+    return log
+}
+
+Run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal("iipost", result.Value);
+    }
+
+    [Fact]
+    public void ContinueInArm_TargetsEnclosingLoop()
+    {
+        var source = @"
+func Run() string {
+    var log = """"
+    for var i = 0; i < 3; i += 1 {
+        switch i {
+            case 1 {
+                continue
+            }
+            default {
+            }
+        }
+        log = log + ""x""
+    }
+    return log
+}
+
+Run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal("xx", result.Value);
+    }
+
+    [Fact]
+    public void CommaArms_MatchAnyListedPattern()
+    {
+        var source = @"
+func Describe(n int32) string {
+    switch n {
+        case 1, 2, 3 {
+            return ""small""
+        }
+        case 10 {
+            return ""ten""
+        }
+        default {
+            return ""big""
+        }
+    }
+}
+
+Describe(2) + Describe(10) + Describe(99)
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal("smalltenbig", result.Value);
+    }
+
+    [Fact]
+    public void Fallthrough_ChainsIntoNextArmSkippingItsTest()
+    {
+        var source = @"
+func Chain(n int32) string {
+    var log = """"
+    switch n {
+        case 1 {
+            log = log + ""1""
+            fallthrough
+        }
+        case 2 {
+            log = log + ""2""
+            fallthrough
+        }
+        default {
+            log = log + ""d""
+        }
+    }
+    return log
+}
+
+Chain(1) + ""|"" + Chain(2) + ""|"" + Chain(9)
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal("12d|2d|d", result.Value);
+    }
+
+    [Fact]
+    public void Fallthrough_NotLastStatement_ReportsGS0168()
+    {
+        var source = @"
+func Run() {
+    switch 1 {
+        case 1 {
+            fallthrough
+            var x = 1
+        }
+        default {
+        }
+    }
+}
+
+Run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0168");
+    }
+
+    [Fact]
+    public void Fallthrough_InFinalArm_ReportsGS0533()
+    {
+        var source = @"
+func Run() {
+    switch 1 {
+        case 1 {
+            fallthrough
+        }
+    }
+}
+
+Run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0533");
+    }
+
+    [Fact]
+    public void Fallthrough_IntoBindingArm_ReportsGS0534()
+    {
+        var source = @"
+func Run(v object) {
+    switch v {
+        case 1 {
+            fallthrough
+        }
+        case string s {
+            System.Console.WriteLine(s)
+        }
+        default {
+        }
+    }
+}
+
+Run(1)
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0534");
+    }
+
+    [Fact]
+    public void BreakInArm_DoesNotSatisfyAllPathsReturn()
+    {
+        var source = @"
+func F(n int32) int32 {
+    switch n {
+        case 1 {
+            break
+        }
+        default {
+            return 10
+        }
+    }
+}
+
+F(1)
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0100");
+    }
+
+    [Fact]
+    public void ConstantDiscriminant_WithFallthrough_KeepsAllArms()
+    {
+        // The lowerer's constant-discriminant fast path must not drop the
+        // fallthrough target arm.
+        var source = @"
+func Run() string {
+    var log = """"
+    switch 1 {
+        case 1 {
+            log = log + ""one""
+            fallthrough
+        }
+        case 2 {
+            log = log + ""two""
+        }
+        default {
+            log = log + ""def""
+        }
+    }
+    return log
+}
+
+Run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal("onetwo", result.Value);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue1675SyntaxNodeChildEnumerationTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue1675SyntaxNodeChildEnumerationTests.cs
@@ -76,6 +76,9 @@ public class Issue1675SyntaxNodeChildEnumerationTests
         // infinite for
         "package p\nfunc F() {\n  for {\n    break\n  }\n}\n",
 
+        // issue #3501 A3: fallthrough statement + comma multi-pattern arm
+        "package p\nfunc F(v int32) {\n  switch v {\n    case 1, 2 {\n      fallthrough\n    }\n    default {\n    }\n  }\n}\n",
+
         // unsafe: fixed, stackalloc, sizeof, indirect assignment
         "package p\nunsafe func F(dest []uint8) {\n  fixed pD *uint8 = dest { }\n  var buf = stackalloc [4]uint8\n  let sz = sizeof(int32)\n  var x = 1\n  var px = &x\n  *px = 2\n}\n",
 

--- a/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
+++ b/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
@@ -89,6 +89,7 @@ EventSubscriptionExpression
 ExpressionCollectionElement
 ExpressionStatement
 FallthroughKeyword
+FallthroughStatement
 FalseKeyword
 FieldAccessExpression
 FieldAssignmentExpression

--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GStatement.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GStatement.cs
@@ -704,6 +704,14 @@ public sealed class SwitchStatementCase : GNode
     /// <summary>Gets the arm pattern, or <see langword="null"/> for the <c>default</c> arm.</summary>
     public GPattern Pattern { get; }
 
+    /// <summary>
+    /// Gets or sets the additional comma-joined patterns of a Go-style
+    /// multi-pattern arm (issue #3501 A3: <c>case 1, 2, 3 { … }</c>).
+    /// Empty for a single-pattern arm. Only meaningful when
+    /// <see cref="Pattern"/> is non-null.
+    /// </summary>
+    public IReadOnlyList<GPattern> AdditionalPatterns { get; set; } = System.Array.Empty<GPattern>();
+
     /// <summary>Gets the arm body block.</summary>
     public BlockStatement Body { get; }
 
@@ -774,6 +782,16 @@ public sealed class BreakStatement : GStatement
 /// <c>continue;</c> directly.
 /// </summary>
 public sealed class ContinueStatement : GStatement
+{
+}
+
+/// <summary>
+/// A <c>fallthrough</c> statement (issue #3501 A3, Go semantics): legal
+/// only as the last statement of a non-final <c>switch</c> arm; transfers
+/// into the next arm's body without evaluating its pattern. The canonical
+/// translation of an adjacent-target C# <c>goto case</c>/<c>goto default</c>.
+/// </summary>
+public sealed class FallthroughStatement : GStatement
 {
 }
 

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -1344,6 +1344,9 @@ public static class GSharpPrinter
             case ContinueStatement:
                 return $"{pad}continue";
 
+            case FallthroughStatement:
+                return $"{pad}fallthrough";
+
             case GotoStatement gotoStatement:
                 return $"{pad}goto {gotoStatement.Label}";
 
@@ -1389,7 +1392,12 @@ public static class GSharpPrinter
             }
             else
             {
-                head = $"case {RenderPattern(arm.Pattern, indent + 1)}";
+                // Issue #3501 A3: a merged multi-label arm renders as the
+                // Go-style comma list `case 1, 2, 3`.
+                string patterns = string.Join(
+                    ", ",
+                    new[] { arm.Pattern }.Concat(arm.AdditionalPatterns).Select(p => RenderPattern(p, indent + 1)));
+                head = $"case {patterns}";
             }
 
             sb.Append($"{head} {RenderBlock(arm.Body, indent + 1)}");

--- a/tools/cs2gs/Cs2Gs.Tests/Coverage/GNodeSamples.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Coverage/GNodeSamples.cs
@@ -181,6 +181,9 @@ public static class GNodeSamples
                 body: Block(new YieldStatement(Int("1"))))),
             [typeof(BreakStatement)] = () => Stmts(new WhileStatement(Id("c"), Block(new BreakStatement()))),
             [typeof(ContinueStatement)] = () => Stmts(new WhileStatement(Id("c"), Block(new ContinueStatement()))),
+            [typeof(FallthroughStatement)] = () => Stmts(new SwitchStatement(Id("v"), List(
+                new SwitchStatementCase(new ConstantPattern(Int("0")), Block(new FallthroughStatement())),
+                new SwitchStatementCase(null, Block())))),
             [typeof(GotoStatement)] = () => Stmts(new GotoStatement("retry")),
             [typeof(LabeledStatement)] = () => Stmts(new LabeledStatement("retry", new GotoStatement("retry"))),
             [typeof(DoWhileStatement)] = () => Stmts(new DoWhileStatement(Block(), Id("c"))),

--- a/tools/cs2gs/Cs2Gs.Tests/Coverage/code-model-surface.golden.txt
+++ b/tools/cs2gs/Cs2Gs.Tests/Coverage/code-model-surface.golden.txt
@@ -54,6 +54,7 @@ ContinueStatement
 DeferStatement
 DoWhileStatement
 ExpressionStatement
+FallthroughStatement
 FixedStatement
 ForInStatement
 ForStatement

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1884GotoLabelTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1884GotoLabelTranslationTests.cs
@@ -79,10 +79,48 @@ namespace Corpus.Issue1884
 }
 ");
 
-        // The `goto case 2;` lowers to a `goto` of a synthesized label
-        // (`__gotoCase<pos>`) placed at the top of case 2's translated body.
+        // Issue #3501 A3: the trailing `goto case 2;` targets the LEXICALLY
+        // NEXT arm, so it is exactly Go's `fallthrough` — the native gsc
+        // statement replaces the synthesized-label lowering.
+        Assert.Contains("fallthrough", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("__gotoCase", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void GotoCase_NonAdjacentTarget_StillLowersToSynthesizedLabel()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1884
+{
+    public class Switcher
+    {
+        public string Run(int value)
+        {
+            string trace = """";
+            switch (value)
+            {
+                case 1:
+                    trace += ""one"";
+                    goto case 3;
+                case 2:
+                    trace += ""two"";
+                    break;
+                case 3:
+                    trace += ""three"";
+                    break;
+            }
+
+            return trace;
+        }
+    }
+}
+");
+
+        // A goto that skips over an arm cannot be a fallthrough; it keeps
+        // the synthesized-label lowering (issue #1884).
         Assert.Contains("goto __gotoCase", rendered, StringComparison.Ordinal);
-        Assert.Contains("__gotoCase", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("fallthrough", rendered, StringComparison.Ordinal);
         AssertRoundTripParses(rendered);
     }
 
@@ -113,8 +151,11 @@ namespace Corpus.Issue1884
 }
 ");
 
-        Assert.Contains("goto __gotoDefault", rendered, StringComparison.Ordinal);
-        Assert.Contains("__gotoDefault", rendered, StringComparison.Ordinal);
+        // Issue #3501 A3: `goto default` targeting the lexically next arm is
+        // Go's `fallthrough`; the synthesized-label lowering remains only for
+        // non-adjacent targets (see GotoCase_NonAdjacentTarget test).
+        Assert.Contains("fallthrough", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("__gotoDefault", rendered, StringComparison.Ordinal);
         AssertRoundTripParses(rendered);
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2462NestedSwitchBreakTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2462NestedSwitchBreakTranslationTests.cs
@@ -72,7 +72,13 @@ namespace Demo
     }
 }");
 
-        Assert.DoesNotContain("break", printed, StringComparison.Ordinal);
+        // Issue #3501 A3: section-terminal breaks (even through transparent
+        // block nesting) still vanish — a G# arm ends there naturally. The
+        // conditional/protected-region breaks that DO have observable flow
+        // now keep the `break` spelling (gsc break exits the switch) instead
+        // of the retired `goto __switchExit` lowering.
+        Assert.DoesNotContain("__switchExit", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("case 0 {\n            break", printed, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -172,9 +178,13 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("goto __switchExit", printed, StringComparison.Ordinal);
-        Assert.Contains("__switchExit", printed, StringComparison.Ordinal);
-        Assert.DoesNotContain("break", printed, StringComparison.Ordinal);
+        // Issue #3501 A3: gsc `break` now exits the switch, so the
+        // non-terminal C# break keeps its spelling — no `goto __switchExit`
+        // lowering — and the stacked `case 1: case 2:` labels merge into one
+        // comma arm instead of duplicating the body.
+        Assert.DoesNotContain("__switchExit", printed, StringComparison.Ordinal);
+        Assert.Contains("break", printed, StringComparison.Ordinal);
+        Assert.Contains("case 1, 2", printed, StringComparison.Ordinal);
         Assert.Equal("start|done", CompileAndRun(printed, "C.Run(1, true)").Trim());
         Assert.Equal("startafter|done", CompileAndRun(printed, "C.Run(2, false)").Trim());
         Assert.Equal("default|done", CompileAndRun(printed, "C.Run(9, true)").Trim());
@@ -210,7 +220,11 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("goto __gotoCase", printed, StringComparison.Ordinal);
+        // Issue #3501 A3: `goto case 1` in case 0 targets the lexically next
+        // arm, so it prints as the native `fallthrough`; `goto default` in
+        // case 2 skips over case 3 and keeps the synthesized-label lowering.
+        Assert.Contains("fallthrough", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("__gotoCase", printed, StringComparison.Ordinal);
         Assert.Contains("goto __gotoDefault", printed, StringComparison.Ordinal);
         Assert.Contains("tagged:", printed, StringComparison.Ordinal);
         Assert.Contains("return 1", printed, StringComparison.Ordinal);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2552NestedBreakTargetTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2552NestedBreakTargetTests.cs
@@ -139,8 +139,12 @@ namespace Demo
     {
         string printed = TranslateAndValidate(Source);
 
-        Assert.Equal(2, CountOccurrences(printed, "break"));
-        Assert.Equal(2, CountOccurrences(printed, "goto __switchExit"));
+        // Issue #3501 A3: gsc `break` exits the innermost switch OR loop
+        // (C#/Go alignment), so the switch-targeting breaks keep their
+        // spelling — the `goto __switchExit` lowering is retired. Two loop
+        // breaks + two switch breaks.
+        Assert.Equal(4, CountOccurrences(printed, "break"));
+        Assert.Equal(0, CountOccurrences(printed, "goto __switchExit"));
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
@@ -1441,6 +1441,15 @@ public sealed partial class CSharpToGSharpTranslator
             {
                 case SyntaxKind.GotoCaseStatement:
                 case SyntaxKind.GotoDefaultStatement:
+                    // Issue #3501 A3: a trailing `goto case`/`goto default`
+                    // that targets the LEXICALLY NEXT section is exactly Go's
+                    // `fallthrough` — the native gsc statement replaces the
+                    // synthesized-label lowering below.
+                    if (this.IsAdjacentFallthroughGoto(gotoStatement))
+                    {
+                        return new[] { (GStatement)new FallthroughStatement() };
+                    }
+
                     // ADR-0139 / issue #1884: `goto case K;` jumps to the
                     // statement list of the case labeled with the constant K
                     // WITHOUT re-evaluating the switch subject; `goto default;`
@@ -1527,6 +1536,50 @@ public sealed partial class CSharpToGSharpTranslator
             => this.SyntheticLabelName(
                 label is DefaultSwitchLabelSyntax ? "gotoDefault" : "gotoCase",
                 label);
+
+        /// <summary>
+        /// Issue #3501 A3: true when a <c>goto case</c>/<c>goto default</c>
+        /// is exactly Go's <c>fallthrough</c>: it is the DIRECT last
+        /// statement of a single-label section (so the section prints as one
+        /// G# arm), and it targets a label of the LEXICALLY NEXT section
+        /// whose labels are all binding-free (constants or <c>default</c> —
+        /// gsc rejects fallthrough into an arm with pattern bindings or a
+        /// guard). Such gotos print as the native <c>fallthrough</c>
+        /// statement and need no synthesized arm-top label.
+        /// </summary>
+        private bool IsAdjacentFallthroughGoto(GotoStatementSyntax gotoStatement)
+        {
+            if (gotoStatement.Kind() is not (SyntaxKind.GotoCaseStatement or SyntaxKind.GotoDefaultStatement))
+            {
+                return false;
+            }
+
+            SwitchSectionSyntax section = gotoStatement.Ancestors().OfType<SwitchSectionSyntax>().FirstOrDefault();
+            if (section == null
+                || section.Statements.LastOrDefault() != gotoStatement
+                || section.Labels.Count != 1)
+            {
+                return false;
+            }
+
+            if (section.Parent is not SwitchStatementSyntax switchStatement
+                || gotoStatement.Ancestors().OfType<SwitchStatementSyntax>().FirstOrDefault() != switchStatement)
+            {
+                return false;
+            }
+
+            int sectionIndex = switchStatement.Sections.IndexOf(section);
+            if (sectionIndex < 0 || sectionIndex + 1 >= switchStatement.Sections.Count)
+            {
+                return false;
+            }
+
+            SwitchSectionSyntax nextSection = switchStatement.Sections[sectionIndex + 1];
+            SwitchLabelSyntax resolvedTarget = this.ResolveGotoCaseOrDefaultTarget(gotoStatement);
+            return resolvedTarget != null
+                && nextSection.Labels.Contains(resolvedTarget)
+                && nextSection.Labels.All(l => l is CaseSwitchLabelSyntax or DefaultSwitchLabelSyntax);
+        }
 
         private GStatement TranslateThrow(ThrowStatementSyntax throwStatement)
         {

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
@@ -852,22 +852,19 @@ public sealed partial class CSharpToGSharpTranslator
             GExpression subject = this.TranslateExpression(node.Expression);
             var cases = new List<SwitchStatementCase>();
 
-            // Issue #2462: a non-terminal break still has observable control
-            // flow after C# switch terminators are removed. Lower it to a jump
-            // past the translated switch and emit that target only when needed.
-            bool needsExitLabel = node.DescendantNodes()
-                .OfType<BreakStatementSyntax>()
-                .Any(b => GetBreakTarget(b) == node && !IsRedundantSwitchSectionBreak(b));
-
             // Issue #1884: a `goto case K;` / `goto default;` anywhere in this
             // switch (but not in a nested switch, whose own gotos target its
             // own labels) needs a synthesized label at the top of the arm it
             // targets, so the goto can be lowered to a plain `goto`.
+            // Issue #3501 A3: gotos that qualify as adjacent fallthroughs
+            // print as the native `fallthrough` statement and need no
+            // synthesized arm-top label.
             var gotoTargets = new HashSet<SwitchLabelSyntax>(
                 node.DescendantNodes()
                     .OfType<GotoStatementSyntax>()
                     .Where(g => (g.Kind() == SyntaxKind.GotoCaseStatement || g.Kind() == SyntaxKind.GotoDefaultStatement)
-                             && g.Ancestors().OfType<SwitchStatementSyntax>().First() == node)
+                             && g.Ancestors().OfType<SwitchStatementSyntax>().First() == node
+                             && !this.IsAdjacentFallthroughGoto(g))
                     .Select(this.ResolveGotoCaseOrDefaultTarget)
                     .Where(target => target != null));
 
@@ -880,6 +877,30 @@ public sealed partial class CSharpToGSharpTranslator
                 // label's bindings (issue #1730) must be installed before the body
                 // is translated, and bindings can differ across stacked labels.
                 var labels = section.Labels.ToList();
+
+                // Issue #3501 A3: a section stacking multiple CONSTANT labels
+                // becomes ONE Go-style comma arm (`case 1, 2 { … }`) with the
+                // body translated once, instead of duplicating the body per
+                // label. Pattern labels keep the per-label form (their
+                // bindings can differ), and goto-targeted labels keep their
+                // own arms so `goto case K` still has a distinct target.
+                if (labels.Count > 1
+                    && labels.All(l => l is CaseSwitchLabelSyntax)
+                    && !labels.Any(gotoTargets.Contains))
+                {
+                    var constantLabels = labels.Cast<CaseSwitchLabelSyntax>().ToList();
+                    var mergedArm = new SwitchStatementCase(
+                        new ConstantPattern(this.TranslateExpression(constantLabels[0].Value)),
+                        this.TranslateSwitchSectionBody(section))
+                    {
+                        AdditionalPatterns = constantLabels
+                            .Skip(1)
+                            .Select(l => (GPattern)new ConstantPattern(this.TranslateExpression(l.Value)))
+                            .ToList(),
+                    };
+                    cases.Add(mergedArm);
+                    continue;
+                }
 
                 foreach (SwitchLabelSyntax label in labels)
                 {
@@ -994,12 +1015,6 @@ public sealed partial class CSharpToGSharpTranslator
             }
 
             yield return new SwitchStatement(subject, cases);
-            if (needsExitLabel)
-            {
-                yield return new LabeledStatement(
-                    this.SwitchExitLabelName(node),
-                    new BlockStatement(new List<GStatement>()));
-            }
         }
 
         private bool RequiresEnumStatementFallback(SwitchStatementSyntax node)
@@ -1104,14 +1119,18 @@ public sealed partial class CSharpToGSharpTranslator
         private IEnumerable<GStatement> TranslateBreakStatement(BreakStatementSyntax node)
         {
             SyntaxNode target = GetBreakTarget(node);
-            if (target is SwitchStatementSyntax targetSwitch)
+            if (target is SwitchStatementSyntax)
             {
                 if (IsRedundantSwitchSectionBreak(node))
                 {
                     return System.Array.Empty<GStatement>();
                 }
 
-                return new[] { (GStatement)new GotoStatement(this.SwitchExitLabelName(targetSwitch)) };
+                // Issue #3501 A3: gsc `break` now exits the enclosing switch
+                // (C#/Go alignment), so a non-terminal C# switch break keeps
+                // its spelling — no `goto __switchExit` lowering, no trailing
+                // exit label.
+                return new[] { (GStatement)new BreakStatement() };
             }
 
             return new[] { (GStatement)new BreakStatement() };
@@ -1183,9 +1202,6 @@ public sealed partial class CSharpToGSharpTranslator
             this.state.SyntheticLabelNames[node] = name;
             return name;
         }
-
-        private string SwitchExitLabelName(SwitchStatementSyntax node)
-            => this.SyntheticLabelName("switchExit", node);
 
         private IEnumerable<GStatement> TranslateYieldStatement(YieldStatementSyntax node)
         {

--- a/tools/cs2gs/selfmig-baseline.json
+++ b/tools/cs2gs/selfmig-baseline.json
@@ -1,7 +1,7 @@
 {
-  "comment": "Issue #3501 Track C: ratcheting baseline for the repo self-migration gate (build/run-cs2gs-selfmig.sh). greenFloor is the minimum number of fully-green apps (translate+compile+ilverify+parity); the *Ceiling metrics cap readability regressions in the migrated output. Recalibrated 2026-08-23 after the #3503-#3507 merges plus the doc-line re-wrap fix (25 green; 84 synthetic labels; 77 __local_ lifts (A2 self-recursion retarget); 3625 lines >300 chars). Improve a metric, then tighten the corresponding number in the same PR.",
+  "comment": "Issue #3501 Track C: ratcheting baseline for the repo self-migration gate (build/run-cs2gs-selfmig.sh). greenFloor is the minimum number of fully-green apps (translate+compile+ilverify+parity); the *Ceiling metrics cap readability regressions in the migrated output. Recalibrated 2026-08-23 after the #3503-#3507 merges plus the doc-line re-wrap fix (25 green; 29 synthetic labels (A3 switch retarget); 77 __local_ lifts (A2 self-recursion retarget); 3637 lines >300 chars). Improve a metric, then tighten the corresponding number in the same PR.",
   "greenFloor": 25,
-  "syntheticLabelCeiling": 100,
+  "syntheticLabelCeiling": 40,
   "liftedLocalCeiling": 85,
   "longLineCeiling": 3700
 }

--- a/website/docs/ref/diagnostics.md
+++ b/website/docs/ref/diagnostics.md
@@ -130,7 +130,7 @@ IDs may be given as `GS0001`, `0001`, or the bare integer `1`; all three forms a
 | GS0165 | Error | Top-level statements may appear in at most one package per compilation. | Two or more `package` declarations in a single compilation each contain top-level statements. |
 | GS0166 | Warning | Top-level statements conflict with an explicit `Main` function. | Both top-level statements and a `func Main()` are present; TLS wins and the explicit `Main` is shadowed. |
 | GS0167 | Error | Multi-assignment target/value count mismatch. | `a, b = 1, 2, 3` — three values for two targets. |
-| GS0168 | Error | `fallthrough` is not supported. | `fallthrough` keyword used in a `switch` case body. |
+| GS0168 | Error | `fallthrough` must be the last statement of a `switch` case body. | `fallthrough` followed by more statements in the same case body (issue #3501 A3: a trailing `fallthrough` is now legal Go-style control flow). |
 | GS0169 | Error | Duplicate `default` arm in `switch`. | Two `default:` arms inside one `switch` statement. |
 | GS0170 | Error | Switch case value is not a constant expression. | `case x:` where `x` is a mutable variable. |
 | GS0171 | Error | Switch case type is incompatible with the switch expression. | `switch (s) { case 42: }` where `s` is `string`. |
@@ -801,6 +801,18 @@ field initializers (`p with { x = 10 }`) parse on separate paths and are unaffec
 | ID | Severity | Message | Example |
 |---|---|---|---|
 | GS0531 | Error | `Constructor initializer arguments cannot reference instance member '<name>' before the delegated or base constructor has run.` | `init() : base({ let self = this 1 }) { }` |
+
+## `fallthrough` placement (GS0533–GS0534)
+
+Issue #3501 A3: `fallthrough` gained Go semantics — legal only as the LAST
+statement of a non-final `switch` arm, transferring into the next arm's body
+without evaluating its pattern or guard. GS0168 (above) reports a misplaced
+`fallthrough`; these report the two structural misuses.
+
+| ID | Severity | Message | Example |
+|---|---|---|---|
+| GS0533 | Error | `'fallthrough' cannot be used in the final arm of a 'switch' statement.` | `switch x { case 1 { fallthrough } }` |
+| GS0534 | Error | `'fallthrough' cannot target a 'switch' arm whose pattern declares bindings or that has a 'when' guard — the jump would skip their assignment.` | `case 1 { fallthrough } case string s { ... }` |
 
 ## Pattern variable outside its definitely-assigned region (GS0532)
 


### PR DESCRIPTION
## What this does

Track A3 of #3501 — the switch family aligns with C#/Go, and cs2gs retires its switch-related synthetic-label lowerings.

### gsc

**`break` in a switch/select arm exits the switch/select** (previously GS0120). `continue` and labeled `break`/`continue` keep their loop binding — the switch/select pushes a `LoopStack` frame with a null continue label, and `continue` binding skips such frames. A used break appends the synthesized exit-label statement right after the construct, so exhaustive all-arms-return switches keep their unconditional-exit shape (`GS0100` verified unaffected: an arm ending in `break` still fails all-paths-return, and `for { switch { default { break } } }` is now a clean infinite loop).

**Comma multi-pattern arms** — `case 1, 2, 3 { … }` is parser sugar folding into the ADR-0166 `or` combinator; binding/emit unchanged.

**`fallthrough`** (reserved since ADR-0013, previously a blanket GS0168) gains Go semantics: legal only as the LAST statement of a non-final arm; lowers to a goto targeting the next arm's body-entry label, skipping that arm's pattern test and guard. Structural misuse diagnostics: GS0168 (not last statement), GS0533 (final arm), **GS0534** (target arm declares pattern bindings or has a `when` guard — the jump would skip their assignment). The lowerer's constant-discriminant fast path bails out when an arm is a fallthrough target so the chain survives. Fallthrough context is isolated from lambda bodies (nested-frame save/clear/restore, same as the loop stack).

### cs2gs retarget

- Non-terminal C# switch `break`s keep the `break` spelling — the `goto __switchExit` lowering and its trailing label are **retired**.
- A section stacking multiple constant labels merges into **one comma arm** with the body translated once (previously duplicated per label). Pattern labels and goto-targeted labels keep the per-label form.
- A trailing `goto case`/`goto default` targeting the lexically next binding-free arm prints as native **`fallthrough`**; non-adjacent targets keep the issue-#1884 synthesized-label lowering.

### Self-migration impact (merged with main = A1+A2+A5+B fixes)

| metric | before | after | ceiling |
|---|---|---|---|
| green apps | 25/55 | 25/55 | floor 25 |
| synthetic labels | 84 | **29** | **100 → 40** |
| `__local_` lifts | 77 | 77 | 85 |
| lines >300 chars | 3627 | 3637 (+10 from comma arms) | 3700 |

## Intended semantic change

Unlabeled `break` inside a switch/select arm previously bound to the enclosing **loop**; it now exits the **switch/select** (the C#/Go rule, and the 1:1 translation target for C# switches). Existing tests that encoded the old binding were updated: the Issue2890/2891 escape shapes either bind clean now (infinite loop) or use labeled breaks to keep their try-region-escape coverage. `docs/diagnostics.md` + website reference updated; syntax corpus, coverage-matrix, and code-model-surface goldens extended.

## Verification

- Core.Tests **8049/8049** green on the merged branch (10 new `Issue3501SwitchFamilyTests`).
- Cs2Gs.Tests **2358/2358** green (switch-translation expectations updated; new non-adjacent `goto case` test).
- LanguageServer + analyzers build clean.
- Full self-migration gate PASSED with the ratcheted baseline.

Closes the A3 track of #3501 — with it, Tracks A1–A5, B1–B3, and C1 are all shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgrKRVPGaEm9zLaYvankA1