### PR TITLE
selfmig gate: a zero-match metric must not kill the script (#3501)

### DIFF
--- a/build/run-cs2gs-selfmig.sh
+++ b/build/run-cs2gs-selfmig.sh
@@ -60,8 +60,14 @@ total=$(jq '.apps | length' "$run_json")
 # strings (and docs quote constructs), so lines containing a string quote or
 # leading with a comment marker are excluded before counting.
 code_grep() {
-  grep -rhE "$1" "$migrated_dir" --include='*.gs' 2>/dev/null \
-    | grep -v '"' | grep -vE '^[[:space:]]*//' | grep -oE "$1" | wc -l | tr -d ' '
+  # A ZERO-match metric is success, not failure: without the || true, the
+  # no-match grep's exit 1 kills the script under `set -eo pipefail` before
+  # the ceilings are ever checked (exactly what happened once the synthetic
+  # label count reached 0).
+  local count
+  count=$(grep -rhE "$1" "$migrated_dir" --include='*.gs' 2>/dev/null \
+    | grep -v '"' | grep -vE '^[[:space:]]*//' | grep -oE "$1" | wc -l | tr -d ' ') || true
+  echo "${count:-0}"
 }
 labels=$(code_grep '__(switchExit|iteratorExit|gotoCase|gotoDefault|patternGuardEnd)')
 lifts=$(code_grep '__local_')


### PR DESCRIPTION
Why the last two nightlies (including run 32906273953) ended right after the report paths with no metric lines, no ceiling checks, and no gate verdict: with synthetic labels genuinely at **zero**, `code_grep`'s no-match `grep` exits 1 and `set -eo pipefail` aborts the script. The zero case is success, not failure — the count is captured with `|| true` (smoke-tested against an empty dir under the same shell flags).

For the record, what run 32906273953 did show before the cutoff, confirming #3538:
- `Cs2Gs.Translator`: **3,093 → 161** compile errors (Roslyn surface restored),
- the InternalAnalyzers leak cluster: FAIL(27) → FAIL(16) across seven apps (remaining tracked by #3536),
- 43 per-app `sdk.build.log`s now land in the artifact — the diagnosability fix works.

Next nightly after this merge should print the full metric/ratchet block again, including labels=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgrKRVPGaEm9zLaYvankA1