### PR TITLE
cs2gs: three residual nullability seams from the #3501 burn-down

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2506PromotedCallReceiverForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2506PromotedCallReceiverForgivenessTranslationTests.cs
@@ -103,8 +103,13 @@ public sealed class Issue2506PromotedCallReceiverForgivenessTranslationTests
         Assert.Contains("FindGeneric[Item]()!!.Name", printed, StringComparison.Ordinal);
         Assert.Equal(2, CountOccurrences(printed, "FindFactory()!!().Name"));
         Assert.Contains("(Find())!!.Name", printed, StringComparison.Ordinal);
-        Assert.Contains("cast[Item](Find())", printed, StringComparison.Ordinal);
-        Assert.DoesNotContain(" as Item", printed, StringComparison.Ordinal);
+        // Issue #3501: a C# reference cast preserves null, so a cast of a
+        // promoted-nullable operand now lowers to the null-preserving safe
+        // cast — the dereference carries the assertion instead of the cast
+        // (`((Item)Find()).Name` NREs at the DEREFERENCE in C#, and `!!`
+        // raises at exactly the same point).
+        Assert.Contains("((Find() as Item))!!.Name", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("cast[Item](", printed, StringComparison.Ordinal);
         Assert.Contains(
             "(if condition { Find() } else { Always() })!!.Name",
             printed,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3501NullableSeamResidualTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3501NullableSeamResidualTests.cs
@@ -1,0 +1,116 @@
+// <copyright file="Issue3501NullableSeamResidualTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3501 residual nullability seams:
+/// (1) a C# reference cast PRESERVES null, so a cast of a promoted-nullable
+/// operand must emit the null-preserving safe cast (`expr as T`) rather than
+/// `cast[T](expr)`, whose operand must be non-null; and
+/// (2) an iterator's element is the method's return sink, so a tainted
+/// iterator (yielding promoted-nullable values) must render `sequence[T?]` —
+/// previously the yield-seam bridge correctly stood down (the return IS
+/// promoted) while the signature disagreed with its own yields.
+/// </summary>
+public class Issue3501NullableSeamResidualTests
+{
+    [Fact]
+    public void Oblivious_ReferenceCastOfPromotedOperand_UsesNullPreservingSafeCast()
+    {
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class Base { }
+    public class Derived : Base { }
+
+    public class Holder
+    {
+        public Derived Primary { get; set; }
+        public Base Fallback { get; set; }
+
+        public void Clear() { this.Primary = null; }
+
+        public Base Pick()
+        {
+            return (Base)this.Primary ?? this.Fallback;
+        }
+    }
+}");
+
+        Assert.Contains("as Base", printed);
+        Assert.DoesNotContain("cast[Base](", printed);
+    }
+
+    [Fact]
+    public void Oblivious_TaintedIterator_PromotesSequenceElement()
+    {
+        string printed = TranslateOblivious(@"
+using System.Collections.Generic;
+
+namespace Demo
+{
+    public class C
+    {
+        public string Find(bool b)
+        {
+            if (b) { return null; }
+            return ""x"";
+        }
+
+        public IEnumerable<string> Names(bool includeMissing)
+        {
+            if (includeMissing)
+            {
+                yield return null;
+            }
+
+            var candidate = Find(true);
+            if (!string.IsNullOrEmpty(candidate))
+            {
+                yield return candidate;
+            }
+        }
+    }
+}");
+
+        Assert.Contains("Names(includeMissing bool) sequence[string?]", printed);
+    }
+
+    private static string TranslateOblivious(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        Assert.Equal(
+            NullableContextOptions.Disable,
+            project.Compilation.Options.NullableContextOptions);
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.DoesNotContain(
+            context.Diagnostics,
+            diagnostic => diagnostic.Severity == TranslationSeverity.Unsupported);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
@@ -1171,6 +1171,17 @@ public sealed partial class CSharpToGSharpTranslator
                 {
                     GTypeReference element = this.typeMapper.Map(
                         enumerable.TypeArguments[0], this.context, node.ReturnType.GetLocation());
+
+                    // Issue #3501: the iterator ELEMENT is the method's return
+                    // sink for T exactly like the async `Task<T>` unwrap below
+                    // (#2421) — a tainted iterator (yielding promoted-nullable
+                    // values) must render `sequence[T?]`, or the signature
+                    // disagrees with its own yields (GS0155 `string?` →
+                    // `string`) while the yield-seam bridge correctly stands
+                    // down because the return IS promoted.
+                    ITypeSymbol elementType = enumerable.TypeArguments[0];
+                    element = this.PromoteTupleDeclarationIfTainted(element, elementType, symbol);
+                    element = this.PromoteAwaitedReturnIfTainted(element, elementType, symbol);
                     return new NamedTypeReference("sequence", new[] { element });
                 }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -1216,7 +1216,11 @@ public sealed partial class CSharpToGSharpTranslator
 
                 case CastExpressionSyntax cast
                     when cast.Type is not NullableTypeSyntax
-                        && this.CastUsesCheckedReferenceConversion(cast):
+                        && this.CastUsesCheckedReferenceConversion(cast)
+                        && !this.CastLowersToNullPreservingSafeCast(cast):
+                    // Issue #3501: a cast that lowers to the null-preserving
+                    // `expr as T` is NOT statically non-null — its dereference
+                    // needs the ordinary receiver forgiveness.
                     return true;
 
                 case ConditionalExpressionSyntax conditional:
@@ -2124,11 +2128,11 @@ public sealed partial class CSharpToGSharpTranslator
                     return this.ReceiverValueIsPromotedNullable(parenthesized.Expression);
 
                 case CastExpressionSyntax cast:
-                    ITypeSymbol castTarget = this.context.GetTypeInfo(cast.Type).Type;
-                    ITypeSymbol castSource = this.context.GetTypeInfo(cast.Expression).Type;
-                    return castTarget != null
-                        && castSource != null
-                        && this.context.Compilation.ClassifyConversion(castSource, castTarget).IsReference
+                    // Issue #3501: align with CastUsesCheckedReferenceConversion
+                    // (identity reference casts included) so a null-preserving
+                    // `expr as T` lowering still surfaces its operand's
+                    // promotion to the receiver-forgiveness pass.
+                    return this.CastUsesCheckedReferenceConversion(cast)
                         && this.ReceiverValueIsPromotedNullable(cast.Expression);
 
                 case AwaitExpressionSyntax awaited:

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -3462,6 +3462,23 @@ public sealed partial class CSharpToGSharpTranslator
                 return new ConversionExpression(objectTargetType, operand);
             }
 
+            // Issue #3501: a C# reference cast PRESERVES null (`(SyntaxNode)
+            // node.Body ?? node.ExpressionBody`), but `cast[T](expr)` requires
+            // a non-null operand. When the operand is nullable on the G# side
+            // (a promoted read the flow-narrow assertion above did not cover,
+            // or a C#-annotated `T?`), emit the null-preserving safe cast
+            // `expr as T` instead — its `T?` result is exactly the C# cast's
+            // nullability.
+            if (cast.Type is not NullableTypeSyntax
+                && this.CastUsesCheckedReferenceConversion(cast)
+                && operand is not NonNullAssertionExpression
+                && (sourceSymbol?.NullableAnnotation == NullableAnnotation.Annotated
+                    || (this.IsObliviousCompilation() && this.IsNullablePromotedValue(cast.Expression))))
+            {
+                return new ParenthesizedExpression(
+                    new BinaryExpression(operand, "as", new TypeExpression(targetType)));
+            }
+
             GTypeReference conversionTargetType = cast.Type is NullableTypeSyntax
                 && !targetType.IsNullable
                     ? MakeNullable(targetType)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -3468,12 +3468,11 @@ public sealed partial class CSharpToGSharpTranslator
             // (a promoted read the flow-narrow assertion above did not cover,
             // or a C#-annotated `T?`), emit the null-preserving safe cast
             // `expr as T` instead — its `T?` result is exactly the C# cast's
-            // nullability.
-            if (cast.Type is not NullableTypeSyntax
-                && this.CastUsesCheckedReferenceConversion(cast)
-                && operand is not NonNullAssertionExpression
-                && (sourceSymbol?.NullableAnnotation == NullableAnnotation.Annotated
-                    || (this.IsObliviousCompilation() && this.IsNullablePromotedValue(cast.Expression))))
+            // nullability. GSharpExpressionIsStaticallyNonNull consults the
+            // same predicate so a dereference of such a cast still gets its
+            // receiver `!!` (`((Item)Find()).Name` → `(Find() as Item)!!.Name`).
+            if (operand is not NonNullAssertionExpression
+                && this.CastLowersToNullPreservingSafeCast(cast))
             {
                 return new ParenthesizedExpression(
                     new BinaryExpression(operand, "as", new TypeExpression(targetType)));
@@ -3487,6 +3486,20 @@ public sealed partial class CSharpToGSharpTranslator
                 conversionTargetType,
                 operand,
                 this.CastUsesCheckedReferenceConversion(cast));
+        }
+
+        // Issue #3501: whether TranslateCast renders this reference cast as the
+        // null-preserving `expr as T` (nullable result) instead of the
+        // non-null `cast[T](expr)` form — true when the operand is nullable on
+        // the G# side and no flow narrowing asserted it.
+        private bool CastLowersToNullPreservingSafeCast(CastExpressionSyntax cast)
+        {
+            ITypeSymbol sourceSymbol = this.context.GetTypeInfo(cast.Expression).Type;
+            return cast.Type is not NullableTypeSyntax
+                && this.CastUsesCheckedReferenceConversion(cast)
+                && !this.IsFlowNarrowedAnnotatedReference(cast.Expression)
+                && (sourceSymbol?.NullableAnnotation == NullableAnnotation.Annotated
+                    || (this.IsObliviousCompilation() && this.IsNullablePromotedValue(cast.Expression)));
         }
 
         private bool CastUsesCheckedReferenceConversion(CastExpressionSyntax cast)

--- a/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
@@ -1919,6 +1919,30 @@ internal static class ObliviousNullabilityAnalyzer
                     transitive: true);
             }
         }
