### PR TITLE
selfmig ilverify: resolve compiler-hosted references for analyzer apps (#3608)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Pipeline/GSharpProjectTransformer.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/GSharpProjectTransformer.cs
@@ -15,6 +15,14 @@ namespace Cs2Gs.Pipeline;
 /// <summary>Transforms a C# project document for use by the G# SDK.</summary>
 internal static class GSharpProjectTransformer
 {
+    // ADR-0169: the MSBuild expression that anchors a compiler-hosted
+    // reference (an assembly supplied at runtime by the gsc host, never copied
+    // to the app's own output) at the compiler's directory. Kept as the single
+    // source of truth for both the injection (RewriteAnalyzerProject) and the
+    // stage-3 resolution (ResolveCompilerHostedReferences, issue #3608).
+    private const string CompilerDirectoryExpression =
+        "$([System.IO.Path]::GetDirectoryName('$(GsharpCompilerFullPath)'))";
+
     private static readonly Regex CSharpSpecSuffix = new Regex(
         "\\.cs(?=\\s*(?:;|$))",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
@@ -77,6 +85,58 @@ internal static class GSharpProjectTransformer
         RewriteAnalyzerConsumerReferences(document);
 
         return document;
+    }
+
+    /// <summary>
+    /// Resolves a transformed project's compiler-hosted <c>Reference</c>
+    /// entries — those whose <c>HintPath</c> is anchored at the compiler's
+    /// directory via <see cref="CompilerDirectoryExpression"/> (e.g. the
+    /// G# analyzer API assembly injected by <c>RewriteAnalyzerProject</c>) —
+    /// against a concrete <c>gsc</c> path. Issue #3608: these assemblies are
+    /// supplied at runtime by the gsc host with <c>Private=false</c>, so they
+    /// appear in neither the app's build output nor the C# source project's
+    /// own reference closure; stage 3 must add them to ilverify's reference
+    /// set explicitly or the verifier cannot resolve them.
+    /// </summary>
+    /// <param name="projectPath">The transformed <c>.gsproj</c> path.</param>
+    /// <param name="gscPath">The <c>gsc.dll</c> path whose directory hosts the referenced assemblies.</param>
+    /// <returns>The resolved absolute paths of existing compiler-hosted reference assemblies.</returns>
+    internal static IReadOnlyList<string> ResolveCompilerHostedReferences(string projectPath, string gscPath)
+    {
+        if (string.IsNullOrEmpty(projectPath)
+            || string.IsNullOrEmpty(gscPath)
+            || !File.Exists(projectPath))
+        {
+            return Array.Empty<string>();
+        }
+
+        string compilerDirectory = Path.GetDirectoryName(Path.GetFullPath(gscPath));
+        if (string.IsNullOrEmpty(compilerDirectory))
+        {
+            return Array.Empty<string>();
+        }
+
+        XDocument document = XDocument.Load(projectPath);
+        var resolved = new List<string>();
+        foreach (XElement hintPath in ElementsNamed(document, "HintPath"))
+        {
+            string value = hintPath.Value.Trim();
+            if (!value.StartsWith(CompilerDirectoryExpression, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            string relative = value
+                .Substring(CompilerDirectoryExpression.Length)
+                .TrimStart('/', '\\');
+            string candidate = Path.GetFullPath(Path.Combine(compilerDirectory, relative));
+            if (File.Exists(candidate))
+            {
+                resolved.Add(candidate);
+            }
+        }
+
+        return resolved;
     }
 
     private static void AddSourceSdkDefaults(XDocument document, string sourceSdk)
@@ -263,7 +323,7 @@ internal static class GSharpProjectTransformer
                 new XAttribute("Include", "GSharp.Core"),
                 new XElement(
                     "HintPath",
-                    "$([System.IO.Path]::GetDirectoryName('$(GsharpCompilerFullPath)'))/GSharp.Core.dll"),
+                    CompilerDirectoryExpression + "/GSharp.Core.dll"),
                 new XElement("Private", "false")));
         document.Root.Add(itemGroup);
     }

