### PR TITLE
cs2gs: keep the native pattern form when a nested subpattern narrows a member type (#3555)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue3555NestedTypeNarrowingPatternTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3555NestedTypeNarrowingPatternTests.cs
@@ -1,0 +1,86 @@
+// <copyright file="Issue3555NestedTypeNarrowingPatternTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3555: a boolean-position C# pattern whose PROPERTY value is itself a
+/// type-matching pattern with further subpatterns (`symbol is IParameterSymbol
+/// { ContainingSymbol: IMethodSymbol { MethodKind: …, ContainingType.IsRecord:
+/// true } }`) used to guard-lower over a smart-castable scrutinee into
+/// unnarrowed member CHAINS (`symbol.ContainingSymbol is IMethodSymbol &&
+/// symbol.ContainingSymbol.MethodKind == …`) — gsc narrows only the scrutinee
+/// local, so the second read failed GS0158. Such shapes now take the native
+/// pattern form.
+/// </summary>
+public class Issue3555NestedTypeNarrowingPatternTests
+{
+    [Fact]
+    public void NestedTypePropertyPattern_UsesNativePatternForm()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class Owner
+    {
+        public bool IsSpecial { get; set; }
+        public string Name { get; set; } = """";
+    }
+
+    public class Member
+    {
+        public object Holder { get; set; } = new object();
+    }
+
+    public static class Probe
+    {
+        public static bool Check(object value) =>
+            value is string
+            || value is Member
+            {
+                Holder: Owner
+                {
+                    IsSpecial: true,
+                    Name.Length: > 0,
+                },
+            };
+    }
+}");
+
+        Assert.Contains("Holder: Owner and {", printed);
+        Assert.DoesNotContain(".Holder is Owner &&", printed);
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.DoesNotContain(
+            context.Diagnostics,
+            diagnostic => diagnostic.Severity == TranslationSeverity.Unsupported);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -662,9 +662,17 @@ public sealed partial class CSharpToGSharpTranslator
             // pattern local and gsc cannot smart-cast the original scrutinee.
             // An implicit property/field can translate to a bare identifier, but
             // only bare locals and parameters are smart-castable (ADR-0069).
+            // Issue #3555: a property subpattern whose VALUE is itself a
+            // type-matching pattern with further subpatterns (`ContainingSymbol:
+            // IMethodSymbol { MethodKind: … }`) cannot be guard-lowered even
+            // over a smart-castable scrutinee — gsc narrows only the scrutinee
+            // local, never member CHAINS, so the lowered
+            // `x.Prop is T && x.Prop.M == …` fails GS0158 on the unnarrowed
+            // second read. Such shapes must take the native pattern form.
             if (!PatternIntroducesBinding(isPattern.Pattern)
-                && !PatternReadsScrutineeAtMostOnce(isPattern.Pattern)
-                && !this.IsSmartCastableScrutinee(isPattern.Expression))
+                && ((!PatternReadsScrutineeAtMostOnce(isPattern.Pattern)
+                        && !this.IsSmartCastableScrutinee(isPattern.Expression))
+                    || PatternRequiresNestedTypeNarrowing(isPattern.Pattern)))
             {
                 var bindings = new List<(ISymbol Symbol, GExpression Replacement)>();
                 var guards = new List<GExpression>();
@@ -718,6 +726,58 @@ public sealed partial class CSharpToGSharpTranslator
                 receiverType,
                 isPattern.Expression);
             return this.MaterializeFallbackPatternBindings(isPattern, receiver, test);
+        }
+
+        // Issue #3555: true when a property subpattern's value is itself a
+        // type-matching pattern that tests MEMBERS of the narrowed value — the
+        // shape guard-lowering cannot express (see TranslateIsPattern).
+        private static bool PatternRequiresNestedTypeNarrowing(PatternSyntax pattern)
+        {
+            switch (pattern)
+            {
+                case RecursivePatternSyntax recursive:
+                    foreach (SubpatternSyntax subpattern in
+                        recursive.PropertyPatternClause?.Subpatterns
+                        ?? default(SeparatedSyntaxList<SubpatternSyntax>))
+                    {
+                        if (subpattern.Pattern is RecursivePatternSyntax { Type: not null } nestedTyped
+                            && (nestedTyped.PropertyPatternClause is { Subpatterns.Count: > 0 }
+                                || nestedTyped.PositionalPatternClause is { Subpatterns.Count: > 0 }))
+                        {
+                            return true;
+                        }
+
+                        if (PatternRequiresNestedTypeNarrowing(subpattern.Pattern))
+                        {
+                            return true;
+                        }
+                    }
+
+                    foreach (SubpatternSyntax subpattern in
+                        recursive.PositionalPatternClause?.Subpatterns
+                        ?? default(SeparatedSyntaxList<SubpatternSyntax>))
+                    {
+                        if (PatternRequiresNestedTypeNarrowing(subpattern.Pattern))
+                        {
+                            return true;
+                        }
+                    }
+
+                    return false;
+
+                case UnaryPatternSyntax unary:
+                    return PatternRequiresNestedTypeNarrowing(unary.Pattern);
+
+                case BinaryPatternSyntax binary:
+                    return PatternRequiresNestedTypeNarrowing(binary.Left)
+                        || PatternRequiresNestedTypeNarrowing(binary.Right);
+
+                case ParenthesizedPatternSyntax parenthesized:
+                    return PatternRequiresNestedTypeNarrowing(parenthesized.Pattern);
+
+                default:
+                    return false;
+            }
         }
 
         private GExpression MaterializeFallbackPatternBindings(


### PR DESCRIPTION
Part of #3501, closes #3555. Boolean-lowering `symbol is IParameterSymbol and { ContainingSymbol: IMethodSymbol and { MethodKind: MethodKind.Constructor, ... } }` re-read `symbol.ContainingSymbol` **without** the `IMethodSymbol` narrowing — G# smart casts narrow only scrutinee locals, never member chains — so the lowered `.MethodKind` access failed to compile.

Fix: when any property subpattern's value is itself a recursive pattern that declares a type plus nested clauses (`PatternRequiresNestedTypeNarrowing`, recursing through unary/binary/parenthesized patterns), emit the native G# pattern form (`is T and { P: U and { ... } }`, ADR-0166) instead of lowering to boolean chains.

Verification: new `Issue3555NestedTypeNarrowingPatternTests`; 225-test pattern sweep green; Issue2412/2506 contract tests 36/36; local pinned-Oahu gate 15/15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Six2MrhXHo6kQ8DSA6c1Pc