### PR TITLE
Fix tuple literal argument conversions

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -4930,9 +4930,11 @@ public sealed class Binder
         Type erasedArgument,
         ref bool hasSymbolicArgument)
     {
-        // #313 / #671: preserve symbolic type parameters, user types, and
-        // nested generic/array/nullable shapes beside their erased CLR form.
-        if (TypeSymbol.RequiresSymbolicProjection(type) || type.ClrType == null)
+        // #313 / #671 / #3560: preserve symbolic type parameters, user types,
+        // and tuple conversion semantics beside their CLR form.
+        if (TypeSymbol.RequiresSymbolicProjection(type)
+            || type.ClrType == null
+            || type is TupleTypeSymbol)
         {
             hasSymbolicArgument = true;
 

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -1376,7 +1376,7 @@ internal sealed class ConversionClassifier
         TypeSymbol? receiverType,
         ImmutableArray<TypeSymbol?> symbolicMethodTypeArgs = default)
     {
-        // Issues #2385/#2664: the receiver type-argument gate below previously only
+        // Issues #2385/#2664: the receiver type-argument gate previously only
         // matched a same-compilation user type when it was DIRECTLY a
         // StructSymbol/InterfaceSymbol/EnumSymbol/DelegateTypeSymbol (or
         // nested inside another ImportedTypeSymbol). A same-compilation
@@ -1398,11 +1398,15 @@ internal sealed class ConversionClassifier
         // same-compilation enums and array/tuple-wrapped shapes used as a
         // generic type argument, and also retains nullable-reference
         // annotations whose CLR type is otherwise identical to its underlying
-        // non-null reference.
+        // non-null reference. Issue #3560 also retains fully CLR-backed tuple
+        // arguments because their element-wise conversion semantics cannot be
+        // recovered from the nominal ValueTuple reflection type alone.
         if (method == null
             || receiverType is not ImportedTypeSymbol imported
             || imported.TypeArguments.IsDefaultOrEmpty
-            || !imported.TypeArguments.Any(TypeSymbol.RequiresSymbolicProjection))
+            || !imported.TypeArguments.Any(
+                static argument => TypeSymbol.RequiresSymbolicProjection(argument)
+                    || argument is TupleTypeSymbol))
         {
             return null;
         }
@@ -1494,7 +1498,8 @@ internal sealed class ConversionClassifier
         mapped = PreserveParameterTopLevelNullability(openParams[paramIndex], mapped);
         return mapped != null
             && mapped != TypeSymbol.Error
-            && TypeSymbol.RequiresSymbolicProjection(mapped)
+            && (TypeSymbol.RequiresSymbolicProjection(mapped)
+                || mapped is TupleTypeSymbol)
             ? mapped
             : null;
     }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -3187,13 +3187,13 @@ internal sealed partial class ExpressionBinder
             var hasUserClassArg = false;
             for (var i = 0; i < arguments.Length; i++)
             {
-                if (argumentNames.IsDefault
-                    && TryProjectArgumentClrTypeFromSymbolicReceiver(
-                        candidates,
-                        i,
-                        effectiveReceiverType,
-                        arguments[i].Type,
-                        out var receiverProjectedArgumentType))
+                if (TryProjectArgumentClrTypeFromSymbolicReceiver(
+                    candidates,
+                    i,
+                    ce,
+                    effectiveReceiverType,
+                    arguments[i].Type,
+                    out var receiverProjectedArgumentType))
                 {
                     argTypes[i] = receiverProjectedArgumentType;
                     continue;
@@ -3473,7 +3473,8 @@ internal sealed partial class ExpressionBinder
 
     private bool TryProjectArgumentClrTypeFromSymbolicReceiver(
         IReadOnlyList<MethodInfo> candidates,
-        int argumentIndex,
+        int sourceArgumentIndex,
+        CallExpressionSyntax call,
         TypeSymbol receiverType,
         TypeSymbol argumentType,
         [NotNullWhen(true)] out Type? projectedType)
@@ -3481,9 +3482,19 @@ internal sealed partial class ExpressionBinder
         projectedType = null;
         foreach (var candidate in candidates)
         {
+            var parameterIndex = MapSourceArgumentToParameter(
+                candidate.GetParameters(),
+                call,
+                sourceArgumentIndex,
+                offset: 0);
+            if (parameterIndex < 0)
+            {
+                continue;
+            }
+
             var symbolicTarget = ConversionClassifier.TrySubstituteParameterTypeFromReceiver(
                 candidate,
-                argumentIndex,
+                parameterIndex,
                 receiverType);
             if (symbolicTarget == null)
             {

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -3188,7 +3188,6 @@ internal sealed partial class ExpressionBinder
             for (var i = 0; i < arguments.Length; i++)
             {
                 if (argumentNames.IsDefault
-                    && ContainsNestedNullType(arguments[i].Type)
                     && TryProjectArgumentClrTypeFromSymbolicReceiver(
                         candidates,
                         i,
@@ -3470,24 +3469,6 @@ internal sealed partial class ExpressionBinder
 
         Diagnostics.ReportUnableToFindFunction(ce.Location, methodName);
         return new BoundErrorExpression(null);
-    }
-
-    private static bool ContainsNestedNullType(TypeSymbol type)
-    {
-        if (type == TypeSymbol.Null)
-        {
-            return true;
-        }
-
-        foreach (var inner in TypeSymbol.GetWrappedTypes(type))
-        {
-            if (ContainsNestedNullType(inner))
-            {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     private bool TryProjectArgumentClrTypeFromSymbolicReceiver(

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -3187,13 +3187,15 @@ internal sealed partial class ExpressionBinder
             var hasUserClassArg = false;
             for (var i = 0; i < arguments.Length; i++)
             {
-                if (TryProjectArgumentClrTypeFromSymbolicReceiver(
-                    candidates,
-                    i,
-                    ce,
-                    effectiveReceiverType,
-                    arguments[i].Type,
-                    out var receiverProjectedArgumentType))
+                if ((arguments[i].Type is TupleTypeSymbol
+                        || ContainsNestedNullType(arguments[i].Type))
+                    && TryProjectArgumentClrTypeFromSymbolicReceiver(
+                        candidates,
+                        i,
+                        ce,
+                        effectiveReceiverType,
+                        arguments[i].Type,
+                        out var receiverProjectedArgumentType))
                 {
                     argTypes[i] = receiverProjectedArgumentType;
                     continue;
@@ -3469,6 +3471,24 @@ internal sealed partial class ExpressionBinder
 
         Diagnostics.ReportUnableToFindFunction(ce.Location, methodName);
         return new BoundErrorExpression(null);
+    }
+
+    private static bool ContainsNestedNullType(TypeSymbol type)
+    {
+        if (type == TypeSymbol.Null)
+        {
+            return true;
+        }
+
+        foreach (var inner in TypeSymbol.GetWrappedTypes(type))
+        {
+            if (ContainsNestedNullType(inner))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private bool TryProjectArgumentClrTypeFromSymbolicReceiver(

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -1540,7 +1540,7 @@ internal sealed partial class ExpressionBinder
     /// <param name="typeArgumentList">The call's <c>[T1, T2]</c> list.</param>
     /// <param name="clrArgs">On success, the resolved (mapped) CLR type arguments ready for MakeGenericType.</param>
     /// <param name="symbolicArgs">On success, the symbolic type arguments in source order.</param>
-    /// <param name="hasSymbolicArg">On success, whether any argument carries information its CLR type cannot represent.</param>
+    /// <param name="hasSymbolicArg">On success, whether any argument carries symbolic or tuple-conversion information to retain.</param>
     /// <returns>Whether all type arguments resolved.</returns>
     private bool TryResolveClrConstructionTypeArgs(
         TypeArgumentListSyntax typeArgumentList,
@@ -1583,11 +1583,9 @@ internal sealed partial class ExpressionBinder
                 continue;
             }
 
-            // Issue #2664: preserve every symbolic argument shape that its CLR
-            // type cannot represent, including nullable references. Indexer and
-            // Add binding can then recover `T?` instead of target-typing `nil`
-            // against the erased non-null `T`.
-            if (TypeSymbol.RequiresSymbolicProjection(ta))
+            // Issues #2664/#3560: preserve symbolic shapes and tuple conversion
+            // semantics so member arguments can recover their language target.
+            if (TypeSymbol.RequiresSymbolicProjection(ta) || ta is TupleTypeSymbol)
             {
                 hasSymbolicArg = true;
             }

--- a/test/Compiler.Tests/Emit/Issue3560TupleGenericArgumentConversionTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3560TupleGenericArgumentConversionTests.cs
@@ -57,6 +57,42 @@ public sealed class Issue3560TupleGenericArgumentConversionTests
         Assert.Equal($"True{Environment.NewLine}", CompileVerifyAndRun(Source));
     }
 
+    [Fact]
+    public void ListAdd_NamedTupleLiteralNullableLift_CompileVerifyAndRun()
+    {
+        const string Source = """
+            package Issue3560
+
+            import System
+            import System.Collections.Generic
+
+            let values = List[(string, int32, int32?)]()
+            values.Add(item: ("a", 1, 2))
+
+            Console.WriteLine(values[0].Item3)
+            """;
+
+        Assert.Equal($"2{Environment.NewLine}", CompileVerifyAndRun(Source));
+    }
+
+    [Fact]
+    public void ListAdd_NamedTupleLiteralNil_CompileVerifyAndRun()
+    {
+        const string Source = """
+            package Issue3560
+
+            import System
+            import System.Collections.Generic
+
+            let values = List[(string, int32, int32?)]()
+            values.Add(item: ("b", 2, nil))
+
+            Console.WriteLine(values[0].Item3 == nil)
+            """;
+
+        Assert.Equal($"True{Environment.NewLine}", CompileVerifyAndRun(Source));
+    }
+
     private static string CompileVerifyAndRun(string source)
     {
         var directory = Path.Combine(

--- a/test/Compiler.Tests/Emit/Issue3560TupleGenericArgumentConversionTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3560TupleGenericArgumentConversionTests.cs
@@ -1,0 +1,132 @@
+// <copyright file="Issue3560TupleGenericArgumentConversionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+public sealed class Issue3560TupleGenericArgumentConversionTests
+{
+    [Fact]
+    public void ListAdd_TupleLiteralNullableLift_CompileVerifyAndRun()
+    {
+        const string Source = """
+            package Issue3560
+
+            import System
+            import System.Collections.Generic
+
+            func Add(values List[(string, int32, int32?)]) {
+                values.Add(("a", 1, 2))
+            }
+
+            let values = List[(string, int32, int32?)]()
+            Add(values)
+
+            Console.WriteLine(values[0].Item3)
+            """;
+
+        Assert.Equal($"2{Environment.NewLine}", CompileVerifyAndRun(Source));
+    }
+
+    [Fact]
+    public void ListAdd_TupleLiteralNil_CompileVerifyAndRun()
+    {
+        const string Source = """
+            package Issue3560
+
+            import System
+            import System.Collections.Generic
+
+            func Add(values List[(string, int32, int32?)]) {
+                values.Add(("b", 2, nil))
+            }
+
+            let values = List[(string, int32, int32?)]()
+            Add(values)
+
+            Console.WriteLine(values[0].Item3 == nil)
+            """;
+
+        Assert.Equal($"True{Environment.NewLine}", CompileVerifyAndRun(Source));
+    }
+
+    private static string CompileVerifyAndRun(string source)
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            nameof(Issue3560TupleGenericArgumentConversionTests),
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            var sourcePath = Path.Combine(directory, "Program.gs");
+            var outputPath = Path.Combine(directory, "Issue3560.dll");
+            File.WriteAllText(sourcePath, source);
+
+            var arguments = new List<string>
+            {
+                "/out:" + outputPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+            foreach (var reference in ReferenceResolver.HostTrustedPlatformAssemblyPaths())
+            {
+                arguments.Add("/r:" + reference);
+            }
+
+            arguments.Add(sourcePath);
+
+            using var standardOut = new StringWriter();
+            using var standardError = new StringWriter();
+            var previousOut = Console.Out;
+            var previousError = Console.Error;
+            Console.SetOut(standardOut);
+            Console.SetError(standardError);
+            int exitCode;
+            try
+            {
+                exitCode = Program.Main(arguments.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+                Console.SetError(previousError);
+            }
+
+            Assert.True(exitCode == 0, $"gsc failed:{Environment.NewLine}{standardOut}{standardError}");
+            IlVerifier.Verify(outputPath);
+
+            using var process = Process.Start(new ProcessStartInfo("dotnet")
+            {
+                ArgumentList =
+                {
+                    "exec",
+                    "--runtimeconfig",
+                    Path.ChangeExtension(outputPath, ".runtimeconfig.json"),
+                    outputPath,
+                },
+                WorkingDirectory = directory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            });
+            var output = process.StandardOutput.ReadToEnd();
+            var error = process.StandardError.ReadToEnd();
+            Assert.True(process.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(process.ExitCode == 0, error);
+            return output.ReplaceLineEndings(Environment.NewLine);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3560

Projects tuple and nested-`nil` call arguments against symbolic generic receiver parameter types before overload resolution, including named arguments, then emits element-wise tuple conversions using rebuilt target tuples. This prevents nil signature-encoding failures and unconverted `IList.Add` runtime crashes without broadening projection to incompatible delegate calls.

Adds positional and named compile/runtime regressions for nullable tuple lifting and nil elements.