### PR TITLE
Target-type initializer lambdas from member types

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
@@ -1923,7 +1923,7 @@ internal sealed partial class ExpressionBinder
                 return conversions.BindConversion(diagnosticLocation, boundValueOverride, elementType);
             }
 
-            return conversions.BindConversion(
+            return BindExpression(
                 Invariant.Required(valueSyntax, "index assignments have a value expression"),
                 elementType);
         }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -521,8 +521,7 @@ internal sealed partial class ExpressionBinder
                 return null;
             }
 
-            var value = BindExpression(initSyntax.Value);
-            var converted = conversions.BindConversion(initSyntax.Value.Location, value, instTargetSymbol);
+            var converted = BindExpression(initSyntax.Value, instTargetSymbol);
             var receiverExpr = new BoundVariableExpression(initSyntax, receiverLocal);
             return new BoundClrPropertyAssignmentExpression(initSyntax, receiverExpr, instanceMember, converted, instTargetSymbol, staticContainerType: null);
         }
@@ -539,8 +538,7 @@ internal sealed partial class ExpressionBinder
                     Diagnostics.ReportMemberInaccessible(initSyntax.PropertyIdentifier.Location, field.Name, fieldDeclaringType.Name, field.Accessibility);
                 }
 
-                var value = BindExpression(initSyntax.Value);
-                var converted = conversions.BindConversion(initSyntax.Value.Location, value, field.Type);
+                var converted = BindExpression(initSyntax.Value, field.Type);
                 return new BoundFieldAssignmentExpression(initSyntax, receiverLocal, fieldDeclaringType, field, converted);
             }
 
@@ -561,8 +559,7 @@ internal sealed partial class ExpressionBinder
                     Diagnostics.ReportMemberInaccessible(initSyntax.PropertyIdentifier.Location, prop.Name, propDeclaringType.Name, prop.SetterAccessibility);
                 }
 
-                var value = BindExpression(initSyntax.Value);
-                var converted = conversions.BindConversion(initSyntax.Value.Location, value, prop.Type);
+                var converted = BindExpression(initSyntax.Value, prop.Type);
                 var receiverExpr = new BoundVariableExpression(initSyntax, receiverLocal);
                 return new BoundPropertyAssignmentExpression(initSyntax, receiverExpr, structSymbol, prop, converted);
             }
@@ -583,8 +580,7 @@ internal sealed partial class ExpressionBinder
                         return null;
                     }
 
-                    var value = BindExpression(initSyntax.Value);
-                    var converted = conversions.BindConversion(initSyntax.Value.Location, value, inhTargetSymbol);
+                    var converted = BindExpression(initSyntax.Value, inhTargetSymbol);
                     var receiverExpr = new BoundVariableExpression(initSyntax, receiverLocal);
                     return new BoundClrPropertyAssignmentExpression(initSyntax, receiverExpr, inhMember, converted, inhTargetSymbol, staticContainerType: null);
                 }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -97,8 +97,7 @@ internal sealed partial class ExpressionBinder
                     Diagnostics.ReportMemberInaccessible(initSyntax.FieldIdentifier.Location, field.Name, fieldDeclaringType.Name, field.Accessibility);
                 }
 
-                var fieldValueExpr = BindExpression(initSyntax.Value);
-                fieldValueExpr = conversions.BindConversion(initSyntax.Value.Location, fieldValueExpr, field.Type);
+                var fieldValueExpr = BindExpression(initSyntax.Value, field.Type);
                 explicitValues[memberName] = (field, null, fieldValueExpr);
                 continue;
             }
@@ -117,8 +116,7 @@ internal sealed partial class ExpressionBinder
                     Diagnostics.ReportMemberInaccessible(initSyntax.FieldIdentifier.Location, property.Name, propertyDeclaringType.Name, property.SetterAccessibility);
                 }
 
-                var propertyValueExpr = BindExpression(initSyntax.Value);
-                propertyValueExpr = conversions.BindConversion(initSyntax.Value.Location, propertyValueExpr, property.Type);
+                var propertyValueExpr = BindExpression(initSyntax.Value, property.Type);
                 explicitValues[memberName] = (null, property, propertyValueExpr);
                 continue;
             }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -1319,6 +1319,13 @@ internal sealed partial class ExpressionBinder
                         continue;
                     }
 
