### PR TITLE
gsc: invoke function-pointer-valued members

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
@@ -3983,10 +3983,10 @@ internal sealed partial class ExpressionBinder
             return MakeStaticGenericCall(null);
         }
 
-        if (structSym != null
-            && TryBindUserDelegateMemberInvocation(
+        if (ownerType is StructSymbol or InterfaceSymbol
+            && TryBindUserCallableMemberInvocation(
                 receiver: null,
-                structSym,
+                ownerType,
                 methodName,
                 arguments,
                 ce,

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
@@ -330,12 +330,12 @@ internal sealed partial class ExpressionBinder
     }
 
     /// <summary>
-    /// Issue #527 (G#-defined struct/class arm): when a member-style call
+    /// Issues #527 and #3523 (G#-defined struct/class arm): when a member-style call
     /// <c>receiver.Member(args)</c> does not match a method on the user
-    /// struct/class, fall back to a field whose type is a function value or
-    /// named delegate. Lowers to a load of the field followed by a
-    /// <see cref="BoundIndirectCallExpression"/> through the function shape.
-    /// Returns <see langword="true"/> when a callable field matched (the
+    /// struct/class, fall back to a callable field or property. Delegate values
+    /// lower to <see cref="BoundIndirectCallExpression"/>; raw function pointers
+    /// lower to <see cref="BoundFunctionPointerInvocationExpression"/>.
+    /// Returns <see langword="true"/> when a callable member matched (the
     /// resulting expression may be a <see cref="BoundErrorExpression"/> if
     /// arity is wrong).
     /// </summary>
@@ -433,7 +433,7 @@ internal sealed partial class ExpressionBinder
         return null;
     }
 
-    private bool TryBindUserDelegateMemberInvocation(
+    private bool TryBindUserCallableMemberInvocation(
         BoundExpression? receiver,
         TypeSymbol receiverType,
         string methodName,
@@ -445,6 +445,7 @@ internal sealed partial class ExpressionBinder
         result = null;
 
         var receiverStruct = receiverType as StructSymbol;
+        var receiverInterface = receiverType as InterfaceSymbol;
         FieldSymbol? matchedField = null;
         StructSymbol? declaringType = null;
         if (isStatic && receiverStruct != null)
@@ -455,9 +456,14 @@ internal sealed partial class ExpressionBinder
                 out matchedField,
                 out declaringType);
         }
+        else if (isStatic && receiverInterface != null)
+        {
+            var fieldOwner = receiverInterface.Definition ?? receiverInterface;
+            matchedField = fieldOwner.GetStaticField(methodName);
+        }
         else if (receiverStruct != null)
         {
-            // Walk the base chain so an inherited delegate field on a base class
+            // Walk the base chain so an inherited callable field on a base class
             // is invokable on a derived instance.
             StructSymbol? current = receiverStruct;
             while (current != null)
@@ -488,6 +494,17 @@ internal sealed partial class ExpressionBinder
                         methodName,
                         out property,
                         out propertyDeclaringType);
+                }
+                else if (receiverInterface != null)
+                {
+                    var propertyOwner = receiverInterface.Definition ?? receiverInterface;
+                    property = propertyOwner.Properties.FirstOrDefault(candidate =>
+                        candidate.IsStatic
+                        && !candidate.IsIndexer
+                        && candidate.Name == methodName
+                        && candidate.HasGetter
+                        && candidate.GetterSymbol != null);
+                    foundProperty = property != null;
                 }
             }
             else
@@ -526,13 +543,37 @@ internal sealed partial class ExpressionBinder
         BoundExpression memberLoad;
         if (matchedField != null)
         {
-            memberLoad = isStatic
+            memberLoad = isStatic && receiverInterface != null
+                ? new BoundFieldAccessExpression(null, matchedField, receiverInterface)
+                : isStatic
                 ? new BoundFieldAccessExpression(null, receiver, declaringType, matchedField, memberType)
                 : new BoundFieldAccessExpression(null, receiver, declaringType, matchedField);
         }
         else if (matchedProperty != null)
         {
-            memberLoad = new BoundPropertyAccessExpression(null, receiver, declaringType, matchedProperty);
+            if (isStatic && receiverInterface != null)
+            {
+                memberLoad = new BoundCallExpression(
+                    null,
+                    Invariant.Required(
+                        matchedProperty.GetterSymbol,
+                        "a matched static interface property has a getter"),
+                    ImmutableArray<BoundExpression>.Empty,
+                    matchedProperty.Type)
+                {
+                    StaticGenericInterfaceOwnerType = receiverInterface.Definition != null
+                        ? receiverInterface
+                        : null,
+                };
+            }
+            else
+            {
+                memberLoad = new BoundPropertyAccessExpression(
+                    null,
+                    receiver,
+                    declaringType,
+                    matchedProperty);
+            }
         }
         else
         {
@@ -562,6 +603,30 @@ internal sealed partial class ExpressionBinder
             {
                 Diagnostics.ReportMemberInaccessible(ce.Identifier.Location, methodName, declaringType.Name, memberAccessibility);
             }
+        }
+
+        if (ce.NullableQuestionToken == null
+            && ce.TypeArgumentList == null
+            && effectiveMemberType is FunctionPointerTypeSymbol functionPointerType)
+        {
+            if (!overloads.TryAnalyzeCallArgumentLayout(
+                    ce.Arguments,
+                    out _,
+                    out var argumentNames))
+            {
+                result = new BoundErrorExpression(null);
+                return true;
+            }
+
+            result = overloads.BindFunctionPointerInvocation(
+                ce,
+                memberLoad,
+                functionPointerType,
+                methodName,
+                ce.Identifier.Location,
+                arguments,
+                argumentNames);
+            return true;
         }
 
         if (ce.NullableQuestionToken == null

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -2955,11 +2955,11 @@ internal sealed partial class ExpressionBinder
                 }
             }
 
