### PR TITLE
gsc: sequence[T] converts to non-generic IEnumerable regardless of reflection context (#3566)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -147,6 +147,21 @@ public sealed class Conversion
             return Conversion.Identity;
         }
 
+        // Issue #3566: IEnumerable<T> (and its sequence[T] alias) implements
+        // the non-generic System.Collections.IEnumerable BY DEFINITION, but
+        // the reflection walk cannot prove it when the element type is a
+        // MetadataLoadContext type constructed onto the runtime
+        // IEnumerable<> definition (a hybrid constructed type whose
+        // interface set is unreadable). Answer semantically so the
+        // non-generic self-parameter of OfType/Cast binds. IAsyncEnumerable
+        // shapes are excluded — they do not implement IEnumerable.
+        if (SequenceTypeSymbol.TryGetEnumerableInterfaceShape(from, out var fromEnumerableDefinition, out _)
+            && fromEnumerableDefinition?.FullName == "System.Collections.Generic.IEnumerable`1"
+            && to.ClrType?.FullName == "System.Collections.IEnumerable")
+        {
+            return Conversion.Implicit;
+        }
+
         // Issue #2290: a referenced (cross-assembly) type can be independently
         // re-minted into TWO non-reference-equal TypeSymbol wrappers for the
         // SAME underlying CLR type — e.g. an imported `data class`/`data

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
@@ -868,6 +868,21 @@ internal sealed partial class MethodBodyEmitter
             return true;
         }
 
