### PR TITLE
cs2gs: scope the repository-mirror contract to the run and record its failures (#3580)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Cli/Program.cs
+++ b/tools/cs2gs/Cs2Gs.Cli/Program.cs
@@ -190,10 +190,25 @@ internal static class Program
             if (options.ExcludeAppIdPrefixes.Count > 0)
             {
                 int before = apps.Count;
-                apps = apps
-                    .Where(app => !options.ExcludeAppIdPrefixes.Any(prefix =>
+                var kept = new List<CorpusApp>(apps.Count);
+                foreach (CorpusApp app in apps)
+                {
+                    if (options.ExcludeAppIdPrefixes.Any(prefix =>
                         app.Id.StartsWith(prefix, StringComparison.Ordinal)))
-                    .ToList();
+                    {
+                        // Issue #3580: the orphan-mirror step must know which
+                        // projects left the run via --exclude — the sources
+                        // they compile are out of scope, not repository
+                        // orphans.
+                        options.ExcludedProjectPaths.Add(app.ProjectPath);
+                    }
+                    else
+                    {
+                        kept.Add(app);
+                    }
+                }
+
+                apps = kept;
                 Console.WriteLine($"cs2gs: excluded {before - apps.Count} project(s) via --exclude.");
             }
         }

--- a/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs
@@ -242,12 +242,28 @@ public sealed class MigrationPipeline
 
         if (repositoryLayout)
         {
+            RepositoryExcludedScope excludedScope = RepositoryExcludedScope.Compute(
+                this.options.SourceRoot,
+                this.options.ExcludedProjectPaths);
             if (runResult.Succeeded)
             {
-                RepositoryOrphanSourceTranslator.TranslateMissing(
+                // Issue #3580: an orphan-mirror failure marks the run failed
+                // (the nightly gate must still catch a checked-in C# file with
+                // no translatable mirror) but no longer throws — the report
+                // table and run.json land either way.
+                IReadOnlyList<string> orphanFailures = RepositoryOrphanSourceTranslator.TranslateMissing(
                     this.options.SourceRoot,
                     destinationRoot,
-                    repositoryFiles);
+                    repositoryFiles,
+                    excludedScope);
+                if (orphanFailures.Count > 0)
+                {
+                    runResult.Succeeded = false;
+                    foreach (string failure in orphanFailures)
+                    {
+                        Console.Error.WriteLine("cs2gs: " + failure);
+                    }
+                }
             }
 
             RepositorySolutionGenerator.Generate(
@@ -257,11 +273,23 @@ public sealed class MigrationPipeline
                 repositoryFiles);
             if (runResult.Succeeded)
             {
-                RepositoryMirror.ValidateCompleted(
-                    this.options.SourceRoot,
-                    destinationRoot,
-                    repositoryFiles,
-                    this.options.RepositoryAdditionalFiles);
+                try
+                {
+                    RepositoryMirror.ValidateCompleted(
+                        this.options.SourceRoot,
+                        destinationRoot,
+                        repositoryFiles,
+                        this.options.RepositoryAdditionalFiles,
+                        excludedScope);
+                }
+                catch (InvalidOperationException ex)
+                {
+                    // Issue #3580: same recorded-not-thrown contract as the
+                    // orphan step — completeness failures gate the run but
+                    // must not eat the report.
+                    runResult.Succeeded = false;
+                    Console.Error.WriteLine("cs2gs: " + ex.Message);
+                }
             }
         }
         else

--- a/tools/cs2gs/Cs2Gs.Pipeline/PipelineOptions.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/PipelineOptions.cs
@@ -4,6 +4,7 @@
 
 namespace Cs2Gs.Pipeline;
 
+using System;
 using System.Collections.Generic;
 using Cs2Gs.Translator.Loading;
 
@@ -69,6 +70,17 @@ public sealed class PipelineOptions
     /// app id.
     /// </summary>
     public List<string> ExcludeAppIdPrefixes { get; } = new List<string>();
+
+    /// <summary>
+    /// Gets the absolute <c>.csproj</c> paths of the apps that
+    /// <see cref="ExcludeAppIdPrefixes"/> filtered out of this run (issue
+    /// #3580). The orphan-mirror step skips checked-in sources these projects
+    /// compile — files under their directories and their explicit
+    /// <c>&lt;Compile Include&gt;</c> links (e.g. <c>test/Shared/*</c>): they
+    /// are out of the run's scope, not repository orphans, and standalone
+    /// translation of them is not meaningful.
+    /// </summary>
+    public List<string> ExcludedProjectPaths { get; } = new List<string>();
 
     /// <summary>
     /// Gets or sets the build configuration used to locate the default compiler

--- a/tools/cs2gs/Cs2Gs.Pipeline/RepositoryExcludedScope.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/RepositoryExcludedScope.cs
@@ -1,0 +1,117 @@
+// <copyright file="RepositoryExcludedScope.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Cs2Gs.Pipeline;
+
+/// <summary>
+/// Issue #3580: the checked-in sources a targeted run's <c>--exclude</c>
+/// removed from scope. The repository-mirror completeness contract (orphan
+/// translation and <see cref="RepositoryMirror.ValidateCompleted"/>) applies
+/// only to in-scope files — out-of-scope sources are not orphans and have no
+/// mirrors to validate. The scope is each excluded project's own directory
+/// plus any explicit non-wildcard <c>&lt;Compile Include&gt;</c> item
+/// resolving inside the repository (shared linked sources such as
+/// <c>test/Shared/*</c> live outside every project directory).
+/// </summary>
+internal sealed class RepositoryExcludedScope
+{
+    /// <summary>An empty scope: every repository file is in scope.</summary>
+    internal static readonly RepositoryExcludedScope None = new(
+        new List<string>(),
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+
+    private readonly List<string> directories;
+    private readonly HashSet<string> compileFiles;
+
+    private RepositoryExcludedScope(List<string> directories, HashSet<string> compileFiles)
+    {
+        this.directories = directories;
+        this.compileFiles = compileFiles;
+    }
+
+    /// <summary>
+    /// Computes the excluded scope for the given projects.
+    /// </summary>
+    /// <param name="sourceRoot">The migrated repository's source root.</param>
+    /// <param name="excludedProjectPaths">Absolute <c>.csproj</c> paths excluded from the run, or <see langword="null"/>.</param>
+    /// <returns>The derived scope; <see cref="None"/> when nothing was excluded.</returns>
+    internal static RepositoryExcludedScope Compute(
+        string sourceRoot,
+        IReadOnlyCollection<string> excludedProjectPaths)
+    {
+        if (excludedProjectPaths == null || excludedProjectPaths.Count == 0)
+        {
+            return None;
+        }
+
+        var directories = new List<string>();
+        var compileFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        string fullSourceRoot = Path.GetFullPath(sourceRoot);
+        foreach (string projectPath in excludedProjectPaths)
+        {
+            string projectDirectory = Path.GetDirectoryName(Path.GetFullPath(projectPath));
+            string relativeDirectory = Path.GetRelativePath(fullSourceRoot, projectDirectory)
+                .Replace('\\', '/');
+            if (relativeDirectory.Length > 0
+                && relativeDirectory != "."
+                && !relativeDirectory.StartsWith("..", StringComparison.Ordinal))
+            {
+                directories.Add(relativeDirectory);
+            }
+
+            foreach (DeclaredProjectItem item in DeclaredProjectItems.Read(projectPath, "Compile"))
+            {
+                string include = item.Element.Attribute("Include")?.Value;
+                if (string.IsNullOrEmpty(include)
+                    || include.Contains("$(", StringComparison.Ordinal)
+                    || include.Contains("@(", StringComparison.Ordinal)
+                    || include.Contains('*', StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                string fullInclude = Path.GetFullPath(Path.Combine(
+                    projectDirectory,
+                    include.Replace('\\', Path.DirectorySeparatorChar)
+                        .Replace('/', Path.DirectorySeparatorChar)));
+                string relativeInclude = Path.GetRelativePath(fullSourceRoot, fullInclude)
+                    .Replace('\\', '/');
+                if (!relativeInclude.StartsWith("..", StringComparison.Ordinal))
+                {
+                    compileFiles.Add(relativeInclude);
+                }
+            }
+        }
+
+        return new RepositoryExcludedScope(directories, compileFiles);
+    }
+
+    /// <summary>
+    /// Returns whether a repository-relative ('/'-separated) source path is
+    /// out of the run's scope.
+    /// </summary>
+    /// <param name="relativePath">The repository-relative source path.</param>
+    /// <returns><see langword="true"/> when the file belongs to an excluded project.</returns>
+    internal bool IsExcluded(string relativePath)
+    {
+        if (this.compileFiles.Contains(relativePath))
+        {
+            return true;
+        }
+
+        foreach (string directory in this.directories)
+        {
+            if (relativePath.StartsWith(directory + "/", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Pipeline/RepositoryMirror.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/RepositoryMirror.cs
@@ -46,10 +46,26 @@ internal static class RepositoryMirror
         string sourceRoot,
         string destinationRoot,
         IReadOnlyList<string> sourceFiles,
-        IEnumerable<string> additionalFiles = null)
+        IEnumerable<string> additionalFiles = null,
+        RepositoryExcludedScope excludedScope = null)
     {
+        // Issue #3580: sources a targeted run's --exclude removed from scope
+        // have no TRANSLATED mirrors by design — the completeness contract
+        // applies only to in-scope files. Only the translated shapes are
+        // filtered (.cs → .gs, .csproj → .gsproj); every other file was
+        // copied verbatim by Prepare regardless of scope and stays expected.
+        excludedScope ??= RepositoryExcludedScope.None;
         var expected = new HashSet<string>(
-            sourceFiles.Select(DestinationRelativePath),
+            sourceFiles
+                .Where(path =>
+                {
+                    string extension = Path.GetExtension(path);
+                    bool translated =
+                        extension.Equals(".cs", StringComparison.OrdinalIgnoreCase)
+                        || extension.Equals(".csproj", StringComparison.OrdinalIgnoreCase);
+                    return !translated || !excludedScope.IsExcluded(path);
+                })
+                .Select(DestinationRelativePath),
             StringComparer.OrdinalIgnoreCase);
         if (additionalFiles is not null)
         {
@@ -63,9 +79,15 @@ internal static class RepositoryMirror
             expected.Add(new DirectoryInfo(Path.GetFullPath(sourceRoot)).Name + ".slnx");
         }
 
+        // Issue #3580: compiling the mirrored projects (the via-sdk stage
+        // builds INSIDE the destination) leaves bin/obj build outputs there.
+        // The source inventory never lists those directories, so the
+        // destination walk must skip them by the same rule or every build
+        // artifact reads as "unexpected".
         var actual = new HashSet<string>(
             Directory.EnumerateFiles(destinationRoot, "*", SearchOption.AllDirectories)
-                .Select(path => Path.GetRelativePath(destinationRoot, path)),
+                .Select(path => Path.GetRelativePath(destinationRoot, path))
+                .Where(path => !RepositoryFileInventory.HasExcludedDirectory(path)),
             StringComparer.OrdinalIgnoreCase);
 
         string missing = expected.Except(actual, StringComparer.OrdinalIgnoreCase).OrderBy(x => x).FirstOrDefault();

--- a/tools/cs2gs/Cs2Gs.Pipeline/RepositoryOrphanSourceTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/RepositoryOrphanSourceTranslator.cs
@@ -17,14 +17,37 @@ namespace Cs2Gs.Pipeline;
 /// <summary>Translates inventoried C# files excluded from every project compilation.</summary>
 internal static class RepositoryOrphanSourceTranslator
 {
-    internal static void TranslateMissing(
+    /// <summary>
+    /// Translates each orphaned C# file into its checked-in G# mirror.
+    /// Issue #3580: failures are RECORDED, not thrown — this step runs after
+    /// every app already succeeded, and an exception here used to abort the
+    /// run before the report table and <c>run.json</c> were written. Files
+    /// under a project directory that <c>--exclude</c> removed from the run
+    /// are skipped entirely: they are out of scope, not orphans, and their
+    /// standalone translation (single-file, no project references) proves
+    /// nothing.
+    /// </summary>
+    /// <param name="sourceRoot">The migrated repository's source root.</param>
+    /// <param name="destinationRoot">The mirror destination root.</param>
+    /// <param name="sourceFiles">The repository-relative inventory ('/'-separated).</param>
+    /// <param name="excludedScope">The out-of-scope source set, or <see langword="null"/> for none.</param>
+    /// <returns>The failure messages, one per file that could not be mirrored; empty on success.</returns>
+    internal static IReadOnlyList<string> TranslateMissing(
         string sourceRoot,
         string destinationRoot,
-        IReadOnlyList<string> sourceFiles)
+        IReadOnlyList<string> sourceFiles,
+        RepositoryExcludedScope excludedScope = null)
     {
+        excludedScope ??= RepositoryExcludedScope.None;
+        var failures = new List<string>();
         foreach (string relativePath in sourceFiles.Where(path =>
             Path.GetExtension(path).Equals(".cs", StringComparison.OrdinalIgnoreCase)))
         {
+            if (excludedScope.IsExcluded(relativePath))
+            {
+                continue;
+            }
+
             string destinationPath = Path.Combine(
                 destinationRoot,
                 Path.ChangeExtension(relativePath, ".gs"));
@@ -52,21 +75,25 @@ internal static class RepositoryOrphanSourceTranslator
                 .FirstOrDefault();
             if (unsupported is not null)
             {
-                throw new InvalidOperationException(
+                failures.Add(
                     $"Checked-in C# file '{relativePath}' is excluded from all projects and " +
                     $"could not be translated independently: {unsupported}");
+                continue;
             }
 
             RoundTripResult roundTrip = GSharpRoundTrip.Validate(generated);
             if (!roundTrip.Success)
             {
-                throw new InvalidOperationException(
+                failures.Add(
                     $"Checked-in C# file '{relativePath}' is excluded from all projects and " +
                     $"its independent translation did not parse: {roundTrip.Errors.FirstOrDefault()}");
+                continue;
             }
 
             Directory.CreateDirectory(Path.GetDirectoryName(destinationPath));
             File.WriteAllText(destinationPath, generated);
         }
+
+        return failures;
     }
 }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3580OrphanMirrorRobustnessTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3580OrphanMirrorRobustnessTests.cs
@@ -1,0 +1,138 @@
+// <copyright file="Issue3580OrphanMirrorRobustnessTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3580: the orphan-mirror step runs after every app already
+/// succeeded, so it must not abort the run. Failures are returned (the
+/// pipeline marks the run failed and still writes the report), and files
+/// under a project directory removed via <c>--exclude</c> are out of scope,
+/// not orphans — they are skipped entirely.
+/// </summary>
+public class Issue3580OrphanMirrorRobustnessTests : IDisposable
+{
+    private readonly string root;
+
+    public Issue3580OrphanMirrorRobustnessTests()
+    {
+        this.root = Path.Combine(Path.GetTempPath(), "cs2gs-3580-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(this.root, "src"));
+        Directory.CreateDirectory(Path.Combine(this.root, "out"));
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(this.root, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+
+    [Fact]
+    public void TranslatableOrphan_IsMirrored()
+    {
+        this.WriteSource("src/Lone.cs", "namespace Demo { public static class Lone { public static int Answer() => 42; } }");
+
+        var failures = RepositoryOrphanSourceTranslator.TranslateMissing(
+            Path.Combine(this.root, "src"),
+            Path.Combine(this.root, "out"),
+            new[] { "Lone.cs" });
+
+        Assert.Empty(failures);
+        Assert.True(File.Exists(Path.Combine(this.root, "out", "Lone.gs")));
+    }
+
+    [Fact]
+    public void UntranslatableOrphan_IsRecordedNotThrown_AndOthersStillMirror()
+    {
+        // References a type no single-file in-memory load can resolve, so the
+        // translator emits the placeholder type and an Unsupported diagnostic.
+        this.WriteSource(
+            "src/Broken.cs",
+            "namespace Demo { public class Broken { public Some.Missing.Type Field; } }");
+        this.WriteSource("src/Fine.cs", "namespace Demo { public static class Fine { public static int One() => 1; } }");
+
+        var failures = RepositoryOrphanSourceTranslator.TranslateMissing(
+            Path.Combine(this.root, "src"),
+            Path.Combine(this.root, "out"),
+            new[] { "Broken.cs", "Fine.cs" });
+
+        Assert.Single(failures);
+        Assert.Contains("Broken.cs", failures[0]);
+        Assert.False(File.Exists(Path.Combine(this.root, "out", "Broken.gs")));
+        Assert.True(File.Exists(Path.Combine(this.root, "out", "Fine.gs")));
+    }
+
+    [Fact]
+    public void FileUnderExcludedProjectDirectory_IsSkipped()
+    {
+        // The file is untranslatable standalone — but its project was
+        // --exclude'd, so the orphan step must not touch it at all.
+        this.WriteSource(
+            "src/Analyzers/Testing/Verifier.cs",
+            "namespace Demo { public class Verifier { public Some.Missing.Type Field; } }");
+        this.WriteSource(
+            "src/Analyzers/Testing/Testing.csproj",
+            "<Project Sdk=\"Microsoft.NET.Sdk\"></Project>");
+
+        RepositoryExcludedScope scope = RepositoryExcludedScope.Compute(
+            Path.Combine(this.root, "src"),
+            new[] { Path.Combine(this.root, "src", "Analyzers", "Testing", "Testing.csproj") });
+        var failures = RepositoryOrphanSourceTranslator.TranslateMissing(
+            Path.Combine(this.root, "src"),
+            Path.Combine(this.root, "out"),
+            new[] { "Analyzers/Testing/Verifier.cs" },
+            scope);
+
+        Assert.Empty(failures);
+        Assert.False(File.Exists(Path.Combine(this.root, "out", "Analyzers", "Testing", "Verifier.gs")));
+    }
+
+    [Fact]
+    public void SharedFileLinkedByExcludedProject_IsSkipped()
+    {
+        // Issue #3580 round 2: a shared source (test/Shared/*) linked via an
+        // explicit <Compile Include> lives outside every project directory —
+        // the excluded project's declared items must carry it out of scope.
+        this.WriteSource(
+            "src/Shared/Oracle.cs",
+            "namespace Demo { public class Oracle { public Some.Missing.Type Field; } }");
+        this.WriteSource(
+            "src/Tests/Tests.csproj",
+            "<Project Sdk=\"Microsoft.NET.Sdk\"><ItemGroup>" +
+            "<Compile Include=\"..\\Shared\\Oracle.cs\" Link=\"Oracle.cs\" />" +
+            "</ItemGroup></Project>");
+
+        RepositoryExcludedScope scope = RepositoryExcludedScope.Compute(
+            Path.Combine(this.root, "src"),
+            new[] { Path.Combine(this.root, "src", "Tests", "Tests.csproj") });
+        var failures = RepositoryOrphanSourceTranslator.TranslateMissing(
+            Path.Combine(this.root, "src"),
+            Path.Combine(this.root, "out"),
+            new[] { "Shared/Oracle.cs" },
+            scope);
+
+        Assert.Empty(failures);
+        Assert.False(File.Exists(Path.Combine(this.root, "out", "Shared", "Oracle.gs")));
+    }
+
+    private void WriteSource(string relativePath, string content)
+    {
+        string path = Path.Combine(this.root, relativePath.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(path));
+        File.WriteAllText(path, content);
+    }
+}


### PR DESCRIPTION
Closes #3580 (part of #3501). A targeted `--exclude` run that went fully green then died with exit 2 before the report table — and behind that first crash sat two more latent post-success killers that had never executed before (no targeted run had ever reached them). All three fixed:

1. **Out-of-scope ≠ orphan.** New `RepositoryExcludedScope`, derived from the excluded apps' project paths: each project's own directory plus its explicit non-wildcard `<Compile Include>` links (shared sources like `test/Shared/EmittedOracle.cs` live outside every project directory). The orphan-mirror step and `ValidateCompleted`'s translated shapes (`.cs → .gs`, `.csproj → .gsproj`) skip them; true orphans stay gated even in targeted runs.
2. **Recorded, not thrown.** Orphan-translation and mirror-completeness failures mark the run failed — the nightly gate still catches a checked-in C# file with no translatable mirror — but the report table and `run.json` always land, and the exit code distinguishes "ran and found gaps" (1) from "tool errored" (2).
3. **Build outputs aren't "unexpected".** The via-sdk compile stage builds inside the destination; `ValidateCompleted`'s destination walk now skips `bin`/`obj` outputs by the same `RepositoryFileInventory.HasExcludedDirectory` rule as the source inventory. (Latent for the full nightly too — it has never reached `ValidateCompleted` with a green run.)

Verification: 4 new unit tests (`Issue3580OrphanMirrorRobustnessTests`: translatable orphan mirrored; untranslatable orphan recorded not thrown while others still mirror; excluded-directory skip; shared-linked-file skip); 13-test mirror/orphan sweep green; local pinned-Oahu gate 15/15; and the end-to-end targeted 3-app run now prints its table and exits 0: **3/3 apps green; run PASSED**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Six2MrhXHo6kQ8DSA6c1Pc