### PR TITLE
gsc: reference-variant method groups bind at native function-type slots (#3505)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -1639,6 +1639,31 @@ public sealed class Conversion
     }
 
     /// <summary>
+    /// Issue #3505: true when <paramref name="from"/> implicitly converts to
+    /// <paramref name="to"/> AND both ends are reference-like — the only
+    /// variance a directly-created delegate can honor. Boxing, numeric
+    /// widening, and nullable lifts ride the general implicit lattice but
+    /// require a real coercion at the boundary, which neither CLR delegate
+    /// variance nor a target-typed <c>ldftn</c>+<c>newobj</c> binding can
+    /// perform.
+    /// </summary>
+    /// <param name="from">The value-producing side of the slot.</param>
+    /// <param name="to">The value-consuming side of the slot.</param>
+    /// <returns><see langword="true"/> for a strict implicit reference conversion.</returns>
+    internal static bool IsImplicitReferenceVariantSlot(TypeSymbol from, TypeSymbol to)
+    {
+        if (from == null || to == null
+            || from == TypeSymbol.Void || to == TypeSymbol.Void
+            || !IsReferenceLikeTarget(from) || !IsReferenceLikeTarget(to))
+        {
+            return false;
+        }
+
+        var conversion = ClassifyNonStructural(from, to);
+        return conversion.Exists && conversion.IsImplicit && !conversion.IsStructuralProjection;
+    }
+
+    /// <summary>
     /// True when <paramref name="type"/> is a reference-capable type for
     /// conversion purposes — a G# interface, a G# <c>class</c> (as opposed to
     /// a value-kind <c>struct</c>), a reference-constrained type parameter, or
@@ -2432,9 +2457,12 @@ public sealed class Conversion
         for (var i = 0; i < from.Arity; i++)
         {
             // Function parameters are contravariant: every value the target
-            // may supply must be accepted by the source callable.
-            var parameterConversion = ClassifyNonStructural(to.ParameterTypes[i], from.ParameterTypes[i]);
-            if (!parameterConversion.IsImplicit
+            // may supply must be accepted by the source callable. Issue #3505:
+            // the relaxation is restricted to REFERENCE conversions — CLR
+            // delegate variance cannot box, so a value-type difference (e.g.
+            // `(object) -> R` into an `(int32) -> R` slot) used to compile
+            // and then NRE at runtime. Value-typed slots must match exactly.
+            if (!IsImplicitReferenceVariantSlot(to.ParameterTypes[i], from.ParameterTypes[i])
                 && !TypeSymbol.AreRuntimeEquivalentIgnoringReferenceNullability(
                     to.ParameterTypes[i],
                     from.ParameterTypes[i]))

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -465,7 +465,15 @@ internal sealed class ConversionClassifier
 
         // ADR-0063 §9: a user-function method group with multiple candidates
         // resolves here against the target delegate/function-type signature.
-        if (expression is BoundMethodGroupExpression { FunctionType: null } userMethodGroup)
+        // Issue #3505: an ALREADY-resolved group whose function type differs
+        // from a native function-type target re-resolves here too, so a
+        // reference-variant slot binds the delegate AT the target type — the
+        // fall-through path would wrap it in a delegate-to-delegate variance
+        // conversion the emitter cannot express.
+        if (expression is BoundMethodGroupExpression userMethodGroup
+            && (userMethodGroup.FunctionType == null
+                || (type is FunctionTypeSymbol targetFn
+                    && HasReferenceVariantSlotMismatch(userMethodGroup.FunctionType, targetFn))))
         {
             return BindUserMethodGroupConversion(diagnosticLocation, userMethodGroup, type);
         }
@@ -1758,6 +1766,14 @@ internal sealed class ConversionClassifier
         ImmutableArray<TypeSymbol> pickMethodTypeArguments = default;
         TypeSymbol[]? pickParameterTypes = null;
         TypeSymbol? pickReturnType = null;
+
+        // Issue #3505: exact-signature candidates are preferred; the
+        // reference-variance relaxation only runs as a second pass when no
+        // candidate matched exactly, mirroring C#'s better-function-member
+        // preference for identity conversions.
+        for (var selectionPass = 0; selectionPass < 2 && pick == null; selectionPass++)
+        {
+        var allowVariance = selectionPass == 1;
         foreach (var candidate in group.Candidates)
         {
             var candidateOwner = group.StaticOwnerType != null && candidate.StaticOwnerType is StructSymbol declaredOwner
@@ -1792,7 +1808,9 @@ internal sealed class ConversionClassifier
                     || !TryCanonicalizeMethodGroupType(
                         candidateParameterTypes[i],
                         targetParameterTypes[i],
-                        out candidateParameterTypes[i]))
+                        out candidateParameterTypes[i],
+                        parameterPosition: true,
+                        allowVariance: allowVariance))
                 {
                     paramsMatch = false;
                     break;
@@ -1807,7 +1825,9 @@ internal sealed class ConversionClassifier
             if (!TryCanonicalizeMethodGroupType(
                 canonicalCandidateReturn,
                 targetReturnType,
-                out canonicalCandidateReturn))
+                out canonicalCandidateReturn,
+                parameterPosition: false,
+                allowVariance: allowVariance))
             {
                 continue;
             }
