### PR TITLE
cs2gs: bridge promoted-nullable yields against the iterator element type (#3501)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue3501YieldSeamBridgingTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3501YieldSeamBridgingTests.cs
@@ -1,0 +1,106 @@
+// <copyright file="Issue3501YieldSeamBridgingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3501 (GS0155 yield family): a `yield` is a value seam against the
+/// iterator's element type, exactly like an argument against its parameter — a
+/// promoted-nullable value flowing into a non-null element needs the same `!!`
+/// bridge the argument path inserts, both for scalar yields
+/// (`yield Canonical(called)` where the callee returns `T?`) and per-element
+/// for tuple literals (`yield (tryOutVar, true)` against `(Base, bool)`).
+/// </summary>
+public class Issue3501YieldSeamBridgingTests
+{
+    [Fact]
+    public void Oblivious_TupleYieldWithPromotedElement_BridgesPerElement()
+    {
+        string printed = TranslateOblivious(@"
+using System.Collections.Generic;
+
+namespace Demo
+{
+    public class C
+    {
+        public string Find(bool b)
+        {
+            if (b) { return null; }
+            return ""x"";
+        }
+
+        public IEnumerable<(string Name, bool Flag)> Rows()
+        {
+            var candidate = Find(true);
+            yield return (candidate, true);
+        }
+    }
+}");
+
+        Assert.Contains("Find(b bool) string?", printed);
+        Assert.Contains("yield (candidate!!, true)", printed);
+    }
+
+    [Fact]
+    public void Oblivious_ScalarYieldOfPromotedCall_Bridges()
+    {
+        string printed = TranslateOblivious(@"
+using System.Collections.Generic;
+
+namespace Demo
+{
+    public class C
+    {
+        public string Find(bool b)
+        {
+            if (b) { return null; }
+            return ""x"";
+        }
+
+        public IEnumerable<int> Lengths()
+        {
+            yield return Find(true).Length;
+        }
+    }
+}");
+
+        Assert.Contains("Find(true)!!.Length", printed);
+    }
+
+    private static string TranslateOblivious(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        Assert.Equal(
+            NullableContextOptions.Disable,
+            project.Compilation.Options.NullableContextOptions);
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.DoesNotContain(
+            context.Diagnostics,
+            diagnostic => diagnostic.Severity == TranslationSeverity.Unsupported);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
@@ -1234,6 +1234,46 @@ public sealed partial class CSharpToGSharpTranslator
                 value = EnsureNonNullAssertion(value);
             }
 
+            // Issue #3501: a yield is a VALUE seam against the iterator's
+            // element type (the yield expression's C# converted type), exactly
+            // like an argument against its parameter — a promoted-nullable
+            // value (`yield Canonical(called)` where `Canonical` returns
+            // `ISymbol?`) flowing into a non-null element needs the same `!!`
+            // bridge the argument path inserts. Tuple literals bridge
+            // per-element (`yield (generatedRegexField, true)` where the
+            // Try-out-var is `FieldDeclaration?` but the element is
+            // `(GMember, bool)`).
+            IMethodSymbol enclosingIterator =
+                this.context.SemanticModel.GetEnclosingSymbol(node.SpanStart) as IMethodSymbol;
+            if (node.Expression is TupleExpressionSyntax tupleValue
+                && typeInfo.ConvertedType is INamedTypeSymbol { IsTupleType: true } tupleTarget
+                && value is TupleLiteralExpression tupleLiteral
+                && tupleValue.Arguments.Count == tupleTarget.TupleElements.Length
+                && tupleLiteral.Elements.Count == tupleValue.Arguments.Count)
+            {
+                var bridged = new List<GExpression>(tupleLiteral.Elements.Count);
+                for (int i = 0; i < tupleLiteral.Elements.Count; i++)
+                {
+                    bridged.Add(this.ForgiveNullableReferenceValue(
+                        tupleValue.Arguments[i].Expression,
+                        tupleLiteral.Elements[i],
+                        tupleTarget.TupleElements[i].Type,
+                        enclosingIterator,
+                        includePromotedValue: true));
+                }
+
+                value = new TupleLiteralExpression(bridged);
+            }
+            else if (typeInfo.ConvertedType is { } elementType)
+            {
+                value = this.ForgiveNullableReferenceValue(
+                    node.Expression,
+                    value,
+                    elementType,
+                    enclosingIterator,
+                    includePromotedValue: true);
+            }
+
             return new[] { (GStatement)new YieldStatement(value) };
         }
 


### PR DESCRIPTION
Part of the #3501 Translator burn-down — retires ~7 GS0155 `T? -> T` errors at yield seams.

A `yield` is a value seam against the iterator's element type (the yield expression's C# converted type), exactly like an argument against its parameter — but `TranslateYieldStatement` only special-cased the foreach-local narrow. A promoted-nullable value flowing into a non-null element compiled to a bare `T? → T`:

- scalar yields: `yield Canonical(called)` where the callee's return is promoted `ISymbol?`;
- tuple literals: `yield (generatedRegexField, true)` where the Try-out-var is `FieldDeclaration?` against element `(GMember, bool)` — the shape the #3544 out-var taint surfaced.

Both now route through the existing `ForgiveNullableReferenceValue` argument-seam helper (with `includePromotedValue`), tuple literals element-by-element, so all its guards (flow-narrowed locals, expression trees, statically-non-null values, already-asserted operands) apply unchanged.

Tests: new `Issue3501YieldSeamBridgingTests` (tuple per-element + scalar member-access bridge, round-tripped through gsc); yield/iterator/oblivious/golden sweep (208 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Six2MrhXHo6kQ8DSA6c1Pc