### PR TITLE
gsc emitter: the five ilverify defect families — src/Core self-migration goes fully green (#3501)

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
+++ b/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
@@ -262,7 +262,10 @@ internal sealed class ImportedMemberRefFactory
 
         if (element.ClrType != null)
         {
-            if (element.ClrType.IsConstructedGenericType)
+            // Issue #3501 (ilverify): element-bearing CLR shapes (arrays from
+            // e.g. an imported `ParameterInfo[]` pattern binding) also route
+            // through the TypeSpec path — see GetTypeHandleForMember.
+            if (element.ClrType.IsConstructedGenericType || element.ClrType.HasElementType)
             {
                 return this.GetTypeHandleForMember(element.ClrType);
             }
@@ -567,7 +570,11 @@ internal sealed class ImportedMemberRefFactory
     /// </summary>
     internal EntityHandle GetTypeHandleForMember(Type type)
     {
-        if (type.IsConstructedGenericType)
+        // Issue #3501 (ilverify): an array (or any element-bearing shape —
+        // byref, pointer) has no TypeRef row; a name-based reference emits a
+        // bogus TypeRef literally called "ParameterInfo[]" that fails to
+        // load. Route through a TypeSpec like constructed generics.
+        if (type.IsConstructedGenericType || type.HasElementType)
         {
             if (this.cache.TypeSpecs.TryGetValue(type, out var existingSpec))
             {
@@ -1209,6 +1216,23 @@ internal sealed class ImportedMemberRefFactory
                 openDefinition = typeof(System.Nullable<>);
                 typeArguments = ImmutableArray.Create<TypeSymbol>((TypeParameterSymbol)nul.UnderlyingType);
                 return true;
+            case NullableTypeSymbol nullableReference
+                when !NullableLifting.IsAnyValueTypeNullable(nullableReference):
+                // Issue #3501 (ilverify): a nullable REFERENCE receiver — e.g.
+                // an iterator-hoisted `IEnumerable[Item]?` local narrowed
+                // non-null before the loop — shares its underlying type's
+                // runtime container; without the unwrap the member ref falls
+                // back to the erased closed shape while sibling state-machine
+                // fields reify, and the two disagree at verification.
+                return TryNormalizeToSymbolicContainer(
+                    nullableReference.UnderlyingType,
+                    out openDefinition,
+                    out typeArguments);
+            case NullabilityAnnotatedTypeSymbol annotated:
+                return TryNormalizeToSymbolicContainer(
+                    annotated.BaseType,
+                    out openDefinition,
+                    out typeArguments);
             case MapTypeSymbol map when map.ClrType == null:
                 // Issue #3311: a `map[K, V]` receiver over type-parameter (or
                 // other not-yet-loadable) arguments has no closed CLR

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
@@ -1931,7 +1931,16 @@ internal sealed partial class MethodBodyEmitter
         var effectiveType = bve.Type;
         if (bve.NarrowedType == null
             || ReflectionMetadataEmitter.IsValueTypeSymbol(declaredType)
-            || declaredType?.ClrType?.IsValueType == true)
+            || declaredType?.ClrType?.IsValueType == true
+
+            // Issue #3501 (ilverify): a reference-to-reference narrowing
+            // (`Type?` re-bound out var read as `Type`) involves no box — the
+            // slot holds the reference itself, so unboxing emits a spurious
+            // `unbox System.Type` (ValueTypeExpected + a readonly pointer
+            // where the call needs a writable one). Only a genuinely
+            // struct-narrowed read of a reference slot goes through unbox.
+            || !(ReflectionMetadataEmitter.IsValueTypeSymbol(effectiveType)
+                || effectiveType?.ClrType?.IsValueType == true))
         {
             // No boxing narrowing involved (or the variable's own slot is
             // already a value type) — safe to take the variable's own address.

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -5328,6 +5328,18 @@ internal sealed class ReflectionMetadataEmitter
             return tuple.ElementTypes.Any(ArgIsSymbolicUserDefined);
         }
 
+        // Issue #3501 (ilverify): a function-typed argument
+        // (`List[(BoundNode) -> object?]`) reifies to `Func<…>` over its
+        // parameter/return symbols in signatures, so a user type anywhere in
+        // its shape makes the whole argument symbolic. Without this the
+        // ctor/member refs stay erased (`List<object>`) while the local slot
+        // reifies (`List<Func<BoundNode, object>>`) — a stack mismatch.
+        if (arg is FunctionTypeSymbol fnArg)
+        {
+            return fnArg.ParameterTypes.Any(ArgIsSymbolicUserDefined)
+                || ArgIsSymbolicUserDefined(fnArg.ReturnType);
+        }
+
         return false;
     }
 

--- a/src/Core/CodeAnalysis/Lowering/Iterators/HoistedFieldRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Iterators/HoistedFieldRewriter.cs
@@ -42,7 +42,19 @@ internal class HoistedFieldRewriter : BoundTreeRewriter
     }
 
     protected BoundExpression FieldRead(FieldSymbol field) =>
-        new BoundFieldAccessExpression(null, new BoundVariableExpression(null, this.thisParameter), this.smClass, field);
+        this.FieldRead(field, narrowedType: null);
+
+    // Issue #3501 (ilverify): a hoisted variable READ may carry an ADR-0069
+    // smart-cast narrowing; the replacement field access must keep it so the
+    // emitter's narrowing castclass still fires (the field itself stays at
+    // the declared type).
+    protected BoundExpression FieldRead(FieldSymbol field, TypeSymbol? narrowedType) =>
+        new BoundFieldAccessExpression(
+            null,
+            new BoundVariableExpression(null, this.thisParameter),
+            this.smClass,
+            field,
+            narrowedType);
 
     protected BoundExpression FieldWrite(FieldSymbol field, BoundExpression value) =>
         new BoundFieldAssignmentExpression(null, this.thisParameter, this.smClass, field, value);
@@ -51,7 +63,7 @@ internal class HoistedFieldRewriter : BoundTreeRewriter
     {
         if (this.fieldMap.TryGetValue(node.Variable, out var field))
         {
-            return this.FieldRead(field);
+            return this.FieldRead(field, node.NarrowedType);
         }
 
         return node;

--- a/test/Compiler.Tests/Issue3501EmitterVerificationTests.cs
+++ b/test/Compiler.Tests/Issue3501EmitterVerificationTests.cs
@@ -1,0 +1,287 @@
+// <copyright file="Issue3501EmitterVerificationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests;
+
+/// <summary>
+/// Issue #3501: emitter IL-verification defects surfaced by compiling the
+/// migrated src/Core. Each case is the minimal reduction of a real
+/// self-migration failure; every emitted assembly must pass ilverify.
+/// </summary>
+public class Issue3501EmitterVerificationTests
+{
+    public static IEnumerable<object[]> Cases()
+    {
+        // Defect 1: `object as IEnumerable[UserType]` iterated inside an
+        // iterator — the hoisted nullable local's symbolic container was not
+        // unwrapped, so GetEnumerator bound erased (IEnumerator<object>)
+        // while the state-machine field reified (IEnumerator<Item>).
+        yield return new object[]
+        {
+            "iterator-as-ienumerable",
+            @"
+package P
+import System.Collections.Generic
+
+class Item {
+    var Name string = ""x""
+}
+
+class Holder {
+    func All(source object) sequence[Item] {
+        let children IEnumerable[Item]? = source as IEnumerable[Item]
+        if children != nil {
+            for child in children {
+                if child != nil {
+                    yield child
+                }
+            }
+        }
+    }
+}
+",
+        };
+
+        // Defect 2: `yield cast[Derived](node)` after a property-pattern
+        // narrowing — the hoisted-field rewrite dropped the read's
+        // NarrowedType, so the narrowing castclass never fired and the
+        // `current` store mismatched.
+        yield return new object[]
+        {
+            "iterator-yield-cast-after-pattern",
+            @"
+package P
+import System.Collections.Generic
+
+open class Node {
+}
+
+class Ret : Node {
+    var Expression string? = nil
+}
+
+class Walker {
+    func Returns(nodes List[Node]) sequence[Ret] {
+        for node in nodes {
+            if node is Ret { Expression: { } expression } {
+                yield cast[Ret](node)
+                continue
+            }
+        }
+    }
+}
+",
+        };
+
+        // Defect 3: a reference-to-reference narrowed out-var re-bind
+        // (`Type?` read as `Type`) went through the boxed-struct unbox path
+        // (`unbox System.Type` — ValueTypeExpected, readonly pointer).
+        yield return new object[]
+        {
+            "narrowed-reference-out-rebind",
+            @"
+package P
+import System
+import System.Collections.Generic
+import System.Diagnostics.CodeAnalysis
+
+class Resolver {
+    private let index Dictionary[string, Type] = Dictionary[string, Type]()
+
+    private func TryAlias(name string, @NotNullWhen(true) out aliased string?) bool {
+        aliased = name + ""!""
+        return true
+    }
+
+    func TryResolve(name string, out type_ Type?) bool {
+        type_ = nil
+        if index.TryGetValue(name, out var indexed) {
+            type_ = indexed
+            return true
+        }
+        if TryAlias(name, out var raw) && index.TryGetValue(raw!!, out indexed) {
+            type_ = indexed
+            return true
+        }
+        return false
+    }
+}
+",
+        };
+
+        // Defect 4: an array-typed pattern binding (`GetIndexParameters() is
+        // { Length: 1 } indexParams`) tokenised `ParameterInfo[]` as a
+        // name-based TypeRef, which fails to load — arrays need a TypeSpec.
+        yield return new object[]
+        {
+            "array-pattern-binding-typespec",
+            @"
+package P
+import System
+import System.Linq
+import System.Reflection
+
+class Finder {
+    func FirstIndexer(type_ Type) PropertyInfo? {
+        return type_
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .FirstOrDefault((p PropertyInfo) -> p.GetIndexParameters() is { Length: 1 } indexParams && indexParams[0].ParameterType == typeof(int32) && p.GetGetMethod(nonPublic: false) != nil)
+    }
+}
+",
+        };
+
+        // Defect 5: `List[(BoundNode) -> object?]()` — a function-typed
+        // generic argument carrying a user type was not classified symbolic,
+        // so the ctor targeted the erased `List<object>` while the local slot
+        // reified `List<Func<BoundNode, object>>`.
+        yield return new object[]
+        {
+            "function-typed-generic-argument",
+            @"
+package P
+import System
+import System.Collections.Concurrent
+import System.Collections.Generic
+import System.Reflection
+
+class BoundNode {
+}
+
+class Accessors {
+    var Count int32 = 0
+
+    init(count int32) {
+        Count = count
+    }
+}
+
+class Model {
+    private let cache ConcurrentDictionary[Type, Accessors] = ConcurrentDictionary[Type, Accessors]()
+
+    func GetAccessors(boundNodeType Type) Accessors {
+        return cache.GetOrAdd(boundNodeType, (type_ Type) -> {
+            let getters = List[(BoundNode) -> object?]()
+            for property in type_.GetProperties(BindingFlags.Public | BindingFlags.Instance) {
+                let getterProperty = property
+                getters.Add((node BoundNode) -> getterProperty.GetValue(node))
+            }
+            return Accessors(getters.Count)
+        })
+    }
+}
+",
+        };
+
+        // Defect 6: a nullable user constructed generic narrowed then called
+        // inside an iterator — the same symbolic-container/narrowing pair as
+        // defects 1–2, over a same-compilation generic class.
+        yield return new object[]
+        {
+            "iterator-user-generic-nullable-call",
+            @"
+package P
+import System.Collections.Generic
+
+class Wrap[T] {
+    var Items List[T] = List[T]()
+
+    func All() List[T] {
+        return Items
+    }
+}
+
+class Node {
+}
+
+class Holder {
+    var wraps List[Wrap[Node]?] = List[Wrap[Node]?]()
+
+    func Children() sequence[Node] {
+        for wrap in wraps {
+            let list Wrap[Node]? = wrap
+            if list != nil {
+                for node in list.All() {
+                    if node != nil {
+                        yield node
+                    }
+                }
+            }
+        }
+    }
+}
+",
+        };
+    }
+
+    [Theory]
+    [MemberData(nameof(Cases))]
+    public void EmittedAssembly_PassesIlVerification(string name, string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_3501_ilv_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "Program.gs");
+            File.WriteAllText(srcPath, source);
+            var outPath = Path.Combine(tempDir, name + ".dll");
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:library",
+                "/targetframework:net10.0",
+            };
+            foreach (var reference in TrustedPlatformAssemblies())
+            {
+                args.Add("/reference:" + reference);
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed for '{name}':\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            IlVerifier.Verify(outPath);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (string.IsNullOrEmpty(tpa))
+        {
+            return Enumerable.Empty<string>();
+        }
+
+        return tpa.Split(Path.PathSeparator).Where(File.Exists);
+    }
+}

--- a/tools/cs2gs/selfmig-baseline.json
+++ b/tools/cs2gs/selfmig-baseline.json
@@ -1,6 +1,6 @@
 {
   "comment": "Issue #3501 Track C: ratcheting baseline for the repo self-migration gate (build/run-cs2gs-selfmig.sh). greenFloor is the minimum number of fully-green apps (translate+compile+ilverify+parity); the *Ceiling metrics cap readability regressions in the migrated output. Recalibrated 2026-08-23 after the #3503-#3507 merges plus the doc-line re-wrap fix (25 green; 29 synthetic labels (A3 switch retarget); 77 __local_ lifts (A2 self-recursion retarget); 3637 lines >300 chars). nullAssertionCeiling added 2026-08-24 with the GS0536 polish pass (measured 20885, down from 23265). Ratcheted 2026-08-25 with the Core blocker burn-down (27 green, 70 lifts, 20444 bangs). Improve a metric, then tighten the corresponding number in the same PR.",
-  "greenFloor": 27,
+  "greenFloor": 28,
   "syntheticLabelCeiling": 40,
   "liftedLocalCeiling": 75,
   "longLineCeiling": 3700,


### PR DESCRIPTION
Part of #3501, continuing from #3516. src/Core's emitted G# compiled but failed ilverify on 8 defects. They reduce to **five emitter root causes**, each fixed with a minimal repro in a new `Issue3501EmitterVerificationTests` theory (6 cases, compile + ilverify):

1. **Symbolic container lost through nullable wrappers** — `TryNormalizeToSymbolicContainer` now unwraps nullable-reference and nullability-annotated types. An iterator-hoisted `IEnumerable[Item]?` local narrowed non-null bound `GetEnumerator` against the erased closed shape (`IEnumerator<object>`) while the state-machine field reified (`IEnumerator<Item>`).
2. **Narrowing dropped by the iterator hoist** — `HoistedFieldRewriter` propagates a variable read's `NarrowedType` into the replacement state-machine field access, so the ADR-0069 narrowing castclass still fires (`yield cast[Ret](node)` after a property-pattern test).
3. **Reference-narrow misrouted through unbox** — `TryLoadStructVariableAddress` only takes the boxed-struct `unbox` path when the *narrowed* type is a value type. A `Type?` out-var re-bound and read narrowed emitted `unbox System.Type` (ValueTypeExpected + a readonly pointer where the out slot needs a writable one).
4. **Arrays tokenised as name-based TypeRefs** — `GetTypeHandleForMember`/`GetElementTypeToken` route element-bearing CLR shapes through a TypeSpec; an array-typed pattern binding (`GetIndexParameters() is { Length: 1 } indexParams`) produced a TypeRef literally named `ParameterInfo[]` that fails to load.
5. **Function-typed generic arguments not classified symbolic** — `ArgIsSymbolicUserDefined` recurses into `FunctionTypeSymbol` parameters/returns, so `List[(BoundNode) -> object?]()` constructs the reified `List<Func<BoundNode, object>>` its local slot declares instead of the erased `List<object>`.

## Result

**src/Core goes fully green in the self-migration gate — translate, compile, ilverify, and test-parity — for the first time.** Gate: 28/55 green (floor ratcheted 27→28); labels 30/40 · lifts 70/75 · long lines 3,647/3,700 · bangs 20,444/21,000.

Full suites green: Core 8,082 · Interpreter 1,510 · Compiler 4,427.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgrKRVPGaEm9zLaYvankA1