### PR TITLE
gsc: a package sees referenced assemblies' types in its own namespace (#3595)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundScope.cs
@@ -688,6 +688,21 @@ public sealed class BoundScope
             }
         }
 
+        // Issue #3595 (#3501): CLR namespaces merge across assemblies, and a
+        // G# package is the same construct — a file in `package X` sees a
+        // REFERENCED assembly's exported types in namespace X without
+        // spelling `import X` (the C#→G# migration splits one namespace
+        // across project boundaries). A fallback AFTER every explicit import
+        // has failed: it can resolve previously-unresolvable names but never
+        // introduces a new ambiguity or changes source-package
+        // disambiguation.
+        if (GetCurrentDeclaringPackage() is { Length: > 0 } declaringPackage
+            && References.TryResolveType(declaringPackage + "." + mangled, out var selfPackageType))
+        {
+            type = selfPackageType;
+            return true;
+        }
+
         return false;
     }
 
@@ -757,6 +772,21 @@ public sealed class BoundScope
                     references: References);
                 return true;
             }
+        }
+
+        // Issue #3595 (#3501): same self-package fallback as
+        // TryLookupImportedGenericClass — a file in `package X` sees a
+        // referenced assembly's namespace-X types after every explicit
+        // import has failed to resolve the name.
+        if (GetCurrentDeclaringPackage() is { Length: > 0 } declaringPackage
+            && References.TryResolveType(declaringPackage + "." + name, out var selfPackageType)
+            && !selfPackageType.IsGenericTypeDefinition)
+        {
+            importedClass = new ImportedClassSymbol(
+                selfPackageType,
+                declaration,
+                references: References);
+            return true;
         }
 
         importedClass = null;

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3595SelfPackageImportedTypeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3595SelfPackageImportedTypeTests.cs
@@ -1,0 +1,84 @@
+// <copyright file="Issue3595SelfPackageImportedTypeTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #3595 (#3501): CLR namespaces merge across assemblies, and a G#
+/// package is the same construct — a file in <c>package X</c> must see a
+/// REFERENCED assembly's exported types in namespace X without spelling
+/// <c>import X</c>. The C#→G# self-migration splits one namespace across
+/// project boundaries (Cs2Gs.ProjectLoading declares types in the referenced
+/// Translator assembly's <c>Cs2Gs.Translator.Loading</c> namespace), and the
+/// missing merge made every such cross-assembly reference GS0113.
+/// </summary>
+public class Issue3595SelfPackageImportedTypeTests
+{
+    [Fact]
+    public void SamePackage_TypeFromReferencedAssembly_ResolvesWithoutImport()
+    {
+        var outputDir = Path.Combine(AppContext.BaseDirectory, "Issue3595");
+        Directory.CreateDirectory(outputDir);
+
+        var libraryPath = Path.Combine(outputDir, "Issue3595.Library.dll");
+        var library = new Compilation(
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package Shared.Loading
+
+                open class Doc {
+                    prop Path string -> "p"
+                }
+
+                open class Doc2[T] {
+                    prop Value T? -> nil
+                }
+                """)))
+        {
+            IsLibrary = true,
+        };
+
+        using (var peStream = File.Create(libraryPath))
+        {
+            var libraryResult = library.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "Issue3595.Library");
+            Assert.True(libraryResult.Success, string.Join(Environment.NewLine, libraryResult.Diagnostics));
+        }
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+        resolver.CurrentAssemblyName = "Issue3595.Consumer";
+
+        var consumer = new Compilation(
+            resolver,
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package Shared.Loading
+
+                class Holder {
+                    func Describe(d Doc) string {
+                        return d.Path
+                    }
+
+                    func First(d Doc2[string]) string? {
+                        return d.Value
+                    }
+                }
+                """)))
+        {
+            IsLibrary = true,
+        };
+
+        using var consumerStream = new MemoryStream();
+        var result = consumer.Emit(consumerStream, pdbStream: null, refStream: null, assemblyName: "Issue3595.Consumer");
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #3595 — the widest remaining wall in the #3501 self-migration gate: ~22 distinct GS0113/GS0158/GS0159 errors in `Cs2Gs.ProjectLoading` (gating the whole cs2gs tool family: Cli, Pipeline, Report) all reduce to one missing language behavior. CLR namespaces merge across assemblies; a G# `package X` file could not see a referenced assembly's exported namespace-X types without an explicit `import X`. The migration splits `Cs2Gs.Translator.Loading` across two projects, so every cross-assembly reference (`LoadedDocument`, `TranslationContext`, …) failed.

## Approach

A compilation-wide implicit `import <package>` seed was tried first and is **wrong** — it breaks per-file import disambiguation (28 failures across the #2455/#2456 suites, "ambiguous between two or more imported packages"). The landed fix is a scoped **fallback** in `BoundScope.TryLookupImportedGenericClass` / `TryLookupImportedClassByArity`: after every explicit import fails to resolve the name, try `<current declaring package>.<name>` against the reference resolver. It runs only when nothing else resolved, so it can green previously-unresolvable names but cannot introduce new ambiguities or change source-package disambiguation.

## Verification

- 10-line two-assembly repro (`package Shared.Loading` in both, no import) compiles.
- New `Issue3595SelfPackageImportedTypeTests`: non-generic and generic imported types resolved cross-assembly with no import spelled.
- 856-test Import/Package/Alias `Core.Tests` sweep green (the same sweep that caught the wrong global-seed approach).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeaEdjqNURnncQ4qAdr4e2