### PR TITLE
cs2gs + LS: escaped identifiers for metadata-visible keyword names (ADR-0170, #3610)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Attributes.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Attributes.cs
@@ -93,7 +93,7 @@ internal sealed partial class DeclarationBinder
             // Also accept the fully qualified name.
             if (annotation.NameSegments.Length >= 2)
             {
-                var fullName = string.Concat(annotation.NameSegments.Select(s => s.Text));
+                var fullName = string.Concat(annotation.NameSegments.Select(s => s.ValueText));
                 if (fullName == "UnscopedRef" || fullName == "UnscopedRefAttribute"
                     || fullName == "System.Diagnostics.CodeAnalysis.UnscopedRef"
                     || fullName == "System.Diagnostics.CodeAnalysis.UnscopedRefAttribute")
@@ -319,7 +319,7 @@ internal sealed partial class DeclarationBinder
                         Diagnostics.ReportNamedArgumentsNotSupportedOnUserAttribute(
                             namedArg.NameToken.Location,
                             nameIsExact ? nameText : (nameText + "Attribute"),
-                            namedArg.NameToken.Text);
+                            namedArg.NameToken.ValueText);
                         continue;
                     }
 
@@ -329,7 +329,7 @@ internal sealed partial class DeclarationBinder
                         continue;
                     }
 
-                    named.Add(new BoundAttributeArgument(namedArg.NameToken.Text, value, valueType));
+                    named.Add(new BoundAttributeArgument(namedArg.NameToken.ValueText, value, valueType));
                 }
                 else
                 {

--- a/src/Core/CodeAnalysis/Syntax/AnnotationSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/AnnotationSyntax.cs
@@ -105,12 +105,17 @@ public sealed class AnnotationSyntax : SyntaxNode
     public bool HasTypeArgumentList => TypeArgumentOpenBracketToken != null;
 
     /// <summary>Gets the dotted attribute name as a string (e.g. <c>"System.Diagnostics.Conditional"</c>).</summary>
+    /// <remarks>
+    /// ADR-0170 / issue #3610: segments use <see cref="SyntaxToken.ValueText"/>
+    /// so an escaped spelling (<c>@$class(...)</c> naming an attribute class
+    /// declared <c>class $class</c>) resolves by its semantic name.
+    /// </remarks>
     /// <returns>The flattened dotted name; segments are joined with <c>.</c>.</returns>
     public string GetNameText()
     {
         if (NameSegments.Length == 1)
         {
-            return NameSegments[0].Text;
+            return NameSegments[0].ValueText;
         }
 
         var sb = new System.Text.StringBuilder();
@@ -121,7 +126,7 @@ public sealed class AnnotationSyntax : SyntaxNode
                 sb.Append('.');
             }
 
-            sb.Append(NameSegments[i].Text);
+            sb.Append(NameSegments[i].ValueText);
         }
 
         return sb.ToString();

--- a/src/LanguageServer/HoverComputer.cs
+++ b/src/LanguageServer/HoverComputer.cs
@@ -2327,6 +2327,16 @@ public static class CompletionComputer
             return;
         }
 
+        // ADR-0170 / issue #3610: a member whose CLR name is a G# reserved
+        // spelling completes as its escaped form so the inserted text parses
+        // (`x.$defer()` for an imported member named `defer`). The escape is
+        // the label too — what you see is what inserts, mirroring how C#
+        // completion shows `@params`.
+        if (GSharp.Core.CodeAnalysis.Syntax.SyntaxFacts.IsReservedIdentifier(label))
+        {
+            label = "$" + label;
+        }
+
         items.Add(new CompletionItem { Label = label, Kind = kind, Detail = detail });
     }
 

--- a/test/Core.Tests/CodeAnalysis/Adr0170EscapedIdentifierTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Adr0170EscapedIdentifierTests.cs
@@ -152,6 +152,50 @@ Console.WriteLine(""value=${$defer + 1}"")
         Assert.Equal("value=42", output.Trim());
     }
 
