### PR TITLE
cs2gs: imported-member taint no longer rewrites tuple-element declarations (#3615)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue3615TupleReceiverPromotionProbeTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3615TupleReceiverPromotionProbeTests.cs
@@ -1,0 +1,122 @@
+// <copyright file="Issue3615TupleReceiverPromotionProbeTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Linq;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Regression coverage for the 2026-08-28 nightly's Cs2Gs.Translator wall
+/// (issue #3615): a defensive <c>reference.SyntaxTree?.FilePath</c> at ONE
+/// site seeds used-as-nullable taint on the IMPORTED
+/// <c>SyntaxReference.SyntaxTree</c> property, and #3604's
+/// generic-receiver tuple flow (<c>staticHelpers.Contains((reference.SyntaxTree,
+/// ...))</c>) then propagated that heuristic taint into a source field's
+/// declared tuple element — widening
+/// <c>HashSet[(SyntaxTree, int32, int32)]</c> to <c>(SyntaxTree?, ...)</c>
+/// while its initializer and deconstructing readers stayed non-nullable
+/// (GS0158 "Cannot find member FilePath" / GS0159). Imported members'
+/// declared annotations are the contract for values flowing into a tuple
+/// element; only source-declared symbols may propagate element taint.
+/// </summary>
+public class Issue3615TupleReceiverPromotionProbeTests
+{
+    [Fact]
+    public void ImportedMemberDefensiveUse_DoesNotPromoteTheTupleElement()
+    {
+        const string source = @"
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+public sealed class Registry
+{
+    private readonly HashSet<(SyntaxTree Tree, int Start, int Length)> staticHelpers = new();
+
+    public void AddStaticHelper(MethodDeclarationSyntax method)
+    {
+        this.staticHelpers.Add((method.SyntaxTree, method.SpanStart, method.Span.Length));
+    }
+
+    public bool IsStaticHelper(IMethodSymbol symbol)
+    {
+        return symbol.DeclaringSyntaxReferences.Any(
+            reference => this.staticHelpers.Contains(
+                (reference.SyntaxTree, reference.Span.Start, reference.Span.Length)));
+    }
+
+    // The defensive `?.` here is the taint seed: it marks the IMPORTED
+    // SyntaxReference.SyntaxTree property used-as-nullable, which must NOT
+    // rewrite the staticHelpers element type above.
+    public static string FirstPath(ISymbol symbol)
+    {
+        foreach (SyntaxReference reference in symbol.DeclaringSyntaxReferences)
+        {
+            string path = reference.SyntaxTree?.FilePath;
+            if (!string.IsNullOrEmpty(path))
+            {
+                return path;
+            }
+        }
+
+        return null;
+    }
+
+    public Registry Filter(HashSet<string> retainedFilePaths)
+    {
+        var filtered = new Registry();
+        foreach ((SyntaxTree tree, int start, int length) in this.staticHelpers)
+        {
+            if (retainedFilePaths.Contains(tree.FilePath))
+            {
+                filtered.staticHelpers.Add((tree, start, length));
+            }
+        }
+
+        return filtered;
+    }
+}
+";
+        string printed = Render(source);
+        Assert.DoesNotContain("(SyntaxTree?", printed, StringComparison.Ordinal);
+        Assert.Contains("HashSet[(SyntaxTree, int32, int32)]", printed, StringComparison.Ordinal);
+        AssertRoundTripParses(printed);
+    }
+
+    private static void AssertRoundTripParses(string rendered)
+    {
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
+
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip-parse. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + rendered);
+    }
+
+    private static string Render(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        Cs2Gs.CodeModel.Ast.CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.DoesNotContain(
+            context.Diagnostics,
+            diagnostic => diagnostic.Severity != TranslationSeverity.Info);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
@@ -1399,6 +1399,37 @@ internal static class ObliviousNullabilityAnalyzer
                         {
                             foreach (ISymbol scalarSource in ResolveSources(elementValue, model))
                             {
+                                // Issue #3615 (2026-08-28 nightly, Cs2Gs.Translator
+                                // wall): only SOURCE-declared symbols propagate
+                                // into a declaration's tuple element. An imported
+                                // metadata member can enter the tainted set only
+                                // through the defensive-use seeds (`x?.M` /
+                                // `x == null` at some OTHER site) — its declared
+                                // annotation is the contract for the value
+                                // flowing HERE, and an annotated-nullable
+                                // imported read is already caught by
+                                // IsDirectlyNullable above. Letting the
+                                // defensive-use heuristic rewrite a source
+                                // field's element type widened
+                                // `HashSet[(SyntaxTree, ...)]` to
+                                // `(SyntaxTree?, ...)` and broke every
+                                // deconstructing reader. Source-declared is
+                                // tested via DeclaringSyntaxReferences (an
+                                // imported metadata symbol has none); the null
+                                // guard also keeps the self-migrated form of
+                                // this loop well-typed — ResolveSources'
+                                // iterator element is promoted to ISymbol? by
+                                // the same analysis this file implements.
+                                if (scalarSource == null)
+                                {
+                                    continue;
+                                }
+
+                                if (scalarSource.DeclaringSyntaxReferences.IsDefaultOrEmpty)
+                                {
+                                    continue;
+                                }
+
                                 tupleScalarEdges.Add((targetKey, scalarSource));
                             }
                         }


### PR DESCRIPTION
## Summary

Fixes #3615 — the 2026-08-28 nightly's widest wall (10 apps: the whole cs2gs+gsgen family + Compiler.Tests, all red through the migrated `Cs2Gs.Translator`).

**Causal chain** (traced with a reflection probe over the real compilation's cached taint graph): one defensive `reference.SyntaxTree?.FilePath` in cs2gs source seeds used-as-nullable taint on the **imported** `SyntaxReference.SyntaxTree` property; #3604's generic-receiver tuple flow (`staticHelpers.Contains((reference.SyntaxTree, …))`) then propagated that heuristic taint into the source field's declared tuple element — `HashSet[(SyntaxTree?, int32, int32)]` — while its initializer and deconstructing readers stayed non-nullable (GS0158/GS0159).

**Fix**: only source-declared symbols (`DeclaringSyntaxReferences` non-empty) may propagate scalar taint into a declaration's tuple element. An imported member's declared annotation is the contract for the value at the call site; genuinely annotated-nullable imported reads are already caught by `IsDirectlyNullable`. The guard also null-checks the loop variable first so the *self-migrated* form of this loop stays well-typed (`ResolveSources`' iterator element is promoted `ISymbol?` by the very analysis this file implements — a nice dogfooding wrinkle: the first two spellings of this fix failed their own migration).

**Verification**:
- New regression test: red without the fix, green with it.
- #3564/#3604 tuple suites: 75/75 pass — their scenarios (source-declared flows) are untouched.
- Targeted 4-app chain (InternalAnalyzers + Core + CodeModel + Translator): **4/4 fully green**, Translator FAIL(4) → 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgTBb1VHmEVc8Un3AdfWjG