### PR TITLE
cs2gs: nightly fallout — Roslyn-consumer misclassification + symlinked polish paths (#3501)

### DIFF
--- a/.github/workflows/cs2gs-selfmig-nightly.yml
+++ b/.github/workflows/cs2gs-selfmig-nightly.yml
@@ -57,3 +57,5 @@ jobs:
             /tmp/gsharp-cs2gs-selfmig/migrate.log
             /tmp/gsharp-cs2gs-selfmig/runs/**/run.json
             /tmp/gsharp-cs2gs-selfmig/runs/**/report.html
+            /tmp/gsharp-cs2gs-selfmig/runs/**/*.json
+            /tmp/gsharp-cs2gs-selfmig/runs/**/sdk.build.log

--- a/tools/cs2gs/Cs2Gs.Pipeline/GSharpProjectTransformer.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/GSharpProjectTransformer.cs
@@ -202,10 +202,12 @@ internal static class GSharpProjectTransformer
     // host supplies.
     private static void RewriteAnalyzerProject(XDocument document)
     {
-        bool isAnalyzerProject =
-            ElementsNamed(document, "PackageReference").Any(reference =>
-                AttributeNamed(reference, "Include")?.Value?.StartsWith("Microsoft.CodeAnalysis", StringComparison.OrdinalIgnoreCase) == true)
-            || ElementsNamed(document, "EnforceExtendedAnalyzerRules").Any();
+        // Issue #3501: classification keys on the analyzer-AUTHORING marker
+        // only. Merely consuming Microsoft.CodeAnalysis as a library (e.g.
+        // Cs2Gs.Translator itself) must NOT strip the Roslyn packages — that
+        // erased the whole Roslyn surface from the migrated Translator and
+        // produced 3,093 unresolved-type errors in the nightly.
+        bool isAnalyzerProject = ElementsNamed(document, "EnforceExtendedAnalyzerRules").Any();
         if (!isAnalyzerProject)
         {
             return;

--- a/tools/cs2gs/Cs2Gs.Pipeline/NullAssertionPolishPass.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/NullAssertionPolishPass.cs
@@ -50,10 +50,7 @@ public static class NullAssertionPolishPass
             return 0;
         }
 
-        Dictionary<string, string> ownedByFullPath = emittedGsFiles
-            .Where(File.Exists)
-            .GroupBy(p => Path.GetFullPath(p), StringComparer.OrdinalIgnoreCase)
-            .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
+        Dictionary<string, string> ownedByFullPath = BuildOwnedIndex(emittedGsFiles);
 
         var stripped = 0;
         IEnumerable<IGrouping<string, GscDiagnostic>> byFile = diagnostics
@@ -118,10 +115,7 @@ public static class NullAssertionPolishPass
             return Array.Empty<string>();
         }
 
-        Dictionary<string, string> ownedByFullPath = emittedGsFiles
-            .Where(File.Exists)
-            .GroupBy(p => Path.GetFullPath(p), StringComparer.OrdinalIgnoreCase)
-            .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
+        Dictionary<string, string> ownedByFullPath = BuildOwnedIndex(emittedGsFiles);
 
         return diagnostics
             .Where(d => string.Equals(d.Id, DiagnosticId, StringComparison.Ordinal))
@@ -129,6 +123,26 @@ public static class NullAssertionPolishPass
             .Where(f => f != null)
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToList();
+    }
+
+    // Indexes the app-owned emitted files by BOTH the raw full path and the
+    // symlink-canonical path, so a diagnostic echoing either spelling matches.
+    private static Dictionary<string, string> BuildOwnedIndex(IReadOnlyCollection<string> emittedGsFiles)
+    {
+        var index = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (string file in emittedGsFiles)
+        {
+            if (!File.Exists(file))
+            {
+                continue;
+            }
+
+            string full = Path.GetFullPath(file);
+            index.TryAdd(full, file);
+            index.TryAdd(CanonicalizePath(full), file);
+        }
+
+        return index;
     }
 
     private static string ResolveStrippableFile(
@@ -151,7 +165,13 @@ public static class NullAssertionPolishPass
             return null;
         }
 
-        if (ownedByFullPath.TryGetValue(normalized, out string owned))
+        // Issue #3501: gsc echoes SYMLINK-RESOLVED paths on macOS
+        // (`/private/tmp/…`) while the pipeline's owned/root paths keep the
+        // spelling it was invoked with (`/tmp/…`), so both comparisons below
+        // run over canonical real paths.
+        string canonical = CanonicalizePath(normalized);
+        if (ownedByFullPath.TryGetValue(normalized, out string owned)
+            || ownedByFullPath.TryGetValue(canonical, out owned))
         {
             return owned;
         }
