### PR TITLE
gsc: harden function-pointer member calls after #3568

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -6005,6 +6005,24 @@ public sealed class Binder
                 : type;
         }
 
+        if (type is ByRefTypeSymbol byRef)
+        {
+            var pointee = SubstituteType(byRef.PointeeType, substitution, mapClrType);
+            return ReferenceEquals(pointee, byRef.PointeeType) ? type : ByRefTypeSymbol.Get(pointee);
+        }
+
+        if (type is PointerTypeSymbol pointer)
+        {
+            var pointee = SubstituteType(pointer.PointeeType, substitution, mapClrType);
+            return ReferenceEquals(pointee, pointer.PointeeType) ? type : PointerTypeSymbol.Get(pointee);
+        }
+
+        if (type is FunctionPointerTypeSymbol functionPointer)
+        {
+            return functionPointer.Substitute(
+                nested => SubstituteType(nested, substitution, mapClrType));
+        }
+
         // Issue #1250: a member-signature type that is itself a constructed
         // generic G# user class (e.g. `Holder[T]` on `Box[T]`) must have its
         // own type arguments substituted with the receiver's type-argument map

--- a/src/Core/CodeAnalysis/Binding/BoundFieldAccessExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundFieldAccessExpression.cs
@@ -38,12 +38,26 @@ public sealed class BoundFieldAccessExpression : BoundExpression
     /// <param name="field">The interface static field to read.</param>
     /// <param name="interfaceType">The owning interface (definition or constructed).</param>
     public BoundFieldAccessExpression(SyntaxNode? syntax, FieldSymbol field, InterfaceSymbol interfaceType)
+        : this(syntax, field, interfaceType, narrowedType: null)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="BoundFieldAccessExpression"/> class for an interface static-field read with a substituted type.</summary>
+    /// <param name="syntax">Originating syntax.</param>
+    /// <param name="field">Field declared on the interface definition.</param>
+    /// <param name="interfaceType">Effective interface construction.</param>
+    /// <param name="narrowedType">Substituted member type.</param>
+    public BoundFieldAccessExpression(
+        SyntaxNode? syntax,
+        FieldSymbol field,
+        InterfaceSymbol interfaceType,
+        TypeSymbol? narrowedType)
         : base(syntax)
     {
         Receiver = null;
         StructType = null;
         Field = field;
-        NarrowedType = null;
+        NarrowedType = narrowedType;
         InterfaceType = interfaceType;
     }
 

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
@@ -2549,7 +2549,21 @@ internal sealed partial class ExpressionBinder
         var field = fieldOwner.GetStaticField(memberName);
         if (field != null)
         {
-            return new BoundFieldAccessExpression(null, field, interfaceSym);
+            if (!AccessibilityChecker.IsAccessible(field.Accessibility, fieldOwner, function))
+            {
+                Diagnostics.ReportMemberInaccessible(
+                    ne.Location,
+                    field.Name,
+                    fieldOwner.Name,
+                    field.Accessibility);
+            }
+
+            var fieldType = interfaceSym.SubstituteMemberType(field.Type);
+            return new BoundFieldAccessExpression(
+                null,
+                field,
+                interfaceSym,
+                ReferenceEquals(fieldType, field.Type) ? null : fieldType);
         }
 
         // Issue #1433: a default-bodied static (`shared`) property on the
