### PR TITLE
gsc: nullable-annotated variance on imported generic interfaces (#3501)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -2203,9 +2203,7 @@ public sealed class Conversion
         ImportedTypeSymbol from,
         ImportedTypeSymbol to)
     {
-        if (from?.OpenDefinition == null
-            || from.TypeArguments.IsDefaultOrEmpty
-            || from.OpenDefinition.IsValueType
+        if (from == null
             || !TryGetConstructedGenericShape(to, out var targetOpen, out var targetArguments)
             || targetOpen == null
             || targetOpen.IsValueType)
@@ -2214,15 +2212,31 @@ public sealed class Conversion
         }
 
         ImmutableArray<TypeSymbol> sourceArguments;
-        if (ClrTypeUtilities.AreSame(from.OpenDefinition, targetOpen))
+        if (from.OpenDefinition != null
+            && !from.TypeArguments.IsDefaultOrEmpty
+            && !from.OpenDefinition.IsValueType)
         {
-            sourceArguments = from.TypeArguments;
+            if (ClrTypeUtilities.AreSame(from.OpenDefinition, targetOpen))
+            {
+                sourceArguments = from.TypeArguments;
+            }
+            else if (!MemberLookup.TryMapConstructedTypeArgumentsThroughHierarchy(
+                         from,
+                         targetOpen,
+                         out sourceArguments))
+            {
+                return false;
+            }
         }
-        else if (!MemberLookup.TryMapConstructedTypeArgumentsThroughHierarchy(
-                     from,
-                     targetOpen,
-                     out sourceArguments))
+        else if (!TryProjectClrInterfaceArguments(from, targetOpen, out sourceArguments))
         {
+            // Issue #3501: a NON-generic imported class (e.g. Roslyn's
+            // `SymbolEqualityComparer : IEqualityComparer<ISymbol?>`) has no
+            // symbolic type arguments to map, but its CLR interface closure
+            // still names the target's open definition; project that closed
+            // interface's CLR arguments so the variance loop below can accept
+            // `SymbolEqualityComparer -> IEqualityComparer[IMethodSymbol]`
+            // exactly as C# does.
             return false;
         }
 
@@ -2246,17 +2260,26 @@ public sealed class Conversion
                 continue;
             }
 
+            // Variance eligibility is about CLR reference-ness, NOT the
+            // `where T : class` constraint: a nullable-annotated reference
+            // argument (`ISymbol?` in `IEqualityComparer[ISymbol?]`) is
+            // reference-shaped and variance-convertible (the annotation has no
+            // runtime representation), while `Binder.IsReferenceTypeForConstraint`
+            // deliberately rejects `T?`. Use the same `IsReferenceTypeArgument`
+            // gate as the source-interface variance path (#1927) so
+            // `IEqualityComparer[ISymbol?] -> IEqualityComparer[IMethodSymbol]`
+            // classifies, matching C# (issue #3501 Translator burn-down).
             var variance = genericParameters[i].GenericParameterAttributes
                 & System.Reflection.GenericParameterAttributes.VarianceMask;
             var compatible = variance switch
             {
                 System.Reflection.GenericParameterAttributes.Covariant =>
-                    Binder.IsReferenceTypeForConstraint(sourceArgument)
-                    && Binder.IsReferenceTypeForConstraint(targetArgument)
+                    IsReferenceTypeArgument(sourceArgument)
+                    && IsReferenceTypeArgument(targetArgument)
                     && Classify(sourceArgument, targetArgument) is { Exists: true, IsImplicit: true },
                 System.Reflection.GenericParameterAttributes.Contravariant =>
-                    Binder.IsReferenceTypeForConstraint(sourceArgument)
-                    && Binder.IsReferenceTypeForConstraint(targetArgument)
+                    IsReferenceTypeArgument(sourceArgument)
+                    && IsReferenceTypeArgument(targetArgument)
                     && Classify(targetArgument, sourceArgument) is { Exists: true, IsImplicit: true },
                 _ => false,
             };