--- a/tools/cs2gs/Cs2Gs.Pipeline/IlVerifyStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/IlVerifyStage.cs
@@ -68,6 +68,19 @@ public sealed class IlVerifyStage : IMigrationStage
         IReadOnlyList<string> verifyReferences = context.App.ReferencedAssemblies is { Count: > 0 } appRefs
             ? appRefs.Concat(context.ExternalReferencePaths).ToList()
             : context.ExternalReferencePaths;
+
+        // Issue #3608: a transformed analyzer project references the G#
+        // analyzer API assembly from the compiler host's own directory with
+        // Private=false, so it is in neither the build output nor the C#
+        // project's reference closure — resolve those compiler-hosted
+        // references here or ilverify fails with FileLoadErrorGeneric on
+        // e.g. 'GSharp.Core'.
+        IReadOnlyList<string> hostedReferences = ResolveCompilerHostedReferences(context);
+        if (hostedReferences.Count > 0)
+        {
+            verifyReferences = verifyReferences.Concat(hostedReferences).ToList();
+        }
+
         IlVerifyResult result = this.runner.Verify(
             context.EmittedAssemblyPath,
             verifyReferences);
@@ -146,6 +159,31 @@ public sealed class IlVerifyStage : IMigrationStage
         }
 
         return Task.FromResult(StageOutcome.Failed(artifacts));
+    }
+
+    // The transformed project is written into the migrated project directory
+    // by both layouts (MigrationPipeline for the repository mirror,
+    // SdkCompileRunner for diagnostic runs); there is exactly one .gsproj.
+    private static IReadOnlyList<string> ResolveCompilerHostedReferences(StageExecutionContext context)
+    {
+        if (string.IsNullOrEmpty(context.ProjectOutputDir)
+            || !Directory.Exists(context.ProjectOutputDir))
+        {
+            return Array.Empty<string>();
+        }
+
+        var resolved = new List<string>();
+        foreach (string projectPath in Directory.EnumerateFiles(
+            context.ProjectOutputDir,
+            "*.gsproj",
+            SearchOption.TopDirectoryOnly))
+        {
+            resolved.AddRange(GSharpProjectTransformer.ResolveCompilerHostedReferences(
+                projectPath,
+                context.Gsc.GscPath));
+        }
+
+        return resolved;
     }
 
     private static string Truncate(string value)

