### PR TITLE
cs2gs: shared documents translate identically in every project (#3501 !! round 2)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
@@ -887,8 +887,20 @@ public sealed class TranslateStage : IMigrationStage
         {
             if (!string.Equals(priorGenerated, generated, StringComparison.Ordinal))
             {
+                string[] priorLines = priorGenerated.Split('\n');
+                string[] currentLines = generated.Split('\n');
+                int line = 0;
+                while (line < priorLines.Length && line < currentLines.Length
+                    && string.Equals(priorLines[line], currentLines[line], StringComparison.Ordinal))
+                {
+                    line++;
+                }
+
+                string prior = line < priorLines.Length ? priorLines[line] : "<eof>";
+                string current = line < currentLines.Length ? currentLines[line] : "<eof>";
                 throw new InvalidOperationException(
-                    $"Linked source '{sourcePath}' translates differently in multiple projects.");
+                    $"Linked source '{sourcePath}' translates differently in multiple projects. "
+                    + $"First divergence at line {line + 1}: prior `{prior.Trim()}` vs current `{current.Trim()}`.");
             }
 
             return;

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
@@ -21,6 +21,8 @@ public sealed partial class CSharpToGSharpTranslator
 {
     private sealed partial class DeclarationVisitor
     {
+        private HashSet<string> repositorySharedDocumentPaths;
+
         // Issue #1072: G# follows Kotlin-style nullability, so `nil`-safety is
         // enforced by the static type, not by a `!!`-on-`nil` escape hatch. A C#
         // symbol DECLARED non-nullable (`T`) but defensively compared against
@@ -690,8 +692,15 @@ public sealed partial class CSharpToGSharpTranslator
             // `null` for every existing single-compilation caller, so this
             // overload reduces to the exact prior single-compilation check —
             // a pure additive fix for the cross-project case.
+            // Issue #3501: a symbol declared in a SHARED document (a source
+            // file linked into several repo projects, e.g. test/Shared/*) must
+            // translate identically in every project — the repository mirror
+            // rejects divergent outputs. Its taint check therefore runs over
+            // the whole repository's compilations, and the per-project
+            // usage-driven fallback below is skipped for it.
+            bool sharedDocument = this.IsDeclaredInRepositorySharedDocument(symbol);
             IReadOnlyList<CSharpCompilation> taintCompilations =
-                IsStoredMemberNullabilitySymbol(symbol)
+                IsStoredMemberNullabilitySymbol(symbol) || sharedDocument
                     ? this.context.RepositoryCompilations ?? this.context.SiblingCompilations
                     : this.context.SiblingCompilations;
             if (declared.NullableAnnotation == NullableAnnotation.None
@@ -703,8 +712,51 @@ public sealed partial class CSharpToGSharpTranslator
                 return true;
             }
 
-            return symbol is not IMethodSymbol
+            return !sharedDocument
+                && symbol is not IMethodSymbol
                 && this.IsUsedAsNullable(symbol, this.GetNullabilityScope(symbol));
+        }
+
+        // Issue #3501: file paths that appear in MORE THAN ONE repository
+        // compilation — linked/shared sources whose translation must not
+        // depend on which project is being translated.
+        private bool IsDeclaredInRepositorySharedDocument(ISymbol symbol)
+        {
+            if (this.context.RepositoryCompilations is not { Count: > 1 } repository)
+            {
+                return false;
+            }
+
+            if (this.repositorySharedDocumentPaths == null)
+            {
+                var counts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+                foreach (CSharpCompilation compilation in repository)
+                {
+                    foreach (SyntaxTree tree in compilation.SyntaxTrees)
+                    {
+                        if (!string.IsNullOrEmpty(tree.FilePath))
+                        {
+                            counts[tree.FilePath] = counts.TryGetValue(tree.FilePath, out int n) ? n + 1 : 1;
+                        }
+                    }
+                }
+
+                this.repositorySharedDocumentPaths = counts
+                    .Where(kv => kv.Value > 1)
+                    .Select(kv => kv.Key)
+                    .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            }
+
+            foreach (SyntaxReference reference in symbol.DeclaringSyntaxReferences)
+            {
+                string path = reference.SyntaxTree?.FilePath;
+                if (!string.IsNullOrEmpty(path) && this.repositorySharedDocumentPaths.Contains(path))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private static bool IsStoredMemberNullabilitySymbol(ISymbol symbol) =>


### PR DESCRIPTION
Part of #3501 (audit item 1, round 2). Analysis of the honest 14,408 residual `!!` shows they concentrate in apps the GS0536 polish never reaches — apps that fail translate/compile. The single biggest blocker chained through **five** apps (Cs2Gs.Pipeline, Core.Tests, Compiler.Tests, Interpreter.Tests, Cs2Gs.Tests): the repository mirror crashed with `Linked source 'test/Shared/GoldenFile.cs' translates differently in multiple projects`.

Root cause: usage-driven oblivious promotion is per-project — Pipeline's callers promoted `goldenPath` to `string?` while Core.Tests' kept `string` (verified by diffing the per-project translations; first divergence at the `CompareFile` signature).

Fix: a symbol declared in a document linked into **more than one repository compilation** now runs its null-taint over the whole repository (converged, order-independent — the same `RepositoryCompilations` channel stored members already use) and skips the per-project usage fallback. The divergence guard also reports the first differing line instead of a bare message, so future divergences are diagnosable from the artifact alone.

Expected effect (CI's selfmig job measures it): the five chained apps proceed past translate, their compiles run the GS0536 polish, and the dominant `!!` families (`project!!` ×1,075, `process!!`, `rtConfig!!`, …) get stripped where narrowing proves them redundant — gsc's early-exit narrowing already covers the throw-guard shape they follow.

Oblivious-analysis suites green locally (156 tests: Issue2412/Oblivious/Issue2113).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgrKRVPGaEm9zLaYvankA1