### PR TITLE
Fix equality lowering for mixed numeric and nullable data structs

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -699,6 +699,16 @@ redundant assertions from translated output automatically.
 |---|---|---|---|
 | GS0536 | Warning | `Redundant '!!': the value is already non-null here.` | `if s != nil { return s!! }` |
 
+## Method-generic operator declarations (GS0537)
+
+G# user-defined operators cannot declare method type parameters. Put generic
+parameters on the containing type; operators on open generic containing types
+remain supported.
+
+| ID | Severity | Message | Example |
+|---|---|---|---|
+| GS0537 | Error | `Operator '<name>' cannot declare method type parameters; put generic parameters on the containing type instead.` | `func (left Value) op_Addition[T](right Value) Value` |
+
 ## Pattern variable outside its definitely-assigned region (GS0532)
 
 [ADR-0166](adr/0166-is-pattern-variables.md): a designation in a boolean `is`

--- a/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
@@ -195,6 +195,24 @@ public sealed record BoundBinaryOperator
             }
         }
 
+        // Issue #3518: same-compilation data/inline structs have no ClrType
+        // while binding, so their Nullable<T> equality cannot use the generic
+        // CLR-backed lift below. Bind the homogeneous symbolic wrapper here;
+        // emit boxes each nullable and delegates to Object.Equals.
+        if ((syntaxKind == SyntaxKind.EqualsEqualsToken || syntaxKind == SyntaxKind.BangEqualsToken)
+            && leftType is NullableTypeSymbol leftStructural
+            && rightType is NullableTypeSymbol rightStructural
+            && leftStructural.UnderlyingType is StructSymbol structural
+            && !structural.IsClass
+            && (structural.IsData || structural.IsInline)
+            && structural == rightStructural.UnderlyingType)
+        {
+            var kind = syntaxKind == SyntaxKind.EqualsEqualsToken
+                ? BoundBinaryOperatorKind.Equals
+                : BoundBinaryOperatorKind.NotEquals;
+            return new BoundBinaryOperator(syntaxKind, kind, leftType, rightType, TypeSymbol.Bool);
+        }
+
         // Phase 3.C.2 / ADR-0001: == and != against nil for any nullable type.
         //
         // Issue #614 audit: intentionally a single arm — only 2 operators (== / !=)

--- a/src/Core/CodeAnalysis/Binding/BoundClrConversionCallExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundClrConversionCallExpression.cs
@@ -12,8 +12,9 @@ using System.Reflection;
 namespace GSharp.Core.CodeAnalysis.Binding;
 
 /// <summary>
-/// User-defined conversion on a CLR type, resolved to a public static
-/// <c>op_Implicit</c> or <c>op_Explicit</c> <see cref="MethodInfo"/>.
+/// User-defined conversion resolved to a public static <c>op_Implicit</c> or
+/// <c>op_Explicit</c>, carried by either <see cref="Method"/> for imported
+/// CLR types or <see cref="Function"/> for same-compilation user types.
 /// Stream E lets GSharp source assign across types that carry CLR conversion
 /// operators (e.g. <c>System.Numerics.BigInteger</c> ↔ <c>int</c>,
 /// <c>System.Half</c> ↔ <c>float</c>).
@@ -21,16 +22,48 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 public sealed class BoundClrConversionCallExpression : BoundExpression
 {
     public BoundClrConversionCallExpression(SyntaxNode? syntax, BoundExpression source, MethodInfo method, TypeSymbol resultType)
+        : this(syntax, source, method, null, null, resultType)
+    {
+    }
+
+    public BoundClrConversionCallExpression(SyntaxNode? syntax, BoundExpression source, FunctionSymbol function, TypeSymbol resultType)
+        : this(syntax, source, function, function.StaticOwnerType as StructSymbol, resultType)
+    {
+    }
+
+    public BoundClrConversionCallExpression(
+        SyntaxNode? syntax,
+        BoundExpression source,
+        FunctionSymbol function,
+        StructSymbol? functionOwnerType,
+        TypeSymbol resultType)
+        : this(syntax, source, null, function, functionOwnerType, resultType)
+    {
+    }
+
+    private BoundClrConversionCallExpression(
+        SyntaxNode? syntax,
+        BoundExpression source,
+        MethodInfo? method,
+        FunctionSymbol? function,
+        StructSymbol? functionOwnerType,
+        TypeSymbol resultType)
         : base(syntax)
     {
         Source = source;
         Method = method;
+        Function = function;
+        FunctionOwnerType = functionOwnerType;
         Type = resultType;
     }
 
     public BoundExpression Source { get; }
 
-    public MethodInfo Method { get; }
+    public MethodInfo? Method { get; }
+
+    public FunctionSymbol? Function { get; }
+
+    public StructSymbol? FunctionOwnerType { get; }
 
     public override TypeSymbol Type { get; }
 

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -1849,7 +1849,18 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundClrConversionCallExpression(null, source, node.Method, node.Type);
+        return node.Function != null
+            ? new BoundClrConversionCallExpression(
+                null,
+                source,
+                node.Function,
+                node.FunctionOwnerType,
+                node.Type)
+            : new BoundClrConversionCallExpression(
+                null,
+                source,
+                Invariant.Required(node.Method, "an imported conversion carries a CLR method"),
+                node.Type);
     }
 
     /// <summary>Rewrites a CLR indexer read.</summary>

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -641,22 +641,24 @@ internal sealed class ConversionClassifier
                 liftedSource.UnderlyingType,
                 liftedTarget.UnderlyingType,
                 allowExplicit,
-                out var liftedMethod)
-            && liftedMethod.StaticOwnerType is StructSymbol { ClrType: null }
+                out var liftedMethod,
+                out var liftedOwner)
+            && liftedOwner is { ClrType: null }
             && liftedMethod.Parameters.Length == 1
             && liftedMethod.Parameters[0].RefKind == RefKind.None
             && liftedMethod.ReturnRefKind == RefKind.None
             && Conversion.ClassifyNonStructural(
                 liftedSource.UnderlyingType,
-                liftedMethod.Parameters[0].Type).IsIdentity
+                liftedOwner.SubstituteMemberType(liftedMethod.Parameters[0].Type)).IsIdentity
             && Conversion.ClassifyNonStructural(
-                liftedMethod.Type,
+                liftedOwner.SubstituteMemberType(liftedMethod.Type),
                 liftedTarget.UnderlyingType).IsIdentity)
         {
             return new BoundClrConversionCallExpression(
                 null,
                 expression,
                 liftedMethod,
+                liftedOwner,
                 type);
         }
 
@@ -694,9 +696,20 @@ internal sealed class ConversionClassifier
             // same-package struct/class is modelled as a static op_Implicit /
             // op_Explicit FunctionSymbol — those types have no reflectible
             // ClrType during binding, so resolve them symbolically first.
-            if (TryResolveUserDefinedSymbolConversion(expression.Type, type, allowExplicit, out var userConvOp))
+            if (TryResolveUserDefinedSymbolConversion(
+                expression.Type,
+                type,
+                allowExplicit,
+                out var userConvOp,
+                out var userConvOwner))
             {
-                return BindUserDefinedSymbolConversion(diagnosticLocation, expression, type, userConvOp, allowExplicit);
+                return BindUserDefinedSymbolConversion(
+                    diagnosticLocation,
+                    expression,
+                    type,
+                    userConvOp,
+                    userConvOwner,
+                    allowExplicit);
             }
 
             // Stream E: fall back to a user-defined op_Implicit (and
@@ -785,9 +798,20 @@ internal sealed class ConversionClassifier
 
         if (conversion.IsStructuralProjection)
         {
-            if (TryResolveUserDefinedSymbolConversion(expression.Type, type, allowExplicit, out var projectionUserConvOp))
+            if (TryResolveUserDefinedSymbolConversion(
+                expression.Type,
+                type,
+                allowExplicit,
+                out var projectionUserConvOp,
+                out var projectionUserConvOwner))
             {
-                return BindUserDefinedSymbolConversion(diagnosticLocation, expression, type, projectionUserConvOp, allowExplicit);
+                return BindUserDefinedSymbolConversion(
+                    diagnosticLocation,
+                    expression,
+                    type,
+                    projectionUserConvOp,
+                    projectionUserConvOwner,
+                    allowExplicit);
             }
 
             if (expression.Type?.ClrType != null && type?.ClrType != null
@@ -1284,13 +1308,19 @@ internal sealed class ConversionClassifier
         if (argument.Type != null
             && expectedType != null
             && argument.Type != TypeSymbol.Error
-            && TryResolveUserDefinedSymbolConversion(argument.Type, expectedType, allowExplicit: false, out var userConvOp))
+            && TryResolveUserDefinedSymbolConversion(
+                argument.Type,
+                expectedType,
+                allowExplicit: false,
+                out var userConvOp,
+                out var userConvOwner))
         {
             converted = BindUserDefinedSymbolConversion(
                 argument.Syntax?.Location ?? default,
                 argument,
                 expectedType,
                 userConvOp,
+                userConvOwner,
                 allowExplicit: false);
             return true;
         }
@@ -2465,8 +2495,22 @@ internal sealed class ConversionClassifier
         TypeSymbol? targetType,
         bool allowExplicit,
         [NotNullWhen(true)] out FunctionSymbol? method)
+        => TryResolveUserDefinedSymbolConversion(
+            sourceType,
+            targetType,
+            allowExplicit,
+            out method,
+            out _);
+
+    private static bool TryResolveUserDefinedSymbolConversion(
+        TypeSymbol? sourceType,
+        TypeSymbol? targetType,
+        bool allowExplicit,
+        [NotNullWhen(true)] out FunctionSymbol? method,
+        [NotNullWhen(true)] out StructSymbol? methodOwner)
     {
         method = null;
+        methodOwner = null;
         if (sourceType == null || targetType == null
             || sourceType == TypeSymbol.Error || targetType == TypeSymbol.Error)
         {
@@ -2478,6 +2522,7 @@ internal sealed class ConversionClassifier
             targetType,
             "op_Implicit",
             out method,
+            out methodOwner,
             out var ambiguousImplicit);
         if (foundImplicit || ambiguousImplicit)
         {
@@ -2489,7 +2534,13 @@ internal sealed class ConversionClassifier
             return false;
         }
 
-        return TryFindUserConversion(sourceType, targetType, "op_Explicit", out method, out _);
+        return TryFindUserConversion(
+            sourceType,
+            targetType,
+            "op_Explicit",
+            out method,
+            out methodOwner,
+            out _);
     }
 
     private static bool TryFindUserConversion(
@@ -2497,11 +2548,13 @@ internal sealed class ConversionClassifier
         TypeSymbol target,
         string opName,
         [NotNullWhen(true)] out FunctionSymbol? method,
+        [NotNullWhen(true)] out StructSymbol? methodOwner,
         out bool ambiguous)
     {
         method = null;
+        methodOwner = null;
         ambiguous = false;
-        var candidates = new List<(FunctionSymbol Method, int SourceRank, int TargetRank)>();
+        var candidates = new List<(FunctionSymbol Method, StructSymbol Owner, int SourceRank, int TargetRank)>();
         CollectUserConversions(GetUserConversionOwner(source), opName, source, target, candidates);
         CollectUserConversions(GetUserConversionOwner(target), opName, source, target, candidates);
         if (candidates.Count == 0)
@@ -2509,7 +2562,7 @@ internal sealed class ConversionClassifier
             return false;
         }
 
-        var best = new List<FunctionSymbol>();
+        var best = new List<(FunctionSymbol Method, StructSymbol Owner)>();
         for (var i = 0; i < candidates.Count; i++)
         {
             var dominated = false;
@@ -2533,7 +2586,7 @@ internal sealed class ConversionClassifier
 
             if (!dominated)
             {
-                best.Add(candidates[i].Method);
+                best.Add((candidates[i].Method, candidates[i].Owner));
             }
         }
 
@@ -2543,7 +2596,7 @@ internal sealed class ConversionClassifier
             return false;
         }
 
-        method = best[0];
+        (method, methodOwner) = best[0];
         return true;
     }
 
@@ -2554,7 +2607,7 @@ internal sealed class ConversionClassifier
             type = nullable.UnderlyingType;
         }
 
