### PR TITLE
cs2gs: analyzer-mode INamespaceSymbol maps to nullable string (#3501)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Adr0169AnalyzerTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Adr0169AnalyzerTranslationTests.cs
@@ -254,6 +254,66 @@ public sealed class BinaryComparisonAnalyzer : DiagnosticAnalyzer
     }
 
     [Fact]
+    public void NamespaceSymbolParameter_MapsToNullableStringWithoutAssert()
+    {
+        // Roslyn annotates INamespaceSymbol non-nullable even though
+        // ContainingNamespace can be null; G#'s counterpart is honestly
+        // `string?`. A null-tolerant helper taking INamespaceSymbol must keep
+        // a nullable parameter — otherwise every ContainingNamespace argument
+        // gets bridged with `!!`, a runtime NRE the C# could not produce (the
+        // migrated EmitCacheKeyRemapScopeAnalyzer crash).
+        var (printed, diagnostics) = TranslateAnalyzer(@"
+#nullable enable
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Sample;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class NamespaceHelperAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Rule = new(
+        ""TEST0007"", ""Title"", ""Message {0}"", ""Testing"", DiagnosticSeverity.Warning, isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.RegisterSymbolAction(AnalyzeField, SymbolKind.Field);
+    }
+
+    private static void AnalyzeField(SymbolAnalysisContext context)
+    {
+        var field = (IFieldSymbol)context.Symbol;
+        AnalyzeCacheMember(context, field, field.Name);
+    }
+
+    private static void AnalyzeCacheMember(SymbolAnalysisContext context, ISymbol member, string memberName)
+    {
+        if (IsEmitNamespace(member.ContainingNamespace))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(Rule, member.Locations[0], memberName));
+        }
+    }
+
+    private static bool IsEmitNamespace(INamespaceSymbol namespaceSymbol)
+    {
+        var name = namespaceSymbol?.ToDisplayString();
+        return name == ""App.Emit"";
+    }
+}
+");
+
+        Assert.Contains("namespaceSymbol string?", printed, StringComparison.Ordinal);
+        Assert.Contains("IsEmitNamespace(member.ContainingNamespace)", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("ContainingNamespace!!", printed, StringComparison.Ordinal);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
+        AssertBindsAgainstGsCore(printed);
+    }
+
+    [Fact]
     public void SemanticModelAnalyzer_TranslatesDeclarationAndOverrideIdioms()
     {
         // The mechanical subset of GSA0005: GetDeclaredSymbol/GetSymbolInfo,

--- a/tools/cs2gs/Cs2Gs.Translator/Analyzers/RoslynAnalyzerApiMap.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/Analyzers/RoslynAnalyzerApiMap.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
 
 namespace Cs2Gs.Translator.Analyzers;
 
@@ -279,6 +280,22 @@ internal static class RoslynAnalyzerApiMap
     /// <returns>True when mapped; false means CS2GS-GAP.</returns>
     public static bool TryMapType(string metadataName, out Entry entry)
         => TypeMap.TryGetValue(metadataName, out entry);
+
+    /// <summary>
+    /// True when <paramref name="type"/> is Roslyn's <c>INamespaceSymbol</c>,
+    /// which analyzer mode maps to G#'s namespace display string. The G#
+    /// surface is honestly nullable (<c>Symbol.ContainingNamespace</c> is
+    /// <c>string?</c>), while Roslyn annotates <c>INamespaceSymbol</c> members
+    /// and parameters non-nullable — so both the mapped type and every
+    /// nullability decision about a value of this type must treat the G#
+    /// counterpart as <c>string?</c> regardless of the C# annotation.
+    /// </summary>
+    /// <param name="type">The bound C# type.</param>
+    /// <returns>True for Microsoft.CodeAnalysis.INamespaceSymbol.</returns>
+    public static bool IsNamespaceSymbolType(ITypeSymbol type)
+        => type is INamedTypeSymbol named
+        && named.Name == "INamespaceSymbol"
+        && named.ContainingNamespace?.ToDisplayString() == "Microsoft.CodeAnalysis";
 
     /// <summary>Maps a Roslyn enum member to its G# spelling.</summary>
     /// <param name="enumMetadataName">The declaring enum's metadata name.</param>

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
@@ -858,6 +858,17 @@ public sealed partial class CSharpToGSharpTranslator
                 return false;
             }
 