@@ -165,7 +185,70 @@ public static class NullAssertionPolishPass
 
         string root = Path.GetFullPath(strippableRoot)
             .TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
-        return normalized.StartsWith(root, StringComparison.OrdinalIgnoreCase) ? normalized : null;
+        string canonicalRoot = CanonicalizePath(root.TrimEnd(Path.DirectorySeparatorChar))
+            + Path.DirectorySeparatorChar;
+        return normalized.StartsWith(root, StringComparison.OrdinalIgnoreCase)
+            || canonical.StartsWith(canonicalRoot, StringComparison.OrdinalIgnoreCase)
+                ? normalized
+                : null;
+    }
+
+    // Resolves directory symlinks in the path's ancestry (macOS `/tmp` →
+    // `/private/tmp`) by round-tripping through the filesystem; falls back to
+    // the input when nothing exists to resolve against.
+    private static string CanonicalizePath(string path)
+    {
+        try
+        {
+            string directory = Path.GetDirectoryName(path);
+            if (string.IsNullOrEmpty(directory) || !Directory.Exists(directory))
+            {
+                return path;
+            }
+
+            var info = new DirectoryInfo(directory);
+            string resolvedDirectory = info.ResolveLinkTarget(returnFinalTarget: true)?.FullName
+                ?? ResolveAncestrySymlinks(directory);
+            return Path.Combine(resolvedDirectory, Path.GetFileName(path));
+        }
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException or ArgumentException)
+        {
+            return path;
+        }
+    }
+
+    private static string ResolveAncestrySymlinks(string directory)
+    {
+        // `ResolveLinkTarget` only resolves when the FINAL component is the
+        // link; `/tmp/foo/bar` needs `/tmp` itself resolved. Walk up until a
+        // component resolves, then reattach the remainder.
+        string current = directory;
+        var suffix = new List<string>();
+        while (!string.IsNullOrEmpty(current))
+        {
+            if (Directory.Exists(current))
+            {
+                string resolved = new DirectoryInfo(current)
+                    .ResolveLinkTarget(returnFinalTarget: true)?.FullName;
+                if (resolved != null)
+                {
+                    suffix.Reverse();
+                    return suffix.Aggregate(resolved, Path.Combine);
+                }
+            }
+
+            string name = Path.GetFileName(current);
+            string parent = Path.GetDirectoryName(current);
+            if (string.IsNullOrEmpty(name) || string.IsNullOrEmpty(parent) || parent == current)
+            {
+                break;
+            }
+
+            suffix.Add(name);
+            current = parent;
+        }
+
+        return directory;
     }
 
     private sealed class SpanComparer : IEqualityComparer<GscDiagnostic>


### PR DESCRIPTION
Dissects the manually-dispatched nightly (run 32890705273: 28/55 green, `Cs2Gs.Translator FAIL(3093)`). Three fixes:

1. **Roslyn-consumer misclassification (the 3,093).** The analyzer-project transform treated any project referencing `Microsoft.CodeAnalysis.*` as an analyzer project and stripped its Roslyn packages. `Cs2Gs.Translator` consumes Roslyn as a *library*, so its migrated build lost the entire Roslyn surface (`ISymbol`, `ExpressionSyntax`, `INamedTypeSymbol`, …). Classification now keys on the authoring marker `EnforceExtendedAnalyzerRules` only — which real analyzer projects carry and library consumers don't.
2. **Symlink-blind polish paths.** gsc echoes symlink-resolved diagnostic paths on macOS (`/private/tmp/…`) while the pipeline's owned/root paths keep the invoked spelling (`/tmp/…`); the GS0536 polish's path checks silently failed for root-relative runs. Both the owned-file index and the strippable-root check now canonicalize through the filesystem.
3. **Diagnosable nightlies.** The workflow uploads per-app `sdk.build.log` and every triage JSON, so the next compile failure reads straight from the artifact (this investigation needed a local reproduction because the logs weren't uploaded).

Scoped verification over the Core→CodeModel→Translator chain: **Core and CodeModel fully green** (translate+compile+ilverify+parity); Translator's residue collapses from 3,093 to ~150 ordinary next-layer gaps (using-alias type imports, `EmittedName` overload shapes) — Core-style burn-down material, tracked under #3501.

Transform + polish suites green locally; full verification via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgrKRVPGaEm9zLaYvankA1