+    [Fact]
+    public void EscapedSpelling_CannotMintADistinctName()
+    {
+        // `$foo` and `foo` declare the SAME name (C#'s @foo rule): the second
+        // declaration collides, and the escape never reaches metadata.
+        const string source = @"
+package P
+
+var $foo = 1
+var foo = 2
+";
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(new MemoryStream());
+        Assert.Contains(
+            result.Diagnostics,
+            d => d.Message.Contains("foo", StringComparison.Ordinal)
+                && d.Message.Contains("already declared", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void NameOf_EscapedIdentifier_YieldsUnescapedName()
+    {
+        // Matches C#: `nameof(@class)` is "class" — the escape is a spelling,
+        // not part of the name. Covers the type, member, and local forms.
+        const string source = @"
+package P
+import System
+
+class $class {
+    prop $defer int32 -> 1
+}
+
+let $type = 5
+Console.WriteLine(nameof($class))
+Console.WriteLine(nameof($class.$defer))
+Console.WriteLine(nameof($type))
+";
+        var (output, _) = CompileLoadRun(source, "Adr0170-NameOf");
+        Assert.Equal(
+            string.Join(Environment.NewLine, "class", "defer", "type"),
+            output.Trim());
+    }
+
     private static (string Output, string[] TypeNames) CompileLoadRun(string source, string contextName)
     {
         var tree = SyntaxTree.Parse(SourceText.From(source));

--- a/test/LanguageServer.Tests/CompletionHandlerTests.cs
+++ b/test/LanguageServer.Tests/CompletionHandlerTests.cs
@@ -362,6 +362,20 @@ public class CompletionHandlerTests
         Assert.Equal(caret.Character, toString.TextEdit.Range.End.Character);
     }
 
+    [Fact]
+    public void ComputeCompletions_KeywordNamedMember_OffersEscapedSpelling()
+    {
+        // ADR-0170 / issue #3610: a member whose CLR name is a G# reserved
+        // spelling completes as `$name` so the inserted text parses.
+        const string source = "class Bag {\nfunc $defer() int32 {\nreturn 1\n}\n}\nvar b = Bag{}\nb.\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        var items = CompletionComputer.ComputeCompletions(content, After(source, "b."));
+
+        Assert.Contains(items, i => i.Label == "$defer" && i.Kind == CompletionItemKind.Method);
+        Assert.DoesNotContain(items, i => i.Label == "defer");
+    }
+
     private static Position After(string source, string marker)
     {
         var start = LanguageServerTestHelpers.PositionOf(source, marker);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1072NullCheckedAsNullableTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1072NullCheckedAsNullableTranslationTests.cs
@@ -318,7 +318,7 @@ namespace Demo
             .ToArray();
 
         Assert.Contains("References Resolver?", printed[0], StringComparison.Ordinal);
-        Assert.Contains("scope_.References!!.Run()", printed[1], StringComparison.Ordinal);
+        Assert.Contains("$scope.References!!.Run()", printed[1], StringComparison.Ordinal);
         TranslationTestValidation.AssertBinds(printed);
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1528VerbatimIdentifierTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1528VerbatimIdentifierTranslationTests.cs
@@ -53,8 +53,10 @@ namespace Corpus.Issue1528
     {
         string rendered = Render();
 
-        // The declaration and every reference use the sanitized `default_` name.
-        Assert.Contains("default_", rendered, StringComparison.Ordinal);
+        // ADR-0170: the metadata-visible static field keeps its CLR name via
+        // the escape at the declaration and every reference.
+        Assert.Contains("$default", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("default_", rendered, StringComparison.Ordinal);
 
         // The unparsable verbatim/keyword forms never leak into the output.
         Assert.DoesNotContain("@default", rendered, StringComparison.Ordinal);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1734DeclarationSiteSanitizationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1734DeclarationSiteSanitizationTests.cs
@@ -50,9 +50,9 @@ namespace Corpus.Issue1734
 }
 ");
 
-        Assert.Contains("class defer_", rendered, StringComparison.Ordinal);
-        Assert.Contains("Make() defer_", rendered, StringComparison.Ordinal);
-        Assert.Contains("return defer_()", rendered, StringComparison.Ordinal);
+        Assert.Contains("class $defer", rendered, StringComparison.Ordinal);
+        Assert.Contains("Make() $defer", rendered, StringComparison.Ordinal);
+        Assert.Contains("return $defer()", rendered, StringComparison.Ordinal);
         AssertNoRawKeywordCollision(rendered, "defer");
         AssertRoundTripParses(rendered);
     }
@@ -80,7 +80,7 @@ namespace Corpus.Issue1734
         // The lifted primary-constructor parameter and the member it feeds must
         // agree on the sanitized spelling everywhere: the parameter list, the
         // parameter-field read inside 'Read', and (if retained) the field itself.
-        Assert.Contains("defer_", rendered, StringComparison.Ordinal);
+        Assert.Contains("$defer", rendered, StringComparison.Ordinal);
         AssertNoRawKeywordCollision(rendered, "defer");
         AssertRoundTripParses(rendered);
     }
@@ -257,7 +257,7 @@ namespace Corpus.Issue1734
 }
 ");
 
-        Assert.Contains("defer_", rendered, StringComparison.Ordinal);
+        Assert.Contains("$defer", rendered, StringComparison.Ordinal);
         AssertNoRawKeywordCollision(rendered, "defer");
         AssertRoundTripParses(rendered);
     }
@@ -283,7 +283,7 @@ namespace Corpus.Issue1734
 }
 ");
 
