### PR TITLE
gsc: an internal new shadow must not hide an inherited public member (#3501)

### DIFF
--- a/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
+++ b/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
@@ -1550,15 +1550,25 @@ public static class ClrTypeUtilities
             return null;
         }
 
+        // Issue #3501: enumerate each hierarchy level DECLARED-ONLY rather
+        // than filtering one flattened enumeration of `type`. Reflection's
+        // flattened view applies hide-by-name BEFORE the visibility filter, so
+        // an INTERNAL `new` shadow in a derived class (Roslyn's
+        // `CSharpSyntaxNode.SyntaxTree` over the public
+        // `SyntaxNode.SyntaxTree`) removes the base member from the flattened
+        // set while the shadow itself is excluded by the Public flag — the
+        // member vanishes entirely and every `node.SyntaxTree` read failed
+        // GS0158. Walking most-derived-first with DeclaredOnly matches C#
+        // lookup: an accessible shadow wins at its own level, and an
+        // inaccessible one simply doesn't hide the base member.
         TMember? FindCanonical()
         {
             for (Type? declaringType = type; declaringType != null; declaringType = declaringType.BaseType)
             {
                 TMember? match = null;
-                foreach (TMember candidate in safeEnumerate(type, flags))
+                foreach (TMember candidate in safeEnumerate(declaringType, flags | BindingFlags.DeclaredOnly))
                 {
-                    if (!EmittedMemberNameMatches(candidate, name)
-                        || !AreSame(candidate.DeclaringType, declaringType))
+                    if (!EmittedMemberNameMatches(candidate, name))
                     {
                         continue;
                     }
@@ -1592,32 +1602,7 @@ public static class ClrTypeUtilities
         }
         catch (AmbiguousMatchException)
         {
-            for (var declaringType = type; declaringType != null; declaringType = declaringType.BaseType)
-            {
-                TMember? match = null;
-                foreach (var member in safeEnumerate(type, flags))
-                {
-                    if (!EmittedMemberNameMatches(member, name)
-                        || !AreSame(member.DeclaringType, declaringType))
-                    {
-                        continue;
-                    }
-
-                    if (match != null)
-                    {
-                        return null;
-                    }
-
-                    match = member;
-                }
-
-                if (match != null)
-                {
-                    return match;
-                }
-            }
-
-            return null;
+            return FindCanonical();
         }
         catch (Exception ex) when (IsMetadataLoadFailure(ex))
         {

--- a/test/Compiler.Tests/Emit/Issue3501HiddenShadowMemberLookupTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3501HiddenShadowMemberLookupTests.cs
@@ -1,0 +1,93 @@
+// <copyright file="Issue3501HiddenShadowMemberLookupTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #3501 (Translator burn-down, GS0158 "Cannot find member SyntaxTree"
+/// ×44): reflection's flattened member view applies hide-by-name BEFORE the
+/// visibility filter, so an INTERNAL <c>new</c> shadow in a derived metadata
+/// class — Roslyn's <c>CSharpSyntaxNode.SyntaxTree</c> over the public
+/// <c>SyntaxNode.SyntaxTree</c> — removes the base member from the flattened
+/// set while the shadow itself is excluded by the Public flag, and the member
+/// vanishes entirely. <c>ClrTypeUtilities.SafeGetMember</c> now walks the base
+/// chain most-derived-first with DeclaredOnly per level, matching C# lookup:
+/// an accessible shadow wins at its own level, and an inaccessible one simply
+/// doesn't hide the base member.
+/// </summary>
+public class Issue3501HiddenShadowMemberLookupTests
+{
+    [Fact]
+    public void InternalNewShadow_DoesNotHideInheritedPublicMember()
+    {
+        var directory = Directory.CreateTempSubdirectory("gs_issue3501_shadow_").FullName;
+        try
+        {
+            var sourcePath = Path.Combine(directory, "test.gs");
+            var outputPath = Path.Combine(directory, "test.dll");
+            File.WriteAllText(sourcePath, """
+                package Probe
+                import System
+                import Microsoft.CodeAnalysis
+                import Microsoft.CodeAnalysis.CSharp
+                import Microsoft.CodeAnalysis.CSharp.Syntax
+
+                func lengthOf(node CSharpSyntaxNode) int32 {
+                    return node.SyntaxTree.Length
+                }
+
+                func viaStatement(statement StatementSyntax) string {
+                    return statement.SyntaxTree.FilePath
+                }
+                """);
+
+            int exitCode = RunCompiler(new[]
+            {
+                "/out:" + outputPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                "/r:" + typeof(Microsoft.CodeAnalysis.SyntaxNode).Assembly.Location,
+                "/r:" + typeof(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode).Assembly.Location,
+                sourcePath,
+            }, out string diagnostics);
+            Assert.True(exitCode == 0, diagnostics);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    private static int RunCompiler(string[] arguments, out string diagnostics)
+    {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            int exitCode = Program.Main(arguments);
+            diagnostics = $"stdout:\n{stdout}\nstderr:\n{stderr}";
+            return exitCode;
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+    }
+}


### PR DESCRIPTION
Part of the #3501 Translator burn-down — retires the GS0158 "Cannot find member SyntaxTree" family (44 distinct sites in the latest local run, plus Cannot-find-function cascades downstream of those reads).

## The bug

Reflection's flattened member view applies **hide-by-name before the visibility filter**: an *internal* `new` shadow in a derived metadata class — Roslyn 5.6's `CSharpSyntaxNode.SyntaxTree` shadowing the public `SyntaxNode.SyntaxTree` — removes the base member from `GetProperties(Public|Instance)` while the shadow itself is excluded by the `Public` flag. The member vanishes entirely: `GetProperty` returns null, the flattened-enumeration fallback in `ClrTypeUtilities.SafeGetMember` never sees it, and every `node.SyntaxTree` read fails GS0158. (C# resolves this fine because Roslyn-the-compiler honors accessibility during lookup, not after.)

Repro: `func f(n CSharpSyntaxNode) { let t = n.SyntaxTree }` with a Microsoft.CodeAnalysis reference — `Language`/`Body` on the same receivers bind; only the shadowed name disappeared.

## The fix

`SafeGetMember`'s canonical fallback now enumerates each hierarchy level **declared-only**, walking most-derived-first — matching C# lookup semantics: an accessible shadow wins at its own level, and an inaccessible one simply doesn't hide the base member. The `AmbiguousMatchException` handler collapses into the same walk (it was the identical loop with the same flattened-enumeration defect).

## Tests

- New `Issue3501HiddenShadowMemberLookupTests` compiling `CSharpSyntaxNode.SyntaxTree` / `StatementSyntax.SyntaxTree` reads against the live Roslyn assemblies.
- Targeted: 823 Core.Tests (member/property lookup) + 563 Compiler.Tests (member/shadow/inherit/access) pass locally; full suite via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Six2MrhXHo6kQ8DSA6c1Pc