### PR TITLE
Complete ADR-0169 analyzer translation for GSA0005

### DIFF
--- a/docs/cs2gs-analyzer-translation.md
+++ b/docs/cs2gs-analyzer-translation.md
@@ -1,13 +1,9 @@
 # cs2gs: translating Roslyn analyzer projects to G# analyzers
 
 Status: implemented through the map/idiom layer (2026-08-19). The real
-GSA0001, GSA0002, GSA0003, and GSA0004 sources translate mechanically —
-attribute swap, imports, kind/type/member maps, idiom rewrites — and bind
-against `GSharp.Core` with CS2GS-ANALYZER-SHAPE review warnings only
-(`Cs2Gs.Tests/Adr0169AnalyzerTranslationTests`). GSA0005 pattern-matches
-deeply C#-specific syntax shapes and is pinned by a ratchet asserting its
-translation stays LOUD (gap or binder failure, never silently wrong) until
-its reviewed adaptation lands.
+GSA0001–GSA0005 sources translate and bind against `GSharp.Core`, with
+shape-changing adaptations reported as `CS2GS-ANALYZER-SHAPE`
+(`Cs2Gs.Tests/Adr0169AnalyzerTranslationTests`).
 
 The two verification follow-ups are implemented (2026-08-19, second pass):
 - **Parity harness** (`Cs2Gs.Tests/Adr0169AnalyzerParityTests`): the real
@@ -25,88 +21,24 @@ The two verification follow-ups are implemented (2026-08-19, second pass):
   REGIONS (G# node spans differ), verified end-to-end in
   `Adr0169SnippetTranslationTests`.
 
-### GSA0005 reviewed-adaptation inventory
+### GSA0005 reviewed adaptations
 
-The ratchet keeps GSA0005 loud until a reviewed port lands. The remaining
-C#-specific surface (from the translation gap inventory):
-`BaseExpressionSyntax` (base-call detection → G# base-call node),
-`SwitchStatementSyntax`/`SwitchSectionSyntax`/`CasePatternSwitchLabelSyntax`
-(→ G# pattern-switch shape), `SubpatternSyntax`/`SingleVariableDesignationSyntax`
-(→ ADR-0166 pattern shapes), `PatternSyntax`, `ArgumentSyntax` (G# call
-arguments are bare expressions), and `MethodKind`. Beyond the API surface,
-the analyzer's semantics must be re-derived for G#: post-migration it
-inspects G#-shaped `BoundTreeRewriter` overrides, so the "rebuilds the node
-while reading fewer members" detection needs G# equivalents of its
-object-creation, base-delegation, and switch-section walks. This is exactly
-the plausible-but-wrong risk class the loud ratchet exists to prevent.
+GSA0005 uses narrow, source-shape-specific rewrites rather than a Roslyn
+compatibility facade. `TypeSymbol.GetConstructors()` exposes constructor
+callables while keeping constructors outside `GetMembers()`. The translator
+combines those callables with static factory functions and adapts constructor
+kind tests, optional parameters, return types, base types, initializer
+wrappers, direct construction calls, static factory calls, base delegation,
+switch cases, property-pattern fields, nested designations, and final
+qualified/generic type-name extraction to their native G# shapes. Every
+shape-changing rewrite remains guarded and reports
+`CS2GS-ANALYZER-SHAPE`.
 
-**Issue #3536 progress.** The mechanical slice of this inventory that has a
-direct, unambiguous G# counterpart is now mapped/idiom-rewritten (see
-`RoslynAnalyzerApiMap` and `CSharpToGSharpTranslator.Analyzers.cs`):
-`PatternSyntax` (exact, name and namespace both carry over), `SwitchStatementSyntax`
-→ `SwitchStatementSyntax` (type-level, exact) and `CasePatternSwitchLabelSyntax`
-→ `SwitchCaseSyntax` (type-level, Adapted — G# has no per-label node), with the
-`Sections.SelectMany(s => s.Labels).OfType<CasePatternSwitchLabelSyntax>()`
-walk itself now idiom-rewritten to `Cases.Where(c => !c.IsDefault && (c.Guard
-!= nil || c.Value is not ConstantPatternSyntax))` (G# switch cases carry one
-pattern each via `SwitchCaseSyntax.Value`, with no section/label nesting and
-no `default`-arm or pattern-label subtype to `OfType` against; Roslyn's
-`OfType<CasePatternSwitchLabelSyntax>()` excludes both the `default` arm and
-plain constant labels (`CaseSwitchLabelSyntax`, e.g. `case 5:`), so the G#
-walk excludes the default arm and any unguarded `ConstantPatternSyntax`
-value — a guarded constant like `case 5 when b:` is still a Roslyn
-`CasePatternSwitchLabelSyntax`, kept via the `Guard` check), `SubpatternSyntax`
-→ `PropertyPatternFieldSyntax` (type-level;
-the `ExpressionColon.Expression` idiom that reads the field name still needs
-rewriting to the direct `Identifier` token), `ArgumentSyntax` →
-`ExpressionSyntax` (G# call arguments are bare expressions with no wrapper
-type, so a variable or lambda parameter typed `ArgumentSyntax` maps directly),
-`.ArgumentList`/`.ParameterList` drop to their direct `.Arguments`/`.Parameters`
-members — each restricted to its one verified receiver type
-(`InvocationExpressionSyntax` and `MethodDeclarationSyntax` respectively,
-checked via the resolved property's declaring type, not spelling), because
-Roslyn's other `ArgumentList`/`ParameterList`-bearing node kinds each
-independently declare their own same-named property with no shared base. For
-`ArgumentList`, `ElementAccessExpressionSyntax` and
-`ObjectCreationExpressionSyntax` are both already mapped to a differently-
-shaped G# node (`IndexExpressionSyntax.Indices`; a nested `Target` call) that
-does not expose `Arguments`, so admitting them would silently rewrite to a
-nonexistent member on an otherwise-clean translation. For `ParameterList`,
-`ConstructorDeclarationSyntax`, `LocalFunctionStatementSyntax`, lambda
-expressions, `DelegateDeclarationSyntax`, `IndexerDeclarationSyntax`, and
-type declarations (primary constructors) have no G# analyzer-API mapping at
-all today, so the restriction is defense-in-depth against a future mapping
-landing without revisiting this idiom — a bare `ArgumentSyntax.Expression`
-drop to the argument itself, and
-`Modifiers.Any(SyntaxKind.OverrideKeyword)` → `.IsOverride`. The C# base-call
-detection idiom (`invocation.Expression is MemberAccessExpressionSyntax {
-Expression: BaseExpressionSyntax }`) is also now idiom-rewritten: G# gives
-`base.M(...)` its own `BaseClassCallExpressionSyntax` node wrapping an
-ordinary `CallExpressionSyntax` as its `Call`, rather than parsing it as a
-member access on a `base` receiver, so a call found by walking for
-`CallExpressionSyntax` nodes is a base call exactly when its *parent* is that
-wrapper node — the idiom rewrites to `invocation.Parent is
-BaseClassCallExpressionSyntax`.
-
-Still open, and still the reason the ratchet stays red: `MethodKind`/
-constructor-vs-static-factory detection has no G# analogue — G# constructors
-are a separate `ConstructorSymbol` type (via `StructSymbol.ExplicitConstructors`,
-not part of `GetMembers()`), not a `FunctionSymbol` flavor, so
-`FormDependentMembers` needs re-deriving against that shape: merging
-`ConstructorSymbol`s and return-type-filtered static `FunctionSymbol`s into one
-collection is a control-flow rewrite of the analyzer's own body, not a
-mechanical rename a declarative map/idiom-rewrite hook can safely make. This
-was investigated in depth for #3536 but intentionally left as a loud gap
-rather than a low-confidence, compiler-unverified port — see the issue for the
-reasoning. Two further gaps surfaced while closing the base-call and switch-walk
-idioms above, previously undocumented: `SingleVariableDesignationSyntax`
-(designation-name extraction inside a nested pattern walk) and
-`QualifiedNameSyntax` (a `TypeSyntax`-shaped switch expression matching Roslyn's
-qualified-name node, which has no direct G# `TypeClauseSyntax` counterpart to
-switch over). Both are the same category of problem as `MethodKind` — a
-C#-side control-flow/pattern-match shape that must be re-derived against G#'s
-differently-shaped surface, not renamed — and stay loud gaps for the same
-reason.
+Consumer project references now retain the migrated analyzer project and
+rewrite `OutputItemType="Analyzer"` to
+`OutputItemType="GsharpCodeAnalyzer"`. Migrated analyzer projects reference
+the compiler host's `GSharp.Core.dll` directly, avoiding a project cycle when
+the translated analyzer is used while building Core itself.
 Companion to [ADR-0169](adr/0169-gsharp-analyzer-framework.md), which defines
 the G#-side analyzer framework this document targets. First migration target:
 `src/Analyzers/InternalAnalyzers` (GSA0001–GSA0005) and its test project, which

--- a/src/Analyzers/InternalAnalyzers/ReflectionTypeComparisonAnalyzer.cs
+++ b/src/Analyzers/InternalAnalyzers/ReflectionTypeComparisonAnalyzer.cs
@@ -110,7 +110,7 @@ public sealed class ReflectionTypeComparisonAnalyzer : DiagnosticAnalyzer
         return operation;
     }
 
-    private static bool IsInsideExemptType(ISymbol symbol)
+    private static bool IsInsideExemptType(ISymbol? symbol)
     {
         for (var type = symbol?.ContainingType; type != null; type = type.ContainingType)
         {

--- a/src/Core/CodeAnalysis/Symbols/NullabilityAnnotatedTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/NullabilityAnnotatedTypeSymbol.cs
@@ -37,7 +37,7 @@ public sealed class NullabilityAnnotatedTypeSymbol : TypeSymbol
     }
 
     /// <summary>Gets the underlying non-annotated type symbol.</summary>
-    public TypeSymbol BaseType { get; }
+    public override TypeSymbol BaseType { get; }
 
     /// <summary>
     /// Gets the full <c>[NullableAttribute]</c> byte array for this type, starting

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -388,6 +388,9 @@ public sealed class StructSymbol : TypeSymbol
         }
     }
 
+    /// <inheritdoc/>
+    public override TypeSymbol? BaseType => BaseClass ?? ImportedBaseType;
+
     /// <summary>Gets the interfaces this type implements (Phase 3.B.4). Populated by the binder after the symbol is constructed; defaults to empty.</summary>
     public ImmutableArray<InterfaceSymbol> Interfaces
     {
@@ -682,6 +685,10 @@ public sealed class StructSymbol : TypeSymbol
         builder.AddRange(StaticEvents);
         return builder.ToImmutable();
     }
+
+    /// <inheritdoc/>
+    public override ImmutableArray<FunctionSymbol> GetConstructors() =>
+        EffectiveExplicitConstructors.Select(constructor => constructor.Function).ToImmutableArray();
 
     /// <summary>Sets <see cref="ImportedBaseType"/> after binding (issue #296). Intended to be called exactly once by the binder for a class inheriting an imported CLR base.</summary>
     /// <param name="importedBaseType">The imported CLR base type symbol.</param>

--- a/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
@@ -196,6 +196,9 @@ public class TypeSymbol : Symbol
     /// </summary>
     public virtual ImmutableArray<FieldSymbol> TupleElements => ImmutableArray<FieldSymbol>.Empty;
 
+    /// <summary>Gets the immediate base type, or <see langword="null"/> when none exists.</summary>
+    public virtual TypeSymbol? BaseType => ClrType?.BaseType is { } baseType ? FromClrType(baseType) : null;
+
     /// <summary>
     /// Gets the members declared on this type — the Roslyn
     /// <c>GetMembers()</c> analogue (ADR-0169). Empty by default; user-defined
@@ -203,6 +206,14 @@ public class TypeSymbol : Symbol
     /// </summary>
     /// <returns>The declared members.</returns>
     public virtual ImmutableArray<Symbol> GetMembers() => ImmutableArray<Symbol>.Empty;
+
+    /// <summary>
+    /// Gets the constructor callables declared on this type. Constructors stay
+    /// outside <see cref="GetMembers"/> because G# models them separately from
+    /// ordinary functions.
+    /// </summary>
+    /// <returns>The declared constructor callables.</returns>
+    public virtual ImmutableArray<FunctionSymbol> GetConstructors() => ImmutableArray<FunctionSymbol>.Empty;
 
     /// <summary>
     /// Renders CLR-backed types the way Roslyn's fully-qualified format does

--- a/src/Core/CodeAnalysis/Syntax/PatternSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/PatternSyntax.cs
@@ -13,4 +13,8 @@ public abstract class PatternSyntax : SyntaxNode
         : base(syntaxTree)
     {
     }
+
+    /// <summary>Gets the identifier bound by this pattern, or <see langword="null"/>.</summary>
+    [SyntaxChildIgnore]
+    public virtual SyntaxToken? BindingIdentifier => null;
 }

--- a/src/Core/CodeAnalysis/Syntax/PropertyPatternSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/PropertyPatternSyntax.cs
@@ -45,4 +45,8 @@ public sealed class PropertyPatternSyntax : PatternSyntax
     /// matched, non-nil value at the pattern's input type.
     /// </summary>
     public SyntaxToken? Designation { get; }
+
+    /// <inheritdoc/>
+    [SyntaxChildIgnore]
+    public override SyntaxToken? BindingIdentifier => Designation;
 }

