### PR TITLE
cs2gs: reuse a source using-alias instead of synthesizing a colliding namespace import (#3501)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue3501AliasReuseAvoidsAmbiguousImportTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3501AliasReuseAvoidsAmbiguousImportTests.cs
@@ -1,0 +1,79 @@
+// <copyright file="Issue3501AliasReuseAvoidsAmbiguousImportTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3501 (GS0532 family in the migrated Translator): when a C# file
+/// references an aliased type (`using GSharpSyntaxFacts =
+/// GSharp.Core.CodeAnalysis.Syntax.SyntaxFacts;`) in symbol-only positions,
+/// the mapper used to shorten to the bare name and synthesize a WHOLE-NAMESPACE
+/// import — which made other simple names (`AssignmentExpressionSyntax`,
+/// `SyntaxKind`) ambiguous between that namespace and Roslyn's, and gsc bound
+/// the wrong package, surfacing as GS0532 "pattern variable not definitely
+/// assigned" on the now-impossible patterns. The mapper now reuses the source
+/// alias (its import is already emitted) so no namespace import is synthesized.
+/// </summary>
+public class Issue3501AliasReuseAvoidsAmbiguousImportTests
+{
+    [Fact]
+    public void AliasedTypeInSymbolPosition_ReusesAliasInsteadOfNamespaceImport()
+    {
+        string printed = TranslateUnit(@"
+using TextEncoding = System.Text.Encoding;
+
+namespace Demo
+{
+    public class Writer
+    {
+        private readonly TextEncoding encoding = TextEncoding.UTF8;
+
+        public TextEncoding Pick(bool wide)
+        {
+            TextEncoding chosen = wide ? TextEncoding.Unicode : this.encoding;
+            return chosen;
+        }
+    }
+}");
+
+        // The alias import survives and the references reuse it...
+        Assert.Contains("import TextEncoding = System.Text.Encoding", printed);
+        Assert.Contains("encoding TextEncoding", printed);
+
+        // ...so no whole-namespace import is synthesized for the alias target.
+        Assert.DoesNotContain("import System.Text\n", printed, StringComparison.Ordinal);
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.DoesNotContain(
+            context.Diagnostics,
+            diagnostic => diagnostic.Severity == TranslationSeverity.Unsupported);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -2261,7 +2261,12 @@ public sealed class CSharpTypeMapper
         out string aliasName)
     {
         aliasName = null;
-        if (named.Arity != 0 || this.reservedTypeAliases.Count == 0)
+
+        // Constraint mapping (issue #2509, WithMetadataImportCollisionQualification)
+        // demands the EXACT qualified semantic identity — a homonym-safe
+        // `A.IContract` — never an alias spelling, so alias reuse is skipped
+        // there.
+        if (named.Arity != 0 || this.reservedTypeAliases.Count == 0 || this.qualifyMetadataImportCollisions)
         {
             return false;
         }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -886,6 +886,14 @@ public sealed class CSharpTypeMapper
         INamedTypeSymbol named,
         TranslationContext context,
         Location location)
+        => this.GetOrCreateImportedTypeAlias(named, context, location, reuseOnly: false, precomputedTarget: null);
+
+    internal string GetOrCreateImportedTypeAlias(
+        INamedTypeSymbol named,
+        TranslationContext context,
+        Location location,
+        bool reuseOnly,
+        string precomputedTarget)
     {
         static bool HasVisibleSourceTypeName(
             string name,
@@ -941,9 +949,9 @@ public sealed class CSharpTypeMapper
         string namespaceName = named.ContainingNamespace is { IsGlobalNamespace: false } ns
             ? this.Names(context).GetNamespaceName(ns)
             : null;
-        string target = namespaceName != null
+        string target = precomputedTarget ?? (namespaceName != null
             ? $"{namespaceName}.{simpleName}"
-            : simpleName;
+            : simpleName);
         foreach (var reservedAlias in this.reservedTypeAliases)
         {
             if (reservedAlias.Value.Count == 1
@@ -967,6 +975,11 @@ public sealed class CSharpTypeMapper
             {
                 return existing.Key;
             }
+        }
+
+        if (reuseOnly)
+        {
+            return null;
         }
 
         this.sourceDeclaredTypeNames ??= BuildSourceDeclaredTypeNames(
@@ -1567,6 +1580,22 @@ public sealed class CSharpTypeMapper
 
         if (named.ContainingType == null)
         {
+            // Issue #3501: when the source file declares a `using Alias = …;`
+            // for this exact type, render the ALIAS instead of shortening to
+            // the bare name. The bare rendering forced a synthesized
+            // whole-namespace import that could collide with another imported
+            // namespace's simple names (EmittedNameAllocator's
+            // `import GSharp.Core.CodeAnalysis.Syntax` made Roslyn's
+            // `AssignmentExpressionSyntax`/`SyntaxKind` ambiguous, and gsc
+            // silently bound the wrong one — surfacing as GS0532 on the
+            // now-impossible patterns). The alias import is already emitted by
+            // the ordinary using-directive translation, so the alias name
+            // resolves without any synthesized namespace import.
+            if (this.TryReuseSourceUsingAlias(named, context, location, out string sourceAlias))
+            {
+                return sourceAlias;
+            }
+
             this.TrackShortenedNamespace(named);
             string simpleName = this.Names(context).GetName(named);
             bool visibleNestedHomonym = this.HasVisibleSourceNestedHomonym(
@@ -2205,6 +2234,51 @@ public sealed class CSharpTypeMapper
             && returnType.NullableAnnotation != NullableAnnotation.Annotated
                 ? WithNullable(mapped, true)
                 : mapped;
+    }
+
+    /// <summary>
+    /// Issue #3501: when the source file declares a `using Alias = Type;` for
+    /// the exact NON-GENERIC top-level type being rendered, reuse that alias
+    /// instead of shortening to the bare name — the bare rendering forces a
+    /// synthesized whole-namespace import that can make OTHER simple names
+    /// ambiguous across imports (EmittedNameAllocator's synthesized
+    /// `import GSharp.Core.CodeAnalysis.Syntax` made Roslyn's
+    /// `AssignmentExpressionSyntax`/`SyntaxKind` resolve to the wrong package,
+    /// surfacing as GS0532 on the now-impossible patterns). Reuses the same
+    /// uniqueness and shadowing gates as <see cref="GetOrCreateImportedTypeAlias(INamedTypeSymbol, TranslationContext, Location)"/>
+    /// (#3466), and generic targets are excluded so constructed spellings keep
+    /// their explicit type arguments (#2500).
+    /// </summary>
+    /// <param name="named">The referenced top-level type.</param>
+    /// <param name="context">The active translation context.</param>
+    /// <param name="location">The reference location (shadowing probes).</param>
+    /// <param name="aliasName">The reusable alias identifier, when one applies.</param>
+    /// <returns><see langword="true"/> when a source alias can be reused.</returns>
+    private bool TryReuseSourceUsingAlias(
+        INamedTypeSymbol named,
+        TranslationContext context,
+        Location location,
+        out string aliasName)
+    {
+        aliasName = null;
+        if (named.Arity != 0 || this.reservedTypeAliases.Count == 0)
+        {
+            return false;
+        }
+
+        string simpleName = this.Names(context).GetName(named);
+        string namespaceName = named.ContainingNamespace is { IsGlobalNamespace: false } ns
+            ? this.Names(context).GetNamespaceName(ns)
+            : null;
+        string target = namespaceName != null ? $"{namespaceName}.{simpleName}" : simpleName;
+        string candidate = this.GetOrCreateImportedTypeAlias(named, context, location, reuseOnly: true, target);
+        if (candidate is null)
+        {
+            return false;
+        }
+
+        aliasName = candidate;
+        return true;
     }
 }
 


### PR DESCRIPTION
Part of the #3501 Translator burn-down — retires the 10-error GS0532 tail in `EmittedNameAllocator.gs` (and the misleading diagnostics it produced).

## The bug

When a C# file references an aliased type (`using GSharpSyntaxFacts = GSharp.Core.CodeAnalysis.Syntax.SyntaxFacts;`) in symbol-only mapping positions, `CSharpTypeMapper.QualifiedTypeName` shortened to the bare name and synthesized a **whole-namespace import**. In the migrated `Cs2Gs.Translator`, that `import GSharp.Core.CodeAnalysis.Syntax` made other simple names — `AssignmentExpressionSyntax`, `SyntaxKind`, `IdentifierNameSyntax` — ambiguous between G#'s own syntax namespace and Roslyn's, and gsc silently bound the wrong package. The Roslyn-typed patterns then became impossible, surfacing as ten GS0532 "pattern variable is not definitely assigned" errors — a spectacularly misleading tail (a 49-line repro needed the import bisect to find it).

## The fix

`QualifiedTypeName` now reuses the file's own `using Alias = Type;` for a non-generic top-level type before shortening: the alias import is already emitted by ordinary using-directive translation, so no namespace import gets synthesized. Reuse routes through the same #3466 uniqueness/shadowing gates as `GetOrCreateImportedTypeAlias` (now shared via a `reuseOnly` mode) so a shadowed alias is never chosen, and generic targets are excluded so constructed spellings keep their explicit type arguments (#2500 stays intact).

## Tests

- New `Issue3501AliasReuseAvoidsAmbiguousImportTests` (alias reused in field/return/local positions; no namespace import synthesized).
- The previously-failing first draft broke `Issue3466NestedHomonymAliasTests` and `Issue2500…UsingAliases_PreserveNullableSemanticArguments`; routing through the shared shadow-gates fixed all three — full alias/golden/oblivious/import sweep (289 tests) passes.

Follow-up worth filing: gsc should diagnose an ambiguous simple-name type reference across imported packages (C# CS0104 parity) instead of silently binding one — that would have turned this ten-error GS0532 mystery into a one-line answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Six2MrhXHo6kQ8DSA6c1Pc