-        return (type as StructSymbol)?.Definition ?? type as StructSymbol;
+        return type as StructSymbol;
     }
 
     private static void CollectUserConversions(
@@ -2562,7 +2615,7 @@ internal sealed class ConversionClassifier
         string opName,
         TypeSymbol source,
         TypeSymbol target,
-        List<(FunctionSymbol Method, int SourceRank, int TargetRank)> candidates)
+        List<(FunctionSymbol Method, StructSymbol Owner, int SourceRank, int TargetRank)> candidates)
     {
         if (owner == null || owner.StaticMethods.IsDefaultOrEmpty)
         {
@@ -2573,13 +2626,16 @@ internal sealed class ConversionClassifier
         {
             if (!string.Equals(candidate.Name, opName, StringComparison.Ordinal)
                 || candidate.Parameters.Length != 1
-                || candidates.Any(c => ReferenceEquals(c.Method, candidate)))
+                || candidates.Any(c => ReferenceEquals(c.Method, candidate)
+                    && TypeSymbol.AreRuntimeEquivalentIgnoringReferenceNullability(c.Owner, owner)))
             {
                 continue;
             }
 
-            var sourceConversion = Conversion.ClassifyNonStructural(source, candidate.Parameters[0].Type);
-            var targetConversion = Conversion.ClassifyNonStructural(candidate.Type, target);
+            var parameterType = owner.SubstituteMemberType(candidate.Parameters[0].Type);
+            var resultType = owner.SubstituteMemberType(candidate.Type);
+            var sourceConversion = Conversion.ClassifyNonStructural(source, parameterType);
+            var targetConversion = Conversion.ClassifyNonStructural(resultType, target);
             if (!sourceConversion.Exists || !sourceConversion.IsImplicit
                 || !targetConversion.Exists || !targetConversion.IsImplicit)
             {
@@ -2588,6 +2644,7 @@ internal sealed class ConversionClassifier
 
             candidates.Add((
                 candidate,
+                owner,
                 sourceConversion.IsIdentity ? 0 : 1,
                 targetConversion.IsIdentity ? 0 : 1));
         }
@@ -2598,14 +2655,27 @@ internal sealed class ConversionClassifier
         BoundExpression expression,
         TypeSymbol targetType,
         FunctionSymbol method,
+        StructSymbol methodOwner,
         bool allowExplicit)
     {
+        var parameterType = methodOwner.SubstituteMemberType(method.Parameters[0].Type);
+        var resultType = methodOwner.SubstituteMemberType(method.Type);
         var operand = BindConversion(
             diagnosticLocation,
             expression,
-            method.Parameters[0].Type,
+            parameterType,
             allowExplicit: false);
-        var call = new BoundCallExpression(null, method, ImmutableArray.Create(operand));
+        var call = new BoundCallExpression(
+            null,
+            method,
+            ImmutableArray.Create(operand),
+            resultType)
+        {
+            StaticGenericOwnerType = !methodOwner.TypeArguments.IsDefaultOrEmpty
+                || !(methodOwner.Definition ?? methodOwner).TypeParameters.IsDefaultOrEmpty
+                ? methodOwner
+                : null,
+        };
         return BindConversion(diagnosticLocation, call, targetType, allowExplicit);
     }
 

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -628,6 +628,38 @@ internal sealed class ConversionClassifier
             }
         }
 