@@ -2267,6 +2290,74 @@ public sealed class Conversion
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// Issue #3501: projects the CLR generic arguments a (possibly non-generic)
+    /// imported reference type supplies for <paramref name="targetOpenDefinition"/>
+    /// by walking its CLR interface closure. This is the CLR-level counterpart
+    /// to <see cref="MemberLookup.TryMapConstructedTypeArgumentsThroughHierarchy"/>
+    /// for sources with no symbolic type-argument vector (e.g. Roslyn's
+    /// non-generic <c>SymbolEqualityComparer : IEqualityComparer&lt;ISymbol?&gt;</c>).
+    /// Nullable annotations are erased at this level, which only widens the
+    /// source side — exactly the C#/CLR variance behaviour.
+    /// </summary>
+    private static bool TryProjectClrInterfaceArguments(
+        ImportedTypeSymbol from,
+        Type targetOpenDefinition,
+        out ImmutableArray<TypeSymbol> sourceArguments)
+    {
+        sourceArguments = default;
+        var clr = from.ClrType;
+        if (clr == null || clr.IsValueType || clr.IsArray)
+        {
+            return false;
+        }
+
+        foreach (var candidate in EnumerateSelfAndClrInterfaces(clr))
+        {
+            Type candidateDefinition;
+            Type[] candidateArguments;
+            try
+            {
+                if (!candidate.IsGenericType || candidate.IsGenericTypeDefinition)
+                {
+                    continue;
+                }
+
+                candidateDefinition = candidate.GetGenericTypeDefinition();
+                candidateArguments = candidate.GetGenericArguments();
+            }
+            catch (NotSupportedException)
+            {
+                continue;
+            }
+
+            if (!ClrTypeUtilities.AreSame(candidateDefinition, targetOpenDefinition))
+            {
+                continue;
+            }
+
+            var builder = ImmutableArray.CreateBuilder<TypeSymbol>(candidateArguments.Length);
+            foreach (var argument in candidateArguments)
+            {
+                builder.Add(TypeSymbol.FromClrType(argument));
+            }
+
+            sourceArguments = builder.MoveToImmutable();
+            return true;
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<Type> EnumerateSelfAndClrInterfaces(Type clr)
+    {
+        yield return clr;
+        foreach (var implemented in ClrTypeUtilities.SafeGetInterfaces(clr))
+        {
+            yield return implemented;
+        }
     }
 
     private static List<StructSymbol> GetStructHierarchy(StructSymbol type)

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/ClrOverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/ClrOverloadResolution.cs
@@ -489,6 +489,20 @@ internal static class ClrOverloadResolution
             return ImplicitConversionKind.Reference;
         }
 
+        // Issue #3501: declaration-site generic-interface variance for a
+        // non-array reference source. `ImplementsInterfaceByName` above
+        // requires the closed generic arguments to match exactly, so a
+        // variance-compatible instantiation (e.g. Roslyn's
+        // `SymbolEqualityComparer : IEqualityComparer<ISymbol>` passed to a
+        // `HashSet<IMethodSymbol>` constructor's contravariant
+        // `IEqualityComparer<IMethodSymbol>` slot) fell through and failed
+        // GS0267 even though C#/the CLR accept it. Mirrors
+        // `IsSafeArrayInterfaceVariance` for the general interface case.
+        if (target.IsInterface && IsVariantGenericInterfaceConversion(target, source))
+        {
+            return ImplicitConversionKind.Reference;
+        }
+
         // Cross-context base-class walk (#610): covers inheritance across
         // reflection contexts (e.g. an MLC-loaded subclass passed to a
         // parameter typed as its live-runtime base class or vice versa).
@@ -1610,6 +1624,152 @@ internal static class ClrOverloadResolution
             Exists: true,
             IsImplicit: true,
         };