+                    // Concrete members cannot constrain this construction's
+                    // type arguments; bind them once in the final closed pass.
+                    if (!TypeSymbol.ContainsTypeParameter(memberType))
+                    {
+                        continue;
+                    }
+
                     var valueExpr = BindExpression(initSyntax.Value);
                     Binder.InferTypeArguments(memberType, valueExpr.Type, substitution);
                 }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -988,18 +988,12 @@ internal sealed partial class ExpressionBinder
             // member type is inferred from the initializer expression exactly
             // like an ordinary `let x = expr` local declaration.
             var memberType = member.TypeClause == null ? null : bindTypeClause(member.TypeClause);
-            var value = BindExpression(member.Value);
+            var value = memberType == null
+                ? BindExpression(member.Value)
+                : BindExpression(member.Value, memberType);
             if (value is BoundErrorExpression)
             {
                 hadError = true;
-            }
-            else if (memberType != null)
-            {
-                value = conversions.BindConversion(member.Value.Location, value, memberType);
-                if (value is BoundErrorExpression)
-                {
-                    hadError = true;
-                }
             }
 
             memberNames.Add(name);
@@ -1495,8 +1489,9 @@ internal sealed partial class ExpressionBinder
                 continue;
             }
 
-            var valueExpr = BindExpression(initSyntax.Value);
-            valueExpr = conversions.BindConversion(initSyntax.Value.Location, valueExpr, memberType);
+            // Issue #3521: member type must reach target-dependent initializer
+            // forms before they bind, not only their later conversion.
+            var valueExpr = BindExpression(initSyntax.Value, memberType);
             inits.Add(hasField
                 ? new BoundFieldInitializer(
                     Invariant.Required(field, "a resolved field has an initializer"),
@@ -1565,10 +1560,8 @@ internal sealed partial class ExpressionBinder
                 continue;
             }
 
-            var value = BindExpression(initializer.Syntax.Value);
-            var converted = conversions.BindConversion(
-                initializer.Syntax.Value.Location,
-                value,
+            var converted = BindExpression(
+                initializer.Syntax.Value,
                 initializer.MemberType);
             BoundExpression assignment = initializer.Field != null
                 ? new BoundFieldAssignmentExpression(
@@ -1700,8 +1693,7 @@ internal sealed partial class ExpressionBinder
                 continue;
             }
 
-            var value = BindExpression(initializer.Value);
-            values.Add(name, conversions.BindConversion(initializer.Value.Location, value, slotType));
+            values.Add(name, BindExpression(initializer.Value, slotType));
             order.Add(name);
         }
 
@@ -1880,8 +1872,7 @@ internal sealed partial class ExpressionBinder
                 continue;
             }
 
