### PR TITLE
Fix imported blittable CLR struct pointer pointees

### DIFF
--- a/docs/adr/0093-pinvoke-struct-marshalling.md
+++ b/docs/adr/0093-pinvoke-struct-marshalling.md
@@ -75,7 +75,7 @@ A G# struct `S` is **blittable** iff **every** instance field of `S` has a type 
 3. a native-int primitive (`nint` / `nuint`),
 4. an unmanaged pointer `*T` for any `T` (the pointer is blittable regardless of its pointee),
 5. another **blittable** G# struct (the relation is recursively defined; user types form a directed acyclic graph because `struct` cannot self-reference without indirection),
-6. an imported CLR struct whose runtime `Type` reports `Marshal.SizeOf` without throwing (i.e. the BCL already classifies it as blittable — `Int32`, `Double`, `IntPtr`, `Guid`, etc.).
+6. an imported sequential- or explicit-layout CLR value struct whose instance fields recursively satisfy these rules (read directly from reflection metadata, including project-reference types loaded through `MetadataLoadContext`).
 
 Anything else makes the struct **non-blittable**. In particular, the following make `S` non-blittable in v1:
 
@@ -85,7 +85,7 @@ Anything else makes the struct **non-blittable**. In particular, the following m
 - A slice (`[]T`) field, a sequence, an array, a map, a tuple, a channel, a delegate, a class reference (regardless of layout), an interface reference, or any other managed reference type.
 - A field whose type itself is non-blittable.
 
-The recursion is performed by `BlittableDetector.IsBlittable(StructSymbol)` (cached per symbol). Cycles cannot occur for value types (the bound-tree builder already rejects recursive struct field types as a separate constraint).
+The recursion is performed by `BlittableDetector.IsBlittable` (cached per symbol). Cyclic value layouts are rejected; recursion through pointer fields is valid because pointers are classified as address-sized leaves.
 
 This is a deliberately **conservative** definition: it matches the subset of C#'s blittability rules that does not require synthesizing per-field `MarshalAs` data. Once `@MarshalAs` is supported (issue #762), the definition will be extended to cover fields with explicit `MarshalAs` directives.
 

--- a/src/Core/CodeAnalysis/Binding/BlittableDetector.cs
+++ b/src/Core/CodeAnalysis/Binding/BlittableDetector.cs
@@ -26,10 +26,10 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// a class instance by-reference across the P/Invoke boundary.
 /// </para>
 /// <para>
-/// Imported CLR struct types use runtime marshalling classification for
-/// blittability. Unmanaged classification instead walks every instance field
-/// recursively because <see cref="System.Runtime.InteropServices.Marshal.SizeOf(System.Type)"/>
-/// can succeed for structs that contain managed references.
+/// Imported CLR struct types are classified from their metadata layout and
+/// instance fields. This works for both runtime types and types loaded through a
+/// <see cref="System.Reflection.MetadataLoadContext"/>, and avoids treating
+/// marshalable structs containing managed references as blittable.
 /// </para>
 /// </remarks>
 internal sealed class BlittableDetector
@@ -129,12 +129,15 @@ internal sealed class BlittableDetector
             return true;
         }
 
-        // Explicitly reject the known non-blittable language primitives
-        // before falling back to the Marshal.SizeOf heuristic — the runtime
-        // happily reports `Marshal.SizeOf(typeof(bool)) == 4`, which would
-        // otherwise cause the fallback to misclassify `bool` and `char` as
-        // blittable.
+        // Explicitly reject the known non-blittable language primitives before
+        // imported metadata classification. In particular, bool and char have
+        // unmanaged representations that require marshalling conversions.
         if (IsKnownNonBlittablePrimitive(type))
+        {
+            return false;
+        }
+
+        if (TypeSymbol.IsByRefLike(type))
         {
             return false;
         }
@@ -166,12 +169,14 @@ internal sealed class BlittableDetector
                 return false;
             }
 
+            if (structSym.ClrType is { } importedClr)
+            {
+                return IsImportedValueType(importedClr, new HashSet<Type>(), unmanaged);
+            }
+
             return IsBlittableStruct(structSym, visiting, unmanaged);
         }
 
