### PR TITLE
Disambiguate arrow-bodied tuple properties

### DIFF
--- a/src/Core/CodeAnalysis/Syntax/Parser.Expressions.Creation.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.Expressions.Creation.cs
@@ -930,11 +930,17 @@ public partial class Parser
         // `ParseTypeClause` nesting that issue #1046 introduced. Scanning only
         // one segment made `List[[][]int32]{ … }` fail to be recognised as a
         // generic composite-literal site.
-        while (Peek(pos).Kind == SyntaxKind.OpenSquareBracketToken)
+        var openBracketAlreadyConsumed = false;
+        while (openBracketAlreadyConsumed || Peek(pos).Kind == SyntaxKind.OpenSquareBracketToken)
         {
             // An array/slice prefix is unambiguously a type shape (Issue #1323).
             isComplex = true;
-            pos++;
+            if (!openBracketAlreadyConsumed)
+            {
+                pos++;
+            }
+
+            openBracketAlreadyConsumed = false;
             if (Peek(pos).Kind == SyntaxKind.NumberToken)
             {
                 pos++;
@@ -953,7 +959,12 @@ public partial class Parser
             }
 
             pos++;
-            if (Peek(pos).Kind == SyntaxKind.QuestionToken)
+            if (Peek(pos).Kind == SyntaxKind.QuestionOpenBracketToken)
+            {
+                pos++;
+                openBracketAlreadyConsumed = true;
+            }
+            else if (Peek(pos).Kind == SyntaxKind.QuestionToken)
             {
                 pos++;
             }

--- a/src/Core/CodeAnalysis/Syntax/Parser.Members.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.Members.cs
@@ -621,7 +621,7 @@ public partial class Parser
         }
 
         var identifier = MatchToken(SyntaxKind.IdentifierToken);