-        Assert.Contains("defer_", rendered, StringComparison.Ordinal);
+        Assert.Contains("$defer", rendered, StringComparison.Ordinal);
         AssertNoRawKeywordCollision(rendered, "defer");
         AssertRoundTripParses(rendered);
     }
@@ -303,7 +303,7 @@ namespace Corpus.Issue1734
 }
 ");
 
-        Assert.Contains("defer_", rendered, StringComparison.Ordinal);
+        Assert.Contains("$defer", rendered, StringComparison.Ordinal);
         AssertNoRawKeywordCollision(rendered, "defer");
         AssertRoundTripParses(rendered);
     }
@@ -326,7 +326,7 @@ namespace Corpus.Issue1734
 }
 ");
 
-        Assert.Contains("select_", rendered, StringComparison.Ordinal);
+        Assert.Contains("$select", rendered, StringComparison.Ordinal);
         AssertNoRawKeywordCollision(rendered, "select");
         AssertRoundTripParses(rendered);
     }
@@ -409,7 +409,7 @@ namespace Corpus.Issue3510
     private static void AssertNoRawKeywordCollision(string rendered, string keyword)
     {
         var regex = new System.Text.RegularExpressions.Regex(
-            $@"(?<![A-Za-z0-9_]){System.Text.RegularExpressions.Regex.Escape(keyword)}(?![A-Za-z0-9_])");
+            $@"(?<![A-Za-z0-9_$]){System.Text.RegularExpressions.Regex.Escape(keyword)}(?![A-Za-z0-9_])");
         System.Text.RegularExpressions.Match match = regex.Match(rendered);
         Assert.False(
             match.Success,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1839PatternDesignatorAndEnumExtensionTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1839PatternDesignatorAndEnumExtensionTests.cs
@@ -209,8 +209,8 @@ namespace Corpus.Issue1839
 }
 ");
 
-        Assert.Contains("func extension (color Color) defer_()", rendered, StringComparison.Ordinal);
-        Assert.Contains("color?.defer_()", rendered, StringComparison.Ordinal);
+        Assert.Contains("func extension (color Color) $defer()", rendered, StringComparison.Ordinal);
+        Assert.Contains("color?.$defer()", rendered, StringComparison.Ordinal);
         Assert.DoesNotContain("select_", rendered, StringComparison.Ordinal);
         AssertRoundTripParses(rendered);
     }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3413NestedPrivateClassTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3413NestedPrivateClassTranslationTests.cs
@@ -404,9 +404,11 @@ public sealed class Issue3413NestedPrivateClassTranslationTests
         Assert.DoesNotContain(
             unit.Members.OfType<MethodDeclaration>(),
             method => method.Name == "func__");
+        // ADR-0170: the metadata-visible `@func` extensions keep their CLR
+        // name via the escape; the legal func_ members keep their own names.
         Assert.Equal(
             2,
-            shared.Members.OfType<MethodDeclaration>().Count(method => method.Name == "func_"));
+            shared.Members.OfType<MethodDeclaration>().Count(method => method.Name == "$func"));
         Assert.DoesNotContain(
             shared.Members.OfType<MethodDeclaration>(),
             method => method.Name == "func__");

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3461FriendAssemblyIdentifierTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3461FriendAssemblyIdentifierTests.cs
@@ -94,8 +94,10 @@ public sealed class Issue3461FriendAssemblyIdentifierTests
             document.FilePath);
         string rendered = GSharpPrinter.Print(
             new CSharpToGSharpTranslator().TranslateDocument(document, context));
