### PR TITLE
Support typeof nested unbound generic types

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -83,15 +83,14 @@ internal sealed partial class ExpressionBinder
             {
                 TryResolveOpenGenericImportedType(typeClauseIdentifier.Text, out typeSymbol);
             }
-            else if (TryGetNestedUnboundGenericReflectionName(typeClause, out var reflectionName))
+            else if (TryGetNestedUnboundGenericReflectionSegments(typeClause, out var reflectionSegments, out var firstGenericSegment))
             {
-                bool resolved = scope.References.TryResolveType(reflectionName, out var qualifiedType);
-                bool isAmbiguous = false;
-                if (!resolved)
-                {
-                    resolved = TryResolveImportedReflectionType(reflectionName, out qualifiedType, out isAmbiguous);
-                }
-
+                bool resolved = TryResolveNestedUnboundGenericType(
+                    reflectionSegments,
+                    firstGenericSegment,
+                    out var qualifiedType,
+                    out var reflectionName,
+                    out var isAmbiguous);
                 if (!resolved)
                 {
                     if (isAmbiguous)
@@ -229,22 +228,25 @@ internal sealed partial class ExpressionBinder
         return true;
     }
 
-    private bool TryGetNestedUnboundGenericReflectionName(TypeClauseSyntax typeClause, out string reflectionName)
+    private bool TryGetNestedUnboundGenericReflectionSegments(
+        TypeClauseSyntax typeClause,
+        out string[] segments,
+        out int firstGenericSegment)
     {
-        reflectionName = string.Empty;
+        segments = Array.Empty<string>();
+        firstGenericSegment = -1;
         if (!typeClause.HasQualifier || typeClause.IsArray || typeClause.IsNullable || lookupType("_") != null)
         {
             return false;
         }
 
-        var segments = new string[typeClause.SegmentCount];
+        segments = new string[typeClause.SegmentCount];
         segments[0] = Invariant.Required(typeClause.Identifier, "a named type clause has an identifier").Text;
         for (var i = 1; i < segments.Length; i++)
         {
             segments[i] = typeClause.QualifierIdentifierTokens[i - 1].Text;
         }
 
-        var firstGenericSegment = -1;
         for (var i = 0; i < segments.Length; i++)
         {
             var args = typeClause.GetSegmentTypeArguments(i);
@@ -272,14 +274,46 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
-        var builder = new StringBuilder(segments[0]);
-        for (var i = 1; i < segments.Length; i++)
+        return true;
+    }
+
+    private bool TryResolveNestedUnboundGenericType(
+        string[] segments,
+        int firstGenericSegment,
+        out Type type,
+        out string reflectionName,
+        out bool isAmbiguous)
+    {
+        type = null!;
+        reflectionName = string.Empty;
+        isAmbiguous = false;
+        for (var firstTypeSegment = firstGenericSegment; firstTypeSegment >= 0; firstTypeSegment--)
         {
-            builder.Append(i > firstGenericSegment ? '+' : '.').Append(segments[i]);
+            var builder = new StringBuilder(segments[0]);
+            for (var i = 1; i < segments.Length; i++)
+            {
+                builder.Append(i > firstTypeSegment ? '+' : '.').Append(segments[i]);
+            }
+
+            reflectionName = builder.ToString();
+            if (scope.References.TryResolveType(reflectionName, out var direct) && direct != null)
+            {
+                type = direct;
+                return true;
+            }
+
+            if (TryResolveImportedReflectionType(reflectionName, out type, out isAmbiguous))
+            {
+                return true;
+            }
+
+            if (isAmbiguous)
+            {
+                return false;
+            }
         }
 
-        reflectionName = builder.ToString();
-        return true;
+        return false;
     }
 
     private bool TryResolveImportedReflectionType(string reflectionName, out Type type, out bool isAmbiguous)

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -85,13 +85,12 @@ internal sealed partial class ExpressionBinder
             }
             else if (TryGetNestedUnboundGenericReflectionSegments(typeClause, out var reflectionSegments, out var firstGenericSegment))
             {
-                bool resolved = TryResolveNestedUnboundGenericType(
+                var qualifiedType = ResolveNestedUnboundGenericType(
                     reflectionSegments,
                     firstGenericSegment,
-                    out var qualifiedType,
                     out var reflectionName,
                     out var isAmbiguous);
-                if (!resolved)
+                if (qualifiedType == null)
                 {
                     if (isAmbiguous)
                     {
@@ -277,14 +276,12 @@ internal sealed partial class ExpressionBinder
         return true;
     }
 
-    private bool TryResolveNestedUnboundGenericType(
+    private Type? ResolveNestedUnboundGenericType(
         string[] segments,
         int firstGenericSegment,
-        out Type type,
         out string reflectionName,
         out bool isAmbiguous)
     {
-        type = null!;
         reflectionName = string.Empty;
         isAmbiguous = false;
         for (var firstTypeSegment = firstGenericSegment; firstTypeSegment >= 0; firstTypeSegment--)
@@ -298,27 +295,26 @@ internal sealed partial class ExpressionBinder
             reflectionName = builder.ToString();
             if (scope.References.TryResolveType(reflectionName, out var direct) && direct != null)
             {
-                type = direct;
-                return true;
+                return direct;
             }
 
-            if (TryResolveImportedReflectionType(reflectionName, out type, out isAmbiguous))
+            var imported = ResolveImportedReflectionType(reflectionName, out isAmbiguous);
+            if (imported != null)
             {
-                return true;
+                return imported;
             }
 
             if (isAmbiguous)
             {
-                return false;
+                return null;
             }
         }
 
-        return false;
+        return null;
     }
 
-    private bool TryResolveImportedReflectionType(string reflectionName, out Type type, out bool isAmbiguous)
+    private Type? ResolveImportedReflectionType(string reflectionName, out bool isAmbiguous)
     {
-        type = null!;
         isAmbiguous = false;
         Type? match = null;
         foreach (var import in scope.GetDeclaredImports())
@@ -331,19 +327,13 @@ internal sealed partial class ExpressionBinder
             if (match != null && match != candidate)
             {
                 isAmbiguous = true;
-                return false;
+                return null;
             }
 
             match = candidate;
         }
 
-        if (match == null)
-        {
-            return false;
-        }
-
-        type = match;
-        return true;
+        return match;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -83,6 +83,31 @@ internal sealed partial class ExpressionBinder
             {
                 TryResolveOpenGenericImportedType(typeClauseIdentifier.Text, out typeSymbol);
             }
+            else if (TryGetNestedUnboundGenericReflectionName(typeClause, out var reflectionName))
+            {
+                bool resolved = scope.References.TryResolveType(reflectionName, out var qualifiedType);
+                bool isAmbiguous = false;
+                if (!resolved)
+                {
+                    resolved = TryResolveImportedReflectionType(reflectionName, out qualifiedType, out isAmbiguous);
+                }
+
+                if (!resolved)
+                {
+                    if (isAmbiguous)
+                    {
+                        Diagnostics.ReportAmbiguousImportedType(typeClause.Location, reflectionName);
+                    }
+                    else
+                    {
+                        Diagnostics.ReportUndefinedType(typeClause.Location, reflectionName);
+                    }
+
+                    return new BoundErrorExpression(null);
+                }
+
+                typeSymbol = TypeSymbol.FromClrType(qualifiedType);
+            }
             else if (typeClause.HasTypeArguments
                 && TryGetUnboundGenericArity(typeClause, out var arity))
             {
@@ -201,6 +226,89 @@ internal sealed partial class ExpressionBinder
         }
 
         type = TypeSymbol.FromClrType(match);
+        return true;
+    }
+
+    private bool TryGetNestedUnboundGenericReflectionName(TypeClauseSyntax typeClause, out string reflectionName)
+    {
+        reflectionName = string.Empty;
+        if (!typeClause.HasQualifier || typeClause.IsArray || typeClause.IsNullable || lookupType("_") != null)
+        {
+            return false;
+        }
+
+        var segments = new string[typeClause.SegmentCount];
+        segments[0] = Invariant.Required(typeClause.Identifier, "a named type clause has an identifier").Text;
+        for (var i = 1; i < segments.Length; i++)
+        {
+            segments[i] = typeClause.QualifierIdentifierTokens[i - 1].Text;
+        }
+
+        var firstGenericSegment = -1;
+        for (var i = 0; i < segments.Length; i++)
+        {
+            var args = typeClause.GetSegmentTypeArguments(i);
+            if (args == null)
+            {
+                continue;
+            }
+
+            if (args.Count == 0 || args.Any(arg =>
+                    arg.Identifier?.Text != "_"
+                    || arg.HasQualifier
+                    || arg.HasTypeArguments
+                    || arg.IsArray
+                    || arg.IsNullable))
+            {
+                return false;
+            }
+
+            firstGenericSegment = firstGenericSegment < 0 ? i : firstGenericSegment;
+            segments[i] += "`" + args.Count;
+        }
+
+        if (firstGenericSegment < 0 || firstGenericSegment == segments.Length - 1)
+        {
+            return false;
+        }
+
+        var builder = new StringBuilder(segments[0]);
+        for (var i = 1; i < segments.Length; i++)
+        {
+            builder.Append(i > firstGenericSegment ? '+' : '.').Append(segments[i]);
+        }
+
+        reflectionName = builder.ToString();
+        return true;
+    }
+
+    private bool TryResolveImportedReflectionType(string reflectionName, out Type type, out bool isAmbiguous)
+    {
+        type = null!;
+        isAmbiguous = false;
+        Type? match = null;
+        foreach (var import in scope.GetDeclaredImports())
+        {
+            if (!scope.References.TryResolveType(import.Target + "." + reflectionName, out var candidate))
+            {
+                continue;
+            }
+
+            if (match != null && match != candidate)
+            {
+                isAmbiguous = true;
+                return false;
+            }
+
+            match = candidate;
+        }
+
+        if (match == null)
+        {
+            return false;
+        }
+
+        type = match;
         return true;
     }
 

--- a/test/Compiler.Tests/Emit/Issue1989MultiArityOpenGenericTypeOfEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1989MultiArityOpenGenericTypeOfEmitTests.cs
@@ -102,6 +102,21 @@ public class Issue1989MultiArityOpenGenericTypeOfEmitTests
     }
 
     [Fact]
+    public void EndToEnd_DictionaryEnumerator_TypeOf_ResolvesOpenNestedDefinition()
+    {
+        const string source = """
+            package i3589dictionaryenumerator
+            import System
+            import System.Collections.Generic
+
+            func Main() { Console.WriteLine(typeof(Dictionary[_, _].Enumerator).FullName) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal($"System.Collections.Generic.Dictionary`2+Enumerator{Environment.NewLine}", output);
+    }
+
+    [Fact]
     public void EndToEnd_BareAction_TypeOf_StillResolvesNonGenericAction()
     {
         const string source = """

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1989MultiArityOpenGenericTypeOfBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1989MultiArityOpenGenericTypeOfBindingTests.cs
@@ -135,6 +135,27 @@ class C {
     }
 
     [Fact]
+    public void NonGenericOuterGenericNestedQualifier_TypeOf_BindsWithNestedSeparators()
+    {
+        var source = @"
+import GSharp.Core.Tests.CodeAnalysis.Binding
+
+class C {
+    func run() {
+        let t = typeof(Issue3589Outer.Nested[_].Leaf)
+    }
+}
+";
+        var result = EmittedOracle.Evaluate(
+    new[] { source },
+            new EmittedOracleOptions
+            {
+                References = new[] { typeof(Issue3589Outer).Assembly.Location },
+            });
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
     public void BareAction_TypeOf_StillResolvesNonGenericAction()
     {
         var source = @"
@@ -196,5 +217,15 @@ class C {
     private static EmittedOracleResult Evaluate(string source)
     {
         return EmittedOracle.Evaluate(source);
+    }
+}
+
+public class Issue3589Outer
+{
+    public class Nested<T>
+    {
+        public class Leaf
+        {
+        }
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1989MultiArityOpenGenericTypeOfBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1989MultiArityOpenGenericTypeOfBindingTests.cs
@@ -105,6 +105,36 @@ class C {
     }
 
     [Fact]
+    public void UnboundGenericQualifierNestedType_TypeOf_BindsToOpenNestedDefinition()
+    {
+        var source = @"
+import System.Collections.Generic
+
+class C {
+    func run() {
+        let t = typeof(Dictionary[_, _].Enumerator)
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void FullyQualifiedUnboundGenericQualifierNestedType_TypeOf_Binds()
+    {
+        var source = @"
+class C {
+    func run() {
+        let t = typeof(System.Collections.Generic.Dictionary[_, _].Enumerator)
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
     public void BareAction_TypeOf_StillResolvesNonGenericAction()
     {
         var source = @"

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2012OpenGenericTypeOfProducerTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2012OpenGenericTypeOfProducerTests.cs
@@ -113,6 +113,34 @@ namespace Demo
         Assert.DoesNotContain("<>", printed);
     }
 
+    [Fact]
+    public void NonGenericOuterGenericNestedQualifier_TypeOf_RendersPlaceholdersOnNestedSegment()
+    {
+        string printed = TranslateNestedUnit(@"
+using System;
+
+namespace Demo
+{
+    public class Outer
+    {
+        public class Nested<T>
+        {
+            public class Leaf
+            {
+            }
+        }
+    }
+
+    public class C
+    {
+        public Type Describe() => typeof(Outer.Nested<>.Leaf);
+    }
+}");
+
+        Assert.Contains("typeof(Outer.Nested[_].Leaf)", printed);
+        Assert.DoesNotContain("<>", printed);
+    }
+
     // Same as TranslateUnit but parse-only for source-defined open nested
     // generics, which have no reflectable CLR type during binding.
     private static string TranslateNestedUnit(string source)

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2012OpenGenericTypeOfProducerTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2012OpenGenericTypeOfProducerTests.cs
@@ -67,13 +67,12 @@ namespace Demo
     /// Issue #3589: an unbound generic in a NON-terminal segment renders each
     /// generic segment with its own <c>_</c> placeholder list instead of
     /// leaking the C# <c>&lt;,&gt;</c> spelling verbatim (which failed the
-    /// round-trip parse). gsc binds only the terminal-segment form today, so
-    /// validation is parse-only until #3589 lands.
+    /// round-trip parse).
     /// </summary>
     [Fact]
     public void UnboundNestedType_TypeOf_RendersPlaceholdersPerSegment()
     {
-        string printed = TranslateNestedUnit(@"
+        string printed = TranslateUnit(@"
 using System;
 using System.Collections.Generic;
 
@@ -114,9 +113,8 @@ namespace Demo
         Assert.DoesNotContain("<>", printed);
     }
 
-    // Same as TranslateUnit but parse-only: gsc cannot BIND a non-terminal
-    // `_` placeholder segment until #3589, while the emitted spelling must
-    // already round-trip-parse.
+    // Same as TranslateUnit but parse-only for source-defined open nested
+    // generics, which have no reflectable CLR type during binding.
     private static string TranslateNestedUnit(string source)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
@@ -365,9 +365,8 @@ public sealed partial class CSharpToGSharpTranslator
         // segment (`Dictionary<,>.Enumerator`, `Outer<>.Inner<>`). Each unbound
         // segment renders with its own `_` placeholder list — the older
         // `qualified.Left.ToString()` composition leaked the C# `<>` spelling
-        // verbatim into the emitted file (a round-trip GS0005). gsc binds only
-        // the terminal-segment form today; the nested spelling parses cleanly
-        // and starts binding when #3589 lands.
+        // verbatim into the emitted file (a round-trip GS0005). #3589 binds
+        // the nested spelling by composing its segment-wise reflection name.
         private GTypeReference MapTypeOfOperand(TypeSyntax type)
         {
             if (type is NameSyntax nameSyntax


### PR DESCRIPTION
Fixes #3589

Resolves `typeof` operands with unbound generic qualifiers and nested types by composing CLR reflection names with the correct namespace/type boundary, including shapes such as `Dictionary[_, _].Enumerator` and `Outer.Nested[_].Leaf`.

Adds binding, emit/runtime, and cs2gs producer regressions.