### PR TITLE
gsc: infer deferred-lambda parameters from the reified receiver shape (#3551)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -1310,7 +1310,13 @@ internal sealed partial class ExpressionBinder
             {
                 // offset is 1 only for a probe collected with includeExtensions:
                 // true, which above is gated on receiverType?.ClrType != null.
-                argTypes[0] = receiverType!.ClrType;
+                // Issue #3551: prefer the REIFIED closed shape over the cached
+                // (possibly erased) ClrType — a symbolic receiver like
+                // IGrouping[string?, (string, int32?)] can cache a closed shape
+                // whose tuple argument lost its Nullable element, and inferring
+                // the deferred lambda's parameter from that shape rebinds the
+                // literal against the wrong tuple.
+                argTypes[0] = ReifiedReceiverClrType(receiverType) ?? receiverType!.ClrType;
             }
 
             var usable = true;
@@ -1506,6 +1512,34 @@ internal sealed partial class ExpressionBinder
     /// resulting parameter types; otherwise the fallback declines (preserving the
     /// existing GS0304 behaviour) to avoid binding against an ambiguous shape.
     /// </summary>
+    /// <summary>
+    /// Issue #3551: resolves the receiver's REIFIED closed CLR shape for
+    /// deferred-lambda parameter inference. The cached <see cref="TypeSymbol.ClrType"/>
+    /// of a symbolic imported generic can carry an erased or stale closed
+    /// shape (e.g. `IGrouping&lt;string, ValueTuple&lt;string, int&gt;&gt;` for the
+    /// symbolic `IGrouping[string?, (string, int32?)]`, the tuple's Nullable
+    /// element lost), and a lambda rebound against a target inferred from that
+    /// shape disagrees with the receiver everywhere else, failing resolution
+    /// (GS0159). Returns <see langword="null"/> when no better shape exists.
+    /// </summary>
+    /// <param name="receiverType">The symbolic receiver type.</param>
+    /// <returns>The reified closed CLR type, or <see langword="null"/>.</returns>
+    private static System.Type? ReifiedReceiverClrType(TypeSymbol? receiverType)
+    {
+        if (receiverType is ImportedTypeSymbol imported
+            && imported.OpenDefinition != null
+            && !imported.TypeArguments.IsDefaultOrEmpty)
+        {
+            var reified = imported.ReifyClosedClrType();
+            if (reified != null && !reified.ContainsGenericParameters)
+            {
+                return reified;
+            }
+        }
+
+        return null;
+    }
+
     private bool TryMapDeferredLambdaParameterTargets(
         IReadOnlyList<MethodInfo> methods,
         int offset,
@@ -1526,7 +1560,10 @@ internal sealed partial class ExpressionBinder
                 return false;
             }
 
-            argTypes[0] = receiverClrType;
+            // Issue #3551: see the full-inference path above — use the reified
+            // closed shape so a nullable tuple element survives into the
+            // deferred lambda's inferred parameter type.
+            argTypes[0] = ReifiedReceiverClrType(receiverType) ?? receiverClrType;
         }
 
         for (var i = 0; i < boundArgs.Length; i++)