+        // Issue #3518: lift a same-compilation user conversion S -> T to
+        // S? -> T?. The emit-side conversion node owns the HasValue branch,
+        // unwrap, call, and target re-wrap/default construction.
+        if (expression.Type is NullableTypeSymbol liftedSource
+            && NullableLifting.IsAnyValueTypeNullable(liftedSource)
+            && type is NullableTypeSymbol liftedTarget
+            && NullableLifting.IsAnyValueTypeNullable(liftedTarget)
+            && !TypeSymbol.IsByRefLike(liftedSource)
+            && !TypeSymbol.IsByRefLike(liftedTarget)
+            && TryResolveUserDefinedSymbolConversion(
+                liftedSource.UnderlyingType,
+                liftedTarget.UnderlyingType,
+                allowExplicit,
+                out var liftedMethod)
+            && liftedMethod.StaticOwnerType is StructSymbol { ClrType: null }
+            && liftedMethod.Parameters.Length == 1
+            && liftedMethod.Parameters[0].RefKind == RefKind.None
+            && liftedMethod.ReturnRefKind == RefKind.None
+            && Conversion.ClassifyNonStructural(
+                liftedSource.UnderlyingType,
+                liftedMethod.Parameters[0].Type).IsIdentity
+            && Conversion.ClassifyNonStructural(
+                liftedMethod.Type,
+                liftedTarget.UnderlyingType).IsIdentity)
+        {
+            return new BoundClrConversionCallExpression(
+                null,
+                expression,
+                liftedMethod,
+                type);
+        }
+
         var conversion = Conversion.Classify(expression.Type, type);
         if (!conversion.Exists
             && allowExplicit

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -345,6 +345,18 @@ internal sealed class ConversionClassifier
     /// <returns><see langword="true"/> when an implicit conversion operator applies.</returns>
     public static bool HasUserDefinedImplicitConversionForTypes(TypeSymbol sourceType, TypeSymbol targetType)
     {
+        if (sourceType is NullableTypeSymbol liftedSource
+            && targetType is NullableTypeSymbol liftedTarget
+            && TryResolveLiftedUserDefinedSymbolConversion(
+                liftedSource,
+                liftedTarget,
+                allowExplicit: false,
+                out _,
+                out _))
+        {
+            return true;
+        }
+
         if (TryResolveUserDefinedSymbolConversion(sourceType, targetType, allowExplicit: false, out _))
         {
             return true;
@@ -481,10 +493,26 @@ internal sealed class ConversionClassifier
         if (expression is BoundFunctionLiteralExpression expressionTreeLiteral
             && MemberLookup.TryGetExpressionTreeDelegateTypeFromSymbol(type, out var expressionTreeDelegateType))
         {
-            if (!MemberLookup.TryGetDelegateFunctionTypeFromSymbol(expressionTreeDelegateType, out _))
+            if (!MemberLookup.TryGetDelegateFunctionTypeFromSymbol(
+                    expressionTreeDelegateType,
+                    out var expressionTreeTargetFunction))
             {
                 Diagnostics.ReportExpressionTreeTargetMustBeDelegate(diagnosticLocation, type);
                 return new BoundErrorExpression(null);
+            }
+
+            // Issue #3518: expression-tree returns initially retain a lambda's
+            // natural body shape. Rebind only when its return needs a
+            // user-defined implicit conversion so LambdaBinder can choose the
+            // target return and EmitTrailingExpression can materialize it.
+            if (expressionTreeLiteral.Syntax is LambdaExpressionSyntax lambdaSyntax
+                && expressionTreeLiteral.FunctionType is FunctionTypeSymbol sourceFunction
+                && sourceFunction.ReturnType != expressionTreeTargetFunction.ReturnType
+                && HasUserDefinedImplicitConversionForTypes(
+                    sourceFunction.ReturnType,
+                    expressionTreeTargetFunction.ReturnType))
+            {
+                return bindExpressionWithTargetType(lambdaSyntax, type);
             }
 
             ExpressionTreeRestrictionValidator.Validate(expressionTreeLiteral, type, Diagnostics);
@@ -632,27 +660,13 @@ internal sealed class ConversionClassifier
         // S? -> T?. The emit-side conversion node owns the HasValue branch,
         // unwrap, call, and target re-wrap/default construction.
         if (expression.Type is NullableTypeSymbol liftedSource
-            && NullableLifting.IsAnyValueTypeNullable(liftedSource)
             && type is NullableTypeSymbol liftedTarget
-            && NullableLifting.IsAnyValueTypeNullable(liftedTarget)
-            && !TypeSymbol.IsByRefLike(liftedSource)
-            && !TypeSymbol.IsByRefLike(liftedTarget)
-            && TryResolveUserDefinedSymbolConversion(
-                liftedSource.UnderlyingType,
-                liftedTarget.UnderlyingType,
+            && TryResolveLiftedUserDefinedSymbolConversion(
+                liftedSource,
+                liftedTarget,
                 allowExplicit,
                 out var liftedMethod,
-                out var liftedOwner)
-            && liftedOwner is { ClrType: null }
-            && liftedMethod.Parameters.Length == 1
-            && liftedMethod.Parameters[0].RefKind == RefKind.None
-            && liftedMethod.ReturnRefKind == RefKind.None
-            && Conversion.ClassifyNonStructural(
-                liftedSource.UnderlyingType,
-                liftedOwner.SubstituteMemberType(liftedMethod.Parameters[0].Type)).IsIdentity
-            && Conversion.ClassifyNonStructural(
-                liftedOwner.SubstituteMemberType(liftedMethod.Type),
-                liftedTarget.UnderlyingType).IsIdentity)
+                out var liftedOwner))
         {
             return new BoundClrConversionCallExpression(
                 null,
@@ -2501,6 +2515,37 @@ internal sealed class ConversionClassifier
             allowExplicit,
             out method,
             out _);
+
+    private static bool TryResolveLiftedUserDefinedSymbolConversion(
+        NullableTypeSymbol source,
+        NullableTypeSymbol target,
+        bool allowExplicit,
+        [NotNullWhen(true)] out FunctionSymbol? method,
+        [NotNullWhen(true)] out StructSymbol? methodOwner)
+    {
+        method = null;
+        methodOwner = null;
+        return NullableLifting.IsAnyValueTypeNullable(source)
+            && NullableLifting.IsAnyValueTypeNullable(target)
+            && !TypeSymbol.IsByRefLike(source)
+            && !TypeSymbol.IsByRefLike(target)
+            && TryResolveUserDefinedSymbolConversion(
+                source.UnderlyingType,
+                target.UnderlyingType,
+                allowExplicit,
+                out method,
+                out methodOwner)
+            && methodOwner is { ClrType: null }
+            && method.Parameters.Length == 1
+            && method.Parameters[0].RefKind == RefKind.None
+            && method.ReturnRefKind == RefKind.None
+            && Conversion.ClassifyNonStructural(
+                source.UnderlyingType,
+                methodOwner.SubstituteMemberType(method.Parameters[0].Type)).IsIdentity
+            && Conversion.ClassifyNonStructural(
+                methodOwner.SubstituteMemberType(method.Type),
+                target.UnderlyingType).IsIdentity;
+    }
 
     private static bool TryResolveUserDefinedSymbolConversion(
         TypeSymbol? sourceType,

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Functions.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Functions.cs
@@ -185,6 +185,19 @@ internal sealed partial class DeclarationBinder
         var functionAttributes = BindFunctionAttributes(syntax, type);
         BindFunctionParameterAttributes(syntax, parameterSymbolBySyntax, type);
 
+        // G# follows C#: user-defined operators cannot be method-generic.
+        // Generic containing types remain supported: their open owner
+        // parameters come from GetGenericOperatorOwnerTypeParameters.
+        if (!typeParameters.IsDefaultOrEmpty
+            && (syntax.IsConversionOperator
+                || syntax.Identifier.Text.StartsWith("op_", StringComparison.Ordinal)))
+        {
+            Diagnostics.ReportGenericOperatorNotSupported(
+                syntax.TypeParameterList?.Location ?? syntax.Identifier.Location,
+                syntax.Identifier.Text);
+            return;
+        }
+
         FunctionSymbol function;
 
         // Issue #1017: a user-defined conversion operator

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -2360,6 +2360,7 @@ internal sealed partial class ExpressionBinder
         return type is not NullableTypeSymbol
             && type is not ByRefTypeSymbol
             && type != TypeSymbol.Void
+            && !TypeSymbol.IsByRefLike(type)
             && (type.IsValueType
                 || type is StructSymbol { IsClass: false }
                 || type is EnumSymbol
@@ -2402,13 +2403,16 @@ internal sealed partial class ExpressionBinder
 
     private static bool CanApplyLiftedUserOperator(TypeSymbol? operandType, TypeSymbol parameterType)
     {
-        var underlyingOperand = operandType is NullableTypeSymbol nullable
-            ? nullable.UnderlyingType
-            : operandType;
-        var conversion = Conversion.Classify(
-            Invariant.Required(underlyingOperand, "an operator operand has a type"),
-            parameterType);
-        return conversion.Exists && conversion.IsImplicit;
+        var underlyingOperand = Invariant.Required(
+            operandType is NullableTypeSymbol nullable
+                ? nullable.UnderlyingType
+                : operandType,
+            "an operator operand has a type");
+        var conversion = Conversion.Classify(underlyingOperand, parameterType);
+        return (conversion.Exists && conversion.IsImplicit)
+            || ConversionClassifier.HasUserDefinedImplicitConversionForTypes(
+                underlyingOperand,
+                parameterType);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -2005,6 +2005,7 @@ internal sealed partial class ExpressionBinder
     /// <param name="leftParameterType">The resolved operator's left parameter type.</param>
     /// <param name="rightParameterType">The resolved operator's right parameter type.</param>
     /// <param name="naturalResultType">The operator's own (non-lifted) result type.</param>
+    /// <param name="hasByRefSignature">Whether any parameter or the return is passed by reference.</param>
     /// <param name="liftedResultType">The lifted result type: <c>bool</c> for comparisons, <c>Nullable&lt;naturalResultType&gt;</c> otherwise.</param>
     /// <returns><see langword="true"/> when lifting applies and <paramref name="left"/>/<paramref name="right"/>/<paramref name="liftedResultType"/> were updated.</returns>
     private bool TryLiftNullableClrOperatorOperands(
@@ -2016,6 +2017,7 @@ internal sealed partial class ExpressionBinder
         TypeSymbol leftParameterType,
         TypeSymbol rightParameterType,
         TypeSymbol naturalResultType,
+        bool hasByRefSignature,
         out TypeSymbol? liftedResultType)
     {
         liftedResultType = null;
@@ -2033,6 +2035,19 @@ internal sealed partial class ExpressionBinder
             && NullableLifting.IsAnyValueTypeNullable(rightNullable);
 
         if (!leftIsNullableValueType && !rightIsNullableValueType)
+        {
+            return false;
+        }
+
+        // CLR lifting is defined only for by-value, non-nullable value-type
+        // parameters. Comparisons must return bool; other operators must
+        // return a by-value, non-nullable value type so their result can lift.
+        if (hasByRefSignature
+            || !IsNonNullableValueTypeOperatorSlot(leftParameterType)
+            || !IsNonNullableValueTypeOperatorSlot(rightParameterType)
+            || (IsClrOperatorLiftedToBool(opKind)
+                ? naturalResultType != TypeSymbol.Bool
+                : !IsNonNullableValueTypeOperatorSlot(naturalResultType)))
         {
             return false;
         }
@@ -2212,6 +2227,8 @@ internal sealed partial class ExpressionBinder
                 var rightParameterType = userOpOwner?.SubstituteMemberType(userOp.Parameters[1].Type)
                     ?? userOp.Parameters[1].Type;
                 var resultType = userOpOwner?.SubstituteMemberType(userOp.Type) ?? userOp.Type;
+                var hasByRefSignature = userOp.Parameters.Any(p => p.RefKind != RefKind.None)
+                    || userOp.ReturnRefKind != RefKind.None;
 
                 if (CanApplyLiftedUserOperator(left.Type, leftParameterType)
                     && CanApplyLiftedUserOperator(right.Type, rightParameterType)
@@ -2224,6 +2241,7 @@ internal sealed partial class ExpressionBinder
                         leftParameterType,
                         rightParameterType,
                         resultType,
+                        hasByRefSignature,
                         out var liftedResultType))
                 {
                     return new BoundClrBinaryOperatorExpression(
@@ -2234,6 +2252,11 @@ internal sealed partial class ExpressionBinder
                         userOp,
                         userOpOwner,
                         Invariant.Required(liftedResultType, "a lifted operator has a result type"));
+                }
+
+                if (hasByRefSignature)
+                {
+                    return null;
                 }
 
                 var convertedLeft = conversions.BindConversion(leftLocation, left, leftParameterType);
@@ -2261,6 +2284,8 @@ internal sealed partial class ExpressionBinder
             var clrParameters = clrMethod.GetParameters();
             var leftParameterType = TypeSymbol.FromClrType(clrParameters[0].ParameterType);
             var rightParameterType = TypeSymbol.FromClrType(clrParameters[1].ParameterType);
+            var hasByRefSignature = clrParameters.Any(p => p.ParameterType.IsByRef)
+                || clrMethod.ReturnType.IsByRef;
 
             // Issue #2388: `ClrOperatorResolution` matches on
             // `TypeSymbol.ClrType`, which for a `NullableTypeSymbol` wrapping
@@ -2287,6 +2312,7 @@ internal sealed partial class ExpressionBinder
                 leftParameterType,
                 rightParameterType,
                 TypeSymbol.FromClrType(clrMethod.ReturnType),
+                hasByRefSignature,
                 out var liftedClrResultType))
             {
                 return new BoundClrBinaryOperatorExpression(
@@ -2298,22 +2324,25 @@ internal sealed partial class ExpressionBinder
                     Invariant.Required(liftedClrResultType, "a lifted CLR operator has a result type"));
             }
 
+            if (hasByRefSignature)
+            {
+                return null;
+            }
+
             // Issue #3518: resolution considers every implicit conversion, so
             // materialize each one before emitting the resolved method call.
             // Keep CLR-compatible nil/reference-nullability shapes unchanged;
             // their language conversions intentionally are not implicit.
-            if (Conversion.Classify(left.Type, leftParameterType).IsImplicit
-                || ConversionClassifier.HasUserDefinedImplicitConversionForTypes(left.Type, leftParameterType))
+            var convertedLeft = left;
+            var convertedRight = right;
+            if (!TryApplyClrOperatorOperandConversion(left, leftParameterType, leftLocation, out convertedLeft)
+                || !TryApplyClrOperatorOperandConversion(right, rightParameterType, rightLocation, out convertedRight))
             {
-                left = conversions.BindConversion(leftLocation, left, leftParameterType);
+                return null;
             }
 
-            if (Conversion.Classify(right.Type, rightParameterType).IsImplicit
-                || ConversionClassifier.HasUserDefinedImplicitConversionForTypes(right.Type, rightParameterType))
-            {
-                right = conversions.BindConversion(rightLocation, right, rightParameterType);
-            }
-
+            left = convertedLeft;
+            right = convertedRight;
             return new BoundClrBinaryOperatorExpression(
                 null,
                 opKind,
@@ -2324,6 +2353,51 @@ internal sealed partial class ExpressionBinder
         }
 
         return null;
+    }
+
+    private static bool IsNonNullableValueTypeOperatorSlot(TypeSymbol type)
+    {
+        return type is not NullableTypeSymbol
+            && type is not ByRefTypeSymbol
+            && type != TypeSymbol.Void
+            && (type.IsValueType
+                || type is StructSymbol { IsClass: false }
+                || type is EnumSymbol
+                || type is TupleTypeSymbol
+                || type is TypeParameterSymbol { HasValueTypeConstraint: true });
+    }
+
+    private bool TryApplyClrOperatorOperandConversion(
+        BoundExpression operand,
+        TypeSymbol parameterType,
+        TextLocation location,
+        out BoundExpression converted)
+    {
+        converted = operand;
+        if (parameterType is ByRefTypeSymbol)
+        {
+            return false;
+        }
+
+        if (Conversion.Classify(operand.Type, parameterType).IsImplicit)
+        {
+            converted = conversions.BindConversion(location, operand, parameterType);
+            return converted is not BoundErrorExpression;
+        }
+
+        bool sourceIsValueNullable = operand.Type is NullableTypeSymbol sourceNullable
+            && NullableLifting.IsAnyValueTypeNullable(sourceNullable);
+        bool targetIsValueNullable = parameterType is NullableTypeSymbol targetNullable
+            && NullableLifting.IsAnyValueTypeNullable(targetNullable);
+        if ((!sourceIsValueNullable || targetIsValueNullable)
+            && ConversionClassifier.HasUserDefinedImplicitConversionForTypes(operand.Type, parameterType))
+        {
+            converted = conversions.BindConversion(location, operand, parameterType);
+            return converted is not BoundErrorExpression;
+        }
+
+        return (operand.Type == TypeSymbol.Null && Conversion.IsReferenceLikeTarget(parameterType))
+            || TypeSymbol.AreRuntimeEquivalentIgnoringReferenceNullability(operand.Type, parameterType);
     }
 
     private static bool CanApplyLiftedUserOperator(TypeSymbol? operandType, TypeSymbol parameterType)

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -2002,6 +2002,8 @@ internal sealed partial class ExpressionBinder
     /// <param name="right">The bound right operand; replaced with its <c>Nullable&lt;T&gt;</c>-converted form when lifting applies.</param>
     /// <param name="leftLocation">The left operand's source location (for the wrapping conversion).</param>
     /// <param name="rightLocation">The right operand's source location (for the wrapping conversion).</param>
+    /// <param name="leftParameterType">The resolved operator's left parameter type.</param>
+    /// <param name="rightParameterType">The resolved operator's right parameter type.</param>
     /// <param name="naturalResultType">The operator's own (non-lifted) result type.</param>
     /// <param name="liftedResultType">The lifted result type: <c>bool</c> for comparisons, <c>Nullable&lt;naturalResultType&gt;</c> otherwise.</param>
     /// <returns><see langword="true"/> when lifting applies and <paramref name="left"/>/<paramref name="right"/>/<paramref name="liftedResultType"/> were updated.</returns>
@@ -2011,6 +2013,8 @@ internal sealed partial class ExpressionBinder
         ref BoundExpression right,
         TextLocation leftLocation,
         TextLocation rightLocation,
+        TypeSymbol leftParameterType,
+        TypeSymbol rightParameterType,
         TypeSymbol naturalResultType,
         out TypeSymbol? liftedResultType)
     {
@@ -2033,8 +2037,10 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
-        var leftLiftedType = leftIsNullableValueType ? (NullableTypeSymbol)left.Type : NullableTypeSymbol.Get(left.Type);
-        var rightLiftedType = rightIsNullableValueType ? (NullableTypeSymbol)right.Type : NullableTypeSymbol.Get(right.Type);
+        // Issue #3518: lift to the resolved signature, not each operand's
+        // original type; overload resolution may have selected numeric widening.
+        var leftLiftedType = NullableTypeSymbol.Get(leftParameterType);
+        var rightLiftedType = NullableTypeSymbol.Get(rightParameterType);
 
         left = conversions.BindConversion(leftLocation, left, leftLiftedType);
         right = conversions.BindConversion(rightLocation, right, rightLiftedType);
@@ -2209,7 +2215,16 @@ internal sealed partial class ExpressionBinder
 
                 if (CanApplyLiftedUserOperator(left.Type, leftParameterType)
                     && CanApplyLiftedUserOperator(right.Type, rightParameterType)
-                    && TryLiftNullableClrOperatorOperands(opKind, ref left, ref right, leftLocation, rightLocation, resultType, out var liftedResultType))
+                    && TryLiftNullableClrOperatorOperands(
+                        opKind,
+                        ref left,
+                        ref right,
+                        leftLocation,
+                        rightLocation,
+                        leftParameterType,
+                        rightParameterType,
+                        resultType,
+                        out var liftedResultType))
                 {
                     return new BoundClrBinaryOperatorExpression(
                         null,
@@ -2243,6 +2258,10 @@ internal sealed partial class ExpressionBinder
         if ((left.Type?.ClrType != null || right.Type?.ClrType != null)
             && ClrOperatorResolution.TryResolveBinary(opKind, left.Type, right.Type, out var clrMethod, out ambiguous))
         {
+            var clrParameters = clrMethod.GetParameters();
+            var leftParameterType = TypeSymbol.FromClrType(clrParameters[0].ParameterType);
+            var rightParameterType = TypeSymbol.FromClrType(clrParameters[1].ParameterType);
+
             // Issue #2388: `ClrOperatorResolution` matches on
             // `TypeSymbol.ClrType`, which for a `NullableTypeSymbol` wrapping
             // a value type is already the UNDERLYING CLR type (see
@@ -2259,7 +2278,16 @@ internal sealed partial class ExpressionBinder
             // spills, HasValue-branches, and unwraps before calling the
             // resolved method — mirroring exactly how the built-in operator
             // table already lifts `int32? + int32?` et al.
-            if (TryLiftNullableClrOperatorOperands(opKind, ref left, ref right, leftLocation, rightLocation, TypeSymbol.FromClrType(clrMethod.ReturnType), out var liftedClrResultType))
+            if (TryLiftNullableClrOperatorOperands(
+                opKind,
+                ref left,
+                ref right,
+                leftLocation,
+                rightLocation,
+                leftParameterType,
+                rightParameterType,
+                TypeSymbol.FromClrType(clrMethod.ReturnType),
+                out var liftedClrResultType))
             {
                 return new BoundClrBinaryOperatorExpression(
                     null,
@@ -2270,15 +2298,18 @@ internal sealed partial class ExpressionBinder
                     Invariant.Required(liftedClrResultType, "a lifted CLR operator has a result type"));
             }
 
-            var clrParameters = clrMethod.GetParameters();
-            var leftParameterType = TypeSymbol.FromClrType(clrParameters[0].ParameterType);
-            if (ConversionClassifier.HasUserDefinedImplicitConversionForTypes(left.Type, leftParameterType))
+            // Issue #3518: resolution considers every implicit conversion, so
+            // materialize each one before emitting the resolved method call.
+            // Keep CLR-compatible nil/reference-nullability shapes unchanged;
+            // their language conversions intentionally are not implicit.
+            if (Conversion.Classify(left.Type, leftParameterType).IsImplicit
+                || ConversionClassifier.HasUserDefinedImplicitConversionForTypes(left.Type, leftParameterType))
             {
                 left = conversions.BindConversion(leftLocation, left, leftParameterType);
             }
 
-            var rightParameterType = TypeSymbol.FromClrType(clrParameters[1].ParameterType);
-            if (ConversionClassifier.HasUserDefinedImplicitConversionForTypes(right.Type, rightParameterType))
+            if (Conversion.Classify(right.Type, rightParameterType).IsImplicit
+                || ConversionClassifier.HasUserDefinedImplicitConversionForTypes(right.Type, rightParameterType))
             {
                 right = conversions.BindConversion(rightLocation, right, rightParameterType);
             }

--- a/src/Core/CodeAnalysis/Binding/ExpressionTreeRestrictionValidator.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionTreeRestrictionValidator.cs
@@ -308,6 +308,10 @@ internal static class ExpressionTreeRestrictionValidator
                 ValidateExpression(clrUnary.Operand, diagnostics);
                 return;
 
+            case BoundClrConversionCallExpression conversion:
+                ValidateExpression(conversion.Source, diagnostics);
+                return;
+
             case BoundIsExpression isExpression:
                 if (!isExpression.IsSimpleTypeTest)
                 {

--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -2008,7 +2008,12 @@ internal sealed class LambdaBinder
                 return TypeSymbol.Void;
             }
 
-            if (targetReturn != null && candidates.All(c => c == TypeSymbol.Error || Conversion.Classify(c, targetReturn).IsImplicit))
+            if (targetReturn != null
+                && candidates.All(c => c == TypeSymbol.Error
+                    || Conversion.Classify(c, targetReturn).IsImplicit
+                    || ConversionClassifier.HasUserDefinedImplicitConversionForTypes(
+                        c,
+                        targetReturn)))
             {
                 return targetReturn;
             }

--- a/src/Core/CodeAnalysis/DiagnosticBag.Reports.Declarations.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.Reports.Declarations.cs
@@ -1034,6 +1034,12 @@ public sealed partial class DiagnosticBag
     public void ReportDuplicateConversionOperator(TextLocation location, TypeSymbol sourceType, TypeSymbol targetType)
     => Report(location, DiagnosticDescriptors.DuplicateConversionOperator, sourceType, targetType);
 
+    /// <summary>Reports GS0537 when an operator declares method type parameters.</summary>
+    /// <param name="location">The generic parameter list location.</param>
+    /// <param name="operatorName">The CLR operator name.</param>
+    public void ReportGenericOperatorNotSupported(TextLocation location, string operatorName)
+    => Report(location, DiagnosticDescriptors.GenericOperatorNotSupported, operatorName);
+
     /// <summary>
     /// ADR-0149: GS0492 — an explicit-interface qualifier clause
     /// (<c>func (X) M(...)</c> / <c>prop (X) P T</c> / <c>event (X) E T</c>)

--- a/src/Core/CodeAnalysis/DiagnosticDescriptors.cs
+++ b/src/Core/CodeAnalysis/DiagnosticDescriptors.cs
@@ -412,6 +412,7 @@ internal static class DiagnosticDescriptors
     // spelling reports this migration error (with recovery). GS0533/GS0534
     // are taken by the #3501-A3 fallthrough diagnostics.
     internal static readonly DiagnosticDescriptor RetiredDelegateDeclarationForm = new("GS0535", DiagnosticSeverity.Error, "The 'type {0} = delegate func(...)' spelling is retired. Declare the delegate as 'delegate {0}(parameters) ReturnType;' (trailing semicolon required; omit the return type for void).");
+    internal static readonly DiagnosticDescriptor GenericOperatorNotSupported = new("GS0537", DiagnosticSeverity.Error, "Operator '{0}' cannot declare method type parameters; put generic parameters on the containing type instead.");
     internal static readonly DiagnosticDescriptor CannotTakeAddressOfNonLvalue = new("GS9001", DiagnosticSeverity.Error, "Cannot take address of '{0}': expression is not an lvalue.");
     internal static readonly DiagnosticDescriptor ArgumentMustBePassedByRef = new("GS9002", DiagnosticSeverity.Error, "Argument {0} to '{1}' must be passed by reference (`&`).");
     internal static readonly DiagnosticDescriptor VariableNotDefinitelyAssignedForRef = new("GS9003", DiagnosticSeverity.Error, "Variable '{0}' must be definitely assigned before being passed by `ref`.");

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
@@ -1342,7 +1342,7 @@ internal sealed partial class MethodBodyEmitter
             && NullableLifting.IsAnyValueTypeNullable(sourceNullable)
             && conv.Type is NullableTypeSymbol liftedTargetNullable
             && NullableLifting.IsAnyValueTypeNullable(liftedTargetNullable)
-            && IsLiftedNullableClrConversionMethod(conv.Method, sourceNullable, liftedTargetNullable))
+            && IsLiftedNullableConversionCall(conv, sourceNullable, liftedTargetNullable))
         {
             this.EmitLiftedNullableClrConversion(conv, sourceNullable, liftedTargetNullable);
             return;
@@ -1350,18 +1350,21 @@ internal sealed partial class MethodBodyEmitter
 
         // Stream E emit parity: user-defined op_Implicit / op_Explicit is a
         // public-static method taking one arg, returning the target type.
+        var method = Invariant.Required(
+            conv.Method,
+            "a non-lifted imported conversion carries a CLR method");
         this.EmitExpression(conv.Source);
         this.il.OpCode(ILOpCode.Call);
-        this.il.Token(this.outer.memberRefs.GetMethodReference(conv.Method));
-        this.EmitErasedObjectReturnWidening(TypeSymbol.FromClrType(conv.Method.ReturnType), conv.Type);
+        this.il.Token(this.outer.memberRefs.GetMethodReference(method));
+        this.EmitErasedObjectReturnWidening(TypeSymbol.FromClrType(method.ReturnType), conv.Type);
 
         // Issue #663: when the operator returns a non-nullable value type T but the
         // target type is Nullable<T> (e.g. op_Explicit(JsonNode) → int, target int32?),
         // lift the result into Nullable<T> via newobj.
         if (conv.Type is NullableTypeSymbol targetNullable
             && ReflectionMetadataEmitter.IsValueTypeNullable(targetNullable)
-            && conv.Method.ReturnType.IsValueType
-            && !IsNullableValueType(conv.Method.ReturnType))
+            && method.ReturnType.IsValueType
+            && !IsNullableValueType(method.ReturnType))
         {
             var innerClr = targetNullable.UnderlyingType.ClrType
                 ?? throw new InvalidOperationException(
@@ -1382,11 +1385,27 @@ internal sealed partial class MethodBodyEmitter
         }
     }
 
-    private static bool IsLiftedNullableClrConversionMethod(
-        MethodInfo method,
+    private static bool IsLiftedNullableConversionCall(
+        BoundClrConversionCallExpression conversion,
         NullableTypeSymbol sourceNullable,
         NullableTypeSymbol targetNullable)
     {
+        if (conversion.Function != null)
+        {
+            return conversion.Function.Parameters.Length == 1
+                && conversion.Function.Parameters[0].RefKind == RefKind.None
+                && conversion.Function.ReturnRefKind == RefKind.None
+                && Conversion.ClassifyNonStructural(
+                    sourceNullable.UnderlyingType,
+                    conversion.Function.Parameters[0].Type).IsIdentity
+                && Conversion.ClassifyNonStructural(
+                    conversion.Function.Type,
+                    targetNullable.UnderlyingType).IsIdentity;
+        }
+
+        var method = Invariant.Required(
+            conversion.Method,
+            "an imported lifted conversion carries a CLR method");
         var parameters = method.GetParameters();
         return parameters.Length == 1
             && !parameters[0].ParameterType.IsByRef
@@ -1422,8 +1441,7 @@ internal sealed partial class MethodBodyEmitter
         this.il.Branch(ILOpCode.Brfalse, nullBranch);
 
         this.EmitUnwrappedNullableValue(sourceSlot, sourceNullable);
-        this.il.OpCode(ILOpCode.Call);
-        this.il.Token(this.outer.memberRefs.GetMethodReference(conv.Method));
+        this.EmitCallResolvedConversion(conv);
         this.il.OpCode(ILOpCode.Newobj);
         this.il.Token(this.GetNullableResultConstructor(targetNullable));
         this.il.Branch(ILOpCode.Br, end);
@@ -1435,6 +1453,22 @@ internal sealed partial class MethodBodyEmitter
         this.il.LoadLocal(resultSlot);
 
         this.il.MarkLabel(end);
+    }
+
+    private void EmitCallResolvedConversion(BoundClrConversionCallExpression conversion)
+    {
+        if (conversion.Function != null)
+        {
+            this.EmitCallResolvedUserFunction(
+                conversion.Function,
+                conversion.FunctionOwnerType);
+            return;
+        }
+
+        this.il.OpCode(ILOpCode.Call);
+        this.il.Token(this.outer.memberRefs.GetMethodReference(Invariant.Required(
+            conversion.Method,
+            "an imported conversion carries a CLR method")));
     }
 
     private static bool IsNullableValueType(Type t)

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
@@ -401,14 +401,14 @@ internal sealed partial class MethodBodyEmitter
             return;
         }
 
-        // Issue #1236: lifted numeric widening between two distinct value-type
-        // `Nullable<T>` operands (e.g. `uint8? → int32?`, `int32? → int64?`).
+        // Issues #1236/#3518: lifted conversion between two distinct value-type
+        // `Nullable<T>` operands (numeric or underlying CLR user-defined).
         // The source struct is already on the stack; spill it, branch on
         // HasValue, and either re-wrap the converted underlying value as a fresh
         // `Nullable<T2>` (HasValue == true) or materialise default(Nullable<T2>)
         // (HasValue == false). Two consecutive scratch slots — the source
         // `Nullable<T1>` and the result `Nullable<T2>` — are pre-allocated by
-        // the planner (CollectNullableNumericWideningConversions) and keyed in
+        // the planner (CollectNullableValueTypeConversions) and keyed in
         // receiverSpillSlots by this conversion node (dest = source + 1).
         if (from is NullableTypeSymbol fromValueNullableLift
             && ReflectionMetadataEmitter.IsValueTypeNullable(fromValueNullableLift)
@@ -416,7 +416,7 @@ internal sealed partial class MethodBodyEmitter
             && ReflectionMetadataEmitter.IsValueTypeNullable(toValueNullableLift2)
             && fromValueNullableLift.UnderlyingType != toValueNullableLift2.UnderlyingType)
         {
-            this.EmitLiftedNullableNumericWidening(conv, fromValueNullableLift, toValueNullableLift2);
+            this.EmitLiftedNullableConversion(conv, fromValueNullableLift, toValueNullableLift2);
             return;
         }
 
@@ -773,11 +773,9 @@ internal sealed partial class MethodBodyEmitter
             && Conversion.ClassifyNonStructural(right, left).IsImplicit;
     }
 
-    // Issue #1236: emit a lifted numeric widening between two distinct value-type
-    // `Nullable<T>` operands. On entry the source `Nullable<T1>` value is already
-    // on the stack. Uses two consecutive planner scratch slots (source, result)
-    // keyed in receiverSpillSlots by the conversion node.
-    private void EmitLiftedNullableNumericWidening(
+    // Issues #1236/#3518: emit a lifted conversion between distinct value-type
+    // nullable operands. On entry the source value is already on the stack.
+    private void EmitLiftedNullableConversion(
         BoundConversionExpression conv,
         NullableTypeSymbol fromNullable,
         NullableTypeSymbol toNullable)
@@ -785,7 +783,7 @@ internal sealed partial class MethodBodyEmitter
         if (!this.receiverSpillSlots.TryGetValue(conv, out var srcSlot))
         {
             throw new InvalidOperationException(
-                "No scratch slot pre-allocated for lifted Nullable<T1> -> Nullable<T2> numeric widening — check CollectNullableNumericWideningConversions and the prepass in CollectLocalsAndLabels.");
+                "No scratch slots allocated for a lifted nullable conversion.");
         }
 
         var dstSlot = srcSlot + 1;
@@ -828,7 +826,23 @@ internal sealed partial class MethodBodyEmitter
         this.il.LoadLocalAddress(srcSlot);
         this.il.OpCode(ILOpCode.Call);
         this.il.Token(getValueOrDefault);
-        this.TryEmitNumericConversion(fromUnderlying, toUnderlying, conv.IsChecked);
+        if (!this.TryEmitNumericConversion(fromUnderlying, toUnderlying, conv.IsChecked))
+        {
+            if (!ClrOperatorResolution.TryResolveConversion(
+                    fromUnderlyingClr,
+                    toUnderlyingClr,
+                    allowExplicit: false,
+                    out var conversionMethod,
+                    out _))
+            {
+                throw new InvalidOperationException(
+                    $"Lifted Nullable<{fromUnderlying.Name}> to Nullable<{toUnderlying.Name}> conversion has no underlying conversion.");
+            }
+
+            this.il.OpCode(ILOpCode.Call);
+            this.il.Token(this.outer.memberRefs.GetMethodReference(conversionMethod));
+        }
+
         this.il.OpCode(ILOpCode.Newobj);
         this.il.Token(this.outer.memberRefs.GetCtorReference(toCtor));
         this.il.Branch(ILOpCode.Br, end);
@@ -911,6 +925,21 @@ internal sealed partial class MethodBodyEmitter
         if (to.IsSameAs(typeof(decimal)) || from.IsSameAs(typeof(decimal)))
         {
             return TryEmitDecimalConversion(from, to);
+        }
+
+        // ECMA-335 conv.r4/conv.r8 interpret integer inputs as signed.
+        // Unsigned inputs must first use conv.r.un; float32 then needs
+        // conv.r4 to truncate the intermediate floating-point value.
+        if (IsUnsignedClrType(from)
+            && (to.IsSameAs(typeof(float)) || to.IsSameAs(typeof(double))))
+        {
+            this.il.OpCode(ILOpCode.Conv_r_un);
+            if (to.IsSameAs(typeof(float)))
+            {
+                this.il.OpCode(ILOpCode.Conv_r4);
+            }
+
+            return true;
         }
 
         if (isChecked)
@@ -1309,6 +1338,16 @@ internal sealed partial class MethodBodyEmitter
 
     private void EmitClrConversionCall(BoundClrConversionCallExpression conv)
     {
+        if (conv.Source.Type is NullableTypeSymbol sourceNullable
+            && NullableLifting.IsAnyValueTypeNullable(sourceNullable)
+            && conv.Type is NullableTypeSymbol liftedTargetNullable
+            && NullableLifting.IsAnyValueTypeNullable(liftedTargetNullable)
+            && IsLiftedNullableClrConversionMethod(conv.Method, sourceNullable, liftedTargetNullable))
+        {
+            this.EmitLiftedNullableClrConversion(conv, sourceNullable, liftedTargetNullable);
+            return;
+        }
+
         // Stream E emit parity: user-defined op_Implicit / op_Explicit is a
         // public-static method taking one arg, returning the target type.
         this.EmitExpression(conv.Source);
@@ -1341,6 +1380,61 @@ internal sealed partial class MethodBodyEmitter
             this.il.OpCode(ILOpCode.Newobj);
             this.il.Token(this.outer.memberRefs.GetCtorReference(ctor));
         }
+    }
+
+    private static bool IsLiftedNullableClrConversionMethod(
+        MethodInfo method,
+        NullableTypeSymbol sourceNullable,
+        NullableTypeSymbol targetNullable)
+    {
+        var parameters = method.GetParameters();
+        return parameters.Length == 1
+            && !parameters[0].ParameterType.IsByRef
+            && !method.ReturnType.IsByRef
+            && ClrTypeUtilities.AreSame(
+                parameters[0].ParameterType,
+                sourceNullable.UnderlyingType.ClrType)
+            && ClrTypeUtilities.AreSame(
+                method.ReturnType,
+                targetNullable.UnderlyingType.ClrType);
+    }
+
+    private void EmitLiftedNullableClrConversion(
+        BoundClrConversionCallExpression conv,
+        NullableTypeSymbol sourceNullable,
+        NullableTypeSymbol targetNullable)
+    {
+        if (!this.receiverSpillSlots.TryGetValue(conv, out var sourceSlot))
+        {
+            throw new InvalidOperationException(
+                "No scratch slots allocated for a lifted nullable CLR conversion.");
+        }
+
+        var resultSlot = sourceSlot + 1;
+        var nullBranch = this.il.DefineLabel();
+        var end = this.il.DefineLabel();
+
+        this.EmitExpression(conv.Source);
+        this.il.StoreLocal(sourceSlot);
+        this.il.LoadLocalAddress(sourceSlot);
+        this.il.OpCode(ILOpCode.Call);
+        this.il.Token(this.GetNullableHasValueRef(sourceNullable));
+        this.il.Branch(ILOpCode.Brfalse, nullBranch);
+
+        this.EmitUnwrappedNullableValue(sourceSlot, sourceNullable);
+        this.il.OpCode(ILOpCode.Call);
+        this.il.Token(this.outer.memberRefs.GetMethodReference(conv.Method));
+        this.il.OpCode(ILOpCode.Newobj);
+        this.il.Token(this.GetNullableResultConstructor(targetNullable));
+        this.il.Branch(ILOpCode.Br, end);
+
+        this.il.MarkLabel(nullBranch);
+        this.il.LoadLocalAddress(resultSlot);
+        this.il.OpCode(ILOpCode.Initobj);
+        this.il.Token(this.outer.memberRefs.GetElementTypeToken(targetNullable));
+        this.il.LoadLocal(resultSlot);
+
+        this.il.MarkLabel(end);
     }
 
     private static bool IsNullableValueType(Type t)

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
@@ -1392,14 +1392,24 @@ internal sealed partial class MethodBodyEmitter
     {
         if (conversion.Function != null)
         {
-            return conversion.Function.Parameters.Length == 1
-                && conversion.Function.Parameters[0].RefKind == RefKind.None
-                && conversion.Function.ReturnRefKind == RefKind.None
-                && Conversion.ClassifyNonStructural(
+            if (conversion.Function.Parameters.Length != 1
+                || conversion.Function.Parameters[0].RefKind != RefKind.None
+                || conversion.Function.ReturnRefKind != RefKind.None)
+            {
+                return false;
+            }
+
+            var parameterType = conversion.FunctionOwnerType?.SubstituteMemberType(
+                conversion.Function.Parameters[0].Type)
+                ?? conversion.Function.Parameters[0].Type;
+            var resultType = conversion.FunctionOwnerType?.SubstituteMemberType(
+                conversion.Function.Type)
+                ?? conversion.Function.Type;
+            return Conversion.ClassifyNonStructural(
                     sourceNullable.UnderlyingType,
-                    conversion.Function.Parameters[0].Type).IsIdentity
+                    parameterType).IsIdentity
                 && Conversion.ClassifyNonStructural(
-                    conversion.Function.Type,
+                    resultType,
                     targetNullable.UnderlyingType).IsIdentity;
         }
 

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
@@ -1517,13 +1517,34 @@ internal sealed partial class MethodBodyEmitter
         this.il.Branch(ILOpCode.Brfalse, bothEmptyLabel);
 
         // Both present: load values and compare.
+        // Issue #3518: ceq rejects arbitrary value types. Structural structs
+        // use the same boxed Object.Equals semantics as non-lifted equality.
+        var structural = underlying is StructSymbol candidate && (candidate.IsData || candidate.IsInline)
+            ? candidate
+            : null;
         this.il.LoadLocalAddress(lhsSlot);
         this.il.OpCode(ILOpCode.Call);
         this.il.Token(getValueLhs);
+        if (structural != null)
+        {
+            this.il.OpCode(ILOpCode.Box);
+            this.il.Token(this.outer.memberRefs.GetElementTypeToken(structural));
+        }
+
         this.il.LoadLocalAddress(rhsSlot);
         this.il.OpCode(ILOpCode.Call);
         this.il.Token(getValueRhs);
-        this.EmitUnderlyingEqualityCeq(underlying);
+        if (structural != null)
+        {
+            this.il.OpCode(ILOpCode.Box);
+            this.il.Token(this.outer.memberRefs.GetElementTypeToken(structural));
+            this.il.Call(this.outer.wellKnown.GetObjectStaticEqualsReference());
+        }
+        else
+        {
+            this.EmitUnderlyingEqualityCeq(underlying);
+        }
+
         this.il.Branch(ILOpCode.Br, end);
 
         this.il.MarkLabel(bothEmptyLabel);

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
@@ -2098,13 +2098,6 @@ internal sealed partial class MethodBodyEmitter
                 fnHandle = definitionHandle;
             }
 
-            if (op.Function.IsGeneric && !op.Function.TypeParameters.IsDefaultOrEmpty)
-            {
-                throw new NotSupportedException(
-                    $"Lifted same-compilation operator '{op.Function.Name}' is generic; MethodSpec construction for "
-                    + "a nullable-lifted generic operator call is not yet supported (deferred follow-up).");
-            }
-
             this.il.OpCode(ILOpCode.Call);
             this.il.Token(fnHandle);
             return;

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
@@ -2080,26 +2080,7 @@ internal sealed partial class MethodBodyEmitter
     {
         if (op.Function != null)
         {
-            EntityHandle fnHandle;
-            if (op.FunctionOwnerType != null
-                && ReflectionMetadataEmitter.IsUserGenericTypeReference(op.FunctionOwnerType))
-            {
-                fnHandle = this.outer.userTokens.ResolveUserStaticMethodToken(op.FunctionOwnerType, op.Function);
-            }
-            else
-            {
-                if (!this.outer.cache.FunctionHandles.TryGetValue(op.Function, out var definitionHandle)
-                    && !this.outer.cache.MethodHandles.TryGetValue(op.Function, out definitionHandle))
-                {
-                    throw new InvalidOperationException(
-                        $"Lifted same-compilation operator '{op.Function.Name}' has no emitted MethodDef.");
-                }
-
-                fnHandle = definitionHandle;
-            }
-
-            this.il.OpCode(ILOpCode.Call);
-            this.il.Token(fnHandle);
+            this.EmitCallResolvedUserFunction(op.Function, op.FunctionOwnerType);
             return;
         }
 
@@ -2107,6 +2088,33 @@ internal sealed partial class MethodBodyEmitter
         this.il.Token(this.outer.memberRefs.GetMethodReference(Invariant.Required(
             op.Method,
             "this is the imported-CLR-operator branch; the same-compilation form (issue #2388) carries Function instead and is handled above")));
+    }
+
+    private void EmitCallResolvedUserFunction(
+        FunctionSymbol function,
+        StructSymbol? functionOwnerType)
+    {
+        EntityHandle functionHandle;
+        if (functionOwnerType != null)
+        {
+            functionHandle = this.outer.userTokens.ResolveUserStaticMethodToken(
+                functionOwnerType,
+                function);
+        }
+        else
+        {
+            if (!this.outer.cache.FunctionHandles.TryGetValue(function, out var definitionHandle)
+                && !this.outer.cache.MethodHandles.TryGetValue(function, out definitionHandle))
+            {
+                throw new InvalidOperationException(
+                    $"Same-compilation function '{function.Name}' has no emitted MethodDef.");
+            }
+
+            functionHandle = definitionHandle;
+        }
+
+        this.il.OpCode(ILOpCode.Call);
+        this.il.Token(functionHandle);
     }
 
     private void EmitClrUnaryOperator(BoundClrUnaryOperatorExpression op)

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
@@ -688,6 +688,12 @@ internal sealed partial class MethodBodyEmitter
             return;
         }
 
+        if ((b.Op.Kind == BoundBinaryOperatorKind.Equals || b.Op.Kind == BoundBinaryOperatorKind.NotEquals)
+            && this.TryEmitNullableUserStructEquality(b))
+        {
+            return;
+        }
+
         // Issue #1298: lifted equality / inequality over a nullable
         // user-defined enum (`E? == E?`, `E? == E`, `E? == nil`, …). A
         // user EnumSymbol has no static CLR type, so the value-type
@@ -1045,7 +1051,7 @@ internal sealed partial class MethodBodyEmitter
         // and compare the resulting reference against null.
         if (leftIsNullableEnum && right.Type == TypeSymbol.Null)
         {
-            this.EmitBoxedEnumOperand(left);
+            this.EmitBoxedNullableValueOperand(left);
             this.il.OpCode(ILOpCode.Ldnull);
             this.il.OpCode(ILOpCode.Ceq);
             this.EmitEqualityNegationIfNeeded(b.Op.Kind);
@@ -1054,7 +1060,7 @@ internal sealed partial class MethodBodyEmitter
 
         if (rightIsNullableEnum && left.Type == TypeSymbol.Null)
         {
-            this.EmitBoxedEnumOperand(right);
+            this.EmitBoxedNullableValueOperand(right);
             this.il.OpCode(ILOpCode.Ldnull);
             this.il.OpCode(ILOpCode.Ceq);
             this.EmitEqualityNegationIfNeeded(b.Op.Kind);
@@ -1069,8 +1075,8 @@ internal sealed partial class MethodBodyEmitter
         bool rightIsEnum = rightIsNullableEnum || right.Type is EnumSymbol;
         if ((leftIsNullableEnum || rightIsNullableEnum) && leftIsEnum && rightIsEnum)
         {
-            this.EmitBoxedEnumOperand(left);
-            this.EmitBoxedEnumOperand(right);
+            this.EmitBoxedNullableValueOperand(left);
+            this.EmitBoxedNullableValueOperand(right);
             this.il.Call(this.outer.wellKnown.GetObjectStaticEqualsReference());
             this.EmitEqualityNegationIfNeeded(b.Op.Kind);
             return true;
@@ -1079,7 +1085,26 @@ internal sealed partial class MethodBodyEmitter
         return false;
     }
 
-    private void EmitBoxedEnumOperand(BoundExpression operand)
+    private bool TryEmitNullableUserStructEquality(BoundBinaryExpression b)
+    {
+        if (b.Left.Type is not NullableTypeSymbol leftNullable
+            || b.Right.Type is not NullableTypeSymbol rightNullable
+            || leftNullable.UnderlyingType is not StructSymbol structural
+            || structural.IsClass
+            || (!structural.IsData && !structural.IsInline)
+            || structural != rightNullable.UnderlyingType)
+        {
+            return false;
+        }
+
+        this.EmitBoxedNullableValueOperand(b.Left);
+        this.EmitBoxedNullableValueOperand(b.Right);
+        this.il.Call(this.outer.wellKnown.GetObjectStaticEqualsReference());
+        this.EmitEqualityNegationIfNeeded(b.Op.Kind);
+        return true;
+    }
+
+    private void EmitBoxedNullableValueOperand(BoundExpression operand)
     {
         this.EmitExpression(operand);
         this.il.OpCode(ILOpCode.Box);

--- a/src/Core/CodeAnalysis/Emit/MethodBodyPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyPlanner.cs
@@ -703,25 +703,32 @@ internal sealed class MethodBodyPlanner
             liftedBinarySlots[lifted] = new LiftedBinarySlots(lhsSlot, rhsSlot, resultSlot);
         }
 
-        // Issue #1236: each lifted Nullable<T1> -> Nullable<T2> numeric widening
+        // Issues #1236/#3518: each lifted Nullable<T1> -> Nullable<T2>
         // conversion needs two consecutive scratch slots — the source
         // Nullable<T1> (spilled so the emitter can take its address for
-        // get_HasValue / GetValueOrDefault) and a result Nullable<T2> (to
+        // get_HasValue / get_Value) and a result Nullable<T2> (to
         // initobj a default value on the null branch). The slot index of the
         // source is stored in receiverSpillSlots (already an aggregate of
         // distinct-by-node scratch-slot kinds); the emitter derives the result
         // slot as source + 1. Skip nodes already owned by another collector.
-        foreach (var widening in this.CollectNullableNumericWideningConversions(body))
+        foreach (var conversion in this.CollectNullableValueTypeConversions(body))
         {
-            if (receiverSpillSlots.ContainsKey(widening))
+            if (receiverSpillSlots.ContainsKey(conversion))
             {
                 continue;
             }
 
+            var source = conversion switch
+            {
+                BoundConversionExpression builtIn => builtIn.Expression,
+                BoundClrConversionCallExpression clr => clr.Source,
+                _ => throw new InvalidOperationException(
+                    $"Unexpected lifted nullable conversion node '{conversion.Kind}'."),
+            };
             var srcSlot = localTypes.Count;
-            localTypes.Add(widening.Expression.Type);
-            localTypes.Add(widening.Type);
-            receiverSpillSlots[widening] = srcSlot;
+            localTypes.Add(source.Type);
+            localTypes.Add(conversion.Type);
+            receiverSpillSlots[conversion] = srcSlot;
         }
     }
 
@@ -1381,10 +1388,10 @@ internal sealed class MethodBodyPlanner
         _ => throw new InvalidOperationException($"DecomposeLiftedBinary: unexpected lifted binary node kind '{lifted.Kind}'."),
     };
 
-    internal IEnumerable<BoundConversionExpression> CollectNullableNumericWideningConversions(BoundNode root)
+    internal IEnumerable<BoundExpression> CollectNullableValueTypeConversions(BoundNode root)
     {
-        var sink = new List<BoundConversionExpression>();
-        this.slotPlanner.CollectNullableNumericWideningConversions((BoundStatement)root, sink);
+        var sink = new List<BoundExpression>();
+        this.slotPlanner.CollectNullableValueTypeConversions((BoundStatement)root, sink);
         return sink;
     }
 

--- a/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
@@ -1893,7 +1893,10 @@ internal sealed class SlotPlanner
 
         protected override void VisitClrConversionCallExpression(BoundClrConversionCallExpression node)
         {
-            if (IsLiftedNullableConversion(node.Source.Type, node.Type))
+            if (IsLiftedNullableConversion(
+                node.Source.Type,
+                node.Type,
+                allowSymbolic: node.Function != null))
             {
                 this.sink.Add(node);
             }
@@ -1902,10 +1905,19 @@ internal sealed class SlotPlanner
         }
 
         private static bool IsLiftedNullableConversion(TypeSymbol source, TypeSymbol target)
+            => IsLiftedNullableConversion(source, target, allowSymbolic: false);
+
+        private static bool IsLiftedNullableConversion(
+            TypeSymbol source,
+            TypeSymbol target,
+            bool allowSymbolic)
             => source is NullableTypeSymbol from
                 && target is NullableTypeSymbol to
-                && from.UnderlyingType?.ClrType is { IsValueType: true }
-                && to.UnderlyingType?.ClrType is { IsValueType: true }
+                && ((from.UnderlyingType?.ClrType is { IsValueType: true }
+                        && to.UnderlyingType?.ClrType is { IsValueType: true })
+                    || (allowSymbolic
+                        && NullableLifting.IsAnyValueTypeNullable(from)
+                        && NullableLifting.IsAnyValueTypeNullable(to)))
                 && from.UnderlyingType != to.UnderlyingType;
     }
 }

