### PR TITLE
gsc: span foreach must dereference the enumerator's ref-returning Current (#3501)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -907,14 +907,14 @@ internal sealed class MemberLookup
         var currentProperty = ClrTypeUtilities.SafeGetProperty(enumeratorType, "Current", BindingFlags.Instance | BindingFlags.Public);
         if (currentProperty != null)
         {
-            elementType = currentProperty.PropertyType;
+            elementType = DereferenceByRefElement(currentProperty.PropertyType);
             return true;
         }
 
         var currentField = ClrTypeUtilities.SafeGetField(enumeratorType, "Current", BindingFlags.Instance | BindingFlags.Public);
         if (currentField != null)
         {
-            elementType = currentField.FieldType;
+            elementType = DereferenceByRefElement(currentField.FieldType);
             return true;
         }
 
@@ -925,7 +925,7 @@ internal sealed class MemberLookup
         var inheritedCurrent = SafeGetPropertyIncludingSelfAndInterfaces(enumeratorType, "Current");
         if (inheritedCurrent != null)
         {
-            elementType = inheritedCurrent.PropertyType;
+            elementType = DereferenceByRefElement(inheritedCurrent.PropertyType);
             return true;
         }
 
@@ -6258,6 +6258,17 @@ internal sealed class MemberLookup
             _ => null,
         };
     }
+
+    /// <summary>
+    /// Issue #3501: a ref-struct enumerator's <c>Current</c> is <c>ref T</c>
+    /// (Span&lt;T&gt;.Enumerator), but the iteration VARIABLE observes the
+    /// pointee value — ADR-0056 §1 auto-dereference. The lowered <c>Current</c>
+    /// read applies the matching <c>BoundDereferenceExpression</c>.
+    /// </summary>
+    /// <param name="elementType">The reflected <c>Current</c> member type.</param>
+    /// <returns>The pointee type for a by-ref member; the type unchanged otherwise.</returns>
+    private static Type DereferenceByRefElement(Type elementType) =>
+        elementType.IsByRef ? elementType.GetElementType() ?? elementType : elementType;
 
     /// <summary>
     /// Issue #985: a single CLR interface method slot that an implementing type

--- a/src/Core/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/Lowerer.cs
@@ -1209,7 +1209,13 @@ public sealed class Lowerer : BoundTreeRewriter
         // those.)
         if (disposeMethod == null)
         {
-            if (!typeof(System.IDisposable).IsAssignableFrom(clrType))
+            // Issue #3501: a byref-like enumerator (Span<T>.Enumerator) can
+            // report IDisposable on modern runtimes (ref structs implement
+            // interfaces since .NET 9), but the interface dispatch below
+            // boxes — invalid IL for a byref-like type. Roslyn likewise
+            // emits no disposal for the span pattern enumerator.
+            if (ClrTypeUtilities.IsByRefLike(clrType)
+                || !typeof(System.IDisposable).IsAssignableFrom(clrType))
             {
                 return null;
             }
@@ -1496,11 +1502,17 @@ public sealed class Lowerer : BoundTreeRewriter
                 moveNextCallFactory = createMoveNextCall;
                 currentAccessFactory = receiver =>
                 {
-                    return new BoundClrPropertyAccessExpression(
-                        null,
-                        receiver,
-                        currentMember,
-                        currentType);
+                    // Issue #3501 / ADR-0056 §1: a ref-struct enumerator's
+                    // `Current` is `ref T` (Span<T>.Enumerator); the loop
+                    // variable observes the pointee, so the read auto-
+                    // dereferences (the emitter's ldind), matching the
+                    // binder-side element typing.
+                    return ConversionClassifier.AutoDereferenceRefReturn(
+                        new BoundClrPropertyAccessExpression(
+                            null,
+                            receiver,
+                            currentMember,
+                            currentType));
                 };
                 return true;
             }
@@ -1536,10 +1548,24 @@ public sealed class Lowerer : BoundTreeRewriter
     {
         return member switch
         {
-            System.Reflection.PropertyInfo property => TypeSymbol.FromClrType(property.PropertyType),
-            System.Reflection.FieldInfo field => TypeSymbol.FromClrType(field.FieldType),
+            System.Reflection.PropertyInfo property => FromClrMemberType(property.PropertyType),
+            System.Reflection.FieldInfo field => FromClrMemberType(field.FieldType),
             _ => TypeSymbol.Error,
         };
+    }
+
+    /// <summary>
+    /// Issue #3501: a ref-returning member (Span&lt;T&gt;.Enumerator's
+    /// <c>Current</c> is <c>ref T</c>) reflects as an <c>IsByRef</c> CLR type,
+    /// which <see cref="TypeSymbol.FromClrType"/> does not model. Wrap the
+    /// pointee in a <see cref="ByRefTypeSymbol"/> so ADR-0056 §1
+    /// auto-dereference sees a managed pointer and inserts the load-indirect.
+    /// </summary>
+    private static TypeSymbol FromClrMemberType(System.Type clrType)
+    {
+        return clrType.IsByRef
+            ? ByRefTypeSymbol.Get(TypeSymbol.FromClrType(clrType.GetElementType()))
+            : TypeSymbol.FromClrType(clrType);
     }
 
     private BoundBlockStatement RewriteProtectedRegionEntries(BoundStatement statement)