+        // Issue #3566: IEnumerable<T> (and its sequence[T] alias) implements
+        // the non-generic System.Collections.IEnumerable by definition, so
+        // the upcast is a no-op reference conversion at the IL level. Mirrors
+        // the binder's matching arm in Conversion.ClassifyCore — needed
+        // because the hybrid runtime/MetadataLoadContext constructed shape
+        // defeats the CLR-backed assignability rules. IAsyncEnumerable
+        // shapes never classify into this conversion binder-side.
+        if (a != null
+            && SequenceTypeSymbol.TryGetEnumerableInterfaceShape(a, out var aEnumerableDefinition, out _)
+            && aEnumerableDefinition?.FullName == "System.Collections.Generic.IEnumerable`1"
+            && b?.ClrType?.FullName == "System.Collections.IEnumerable")
+        {
+            return true;
+        }
+
         if (a is StructSymbol aClass && b is StructSymbol bClass && aClass.IsClass && bClass.IsClass)
         {
             // Issue #1248: a constructed generic class's base-type reference is

--- a/test/Compiler.Tests/Emit/Issue3566SequenceToNonGenericEnumerableTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3566SequenceToNonGenericEnumerableTests.cs
@@ -1,0 +1,140 @@
+// <copyright file="Issue3566SequenceToNonGenericEnumerableTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #3566 (emit side): the <c>sequence[T]</c> → non-generic
+/// <c>System.Collections.IEnumerable</c> upcast the binder's semantic arm
+/// admits must emit as a no-op reference conversion. Without the matching
+/// <c>IsReferenceCompatible</c> arm the emitter threw NotSupportedException
+/// (GS9998) for exactly the conversions the classifier had just accepted.
+/// </summary>
+public class Issue3566SequenceToNonGenericEnumerableTests
+{
+    [Fact]
+    public void SequenceUpcastToIEnumerable_EmitsAndRuns()
+    {
+        const string Source = """
+            package Issue3566
+            import System
+            import System.Collections
+            import System.Linq
+
+            func Flatten(xs sequence[string]) IEnumerable {
+                return xs
+            }
+
+            func Main() {
+                let seq = []string{"a", "b", "c"}.AsEnumerable()
+                var count = 0
+                for item in Flatten(seq) {
+                    count = count + 1
+                }
+                Console.WriteLine(count.ToString())
+            }
+            """;
+
+        Assert.Equal($"3{Environment.NewLine}", CompileAndRun(Source));
+    }
+
+    [Fact]
+    public void OfTypeOnSequenceReceiver_EmitsAndRuns()
+    {
+        const string Source = """
+            package Issue3566
+            import System
+            import System.Linq
+
+            func CountStrings(xs sequence[object]) int32 {
+                return xs.OfType[string]().Count()
+            }
+
+            func Main() {
+                let items = []object{"a", 1, "b"}.AsEnumerable()
+                Console.WriteLine(CountStrings(items).ToString())
+            }
+            """;
+
+        Assert.Equal($"2{Environment.NewLine}", CompileAndRun(Source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var outputDirectory = Path.Combine(AppContext.BaseDirectory, "issue3566", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(outputDirectory);
+        try
+        {
+            var sourcePath = Path.Combine(outputDirectory, "Program.gs");
+            var outputPath = Path.Combine(outputDirectory, "Issue3566.dll");
+            File.WriteAllText(sourcePath, source);
+
+            using var standardOut = new StringWriter();
+            using var standardError = new StringWriter();
+            var previousOut = Console.Out;
+            var previousError = Console.Error;
+            Console.SetOut(standardOut);
+            Console.SetError(standardError);
+            int exitCode;
+            try
+            {
+                exitCode = Program.Main(new[]
+                {
+                    "/out:" + outputPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    sourcePath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+                Console.SetError(previousError);
+            }
+
+            Assert.True(
+                exitCode == 0,
+                $"gsc failed:\nstdout:\n{standardOut}\nstderr:\n{standardError}");
+            IlVerifier.Verify(outputPath);
+            var assembly = Assembly.Load(File.ReadAllBytes(outputPath));
+            _ = assembly.GetTypes();
+            var entryPoint = assembly.EntryPoint
+                ?? throw new InvalidOperationException("Emitted assembly has no entry point.");
+
+            previousOut = Console.Out;
+            using var output = new StringWriter();
+            Console.SetOut(output);
+            try
+            {
+                entryPoint.Invoke(
+                    null,
+                    entryPoint.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+            }
+
+            return output.ToString();
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(outputDirectory, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3566OfTypeMlcSequenceTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3566OfTypeMlcSequenceTests.cs
@@ -1,0 +1,119 @@
+// <copyright file="Issue3566OfTypeMlcSequenceTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #3566: <c>xs.OfType[U]()</c> / <c>xs.Cast[U]()</c> on a
+/// <c>sequence[T]</c> receiver whose element type resolves through a
+/// <see cref="System.Reflection.MetadataLoadContext"/> reported GS0159.
+/// The extensions' self-parameter is the NON-generic
+/// <c>System.Collections.IEnumerable</c>, and <c>sequence[T]</c>'s CLR type
+/// is the runtime <c>IEnumerable&lt;&gt;</c> closed over the MLC element — a
+/// hybrid constructed type whose interface set the cross-context by-name
+/// walk cannot read. The conversion classifier now answers semantically:
+/// an <c>IEnumerable&lt;T&gt;</c> shape implements non-generic
+/// <c>IEnumerable</c> by definition.
+/// </summary>
+public class Issue3566OfTypeMlcSequenceTests
+{
+    private static ReferenceResolver MetadataLoadContextResolver()
+    {
+        var paths = new[]
+        {
+            typeof(object).Assembly.Location,
+            typeof(System.Collections.Generic.List<>).Assembly.Location,
+            typeof(System.Console).Assembly.Location,
+            typeof(System.Linq.Enumerable).Assembly.Location,
+        }
+        .Where(p => !string.IsNullOrEmpty(p))
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .ToArray();
+
+        return ReferenceResolver.WithReferences(paths);
+    }
+
+    private static ImmutableArray<Diagnostic> BindWithMlc(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var globalScope = Binder.BindGlobalScope(
+            previous: null,
+            ImmutableArray.Create(tree),
+            MetadataLoadContextResolver());
+        return globalScope.Diagnostics;
+    }
+
+    [Fact]
+    public void OfType_OnSequenceOfMlcElement_Binds()
+    {
+        var source = """
+            package Repro
+            import System
+            import System.Linq
+
+            func CountVersions(xs sequence[Version]) int32 {
+                return xs.OfType[Version]().Count()
+            }
+            """;
+
+        var diagnostics = BindWithMlc(source);
+
+        Assert.DoesNotContain(
+            diagnostics,
+            d => d.Severity == DiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public void Cast_OnSequenceOfMlcElement_Binds()
+    {
+        var source = """
+            package Repro
+            import System
+            import System.Linq
+
+            func AsObjects(xs sequence[Version]) sequence[object] {
+                return xs.Cast[object]()
+            }
+            """;
+
+        var diagnostics = BindWithMlc(source);
+
+        Assert.DoesNotContain(
+            diagnostics,
+            d => d.Severity == DiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public void SequenceConvertsToNonGenericIEnumerable()
+    {
+        // IEnumerable<T> implements the non-generic IEnumerable by
+        // definition — the direct upcast the new classifier arm answers.
+        // (The arm itself gates on the IEnumerable`1 shape so async
+        // sequences never enter it; their conversion behavior is governed
+        // by pre-existing rules.)
+        var source = """
+            package Repro
+            import System
+            import System.Collections
+
+            func Sync(xs sequence[Version]) IEnumerable {
+                return xs
+            }
+            """;
+
+        Assert.DoesNotContain(
+            BindWithMlc(source),
+            d => d.Severity == DiagnosticSeverity.Error);
+    }
+}


### PR DESCRIPTION
Closes #3566 (the extension-form case; part of #3501). `xs.OfType[U]()` / `xs.Cast[U]()` on a `sequence[T]` receiver whose element type resolves through a MetadataLoadContext reported GS0159.

Root cause: the extensions' self-parameter is the **non-generic** `System.Collections.IEnumerable`, and `sequence[T]`'s CLR type is the runtime `IEnumerable<>` closed over the MLC element — a hybrid constructed type whose interface set the cross-context by-name walk (`ImplementsInterfaceByName`) cannot read. The conversion classifier now answers semantically: an `IEnumerable`1`-shaped source (per `TryGetEnumerableInterfaceShape`) implements non-generic `IEnumerable` by definition. `IAsyncEnumerable` shapes are excluded from the arm.

Residual (left open on the issue): the *static* spelling `Enumerable.OfType[U](xs)` still fails under an MLC element via a separate mixed-context `MakeGenericMethod` path; the receiver/extension form is what cs2gs emits.

Verification: new `Issue3566OfTypeMlcSequenceTests` (OfType + Cast bind under an MLC resolver; the direct `sequence[T]` → `IEnumerable` upcast binds); 649-test conversion/LINQ/sequence/extension sweep green; local pinned-Oahu gate 15/15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Six2MrhXHo6kQ8DSA6c1Pc