### PR TITLE
gsc: give each spiller pass its own spill-temp name domain (#3592)

### DIFF
--- a/src/Core/CodeAnalysis/Lowering/Async/GeneratedNames.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/GeneratedNames.cs
@@ -88,8 +88,19 @@ public static class GeneratedNames
     /// Returns the name of a reusable hoisted temp introduced by the spiller
     /// (analogue of Roslyn's <c>&lt;&gt;7__wrapN</c>).
     /// </summary>
-    /// <param name="ordinal">A per-method monotonic ordinal.</param>
+    /// <param name="ordinal">A per-spiller-pass monotonic ordinal.</param>
+    /// <param name="domain">A pass-distinguishing tag appended to the shared
+    /// prefix. A method body can run through SEVERAL spiller passes
+    /// (control-flow block lifting during general lowering, iterator block
+    /// lifting, and the async await spiller), each with its own ordinal
+    /// counter starting at zero — without a domain tag two passes both mint
+    /// <c>&lt;&gt;7__wrap0</c> with different types, and the async state
+    /// machine (which maps hoisted locals to fields by name) silently binds
+    /// both to one field (issue #3592, ilverify StackUnexpected). Every name
+    /// still starts with <see cref="SpillTempPrefix"/> so
+    /// <see cref="AsyncCaptureWalker"/>'s prefix detection keeps hoisting
+    /// them.</param>
     /// <returns>The mangled spill-temp field name.</returns>
-    public static string SpillTempField(int ordinal)
-        => SpillTempPrefix + ordinal.ToString(System.Globalization.CultureInfo.InvariantCulture);
+    public static string SpillTempField(int ordinal, string domain = "")
+        => SpillTempPrefix + domain + ordinal.ToString(System.Globalization.CultureInfo.InvariantCulture);
 }

--- a/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
@@ -212,6 +212,13 @@ public static class SpillSequenceSpiller
         private readonly bool includeYieldInBlockExpressions;
         private readonly bool includeControlFlowInBlockExpressions;
 