-        Assert.Contains("func defer__()", rendered, StringComparison.Ordinal);
-        Assert.Contains("func Run() int32 -> defer__()", rendered, StringComparison.Ordinal);
+        // ADR-0170: the derived keyword-named method keeps its CLR name via
+        // the escape; no allocation around the friend-internal defer_ needed.
+        Assert.Contains("func $defer()", rendered, StringComparison.Ordinal);
+        Assert.Contains("func Run() int32 -> $defer()", rendered, StringComparison.Ordinal);
 
         using var resolver = GSharpReferenceResolver.WithReferences(
             new[] { libraryPath });

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3461IdentifierSanitizationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3461IdentifierSanitizationTests.cs
@@ -108,10 +108,15 @@ public sealed class Issue3461IdentifierSanitizationTests
 
         Assert.Contains("import import_ = System.Text.StringBuilder", rendered, StringComparison.Ordinal);
         Assert.Contains("import import__ = System.Text.StringBuilder", rendered, StringComparison.Ordinal);
+
+        // ADR-0170: the metadata-visible keyword-named class keeps its CLR
+        // name via the escape; the legal `defer_` neighbor keeps its own name
+        // — the #3461 collision is gone rather than allocated around.
+        Assert.Contains("class $defer", rendered, StringComparison.Ordinal);
         Assert.Contains("class defer_", rendered, StringComparison.Ordinal);
-        Assert.Contains("class defer__", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("defer__", rendered, StringComparison.Ordinal);
+        Assert.Contains("$select(params__ int32, params_ int32", rendered, StringComparison.Ordinal);
         Assert.Contains("select_(params__ int32, params_ int32", rendered, StringComparison.Ordinal);
-        Assert.Contains("select__(params__ int32, params_ int32", rendered, StringComparison.Ordinal);
         Assert.Contains("range_", rendered, StringComparison.Ordinal);
         Assert.Contains("range__", rendered, StringComparison.Ordinal);
         Assert.Contains("guard_", rendered, StringComparison.Ordinal);
@@ -168,7 +173,10 @@ public sealed class Issue3461IdentifierSanitizationTests
 
         foreach (string word in reserved)
         {
-            Assert.Contains(word + "_", rendered, StringComparison.Ordinal);
+            // ADR-0170: fields are metadata-visible, so every reserved name
+            // keeps its CLR spelling via the `$` escape instead of a rename.
+            Assert.Contains("$" + word, rendered, StringComparison.Ordinal);
+            Assert.DoesNotContain(word + "_", rendered, StringComparison.Ordinal);
             Assert.DoesNotContain($"var {word} ", rendered, StringComparison.Ordinal);
             Assert.DoesNotMatch(
                 $@"\.{Regex.Escape(word)}(?![A-Za-z0-9_])",
@@ -234,7 +242,7 @@ public sealed class Issue3461IdentifierSanitizationTests
             }
             """);
 
-        Assert.Contains("class event_", rendered, StringComparison.Ordinal);
+        Assert.Contains("class $event", rendered, StringComparison.Ordinal);
         Assert.Contains("class Holder[in_, out_]", rendered, StringComparison.Ordinal);
         Assert.Contains(
             "Run(params_ int32, scoped_ int32, ref_ int32, out_ int32, in_ int32)",
@@ -243,11 +251,11 @@ public sealed class Issue3461IdentifierSanitizationTests
         Assert.True(
             rendered.Split("params_ int32", StringSplitOptions.None).Length >= 3,
             rendered);
-        Assert.Contains("func checked_()", rendered, StringComparison.Ordinal);
-        Assert.Contains("func typeof_()", rendered, StringComparison.Ordinal);
-        Assert.Contains("func sizeof_()", rendered, StringComparison.Ordinal);
-        Assert.Contains("func unchecked_()", rendered, StringComparison.Ordinal);
-        Assert.Contains("func init_()", rendered, StringComparison.Ordinal);
+        Assert.Contains("func $checked()", rendered, StringComparison.Ordinal);
+        Assert.Contains("func $typeof()", rendered, StringComparison.Ordinal);
+        Assert.Contains("func $sizeof()", rendered, StringComparison.Ordinal);
+        Assert.Contains("func $unchecked()", rendered, StringComparison.Ordinal);
+        Assert.Contains("func $init()", rendered, StringComparison.Ordinal);
         Assert.Contains("func make()", rendered, StringComparison.Ordinal);
         Assert.Contains("names.nameof()", rendered, StringComparison.Ordinal);
         Assert.Contains("names.checked()", rendered, StringComparison.Ordinal);
@@ -255,8 +263,7 @@ public sealed class Issue3461IdentifierSanitizationTests
         Assert.Contains("names.sizeof()", rendered, StringComparison.Ordinal);
         Assert.Contains("names.unchecked()", rendered, StringComparison.Ordinal);
         Assert.Contains("names.make()", rendered, StringComparison.Ordinal);
-        Assert.Contains("names.init_()", rendered, StringComparison.Ordinal);
-        Assert.Contains("func init_()", rendered, StringComparison.Ordinal);
+        Assert.Contains("names.$init()", rendered, StringComparison.Ordinal);
         Assert.DoesNotContain("func nameof_()", rendered, StringComparison.Ordinal);
         TranslationTestValidation.AssertBinds(rendered);
     }
@@ -288,9 +295,11 @@ public sealed class Issue3461IdentifierSanitizationTests
             }
             """);
 
+        // ADR-0170: both contract endpoints keep the CLR name via the
+        // escape; the legal defer_ sibling keeps its own name.
         Assert.Equal(
             2,
-            rendered.Split("func defer__()", StringSplitOptions.None).Length - 1);
+            rendered.Split("func $defer()", StringSplitOptions.None).Length - 1);
         Assert.Contains("func defer_()", rendered, StringComparison.Ordinal);
         TranslationTestValidation.AssertBinds(rendered);
 
