### PR TITLE
G#: escaped identifiers — $name spells keyword-named CLR surface (ADR-0170, #3610)

### DIFF
--- a/docs/adr/0170-escaped-identifiers.md
+++ b/docs/adr/0170-escaped-identifiers.md
@@ -1,0 +1,155 @@
+# ADR-0170: Escaped identifiers (`$name`)
+
+- **Status**: Accepted
+- **Date**: 2026-08-28
+- **Related**: issue #3610, issue #3501 (self-migration fixture-policy), issue #3461 (keyword sanitizer), ADR-0047 (annotations), ADR-0096 (`@MarshalAs` parameter annotations), ADR-0115 (cs2gs).
+
+## Context
+
+A CLR assembly may declare namespaces, types, or members whose metadata
+names are G# keywords — C# spells them `@class`, `@defer`, `@params`.
+G# had no identifier-escape mechanism, which breaks both directions of
+CLR interop:
+
+- **Consumption**: G# code cannot reference an imported type, member, or
+  namespace literally named a G# keyword. Import aliasing could rescue
+  type names, but nothing rescues member access (`obj.defer()`).
+- **Declaration**: migrated G# (#3501) cannot declare a member whose
+  metadata name is a keyword without renaming it — which changes the ABI
+  (reflection, `InternalsVisibleTo`, cross-assembly consumers) and can
+  collide with a legal neighbor (`defer` → `defer_` collides with a real
+  `defer_`; the adversarial shapes are pinned by
+  `tools/cs2gs/Cs2Gs.Tests/Issue3461ReservedMetadataFixtures.cs`).
+
+The #3461 keyword sanitizer (rename `params` → `params_`) remains
+correct for locals and parameters, where the metadata name does not
+matter; it is lossy for metadata-visible surface.
+
+## Decision
+
+G# gains **escaped identifiers**: `$` immediately followed by an
+identifier-start character spells an identifier whose name is the
+characters after the `$`.
+
+```gs
+class $defer {                      // metadata name: "defer"
+    prop Value int32 -> 19
+}
+
+package $class { ... }              // namespace segment "class"
+
+func f($params JsonElement) { ... } // parameter named "params"
+
+let d = $defer{}
+Console.WriteLine(d.Value)
+let n = nameof($defer)              // "defer"
+```
+
+### Semantics
+
+1. **Purely a spelling.** An escaped identifier is *just* an identifier:
+   `$Value` ≡ `Value` when `Value` is not a keyword (C#'s rule for
+   `@id`). Escaping is legal-but-redundant on non-keywords; no keyword
+   semantics ever leak through an escape. The formatter may normalize
+   redundant escapes away; the compiler does not diagnose them.
+2. **Positions.** Every name position accepts the escape: type, member,
+   parameter, and local names; member access (`x.$defer`); qualified
+   type segments; `package` declaration segments and `import` paths;
+   `nameof`. Annotation *names* are excluded (an attribute class named
+   `defer` is out of scope; revisit on demand).
+3. **Metadata.** Symbols carry the unescaped name, so emitted metadata,
+   reflection, and cross-assembly consumption see `defer` — ABI-faithful
+   round-tripping falls out with no emitter work.
+4. **Never keyword-classified.** The lexer produces an
+   `IdentifierToken` for `$name` unconditionally; contextual-keyword
+   commitments (e.g. `unmanaged` at a type-clause start) compare source
+   text and therefore never fire for the escaped spelling.
+
+### Spelling rationale (why `$`, and why not `@name` / `@"name"`)
+
+- **`@name` (C#'s spelling) is rejected.** G#'s `@` is the annotation
+  sigil, and annotations occupy two positions where the overload is a
+  genuine ambiguity, not mere awkwardness: statement-leading
+  annotations (ADR-0047 §2 — `@defer(x)` is byte-for-byte both an
+  annotation with arguments and an invocation of an escaped-name
+  function, distinguishable only by the *next* statement) and
+  parameter-leading annotations (ADR-0096 — `@a b.c` parses both as a
+  bare annotation `a` on parameter `b` typed `c` and as escaped
+  parameter `a` of qualified type `b.c`). No known language overloads
+  one sigil for both jobs: C# affords `@name` only because its
+  attributes are `[Attr]`; Java/Kotlin/Swift use `@` for annotations
+  and chose different escapes.
+- **`@"name"` (Zig's spelling) is rejected** for readability: it reads
+  as an annotated string literal.
+- **Backticks are taken** by raw strings; **`#` is reserved** as the
+  natural future directive sigil (the compiler API already threads
+  preprocessor symbols); **`\`** reads as an escape character.
+- **`$` is free and effectively pre-reserved.** Outside strings `$` has
+  no meaning in G#; the string lexer's own comment reserves bare `$`
+  "forward-compatible: future grammar may attach meaning to it". The
+  spelling is a bare sigil, visually symmetrical with C#'s `@name`.
+
+### Interaction with string interpolation
+
+`$` retains its interpolation meaning *inside* string literals,
+unchanged, and the two meanings compose:
+
+- `"$defer"` interpolates the in-scope variable whose name is `defer` —
+  including one declared as `var $defer = …` (interpolation resolves by
+  name text).
+- `"$$class"` remains literal text `$class` (the existing `$$` escape).
+- `"${$class.Value}"` is the explicit hole spelling when an escaped
+  identifier appears inside an interpolation expression.
+
+### Lexing
+
+In the main token dispatch, `$` followed by a letter or `_` consumes the
+`$` and the identifier run. The token is an `IdentifierToken` whose
+`Text` is the full source spelling (`"$defer"`, so spans, printing, and
+round-tripping stay source-faithful) and whose `Value` is the unescaped
+name (`"defer"`). A `$` not followed by an identifier-start keeps the
+prior behavior (bad-character diagnostic), preserving room for future
+grammar.
+
+`SyntaxToken` gains `ValueText` (Roslyn's concept): the string `Value`
+when present, else `Text`. Semantic consumers (binder, symbols,
+lowering, emit) read names via `ValueText`; syntactic consumers
+(printer, formatter, contextual-keyword commitments) keep `Text`.
+
+### cs2gs policy (#3501)
+
+The printer emits the escape **only for metadata-visible names** (public
+or internal surface and anything reflection-reachable) whose names are
+G# keywords; the #3461 sanitizer keeps renaming locals and parameters
+where readability wins and metadata does not care. The reserved-metadata
+fixtures re-enter the corpus once the translator side lands.
+
+### Tooling
+
+The language server's completion inserts the `$` escape automatically
+when completing an imported member or type whose name is a G# keyword.
+The formatter treats `$name` as an ordinary identifier token.
+
+## Consequences
+
+- Keyword-named CLR surface becomes both consumable and declarable from
+  G#, closing the Issue3461 fixture-policy item on #3501.
+- The lexer change is additive; no parser changes are needed — `$name`
+  is an ordinary `IdentifierToken`, so every existing name slot accepts
+  it structurally.
+- The `Identifier.Text` → `Identifier.ValueText` migration in the
+  semantic layers is behavior-preserving for all existing code
+  (identifier tokens previously carried a null `Value`).
+
+## Alternatives considered
+
+- **Context-sensitive `@name`** — rejected (see spelling rationale).
+- **`@"name"` quoted escape** — rejected for readability.
+- **`CompiledName`-style attribute only** (F# precedent: declare
+  `defer_`, emit metadata `defer`) — solves declaration but not
+  consumption (member access has no alias point); may still be added
+  later as a complement for G#-authored libraries wanting distinct
+  source and CLR names.
+- **Import aliasing only** — rescues type names, not member access.
+- **Stay out (sanitizer renames as policy)** — lossy for public
+  metadata; breaks ABI round-tripping, the project's positioning.

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -891,7 +891,7 @@ public sealed class Binder
         {
             var packageSyntax = tree.Root.Members.OfType<PackageSyntax>().FirstOrDefault();
             var packageName = packageSyntax != null
-                ? string.Concat(packageSyntax.IdentifiersWithDots.Select(t => t.Text))
+                ? string.Concat(packageSyntax.IdentifiersWithDots.Select(t => t.ValueText))
                 : defaultPackageName;
             if (!packagesByName.TryGetValue(packageName, out var packageSymbol))
             {
@@ -1159,7 +1159,7 @@ public sealed class Binder
                 StringComparer.Ordinal);
             foreach (var nested in container.NestedTypes.OfType<StructDeclarationSyntax>())
             {
-                visibleNestedTypeNames.Add(nested.Identifier.Text);
+                visibleNestedTypeNames.Add(nested.Identifier.ValueText);
             }
 
             foreach (var nested in container.NestedTypes.OfType<StructDeclarationSyntax>())
@@ -2945,7 +2945,7 @@ public sealed class Binder
                         // The rich path materializes fields as ordinary class
                         // fields, which require an explicit type. Inferred-type
                         // fields are only supported on the field-only path.
-                        diagnostics.ReportInferredFieldTypeNotAllowedInRichAnonymousObject(field.Identifier.Location, field.Identifier.Text);
+                        diagnostics.ReportInferredFieldTypeNotAllowedInRichAnonymousObject(field.Identifier.Location, field.Identifier.ValueText);
                         continue;
                     }
 
@@ -3261,11 +3261,13 @@ public sealed class Binder
         var sb = new StringBuilder();
         foreach (var i in import.IdentifiersWithDots)
         {
-            sb.Append(i.Text);
+            // ADR-0170: escaped segments (`import $class`) contribute their
+            // unescaped name; dot separators pass through unchanged.
+            sb.Append(i.ValueText);
         }
 
         var targetPath = sb.ToString();
-        var localName = import.AliasIdentifier?.Text ?? targetPath;
+        var localName = import.AliasIdentifier?.ValueText ?? targetPath;
         var importSymbol = new ImportSymbol(localName, targetPath, import);
         AttachDocumentation(importSymbol, import);
         scope.TryImport(importSymbol);
@@ -3765,8 +3767,8 @@ public sealed class Binder
             : 0;
         if (!syntax.HasQualifier &&
             syntax.HasTypeArguments &&
-            scope.TryLookupImportedGenericClass(identifierToken.Text, topLevelTypeArgumentCount, out var clrOpenType) &&
-            ImportedGenericTypeHasPrecedence(identifierToken.Text, topLevelTypeArgumentCount, clrOpenType))
+            scope.TryLookupImportedGenericClass(identifierToken.ValueText, topLevelTypeArgumentCount, out var clrOpenType) &&
+            ImportedGenericTypeHasPrecedence(identifierToken.ValueText, topLevelTypeArgumentCount, clrOpenType))
         {
             var topLevelTypeArguments = Invariant.Required(syntax.TypeArguments, "HasTypeArguments implies the parser set TypeArguments");
             var clrArgs = new System.Type[topLevelTypeArguments.Count];
@@ -3839,7 +3841,7 @@ public sealed class Binder
             }
             catch (System.ArgumentException)
             {
-                Diagnostics.ReportTypeNotGeneric(identifierToken.Location, identifierToken.Text);
+                Diagnostics.ReportTypeNotGeneric(identifierToken.Location, identifierToken.ValueText);
                 return null;
             }
         }
@@ -3874,7 +3876,7 @@ public sealed class Binder
             // list, prefer the matching generic definition; without one, prefer
             // the arity-0 type.
             var requestedArity = syntax.HasTypeArguments ? Invariant.Required(syntax.TypeArguments, "HasTypeArguments implies the parser set TypeArguments").Count : 0;
-            element = LookupType(identifierToken.Text, requestedArity, out var ambiguousAcrossImportedPackages);
+            element = LookupType(identifierToken.ValueText, requestedArity, out var ambiguousAcrossImportedPackages);
             if (element == null)
             {
                 // Issue #2455: "ambiguous between imported packages" and "no
@@ -3884,11 +3886,11 @@ public sealed class Binder
                 // that the type is undefined.
                 if (ambiguousAcrossImportedPackages)
                 {
-                    Diagnostics.ReportAmbiguousSourceType(identifierToken.Location, identifierToken.Text);
+                    Diagnostics.ReportAmbiguousSourceType(identifierToken.Location, identifierToken.ValueText);
                 }
                 else
                 {
-                    Diagnostics.ReportUndefinedType(identifierToken.Location, identifierToken.Text);
+                    Diagnostics.ReportUndefinedType(identifierToken.Location, identifierToken.ValueText);
                 }
 
                 return null;
@@ -3938,13 +3940,13 @@ public sealed class Binder
                 {
                     if (!iface.IsGenericDefinition)
                     {
-                        Diagnostics.ReportTypeNotGeneric(identifierToken.Location, identifierToken.Text);
+                        Diagnostics.ReportTypeNotGeneric(identifierToken.Location, identifierToken.ValueText);
                         return null;
                     }
 
                     if (iface.TypeParameters.Length != typeArgs.Length)
                     {
-                        Diagnostics.ReportWrongTypeArgumentCount(identifierToken.Location, identifierToken.Text, iface.TypeParameters.Length, typeArgs.Length);
+                        Diagnostics.ReportWrongTypeArgumentCount(identifierToken.Location, identifierToken.ValueText, iface.TypeParameters.Length, typeArgs.Length);
                         return null;
                     }
 
@@ -3954,13 +3956,13 @@ public sealed class Binder
                 {
                     if (!genericStruct.IsGenericDefinition)
                     {
-                        Diagnostics.ReportTypeNotGeneric(identifierToken.Location, identifierToken.Text);
+                        Diagnostics.ReportTypeNotGeneric(identifierToken.Location, identifierToken.ValueText);
                         return null;
                     }
 
                     if (genericStruct.TypeParameters.Length != typeArgs.Length)
                     {
-                        Diagnostics.ReportWrongTypeArgumentCount(identifierToken.Location, identifierToken.Text, genericStruct.TypeParameters.Length, typeArgs.Length);
+                        Diagnostics.ReportWrongTypeArgumentCount(identifierToken.Location, identifierToken.ValueText, genericStruct.TypeParameters.Length, typeArgs.Length);
                         return null;
                     }
 
@@ -3974,13 +3976,13 @@ public sealed class Binder
                     // substituted with the supplied type arguments.
                     if (!genericDelegate.IsGenericDefinition)
                     {
-                        Diagnostics.ReportTypeNotGeneric(identifierToken.Location, identifierToken.Text);
+                        Diagnostics.ReportTypeNotGeneric(identifierToken.Location, identifierToken.ValueText);
                         return null;
                     }
 
                     if (genericDelegate.TypeParameters.Length != typeArgs.Length)
                     {
-                        Diagnostics.ReportWrongTypeArgumentCount(identifierToken.Location, identifierToken.Text, genericDelegate.TypeParameters.Length, typeArgs.Length);
+                        Diagnostics.ReportWrongTypeArgumentCount(identifierToken.Location, identifierToken.ValueText, genericDelegate.TypeParameters.Length, typeArgs.Length);
                         return null;
                     }
 
@@ -3988,7 +3990,7 @@ public sealed class Binder
                 }
                 else
                 {
-                    Diagnostics.ReportTypeNotGeneric(identifierToken.Location, identifierToken.Text);
+                    Diagnostics.ReportTypeNotGeneric(identifierToken.Location, identifierToken.ValueText);
                     return null;
                 }
             }
@@ -4234,7 +4236,7 @@ public sealed class Binder
             // This method resolves a dotted-qualifier chain, so its head
             // segment always has an Identifier token.
             var headIdentifier = Invariant.Required(syntax.Identifier, "a dotted-qualifier type-clause chain has a head Identifier");
-            var segmentName = i == 0 ? headIdentifier.Text : string.Join(".", segmentTexts, 0, i + 1);
+            var segmentName = i == 0 ? headIdentifier.ValueText : string.Join(".", segmentTexts, 0, i + 1);
             var segmentLocation = i == 0 ? headIdentifier.Location : syntax.QualifierIdentifierTokens[i - 1].Location;
             var constructed = BindAndConstructUserGenericSegment(syntax, ResolvedDefinition(i), SegmentTypeArguments(i), segmentLocation, segmentName);
             if (constructed == null)
@@ -4388,7 +4390,7 @@ public sealed class Binder
         var qualifiedIdentifier = Invariant.Required(syntax.Identifier, "a dotted-qualifier type clause has a head Identifier");
         var totalSegments = 1 + syntax.QualifierIdentifierTokens.Length;
         var segmentTexts = new string[totalSegments];
-        segmentTexts[0] = qualifiedIdentifier.Text;
+        segmentTexts[0] = qualifiedIdentifier.ValueText;
         for (var i = 0; i < syntax.QualifierIdentifierTokens.Length; i++)
         {
             segmentTexts[1 + i] = syntax.QualifierIdentifierTokens[i].Text;
@@ -4486,7 +4488,7 @@ public sealed class Binder
         // a regular "undefined type". Otherwise walk from the outermost
         // resolvable segment and emit "Outer does not contain a nested type
         // 'X'" for the first failing segment.
-        var outermost = LookupType(qualifiedIdentifier.Text);
+        var outermost = LookupType(qualifiedIdentifier.ValueText);
         if (outermost == null)
         {
             Diagnostics.ReportUndefinedType(qualifiedIdentifier.Location, syntax.DottedName);
@@ -4502,7 +4504,7 @@ public sealed class Binder
             return null;
         }
 
-        var lastGoodName = qualifiedIdentifier.Text;
+        var lastGoodName = qualifiedIdentifier.ValueText;
         for (var i = 0; i < syntax.QualifierIdentifierTokens.Length; i++)
         {
             var segmentText = syntax.QualifierIdentifierTokens[i].Text;
@@ -5283,7 +5285,7 @@ public sealed class Binder
     {
         return body.Statements.Length > 0
             && body.Statements[0] is ExpressionStatementSyntax { Expression: CallExpressionSyntax call }
-            && call.Identifier.Text == "init";
+            && call.Identifier.ValueText == "init";
     }
 
     private static bool IsConstructorChainingExpression(BoundExpression expression)
@@ -7458,7 +7460,7 @@ public sealed class Binder
                 {
                     var pkgSyntax = st.Root.Members.OfType<PackageSyntax>().FirstOrDefault();
                     return pkgSyntax != null
-                        ? string.Concat(pkgSyntax.IdentifiersWithDots.Select(t => t.Text))
+                        ? string.Concat(pkgSyntax.IdentifiersWithDots.Select(t => t.ValueText))
                         : "Default";
                 })
                 .Distinct(StringComparer.Ordinal)

--- a/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
@@ -799,7 +799,7 @@ public static class BoundNodePrinter
                     writer.WriteKeyword(SyntaxKind.IsKeyword);
                     writer.WriteSpace();
                 }
-                else if (typePattern.Syntax is TypePatternSyntax { Identifier.Text: "_" })
+                else if (typePattern.Syntax is TypePatternSyntax { Identifier.ValueText: "_" })
                 {
                     writer.WriteIdentifier("_");
                     writer.WriteSpace();

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Attributes.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Attributes.cs
@@ -222,7 +222,7 @@ internal sealed partial class DeclarationBinder
         var targetKind = defaultTarget;
         if (annotation.Target != null)
         {
-            if (TryParseTargetKind(annotation.Target.KindIdentifier.Text, out var parsedTarget))
+            if (TryParseTargetKind(annotation.Target.KindIdentifier.ValueText, out var parsedTarget))
             {
                 targetKind = parsedTarget;
             }
@@ -235,7 +235,7 @@ internal sealed partial class DeclarationBinder
             {
                 Diagnostics.ReportAttributeTargetInvalidForPosition(
                     annotation.Target.KindIdentifier.Location,
-                    annotation.Target.KindIdentifier.Text,
+                    annotation.Target.KindIdentifier.ValueText,
                     positionDescription);
             }
         }

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Constructors.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Constructors.cs
@@ -993,7 +993,7 @@ internal sealed partial class DeclarationBinder
         var seenParameterNames = new HashSet<string>();
         foreach (var parameterSyntax in ctorSyntax.Parameters)
         {
-            var parameterName = parameterSyntax.Identifier.Text;
+            var parameterName = parameterSyntax.Identifier.ValueText;
             var parameterType = parameterSyntax.Type is { } parameterTypeSyntax
                 ? bindTypeClause(parameterTypeSyntax) ?? TypeSymbol.Error
                 : TypeSymbol.Error;

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Functions.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Functions.cs
@@ -79,7 +79,7 @@ internal sealed partial class DeclarationBinder
         FunctionDeclarationSyntax syntax,
         PackageSymbol package)
     {
-        if (syntax.IsExtension && syntax.Identifier.Text.StartsWith("op_", StringComparison.Ordinal))
+        if (syntax.IsExtension && syntax.Identifier.ValueText.StartsWith("op_", StringComparison.Ordinal))
         {
             return syntax.Receiver is { Type: { } receiverType }
                 ? TryGetOpenSelfTypeParameters(receiverType, package)
@@ -121,7 +121,7 @@ internal sealed partial class DeclarationBinder
         var identifier = syntax.Identifier;
         if (identifier == null
             || syntax.TypeArguments is not { } typeArguments
-            || !scope.TryLookupTypeAlias(identifier.Text, typeArguments.Count, out var candidate)
+            || !scope.TryLookupTypeAlias(identifier.ValueText, typeArguments.Count, out var candidate)
             || candidate is not StructSymbol candidateStruct)
         {
             return ImmutableArray<TypeParameterSymbol>.Empty;
@@ -151,7 +151,7 @@ internal sealed partial class DeclarationBinder
                 || argument.IsChannel
                 || argument.IsPointer
                 || argument.IsSequence
-                || argument.Identifier.Text != owner.TypeParameters[i].Name)
+                || argument.Identifier.ValueText != owner.TypeParameters[i].Name)
             {
                 return ImmutableArray<TypeParameterSymbol>.Empty;
             }
@@ -190,11 +190,11 @@ internal sealed partial class DeclarationBinder
         // parameters come from GetGenericOperatorOwnerTypeParameters.
         if (!typeParameters.IsDefaultOrEmpty
             && (syntax.IsConversionOperator
-                || syntax.Identifier.Text.StartsWith("op_", StringComparison.Ordinal)))
+                || syntax.Identifier.ValueText.StartsWith("op_", StringComparison.Ordinal)))
         {
             Diagnostics.ReportGenericOperatorNotSupported(
                 syntax.TypeParameterList?.Location ?? syntax.Identifier.Location,
-                syntax.Identifier.Text);
+                syntax.Identifier.ValueText);
             return;
         }
 
@@ -214,7 +214,7 @@ internal sealed partial class DeclarationBinder
 
         if (methodReceiverStruct != null)
         {
-            var methodName = syntax.Identifier.Text;
+            var methodName = syntax.Identifier.ValueText;
 
             // ADR-0079 / issue #719: warn when a receiver-clause method
             // targets a same-package ("owned") struct or class. The
@@ -386,7 +386,7 @@ internal sealed partial class DeclarationBinder
             return;
         }
 
-        function = new FunctionSymbol(syntax.Identifier.Text, parameters.ToImmutable(), type, syntax, package, accessibility);
+        function = new FunctionSymbol(syntax.Identifier.ValueText, parameters.ToImmutable(), type, syntax, package, accessibility);
         function.TypeParameters = typeParameters;
         function.IsAsync = syntax.IsAsync
             || (isAsyncIteratorReturnType(type) && syntax.Body is { } body && IteratorDetection.ContainsYield(body));
@@ -684,7 +684,7 @@ internal sealed partial class DeclarationBinder
                 return new FunctionReceiverBindingResult(TypeSymbol.Error, null, null, false);
             }
 
-            var recvName = receiverSyntax.Identifier.Text;
+            var recvName = receiverSyntax.Identifier.ValueText;
             receiverType = receiverSyntax.Type is { } receiverTypeSyntax
                 ? bindTypeClause(receiverTypeSyntax)
                 : TypeSymbol.Error;
@@ -728,7 +728,7 @@ internal sealed partial class DeclarationBinder
         for (var pIndex = 0; pIndex < syntax.Parameters.Count; pIndex++)
         {
             var parameterSyntax = syntax.Parameters[pIndex];
-            var parameterName = parameterSyntax.Identifier.Text;
+            var parameterName = parameterSyntax.Identifier.ValueText;
             var parameterType = parameterSyntax.Type is { } parameterTypeSyntax
                 ? bindTypeClause(parameterTypeSyntax) ?? TypeSymbol.Error
                 : TypeSymbol.Error;
@@ -840,7 +840,7 @@ internal sealed partial class DeclarationBinder
         // call site still elides; the diagnostic is per-declaration.
         if (KnownAttributes.HasConditional(functionAttributes) && type != TypeSymbol.Void)
         {
-            Diagnostics.ReportConditionalMethodMustReturnVoid(syntax.Identifier.Location, syntax.Identifier.Text);
+            Diagnostics.ReportConditionalMethodMustReturnVoid(syntax.Identifier.Location, syntax.Identifier.ValueText);
         }
 
         return functionAttributes;
@@ -1161,7 +1161,7 @@ internal sealed partial class DeclarationBinder
         for (var i = 0; i < count; i++)
         {
             var p = syntax.Parameters[i];
-            var name = p.Identifier.Text;
+            var name = p.Identifier.ValueText;
             if (!seen.Add(name))
             {
                 Diagnostics.ReportSymbolAlreadyDeclared(p.Identifier.Location, name);
@@ -2847,13 +2847,13 @@ internal sealed partial class DeclarationBinder
 
             if (firstVariadicSeen)
             {
-                Diagnostics.ReportMultipleVariadicParameters(parameters[i].Location, parameters[i].Identifier.Text);
+                Diagnostics.ReportMultipleVariadicParameters(parameters[i].Location, parameters[i].Identifier.ValueText);
             }
 
             firstVariadicSeen = true;
             if (i < parameters.Count - 1)
             {
-                Diagnostics.ReportVariadicParameterMustBeLast(parameters[i].Location, parameters[i].Identifier.Text);
+                Diagnostics.ReportVariadicParameterMustBeLast(parameters[i].Location, parameters[i].Identifier.ValueText);
             }
         }
     }
@@ -2906,7 +2906,7 @@ internal sealed partial class DeclarationBinder
 
     internal VariableSymbol BindVariableDeclaration(SyntaxToken identifier, bool isReadOnly, TypeSymbol type, Accessibility accessibility)
     {
-        var name = identifier.Text ?? "?";
+        var name = identifier.ValueText ?? "?";
         if (name == "_")
         {
             // `_` is a discard declaration, not a lookup-visible binding.

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.InterfaceVerification.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.InterfaceVerification.cs
@@ -2028,10 +2028,10 @@ internal sealed partial class DeclarationBinder
         switch (node)
         {
             case NameExpressionSyntax nameExpr:
-                if (forbiddenNames.Contains(nameExpr.IdentifierToken.Text) &&
-                    !shadowedNames.Contains(nameExpr.IdentifierToken.Text))
+                if (forbiddenNames.Contains(nameExpr.IdentifierToken.ValueText) &&
+                    !shadowedNames.Contains(nameExpr.IdentifierToken.ValueText))
                 {
-                    offendingName = nameExpr.IdentifierToken.Text;
+                    offendingName = nameExpr.IdentifierToken.ValueText;
                     offendingLocation = nameExpr.IdentifierToken.Location;
                     return true;
                 }
@@ -2048,7 +2048,7 @@ internal sealed partial class DeclarationBinder
                 var lambdaParameterNames = new string[lambda.Parameters.Count];
                 for (var i = 0; i < lambda.Parameters.Count; i++)
                 {
-                    lambdaParameterNames[i] = lambda.Parameters[i].Identifier.Text;
+                    lambdaParameterNames[i] = lambda.Parameters[i].Identifier.ValueText;
                 }
 
                 return TryFindInstanceMemberReference(
@@ -2058,7 +2058,7 @@ internal sealed partial class DeclarationBinder
                 var functionParameterNames = new string[func.Parameters.Count];
                 for (var i = 0; i < func.Parameters.Count; i++)
                 {
-                    functionParameterNames[i] = func.Parameters[i].Identifier.Text;
+                    functionParameterNames[i] = func.Parameters[i].Identifier.ValueText;
                 }
 
                 return TryFindInstanceMemberReference(
@@ -2068,7 +2068,7 @@ internal sealed partial class DeclarationBinder
             // scrutinee/collection/bounds are evaluated in the outer scope.
             case CatchClauseSyntax catchClause when catchClause.Identifier != null:
                 return TryFindInstanceMemberReference(
-                    catchClause.Body, forbiddenNames, WithShadowed(shadowedNames, new[] { catchClause.Identifier.Text }), out offendingName, out offendingLocation);
+                    catchClause.Body, forbiddenNames, WithShadowed(shadowedNames, new[] { catchClause.Identifier.ValueText }), out offendingName, out offendingLocation);
 
             case ForRangeStatementSyntax forRange:
                 if (TryFindInstanceMemberReference(forRange.Collection, forbiddenNames, shadowedNames, out offendingName, out offendingLocation))
@@ -2077,8 +2077,8 @@ internal sealed partial class DeclarationBinder
                 }
 
                 var forRangeNames = forRange.SecondIdentifier != null
-                    ? new[] { forRange.FirstIdentifier.Text, forRange.SecondIdentifier.Text }
-                    : new[] { forRange.FirstIdentifier.Text };
+                    ? new[] { forRange.FirstIdentifier.ValueText, forRange.SecondIdentifier.ValueText }
+                    : new[] { forRange.FirstIdentifier.ValueText };
                 return TryFindInstanceMemberReference(forRange.Body, forbiddenNames, WithShadowed(shadowedNames, forRangeNames), out offendingName, out offendingLocation);
 
             case ForTupleRangeStatementSyntax forTupleRange:
@@ -2103,7 +2103,7 @@ internal sealed partial class DeclarationBinder
                 }
 
                 return TryFindInstanceMemberReference(
-                    forEllipsis.Body, forbiddenNames, WithShadowed(shadowedNames, new[] { forEllipsis.Identifier.Text }), out offendingName, out offendingLocation);
+                    forEllipsis.Body, forbiddenNames, WithShadowed(shadowedNames, new[] { forEllipsis.Identifier.ValueText }), out offendingName, out offendingLocation);
 
             case AwaitForRangeStatementSyntax awaitForRange:
                 if (TryFindInstanceMemberReference(awaitForRange.Stream, forbiddenNames, shadowedNames, out offendingName, out offendingLocation))
@@ -2112,7 +2112,7 @@ internal sealed partial class DeclarationBinder
                 }
 
                 return TryFindInstanceMemberReference(
-                    awaitForRange.Body, forbiddenNames, WithShadowed(shadowedNames, new[] { awaitForRange.Identifier.Text }), out offendingName, out offendingLocation);
+                    awaitForRange.Body, forbiddenNames, WithShadowed(shadowedNames, new[] { awaitForRange.Identifier.ValueText }), out offendingName, out offendingLocation);
 
             // `if let` bindings are visible only in the then/else clauses, not
             // to statements following the `if`.
@@ -2125,7 +2125,7 @@ internal sealed partial class DeclarationBinder
                         return true;
                     }
 
-                    ifLetNames.Add(binding.Identifier.Text);
+                    ifLetNames.Add(binding.Identifier.ValueText);
                 }
 
                 var ifLetShadowed = WithShadowed(shadowedNames, ifLetNames);
@@ -2147,7 +2147,7 @@ internal sealed partial class DeclarationBinder
                         return true;
                     }
 
-                    whileLetNames.Add(binding.Identifier.Text);
+                    whileLetNames.Add(binding.Identifier.ValueText);
                 }
 
                 return TryFindInstanceMemberReference(
@@ -2221,7 +2221,7 @@ internal sealed partial class DeclarationBinder
         switch (node)
         {
             case VariableDeclarationSyntax variableDeclaration:
-                return new[] { variableDeclaration.Identifier.Text };
+                return new[] { variableDeclaration.Identifier.ValueText };
 
             case TupleDeconstructionStatementSyntax tupleDeconstruction:
                 var tupleNames = new string[tupleDeconstruction.Identifiers.Count];
@@ -2236,7 +2236,7 @@ internal sealed partial class DeclarationBinder
                 var fieldNames = new string[namedDeconstruction.Fields.Count];
                 for (var i = 0; i < namedDeconstruction.Fields.Count; i++)
                 {
-                    fieldNames[i] = namedDeconstruction.Fields[i].LocalIdentifier.Text;
+                    fieldNames[i] = namedDeconstruction.Fields[i].LocalIdentifier.ValueText;
                 }
 
                 return fieldNames;
@@ -2245,7 +2245,7 @@ internal sealed partial class DeclarationBinder
                 var names = new string[guardLet.Bindings.Count];
                 for (var i = 0; i < guardLet.Bindings.Count; i++)
                 {
-                    names[i] = guardLet.Bindings[i].Identifier.Text;
+                    names[i] = guardLet.Bindings[i].Identifier.ValueText;
                 }
 
                 return names;
@@ -2266,7 +2266,7 @@ internal sealed partial class DeclarationBinder
         switch (node)
         {
             case TypePatternSyntax typePattern when typePattern.BindingIdentifier != null:
-                captures.Add(typePattern.BindingIdentifier.Text);
+                captures.Add(typePattern.BindingIdentifier.ValueText);
                 break;
             case PropertyPatternSyntax propertyPattern when propertyPattern.Designation != null:
                 captures.Add(propertyPattern.Designation.Text);
@@ -2276,7 +2276,7 @@ internal sealed partial class DeclarationBinder
                 break;
 
             case SlicePatternSyntax slicePattern when slicePattern.CaptureIdentifier != null:
-                captures.Add(slicePattern.CaptureIdentifier.Text);
+                captures.Add(slicePattern.CaptureIdentifier.ValueText);
                 break;
         }
 

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Interfaces.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Interfaces.cs
@@ -23,7 +23,7 @@ internal sealed partial class DeclarationBinder
 {
     internal InterfaceSymbol? DeclareInterfaceSymbol(InterfaceDeclarationSyntax syntax, PackageSymbol package, TypeSymbol? containingType = null)
     {
-        var name = syntax.Identifier.Text;
+        var name = syntax.Identifier.ValueText;
         var accessibility = resolveAccessibility(syntax.AccessibilityModifier);
         var interfaceSymbol = new InterfaceSymbol(name, accessibility, syntax, package.Name);
         Binder.AttachDocumentation(interfaceSymbol, syntax);
@@ -116,7 +116,7 @@ internal sealed partial class DeclarationBinder
             return;
         }
 
-        var name = syntax.Identifier.Text;
+        var name = syntax.Identifier.ValueText;
         var baseInterfaces = ImmutableArray.CreateBuilder<InterfaceSymbol>();
         var baseClrInterfaces = ImmutableArray.CreateBuilder<TypeSymbol>();
         for (var i = 0; i < syntax.BaseTypeClauses.Count; i++)
@@ -198,7 +198,7 @@ internal sealed partial class DeclarationBinder
         var staticPrivateMethodsBuilder = ImmutableArray.CreateBuilder<FunctionSymbol>();
         foreach (var methodSyntax in syntax.Methods)
         {
-            var methodName = methodSyntax.Identifier.Text;
+            var methodName = methodSyntax.Identifier.ValueText;
 
             // ADR-0089 / issue #755: detect a `static` modifier early — the
             // method is a static-virtual interface member. Static methods do
@@ -260,7 +260,7 @@ internal sealed partial class DeclarationBinder
             var seenParameterNames = new HashSet<string>();
             foreach (var parameterSyntax in methodSyntax.Parameters)
             {
-                var parameterName = parameterSyntax.Identifier.Text;
+                var parameterName = parameterSyntax.Identifier.ValueText;
                 var parameterType = parameterSyntax.Type is { } parameterTypeSyntax
                     ? bindTypeClause(parameterTypeSyntax) ?? TypeSymbol.Error
                     : TypeSymbol.Error;
@@ -473,7 +473,7 @@ internal sealed partial class DeclarationBinder
                     var seenIndexParamNames = new HashSet<string>();
                     foreach (var indexParamSyntax in propSyntax.Parameters)
                     {
-                        var indexParamName = indexParamSyntax.Identifier.Text;
+                        var indexParamName = indexParamSyntax.Identifier.ValueText;
                         var indexParamType = indexParamSyntax.Type is { } indexParamTypeSyntax
                             ? bindTypeClause(indexParamTypeSyntax) ?? TypeSymbol.Error
                             : TypeSymbol.Error;
@@ -493,7 +493,7 @@ internal sealed partial class DeclarationBinder
                     indexerParameters = indexerParamBuilder.ToImmutable();
                 }
 
-                var propName = isIndexer ? "Item" : propSyntax.Identifier.Text;
+                var propName = isIndexer ? "Item" : propSyntax.Identifier.ValueText;
                 if (!seenNames.Add(propName))
                 {
                     Diagnostics.ReportSymbolAlreadyDeclared(propSyntax.Identifier.Location, propName);
@@ -697,7 +697,7 @@ internal sealed partial class DeclarationBinder
             var eventsBuilder = ImmutableArray.CreateBuilder<EventSymbol>();
             foreach (var eventSyntax in syntax.Events)
             {
-                var eventName = eventSyntax.Identifier.Text;
+                var eventName = eventSyntax.Identifier.ValueText;
                 if (!seenNames.Add(eventName))
                 {
                     Diagnostics.ReportSymbolAlreadyDeclared(eventSyntax.Identifier.Location, eventName);
@@ -811,7 +811,7 @@ internal sealed partial class DeclarationBinder
                 var initializersBuilder = ImmutableDictionary.CreateBuilder<FieldSymbol, BoundExpression>();
                 foreach (var fieldSyntax in syntax.StaticFields)
                 {
-                    var fieldName = fieldSyntax.Identifier.Text;
+                    var fieldName = fieldSyntax.Identifier.ValueText;
                     if (!seenNames.Add(fieldName))
                     {
                         Diagnostics.ReportSymbolAlreadyDeclared(fieldSyntax.Identifier.Location, fieldName);
@@ -1089,6 +1089,6 @@ internal sealed partial class DeclarationBinder
 
     private static bool HasAttributeTarget(AnnotationSyntax annotation, AttributeTargetKind target)
         => annotation.Target != null
-            && TryParseTargetKind(annotation.Target.KindIdentifier.Text, out var parsedTarget)
+            && TryParseTargetKind(annotation.Target.KindIdentifier.ValueText, out var parsedTarget)
             && parsedTarget == target;
 }

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
@@ -291,7 +291,7 @@ internal sealed partial class DeclarationBinder
             var ctorBuilder = ImmutableArray.CreateBuilder<ParameterSymbol>();
             foreach (var paramSyntax in primaryConstructorParameters)
             {
-                var paramName = paramSyntax.Identifier.Text;
+                var paramName = paramSyntax.Identifier.ValueText;
                 var paramType = paramSyntax.Type is { } paramTypeSyntax
                     ? bindTypeClause(paramTypeSyntax)
                     : TypeSymbol.Error;
@@ -407,7 +407,7 @@ internal sealed partial class DeclarationBinder
 
         foreach (var fieldSyntax in syntax.Fields)
         {
-            var fieldName = fieldSyntax.Identifier.Text;
+            var fieldName = fieldSyntax.Identifier.ValueText;
             if (!seenFieldNames.Add(fieldName))
             {
                 Diagnostics.ReportSymbolAlreadyDeclared(fieldSyntax.Identifier.Location, fieldName);
@@ -945,7 +945,7 @@ internal sealed partial class DeclarationBinder
             var methodsBuilder = ImmutableArray.CreateBuilder<FunctionSymbol>();
             foreach (var methodSyntax in syntax.Methods)
             {
-                var methodName = methodSyntax.Identifier.Text;
+                var methodName = methodSyntax.Identifier.ValueText;
 
                 // Issue #938 / ADR-0029: inline and data structs synthesize a
                 // fixed set of members (Equals, GetHashCode, ToString,
@@ -1017,7 +1017,7 @@ internal sealed partial class DeclarationBinder
                     for (var pIndex = 0; pIndex < methodSyntax.Parameters.Count; pIndex++)
                     {
                         var parameterSyntax = methodSyntax.Parameters[pIndex];
-                        var parameterName = parameterSyntax.Identifier.Text;
+                        var parameterName = parameterSyntax.Identifier.ValueText;
                         var parameterType = parameterSyntax.Type is { } parameterTypeSyntax
                             ? bindTypeClause(parameterTypeSyntax) ?? TypeSymbol.Error
                             : TypeSymbol.Error;
@@ -1460,7 +1460,7 @@ internal sealed partial class DeclarationBinder
                     ParameterSyntax? parameterSyntax = null;
                     foreach (var candidate in primaryConstructorParameters)
                     {
-                        if (candidate.Identifier.Text == parameter.Name)
+                        if (candidate.Identifier.ValueText == parameter.Name)
                         {
                             parameterSyntax = candidate;
                             break;
@@ -1500,7 +1500,7 @@ internal sealed partial class DeclarationBinder
                     var seenIndexParamNames = new HashSet<string>();
                     foreach (var indexParamSyntax in propSyntax.Parameters)
                     {
-                        var indexParamName = indexParamSyntax.Identifier.Text;
+                        var indexParamName = indexParamSyntax.Identifier.ValueText;
                         var indexParamType = indexParamSyntax.Type is { } indexParamTypeSyntax
                             ? bindTypeClause(indexParamTypeSyntax) ?? TypeSymbol.Error
                             : TypeSymbol.Error;
@@ -1520,7 +1520,7 @@ internal sealed partial class DeclarationBinder
                     indexerParameters = indexerParamBuilder.ToImmutable();
                 }
 
-                var propName = isIndexer ? "Item" : propSyntax.Identifier.Text;
+                var propName = isIndexer ? "Item" : propSyntax.Identifier.ValueText;
 
                 // Check for duplicate names (fields + methods + other properties).
                 // ADR-0149: exempt when either the new property, or ANY
@@ -1608,7 +1608,7 @@ internal sealed partial class DeclarationBinder
 
                     if (writeAccessor != null && writeAccessor.ParameterIdentifier != null)
                     {
-                        setterParamName = writeAccessor.ParameterIdentifier.Text;
+                        setterParamName = writeAccessor.ParameterIdentifier.ValueText;
                     }
 
                     // Auto-property if accessors have no bodies
@@ -1835,7 +1835,7 @@ internal sealed partial class DeclarationBinder
             var eventsBuilder = ImmutableArray.CreateBuilder<EventSymbol>();
             foreach (var eventSyntax in syntax.Events)
             {
-                var eventName = eventSyntax.Identifier.Text;
+                var eventName = eventSyntax.Identifier.ValueText;
 
                 // Check for duplicate names.
                 // ADR-0149: mirrors the property collision exemption above —
@@ -2198,7 +2198,7 @@ internal sealed partial class DeclarationBinder
             var sharedConstFieldsBuilder = ImmutableArray.CreateBuilder<FieldSymbol>();
             foreach (var fieldSyntax in syntax.SharedBlock.Fields)
             {
-                var fieldName = fieldSyntax.Identifier.Text;
+                var fieldName = fieldSyntax.Identifier.ValueText;
                 if (methodNames.Contains(fieldName) || !existingNames.Add(fieldName))
                 {
                     Diagnostics.ReportSymbolAlreadyDeclared(fieldSyntax.Identifier.Location, fieldName);
@@ -2337,7 +2337,7 @@ internal sealed partial class DeclarationBinder
             var staticMethodsBuilder = ImmutableArray.CreateBuilder<FunctionSymbol>();
             foreach (var methodSyntax in syntax.SharedBlock.Methods)
             {
-                var methodName = methodSyntax.Identifier.Text;
+                var methodName = methodSyntax.Identifier.ValueText;
 
                 // ADR-0063: allow same-name overloads in a shared block; only reject
                 // collision with a non-method member of the same name (field/property/event).
@@ -2387,7 +2387,7 @@ internal sealed partial class DeclarationBinder
                     var seenParameterNames = new HashSet<string>();
                     foreach (var parameterSyntax in methodSyntax.Parameters)
                     {
-                        var parameterName = parameterSyntax.Identifier.Text;
+                        var parameterName = parameterSyntax.Identifier.ValueText;
                         var parameterType = parameterSyntax.Type is { } parameterTypeSyntax
                             ? bindTypeClause(parameterTypeSyntax) ?? TypeSymbol.Error
                             : TypeSymbol.Error;
@@ -2588,7 +2588,7 @@ internal sealed partial class DeclarationBinder
                     continue;
                 }
 
-                var propName = propSyntax.Identifier.Text;
+                var propName = propSyntax.Identifier.ValueText;
 
                 // ADR-0149 follow-up (issue #2370): mirrors the instance-
                 // property exemption above (`propExemptCollision`) — a static
@@ -2664,7 +2664,7 @@ internal sealed partial class DeclarationBinder
 
                     if (setAccessor != null && setAccessor.ParameterIdentifier != null)
                     {
-                        setterParamName = setAccessor.ParameterIdentifier.Text;
+                        setterParamName = setAccessor.ParameterIdentifier.ValueText;
                     }
 
                     isAutoProperty = (getAccessor == null || getAccessor.Body == null)
@@ -2772,7 +2772,7 @@ internal sealed partial class DeclarationBinder
             var staticEventsBuilder = ImmutableArray.CreateBuilder<EventSymbol>();
             foreach (var eventSyntax in syntax.SharedBlock.Events)
             {
-                var eventName = eventSyntax.Identifier.Text;
+                var eventName = eventSyntax.Identifier.ValueText;
                 if (methodNames.Contains(eventName) || !existingNames.Add(eventName))
                 {
                     Diagnostics.ReportSymbolAlreadyDeclared(eventSyntax.Identifier.Location, eventName);

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -209,7 +209,7 @@ internal sealed partial class DeclarationBinder
     /// </param>
     internal void BindTypeAliasDeclaration(TypeAliasDeclarationSyntax syntax, PackageSymbol package)
     {
-        var name = syntax.Identifier.Text;
+        var name = syntax.Identifier.ValueText;
 
         // Reject shadowing of primitive type names.
         if (isPrimitiveTypeName(name))
@@ -249,7 +249,7 @@ internal sealed partial class DeclarationBinder
     /// </summary>
     internal DelegateTypeSymbol? DeclareDelegateSymbol(DelegateDeclarationSyntax syntax, PackageSymbol package)
     {
-        var name = syntax.Identifier.Text;
+        var name = syntax.Identifier.ValueText;
 
         // Reject shadowing of primitive type names — same rule as struct/enum.
         if (isPrimitiveTypeName(name))
@@ -318,7 +318,7 @@ internal sealed partial class DeclarationBinder
         for (var pIndex = 0; pIndex < syntax.Parameters.Count; pIndex++)
         {
             var parameterSyntax = syntax.Parameters[pIndex];
-            var parameterName = parameterSyntax.Identifier.Text;
+            var parameterName = parameterSyntax.Identifier.ValueText;
             var parameterType = parameterSyntax.Type is { } parameterTypeSyntax
                 ? bindTypeClause(parameterTypeSyntax) ?? TypeSymbol.Error
                 : TypeSymbol.Error;
@@ -385,7 +385,7 @@ internal sealed partial class DeclarationBinder
 
     internal EnumSymbol? BindEnumDeclaration(EnumDeclarationSyntax syntax, PackageSymbol package, TypeSymbol? containingType = null)
     {
-        var name = syntax.Identifier.Text;
+        var name = syntax.Identifier.ValueText;
 
         if (isPrimitiveTypeName(name))
         {
@@ -419,7 +419,7 @@ internal sealed partial class DeclarationBinder
         var nextValue = 0;
         foreach (var memberSyntax in syntax.Members)
         {
-            var memberName = memberSyntax.Identifier.Text;
+            var memberName = memberSyntax.Identifier.ValueText;
             if (!seenMemberNames.Add(memberName))
             {
                 Diagnostics.ReportDuplicateEnumMember(memberSyntax.Identifier.Location, memberName, name);
@@ -521,7 +521,7 @@ internal sealed partial class DeclarationBinder
                 }
 
             case NameExpressionSyntax name:
-                return declaredValues.TryGetValue(name.IdentifierToken.Text, out value);
+                return declaredValues.TryGetValue(name.IdentifierToken.ValueText, out value);
 
             case UnaryExpressionSyntax unary:
                 // Issue #1912 follow-up: the lexer types a decimal literal one past
@@ -733,7 +733,7 @@ internal sealed partial class DeclarationBinder
     /// </summary>
     internal StructSymbol? DeclareStructShell(StructDeclarationSyntax syntax, PackageSymbol package, TypeSymbol? containingType = null)
     {
-        var name = syntax.Identifier.Text;
+        var name = syntax.Identifier.ValueText;
 
         if (isPrimitiveTypeName(name))
         {

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
@@ -105,9 +105,9 @@ internal sealed partial class ExpressionBinder
         // type receiver below), so it cannot shadow ordinary static-member access.
         if (syntax.LeftPart is NameExpressionSyntax enclosingNameSyntax
             && syntax.RightPart is not NameExpressionSyntax
-            && scope.TryLookupSymbol(enclosingNameSyntax.IdentifierToken.Text) is not VariableSymbol
+            && scope.TryLookupSymbol(enclosingNameSyntax.IdentifierToken.ValueText) is not VariableSymbol
             && TryLookupSourceTypeWithImportPrecedence(
-                enclosingNameSyntax.IdentifierToken.Text,
+                enclosingNameSyntax.IdentifierToken.ValueText,
                 preferredArity: -1,
                 enclosingNameSyntax,
                 out var enclosingAliasType)
@@ -179,7 +179,7 @@ internal sealed partial class ExpressionBinder
             // scope regardless), so peel it off the same way as the
             // nested-type case above whenever the qualifier names the type's own
             // simple name AND that name is also the tail of its package.
-            if (headIdentifier == enclosingNameSyntax.IdentifierToken.Text
+            if (headIdentifier == enclosingNameSyntax.IdentifierToken.ValueText
                 && GetSymbolPackageName(enclosingAliasType) is string ownPackageName
                 && (ownPackageName == headIdentifier || ownPackageName.EndsWith("." + headIdentifier, StringComparison.Ordinal)))
             {
@@ -243,7 +243,7 @@ internal sealed partial class ExpressionBinder
 
         if (leftName is not null)
         {
-            var name = leftName.IdentifierToken.Text;
+            var name = leftName.IdentifierToken.ValueText;
             var variableHit = scope.TryLookupSymbol(name) as VariableSymbol;
 
             // Issue #1104: `base.Prop` — a non-virtual read of the nearest base
@@ -783,7 +783,7 @@ internal sealed partial class ExpressionBinder
         StructSymbol? sourceType = null;
         if (syntax.LeftPart is NameExpressionSyntax sourceName
             && TryLookupSourceTypeWithImportPrecedence(
-                sourceName.IdentifierToken.Text,
+                sourceName.IdentifierToken.ValueText,
                 preferredArity: -1,
                 sourceName,
                 out var sourceAlias)
@@ -954,17 +954,17 @@ internal sealed partial class ExpressionBinder
         switch (expression)
         {
             case NameExpressionSyntax name:
-                identifier = name.IdentifierToken.Text;
+                identifier = name.IdentifierToken.ValueText;
                 return true;
             case CallExpressionSyntax call:
-                identifier = call.Identifier.Text;
+                identifier = call.Identifier.ValueText;
                 return true;
             case AccessorExpressionSyntax accessor:
                 return TryGetHeadIdentifier(accessor.LeftPart, out identifier);
             case IndexExpressionSyntax index:
                 return TryGetHeadIdentifier(index.Target, out identifier);
             case StructLiteralExpressionSyntax structLiteral:
-                identifier = structLiteral.TypeIdentifier.Text;
+                identifier = structLiteral.TypeIdentifier.ValueText;
                 return true;
             case ObjectCreationExpressionSyntax objectCreation:
                 return TryGetHeadIdentifier(objectCreation.Target, out identifier);
@@ -1010,17 +1010,17 @@ internal sealed partial class ExpressionBinder
         switch (expr)
         {
             case NameExpressionSyntax name:
-                headName = name.IdentifierToken.Text;
+                headName = name.IdentifierToken.ValueText;
                 headArity = -1;
                 return true;
             case GenericNameExpressionSyntax generic:
-                headName = generic.Identifier.Text;
+                headName = generic.Identifier.ValueText;
                 headArity = generic.TypeArgumentList.Arguments.Count;
                 return true;
             case IndexExpressionSyntax index
                 when !index.IsNullConditional
                     && index.Target is NameExpressionSyntax indexName:
-                headName = indexName.IdentifierToken.Text;
+                headName = indexName.IdentifierToken.ValueText;
                 headArity = index.Indices.Count;
                 return true;
             case IndexExpressionSyntax index when !index.IsNullConditional:
@@ -1265,7 +1265,7 @@ internal sealed partial class ExpressionBinder
         switch (expr)
         {
             case NameExpressionSyntax name:
-                segments.Add((name.IdentifierToken.Text, default));
+                segments.Add((name.IdentifierToken.ValueText, default));
                 return true;
 
             case GenericNameExpressionSyntax generic:
@@ -1274,7 +1274,7 @@ internal sealed partial class ExpressionBinder
                     return false;
                 }
 
-                segments.Add((generic.Identifier.Text, genericArgs));
+                segments.Add((generic.Identifier.ValueText, genericArgs));
                 return true;
 
             case IndexExpressionSyntax index when !index.IsNullConditional:
@@ -1285,7 +1285,7 @@ internal sealed partial class ExpressionBinder
                         return false;
                     }
 
-                    segments.Add((indexTargetName.IdentifierToken.Text, rootArgs));
+                    segments.Add((indexTargetName.IdentifierToken.ValueText, rootArgs));
                     return true;
                 }
 
@@ -1317,11 +1317,11 @@ internal sealed partial class ExpressionBinder
                 switch (accessor.RightPart)
                 {
                     case NameExpressionSyntax rightName:
-                        segments.Add((rightName.IdentifierToken.Text, default));
+                        segments.Add((rightName.IdentifierToken.ValueText, default));
                         return true;
                     case GenericNameExpressionSyntax rightGeneric
                         when TryBindGenericSegmentArguments(rightGeneric, out var rightArgs):
-                        segments.Add((rightGeneric.Identifier.Text, rightArgs));
+                        segments.Add((rightGeneric.Identifier.ValueText, rightArgs));
                         return true;
                     default:
                         return false;
@@ -1584,7 +1584,7 @@ internal sealed partial class ExpressionBinder
         NameExpressionSyntax leftName,
         ref ExpressionSyntax rightPart,
         [NotNullWhen(true)] out ImportedClassSymbol? importedClass)
-        => TryWalkQualifiedClrTypePath(leftName.IdentifierToken.Text, ref rightPart, out importedClass);
+        => TryWalkQualifiedClrTypePath(leftName.IdentifierToken.ValueText, ref rightPart, out importedClass);
 
     /// <summary>
     /// Walks a dotted accessor chain, extending a namespace prefix segment by
@@ -1665,7 +1665,7 @@ internal sealed partial class ExpressionBinder
                     return false;
             }
 
-            var fullTypeName = currentPath + "." + typeNameSyntax.IdentifierToken.Text;
+            var fullTypeName = currentPath + "." + typeNameSyntax.IdentifierToken.ValueText;
             if (scope.References.TryResolveType(fullTypeName, out var type))
             {
                 importedClass = new ImportedClassSymbol(type, typeNameSyntax, references: scope.References);
@@ -1709,12 +1709,12 @@ internal sealed partial class ExpressionBinder
                     return false;
                 }
 
-                name = indexName.IdentifierToken.Text;
+                name = indexName.IdentifierToken.ValueText;
                 arity = index.Indices.Count;
                 return true;
 
             case GenericNameExpressionSyntax generic:
-                name = generic.Identifier.Text;
+                name = generic.Identifier.ValueText;
                 arity = generic.TypeArgumentList.Arguments.Count;
                 return true;
 
@@ -1910,7 +1910,7 @@ internal sealed partial class ExpressionBinder
         [NotNullWhen(true)] out BoundExpression? result)
     {
         result = null;
-        var methodName = ce.Identifier.Text;
+        var methodName = ce.Identifier.ValueText;
 
         var instanceGroup = TypeMemberModel.GetMethods(structSym, methodName, MemberQuery.Instance(MemberKinds.Method));
         var staticGroup = TypeMemberModel.GetMethods(structSym, methodName, MemberQuery.Static(MemberKinds.Method));
@@ -2022,12 +2022,12 @@ internal sealed partial class ExpressionBinder
         switch (rightPart)
         {
             case CallExpressionSyntax ce when !ce.Identifier.IsMissing:
-                headName = ce.Identifier.Text;
+                headName = ce.Identifier.ValueText;
                 isCall = true;
                 return !string.IsNullOrEmpty(headName);
 
             case NameExpressionSyntax ne when !ne.IdentifierToken.IsMissing:
-                headName = ne.IdentifierToken.Text;
+                headName = ne.IdentifierToken.ValueText;
                 isCall = false;
                 return !string.IsNullOrEmpty(headName);
 
@@ -2165,7 +2165,7 @@ internal sealed partial class ExpressionBinder
                 return BindAccessorStep(head, null, nested.RightPart);
 
             case NameExpressionSyntax ne:
-                var memberName = ne.IdentifierToken.Text;
+                var memberName = ne.IdentifierToken.ValueText;
                 if (enumSymbol.TryGetMember(memberName, out var member))
                 {
                     // Issue #188 / #175: every read of an `@Obsolete` enum
@@ -2312,21 +2312,21 @@ internal sealed partial class ExpressionBinder
         var literalArity = structLiteral.TypeArgumentList != null ? structLiteral.TypeArgumentList.Arguments.Count : -1;
         TypeSymbol? nestedType;
         StructSymbol? declaringContainer = outerConstructed;
-        if (!scope.TryLookupNestedTypeAlias(container, structLiteral.TypeIdentifier.Text, literalArity, out nestedType)
+        if (!scope.TryLookupNestedTypeAlias(container, structLiteral.TypeIdentifier.ValueText, literalArity, out nestedType)
             && !scope.TryLookupNestedTypeAliasIncludingInherited(
                 outerConstructed,
-                structLiteral.TypeIdentifier.Text,
+                structLiteral.TypeIdentifier.ValueText,
                 literalArity,
                 out nestedType,
                 out declaringContainer))
         {
-            Diagnostics.ReportUnableToFindType(structLiteral.TypeIdentifier.Location, structLiteral.TypeIdentifier.Text);
+            Diagnostics.ReportUnableToFindType(structLiteral.TypeIdentifier.Location, structLiteral.TypeIdentifier.ValueText);
             return new BoundErrorExpression(null);
         }
 
         if (nestedType is not StructSymbol nestedStructDef)
         {
-            Diagnostics.ReportUnableToFindType(structLiteral.TypeIdentifier.Location, structLiteral.TypeIdentifier.Text);
+            Diagnostics.ReportUnableToFindType(structLiteral.TypeIdentifier.Location, structLiteral.TypeIdentifier.ValueText);
             return new BoundErrorExpression(null);
         }
 
@@ -2544,7 +2544,7 @@ internal sealed partial class ExpressionBinder
     /// <returns>The bound access, or a bound error expression.</returns>
     private BoundExpression BindInterfaceStaticMemberAccess(InterfaceSymbol interfaceSym, InterfaceSymbol fieldOwner, NameExpressionSyntax ne)
     {
-        var memberName = ne.IdentifierToken.Text;
+        var memberName = ne.IdentifierToken.ValueText;
 
         var field = fieldOwner.GetStaticField(memberName);
         if (field != null)
@@ -2640,7 +2640,7 @@ internal sealed partial class ExpressionBinder
 
         if (!binderCtx.TryLookupSourceType(
                 scope,
-                targetName.IdentifierToken.Text,
+                targetName.IdentifierToken.ValueText,
                 index.Indices.Count,
                 getCurrentFunction(),
                 out var alias,
@@ -2699,7 +2699,7 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
-        var name = targetName.IdentifierToken.Text;
+        var name = targetName.IdentifierToken.ValueText;
 
         // Genuine indexing (`arr[i]`, `dict[key]`) requires the target to name a
         // value. Only when the name is NOT a value do we consider the
@@ -2798,7 +2798,7 @@ internal sealed partial class ExpressionBinder
         constructedInterface = null;
         constructedImported = null;
 
-        var name = generic.Identifier.Text;
+        var name = generic.Identifier.ValueText;
 
         // A value-named receiver is genuine element access, never a type.
         if (scope.TryLookupSymbol(name) is VariableSymbol)
@@ -2991,7 +2991,7 @@ internal sealed partial class ExpressionBinder
         while (current is AccessorExpressionSyntax accessor
                && !accessor.IsNullConditional
                && accessor.LeftPart is NameExpressionSyntax leftName
-               && IsNamespacePrefixSegment(leftName.IdentifierToken.Text, isLeadingSegment: !peeledAny))
+               && IsNamespacePrefixSegment(leftName.IdentifierToken.ValueText, isLeadingSegment: !peeledAny))
         {
             current = accessor.RightPart;
             peeledAny = true;
@@ -3175,7 +3175,7 @@ internal sealed partial class ExpressionBinder
         [NotNullWhen(true)] out BoundExpression? result)
     {
         result = null;
-        var name = syntax.IdentifierToken.Text;
+        var name = syntax.IdentifierToken.ValueText;
 
         StructSymbol? match = null;
         var ambiguous = false;
@@ -3273,7 +3273,7 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
-        var name = syntax.IdentifierToken.Text;
+        var name = syntax.IdentifierToken.ValueText;
         if (!submissionImports.TryFindMemberContainer(scope.References, name, out var programType))
         {
             return false;
@@ -3385,7 +3385,7 @@ internal sealed partial class ExpressionBinder
 
     private BoundExpression BindUserTypeStaticMemberAccess(StructSymbol structSym, NameExpressionSyntax ne)
     {
-        var memberName = ne.IdentifierToken.Text;
+        var memberName = ne.IdentifierToken.ValueText;
 
         // ADR-0112: static field/property lookups go through the canonical layer.
         if (TypeMemberModel.TryGetStaticFieldIncludingInherited(structSym, memberName, out var field, out var fieldOwner))
@@ -3457,7 +3457,7 @@ internal sealed partial class ExpressionBinder
         var structSym = ownerType as StructSymbol;
         var ifaceSym = ownerType as InterfaceSymbol;
 
-        var methodName = ce.Identifier.Text;
+        var methodName = ce.Identifier.ValueText;
 
         if (!overloads.TryAnalyzeCallArgumentLayout(ce.Arguments, out _, out var argumentNames))
         {

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
@@ -166,7 +166,7 @@ internal sealed partial class ExpressionBinder
                 // projection cannot expose the stored function as a delegate.
                 if (ce.NullableQuestionToken == null
                     && receiver?.Type is TupleTypeSymbol tupleType
-                    && TryGetTupleElementIndex(ce.Identifier.Text, tupleType, out var tupleIndex)
+                    && TryGetTupleElementIndex(ce.Identifier.ValueText, tupleType, out var tupleIndex)
                     && RequiresSymbolicTupleElementInvocation(tupleType, tupleIndex))
                 {
                     var tupleElement = new BoundTupleElementAccessExpression(
@@ -177,7 +177,7 @@ internal sealed partial class ExpressionBinder
                     return overloads.BindIndirectCallExpression(
                         ce,
                         tupleElement,
-                        ce.Identifier.Text,
+                        ce.Identifier.ValueText,
                         ce.Identifier.Location,
                         nullSafeInvocation: "?(...)");
                 }
@@ -248,7 +248,7 @@ internal sealed partial class ExpressionBinder
 
                 if (classSymbol != null)
                 {
-                    var foundMember = classSymbol.TryLookupMember(ne.IdentifierToken.Text, ne, out var staticMember);
+                    var foundMember = classSymbol.TryLookupMember(ne.IdentifierToken.ValueText, ne, out var staticMember);
                     if (!foundMember || staticMember is null)
                     {
                         // Issue #337: a static member name that resolves to a
@@ -256,14 +256,14 @@ internal sealed partial class ExpressionBinder
                         // delegate-conversion context it materializes as a
                         // delegate over the selected overload; the conversion
                         // classifier decides which overload (if any) applies.
-                        var staticMethods = classSymbol.GetStaticMethodGroup(ne.IdentifierToken.Text);
+                        var staticMethods = classSymbol.GetStaticMethodGroup(ne.IdentifierToken.ValueText);
                         if (!staticMethods.IsEmpty)
                         {
                             return new BoundClrMethodGroupExpression(
                                 null,
                                 receiver: null,
                                 classSymbol.ClassType,
-                                ne.IdentifierToken.Text,
+                                ne.IdentifierToken.ValueText,
                                 staticMethods);
                         }
 
@@ -320,7 +320,7 @@ internal sealed partial class ExpressionBinder
                     // ADR-0112 A3: this-first base-chain instance field walk via
                     // the canonical member-resolution layer, surfacing the
                     // declaring struct so the emitted field token names the right owner.
-                    if (TypeMemberModel.TryGetFieldIncludingInherited(structSym, ne.IdentifierToken.Text, MemberQuery.Instance(MemberKinds.Field), out var field, out var declaringType))
+                    if (TypeMemberModel.TryGetFieldIncludingInherited(structSym, ne.IdentifierToken.ValueText, MemberQuery.Instance(MemberKinds.Field), out var field, out var declaringType))
                     {
                         // Issue #186 / #175: dotted field read fires
                         // GS0204 if the field carries `@Obsolete`.
@@ -350,11 +350,11 @@ internal sealed partial class ExpressionBinder
                     }
 
                     // ADR-0051: check properties before reporting "unable to find member".
-                    if (TypeMemberModel.TryGetProperty(structSym, ne.IdentifierToken.Text, out var prop, out var propDeclaringType))
+                    if (TypeMemberModel.TryGetProperty(structSym, ne.IdentifierToken.ValueText, out var prop, out var propDeclaringType))
                     {
                         if (!prop.HasGetter)
                         {
-                            Diagnostics.ReportCannotAssign(ne.Location, ne.IdentifierToken.Text);
+                            Diagnostics.ReportCannotAssign(ne.Location, ne.IdentifierToken.ValueText);
                             return new BoundErrorExpression(null);
                         }
 
@@ -389,7 +389,7 @@ internal sealed partial class ExpressionBinder
                         while (evtDeclType != null)
                         {
                             var evt = evtDeclType.Events.FirstOrDefault(e =>
-                                e.Name == ne.IdentifierToken.Text && e.IsFieldLike && e.BackingField != null);
+                                e.Name == ne.IdentifierToken.ValueText && e.IsFieldLike && e.BackingField != null);
                             if (evt != null)
                             {
                                 return ApplyMemberNarrowing(new BoundFieldAccessExpression(null, receiver, evtDeclType, evt.BackingField!));
@@ -407,7 +407,7 @@ internal sealed partial class ExpressionBinder
                     // then reflect the member (reflection walks the CLR chain).
                     if (GetInheritedClrBaseType(structSym) is System.Type inheritedBaseClr)
                     {
-                        var memberName = ne.IdentifierToken.Text;
+                        var memberName = ne.IdentifierToken.ValueText;
                         var clrProp = ClrTypeUtilities.SafeGetInheritedInstanceProperty(inheritedBaseClr, memberName);
                         if (clrProp != null && clrProp.CanRead)
                         {
@@ -426,7 +426,7 @@ internal sealed partial class ExpressionBinder
                     // conversion classifier selects the overload (if any) from the
                     // target delegate signature; the emitter binds the delegate's
                     // Target to this receiver (boxing value-type receivers).
-                    var instanceMethods = TypeMemberModel.GetMethods(structSym, ne.IdentifierToken.Text, MemberQuery.Instance(MemberKinds.Method));
+                    var instanceMethods = TypeMemberModel.GetMethods(structSym, ne.IdentifierToken.ValueText, MemberQuery.Instance(MemberKinds.Method));
                     if (TryBuildUserMethodGroup(receiver, instanceMethods, out var instanceUserGroup))
                     {
                         return instanceUserGroup;
@@ -438,7 +438,7 @@ internal sealed partial class ExpressionBinder
                     // base, fall back to typeof(object) so the member is captured
                     // as a CLR method group resolvable against a target delegate.
                     var inheritedMgClr = structSym.ImportedBaseType?.ClrType ?? typeof(object);
-                    if (TryBindClrMethodGroup(receiver, inheritedMgClr, wantStatic: false, ne.IdentifierToken.Text, out var inheritedClrGroup))
+                    if (TryBindClrMethodGroup(receiver, inheritedMgClr, wantStatic: false, ne.IdentifierToken.ValueText, out var inheritedClrGroup))
                     {
                         return inheritedClrGroup;
                     }
@@ -453,7 +453,7 @@ internal sealed partial class ExpressionBinder
                     // as a CLR method group over typeof(System.Enum) so it resolves
                     // against a target delegate signature; the emitter boxes the
                     // value-type receiver into the delegate Target.
-                    if (TryBindClrMethodGroup(receiver, typeof(System.Enum), wantStatic: false, ne.IdentifierToken.Text, out var enumClrGroup))
+                    if (TryBindClrMethodGroup(receiver, typeof(System.Enum), wantStatic: false, ne.IdentifierToken.ValueText, out var enumClrGroup))
                     {
                         return enumClrGroup;
                     }
@@ -473,13 +473,13 @@ internal sealed partial class ExpressionBinder
                     // TypeMemberModel.TryGetProperty walks SelfAndAllBaseInterfaces.
                     if (TypeMemberModel.TryGetPropertyWithOwner(
                         ifaceSym,
-                        ne.IdentifierToken.Text,
+                        ne.IdentifierToken.ValueText,
                         out var ifaceProp,
                         out var ifacePropertyOwner))
                     {
                         if (!ifaceProp.HasGetter)
                         {
-                            Diagnostics.ReportCannotAssign(ne.Location, ne.IdentifierToken.Text);
+                            Diagnostics.ReportCannotAssign(ne.Location, ne.IdentifierToken.ValueText);
                             return new BoundErrorExpression(null);
                         }
 
@@ -522,7 +522,7 @@ internal sealed partial class ExpressionBinder
                     // the concrete implementation through interface dispatch.
                     // TypeMemberModel.GetMethods walks SelfAndAllBaseInterfaces
                     // so an inherited base-interface method binds too.
-                    var ifaceInstanceMethods = TypeMemberModel.GetMethods(ifaceSym, ne.IdentifierToken.Text, MemberQuery.Instance(MemberKinds.Method));
+                    var ifaceInstanceMethods = TypeMemberModel.GetMethods(ifaceSym, ne.IdentifierToken.ValueText, MemberQuery.Instance(MemberKinds.Method));
                     if (TryBuildUserMethodGroup(receiver, ifaceInstanceMethods, out var ifaceUserGroup))
                     {
                         return ifaceUserGroup;
@@ -537,7 +537,7 @@ internal sealed partial class ExpressionBinder
                     // `callvirt get_Count`. The receiver carries an
                     // InterfaceImpl row to each imported base interface, so a
                     // CLR member access on it is verifiable.
-                    var ifaceMemberName = ne.IdentifierToken.Text;
+                    var ifaceMemberName = ne.IdentifierToken.ValueText;
                     foreach (var clrBaseIface in MemberLookup.GetTransitiveClrBaseInterfaces(ifaceSym))
                     {
                         var clrProp = ClrTypeUtilities.SafeGetProperty(clrBaseIface, ifaceMemberName, BindingFlags.Public | BindingFlags.Instance);
@@ -570,7 +570,7 @@ internal sealed partial class ExpressionBinder
                 {
                     // Phase 4.5 / issue #2924: tuple element access via
                     // one-based Item1..ItemN or zero-based .0...N selectors.
-                    var memberName = ne.IdentifierToken.Text;
+                    var memberName = ne.IdentifierToken.ValueText;
                     if (TryGetTupleElementIndex(memberName, tupleSym, out var zeroBased))
                     {
                         return new BoundTupleElementAccessExpression(null, receiver, tupleSym, zeroBased);
@@ -597,7 +597,7 @@ internal sealed partial class ExpressionBinder
                     // over the erased closed shape with symbolic [K, V]
                     // re-projection, exactly as on `Dictionary[K, V]`.
                     var clrReceiverType = Invariant.Required(clrInstanceReceiverType.ClrType, "a CLR member receiver has a CLR type");
-                    var memberName = ne.IdentifierToken.Text;
+                    var memberName = ne.IdentifierToken.ValueText;
 
                     // Issue #529: use interface-aware lookup so that members
                     // declared on a base interface (e.g. IReadOnlyCollection<T>.Count
@@ -702,7 +702,7 @@ internal sealed partial class ExpressionBinder
                     // against `typeof(System.Array)` and bind it as an
                     // ordinary CLR property read; the IL is correct
                     // because the array genuinely exposes the member.
-                    var arrayMemberName = ne.IdentifierToken.Text;
+                    var arrayMemberName = ne.IdentifierToken.ValueText;
                     var arrayProp = ClrTypeUtilities.SafeGetPropertyIncludingInterfaces(typeof(System.Array), arrayMemberName, BindingFlags.Public | BindingFlags.Instance);
                     if (arrayProp != null && arrayProp.GetIndexParameters().Length == 0 && arrayProp.CanRead)
                     {
@@ -760,7 +760,7 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
-        var memberName = name.IdentifierToken.Text;
+        var memberName = name.IdentifierToken.ValueText;
         var nullableInnerClr = nullableType.UnderlyingType?.ClrType;
         if (nullableInnerClr?.IsValueType == true
             && this.memberLookup.TryGetNullableConstructedType(nullableInnerClr, out var nullableClr))
@@ -899,7 +899,7 @@ internal sealed partial class ExpressionBinder
 
         if (receiver != null)
         {
-            var userCandidates = scope.TryLookupExtensionFunctions(receiver.Type, name.IdentifierToken.Text);
+            var userCandidates = scope.TryLookupExtensionFunctions(receiver.Type, name.IdentifierToken.ValueText);
             if (!userCandidates.IsDefaultOrEmpty)
             {
                 if (userCandidates.Length == 1
@@ -921,19 +921,19 @@ internal sealed partial class ExpressionBinder
                 return new BoundMethodGroupExpression(name, receiver, userCandidates);
             }
 
-            var importedCandidates = this.memberLookup.CollectImportedExtensionMethods(name.IdentifierToken.Text);
+            var importedCandidates = this.memberLookup.CollectImportedExtensionMethods(name.IdentifierToken.ValueText);
             if (importedCandidates.Count > 0)
             {
                 return new BoundClrMethodGroupExpression(
                     name,
                     receiver,
                     declaringType: null,
-                    name.IdentifierToken.Text,
+                    name.IdentifierToken.ValueText,
                     importedCandidates.ToImmutableArray());
             }
         }
 
-        Diagnostics.ReportUnableToFindMember(name.Location, name.IdentifierToken.Text);
+        Diagnostics.ReportUnableToFindMember(name.Location, name.IdentifierToken.ValueText);
         return new BoundErrorExpression(null);
     }
 
@@ -954,7 +954,7 @@ internal sealed partial class ExpressionBinder
 
         if (leftPart is NameExpressionSyntax nameExpr)
         {
-            var name = nameExpr.IdentifierToken.Text;
+            var name = nameExpr.IdentifierToken.ValueText;
 
             // Only resolve as a nested type when the name is NOT a static
             // field/property or method group — those take precedence.
@@ -993,7 +993,7 @@ internal sealed partial class ExpressionBinder
 
             if (accessor.RightPart is NameExpressionSyntax innerName)
             {
-                var innerNameText = innerName.IdentifierToken.Text;
+                var innerNameText = innerName.IdentifierToken.ValueText;
                 if (scope.References.TryResolveNestedType(intermediateSymbol.ClassType, innerNameText, out var deepNested))
                 {
                     nestedClassSymbol = new ImportedClassSymbol(deepNested, innerName, references: scope.References);
@@ -3593,7 +3593,7 @@ internal sealed partial class ExpressionBinder
         BoundExpression receiver,
         NameExpressionSyntax ne)
     {
-        var memberName = ne.IdentifierToken.Text;
+        var memberName = ne.IdentifierToken.ValueText;
 
         // Class constraint (issue #1056 surfaced methods; this adds the rest):
         // fields and properties, walking the base chain of the constraint class.
@@ -3733,7 +3733,7 @@ internal sealed partial class ExpressionBinder
         if (tpSym.InterfaceConstraint == null && tpSym.ClrInterfaceConstraint == null)
         {
             Diagnostics.ReportStaticVirtualMemberNotFoundOnTypeParameter(
-                leftName.Location, tpSym.Name, rightPart is CallExpressionSyntax ce0 ? ce0.Identifier.Text : (rightPart is NameExpressionSyntax ne0 ? ne0.IdentifierToken.Text : "?"));
+                leftName.Location, tpSym.Name, rightPart is CallExpressionSyntax ce0 ? ce0.Identifier.ValueText : (rightPart is NameExpressionSyntax ne0 ? ne0.IdentifierToken.ValueText : "?"));
             return new BoundErrorExpression(null);
         }
 
@@ -3774,7 +3774,7 @@ internal sealed partial class ExpressionBinder
 
             case CallExpressionSyntax callSyntax:
                 {
-                    var methodName = callSyntax.Identifier.Text;
+                    var methodName = callSyntax.Identifier.ValueText;
                     if (tpSym.InterfaceConstraint != null)
                     {
                         FunctionSymbol? slot = null;
@@ -3836,7 +3836,7 @@ internal sealed partial class ExpressionBinder
                     // *property* read `T.Prop` dispatches through the
                     // property's getter accessor (a static-virtual slot),
                     // emitted as `constrained. !!T  call I::get_Prop()`.
-                    var propName = ne.IdentifierToken.Text;
+                    var propName = ne.IdentifierToken.ValueText;
                     PropertySymbol? slotProp = null;
                     InterfaceSymbol? slotIface = null;
                     foreach (var iface in tpSym.InterfaceConstraint?.SelfAndAllBaseInterfaces() ?? Enumerable.Empty<InterfaceSymbol>())

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -213,7 +213,7 @@ internal sealed partial class ExpressionBinder
                     return false;
                 }
 
-                segments.Add(leftName.IdentifierToken.Text);
+                segments.Add(leftName.IdentifierToken.ValueText);
                 current = accessor.RightPart;
                 continue;
             }
@@ -241,7 +241,7 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
-        var typeSimpleName = terminalCall.Identifier.Text;
+        var typeSimpleName = terminalCall.Identifier.ValueText;
         var namespacePrefix = string.Join(".", segments);
 
         if (!TryResolveQualifiedClrType(namespacePrefix, typeSimpleName, terminalCall.TypeArgumentList, out var clrType, out var openGenericDef, out var symbolicArgs))
@@ -317,7 +317,7 @@ internal sealed partial class ExpressionBinder
                     return false;
                 }
 
-                segments.Add(leftName.IdentifierToken.Text);
+                segments.Add(leftName.IdentifierToken.ValueText);
                 current = accessor.RightPart;
                 continue;
             }
@@ -337,7 +337,7 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
-        var typeSimpleName = terminalLiteral.TypeIdentifier.Text;
+        var typeSimpleName = terminalLiteral.TypeIdentifier.ValueText;
         var namespacePrefix = string.Join(".", segments);
 
         if (!TryResolveQualifiedClrType(namespacePrefix, typeSimpleName, terminalLiteral.TypeArgumentList, out var clrType, out _, out _))
@@ -351,7 +351,7 @@ internal sealed partial class ExpressionBinder
 
     private bool QualifiedAccessStartsWithValue(AccessorExpressionSyntax syntax) =>
         syntax.LeftPart is NameExpressionSyntax name
-        && scope.TryLookupSymbol(name.IdentifierToken.Text) is VariableSymbol;
+        && scope.TryLookupSymbol(name.IdentifierToken.ValueText) is VariableSymbol;
 
     /// <summary>
     /// Binds a same-compilation SOURCE type constructed or referenced through a
@@ -403,9 +403,9 @@ internal sealed partial class ExpressionBinder
         while (current is AccessorExpressionSyntax accessor
                && !accessor.IsNullConditional
                && accessor.LeftPart is NameExpressionSyntax leftName
-               && IsNamespacePrefixSegment(leftName.IdentifierToken.Text, isLeadingSegment: !peeledAny))
+               && IsNamespacePrefixSegment(leftName.IdentifierToken.ValueText, isLeadingSegment: !peeledAny))
         {
-            peeledSegments.Add(leftName.IdentifierToken.Text);
+            peeledSegments.Add(leftName.IdentifierToken.ValueText);
             current = accessor.RightPart;
             peeledAny = true;
         }
@@ -465,19 +465,19 @@ internal sealed partial class ExpressionBinder
         switch (remainder)
         {
             case CallExpressionSyntax call when !call.Identifier.IsMissing:
-                simpleName = call.Identifier.Text;
+                simpleName = call.Identifier.ValueText;
                 arity = call.TypeArgumentList?.Arguments.Count ?? 0;
                 break;
             case StructLiteralExpressionSyntax literal when !literal.TypeIdentifier.IsMissing:
-                simpleName = literal.TypeIdentifier.Text;
+                simpleName = literal.TypeIdentifier.ValueText;
                 arity = literal.TypeArgumentList?.Arguments.Count ?? 0;
                 break;
             case AccessorExpressionSyntax { LeftPart: GenericNameExpressionSyntax genericHead }:
-                simpleName = genericHead.Identifier.Text;
+                simpleName = genericHead.Identifier.ValueText;
                 arity = genericHead.TypeArgumentList?.Arguments.Count ?? 0;
                 break;
             case AccessorExpressionSyntax { LeftPart: NameExpressionSyntax nameHead }:
-                simpleName = nameHead.IdentifierToken.Text;
+                simpleName = nameHead.IdentifierToken.ValueText;
                 arity = 0;
                 break;
             case AccessorExpressionSyntax accessor:
@@ -490,7 +490,7 @@ internal sealed partial class ExpressionBinder
                     return false;
                 }
 
-                simpleName = indexNameHead.IdentifierToken.Text;
+                simpleName = indexNameHead.IdentifierToken.ValueText;
                 arity = 0;
                 break;
             default:

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -27,7 +27,7 @@ internal sealed partial class ExpressionBinder
 {
     private BoundExpression BindAssignmentExpression(AssignmentExpressionSyntax syntax)
     {
-        var name = syntax.IdentifierToken.Text;
+        var name = syntax.IdentifierToken.ValueText;
 
         // Issue #1316: resolve the assignment target before binding the RHS so the
         // target's declared type can be threaded into the RHS binder as the
@@ -491,7 +491,7 @@ internal sealed partial class ExpressionBinder
 
     private BoundExpression? BindObjectInitializerAssignment(LocalVariableSymbol receiverLocal, TypeSymbol receiverType, PropertyInitializerSyntax initSyntax)
     {
-        var propertyName = initSyntax.PropertyIdentifier.Text;
+        var propertyName = initSyntax.PropertyIdentifier.ValueText;
 
         // Receiver-side type discriminator mirrors the receiver dispatch in
         // BindFieldAssignmentExpression: pure CLR types go through reflection;
@@ -608,7 +608,7 @@ internal sealed partial class ExpressionBinder
         {
             var baseValue = BindExpression(syntax.Value);
             return BindBaseClassPropertyWrite(
-                syntax.FieldIdentifier.Text,
+                syntax.FieldIdentifier.ValueText,
                 syntax.FieldIdentifier.Location,
                 syntax.Receiver.Location,
                 baseValue,
@@ -640,7 +640,7 @@ internal sealed partial class ExpressionBinder
         if (importedTypeOverride == null
             && sourceTypeAlias is StructSymbol userStruct)
         {
-            var fieldName = syntax.FieldIdentifier.Text;
+            var fieldName = syntax.FieldIdentifier.ValueText;
             if (TypeMemberModel.TryGetStaticFieldIncludingInherited(userStruct, fieldName, out var staticField, out var fieldOwner))
             {
                 if (!AccessibilityChecker.IsAccessible(staticField.Accessibility, fieldOwner, function))
@@ -701,7 +701,7 @@ internal sealed partial class ExpressionBinder
         if (importedTypeOverride == null
             && sourceTypeAlias is InterfaceSymbol userInterface)
         {
-            var fieldName = syntax.FieldIdentifier.Text;
+            var fieldName = syntax.FieldIdentifier.ValueText;
             var staticField = userInterface.GetStaticField(fieldName);
             if (staticField != null)
             {
@@ -746,15 +746,15 @@ internal sealed partial class ExpressionBinder
         if (importedClass != null
             || scope.TryLookupImportedClass(receiverName, declaration: null, out importedClass))
         {
-            if (!importedClass.TryLookupMember(syntax.FieldIdentifier.Text, ne: null, out var staticMember))
+            if (!importedClass.TryLookupMember(syntax.FieldIdentifier.ValueText, ne: null, out var staticMember))
             {
-                Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, syntax.FieldIdentifier.Text);
+                Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, syntax.FieldIdentifier.ValueText);
                 return new BoundErrorExpression(null);
             }
 
             if (!TryGetWritableClrMember(staticMember, out var staticTargetType, out var staticTargetSymbol, out var staticWritable))
             {
-                Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, syntax.FieldIdentifier.Text);
+                Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, syntax.FieldIdentifier.ValueText);
                 return new BoundErrorExpression(null);
             }
 
@@ -859,7 +859,7 @@ internal sealed partial class ExpressionBinder
             && assignmentReceiverType?.ClrType != null)
         {
             var clrReceiverType = assignmentReceiverType.ClrType;
-            var fieldName = syntax.FieldIdentifier.Text;
+            var fieldName = syntax.FieldIdentifier.ValueText;
             MemberInfo? instanceMember = ClrTypeUtilities.SafeGetPropertyIncludingInterfaces(clrReceiverType, fieldName, BindingFlags.Public | BindingFlags.Instance);
             if (instanceMember is PropertyInfo prop && prop.GetIndexParameters().Length != 0)
             {
@@ -893,13 +893,13 @@ internal sealed partial class ExpressionBinder
         {
             if (TypeMemberModel.TryGetPropertyWithOwner(
                 ifaceVarType,
-                syntax.FieldIdentifier.Text,
+                syntax.FieldIdentifier.ValueText,
                 out var ifaceProp,
                 out var ifaceOwner))
             {
                 if (!ifaceProp.HasSetter)
                 {
-                    Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, syntax.FieldIdentifier.Text);
+                    Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, syntax.FieldIdentifier.ValueText);
                     return new BoundErrorExpression(null);
                 }
 
@@ -934,7 +934,7 @@ internal sealed partial class ExpressionBinder
                     effectiveInterface);
             }
 
-            Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, syntax.FieldIdentifier.Text);
+            Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, syntax.FieldIdentifier.ValueText);
             return new BoundErrorExpression(null);
         }
 
@@ -951,17 +951,17 @@ internal sealed partial class ExpressionBinder
         {
             if (tpVarType.ClassConstraint is StructSymbol tpClassConstraint)
             {
-                if (TypeMemberModel.TryGetFieldIncludingInherited(tpClassConstraint, syntax.FieldIdentifier.Text, MemberQuery.Instance(MemberKinds.Field), out var tpField, out var tpFieldDeclaringType))
+                if (TypeMemberModel.TryGetFieldIncludingInherited(tpClassConstraint, syntax.FieldIdentifier.ValueText, MemberQuery.Instance(MemberKinds.Field), out var tpField, out var tpFieldDeclaringType))
                 {
                     var tpFieldConverted = conversions.BindConversion(syntax.Value.Location, BindValue(tpField.Type), tpField.Type);
                     return new BoundFieldAssignmentExpression(null, variable, tpFieldDeclaringType, tpField, tpFieldConverted);
                 }
 
-                if (TypeMemberModel.TryGetProperty(tpClassConstraint, syntax.FieldIdentifier.Text, out var tpProp, out var tpPropDeclaringType))
+                if (TypeMemberModel.TryGetProperty(tpClassConstraint, syntax.FieldIdentifier.ValueText, out var tpProp, out var tpPropDeclaringType))
                 {
                     if (!tpProp.HasSetter)
                     {
-                        Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, syntax.FieldIdentifier.Text);
+                        Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, syntax.FieldIdentifier.ValueText);
                         return new BoundErrorExpression(null);
                     }
 
@@ -974,11 +974,11 @@ internal sealed partial class ExpressionBinder
             if (tpVarType.InterfaceConstraint is InterfaceSymbol tpIfaceConstraint
                 && !tpIfaceConstraint.IsGenericDefinition
                 && tpIfaceConstraint.TypeArguments.IsDefaultOrEmpty
-                && TypeMemberModel.TryGetProperty(tpIfaceConstraint, syntax.FieldIdentifier.Text, out var tpIfaceProp, out _))
+                && TypeMemberModel.TryGetProperty(tpIfaceConstraint, syntax.FieldIdentifier.ValueText, out var tpIfaceProp, out _))
             {
                 if (!tpIfaceProp.HasSetter)
                 {
-                    Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, syntax.FieldIdentifier.Text);
+                    Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, syntax.FieldIdentifier.ValueText);
                     return new BoundErrorExpression(null);
                 }
 
@@ -993,13 +993,13 @@ internal sealed partial class ExpressionBinder
             {
                 var clrProperty = ClrTypeUtilities.SafeGetPropertyIncludingInterfaces(
                     clrInterface,
-                    syntax.FieldIdentifier.Text,
+                    syntax.FieldIdentifier.ValueText,
                     BindingFlags.Public | BindingFlags.Instance);
                 if (clrProperty != null && clrProperty.GetIndexParameters().Length == 0)
                 {
                     if (clrProperty.GetSetMethod(nonPublic: false) == null)
                     {
-                        Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, syntax.FieldIdentifier.Text);
+                        Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, syntax.FieldIdentifier.ValueText);
                         return new BoundErrorExpression(null);
                     }
 
@@ -1023,25 +1023,25 @@ internal sealed partial class ExpressionBinder
                 }
             }
 
-            Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, syntax.FieldIdentifier.Text);
+            Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, syntax.FieldIdentifier.ValueText);
             return new BoundErrorExpression(null);
         }
 
         if (!(assignmentReceiverType is StructSymbol structSymbol))
         {
-            Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, syntax.FieldIdentifier.Text);
+            Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, syntax.FieldIdentifier.ValueText);
             return new BoundErrorExpression(null);
         }
 
-        if (!TypeMemberModel.TryGetFieldIncludingInherited(structSymbol, syntax.FieldIdentifier.Text, MemberQuery.Instance(MemberKinds.Field), out var field, out var fieldDeclaringType))
+        if (!TypeMemberModel.TryGetFieldIncludingInherited(structSymbol, syntax.FieldIdentifier.ValueText, MemberQuery.Instance(MemberKinds.Field), out var field, out var fieldDeclaringType))
         {
             // ADR-0051: check if it's a property.
-            if (TypeMemberModel.TryGetProperty(structSymbol, syntax.FieldIdentifier.Text, out var prop, out var propDeclaringType))
+            if (TypeMemberModel.TryGetProperty(structSymbol, syntax.FieldIdentifier.ValueText, out var prop, out var propDeclaringType))
             {
                 propDeclaringType = Invariant.Required(propDeclaringType, "a user-defined struct property has a declaring type");
                 if (!prop.HasSetter)
                 {
-                    Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, syntax.FieldIdentifier.Text);
+                    Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, syntax.FieldIdentifier.ValueText);
                     return new BoundErrorExpression(null);
                 }
 
@@ -1074,7 +1074,7 @@ internal sealed partial class ExpressionBinder
             // = 42` and protected-field writes work the same as the read fallback.
             if (GetInheritedClrBaseType(structSymbol) is System.Type inheritedBaseClr)
             {
-                var memberName = syntax.FieldIdentifier.Text;
+                var memberName = syntax.FieldIdentifier.ValueText;
                 MemberInfo? clrMember = ClrTypeUtilities.SafeGetInheritedInstanceProperty(inheritedBaseClr, memberName);
                 clrMember ??= ClrTypeUtilities.SafeGetInheritedInstanceField(inheritedBaseClr, memberName);
                 if (clrMember != null)
@@ -1092,7 +1092,7 @@ internal sealed partial class ExpressionBinder
                 }
             }
 
-            Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, syntax.FieldIdentifier.Text);
+            Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, syntax.FieldIdentifier.ValueText);
             return new BoundErrorExpression(null);
         }
 