-        var type = ParseTypeClause();
+        var type = ParseDeclarationTypeClauseBeforeArrowBody(isProperty: true);
 
         if (Current.Kind == SyntaxKind.OpenBraceToken)
         {
@@ -690,7 +690,7 @@ public partial class Parser
         var openBracket = MatchToken(SyntaxKind.OpenSquareBracketToken);
         var parameters = ParseIndexerParameterList();
         var closeBracket = MatchToken(SyntaxKind.CloseSquareBracketToken);
-        var type = ParseTypeClause();
+        var type = ParseDeclarationTypeClauseBeforeArrowBody(isProperty: true);
 
         SyntaxToken? openBrace = null;
         var accessors = ImmutableArray<PropertyAccessorSyntax>.Empty;
@@ -1232,20 +1232,65 @@ public partial class Parser
 
     private TypeClauseSyntax? ParseOptionalFunctionReturnTypeClause()
     {
-        if (LooksLikeTupleReturnTypeBeforeArrowBody())
+        if (!CanStartTypeClause(Current)
+            || (Current.Kind == SyntaxKind.IdentifierToken && IsContextualMemberKeyword(Current.Text)))
         {
-            return ParseTupleTypeClause();
+            return null;
         }
 
-        return ParseOptionalTypeClause();
+        return ParseDeclarationTypeClauseBeforeArrowBody(isProperty: false);
     }
 
-    private bool LooksLikeTupleReturnTypeBeforeArrowBody()
+    private TypeClauseSyntax ParseDeclarationTypeClauseBeforeArrowBody(bool isProperty)
     {
-        // `(T1, T2) -> ...` is ambiguous with an arrow function type. Keep the
-        // type interpretation only when its complete scan reaches a declaration
-        // body marker; otherwise the arrow starts this function's expression body.
-        if (!LooksLikeArrowFunctionTypeClauseStart(0, out var hasTopLevelComma) ||
+        if (!LooksLikeTupleTypeBeforeArrowBody(isProperty, out var tupleOffset))
+        {
+            return ParseTypeClause();
+        }
+
+        var previous = tupleTypeBeforeArrowBodyPosition;
+        tupleTypeBeforeArrowBodyPosition = Peek(tupleOffset).Position;
+        try
+        {
+            return ParseTypeClause();
+        }
+        finally
+        {
+            tupleTypeBeforeArrowBodyPosition = previous;
+        }
+    }
+
+    private bool LooksLikeTupleTypeBeforeArrowBody(bool isProperty, out int tupleOffset)
+    {
+        tupleOffset = 0;
+        while (Peek(tupleOffset).Kind == SyntaxKind.OpenSquareBracketToken)
+        {
+            tupleOffset++;
+            if (Peek(tupleOffset).Kind == SyntaxKind.NumberToken)
+            {
+                tupleOffset++;
+            }
+            else
+            {
+                while (Peek(tupleOffset).Kind == SyntaxKind.CommaToken)
+                {
+                    tupleOffset++;
+                }
+            }
+
+            if (Peek(tupleOffset).Kind != SyntaxKind.CloseSquareBracketToken)
+            {
+                return false;
+            }
+
+            tupleOffset++;
+            if (Peek(tupleOffset).Kind == SyntaxKind.QuestionToken)
+            {
+                tupleOffset++;
+            }
+        }
+
+        if (!LooksLikeArrowFunctionTypeClauseStart(tupleOffset, out var hasTopLevelComma) ||
             !hasTopLevelComma)
         {
             return false;
@@ -1257,10 +1302,26 @@ public partial class Parser
             return true;
         }
 
-        return Peek(functionTypeEnd).Kind is not (
-            SyntaxKind.OpenBraceToken or
-            SyntaxKind.SemicolonToken or
-            SyntaxKind.RightArrowToken);
+        var endKind = Peek(functionTypeEnd).Kind;
+        if (endKind is SyntaxKind.SemicolonToken or SyntaxKind.RightArrowToken)
+        {
+            return false;
+        }
+
+        if (endKind != SyntaxKind.OpenBraceToken)
+        {
+            return true;
+        }
+
+        if (!isProperty)
+        {
+            return false;
+        }
+
+        var firstBodyToken = Peek(functionTypeEnd + 1);
+        return firstBodyToken.Kind != SyntaxKind.CloseBraceToken
+            && !(firstBodyToken.Kind == SyntaxKind.IdentifierToken
+                && firstBodyToken.Text is "get" or "set" or "init");
     }
 
     // Stream D: `func (a Point) operator +(b Point) Point { … }`. After the

--- a/src/Core/CodeAnalysis/Syntax/Parser.Members.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.Members.cs
@@ -1263,9 +1263,15 @@ public partial class Parser
     private bool LooksLikeTupleTypeBeforeArrowBody(bool isProperty, out int tupleOffset)
     {
         tupleOffset = 0;
-        while (Peek(tupleOffset).Kind == SyntaxKind.OpenSquareBracketToken)
+        var openBracketAlreadyConsumed = false;
+        while (openBracketAlreadyConsumed || Peek(tupleOffset).Kind == SyntaxKind.OpenSquareBracketToken)
         {
-            tupleOffset++;
+            if (!openBracketAlreadyConsumed)
+            {
+                tupleOffset++;
+            }
+
+            openBracketAlreadyConsumed = false;
             if (Peek(tupleOffset).Kind == SyntaxKind.NumberToken)
             {
                 tupleOffset++;
@@ -1284,7 +1290,12 @@ public partial class Parser
             }
 
             tupleOffset++;
-            if (Peek(tupleOffset).Kind == SyntaxKind.QuestionToken)
+            if (Peek(tupleOffset).Kind == SyntaxKind.QuestionOpenBracketToken)
+            {
+                tupleOffset++;
+                openBracketAlreadyConsumed = true;
+            }
+            else if (Peek(tupleOffset).Kind == SyntaxKind.QuestionToken)
             {
                 tupleOffset++;
             }
@@ -1308,6 +1319,11 @@ public partial class Parser
             return false;
         }
 
+        if (isProperty && IsFunctionTypedPropertyFollower(functionTypeEnd))
+        {
+            return false;
+        }
+
         if (endKind != SyntaxKind.OpenBraceToken)
         {
             return true;
@@ -1321,7 +1337,37 @@ public partial class Parser
         var firstBodyToken = Peek(functionTypeEnd + 1);
         return firstBodyToken.Kind != SyntaxKind.CloseBraceToken
             && !(firstBodyToken.Kind == SyntaxKind.IdentifierToken
-                && firstBodyToken.Text is "get" or "set" or "init");
+                && firstBodyToken.Text is "get" or "set" or "init")
+            && !((firstBodyToken.Kind is SyntaxKind.PublicKeyword
+                    or SyntaxKind.InternalKeyword
+                    or SyntaxKind.PrivateKeyword
+                    or SyntaxKind.ProtectedKeyword)
+                && Peek(functionTypeEnd + 2).Kind == SyntaxKind.IdentifierToken
+                && Peek(functionTypeEnd + 2).Text is "get" or "set" or "init");
+    }
+
+    private bool IsFunctionTypedPropertyFollower(int offset)
+    {
+        var token = Peek(offset);
+        if (token.Kind is SyntaxKind.EndOfFileToken
+            or SyntaxKind.CloseBraceToken
+            or SyntaxKind.AtToken
+            or SyntaxKind.FuncKeyword
+            or SyntaxKind.AsyncKeyword
+            or SyntaxKind.VarKeyword
+            or SyntaxKind.LetKeyword
+            or SyntaxKind.ConstKeyword
+            or SyntaxKind.PublicKeyword
+            or SyntaxKind.InternalKeyword
+            or SyntaxKind.PrivateKeyword
+            or SyntaxKind.ProtectedKeyword
+            or SyntaxKind.OpenKeyword
+            or SyntaxKind.OverrideKeyword)
+        {
+            return true;
+        }
+
+        return token.Kind == SyntaxKind.IdentifierToken && IsContextualMemberKeyword(token.Text);
     }
 
     // Stream D: `func (a Point) operator +(b Point) Point { … }`. After the

--- a/src/Core/CodeAnalysis/Syntax/Parser.Members.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.Members.cs
@@ -1348,6 +1348,11 @@ public partial class Parser
 
     private bool IsFunctionTypedPropertyFollower(int offset)
     {
+        if (TryDetectAggregateDeclarationHead(offset))
+        {
+            return true;
+        }
+
         var token = Peek(offset);
         if (token.Kind is SyntaxKind.EndOfFileToken
             or SyntaxKind.CloseBraceToken

--- a/src/Core/CodeAnalysis/Syntax/Parser.Members.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.Members.cs
@@ -1393,6 +1393,11 @@ public partial class Parser
             return true;
         }
 
+        if (token.Text == "fixed")
+        {
+            return Peek(offset + 1).Kind == SyntaxKind.IdentifierToken;
+        }
+
         if (token.Text == "init")
         {
             return Peek(offset + 1).Kind == SyntaxKind.OpenParenthesisToken;

--- a/src/Core/CodeAnalysis/Syntax/Parser.Members.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.Members.cs
@@ -1353,6 +1353,11 @@ public partial class Parser
             return true;
         }
 
+        if (LooksLikeContextualAggregateMemberHead(offset))
+        {
+            return true;
+        }
+
         var token = Peek(offset);
         if (token.Kind is SyntaxKind.EndOfFileToken
             or SyntaxKind.CloseBraceToken
@@ -1372,7 +1377,55 @@ public partial class Parser
             return true;
         }
 
-        return token.Kind == SyntaxKind.IdentifierToken && IsContextualMemberKeyword(token.Text);
+        return false;
+    }
+
+    private bool LooksLikeContextualAggregateMemberHead(int offset)
+    {
+        var token = Peek(offset);
+        if (token.Kind != SyntaxKind.IdentifierToken)
+        {
+            return false;
+        }
+
+        if (token.Text is "prop" or "event")
+        {
+            return true;
+        }
+
+        if (token.Text == "init")
+        {
+            return Peek(offset + 1).Kind == SyntaxKind.OpenParenthesisToken;
+        }
+
+        if (token.Text == "shared")
+        {
+            return Peek(offset + 1).Kind == SyntaxKind.OpenBraceToken;
+        }
+
+        if (token.Text == "unsafe")
+        {
+            return Peek(offset + 1).Kind == SyntaxKind.FuncKeyword
+                || (Peek(offset + 1).Kind == SyntaxKind.AsyncKeyword
+                    && Peek(offset + 2).Kind == SyntaxKind.FuncKeyword);
+        }
+
+        if (token.Text == "convenience")
+        {
+            return (Peek(offset + 1).Kind == SyntaxKind.IdentifierToken
+                    && Peek(offset + 1).Text == "init"
+                    && Peek(offset + 2).Kind == SyntaxKind.OpenParenthesisToken)
+                || (Peek(offset + 1).Kind == SyntaxKind.FuncKeyword
+                    && Peek(offset + 2).Kind == SyntaxKind.IdentifierToken
+                    && Peek(offset + 2).Text == "init"
+                    && Peek(offset + 3).Kind == SyntaxKind.OpenParenthesisToken);
+        }
+
+        return token.Text == "deinit"
+            && (Peek(offset + 1).Kind == SyntaxKind.OpenBraceToken
+                || Peek(offset + 1).Kind == SyntaxKind.OpenParenthesisToken
+                || (Peek(offset + 1).Kind == SyntaxKind.IdentifierToken
+                    && Peek(offset + 2).Kind == SyntaxKind.OpenBraceToken));
     }
 
     // Stream D: `func (a Point) operator +(b Point) Point { … }`. After the

--- a/src/Core/CodeAnalysis/Syntax/Parser.TypeClauses.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.TypeClauses.cs
@@ -39,6 +39,11 @@ public partial class Parser
 
         if (Current.Kind == SyntaxKind.OpenParenthesisToken)
         {
+            if (tupleTypeBeforeArrowBodyPosition == Current.Position)
+            {
+                return ParseTupleTypeClause();
+            }
+
             // ADR-0075 / issue #715: the canonical function-type clause is
             // `(T1, T2, ...) -> R`. Disambiguated from a tuple type clause by
             // bounded look-ahead — if the matching `)` is immediately followed

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -59,6 +59,11 @@ public partial class Parser
 
     private int position;
 
+    // Issue #3587: declaration return/property types can contain a slice-wrapped
+    // tuple immediately before an expression-body arrow. This position marks
+    // the one ambiguous tuple that must be parsed as a tuple, not a function type.
+    private int? tupleTypeBeforeArrowBodyPosition;
+
     // Issue #522: depth counter that suppresses trailing object-initializer
     // wrapping (`Call(args) { Prop = value }`). The default of zero allows
     // wrapping in regular expression contexts (variable declarations, return

--- a/test/Compiler.Tests/Emit/Issue1278ArrowExpressionMemberEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1278ArrowExpressionMemberEmitTests.cs
@@ -101,6 +101,56 @@ public class Issue1278ArrowExpressionMemberEmitTests
     }
 
     [Fact]
+    public void Issue3587_SliceOfTuplePropertyArrow_RunsAndReturns()
+    {
+        var source = """
+            package P
+
+            class C {
+                prop Rows [](string, string) -> [](string, string){("a", "b")}
+            }
+
+            public var result = C().Rows.Length
+            """;
+
+        Assert.Equal(1, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void Issue3587_SliceOfTupleFunctionArrow_RunsAndReturns()
+    {
+        var source = """
+            package P
+
+            func MakeRows() [](string, string) {
+                return [](string, string){("a", "b"), ("c", "d")}
+            }
+
+            func Rows() [](string, string) -> MakeRows()
+
+            public var result = Rows().Length
+            """;
+
+        Assert.Equal(2, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void Issue3587_MissingPropertyArrowExpression_FailsCompilation()
+    {
+        var source = """
+            package P
+
+            class C {
+                prop Rows [](string, string) ->
+            }
+            """;
+
+        var (exitCode, output, _) = CompileToFile(source);
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("GS0005", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void AccessorArrows_RoundTripThroughField()
     {
         var source = """

--- a/test/Compiler.Tests/Emit/Issue1278ArrowExpressionMemberEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1278ArrowExpressionMemberEmitTests.cs
@@ -151,6 +151,31 @@ public class Issue1278ArrowExpressionMemberEmitTests
     }
 
     [Fact]
+    public void Issue3587_NullableNestedSliceTupleArrows_RunAndReturn()
+    {
+        var source = """
+            package P
+
+            func MakeRows() []?[](string, string) {
+                return [][](string, string){
+                    [](string, string){("a", "b")},
+                    [](string, string){("c", "d")},
+                }
+            }
+
+            class C {
+                prop Rows []?[](string, string) -> MakeRows()
+            }
+
+            func Rows() []?[](string, string) -> MakeRows()
+
+            public var result = C().Rows!!.Length * 10 + Rows()!!.Length
+            """;
+
+        Assert.Equal(22, RunAndGetIntResult(source));
+    }
+
+    [Fact]
     public void AccessorArrows_RoundTripThroughField()
     {
         var source = """

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue1278ArrowExpressionMemberParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue1278ArrowExpressionMemberParserTests.cs
@@ -233,6 +233,25 @@ public class Issue1278ArrowExpressionMemberParserTests
         Assert.Empty(property.Accessors);
     }
 
+    [Theory]
+    [InlineData("deinit { }")]
+    [InlineData("unsafe func M() { }")]
+    public void Issue3587_FunctionTypedPropertyBeforeContextualMember_RemainsFunctionType(string followingMember)
+    {
+        var source =
+            "package P\n" +
+            "class C {\n" +
+            "  prop Handler (int32, int32) -> int32\n" +
+            "  " + followingMember + "\n" +
+            "}\n";
+        var tree = SyntaxTree.Parse(source);
+
+        Assert.Empty(tree.Diagnostics);
+        var property = tree.Root.Members.OfType<StructDeclarationSyntax>().Single().Properties.Single();
+        Assert.True(property.Type.IsArrowFunction);
+        Assert.Empty(property.Accessors);
+    }
+
     [Fact]
     public void Issue3587_FunctionTypedPropertyWithAccessibleAccessor_RemainsFunctionType()
     {

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue1278ArrowExpressionMemberParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue1278ArrowExpressionMemberParserTests.cs
@@ -212,6 +212,27 @@ public class Issue1278ArrowExpressionMemberParserTests
         Assert.Empty(property.Accessors);
     }
 
+    [Theory]
+    [InlineData("class Nested { }")]
+    [InlineData("struct Nested { }")]
+    [InlineData("interface Nested { }")]
+    [InlineData("enum Nested { A }")]
+    public void Issue3587_FunctionTypedPropertyBeforeNestedAggregate_RemainsFunctionType(string nestedType)
+    {
+        var source =
+            "package P\n" +
+            "class C {\n" +
+            "  prop Handler (int32, int32) -> int32\n" +
+            "  " + nestedType + "\n" +
+            "}\n";
+        var tree = SyntaxTree.Parse(source);
+
+        Assert.Empty(tree.Diagnostics);
+        var property = tree.Root.Members.OfType<StructDeclarationSyntax>().Single().Properties.Single();
+        Assert.True(property.Type.IsArrowFunction);
+        Assert.Empty(property.Accessors);
+    }
+
     [Fact]
     public void Issue3587_FunctionTypedPropertyWithAccessibleAccessor_RemainsFunctionType()
     {

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue1278ArrowExpressionMemberParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue1278ArrowExpressionMemberParserTests.cs
@@ -236,6 +236,7 @@ public class Issue1278ArrowExpressionMemberParserTests
     [Theory]
     [InlineData("deinit { }")]
     [InlineData("unsafe func M() { }")]
+    [InlineData("fixed data [8]int32")]
     public void Issue3587_FunctionTypedPropertyBeforeContextualMember_RemainsFunctionType(string followingMember)
     {
         var source =

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue1278ArrowExpressionMemberParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue1278ArrowExpressionMemberParserTests.cs
@@ -194,6 +194,74 @@ public class Issue1278ArrowExpressionMemberParserTests
         Assert.Single(property.Accessors);
     }
 
+    [Theory]
+    [InlineData("")]
+    [InlineData("\n  prop Other int32")]
+    public void Issue3587_BareFunctionTypedProperty_RemainsFunctionType(string followingMember)
+    {
+        var source =
+            "package P\n" +
+            "class C {\n" +
+            "  prop Handler (int32, int32) -> int32" + followingMember + "\n" +
+            "}\n";
+        var tree = SyntaxTree.Parse(source);
+
+        Assert.Empty(tree.Diagnostics);
+        var property = tree.Root.Members.OfType<StructDeclarationSyntax>().Single().Properties.First();
+        Assert.True(property.Type.IsArrowFunction);
+        Assert.Empty(property.Accessors);
+    }
+
+    [Fact]
+    public void Issue3587_FunctionTypedPropertyWithAccessibleAccessor_RemainsFunctionType()
+    {
+        const string source =
+            "package P\n" +
+            "class C {\n" +
+            "  prop Handler (int32, int32) -> int32 { private set; get; }\n" +
+            "}\n";
+        var tree = SyntaxTree.Parse(source);
+
+        Assert.Empty(tree.Diagnostics);
+        var property = tree.Root.Members.OfType<StructDeclarationSyntax>().Single().Properties.Single();
+        Assert.True(property.Type.IsArrowFunction);
+        Assert.Equal(2, property.Accessors.Length);
+    }
+
+    [Fact]
+    public void Issue3587_NullableNestedSliceTuplePropertyArrow_ParsesAsPropertyBody()
+    {
+        const string source =
+            "package P\n" +
+            "class C {\n" +
+            "  prop Rows []?[](string, string) -> makeRows()\n" +
+            "}\n";
+        var tree = SyntaxTree.Parse(source);
+
+        Assert.Empty(tree.Diagnostics);
+        var property = tree.Root.Members.OfType<StructDeclarationSyntax>().Single().Properties.Single();
+        Assert.True(property.Type.IsArrayNullable);
+        Assert.True(property.Type.ArrayElementType.IsSlice);
+        Assert.True(property.Type.ArrayElementType.ArrayElementType.IsTuple);
+        Assert.Single(property.Accessors);
+    }
+
+    [Fact]
+    public void Issue3587_NullableNestedSliceTupleFunctionArrow_ParsesAsFunctionBody()
+    {
+        const string source =
+            "package P\n" +
+            "func Rows() []?[](string, string) -> makeRows()\n";
+        var tree = SyntaxTree.Parse(source);
+
+        Assert.Empty(tree.Diagnostics);
+        var function = tree.Root.Members.OfType<FunctionDeclarationSyntax>().Single();
+        Assert.True(function.Type.IsArrayNullable);
+        Assert.True(function.Type.ArrayElementType.IsSlice);
+        Assert.True(function.Type.ArrayElementType.ArrayElementType.IsTuple);
+        Assert.NotNull(function.Body);
+    }
+
     [Fact]
     public void FunctionFatArrowBody_ReportsDiagnostic()
     {

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue1278ArrowExpressionMemberParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue1278ArrowExpressionMemberParserTests.cs
@@ -116,6 +116,85 @@ public class Issue1278ArrowExpressionMemberParserTests
     }
 
     [Fact]
+    public void Issue3587_SliceOfTuplePropertyArrowBody_ParsesAsPropertyBody()
+    {
+        const string source =
+            "package P\n" +
+            "class C {\n" +
+            "  prop Rows [](string, string) -> [](string, string){(\"a\", \"b\")}\n" +
+            "}\n";
+        var tree = SyntaxTree.Parse(source);
+
+        Assert.Empty(tree.Diagnostics);
+        var property = tree.Root.Members.OfType<StructDeclarationSyntax>().Single().Properties.Single();
+        Assert.True(property.Type.IsSlice);
+        Assert.True(property.Type.ArrayElementType.IsTuple);
+        Assert.False(property.Type.ArrayElementType.IsArrowFunction);
+        Assert.Single(property.Accessors);
+    }
+
+    [Fact]
+    public void Issue3587_TuplePropertyArrowBody_ParsesAsPropertyBody()
+    {
+        const string source =
+            "package P\n" +
+            "class C {\n" +
+            "  prop Pair (int32, int32) -> (1, 2)\n" +
+            "}\n";
+        var tree = SyntaxTree.Parse(source);
+
+        Assert.Empty(tree.Diagnostics);
+        var property = tree.Root.Members.OfType<StructDeclarationSyntax>().Single().Properties.Single();
+        Assert.True(property.Type.IsTuple);
+        Assert.Single(property.Accessors);
+    }
+
+    [Fact]
+    public void Issue3587_SliceOfTupleFunctionArrowBody_ParsesAsFunctionBody()
+    {
+        const string source =
+            "package P\n" +
+            "func Rows() [](string, string) -> makeRows()\n";
+        var tree = SyntaxTree.Parse(source);
+
+        Assert.Empty(tree.Diagnostics);
+        var function = tree.Root.Members.OfType<FunctionDeclarationSyntax>().Single();
+        Assert.True(function.Type.IsSlice);
+        Assert.True(function.Type.ArrayElementType.IsTuple);
+        Assert.NotNull(function.Body);
+    }
+
+    [Fact]
+    public void Issue3587_MissingPropertyArrowExpression_ReportsDiagnostic()
+    {
+        const string source =
+            "package P\n" +
+            "class C {\n" +
+            "  prop Rows [](string, string) ->\n" +
+            "}\n";
+        var tree = SyntaxTree.Parse(source);
+
+        Assert.Contains(tree.Diagnostics, diagnostic => diagnostic.Id == "GS0005");
+    }
+
+    [Fact]
+    public void Issue3587_SliceOfFunctionPropertyWithAccessors_RemainsFunctionType()
+    {
+        const string source =
+            "package P\n" +
+            "class C {\n" +
+            "  prop Handlers [](string, string) -> int32 { get }\n" +
+            "}\n";
+        var tree = SyntaxTree.Parse(source);
+
+        Assert.Empty(tree.Diagnostics);
+        var property = tree.Root.Members.OfType<StructDeclarationSyntax>().Single().Properties.Single();
+        Assert.True(property.Type.IsSlice);
+        Assert.True(property.Type.ArrayElementType.IsArrowFunction);
+        Assert.Single(property.Accessors);
+    }
+
+    [Fact]
     public void FunctionFatArrowBody_ReportsDiagnostic()
     {
         // Issue #1278: the C# fat arrow `=>` is not a G# member body form.


### PR DESCRIPTION
Fixes #3587

Stops tuple and slice-of-tuple declaration types before expression-body arrows while preserving explicit function-typed properties across every valid aggregate-member follower. Nullable nested slices and malformed arrow bodies are handled correctly instead of silently producing nil properties.

Adds parser and compiler/runtime regressions for property, function, accessor, nested-type, contextual-member, and fixed-buffer forms.