-            // Issues #527 and #2925: source struct/class and interface
-            // delegate members are callable before their CLR types exist.
+            // Issues #527, #2925, and #3523: source struct/class and interface
+            // callable members are invokable before their CLR types exist.
             if (receiver != null
                 && receiver.Type is StructSymbol or InterfaceSymbol
-                && TryBindUserDelegateMemberInvocation(receiver, receiver.Type, methodName, arguments, ce, isStatic: false, out var userDelegateFieldCall))
+                && TryBindUserCallableMemberInvocation(receiver, receiver.Type, methodName, arguments, ce, isStatic: false, out var userDelegateFieldCall))
             {
                 return userDelegateFieldCall;
             }
@@ -3142,10 +3142,10 @@ internal sealed partial class ExpressionBinder
             }
         }
 
-        // Issues #527 and #2925: a G#-defined struct/class or interface
-        // delegate member is invokable through bare call syntax.
+        // Issues #527, #2925, and #3523: a G#-defined struct/class or interface
+        // callable member is invokable through bare call syntax.
         if (receiver.Type is StructSymbol or InterfaceSymbol
-            && TryBindUserDelegateMemberInvocation(receiver, receiver.Type, methodName, arguments, ce, isStatic: false, out var userDelegateCall))
+            && TryBindUserCallableMemberInvocation(receiver, receiver.Type, methodName, arguments, ce, isStatic: false, out var userDelegateCall))
         {
             return userDelegateCall;
         }