--- a/src/Core/CodeAnalysis/Syntax/TypeClauseSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/TypeClauseSyntax.cs
@@ -514,6 +514,11 @@ public sealed class TypeClauseSyntax : SyntaxNode
     /// <summary>Gets the qualifier identifier tokens that follow each <c>.</c> in source order (issue #526). Empty when the name is a single identifier.</summary>
     public ImmutableArray<SyntaxToken> QualifierIdentifierTokens { get; } = ImmutableArray<SyntaxToken>.Empty;
 
+    /// <summary>Gets the final identifier of a named type clause, or <see langword="null"/> for a composite type.</summary>
+    [SyntaxChildIgnore]
+    public SyntaxToken? NameIdentifier =>
+        QualifierIdentifierTokens.IsDefaultOrEmpty ? Identifier : QualifierIdentifierTokens[^1];
+
     /// <summary>Gets a value indicating whether this clause uses a dotted-qualifier name <c>Outer.Inner</c> (issue #526).</summary>
     public bool HasQualifier => !QualifierIdentifierTokens.IsDefaultOrEmpty;
 

--- a/src/Core/CodeAnalysis/Syntax/TypePatternSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/TypePatternSyntax.cs
@@ -61,5 +61,5 @@ public sealed class TypePatternSyntax : PatternSyntax
     /// or <see langword="null"/> when the pattern binds nothing.
     /// </summary>
     [SyntaxChildIgnore]
-    public SyntaxToken? BindingIdentifier => Identifier ?? Designation;
+    public override SyntaxToken? BindingIdentifier => Identifier ?? Designation;
 }

--- a/src/Core/CodeAnalysis/Syntax/VarPatternSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/VarPatternSyntax.cs
@@ -32,4 +32,8 @@ public sealed class VarPatternSyntax : PatternSyntax
 
     /// <summary>Gets the binding identifier or discard.</summary>
     public SyntaxToken Designation { get; }
+
+    /// <inheritdoc/>
+    [SyntaxChildIgnore]
+    public override SyntaxToken? BindingIdentifier => Designation.Text == "_" ? null : Designation;
 }

