### PR TITLE
cs2gs: multiline string fixtures keep their line structure (#3501)

### DIFF
--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GExpression.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GExpression.cs
@@ -69,6 +69,11 @@ public sealed class LiteralExpression : GExpression
     /// <returns>The literal.</returns>
     public static LiteralExpression String(string value) => new LiteralExpression(LiteralKind.String, value);
 
+    /// <summary>Creates a Go-style backtick raw string literal (issue #3501); the value must contain no backtick or CR.</summary>
+    /// <param name="value">The verbatim string value.</param>
+    /// <returns>The literal.</returns>
+    public static LiteralExpression Raw(string value) => new LiteralExpression(LiteralKind.RawString, value);
+
     /// <summary>Creates a character literal from its unescaped inner text.</summary>
     /// <param name="value">The unescaped inner text.</param>
     /// <returns>The literal.</returns>

--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/LiteralKind.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/LiteralKind.cs
@@ -18,6 +18,13 @@ public enum LiteralKind
     /// <summary>A string literal; rendered double-quoted with <c>$</c> escaped to <c>$$</c>.</summary>
     String,
 
+    /// <summary>
+    /// A Go-style backtick raw string literal (issue #3501): rendered verbatim
+    /// between backticks — no escape processing, real newlines. The value must
+    /// not contain a backtick or a carriage return.
+    /// </summary>
+    RawString,
+
     /// <summary>A boolean literal (<c>true</c>/<c>false</c>).</summary>
     Bool,
 

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -946,7 +946,25 @@ public static class GSharpPrinter
         switch (literal.Kind)
         {
             case LiteralKind.String:
+                // Issue #3501: a multiline C# literal (raw/verbatim test
+                // fixture) renders as a Go-style backtick raw string keeping
+                // its original line structure, instead of collapsing into an
+                // escaped one-liner — the source of most >300-char emitted
+                // lines. Backtick strings process no escapes and normalize
+                // CR at lexing, so values containing a backtick or CR keep
+                // the escaped form; trivially short values do too.
+                if (literal.Value.IndexOf('\n') >= 0
+                    && literal.Value.IndexOf('`') < 0
+                    && literal.Value.IndexOf('\r') < 0
+                    && (literal.Value.Length > 120
+                        || literal.Value.IndexOf('\n') != literal.Value.LastIndexOf('\n')))
+                {
+                    return $"`{literal.Value}`";
+                }
+
                 return $"\"{RenderStringLiteralBody(literal.Value)}\"";
+            case LiteralKind.RawString:
+                return $"`{literal.Value}`";
             case LiteralKind.Char:
                 return $"'{RenderCharLiteralBody(literal.Value)}'";
             default:

--- a/tools/cs2gs/Cs2Gs.Tests/Coverage/code-model-surface.golden.txt
+++ b/tools/cs2gs/Cs2Gs.Tests/Coverage/code-model-surface.golden.txt
@@ -136,7 +136,7 @@ TypeParameter
 AccessorKind = Get, Set, Init
 BindingKind = Let, Var, Const
 CollectionInitializerElementKind = Expression, Keyed, Indexed, Assignment
-LiteralKind = Int, Float, String, Bool, Char, Null
+LiteralKind = Int, Float, String, RawString, Bool, Char, Null
 TypeDeclarationKind = Class, Struct, DataClass, DataStruct, InlineStruct, Interface
 Variance = None, Out, In
 Visibility = Default, Public, Internal, Private, Protected

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3501ResidualSyntheticRetargetTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3501ResidualSyntheticRetargetTests.cs
@@ -424,6 +424,73 @@ public class Issue3501ResidualSyntheticRetargetTests
         TranslationTestValidation.AssertBinds(printed);
     }
 
+    [Fact]
+    public void MultilineStringLiterals_KeepTheirLineStructure()
+    {
+        // A C# raw/verbatim multiline literal previously collapsed into an
+        // escaped one-liner — the source of most >300-char emitted lines.
+        // It now renders as a Go-style backtick raw string with the original
+        // line breaks; values embedding a backtick keep the escaped form.
+        string printed = Translate("""""
+            public static class Fixtures
+            {
+                public const string Source = """
+                    import System
+
+                    func Marker() int32 { return 401 }
+
+                    Console.WriteLine(Marker())
+                    """;
+
+                public const string WithBacktick = "a`b\nc";
+            }
+            """"");
+
+        Assert.Contains("`import System", printed.Replace("\r", string.Empty), StringComparison.Ordinal);
+        Assert.Contains("func Marker() int32 { return 401 }", printed, StringComparison.Ordinal);
+        Assert.Contains("\"a`b\\nc\"", printed, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(printed);
+    }
+
+    [Fact]
+    public void MultilineInterpolatedRawString_LowersToBacktickConcat()
+    {
+        // C# raw strings can carry interpolation holes; G# backtick raws are
+        // fully literal. A multiline interpolated raw lowers to a
+        // concatenation of backtick segments and hole values (non-string
+        // holes gain ToString), preserving the author's line structure.
+        string printed = Translate("""""
+            public static class Fixtures
+            {
+                public static string Build(string name, int count)
+                {
+                    return $"""
+                        header for {name}
+                        body line one
+                        count is {count}
+                        trailer
+                        """;
+                }
+
+                public static string Formatted(double ratio)
+                {
+                    return $"""
+                        first {ratio:0.00}
+                        second
+                        third
+                        """;
+                }
+            }
+            """"");
+
+        string normalized = printed.Replace("\r", string.Empty);
+        Assert.Contains("\"header for \" + name + `\nbody line one\ncount is ` + count.ToString() + `\ntrailer`", normalized, StringComparison.Ordinal);
+
+        // A hole with a format clause keeps the classic interpolated form.
+        Assert.Contains("${ratio", printed, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(printed);
+    }
+
     private static string Translate(string source)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -3612,7 +3612,86 @@ public sealed partial class CSharpToGSharpTranslator
                 }
             }
 
+            // Issue #3501: a MULTILINE interpolated string (a C# interpolated
+            // raw fixture) cannot become a backtick raw — G# backtick strings
+            // are fully literal, holes only interpolate inside quoted strings.
+            // Lower it to a concatenation of backtick raw segments and hole
+            // values instead, preserving the author's line structure. Bail to
+            // the classic escaped interpolated form when a hole carries an
+            // alignment/format clause (interpolation-only semantics) or a text
+            // chunk holds a character a backtick raw cannot represent.
+            if (this.TryLowerMultilineInterpolationToConcat(interpolated, parts, out GExpression concat))
+            {
+                return concat;
+            }
+
             return new InterpolatedStringExpression(parts);
+        }
+
+        private bool TryLowerMultilineInterpolationToConcat(
+            InterpolatedStringExpressionSyntax interpolated,
+            IReadOnlyList<InterpolationPart> parts,
+            out GExpression concat)
+        {
+            concat = null;
+            int newlines = 0;
+            foreach (InterpolationPart part in parts)
+            {
+                if (!part.IsHole)
+                {
+                    if (part.Text.IndexOf('`') >= 0 || part.Text.IndexOf('\r') >= 0)
+                    {
+                        return false;
+                    }
+
+                    newlines += part.Text.Count(c => c == '\n');
+                }
+                else if (part.Alignment != null || part.Format != null)
+                {
+                    return false;
+                }
+            }
+
+            if (newlines < 2)
+            {
+                return false;
+            }
+
+            var holeSyntaxes = interpolated.Contents.OfType<InterpolationSyntax>().ToList();
+            var holeIndex = 0;
+            GExpression result = null;
+            foreach (InterpolationPart part in parts)
+            {
+                GExpression segment;
+                if (part.IsHole)
+                {
+                    InterpolationSyntax holeSyntax = holeSyntaxes[holeIndex++];
+                    segment = part.Expression;
+                    ITypeSymbol holeType = this.context.GetTypeInfo(holeSyntax.Expression).Type;
+                    if (holeType?.SpecialType != SpecialType.System_String)
+                    {
+                        segment = new InvocationExpression(
+                            new MemberAccessExpression(segment, "ToString"),
+                            Array.Empty<GExpression>());
+                    }
+                }
+                else
+                {
+                    if (part.Text.Length == 0)
+                    {
+                        continue;
+                    }
+
+                    segment = part.Text.IndexOf('\n') >= 0
+                        ? LiteralExpression.Raw(part.Text)
+                        : LiteralExpression.String(part.Text);
+                }
+
+                result = result == null ? segment : new BinaryExpression(result, "+", segment);
+            }
+
+            concat = result ?? LiteralExpression.Raw(string.Empty);
+            return true;
         }
     }
 }


