### PR TITLE
Fix netstandard core assembly resolution

### DIFF
--- a/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
+++ b/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
@@ -1633,23 +1633,53 @@ public sealed class ReferenceResolver : IDisposable
     private static string? ChooseCoreAssemblyName(IReadOnlyList<string> paths)
     {
         // MetadataLoadContext needs a "core assembly" — the one declaring the
-        // primitive types (Object, String, etc.). For modern .NET reference
-        // packs this is System.Runtime.dll; older targets ship mscorlib.dll
-        // as the canonical home. Pick whichever we can see in the supplied
-        // reference set, falling back to letting MLC autodetect.
+        // primitive types (Object, String, etc.). Most modern reference packs
+        // define them in System.Runtime.dll, but netstandard2.0 defines them in
+        // netstandard.dll and makes System.Runtime/mscorlib facades that forward
+        // back to it. Inspect the candidates rather than guessing by filename.
         var hasMscorlib = false;
         foreach (var path in paths)
         {
             var fileName = Path.GetFileNameWithoutExtension(path);
-            if (string.Equals(fileName, "System.Runtime", StringComparison.OrdinalIgnoreCase))
+            if ((string.Equals(fileName, "System.Runtime", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(fileName, "mscorlib", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(fileName, "netstandard", StringComparison.OrdinalIgnoreCase))
+                && DeclaresSystemObject(path))
             {
-                return "System.Runtime";
+                return fileName;
             }
 
             hasMscorlib |= string.Equals(fileName, "mscorlib", StringComparison.OrdinalIgnoreCase);
         }
 
         return hasMscorlib ? "mscorlib" : null;
+    }
+
+    private static bool DeclaresSystemObject(string path)
+    {
+        try
+        {
+            using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+            using var peReader = new PEReader(stream);
+            var metadata = peReader.GetMetadataReader();
+            foreach (var handle in metadata.TypeDefinitions)
+            {
+                var definition = metadata.GetTypeDefinition(handle);
+                if (metadata.StringComparer.Equals(definition.Namespace, "System")
+                    && metadata.StringComparer.Equals(definition.Name, "Object"))
+                {
+                    return true;
+                }
+            }
+        }
+        catch (Exception ex) when (
+            ex is IOException
+                or UnauthorizedAccessException
+                or BadImageFormatException)
+        {
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
+++ b/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
@@ -1661,6 +1661,11 @@ public sealed class ReferenceResolver : IDisposable
         {
             using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
             using var peReader = new PEReader(stream);
+            if (!peReader.HasMetadata)
+            {
+                return false;
+            }
+
             var metadata = peReader.GetMetadataReader();
             foreach (var handle in metadata.TypeDefinitions)
             {

--- a/test/Core.Tests/CodeAnalysis/Symbols/ReferenceResolverTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/ReferenceResolverTests.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System;
+using System.Buffers.Binary;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -81,6 +82,29 @@ public class ReferenceResolverTests
 
         Assert.True(resolver.TryResolveType(fullName, out var type));
         Assert.Equal("netstandard", type.Assembly.GetName().Name);
+    }
+
+    [Fact]
+    public void WithReferences_Ignores_Native_PE_With_Core_Assembly_Name()
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            "reference-resolver-3594",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+
+        try
+        {
+            var path = Path.Combine(directory, "System.Runtime.dll");
+            File.WriteAllBytes(path, CreateNativePeImage());
+
+            using var resolver = ReferenceResolver.WithReferences(new[] { path });
+            Assert.Empty(resolver.Assemblies);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
     }
 
     /// <summary>
@@ -438,6 +462,29 @@ public class ReferenceResolverTests
             result.Success,
             string.Join(Environment.NewLine, result.Diagnostics));
         return path;
+    }
+
+    private static byte[] CreateNativePeImage()
+    {
+        var image = new byte[512];
+        image[0] = (byte)'M';
+        image[1] = (byte)'Z';
+        BinaryPrimitives.WriteInt32LittleEndian(image.AsSpan(0x3c), 0x80);
+        image[0x80] = (byte)'P';
+        image[0x81] = (byte)'E';
+        BinaryPrimitives.WriteUInt16LittleEndian(image.AsSpan(0x84), 0x14c);
+        BinaryPrimitives.WriteUInt16LittleEndian(image.AsSpan(0x94), 0xe0);
+        BinaryPrimitives.WriteUInt16LittleEndian(image.AsSpan(0x96), 0x102);
+        BinaryPrimitives.WriteUInt16LittleEndian(image.AsSpan(0x98), 0x10b);
+        BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(0xb4), 0x400000);
+        BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(0xb8), 0x1000);
+        BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(0xbc), 0x200);
+        BinaryPrimitives.WriteUInt16LittleEndian(image.AsSpan(0xc0), 4);
+        BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(0xd0), 0x1000);
+        BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(0xd4), 0x200);
+        BinaryPrimitives.WriteUInt16LittleEndian(image.AsSpan(0xdc), 3);
+        BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(0xf4), 16);
+        return image;
     }
 
     private static ReferenceResolver BuildMetadataLoadContextResolver()