--- a/tools/cs2gs/Cs2Gs.Tests/Adr0169AnalyzerProjectTransformTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Adr0169AnalyzerProjectTransformTests.cs
@@ -137,6 +137,76 @@ public sealed class Adr0169AnalyzerProjectTransformTests : IDisposable
         Assert.DoesNotContain("<Reference Include=\"GSharp.Core\">", transformed.ToString(), StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void AnalyzerProject_CompilerHostedReferenceResolvesAgainstGscDirectory()
+    {
+        // Issue #3608: the injected GSharp.Core reference is anchored at the
+        // compiler's directory with Private=false, so stage 3 must be able to
+        // resolve it against a concrete gsc path for ilverify's reference set.
+        string projectPath = Write("Analyzers.csproj", @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+  </PropertyGroup>
+</Project>");
+
+        XDocument transformed = GSharpProjectTransformer.Transform(
+            projectPath,
+            root.FullName,
+            "Gsharp.NET.Sdk",
+            new Dictionary<string, string>());
+        string gsprojPath = Path.Combine(root.FullName, "Analyzers.gsproj");
+        transformed.Save(gsprojPath);
+
+        string compilerDir = Path.Combine(root.FullName, "compiler");
+        Directory.CreateDirectory(compilerDir);
+        string gscPath = Path.Combine(compilerDir, "gsc.dll");
+        File.WriteAllText(gscPath, string.Empty);
+        string coreDll = Path.Combine(compilerDir, "GSharp.Core.dll");
+        File.WriteAllText(coreDll, string.Empty);
+
+        IReadOnlyList<string> resolved =
+            GSharpProjectTransformer.ResolveCompilerHostedReferences(gsprojPath, gscPath);
+
+        string single = Assert.Single(resolved);
+        Assert.Equal(Path.GetFullPath(coreDll), single);
+    }
+
+    [Fact]
+    public void CompilerHostedReferences_MissingAssemblyOrPlainProject_ResolveEmpty()
+    {
+        // A gsc directory without the hosted assembly resolves to nothing (no
+        // phantom -r paths), as does a project with no compiler-hosted refs.
+        string analyzerProject = Write("Analyzers.csproj", @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+  </PropertyGroup>
+</Project>");
+        XDocument analyzerTransformed = GSharpProjectTransformer.Transform(
+            analyzerProject, root.FullName, "Gsharp.NET.Sdk", new Dictionary<string, string>());
+        string analyzerGsproj = Path.Combine(root.FullName, "Analyzers.gsproj");
+        analyzerTransformed.Save(analyzerGsproj);
+
+        string emptyCompilerDir = Path.Combine(root.FullName, "compiler-empty");
+        Directory.CreateDirectory(emptyCompilerDir);
+        string gscPath = Path.Combine(emptyCompilerDir, "gsc.dll");
+        File.WriteAllText(gscPath, string.Empty);
+
+        Assert.Empty(GSharpProjectTransformer.ResolveCompilerHostedReferences(analyzerGsproj, gscPath));
+
+        string plainProject = Write("Plain2.csproj", @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+</Project>");
+        XDocument plainTransformed = GSharpProjectTransformer.Transform(
+            plainProject, root.FullName, "Gsharp.NET.Sdk", new Dictionary<string, string>());
+        string plainGsproj = Path.Combine(root.FullName, "Plain2.gsproj");
+        plainTransformed.Save(plainGsproj);
+
+        Assert.Empty(GSharpProjectTransformer.ResolveCompilerHostedReferences(plainGsproj, gscPath));
+    }
+
     private string Write(string fileName, string content)
     {
         string path = Path.Combine(root.FullName, fileName);


### PR DESCRIPTION
## Summary

Fixes #3608 — the last red stage on the migrated `src/Analyzers/InternalAnalyzers` chain.

An ADR-0169-transformed analyzer project references `GSharp.Core` from the compiler host's directory (`$(GsharpCompilerFullPath)`-anchored HintPath, `Private=false`). The assembly is therefore in neither the app's build output nor the C# source project's reference closure (the C# original references Microsoft.CodeAnalysis, not GSharp.Core) — so stage 3's ilverify reference set could not resolve it:

```
[IL]: Error [FileLoadErrorGeneric]: [.../GSharp.InternalAnalyzers.dll : DiagnosticDescriptors::.cctor()] Failed to load assembly 'GSharp.Core'
```

**Fix**
- `GSharpProjectTransformer.ResolveCompilerHostedReferences`: resolves HintPaths anchored at the compiler-directory MSBuild expression (now a shared constant with the injection site, so injection and resolution can't drift) against a concrete gsc path; missing assemblies and non-analyzer projects resolve to nothing.
- `IlVerifyStage`: appends the resolved paths to the verifier's reference set.
- Unit tests for both resolution and the empty cases.

**Verification**: targeted 2-app migration (InternalAnalyzers + Core) on this branch is **2/2 fully green** — InternalAnalyzers passes translate, compile, ilverify, and test-parity for the first time. Existing IlVerifyStage tests (16) and analyzer-transform tests all pass.

With this + the merged #3607, the whole `src/Analyzers` analyzer chain is clean; the running nightly's successor should reflect it. Baseline ratchet left to the next measured full-corpus snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgTBb1VHmEVc8Un3AdfWjG