### PR TITLE
cs2gs: ratchet the self-migration baseline after the #3501 burn-down

### DIFF
--- a/tools/cs2gs/selfmig-baseline.json
+++ b/tools/cs2gs/selfmig-baseline.json
@@ -1,8 +1,8 @@
 {
-  "comment": "Issue #3501 Track C: ratcheting baseline for the repo self-migration gate (build/run-cs2gs-selfmig.sh). greenFloor is the minimum number of fully-green apps; the *Ceiling metrics cap readability regressions in the migrated output, counted over CODE lines only (string fixtures and comments excluded \u2014 re-baselined 2026-08-25: labels 0, lifts 29, bangs 14408). Improve a metric, then tighten the corresponding number in the same PR.",
-  "greenFloor": 28,
-  "syntheticLabelCeiling": 2,
-  "liftedLocalCeiling": 35,
-  "longLineCeiling": 3700,
-  "nullAssertionCeiling": 15000
+  "comment": "Issue #3501 Track C: ratcheting baseline for the repo self-migration gate (build/run-cs2gs-selfmig.sh). greenFloor is the minimum number of fully-green apps; the *Ceiling metrics cap readability regressions in the migrated output, counted over CODE lines only (string fixtures and comments excluded — re-baselined 2026-08-26 after the #3542-#3550 burn-down: 29/55 green, labels 0, lifts 29, lines>300 467, bangs 13990). Improve a metric, then tighten the corresponding number in the same PR.",
+  "greenFloor": 29,
+  "syntheticLabelCeiling": 0,
+  "liftedLocalCeiling": 32,
+  "longLineCeiling": 600,
+  "nullAssertionCeiling": 14200
 }


### PR DESCRIPTION
First fully-PASSING self-migration nightly ([run 32966599031](https://github.com/DavidObando/gsharp/actions/runs/32966599031)) on main with #3542–#3550 merged:

| metric | value | old ceiling | new |
|---|---:|---:|---:|
| green apps | **29/55** | floor 28 | floor **29** |
| synthetic labels | 0 | 2 | **0** |
| `__local_` lifts | 29 | 35 | **32** |
| lines >300 chars | 467 | 3700 | **600** |
| `!!` assertions | 13990 | 15000 | **14200** |

Per the Track C rule: improve a metric, tighten the number in the same PR. #3558/#3559 (CI-green, awaiting merge) should push the Translator app itself toward green next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Six2MrhXHo6kQ8DSA6c1Pc