@@ -327,9 +336,11 @@ public sealed class Issue3461IdentifierSanitizationTests
             }
             """);
 
+        // ADR-0170: base virtual and override keep the CLR name via the
+        // escape; the legal defer_ sibling keeps its own name.
         Assert.Equal(
             2,
-            rendered.Split("func defer__()", StringSplitOptions.None).Length - 1);
+            rendered.Split("func $defer()", StringSplitOptions.None).Length - 1);
         Assert.Contains("func defer_()", rendered, StringComparison.Ordinal);
         TranslationTestValidation.AssertBinds(rendered);
 
@@ -364,9 +375,12 @@ public sealed class Issue3461IdentifierSanitizationTests
             }
             """);
 
-        Assert.Contains("func defer__()", rendered, StringComparison.Ordinal);
+        // ADR-0170: the derived keyword-named method escapes to keep its CLR
+        // name; no allocation around the inherited legal defer_ is needed.
+        Assert.Contains("func $defer()", rendered, StringComparison.Ordinal);
         Assert.Contains("func defer_()", rendered, StringComparison.Ordinal);
-        Assert.Contains("value.defer__()", rendered, StringComparison.Ordinal);
+        Assert.Contains("value.$defer()", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("defer__", rendered, StringComparison.Ordinal);
         TranslationTestValidation.AssertBinds(rendered);
 
         var result = EmittedOracle.Evaluate(
@@ -395,9 +409,11 @@ public sealed class Issue3461IdentifierSanitizationTests
             }
             """);
 
-        Assert.Contains("data class R(params__ int32)", rendered, StringComparison.Ordinal);
+        // ADR-0170: the positional property is metadata-visible, so the whole
+        // parameter/property contract group keeps the CLR name via the escape.
+        Assert.Contains("data class R($params int32)", rendered, StringComparison.Ordinal);
         Assert.Contains("prop params_", rendered, StringComparison.Ordinal);
-        Assert.Contains("value.params__", rendered, StringComparison.Ordinal);
+        Assert.Contains("value.$params", rendered, StringComparison.Ordinal);
         TranslationTestValidation.AssertBinds(rendered);
 
         var result = EmittedOracle.Evaluate(
@@ -650,8 +666,8 @@ public sealed class Issue3461IdentifierSanitizationTests
                 }
                 """));
 