--- a/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
@@ -253,8 +253,8 @@ internal sealed class SlotPlanner
     public void CollectLiftedBinaryOperators(BoundStatement root, List<BoundExpression> sink)
         => new LiftedBinaryOperatorCollector(sink).Visit(root);
 
-    public void CollectNullableNumericWideningConversions(BoundStatement root, List<BoundConversionExpression> sink)
-        => new NullableNumericWideningConversionCollector(sink).Visit(root);
+    public void CollectNullableValueTypeConversions(BoundStatement root, List<BoundExpression> sink)
+        => new NullableValueTypeConversionCollector(sink).Visit(root);
 
     public void RunPatternSwitchAllocator(
         BoundNode node,
@@ -1870,34 +1870,43 @@ internal sealed class SlotPlanner
         }
     }
 
-    // Issue #1236: walks the bound tree collecting every BoundConversionExpression
-    // that is a lifted numeric widening between two distinct value-type
-    // Nullable<T> operands (e.g. `uint8? -> int32?`). Each such conversion needs
-    // two consecutive scratch slots so the emitter can spill the source
-    // Nullable<T1> (to call get_HasValue / GetValueOrDefault off its address) and
-    // initobj a default Nullable<T2> on the null branch.
-    private sealed class NullableNumericWideningConversionCollector : BoundTreeWalker
+    // Issues #1236/#3518: lifted numeric and CLR user-defined conversions
+    // between value-type Nullable<T> shapes share the same two-slot lowering.
+    private sealed class NullableValueTypeConversionCollector : BoundTreeWalker
     {
-        private readonly List<BoundConversionExpression> sink;
+        private readonly List<BoundExpression> sink;
 
-        public NullableNumericWideningConversionCollector(List<BoundConversionExpression> sink)
+        public NullableValueTypeConversionCollector(List<BoundExpression> sink)
         {
             this.sink = sink;
         }
 
         protected override void VisitConversionExpression(BoundConversionExpression node)
         {
-            if (node.Expression.Type is NullableTypeSymbol from
-                && node.Type is NullableTypeSymbol to
-                && from.UnderlyingType?.ClrType is { IsValueType: true }
-                && to.UnderlyingType?.ClrType is { IsValueType: true }
-                && from.UnderlyingType != to.UnderlyingType)
+            if (IsLiftedNullableConversion(node.Expression.Type, node.Type))
             {
                 this.sink.Add(node);
             }
 
             base.VisitConversionExpression(node);
         }
+
+        protected override void VisitClrConversionCallExpression(BoundClrConversionCallExpression node)
+        {
+            if (IsLiftedNullableConversion(node.Source.Type, node.Type))
+            {
+                this.sink.Add(node);
+            }
+
+            base.VisitClrConversionCallExpression(node);
+        }
+
+        private static bool IsLiftedNullableConversion(TypeSymbol source, TypeSymbol target)
+            => source is NullableTypeSymbol from
+                && target is NullableTypeSymbol to
+                && from.UnderlyingType?.ClrType is { IsValueType: true }
+                && to.UnderlyingType?.ClrType is { IsValueType: true }
+                && from.UnderlyingType != to.UnderlyingType;
     }
 }
 