@@ -1122,7 +1122,7 @@ internal sealed partial class ExpressionBinder
         if (field.IsReadOnly
             && !IsReadOnlyFieldAssignmentAllowed(field, fieldDeclaringType, receiverIsThisField))
         {
-            Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, syntax.FieldIdentifier.Text);
+            Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, syntax.FieldIdentifier.ValueText);
         }
 
         // Issue #186 / #175: dotted field write fires GS0204 if the field
@@ -1229,7 +1229,7 @@ internal sealed partial class ExpressionBinder
 
     private BoundExpression? BindBareEventOrCompoundAssignment(NameExpressionSyntax bareName, EventSubscriptionExpressionSyntax syntax)
     {
-        var name = bareName.IdentifierToken.Text;
+        var name = bareName.IdentifierToken.ValueText;
         var isAdd = syntax.OperatorToken.Kind == SyntaxKind.PlusEqualsToken;
         var isEventOperator = isAdd || syntax.OperatorToken.Kind == SyntaxKind.MinusEqualsToken;
 
@@ -1428,7 +1428,7 @@ internal sealed partial class ExpressionBinder
         SyntaxKind baseOpSyntaxKind,
         out BoundExpression? result)
     {
-        var memberName = memberNameSyntax.IdentifierToken.Text;
+        var memberName = memberNameSyntax.IdentifierToken.ValueText;
         var boundRhs = BindExpression(syntax.Value);
 
         if (TypeMemberModel.TryGetStaticFieldIncludingInherited(staticStruct, memberName, out var staticField, out var fieldOwner))
@@ -1541,7 +1541,7 @@ internal sealed partial class ExpressionBinder
         SyntaxKind baseOpSyntaxKind,
         out BoundExpression? result)
     {
-        var memberName = memberNameSyntax.IdentifierToken.Text;
+        var memberName = memberNameSyntax.IdentifierToken.ValueText;
         var fieldOwner = interfaceSym.Definition ?? interfaceSym;
         var staticField = fieldOwner.GetStaticField(memberName);
         if (staticField == null)
@@ -2302,7 +2302,7 @@ internal sealed partial class ExpressionBinder
 
     private BoundExpression BindIndexAssignmentExpression(IndexAssignmentExpressionSyntax syntax)
     {
-        var name = syntax.TargetIdentifier.Text;
+        var name = syntax.TargetIdentifier.ValueText;
         if (scope.TryLookupSymbol(name) is not VariableSymbol variable)
         {
             // ADR-0156 Phase 2 (issue #3251): a bare indexed write
@@ -2631,8 +2631,8 @@ internal sealed partial class ExpressionBinder
 
         var receiverType = receiver.Type;
         var fieldName = receiverType is TupleTypeSymbol tupleType
-            ? GetTupleFieldName(syntax.FieldIdentifier.Text, tupleType)
-            : syntax.FieldIdentifier.Text;
+            ? GetTupleFieldName(syntax.FieldIdentifier.ValueText, tupleType)
+            : syntax.FieldIdentifier.ValueText;
         BoundExpression? value = null;
         BoundExpression BindValue(TypeSymbol targetType) => value ??= BindAssignmentRhs(syntax.Value, targetType);
 
@@ -2880,7 +2880,7 @@ internal sealed partial class ExpressionBinder
         InterfaceSymbol? constructedInterface,
         ImportedClassSymbol? constructedImported)
     {
-        var fieldName = syntax.FieldIdentifier.Text;
+        var fieldName = syntax.FieldIdentifier.ValueText;
         BoundExpression? value = null;
         BoundExpression BindValue(TypeSymbol targetType) => value ??= BindAssignmentRhs(syntax.Value, targetType);
 
@@ -3216,7 +3216,7 @@ internal sealed partial class ExpressionBinder
     {
         result = null;
         var submissionImports = scope.SubmissionImports;
-        var name = syntax.TargetIdentifier.Text;
+        var name = syntax.TargetIdentifier.ValueText;
         if (submissionImports is null
             || !submissionImports.TryFindGlobalVariable(scope.References, name, out _, out _))
         {
@@ -3312,7 +3312,7 @@ internal sealed partial class ExpressionBinder
             isReadOnlySubmissionGlobal: resolvedDeclared.IsReadOnly);
 
         var clrReceiverType = globalType.ClrType;
-        var memberName = syntax.FieldIdentifier.Text;
+        var memberName = syntax.FieldIdentifier.ValueText;
         MemberInfo? instanceMember = ClrTypeUtilities.SafeGetPropertyIncludingInterfaces(clrReceiverType, memberName, BindingFlags.Public | BindingFlags.Instance);
         if (instanceMember is PropertyInfo indexedProperty && indexedProperty.GetIndexParameters().Length != 0)
         {

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
@@ -57,7 +57,7 @@ internal sealed partial class ExpressionBinder
             return new BoundErrorExpression(null);
         }
 
-        var eventName = eventNameSyntax.IdentifierToken.Text;
+        var eventName = eventNameSyntax.IdentifierToken.ValueText;
         var isAdd = syntax.OperatorToken.Kind == SyntaxKind.PlusEqualsToken;
 
         // Issue #2154: events only support `+=`/`-=` subscription semantics —
@@ -82,14 +82,14 @@ internal sealed partial class ExpressionBinder
         if (staticLeftName != null
             && binderCtx.TryLookupSourceType(
                 scope,
-                staticLeftName.IdentifierToken.Text,
+                staticLeftName.IdentifierToken.ValueText,
                 preferredArity: 0,
                 getCurrentFunction(),
                 out staticSourceType,
                 out _))
         {
             _ = TryResolveImportedTypeOverride(
-                staticLeftName.IdentifierToken.Text,
+                staticLeftName.IdentifierToken.ValueText,
                 staticSourceType,
                 requestedArity: 0,
                 staticLeftName,
@@ -159,7 +159,7 @@ internal sealed partial class ExpressionBinder
             && EventReceiverNameCanBindAsType(staticLeftName, eventNameSyntax)
             && (staticImportedOverride != null
                 || scope.TryLookupImportedClass(
-                    staticLeftName.IdentifierToken.Text,
+                    staticLeftName.IdentifierToken.ValueText,
                     staticLeftName,
                     out staticImportedOverride)))
         {
@@ -479,7 +479,7 @@ internal sealed partial class ExpressionBinder
         NameExpressionSyntax receiver,
         ExpressionSyntax rightPart)
     {
-        string name = receiver.IdentifierToken.Text;
+        string name = receiver.IdentifierToken.ValueText;
         if (scope.TryLookupSymbol(name) is not VariableSymbol)
         {
             return true;
@@ -534,7 +534,7 @@ internal sealed partial class ExpressionBinder
             && function?.ThisParameter != null
             && function.ReceiverType is StructSymbol implicitThisStruct)
         {
-            var methods = TypeMemberModel.GetMethods(implicitThisStruct, bareName.IdentifierToken.Text, MemberQuery.Instance(MemberKinds.Method));
+            var methods = TypeMemberModel.GetMethods(implicitThisStruct, bareName.IdentifierToken.ValueText, MemberQuery.Instance(MemberKinds.Method));
             if (!methods.IsDefaultOrEmpty)
             {
                 var receiver = new BoundVariableExpression(null, function.ThisParameter);
@@ -562,7 +562,7 @@ internal sealed partial class ExpressionBinder
 
             if (boundReceiver.Type is StructSymbol receiverStruct)
             {
-                var methods = TypeMemberModel.GetMethods(receiverStruct, memberName.IdentifierToken.Text, MemberQuery.Instance(MemberKinds.Method));
+                var methods = TypeMemberModel.GetMethods(receiverStruct, memberName.IdentifierToken.ValueText, MemberQuery.Instance(MemberKinds.Method));
                 if (!methods.IsDefaultOrEmpty)
                 {
                     var group = BuildInstanceMethodGroup(boundReceiver, methods);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
@@ -2284,7 +2284,7 @@ internal sealed partial class ExpressionBinder
 
                 var boundValue = BindExpression(valueSyntax);
                 return BindBaseClassPropertyWrite(
-                    syntax.MethodIdentifier.Text,
+                    syntax.MethodIdentifier.ValueText,
                     syntax.MethodIdentifier.Location,
                     syntax.BaseKeyword.Location,
                     boundValue,
@@ -2373,11 +2373,11 @@ internal sealed partial class ExpressionBinder
             Diagnostics.ReportBaseInterfaceCallMemberNotFound(
                 syntax.MethodIdentifier.Location,
                 ifaceSym.Name,
-                syntax.MethodIdentifier.Text + "[…]");
+                syntax.MethodIdentifier.ValueText + "[…]");
             return new BoundErrorExpression(null);
         }
 
-        var methodName = syntax.MethodIdentifier.Text;
+        var methodName = syntax.MethodIdentifier.ValueText;
 
         // Private helpers (ADR-0090) are intentionally invisible to
         // implementers; calling one through base[IFoo] would defeat that
@@ -2572,7 +2572,7 @@ internal sealed partial class ExpressionBinder
             return new BoundErrorExpression(null);
         }
 
-        var methodName = ce.Identifier.Text;
+        var methodName = ce.Identifier.ValueText;
 
         // Resolve the overload set on the user base chain (this-first from the
         // search base), which walks grandparents — so the nearest user base
@@ -2879,7 +2879,7 @@ internal sealed partial class ExpressionBinder
             return new BoundErrorExpression(null);
         }
 
-        var memberName = member.IdentifierToken.Text;
+        var memberName = member.IdentifierToken.ValueText;
         if (searchBase == null || !TypeMemberModel.TryGetProperty(searchBase, memberName, out var prop, out var declaringType))
         {
             // Issue #3501: `base.M` used as a method GROUP (an argument, a
@@ -3075,7 +3075,7 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
-        var memberName = member.IdentifierToken.Text;
+        var memberName = member.IdentifierToken.ValueText;
         var clrProp = ClrTypeUtilities.SafeGetProperty(clrBase, memberName, BindingFlags.Public | BindingFlags.Instance);
         if (clrProp == null || clrProp.GetIndexParameters().Length != 0 || !clrProp.CanRead)
         {

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -2333,7 +2333,7 @@ internal sealed partial class ExpressionBinder
         ExpressionSyntax? receiverSyntax = null,
         int? receiverStart = null)
     {
-        var methodName = ce.Identifier.Text;
+        var methodName = ce.Identifier.ValueText;
         if (string.Equals(methodName, "Invoke", System.StringComparison.Ordinal))
         {
             SyntaxNode? effectiveReceiverSyntax = receiverSyntax ?? receiver?.Syntax;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -79,7 +79,7 @@ internal sealed partial class ExpressionBinder
         var explicitValues = new Dictionary<string, (FieldSymbol? Field, PropertySymbol? Property, BoundExpression Value)>();
         foreach (var initSyntax in overrides)
         {
-            var memberName = initSyntax.FieldIdentifier.Text;
+            var memberName = initSyntax.FieldIdentifier.ValueText;
             if (!seen.Add(memberName))
             {
                 Diagnostics.ReportSymbolAlreadyDeclared(initSyntax.FieldIdentifier.Location, memberName);
@@ -202,7 +202,7 @@ internal sealed partial class ExpressionBinder
         var seen = new HashSet<string>();
         foreach (var initSyntax in syntax.Initializers)
         {
-            var propertyName = initSyntax.PropertyIdentifier.Text;
+            var propertyName = initSyntax.PropertyIdentifier.ValueText;
             if (!seen.Add(propertyName))
             {
                 Diagnostics.ReportSymbolAlreadyDeclared(initSyntax.PropertyIdentifier.Location, propertyName);
@@ -1030,7 +1030,7 @@ internal sealed partial class ExpressionBinder
         [NotNullWhen(true)] out BoundExpression? result)
     {
         result = null;
-        var name = syntax.Identifier.Text;
+        var name = syntax.Identifier.ValueText;
         switch (name)
         {
             case "cast":
@@ -1233,7 +1233,7 @@ internal sealed partial class ExpressionBinder
         [NotNullWhen(true)] out BoundExpression? result)
     {
         result = null;
-        var name = syntax.Identifier.Text;
+        var name = syntax.Identifier.ValueText;
 
         System.Type? clrType = null;
         System.Type? openGenericDefinition = null;
@@ -2767,7 +2767,7 @@ internal sealed partial class ExpressionBinder
         [NotNullWhen(true)] out BoundExpression? result)
     {
         result = null;
-        var nestedName = syntax.Identifier.Text;
+        var nestedName = syntax.Identifier.ValueText;
         var arity = syntax.TypeArgumentList?.Arguments.Count ?? 0;
 
         System.Type? nestedType = null;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.IfLet.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.IfLet.cs
@@ -192,7 +192,7 @@ internal sealed partial class ExpressionBinder
         // Defensive: an ExpressionBinder constructed without the declaration
         // callback (no production path does this) still produces a usable
         // symbol so binding can continue and report the real diagnostics.
-        var fallback = new LocalVariableSymbol(identifier.Text ?? "?", isReadOnly, type, declaringSyntax: identifier);
+        var fallback = new LocalVariableSymbol(identifier.ValueText ?? "?", isReadOnly, type, declaringSyntax: identifier);
         scope.TryDeclareVariable(fallback);
         return fallback;
     }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -81,7 +81,7 @@ internal sealed partial class ExpressionBinder
         {
             if (!typeClause.HasQualifier && !typeClause.HasTypeArguments)
             {
-                TryResolveOpenGenericImportedType(typeClauseIdentifier.Text, out typeSymbol);
+                TryResolveOpenGenericImportedType(typeClauseIdentifier.ValueText, out typeSymbol);
             }
             else if (TryGetNestedUnboundGenericReflectionSegments(typeClause, out var reflectionSegments, out var firstGenericSegment))
             {
@@ -122,7 +122,7 @@ internal sealed partial class ExpressionBinder
                 else
                 {
                     resolved = TryResolveOpenGenericImportedTypeWithArity(
-                        typeClauseIdentifier.Text,
+                        typeClauseIdentifier.ValueText,
                         arity,
                         out typeSymbol,
                         out isAmbiguous);
@@ -136,7 +136,7 @@ internal sealed partial class ExpressionBinder
                     // candidates matched, not that the type is undefined.
                     if (isAmbiguous)
                     {
-                        Diagnostics.ReportAmbiguousImportedType(typeClause.Location, typeClauseIdentifier.Text + "`" + arity);
+                        Diagnostics.ReportAmbiguousImportedType(typeClause.Location, typeClauseIdentifier.ValueText + "`" + arity);
                     }
                     else
                     {
@@ -535,7 +535,7 @@ internal sealed partial class ExpressionBinder
         {
             case NameExpressionSyntax n:
                 {
-                    var ident = n.IdentifierToken.Text;
+                    var ident = n.IdentifierToken.ValueText;
                     if (string.IsNullOrEmpty(ident) || ident == "this" || ident == "it")
                     {
                         name = null;
@@ -553,7 +553,7 @@ internal sealed partial class ExpressionBinder
                 // Generic name like `List[int]` parsed as an empty-arg generic
                 // call site is treated as a type reference whose short name is
                 // the identifier (matches C# `nameof(List<int>)` -> "List").
-                name = call.Identifier.Text;
+                name = call.Identifier.ValueText;
                 return !string.IsNullOrEmpty(name);
 
             case GenericNameExpressionSyntax generic:
@@ -562,7 +562,7 @@ internal sealed partial class ExpressionBinder
                 // is parsed (issue #1323) as a GenericNameExpression. `nameof` of
                 // a generic type yields the unqualified type name with the type
                 // arguments dropped (matches C# `nameof(List<int>)` -> "List").
-                name = generic.Identifier.Text;
+                name = generic.Identifier.ValueText;
                 return !string.IsNullOrEmpty(name);
 
             case ParenthesizedExpressionSyntax p:
@@ -1106,7 +1106,7 @@ internal sealed partial class ExpressionBinder
                 continue;
             }
 
-            var name = member.Identifier.Text;
+            var name = member.Identifier.ValueText;
             if (!seenNames.Add(name))
             {
                 Diagnostics.ReportSymbolAlreadyDeclared(member.Identifier.Location, name);
@@ -1244,7 +1244,7 @@ internal sealed partial class ExpressionBinder
             return BindStructuralSpreadLiteral(syntax, resolvedDefinition, enclosingTypeArguments);
         }
 
-        var typeName = syntax.TypeIdentifier.Text;
+        var typeName = syntax.TypeIdentifier.ValueText;
 
         StructSymbol? structSymbol = null;
         if (resolvedDefinition != null)
@@ -1438,11 +1438,11 @@ internal sealed partial class ExpressionBinder
                 foreach (var initSyntax in syntax.Initializers)
                 {
                     TypeSymbol memberType;
-                    if (TypeMemberModel.TryGetFieldIncludingInherited(structSymbol, initSyntax.FieldIdentifier.Text, MemberQuery.Instance(MemberKinds.Field), out var field, out _))
+                    if (TypeMemberModel.TryGetFieldIncludingInherited(structSymbol, initSyntax.FieldIdentifier.ValueText, MemberQuery.Instance(MemberKinds.Field), out var field, out _))
                     {
                         memberType = field.Type;
                     }
-                    else if (TypeMemberModel.TryGetProperty(structSymbol, initSyntax.FieldIdentifier.Text, out var property))
+                    else if (TypeMemberModel.TryGetProperty(structSymbol, initSyntax.FieldIdentifier.ValueText, out var property))
                     {
                         memberType = property.Type;
                     }
@@ -1530,7 +1530,7 @@ internal sealed partial class ExpressionBinder
                 : null;
         foreach (var initSyntax in syntax.Initializers)
         {
-            var fieldName = initSyntax.FieldIdentifier.Text;
+            var fieldName = initSyntax.FieldIdentifier.ValueText;
 
             // Issue #1211: a composite literal targets `var` fields AND settable
             // `prop` auto-properties (a property with a `set` or `init`
@@ -1685,7 +1685,7 @@ internal sealed partial class ExpressionBinder
                 var litReceiver = new BoundVariableExpression(initializer.Syntax, litTemp);
                 if (!TryEmitMemberCollectionInitializer(
                     litReceiver,
-                    initializer.Syntax.FieldIdentifier.Text,
+                    initializer.Syntax.FieldIdentifier.ValueText,
                     initializer.Syntax.FieldIdentifier,
                     initializer.Braced,
                     bracedStatements))
@@ -1762,7 +1762,7 @@ internal sealed partial class ExpressionBinder
         var explicitNames = new HashSet<string>(StringComparer.Ordinal);
         foreach (var initializer in syntax.Initializers)
         {
-            explicitNames.Add(initializer.FieldIdentifier.Text);
+            explicitNames.Add(initializer.FieldIdentifier.ValueText);
         }
 
         if (!StructuralProjectionPlanner.TryCreate(
@@ -1778,8 +1778,8 @@ internal sealed partial class ExpressionBinder
             var failedOrder = ImmutableArray.CreateBuilder<string>(syntax.Initializers.Count);
             foreach (var initializer in syntax.Initializers)
             {
-                failedValues[initializer.FieldIdentifier.Text] = BindExpression(initializer.Value);
-                failedOrder.Add(initializer.FieldIdentifier.Text);
+                failedValues[initializer.FieldIdentifier.ValueText] = BindExpression(initializer.Value);
+                failedOrder.Add(initializer.FieldIdentifier.ValueText);
             }
 
             return conversions.BindStructuralProjection(
@@ -1802,7 +1802,7 @@ internal sealed partial class ExpressionBinder
         var order = ImmutableArray.CreateBuilder<string>(syntax.Initializers.Count);
         foreach (var initializer in syntax.Initializers)
         {
-            var name = initializer.FieldIdentifier.Text;
+            var name = initializer.FieldIdentifier.ValueText;
             if (values.ContainsKey(name))
             {
                 Diagnostics.ReportSymbolAlreadyDeclared(initializer.FieldIdentifier.Location, name);
@@ -1877,7 +1877,7 @@ internal sealed partial class ExpressionBinder
         var parameterlessCtor = FindPublicParameterlessConstructor(clrType);
         if (parameterlessCtor == null)
         {
-            Diagnostics.ReportUnableToFindType(syntax.TypeIdentifier.Location, syntax.TypeIdentifier.Text);
+            Diagnostics.ReportUnableToFindType(syntax.TypeIdentifier.Location, syntax.TypeIdentifier.ValueText);
             foreach (var initSyntax in syntax.Initializers)
             {
                 _ = BindExpression(initSyntax.Value);
@@ -1961,7 +1961,7 @@ internal sealed partial class ExpressionBinder
         var seen = new HashSet<string>();
         foreach (var initSyntax in syntax.Initializers)
         {
-            var memberName = initSyntax.FieldIdentifier.Text;
+            var memberName = initSyntax.FieldIdentifier.ValueText;
             if (!seen.Add(memberName))
             {
                 Diagnostics.ReportSymbolAlreadyDeclared(initSyntax.FieldIdentifier.Location, memberName);
@@ -2093,7 +2093,7 @@ internal sealed partial class ExpressionBinder
         var seen = new HashSet<string>();
         foreach (var initSyntax in syntax.Initializers)
         {
-            var memberName = initSyntax.FieldIdentifier.Text;
+            var memberName = initSyntax.FieldIdentifier.ValueText;
             if (!seen.Add(memberName))
             {
                 Diagnostics.ReportSymbolAlreadyDeclared(initSyntax.FieldIdentifier.Location, memberName);
@@ -2477,10 +2477,10 @@ internal sealed partial class ExpressionBinder
             var elementTypeIdentifier = Invariant.Required(
                 syntax.ElementTypeIdentifier,
                 "a non-nested array literal has an element type identifier");
-            elementType = lookupType(elementTypeIdentifier.Text);
+            elementType = lookupType(elementTypeIdentifier.ValueText);
             if (elementType == null)
             {
-                Diagnostics.ReportUndefinedType(elementTypeIdentifier.Location, elementTypeIdentifier.Text);
+                Diagnostics.ReportUndefinedType(elementTypeIdentifier.Location, elementTypeIdentifier.ValueText);
                 return new BoundErrorExpression(null);
             }
         }
@@ -2713,10 +2713,10 @@ internal sealed partial class ExpressionBinder
     /// <returns>The bound stackalloc expression.</returns>
     internal BoundExpression BindStackAllocExpression(StackAllocExpressionSyntax syntax, TypeSymbol? targetType = null)
     {
-        var elementType = lookupType(syntax.ElementTypeIdentifier.Text);
+        var elementType = lookupType(syntax.ElementTypeIdentifier.ValueText);
         if (elementType == null)
         {
-            Diagnostics.ReportUndefinedType(syntax.ElementTypeIdentifier.Location, syntax.ElementTypeIdentifier.Text);
+            Diagnostics.ReportUndefinedType(syntax.ElementTypeIdentifier.Location, syntax.ElementTypeIdentifier.ValueText);
             return new BoundErrorExpression(null);
         }
 

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -299,7 +299,7 @@ internal sealed partial class ExpressionBinder
         if (binderCtx.InUnsafeContext
             && syntax.Operand is CallExpressionSyntax voidCast
             && voidCast.Identifier.Kind == SyntaxKind.IdentifierToken
-            && voidCast.Identifier.Text == "void"
+            && voidCast.Identifier.ValueText == "void"
             && voidCast.TypeArgumentList == null
             && voidCast.NullableQuestionToken == null
             && voidCast.Arguments.Count == 1)
@@ -321,7 +321,7 @@ internal sealed partial class ExpressionBinder
             && structCast.TypeArgumentList == null
             && structCast.NullableQuestionToken == null
             && structCast.Arguments.Count == 1
-            && lookupType(structCast.Identifier.Text) is { } castTarget
+            && lookupType(structCast.Identifier.ValueText) is { } castTarget
             && BlittableDetector.IsBlittableValueStructPointee(castTarget))
         {
             var castArg = BindExpression(structCast.Arguments[0]);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -604,7 +604,7 @@ internal sealed partial class ExpressionBinder
 
     private BoundExpression BindNameExpression(NameExpressionSyntax syntax)
     {
-        var name = syntax.IdentifierToken.Text;
+        var name = syntax.IdentifierToken.ValueText;
         if (syntax.IdentifierToken.IsMissing)
         {
             // This means the token was inserted by the parser. We already
@@ -678,7 +678,7 @@ internal sealed partial class ExpressionBinder
             // resolve via the method-group path above; this mirrors that for
             // properties/fields so bare and `this.`-qualified access behave
             // identically for a metadata base, matching a user-defined base.
-            if (TryBindInheritedClrInstanceMemberByBareName(syntax.IdentifierToken.Text, out var inheritedClrMember))
+            if (TryBindInheritedClrInstanceMemberByBareName(syntax.IdentifierToken.ValueText, out var inheritedClrMember))
             {
                 return inheritedClrMember;
             }
@@ -1720,7 +1720,7 @@ internal sealed partial class ExpressionBinder
     private bool TryBindMethodGroup(NameExpressionSyntax syntax, [NotNullWhen(true)] out BoundExpression? methodGroup)
     {
         methodGroup = null;
-        var name = syntax.IdentifierToken.Text;
+        var name = syntax.IdentifierToken.ValueText;
 
         // ADR-0063 §9: a name may resolve to multiple user-function overloads.
         // Gather every candidate so BindConversion can pick the one matching the

--- a/src/Core/CodeAnalysis/Binding/FriendAssemblyDeclarations.cs
+++ b/src/Core/CodeAnalysis/Binding/FriendAssemblyDeclarations.cs
@@ -64,7 +64,7 @@ internal static class FriendAssemblyDeclarations
             foreach (var annotation in annotations)
             {
                 var name = annotation.GetNameText();
-                if (annotation.Target?.KindIdentifier.Text == "assembly"
+                if (annotation.Target?.KindIdentifier.ValueText == "assembly"
                     && (string.Equals(name, AnnotationName, StringComparison.Ordinal)
                         || string.Equals(name, AnnotationNameWithSuffix, StringComparison.Ordinal)))
                 {

--- a/src/Core/CodeAnalysis/Binding/IfLetBindingSupport.cs
+++ b/src/Core/CodeAnalysis/Binding/IfLetBindingSupport.cs
@@ -106,7 +106,7 @@ internal static class IfLetBindingSupport
             // the declared underlying type if available, otherwise error.
             if (declaredUnderlying == null)
             {
-                diagnostics.ReportIfLetInitializerMustBeNullable(binding.Initializer.Location, binding.Identifier.Text, initializerType);
+                diagnostics.ReportIfLetInitializerMustBeNullable(binding.Initializer.Location, binding.Identifier.ValueText, initializerType);
                 var errorVar = declareLocal(binding.Identifier, true, TypeSymbol.Error);
                 return new BoundIfLetBinding(errorVar, null, initializerExpr);
             }
@@ -116,7 +116,7 @@ internal static class IfLetBindingSupport
         }
         else
         {
-            diagnostics.ReportIfLetInitializerMustBeNullable(binding.Initializer.Location, binding.Identifier.Text, initializerType);
+            diagnostics.ReportIfLetInitializerMustBeNullable(binding.Initializer.Location, binding.Identifier.ValueText, initializerType);
             var errorVar = declareLocal(binding.Identifier, true, declaredUnderlying ?? initializerType);
             return new BoundIfLetBinding(errorVar, null, initializerExpr);
         }

--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -258,7 +258,7 @@ internal sealed class LambdaBinder
         var seen = new HashSet<string>();
         foreach (var p in syntax.Parameters)
         {
-            var pname = p.Identifier.Text;
+            var pname = p.Identifier.ValueText;
 
             // The pre-migration code was `bindTypeClause(p.Type) ?? TypeSymbol.Error`.
             // Restored: a parameter whose type clause fails to bind should
@@ -530,7 +530,7 @@ internal sealed class LambdaBinder
     /// <returns>The bound statement (a no-op declaration; the underlying method is emitted independently).</returns>
     public BoundStatement BindGenericLocalFunctionDeclaration(VariableDeclarationSyntax syntax)
     {
-        var name = syntax.Identifier.Text;
+        var name = syntax.Identifier.ValueText;
         if (syntax.Keyword?.Kind != SyntaxKind.LetKeyword || syntax.Initializer is not FunctionLiteralExpressionSyntax literalSyntax)
         {
             Diagnostics.ReportGenericLocalFunctionMustBeLetBoundLiteral(syntax.Identifier.Location, name);
@@ -693,7 +693,7 @@ internal sealed class LambdaBinder
         for (var i = 0; i < syntax.Parameters.Count; i++)
         {
             var p = syntax.Parameters[i];
-            var pname = p.Identifier.Text;
+            var pname = p.Identifier.ValueText;
             TypeSymbol ptype;
             if (p.Type != null)
             {
@@ -1860,13 +1860,13 @@ internal sealed class LambdaBinder
 
             if (firstVariadicSeen)
             {
-                Diagnostics.ReportMultipleVariadicParameters(parameters[i].Location, parameters[i].Identifier.Text);
+                Diagnostics.ReportMultipleVariadicParameters(parameters[i].Location, parameters[i].Identifier.ValueText);
             }
 
             firstVariadicSeen = true;
             if (i < parameters.Count - 1)
             {
-                Diagnostics.ReportVariadicParameterMustBeLast(parameters[i].Location, parameters[i].Identifier.Text);
+                Diagnostics.ReportVariadicParameterMustBeLast(parameters[i].Location, parameters[i].Identifier.ValueText);
             }
         }
     }

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
@@ -248,7 +248,7 @@ internal sealed partial class OverloadResolver
     /// </remarks>
     private bool HasNonConstructorCallableCandidate(CallExpressionSyntax syntax)
     {
-        var name = syntax.Identifier.Text;
+        var name = syntax.Identifier.ValueText;
 
         // A same-compilation free function or extension function (extension
         // functions are flattened into the global function table — issue
@@ -390,7 +390,7 @@ internal sealed partial class OverloadResolver
         // Issue #3421 review: `cast[T](value)` is the unambiguous,
         // constructor-independent explicit-conversion form. Bind it before
         // callable/type lookup so no symbol named `cast` can redirect it.
-        if (syntax.Identifier.Text == "cast"
+        if (syntax.Identifier.ValueText == "cast"
             && tryBindIntrinsicCall(syntax, out var checkedCast))
         {
             return checkedCast;
@@ -404,7 +404,7 @@ internal sealed partial class OverloadResolver
         // function" diagnostic.
         if (syntax.TypeArgumentList == null
             && syntax.Identifier.Kind == SyntaxKind.IdentifierToken
-            && syntax.Identifier.Text == "init")
+            && syntax.Identifier.ValueText == "init")
         {
             var inCtor = getCurrentFunction();
             if (inCtor != null
@@ -461,13 +461,13 @@ internal sealed partial class OverloadResolver
         // its containing lexical scope; outside it, an explicit alias or
         // same-named top-level import remains the visible constructor target.
         bool hasImportedType = Scope.TryLookupImportedClassByArity(
-                syntax.Identifier.Text,
+                syntax.Identifier.ValueText,
                 ctorPreferredArity,
                 declaration: null,
                 out var importedCtorCandidate);
         var hasSourceConstructibleType = binderCtx.TryLookupSourceType(
                 Scope,
-                syntax.Identifier.Text,
+                syntax.Identifier.ValueText,
                 ctorPreferredArity,
                 getCurrentFunction(),
                 out var sourceCtorCandidate,
@@ -476,7 +476,7 @@ internal sealed partial class OverloadResolver
             && !(hasImportedType
                 && binderCtx.ImportedTypeOverridesSourceType(
                     Scope,
-                    syntax.Identifier.Text,
+                    syntax.Identifier.ValueText,
                     sourceCtorStruct,
                     ctorPreferredArity,
                     getCurrentFunction(),
@@ -504,7 +504,7 @@ internal sealed partial class OverloadResolver
         }
 
         var conversionType = lookupTypeWithArity(
-            syntax.Identifier.Text,
+            syntax.Identifier.ValueText,
             ctorPreferredArity);
         var hasSingleInlineOutArgument = syntax.Arguments.Count == 1
             && UnwrapNamedArgumentValue(syntax.Arguments[0])
@@ -588,7 +588,7 @@ internal sealed partial class OverloadResolver
         // primary constructor is also positionally constructible —
         // `Entry(1, 2)` lowers to a struct literal initializing its fields.
         if (!hasNonConstructorCallable
-            && lookupTypeWithArity(syntax.Identifier.Text, ctorPreferredArity) is StructSymbol classType
+            && lookupTypeWithArity(syntax.Identifier.ValueText, ctorPreferredArity) is StructSymbol classType
             && (classType.IsClass
                 || classType.IsInline
                 || classType.HasPrimaryConstructor
@@ -606,7 +606,7 @@ internal sealed partial class OverloadResolver
         // report GS0389 pointing at the missing constraint.
         if (syntax.Arguments.Count == 0
             && syntax.TypeArgumentList == null
-            && lookupType(syntax.Identifier.Text) is TypeParameterSymbol typeParam)
+            && lookupType(syntax.Identifier.ValueText) is TypeParameterSymbol typeParam)
         {
             if (typeParam.HasDefaultConstructorConstraint)
             {
@@ -679,7 +679,7 @@ internal sealed partial class OverloadResolver
             boundArguments.Add(boundArgument);
         }
 
-        var symbol = Scope.TryLookupSymbol(syntax.Identifier.Text);
+        var symbol = Scope.TryLookupSymbol(syntax.Identifier.ValueText);
         if (symbol is VariableSymbol callTarget
             && AccessibilityChecker.TryGetInaccessibleImplicitMemberRead(
                 callTarget,
@@ -725,7 +725,7 @@ internal sealed partial class OverloadResolver
         // receiver-form `x.Ext(...)` and free-call extension usage, and calls
         // from types with no such member, are unaffected).
         var resolvedIsExtensionOnly = symbol is FunctionSymbol
-            && IsAllExtensionOverloadSet(syntax.Identifier.Text);
+            && IsAllExtensionOverloadSet(syntax.Identifier.ValueText);
 
         // Issue #3527: a same-named PACKAGE-level function is visible through
         // the same scope symbol table as any enclosing-type member (issue
@@ -745,7 +745,7 @@ internal sealed partial class OverloadResolver
         var resolvedIsShadowedByEnclosingMember = symbol is FunctionSymbol shadowCandidateFunction
             && shadowCandidateFunction.Package != null
             && !resolvedIsExtensionOnly
-            && HasEnclosingMemberCallableCandidate(syntax.Identifier.Text);
+            && HasEnclosingMemberCallableCandidate(syntax.Identifier.ValueText);
         if (symbol == null || resolvedIsExtensionOnly || resolvedIsShadowedByEnclosingMember)
         {
             if (binderCtx.InConstructorInitializer
@@ -753,7 +753,7 @@ internal sealed partial class OverloadResolver
             {
                 var staticMethods = TypeMemberModel.GetMethods(
                     initializerReceiverType,
-                    syntax.Identifier.Text,
+                    syntax.Identifier.ValueText,
                     MemberQuery.Static(MemberKinds.Method));
                 if (!staticMethods.IsDefaultOrEmpty)
                 {
@@ -766,7 +766,7 @@ internal sealed partial class OverloadResolver
                         staticMethods,
                         boundArguments.ToImmutable(),
                         syntax,
-                        syntax.Identifier.Text,
+                        syntax.Identifier.ValueText,
                         argumentNames);
                     if (staticMethod == null)
                     {
@@ -781,12 +781,12 @@ internal sealed partial class OverloadResolver
                 }
                 else if (!TypeMemberModel.GetMethods(
                         initializerReceiverType,
-                        syntax.Identifier.Text,
+                        syntax.Identifier.ValueText,
                         MemberQuery.Instance(MemberKinds.Method)).IsDefaultOrEmpty)
                 {
                     Diagnostics.ReportConstructorInitializerCannotReferenceInstanceMember(
                         syntax.Identifier.Location,
-                        syntax.Identifier.Text);
+                        syntax.Identifier.ValueText);
                     return new BoundErrorExpression(syntax);
                 }
             }
@@ -809,7 +809,7 @@ internal sealed partial class OverloadResolver
                 // overloads. The selected method's IsStatic routes emission.
                 var implicitMethod = SelectUnifiedInstanceStaticOverload(
                     implicitReceiverStruct,
-                    syntax.Identifier.Text,
+                    syntax.Identifier.ValueText,
                     boundArguments.ToImmutable(),
                     syntax,
                     argumentNames,
@@ -863,7 +863,7 @@ internal sealed partial class OverloadResolver
                 var implicitReceiverExpr = new BoundVariableExpression(null, effThis);
 
                 // The callback uses null to mean that no explicit type arguments were supplied.
-                if (tryBindInheritedClrInstanceCall(implicitReceiverExpr, implicitBaseClr, syntax.Identifier.Text, boundArguments.ToImmutable(), syntax, out var implicitInheritedCall, inheritedClrTypeArgs, inheritedTypeArgSymbols, argumentNames, allowProtectedInherited: true))
+                if (tryBindInheritedClrInstanceCall(implicitReceiverExpr, implicitBaseClr, syntax.Identifier.ValueText, boundArguments.ToImmutable(), syntax, out var implicitInheritedCall, inheritedClrTypeArgs, inheritedTypeArgSymbols, argumentNames, allowProtectedInherited: true))
                 {
                     return implicitInheritedCall;
                 }
@@ -880,8 +880,8 @@ internal sealed partial class OverloadResolver
             if (effThis != null
                 && effThis.Type is InterfaceSymbol implicitReceiverIface)
             {
-                var implicitIfaceOverloads = TypeMemberModel.GetMethods(implicitReceiverIface, syntax.Identifier.Text, MemberQuery.Instance(MemberKinds.Method));
-                var implicitPrivateIfaceOverloads = implicitReceiverIface.GetPrivateMethods(syntax.Identifier.Text);
+                var implicitIfaceOverloads = TypeMemberModel.GetMethods(implicitReceiverIface, syntax.Identifier.ValueText, MemberQuery.Instance(MemberKinds.Method));
+                var implicitPrivateIfaceOverloads = implicitReceiverIface.GetPrivateMethods(syntax.Identifier.ValueText);
                 if (implicitPrivateIfaceOverloads.Length > 0)
                 {
                     implicitIfaceOverloads = implicitIfaceOverloads.AddRange(implicitPrivateIfaceOverloads);
@@ -889,7 +889,7 @@ internal sealed partial class OverloadResolver
 
                 if (implicitIfaceOverloads.Length > 0)
                 {
-                    var implicitIfaceMethod = SelectInstanceOverloadOrReport(implicitIfaceOverloads, boundArguments.ToImmutable(), syntax, syntax.Identifier.Text, argumentNames);
+                    var implicitIfaceMethod = SelectInstanceOverloadOrReport(implicitIfaceOverloads, boundArguments.ToImmutable(), syntax, syntax.Identifier.ValueText, argumentNames);
                     if (implicitIfaceMethod == null)
                     {
                         return new BoundErrorExpression(null);
@@ -907,7 +907,7 @@ internal sealed partial class OverloadResolver
                 var implicitObjectReceiver = new BoundVariableExpression(null, effThis);
 
                 // The callback uses null to mean that no explicit type arguments were supplied.
-                if (tryBindInheritedClrInstanceCall(implicitObjectReceiver, typeof(object), syntax.Identifier.Text, boundArguments.ToImmutable(), syntax, out var implicitObjectCall, null, default, argumentNames))
+                if (tryBindInheritedClrInstanceCall(implicitObjectReceiver, typeof(object), syntax.Identifier.ValueText, boundArguments.ToImmutable(), syntax, out var implicitObjectCall, null, default, argumentNames))
                 {
                     return implicitObjectCall;
                 }
@@ -921,8 +921,8 @@ internal sealed partial class OverloadResolver
             // (public + private) buckets.
             if (GetImplicitStaticSelfOwner() is InterfaceSymbol implicitStaticIface)
             {
-                var implicitStaticOverloads = TypeMemberModel.GetMethods(implicitStaticIface, syntax.Identifier.Text, MemberQuery.Static(MemberKinds.Method));
-                var implicitStaticPrivateOverloads = implicitStaticIface.GetStaticPrivateMethods(syntax.Identifier.Text);
+                var implicitStaticOverloads = TypeMemberModel.GetMethods(implicitStaticIface, syntax.Identifier.ValueText, MemberQuery.Static(MemberKinds.Method));
+                var implicitStaticPrivateOverloads = implicitStaticIface.GetStaticPrivateMethods(syntax.Identifier.ValueText);
                 if (implicitStaticPrivateOverloads.Length > 0)
                 {
                     implicitStaticOverloads = implicitStaticOverloads.AddRange(implicitStaticPrivateOverloads);
@@ -930,7 +930,7 @@ internal sealed partial class OverloadResolver
 
                 if (implicitStaticOverloads.Length > 0)
                 {
-                    var implicitStaticMethod = SelectInstanceOverloadOrReport(implicitStaticOverloads, boundArguments.ToImmutable(), syntax, syntax.Identifier.Text, argumentNames);
+                    var implicitStaticMethod = SelectInstanceOverloadOrReport(implicitStaticOverloads, boundArguments.ToImmutable(), syntax, syntax.Identifier.ValueText, argumentNames);
                     if (implicitStaticMethod == null)
                     {
                         return new BoundErrorExpression(null);
@@ -968,7 +968,7 @@ internal sealed partial class OverloadResolver
             {
                 var implicitStaticStructOverloads = TypeMemberModel.GetMethods(
                     implicitStaticStruct,
-                    syntax.Identifier.Text,
+                    syntax.Identifier.ValueText,
                     MemberQuery.Static(MemberKinds.Method));
                 if (!implicitStaticStructOverloads.IsDefaultOrEmpty)
                 {
@@ -1002,7 +1002,7 @@ internal sealed partial class OverloadResolver
                     {
                         var importedStatics = TypeMemberModel.GetMethods(
                             importedType,
-                            syntax.Identifier.Text,
+                            syntax.Identifier.ValueText,
                             MemberQuery.Static(MemberKinds.Method));
                         if (importedStatics.IsDefaultOrEmpty)
                         {
@@ -1022,7 +1022,7 @@ internal sealed partial class OverloadResolver
 
                     if (ambiguousStaticImport)
                     {
-                        Diagnostics.ReportAmbiguousImportedStaticMember(syntax.Identifier.Location, syntax.Identifier.Text);
+                        Diagnostics.ReportAmbiguousImportedStaticMember(syntax.Identifier.Location, syntax.Identifier.ValueText);
                         return new BoundErrorExpression(null);
                     }
 
@@ -1044,7 +1044,7 @@ internal sealed partial class OverloadResolver
                     var ambiguousClrStaticImport = false;
                     foreach (var clrType in Scope.EnumerateStaticImportClrTypes())
                     {
-                        if (!ClrTypeExposesStaticMethod(clrType, syntax.Identifier.Text))
+                        if (!ClrTypeExposesStaticMethod(clrType, syntax.Identifier.ValueText))
                         {
                             continue;
                         }
@@ -1062,7 +1062,7 @@ internal sealed partial class OverloadResolver
 
                     if (ambiguousClrStaticImport)
                     {
-                        Diagnostics.ReportAmbiguousImportedStaticMember(syntax.Identifier.Location, syntax.Identifier.Text);
+                        Diagnostics.ReportAmbiguousImportedStaticMember(syntax.Identifier.Location, syntax.Identifier.ValueText);
                         return new BoundErrorExpression(null);
                     }
 
@@ -1081,7 +1081,7 @@ internal sealed partial class OverloadResolver
                 if (Scope.SubmissionImports is { } submissionImports)
                 {
                     if (bindImportedClrStaticCall != null
-                        && submissionImports.TryFindFunctionContainer(Scope.References, syntax.Identifier.Text, out var submissionProgramType)
+                        && submissionImports.TryFindFunctionContainer(Scope.References, syntax.Identifier.ValueText, out var submissionProgramType)
                         && submissionProgramType is not null)
                     {
                         return bindImportedClrStaticCall(submissionProgramType, syntax);
@@ -1097,7 +1097,7 @@ internal sealed partial class OverloadResolver
                     }
                 }
 
-                Diagnostics.ReportUndefinedFunction(syntax.Identifier.Location, syntax.Identifier.Text);
+                Diagnostics.ReportUndefinedFunction(syntax.Identifier.Location, syntax.Identifier.ValueText);
                 return new BoundErrorExpression(null);
             }
         }
@@ -1299,14 +1299,14 @@ internal sealed partial class OverloadResolver
                 return new BoundErrorExpression(null);
             }
 
-            Diagnostics.ReportNotAFunction(syntax.Identifier.Location, syntax.Identifier.Text);
+            Diagnostics.ReportNotAFunction(syntax.Identifier.Location, syntax.Identifier.ValueText);
             return new BoundErrorExpression(null);
         }
 
         var function = symbol as FunctionSymbol;
         if (function == null)
         {
-            Diagnostics.ReportNotAFunction(syntax.Identifier.Location, syntax.Identifier.Text);
+            Diagnostics.ReportNotAFunction(syntax.Identifier.Location, syntax.Identifier.ValueText);
             return new BoundErrorExpression(null);
         }
 
@@ -1314,7 +1314,7 @@ internal sealed partial class OverloadResolver
         // perform overload selection over the supplied argument shape (count
         // and, where useful, types). The legacy `TryLookupSymbol` returned the
         // first declared overload; we now consult the overload-set store.
-        var overloadSet = Scope.TryLookupFunctions(syntax.Identifier.Text);
+        var overloadSet = Scope.TryLookupFunctions(syntax.Identifier.ValueText);
         var explicitOverloadTypeArguments = default(ImmutableArray<TypeSymbol>);
         if (overloadSet.Length > 1)
         {
@@ -1381,17 +1381,17 @@ internal sealed partial class OverloadResolver
                     {
                         Diagnostics.ReportUnconstrainedNullableIteratorCall(
                             syntax.Identifier.Location,
-                            syntax.Identifier.Text,
+                            syntax.Identifier.ValueText,
                             Invariant.Required(unconstrainedTypeParameter, "an unconstrained nullable iterator diagnostic has a type parameter").Name);
                     }
                     else
                     {
-                        Diagnostics.ReportAmbiguousOverloadResolution(syntax.Identifier.Location, syntax.Identifier.Text);
+                        Diagnostics.ReportAmbiguousOverloadResolution(syntax.Identifier.Location, syntax.Identifier.ValueText);
                     }
                 }
                 else
                 {
-                    Diagnostics.ReportNoApplicableOverload(syntax.Identifier.Location, syntax.Identifier.Text);
+                    Diagnostics.ReportNoApplicableOverload(syntax.Identifier.Location, syntax.Identifier.ValueText);
                 }
 
                 return new BoundErrorExpression(null);
@@ -2477,7 +2477,7 @@ internal sealed partial class OverloadResolver
     private bool TryBindSubmissionDelegateGlobalCall(CallExpressionSyntax syntax, SubmissionImports submissionImports, out BoundExpression? result)
     {
         result = null;
-        var name = syntax.Identifier.Text;
+        var name = syntax.Identifier.ValueText;
         if (!submissionImports.TryFindGlobalVariable(Scope.References, name, out var programType, out _))
         {
             return false;

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Candidates.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Candidates.cs
@@ -1364,13 +1364,13 @@ internal sealed partial class OverloadResolver
             DoWhileStatementSyntax loop when IsConstantTrue(loop.Condition) =>
                 !ContainsPotentialLoopExit(loop.Body, loopLabel: null),
             LabeledStatementSyntax { Statement: ForInfiniteStatementSyntax loop } labeledLoop =>
-                !ContainsPotentialLoopExit(loop.Body, labeledLoop.LabelIdentifier.Text),
+                !ContainsPotentialLoopExit(loop.Body, labeledLoop.LabelIdentifier.ValueText),
             LabeledStatementSyntax { Statement: WhileStatementSyntax loop } labeledLoop
                 when IsConstantTrue(loop.Condition) =>
-                    !ContainsPotentialLoopExit(loop.Body, labeledLoop.LabelIdentifier.Text),
+                    !ContainsPotentialLoopExit(loop.Body, labeledLoop.LabelIdentifier.ValueText),
             LabeledStatementSyntax { Statement: DoWhileStatementSyntax loop } labeledLoop
                 when IsConstantTrue(loop.Condition) =>
-                    !ContainsPotentialLoopExit(loop.Body, labeledLoop.LabelIdentifier.Text),
+                    !ContainsPotentialLoopExit(loop.Body, labeledLoop.LabelIdentifier.ValueText),
             _ => false,
         };
 
@@ -1386,7 +1386,7 @@ internal sealed partial class OverloadResolver
                 && ((breakStatement.LabelIdentifier == null && nestedLoopDepth == 0)
                     || (breakStatement.LabelIdentifier != null
                         && string.Equals(
-                            breakStatement.LabelIdentifier.Text,
+                            breakStatement.LabelIdentifier.ValueText,
                             loopLabel,
                             StringComparison.Ordinal))))
             {
@@ -1394,7 +1394,7 @@ internal sealed partial class OverloadResolver
             }
 
             if (node is GotoStatementSyntax gotoStatement
-                && !localGotoLabels.Contains(gotoStatement.LabelIdentifier.Text))
+                && !localGotoLabels.Contains(gotoStatement.LabelIdentifier.ValueText))
             {
                 return true;
             }
@@ -1436,7 +1436,7 @@ internal sealed partial class OverloadResolver
             if (node is LabeledStatementSyntax labeled
                 && !IsLoopSyntax(labeled.Statement))
             {
-                labels.Add(labeled.LabelIdentifier.Text);
+                labels.Add(labeled.LabelIdentifier.ValueText);
             }
 
             foreach (var child in node.GetChildren())

--- a/src/Core/CodeAnalysis/Binding/PInvokeBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/PInvokeBinder.cs
@@ -1111,7 +1111,7 @@ internal static class PInvokeBinder
                 {
                     diagnostics.ReportMarshalAsRejected(
                         ann.Location,
-                        ps.Identifier.Text,
+                        ps.Identifier.ValueText,
                         "the enclosing function is not a P/Invoke declaration (`@DllImport` or `@LibraryImport`)");
                 }
             }

--- a/src/Core/CodeAnalysis/Binding/PatternBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/PatternBinder.cs
@@ -698,7 +698,7 @@ internal sealed class PatternBinder
         }
 
         var nameToken = identifier ?? designation;
-        var bindingIdentifier = nameToken != null && nameToken.Text != "_"
+        var bindingIdentifier = nameToken != null && nameToken.ValueText != "_"
             ? nameToken
             : null;
         var hasBinding = bindingIdentifier != null;
@@ -717,7 +717,7 @@ internal sealed class PatternBinder
                 {
                     Diagnostics.ReportSymbolAlreadyDeclared(
                         bindingIdentifier.Location,
-                        bindingIdentifier.Text);
+                        bindingIdentifier.ValueText);
                 }
             }
             else if (bindingContext == PatternBindingContext.OrOrNot)
@@ -727,7 +727,7 @@ internal sealed class PatternBinder
                 // definitely assigned. The discard identifier `_` is permitted.
                 Diagnostics.ReportPatternVariableNotAllowedUnderOrNot(
                     bindingIdentifier.Location,
-                    bindingIdentifier.Text);
+                    bindingIdentifier.ValueText);
             }
             else if (identifier != null)
             {
@@ -736,7 +736,7 @@ internal sealed class PatternBinder
                 // reading as an incoherent double test.
                 Diagnostics.ReportPatternBindingNotAllowedInIsExpression(
                     bindingIdentifier.Location,
-                    bindingIdentifier.Text);
+                    bindingIdentifier.ValueText);
             }
 
             // ADR-0166: a designation in a boolean `is` is declared by the
@@ -825,13 +825,13 @@ internal sealed class PatternBinder
         {
             foreach (var tupleFieldSyntax in syntax.Fields)
             {
-                if (!TryGetTupleField(tupleType, tupleFieldSyntax.Identifier.Text, out var tupleField)
+                if (!TryGetTupleField(tupleType, tupleFieldSyntax.Identifier.ValueText, out var tupleField)
                     || tupleField is null)
                 {
-                    Diagnostics.ReportUndefinedFieldOnType(tupleFieldSyntax.Identifier.Location, tupleFieldSyntax.Identifier.Text, discriminantType);
+                    Diagnostics.ReportUndefinedFieldOnType(tupleFieldSyntax.Identifier.Location, tupleFieldSyntax.Identifier.ValueText, discriminantType);
                     fields.Add(new BoundPropertyPatternField(
                         syntax,
-                        new FieldSymbol(tupleFieldSyntax.Identifier.Text, TypeSymbol.Error, Accessibility.Public),
+                        new FieldSymbol(tupleFieldSyntax.Identifier.ValueText, TypeSymbol.Error, Accessibility.Public),
                         BindPattern(
                             tupleFieldSyntax.Pattern,
                             TypeSymbol.Error,
@@ -872,10 +872,10 @@ internal sealed class PatternBinder
                     out var field)
                 || field is null)
             {
-                Diagnostics.ReportUndefinedFieldOnType(fieldSyntax.Identifier.Location, fieldSyntax.Identifier.Text, discriminantType);
+                Diagnostics.ReportUndefinedFieldOnType(fieldSyntax.Identifier.Location, fieldSyntax.Identifier.ValueText, discriminantType);
                 fields.Add(new BoundPropertyPatternField(
                     syntax,
-                    new FieldSymbol(fieldSyntax.Identifier.Text, TypeSymbol.Error, Accessibility.Public),
+                    new FieldSymbol(fieldSyntax.Identifier.ValueText, TypeSymbol.Error, Accessibility.Public),
                     BindPattern(
                         fieldSyntax.Pattern,
                         TypeSymbol.Error,
@@ -898,7 +898,7 @@ internal sealed class PatternBinder
         out BoundPropertyPatternField? boundField)
     {
         boundField = null;
-        var name = syntax.Identifier.Text;
+        var name = syntax.Identifier.ValueText;
         if (lookupType is StructSymbol structType)
         {
             StructSymbol? current = structType;
@@ -1044,7 +1044,7 @@ internal sealed class PatternBinder
         bool preferTypeNames,
         out BoundPropertyPatternField? boundField)
     {
-        var name = syntax.Identifier.Text;
+        var name = syntax.Identifier.ValueText;
         var property = ClrTypeUtilities.SafeGetPropertyIncludingInterfaces(
             clrType,
             name,
@@ -1289,7 +1289,7 @@ internal sealed class PatternBinder
         if (syntax.CaptureIdentifier != null)
         {
             variable = CreatePatternVariable(
-                syntax.CaptureIdentifier.Text,
+                syntax.CaptureIdentifier.ValueText,
                 sliceType,
                 syntax.CaptureIdentifier,
                 isExpressionBinding: bindingContext == PatternBindingContext.IsExpression);
@@ -1297,14 +1297,14 @@ internal sealed class PatternBinder
             {
                 if (!Scope.TryDeclareVariable(variable))
                 {
-                    Diagnostics.ReportSymbolAlreadyDeclared(syntax.CaptureIdentifier.Location, syntax.CaptureIdentifier.Text);
+                    Diagnostics.ReportSymbolAlreadyDeclared(syntax.CaptureIdentifier.Location, syntax.CaptureIdentifier.ValueText);
                 }
             }
             else if (bindingContext == PatternBindingContext.OrOrNot)
             {
                 Diagnostics.ReportPatternVariableNotAllowedUnderOrNot(
                     syntax.CaptureIdentifier.Location,
-                    syntax.CaptureIdentifier.Text);
+                    syntax.CaptureIdentifier.ValueText);
             }
 
             // ADR-0166: a slice capture in a boolean `is` is scoped by the

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Blocks.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Blocks.cs
@@ -878,10 +878,10 @@ internal sealed partial class StatementBinder
                 // the case body — matches `for v := range` lexical hygiene.
                 scope = new BoundScope(scope);
                 var identifier = Invariant.Required(caseSyntax.Identifier, "a receive-bind select case has an identifier");
-                variable = new LocalVariableSymbol(identifier.Text, isReadOnly: true, chan.ElementType, declaringSyntax: identifier);
+                variable = new LocalVariableSymbol(identifier.ValueText, isReadOnly: true, chan.ElementType, declaringSyntax: identifier);
                 if (!scope.TryDeclareVariable(variable))
                 {
-                    Diagnostics.ReportSymbolAlreadyDeclared(identifier.Location, identifier.Text);
+                    Diagnostics.ReportSymbolAlreadyDeclared(identifier.Location, identifier.ValueText);
                 }
 
                 body = Invariant.Required(BindStatement(caseSyntax.Body), "a receive-bind select case has a bound body");

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Jumps.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Jumps.cs
@@ -25,7 +25,7 @@ internal sealed partial class StatementBinder
 {
     private BoundStatement BindGotoStatement(GotoStatementSyntax syntax)
     {
-        var labelName = syntax.LabelIdentifier.Text;
+        var labelName = syntax.LabelIdentifier.ValueText;
         var label = GetOrCreateUserLabelForGoto(labelName, syntax.LabelIdentifier.Location);
         userGotoHandlerRegions.Add((
             labelName,
@@ -267,7 +267,7 @@ internal sealed partial class StatementBinder
 
         if (syntax.LabelIdentifier != null)
         {
-            var name = syntax.LabelIdentifier.Text;
+            var name = syntax.LabelIdentifier.ValueText;
             foreach (var frame in binderCtx.LoopStack)
             {
                 if (frame.LabelName == name)
@@ -325,7 +325,7 @@ internal sealed partial class StatementBinder
 
         if (syntax.LabelIdentifier != null)
         {
-            var name = syntax.LabelIdentifier.Text;
+            var name = syntax.LabelIdentifier.ValueText;
             foreach (var frame in binderCtx.LoopStack)
             {
                 if (frame.LabelName == name && frame.ContinueLabel is { } labeledContinue)

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Loops.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Loops.cs
@@ -1037,7 +1037,7 @@ internal sealed partial class StatementBinder
 
     private BoundStatement BindLabeledStatement(LabeledStatementSyntax syntax)
     {
-        var labelName = syntax.LabelIdentifier.Text;
+        var labelName = syntax.LabelIdentifier.ValueText;
         var inner = syntax.Statement;
 
         // Issue #1884: a label on any non-loop statement is a `goto` target

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
@@ -360,14 +360,14 @@ internal sealed partial class StatementBinder
                 mayMutateMemberPaths = true;
                 break;
             case AssignmentExpressionSyntax a:
-                assigned.Add(a.IdentifierToken.Text);
+                assigned.Add(a.IdentifierToken.ValueText);
                 break;
             case MultiAssignmentStatementSyntax m:
                 foreach (var t in m.Targets)
                 {
                     if (t is NameExpressionSyntax ne)
                     {
-                        assigned.Add(ne.IdentifierToken.Text);
+                        assigned.Add(ne.IdentifierToken.ValueText);
                     }
                     else if (t is MultiAssignmentDeclarationExpressionSyntax)
                     {
@@ -590,7 +590,7 @@ internal sealed partial class StatementBinder
         foreach (var node in descendants)
         {
             if (node is VariableDeclarationSyntax variable
-                && string.Equals(variable.Identifier.Text, function.Type.Name, StringComparison.Ordinal))
+                && string.Equals(variable.Identifier.ValueText, function.Type.Name, StringComparison.Ordinal))
             {
                 return false;
             }
@@ -628,8 +628,8 @@ internal sealed partial class StatementBinder
         }
 
         return expectedType is StructSymbol
-            && string.Equals(call.Identifier.Text, expectedType.Name, StringComparison.Ordinal)
-            && scope.TryLookupFunctions(call.Identifier.Text).IsDefaultOrEmpty;
+            && string.Equals(call.Identifier.ValueText, expectedType.Name, StringComparison.Ordinal)
+            && scope.TryLookupFunctions(call.Identifier.ValueText).IsDefaultOrEmpty;
     }
 
     private static IEnumerable<SyntaxNode> DescendantsAndSelf(SyntaxNode node)
@@ -1475,7 +1475,7 @@ internal sealed partial class StatementBinder
                 if (initializer is BoundFunctionLiteralExpression functionLiteral
                     && checkNonGenericLocalFunctionEnclosingTypeParameterReference != null)
                 {
-                    checkNonGenericLocalFunctionEnclosingTypeParameterReference(syntax.Identifier.Location, syntax.Identifier.Text, functionLiteral);
+                    checkNonGenericLocalFunctionEnclosingTypeParameterReference(syntax.Identifier.Location, syntax.Identifier.ValueText, functionLiteral);
                 }
             }
         }
@@ -1493,7 +1493,7 @@ internal sealed partial class StatementBinder
         // model, and Go's declare-then-assign shape becomes legal.
         if (channelSlotWithoutInitializer && variable is not LocalVariableSymbol)
         {
-            Diagnostics.ReportChannelRequiresInitializer(syntax.Identifier.Location, syntax.Identifier.Text, variableType.Name);
+            Diagnostics.ReportChannelRequiresInitializer(syntax.Identifier.Location, syntax.Identifier.ValueText, variableType.Name);
         }
 
         // Issue #3324 (ADR-0008): a bare `var s string` / `let s string`
@@ -1602,7 +1602,7 @@ internal sealed partial class StatementBinder
             {
                 Diagnostics.ReportConstNativeIntegerNotSupported(
                     syntax.Identifier.Location,
-                    syntax.Identifier.Text,
+                    syntax.Identifier.ValueText,
                     Invariant.Required(nativeType, "a detected native integer has a type").Name);
             }
             else if (ConstantExpressionEvaluator.TryFold(convertedInitializer, declaredVariable.Type, out constValue))
@@ -1617,7 +1617,7 @@ internal sealed partial class StatementBinder
             {
                 Diagnostics.ReportConstFieldInitializerNotConstant(
                     syntax.Initializer?.Location ?? syntax.Identifier.Location,
-                    syntax.Identifier.Text);
+                    syntax.Identifier.ValueText);
             }
         }
 
@@ -1676,7 +1676,7 @@ internal sealed partial class StatementBinder
         // not a runtime storage slot, so there is no storage to alias.
         if (syntax.Keyword?.Kind == SyntaxKind.ConstKeyword)
         {
-            Diagnostics.ReportRefLocalCannotBeDeclaredHere(refModifierLoc, syntax.Identifier.Text, "a 'const' binding");
+            Diagnostics.ReportRefLocalCannotBeDeclaredHere(refModifierLoc, syntax.Identifier.ValueText, "a 'const' binding");
         }
 
         // An initializer is required: the local must alias an existing lvalue.
@@ -1737,13 +1737,13 @@ internal sealed partial class StatementBinder
         // field (`async`/iterator functions).
         if (function == null || function.IsTopLevelEntryPoint)
         {
-            Diagnostics.ReportRefLocalCannotBeDeclaredHere(refModifierLoc, syntax.Identifier.Text, "a top-level variable (it would be emitted as a heap-rooted static field)");
+            Diagnostics.ReportRefLocalCannotBeDeclaredHere(refModifierLoc, syntax.Identifier.ValueText, "a top-level variable (it would be emitted as a heap-rooted static field)");
             rhsValid = false;
         }
         else if (function.IsAsync || isIteratorReturnType(function.Type))
         {
             var context = function.IsAsync ? "a local in an async function" : "a local in an iterator";
-            Diagnostics.ReportRefLocalCannotBeDeclaredHere(refModifierLoc, syntax.Identifier.Text, context + " (it would be hoisted into the state machine)");
+            Diagnostics.ReportRefLocalCannotBeDeclaredHere(refModifierLoc, syntax.Identifier.ValueText, context + " (it would be hoisted into the state machine)");
             rhsValid = false;
         }
 
@@ -2265,7 +2265,7 @@ internal sealed partial class StatementBinder
         statements.Add(new BoundVariableDeclaration(syntax, tempVar, initializer));
         foreach (var fieldSyntax in syntax.Fields)
         {
-            var fieldName = fieldSyntax.FieldIdentifier.Text;
+            var fieldName = fieldSyntax.FieldIdentifier.ValueText;
             if (!seen.Add(fieldName))
             {
                 Diagnostics.ReportSymbolAlreadyDeclared(fieldSyntax.FieldIdentifier.Location, fieldName);

--- a/src/Core/CodeAnalysis/Symbols/Display/SymbolDisplay.cs
+++ b/src/Core/CodeAnalysis/Symbols/Display/SymbolDisplay.cs
@@ -1219,7 +1219,7 @@ public static class SymbolDisplay
                     if (ReferenceEquals(declaration.Identifier, identifier)
                         || (declaration.Identifier.Span.Start == identifier.Span.Start
                             && declaration.Identifier.Span.Length == identifier.Span.Length
-                            && declaration.Identifier.Text == identifier.Text))
+                            && declaration.Identifier.ValueText == identifier.ValueText))
                     {
                         var keyword = declaration.Keyword?.Text;
                         if (!string.IsNullOrEmpty(keyword))

--- a/src/Core/CodeAnalysis/Syntax/Lexer.cs
+++ b/src/Core/CodeAnalysis/Syntax/Lexer.cs
@@ -511,6 +511,37 @@ public sealed class Lexer
                 kind = SyntaxKind.AtToken;
                 position++;
                 break;
+            case '$':
+                // ADR-0170 / issue #3610: `$` immediately followed by an
+                // identifier-start spells an ESCAPED IDENTIFIER — an ordinary
+                // IdentifierToken whose semantic name is the characters after
+                // the `$` (carried via Value/ValueText) and whose Text keeps
+                // the full source spelling for fidelity. Never
+                // keyword-classified, so `class $defer {}` declares a type
+                // whose metadata name is `defer`. A `$` not followed by an
+                // identifier-start keeps the prior bad-character behavior
+                // (room for future grammar; `$` inside string literals keeps
+                // its interpolation meaning, handled by ReadString).
+                if (char.IsLetter(Lookahead) || Lookahead == '_')
+                {
+                    position++; // consume '$'
+                    var nameStart = position;
+                    while (char.IsLetterOrDigit(Current) || Current == '_')
+                    {
+                        position++;
+                    }
+
+                    kind = SyntaxKind.IdentifierToken;
+                    value = this.text.ToString(nameStart, position - nameStart);
+                }
+                else
+                {
+                    var badDollarLocation = new TextLocation(this.text, new TextSpan(position, 1));
+                    Diagnostics.ReportBadCharacter(badDollarLocation, Current);
+                    position++;
+                }
+
+                break;
             case '0':
             case '1':
             case '2':

--- a/src/Core/CodeAnalysis/Syntax/SyntaxToken.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxToken.cs
@@ -55,6 +55,18 @@ public class SyntaxToken : SyntaxNode
     public object? Value { get; }
 
     /// <summary>
+    /// Gets the semantic name text of this token (ADR-0170 / issue #3610):
+    /// for an escaped identifier <c>$name</c> this is the unescaped
+    /// <c>name</c> the lexer stashed in <see cref="Value"/>; for every other
+    /// token it is <see cref="Text"/>. Semantic consumers (binder, symbols,
+    /// lowering, emit) read identifier names through this property so an
+    /// escaped spelling and its plain form denote the same name; syntactic
+    /// consumers (printers, formatters, contextual-keyword commitments) keep
+    /// using <see cref="Text"/> for source fidelity.
+    /// </summary>
+    public string ValueText => Value as string ?? Text;
+
+    /// <summary>
     /// Gets the text span associated to the token.
     /// </summary>
     public override TextSpan Span => new TextSpan(Position, Text?.Length ?? 0);

--- a/test/Core.Tests/CodeAnalysis/Adr0170EscapedIdentifierTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Adr0170EscapedIdentifierTests.cs
@@ -1,0 +1,199 @@
+// <copyright file="Adr0170EscapedIdentifierTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis;
+
+/// <summary>
+/// ADR-0170 / issue #3610: escaped identifiers. <c>$name</c> spells an
+/// ordinary identifier whose semantic name is the characters after the
+/// <c>$</c> — never keyword-classified, byte-identical metadata to the
+/// unescaped name, legal (and redundant) on non-keywords, accepted in every
+/// name position including package segments and member access.
+/// </summary>
+public class Adr0170EscapedIdentifierTests
+{
+    [Fact]
+    public void Lexer_EscapedIdentifier_KeepsSourceTextAndCarriesName()
+    {
+        var tokens = SyntaxTree.ParseTokens("$defer");
+        var token = Assert.Single(tokens.Where(t => t.Kind != SyntaxKind.EndOfFileToken));
+        Assert.Equal(SyntaxKind.IdentifierToken, token.Kind);
+        Assert.Equal("$defer", token.Text);
+        Assert.Equal("defer", token.ValueText);
+    }
+
+    [Fact]
+    public void Lexer_BareDollar_ReportsBadCharacter()
+    {
+        var tree = SyntaxTree.Parse(SourceText.From("var x = $ 1"));
+        Assert.Contains(tree.Diagnostics, d => d.Message.Contains("$", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void KeywordNamedClass_DeclaresConstructsAndEmitsUnescapedMetadataName()
+    {
+        const string source = @"
+package P
+import System
+
+class $defer {
+    prop Value int32 -> 19
+}
+
+let d = $defer{}
+Console.WriteLine(d.Value)
+";
+        var (output, assembly) = CompileLoadRun(source, "Adr0170-Class");
+        Assert.Equal("19", output.Trim());
+
+        // ADR-0170 §Metadata: the emitted type's name is the UNESCAPED name.
+        Assert.Contains(assembly, name => name == "defer");
+    }
+
+    [Fact]
+    public void EscapedAndPlainSpellings_DenoteTheSameName()
+    {
+        const string source = @"
+package P
+import System
+
+class Widget {
+    prop Value int32 -> 7
+}
+
+// `$Widget` ≡ `Widget`: escaping a non-keyword is legal and redundant.
+let w = $Widget{}
+Console.WriteLine(w.$Value)
+";
+        var (output, _) = CompileLoadRun(source, "Adr0170-Equivalence");
+        Assert.Equal("7", output.Trim());
+    }
+
+    [Fact]
+    public void KeywordNamedParameterAndLocal_Work()
+    {
+        const string source = @"
+package P
+import System
+
+func describe($params string) string {
+    let $type = $params + ""!""
+    return $type
+}
+
+Console.WriteLine(describe(""go""))
+";
+        var (output, _) = CompileLoadRun(source, "Adr0170-ParamLocal");
+        Assert.Equal("go!", output.Trim());
+    }
+
+    [Fact]
+    public void KeywordNamedPackageSegment_DeclaresAndEmits()
+    {
+        const string source = @"
+package $class.Inner
+import System
+
+class Marker {
+    prop Value int32 -> 3
+}
+
+let m = Marker{}
+Console.WriteLine(m.Value)
+";
+        var (output, _) = CompileLoadRun(source, "Adr0170-Package");
+        Assert.Equal("3", output.Trim());
+    }
+
+    [Fact]
+    public void KeywordNamedMemberAccess_ResolvesThroughEscape()
+    {
+        const string source = @"
+package P
+import System
+
+class Bag {
+    prop $func int32 -> 11
+    func $defer() int32 {
+        return this.$func + 1
+    }
+}
+
+let b = Bag{}
+Console.WriteLine(b.$defer())
+";
+        var (output, assembly) = CompileLoadRun(source, "Adr0170-Members");
+        Assert.Equal("12", output.Trim());
+        Assert.Contains(assembly, name => name == "Bag");
+    }
+
+    [Fact]
+    public void Interpolation_ResolvesEscapedDeclaredVariableByName()
+    {
+        const string source = @"
+package P
+import System
+
+var $defer = 41
+Console.WriteLine(""value=${$defer + 1}"")
+";
+        var (output, _) = CompileLoadRun(source, "Adr0170-Interpolation");
+        Assert.Equal("value=42", output.Trim());
+    }
+
+    private static (string Output, string[] TypeNames) CompileLoadRun(string source, string contextName)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        Assert.Empty(tree.Diagnostics);
+
+        using var peStream = new MemoryStream();
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        try
+        {
+            var asm = loadContext.LoadFromStream(peStream);
+            var typeNames = asm.GetTypes().Select(t => t.Name).ToArray();
+            var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+            Assert.NotNull(programType);
+            var entry = programType!.GetMethod(
+                "<Main>$",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(entry);
+
+            var stdout = Console.Out;
+            var captured = new StringWriter();
+            Console.SetOut(captured);
+            try
+            {
+                entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+            }
+            finally
+            {
+                Console.SetOut(stdout);
+            }
+
+            return (captured.ToString(), typeNames);
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements the gsc half of #3610 per the revised design (see the issue discussion): **`$name` is G#'s identifier escape**, closing the keyword-named-CLR-metadata gap in both directions (consuming imported `@class`/`@defer`-style surface, and declaring it for ABI-faithful migration under #3501).

### Language
- `$` + identifier-start = an ordinary `IdentifierToken` whose semantic name is the characters after the `$`. Purely a spelling: `$Value` ≡ `Value` on non-keywords (C#'s rule), never keyword-classified, accepted in **every** name position — types, members, params, locals, member access, `package $class.Inner`, import paths.
- Symbols carry the unescaped name → metadata/reflection see `defer`, not `$defer` — verified by reflection in the tests, no emitter work needed.
- Interpolation composes: `"${$defer + 1}"` works; `"$$x"` stays literal; bare `$` elsewhere keeps the bad-character behavior.

### Why `$` (ADR-0170 records the full analysis)
`@name` is genuinely ambiguous at G#'s two annotation positions (statement-leading per ADR-0047 — `@defer(x)` is byte-identical to an annotation with arguments — and parameter-leading per ADR-0096); `@"name"` reads as an annotated string; backticks are raw strings; `#` stays reserved for directives. `$` is free outside strings and the lexer already reserved it as forward-compatible.

### Implementation
- **Lexer**: one new dispatch arm. `Text` keeps the full source spelling (spans/round-trips), `Value` carries the unescaped name.
- **`SyntaxToken.ValueText`** (Roslyn's concept) + a mechanical migration of the semantic layers (Binding/Symbols/Lowering/Emit/Compilation) to read names through it — behavior-preserving since identifier tokens previously had null `Value`. Syntactic consumers (printer, formatter, contextual-keyword commitments) keep `Text`.
- **Zero parser changes** — every existing name slot accepts the token structurally.

### Tests
8 new (lexer shape, bad `$`, keyword-named class + unescaped-metadata reflection check, escape/plain equivalence, keyword params+locals, package segment, member access, interpolation). **Full Core.Tests: 8176/8176.**

### Remaining #3610 scope (follow-ups)
cs2gs printer policy (emit the escape only for metadata-visible keyword names; re-enter the Issue3461 reserved-metadata fixtures into the selfmig corpus) and LS completion auto-escape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgTBb1VHmEVc8Un3AdfWjG