### PR DESCRIPTION
Part of #3501 (audit item 5, the string side), following David's review observation on #3530: the 3,389 string-carrying >300-char lines were C# multiline raw/verbatim literals collapsing into escaped one-liners — Roslyn hands the translator the *value* (real newlines) and the printer only knew the quoted form. Verified against `ImportedMemberMatrixTests` (a 25-line `"""` fixture emitted as one `"…\n…"` mega-line).

Two renderings restore the author's structure:

1. **Non-interpolated multiline literals** render as Go-style backtick raw strings (new `LiteralKind.RawString`) with the original line breaks. Values holding a backtick or CR keep the escaped form — backtick raws process no escapes and normalize CR at lexing, so those aren't representable verbatim.
2. **Interpolated raws**: C# raw strings can carry holes; G# backtick raws are *fully literal* (verified — `${name}` prints verbatim inside backticks). A multiline interpolated raw (273 sites repo-wide) lowers to a **concatenation of backtick segments and hole values**, non-string holes gaining `.ToString()` via the semantic model; holes with alignment/format clauses keep the classic escaped interpolated form.

```gs
return "header for " + name + `
body line one
count is ` + count.ToString() + `
trailer`
```

Regression tests for both paths (+ the backtick-fallback case); code-model surface golden updated for the new literal kind; printer/coverage suites green locally. Full verification via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgrKRVPGaEm9zLaYvankA1