-        // Imported CLR types: unmanaged classification must inspect fields;
-        // Marshal.SizeOf can accept structs that still contain GC references.
-        // Blittability keeps the existing runtime marshalling classification.
         var clr = type.ClrType;
         if (clr?.IsGenericParameter == true || clr?.ContainsGenericParameters == true)
         {
@@ -180,72 +185,62 @@ internal sealed class BlittableDetector
 
         if (clr != null && clr.IsValueType)
         {
-            if (clr.IsEnum)
-            {
-                return true;
-            }
-
-            if (unmanaged)
-            {
-                if (clr.IsGenericType
-                    && clr.GetGenericTypeDefinition().FullName == "System.Nullable`1")
-                {
-                    return false;
-                }
-
-                return IsImportedUnmanagedType(clr, new HashSet<Type>());
-            }
-
-            try
-            {
-                System.Runtime.InteropServices.Marshal.SizeOf(clr);
-                return true;
-            }
-            catch
-            {
-                return false;
-            }
+            return IsImportedValueType(clr, new HashSet<Type>(), unmanaged);
         }
 
         return false;
     }
 
-    private static bool IsImportedUnmanagedType(Type? type, HashSet<Type> visiting)
+    private static bool IsImportedValueType(Type? type, HashSet<Type> visiting, bool unmanaged)
     {
-        if (type == null
-            || type.IsByRef
-            || type.IsByRefLike
-            || type.IsGenericParameter
-            || type.ContainsGenericParameters)
-        {
-            return false;
-        }
-
-        if (type.IsPointer || type.IsFunctionPointer || type.IsEnum || type.IsPrimitive)
-        {
-            return true;
-        }
-
-        if (!type.IsValueType)
-        {
-            return false;
-        }
-
-        // C# excludes Nullable<T> from the unmanaged-type set. That applies
-        // recursively too: a struct containing an int? field is not unmanaged.
-        if (type.IsGenericType
-            && type.GetGenericTypeDefinition().FullName == "System.Nullable`1")
-        {
-            return false;
-        }
-
-        if (!visiting.Add(type))
-        {
-            return true;
-        }
-
+        var added = false;
         try
         {
+            if (type == null
+                || type.IsByRef
+                || ClrTypeUtilities.IsByRefLike(type)
+                || type.IsGenericParameter
+                || type.ContainsGenericParameters)
+            {
+                return false;
+            }
+
+            if (type.IsPointer || type.IsFunctionPointer || type.IsEnum)
+            {
+                return true;
+            }
+
+            var symbol = TypeSymbol.FromClrType(type);
+            if (IsBlittablePrimitive(symbol)
+                || (unmanaged && IsUnmanagedOnlyPrimitive(symbol)))
+            {
+                return true;
+            }
+
+            if (IsKnownNonBlittablePrimitive(symbol) || !type.IsValueType)
+            {
+                return false;
+            }
+
+            // C# excludes Nullable<T> from the unmanaged-type set. It is also
+            // non-blittable because its layout contains a bool discriminator.
+            if (type.IsGenericType
+                && type.GetGenericTypeDefinition().FullName == "System.Nullable`1")
+            {
+                return false;
+            }
+
+            if (!unmanaged && !type.IsLayoutSequential && !type.IsExplicitLayout)
+            {
+                return false;
+            }
+
+            added = visiting.Add(type);
+            if (!added)
+            {
+                return false;
+            }
+
             var fields = type.GetFields(
                 System.Reflection.BindingFlags.Instance
                     | System.Reflection.BindingFlags.Public
@@ -253,7 +248,7 @@ internal sealed class BlittableDetector
 
             foreach (var field in fields)
             {
-                if (!IsImportedUnmanagedType(field.FieldType, visiting))
+                if (!IsImportedValueType(field.FieldType, visiting, unmanaged))
                 {
                     return false;
                 }
@@ -267,7 +262,10 @@ internal sealed class BlittableDetector
         }
         finally
         {
-            visiting.Remove(type);
+            if (added && type != null)
+            {
+                visiting.Remove(type);
+            }
         }
     }
 
@@ -314,12 +312,11 @@ internal sealed class BlittableDetector
             }
         }
 
-        // Cycle guard: recursive struct definitions are already rejected
-        // elsewhere, but defensively treat a visited node as blittable to
-        // avoid unbounded recursion in pathological cases.
+        // Recursive value layouts are invalid. Pointer recursion never reaches
+        // this guard because pointers classify as address-sized leaves above.
         if (!visiting.Add(structSym))
         {
-            return true;
+            return false;
         }
 
         try