@@ -3654,7 +3654,7 @@ internal sealed partial class ExpressionBinder
             }
 
             if (underlyingType is StructSymbol or InterfaceSymbol
-                && TryBindUserDelegateMemberInvocation(
+                && TryBindUserCallableMemberInvocation(
                     narrowedReceiver,
                     underlyingType,
                     methodName,

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
@@ -1033,76 +1033,39 @@ internal sealed partial class OverloadResolver
             }
         }
 
-        // ADR-0122 §9 / issue #1035: invoking a function-pointer-typed
-        // variable goes through the `calli` path. Sites like `fp(1, 2)` where
-        // `fp` is `let fp *func(int32, int32) int32 = &Add` reduce to a
-        // BoundFunctionPointerInvocationExpression.
+        // ADR-0122 §9 / issues #1035 and #3523: invoking a function-pointer-
+        // typed variable goes through the shared `calli` path. Implicit field
+        // and property symbols must first become real member loads rather than
+        // non-existent local slots.
         var fpVar = symbol as VariableSymbol;
-        var fpSym = fpVar?.Type as FunctionPointerTypeSymbol;
+        var fpSym = (narrowedCallTargetType ?? fpVar?.Type) as FunctionPointerTypeSymbol;
         if (fpVar != null && fpSym != null)
         {
-            Func<int, string> functionPointerParameterNameAt =
-                parameterIndex => fpVar.CallableParameterNames[parameterIndex];
-            if (syntax.Arguments.Count != fpSym.Arity)
+            BoundExpression pointer;
+            if (TryBuildImplicitMemberLoad(
+                fpVar,
+                syntax.Identifier.Location,
+                out var implicitPointer,
+                narrowedCallTargetType))
             {
-                Diagnostics.ReportWrongArgumentCount(syntax.Identifier.Location, fpVar.Name, fpSym.Arity, syntax.Arguments.Count);
-                return new BoundErrorExpression(null);
-            }
-
-            ExpressionSyntax?[] fpParameterSyntax;
-            var fpArguments = boundArguments.ToImmutable();
-            if (!argumentNames.IsDefault)
-            {
-                if (fpVar.CallableParameterNames.IsDefaultOrEmpty ||
-                    fpVar.CallableParameterNames.Length != fpSym.Arity)
-                {
-                    Diagnostics.ReportNamedArgumentParameterNotFound(
-                        syntax.Identifier.Location,
-                        fpVar.Name,
-                        FirstNamedArgumentName(argumentNames));
-                    return new BoundErrorExpression(null);
-                }
-
-                if (!TryReorderUserCallArguments(
-                        syntax.Arguments,
-                        fpArguments,
-                        fpSym.Arity,
-                        functionPointerParameterNameAt,
-                        fpVar.Name,
-                        out fpParameterSyntax,
-                        out fpArguments))
-                {
-                    return new BoundErrorExpression(null);
-                }
+                pointer = Invariant.Required(
+                    implicitPointer,
+                    "an implicit function-pointer member load succeeds with a bound expression");
             }
             else
             {
-                fpParameterSyntax = new ExpressionSyntax[syntax.Arguments.Count];
-                for (var i = 0; i < syntax.Arguments.Count; i++)
-                {
-                    fpParameterSyntax[i] = syntax.Arguments[i];
-                }
+                pointer = new BoundVariableExpression(null, fpVar, narrowedCallTargetType);
             }
 
-            var fpConvertedArgs = ImmutableArray.CreateBuilder<BoundExpression>(fpSym.Arity);
-            for (var i = 0; i < fpSym.Arity; i++)
-            {
-                var argLoc = i < fpParameterSyntax.Length
-                    ? fpParameterSyntax[i]?.Location ?? syntax.Identifier.Location
-                    : syntax.Identifier.Location;
-                fpConvertedArgs.Add(conversions.BindConversion(argLoc, fpArguments[i], fpSym.ParameterTypes[i]));
-            }
-
-            var finalArguments = PreserveNamedArgumentEvaluationOrder(
-                syntax.Arguments,
-                fpConvertedArgs.MoveToImmutable(),
-                functionPointerParameterNameAt);
-
-            return new BoundFunctionPointerInvocationExpression(
-                null,
-                new BoundVariableExpression(null, fpVar),
-                finalArguments,
-                fpSym);
+            return BindFunctionPointerInvocation(
+                syntax,
+                pointer,
+                fpSym,
+                fpVar.Name,
+                syntax.Identifier.Location,
+                boundArguments.ToImmutable(),
+                argumentNames,
+                fpVar.CallableParameterNames);
         }
 
         if (symbol is VariableSymbol nullableDelegateVar

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Invocations.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Invocations.cs
@@ -307,6 +307,88 @@ internal sealed partial class OverloadResolver
         return default;
     }
 
+    internal BoundExpression BindFunctionPointerInvocation(
+        CallExpressionSyntax syntax,
+        BoundExpression pointer,
+        FunctionPointerTypeSymbol functionPointerType,
+        string calleeName,
+        TextLocation calleeLocation,
+        ImmutableArray<BoundExpression> boundArguments,
+        ImmutableArray<string> argumentNames,
+        ImmutableArray<string> parameterNames = default)
+    {
+        if (syntax.Arguments.Count != functionPointerType.Arity)
+        {
+            Diagnostics.ReportWrongArgumentCount(
+                calleeLocation,
+                calleeName,
+                functionPointerType.Arity,
+                syntax.Arguments.Count);
+            return new BoundErrorExpression(null);
+        }
+
+        Func<int, string> parameterNameAt = parameterIndex => parameterNames[parameterIndex];
+        ExpressionSyntax?[] parameterSyntax;
+        var arguments = boundArguments;
+        if (!argumentNames.IsDefault)
+        {
+            if (parameterNames.IsDefaultOrEmpty
+                || parameterNames.Length != functionPointerType.Arity)
+            {
+                Diagnostics.ReportNamedArgumentParameterNotFound(
+                    calleeLocation,
+                    calleeName,
+                    FirstNamedArgumentName(argumentNames));
+                return new BoundErrorExpression(null);
+            }
+
+            if (!TryReorderUserCallArguments(
+                    syntax.Arguments,
+                    arguments,
+                    functionPointerType.Arity,
+                    parameterNameAt,
+                    calleeName,
+                    out parameterSyntax,
+                    out arguments))
+            {
+                return new BoundErrorExpression(null);
+            }
+        }
+        else
+        {
+            parameterSyntax = new ExpressionSyntax[syntax.Arguments.Count];
+            for (var i = 0; i < syntax.Arguments.Count; i++)
+            {
+                parameterSyntax[i] = syntax.Arguments[i];
+            }
+        }
+
+        var convertedArguments = ImmutableArray.CreateBuilder<BoundExpression>(
+            functionPointerType.Arity);
+        for (var i = 0; i < functionPointerType.Arity; i++)
+        {
+            var argumentLocation = i < parameterSyntax.Length
+                ? parameterSyntax[i]?.Location ?? calleeLocation
+                : calleeLocation;
+            convertedArguments.Add(
+                conversions.BindConversion(
+                    argumentLocation,
+                    arguments[i],
+                    functionPointerType.ParameterTypes[i]));
+        }
+
+        var finalArguments = PreserveNamedArgumentEvaluationOrder(
+            syntax.Arguments,
+            convertedArguments.MoveToImmutable(),
+            parameterNameAt);
+
+        return new BoundFunctionPointerInvocationExpression(
+            syntax,
+            pointer,
+            finalArguments,
+            functionPointerType);
+    }
+
     private bool TryBindFunctionTypeArguments(
         string calleeName,
         FunctionTypeSymbol functionType,
@@ -1001,6 +1083,19 @@ internal sealed partial class OverloadResolver
             nullSafeInvocation))
         {
             return new BoundErrorExpression(null);
+        }
+
+        if (callee.Type is FunctionPointerTypeSymbol functionPointerType)
+        {
+            return CompleteInvocation(BindFunctionPointerInvocation(
+                syntax,
+                callee,
+                functionPointerType,
+                calleeName,
+                calleeLocation,
+                boundArguments.ToImmutable(),
+                argumentNames,
+                GetIndirectCallableParameterNames(callee)));
         }
 
         if (callee.Type is FunctionTypeSymbol fnType)