--- a/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
@@ -949,7 +949,18 @@ public static class SpillSequenceSpiller
                     return SpillOneOperand(
                         clrConv,
                         clrConv.Source,
-                        src => new BoundClrConversionCallExpression(null, src, clrConv.Method, clrConv.Type));
+                        src => clrConv.Function != null
+                            ? new BoundClrConversionCallExpression(
+                                null,
+                                src,
+                                clrConv.Function,
+                                clrConv.FunctionOwnerType,
+                                clrConv.Type)
+                            : new BoundClrConversionCallExpression(
+                                null,
+                                src,
+                                Invariant.Required(clrConv.Method, "an imported conversion carries a CLR method"),
+                                clrConv.Type));
                 case BoundClrEventSubscriptionExpression clrEventSub:
                     if (clrEventSub.Receiver == null)
                     {

--- a/src/Core/CodeAnalysis/Lowering/ExpressionTreeLowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/ExpressionTreeLowerer.cs
@@ -423,6 +423,8 @@ internal sealed class ExpressionTreeLowerer : NestedFunctionBodyRewriter
                 return BuildClrBinaryOperatorExpression(clrBinary, parameterMap);
             case BoundClrUnaryOperatorExpression clrUnary:
                 return BuildClrUnaryOperatorExpression(clrUnary, parameterMap);
+            case BoundClrConversionCallExpression userConversion:
+                return BuildUserDefinedConversionExpression(userConversion, parameterMap);
             case BoundFunctionLiteralExpression nestedDelegateLiteral:
                 return BuildRuntimeConstant(nestedDelegateLiteral, nestedDelegateLiteral.Type);
             case BoundStructLiteralExpression structLiteral:
@@ -845,6 +847,36 @@ internal sealed class ExpressionTreeLowerer : NestedFunctionBodyRewriter
                 CreateTypeOf(conversion.Type)));
     }
 