@@ -2565,7 +2579,23 @@ internal sealed partial class ExpressionBinder
             {
                 if (prop.GetterSymbol != null && prop.HasGetter)
                 {
-                    return new BoundCallExpression(null, prop.GetterSymbol, ImmutableArray<BoundExpression>.Empty, prop.Type)
+                    if (!AccessibilityChecker.IsAccessible(
+                        prop.GetterAccessibility,
+                        fieldOwner,
+                        function))
+                    {
+                        Diagnostics.ReportMemberInaccessible(
+                            ne.Location,
+                            prop.Name,
+                            fieldOwner.Name,
+                            prop.GetterAccessibility);
+                    }
+
+                    return new BoundCallExpression(
+                        null,
+                        prop.GetterSymbol,
+                        ImmutableArray<BoundExpression>.Empty,
+                        interfaceSym.SubstituteMemberType(prop.Type))
                     {
                         StaticGenericInterfaceOwnerType = interfaceSym.Definition != null ? interfaceSym : null,
                     };

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
@@ -470,7 +470,11 @@ internal sealed partial class ExpressionBinder
                     // accessor and emits a verifiable `callvirt get_H`.
                     // Inherited base-interface members are surfaced because
                     // TypeMemberModel.TryGetProperty walks SelfAndAllBaseInterfaces.
-                    if (TypeMemberModel.TryGetProperty(ifaceSym, ne.IdentifierToken.Text, out var ifaceProp, out _))
+                    if (TypeMemberModel.TryGetPropertyWithOwner(
+                        ifaceSym,
+                        ne.IdentifierToken.Text,
+                        out var ifaceProp,
+                        out var ifacePropertyOwner))
                     {
                         if (!ifaceProp.HasGetter)
                         {
@@ -478,7 +482,32 @@ internal sealed partial class ExpressionBinder
                             return new BoundErrorExpression(null);
                         }
 
-                        return new BoundPropertyAccessExpression(null, receiver, null, ifaceProp);
+                        if (!AccessibilityChecker.IsAccessible(
+                            ifaceProp.GetterAccessibility,
+                            ifacePropertyOwner,
+                            this.function))
+                        {
+                            Diagnostics.ReportMemberInaccessible(
+                                ne.IdentifierToken.Location,
+                                ifaceProp.Name,
+                                ifacePropertyOwner?.Name ?? ifaceSym.Name,
+                                ifaceProp.GetterAccessibility);
+                        }
+
+                        var propertyType = ifacePropertyOwner is InterfaceSymbol effectiveOwner
+                            ? effectiveOwner.SubstituteMemberType(ifaceProp.Type)
+                            : ifaceProp.Type;
+                        var substitutedPropertyType = ReferenceEquals(
+                            propertyType,
+                            ifaceProp.Type)
+                            ? null
+                            : propertyType;
+                        return new BoundPropertyAccessExpression(
+                            null,
+                            receiver,
+                            null,
+                            ifaceProp,
+                            substitutedPropertyType);
                     }
 
                     // Issue #1397: an instance method declared on the static

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
@@ -448,6 +448,8 @@ internal sealed partial class ExpressionBinder
         var receiverInterface = receiverType as InterfaceSymbol;
         FieldSymbol? matchedField = null;
         StructSymbol? declaringType = null;
+        TypeSymbol? declaringOwner = null;
+        InterfaceSymbol? effectiveInterfaceOwner = null;
         if (isStatic && receiverStruct != null)
         {
             TypeMemberModel.TryGetStaticFieldIncludingInherited(
@@ -455,11 +457,17 @@ internal sealed partial class ExpressionBinder
                 methodName,
                 out matchedField,
                 out declaringType);
+            declaringOwner = declaringType;
         }
         else if (isStatic && receiverInterface != null)
         {
             var fieldOwner = receiverInterface.Definition ?? receiverInterface;
             matchedField = fieldOwner.GetStaticField(methodName);
+            if (matchedField != null)
+            {
+                declaringOwner = fieldOwner;
+                effectiveInterfaceOwner = receiverInterface;
+            }
         }
         else if (receiverStruct != null)
         {
@@ -472,6 +480,7 @@ internal sealed partial class ExpressionBinder
                 {
                     matchedField = f;
                     declaringType = current;
+                    declaringOwner = current;
                     break;
                 }
 
@@ -483,7 +492,7 @@ internal sealed partial class ExpressionBinder
         if (matchedField == null)
         {
             PropertySymbol? property = null;
-            StructSymbol? propertyDeclaringType = null;
+            TypeSymbol? propertyDeclaringOwner = null;
             var foundProperty = false;
             if (isStatic)
             {
@@ -493,7 +502,8 @@ internal sealed partial class ExpressionBinder
                         receiverStruct,
                         methodName,
                         out property,
-                        out propertyDeclaringType);
+                        out var propertyDeclaringType);
+                    propertyDeclaringOwner = propertyDeclaringType;
                 }
                 else if (receiverInterface != null)
                 {
@@ -505,38 +515,43 @@ internal sealed partial class ExpressionBinder
                         && candidate.HasGetter
                         && candidate.GetterSymbol != null);
                     foundProperty = property != null;
+                    propertyDeclaringOwner = propertyOwner;
                 }
             }
             else
             {
-                foundProperty = TypeMemberModel.TryGetProperty(
+                foundProperty = TypeMemberModel.TryGetPropertyWithOwner(
                     receiverType,
                     methodName,
                     out property,
-                    out propertyDeclaringType);
+                    out propertyDeclaringOwner);
             }
 
             if (foundProperty && property is { HasGetter: true })
             {
                 matchedProperty = property;
-                declaringType = propertyDeclaringType;
+                declaringOwner = propertyDeclaringOwner;
+                declaringType = propertyDeclaringOwner as StructSymbol;
+                effectiveInterfaceOwner = isStatic && receiverInterface != null
+                    ? receiverInterface
+                    : propertyDeclaringOwner as InterfaceSymbol;
             }
         }
 
-        var memberType = matchedField != null && isStatic && declaringType != null
-            ? declaringType.SubstituteMemberType(matchedField.Type)
-            : matchedField?.Type ?? matchedProperty?.Type;
-
-        // declaringType is null for a property declared on an INTERFACE: the
-        // out-parameter is a StructSymbol and an interface is not one. Bailing
-        // out here (as a nullable-warning guard once did) silently unbinds
-        // `ifaceReceiver.DelegateProp(args)` and reports GS0159 -- issues #2925
-        // and #3016. BoundPropertyAccessExpression.StructType is nullable for
-        // exactly this form, so the null flows through correctly.
-        if (memberType == null)
+        var declaredMemberType = matchedField?.Type ?? matchedProperty?.Type;
+        if (declaredMemberType == null)
         {
             return false;
         }
+
+        var memberType = effectiveInterfaceOwner != null
+            ? effectiveInterfaceOwner.SubstituteMemberType(declaredMemberType)
+            : matchedField != null && isStatic && declaringType != null
+                ? declaringType.SubstituteMemberType(declaredMemberType)
+                : declaredMemberType;
+        var substitutedMemberType = ReferenceEquals(memberType, declaredMemberType)
+            ? null
+            : memberType;
 
         // Issue #2849: derive both argument conversions and Invoke shape from
         // the narrowed stable member read, not the nullable declaration.
@@ -544,10 +559,17 @@ internal sealed partial class ExpressionBinder
         if (matchedField != null)
         {
             memberLoad = isStatic && receiverInterface != null
-                ? new BoundFieldAccessExpression(null, matchedField, receiverInterface)
-                : isStatic
-                ? new BoundFieldAccessExpression(null, receiver, declaringType, matchedField, memberType)
-                : new BoundFieldAccessExpression(null, receiver, declaringType, matchedField);
+                ? new BoundFieldAccessExpression(
+                    null,
+                    matchedField,
+                    receiverInterface,
+                    substitutedMemberType)
+                : new BoundFieldAccessExpression(
+                    null,
+                    receiver,
+                    declaringType,
+                    matchedField,
+                    substitutedMemberType);
         }
         else if (matchedProperty != null)
         {
@@ -559,7 +581,7 @@ internal sealed partial class ExpressionBinder
                         matchedProperty.GetterSymbol,
                         "a matched static interface property has a getter"),
                     ImmutableArray<BoundExpression>.Empty,