--- a/src/Core/CodeAnalysis/Binding/BlittableDetector.cs
+++ b/src/Core/CodeAnalysis/Binding/BlittableDetector.cs
@@ -115,6 +115,11 @@ internal sealed class BlittableDetector
 
     private bool ClassifyImpl(TypeSymbol type, HashSet<StructSymbol> visiting, bool unmanaged)
     {
+        if (type is NullableTypeSymbol)
+        {
+            return false;
+        }
+
         if (IsBlittablePrimitive(type))
         {
             return true;

--- a/test/Compiler.Tests/Emit/Issue3520ImportedBlittablePointerEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3520ImportedBlittablePointerEmitTests.cs
@@ -177,6 +177,12 @@ public sealed class Issue3520ImportedBlittablePointerEmitTests
     {
         using var artifacts = new TestArtifacts();
         using var resolver = ReferenceResolver.WithReferences(new[] { artifacts.FixturePath });
+        var detector = new BlittableDetector();
+        var nullableInt = NullableTypeSymbol.Get(TypeSymbol.Int32);
+
+        Assert.False(detector.IsBlittable(nullableInt));
+        Assert.False(detector.IsUnmanaged(nullableInt));
+        Assert.False(BlittableDetector.IsBlittableValueStructPointee(nullableInt));
 
         AssertClassification("BlittablePair", expected: true);
         AssertClassification("NestedBlittablePair", expected: true);
@@ -201,6 +207,14 @@ public sealed class Issue3520ImportedBlittablePointerEmitTests
         void AssertClassification(string name, bool expected)
         {
             Assert.True(resolver.TryResolveType("Issue3520.Library." + name, out var type));
+            if (expected)
+            {
+                var nullableType = NullableTypeSymbol.Get(TypeSymbol.FromClrType(type));
+                Assert.False(detector.IsBlittable(nullableType));
+                Assert.False(detector.IsUnmanaged(nullableType));
+                Assert.False(BlittableDetector.IsBlittableValueStructPointee(nullableType));
+            }
+
             Assert.Equal(
                 expected,
                 BlittableDetector.IsBlittableValueStructPointee(TypeSymbol.FromClrType(type)));

--- a/test/Compiler.Tests/Emit/Issue3520ImportedBlittablePointerEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3520ImportedBlittablePointerEmitTests.cs
@@ -1,0 +1,308 @@
+// <copyright file="Issue3520ImportedBlittablePointerEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+public sealed class Issue3520ImportedBlittablePointerEmitTests
+{
+    private static readonly string[] UnsafeIlVerifyIgnored =
+    {
+        "UnmanagedPointer",
+        "StackUnexpected",
+        "StackByRef",
+        "ExpectedPtr",
+        "StackUnexpectedArrayType",
+    };
+
+    private const string FixtureSource = """
+        using System.Runtime.InteropServices;
+
+        namespace Issue3520.Library;
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct BlittablePair
+        {
+            public int X;
+            public int Y;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct NestedBlittablePair
+        {
+            public BlittablePair Pair;
+            public long Z;
+        }
+
+        [StructLayout(LayoutKind.Explicit)]
+        public struct ExplicitBlittablePair
+        {
+            [FieldOffset(0)]
+            public int X;
+
+            [FieldOffset(4)]
+            public int Y;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct ManagedPair
+        {
+            public string Text;
+            public int Value;
+        }
+
+        [StructLayout(LayoutKind.Auto)]
+        public struct AutoLayoutPair
+        {
+            public int Value;
+        }
+
+        public ref struct RefPair
+        {
+            public int Value;
+        }
+
+        public struct NullablePair
+        {
+            public int? Value;
+        }
+
+        public struct BoolPair
+        {
+            public bool Value;
+        }
+
+        public struct GenericPair<T>
+        {
+            public T Value;
+        }
+
+        public unsafe struct PointerNode
+        {
+            public int Value;
+            public PointerNode* Next;
+        }
+        """;
+
+    [Fact]
+    public void ImportedSequentialNestedAndExplicitStructPointers_RunAndVerify()
+    {
+        using var artifacts = new TestArtifacts();
+        const string source = """
+            package Issue3520.Consumer
+            import System
+            import Issue3520.Library
+
+            unsafe func ReadPair(value *BlittablePair) int32 {
+                return value->X + value->Y
+            }
+
+            unsafe func ReadNested(value *NestedBlittablePair) int64 {
+                return int64(value->Pair.X + value->Pair.Y) + value->Z
+            }
+
+            unsafe func ReadExplicit(value *ExplicitBlittablePair) int32 {
+                return value->X + value->Y
+            }
+
+            unsafe func Main() {
+                var pair = BlittablePair()
+                pair.X = 20
+                pair.Y = 22
+                var pairs = []BlittablePair{pair}
+                Console.WriteLine(ReadPair(&pairs[0]))
+
+                var nested = NestedBlittablePair()
+                nested.Pair = pair
+                nested.Z = 8L
+                var nestedValues = []NestedBlittablePair{nested}
+                Console.WriteLine(ReadNested(&nestedValues[0]))
+
+                var explicitPair = ExplicitBlittablePair()
+                explicitPair.X = 7
+                explicitPair.Y = 9
+                var explicitValues = []ExplicitBlittablePair{explicitPair}
+                Console.WriteLine(ReadExplicit(&explicitValues[0]))
+            }
+            """;
+
+        var compilation = Compile(artifacts, source, target: "exe");
+
+        Assert.True(compilation.ExitCode == 0, $"gsc failed:\n{compilation.Diagnostics}");
+        IlVerifier.Verify(
+            compilation.OutputPath,
+            additionalReferences: new[] { artifacts.FixturePath },
+            ignoredErrorCodes: UnsafeIlVerifyIgnored);
+        Assert.Equal(
+            $"42{Environment.NewLine}50{Environment.NewLine}16{Environment.NewLine}",
+            Run(compilation.OutputPath));
+    }
+
+    [Fact]
+    public void ImportedNonBlittableStructPointers_ReportGS0398()
+    {
+        using var artifacts = new TestArtifacts();
+        const string source = """
+            package Issue3520.Consumer
+            import Issue3520.Library
+
+            unsafe func ReadManaged(value *ManagedPair) int32 -> 0
+            unsafe func ReadAuto(value *AutoLayoutPair) int32 -> 0
+            unsafe func ReadRef(value *RefPair) int32 -> 0
+            unsafe func ReadNullable(value *NullablePair) int32 -> 0
+            unsafe func ReadBool(value *BoolPair) int32 -> 0
+            unsafe func ReadGeneric(value *GenericPair[string]) int32 -> 0
+            """;
+
+        var compilation = Compile(artifacts, source, target: "library");
+
+        Assert.NotEqual(0, compilation.ExitCode);
+        Assert.Equal(6, Regex.Matches(compilation.Diagnostics, @"\berror GS0398:").Count);
+        Assert.DoesNotContain("GS9998", compilation.Diagnostics, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ImportedMetadataClassifier_HandlesLayoutFieldsAndGenerics()
+    {
+        using var artifacts = new TestArtifacts();
+        using var resolver = ReferenceResolver.WithReferences(new[] { artifacts.FixturePath });
+
+        AssertClassification("BlittablePair", expected: true);
+        AssertClassification("NestedBlittablePair", expected: true);
+        AssertClassification("ExplicitBlittablePair", expected: true);
+        AssertClassification("PointerNode", expected: true);
+        AssertClassification("ManagedPair", expected: false);
+        AssertClassification("AutoLayoutPair", expected: false);
+        AssertClassification("RefPair", expected: false);
+        AssertClassification("NullablePair", expected: false);
+        AssertClassification("BoolPair", expected: false);
+
+        Assert.True(resolver.TryResolveType("Issue3520.Library.GenericPair`1", out var openGeneric));
+        Assert.False(BlittableDetector.IsBlittableValueStructPointee(TypeSymbol.FromClrType(openGeneric)));
+
+        var intType = resolver.MapClrTypeToReferences(typeof(int));
+        var stringType = resolver.MapClrTypeToReferences(typeof(string));
+        Assert.True(BlittableDetector.IsBlittableValueStructPointee(
+            TypeSymbol.FromClrType(openGeneric.MakeGenericType(intType))));
+        Assert.False(BlittableDetector.IsBlittableValueStructPointee(
+            TypeSymbol.FromClrType(openGeneric.MakeGenericType(stringType))));
+
+        void AssertClassification(string name, bool expected)
+        {
+            Assert.True(resolver.TryResolveType("Issue3520.Library." + name, out var type));
+            Assert.Equal(
+                expected,
+                BlittableDetector.IsBlittableValueStructPointee(TypeSymbol.FromClrType(type)));
+        }
+    }
+
+    private static (int ExitCode, string Diagnostics, string OutputPath) Compile(
+        TestArtifacts artifacts,
+        string source,
+        string target)
+    {
+        var sourcePath = Path.Combine(artifacts.Directory, "Consumer.gs");
+        var outputPath = Path.Combine(artifacts.Directory, "Issue3520.Consumer.dll");
+        File.WriteAllText(sourcePath, source);
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        int exitCode;
+        try
+        {
+            exitCode = Program.Main(
+                new[]
+                {
+                    "/out:" + outputPath,
+                    "/target:" + target,
+                    "/targetframework:net10.0",
+                    "/reference:" + artifacts.FixturePath,
+                    sourcePath,
+                });
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+
+        return (exitCode, stdout.ToString() + stderr.ToString(), outputPath);
+    }
+
+    private static string Run(string assemblyPath)
+    {
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = Path.GetDirectoryName(assemblyPath)!,
+        };
+        startInfo.ArgumentList.Add("exec");
+        startInfo.ArgumentList.Add("--runtimeconfig");
+        startInfo.ArgumentList.Add(Path.ChangeExtension(assemblyPath, ".runtimeconfig.json"));
+        startInfo.ArgumentList.Add(assemblyPath);
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start dotnet exec.");
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), "dotnet exec timed out.");
+        Assert.True(process.ExitCode == 0, $"exited {process.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout.ReplaceLineEndings(Environment.NewLine);
+    }
+
+    private sealed class TestArtifacts : IDisposable
+    {
+        public TestArtifacts()
+        {
+            Directory = Path.Combine(
+                AppContext.BaseDirectory,
+                nameof(Issue3520ImportedBlittablePointerEmitTests),
+                Guid.NewGuid().ToString("N"));
+            System.IO.Directory.CreateDirectory(Directory);
+            FixturePath = Path.Combine(Directory, "Issue3520.Library.dll");
+
+            var references = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
+                .Split(Path.PathSeparator)
+                .Select(path => MetadataReference.CreateFromFile(path));
+            var compilation = CSharpCompilation.Create(
+                "Issue3520.Library",
+                new[] { CSharpSyntaxTree.ParseText(FixtureSource, new CSharpParseOptions(LanguageVersion.Latest)) },
+                references,
+                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
+            var result = compilation.Emit(FixturePath);
+            Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        }
+
+        public string Directory { get; }
+
+        public string FixturePath { get; }
+
+        public void Dispose()
+        {
+            try
+            {
+                System.IO.Directory.Delete(Directory, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1034StructPointerBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1034StructPointerBinderTests.cs
@@ -82,6 +82,27 @@ unsafe func f(p *Managed) {
     }
 
     [Fact]
+    public void PointerToNullableValueTypes_ReportsGS0398()
+    {
+        const string source = """
+            package P
+
+            struct Pair {
+                var x int32
+                var y int32
+            }
+
+            unsafe func primitive(p *int32?) {}
+            unsafe func valueStruct(p *Pair?) {}
+            """;
+
+        var diagnostics = GetDiagnostics(source).Where(d => d.Id == "GS0398").ToArray();
+        Assert.Equal(2, diagnostics.Length);
+        Assert.Contains(diagnostics, d => d.Location.Text.ToString(d.Location.Span) == "int32?");
+        Assert.Contains(diagnostics, d => d.Location.Text.ToString(d.Location.Span) == "Pair?");
+    }
+
+    [Fact]
     public void DereferenceMemberAccess_Binds_NoErrors()
     {
         const string source = @"


### PR DESCRIPTION
Fixes #3520

## Root cause

`BlittableDetector` classified imported CLR value types with `Marshal.SizeOf(Type)`. Project references are loaded through `MetadataLoadContext`; those reflection-only `Type` objects cannot be passed to `Marshal.SizeOf`, so valid sequential structs fell into the catch path and were reported as non-blittable. The heuristic could also accept marshalable structs that still contain managed fields.

A direct `NullableTypeSymbol` also borrowed its underlying `ClrType`. That let `int32?` classify as `Int32`, after which `PointerTypeSymbol` emitted `Int32*` and erased nullable semantics.

## Fix

- Classify imported value types directly from metadata layout and instance fields.
- Accept closed sequential/explicit structs whose fields recursively classify as blittable, including nested structs and pointer-recursive shapes.
- Conservatively reject managed fields, auto layout, by-ref-like types, nullable/non-blittable primitive fields, open generics, and cyclic value layouts.
- Reject direct `NullableTypeSymbol` values before shared blittable/unmanaged classification.
- Route metadata-backed aggregate symbols through the same classifier and document the metadata-based rule.

## Tests

- Added referenced-C# regressions for sequential, nested, and explicit structs with runtime execution and ILVerify.
- Added negative coverage for reference fields, auto layout, ref structs, nullable/bool fields, and managed generic constructions, plus open/closed generic classifier coverage.
- Added classifier coverage for direct nullable primitives and imported value structs in both blittable and unmanaged modes.
- Added binder coverage proving `*int32?` and `*Pair?` report GS0398.
- Verified the exact C# `ProjectReference` -> G# SDK repro builds successfully.
- Focused runs: 11 Core binder, 3 issue #3520, and 15 related Compiler tests passed.
- Full `Core.Tests`: 8,083 passed.
- Full `Interpreter.Tests`: 1,510 passed.
- `dotnet build GSharp.sln --configuration Release --no-restore -graph`: succeeded, 0 warnings/errors.

