### PR TITLE
gsc: box a value-type source to a variant interface target (#3501 Track A6)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -2211,10 +2211,17 @@ public sealed class Conversion
             return false;
         }
 
+        // Issue #3501 (Track A6 keystone): a VALUE-TYPE source converting to a
+        // variant INTERFACE target is C#'s boxing conversion composed with
+        // interface variance (`ImmutableArray[IMethodSymbol]` →
+        // `IEnumerable[ISymbol]`); the emitter's struct→interface arm already
+        // boxes, and the boxed reference is runtime-assignment-compatible with
+        // the variant interface, so only classification was missing. Non-
+        // interface targets keep the value-type exclusion.
         ImmutableArray<TypeSymbol> sourceArguments;
         if (from.OpenDefinition != null
             && !from.TypeArguments.IsDefaultOrEmpty
-            && !from.OpenDefinition.IsValueType)
+            && (!from.OpenDefinition.IsValueType || targetOpen.IsInterface))
         {
             if (ClrTypeUtilities.AreSame(from.OpenDefinition, targetOpen))
             {
@@ -2309,7 +2316,7 @@ public sealed class Conversion
     {
         sourceArguments = default;
         var clr = from.ClrType;
-        if (clr == null || clr.IsValueType || clr.IsArray)
+        if (clr == null || clr.IsArray)
         {
             return false;
         }

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/ClrOverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/ClrOverloadResolution.cs
@@ -1638,7 +1638,12 @@ internal static class ClrOverloadResolution
     /// </summary>
     private static bool IsVariantGenericInterfaceConversion(Type target, Type source)
     {
-        if (source.IsValueType || source.IsArray || source.IsGenericParameter
+        // Issue #3501: a VALUE-TYPE source is allowed — struct→variant-interface
+        // is C#'s boxing conversion composed with variance
+        // (`ImmutableArray<IMethodSymbol>` → `IEnumerable<ISymbol>`); the
+        // emitter's struct→interface arm boxes and the boxed reference is
+        // runtime-assignment-compatible with the variant interface.
+        if (source.IsArray || source.IsGenericParameter
             || !target.IsGenericType || target.IsGenericTypeDefinition)
         {
             return false;

--- a/test/Compiler.Tests/Emit/Issue3501StructVariantInterfaceBoxingTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3501StructVariantInterfaceBoxingTests.cs
@@ -1,0 +1,137 @@
+// <copyright file="Issue3501StructVariantInterfaceBoxingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #3501 (Track A6 keystone): a value-type source converting to a
+/// VARIANT interface target is C#'s boxing conversion composed with interface
+/// variance — `ImmutableArray&lt;IMethodSymbol&gt;` → `IEnumerable&lt;ISymbol&gt;`.
+/// The exact implemented interface already boxed; only the variance-composed
+/// classification was missing (GS0155), in both the symbolic classifier and
+/// the CLR overload-resolution applicability rule.
+/// </summary>
+public class Issue3501StructVariantInterfaceBoxingTests
+{
+    [Fact]
+    public void ImmutableArray_BoxesToCovariantEnumerable()
+    {
+        var output = CompileAndRun("""
+            package Probe
+            import System
+            import System.Collections.Generic
+            import System.Collections.Immutable
+            import System.Linq
+
+            open class Animal {
+                var Name string
+            }
+
+            class Dog : Animal {
+            }
+
+            func count(items IEnumerable[Animal]) int32 {
+                var n = 0
+                for item in items {
+                    n = n + 1
+                }
+                return n
+            }
+
+            let dogs = ImmutableArray.Create(Dog{ Name: "a" }, Dog{ Name: "b" })
+            let widened IEnumerable[Animal] = dogs
+            Console.WriteLine(count(widened))
+            Console.WriteLine(count(dogs))
+            Console.WriteLine(dogs.Cast[Animal]().Count())
+            """);
+
+        Assert.Equal(
+            string.Join(Environment.NewLine, "2", "2", "2") + Environment.NewLine,
+            output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var directory = Directory.CreateTempSubdirectory("gs_issue3501_boxvar_").FullName;
+        try
+        {
+            var sourcePath = Path.Combine(directory, "test.gs");
+            var outputPath = Path.Combine(directory, "test.dll");
+            File.WriteAllText(sourcePath, source);
+
+            int exitCode = RunCompiler(new[]
+            {
+                "/out:" + outputPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                sourcePath,
+            }, out string diagnostics);
+            Assert.True(exitCode == 0, diagnostics);
+            IlVerifier.Verify(outputPath);
+            return RunAssembly(directory, outputPath);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    private static int RunCompiler(string[] arguments, out string diagnostics)
+    {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            int exitCode = Program.Main(arguments);
+            diagnostics = $"stdout:\n{stdout}\nstderr:\n{stderr}";
+            return exitCode;
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+    }
+
+    private static string RunAssembly(string workingDirectory, string assemblyPath)
+    {
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = workingDirectory,
+        };
+        startInfo.ArgumentList.Add("exec");
+        startInfo.ArgumentList.Add("--runtimeconfig");
+        startInfo.ArgumentList.Add(Path.ChangeExtension(assemblyPath, ".runtimeconfig.json"));
+        startInfo.ArgumentList.Add(assemblyPath);
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start dotnet exec.");
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), "dotnet exec timed out.");
+        Assert.True(
+            process.ExitCode == 0,
+            $"dotnet exec exited {process.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout.ReplaceLineEndings(Environment.NewLine);
+    }
+}


### PR DESCRIPTION
Part of the #3501 Translator burn-down — the **Track A6 keystone** (`ImmutableArray[Derived]` covariance) from the original plan, and 3 of the last Translator errors (`EmittedNameAllocator.gs` `ExplicitInterfaceImplementations` → `IEnumerable[ISymbol]`).

A struct converting to a *variant* interface target is C#'s boxing conversion composed with interface variance. The exact implemented interface already boxed (`IEnumerable[IMethodSymbol]` worked); only the variance-composed classification was missing (GS0155), in two places:

- `Conversion.TryClassifyConstructedImportedReferenceConversion` excluded value-type sources outright — interface targets now pass through both the symbolic-hierarchy branch and the CLR interface-closure projection;
- `ClrOverloadResolution.IsVariantGenericInterfaceConversion` likewise.

No emitter change needed: the struct→interface arm boxes for any interface target the binder accepts, and the boxed reference is runtime-assignment-compatible with the variant instantiation.

Tests: new `Issue3501StructVariantInterfaceBoxingTests` (`ImmutableArray.Create(Dog…)` → `IEnumerable[Animal]` by declaration, argument, and LINQ `Cast`, compile+ilverify+run); variance/conversion/box sweeps (808 tests) pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Six2MrhXHo6kQ8DSA6c1Pc