+            // ADR-0169 analyzer mode: an INamespaceSymbol target renders as
+            // G#'s namespace display string, which the mapper forces to
+            // `string?` (see CSharpTypeMapper.Map) — Roslyn's non-nullable
+            // annotation on the C# side is not honored by the G# surface, so
+            // the target never remains non-nullable and nullable arguments
+            // need no `!!` bridge.
+            if (this.InAnalyzerApiMode && Analyzers.RoslynAnalyzerApiMap.IsNamespaceSymbolType(targetType))
+            {
+                return false;
+            }
+
             bool targetDeclaredInThisCompilation = targetSymbol?.DeclaringSyntaxReferences
                 .Any(reference => this.context.Compilation.ContainsSyntaxTree(reference.SyntaxTree)) == true;
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -389,8 +389,21 @@ public sealed class CSharpTypeMapper
         // ITypeParameterSymbol here is always the nullable-reference-like form.
         bool nullableReference = type.NullableAnnotation == NullableAnnotation.Annotated
             && (type.IsReferenceType || type is ITypeParameterSymbol);
+
+        // ADR-0169 analyzer mode: a declared INamespaceSymbol renders as G#'s
+        // namespace display string, whose honest type is `string?` —
+        // `Symbol.ContainingNamespace` is nil for symbols without a containing
+        // namespace, while Roslyn annotates `INamespaceSymbol` members and
+        // parameters non-nullable. Without the forced `?`, a null-tolerant C#
+        // helper taking INamespaceSymbol translates to a non-nullable `string`
+        // parameter and every `ContainingNamespace` argument gets bridged with
+        // `!!` — an assert at a site where the C# never dereferences, i.e. a
+        // runtime NRE the original could not produce (the migrated
+        // EmitCacheKeyRemapScopeAnalyzer crashed exactly this way).
+        bool analyzerNamespaceString = this.AnalyzerApiMode
+            && Analyzers.RoslynAnalyzerApiMap.IsNamespaceSymbolType(type);
         GTypeReference mapped = this.MapCore(type, context, location);
-        return nullableReference ? WithNullable(mapped, true) : mapped;
+        return nullableReference || analyzerNamespaceString ? WithNullable(mapped, true) : mapped;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Fixes the root cause of the 2026-08-27 full-corpus gate regression (33 → 26 green, run [33118261767](https://github.com/DavidObando/gsharp/actions/runs/33118261767)).

**What happened**: #3598 made the migrated `InternalAnalyzers` compile for the first time; `Core.gsproj` loads it as a gsc analyzer, and the G#-compiled `EmitCacheKeyRemapScopeAnalyzer` threw a NullReferenceException. gsc reports that as GS9300 (a warning, mirroring Roslyn's AD0001), but the repo's inherited `TreatWarningsAsErrors` elevates it in the migrated mirror — failing Core and cascading ~20 dependent apps as `GS9999 no parseable diagnostic`.

**Root cause** (bisected on the migrated tree with a stack-trace-instrumented driver): analyzer mode maps Roslyn's `INamespaceSymbol` to G#'s namespace display string but kept the C#-declared non-nullability. gsc's `Symbol.ContainingNamespace` is honestly `string?`, while Roslyn annotates `INamespaceSymbol` non-nullable even where it returns null. So the null-tolerant helper `IsEmitNamespace(INamespaceSymbol ns) => ns?.ToDisplayString() …` translated to a non-nullable `string` parameter and every `ContainingNamespace` argument got bridged with `!!` — an assert where the C# never dereferences, violating the #2412/#3567 contract that `!!` lands only at exact C# NRE points. `StrongStaticReflectionCacheAnalyzer` carried the same latent crash.

**Fix** — both halves of the seam:
- `CSharpTypeMapper.Map`: an analyzer-mode `INamespaceSymbol` renders nullable (`string?`).
- `TargetWillRemainNonNullableReference`: an `INamespaceSymbol` target is never non-nullable in analyzer mode, so arguments stop being `!!`-bridged.
- Shared predicate on `RoslynAnalyzerApiMap`.

**Verification**: targeted 2-app migration (InternalAnalyzers + Core) — `src/Core` now passes translate/compile/ilverify/test-parity fully green; zero `!!` in the migrated analyzer. New regression test compiles the analyzer shape under `#nullable enable` (the in-memory harness is oblivious; the assert only reproduces under NRT). `InternalAnalyzers`' own remaining red is the separate ilverify reference-resolution gap (`Failed to load assembly 'GSharp.Core'`), unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgTBb1VHmEVc8Un3AdfWjG