-            var value = BindExpression(initSyntax.Value);
-            var converted = conversions.BindConversion(initSyntax.Value.Location, value, targetSymbol);
+            var converted = BindExpression(initSyntax.Value, targetSymbol);
             var receiverExpr = new BoundVariableExpression(initSyntax, tempVar);
             statements.Add(new BoundExpressionStatement(
                 initSyntax,
@@ -1977,8 +1968,7 @@ internal sealed partial class ExpressionBinder
             {
                 if (TypeMemberModel.TryGetFieldIncludingInherited(classConstraint, memberName, MemberQuery.Instance(MemberKinds.Field), out var field, out var fieldDeclaringType))
                 {
-                    var fieldValue = BindExpression(initSyntax.Value);
-                    var fieldConverted = conversions.BindConversion(initSyntax.Value.Location, fieldValue, field.Type);
+                    var fieldConverted = BindExpression(initSyntax.Value, field.Type);
                     statements.Add(new BoundExpressionStatement(
                         initSyntax,
                         BoundFieldAssignmentExpression.WithExpressionReceiver(initSyntax, receiverExpr, fieldDeclaringType, field, fieldConverted)));
@@ -1994,8 +1984,7 @@ internal sealed partial class ExpressionBinder
                         continue;
                     }
 
-                    var classPropValue = BindExpression(initSyntax.Value);
-                    var classPropConverted = conversions.BindConversion(initSyntax.Value.Location, classPropValue, classProp.Type);
+                    var classPropConverted = BindExpression(initSyntax.Value, classProp.Type);
                     statements.Add(new BoundExpressionStatement(
                         initSyntax,
                         new BoundPropertyAssignmentExpression(initSyntax, receiverExpr, classPropDeclaringType, classProp, classPropConverted)));
@@ -2015,8 +2004,7 @@ internal sealed partial class ExpressionBinder
                     continue;
                 }
 
-                var ifacePropValue = BindExpression(initSyntax.Value);
-                var ifacePropConverted = conversions.BindConversion(initSyntax.Value.Location, ifacePropValue, ifaceProp.Type);
+                var ifacePropConverted = BindExpression(initSyntax.Value, ifaceProp.Type);
                 statements.Add(new BoundExpressionStatement(
                     initSyntax,
                     new BoundPropertyAssignmentExpression(initSyntax, receiverExpr, null, ifaceProp, ifacePropConverted)));
@@ -2044,11 +2032,7 @@ internal sealed partial class ExpressionBinder
                     var declaringInterface = MemberLookup.GetClrMemberDeclaringTypeSymbol(
                         clrInterfaceConstraint,
                         clrProperty);
-                    var propertyValue = BindExpression(initSyntax.Value);
-                    var converted = conversions.BindConversion(
-                        initSyntax.Value.Location,
-                        propertyValue,
-                        propertyType);
+                    var converted = BindExpression(initSyntax.Value, propertyType);
                     statements.Add(new BoundExpressionStatement(
                         initSyntax,
                         new BoundClrPropertyAssignmentExpression(
@@ -2402,7 +2386,7 @@ internal sealed partial class ExpressionBinder
             var rectangularElements = ImmutableArray.CreateBuilder<BoundExpression>(elementSyntaxes.Count);
             foreach (var elementSyntax in elementSyntaxes)
             {
-                rectangularElements.Add(conversions.BindConversion(elementSyntax, elementType));
+                rectangularElements.Add(BindExpression(elementSyntax, elementType));
             }
 
             var rectangularLengths = ImmutableArray<int>.Empty;
@@ -2465,7 +2449,7 @@ internal sealed partial class ExpressionBinder
 
         foreach (var elementSyntax in elementSyntaxes)
         {
-            elements.Add(conversions.BindConversion(elementSyntax, elementType));
+            elements.Add(BindExpression(elementSyntax, elementType));
         }
 
         if (syntax.LengthToken == null)
@@ -2720,8 +2704,8 @@ internal sealed partial class ExpressionBinder
         var entries = ImmutableArray.CreateBuilder<BoundMapEntry>(syntax.Entries.Count);
         foreach (var entrySyntax in syntax.Entries)
         {
-            var key = conversions.BindConversion(entrySyntax.Key, mts.KeyType);
-            var value = conversions.BindConversion(entrySyntax.Value, mts.ValueType);
+            var key = BindExpression(entrySyntax.Key, mts.KeyType);
+            var value = BindExpression(entrySyntax.Value, mts.ValueType);
             entries.Add(new BoundMapEntry(key, value));
         }
 

--- a/test/Compiler.Tests/Emit/Issue3521InitializerLambdaTargetEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3521InitializerLambdaTargetEmitTests.cs
@@ -1,0 +1,257 @@
+// <copyright file="Issue3521InitializerLambdaTargetEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+public sealed class Issue3521InitializerLambdaTargetEmitTests
+{
+    [Fact]
+    public void DestinationMemberTypes_TargetUntypedLambdas_RunAndVerify()
+    {
+        const string source = """
+            package Issue3521Positive
+            import System.Collections.Generic
+
+            class NullableHolder3521 { var Callback ((int32) -> void)? }
+            class ClassHolder3521 { var Callback (int32) -> void }
+            data class DataClassHolder3521 { var Callback (int32) -> void }
+            struct StructHolder3521 { var Callback (int32) -> void }
+            data struct DataStructHolder3521 { var Callback (int32) -> void }
+            class PropertyHolder3521 {
+                prop Callback (int32) -> void { get; init; }
+                init() {}
+            }
+            class SuffixHolder3521 {
+                var Callback (int32) -> void
+                init() {}
+            }
+            data class CopyHolder3521 { var Callback (int32) -> void }
+            class MixedHolder3521 {
+                var Callback (int32) -> void
+                prop Items IList[int32] { get; init; }
+                init() { Items = List[int32]() }
+            }
+            class NestedHolder3521 {
+                var Factory (int32) -> ((int32) -> int32)
+            }
+
+            func Main() int32 {
+                var seen int32 = 0
+
+                let nullable = NullableHolder3521{
+                    Callback: (value) -> { seen = seen + value }
+                }
+                nullable.Callback?(1)
+
+                let plain = ClassHolder3521{
+                    Callback: (value) -> { seen = seen + value }
+                }
+                plain.Callback(2)
+
+                let dataClass = DataClassHolder3521{
+                    Callback: (value) -> { seen = seen + value }
+                }
+                dataClass.Callback(3)
+
+                let structure = StructHolder3521{
+                    Callback: (value) -> { seen = seen + value }
+                }
+                structure.Callback(4)
+
+                let dataStructure = DataStructHolder3521{
+                    Callback: (value) -> { seen = seen + value }
+                }
+                dataStructure.Callback(5)
+
+                let projected = DataStructHolder3521{
+                    ...dataStructure,
+                    Callback: (value) -> { seen = seen + value }
+                }
+                projected.Callback(6)
+
+                let mixed = MixedHolder3521{
+                    Callback: (value) -> { seen = seen + value },
+                    Items: { 1 }
+                }
+                mixed.Callback(7)
+
+                let suffix = SuffixHolder3521(){
+                    Callback = (value) -> { seen = seen + value }
+                }
+                suffix.Callback(8)
+
+                let original = CopyHolder3521{
+                    Callback: (value int32) -> { seen = seen + value }
+                }
+                let copied = original with {
+                    Callback = (value) -> { seen = seen + value }
+                }
+                copied.Callback(9)
+
+                let anonymous = object {
+                    let Callback (int32) -> void =
+                        (value) -> { seen = seen + value }
+                }
+                anonymous.Callback(10)
+
+                let array = []((int32) -> void){
+                    (value) -> { seen = seen + value }
+                }
+                array[0](11)
+
+                let list = List[(int32) -> void]{
+                    (value) -> { seen = seen + value }
+                }
+                list[0](12)
+
+                let indexed = Dictionary[int32, (int32) -> void]{
+                    [1] = (value) -> { seen = seen + value }
+                }
+                indexed[1](13)
+
+                let mapped = map[int32, (int32) -> void]{
+                    1: (value) -> { seen = seen + value }
+                }
+                mapped[1](14)
+
+                let property = PropertyHolder3521{
+                    Callback: (value) -> { seen = seen + value }
+                }
+                property.Callback(15)
+
+                let nested = NestedHolder3521{
+                    Factory: (left) -> {
+                        return (right) -> left + right
+                    }
+                }
+                seen = seen + nested.Factory(8)(8)
+
+                return seen == 136 ? 0 : 1
+            }
+            """;
+
+        var directory = NewDirectory("positive");
+        try
+        {
+            var outputPath = Path.Combine(directory, "Issue3521Positive.dll");
+            Emit(source, outputPath);
+            IlVerifier.Verify(outputPath);
+            Assert.Equal(0, Run(outputPath));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void WrongLambdaArity_ReportsArgumentCountDiagnostic()
+    {
+        var diagnostics = CompileErrors("""
+            package Issue3521WrongArity
+
+            class Holder3521WrongArity {
+                var Callback (int32) -> void
+            }
+
+            func Build() Holder3521WrongArity ->
+                Holder3521WrongArity{ Callback: (left, right) -> {} }
+            """);
+
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Id == "GS0144");
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.Id == "GS9998");
+    }
+
+    [Fact]
+    public void IncompatibleExplicitParameterType_ReportsConversionDiagnostic()
+    {
+        var diagnostics = CompileErrors("""
+            package Issue3521WrongType
+
+            class Holder3521WrongType {
+                var Callback (int32) -> void
+            }
+
+            func Build() Holder3521WrongType ->
+                Holder3521WrongType{ Callback: (value string) -> {} }
+            """);
+
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Id == "GS0155");
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.Id == "GS9998");
+    }
+
+    private static void Emit(string source, string outputPath)
+    {
+        using var resolver = ReferenceResolver.Default();
+        var compilation = new Compilation(
+            resolver,
+            SyntaxTree.Parse(SourceText.From(source)));
+        using var stream = File.Create(outputPath);
+        var result = compilation.Emit(
+            stream,
+            pdbStream: null,
+            refStream: null,
+            assemblyName: Path.GetFileNameWithoutExtension(outputPath));
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+
+    private static Diagnostic[] CompileErrors(string source)
+    {
+        using var resolver = ReferenceResolver.Default();
+        var compilation = new Compilation(
+            resolver,
+            SyntaxTree.Parse(SourceText.From(source)));
+        using var stream = new MemoryStream();
+        var result = compilation.Emit(
+            stream,
+            pdbStream: null,
+            refStream: null,
+            assemblyName: "Issue3521Negative" + Guid.NewGuid().ToString("N"));
+        Assert.False(result.Success);
+        return result.Diagnostics.ToArray();
+    }
+
+    private static int Run(string assemblyPath)
+    {
+        var context = new AssemblyLoadContext(
+            "Issue3521-" + Guid.NewGuid().ToString("N"),
+            isCollectible: true);
+        try
+        {
+            var assembly = context.LoadFromAssemblyPath(Path.GetFullPath(assemblyPath));
+            var entryPoint = assembly.EntryPoint;
+            Assert.NotNull(entryPoint);
+            var arguments = entryPoint.GetParameters().Length == 0
+                ? null
+                : new object[] { Array.Empty<string>() };
+            return Convert.ToInt32(entryPoint.Invoke(null, arguments));
+        }
+        finally
+        {
+            context.Unload();
+        }
+    }
+
+    private static string NewDirectory(string name)
+    {
+        var directory = Path.Combine(
+            Environment.CurrentDirectory,
+            "TestArtifacts",
+            "Issue3521",
+            name + "-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue3521InitializerLambdaTargetEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3521InitializerLambdaTargetEmitTests.cs
@@ -157,6 +157,65 @@ public sealed class Issue3521InitializerLambdaTargetEmitTests
     }
 
     [Fact]
+    public void InferredGenericComposites_DeferConcreteLambdaMembers_RunAndVerify()
+    {
+        const string source = """
+            package Issue3521Generic
+
+            class GenericClass3521[T] {
+                var Value T
+                var Callback (int32) -> void
+            }
+
+            data struct GenericDataStruct3521[T] {
+                var Value T
+                var Callback (int32) -> void
+            }
+
+            class GenericCallback3521[T] {
+                var Callback (T) -> void
+            }
+
+            func Main() int32 {
+                var seen int32 = 0
+
+                let classBox = GenericClass3521{
+                    Value: 40,
+                    Callback: (value) -> { seen = seen + value }
+                }
+                seen = seen + classBox.Value
+                classBox.Callback(1)
+
+                let dataBox = GenericDataStruct3521{
+                    Callback: (value) -> { seen = seen + value },
+                    Value: "ok"
+                }
+                dataBox.Callback(dataBox.Value.Length)
+
+                let callbackBox = GenericCallback3521{
+                    Callback: (value int32) -> { seen = seen + value }
+                }
+                callbackBox.Callback(1)
+
+                return seen == 44 ? 0 : 1
+            }
+            """;
+
+        var directory = NewDirectory("generic");
+        try
+        {
+            var outputPath = Path.Combine(directory, "Issue3521Generic.dll");
+            Emit(source, outputPath);
+            IlVerifier.Verify(outputPath);
+            Assert.Equal(0, Run(outputPath));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
     public void WrongLambdaArity_ReportsArgumentCountDiagnostic()
     {
         var diagnostics = CompileErrors("""
@@ -180,12 +239,16 @@ public sealed class Issue3521InitializerLambdaTargetEmitTests
         var diagnostics = CompileErrors("""
             package Issue3521WrongType
 
-            class Holder3521WrongType {
+            class Holder3521WrongType[T] {
+                var Value T
                 var Callback (int32) -> void
             }
 
-            func Build() Holder3521WrongType ->
-                Holder3521WrongType{ Callback: (value string) -> {} }
+            func Build() Holder3521WrongType[int32] ->
+                Holder3521WrongType{
+                    Value: 1,
+                    Callback: (value string) -> {}
+                }
             """);
 
         Assert.Contains(diagnostics, diagnostic => diagnostic.Id == "GS0155");


### PR DESCRIPTION
## Root cause

Initializer binders eagerly bound member values without a destination type, then converted the completed bound expression. Untyped lambdas therefore emitted GS0304 before the resolved field/property/element function type could participate.

The inferred-generic composite prepass also bound every initializer while gathering substitution evidence. Concrete member types cannot constrain generic parameters, but their target-dependent values still bound without targets before the final closed-type pass.

## Fix

- Route valid composite, object-suffix, `with`, anonymous-object, imported/type-parameter, and structural-spread initializer values through the existing target-aware expression binder.
- Apply the same destination-aware binding to array, map, and indexed collection values; collection `Add` overloads keep using normal overload resolution.
- Skip concrete member types during inferred-generic composite substitution; generic-bearing members still bind and contribute inference evidence, while concrete values bind once against the closed destination type.
- Leave member lookup, accessibility, writability, duplicate detection, conversion, and nullable-function handling on their existing paths.

## Tests

- Added nullable/nonnullable function members across class, data class, struct, and data struct literals.
- Covered inferred generic class/data-struct composites, initializer ordering, generic-bearing callback inference, and final-pass mismatch diagnostics.
- Covered properties, object-initializer suffixes, `with`, structural spread, anonymous objects, ordered member collection initialization, arrays, lists, maps, indexed collections, and nested lambda returns.
- Added wrong-arity and explicit parameter-type mismatch diagnostics.
- Runtime exit code `0` and per-test ILVerify pass.
- Release solution build: 0 warnings/errors.
- Follow-up generic/composite Core tests: 117 passed; Compiler emit tests: 37 passed.
- Full Core suite: 8,083 passed.
- Repository ILVerify gate: 125/125 verified (2 documented suppressions, 0 failures).

Fixes #3521