--- a/test/Core.Tests/CodeAnalysis/Symbols/ReferenceResolverTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/ReferenceResolverTests.cs
@@ -64,6 +64,25 @@ public class ReferenceResolverTests
         Assert.Equal(typeof(ReferenceResolver).FullName, type.FullName);
     }
 
+    [Theory]
+    [InlineData("System.Object")]
+    [InlineData("System.IO.Stream")]
+    [InlineData("System.Text.Encoding")]
+    public void WithReferences_Resolves_NetStandard20_Core_Types(string fullName)
+    {
+        var referenceDirectory = typeof(ReferenceResolverTests).Assembly
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .Single(attribute => attribute.Key == "NetStandard20ReferenceDirectory")
+            .Value;
+        Assert.True(Directory.Exists(referenceDirectory));
+
+        using var resolver = ReferenceResolver.WithReferences(
+            Directory.EnumerateFiles(referenceDirectory, "*.dll"));
+
+        Assert.True(resolver.TryResolveType(fullName, out var type));
+        Assert.Equal("netstandard", type.Assembly.GetName().Name);
+    }
+
     /// <summary>
     /// An <c>internal</c> (non-externally-visible) type declared by a referenced
     /// assembly that does not grant this compilation friendship must not satisfy

--- a/test/Core.Tests/Core.Tests.csproj
+++ b/test/Core.Tests/Core.Tests.csproj
@@ -10,11 +10,19 @@
   <ItemGroup>
     <PackageReference Include="FsCheck.Xunit" Version="3.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+    <PackageReference Include="NETStandard.Library" Version="2.0.3" ExcludeAssets="all" GeneratePathProperty="true" PrivateAssets="all" />
     <!-- Issue #2345 follow-up: real third-party "Microsoft.*"-named NuGet
          package, referenced test-only, to regression-test
          ReferenceResolver.IsBclOrRuntimeAssemblyPath against an actual
          non-BCL assembly rather than a synthetic stand-in. -->
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>NetStandard20ReferenceDirectory</_Parameter1>
+      <_Parameter2>$(PkgNETStandard_Library)/build/netstandard2.0/ref</_Parameter2>
+    </AssemblyAttribute>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Core.Tests/packages.lock.json
+++ b/test/Core.Tests/packages.lock.json
@@ -63,6 +63,15 @@
         "resolved": "3.11.13-beta",
         "contentHash": "eQjDhod5E9dpL/UJ65c53VO2Cp1bXMzNRmrVwWt7ryAHltxotThkBDp8VdLjkJtMBnRrc6237vxKAbSpUcChMg=="
       },
+      "NETStandard.Library": {
+        "type": "Direct",
+        "requested": "[2.0.3, )",
+        "resolved": "2.0.3",
+        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
+      },
       "xunit": {
         "type": "Direct",
         "requested": "[2.9.2, )",
@@ -204,6 +213,11 @@
         "type": "Transitive",
         "resolved": "10.0.0",
         "contentHash": "inRnbpCS0nwO/RuoZIAqxQUuyjaknOOnCEZB55KSMMjRhl0RQDttSmLSGsUJN3RQ3ocf5NDLFd2mOQViHqMK5w=="
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",


### PR DESCRIPTION
Fixes #3594

Selects the MetadataLoadContext core assembly by locating the reference that actually defines `System.Object`, allowing netstandard2.0 facade references to resolve forwarded core types correctly. Native PE candidates without managed metadata are ignored safely.

Adds focused netstandard2.0 and native-PE resolver regressions.