+        // Issue #3592: each spiller pass names its temps in its own domain
+        // ("c" = control-flow block lifting, "y" = iterator block lifting,
+        // "" = the async await spiller) so passes running over the SAME method
+        // body never mint two same-named locals with different types — the
+        // async state machine maps hoisted locals to fields by name.
+        private readonly string spillTempDomain;
+
         private int spillOrdinal;
 
         public Spiller(
@@ -220,6 +227,10 @@ public static class SpillSequenceSpiller
         {
             this.includeYieldInBlockExpressions = includeYieldInBlockExpressions;
             this.includeControlFlowInBlockExpressions = includeControlFlowInBlockExpressions;
+            this.spillTempDomain =
+                includeControlFlowInBlockExpressions ? "c" :
+                includeYieldInBlockExpressions ? "y" :
+                string.Empty;
         }
 
         public BoundBlockStatement RewriteBlock(BoundBlockStatement block)
@@ -3025,7 +3036,7 @@ public static class SpillSequenceSpiller
 
         private LocalVariableSymbol MakeSpillTemp(TypeSymbol type)
         {
-            var name = GeneratedNames.SpillTempField(spillOrdinal++);
+            var name = GeneratedNames.SpillTempField(spillOrdinal++, spillTempDomain);
             return new LocalVariableSymbol(name, isReadOnly: false, type);
         }
 

--- a/test/Compiler.Tests/Emit/Issue3592SpillTempNameCollisionTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3592SpillTempNameCollisionTests.cs
@@ -1,0 +1,149 @@
+// <copyright file="Issue3592SpillTempNameCollisionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #3592: a method body can pass through SEVERAL spiller passes — the
+/// control-flow block lifter during general lowering, then the async await
+/// spiller — and each started its <c>&lt;&gt;7__wrapN</c> ordinal at zero.
+/// Two same-named locals with DIFFERENT types collided in the async state
+/// machine, which maps hoisted locals to fields by name: a generic async
+/// method whose if-expression arm throws before its trailing value stored the
+/// await's <c>TResult</c> through the class-typed wrap field (ilverify
+/// StackUnexpected; the migrated <c>GSharpLanguageServerRpc.InvokeAsync</c>
+/// wall). Each pass now names its temps in a distinct domain.
+/// </summary>
+public class Issue3592SpillTempNameCollisionTests
+{
+    [Fact]
+    public void GenericAsync_ThrowingIfExpressionArm_VerifiesAndRuns()
+    {
+        const string Source = """
+            package Issue3592
+
+            import System
+            import System.Threading.Tasks
+
+            class Rpc {
+                async func Get[T](name string) T {
+                    await Task.Delay(1)
+                    return default(T)
+                }
+            }
+
+            class Client {
+                private var rpc Rpc? = nil
+                private var ready bool = false
+
+                internal func Attach(connection Rpc) {
+                    rpc = connection
+                    ready = true
+                }
+
+                internal async func Invoke[TResult](method string) TResult {
+                    var current Rpc
+                    current = if ready && rpc != nil { rpc!! } else { throw InvalidOperationException("not ready")
+                        default(Rpc) }
+                    return await current.Get[TResult](method)
+                }
+            }
+
+            func Main() {
+                let c = Client()
+                c.Attach(Rpc())
+                let n = c.Invoke[int32]("answer").GetAwaiter().GetResult()
+                Console.WriteLine(n.ToString())
+                let missing = Client()
+                var threw = false
+                try {
+                    missing.Invoke[int32]("nope").GetAwaiter().GetResult()
+                } catch (ex InvalidOperationException) {
+                    threw = true
+                }
+                Console.WriteLine(threw.ToString())
+            }
+            """;
+
+        Assert.Equal($"0{Environment.NewLine}True{Environment.NewLine}", CompileAndRun(Source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var outputDirectory = Path.Combine(AppContext.BaseDirectory, "issue3592spill", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(outputDirectory);
+        try
+        {
+            var sourcePath = Path.Combine(outputDirectory, "Program.gs");
+            var outputPath = Path.Combine(outputDirectory, "Issue3592Spill.dll");
+            File.WriteAllText(sourcePath, source);
+
+            using var standardOut = new StringWriter();
+            using var standardError = new StringWriter();
+            var previousOut = Console.Out;
+            var previousError = Console.Error;
+            Console.SetOut(standardOut);
+            Console.SetError(standardError);
+            int exitCode;
+            try
+            {
+                exitCode = Program.Main(new[]
+                {
+                    "/out:" + outputPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    sourcePath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+                Console.SetError(previousError);
+            }
+
+            Assert.True(
+                exitCode == 0,
+                $"gsc failed:\nstdout:\n{standardOut}\nstderr:\n{standardError}");
+            IlVerifier.Verify(outputPath);
+            var assembly = Assembly.Load(File.ReadAllBytes(outputPath));
+            _ = assembly.GetTypes();
+            var entryPoint = assembly.EntryPoint
+                ?? throw new InvalidOperationException("Emitted assembly has no entry point.");
+
+            previousOut = Console.Out;
+            using var output = new StringWriter();
+            Console.SetOut(output);
+            try
+            {
+                entryPoint.Invoke(
+                    null,
+                    entryPoint.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+            }
+
+            return output.ToString();
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(outputDirectory, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #3592 — the last red stage (ilverify `StackUnexpected`) for `src/vs-gsharp/test/VsGsharp.UnitTests` in the #3501 repo self-migration.

A method body can run through several spiller passes: the control-flow block lifter during general lowering (#3355), the iterator block lifter, and the async await spiller. Each `Spiller` instance started its `<>7__wrapN` ordinal at zero, so two passes over the same body could mint two locals **both named `<>7__wrap0` with different types**. The async state machine maps hoisted locals to fields **by name** — in the repro (a generic async method whose if-expression arm throws before its trailing value), the await's `TResult` result was stored through the `Rpc`-typed `<>7__wrap0` field minted earlier by the control-flow pass:

```
IL_013e: call !0 TaskAwaiter`1<!TResult>::GetResult()
IL_0143: stfld class ar3.Rpc ...::'<>7__wrap0'   // TResult into an Rpc field
```

Fix: each pass appends a domain tag to the shared prefix — `<>7__wrapc0` (control-flow), `<>7__wrapy0` (iterator), `<>7__wrap0` (await spiller) — so names are unique per method while `AsyncCaptureWalker`'s `<>7__wrap` prefix detection keeps hoisting them.

## Verification

- The minimal repro and the original `GSharpLanguageServerRpc.InvokeAsync` shape (lock + throwing if-expression arm + generic double-await) both ilverify clean and run.
- New `Issue3592SpillTempNameCollisionTests` emit test: compile → ilverify → execute success AND throwing paths.
- 424-test Async/Spill/Iterator `Compiler.Tests` sweep green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeaEdjqNURnncQ4qAdr4e2