+
+        // Issue #3501: an ITERATOR'S yields are its returns for element-taint
+        // purposes — `yield return null` (or yielding a promoted-nullable
+        // value) makes the iterator's ELEMENT nullable, which the translator
+        // renders as `sequence[T?]`. Without this, the signature stayed
+        // `sequence[T]` while the yield-seam bridge stood down (the method
+        // looked promoted), leaving a bare `T? -> T` at every guarded yield.
+        foreach (SyntaxNode descendant in body?.DescendantNodes(
+            n => n is not (LocalFunctionStatementSyntax or AnonymousFunctionExpressionSyntax))
+            ?? System.Linq.Enumerable.Empty<SyntaxNode>())
+        {
+            if (descendant is YieldStatementSyntax { Expression: { } yielded }
+                && descendant.IsKind(SyntaxKind.YieldReturnStatement))
+            {
+                ApplyReturnValue(
+                    canonicalReturn,
+                    yielded,
+                    model,
+                    tainted,
+                    edges,
+                    scalarTupleEdges,
+                    transitive: true);
+            }
+        }
     }
 
     private static void SeedPropertyLikeReturnTaint(


### PR DESCRIPTION
Part of the #3501 Translator burn-down — clears 2 of the last 6 Translator errors (the null-preserving cast at `Constructors.gs:2158` and the `RoslynAnalyzerApiMap.EnumerateTargetNamespaces` yield mismatch).

1. **Null-preserving casts**: a C# reference cast preserves null, but `cast[T](expr)` requires a non-null operand. A cast of a promoted-nullable operand (`(SyntaxNode)node.Body ?? node.ExpressionBody`) now emits the safe cast `expr as T`, whose `T?` result is exactly the C# cast's nullability — and composes with the surrounding `??`.

2. **Yields seed return taint**: the oblivious analyzer treats `yield return` values as returns, so `yield return null` (or yielding a promoted-nullable value) taints the iterator's element.

3. **Iterator signatures render that taint**: the `sequence[T]` element now promotes exactly like the async `Task<T>` unwrap (#2421), via the same promotion pair. Previously the signature stayed `sequence[T]` while the yield-seam bridge (#3550) stood down because the method looked promoted — leaving a bare `T? → T` at every guarded yield.

Tests: new `Issue3501NullableSeamResidualTests` (promoted-operand cast → `as Base`; null-yielding iterator → `sequence[string?]`); oblivious/yield/iterator/golden sweep (414 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Six2MrhXHo6kQ8DSA6c1Pc