--- a/test/Compiler.Tests/Emit/Issue3551DeferredLambdaReifiedReceiverTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3551DeferredLambdaReifiedReceiverTests.cs
@@ -1,0 +1,142 @@
+// <copyright file="Issue3551DeferredLambdaReifiedReceiverTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #3551: deferred arrow-lambda parameter inference used the receiver's
+/// CACHED (possibly erased) <c>ClrType</c>. A symbolic receiver such as
+/// <c>IGrouping[string?, (string, int32?)]</c> (a nullable-annotated key from
+/// a <c>GroupBy</c> whose selector returns <c>string?</c>) can cache a closed
+/// shape whose tuple argument lost its <c>Nullable</c> element
+/// (<c>ValueTuple&lt;string, int&gt;</c>), so the lambda was rebound against the
+/// wrong tuple and every extension call on the grouping failed GS0159
+/// ("Cannot find function Select"). The inference paths now prefer
+/// <c>ReifyClosedClrType()</c>, matching the extension-dispatch path.
+/// </summary>
+public class Issue3551DeferredLambdaReifiedReceiverTests
+{
+    [Fact]
+    public void NullableKeyGrouping_TupleElementLambdas_Resolve()
+    {
+        var output = CompileAndRun("""
+            package Probe
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            let two int32? = 2
+            let none int32? = nil
+            let xs = List[(string, int32, int32?)]()
+            xs.Add(("a", 1, two))
+            xs.Add(("b", 2, none))
+            xs.Add(("c", 3, two))
+
+            let keys = List[string]()
+            keys.Add("k0")
+            keys.Add("k1")
+            keys.Add("k2")
+
+            var n = 0
+            var names = ""
+            for group in xs.GroupBy((t (string, int32, int32?)) -> if (t.Item3 != nil) { keys[t.Item3!!] } else { default(string?) }) {
+                let members = group.Select((t (string, int32, int32?)) -> t.Item1).ToList()
+                n = n + members.Count
+                for name in members.OrderBy((s string) -> s) {
+                    names = names + name
+                }
+            }
+            Console.WriteLine(n)
+            Console.WriteLine(names)
+            """);
+
+        Assert.Equal(
+            string.Join(Environment.NewLine, "3", "acb") + Environment.NewLine,
+            output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var directory = Directory.CreateTempSubdirectory("gs_issue3551_").FullName;
+        try
+        {
+            var sourcePath = Path.Combine(directory, "test.gs");
+            var outputPath = Path.Combine(directory, "test.dll");
+            File.WriteAllText(sourcePath, source);
+
+            int exitCode = RunCompiler(new[]
+            {
+                "/out:" + outputPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                sourcePath,
+            }, out string diagnostics);
+            Assert.True(exitCode == 0, diagnostics);
+            IlVerifier.Verify(outputPath);
+            return RunAssembly(directory, outputPath);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    private static int RunCompiler(string[] arguments, out string diagnostics)
+    {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            int exitCode = Program.Main(arguments);
+            diagnostics = $"stdout:\n{stdout}\nstderr:\n{stderr}";
+            return exitCode;
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+    }
+
+    private static string RunAssembly(string workingDirectory, string assemblyPath)
+    {
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = workingDirectory,
+        };
+        startInfo.ArgumentList.Add("exec");
+        startInfo.ArgumentList.Add("--runtimeconfig");
+        startInfo.ArgumentList.Add(Path.ChangeExtension(assemblyPath, ".runtimeconfig.json"));
+        startInfo.ArgumentList.Add(assemblyPath);
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start dotnet exec.");
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), "dotnet exec timed out.");
+        Assert.True(
+            process.ExitCode == 0,
+            $"dotnet exec exited {process.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout.ReplaceLineEndings(Environment.NewLine);
+    }
+}


### PR DESCRIPTION
Fixes #3551; part of the #3501 Translator burn-down (~8 of the last 29 errors — the `Constructors.gs` local-function-hoisting `GroupBy`/`Select` family).

## Root cause (a fun one)

The lambda literal bound its declared `(t (string, int32?))` parameters **correctly**. The corruption happened afterwards: deferred arrow-lambda parameter inference (`ResolveDeferredArrowLambdaArguments` → `TryMapDeferredLambdaParameterTargets`) used the receiver's **cached ClrType**. A symbolic receiver like `IGrouping[string?, (string, int32?)]` — what a `GroupBy` whose key selector returns a nullable reference produces — can cache a closed CLR shape whose tuple argument lost its `Nullable` element (`ValueTuple<string, int>`). Inference then derived the lambda target from that shape and silently rebound the literal as an erased adapter with `(string, int32)` parameters. The corrupted argument disagreed with the receiver at applicability time, so `Select`/`Any`/`FirstOrDefault`… failed GS0159 — even with explicit type arguments.

Traced by instrumenting literal binds (`[lambda] params=[(string, int32?)]` ✓), the erased-adapter creation (`((string, int32?)) -> string -> ((string, int32)) -> string` ✗ with stack), and the deferred path's raw receiver (`recvClr=IGrouping<string, ValueTuple<string, Int32>>` ✗).

## Fix

Both deferred-inference fallbacks (full-inference and partial-parameter) now prefer `ReifyClosedClrType()` — the same Nullable-preserving reconstruction the extension-dispatch path already uses (#2523) — over the cached shape, via a shared `ReifiedReceiverClrType` helper.

## Tests

- New `Issue3551DeferredLambdaReifiedReceiverTests`: nullable-key `GroupBy` over tuple elements with `Select`/`OrderBy` lambdas, compile+ilverify+run.
- Lambda/LINQ/deferred/extension sweep (412 tests) passes locally; the seven reduction probes from the issue all compile.

Two latent tuple-literal gaps surfaced while writing the test (worked around with typed locals; will file separately): `(a, 1, nil)` in argument position fails GS9998 "Cannot encode signature for type 'nil'", and a tuple literal needing element-wise conversion `(string,int32,int32) → (string,int32,int32?)` at a generic `List.Add` argument emits through non-generic `IList.Add` and throws at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Six2MrhXHo6kQ8DSA6c1Pc