@@ -1839,6 +1859,7 @@ internal sealed class ConversionClassifier
             pickMethodTypeArguments = candidateMethodTypeArguments;
             pickParameterTypes = candidateParameterTypes;
             pickReturnType = canonicalCandidateReturn;
+        }
         }
 
         if (pick == null)
@@ -2716,10 +2737,59 @@ internal sealed class ConversionClassifier
         return ClrTypeUtilities.IsAssignableByName(invokeReturn, methodReturn);
     }
 
+    /// <summary>
+    /// Issue #3505: true when <paramref name="from"/> and <paramref name="to"/>
+    /// share an arity and differ in at least one slot by a strict implicit
+    /// REFERENCE conversion (contravariant parameters, covariant return) with
+    /// every remaining slot runtime-equivalent. Such a group must re-resolve
+    /// AT the target type — the generic conversion path would wrap it in a
+    /// delegate-to-delegate variance conversion the emitter cannot express.
+    /// Shapes that differ any other way stay on the generic path so its
+    /// richer equivalence rules (and diagnostics) apply.
+    /// </summary>
+    private static bool HasReferenceVariantSlotMismatch(FunctionTypeSymbol from, FunctionTypeSymbol to)
+    {
+        if (from == null || to == null || from.Arity != to.Arity)
+        {
+            return false;
+        }
+
+        var anyVariant = false;
+        for (var i = 0; i < from.Arity; i++)
+        {
+            if (TypeSymbol.AreRuntimeEquivalentIgnoringReferenceNullability(from.ParameterTypes[i], to.ParameterTypes[i]))
+            {
+                continue;
+            }
+
+            if (Conversion.IsImplicitReferenceVariantSlot(to.ParameterTypes[i], from.ParameterTypes[i]))
+            {
+                anyVariant = true;
+                continue;
+            }
+
+            return false;
+        }
+
+        if (!TypeSymbol.AreRuntimeEquivalentIgnoringReferenceNullability(from.ReturnType, to.ReturnType))
+        {
+            if (!Conversion.IsImplicitReferenceVariantSlot(from.ReturnType, to.ReturnType))
+            {
+                return false;
+            }
+
+            anyVariant = true;
+        }
+
+        return anyVariant;
+    }
+
     private static bool TryCanonicalizeMethodGroupType(
         TypeSymbol actual,
         TypeSymbol expected,
-        out TypeSymbol canonical)
+        out TypeSymbol canonical,
+        bool parameterPosition = false,
+        bool allowVariance = true)
     {
         canonical = actual;
         if (TypeSymbol.AreRuntimeEquivalentIgnoringReferenceNullability(actual, expected))
@@ -2727,10 +2797,31 @@ internal sealed class ConversionClassifier
             return true;
         }
 