-        Assert.Contains(".params_", rendered["Consumer.cs"], StringComparison.Ordinal);
-        Assert.Contains("data class R(params_", rendered["Record.cs"], StringComparison.Ordinal);
+        Assert.Contains(".$params", rendered["Consumer.cs"], StringComparison.Ordinal);
+        Assert.Contains("data class R($params", rendered["Record.cs"], StringComparison.Ordinal);
         TranslationTestValidation.AssertBinds(rendered.Values.ToArray());
     }
 
@@ -684,12 +700,12 @@ public sealed class Issue3461IdentifierSanitizationTests
             }
             """);
 
-        Assert.Contains("class base_", rendered, StringComparison.Ordinal);
-        Assert.Contains("class stackalloc_", rendered, StringComparison.Ordinal);
-        Assert.Contains("func base_[T]", rendered, StringComparison.Ordinal);
-        Assert.Contains("func stackalloc_[T]", rendered, StringComparison.Ordinal);
-        Assert.Contains("base_[int32](1)", rendered, StringComparison.Ordinal);
-        Assert.Contains("stackalloc_[int32](2)", rendered, StringComparison.Ordinal);
+        Assert.Contains("class $base", rendered, StringComparison.Ordinal);
+        Assert.Contains("class $stackalloc", rendered, StringComparison.Ordinal);
+        Assert.Contains("func $base[T]", rendered, StringComparison.Ordinal);
+        Assert.Contains("func $stackalloc[T]", rendered, StringComparison.Ordinal);
+        Assert.Contains("$base[int32](1)", rendered, StringComparison.Ordinal);
+        Assert.Contains("$stackalloc[int32](2)", rendered, StringComparison.Ordinal);
         TranslationTestValidation.AssertBinds(rendered);
     }
 
@@ -715,8 +731,8 @@ public sealed class Issue3461IdentifierSanitizationTests
                 }
                 """));
 
-        Assert.Contains("package class_", rendered["Extensions.cs"], StringComparison.Ordinal);
-        Assert.Contains("import class_", rendered["Consumer.cs"], StringComparison.Ordinal);
+        Assert.Contains("package $class", rendered["Extensions.cs"], StringComparison.Ordinal);
+        Assert.Contains("import $class", rendered["Consumer.cs"], StringComparison.Ordinal);
         TranslationTestValidation.AssertBinds(rendered.Values.ToArray());
     }
 
@@ -746,12 +762,13 @@ public sealed class Issue3461IdentifierSanitizationTests
             """,
             references);
 
-        Assert.Contains("fields.defer__", rendered, StringComparison.Ordinal);
+        Assert.Contains("fields.$defer", rendered, StringComparison.Ordinal);
         Assert.Contains("fields.defer_", rendered, StringComparison.Ordinal);
-        Assert.Contains("properties.defer__", rendered, StringComparison.Ordinal);
-        Assert.Contains("methods.defer__()", rendered, StringComparison.Ordinal);
+        Assert.Contains("properties.$defer", rendered, StringComparison.Ordinal);
+        Assert.Contains("methods.$defer()", rendered, StringComparison.Ordinal);
         Assert.Contains("methods.make()", rendered, StringComparison.Ordinal);
         Assert.DoesNotContain("methods.make_()", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("defer__", rendered, StringComparison.Ordinal);
 
         using var resolver = ReferenceResolver.WithReferences(new[] { fixtureAssembly });
         TranslationTestValidation.AssertBinds(resolver, rendered);
@@ -881,8 +898,8 @@ public sealed class Issue3461IdentifierSanitizationTests
             """,
             references);
 
-        Assert.Contains("import class__", rendered, StringComparison.Ordinal);
-        Assert.Contains("defer__()", rendered, StringComparison.Ordinal);
+        Assert.Contains("import $class", rendered, StringComparison.Ordinal);
+        Assert.Contains("$defer()", rendered, StringComparison.Ordinal);
         Assert.Contains("defer_()", rendered, StringComparison.Ordinal);
 
         using var resolver = ReferenceResolver.WithReferences(new[] { fixtureAssembly });
