### PR TITLE
gsc: store a value-type T? through a byref with stobj, not the underlying stind (#3501)

### DIFF
--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
@@ -2120,6 +2120,20 @@ internal sealed partial class MethodBodyEmitter
     /// <summary>ADR-0039: Emits ldind.* or ldobj for loading a value through a managed pointer.</summary>
     private void EmitLoadIndirect(TypeSymbol pointeeType)
     {
+        // Issue #3501: a value-type `T?` pointee (e.g. an `out x int32?`
+        // parameter) stores/loads the full Nullable<T> struct, but
+        // NullableTypeSymbol borrows the UNDERLYING type's ClrType, so the
+        // primitive arms below would pick the bare-T ldind/stind form and
+        // desynchronize the stack from the Nullable<T> slot (ilverify
+        // StackUnexpected). Route through ldobj/stobj with the wrapper token.
+        if (pointeeType is NullableTypeSymbol loadNullable
+            && NullableLifting.IsAnyValueTypeNullable(loadNullable))
+        {
+            this.il.OpCode(ILOpCode.Ldobj);
+            this.il.Token(this.outer.memberRefs.GetElementTypeToken(pointeeType));
+            return;
+        }
+
         var clrType = pointeeType.ClrType;
         if (clrType.IsSameAs(typeof(int)) || clrType.IsSameAs(typeof(uint)))
         {
@@ -2172,6 +2186,16 @@ internal sealed partial class MethodBodyEmitter
     /// <summary>ADR-0056 §2: Emits stind.* or stobj to store a value through a managed pointer.</summary>
     private void EmitStoreIndirect(TypeSymbol pointeeType)
     {
+        // Issue #3501: see EmitLoadIndirect — a value-type `T?` pointee needs
+        // the Nullable<T> stobj, not the underlying primitive's stind.
+        if (pointeeType is NullableTypeSymbol storeNullable
+            && NullableLifting.IsAnyValueTypeNullable(storeNullable))
+        {
+            this.il.OpCode(ILOpCode.Stobj);
+            this.il.Token(this.outer.memberRefs.GetElementTypeToken(pointeeType));
+            return;
+        }
+
         var clrType = pointeeType.ClrType;
         if (clrType.IsSameAs(typeof(int)) || clrType.IsSameAs(typeof(uint)))
         {

--- a/test/Compiler.Tests/Emit/Issue3501NullableOutParameterStoreTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3501NullableOutParameterStoreTests.cs
@@ -1,0 +1,126 @@
+// <copyright file="Issue3501NullableOutParameterStoreTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #3501: assigning through an <c>out</c>/<c>ref</c> parameter of
+/// value-type nullable type (<c>out x int32?</c>) emitted <c>stind.i4</c>
+/// instead of <c>stobj Nullable&lt;int32&gt;</c> — NullableTypeSymbol borrows
+/// the UNDERLYING type's ClrType, so the indirect-store opcode selection saw
+/// a bare int (ilverify StackUnexpected; hit by the migrated Translator's
+/// <c>TryClassifyStructInitializerValue</c>). Load and store indirection now
+/// route value-type nullables through ldobj/stobj.
+/// </summary>
+public class Issue3501NullableOutParameterStoreTests
+{
+    [Fact]
+    public void NullableIntOutParameter_AssignsAndReads()
+    {
+        const string Source = """
+            package Issue3501
+            import System
+
+            func TryPick(value int32, out ordinal int32?) bool {
+                if value > 0 {
+                    ordinal = value
+                    return true
+                }
+                ordinal = nil
+                return false
+            }
+
+            func Main() {
+                var slot int32? = nil
+                if TryPick(7, out slot) {
+                    Console.WriteLine(slot!!.ToString())
+                }
+                var missing int32? = 3
+                if !TryPick(-1, out missing) {
+                    Console.WriteLine((missing == nil).ToString())
+                }
+            }
+            """;
+
+        Assert.Equal($"7{Environment.NewLine}True{Environment.NewLine}", CompileAndRun(Source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var outputDirectory = Path.Combine(AppContext.BaseDirectory, "issue3501nullout", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(outputDirectory);
+        try
+        {
+            var sourcePath = Path.Combine(outputDirectory, "Program.gs");
+            var outputPath = Path.Combine(outputDirectory, "Issue3501NullOut.dll");
+            File.WriteAllText(sourcePath, source);
+
+            using var standardOut = new StringWriter();
+            using var standardError = new StringWriter();
+            var previousOut = Console.Out;
+            var previousError = Console.Error;
+            Console.SetOut(standardOut);
+            Console.SetError(standardError);
+            int exitCode;
+            try
+            {
+                exitCode = Program.Main(new[]
+                {
+                    "/out:" + outputPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    sourcePath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+                Console.SetError(previousError);
+            }
+
+            Assert.True(
+                exitCode == 0,
+                $"gsc failed:\nstdout:\n{standardOut}\nstderr:\n{standardError}");
+            IlVerifier.Verify(outputPath);
+            var assembly = Assembly.Load(File.ReadAllBytes(outputPath));
+            _ = assembly.GetTypes();
+            var entryPoint = assembly.EntryPoint
+                ?? throw new InvalidOperationException("Emitted assembly has no entry point.");
+
+            previousOut = Console.Out;
+            using var output = new StringWriter();
+            Console.SetOut(output);
+            try
+            {
+                entryPoint.Invoke(
+                    null,
+                    entryPoint.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+            }
+
+            return output.ToString();
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(outputDirectory, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
Part of #3501 — found by the Translator self-migration's first-ever ilverify leg (run 17). Assigning through an `out`/`ref` parameter of value-type nullable type (`out x int32?`) emitted `stind.i4` instead of `stobj Nullable<int32>`.

Root cause: `NullableTypeSymbol` borrows the UNDERLYING type's `ClrType`, so `EmitStoreIndirect`'s opcode selection matched the bare-primitive arm and desynchronized the stack from the `Nullable<T>` slot — ilverify StackUnexpected in the migrated `TryClassifyStructInitializerValue` (`parameterOrdinal = parameter.Ordinal` against `out parameterOrdinal int32?`). Both `EmitLoadIndirect` and `EmitStoreIndirect` now route value-type nullables through `ldobj`/`stobj` with the wrapper token.

Verification: runtime emit test (assign + nil branch through `out int32?`, ilverify + executed output asserted); 817-test nullable/ref/indirection Core sweep green; local pinned-Oahu gate 15/15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Six2MrhXHo6kQ8DSA6c1Pc