-        return MemberLookup.TryCanonicalizeStructuralFunctionType(actual, expected, out canonical)
+        if (MemberLookup.TryCanonicalizeStructuralFunctionType(actual, expected, out canonical)
             && actual.ClrType != null
             && expected.ClrType != null
-            && ClrTypeUtilities.AreSame(actual.ClrType, expected.ClrType);
+            && ClrTypeUtilities.AreSame(actual.ClrType, expected.ClrType))
+        {
+            return true;
+        }
+
+        // Issue #3505: a reference-variant slot canonicalizes to the TARGET's
+        // slot type, so the resolved group is built AT the target function
+        // type and the emitter creates the target-typed delegate directly
+        // over the method (plain ldftn+newobj — valid IL for reference
+        // variance; a delegate-to-delegate variance conversion is not).
+        // Parameters are contravariant (target flows into the candidate),
+        // returns covariant (candidate flows into the target); value-typed
+        // slots stay exact — CLR delegate variance is reference-only.
+        var (variantFrom, variantTo) = parameterPosition ? (expected, actual) : (actual, expected);
+        if (allowVariance && Conversion.IsImplicitReferenceVariantSlot(variantFrom, variantTo))
+        {
+            canonical = expected;
+            return true;
+        }
+
+        canonical = actual;
+        return false;
     }
 
     private static ImmutableArray<RefKind> GetMethodGroupTargetRefKinds(

--- a/test/Core.Tests/CodeAnalysis/Issue3505NativeSlotVariantMethodGroupTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Issue3505NativeSlotVariantMethodGroupTests.cs
@@ -1,0 +1,185 @@
+// <copyright file="Issue3505NativeSlotVariantMethodGroupTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis;
+
+/// <summary>
+/// Issue #3505: reference-variant method groups bind AT native
+/// function-type slots — the resolved group is built at the target type, so
+/// the emitter creates the target-typed delegate directly over the method
+/// (plain ldftn+newobj) instead of hitting the unsupported
+/// delegate-to-delegate variance conversion. Value-type variance — which
+/// CLR delegate variance cannot honor and which used to compile and then
+/// NRE — is rejected at bind time, for method groups and literals alike.
+/// </summary>
+public class Issue3505NativeSlotVariantMethodGroupTests
+{
+    [Fact]
+    public void ContravariantParameter_MethodGroupIntoNativeSlot_BindsAndRuns()
+    {
+        var source = @"
+class Cell {
+}
+
+class W {
+    shared {
+        func Describe(value object) string {
+            return value.GetType().Name
+        }
+
+        func Apply(cell Cell, f (Cell) -> object) object {
+            return f(cell)
+        }
+
+        func Run() object {
+            return Apply(Cell(), Describe)
+        }
+    }
+}
+
+W.Run().ToString()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal("Cell", result.Value);
+    }
+
+    [Fact]
+    public void CovariantReturn_MethodGroupIntoNativeSlot_BindsAndRuns()
+    {
+        var source = @"
+class W {
+    shared {
+        func Name(value string) string {
+            return value + ""!""
+        }
+
+        func Apply(value string, f (string) -> object) object {
+            return f(value)
+        }
+
+        func Run() object {
+            return Apply(""hi"", Name)
+        }
+    }
+}
+
+W.Run().ToString()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal("hi!", result.Value);
+    }
+
+    [Fact]
+    public void VariantGroup_AssignedToNativeTypedLocal_BindsAndRuns()
+    {
+        var source = @"
+class Cell {
+}
+
+class W {
+    shared {
+        func Describe(value object) string {
+            return value.GetType().Name
+        }
+
+        func Run() object {
+            let f ((Cell) -> object) = Describe
+            return f(Cell())
+        }
+    }
+}
+
+W.Run().ToString()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal("Cell", result.Value);
+    }
+
+    [Fact]
+    public void ValueTypeVariance_MethodGroup_IsRejectedAtBindTime()
+    {
+        // Used to compile and NRE at runtime — CLR delegate variance cannot
+        // box the int32 argument.
+        var source = @"
+class W {
+    shared {
+        func Describe(value object) string {
+            return value.GetType().Name
+        }
+
+        func Apply(cell int32, f (int32) -> object) object {
+            return f(cell)
+        }
+
+        func Run() object {
+            return Apply(3, Describe)
+        }
+    }
+}
+
+W.Run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.IsError && (d.Id == "GS0218" || d.Id == "GS0154"));
+    }
+
+    [Fact]
+    public void ValueTypeVariance_FunctionValue_IsRejectedAtBindTime()
+    {
+        var source = @"
+class W {
+    shared {
+        func Apply(cell int32, f (int32) -> object) object {
+            return f(cell)
+        }
+
+        func Run() object {
+            let g = func(value object) string {
+                return value.GetType().Name
+            }
+            return Apply(3, g)
+        }
+    }
+}
+
+W.Run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.IsError && d.Id == "GS0154");
+    }
+
+    [Fact]
+    public void ExactMatch_MethodGroupIntoNativeSlot_StillBinds()
+    {
+        var source = @"
+class W {
+    shared {
+        func Double(value int32) int32 {
+            return value * 2
+        }
+
+        func Apply(value int32, f (int32) -> int32) int32 {
+            return f(value)
+        }
+
+        func Run() int32 {
+            return Apply(21, Double)
+        }
+    }
+}
+
+W.Run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(42, result.Value);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3414DelegateArgumentInferenceTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3414DelegateArgumentInferenceTests.cs
@@ -202,11 +202,11 @@ public sealed class Issue3414DelegateArgumentInferenceTests
         Assert.Contains("Count(", consumer, StringComparison.Ordinal);
         Assert.Contains("DiagnosticsOf", consumer, StringComparison.Ordinal);
         Assert.Contains("IsError", consumer, StringComparison.Ordinal);
-        Assert.Contains(
-            "ApplyDescription(cell, func (value Cell) object",
-            consumer,
-            StringComparison.Ordinal);
-        Assert.Contains("return Program.Describe(value)", consumer, StringComparison.Ordinal);
+        // Issue #3505 (fixed): a reference-variant method group against a
+        // source-defined callee's native slot now emits the direct reference
+        // — gsc binds it at the target type — instead of the wrapper lambda.
+        Assert.Contains("ApplyDescription(cell, Describe)", consumer, StringComparison.Ordinal);
+        Assert.DoesNotContain("return Program.Describe(value)", consumer, StringComparison.Ordinal);
         Assert.Contains(
             "Rebuilder(func (value Cell) object",
             consumer,

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -1528,17 +1528,14 @@ public sealed partial class CSharpToGSharpTranslator
                 return false;
             }
 
-            // Issue #3501 A5: variance-direct emission is safe only when the
-            // CALLEE is imported CLR — its delegate slots are real CLR
-            // delegate types, where gsc creates variant method-group
-            // delegates correctly (proven end-to-end). A source-defined
-            // callee's slot translates to a NATIVE function type, whose
-            // erased-delegate semantics do not support variant groups yet
-            // (gsc emits NotSupported or unsound IL) — those keep wrappers.
-            ISymbol targetMethod = argumentOperation.Parameter?.ContainingSymbol;
-            bool calleeIsImported = targetMethod != null
-                && targetMethod.DeclaringSyntaxReferences.IsDefaultOrEmpty;
-            isImplicitConversion = delegateCreation.IsImplicit && calleeIsImported;
+            // Issue #3505 (fixed): gsc now binds reference-variant method
+            // groups AT native function-type slots too (the resolved group is
+            // built at the target type, so emit is a plain target-typed
+            // ldftn+newobj), and rejects the unsound value-type variance C#
+            // never allowed either. Variance-direct emission is therefore
+            // safe for imported and source-defined callees alike; the A5
+            // imported-callee carve-out is retired.
+            isImplicitConversion = delegateCreation.IsImplicit;
 
             method = methodReference.Method;
             invoke = delegateType.DelegateInvokeMethod;


### PR DESCRIPTION
## What this does

Fixes both defects of #3505 — reference-variant method groups against NATIVE function-type slots — and retires the matching cs2gs carve-out.

### 1. Contravariant/covariant reference groups now bind (previously emitter `NotSupportedException`)

A reference-variant group used to resolve at its OWN function type, leaving a delegate-to-delegate variance conversion the emitter cannot express. `TryCanonicalizeMethodGroupType` now canonicalizes a strictly reference-variant slot to the **target's** type — parameters contravariant, return covariant — so the resolved group is built at the target function type and emit is a plain target-typed `ldftn`+`newobj` (valid IL for reference variance):

```gsharp
func Describe(value object) string { ... }
func Apply(cell Cell, f (Cell) -> object) object -> f(cell)
Apply(Cell(), Describe)                  // works now; let-position and returns too
```

- **Exact candidates still win**: the relaxation runs as a second selection pass only when no candidate matches exactly (C#'s identity-conversion preference; `ExactCandidate_StillPreferredOverVariant` still green).
- An already-resolved group re-routes into this resolution **only** when its shape differs from a native target by pure reference variance (`HasReferenceVariantSlotMismatch`) — equivalent-shape conversions keep the generic path and its richer equivalence rules.

### 2. Value-type variance is now a bind-time error (previously compiled, then NRE'd)

`IsFunctionShapeAssignable`'s parameter relaxation accepted any implicit conversion including boxing, which CLR delegate variance cannot perform — `(object) -> R` into an `(int32) -> R` slot compiled and crashed in the callee. The relaxation is restricted to strict implicit **reference** conversions (new `Conversion.IsImplicitReferenceVariantSlot`: both ends reference-like, no structural projection), so the shape is rejected for method groups and function literals alike. C# never allowed it either, so cs2gs-translated code is unaffected.

### 3. cs2gs

The #3501-A5 imported-callee carve-out in `TryGetMethodGroupArgument` is retired — variance-direct method-group emission is now safe against source-defined callees' native slots too, so those arguments drop their wrapper lambdas (`Issue3414` expectations updated to the direct-reference form).

## Verification

- Core.Tests **8045/8045** (6 new `Issue3505NativeSlotVariantMethodGroupTests`: contravariant param, covariant return, let-position, value-type rejection for groups and literals, exact-match untouched)
- Compiler.Tests **4421/4421**
- Cs2Gs.Tests **2356/2356**

Fixes #3505.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgrKRVPGaEm9zLaYvankA1