### PR TITLE
cs2gs: suppress the guarded GetNamespaceName result in ResolvePackage (#3564)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -1063,7 +1063,12 @@ public sealed partial class CSharpToGSharpTranslator
                 Location: member.GetLocation()))
             .Where(item => item.Symbol?.ContainingNamespace is { IsGlobalNamespace: false })
             .Select(item => (
-                nameAllocator.GetNamespaceName(item.Symbol.ContainingNamespace),
+
+                // The Where guard admits only non-global namespaces, for which
+                // GetNamespaceName never returns null (issue #3564: the
+                // suppression keeps the tuple element non-null through
+                // self-migration).
+                nameAllocator.GetNamespaceName(item.Symbol.ContainingNamespace)!,
                 item.Location))
             .ToList();
 


### PR DESCRIPTION
Part of #3501 / #3564 — the **last** Translator self-migration compile error. `ResolvePackage`'s second `Select` carries `GetNamespaceName`'s promoted `string?` into a local explicitly declared `List[(string, Location)]`; G# has no implicit `List[(string?, L)] → List[(string, L)]`.

The `Where` guard admits only non-global namespaces, for which `GetNamespaceName` never returns null — so this asserts that contract in the C# itself with a null-forgiveness operator (`GetNamespaceName(...)!`). cs2gs maps C# `!` to G# `!!` and the oblivious analyzer stops the taint at the suppression, so the chain and the declared local agree (verified by translation: the element types as `string`).

Translator-side alternatives were rejected on #3564: blanket lambda-return bridging would also assert the FIRST `Select`, whose null `Symbol` flows by design into the `Where` filter; promoting the declared local cascades into every consumer.

Verification: Cs2Gs.Translator builds warning-clean; local pinned-Oahu gate 15/15 (the `!` is a C# no-op, translator behavior unchanged — only its own migration output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Six2MrhXHo6kQ8DSA6c1Pc