--- a/test/Core.Tests/CodeAnalysis/Symbols/TypeMemberModelTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/TypeMemberModelTests.cs
@@ -33,6 +33,8 @@ open class Base {
 open class Animal : Base {
     prop Name string
     var legs int32
+    init() { }
+    init(name string) { }
     func Speak() string { return ""..."" }
     func Speak(loud bool) string { return ""!"" }
     func Shadowed() int32 { return 1 }
@@ -132,6 +134,17 @@ enum Color {
         var animal = GetStruct("Animal");
         var methods = TypeMemberModel.GetMethods(animal, "Make", MemberQuery.Static());
         Assert.Equal(2, methods.Length);
+    }
+
+    [Fact]
+    public void ConstructorIntrospection_StaysSeparateFromOrdinaryMembers()
+    {
+        var animal = GetStruct("Animal");
+
+        Assert.Equal(2, animal.GetConstructors().Length);
+        Assert.All(animal.GetConstructors(), constructor => Assert.Equal(".ctor", constructor.Name));
+        Assert.DoesNotContain(animal.GetMembers(), member => member.Name == ".ctor");
+        Assert.Contains(animal.GetMembers(), member => member.Name == "Make");
     }
 
     [Fact]

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue3409PatternDesignationParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue3409PatternDesignationParserTests.cs
@@ -55,6 +55,7 @@ public sealed class Issue3409PatternDesignationParserTests
         var property = Assert.IsType<PropertyPatternSyntax>(Assert.IsType<IsExpressionSyntax>(statement.Condition).Pattern);
 
         Assert.Equal("text", property.Designation?.Text);
+        Assert.Equal("text", property.BindingIdentifier?.Text);
         Assert.Single(property.Fields);
         Assert.Single(Assert.IsType<BlockStatementSyntax>(statement.ThenStatement).Statements);
     }

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue526NestedTypeClauseParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue526NestedTypeClauseParserTests.cs
@@ -66,6 +66,7 @@ func Use() {
         Assert.Equal(2, type.QualifierIdentifierTokens.Length);
         Assert.Equal("B", type.QualifierIdentifierTokens[0].Text);
         Assert.Equal("C", type.QualifierIdentifierTokens[1].Text);
+        Assert.Equal("C", type.NameIdentifier.Text);
         Assert.Equal("A.B.C", type.DottedName);
     }
 
@@ -111,6 +112,7 @@ class Impl : IComparable[string] {
         var baseType = typeDecl.BaseTypeClauses[0];
         Assert.Equal("IComparable", baseType.DottedName);
         Assert.True(baseType.HasTypeArguments);
+        Assert.Equal("IComparable", baseType.NameIdentifier.Text);
         Assert.Single(baseType.TypeArguments);
         Assert.Equal("string", baseType.TypeArguments[0].DottedName);
     }

--- a/tools/cs2gs/Cs2Gs.Pipeline/CompileStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/CompileStage.cs
@@ -45,6 +45,24 @@ public sealed class CompileStage : IMigrationStage
             .ToList();
         IReadOnlyList<string> references =
             BuildReferenceSet(context.App.ReferencedAssemblies, context.ExternalReferencePaths);
+        IReadOnlyList<DeclaredPackageReference> buildOnlyPackageReferences = context.BuildOnlyPackageReferences;
+        IReadOnlyList<DeclaredProjectItem> packageReferences = context.PackageReferences;
+        if (context.IsAnalyzerProject)
+        {
+            references = references
+                .Where(path => !Path.GetFileName(path).StartsWith("Microsoft.CodeAnalysis", StringComparison.OrdinalIgnoreCase))
+                .Append(typeof(GSharp.Core.CodeAnalysis.Diagnostic).Assembly.Location)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            buildOnlyPackageReferences = buildOnlyPackageReferences
+                .Where(reference => !reference.Id.StartsWith("Microsoft.CodeAnalysis", StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            packageReferences = packageReferences
+                .Where(reference => reference.Element.Attribute("Include")?.Value?.StartsWith(
+                    "Microsoft.CodeAnalysis",
+                    StringComparison.OrdinalIgnoreCase) != true)
+                .ToList();
+        }
 
         if (context.Options.CompileViaSdk)
         {
@@ -67,8 +85,8 @@ public sealed class CompileStage : IMigrationStage
                         context.AdditionalGeneratorFiles,
                         context.RootNamespace,
                         context.Options.Config,
-                        context.BuildOnlyPackageReferences,
-                        context.PackageReferences,
+                        buildOnlyPackageReferences,
+                        packageReferences,
                         context.ProjectReferences,
                         context.Options.GeneratedProjectPaths,
                         context.UsesCentralPackageManagement,

--- a/tools/cs2gs/Cs2Gs.Pipeline/GSharpProjectTransformer.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/GSharpProjectTransformer.cs
@@ -198,16 +198,22 @@ internal static class GSharpProjectTransformer
     // value (the in-proc gsc host is net10; the VS/old-host rationale for
     // netstandard2.0 does not exist for G#), drops the Roslyn compiler
     // packages and Roslyn-analyzer-authoring properties, and references the
-    // G# analyzer API via the GsharpAnalyzerApiProject property the migration
-    // host supplies.
+    // G# analyzer API assembly loaded by the compiler host.
     private static void RewriteAnalyzerProject(XDocument document)
     {
-        // Issue #3501: classification keys on the analyzer-AUTHORING marker
-        // only. Merely consuming Microsoft.CodeAnalysis as a library (e.g.
-        // Cs2Gs.Translator itself) must NOT strip the Roslyn packages — that
-        // erased the whole Roslyn surface from the migrated Translator and
-        // produced 3,093 unresolved-type errors in the nightly.
-        bool isAnalyzerProject = ElementsNamed(document, "EnforceExtendedAnalyzerRules").Any();
+        // Issue #3501: a plain Microsoft.CodeAnalysis dependency is not enough
+        // (Cs2Gs.Translator needs Roslyn at runtime). Analyzer packages use
+        // PrivateAssets=all; that marker also survives the pipeline's evaluated
+        // project projection when EnforceExtendedAnalyzerRules does not.
+        bool isAnalyzerProject = ElementsNamed(document, "EnforceExtendedAnalyzerRules").Any()
+            || ElementsNamed(document, "PackageReference").Any(reference =>
+                AttributeNamed(reference, "Include")?.Value?.StartsWith(
+                    "Microsoft.CodeAnalysis",
+                    StringComparison.OrdinalIgnoreCase) == true
+                && string.Equals(
+                    AttributeNamed(reference, "PrivateAssets")?.Value?.Trim(),
+                    "all",
+                    StringComparison.OrdinalIgnoreCase));
         if (!isAnalyzerProject)
         {
             return;
@@ -253,34 +259,26 @@ internal static class GSharpProjectTransformer
         var itemGroup = new XElement(
             "ItemGroup",
             new XElement(
-                "ProjectReference",
-                new XAttribute("Include", "$(GsharpAnalyzerApiProject)"),
-                new XAttribute("Condition", " '$(GsharpAnalyzerApiProject)' != '' ")));
+                "Reference",
+                new XAttribute("Include", "GSharp.Core"),
+                new XElement(
+                    "HintPath",
+                    "$([System.IO.Path]::GetDirectoryName('$(GsharpCompilerFullPath)'))/GSharp.Core.dll"),
+                new XElement("Private", "false")));
         document.Root.Add(itemGroup);
     }
 
-    // ADR-0169: a consumer wiring an analyzer project via
-    // OutputItemType="Analyzer" (Roslyn's item) DROPS the reference for now.
-    // The cs2gs analyzer-API translation (Roslyn syntax/symbol surface →
-    // GSharpDiagnosticAnalyzer) is built for GSA0001-GSA0004 (#3536), but
-    // GSA0005 (RewriterClonePreservationAnalyzer) still translates loud —
-    // MethodKind/constructor-vs-static-factory detection has no G# analogue
-    // yet (docs/cs2gs-analyzer-translation.md) — so InternalAnalyzers as a
-    // whole does not compile, the migrated assembly carries no
-    // [GSharpDiagnosticAnalyzer] types, and the SDK rejects it as an analyzer
-    // input (GS9301) — wiring it via GsharpCodeAnalyzer would fail every
-    // consumer build. Restore the rewrite to the G# item once GSA0005's
-    // reviewed adaptation lands and InternalAnalyzers compiles clean.
+    // ADR-0169: retain analyzer project references while changing Roslyn's
+    // analyzer item type to the G# SDK item type.
     private static void RewriteAnalyzerConsumerReferences(XDocument document)
     {
-        foreach (XElement projectReference in ElementsNamed(document, "ProjectReference").ToList())
+        foreach (XElement projectReference in ElementsNamed(document, "ProjectReference"))
         {
             XAttribute outputItemType = AttributeNamed(projectReference, "OutputItemType");
             if (outputItemType is not null
-                && (string.Equals(outputItemType.Value.Trim(), "Analyzer", StringComparison.OrdinalIgnoreCase)
-                    || string.Equals(outputItemType.Value.Trim(), "GsharpCodeAnalyzer", StringComparison.OrdinalIgnoreCase)))
+                && string.Equals(outputItemType.Value.Trim(), "Analyzer", StringComparison.OrdinalIgnoreCase))
             {
-                projectReference.Remove();
+                outputItemType.Value = "GsharpCodeAnalyzer";
             }
         }
     }

--- a/tools/cs2gs/Cs2Gs.Pipeline/IMigrationStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/IMigrationStage.cs
@@ -159,6 +159,9 @@ public sealed class StageExecutionContext
     /// </summary>
     public string AssemblyName { get; set; }
 
+    /// <summary>Gets or sets a value indicating whether the app is translated against the G# analyzer API.</summary>
+    public bool IsAnalyzerProject { get; set; }
+
     /// <summary>
     /// Gets the source project's declared build/dev-only <c>PackageReference</c>s
     /// (issue #2267) — e.g. a version-bumped <c>Nerdbank.GitVersioning</c> — that

--- a/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
@@ -327,6 +327,11 @@ public sealed class TranslateStage : IMigrationStage
             // is rewritten to the G# analyzer API instead of passing through.
             bool analyzerApiMode = Cs2Gs.Translator.Analyzers.AnalyzerProjectDetector
                 .IsAnalyzerProject(currentProject.Compilation);
+            if (!isReferencedProject)
+            {
+                context.IsAnalyzerProject = analyzerApiMode;
+            }
+
             var translator = new CSharpToGSharpTranslator(
                 preservePartialParts: true,
                 retainedFilePaths: retainedFilePaths,

--- a/tools/cs2gs/Cs2Gs.Tests/Adr0169AnalyzerProjectTransformTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Adr0169AnalyzerProjectTransformTests.cs
@@ -18,7 +18,7 @@ namespace Cs2Gs.Tests;
 /// Microsoft.CodeAnalysis packages and Roslyn-authoring properties, and gains
 /// a G# analyzer-API reference; a consumer's
 /// <c>OutputItemType="Analyzer"</c> wiring becomes
-/// dropped analyzer wiring (until the analyzer translation lands).
+/// <c>OutputItemType="GsharpCodeAnalyzer"</c>.
 /// </summary>
 public sealed class Adr0169AnalyzerProjectTransformTests : IDisposable
 {
@@ -59,7 +59,8 @@ public sealed class Adr0169AnalyzerProjectTransformTests : IDisposable
         Assert.Contains("<TargetFramework>net10.0</TargetFramework>", xml, StringComparison.Ordinal);
         Assert.DoesNotContain("EnforceExtendedAnalyzerRules", xml, StringComparison.Ordinal);
         Assert.DoesNotContain("Microsoft.CodeAnalysis.CSharp", xml, StringComparison.Ordinal);
-        Assert.Contains("$(GsharpAnalyzerApiProject)", xml, StringComparison.Ordinal);
+        Assert.Contains("<Reference Include=\"GSharp.Core\">", xml, StringComparison.Ordinal);
+        Assert.Contains("$(GsharpCompilerFullPath)", xml, StringComparison.Ordinal);
 
         // RS suppressions drop; unrelated suppressions survive.
         Assert.DoesNotContain("RS1036", xml, StringComparison.Ordinal);
@@ -67,13 +68,32 @@ public sealed class Adr0169AnalyzerProjectTransformTests : IDisposable
     }
 
     [Fact]
-    public void ConsumerAnalyzerWiring_DropsTheReferenceUntilTranslationLands()
+    public void AnalyzerProject_PrivateRoslynPackageMarkerSurvivesEvaluatedProjection()
     {
-        // Issue #3501: the cs2gs analyzer-API translation is designed but not
-        // built, so the migrated analyzer assembly carries no
-        // [GSharpDiagnosticAnalyzer] types and wiring it fails every consumer
-        // build (GS9301). Restore the GsharpCodeAnalyzer rewrite once the
-        // translation exists.
+        string projectPath = Write("ProjectedAnalyzer.csproj", @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include=""Microsoft.CodeAnalysis.CSharp"" Version=""5.6.0"" PrivateAssets=""all"" />
+  </ItemGroup>
+</Project>");
+
+        XDocument transformed = GSharpProjectTransformer.Transform(
+            projectPath,
+            root.FullName,
+            "Gsharp.NET.Sdk",
+            new Dictionary<string, string>());
+
+        string xml = transformed.ToString();
+        Assert.Contains("<TargetFramework>net10.0</TargetFramework>", xml, StringComparison.Ordinal);
+        Assert.DoesNotContain("Microsoft.CodeAnalysis.CSharp", xml, StringComparison.Ordinal);
+        Assert.Contains("<Reference Include=\"GSharp.Core\">", xml, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ConsumerAnalyzerWiring_RetainsReferenceWithGSharpItemType()
+    {
         string projectPath = Write("Consumer.csproj", @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -89,9 +109,13 @@ public sealed class Adr0169AnalyzerProjectTransformTests : IDisposable
             "Gsharp.NET.Sdk",
             new Dictionary<string, string>());
 
-        Assert.DoesNotContain(
+        XElement reference = Assert.Single(
             transformed.Descendants(),
             element => element.Name.LocalName == "ProjectReference");
+        Assert.Equal("GsharpCodeAnalyzer", reference.Attribute("OutputItemType")?.Value);
+        Assert.Equal(@"..\Analyzers\Analyzers.csproj", reference.Attribute("Include")?.Value);
+        Assert.Equal("false", reference.Attribute("ReferenceOutputAssembly")?.Value);
+        Assert.Equal("all", reference.Attribute("PrivateAssets")?.Value);
     }
 
     [Fact]
@@ -110,7 +134,7 @@ public sealed class Adr0169AnalyzerProjectTransformTests : IDisposable
             new Dictionary<string, string>());
 
         Assert.Contains("<TargetFramework>netstandard2.0</TargetFramework>", transformed.ToString(), StringComparison.Ordinal);
-        Assert.DoesNotContain("GsharpAnalyzerApiProject", transformed.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("<Reference Include=\"GSharp.Core\">", transformed.ToString(), StringComparison.Ordinal);
     }
 
     private string Write(string fileName, string content)

--- a/tools/cs2gs/Cs2Gs.Tests/Adr0169AnalyzerTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Adr0169AnalyzerTranslationTests.cs
@@ -823,6 +823,7 @@ public static class DiagnosticDescriptors
     [InlineData("StrongStaticReflectionCacheAnalyzer.cs")]
     [InlineData("ReflectionTypeComparisonAnalyzer.cs")]
     [InlineData("EmitCacheKeyRemapScopeAnalyzer.cs")]
+    [InlineData("RewriterClonePreservationAnalyzer.cs")]
     public void RealAnalyzerSources_TranslateWithReviewWarningsOnly(string fileName)
     {
         string realSource = File.ReadAllText(Path.Combine(
@@ -842,6 +843,8 @@ public static class DiagnosticDescriptors
         ""GSA0003"", ""T"", ""M {0}"", ""GSharp.InternalAnalyzers"", DiagnosticSeverity.Warning, isEnabledByDefault: true);
     public static readonly DiagnosticDescriptor EmitCacheKeyMissingRemapScope = new(
         ""GSA0004"", ""T"", ""M {0}"", ""GSharp.InternalAnalyzers"", DiagnosticSeverity.Warning, isEnabledByDefault: true);
+    public static readonly DiagnosticDescriptor RewriterCloneDropsMember = new(
+        ""GSA0005"", ""T"", ""M {0} {1} {2} {3}"", ""GSharp.InternalAnalyzers"", DiagnosticSeverity.Warning, isEnabledByDefault: true);
 }
 ";
 
@@ -851,51 +854,18 @@ public static class DiagnosticDescriptors
 
         Assert.DoesNotContain(diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
         AssertBindsAgainstGsCore(printedByFile.Values.ToArray());
-    }
 
-    [Fact]
-    public void RealGsa0005Source_FailsLoudly_NeverSilently()
-    {
-        // GSA0005 pattern-matches deeply C#-specific syntax shapes (switch
-        // sections, subpatterns, designations); its migration requires the
-        // reviewed adaptation the design doc predicts. This ratchet pins the
-        // honest behavior: translation is LOUD — either a translation gap or
-        // a round-trip binder failure — never a silently wrong analyzer.
-        string realSource = File.ReadAllText(Path.Combine(
-            FindRepoRoot(), "src", "Analyzers", "InternalAnalyzers", "RewriterClonePreservationAnalyzer.cs"));
-        string descriptors = @"
-using Microsoft.CodeAnalysis;
-
-namespace GSharp.InternalAnalyzers;
-
-public static class DiagnosticDescriptors
-{
-    public static readonly DiagnosticDescriptor RewriterCloneDropsMember = new(
-        ""GSA0005"", ""T"", ""M {0} {1} {2} {3}"", ""GSharp.InternalAnalyzers"", DiagnosticSeverity.Warning, isEnabledByDefault: true);
-}
-";
-
-        var (printedByFile, diagnostics) = TranslateAnalyzerProject(
-            ("RewriterClonePreservationAnalyzer.cs", realSource),
-            ("DiagnosticDescriptors.cs", descriptors));
-
-        bool translationIsLoud = diagnostics.Any(d => d.Severity == TranslationSeverity.Unsupported);
-        if (!translationIsLoud)
+        if (fileName == "RewriterClonePreservationAnalyzer.cs")
         {
-            var trees = printedByFile.Values
-                .Select(printed => GSharp.Core.CodeAnalysis.Syntax.SyntaxTree.Parse(
-                    GSharp.Core.CodeAnalysis.Text.SourceText.From(printed, "gsa0005.gs")))
-                .ToArray();
-            using var resolver = GSharp.Core.CodeAnalysis.Symbols.ReferenceResolver.WithRuntimeReferences(
-                new[] { typeof(GSharp.Core.CodeAnalysis.Diagnostic).Assembly.Location });
-            var compilation = new GSharp.Core.CodeAnalysis.Compilation.Compilation(resolver, trees) { IsLibrary = true };
-            translationIsLoud = trees.Any(t => !t.Diagnostics.IsEmpty)
-                || compilation.GlobalScope.Diagnostics.Concat(compilation.BoundProgram.Diagnostics).Any(d => d.IsError);
+            string printed = printedByFile[fileName];
+            Assert.Contains(".GetConstructors()", printed, StringComparison.Ordinal);
+            Assert.Contains("candidate.Name == \".ctor\"", printed, StringComparison.Ordinal);
+            Assert.Contains("parameter.HasExplicitDefaultValue", printed, StringComparison.Ordinal);
+            Assert.Contains("pattern.BindingIdentifier != nil", printed, StringComparison.Ordinal);
+            Assert.Contains("type.NameIdentifier", printed, StringComparison.Ordinal);
+            Assert.Contains("creation.Identifier.Text == nodeTypeName", printed, StringComparison.Ordinal);
+            Assert.Contains("Parent: AccessorExpressionSyntax access", printed, StringComparison.Ordinal);
         }
-
-        Assert.True(
-            translationIsLoud,
-            "GSA0005 translated AND bound cleanly — promote it into RealAnalyzerSources_TranslateWithReviewWarningsOnly and delete this ratchet.");
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Translator/Analyzers/RoslynAnalyzerApiMap.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/Analyzers/RoslynAnalyzerApiMap.cs
@@ -86,7 +86,10 @@ internal static class RoslynAnalyzerApiMap
             "AssignmentExpressionSyntax",
             "G# simple assignment targets an identifier token, and index/member writes are distinct Index/MemberIndexAssignmentExpression nodes — assignment-LHS pattern checks are usually structural no-ops in G#."),
         ["Microsoft.CodeAnalysis.CSharp.Syntax.InvocationExpressionSyntax"] = new("GSharp.Core.CodeAnalysis.Syntax", "CallExpressionSyntax"),
-        ["Microsoft.CodeAnalysis.CSharp.Syntax.ObjectCreationExpressionSyntax"] = new("GSharp.Core.CodeAnalysis.Syntax", "ObjectCreationExpressionSyntax"),
+        ["Microsoft.CodeAnalysis.CSharp.Syntax.ObjectCreationExpressionSyntax"] = new(
+            "GSharp.Core.CodeAnalysis.Syntax",
+            "CallExpressionSyntax",
+            "A C# construction without an object initializer is a direct type call in G#; construction-detection idioms inspect CallExpressionSyntax.Identifier."),
         ["Microsoft.CodeAnalysis.CSharp.Syntax.IsPatternExpressionSyntax"] = new(
             "GSharp.Core.CodeAnalysis.Syntax",
             "IsExpressionSyntax",
@@ -121,6 +124,10 @@ internal static class RoslynAnalyzerApiMap
             "GSharp.Core.CodeAnalysis.Syntax",
             "ExpressionSyntax",
             "G# call arguments are bare expressions with no ArgumentSyntax wrapper; a lambda parameter or local typed ArgumentSyntax maps to ExpressionSyntax directly (#3536)."),
+        ["Microsoft.CodeAnalysis.CSharp.Syntax.SingleVariableDesignationSyntax"] = new(
+            "GSharp.Core.CodeAnalysis.Syntax",
+            "PatternSyntax",
+            "G# stores a pattern's optional binding token on the pattern node itself; designation walks filter PatternSyntax.BindingIdentifier."),
 
         // Symbols (Exact by design where names align).
         ["Microsoft.CodeAnalysis.ISymbol"] = new("GSharp.Core.CodeAnalysis.Symbols", "Symbol"),
@@ -204,6 +211,10 @@ internal static class RoslynAnalyzerApiMap
             "RightPart",
             "AccessorExpressionSyntax.RightPart is an expression; identifier extraction becomes GetLastToken()."),
         [("Microsoft.CodeAnalysis.CSharp.Syntax.MemberAccessExpressionSyntax", "Expression")] = new(null, "LeftPart"),
+        [("Microsoft.CodeAnalysis.CSharp.Syntax.InvocationExpressionSyntax", "Expression")] = new(
+            null,
+            "Parent",
+            "G# member calls are CallExpressionSyntax nodes whose parent is the AccessorExpressionSyntax."),
         [("Microsoft.CodeAnalysis.SyntaxToken", "ValueText")] = new(null, "Text"),
         [("Microsoft.CodeAnalysis.Operations.IConversionOperation", "Operand")] = new(null, "Expression"),
         [("Microsoft.CodeAnalysis.Diagnostics.OperationAnalysisContext", "Operation")] = new(null, "BoundNode"),
@@ -218,6 +229,9 @@ internal static class RoslynAnalyzerApiMap
         [("Microsoft.CodeAnalysis.Operations.IBinaryOperation", "RightOperand")] = new(null, "Right"),
         [("Microsoft.CodeAnalysis.Operations.IInvocationOperation", "TargetMethod")] = new(null, "Function"),
         [("Microsoft.CodeAnalysis.IMethodSymbol", "OverriddenMethod")] = new(null, "OverriddenMethod"),
+        [("Microsoft.CodeAnalysis.IMethodSymbol", "ReturnType")] = new(null, "Type"),
+        [("Microsoft.CodeAnalysis.IParameterSymbol", "IsOptional")] = new(null, "HasExplicitDefaultValue"),
+        [("Microsoft.CodeAnalysis.INamedTypeSymbol", "BaseType")] = new(null, "BaseType"),
         [("Microsoft.CodeAnalysis.ISymbol", "DeclaringSyntaxReferences")] = new(
             null,
             "DeclaringSyntaxNodes",
@@ -235,6 +249,10 @@ internal static class RoslynAnalyzerApiMap
             null,
             null,
             "SubpatternSyntax.ExpressionColon.Expression names the field; G#'s PropertyPatternFieldSyntax.Identifier names it directly and has no ExpressionColon wrapper (#3536)."),
+        [("Microsoft.CodeAnalysis.CSharp.Syntax.SingleVariableDesignationSyntax", "Identifier")] = new(
+            null,
+            "BindingIdentifier",
+            "G# stores the designation token on PatternSyntax.BindingIdentifier rather than a child designation node."),
     };
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Analyzers.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Analyzers.cs
@@ -82,6 +82,53 @@ public sealed partial class CSharpToGSharpTranslator
         private bool TryTranslateAnalyzerMemberAccess(MemberAccessExpressionSyntax member, out GExpression result)
         {
             result = null;
+            if (member.Name.Identifier.Text == "Value"
+                && this.context.GetSymbolInfo(member).Symbol is IPropertySymbol
+                    {
+                        Name: "Value",
+                        ContainingType.Name: "EqualsValueClauseSyntax",
+                    })
+            {
+                result = this.TranslateExpression(member.Expression);
+                return true;
+            }
+
+            if (member.Name.Identifier.Text == "Pattern"
+                && this.context.GetSymbolInfo(member).Symbol is IPropertySymbol
+                    {
+                        Name: "Pattern",
+                        ContainingType.Name: "CasePatternSwitchLabelSyntax",
+                    })
+            {
+                result = new NonNullAssertionExpression(
+                    new MemberAccessExpression(
+                        this.TranslateExpression(member.Expression),
+                        "Value",
+                        isArrow: false));
+                return true;
+            }
+
+            if (member.Name.Identifier.Text == "Identifier"
+                && member.Expression is IdentifierNameSyntax designationName
+                && this.context.GetSymbolInfo(designationName).Symbol is ILocalSymbol designationLocal
+                && designationLocal.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax() is SingleVariableDesignationSyntax
+                {
+                    Parent.Parent: IsPatternExpressionSyntax
+                    {
+                        Expression: ConditionalAccessExpressionSyntax
+                        {
+                            Expression: MemberAccessExpressionSyntax
+                            {
+                                Name.Identifier.Text: "ExpressionColon",
+                            },
+                        },
+                    },
+                })
+            {
+                result = this.TranslateExpression(member.Expression);
+                return true;
+            }
+
             if (member.Name.Identifier.Text == "OperatorKind"
                 && this.context.GetSymbolInfo(member).Symbol is IPropertySymbol { Name: "OperatorKind" } operatorKind
                 && RoslynTypeMetadataName(operatorKind.ContainingType) == "Microsoft.CodeAnalysis.Operations.IBinaryOperation")
@@ -204,6 +251,45 @@ public sealed partial class CSharpToGSharpTranslator
         private bool TryTranslateAnalyzerBaseCallCheck(IsPatternExpressionSyntax isPattern, out GExpression result)
         {
             result = null;
+            if (isPattern.Expression is ConditionalAccessExpressionSyntax conditional
+                && conditional.Expression is MemberAccessExpressionSyntax expressionColon
+                && expressionColon.Name.Identifier.Text == "ExpressionColon"
+                && conditional.WhenNotNull is MemberBindingExpressionSyntax { Name.Identifier.Text: "Expression" }
+                && expressionColon.Expression is ExpressionSyntax propertyFieldSource
+                && this.context.GetTypeInfo(propertyFieldSource).Type is INamedTypeSymbol propertyFieldType
+                && RoslynTypeMetadataName(propertyFieldType)
+                    == "Microsoft.CodeAnalysis.CSharp.Syntax.SubpatternSyntax"
+                && isPattern.Pattern is DeclarationPatternSyntax
+                {
+                    Type: IdentifierNameSyntax { Identifier.Text: "IdentifierNameSyntax" },
+                    Designation: SingleVariableDesignationSyntax
+                    {
+                        Identifier.Text: { } designation,
+                    },
+                })
+            {
+                this.context.Report(new TranslationDiagnostic(
+                    "analyzer-api",
+                    "SubpatternSyntax.ExpressionColon.Expression identifier test translated to PropertyPatternFieldSyntax.Identifier: G# property-pattern fields always carry the field token directly.",
+                    isPattern.GetLocation(),
+                    TranslationSeverity.Warning)
+                {
+                    DiagnosticId = "CS2GS-ANALYZER-SHAPE",
+                });
+
+                this.typeMapper.TrackSubstitutedNamespace("GSharp.Core.CodeAnalysis.Syntax");
+                result = new PatternTestExpression(
+                    new MemberAccessExpression(
+                        this.TranslateExpression(propertyFieldSource),
+                        "Identifier",
+                        isArrow: false),
+                    new TypePattern(
+                        designation,
+                        new NamedTypeReference("SyntaxToken"),
+                        designationAfterType: true));
+                return true;
+            }
+
             if (isPattern.Expression is not MemberAccessExpressionSyntax { Name.Identifier.Text: "Expression" } expressionAccess
                 || this.context.GetSymbolInfo(expressionAccess).Symbol is not IPropertySymbol { Name: "Expression" } expressionProperty
                 || RoslynTypeMetadataName(expressionProperty.ContainingType) != "Microsoft.CodeAnalysis.CSharp.Syntax.InvocationExpressionSyntax"
@@ -314,6 +400,90 @@ public sealed partial class CSharpToGSharpTranslator
             return true;
         }
 
+        private bool TryTranslateAnalyzerDesignationWalk(InvocationExpressionSyntax invocation, out GExpression result)
+        {
+            result = null;
+            if (this.context.GetSymbolInfo(invocation).Symbol is not IMethodSymbol { Name: "OfType", TypeArguments.Length: 1 } method
+                || RoslynTypeMetadataName(method.TypeArguments[0] as INamedTypeSymbol)
+                    != "Microsoft.CodeAnalysis.CSharp.Syntax.SingleVariableDesignationSyntax"
+                || invocation.Expression is not MemberAccessExpressionSyntax { Expression: InvocationExpressionSyntax descendants }
+                || this.context.GetSymbolInfo(descendants).Symbol is not IMethodSymbol { Name: "DescendantNodesAndSelf" })
+            {
+                return false;
+            }
+
+            this.context.Report(new TranslationDiagnostic(
+                "analyzer-api",
+                "SingleVariableDesignationSyntax walk translated to PatternSyntax nodes with a non-nil BindingIdentifier: G# stores designation tokens directly on pattern nodes.",
+                invocation.GetLocation(),
+                TranslationSeverity.Warning)
+            {
+                DiagnosticId = "CS2GS-ANALYZER-SHAPE",
+            });
+
+            this.typeMapper.TrackSubstitutedNamespace("GSharp.Core.CodeAnalysis.Syntax");
+            GExpression patterns = new InvocationExpression(
+                new MemberAccessExpression(
+                    this.TranslateExpression(descendants),
+                    "OfType",
+                    isArrow: false),
+                typeArguments: new[] { new NamedTypeReference("PatternSyntax") });
+            var parameter = new Parameter("pattern", new NamedTypeReference("PatternSyntax"));
+            GExpression binding = new MemberAccessExpression(
+                new IdentifierExpression("pattern"),
+                "BindingIdentifier",
+                isArrow: false);
+            result = new InvocationExpression(
+                new MemberAccessExpression(patterns, "Where", isArrow: false),
+                new[]
+                {
+                    new LambdaExpression(
+                        new[] { parameter },
+                        expressionBody: new BinaryExpression(binding, "!=", LiteralExpression.Null())),
+                });
+            return true;
+        }
+
+        private bool TryTranslateAnalyzerConstructionForms(InvocationExpressionSyntax invocation, out GExpression result)
+        {
+            result = null;
+            if (this.context.GetSymbolInfo(invocation).Symbol is not IMethodSymbol { Name: "GetMembers" } getMembers
+                || RoslynTypeMetadataName(getMembers.ContainingType) != "Microsoft.CodeAnalysis.INamespaceOrTypeSymbol"
+                || invocation.Expression is not MemberAccessExpressionSyntax { Expression: ExpressionSyntax receiver }
+                || invocation.Parent is not MemberAccessExpressionSyntax { Name: GenericNameSyntax { Identifier.Text: "OfType" } } ofTypeAccess
+                || ofTypeAccess.Parent is not InvocationExpressionSyntax ofTypeInvocation
+                || this.context.GetSymbolInfo(ofTypeInvocation).Symbol is not IMethodSymbol { Name: "OfType", TypeArguments.Length: 1 } ofType
+                || RoslynTypeMetadataName(ofType.TypeArguments[0] as INamedTypeSymbol) != "Microsoft.CodeAnalysis.IMethodSymbol"
+                || ofTypeInvocation.Parent is not MemberAccessExpressionSyntax { Name.Identifier.Text: "Where" }
+                || ofTypeInvocation.Parent.Parent is not InvocationExpressionSyntax whereInvocation
+                || !whereInvocation.ArgumentList.Arguments.Any(argument =>
+                    argument.Expression.DescendantNodesAndSelf().OfType<MemberAccessExpressionSyntax>().Any(access =>
+                        access.Name.Identifier.Text == "MethodKind"
+                        && this.context.GetSymbolInfo(access).Symbol is IPropertySymbol { ContainingType.Name: "IMethodSymbol" })))
+            {
+                return false;
+            }
+
+            this.context.Report(new TranslationDiagnostic(
+                "analyzer-api",
+                "TypeSymbol.GetMembers() constructor-form query augmented with TypeSymbol.GetConstructors(): G# keeps constructors outside ordinary member enumeration.",
+                invocation.GetLocation(),
+                TranslationSeverity.Warning)
+            {
+                DiagnosticId = "CS2GS-ANALYZER-SHAPE",
+            });
+
+            GExpression translatedReceiver = this.TranslateExpression(receiver);
+            GExpression members = new InvocationExpression(
+                new MemberAccessExpression(translatedReceiver, "GetMembers", isArrow: false));
+            GExpression constructors = new InvocationExpression(
+                new MemberAccessExpression(this.TranslateExpression(receiver), "GetConstructors", isArrow: false));
+            result = new InvocationExpression(
+                new MemberAccessExpression(members, "Concat", isArrow: false),
+                new[] { constructors });
+            return true;
+        }
+
         /// <summary>
         /// Invocation-level analyzer idioms: Roslyn methods whose G#
         /// counterpart is not a same-shaped method (e.g.
@@ -322,6 +492,33 @@ public sealed partial class CSharpToGSharpTranslator
         private bool TryTranslateAnalyzerInvocation(InvocationExpressionSyntax invocation, out GExpression result)
         {
             result = null;
+            if (this.TryTranslateAnalyzerDesignationWalk(invocation, out result)
+                || this.TryTranslateAnalyzerConstructionForms(invocation, out result))
+            {
+                return true;
+            }
+
+            if (invocation.Expression is IdentifierNameSyntax { Identifier.Text: "TypeNameOf" }
+                && invocation.ArgumentList.Arguments.Count == 1
+                && invocation.ArgumentList.Arguments[0].Expression is MemberAccessExpressionSyntax typeAccess
+                && typeAccess.Name.Identifier.Text == "Type"
+                && typeAccess.Expression is ExpressionSyntax creation
+                && this.context.GetSymbolInfo(typeAccess).Symbol is IPropertySymbol
+                {
+                    Name: "Type",
+                    ContainingType.Name: "ObjectCreationExpressionSyntax",
+                })
+            {
+                result = new MemberAccessExpression(
+                    new MemberAccessExpression(
+                        this.TranslateExpression(creation),
+                        "Identifier",
+                        isArrow: false),
+                    "Text",
+                    isArrow: false);
+                return true;
+            }
+
             if (this.context.GetSymbolInfo(invocation).Symbol is not IMethodSymbol method
                 || !RoslynAnalyzerApiMap.IsRoslynNamespace(method.ContainingType?.ContainingNamespace?.ToDisplayString()))
             {
@@ -393,6 +590,72 @@ public sealed partial class CSharpToGSharpTranslator
             return false;
         }
 
+        private bool TryTranslateAnalyzerTypeNameSwitch(SwitchExpressionSyntax node, out GExpression result)
+        {
+            result = null;
+            if (node.GoverningExpression is not IdentifierNameSyntax { Identifier.Text: { } parameterName }
+                || node.Arms.Count != 4
+                || node.Arms[0].Pattern is not DeclarationPatternSyntax first
+                || first.Type is not IdentifierNameSyntax { Identifier.Text: "IdentifierNameSyntax" }
+                || node.Arms[1].Pattern is not DeclarationPatternSyntax second
+                || second.Type is not IdentifierNameSyntax { Identifier.Text: "QualifiedNameSyntax" }
+                || node.Arms[2].Pattern is not DeclarationPatternSyntax third
+                || third.Type is not IdentifierNameSyntax { Identifier.Text: "GenericNameSyntax" }
+                || node.Arms[3].Pattern is not DiscardPatternSyntax)
+            {
+                return false;
+            }
+
+            this.context.Report(new TranslationDiagnostic(
+                "analyzer-api",
+                "Roslyn simple/qualified/generic TypeSyntax name switch translated to TypeClauseSyntax.NameIdentifier: G# represents all named type clauses in one node.",
+                node.GetLocation(),
+                TranslationSeverity.Warning)
+            {
+                DiagnosticId = "CS2GS-ANALYZER-SHAPE",
+            });
+
+            GExpression nameIdentifier = new MemberAccessExpression(
+                new IdentifierExpression(parameterName),
+                "NameIdentifier",
+                isArrow: false);
+            result = new IfExpression(
+                new BinaryExpression(nameIdentifier, "!=", LiteralExpression.Null()),
+                new MemberAccessExpression(
+                    new NonNullAssertionExpression(nameIdentifier),
+                    "Text",
+                    isArrow: false),
+                LiteralExpression.Null());
+            return true;
+        }
+
+        private string TranslateAnalyzerPatternFieldName(
+            RecursivePatternSyntax recursive,
+            SubpatternSyntax subpattern,
+            string fieldName)
+        {
+            if (!this.InAnalyzerApiMode
+                || fieldName != "Expression"
+                || recursive.Type is not IdentifierNameSyntax invocationType
+                || invocationType.Identifier.Text != "InvocationExpressionSyntax"
+                || this.GetPatternMemberSymbol(subpattern.NameColon?.Name) is not IPropertySymbol property
+                || RoslynTypeMetadataName(property.ContainingType)
+                    != "Microsoft.CodeAnalysis.CSharp.Syntax.InvocationExpressionSyntax")
+            {
+                return fieldName;
+            }
+
+            this.context.Report(new TranslationDiagnostic(
+                "analyzer-api",
+                "InvocationExpressionSyntax.Expression property pattern translated to CallExpressionSyntax.Parent.",
+                subpattern.GetLocation(),
+                TranslationSeverity.Warning)
+            {
+                DiagnosticId = "CS2GS-ANALYZER-SHAPE",
+            });
+            return "Parent";
+        }
+
         /// <summary>
         /// Rewrites <c>namespaceSymbol?.ToDisplayString()</c> to the bare
         /// receiver: G#'s <c>ContainingNamespace</c> is already the (nullable)
@@ -401,6 +664,23 @@ public sealed partial class CSharpToGSharpTranslator
         private bool TryTranslateAnalyzerConditionalDisplay(ConditionalAccessExpressionSyntax conditionalAccess, out GExpression result)
         {
             result = null;
+            if (conditionalAccess.WhenNotNull is MemberBindingExpressionSyntax { Name.Identifier.Text: "Value" }
+                && this.context.GetTypeInfo(conditionalAccess.Expression).Type is INamedTypeSymbol initializerType
+                && RoslynTypeMetadataName(initializerType)
+                    == "Microsoft.CodeAnalysis.CSharp.Syntax.EqualsValueClauseSyntax")
+            {
+                this.context.Report(new TranslationDiagnostic(
+                    "analyzer-api",
+                    "EqualsValueClauseSyntax.Value wrapper dropped: G# VariableDeclarationSyntax exposes Initializer directly.",
+                    conditionalAccess.GetLocation(),
+                    TranslationSeverity.Warning)
+                {
+                    DiagnosticId = "CS2GS-ANALYZER-SHAPE",
+                });
+                result = this.TranslateExpression(conditionalAccess.Expression);
+                return true;
+            }
+
             if (conditionalAccess.WhenNotNull is not InvocationExpressionSyntax { Expression: MemberBindingExpressionSyntax { Name.Identifier.Text: "ToDisplayString" }, ArgumentList.Arguments.Count: 0 }
                 || this.context.GetTypeInfo(conditionalAccess.Expression).Type is not INamedTypeSymbol receiverType
                 || RoslynTypeMetadataName(receiverType) != "Microsoft.CodeAnalysis.INamespaceSymbol")
@@ -553,6 +833,43 @@ public sealed partial class CSharpToGSharpTranslator
                         }),
                     isEquals ? "==" : "!=",
                     LiteralExpression.String("global::" + specialName.Replace('_', '.')));
+                return true;
+            }
+
+            foreach ((ExpressionSyntax methodSide, ExpressionSyntax kindSide) in new[]
+                {
+                    (binary.Left, binary.Right),
+                    (binary.Right, binary.Left),
+                })
+            {
+                if (methodSide is not MemberAccessExpressionSyntax { Name.Identifier.Text: "MethodKind" } methodKindAccess
+                    || this.context.GetSymbolInfo(methodKindAccess).Symbol is not IPropertySymbol methodKindProperty
+                    || methodKindProperty.Name != "MethodKind"
+                    || methodKindProperty.ContainingType.Name != "IMethodSymbol"
+                    || kindSide is not MemberAccessExpressionSyntax { Name.Identifier.Text: "Constructor" or "Ordinary" } kindAccess
+                    || this.context.GetSymbolInfo(kindAccess).Symbol is not IFieldSymbol kindField
+                    || kindField.ContainingType.Name != "MethodKind")
+                {
+                    continue;
+                }
+
+                bool constructorKind = kindAccess.Name.Identifier.Text == "Constructor";
+                string op = constructorKind == isEquals ? "==" : "!=";
+                result = new BinaryExpression(
+                    new MemberAccessExpression(
+                        this.TranslateExpression(methodKindAccess.Expression),
+                        "Name",
+                        isArrow: false),
+                    op,
+                    LiteralExpression.String(".ctor"));
+                this.context.Report(new TranslationDiagnostic(
+                    "analyzer-api",
+                    $"MethodKind.{kindAccess.Name.Identifier.Text} comparison translated to the G# constructor callable name '.ctor'.",
+                    binary.GetLocation(),
+                    TranslationSeverity.Warning)
+                {
+                    DiagnosticId = "CS2GS-ANALYZER-SHAPE",
+                });
                 return true;
             }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.PatternVariables.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.PatternVariables.cs
@@ -703,10 +703,13 @@ public sealed partial class CSharpToGSharpTranslator
             {
                 if (sub.NameColon != null)
                 {
+                    string fieldName = this.EmittedName(
+                        this.GetPatternMemberSymbol(sub.NameColon.Name),
+                        this.GetSubpatternMemberName(sub));
+                    fieldName = this.TranslateAnalyzerPatternFieldName(recursive, sub, fieldName);
+
                     fields.Add(new PropertyPatternField(
-                        this.EmittedName(
-                            this.GetPatternMemberSymbol(sub.NameColon.Name),
-                            this.GetSubpatternMemberName(sub)),
+                        fieldName,
                         this.BuildNativePattern(sub.Pattern, binders)));
                     continue;
                 }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
@@ -495,6 +495,12 @@ public sealed partial class CSharpToGSharpTranslator
 
         private GExpression TranslateSwitchExpression(SwitchExpressionSyntax node)
         {
+            if (this.InAnalyzerApiMode
+                && this.TryTranslateAnalyzerTypeNameSwitch(node, out GExpression analyzerTypeName))
+            {
+                return analyzerTypeName;
+            }
+
             GExpression subject = this.TranslateExpression(node.GoverningExpression);
             GTypeReference nullableResultType = this.NullableReferenceSwitchResultType(node);
             var arms = new List<SwitchArm>();
@@ -1806,9 +1812,12 @@ public sealed partial class CSharpToGSharpTranslator
                         if (sub.NameColon != null)
                         {
                             string rawFieldName = this.GetSubpatternMemberName(sub);
+                            ISymbol memberSymbol = this.GetPatternMemberSymbol(sub.NameColon.Name);
                             string fieldName = this.EmittedName(
-                                this.GetPatternMemberSymbol(sub.NameColon.Name),
+                                memberSymbol,
                                 rawFieldName);
+                            fieldName = this.TranslateAnalyzerPatternFieldName(recursive, sub, fieldName);
+
                             fields.Add(new PropertyPatternField(
                                 fieldName,
                                 this.TranslatePattern(


### PR DESCRIPTION
Closes #3536

## Summary
- add native constructor, base-type, pattern-binding, and final type-name introspection
- narrowly rewrite GSA0005 Roslyn shapes to native G# analyzer APIs with review warnings
- promote GSA0005 coverage and restore analyzer project/consumer wiring without a Core project cycle
- update ADR-0169 documentation and focused coverage

## Validation
- 27 ADR-0169 translation/project-transform tests passed
- 47 targeted Core symbol/syntax tests passed
- 10 GSA0005/ReflectionTypeComparison analyzer tests passed
- real `InternalAnalyzers` migration passed translate, compile, IL verification, and parity