+    private BoundExpression BuildUserDefinedConversionExpression(
+        BoundClrConversionCallExpression conversion,
+        Dictionary<VariableSymbol, LocalVariableSymbol> parameterMap)
+    {
+        BoundExpression methodInfo;
+        if (conversion.Method != null)
+        {
+            methodInfo = BuildMethodInfoConstant(conversion.Method);
+        }
+        else
+        {
+            var function = conversion.Function
+                ?? throw new NotSupportedException(
+                    "A same-compilation expression-tree conversion requires a function symbol.");
+            methodInfo = BuildUserFunctionMethodInfoLookup(
+                conversion.Syntax,
+                function,
+                conversion.FunctionOwnerType);
+        }
+
+        return new BoundClrStaticCallExpression(
+            conversion.Syntax,
+            ExpressionConvertWithMethodMethod,
+            TypeSymbol.FromClrType(typeof(System.Linq.Expressions.UnaryExpression)),
+            ImmutableArray.Create<BoundExpression>(
+                UpcastToExpression(this.TranslateExpression(conversion.Source, parameterMap)),
+                CreateTypeOf(conversion.Type),
+                methodInfo));
+    }
+
     private BoundExpression BuildImportedInstanceCallExpression(
         BoundImportedInstanceCallExpression call,
         Dictionary<VariableSymbol, LocalVariableSymbol> parameterMap)
@@ -1215,8 +1247,19 @@ internal sealed class ExpressionTreeLowerer : NestedFunctionBodyRewriter
     {
         var function = expression.Function
             ?? throw new NotSupportedException("A same-compilation expression-tree operator requires a function symbol.");
-        var ownerType = expression.FunctionOwnerType ?? function.StaticOwnerType as StructSymbol
-            ?? throw new NotSupportedException($"Operator '{function.Name}' has no same-compilation declaring type.");
+        return BuildUserFunctionMethodInfoLookup(
+            expression.Syntax,
+            function,
+            expression.FunctionOwnerType);
+    }
+
+    private static BoundExpression BuildUserFunctionMethodInfoLookup(
+        SyntaxNode? syntax,
+        FunctionSymbol function,
+        StructSymbol? functionOwnerType)
+    {
+        var ownerType = functionOwnerType ?? function.StaticOwnerType as StructSymbol
+            ?? throw new NotSupportedException($"Function '{function.Name}' has no same-compilation declaring type.");
 
         var parameterTypes = ImmutableArray.CreateBuilder<TypeSymbol>(function.Parameters.Length);
         foreach (var parameter in function.Parameters)
@@ -1225,7 +1268,7 @@ internal sealed class ExpressionTreeLowerer : NestedFunctionBodyRewriter
         }
 
         return new BoundImportedInstanceCallExpression(
-            expression.Syntax,
+            syntax,
             CreateTypeOf(ownerType),
             TypeGetMethodByParameterTypesMethod,
             ReflectionMethodInfoTypeSymbol,

--- a/src/Core/CodeAnalysis/Lowering/ExpressionTreeLowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/ExpressionTreeLowerer.cs
@@ -819,7 +819,8 @@ internal sealed class ExpressionTreeLowerer : NestedFunctionBodyRewriter
 
         var methodInfo = conversion switch
         {
-            BoundConversionExpression { Expression: BoundClrConversionCallExpression clrConversion } => BuildMethodInfoConstant(clrConversion.Method),
+            BoundConversionExpression { Expression: BoundClrConversionCallExpression clrConversion }
+                when clrConversion.Method != null => BuildMethodInfoConstant(clrConversion.Method),
             _ => null,
         };
 

--- a/test/Compiler.Tests/Emit/Issue2377OperatorMetadataShapeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2377OperatorMetadataShapeEmitTests.cs
@@ -460,6 +460,52 @@ public class Issue2377OperatorMetadataShapeEmitTests
         Assert.Contains(result.Diagnostics, d => d.Id == "GS0129");
     }
 
