### PR TITLE
gsc: satisfy an imported-class constraint from a source derived class (#3501)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -6295,9 +6295,29 @@ public sealed class Binder
 
         // Imported reference class: use CLR assignability when both project to a
         // CLR type.
-        if (classConstraint.ClrType is { } constraintClr && typeArgument.ClrType is { } argClr)
+        if (classConstraint.ClrType is { } constraintClr)
         {
-            return constraintClr.IsAssignableFrom(argClr);
+            if (typeArgument.ClrType is { } argClr)
+            {
+                return constraintClr.IsAssignableFrom(argClr);
+            }
+
+            // Issue #3501: a SOURCE class deriving (possibly through source
+            // bases) from an imported CLR base has no ClrType of its own —
+            // walk the source base chain to the first ImportedBaseType and
+            // check CLR assignability there (`class Derived : ImportedBase`
+            // must satisfy `[T ImportedBase]`).
+            if (typeArgument is StructSymbol sourceClass)
+            {
+                for (var current = sourceClass; current != null; current = current.BaseClass)
+                {
+                    if (current.ImportedBaseType?.ClrType is { } importedBaseClr
+                        && constraintClr.IsAssignableFrom(importedBaseClr))
+                    {
+                        return true;
+                    }
+                }
+            }
         }
 
         return false;

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -1949,16 +1949,8 @@ internal sealed class MemberLookup
 
         switch (t)
         {
-            case TypeParameterSymbol typeParam:
-                // Issue #3501: a type parameter with a CLR-backed class
-                // constraint erases to that class, not bare `object` — a
-                // `[T Base init()]`-typed argument passed to an imported
-                // `Base`-typed parameter must gate as assignable
-                // (`ImmutableArray.Create[Base](T())`, the
-                // GSharpAnalyzerVerifier wall). Erasing tighter is sound for
-                // gating: any `object`-typed candidate still accepts the
-                // constraint class.
-                erased = typeParam.ClassConstraint?.ClrType ?? typeof(object);
+            case TypeParameterSymbol:
+                erased = typeof(object);
                 return true;
             case SliceTypeSymbol slice:
                 if (TryProjectErasedClrType(slice.ElementType, out var sliceElement)

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -1949,8 +1949,16 @@ internal sealed class MemberLookup
 
         switch (t)
         {
-            case TypeParameterSymbol:
-                erased = typeof(object);
+            case TypeParameterSymbol typeParam:
+                // Issue #3501: a type parameter with a CLR-backed class
+                // constraint erases to that class, not bare `object` — a
+                // `[T Base init()]`-typed argument passed to an imported
+                // `Base`-typed parameter must gate as assignable
+                // (`ImmutableArray.Create[Base](T())`, the
+                // GSharpAnalyzerVerifier wall). Erasing tighter is sound for
+                // gating: any `object`-typed candidate still accepts the
+                // constraint class.
+                erased = typeParam.ClassConstraint?.ClrType ?? typeof(object);
                 return true;
             case SliceTypeSymbol slice:
                 if (TryProjectErasedClrType(slice.ElementType, out var sliceElement)

--- a/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
@@ -376,6 +376,12 @@ public sealed class ImportedClassSymbol : Symbol
             filteredNameMatches.Add(method);
         }
 
+        // Issue #3501: `structuralProjectionArgumentCheck` (the ADR-0148
+        // symbol-aware applicability fallback) was wired on the
+        // instance/extension call paths but not here — a `[T ImportedBase]`-
+        // typed argument erases to `object`, so a static imported call like
+        // `ImmutableArray.Create[Base](T())` found no applicable candidate
+        // even though `T -> Base` is a constraint-proven implicit conversion.
         var result = ClrOverloadResolution.Resolve<MethodInfo>(
             filteredNameMatches,
             argTypes,
@@ -393,6 +399,7 @@ public sealed class ImportedClassSymbol : Symbol
             },
             supplementaryInterfaceCheck: supplementaryInterfaceCheck,
             constantNarrowingArgumentCheck: ExpressionBinder.MakeConstantNarrowingArgumentCheck(arguments),
+            structuralProjectionArgumentCheck: ExpressionBinder.MakeStructuralProjectionArgumentCheck(arguments),
             delegateRefKindArgumentCheck: ExpressionBinder.MakeDelegateRefKindArgumentCheck(arguments),
             methodGroupInference: ExpressionBinder.MakeMethodGroupInference(
                 arguments,

--- a/test/Compiler.Tests/Emit/Issue2857ExplicitGenericLambdaProjectReferenceEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2857ExplicitGenericLambdaProjectReferenceEmitTests.cs
@@ -353,8 +353,15 @@ public sealed class Issue2857ExplicitGenericLambdaProjectReferenceEmitTests
         Assert.Equal(new[] { "GS0159" }, diagnosticIds);
     }
 
+    // Issue #3501: this shape was pinned as REJECTED (GS0159) while
+    // `SatisfiesClassConstraint` could not see a source class deriving an
+    // imported base — the constraint failure was the loud guard for the
+    // then-unclosable delegate-in-constructed-generic. With the constraint
+    // fixed the call closes, ilverifies, and runs (the configure delegate
+    // observably mutates the constructed T), so the guard flips to a
+    // behavior assertion.
     [Fact]
-    public void ExplicitGenericTypeArgument_WithDelegateInConstructedGenericAcrossReference_IsRejected()
+    public void ExplicitGenericTypeArgument_WithDelegateInConstructedGenericAcrossReference_Runs()
     {
         const string PackageName = "i3178constructedgeneric";
         var library = $$"""
@@ -382,15 +389,12 @@ public sealed class Issue2857ExplicitGenericLambdaProjectReferenceEmitTests
             func Main() {
                 let configure = List[((Derived) -> void)]()
                 configure.Add((item Derived) -> { item.Value = 9 })
-                {{PackageName}}.Base.Make[Derived](configure)
+                let made = {{PackageName}}.Base.Make[Derived](configure)
+                System.Console.WriteLine(made.Value)
             }
             """;
 
-        var output = CompileExpectingFailure(library, consumer, PackageName);
-        var diagnosticIds = Regex.Matches(output, @"\berror (GS\d{4}):")
-            .Select(match => match.Groups[1].Value)
-            .ToArray();
-        Assert.Equal(new[] { "GS0159" }, diagnosticIds);
+        Assert.Equal($"9{Environment.NewLine}", CompileAndRun(library, consumer, PackageName));
     }
 
     private static string CompileAndRun(string library, string consumer, string libraryAssemblyName)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3501ImportedBaseConstraintTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3501ImportedBaseConstraintTests.cs
@@ -1,0 +1,90 @@
+// <copyright file="Issue3501ImportedBaseConstraintTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #3501 (the GSharpAnalyzerVerifier wall): two composed gaps around a
+/// class constraint whose base lives in a REFERENCED assembly.
+/// (1) `SatisfiesClassConstraint` never walked a SOURCE class's base chain to
+/// its <c>ImportedBaseType</c>, so `class Derived : ImportedBase` failed
+/// `[T ImportedBase]` (GS0152). (2) A <c>T</c>-typed argument erased to bare
+/// <c>object</c> in overload gating, so `ImmutableArray.Create[ImportedBase](T())`
+/// found no applicable overload (GS0159); it now erases to the constraint's
+/// CLR class.
+/// </summary>
+public class Issue3501ImportedBaseConstraintTests
+{
+    [Fact]
+    public void SourceClassDerivingImportedBase_SatisfiesConstraint_AndTTypedArgumentBinds()
+    {
+        var outputDir = Path.Combine(AppContext.BaseDirectory, "Issue3501ImportedBase");
+        Directory.CreateDirectory(outputDir);
+
+        var libraryPath = Path.Combine(outputDir, "Issue3501.Base.dll");
+        var library = new Compilation(
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package IC.Analyzers
+
+                open class Base {
+                    prop Id string -> "b"
+                }
+                """)))
+        {
+            IsLibrary = true,
+        };
+
+        using (var peStream = File.Create(libraryPath))
+        {
+            var libraryResult = library.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "Issue3501.Base");
+            Assert.True(libraryResult.Success, string.Join(Environment.NewLine, libraryResult.Diagnostics));
+        }
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+        resolver.CurrentAssemblyName = "Issue3501.Consumer";
+
+        var consumer = new Compilation(
+            resolver,
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package IC.Consumer
+
+                import IC.Analyzers
+                import System.Collections.Immutable
+
+                class Derived : Base {
+                }
+
+                class Runner[T Base init()] {
+                    func Go() int32 {
+                        let items = ImmutableArray.Create[Base](T())
+                        return items.Length
+                    }
+                }
+
+                class Entry {
+                    func Use() int32 {
+                        return Runner[Derived]().Go()
+                    }
+                }
+                """)))
+        {
+            IsLibrary = true,
+        };
+
+        using var consumerStream = new MemoryStream();
+        var result = consumer.Emit(consumerStream, pdbStream: null, refStream: null, assemblyName: "Issue3501.Consumer");
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+}


### PR DESCRIPTION
## Summary

Burns down the `src/Analyzers/GSharp.CodeAnalysis.Analyzers.Testing` wall in the #3501 self-migration gate (4 reported errors; 3 were cascades of a single poisoned local). Two composed gsc gaps around a class constraint whose base lives in a **referenced assembly** — exactly the migrated-repo shape, where `GSharpDiagnosticAnalyzer` comes from the migrated Core package:

1. **`SatisfiesClassConstraint`** fell to CLR assignability for an imported constraint, but a SOURCE class has no `ClrType`, so `class Derived : ImportedBase` failed `[T ImportedBase init()]` with GS0152. Now walks the source base chain to the first `ImportedBaseType` and checks CLR assignability there.
2. **`TryProjectErasedClrType`** erased every type-parameter-typed argument to bare `object`, so `ImmutableArray.Create[ImportedBase](T())` had no applicable candidate (GS0159). A type parameter with a CLR-backed class constraint now erases to that class — sound for gating (any `object`-typed candidate still accepts the constraint class), and C#-consistent for ranking.

## Verification

- Two-assembly repro (imported `Base`, source `Derived : Base`, `Runner[T Base init()]` calling `ImmutableArray.Create[Base](T())` + LINQ over the result) compiles clean; both failure modes probe-isolated first.
- New `Issue3501ImportedBaseConstraintTests` (two-assembly emit harness).
- 1410-test Overload/Constraint/Generic `Core.Tests` sweep green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeaEdjqNURnncQ4qAdr4e2