-                    matchedProperty.Type)
+                    memberType)
                 {
                     StaticGenericInterfaceOwnerType = receiverInterface.Definition != null
                         ? receiverInterface
@@ -572,7 +594,8 @@ internal sealed partial class ExpressionBinder
                     null,
                     receiver,
                     declaringType,
-                    matchedProperty);
+                    matchedProperty,
+                    substitutedMemberType);
             }
         }
         else
@@ -592,17 +615,21 @@ internal sealed partial class ExpressionBinder
             ? nullableMember.UnderlyingType
             : effectiveMemberType;
 
-        if (isStatic)
+        var memberAccessibility = matchedField != null
+            ? matchedField.Accessibility
+            : matchedProperty?.GetterAccessibility;
+        if (declaringOwner != null
+            && memberAccessibility is { } accessibility
+            && !AccessibilityChecker.IsAccessible(
+                accessibility,
+                declaringOwner,
+                function))
         {
-            var accessibility = matchedField != null
-                ? matchedField.Accessibility
-                : matchedProperty?.Accessibility;
-            if (declaringType != null
-                && accessibility is { } memberAccessibility
-                && !AccessibilityChecker.IsAccessible(memberAccessibility, declaringType, function))
-            {
-                Diagnostics.ReportMemberInaccessible(ce.Identifier.Location, methodName, declaringType.Name, memberAccessibility);
-            }
+            Diagnostics.ReportMemberInaccessible(
+                ce.Identifier.Location,
+                methodName,
+                declaringOwner.Name,
+                accessibility);
         }
 
         if (ce.NullableQuestionToken == null

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Invocations.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Invocations.cs
@@ -317,6 +317,12 @@ internal sealed partial class OverloadResolver
         ImmutableArray<string> argumentNames,
         ImmutableArray<string> parameterNames = default)
     {
+        if (functionPointerType.IsManaged && !binderCtx.InUnsafeContext)
+        {
+            Diagnostics.ReportUnmanagedPointerOutsideUnsafe(calleeLocation);
+            return new BoundErrorExpression(null);
+        }
+
         if (syntax.Arguments.Count != functionPointerType.Arity)
         {
             Diagnostics.ReportWrongArgumentCount(

--- a/src/Core/CodeAnalysis/Symbols/AccessibilityChecker.cs
+++ b/src/Core/CodeAnalysis/Symbols/AccessibilityChecker.cs
@@ -2,6 +2,8 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using System.Linq;
+
 namespace GSharp.Core.CodeAnalysis.Symbols;
 
 /// <summary>
@@ -38,12 +40,34 @@ internal static class AccessibilityChecker
     /// <param name="declaringType">The type that declares the member.</param>
     /// <param name="currentFunction">The function whose body contains the access (may be <see langword="null"/> for top-level code).</param>
     /// <returns><see langword="true"/> when the access is permitted.</returns>
-    public static bool IsAccessible(Accessibility accessibility, StructSymbol? declaringType, FunctionSymbol? currentFunction)
+    public static bool IsAccessible(
+        Accessibility accessibility,
+        TypeSymbol? declaringType,
+        FunctionSymbol? currentFunction)
     {
+        if (declaringType is InterfaceSymbol declaringInterface)
+        {
+            if (accessibility != Accessibility.Protected
+                && accessibility != Accessibility.Private)
+            {
+                return true;
+            }
+
+            var enclosingInterface = GetEnclosingInterface(currentFunction);
+            if (accessibility == Accessibility.Private)
+            {
+                return SameDeclaringInterface(enclosingInterface, declaringInterface);
+            }
+
+            return enclosingInterface?.SelfAndAllBaseInterfaces()
+                .Any(candidate => SameDeclaringInterface(candidate, declaringInterface))
+                == true;
+        }
+
         var enclosingType = (currentFunction?.ReceiverType as StructSymbol)
             ?? (currentFunction?.StaticOwnerType as StructSymbol)
             ?? (currentFunction?.LexicalEnclosingType as StructSymbol);
-        return IsAccessibleFromType(accessibility, declaringType, enclosingType);
+        return IsAccessibleFromType(accessibility, declaringType as StructSymbol, enclosingType);
     }
 
     /// <summary>
@@ -124,5 +148,48 @@ internal static class AccessibilityChecker
 
         return string.Equals(a.Name, b.Name, System.StringComparison.Ordinal)
             && string.Equals(a.PackageName, b.PackageName, System.StringComparison.Ordinal);
+    }
+
+    private static InterfaceSymbol? GetEnclosingInterface(FunctionSymbol? function)
+    {
+        var candidates = new[]
+        {
+            function?.ReceiverType,
+            function?.StaticOwnerType,
+            function?.LexicalEnclosingType,
+        };
+        foreach (var candidate in candidates)
+        {
+            for (var current = candidate; current != null; current = current.ContainingType)
+            {
+                if (current is InterfaceSymbol iface)
+                {
+                    return iface;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static bool SameDeclaringInterface(InterfaceSymbol? left, InterfaceSymbol? right)
+    {
+        if (left == null || right == null)
+        {
+            return false;
+        }
+
+        var leftDefinition = left.Definition ?? left;
+        var rightDefinition = right.Definition ?? right;
+        return ReferenceEquals(leftDefinition, rightDefinition)
+            || ReferenceEquals(leftDefinition.Declaration, rightDefinition.Declaration)
+            || (string.Equals(
+                    leftDefinition.Name,
+                    rightDefinition.Name,
+                    System.StringComparison.Ordinal)
+                && string.Equals(
+                    leftDefinition.PackageName,
+                    rightDefinition.PackageName,
+                    System.StringComparison.Ordinal));
     }
 }

--- a/src/Core/CodeAnalysis/Symbols/FunctionPointerTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/FunctionPointerTypeSymbol.cs
@@ -96,6 +96,35 @@ public sealed class FunctionPointerTypeSymbol : TypeSymbol
     }
 
     /// <summary>
+    /// Recursively substitutes this pointer's parameter and return types while
+    /// preserving its managed/unmanaged ABI.
+    /// </summary>
+    /// <param name="substitute">Substitution applied to each signature type.</param>
+    /// <returns>This symbol when unchanged; otherwise the interned substituted symbol.</returns>
+    internal FunctionPointerTypeSymbol Substitute(System.Func<TypeSymbol, TypeSymbol> substitute)
+    {
+        var parameters = ImmutableArray.CreateBuilder<TypeSymbol>(ParameterTypes.Length);
+        var changed = false;
+        foreach (var parameterType in ParameterTypes)
+        {
+            var substituted = substitute(parameterType);
+            parameters.Add(substituted);
+            changed |= !ReferenceEquals(substituted, parameterType);
+        }
+
+        var returnType = substitute(ReturnType);
+        changed |= !ReferenceEquals(returnType, ReturnType);
+        if (!changed)
+        {
+            return this;
+        }
+
+        return IsManaged
+            ? GetManaged(parameters.MoveToImmutable(), returnType)
+            : Get(CallingConvention, parameters.MoveToImmutable(), returnType);
+    }
+
+    /// <summary>
     /// Removes all entries from the static type cache. Called by
     /// <see cref="ReferenceResolver.Dispose"/> to release stale
     /// <see cref="Type"/> objects backed by a disposed metadata load context

--- a/src/Core/CodeAnalysis/Symbols/InterfaceSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/InterfaceSymbol.cs
@@ -611,6 +611,18 @@ public sealed class InterfaceSymbol : TypeSymbol
     /// </summary>
     internal static void ClearCache() => ConstructedCache.Clear();
 
+    /// <summary>Substitutes a member type through this interface construction.</summary>
+    /// <param name="type">Member type declared on the generic definition.</param>
+    /// <returns>Type closed over this interface's type arguments.</returns>
+    internal TypeSymbol SubstituteMemberType(TypeSymbol type)
+    {
+        return Definition != null
+            && !ReferenceEquals(Definition, this)
+            && !TypeArguments.IsDefaultOrEmpty
+            ? SubstituteType(type, GetTypeSubstitution(), mapClrType)
+            : type;
+    }
+
     private static TypeArgsKey BuildArgsKey(ImmutableArray<TypeSymbol> typeArguments) => new(typeArguments);
 
     private static InterfaceSymbol CreateConstructed(InterfaceSymbol definition, ImmutableArray<TypeSymbol> typeArguments, System.Func<System.Type, System.Type>? mapClrType)
@@ -988,6 +1000,42 @@ public sealed class InterfaceSymbol : TypeSymbol
         {
             var sub = SubstituteType(n.UnderlyingType, subst, mapClrType);
             return sub == n.UnderlyingType ? n : NullableTypeSymbol.Get(sub);
+        }
+
+        if (type is ByRefTypeSymbol byRef)
+        {
+            var pointee = SubstituteType(byRef.PointeeType, subst, mapClrType);
+            return ReferenceEquals(pointee, byRef.PointeeType) ? type : ByRefTypeSymbol.Get(pointee);
+        }
+
+        if (type is PointerTypeSymbol pointer)
+        {
+            var pointee = SubstituteType(pointer.PointeeType, subst, mapClrType);
+            return ReferenceEquals(pointee, pointer.PointeeType) ? type : PointerTypeSymbol.Get(pointee);
+        }
+
+        if (type is FunctionTypeSymbol function)
+        {
+            var parameters = ImmutableArray.CreateBuilder<TypeSymbol>(function.ParameterTypes.Length);
+            var changed = false;
+            foreach (var parameterType in function.ParameterTypes)
+            {
+                var substituted = SubstituteType(parameterType, subst, mapClrType);
+                parameters.Add(substituted);
+                changed |= !ReferenceEquals(substituted, parameterType);
+            }
+
+            var returnType = SubstituteType(function.ReturnType, subst, mapClrType);
+            changed |= !ReferenceEquals(returnType, function.ReturnType);
+            return changed
+                ? FunctionTypeSymbol.Get(parameters.MoveToImmutable(), function.IsVariadic, returnType)
+                : type;
+        }
+
+        if (type is FunctionPointerTypeSymbol functionPointer)
+        {
+            return functionPointer.Substitute(
+                nested => SubstituteType(nested, subst, mapClrType));
         }
 
         return type;

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -2678,13 +2678,13 @@ public sealed class StructSymbol : TypeSymbol
                 : MapTypeSymbol.Get(substKey, substValue);
         }
 
-        if (eraseReferenceNullability && type is ByRefTypeSymbol byRef)
+        if (type is ByRefTypeSymbol byRef)
         {
             var pointee = SubstituteNested(byRef.PointeeType);
             return ReferenceEquals(pointee, byRef.PointeeType) ? type : ByRefTypeSymbol.Get(pointee);
         }
 
-        if (eraseReferenceNullability && type is PointerTypeSymbol pointer)
+        if (type is PointerTypeSymbol pointer)
         {
             var pointee = SubstituteNested(pointer.PointeeType);
             return ReferenceEquals(pointee, pointer.PointeeType) ? type : PointerTypeSymbol.Get(pointee);
@@ -2739,6 +2739,11 @@ public sealed class StructSymbol : TypeSymbol
             return fn.IsVariadic.IsDefaultOrEmpty
                 ? FunctionTypeSymbol.Get(substitutedParams.MoveToImmutable(), substitutedReturn)
                 : FunctionTypeSymbol.Get(substitutedParams.MoveToImmutable(), fn.IsVariadic, substitutedReturn);
+        }
+
+        if (type is FunctionPointerTypeSymbol functionPointer)
+        {
+            return functionPointer.Substitute(SubstituteNested);
         }
 
         return type;

--- a/src/Core/CodeAnalysis/Symbols/TypeMemberModel.cs
+++ b/src/Core/CodeAnalysis/Symbols/TypeMemberModel.cs
@@ -359,6 +359,27 @@ public static class TypeMemberModel
     /// <returns>True if found.</returns>
     public static bool TryGetProperty(TypeSymbol type, string name, [NotNullWhen(true)] out PropertySymbol? property, out StructSymbol? declaringType)
     {
+        var found = TryGetPropertyWithOwner(type, name, out property, out var owner);
+        declaringType = owner as StructSymbol;
+        return found;
+    }
+
+    /// <summary>
+    /// Finds an instance property and returns its effective struct or interface
+    /// owner. Constructed interface owners are preserved so callers can close
+    /// member signature types before binding a load.
+    /// </summary>
+    /// <param name="type">Type to resolve against.</param>
+    /// <param name="name">Property name.</param>
+    /// <param name="property">Found property.</param>
+    /// <param name="declaringType">Effective declaring struct/class/interface.</param>
+    /// <returns>Whether a property was found.</returns>
+    public static bool TryGetPropertyWithOwner(
+        TypeSymbol type,
+        string name,
+        [NotNullWhen(true)] out PropertySymbol? property,
+        out TypeSymbol? declaringType)
+    {
         if (type is StructSymbol structSymbol)
         {
             foreach (var c in GetHierarchy(structSymbol))
@@ -387,12 +408,16 @@ public static class TypeMemberModel
             foreach (var iface in interfaceSymbol.SelfAndAllBaseInterfaces())
             {
                 iface.EnsureMembersResolved();
-                foreach (var p in iface.Properties)
+                var propertyOwner = iface.Definition != null
+                    && !ReferenceEquals(iface.Definition, iface)
+                    ? iface.Definition
+                    : iface;
+                foreach (var p in propertyOwner.Properties)
                 {
-                    if (p.Name == name)
+                    if (!p.IsIndexer && p.Name == name)
                     {
                         property = p;
-                        declaringType = null;
+                        declaringType = iface;
                         return true;
                     }
                 }

--- a/test/Compiler.Tests/Emit/Issue3523FunctionPointerMemberInvocationEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3523FunctionPointerMemberInvocationEmitTests.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection.Emit;
 using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
 using Xunit;
@@ -194,12 +195,103 @@ public class Issue3523FunctionPointerMemberInvocationEmitTests
         Assert.Equal($"41{Environment.NewLine}", CompileAndRun(source));
     }
 
-    private static string CompileAndRun(string source)
+    [Fact]
+    public void GenericStructClassAndMethodPointerSignatures_RunClosed()
+    {
+        const string source = """
+            package Issue3523GenericOwners
+            import System
+
+            unsafe func identity(value int32) int32 -> value
+            unsafe func choose[T](pointer *func(T) T) *func(T) T -> pointer
+
+            unsafe struct Dispatch[T] {
+                var Apply *func(T) T
+                prop Handler *func(T) T -> Apply
+                shared { var SharedApply *func(T) T }
+            }
+
+            unsafe class Holder[T] {
+                let Apply *func(T) T
+                init(apply *func(T) T) { Apply = apply }
+            }
+
+            unsafe func Main() {
+                let dispatch = Dispatch[int32]{Apply: &identity}
+                Dispatch[int32].SharedApply = &identity
+                let holder = Holder[int32](&identity)
+                let selected *func(int32) int32 = choose[int32](&identity)
+
+                Console.WriteLine(dispatch.Apply(41))
+                Console.WriteLine(dispatch.Handler(42))
+                Console.WriteLine(Dispatch[int32].SharedApply(43))
+                Console.WriteLine(holder.Apply(44))
+                Console.WriteLine(selected(45))
+            }
+            """;
+
+        var output = CompileAndRun(source, AssertCalliSignaturesClosedInt32);
+        Assert.Equal(
+            string.Join(
+                Environment.NewLine,
+                "41",
+                "42",
+                "43",
+                "44",
+                "45",
+                string.Empty),
+            output);
+    }
+
+    [Fact]
+    public void GenericInterfaceInstanceAndStaticCalls_EmitClosedCalli()
+    {
+        const string source = """
+            package Issue3523GenericInterface
+
+            interface IDispatch[T] {
+                prop Apply unmanaged[Cdecl] (T) -> T { get }
+                shared { var SharedApply unmanaged[Cdecl] (T) -> T }
+            }
+
+            struct Dispatch[T] : IDispatch[T] {
+                var Pointer unmanaged[Cdecl] (T) -> T
+                prop Apply unmanaged[Cdecl] (T) -> T -> Pointer
+            }
+
+            func invoke(dispatch IDispatch[int32]) int32 {
+                let first int32 = dispatch.Apply(41)
+                let second int32 = IDispatch[int32].SharedApply(42)
+                return first + second
+            }
+
+            func Main() { }
+            """;
+
+        var outputDirectory = Compile(source, out var outputPath);
+        try
+        {
+            VerifyFunctionPointerAssembly(outputPath);
+            Assert.True(
+                CountCalli(outputPath) >= 2,
+                "expected closed generic interface instance/static calli sites");
+            AssertCalliSignaturesClosedInt32(outputPath);
+        }
+        finally
+        {
+            DeleteDirectory(outputDirectory);
+        }
+    }
+
+    private static string CompileAndRun(
+        string source,
+        Action<string> inspectAssembly = null)
     {
         var outputDirectory = Compile(source, out var outputPath);
         try
         {
             VerifyFunctionPointerAssembly(outputPath);
+            inspectAssembly?.Invoke(outputPath);
 
             var startInfo = new ProcessStartInfo("dotnet")
             {
@@ -285,7 +377,11 @@ public class Issue3523FunctionPointerMemberInvocationEmitTests
     }
 
     private static bool ContainsCalli(string outputPath)
+        => CountCalli(outputPath) != 0;
+
+    private static int CountCalli(string outputPath)
     {
+        var count = 0;
         using var peReader = new PEReader(File.OpenRead(outputPath));
         var metadata = peReader.GetMetadataReader();
         foreach (var methodHandle in metadata.MethodDefinitions)
@@ -298,13 +394,49 @@ public class Issue3523FunctionPointerMemberInvocationEmitTests
 
             var body = peReader.GetMethodBody(method.RelativeVirtualAddress);
             var instructions = IlInstructionReader.Read(body.GetILBytes() ?? Array.Empty<byte>());
-            if (instructions.Any(instruction => instruction.OpCode == OpCodes.Calli))
+            count += instructions.Count(instruction => instruction.OpCode == OpCodes.Calli);
+        }
+
+        return count;
+    }
+
+    private static void AssertCalliSignaturesClosedInt32(string outputPath)
+    {
+        using var peReader = new PEReader(File.OpenRead(outputPath));
+        var metadata = peReader.GetMetadataReader();
+        var calliCount = 0;
+        foreach (var methodHandle in metadata.MethodDefinitions)
+        {
+            var method = metadata.GetMethodDefinition(methodHandle);
+            if (method.RelativeVirtualAddress == 0)
             {
-                return true;
+                continue;
+            }
+
+            var body = peReader.GetMethodBody(method.RelativeVirtualAddress);
+            var il = body.GetILBytes() ?? Array.Empty<byte>();
+            foreach (var instruction in IlInstructionReader.Read(il))
+            {
+                if (instruction.OpCode != OpCodes.Calli)
+                {
+                    continue;
+                }
+
+                calliCount++;
+                var token = BitConverter.ToInt32(il, instruction.Offset + 1);
+                var signatureHandle = MetadataTokens.StandaloneSignatureHandle(
+                    token & 0x00FFFFFF);
+                var signature = metadata.GetStandaloneSignature(signatureHandle);
+                var blob = metadata.GetBlobBytes(signature.Signature);
+                Assert.DoesNotContain((byte)SignatureTypeCode.GenericTypeParameter, blob);
+                Assert.DoesNotContain((byte)SignatureTypeCode.GenericMethodParameter, blob);
+                Assert.True(
+                    blob.Count(value => value == (byte)SignatureTypeCode.Int32) >= 2,
+                    $"expected closed int32 parameter/return signature: {Convert.ToHexString(blob)}");
             }
         }
 
-        return false;
+        Assert.True(calliCount > 0, "expected at least one calli signature");
     }
 
     private static void DeleteDirectory(string path)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3523FunctionPointerMemberInvocationTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3523FunctionPointerMemberInvocationTests.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Runtime.InteropServices;
 using GSharp.Core.CodeAnalysis;
@@ -245,6 +246,302 @@ public class Issue3523FunctionPointerMemberInvocationTests
 
         var error = Assert.Single(GetErrors(source));
         Assert.Equal("GS0503", error.Id);
+    }
+
+    [Fact]
+    public void ManagedPointerCallsOutsideUnsafe_ReportAtEveryCallee()
+    {
+        const string source = """
+            package Issue3523UnsafeCalls
+
+            unsafe struct Dispatch {
+                var Apply *func(int32) int32
+                prop Handler *func(int32) int32 -> Apply
+                var Pointers []*func(int32) int32
+                shared { var SharedApply *func(int32) int32 }
+            }
+
+            open unsafe class Base {
+                protected var Apply *func(int32) int32
+            }
+
+            class Derived : Base {
+                func Invoke() { Apply(1) }
+            }
+
+            func Main() {
+                let dispatch = Dispatch{}
+                dispatch.Apply(1)
+                dispatch.Handler(2)
+                (dispatch.Apply)(3)
+                dispatch.Pointers[0](4)
+                Dispatch.SharedApply(5)
+            }
+            """;
+
+        var errors = GetErrors(source);
+        Assert.Equal(6, errors.Length);
+        Assert.All(errors, diagnostic => Assert.Equal("GS0404", diagnostic.Id));
+        Assert.Equal(
+            new[]
+            {
+                "Apply",
+                "Apply",
+                "Handler",
+                "(dispatch.Apply)",
+                "dispatch.Pointers[0]",
+                "SharedApply",
+            },
+            errors.Select(diagnostic => diagnostic.Location.Text.ToString(diagnostic.Location.Span)));
+    }
+
+    [Fact]
+    public void UnmanagedPointerCalls_DoNotRequireUnsafeContext()
+    {
+        const string source = """
+            package Issue3523UnmanagedCalls
+
+            struct Dispatch {
+                var Apply unmanaged[Cdecl] (int32) -> int32
+                prop Handler unmanaged[Cdecl] (int32) -> int32 -> Apply
+                shared { var SharedApply unmanaged[Cdecl] (int32) -> int32 }
+            }
+
+            func Main() {
+                let dispatch = Dispatch{}
+                dispatch.Apply(1)
+                dispatch.Handler(2)
+                (dispatch.Apply)(3)
+                Dispatch.SharedApply(4)
+            }
+            """;
+
+        _ = BindWithoutErrors(source);
+    }
+
+    [Fact]
+    public void GenericStructClassAndMethodPointerSignatures_Close()
+    {
+        const string source = """
+            package Issue3523GenericOwners
+
+            unsafe func identity(value int32) int32 -> value
+            unsafe func choose[T](pointer *func(T) T) *func(T) T -> pointer
+
+            unsafe struct Dispatch[T] {
+                var Apply *func(T) T
+                prop Handler *func(T) T -> Apply
+                shared { var SharedApply *func(T) T }
+            }
+
+            unsafe class Holder[T] {
+                let Apply *func(T) T
+                init(apply *func(T) T) { Apply = apply }
+            }
+
+            unsafe func Main() {
+                let dispatch = Dispatch[int32]{Apply: &identity}
+                Dispatch[int32].SharedApply = &identity
+                let holder = Holder[int32](&identity)
+                let selected *func(int32) int32 = choose[int32](&identity)
+                let a int32 = dispatch.Apply(41)
+                let b int32 = dispatch.Handler(42)
+                let c int32 = Dispatch[int32].SharedApply(43)
+                let d int32 = holder.Apply(44)
+                let e int32 = selected(45)
+            }
+            """;
+
+        var invocations = CollectInvocations(BindWithoutErrors(source));
+        Assert.Equal(5, invocations.Count);
+        Assert.All(
+            invocations,
+            invocation =>
+            {
+                Assert.True(invocation.FunctionPointerType.IsManaged);
+                Assert.Same(TypeSymbol.Int32, Assert.Single(invocation.FunctionPointerType.ParameterTypes));
+                Assert.Same(TypeSymbol.Int32, invocation.FunctionPointerType.ReturnType);
+            });
+    }
+
+    [Fact]
+    public void GenericInterfaceInstanceAndStaticPointerSignatures_Close()
+    {
+        const string source = """
+            package Issue3523GenericInterface
+
+            interface IDispatch[T] {
+                prop Apply unmanaged[Cdecl] (T) -> T { get }
+                shared { var SharedApply unmanaged[Cdecl] (T) -> T }
+            }
+
+            struct Dispatch[T] : IDispatch[T] {
+                var Pointer unmanaged[Cdecl] (T) -> T
+                prop Apply unmanaged[Cdecl] (T) -> T -> Pointer
+            }
+
+            func invoke(dispatch IDispatch[int32]) int32 {
+                let first int32 = dispatch.Apply(41)
+                let second int32 = IDispatch[int32].SharedApply(42)
+                return first + second
+            }
+            """;
+
+        var invocations = CollectInvocations(BindWithoutErrors(source));
+        Assert.Equal(2, invocations.Count);
+        Assert.All(
+            invocations,
+            invocation =>
+            {
+                Assert.False(invocation.FunctionPointerType.IsManaged);
+                Assert.Equal(CallingConvention.Cdecl, invocation.FunctionPointerType.CallingConvention);
+                Assert.Same(TypeSymbol.Int32, Assert.Single(invocation.FunctionPointerType.ParameterTypes));
+                Assert.Same(TypeSymbol.Int32, invocation.FunctionPointerType.ReturnType);
+            });
+    }
+
+    [Fact]
+    public void ClosedGenericPointerMembers_RejectWrongArgumentTypes()
+    {
+        const string source = """
+            package Issue3523GenericDiagnostics
+
+            unsafe func identity(value int32) int32 -> value
+
+            unsafe struct Dispatch[T] {
+                var Apply *func(T) T
+                prop Handler *func(T) T -> Apply
+                shared { var SharedApply *func(T) T }
+            }
+
+            interface IDispatch[T] {
+                prop Apply unmanaged[Cdecl] (T) -> T { get }
+                shared { var SharedApply unmanaged[Cdecl] (T) -> T }
+            }
+
+            unsafe func bad(dispatch Dispatch[int32], iface IDispatch[int32]) {
+                dispatch.Apply("bad")
+                dispatch.Handler("bad")
+                Dispatch[int32].SharedApply("bad")
+                iface.Apply("bad")
+                IDispatch[int32].SharedApply("bad")
+            }
+            """;
+
+        var errors = GetErrors(source);
+        Assert.Equal(5, errors.Length);
+        Assert.All(
+            errors,
+            diagnostic =>
+            {
+                Assert.Equal("GS0155", diagnostic.Id);
+                Assert.Contains("string", diagnostic.Message);
+                Assert.Contains("int32", diagnostic.Message);
+            });
+    }
+
+    [Fact]
+    public void PointerSubstitution_PreservesAbiAndByRefShapes()
+    {
+        var parameter = new TypeParameterSymbol(
+            "T",
+            0,
+            TypeParameterConstraint.Any,
+            TypeParameterVariance.None);
+        var substitution = new Dictionary<TypeParameterSymbol, TypeSymbol>
+        {
+            [parameter] = TypeSymbol.Int32,
+        };
+        var parameterTypes = ImmutableArray.Create<TypeSymbol>(
+            ByRefTypeSymbol.Get(parameter));
+
+        var managed = FunctionPointerTypeSymbol.GetManaged(
+            parameterTypes,
+            PointerTypeSymbol.Get(parameter));
+        var unmanaged = FunctionPointerTypeSymbol.Get(
+            CallingConvention.StdCall,
+            parameterTypes,
+            PointerTypeSymbol.Get(parameter));
+
+        var closedManaged = Assert.IsType<FunctionPointerTypeSymbol>(
+            Binder.SubstituteType(managed, substitution));
+        var closedUnmanaged = Assert.IsType<FunctionPointerTypeSymbol>(
+            Binder.SubstituteType(unmanaged, substitution));
+
+        Assert.True(closedManaged.IsManaged);
+        Assert.False(closedUnmanaged.IsManaged);
+        Assert.Equal(CallingConvention.StdCall, closedUnmanaged.CallingConvention);
+        foreach (var pointer in new[] { closedManaged, closedUnmanaged })
+        {
+            var byRef = Assert.IsType<ByRefTypeSymbol>(Assert.Single(pointer.ParameterTypes));
+            Assert.Same(TypeSymbol.Int32, byRef.PointeeType);
+            var returnPointer = Assert.IsType<PointerTypeSymbol>(pointer.ReturnType);
+            Assert.Same(TypeSymbol.Int32, returnPointer.PointeeType);
+        }
+    }
+
+    [Fact]
+    public void CallableMembers_ApplyFieldAndGetterAccessibility()
+    {
+        const string source = """
+            package Issue3523Accessibility
+
+            open class Owner {
+                private var PrivateField unmanaged[Cdecl] (int32) -> int32
+                protected var ProtectedField unmanaged[Cdecl] (int32) -> int32
+                internal var InternalField unmanaged[Cdecl] (int32) -> int32
+                private var PrivateDelegate (int32) -> int32
+
+                prop Restricted unmanaged[Cdecl] (int32) -> int32 {
+                    private get -> PrivateField
+                }
+
+                func Allowed() {
+                    PrivateField(1)
+                    Restricted(2)
+                    PrivateDelegate(3)
+                }
+            }
+
+            class Derived : Owner {
+                func AllowedDerived(owner Owner) {
+                    owner.ProtectedField(1)
+                    owner.InternalField(2)
+                }
+            }
+
+            class Unrelated {
+                func Denied(owner Owner) {
+                    owner.PrivateField(1)
+                    owner.ProtectedField(2)
+                    owner.Restricted(3)
+                    owner.PrivateDelegate(4)
+                    owner.InternalField(5)
+                }
+            }
+
+            interface IStatic {
+                shared {
+                    private var Hidden unmanaged[Cdecl] (int32) -> int32
+                    internal var Internal unmanaged[Cdecl] (int32) -> int32
+                    private func Allowed() { IStatic.Hidden(1) }
+                }
+            }
+
+            func DeniedStatic() {
+                IStatic.Hidden(1)
+                (IStatic.Hidden)(2)
+                IStatic.Internal(3)
+            }
+            """;
+
+        var errors = GetErrors(source);
+        Assert.Equal(
+            new[] { "GS0472", "GS0379", "GS0472", "GS0472", "GS0472", "GS0472" },
+            errors.Select(diagnostic => diagnostic.Id));
+        Assert.Contains(errors, diagnostic => diagnostic.Message.Contains("Owner.Restricted"));
+        Assert.Contains(errors, diagnostic => diagnostic.Message.Contains("Owner.PrivateDelegate"));
+        Assert.Equal(2, errors.Count(diagnostic => diagnostic.Message.Contains("IStatic.Hidden")));
     }
 
     private static BoundProgram BindWithoutErrors(string source)


### PR DESCRIPTION
## Summary

Follow-up to #3568. Closes all three post-merge blockers at shared paths:

1. `BindFunctionPointerInvocation` now rejects managed pointer calls outside an unsafe context with GS0404 at the callee. Qualified, implicit, property, indexer, static, and arbitrary-expression callees share the gate. Raw `unmanaged[CC]` calls retain ADR-0095 behavior.
2. `FunctionPointerTypeSymbol` recursively substitutes parameter/return types while preserving managed state or unmanaged calling convention. `Binder`, `StructSymbol`, and `InterfaceSymbol` route through it, including by-ref/raw-pointer wrappers. Constructed struct/class/interface instance/static field/property loads now expose closed pointer signatures.
3. Callable-member fallback now applies normal read accessibility using actual declaring owners: field `Accessibility`, property `GetterAccessibility`, including interface statics. Shared delegate fallback receives the same fix.

## Coverage

- managed unsafe-gate diagnostics: qualified/implicit/property/indexer/static/arbitrary callees; unmanaged control
- generic `Dispatch[int32]`/class/interface instance and static fields/properties; good argument/result and bad-string GS0155
- generic method pointer parameter/return substitution
- managed/unmanaged ABI plus by-ref/pointer shape preservation
- private/protected/internal access from owner, derived, unrelated callers; private interface statics; delegate regression
- runtime managed generic calls, emitted closed `calli` signature blobs, and ILVerify invocation

## Validation

Release, rebased on merged #3568 (`ce9181f56`):

- full solution build: 0 warnings/errors
- related Core tests: 59 passed
- related Compiler emit tests: 28 passed
- full Core.Tests: 8,112 passed
- customary compiler-remainder shard: 1,155 passed
- repository ILVerify gate: 125/125 verified
- nullable hygiene: passed before rebase; no nullable-affecting rebase changes

All nullable-hygiene-listed guards are behavior-bearing by design: managed-call unsafe gating, callable match/owner selection, and interface accessibility/owner identity. None exist only to silence annotations.

Refs #3568
Refs #3523
