### PR TITLE
cs2gs: rebuild a promoted tuple index key element-wise with !! bridging (#3564)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue3564TupleKeyIndexBridgingTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3564TupleKeyIndexBridgingTests.cs
@@ -1,0 +1,121 @@
+// <copyright file="Issue3564TupleKeyIndexBridgingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3564: a tuple-typed index key whose G#-side elements are
+/// promoted-nullable while the indexer's key tuple elements are not
+/// (`store[key]` where `key` is `(ISymbol?, SyntaxNode)` against a
+/// `Dictionary[(ISymbol, SyntaxNode), bool]` field) cannot be bridged with a
+/// whole-value `!!` — G# has no implicit `(T?, U) → (T, U)`. The index
+/// argument now rebuilds per element, asserting only the promoted slots:
+/// `store[(key.Item1!!, key.Item2)]`.
+/// </summary>
+public class Issue3564TupleKeyIndexBridgingTests
+{
+    [Fact]
+    public void PromotedTupleKey_RebuildsPerElementAtIndexer()
+    {
+        string printed = TranslateOblivious(@"
+using System.Collections.Generic;
+
+namespace Demo
+{
+    public class Node
+    {
+        public string Label { get; set; } = """";
+    }
+
+    public class Cache
+    {
+        private readonly Dictionary<(string, Node), bool> store = new();
+
+        private static string Resolve(Node node) => null;
+
+        public bool Lookup(Node scope)
+        {
+            var name = Resolve(scope);
+            var key = (name, scope);
+            if (this.store.TryGetValue(key, out var cached))
+            {
+                return cached;
+            }
+
+            this.store[key] = true;
+            return this.store[key];
+        }
+    }
+}");
+
+        Assert.Contains("this.store[(key.Item1!!, key.Item2)] = true", printed);
+        Assert.Contains("return this.store[(key.Item1!!, key.Item2)]", printed);
+    }
+
+    [Fact]
+    public void UnpromotedTupleKey_StaysBare()
+    {
+        string printed = TranslateOblivious(@"
+using System.Collections.Generic;
+
+namespace Demo
+{
+    public class Node
+    {
+        public string Label { get; set; } = """";
+    }
+
+    public class Cache
+    {
+        private readonly Dictionary<(string, Node), bool> store = new();
+
+        public bool Lookup(Node scope)
+        {
+            var key = (scope.Label, scope);
+            this.store[key] = true;
+            return this.store[key];
+        }
+    }
+}");
+
+        Assert.Contains("this.store[key] = true", printed);
+        Assert.DoesNotContain("key.Item1!!", printed);
+    }
+
+    private static string TranslateOblivious(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        Assert.Equal(
+            NullableContextOptions.Disable,
+            project.Compilation.Options.NullableContextOptions);
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.DoesNotContain(
+            context.Diagnostics,
+            diagnostic => diagnostic.Severity == TranslationSeverity.Unsupported);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -1848,6 +1848,20 @@ public sealed partial class CSharpToGSharpTranslator
                 translated = new ParenthesizedExpression(translated);
             }
 
+            // Issue #3564: a TUPLE-typed key whose G#-side elements are
+            // promoted-nullable while the indexer's key tuple elements are not
+            // (`store[key]` where `key` is `(ISymbol?, SyntaxNode)` against a
+            // `Dictionary[(ISymbol, SyntaxNode), bool]` field) cannot be
+            // bridged with a whole-value `!!` — G# has no implicit
+            // `(T?, U) -> (T, U)`. Rebuild the key per element, asserting only
+            // the promoted slots: `store[(key.Item1!!, key.Item2)]`. A
+            // genuinely null element follows the established `!!` bridge
+            // policy and fails at runtime before the index operation.
+            if (this.TryRebuildPromotedTupleIndexKey(argument, translated, out GExpression rebuiltKey))
+            {
+                return rebuiltKey;
+            }
+
             if (!this.IndexArgumentTargetsNonNullableReference(argument)
                 || !this.IndexArgumentValueNeedsNullForgiveness(argument.Expression))
             {
@@ -1860,6 +1874,65 @@ public sealed partial class CSharpToGSharpTranslator
                     ? new ParenthesizedExpression(translated)
                     : translated;
             return EnsureNonNullAssertion(assertionOperand);
+        }
+
+        private bool TryRebuildPromotedTupleIndexKey(
+            ArgumentSyntax argument,
+            GExpression translated,
+            out GExpression rebuilt)
+        {
+            rebuilt = null;
+            if (!this.IsObliviousCompilation())
+            {
+                return false;
+            }
+
+            if (this.context.SemanticModel.GetOperation(argument) is not IArgumentOperation
+                {
+                    Parameter.Type: INamedTypeSymbol { IsTupleType: true } keyTuple,
+                })
+            {
+                return false;
+            }
+
+            ISymbol valueSymbol = this.context.GetSymbolInfo(argument.Expression).Symbol;
+            if (valueSymbol is not (ILocalSymbol or IParameterSymbol or IFieldSymbol or IPropertySymbol)
+                || this.context.GetTypeInfo(argument.Expression).Type
+                    is not INamedTypeSymbol { IsTupleType: true } valueTuple
+                || valueTuple.TupleElements.Length != keyTuple.TupleElements.Length)
+            {
+                return false;
+            }
+
+            var elements = new List<GExpression>(keyTuple.TupleElements.Length);
+            bool anyAsserted = false;
+            for (int i = 0; i < keyTuple.TupleElements.Length; i++)
+            {
+                GExpression element = new MemberAccessExpression(translated, $"Item{i + 1}", isArrow: false);
+                IFieldSymbol keyElement = keyTuple.TupleElements[i];
+                bool keyElementStaysNonNull = keyElement.Type is { IsReferenceType: true }
+                    && keyElement.Type.NullableAnnotation != NullableAnnotation.Annotated;
+                if (keyElementStaysNonNull
+                    && ObliviousNullabilityAnalyzer.IsTupleElementTainted(
+                        this.context.Compilation,
+                        valueSymbol,
+                        new List<int> { i },
+                        this.context.SiblingCompilations))
+                {
+                    element = new NonNullAssertionExpression(element);
+                    anyAsserted = true;
+                }
+
+                elements.Add(element);
+            }
+
+            if (!anyAsserted)
+            {
+                return false;
+            }
+
+            rebuilt = new TupleLiteralExpression(elements);
+            return true;
         }
 
         private bool IndexArgumentValueNeedsNullForgiveness(ExpressionSyntax value)


### PR DESCRIPTION
Part of #3501, addresses the two GS0116 sites of #3564. A tuple-typed dictionary key whose element was nullability-promoted (`(ISymbol?, SyntaxNode)`) no longer converts to the declared key type (`(ISymbol, SyntaxNode)`) — G# has no implicit `(T?, U) → (T, U)` tuple conversion, so `this.store[key]` failed with GS0116.

Fix: at indexer arguments only (`TryRebuildPromotedTupleIndexKey`), when the argument is a tuple-typed identifier bound to a tuple-typed key parameter and `IsTupleElementTainted` reports a promoted element whose target element stays non-null, rebuild the key as a tuple literal with per-element forgiveness: `this.store[(key.Item1!!, key.Item2)]`. Unpromoted keys stay bare.

Deliberately bounded: promoting the dictionary's declared key type cascades into `IEqualityComparer` interface arguments unboundedly, and blanket tuple-literal bridging would throw where C# tolerates a guarded-later element (`var pair = (maybeNull, x); if (pair.Item1 != null) ...`). The remaining #3564-family error (LINQ `Select` producing a promoted `List[(string?, Location)]` into a declared `List[(string, Location)]` local) is deferred — lambda-return bridging risks runtime throws where C# tolerates nulls; noted on the issue.

Verification: new `Issue3564TupleKeyIndexBridgingTests`; 325-test golden/oblivious/index sweep green; Issue2412/2506 contract tests 36/36; local pinned-Oahu gate 15/15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Six2MrhXHo6kQ8DSA6c1Pc