+    [Fact]
+    public void ImportedNonLiftableOperatorSignatures_ReportConversionErrorsNotEmitterFailures()
+    {
+        var libraryPath = EmitGSharpLibrary(
+            nameof(ImportedNonLiftableOperatorSignatures_ReportConversionErrorsNotEmitterFailures),
+            """
+            package Lib
+
+            struct ReferenceParameterValue(N int32) { }
+            func (left ReferenceParameterValue) operator +(right object) ReferenceParameterValue -> left
+
+            struct ReferenceResultValue(N int32) { }
+            func (left ReferenceResultValue) operator +(right ReferenceResultValue) object -> left
+            """);
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+        var consumer = new GsCompilation(
+            resolver,
+            GsSyntaxTree.Parse(SourceText.From(
+                """
+                package App
+                import Lib
+
+                func BadParameter(left ReferenceParameterValue?, right object) ReferenceParameterValue? {
+                    return left + right
+                }
+
+                func BadResult(left ReferenceResultValue?, right ReferenceResultValue?) object? {
+                    return left + right
+                }
+                """)))
+        {
+            IsLibrary = true,
+        };
+
+        using var peStream = new MemoryStream();
+        var result = consumer.Emit(
+            peStream,
+            pdbStream: null,
+            refStream: null,
+            assemblyName: "Issue2377Emit.NonLiftableSignatures");
+        Assert.False(result.Success);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0129");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS9998");
+    }
+
     private static string EmitGSharpLibrary(string caseName, string gsharpSource)
     {
         var libraryDir = LibraryDirectory();

--- a/test/Compiler.Tests/Emit/Issue2388NullableCustomEqualityEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2388NullableCustomEqualityEmitTests.cs
@@ -490,7 +490,7 @@ public class Issue2388NullableCustomEqualityEmitTests
         }
     }
 
-    private static (int ExitCode, string Stdout, string Stderr) TryCompile(string source)
+    internal static (int ExitCode, string Stdout, string Stderr) TryCompile(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_issue2388_neg_").FullName;
         try

--- a/test/Compiler.Tests/Emit/Issue2398ExpressionTreeLiftedUserOperatorEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2398ExpressionTreeLiftedUserOperatorEmitTests.cs
@@ -156,6 +156,60 @@ public class Issue2398ExpressionTreeLiftedUserOperatorEmitTests
         }
     }
 