--- a/src/Core/CodeAnalysis/Lowering/SideEffectSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/SideEffectSpiller.cs
@@ -124,6 +124,32 @@ internal sealed class SideEffectSpiller : NestedFunctionBodyRewriter
     }
 
     /// <inheritdoc/>
+    protected override BoundExpression RewriteFunctionPointerInvocationExpression(
+        BoundFunctionPointerInvocationExpression node)
+    {
+        var rewritten = (BoundFunctionPointerInvocationExpression)base.RewriteFunctionPointerInvocationExpression(node);
+        if (rewritten.Arguments.IsDefaultOrEmpty)
+        {
+            return rewritten;
+        }
+
+        // `calli` requires arguments below the pointer on the IL stack, while
+        // source order evaluates the pointer first. Capture it before arguments
+        // so a member owner is evaluated exactly once at the correct point.
+        var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+        var pointer = this.MaybeSpill(rewritten.Pointer, true, "fnptr", statements);
+        var invocation = new BoundFunctionPointerInvocationExpression(
+            rewritten.Syntax,
+            pointer,
+            rewritten.Arguments,
+            rewritten.FunctionPointerType);
+        return new BoundBlockExpression(
+            rewritten.Syntax,
+            statements.ToImmutable(),
+            invocation);
+    }
+
+    /// <inheritdoc/>
     protected override BoundExpression RewriteIndexAssignmentExpression(BoundIndexAssignmentExpression node)
     {
         // Rewrite children first so any nested duplicating contexts inside

--- a/test/Compiler.Tests/Emit/Issue3523FunctionPointerMemberInvocationEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3523FunctionPointerMemberInvocationEmitTests.cs
@@ -1,0 +1,320 @@
+// <copyright file="Issue3523FunctionPointerMemberInvocationEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection.Emit;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #3523 end-to-end coverage for function-pointer-valued member calls.
+/// </summary>
+public class Issue3523FunctionPointerMemberInvocationEmitTests
+{
+    private static readonly string[] UnsafeIlVerifyIgnored =
+    {
+        "UnmanagedPointer",
+        "StackUnexpected",
+        "StackByRef",
+        "ExpectedPtr",
+        "StackUnexpectedArrayType",
+    };
+
+    [Fact]
+    public void ExactUnmanagedFieldRepro_BuildsAndContainsCalli_WithoutExecution()
+    {
+        const string source = """
+            package FindingFunctionPointerFieldInvocation
+
+            unsafe struct Dispatch {
+                var Apply unmanaged[Cdecl] (int32) -> int32
+            }
+
+            unsafe func Main() int32 {
+                let dispatch = Dispatch{}
+                return dispatch.Apply(41)
+            }
+            """;
+
+        var outputDirectory = Compile(source, out var outputPath);
+        try
+        {
+            VerifyFunctionPointerAssembly(outputPath);
+            Assert.True(ContainsCalli(outputPath), "expected field invocation to emit calli");
+        }
+        finally
+        {
+            DeleteDirectory(outputDirectory);
+        }
+    }
+
+    [Fact]
+    public void ManagedFieldPropertyIndexerConditionalStaticAndRefCalls_Run()
+    {
+        const string source = """
+            package Issue3523Managed
+            import System
+
+            class Tracker {
+                shared {
+                    var OwnerCalls int32
+                }
+            }
+
+            unsafe func increment(value int32) int32 -> value + 1
+
+            unsafe struct Dispatch {
+                var Apply *func(int32) int32
+                prop Handler *func(int32) int32 -> Apply
+
+                func InvokeField(value int32) int32 -> Apply(value)
+                func InvokeProperty(value int32) int32 -> Handler(value)
+
+                shared {
+                    var SharedApply *func(int32) int32
+                    prop SharedHandler *func(int32) int32 -> SharedApply
+                    func InvokeShared(value int32) int32 -> SharedApply(value)
+                }
+            }
+
+            unsafe class Box {
+                let Apply *func(int32) int32
+                init(apply *func(int32) int32) {
+                    Apply = apply
+                }
+            }
+
+            unsafe func makeDispatch() Dispatch {
+                Tracker.OwnerCalls += 1
+                Console.Write("R")
+                return Dispatch{Apply: &increment}
+            }
+
+            func nextArgument() int32 {
+                Console.Write("A")
+                return 41
+            }
+
+            unsafe func invokeRef(ref pointer *func(int32) int32, value int32) int32 {
+                return pointer(value)
+            }
+
+            unsafe func Main() {
+                let dispatch = Dispatch{Apply: &increment}
+                Dispatch.SharedApply = &increment
+
+                Console.WriteLine(dispatch.Apply(41))
+                Console.WriteLine(dispatch.Handler(40))
+                Console.WriteLine(dispatch.InvokeField(39))
+                Console.WriteLine(dispatch.InvokeProperty(38))
+                Console.WriteLine(Dispatch.SharedApply(37))
+                Console.WriteLine(Dispatch.SharedHandler(36))
+                Console.WriteLine(Dispatch.InvokeShared(35))
+
+                let pointers = []*func(int32) int32{&increment}
+                Console.WriteLine(pointers[0](34))
+                Console.WriteLine((true ? dispatch.Apply : dispatch.Handler)(33))
+                Console.WriteLine((dispatch.Apply)(32))
+
+                var pointer = &increment
+                Console.WriteLine(invokeRef(ref pointer, 31))
+
+                let present Box? = Box(&increment)
+                let absent Box? = nil
+                Console.WriteLine(present?.Apply(30))
+                Console.WriteLine(absent?.Apply(30) == nil)
+
+                Console.WriteLine(makeDispatch().Apply(nextArgument()))
+                Console.WriteLine(Tracker.OwnerCalls)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal(
+            string.Join(
+                Environment.NewLine,
+                "42",
+                "41",
+                "40",
+                "39",
+                "38",
+                "37",
+                "36",
+                "35",
+                "34",
+                "33",
+                "32",
+                "31",
+                "True",
+                "RA42",
+                "1",
+                string.Empty),
+            output);
+    }
+
+    [Fact]
+    public void UnmanagedCdeclField_RealNativeAddress_Runs()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
+        var defaultSymbolHandle = RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+            ? "-2"
+            : "0";
+        var source = $$"""
+            package Issue3523Unmanaged
+            import System
+            import System.Runtime.InteropServices
+
+            @DllImport("libc", EntryPoint: "dlsym")
+            func native_dlsym(handle nint, name string) unmanaged[Cdecl] (int32) -> int32;
+
+            unsafe struct NativeDispatch {
+                var Apply unmanaged[Cdecl] (int32) -> int32
+            }
+
+            unsafe func Main() {
+                let dispatch = NativeDispatch{
+                    Apply: native_dlsym(nint({{defaultSymbolHandle}}), "abs")
+                }
+                Console.WriteLine(dispatch.Apply(-41))
+            }
+            """;
+
+        Assert.Equal($"41{Environment.NewLine}", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var outputDirectory = Compile(source, out var outputPath);
+        try
+        {
+            VerifyFunctionPointerAssembly(outputPath);
+
+            var startInfo = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = outputDirectory,
+            };
+            startInfo.ArgumentList.Add("exec");
+            startInfo.ArgumentList.Add("--runtimeconfig");
+            startInfo.ArgumentList.Add(Path.ChangeExtension(outputPath, ".runtimeconfig.json"));
+            startInfo.ArgumentList.Add(outputPath);
+
+            using var process = Process.Start(startInfo)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec.");
+            var standardOutput = process.StandardOutput.ReadToEnd();
+            var standardError = process.StandardError.ReadToEnd();
+            Assert.True(process.WaitForExit(30_000), "dotnet exec timed out.");
+            Assert.True(
+                process.ExitCode == 0,
+                $"exited {process.ExitCode}\nstdout:\n{standardOutput}\nstderr:\n{standardError}");
+            return standardOutput.ReplaceLineEndings(Environment.NewLine);
+        }
+        finally
+        {
+            DeleteDirectory(outputDirectory);
+        }
+    }
+
+    private static string Compile(string source, out string outputPath)
+    {
+        var outputDirectory = Path.Combine(
+            AppContext.BaseDirectory,
+            "issue3523",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(outputDirectory);
+
+        var sourcePath = Path.Combine(outputDirectory, "Program.gs");
+        outputPath = Path.Combine(outputDirectory, "Issue3523.dll");
+        File.WriteAllText(sourcePath, source);
+
+        using var standardOut = new StringWriter();
+        using var standardError = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(standardOut);
+        Console.SetError(standardError);
+        int exitCode;
+        try
+        {
+            exitCode = Program.Main(new[]
+            {
+                "/out:" + outputPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                sourcePath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+
+        Assert.True(
+            exitCode == 0,
+            $"gsc failed:\nstdout:\n{standardOut}\nstderr:\n{standardError}");
+        return outputDirectory;
+    }
+
+    private static void VerifyFunctionPointerAssembly(string outputPath)
+    {
+        try
+        {
+            IlVerifier.Verify(outputPath, null, UnsafeIlVerifyIgnored);
+        }
+        catch (Exception exception)
+            when (exception.Message.Contains(
+                "ImportCalli not implemented",
+                StringComparison.Ordinal))
+        {
+        }
+    }
+
+    private static bool ContainsCalli(string outputPath)
+    {
+        using var peReader = new PEReader(File.OpenRead(outputPath));
+        var metadata = peReader.GetMetadataReader();
+        foreach (var methodHandle in metadata.MethodDefinitions)
+        {
+            var method = metadata.GetMethodDefinition(methodHandle);
+            if (method.RelativeVirtualAddress == 0)
+            {
+                continue;
+            }
+
+            var body = peReader.GetMethodBody(method.RelativeVirtualAddress);
+            var instructions = IlInstructionReader.Read(body.GetILBytes() ?? Array.Empty<byte>());
+            if (instructions.Any(instruction => instruction.OpCode == OpCodes.Calli))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static void DeleteDirectory(string path)
+    {
+        try
+        {
+            Directory.Delete(path, recursive: true);
+        }
+        catch
+        {
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3523FunctionPointerMemberInvocationTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3523FunctionPointerMemberInvocationTests.cs
@@ -1,0 +1,325 @@
+// <copyright file="Issue3523FunctionPointerMemberInvocationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #3523: every expression whose value has a function-pointer type is
+/// callable, including source fields and properties that previously fell
+/// through member-method lookup to GS0159.
+/// </summary>
+public class Issue3523FunctionPointerMemberInvocationTests
+{
+    [Theory]
+    [InlineData("Cdecl", CallingConvention.Cdecl)]
+    [InlineData("Stdcall", CallingConvention.StdCall)]
+    [InlineData("Thiscall", CallingConvention.ThisCall)]
+    [InlineData("Fastcall", CallingConvention.FastCall)]
+    public void UnmanagedFieldCall_BindsFieldLoadAndCallingConvention(
+        string convention,
+        CallingConvention expectedConvention)
+    {
+        var source = $$"""
+            package Issue3523
+
+            unsafe struct Dispatch {
+                var Apply unmanaged[{{convention}}] (int32) -> int32
+            }
+
+            unsafe func Main() int32 {
+                let dispatch = Dispatch{}
+                return dispatch.Apply(41)
+            }
+            """;
+
+        var program = BindWithoutErrors(source);
+        var invocation = Assert.Single(CollectInvocations(program));
+        var field = Assert.IsType<BoundFieldAccessExpression>(invocation.Pointer);
+
+        Assert.Equal("Apply", field.Field.Name);
+        Assert.Equal("Dispatch", field.StructType?.Name);
+        Assert.False(invocation.FunctionPointerType.IsManaged);
+        Assert.Equal(expectedConvention, invocation.FunctionPointerType.CallingConvention);
+        Assert.Same(invocation.FunctionPointerType, field.Type);
+        Assert.Single(invocation.Arguments);
+        Assert.Same(TypeSymbol.Int32, invocation.Arguments[0].Type);
+    }
+
+    [Fact]
+    public void ManagedPointer_AllExpressionCalleeForms_BindFunctionPointerInvocations()
+    {
+        const string source = """
+            package Issue3523Forms
+
+            unsafe func increment(value int32) int32 -> value + 1
+
+            unsafe struct Dispatch {
+                var Apply *func(int32) int32
+                prop Handler *func(int32) int32 -> Apply
+
+                func InvokeField(value int32) int32 -> Apply(value)
+                func InvokeProperty(value int32) int32 -> Handler(value)
+
+                shared {
+                    var SharedApply *func(int32) int32
+                    prop SharedHandler *func(int32) int32 -> SharedApply
+                }
+            }
+
+            unsafe func invokeRef(ref pointer *func(int32) int32, value int32) int32 {
+                return pointer(value)
+            }
+
+            unsafe func Main() {
+                let dispatch = Dispatch{Apply: &increment}
+                Dispatch.SharedApply = &increment
+                let pointers = []*func(int32) int32{&increment}
+                var pointer = &increment
+
+                dispatch.Apply(1)
+                dispatch.Handler(2)
+                dispatch.InvokeField(3)
+                dispatch.InvokeProperty(4)
+                Dispatch.SharedApply(5)
+                Dispatch.SharedHandler(6)
+                pointers[0](7)
+                (true ? dispatch.Apply : dispatch.Handler)(8)
+                (dispatch.Apply)(9)
+                invokeRef(ref pointer, 10)
+            }
+            """;
+
+        var invocations = CollectInvocations(BindWithoutErrors(source));
+
+        Assert.All(invocations, invocation => Assert.True(invocation.FunctionPointerType.IsManaged));
+        Assert.Contains(invocations, invocation => invocation.Pointer is BoundFieldAccessExpression);
+        Assert.Contains(invocations, invocation => invocation.Pointer is BoundPropertyAccessExpression);
+        Assert.Contains(invocations, invocation => invocation.Pointer is BoundIndexExpression);
+        Assert.Contains(invocations, invocation => invocation.Pointer is BoundConditionalExpression);
+        Assert.Contains(invocations, invocation => invocation.Pointer is BoundVariableExpression);
+    }
+
+    [Fact]
+    public void PointerAndDelegateMembers_KeepDistinctBoundNodes()
+    {
+        const string source = """
+            package Issue3523Distinct
+
+            unsafe func increment(value int32) int32 -> value + 1
+
+            unsafe struct Mixed {
+                var Pointer *func(int32) int32
+                var Handler (int32) -> int32
+            }
+
+            unsafe func Main() {
+                let mixed = Mixed{
+                    Pointer: &increment,
+                    Handler: (value int32) -> value + 2
+                }
+                mixed.Pointer(1)
+                mixed.Handler(1)
+            }
+            """;
+
+        var program = BindWithoutErrors(source);
+        Assert.Single(CollectInvocations(program));
+
+        var indirectCalls = new IndirectCallCollector();
+        VisitProgram(program, indirectCalls);
+        Assert.Single(indirectCalls.Calls);
+        Assert.IsType<FunctionTypeSymbol>(indirectCalls.Calls[0].Target.Type);
+    }
+
+    [Fact]
+    public void InterfacePropertyAndStaticField_BindFunctionPointerLoads()
+    {
+        const string source = """
+            package Issue3523Interfaces
+
+            interface IDispatch {
+                prop Apply unmanaged[Cdecl] (int32) -> int32 { get }
+            }
+
+            unsafe struct Dispatch : IDispatch {
+                var Pointer unmanaged[Cdecl] (int32) -> int32
+                prop Apply unmanaged[Cdecl] (int32) -> int32 -> Pointer
+            }
+
+            interface IStaticDispatch {
+                shared {
+                    var Apply unmanaged[Cdecl] (int32) -> int32
+                }
+            }
+
+            unsafe func invoke(dispatch IDispatch) int32 {
+                return dispatch.Apply(41)
+            }
+
+            unsafe func invokeStatic() int32 {
+                return IStaticDispatch.Apply(41)
+            }
+            """;
+
+        var invocations = CollectInvocations(BindWithoutErrors(source));
+        Assert.Equal(2, invocations.Count);
+
+        var property = Assert.IsType<BoundPropertyAccessExpression>(
+            invocations.Single(invocation => invocation.Pointer is BoundPropertyAccessExpression).Pointer);
+        Assert.Null(property.StructType);
+        Assert.IsType<InterfaceSymbol>(property.Receiver?.Type);
+
+        var field = Assert.IsType<BoundFieldAccessExpression>(
+            invocations.Single(invocation => invocation.Pointer is BoundFieldAccessExpression).Pointer);
+        Assert.Equal("IStaticDispatch", field.InterfaceType?.Name);
+        Assert.Null(field.Receiver);
+    }
+
+    [Fact]
+    public void PointerMemberCall_ReportsCallDiagnostics_NotMethodLookup()
+    {
+        const string source = """
+            package Issue3523Diagnostics
+
+            unsafe struct Dispatch {
+                var Apply unmanaged[Cdecl] (int32) -> int32
+                var Value int32
+            }
+
+            unsafe func Main() {
+                let dispatch = Dispatch{}
+                dispatch.Apply()
+                dispatch.Apply("bad")
+                dispatch.Value(41)
+            }
+            """;
+
+        var errors = GetErrors(source);
+        Assert.Equal(
+            new[] { "GS0144", "GS0155", "GS0159" },
+            errors.Select(diagnostic => diagnostic.Id).ToArray());
+    }
+
+    [Fact]
+    public void ManagedPointerMember_StillRequiresUnsafeContext()
+    {
+        const string source = """
+            package Issue3523Unsafe
+
+            struct Dispatch {
+                var Apply *func(int32) int32
+            }
+            """;
+
+        var error = Assert.Single(GetErrors(source));
+        Assert.Equal("GS0404", error.Id);
+    }
+
+    [Fact]
+    public void NullableDelegateMember_KeepsDelegateDiagnostic()
+    {
+        const string source = """
+            package Issue3523NullableDelegate
+
+            struct Mixed {
+                var Handler ((int32) -> int32)?
+            }
+
+            func Main() {
+                let mixed = Mixed{}
+                mixed.Handler(1)
+            }
+            """;
+
+        var error = Assert.Single(GetErrors(source));
+        Assert.Equal("GS0503", error.Id);
+    }
+
+    private static BoundProgram BindWithoutErrors(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var program = compilation.BoundProgram;
+        var errors = tree.Diagnostics
+            .Concat(compilation.GlobalScope.Diagnostics)
+            .Concat(program.Diagnostics)
+            .Where(diagnostic => diagnostic.IsError)
+            .ToArray();
+
+        Assert.True(errors.Length == 0, string.Join("; ", errors.Select(error => error.Message)));
+        return program;
+    }
+
+    private static Diagnostic[] GetErrors(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var program = compilation.BoundProgram;
+        return tree.Diagnostics
+            .Concat(compilation.GlobalScope.Diagnostics)
+            .Concat(program.Diagnostics)
+            .Where(diagnostic => diagnostic.IsError)
+            .GroupBy(diagnostic => new
+            {
+                diagnostic.Id,
+                diagnostic.Location.Span.Start,
+                diagnostic.Location.Span.Length,
+            })
+            .Select(group => group.First())
+            .OrderBy(diagnostic => diagnostic.Location.Span.Start)
+            .ToArray();
+    }
+
+    private static List<BoundFunctionPointerInvocationExpression> CollectInvocations(
+        BoundProgram program)
+    {
+        var collector = new FunctionPointerInvocationCollector();
+        VisitProgram(program, collector);
+        return collector.Invocations;
+    }
+
+    private static void VisitProgram(BoundProgram program, BoundTreeWalker walker)
+    {
+        foreach (var body in program.Functions.Values)
+        {
+            walker.Visit(body);
+        }
+
+        walker.Visit(program.Statement);
+    }
+
+    private sealed class FunctionPointerInvocationCollector : BoundTreeWalker
+    {
+        public List<BoundFunctionPointerInvocationExpression> Invocations { get; } = new();
+
+        protected override void VisitFunctionPointerInvocationExpression(
+            BoundFunctionPointerInvocationExpression node)
+        {
+            Invocations.Add(node);
+            base.VisitFunctionPointerInvocationExpression(node);
+        }
+    }
+
+    private sealed class IndirectCallCollector : BoundTreeWalker
+    {
+        public List<BoundIndirectCallExpression> Calls { get; } = new();
+
+        protected override void VisitIndirectCallExpression(BoundIndirectCallExpression node)
+        {
+            Calls.Add(node);
+            base.VisitIndirectCallExpression(node);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- route function-pointer variables, source fields/properties, and arbitrary expression callees through one shared `BoundFunctionPointerInvocationExpression` binder
- generalize source callable-member fallback without changing method precedence or delegate lowering; cover instance/static and struct/class/interface owners
- capture a `calli` target before its arguments so side-effectful member receivers retain left-to-right, exactly-once evaluation

## Root cause and flow

`BindCallExpression` only created `BoundFunctionPointerInvocationExpression` when its resolved symbol was a `VariableSymbol`. Member syntax (`dispatch.Apply(41)`) instead entered `BindAccessorCall`, performed method lookup, and used a fallback limited to delegate-typed fields/properties. A function-pointer field therefore fell through to GS0159.

This change keeps the existing call-callee split but shares final binding:

- locals, parameters, ref parameters, and implicit instance/static members build their correct variable/member load, then call `BindFunctionPointerInvocation`
- direct field/property member syntax reaches the generalized callable-member fallback after real methods, preserving lookup precedence
- parenthesized, indexer, conditional, null-conditional-member, and other #2185 `Callee` expressions bind normally, then dispatch by their bound `FunctionPointerTypeSymbol`
- argument arity, named ordering, conversions, and diagnostics use the same path for every pointer callee
- managed vs unmanaged calling convention remains on `FunctionPointerTypeSymbol`; existing emit produces the matching standalone signature and `calli`
- delegates remain `BoundIndirectCallExpression`/`Invoke`; nullable delegates retain GS0503; non-callable members retain GS0159

`calli` needs arguments below the target pointer on the IL stack. Member targets can have side effects, so `SideEffectSpiller` now captures the pointer before argument evaluation and emission loads that temp last.

The nullable-hygiene-reported guards in `ExpressionBinder.Calls.Arguments.cs` are intentional behavior branches: they add static interface callable-field/property lookup and select the function-pointer path; none are warning-only guards.

## Tests

- exact zero-initialized unmanaged field repro: compile only, ILVerify invocation, and emitted `calli` assertion; never executed
- safe managed execution: local/ref, instance/static field, property, indexer, ternary, parenthesized, null-conditional member, implicit member, and receiver evaluation-order forms
- safe unmanaged execution: real Cdecl `abs` address obtained from `dlsym`
- all unmanaged conventions bind with preserved convention
- interface property/static field loads, delegate distinction, unsafe gating, wrong arity/type, and non-callable diagnostics

Validation (Release):

- `dotnet build GSharp.sln --configuration Release --no-restore -graph` — 0 warnings/errors
- full Core.Tests — 8,105 passed
- customary compiler-remainder CI shard — 1,153 passed
- related Core regression set — 38 passed
- related compiler emit set — 19 passed
- issue-specific Core.Tests — 10 passed
- issue-specific Compiler.Tests — 3 passed
- related Interpreter.Tests — 1 passed
- `./build/run-ilverify.sh` — 125/125 samples verified
- nullable hygiene — passed

Fixes #3523
Refs #2185
Refs #2925
