### PR TITLE
cs2gs: parenthesize a combinator pattern under `not` (#3501)

### DIFF
--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -1111,7 +1111,14 @@ public static class GSharpPrinter
                 return $"{RenderPattern(binary.Left, indent, includeTypeDesignator)} {(binary.IsConjunction ? "and" : "or")} {RenderPattern(binary.Right, indent, includeTypeDesignator)}";
 
             case NotPattern not:
-                return $"not {RenderPattern(not.Pattern, indent, includeTypeDesignator)}";
+                // Issue #3501: `not` binds tighter than `and`/`or` in gsc's
+                // pattern grammar, so a combinator child must keep its grouping
+                // (`not (T and { … })`); printing it bare re-associates to
+                // `(not T) and { … }` and the property pattern escapes the
+                // negation (GS0172/GS0173 against the scrutinee's own type).
+                return not.Pattern is BinaryPattern
+                    ? $"not ({RenderPattern(not.Pattern, indent, includeTypeDesignator)})"
+                    : $"not {RenderPattern(not.Pattern, indent, includeTypeDesignator)}";
 
             case ParenthesizedPattern paren:
                 return $"({RenderPattern(paren.Pattern, indent, includeTypeDesignator)})";

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3501NegatedTypePropertyPatternTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3501NegatedTypePropertyPatternTests.cs
@@ -1,0 +1,83 @@
+// <copyright file="Issue3501NegatedTypePropertyPatternTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3501 (GS0172/GS0173 family): a boolean-position C# `is not
+/// T { props }` translates to a G# `not` over an `and`-combined
+/// type+property pattern, but `not` binds tighter than `and` in gsc's
+/// pattern grammar — printing the combinator child bare re-associated to
+/// `(not T) and { props }`, so the property pattern escaped the negation and
+/// was checked against the scrutinee's own (possibly nullable) type. The
+/// printer now parenthesizes a combinator child of `not`.
+/// </summary>
+public class Issue3501NegatedTypePropertyPatternTests
+{
+    [Fact]
+    public void NegatedTypeWithPropertyPattern_KeepsGroupingUnderNot()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class Node
+    {
+        public Node Inner { get; set; }
+        public int Rank { get; set; }
+    }
+
+    public static class Probe
+    {
+        public static bool Reject(object value)
+        {
+            if (value is not Node { Rank: 3 })
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}");
+
+        Assert.DoesNotContain("not Node and {", printed, StringComparison.Ordinal);
+        Assert.True(
+            printed.Contains("not (Node and { Rank: 3 })", StringComparison.Ordinal)
+                || printed.Contains("not Node { Rank: 3 }", StringComparison.Ordinal)
+                || printed.Contains("!(value is Node", StringComparison.Ordinal),
+            "The negation must cover the whole type+property pattern. Printed:\n" + printed);
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.DoesNotContain(
+            context.Diagnostics,
+            diagnostic => diagnostic.Severity == TranslationSeverity.Unsupported);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}


### PR DESCRIPTION
Part of the #3501 Translator burn-down — retires the GS0172/GS0173 family (6 errors).

A boolean-position C# `is not T { props }` translates to a G# `not` over an `and`-combined type+property pattern (`RecursivePatternSyntax` under `TranslatingBooleanPattern` builds `BinaryPattern(and, TypePattern, PropertyPattern)`), but `not` binds tighter than `and` in gsc's pattern grammar. Printing the combinator child bare re-associated to `(not T) and { props }`, so the property pattern escaped the negation and was checked against the scrutinee's own (possibly nullable) type — surfacing as GS0172 "Property pattern requires a struct or class value, not '?'" and GS0173 "does not define a readable instance property" at every `is not InvocationExpressionSyntax { … }`-style guard in the migrated Translator.

`GSharpPrinter` now parenthesizes a `BinaryPattern` child of `NotPattern`: `not (T and { … })`. Any builder that genuinely wants `(not A) and B` builds the `BinaryPattern` with the `NotPattern` as its operand, so the grouping is always correct.

Tests: new `Issue3501NegatedTypePropertyPatternTests` (grouping preserved and round-trips through gsc); full pattern sweep (182 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Six2MrhXHo6kQ8DSA6c1Pc