+    [Fact]
+    public void SameCompilationLiftedConversion_UsesResolvedConversionMethod()
+    {
+        var source = """
+            package Issue2398Conversion
+            import System
+            import System.Linq.Expressions
+
+            struct Source(Raw int32) { }
+            struct Target(Code string) { }
+
+            func operator implicit(value Source) Target -> Target(value.Raw.ToString())
+            func (left Target) operator ==(right Target) bool -> left.Code == right.Code
+
+            func Predicate() Expression[Func[Source?, Target?, bool]] {
+                return (left Source?, right Target?) -> left == right
+            }
+            """;
+
+        var (assembly, loadContext) = CompileToAssembly(
+            source,
+            nameof(SameCompilationLiftedConversion_UsesResolvedConversionMethod));
+        try
+        {
+            var lambda = GetLambda(assembly, "Predicate");
+            var binary = Assert.IsAssignableFrom<BinaryExpression>(lambda.Body);
+            var conversion = Assert.IsAssignableFrom<UnaryExpression>(binary.Left);
+            var sourceType = assembly.GetTypes().Single(t => t.Name == "Source");
+            var targetType = assembly.GetTypes().Single(t => t.Name == "Target");
+
+            Assert.Equal(ExpressionType.Convert, conversion.NodeType);
+            Assert.True(conversion.IsLifted);
+            Assert.True(conversion.IsLiftedToNull);
+            Assert.Equal("op_Implicit", conversion.Method?.Name);
+            Assert.Equal(sourceType, conversion.Method?.DeclaringType);
+
+            var compiled = lambda.Compile();
+            var sourceValue = Activator.CreateInstance(sourceType);
+            sourceType.GetField("Raw")!.SetValue(sourceValue, 7);
+            var equal = Activator.CreateInstance(targetType);
+            targetType.GetField("Code")!.SetValue(equal, "7");
+            var different = Activator.CreateInstance(targetType);
+            targetType.GetField("Code")!.SetValue(different, "8");
+            Assert.True((bool)compiled.DynamicInvoke(sourceValue, equal)!);
+            Assert.False((bool)compiled.DynamicInvoke(sourceValue, different)!);
+            Assert.False((bool)compiled.DynamicInvoke(null, equal)!);
+            Assert.True((bool)compiled.DynamicInvoke(null, null)!);
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+
     private static LambdaExpression GetLambda(Assembly assembly, string methodName)
     {
         var programType = assembly.GetTypes().Single(t => t.Name == "<Program>");

--- a/test/Compiler.Tests/Emit/Issue2398ExpressionTreeLiftedUserOperatorEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2398ExpressionTreeLiftedUserOperatorEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Numerics;
 using System.Reflection;
 using System.Runtime.Loader;
 using GsCompilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
@@ -203,6 +204,93 @@ public class Issue2398ExpressionTreeLiftedUserOperatorEmitTests
             Assert.False((bool)compiled.DynamicInvoke(sourceValue, different)!);
             Assert.False((bool)compiled.DynamicInvoke(null, equal)!);
             Assert.True((bool)compiled.DynamicInvoke(null, null)!);
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+
+    [Fact]
+    public void ImportedLiftedConversion_DirectLambdaBody_IsMaterialized()
+    {
+        var source = """
+            package Issue2398ImportedConversion
+            import System
+            import System.Linq.Expressions
+            import System.Numerics
+
+            func Conversion() Expression[Func[int32?, BigInteger?]] {
+                return (value int32?) -> value
+            }
+            """;
+
+        var (assembly, loadContext) = CompileToAssembly(
+            source,
+            nameof(ImportedLiftedConversion_DirectLambdaBody_IsMaterialized));
+        try
+        {
+            var lambda = GetLambda(assembly, "Conversion");
+            var conversion = Assert.IsAssignableFrom<UnaryExpression>(lambda.Body);
+
+            Assert.Equal(ExpressionType.Convert, conversion.NodeType);
+            Assert.True(conversion.IsLifted);
+            Assert.True(conversion.IsLiftedToNull);
+            Assert.Equal("op_Implicit", conversion.Method?.Name);
+            Assert.Equal(typeof(BigInteger), conversion.Method?.DeclaringType);
+
+            var compiled = lambda.Compile();
+            Assert.Equal(new BigInteger(7), compiled.DynamicInvoke(7));
+            Assert.Null(compiled.DynamicInvoke(new object[] { null! }));
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+
+    [Fact]
+    public void ClosedGenericLiftedConversion_DirectLambdaBody_UsesClosedOwner()
+    {
+        var source = """
+            package Issue2398ClosedConversion
+            import System
+            import System.Linq.Expressions
+
+            struct Box[T] {
+                var Value T
+                var Rank int32
+            }
+
+            func operator implicit(value Box[T]) int32 -> value.Rank
+
+            func Conversion() Expression[Func[Box[string]?, int32?]] {
+                return (value Box[string]?) -> value
+            }
+            """;
+
+        var (assembly, loadContext) = CompileToAssembly(
+            source,
+            nameof(ClosedGenericLiftedConversion_DirectLambdaBody_UsesClosedOwner));
+        try
+        {
+            var lambda = GetLambda(assembly, "Conversion");
+            var conversion = Assert.IsAssignableFrom<UnaryExpression>(lambda.Body);
+            var method = Assert.IsAssignableFrom<MethodInfo>(conversion.Method);
+            var boxType = assembly.GetTypes().Single(t => t.Name.StartsWith("Box`", StringComparison.Ordinal))
+                .MakeGenericType(typeof(string));
+
+            Assert.True(conversion.IsLifted);
+            Assert.True(conversion.IsLiftedToNull);
+            Assert.Equal("op_Implicit", method.Name);
+            Assert.Equal(boxType, method.DeclaringType);
+            Assert.Equal(boxType, method.GetParameters().Single().ParameterType);
+
+            var value = Activator.CreateInstance(boxType);
+            boxType.GetField("Rank")!.SetValue(value, 7);
+            var compiled = lambda.Compile();
+            Assert.Equal(7, compiled.DynamicInvoke(value));
+            Assert.Null(compiled.DynamicInvoke(new object[] { null! }));
         }
         finally
         {

--- a/test/Compiler.Tests/Emit/Issue2866ImportedDataEqualityEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2866ImportedDataEqualityEmitTests.cs
@@ -154,7 +154,7 @@ public class Issue2866ImportedDataEqualityEmitTests
         Assert.Equal($"True,False{Environment.NewLine}", CompileAndRun(source));
     }
 
-    private static string CompileAndRun(string source, string library = null, string libraryAssemblyName = null)
+    internal static string CompileAndRun(string source, string library = null, string libraryAssemblyName = null)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_2866_").FullName;
         try

--- a/test/Compiler.Tests/Emit/Issue3518EqualityLoweringEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3518EqualityLoweringEmitTests.cs
@@ -78,4 +78,168 @@ public class Issue3518EqualityLoweringEmitTests
             library,
             "FindingNullableDataStructEquality"));
     }
+
+    [Fact]
+    public void UnsignedHighBitMixedEquality_RunsAndVerifies()
+    {
+        const string source = """
+            package FindingUnsignedMixedEquality
+
+            func Main() int32 {
+                let u32 = uint32(1) << 31
+                let u64 = uint64(1) << 63
+                let un = nuint(1) << 63
+                let f32 = float32(2147483648.0)
+                let f64 = 9223372036854775808.0
+
+                let n32 uint32? = u32
+                let n64 uint64? = u64
+                let nn nuint? = un
+                let nf32 float32? = f32
+                let nf64 float64? = f64
+
+                let direct = u32 == f32 && u64 == f64 && un == f64
+                let lifted = n32 == nf32 && n64 == nf64 && nn == nf64
+                return direct && lifted ? 0 : 1
+            }
+            """;
+
+        Assert.Empty(Issue2866ImportedDataEqualityEmitTests.CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ImportedNullableImplicitConversionEquality_RunsAndVerifies()
+    {
+        const string library = """
+            package FindingNullableConversionEquality
+
+            public struct Source(Raw int32) { }
+            public struct Target(Value int32) { }
+
+            func operator implicit(value Source) Target -> Target(value.Raw)
+            func (left Target) operator ==(right Target) bool -> left.Value == right.Value
+            """;
+
+        const string source = """
+            package FindingNullableConversionEqualityApp
+
+            import FindingNullableConversionEquality
+
+            func Equal(left Source?, right Target?) bool -> left == right
+
+            func Main() int32 {
+                let source Source? = Source(7)
+                let equal Target? = Target(7)
+                let different Target? = Target(8)
+                let missingSource Source? = nil
+                let missingTarget Target? = nil
+
+                let present = Equal(source, equal)
+                let valueMismatch = !Equal(source, different)
+                let presenceMismatch = !Equal(missingSource, equal)
+                let absent = Equal(missingSource, missingTarget)
+                return present && valueMismatch && presenceMismatch && absent ? 0 : 1
+            }
+            """;
+
+        Assert.Empty(Issue2866ImportedDataEqualityEmitTests.CompileAndRun(
+            source,
+            library,
+            "FindingNullableConversionEquality"));
+    }
+
+    [Fact]
+    public void NullableBoxingOperator_UsesNonLiftedCallAndVerifies()
+    {
+        const string source = """
+            package FindingNullableBoxingOperator
+
+            struct Token(Value int32) { }
+
+            func (left Token) operator ==(right object) bool {
+                return left.Value == 7 && right != nil
+            }
+
+            func Main() int32 {
+                let value int32? = 7
+                return Token(7) == value ? 0 : 1
+            }
+            """;
+
+        Assert.Empty(Issue2866ImportedDataEqualityEmitTests.CompileAndRun(source));
+    }
+
+    [Fact]
+    public void NonLiftableOperatorSignatures_FailWithoutInternalCompilerError()
+    {
+        var sources = new[]
+        {
+            """
+            package FindingNonLiftableReferenceParameter
+
+            struct Value(N int32) { }
+            func (left Value) operator +(right object) Value -> left
+
+            func Bad(left Value?, right object) Value? -> left + right
+            """,
+            """
+            package FindingNonLiftableReferenceResult
+
+            struct Value(N int32) { }
+            func (left Value) operator +(right Value) object -> left
+
+            func Bad(left Value?, right Value?) object? -> left + right
+            """,
+        };
+
+        foreach (var source in sources)
+        {
+            var (exitCode, stdout, stderr) =
+                Issue2388NullableCustomEqualityEmitTests.TryCompile(source);
+            var diagnostics = stdout + stderr;
+            Assert.NotEqual(0, exitCode);
+            Assert.Contains("GS0155", diagnostics);
+            Assert.DoesNotContain("GS9998", diagnostics);
+        }
+    }
+
+    [Fact]
+    public void MethodGenericOperator_ReportsSourceDiagnostic()
+    {
+        const string source = """
+            package FindingMethodGenericOperator
+
+            struct Value(N int32) { }
+            func (left Value) op_Addition[T struct](right Value) Value -> left
+
+            func Bad(left Value?, right Value?) Value? -> left + right
+            """;
+
+        var (exitCode, stdout, stderr) =
+            Issue2388NullableCustomEqualityEmitTests.TryCompile(source);
+        var diagnostics = stdout + stderr;
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("GS0537", diagnostics);
+        Assert.DoesNotContain("GS9998", diagnostics);
+    }
+
+    [Fact]
+    public void ByRefOperatorSignature_IsNotCallableThroughBinarySyntax()
+    {
+        const string source = """
+            package FindingByRefOperator
+
+            struct Value(N int32) { }
+            func (left Value) op_Addition(ref right Value) Value -> left
+
+            func Bad(left Value, right Value) Value -> left + right
+            """;
+
+        var (exitCode, stdout, stderr) =
+            Issue2388NullableCustomEqualityEmitTests.TryCompile(source);
+        var diagnostics = stdout + stderr;
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("GS0129", diagnostics);
+        Assert.DoesNotContain("GS9998", diagnostics);
+    }
 }

--- a/test/Compiler.Tests/Emit/Issue3518EqualityLoweringEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3518EqualityLoweringEmitTests.cs
@@ -1,0 +1,81 @@
+// <copyright file="Issue3518EqualityLoweringEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #3518: equality operands must match emitted operator stack types.
+/// </summary>
+public class Issue3518EqualityLoweringEmitTests
+{
+    [Fact]
+    public void MixedInt32AndFloat64Equality_RunsAndVerifies()
+    {
+        const string source = """
+            package FindingMixedNumericEquality
+
+            class Holder {
+                var Value float64
+            }
+
+            func Main() int32 {
+                let integer int32 = 7
+                let decimal float64 = 7.0
+                let first = integer == decimal
+                let holder = Holder{ Value: 7.0 }
+                let second = holder.Value == 7
+                let nullableInteger int32? = integer
+                let nullableDecimal float64? = decimal
+                let third = nullableInteger == nullableDecimal
+                return first && second && third ? 0 : 1
+            }
+            """;
+
+        Assert.Empty(Issue2866ImportedDataEqualityEmitTests.CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ImportedNullableDataStructEquality_RunsAndVerifies()
+    {
+        const string library = """
+            package FindingNullableDataStructEquality
+
+            public data struct Identifier(Value string) { }
+            """;
+
+        const string source = """
+            package FindingNullableDataStructEqualityApp
+
+            import FindingNullableDataStructEquality
+
+            class Holder {
+                private var current Identifier?
+
+                public func Equal(next Identifier?) bool {
+                    return this.current == next
+                }
+
+                public func Set(next Identifier?) {
+                    this.current = next
+                }
+            }
+
+            func Main() int32 {
+                let holder = Holder()
+                let bothNil = holder.Equal(nil)
+                holder.Set(Identifier("same"))
+                let bothEqual = holder.Equal(Identifier("same"))
+                let different = holder.Equal(Identifier("different"))
+                return bothNil && bothEqual && !different ? 0 : 1
+            }
+            """;
+
+        Assert.Empty(Issue2866ImportedDataEqualityEmitTests.CompileAndRun(
+            source,
+            library,
+            "FindingNullableDataStructEquality"));
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue3518EqualityLoweringEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3518EqualityLoweringEmitTests.cs
@@ -302,4 +302,109 @@ public class Issue3518EqualityLoweringEmitTests
 
         Assert.Empty(Issue2866ImportedDataEqualityEmitTests.CompileAndRun(source));
     }
+
+    [Fact]
+    public void ImportedLiftedConversionExpressionTree_RunsAndVerifies()
+    {
+        const string library = """
+            package FindingImportedConversionTree
+
+            public struct Source(Raw int32) { }
+            public struct Target(Code string) { }
+
+            func operator implicit(value Source) Target -> Target(value.Raw.ToString())
+            func (left Target) operator ==(right Target) bool -> left.Code == right.Code
+            """;
+
+        const string source = """
+            package FindingImportedConversionTreeApp
+
+            import FindingImportedConversionTree
+            import System
+            import System.Linq.Expressions
+
+            func Predicate() Expression[Func[Source?, Target?, bool]] {
+                return (left Source?, right Target?) -> left == right
+            }
+
+            func Main() int32 {
+                let compare = Predicate().Compile()
+                let source Source? = Source(7)
+                let equal Target? = Target("7")
+                let different Target? = Target("8")
+                let missingSource Source? = nil
+                let missingTarget Target? = nil
+                return compare(source, equal)
+                    && !compare(source, different)
+                    && !compare(missingSource, equal)
+                    && compare(missingSource, missingTarget) ? 0 : 1
+            }
+            """;
+
+        Assert.Empty(Issue2866ImportedDataEqualityEmitTests.CompileAndRun(
+            source,
+            library,
+            "FindingImportedConversionTree"));
+    }
+
+    [Fact]
+    public void ClosedGenericNullableConversion_PreservesConstructedOwner()
+    {
+        const string source = """
+            package FindingClosedGenericNullableConversion
+
+            struct Box[T] {
+                var Value T
+                var Rank int32
+            }
+
+            func operator implicit(value Box[T]) int32 -> value.Rank
+
+            func Convert(value Box[string]?) int32? -> value
+
+            func Main() int32 {
+                let present Box[string]? = Box[string]{Value: "x", Rank: 7}
+                let converted = Convert(present)
+                let missing Box[string]? = nil
+                return converted!! == 7 && Convert(missing) == nil ? 0 : 1
+            }
+            """;
+
+        Assert.Empty(Issue2866ImportedDataEqualityEmitTests.CompileAndRun(source));
+    }
+
+    [Fact]
+    public void SameCompilationNullableStructuralEquality_RunsAndVerifies()
+    {
+        const string source = """
+            package FindingLocalNullableStructuralEquality
+
+            data struct DataId(Value string) { }
+            inline struct InlineId(value string)
+
+            func Main() int32 {
+                let data DataId? = DataId("same")
+                let sameData DataId? = DataId("same")
+                let otherData DataId? = DataId("other")
+                let missingData DataId? = nil
+
+                let inline InlineId? = InlineId("same")
+                let sameInline InlineId? = InlineId("same")
+                let otherInline InlineId? = InlineId("other")
+                let missingInline InlineId? = nil
+
+                let dataOk = data == sameData
+                    && data != otherData
+                    && data != missingData
+                    && missingData == missingData
+                let inlineOk = inline == sameInline
+                    && inline != otherInline
+                    && inline != missingInline
+                    && missingInline == missingInline
+                return dataOk && inlineOk ? 0 : 1
+            }
+            """;
+
+        Assert.Empty(Issue2866ImportedDataEqualityEmitTests.CompileAndRun(source));
+    }
 }

--- a/test/Compiler.Tests/Emit/Issue3518EqualityLoweringEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3518EqualityLoweringEmitTests.cs
@@ -242,4 +242,64 @@ public class Issue3518EqualityLoweringEmitTests
         Assert.Contains("GS0129", diagnostics);
         Assert.DoesNotContain("GS9998", diagnostics);
     }
+
+    [Fact]
+    public void LiftedOperatorReturningRefStruct_FailsWithoutInvalidMetadata()
+    {
+        const string source = """
+            package FindingRefStructLift
+
+            ref struct StackResult {
+                var Value int32
+            }
+
+            struct Number(Value int32) { }
+            func (left Number) operator +(right Number) StackResult {
+                return StackResult{Value: left.Value + right.Value}
+            }
+
+            func Bad(left Number?, right Number?) {
+                let result = left + right
+            }
+            """;
+
+        var (exitCode, stdout, stderr) =
+            Issue2388NullableCustomEqualityEmitTests.TryCompile(source);
+        var diagnostics = stdout + stderr;
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("GS0155", diagnostics);
+        Assert.DoesNotContain("GS9998", diagnostics);
+    }
+
+    [Fact]
+    public void SameCompilationNullableImplicitConversionEquality_RunsAndVerifies()
+    {
+        const string source = """
+            package FindingSameCompilationNullableConversion
+
+            struct Source(Raw int32) { }
+            struct Target(Code string) { }
+
+            func operator implicit(value Source) Target -> Target(value.Raw.ToString())
+            func (left Target) operator ==(right Target) bool -> left.Code == right.Code
+
+            func Equal(left Source?, right Target?) bool -> left == right
+
+            func Main() int32 {
+                let source Source? = Source(7)
+                let equal Target? = Target("7")
+                let different Target? = Target("8")
+                let missingSource Source? = nil
+                let missingTarget Target? = nil
+
+                let present = Equal(source, equal)
+                let valueMismatch = !Equal(source, different)
+                let presenceMismatch = !Equal(missingSource, equal)
+                let absent = Equal(missingSource, missingTarget)
+                return present && valueMismatch && presenceMismatch && absent ? 0 : 1
+            }
+            """;
+
+        Assert.Empty(Issue2866ImportedDataEqualityEmitTests.CompileAndRun(source));
+    }
 }

--- a/website/docs/ref/diagnostics.md
+++ b/website/docs/ref/diagnostics.md
@@ -840,6 +840,16 @@ redundant assertions from translated output automatically.
 |---|---|---|---|
 | GS0536 | Warning | `Redundant '!!': the value is already non-null here.` | `if s != nil { return s!! }` |
 
+## Method-generic operator declarations (GS0537)
+
+G# user-defined operators cannot declare method type parameters. Put generic
+parameters on the containing type; operators on open generic containing types
+remain supported.
+
+| ID | Severity | Message | Example |
+|---|---|---|---|
+| GS0537 | Error | `Operator '<name>' cannot declare method type parameters; put generic parameters on the containing type instead.` | `func (left Value) op_Addition[T](right Value) Value` |
+
 
 ## Pattern variable outside its definitely-assigned region (GS0532)
 


### PR DESCRIPTION
Fixes #3518

## Summary

- Materialize implicit conversions selected by CLR operator resolution, including lifted conversions to resolved parameter types, while preserving CLR-compatible nil/reference-nullability no-ops.
- Admit nullable lifting only for by-value, non-nullable, non-by-ref-like value-type parameters and liftable results; otherwise use valid normal conversions or reject candidate safely.
- Lower imported and same-compilation lifted nullable conversions through one shared `HasValue`/unwrap/conversion-call/rewrap-or-default pipeline, preserving constructed generic owners.
- Support imported and symbolic lifted conversions inside expression trees through `Expression.Convert(..., MethodInfo)` and runtime resolution of same-compilation conversion methods.
- Recognize user-defined lifted conversions during target-typed lambda return inference, then rebind only affected expression-tree lambdas so trailing conversion nodes are materialized.
- Bind same-compilation nullable data/inline-struct equality and lower through boxed nullable `Object.Equals`, matching non-lifted structural semantics.
- Convert unsigned integral values to `float32`/`float64` through `conv.r.un` (`conv.r4` additionally for `float32`).
- Remove #2388's generic-operator emit defer: method-generic operator declarations now report GS0537 at binding; operators on generic containing types remain supported.

## Verification

- `dotnet build GSharp.sln --configuration Release --no-restore -graph` — 0 warnings, 0 errors.
- Fourth-follow-up direct-body regressions — 2 passed.
- Fourth-follow-up expression-tree/lambda/conversion compiler suites — 70 passed.
- Fourth-follow-up lambda inference/binding suites — 391 passed.
- `./build/run-ilverify.sh` — 125/125 verified; 0 verification failures; 0 compile failures.
- Earlier focused compiler/operator suites — 154 passed; diagnostic contract — 4 passed.
- GitHub CI for `2d1b112cf` — all 36 checks completed successfully or were intentionally skipped; 0 failures.
- `git diff --check origin/main...HEAD` — passed.
- ADR-0154 witnesses include direct expression-tree lambda bodies throwing `ArgumentException` before target-return conversion materialization, plus earlier invalid IL/runtime/diagnostic cases documented by focused regressions.

## Checklist

- [x] Behavioral tests carry witnesses of discrimination (ADR-0154).
- [x] Self-review verdict: **MERGEABLE**. No residual findings or deferred work.
