### PR TITLE
cs2gs: query a positional record property's taint through its primary-ctor parameter (#3501)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue3501PositionalRecordPropertyTaintTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3501PositionalRecordPropertyTaintTests.cs
@@ -1,0 +1,123 @@
+// <copyright file="Issue3501PositionalRecordPropertyTaintTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3501: a positional record's synthesized property and its
+/// primary-constructor parameter share ONE declaration (the ParameterSyntax)
+/// but are TWO Roslyn symbols. The oblivious taint fixpoint keys argument
+/// edges on the parameter (`new Entry(null, …)`), while a member read
+/// (`entry.GsNamespace`) binds the property — so the value bridge never saw
+/// the promotion and a guarded `yield return entry.GsNamespace` in a
+/// `sequence[string]` iterator failed with GS0155 (`string?` → `string`).
+/// The promotion query now normalizes the property back to its parameter.
+/// </summary>
+public class Issue3501PositionalRecordPropertyTaintTests
+{
+    [Fact]
+    public void GuardedYieldOfPromotedPositionalProperty_GetsBridge()
+    {
+        string printed = TranslateOblivious(@"
+using System.Collections.Generic;
+
+namespace Demo
+{
+    internal static class ApiMap
+    {
+        private static readonly Dictionary<string, Entry> TypeMap = new()
+        {
+            [""A""] = new Entry(""GS.Analysis"", ""Alpha""),
+            [""B""] = new Entry(null, ""Beta""),
+        };
+
+        internal static IEnumerable<string> EnumerateTargetNamespaces()
+        {
+            foreach (Entry entry in TypeMap.Values)
+            {
+                if (!string.IsNullOrEmpty(entry.GsNamespace))
+                {
+                    yield return entry.GsNamespace;
+                }
+            }
+        }
+    }
+
+    internal readonly record struct Entry(string GsNamespace, string GsName, string AdaptationNote = null);
+}");
+
+        // The parameter-side taint promotes the positional declaration…
+        Assert.Contains("GsNamespace string?", printed);
+
+        // …and the property read at the yield seam is now bridged.
+        Assert.Contains("yield entry.GsNamespace!!", printed);
+    }
+
+    [Fact]
+    public void UntaintedPositionalProperty_StaysBare()
+    {
+        string printed = TranslateOblivious(@"
+using System.Collections.Generic;
+
+namespace Demo
+{
+    internal static class ApiMap
+    {
+        private static readonly Dictionary<string, Entry> TypeMap = new()
+        {
+            [""A""] = new Entry(""GS.Analysis"", ""Alpha""),
+        };
+
+        internal static IEnumerable<string> EnumerateTargetNamespaces()
+        {
+            foreach (Entry entry in TypeMap.Values)
+            {
+                yield return entry.GsNamespace;
+            }
+        }
+    }
+
+    internal readonly record struct Entry(string GsNamespace, string GsName);
+}");
+
+        Assert.Contains("GsNamespace string,", printed);
+        Assert.DoesNotContain("GsNamespace!!", printed);
+    }
+
+    private static string TranslateOblivious(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        Assert.Equal(
+            NullableContextOptions.Disable,
+            project.Compilation.Options.NullableContextOptions);
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.DoesNotContain(
+            context.Diagnostics,
+            diagnostic => diagnostic.Severity == TranslationSeverity.Unsupported);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
@@ -703,10 +703,18 @@ public sealed partial class CSharpToGSharpTranslator
                 IsStoredMemberNullabilitySymbol(symbol) || sharedDocument
                     ? this.context.RepositoryCompilations ?? this.context.SiblingCompilations
                     : this.context.SiblingCompilations;
+
+            // Issue #3501: a positional record's synthesized property and its
+            // primary-constructor parameter are ONE declaration site (the same
+            // ParameterSyntax) but TWO Roslyn symbols. The taint fixpoint keys
+            // argument edges on the parameter (`new Entry(null, …)`), while a
+            // member read (`entry.GsNamespace`) binds the property — query the
+            // parameter's taint for such a property so the value bridge and the
+            // promoted declaration agree.
             if (declared.NullableAnnotation == NullableAnnotation.None
                 && ObliviousNullabilityAnalyzer.IsTainted(
                     this.context.Compilation,
-                    symbol,
+                    NormalizePositionalRecordProperty(symbol),
                     taintCompilations))
             {
                 return true;
@@ -715,6 +723,35 @@ public sealed partial class CSharpToGSharpTranslator
             return !sharedDocument
                 && symbol is not IMethodSymbol
                 && this.IsUsedAsNullable(symbol, this.GetNullabilityScope(symbol));
+        }
+
+        /// <summary>
+        /// Issue #3501: maps a positional record's synthesized property back to
+        /// the primary-constructor parameter it was generated from (both
+        /// symbols share the SAME <see cref="ParameterSyntax"/> declaration).
+        /// Any other symbol is returned unchanged.
+        /// </summary>
+        private static ISymbol NormalizePositionalRecordProperty(ISymbol symbol)
+        {
+            if (symbol is IPropertySymbol { ContainingType: { IsRecord: true } owner } property
+                && property.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax()
+                    is ParameterSyntax declaringParameter)
+            {
+                foreach (IMethodSymbol constructor in owner.InstanceConstructors)
+                {
+                    foreach (IParameterSymbol parameter in constructor.Parameters)
+                    {
+                        if (parameter.Name == property.Name
+                            && parameter.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax()
+                                == declaringParameter)
+                        {
+                            return parameter;
+                        }
+                    }
+                }
+            }
+
+            return symbol;
         }
 
         // Issue #3501: file paths that appear in MORE THAN ONE repository


### PR DESCRIPTION
Part of #3501. Found by run 13 of the targeted 3-app migration: `yield return entry.GsNamespace` (RoslynAnalyzerApiMap, guarded by `!string.IsNullOrEmpty`) failed with GS0155 `string?` → `string`.

A positional record's synthesized property and its primary-constructor parameter share ONE declaration — the same `ParameterSyntax` — but are TWO Roslyn symbols. The oblivious taint fixpoint keys argument edges on the **parameter** (`new Entry(null, …)` promotes it), while a member read (`entry.GsNamespace`) binds the **property**. Result: the record declaration rendered `GsNamespace string?`, but `IsNullablePromotedValue` at the yield seam saw an untainted property and skipped the `!!` bridge.

Fix: `ShouldPromoteToNullableReference` normalizes such a property back to its primary-ctor parameter (matched by name + identical declaring syntax node) before the taint query, so the declaration and every value bridge agree.

Verification: new `Issue3501PositionalRecordPropertyTaintTests` (bridged when tainted, bare when not); 350-test oblivious/promotion/golden/record/forgiveness sweep green incl. Issue2412/2506 contract tests; local pinned-Oahu gate 15/15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Six2MrhXHo6kQ8DSA6c1Pc