### PR TITLE
gsc: pre-seed while-pattern bindings in the lambda capture collector (#3501)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -2338,6 +2338,31 @@ internal sealed class LambdaBinder
 
             return base.RewriteAddressOfExpression(node);
         }
+
+        // Issue #3501: a `while value is T binding { … }` condition declares
+        // its pattern binding with no BoundVariableDeclaration, and the
+        // loop's bound shape places the BODY before the controlling
+        // condition — the same order dependency as the inline out-var above.
+        // A single in-order pass walks the binding's reads first and
+        // misclassifies them as enclosing-scope captures (GS9998 "no local
+        // slot" at emit), so pattern bindings are pre-seeded here too.
+        protected override BoundPattern RewritePattern(BoundPattern node)
+        {
+            switch (node)
+            {
+                case BoundDiscardPattern { Variable: not null } varPattern:
+                    this.Declared.Add(varPattern.Variable);
+                    break;
+                case BoundTypePattern { Variable: not null } typePattern:
+                    this.Declared.Add(typePattern.Variable);
+                    break;
+                case BoundSlicePattern { Variable: not null } slicePattern:
+                    this.Declared.Add(slicePattern.Variable);
+                    break;
+            }
+
+            return base.RewritePattern(node);
+        }
     }
 
     // ADR-0076 / issue #716: walks a bound block-expression body collecting

--- a/src/Core/CodeAnalysis/Compilation/Compilation.cs
+++ b/src/Core/CodeAnalysis/Compilation/Compilation.cs
@@ -395,6 +395,11 @@ public class Compilation
         }
         catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
         {
+            if (System.Environment.GetEnvironmentVariable("GS_DEBUG_STACK") != null)
+            {
+                System.Console.Error.WriteLine(ex.ToString());
+            }
+
             var diagnostic = CreateInternalErrorDiagnostic(ex);
             var combined = allWarnings.Add(diagnostic);
             return new EmitResult(success: false, combined);
@@ -544,6 +549,11 @@ public class Compilation
             // type) produces a structured GS9998 diagnostic anchored at the
             // offending source construct. Previously this only caught
             // NotSupportedException and InvalidOperationException (#519).
+            if (System.Environment.GetEnvironmentVariable("GS_DEBUG_STACK") != null)
+            {
+                System.Console.Error.WriteLine(ex.ToString());
+            }
+
             var diagnostic = CreateInternalErrorDiagnostic(ex);
             var combined = allWarnings.Add(diagnostic);
             return new EmitResult(success: false, combined);

--- a/test/Compiler.Tests/Emit/Issue3501LambdaWhilePatternCaptureTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3501LambdaWhilePatternCaptureTests.cs
@@ -1,0 +1,161 @@
+// <copyright file="Issue3501LambdaWhilePatternCaptureTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #3501: a `while value is T binding { … }` inside a function literal
+/// crashed emit with GS9998 ("Variable 'binding' has no local slot"). The
+/// loop's bound shape places the body before the controlling condition, so
+/// the lambda capture collector walked the pattern binding's reads before
+/// <c>RewritePattern</c> recorded the declaration and misclassified the
+/// binding as an enclosing-scope capture — the same order dependency inline
+/// out-vars had (issue #1451). Pattern bindings are now pre-seeded.
+/// </summary>
+public class Issue3501LambdaWhilePatternCaptureTests
+{
+    [Fact]
+    public void WhilePatternBindingInLambda_RunsCorrectly()
+    {
+        const string Source = """
+            package Issue3501
+            import System
+
+            class Box {
+                let Inner object
+                init(inner object) { Inner = inner }
+            }
+
+            func Unwrap(value object) object {
+                let unwrapCore = func (start object) object {
+                    var current = start
+                    while current is Box inner {
+                        current = inner.Inner
+                    }
+                    return current
+                }
+                return unwrapCore(value)
+            }
+
+            func Main() {
+                Console.WriteLine(Unwrap(Box(Box("x"))).ToString())
+            }
+            """;
+
+        Assert.Equal($"x{Environment.NewLine}", CompileAndRun(Source));
+    }
+
+    [Fact]
+    public void WhilePatternBindingInCapturingLambda_RunsCorrectly()
+    {
+        const string Source = """
+            package Issue3501
+            import System
+
+            class Box {
+                let Inner object
+                init(inner object) { Inner = inner }
+            }
+
+            func Unwrap(value object, depthLimit int32) object {
+                var limit = depthLimit
+                let unwrapCore = func (start object) object {
+                    var current = start
+                    while current is Box inner && limit > 0 {
+                        current = inner.Inner
+                        limit = limit - 1
+                    }
+                    return current
+                }
+                return unwrapCore(value)
+            }
+
+            func Main() {
+                Console.WriteLine(Unwrap(Box(Box("x")), 1).ToString())
+            }
+            """;
+
+        // depthLimit 1 unwraps exactly one Box; the result is the inner Box,
+        // whose ToString is the class name.
+        Assert.Equal($"Issue3501.Box{Environment.NewLine}", CompileAndRun(Source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var outputDirectory = Path.Combine(AppContext.BaseDirectory, "issue3501lambda", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(outputDirectory);
+        try
+        {
+            var sourcePath = Path.Combine(outputDirectory, "Program.gs");
+            var outputPath = Path.Combine(outputDirectory, "Issue3501Lambda.dll");
+            File.WriteAllText(sourcePath, source);
+
+            using var standardOut = new StringWriter();
+            using var standardError = new StringWriter();
+            var previousOut = Console.Out;
+            var previousError = Console.Error;
+            Console.SetOut(standardOut);
+            Console.SetError(standardError);
+            int exitCode;
+            try
+            {
+                exitCode = Program.Main(new[]
+                {
+                    "/out:" + outputPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    sourcePath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+                Console.SetError(previousError);
+            }
+
+            Assert.True(
+                exitCode == 0,
+                $"gsc failed:\nstdout:\n{standardOut}\nstderr:\n{standardError}");
+            IlVerifier.Verify(outputPath);
+            var assembly = Assembly.Load(File.ReadAllBytes(outputPath));
+            _ = assembly.GetTypes();
+            var entryPoint = assembly.EntryPoint
+                ?? throw new InvalidOperationException("Emitted assembly has no entry point.");
+
+            previousOut = Console.Out;
+            using var output = new StringWriter();
+            Console.SetOut(output);
+            try
+            {
+                entryPoint.Invoke(
+                    null,
+                    entryPoint.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+            }
+
+            return output.ToString();
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(outputDirectory, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
Part of #3501 — the last Translator self-migration blocker after #3576/#3577. `while value is T binding { … }` inside a function literal crashed emit with GS9998 ("Variable 'binding' has no local slot"), hit by the migrated `ObliviousNullabilityAnalyzer`'s nested unwrap helper.

Root cause: the loop's bound shape places the body before the controlling condition, so `CollectCapturedVariables` walked the pattern binding's reads before `RewritePattern` recorded the declaration and misclassified the lambda's **own** pattern local as an enclosing-scope capture. `EmitFunctionLiteral` then tried to load the "captured" local in the enclosing method, where it has no slot. This is the identical order dependency inline out-vars had (#1451); pattern bindings (`is T x`, slice captures) now join the same up-front declaration pre-pass.

Also honors `GS_DEBUG_STACK` at the inner `Compilation.Emit` catch so an emit-phase ICE prints its stack like the outer ring already does.

Verification: two runtime emit tests (non-capturing and capturing lambda, ilverify + executed output asserted); 654-test lambda/capture/closure/pattern Core sweep green; local pinned-Oahu gate 15/15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Six2MrhXHo6kQ8DSA6c1Pc