--- a/test/Compiler.Tests/Emit/Issue3501SpanForeachTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3501SpanForeachTests.cs
@@ -1,0 +1,150 @@
+// <copyright file="Issue3501SpanForeachTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #3501: `for x in span` over a <c>Span[T]</c> / <c>ReadOnlySpan[T]</c>.
+/// The span enumerator's <c>Current</c> returns <c>ref T</c>, so the element
+/// read must auto-dereference (ADR-0056 §1) — both in the binder (loop
+/// variable types as <c>T</c>, not <c>T@</c>) and in the lowered IL
+/// (<c>ldind</c> after <c>get_Current</c>). The enumerator is also byref-like:
+/// on runtimes where ref structs implement <c>IDisposable</c> the disposal
+/// wrap must be skipped because interface dispatch would box.
+/// </summary>
+public class Issue3501SpanForeachTests
+{
+    [Fact]
+    public void SpanForeach_ElementValuesAndSlice_RunCorrectly()
+    {
+        const string Source = """
+            package Issue3501
+            import System
+
+            func Main() {
+                var arr = []uint8{1, 2, 3, 42, 5}
+                let span = arr.AsSpan()
+                var sum = 0
+                var hits = 0
+                for b in span {
+                    if b != 42 {
+                        sum = sum + int32(b)
+                    } else {
+                        hits = hits + 1
+                    }
+                }
+                let tail = span.Slice(1)
+                var tsum = 0
+                for b in tail {
+                    tsum = tsum + int32(b)
+                }
+                Console.WriteLine(sum.ToString() + " " + hits.ToString() + " " + tsum.ToString())
+            }
+            """;
+
+        Assert.Equal($"11 1 52{Environment.NewLine}", CompileAndRun(Source));
+    }
+
+    [Fact]
+    public void ReadOnlySpanForeach_SumsElements()
+    {
+        const string Source = """
+            package Issue3501
+            import System
+
+            func Total(data System.ReadOnlySpan[int32]) int32 {
+                var total = 0
+                for value in data {
+                    total = total + value
+                }
+                return total
+            }
+
+            func Main() {
+                var arr = []int32{10, 20, 12}
+                Console.WriteLine(Total(arr.AsSpan()).ToString())
+            }
+            """;
+
+        Assert.Equal($"42{Environment.NewLine}", CompileAndRun(Source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var outputDirectory = Path.Combine(AppContext.BaseDirectory, "issue3501", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(outputDirectory);
+        try
+        {
+            var sourcePath = Path.Combine(outputDirectory, "Program.gs");
+            var outputPath = Path.Combine(outputDirectory, "Issue3501.dll");
+            File.WriteAllText(sourcePath, source);
+
+            using var standardOut = new StringWriter();
+            using var standardError = new StringWriter();
+            var previousOut = Console.Out;
+            var previousError = Console.Error;
+            Console.SetOut(standardOut);
+            Console.SetError(standardError);
+            int exitCode;
+            try
+            {
+                exitCode = Program.Main(new[]
+                {
+                    "/out:" + outputPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    sourcePath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+                Console.SetError(previousError);
+            }
+
+            Assert.True(
+                exitCode == 0,
+                $"gsc failed:\nstdout:\n{standardOut}\nstderr:\n{standardError}");
+            IlVerifier.Verify(outputPath);
+            var assembly = Assembly.Load(File.ReadAllBytes(outputPath));
+            _ = assembly.GetTypes();
+            var entryPoint = assembly.EntryPoint
+                ?? throw new InvalidOperationException("Emitted assembly has no entry point.");
+
+            previousOut = Console.Out;
+            using var output = new StringWriter();
+            Console.SetOut(output);
+            try
+            {
+                entryPoint.Invoke(
+                    null,
+                    entryPoint.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+            }
+
+            return output.ToString();
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(outputDirectory, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
Part of #3501 (self-migration). Newly-merged C# on main iterates a `Span<byte>` (`foreach (byte flag in tail)` in NullableFlagsBuilder), and the migrated G# failed with `GS0129: '!=' is not defined for types 'uint8@' and 'uint8'` — gsc never supported span foreach because `Span<T>.Enumerator.Current` returns `ref T`.

Three fixes, per ADR-0056 §1 auto-dereference:

- **Binder**: `MemberLookup.TryGetClrCurrentMemberType` dereferences a byref member type, so the loop variable types as `T`, not `T@`.
- **Lowerer**: the `Current` access models the ref return as a `ByRefTypeSymbol` and wraps it with `ConversionClassifier.AutoDereferenceRefReturn`, so emit produces the `ldind` after `get_Current`.
- **Disposal**: the try/finally dispose wrap is skipped for byref-like enumerators. On .NET 9+ ref structs implement `IDisposable`, so the `IsAssignableFrom` gate started passing and the interface dispatch **boxed the ref struct** — invalid IL (runtime `InvalidProgramException`; probe verified). Roslyn likewise emits no disposal for the span pattern enumerator.

Verification:
- New runtime emit tests (`Issue3501SpanForeachTests`): `Span[uint8]` iteration with branch on the element + `Slice`, and `ReadOnlySpan[int32]` — ilverify + executed output asserted.
- 281 targeted loop/span/enumerator/dispose Core tests pass.
- Local pinned-Oahu gate: 15/15 apps green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Six2MrhXHo6kQ8DSA6c1Pc