@@ -970,13 +987,13 @@ public sealed class Issue3461IdentifierSanitizationTests
 
         foreach ((string method, string name) in new[]
                  {
-                     ("Event", "event_"),
-                     ("Prop", "prop_"),
-                     ("Init", "init_"),
-                     ("Convenience", "convenience_"),
-                     ("Shared", "shared_"),
-                     ("Delegate", "delegate_"),
-                     ("Unmanaged", "unmanaged_"),
+                     ("Event", "$event"),
+                     ("Prop", "$prop"),
+                     ("Init", "$init"),
+                     ("Convenience", "$convenience"),
+                     ("Shared", "$shared"),
+                     ("Delegate", "$delegate"),
+                     ("Unmanaged", "$unmanaged"),
                  })
         {
             Assert.Contains($"class {name}", rendered, StringComparison.Ordinal);
@@ -1049,7 +1066,7 @@ public sealed class Issue3461IdentifierSanitizationTests
             }
             """);
 
-        Assert.Contains("class class_", rendered, StringComparison.Ordinal);
+        Assert.Contains("class $class", rendered, StringComparison.Ordinal);
         Assert.Contains("var params int32", rendered, StringComparison.Ordinal);
         Assert.Contains("Read(params_ int32)", rendered, StringComparison.Ordinal);
         Assert.Contains("let ordinary", rendered, StringComparison.Ordinal);
@@ -1102,9 +1119,9 @@ public sealed class Issue3461IdentifierSanitizationTests
                 }
                 """));
 
-        Assert.Contains("package class_", rendered["Producer.cs"], StringComparison.Ordinal);
+        Assert.Contains("package $class", rendered["Producer.cs"], StringComparison.Ordinal);
         Assert.Contains(
-            "import import_ = class_.Widget",
+            "import import_ = $class.Widget",
             rendered["Consumer.cs"],
             StringComparison.Ordinal);
         Assert.DoesNotContain("@class", rendered["Consumer.cs"], StringComparison.Ordinal);
@@ -1129,7 +1146,7 @@ public sealed class Issue3461IdentifierSanitizationTests
             references);
 
         Assert.Contains(
-            "@ReservedNamed(\"a\", \"b\", defer__: \"c\", defer_: \"d\")",
+            "@ReservedNamed(\"a\", \"b\", $defer: \"c\", defer_: \"d\")",
             rendered,
             StringComparison.Ordinal);
         using var resolver = ReferenceResolver.WithReferences(new[] { fixtureAssembly });
