### PR TITLE
cs2gs: qualify metadata homonyms across imported namespaces in ordinary positions (#3554)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue3554MetadataHomonymQualificationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3554MetadataHomonymQualificationTests.cs
@@ -1,0 +1,97 @@
+// <copyright file="Issue3554MetadataHomonymQualificationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3554: a fully-qualified METADATA reference used to shorten to its
+/// bare simple name even when a DISTINCT same-named type sits in another of
+/// the file's imported namespaces — gsc then silently bound the bare name to
+/// the wrong package (the `GSharp.Core…Syntax.SyntaxFacts` vs Roslyn
+/// `SyntaxFacts` family, GS0159 "Cannot find function IsReservedIdentifier").
+/// The imported-namespace homonym scan now runs for metadata types in
+/// ordinary positions too; it only fires on genuine collisions, so common
+/// framework types still print bare.
+/// </summary>
+public class Issue3554MetadataHomonymQualificationTests
+{
+    [Fact]
+    public void FullyQualifiedMetadataHomonym_StaysDisambiguated()
+    {
+        string printed = TranslateUnit(@"
+using System.Timers;
+
+namespace Demo
+{
+    public class Probe
+    {
+        public ElapsedEventHandler Handler { get; set; }
+
+        public object MakeThreadingTimer()
+        {
+            return new System.Threading.Timer(_ => { }, null, 0, 1000);
+        }
+    }
+}");
+
+        // The System.Threading.Timer reference must not shorten to a bare
+        // `Timer` that gsc would bind to System.Timers.Timer.
+        Assert.DoesNotContain("return Timer(", printed);
+        Assert.True(
+            printed.Contains("System.Threading.Timer(", StringComparison.Ordinal)
+                || System.Text.RegularExpressions.Regex.IsMatch(printed, @"import \w+ = System\.Threading\.Timer"),
+            "The threading Timer must stay qualified or aliased. Printed:\n" + printed);
+    }
+
+    [Fact]
+    public void UncollidedMetadataType_StaysBare()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class Probe
+    {
+        public System.Text.StringBuilder Make()
+        {
+            return new System.Text.StringBuilder();
+        }
+    }
+}");
+
+        Assert.Contains("StringBuilder()", printed);
+        Assert.DoesNotContain("System.Text.StringBuilder()", printed);
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.DoesNotContain(
+            context.Diagnostics,
+            diagnostic => diagnostic.Severity == TranslationSeverity.Unsupported);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -1893,6 +1893,17 @@ public sealed class CSharpTypeMapper
                     continue;
                 }
 
+                // Issue #3554 follow-up: an arity-differing pair
+                // (System.Collections.IEnumerator vs
+                // System.Collections.Generic.IEnumerator<T>) is not a G#
+                // ambiguity — gsc disambiguates a bare name by its type-argument
+                // count, exactly like the same-namespace
+                // IComparable/IComparable<T> case filtered below.
+                if (candidate.Arity != named.Arity)
+                {
+                    continue;
+                }
+
                 // Types in the same namespace/package are not an import
                 // collision. This also filters facade/implementation symbols
                 // for the same forwarded metadata type, and same-namespace

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -1619,16 +1619,21 @@ public sealed class CSharpTypeMapper
             // metadata types in that case so gsc binds the reference to the
             // right type instead of whichever homonym happens to resolve first.
             //
-            // Constraint mapping also enables this scan for metadata/metadata
-            // collisions (issue #2509). Ordinary positions retain the
-            // source-authored gate so common framework types are not qualified
-            // spuriously.
+            // Issue #3554: the imported-namespace scan now runs for METADATA
+            // types in ordinary positions too (previously constraint-mapping
+            // only, #2509). The scan only fires when a DISTINCT same-named
+            // type actually sits in another of this file's imported
+            // namespaces, so common framework types still print bare; but a
+            // genuine metadata/metadata collision — G#'s own
+            // `GSharp.Core.CodeAnalysis.Syntax.SyntaxFacts` referenced
+            // fully-qualified in a file that also imports
+            // `Microsoft.CodeAnalysis.CSharp` (Roslyn's `SyntaxFacts`) —
+            // previously shortened to a bare name gsc silently bound to the
+            // WRONG package (GS0159 "Cannot find function IsReservedIdentifier").
             bool isSourceType = named.Locations.Any(l => l.IsInSource);
-            bool scanImportedNamespaces = isSourceType
-                || this.qualifyMetadataImportCollisions;
             bool ambiguous = this.HasSourceHomonym(named, context)
                 || visibleNestedHomonym
-                || (scanImportedNamespaces && this.HasImportedNamespaceHomonym(named, context));
+                || this.HasImportedNamespaceHomonym(named, context);
             if (!ambiguous)
             {
                 return simpleName;
@@ -1664,11 +1669,13 @@ public sealed class CSharpTypeMapper
 
         this.TrackShortenedNamespace(outermost);
         string nestedName = string.Join(".", parts);
-        bool scanOutermostImports = outermost.Locations.Any(l => l.IsInSource)
-            || this.qualifyMetadataImportCollisions;
+
+        // Issue #3554: same unconditional imported-namespace scan as the
+        // top-level branch above — the containing type of a nested reference
+        // can collide across imported metadata namespaces just as easily.
         bool outermostAmbiguous = this.HasSourceHomonym(outermost, context)
             || this.HasVisibleSourceNestedHomonym(outermost, context, location)
-            || (scanOutermostImports && this.HasImportedNamespaceHomonym(outermost, context));
+            || this.HasImportedNamespaceHomonym(outermost, context);
         if (!outermostAmbiguous)
         {
             return nestedName;


### PR DESCRIPTION
Fixes #3554; part of the #3501 Translator burn-down (~8 of the last 21 errors — the bare-`SyntaxFacts`/`GetEmittedIdentifier` GS0159 family).

A fully-qualified metadata reference (`GSharp.Core.CodeAnalysis.Syntax.SyntaxFacts.IsReservedIdentifier(...)`) shortened to its bare simple name even when a distinct same-named type sits in another of the file's imported namespaces (Roslyn's `Microsoft.CodeAnalysis.CSharp.SyntaxFacts`) — and gsc silently bound the bare name to the wrong package.

`HasImportedNamespaceHomonym` (#2222) already detects exactly this — it only fires when a genuine collision exists among the file's actual imports — but for metadata types it was gated behind constraint mapping (#2509). The scan now runs unconditionally for both the top-level and nested-outermost branches: common framework types still print bare, while genuine collisions qualify (System.* alias / namespace-qualified), exactly as constraint mapping already produced.

Tests: new `Issue3554MetadataHomonymQualificationTests` (`System.Threading.Timer` vs imported `System.Timers` stays disambiguated; uncollided `StringBuilder` stays bare); alias/import/oblivious/golden/#2509 sweep (456 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Six2MrhXHo6kQ8DSA6c1Pc