### PR TITLE
Propagate nullable tuple receiver types

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue3564TupleKeyIndexBridgingTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3564TupleKeyIndexBridgingTests.cs
@@ -92,6 +92,82 @@ namespace Demo
     }
 
     [Fact]
+    public void TupleValuedTryGetValueOut_DoesNotPromoteReceiverValueType()
+    {
+        string printed = TranslateOblivious(@"
+using System.Collections.Generic;
+
+namespace Demo
+{
+    public class Node
+    {
+        public string Label { get; set; } = """";
+    }
+
+    public interface ICache
+    {
+        Dictionary<(string, Node), (string, Node)> Store { get; }
+    }
+
+    public class Cache : ICache
+    {
+        public Dictionary<(string, Node), (string, Node)> Store { get; } = new();
+
+        private static string Resolve(Node node) => null;
+
+        public bool Lookup(Node scope)
+        {
+            var key = (scope.Label, scope);
+            (string, Node) value = (Resolve(scope), scope);
+            return this.Store.TryGetValue(key, out value);
+        }
+    }
+}");
+
+        Assert.Equal(
+            2,
+            printed.Split("prop Store Dictionary[(string, Node), (string, Node)]").Length - 1);
+        Assert.DoesNotContain("Dictionary[(string, Node), (string?, Node)]", printed);
+    }
+
+    [Fact]
+    public void ReorderedInheritedGeneric_UsesSubstitutedReceiverArgumentPath()
+    {
+        string printed = TranslateOblivious(@"
+using System.Collections.Generic;
+
+namespace Demo
+{
+    public class Node
+    {
+    }
+
+    public class Reordered<TValue, TKey> : Dictionary<TKey, TValue>
+    {
+    }
+
+    public class Cache
+    {
+        private readonly Reordered<bool, (string, Node)> store = new();
+
+        private static string Resolve(Node node) => null;
+
+        public bool Lookup(Node scope)
+        {
+            var key = (Resolve(scope), scope);
+            this.store[key] = true;
+            return this.store[key];
+        }
+    }
+}",
+            "G# does not currently bind inherited indexers on a source generic subclass.");
+
+        Assert.Contains("let store Reordered[bool, (string?, Node)]", printed);
+        Assert.Contains("this.store[key] = true", printed);
+        Assert.DoesNotContain("key.Item1!!", printed);
+    }
+
+    [Fact]
     public void UnpromotedTupleKey_StaysBare()
     {
         string printed = TranslateOblivious(@"
@@ -121,7 +197,7 @@ namespace Demo
         Assert.DoesNotContain("key.Item1!!", printed);
     }
 
-    private static string TranslateOblivious(string source)
+    private static string TranslateOblivious(string source, string roundTripOnlyReason = null)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
         Assert.True(
@@ -140,7 +216,9 @@ namespace Demo
             diagnostic => diagnostic.Severity == TranslationSeverity.Unsupported);
 
         string printed = GSharpPrinter.Print(unit);
-        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
+        RoundTripResult result = roundTripOnlyReason == null
+            ? TranslationTestValidation.AssertBinds(printed)
+            : TranslationTestValidation.ValidateRoundTripOnly(printed, roundTripOnlyReason);
         Assert.True(
             result.Success,
             "Translated G# must round-trip. Errors:\n" +

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3564TupleKeyIndexBridgingTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3564TupleKeyIndexBridgingTests.cs
@@ -14,18 +14,14 @@ using Xunit;
 namespace Cs2Gs.Tests;
 
 /// <summary>
-/// Issue #3564: a tuple-typed index key whose G#-side elements are
-/// promoted-nullable while the indexer's key tuple elements are not
-/// (`store[key]` where `key` is `(ISymbol?, SyntaxNode)` against a
-/// `Dictionary[(ISymbol, SyntaxNode), bool]` field) cannot be bridged with a
-/// whole-value `!!` — G# has no implicit `(T?, U) → (T, U)`. The index
-/// argument now rebuilds per element, asserting only the promoted slots:
-/// `store[(key.Item1!!, key.Item2)]`.
+/// Issue #3564: tuple-element taint flowing through a generic field/property
+/// key promotes that declaration's matching type argument, avoiding unsafe
+/// per-use assertions.
 /// </summary>
 public class Issue3564TupleKeyIndexBridgingTests
 {
     [Fact]
-    public void PromotedTupleKey_RebuildsPerElementAtIndexer()
+    public void PromotedTupleKey_PromotesDictionaryFieldKey()
     {
         string printed = TranslateOblivious(@"
 using System.Collections.Generic;
@@ -58,8 +54,41 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("this.store[(key.Item1!!, key.Item2)] = true", printed);
-        Assert.Contains("return this.store[(key.Item1!!, key.Item2)]", printed);
+        Assert.Contains("let store Dictionary[(string?, Node), bool]", printed);
+        Assert.Contains("this.store[key] = true", printed);
+        Assert.Contains("return this.store[key]", printed);
+        Assert.DoesNotContain("key.Item1!!", printed);
+    }
+
+    [Fact]
+    public void PromotedTupleKey_PromotesDictionaryPropertyKeyFromMethodArgument()
+    {
+        string printed = TranslateOblivious(@"
+using System.Collections.Generic;
+
+namespace Demo
+{
+    public class Node
+    {
+    }
+
+    public class Cache
+    {
+        private Dictionary<(string, Node), bool> Store { get; } = new();
+
+        private static string Resolve(Node node) => null;
+
+        public bool Lookup(Node scope)
+        {
+            var key = (Resolve(scope), scope);
+            return this.Store.TryGetValue(key, out var cached) && cached;
+        }
+    }
+}");
+
+        Assert.Contains("prop Store Dictionary[(string?, Node), bool]", printed);
+        Assert.Contains("this.Store.TryGetValue(key", printed);
+        Assert.DoesNotContain("key.Item1!!", printed);
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -1913,6 +1913,17 @@ public sealed partial class CSharpToGSharpTranslator
                 bool keyElementStaysNonNull = keyElement.Type is { IsReferenceType: true }
                     && keyElement.Type.NullableAnnotation != NullableAnnotation.Annotated;
                 if (keyElementStaysNonNull
+                    && this.TryGetIndexReceiverGenericTuple(argument, out ISymbol receiver, out int typeArgument)
+                    && ObliviousNullabilityAnalyzer.IsTupleElementTainted(
+                        this.context.Compilation,
+                        receiver,
+                        new List<int> { typeArgument, i },
+                        this.context.SiblingCompilations))
+                {
+                    keyElementStaysNonNull = false;
+                }
+
+                if (keyElementStaysNonNull
                     && ObliviousNullabilityAnalyzer.IsTupleElementTainted(
                         this.context.Compilation,
                         valueSymbol,
@@ -1932,6 +1943,32 @@ public sealed partial class CSharpToGSharpTranslator
             }
 
             rebuilt = new TupleLiteralExpression(elements);
+            return true;
+        }
+
+        private bool TryGetIndexReceiverGenericTuple(
+            ArgumentSyntax argument,
+            out ISymbol receiver,
+            out int typeArgument)
+        {
+            receiver = null;
+            typeArgument = -1;
+            if (argument.Parent?.Parent is not ElementAccessExpressionSyntax elementAccess
+                || this.context.SemanticModel.GetOperation(argument) is not IArgumentOperation operation
+                || operation.Parameter?.OriginalDefinition.Type
+                    is not ITypeParameterSymbol { TypeParameterKind: TypeParameterKind.Type } parameter)
+            {
+                return false;
+            }
+
+            ISymbol receiverSymbol = this.context.GetSymbolInfo(elementAccess.Expression).Symbol;
+            if (receiverSymbol is not (IFieldSymbol or IPropertySymbol))
+            {
+                return false;
+            }
+
+            receiver = receiverSymbol;
+            typeArgument = parameter.Ordinal;
             return true;
         }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -1913,11 +1913,14 @@ public sealed partial class CSharpToGSharpTranslator
                 bool keyElementStaysNonNull = keyElement.Type is { IsReferenceType: true }
                     && keyElement.Type.NullableAnnotation != NullableAnnotation.Annotated;
                 if (keyElementStaysNonNull
-                    && this.TryGetIndexReceiverGenericTuple(argument, out ISymbol receiver, out int typeArgument)
+                    && this.TryGetIndexReceiverGenericTuple(
+                        argument,
+                        out ISymbol receiver,
+                        out IReadOnlyList<int> tuplePath)
                     && ObliviousNullabilityAnalyzer.IsTupleElementTainted(
                         this.context.Compilation,
                         receiver,
-                        new List<int> { typeArgument, i },
+                        tuplePath.Concat(new[] { i }).ToList(),
                         this.context.SiblingCompilations))
                 {
                     keyElementStaysNonNull = false;
@@ -1949,14 +1952,13 @@ public sealed partial class CSharpToGSharpTranslator
         private bool TryGetIndexReceiverGenericTuple(
             ArgumentSyntax argument,
             out ISymbol receiver,
-            out int typeArgument)
+            out IReadOnlyList<int> tuplePath)
         {
             receiver = null;
-            typeArgument = -1;
+            tuplePath = null;
             if (argument.Parent?.Parent is not ElementAccessExpressionSyntax elementAccess
                 || this.context.SemanticModel.GetOperation(argument) is not IArgumentOperation operation
-                || operation.Parameter?.OriginalDefinition.Type
-                    is not ITypeParameterSymbol { TypeParameterKind: TypeParameterKind.Type } parameter)
+                || operation.Parameter is not IParameterSymbol parameter)
             {
                 return false;
             }
@@ -1967,8 +1969,23 @@ public sealed partial class CSharpToGSharpTranslator
                 return false;
             }
 
+            ITypeSymbol receiverType = receiverSymbol switch
+            {
+                IFieldSymbol field => field.Type,
+                IPropertySymbol property => property.Type,
+                _ => null,
+            };
+            if (receiverType is not INamedTypeSymbol namedReceiver
+                || !ObliviousNullabilityAnalyzer.TryGetGenericReceiverTuplePath(
+                    namedReceiver,
+                    parameter,
+                    out _,
+                    out tuplePath))
+            {
+                return false;
+            }
+
             receiver = receiverSymbol;
-            typeArgument = parameter.Ordinal;
             return true;
         }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
@@ -244,15 +244,53 @@ public sealed partial class CSharpToGSharpTranslator
             ITypeSymbol returnType,
             ISymbol symbol)
         {
-            if (!this.IsObliviousCompilation()
-                || mapped is not TupleTypeReference tuple
-                || returnType is not INamedTypeSymbol { IsTupleType: true } tupleType
-                || tupleType.TupleElements.Length != tuple.ElementTypes.Count)
+            if (!this.IsObliviousCompilation())
             {
                 return mapped;
             }
 
-            return this.PromoteTupleElements(tuple, tupleType, symbol, new List<int>());
+            return this.PromoteTupleTypeArguments(mapped, returnType, symbol, new List<int>());
+        }
+
+        private GTypeReference PromoteTupleTypeArguments(
+            GTypeReference mapped,
+            ITypeSymbol declaredType,
+            ISymbol symbol,
+            List<int> path)
+        {
+            if (mapped is TupleTypeReference tuple
+                && declaredType is INamedTypeSymbol { IsTupleType: true } tupleType
+                && tupleType.TupleElements.Length == tuple.ElementTypes.Count)
+            {
+                return this.PromoteTupleElements(tuple, tupleType, symbol, path);
+            }
+
+            if (mapped is not NamedTypeReference named
+                || declaredType is not INamedTypeSymbol declaredNamed
+                || named.TypeArguments.Count != declaredNamed.TypeArguments.Length)
+            {
+                return mapped;
+            }
+
+            var arguments = new List<GTypeReference>(named.TypeArguments.Count);
+            bool changed = false;
+            for (int i = 0; i < named.TypeArguments.Count; i++)
+            {
+                path.Add(i);
+                GTypeReference argument = this.PromoteTupleTypeArguments(
+                    named.TypeArguments[i],
+                    declaredNamed.TypeArguments[i],
+                    symbol,
+                    path);
+                path.RemoveAt(path.Count - 1);
+                changed |= !ReferenceEquals(argument, named.TypeArguments[i]);
+                arguments.Add(argument);
+            }
+
+            return changed
+                ? new NamedTypeReference(named.Name, arguments, named.ContainingType)
+                    { IsNullable = named.IsNullable }
+                : mapped;
         }
 
         private GTypeReference PromoteTupleElements(

--- a/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
@@ -272,6 +272,37 @@ internal static class ObliviousNullabilityAnalyzer
         return entities;
     }
 
+    internal static bool TryGetGenericReceiverTuplePath(
+        INamedTypeSymbol receiverType,
+        IParameterSymbol parameter,
+        out INamedTypeSymbol tupleType,
+        out IReadOnlyList<int> tuplePath)
+    {
+        tupleType = null;
+        tuplePath = null;
+        if (receiverType == null
+            || parameter?.OriginalDefinition.Type
+                is not ITypeParameterSymbol { TypeParameterKind: TypeParameterKind.Type } typeParameter
+            || typeParameter.ContainingType is not INamedTypeSymbol declaringType)
+        {
+            return false;
+        }
+
+        if (!TryResolveReceiverTypeParameterPath(
+                receiverType,
+                declaringType.OriginalDefinition,
+                typeParameter.Ordinal,
+                out INamedTypeSymbol actualTuple,
+                out IReadOnlyList<int> path))
+        {
+            return false;
+        }
+
+        tupleType = actualTuple;
+        tuplePath = path;
+        return true;
+    }
+
     private static bool IsTaintedCore(
         CSharpCompilation compilation,
         ISymbol symbol,
@@ -1278,13 +1309,17 @@ internal static class ObliviousNullabilityAnalyzer
             _ => null,
         };
 
+        // Scalar flow already treats out as callee-to-caller and deliberately
+        // excludes ref, so neither is receiver-directed here.
         if (target is not (IFieldSymbol or IPropertySymbol)
             || targetType is not INamedTypeSymbol receiverType
-            || argument.Parameter?.OriginalDefinition.Type
-                is not ITypeParameterSymbol { TypeParameterKind: TypeParameterKind.Type } typeParameter
-            || typeParameter.Ordinal >= receiverType.TypeArguments.Length
-            || receiverType.TypeArguments[typeParameter.Ordinal]
-                is not INamedTypeSymbol { IsTupleType: true } tupleType
+            || argument.Parameter is not IParameterSymbol parameter
+            || parameter.RefKind is RefKind.Out or RefKind.Ref
+            || !TryGetGenericReceiverTuplePath(
+                receiverType,
+                parameter,
+                out INamedTypeSymbol tupleType,
+                out IReadOnlyList<int> tuplePath)
             || argument.Value?.Syntax is not ExpressionSyntax value)
         {
             return;
@@ -1295,7 +1330,7 @@ internal static class ObliviousNullabilityAnalyzer
             tupleType,
             value,
             model,
-            typeParameter.Ordinal.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            EncodeTuplePath(tuplePath),
             tupleTainted,
             tupleEdges,
             tupleScalarEdges);
@@ -1801,6 +1836,99 @@ internal static class ObliviousNullabilityAnalyzer
 
         tupleType = type as INamedTypeSymbol;
         return tupleType is { IsTupleType: true };
+    }
+
+    private static bool TryResolveReceiverTypeParameterPath(
+        INamedTypeSymbol receiverType,
+        INamedTypeSymbol declaringType,
+        int ordinal,
+        out INamedTypeSymbol tupleType,
+        out IReadOnlyList<int> path)
+    {
+        tupleType = null;
+        path = null;
+        if (SymbolEqualityComparer.Default.Equals(receiverType.OriginalDefinition, declaringType))
+        {
+            if (ordinal >= receiverType.TypeArguments.Length
+                || receiverType.TypeArguments[ordinal]
+                    is not INamedTypeSymbol { IsTupleType: true } directTuple)
+            {
+                return false;
+            }
+
+            tupleType = directTuple;
+            path = new[] { ordinal };
+            return true;
+        }
+
+        foreach ((INamedTypeSymbol constructed, INamedTypeSymbol template) in
+            EnumerateDirectReceiverTypes(receiverType))
+        {
+            if (!TryResolveReceiverTypeParameterPath(
+                    constructed,
+                    declaringType,
+                    ordinal,
+                    out INamedTypeSymbol inheritedTuple,
+                    out IReadOnlyList<int> inheritedPath)
+                || !TryFollowTypeArgumentPath(template, inheritedPath, out ITypeSymbol source)
+                || source is not ITypeParameterSymbol sourceParameter
+                || sourceParameter.ContainingType is not INamedTypeSymbol sourceOwner
+                || !SymbolEqualityComparer.Default.Equals(
+                    sourceOwner.OriginalDefinition,
+                    receiverType.OriginalDefinition))
+            {
+                continue;
+            }
+
+            tupleType = inheritedTuple;
+            path = new[] { sourceParameter.Ordinal };
+            return true;
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<(INamedTypeSymbol Constructed, INamedTypeSymbol Template)>
+        EnumerateDirectReceiverTypes(INamedTypeSymbol receiverType)
+    {
+        INamedTypeSymbol original = receiverType.OriginalDefinition;
+        if (receiverType.BaseType is INamedTypeSymbol baseType
+            && original.BaseType is INamedTypeSymbol baseTemplate)
+        {
+            yield return (baseType, baseTemplate);
+        }
+
+        foreach (INamedTypeSymbol iface in receiverType.Interfaces)
+        {
+            INamedTypeSymbol template = original.Interfaces.FirstOrDefault(candidate =>
+                SymbolEqualityComparer.Default.Equals(
+                    candidate.OriginalDefinition,
+                    iface.OriginalDefinition));
+            if (template != null)
+            {
+                yield return (iface, template);
+            }
+        }
+    }
+
+    private static bool TryFollowTypeArgumentPath(
+        INamedTypeSymbol type,
+        IReadOnlyList<int> path,
+        out ITypeSymbol result)
+    {
+        result = type;
+        foreach (int index in path)
+        {
+            if (result is not INamedTypeSymbol named || index >= named.TypeArguments.Length)
+            {
+                result = null;
+                return false;
+            }
+
+            result = named.TypeArguments[index];
+        }
+
+        return true;
     }
 
     private static bool IsEligibleTupleLeaf(ITypeSymbol type) =>

--- a/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
@@ -1239,7 +1239,66 @@ internal static class ObliviousNullabilityAnalyzer
                     tupleEdges,
                     tupleScalarEdges);
             }
+
+            CollectGenericReceiverTupleArgumentFlow(
+                call,
+                argument,
+                model,
+                tupleTainted,
+                tupleEdges,
+                tupleScalarEdges);
         }
+    }
+
+    // Issue #3564: Dictionary<TKey, TValue> indexer/method parameters use the
+    // receiver's generic TKey slot. When a promoted tuple flows into that slot,
+    // carry its per-element taint back to the source field/property type so all
+    // uses share Dictionary[(T?, U), TValue] instead of asserting at each use.
+    private static void CollectGenericReceiverTupleArgumentFlow(
+        SyntaxNode call,
+        IArgumentOperation argument,
+        SemanticModel model,
+        HashSet<TupleElementKey> tupleTainted,
+        List<(TupleElementKey Target, TupleElementKey Source)> tupleEdges,
+        List<(TupleElementKey Target, ISymbol Source)> tupleScalarEdges)
+    {
+        ExpressionSyntax receiver = call switch
+        {
+            InvocationExpressionSyntax { Expression: MemberAccessExpressionSyntax member } =>
+                member.Expression,
+            ElementAccessExpressionSyntax elementAccess => elementAccess.Expression,
+            _ => null,
+        };
+
+        ISymbol target = receiver == null ? null : model.GetSymbolInfo(receiver).Symbol;
+        ITypeSymbol targetType = target switch
+        {
+            IFieldSymbol field => field.Type,
+            IPropertySymbol property => property.Type,
+            _ => null,
+        };
+
+        if (target is not (IFieldSymbol or IPropertySymbol)
+            || targetType is not INamedTypeSymbol receiverType
+            || argument.Parameter?.OriginalDefinition.Type
+                is not ITypeParameterSymbol { TypeParameterKind: TypeParameterKind.Type } typeParameter
+            || typeParameter.Ordinal >= receiverType.TypeArguments.Length
+            || receiverType.TypeArguments[typeParameter.Ordinal]
+                is not INamedTypeSymbol { IsTupleType: true } tupleType
+            || argument.Value?.Syntax is not ExpressionSyntax value)
+        {
+            return;
+        }
+
+        CollectTupleValueFlow(
+            Canonical(target),
+            tupleType,
+            value,
+            model,
+            typeParameter.Ordinal.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            tupleTainted,
+            tupleEdges,
+            tupleScalarEdges);
     }
 
     private static void CollectTupleValueFlow(


### PR DESCRIPTION
Fixes #3564

Propagates nullable tuple-element flow into generic field/property receiver declarations so tuple-keyed dictionary access remains type-correct. The analyzer now respects argument direction and resolves inherited generic substitutions before choosing declaration paths or suppressing seam assertions.

Adds regressions for index access, `TryGetValue(out ...)`, interface compatibility, and reordered inherited generic parameters.