### PR TITLE
printer: wrap init headers and object-creation initializers (#3501 long lines)

### DIFF
--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -569,6 +569,23 @@ public static class GSharpPrinter
                 + ")";
         }
 
+        // Issue #3501: a construction WITH an object initializer
+        // (`new T(...) { A = x, B = y }` → `T(…){A: …}`-style G#) escaped
+        // every wrap — the construction wraps through the invocation branch
+        // above, and each member initializer takes its own line.
+        if (expression is ObjectCreationInitializerExpression objectCreationWrap)
+        {
+            string construction =
+                RenderWrapped(objectCreationWrap.Construction, indent, prefixWidth)
+                ?? RenderExpression(objectCreationWrap.Construction, indent);
+            IEnumerable<string> memberTexts = objectCreationWrap.MemberInitializers.Select(f =>
+                $"{f.Name} = {RenderExpression(f.Value, indent + 1)}");
+            return construction
+                + "{\n" + continuation
+                + string.Join($",\n{continuation}", memberTexts)
+                + "}";
+        }
+
         return null;
     }
 
@@ -2146,7 +2163,32 @@ public static class GSharpPrinter
             sb.Append("convenience ");
         }
 
-        sb.Append($"init({RenderParameterList(constructor.Parameters)})");
+        sb.Append("init");
+
+        // Issue #3501: same budgeted parameter-list wrap the func-header
+        // renderer applies — `init`/`convenience init` headers were the
+        // dominant string-free >300-char lines in the migrated corpus.
+        string ctorParameterList = RenderParameterList(constructor.Parameters);
+        int ctorLineStart = sb.ToString().LastIndexOf('\n') + 1;
+        int ctorLineLength = sb.Length - ctorLineStart;
+        if (constructor.Parameters.Count > 1
+            && ctorLineLength + ctorParameterList.Length + 2 > MaxLineWidth)
+        {
+            string ctorParameterPad = Indent(indent + 1);
+            sb.Append("(\n");
+            sb.Append(ctorParameterPad);
+            sb.Append(string.Join(
+                ",\n" + ctorParameterPad,
+                constructor.Parameters.Select(RenderParameter)));
+            sb.Append(')');
+        }
+        else
+        {
+            sb.Append('(');
+            sb.Append(ctorParameterList);
+            sb.Append(')');
+        }
+
         if (constructor.BaseArguments != null)
         {
             var baseArgs = string.Join(", ", constructor.BaseArguments.Select(a => RenderExpression(a, indent)));

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3501ResidualSyntheticRetargetTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3501ResidualSyntheticRetargetTests.cs
@@ -342,6 +342,88 @@ public class Issue3501ResidualSyntheticRetargetTests
         TranslationTestValidation.AssertBinds(printed);
     }
 
+    [Fact]
+    public void LongConstructorHeader_WrapsItsParameterList()
+    {
+        // Issue #3501: `init`/`convenience init` headers were the dominant
+        // string-free >300-char lines; over-budget headers wrap after `(`
+        // and each comma, the same continuation the func renderer emits.
+        string printed = Translate("""
+            public sealed class WideNode
+            {
+                public WideNode(
+                    string firstComponentIdentifier,
+                    string secondComponentIdentifier,
+                    string thirdComponentIdentifier,
+                    string fourthComponentIdentifier,
+                    string fifthComponentIdentifier,
+                    string sixthComponentIdentifier,
+                    string seventhComponentIdentifier)
+                {
+                    Summary = firstComponentIdentifier + secondComponentIdentifier + thirdComponentIdentifier
+                        + fourthComponentIdentifier + fifthComponentIdentifier + sixthComponentIdentifier
+                        + seventhComponentIdentifier;
+                }
+
+                public string Summary { get; }
+            }
+            """);
+
+        Assert.Contains("init(\n", printed.Replace("\r", string.Empty), StringComparison.Ordinal);
+        foreach (string line in printed.Split('\n'))
+        {
+            Assert.True(line.Length <= 300, "over-300 line: " + line);
+        }
+
+        TranslationTestValidation.AssertBinds(printed);
+    }
+
+    [Fact]
+    public void LongObjectCreationWithInitializer_Wraps()
+    {
+        // A construction WITH an object initializer escaped every wrap rule
+        // (the SideEffectSpiller/ExpressionTreeLowerer BoundProgram returns —
+        // the last string-free >300-char statement family).
+        string printed = Translate("""
+            public sealed class ProgramInfo
+            {
+                public ProgramInfo(string entryPointPackage, string packages, string diagnostics, string functions, string entryPoint, string statement, string structs, string interfaces, string enums, string delegates) { }
+
+                public string EntryPointPackage { get; } = "";
+                public string Packages { get; } = "";
+                public string Diagnostics { get; } = "";
+                public string EntryPoint { get; } = "";
+                public string Statement { get; } = "";
+                public string Structs { get; } = "";
+                public string Interfaces { get; } = "";
+                public string Enums { get; } = "";
+                public string Delegates { get; } = "";
+                public string Imports { get; init; } = "";
+                public string FriendAssemblies { get; init; } = "";
+            }
+
+            public static class Rewriter
+            {
+                public static ProgramInfo Clone(ProgramInfo program, string functions)
+                {
+                    return new ProgramInfo(program.EntryPointPackage, program.Packages, program.Diagnostics, functions, program.EntryPoint, program.Statement, program.Structs, program.Interfaces, program.Enums, program.Delegates)
+                    {
+                        Imports = program.Imports,
+                        FriendAssemblies = program.FriendAssemblies,
+                    };
+                }
+            }
+            """);
+
+        foreach (string line in printed.Split('\n'))
+        {
+            Assert.True(line.Length <= 300, "over-300 line: " + line);
+        }
+
+        Assert.Contains("Imports = program.Imports,", printed, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(printed);
+    }
+
     private static string Translate(string source)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(


### PR DESCRIPTION
Part of #3501 (audit item 5), stacked on #3529.

Of the 3,647 raw >300-char lines, only **258 are string-free code** — the rest are giant string literals in test data. The code residue was dominated by two shapes the wrap pass missed, both fixed:

1. **`init`/`convenience init` parameter lists** — now budgeted exactly like func headers (break after `(` and each comma; gsc's open-delimiter line joining parses it).
2. **Constructions with an object initializer** (`new T(...) { A = x, B = y }`) — these escaped every wrap rule; the construction now wraps through the invocation branch and each member initializer takes its own line (the `BoundProgram` returns in `SideEffectSpiller`/`ExpressionTreeLowerer`).

Regression tests for both shapes (every emitted line asserted ≤300 chars + round-trip binds); printer suites green (163 tests). The gate's `longLineCeiling` can tighten after CI's selfmig run reports the new count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgrKRVPGaEm9zLaYvankA1