+    }
+
+    /// <summary>
+    /// Issue #3501: declaration-site variance for a general (non-array)
+    /// reference source against a constructed generic interface target.
+    /// Succeeds when the source (or one of its implemented interfaces) closes
+    /// the target's open definition with per-slot variance-compatible
+    /// arguments: identity for invariant slots, an implicit reference
+    /// conversion source→target for `out` slots, and target→source for `in`
+    /// slots — the ECMA-335 II.9.7 rule `ImplementsInterfaceByName` cannot
+    /// express because it requires exact closed-argument identity.
+    /// </summary>
+    private static bool IsVariantGenericInterfaceConversion(Type target, Type source)
+    {
+        if (source.IsValueType || source.IsArray || source.IsGenericParameter
+            || !target.IsGenericType || target.IsGenericTypeDefinition)
+        {
+            return false;
+        }
+
+        Type definition;
+        Type[] targetArguments;
+        Type[] parameters;
+        try
+        {
+            definition = target.GetGenericTypeDefinition();
+            targetArguments = target.GetGenericArguments();
+            parameters = definition.GetGenericArguments();
+        }
+        catch (NotSupportedException)
+        {
+            return false;
+        }
+
+        if (parameters.Length != targetArguments.Length)
+        {
+            return false;
+        }
+
+        var hasVariantSlot = false;
+        foreach (var parameter in parameters)
+        {
+            if ((parameter.GenericParameterAttributes & GenericParameterAttributes.VarianceMask)
+                != GenericParameterAttributes.None)
+            {
+                hasVariantSlot = true;
+                break;
+            }
+        }
+
+        if (!hasVariantSlot)
+        {
+            return false;
+        }
+
+        foreach (var candidate in EnumerateSelfAndInterfaces(source))
+        {
+            Type candidateDefinition;
+            Type[] candidateArguments;
+            try
+            {
+                if (!candidate.IsGenericType || candidate.IsGenericTypeDefinition)
+                {
+                    continue;
+                }
+
+                candidateDefinition = candidate.GetGenericTypeDefinition();
+                candidateArguments = candidate.GetGenericArguments();
+            }
+            catch (NotSupportedException)
+            {
+                continue;
+            }
+
+            if (!ClrTypeUtilities.AreSame(candidateDefinition, definition)
+                || candidateArguments.Length != targetArguments.Length)
+            {
+                continue;
+            }
+
+            if (AreVarianceCompatibleArguments(parameters, candidateArguments, targetArguments))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<Type> EnumerateSelfAndInterfaces(Type source)
+    {
+        if (source.IsInterface)
+        {
+            yield return source;
+        }
+
+        foreach (var implemented in ClrTypeUtilities.SafeGetInterfaces(source))
+        {
+            yield return implemented;
+        }
+    }
+
+    private static bool AreVarianceCompatibleArguments(
+        Type[] parameters,
+        Type[] sourceArguments,
+        Type[] targetArguments)
+    {
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            var sourceArgument = sourceArguments[i];
+            var targetArgument = targetArguments[i];
+            if (ClrTypeUtilities.AreSame(sourceArgument, targetArgument))
+            {
+                continue;
+            }
+
+            var variance = parameters[i].GenericParameterAttributes & GenericParameterAttributes.VarianceMask;
+            bool compatible;
+            switch (variance)
+            {
+                case GenericParameterAttributes.Covariant:
+                    compatible = IsClrVarianceReferenceType(sourceArgument)
+                        && IsClrVarianceReferenceType(targetArgument)
+                        && Conversion.ClassifyNonStructural(
+                            TypeSymbol.FromClrType(sourceArgument),
+                            TypeSymbol.FromClrType(targetArgument)) is { Exists: true, IsImplicit: true };
+                    break;
+                case GenericParameterAttributes.Contravariant:
+                    compatible = IsClrVarianceReferenceType(sourceArgument)
+                        && IsClrVarianceReferenceType(targetArgument)
+                        && Conversion.ClassifyNonStructural(
+                            TypeSymbol.FromClrType(targetArgument),
+                            TypeSymbol.FromClrType(sourceArgument)) is { Exists: true, IsImplicit: true };
+                    break;
+                default:
+                    compatible = false;
+                    break;
+            }
+
+            if (!compatible)
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static bool IsClrVarianceReferenceType(Type? type)

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
@@ -696,6 +696,21 @@ internal sealed partial class MethodBodyEmitter
 
     private static bool IsReferenceCompatible(TypeSymbol? a, TypeSymbol? b)
     {
+        // Issue #3501: inner generic nullability metadata does not change the
+        // CLR reference shape — mirror ClassifyCore's unwrap so an annotated
+        // imported target (e.g. the `IEqualityComparer<T>?` constructor
+        // parameter surfaced through the MetadataLoadContext) matches the
+        // same arms its bare shape would.
+        while (a is NullabilityAnnotatedTypeSymbol aAnnotated)
+        {
+            a = aAnnotated.BaseType;
+        }
+
+        while (b is NullabilityAnnotatedTypeSymbol bAnnotated)
+        {
+            b = bAnnotated.BaseType;
+        }
+
         if (a == b)
         {
             return true;
@@ -972,9 +987,16 @@ internal sealed partial class MethodBodyEmitter
         // therefore requires no instruction. Reuse the binder classification
         // instead of repeating nullable substitution, variance, and
         // cross-context identity logic here.
+        // Issue #3501: also admit a NON-generic imported reference source
+        // (no symbolic TypeArguments, e.g. Roslyn's `SymbolEqualityComparer`)
+        // converting to a variant constructed interface
+        // (`IEqualityComparer[IMethodSymbol]`): the binder now classifies it
+        // through the CLR interface-closure projection, and the emitted form
+        // is the same no-op reference upcast.
         if (a is ImportedTypeSymbol importedReference
-            && importedReference.OpenDefinition?.IsValueType == false
-            && !importedReference.TypeArguments.IsDefaultOrEmpty
+            && (importedReference.OpenDefinition?.IsValueType == false
+                || (importedReference.OpenDefinition == null
+                    && importedReference.ClrType is { IsValueType: false, IsArray: false }))
             && b is ImportedTypeSymbol
             && Conversion.ClassifyNonStructural(a, b) is
             {

--- a/test/Compiler.Tests/Emit/Issue3501NullableVariantInterfaceEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3501NullableVariantInterfaceEmitTests.cs
@@ -1,0 +1,215 @@
+// <copyright file="Issue3501NullableVariantInterfaceEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #3501 (Translator burn-down): declaration-site variance must compose
+/// with a nullable-annotated reference type argument on an IMPORTED generic
+/// interface. Roslyn's <c>SymbolEqualityComparer : IEqualityComparer&lt;ISymbol?&gt;</c>
+/// passed to <c>HashSet&lt;IMethodSymbol&gt;(IEqualityComparer&lt;T&gt;?)</c> is the
+/// motivating shape; the BCL-only equivalent is
+/// <c>IEqualityComparer[object?] → IEqualityComparer[string]</c>. Three gaps
+/// conspired:
+/// <list type="number">
+/// <item><c>TryClassifyConstructedImportedReferenceConversion</c> gated
+/// variance slots on <c>Binder.IsReferenceTypeForConstraint</c>, which
+/// deliberately rejects <c>T?</c> (correct for <c>where T : class</c>, wrong
+/// for variance eligibility — the annotation has no runtime shape);</item>
+/// <item>the same classifier bailed for a NON-generic imported source class
+/// (no symbolic type arguments), never consulting its CLR interface
+/// closure;</item>
+/// <item>the CLR-level overload-resolution applicability check only knew
+/// exact-argument interface matches (`ImplementsInterfaceByName`) and array
+/// covariance, so constructor arguments failed GS0267; and the emitter's
+/// <c>IsReferenceCompatible</c> neither unwrapped
+/// <c>NullabilityAnnotatedTypeSymbol</c> nor admitted the non-generic
+/// source, throwing NotSupportedException after the binder accepted.</item>
+/// </list>
+/// </summary>
+public class Issue3501NullableVariantInterfaceEmitTests
+{
+    [Fact]
+    public void ContravariantNullableArgument_ParameterAndConstructor_CompileAndRun()
+    {
+        var output = CompileAndRun("""
+            package Probe
+            import System
+            import System.Collections.Generic
+
+            func check(c IEqualityComparer[string]) bool {
+                return c.Equals("a", "a")
+            }
+
+            // Contravariance composed with a nullable reference argument:
+            // IEqualityComparer[object?] -> IEqualityComparer[string].
+            let comparer IEqualityComparer[object?] = EqualityComparer[object?].Default
+            Console.WriteLine(check(comparer))
+
+            // Same conversion at a BCL constructor slot (the parameter is the
+            // nullable-annotated `IEqualityComparer[T]?`).
+            let set = HashSet[string](EqualityComparer[object?].Default)
+            set.Add("x")
+            set.Add("x")
+            Console.WriteLine(set.Count)
+            """);
+
+        Assert.Equal(
+            string.Join(Environment.NewLine, "True", "1") + Environment.NewLine,
+            output);
+    }
+
+    [Fact]
+    public void WrongDirectionContravariance_StillDiagnoses()
+    {
+        // Guardrail: the CLR interface-closure projection must not over-accept.
+        // StringComparer implements IEqualityComparer[string]; converting it to
+        // the WIDER IEqualityComparer[object] would need object -> string on
+        // the contravariant slot and must keep failing.
+        var diagnostics = CompileExpectingFailure("""
+            package Probe
+            import System
+            import System.Collections.Generic
+
+            let c IEqualityComparer[object] = StringComparer.Ordinal
+            Console.WriteLine(c.GetHashCode())
+            """);
+
+        // GS0156: an explicit reference downcast exists, but the implicit
+        // variance conversion must not.
+        Assert.Contains("GS0156", diagnostics, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ValueTypeArgument_StaysVarianceIneligible()
+    {
+        // Guardrail: a value-type slot never participates in reference
+        // variance, nullable-annotated or not.
+        var diagnostics = CompileExpectingFailure("""
+            package Probe
+            import System
+            import System.Collections.Generic
+
+            let c IEqualityComparer[int32] = EqualityComparer[object?].Default
+            Console.WriteLine(c.GetHashCode())
+            """);
+
+        Assert.Contains("GS0155", diagnostics, StringComparison.Ordinal);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var directory = Directory.CreateTempSubdirectory("gs_issue3501_variance_").FullName;
+        try
+        {
+            var sourcePath = Path.Combine(directory, "test.gs");
+            var outputPath = Path.Combine(directory, "test.dll");
+            File.WriteAllText(sourcePath, source);
+
+            int exitCode = RunCompiler(new[]
+            {
+                "/out:" + outputPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                sourcePath,
+            }, out string diagnostics);
+            Assert.True(exitCode == 0, diagnostics);
+            IlVerifier.Verify(outputPath);
+            return RunAssembly(directory, outputPath);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    private static string CompileExpectingFailure(string source)
+    {
+        var directory = Directory.CreateTempSubdirectory("gs_issue3501_variance_neg_").FullName;
+        try
+        {
+            var sourcePath = Path.Combine(directory, "test.gs");
+            var outputPath = Path.Combine(directory, "test.dll");
+            File.WriteAllText(sourcePath, source);
+
+            int exitCode = RunCompiler(new[]
+            {
+                "/out:" + outputPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                sourcePath,
+            }, out string diagnostics);
+            Assert.NotEqual(0, exitCode);
+            return diagnostics;
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    private static int RunCompiler(string[] arguments, out string diagnostics)
+    {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            int exitCode = Program.Main(arguments);
+            diagnostics = $"stdout:\n{stdout}\nstderr:\n{stderr}";
+            return exitCode;
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+    }
+
+    private static string RunAssembly(string workingDirectory, string assemblyPath)
+    {
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = workingDirectory,
+        };
+        startInfo.ArgumentList.Add("exec");
+        startInfo.ArgumentList.Add("--runtimeconfig");
+        startInfo.ArgumentList.Add(Path.ChangeExtension(assemblyPath, ".runtimeconfig.json"));
+        startInfo.ArgumentList.Add(assemblyPath);
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start dotnet exec.");
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), "dotnet exec timed out.");
+        Assert.True(
+            process.ExitCode == 0,
+            $"dotnet exec exited {process.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout.ReplaceLineEndings(Environment.NewLine);
+    }
+}


### PR DESCRIPTION
Part of the #3501 Translator burn-down (the `Cs2Gs.Translator` 161-error wall).

## The bug

Roslyn's `SymbolEqualityComparer : IEqualityComparer<ISymbol?>` failed to convert to `IEqualityComparer[IMethodSymbol]`:

- **GS0267** at every `HashSet[T](SymbolEqualityComparer.Default)` / `Dictionary[K,V](...)` constructor slot (~39 sites),
- **GS0154** at parameter slots,
- and the poisoned locals then cascaded into ~200 `Cannot find function Add/Contains/TryGetValue` (GS0159) and `Cannot find member SyntaxTree` (GS0158) errors across the migrated Translator.

Minimal repro (9 lines): `HashSet[IMethodSymbol](SymbolEqualityComparer.Default)` with a Roslyn reference. The BCL-only distillation is `IEqualityComparer[object?] → IEqualityComparer[string]` — contravariance **composed with** a nullable-annotated reference argument. Each dimension worked alone; the composition failed.

## Four composed gaps, fixed

1. **`Conversion.TryClassifyConstructedImportedReferenceConversion`** gated variance slots on `Binder.IsReferenceTypeForConstraint`, which deliberately rejects `T?` (right for `where T : class`, wrong for variance — the annotation has no runtime shape). Now uses the same `IsReferenceTypeArgument` gate as the source-interface variance path (#1927).
2. The same classifier **bailed for a non-generic imported source class** (no symbolic type arguments). New `TryProjectClrInterfaceArguments` projects the source's CLR interface closure so its closed interface arguments feed the ordinary per-slot variance loop.
3. **`ClrOverloadResolution`** applicability only knew exact-argument interface matches (`ImplementsInterfaceByName`) and array covariance. New `IsVariantGenericInterfaceConversion` adds the general ECMA-335 II.9.7 declaration-site rule for non-array sources, mirroring `IsSafeArrayInterfaceVariance`.
4. **`MethodBodyEmitter.IsReferenceCompatible`** neither unwrapped `NullabilityAnnotatedTypeSymbol` (the shape of the annotated `IEqualityComparer<T>?` ctor parameter surfaced through the MetadataLoadContext) nor admitted the non-generic imported source — it threw `NotSupportedException` on conversions the binder now accepts. Both are no-op reference loads at IL level.

## Tests

- New `Issue3501NullableVariantInterfaceEmitTests`: positive compile+ilverify+run for parameter and BCL-ctor slots, plus wrong-direction (GS0156 stays) and value-type-slot (GS0155 stays) guardrails.
- Targeted: 258 Core.Tests (Variance|Conversion) + 691 Compiler.Tests (Variance|Comparer|Overload|Nullable) pass locally; full suite via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Six2MrhXHo6kQ8DSA6c1Pc