### PR TITLE
cs2gs: a dropped member translation must not crash the document (#3501)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue3501ResidualSyntheticRetargetTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3501ResidualSyntheticRetargetTests.cs
@@ -491,6 +491,65 @@ public class Issue3501ResidualSyntheticRetargetTests
         TranslationTestValidation.AssertBinds(printed);
     }
 
+    [Fact]
+    public void DualDictionaryFixture_DroppedMember_DoesNotCrashTheDocument()
+    {
+        // A dual IDictionary<int,int>/IReadOnlyDictionary<string,string>
+        // implementer drops the second colliding explicit-interface property
+        // (a reported gap); the null must not reach the member list — the
+        // printer throws on it and the whole document (and every app linking
+        // it) failed translate (the Core.Tests/Compiler.Tests/Interpreter.Tests
+        // self-migration blocker).
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Snippet.cs", """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+
+                public sealed class DualMapFixture : IDictionary<int, int>, IReadOnlyDictionary<string, string>
+                {
+                    string IReadOnlyDictionary<string, string>.this[string key] => throw new NotImplementedException();
+
+                    int IDictionary<int, int>.this[int key]
+                    {
+                        get => throw new NotImplementedException();
+                        set => throw new NotImplementedException();
+                    }
+
+                    ICollection<int> IDictionary<int, int>.Keys => throw new NotImplementedException();
+                    ICollection<int> IDictionary<int, int>.Values => throw new NotImplementedException();
+                    IEnumerable<string> IReadOnlyDictionary<string, string>.Keys => throw new NotImplementedException();
+                    IEnumerable<string> IReadOnlyDictionary<string, string>.Values => throw new NotImplementedException();
+                    int ICollection<KeyValuePair<int, int>>.Count => throw new NotImplementedException();
+                    int IReadOnlyCollection<KeyValuePair<string, string>>.Count => throw new NotImplementedException();
+                    bool ICollection<KeyValuePair<int, int>>.IsReadOnly => throw new NotImplementedException();
+                    void IDictionary<int, int>.Add(int key, int value) => throw new NotImplementedException();
+                    void ICollection<KeyValuePair<int, int>>.Add(KeyValuePair<int, int> item) => throw new NotImplementedException();
+                    void ICollection<KeyValuePair<int, int>>.Clear() => throw new NotImplementedException();
+                    bool ICollection<KeyValuePair<int, int>>.Contains(KeyValuePair<int, int> item) => throw new NotImplementedException();
+                    bool IDictionary<int, int>.ContainsKey(int key) => throw new NotImplementedException();
+                    bool IReadOnlyDictionary<string, string>.ContainsKey(string key) => throw new NotImplementedException();
+                    void ICollection<KeyValuePair<int, int>>.CopyTo(KeyValuePair<int, int>[] array, int arrayIndex) => throw new NotImplementedException();
+                    bool IDictionary<int, int>.Remove(int key) => throw new NotImplementedException();
+                    bool ICollection<KeyValuePair<int, int>>.Remove(KeyValuePair<int, int> item) => throw new NotImplementedException();
+                    bool IDictionary<int, int>.TryGetValue(int key, out int value) => throw new NotImplementedException();
+                    bool IReadOnlyDictionary<string, string>.TryGetValue(string key, out string value) => throw new NotImplementedException();
+                    IEnumerator<KeyValuePair<int, int>> IEnumerable<KeyValuePair<int, int>>.GetEnumerator() => throw new NotImplementedException();
+                    IEnumerator<KeyValuePair<string, string>> IEnumerable<KeyValuePair<string, string>>.GetEnumerator() => throw new NotImplementedException();
+                    IEnumerator IEnumerable.GetEnumerator() => throw new NotImplementedException();
+                }
+                """) });
+        Assert.True(project.BoundWithoutErrors);
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+
+        // The drop itself is a reported gap; the assertion is only that the
+        // print completes instead of throwing on a null member.
+        string printed = GSharpPrinter.Print(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+        Assert.Contains("DualMapFixture", printed, StringComparison.Ordinal);
+    }
+
     private static string Translate(string source)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Declarations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Declarations.cs
@@ -1270,6 +1270,16 @@ public sealed partial class CSharpToGSharpTranslator
                         attachedMemberComments = true;
                     }
 
+                    // Issue #3501: a member translation may DROP its output (a
+                    // reported gap, e.g. the second colliding explicit-interface
+                    // property in a dual-dictionary fixture). A null must not
+                    // reach the member lists — the printer throws on it and the
+                    // whole document (and its app) fails translate.
+                    if (translated == null)
+                    {
+                        continue;
+                    }
+
                     // A C# operator overload translates to a receiver-clause
                     // `func (a T) operator <op>(...)`; like every receiver-clause
                     // func it only binds at top level, so it is lifted out as a


### PR DESCRIPTION
Follow-up to #3533 (its second finding, landed after that PR merged). The selfmig dispatch on #3533's branch showed the shared-document convergence working — Cs2Gs.Pipeline passes translate — but the test projects (Core.Tests, Compiler.Tests, Interpreter.Tests) had a second blocker: the dual `IDictionary<int,int>`/`IReadOnlyDictionary<string,string>` fixture in `Issue1483ReadOnlyDictionaryForRangeTests.cs` drops its second colliding explicit-interface property (a reported translation gap), and the null member reached the printer, whose `ArgumentException` took down the entire document — and with it all three apps in the self-migration run.

Null member yields now skip after the comment-attach step, with a regression test over the full dual-dictionary fixture shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgrKRVPGaEm9zLaYvankA1