@@ -1152,8 +1169,8 @@ public sealed class Issue3461IdentifierSanitizationTests
             public sealed class Holder { }
             """);
 
-        Assert.Contains("class class_", rendered, StringComparison.Ordinal);
-        Assert.Contains("@class_(\"ok\")", rendered, StringComparison.Ordinal);
+        Assert.Contains("class $class", rendered, StringComparison.Ordinal);
+        Assert.Contains("@$class(\"ok\")", rendered, StringComparison.Ordinal);
         TranslationTestValidation.AssertBinds(rendered);
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/LockKeywordSanitizationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/LockKeywordSanitizationTranslationTests.cs
@@ -48,7 +48,9 @@ namespace Corpus.LockSanitize
     {
         string rendered = Render();
 
-        Assert.Contains("lock_", rendered, StringComparison.Ordinal);
+        // ADR-0170: the metadata-visible field keeps its CLR name via the escape.
+        Assert.Contains("$lock", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("lock_", rendered, StringComparison.Ordinal);
 
         // The bare `lock` keyword must never appear as an identifier: neither the
         // field declaration nor the lock-statement operand may leak it.

--- a/tools/cs2gs/Cs2Gs.Tests/OahuFoundationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuFoundationTranslationTests.cs
@@ -52,7 +52,7 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("default_", printed);
+        Assert.Contains("$default", printed);
 
         // Issue #3510: `type` left the reserved keyword set, so the C#
         // parameter keeps its spelling instead of the `type_` suffix.

--- a/tools/cs2gs/Cs2Gs.Translator/EmittedNameAllocator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/EmittedNameAllocator.cs
@@ -75,8 +75,29 @@ internal sealed class EmittedNameAllocator
                 context |= this.GetContext(member) | precomputed;
             }
 
+            // ADR-0170 / issue #3610: a METADATA-VISIBLE symbol whose name is
+            // a G# reserved spelling keeps its exact CLR name via the `$name`
+            // escape instead of the lossy `name_` rename — the rename changes
+            // the emitted metadata (reflection, InternalsVisibleTo,
+            // cross-assembly consumers) and can collide with a legal `name_`
+            // neighbor. Locals, parameters, and other non-metadata names keep
+            // the #3461 rename below, where readability wins and metadata
+            // does not care.
+            string sourceName = SourceName(symbol);
+            if (contract.Any(IsMetadataVisible)
+                && GSharpSyntaxFacts.IsReservedIdentifier(sourceName, context))
+            {
+                string escaped = "$" + sourceName;
+                foreach (ISymbol member in contract)
+                {
+                    this.emittedNames[member] = escaped;
+                }
+
+                return escaped;
+            }
+
             string emitted = GSharpSyntaxFacts.GetEmittedIdentifier(
-                SourceName(symbol),
+                sourceName,
                 context,
                 contract.SelectMany(this.GetScopeNames).Distinct(StringComparer.Ordinal));
             foreach (ISymbol member in contract)
@@ -111,6 +132,24 @@ internal sealed class EmittedNameAllocator
 
         return string.Join(".", parts);
     }
+
+    // ADR-0170: symbols whose emitted names ARE their CLR metadata names —
+    // namespaces, named types, and type members. Everything scoped to a body
+    // (locals, parameters, type parameters, range variables, local/anonymous
+    // functions) and synthesized shapes (anonymous-type members, aliases,
+    // discards) stay on the rename path.
+    private static bool IsMetadataVisible(ISymbol symbol) =>
+        symbol switch
+        {
+            INamespaceSymbol => true,
+            INamedTypeSymbol { IsAnonymousType: false } => true,
+            IMethodSymbol { MethodKind: MethodKind.LocalFunction or MethodKind.AnonymousFunction } => false,
+            IMethodSymbol method => method.ContainingType?.IsAnonymousType == false,
+            IPropertySymbol property => property.ContainingType?.IsAnonymousType == false,
+            IFieldSymbol field => field.ContainingType?.IsAnonymousType == false,
+            IEventSymbol => true,
+            _ => false,
+        };
 
     private static ISymbol Canonical(ISymbol symbol) =>
         symbol switch


### PR DESCRIPTION
## Summary

Completes #3610 on top of the merged gsc half (#3618).

### cs2gs printer policy
`EmittedNameAllocator`: a symbol whose **contract group** contains a metadata-visible member (namespaces, named types, methods, properties, fields, events) and whose name is a G# reserved spelling now emits the ADR-0170 **`$name` escape** instead of the lossy #3461 `name_` rename — the rename changed emitted metadata (reflection, `InternalsVisibleTo`, cross-assembly consumers) and could collide with a legal `name_` neighbor. Locals/parameters/type-parameters/aliases keep the #3461 renames where readability wins. The group-wide check keeps positional-record parameter/property pairs consistent.

### gsc follow-ups the new spellings exposed
`AnnotationSyntax.GetNameText` + the attribute binder's named-argument names read `ValueText`, so `@$class(...)` resolves an attribute class declared `class $class`, and `$defer: ...` named arguments resolve imported keyword-named attribute properties.

### LanguageServer
Member completions (all funnel through `AddItem`) present/insert the escaped spelling for reserved-named members — `x.$defer()` for an imported member named `defer`, mirroring C#'s `@params` completion.

### Verification
- All **34 Issue3461 suites** updated to the new policy and green — including the **imported-consumption** paths against the reserved-metadata fixture assembly: bind + runtime oracle prove gsc resolves `$defer` / `import $class` against real CLR metadata while the legal `defer_` siblings keep their names (the adversarial collision the old allocator had to dance around is simply gone).
- cs2gs GoldenTests 42/42; LS completion 26/26 (new escaped-member test); Core attribute/annotation families 205/205.

Closes the reserved-identifier fixture-policy item on #3501 — the Issue3461 shapes now translate faithfully instead of being corpus-policy exclusions.

Fixes #3610.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgTBb1VHmEVc8Un3AdfWjG