### PR TITLE
selfmig gate: build the Debug bootstrap prerequisites before migrating (#3501)

### DIFF
--- a/build/run-cs2gs-selfmig.sh
+++ b/build/run-cs2gs-selfmig.sh
@@ -35,6 +35,17 @@ work_root=$(cd "$work_root" && pwd -P)
 migrated_dir="$work_root/migrated"
 runs_dir="$work_root/runs"
 
+# MSBuildWorkspace design-time project loads evaluate in Debug regardless of
+# --config Release, and Gsharp.Extensions.csproj's Bootstrap SDK import
+# hard-errors when out/bin/Debug/{Compiler/gsc.dll, Gsharp.NET.Sdk/
+# Gsharp.NET.Sdk.dll} are missing — which fails ProjectLoad (CS2GS0001) for
+# every app that transitively references Gsharp.Extensions (Repl, the
+# Compiler/Extensions/Interpreter test projects, ...). Build both Debug
+# prerequisites up front; the Compiler must come first because the SDK build
+# compiles Gsharp.Extensions' .gs sources with the bootstrap gsc.
+dotnet build "$repo_root/src/Compiler/Compiler.csproj" -c Debug -graph
+dotnet build "$repo_root/src/Sdk/Gsharp.NET.Sdk/Gsharp.NET.Sdk.csproj" -c Debug -graph
+
 set +e
 dotnet "$repo_root/out/bin/Release/Cs2Gs.Cli/cs2gs.dll" migrate \
   --corpus "$repo_root" \


### PR DESCRIPTION
## Summary

Part of the #3501 slice "widen the migration gate beyond the 3-app chain (29/55 → 57/57)".

Five corpus apps fail the self-migration gate at **ProjectLoad** (`CS2GS0001`) before a single document is translated: `src/Repl`, `src/Sdk/Gsharp.Extensions`, `test/Compiler.Tests`, `test/Extensions.Tests`, `test/Interpreter.Tests`. Root cause: MSBuildWorkspace design-time loads evaluate in **Debug** regardless of `--config Release`, and the `Gsharp.NET.Sdk.Bootstrap` import in `Gsharp.Extensions.csproj` hard-errors when `out/bin/Debug/Compiler/gsc.dll` / `out/bin/Debug/Gsharp.NET.Sdk/Gsharp.NET.Sdk.dll` are missing — the nightly only builds `Cs2Gs.Cli` in Release, so every app transitively referencing Gsharp.Extensions dies at workspace load.

Fix: the gate script builds the two Debug prerequisites up front (Compiler first — the SDK build compiles Gsharp.Extensions' `.gs` sources with the bootstrap gsc).

## Verification

- Local targeted `src/Repl` migration reproduces the exact nightly fingerprint (`d6e6b9b6a375`) without the Debug outputs, and **passes translate** with them (remaining compile errors in the targeted run are the expected missing-dependency cascade from `--exclude`ing Core/LanguageServer).
- `bash -n` clean.

Not covered here (follow-ups): the `src/vs-gsharp` pair fails ProjectLoad for a different root (`net472` targeting pack absent on Linux), and the deeper fix of threading `--config` into the MSBuildWorkspace load (which would also retire the stale-Debug-ref local trap) has golden-baseline blast radius (`#if DEBUG` semantics) and deserves its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeaEdjqNURnncQ4qAdr4e2