### PR TITLE
Order selfmig apps by declared analyzer references (fixes GS9301 husk)

### DIFF
--- a/src/Core/CodeAnalysis/Analyzers/GSharpAnalyzerHost.cs
+++ b/src/Core/CodeAnalysis/Analyzers/GSharpAnalyzerHost.cs
@@ -82,7 +82,8 @@ public static class GSharpAnalyzerHost
             CheckCoreVersion(assembly, fullPath, hostDiagnostics);
 
             var found = 0;
-            foreach (var type in assembly.GetExportedTypes())
+            var exportedTypes = assembly.GetExportedTypes();
+            foreach (var type in exportedTypes)
             {
                 if (type.IsAbstract
                     || !typeof(GSharpDiagnosticAnalyzer).IsAssignableFrom(type)
@@ -100,11 +101,21 @@ public static class GSharpAnalyzerHost
 
             if (found == 0)
             {
+                // Issue #3617: a zero-discovery result has three very
+                // different causes — wrong bytes at the path (e.g. a stale
+                // Roslyn-era assembly), a type-identity split (the analyzer's
+                // GSharpDiagnosticAnalyzer base bound to a DIFFERENT
+                // GSharp.Core instance than the host's), or a genuinely empty
+                // assembly. Emit enough forensic detail that one CI log
+                // distinguishes them.
+                string zeroDiscovery =
+                    "the assembly contains no [GSharpDiagnosticAnalyzer] types deriving from GSharpDiagnosticAnalyzer. "
+                    + DescribeZeroDiscovery(assembly, fullPath, exportedTypes);
                 hostDiagnostics.Add(Diagnostic.Create(
                     DiagnosticDescriptors.AnalyzerAssemblyLoadFailure,
                     default,
                     path,
-                    "the assembly contains no [GSharpDiagnosticAnalyzer] types deriving from GSharpDiagnosticAnalyzer."));
+                    zeroDiscovery));
             }
         }
         catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
@@ -113,8 +124,113 @@ public static class GSharpAnalyzerHost
                 DiagnosticDescriptors.AnalyzerAssemblyLoadFailure,
                 default,
                 path,
-                ex.Message));
+                DescribeLoadException(ex)));
         }
+    }
+
+    /// <summary>
+    /// Issue #3617: builds the forensic tail of the zero-discovery GS9301 —
+    /// the exported-type census, per-candidate filter verdicts with the
+    /// identity/location/MVID of each candidate's resolved analyzer base
+    /// assembly versus the host's own, and the analyzer file's size and MVID.
+    /// </summary>
+    private static string DescribeZeroDiscovery(Assembly assembly, string fullPath, Type[] exportedTypes)
+    {
+        var sb = new System.Text.StringBuilder();
+        try
+        {
+            var hostBase = typeof(GSharpDiagnosticAnalyzer);
+            sb.Append("Forensics: exportedTypes=").Append(exportedTypes.Length);
+
+            var fileInfo = new FileInfo(fullPath);
+            sb.Append("; file(size=").Append(fileInfo.Exists ? fileInfo.Length : -1)
+                .Append(", mvid=").Append(assembly.ManifestModule.ModuleVersionId)
+                .Append(')');
+
+            var referencedCore = assembly.GetReferencedAssemblies()
+                .FirstOrDefault(name => string.Equals(name.Name, hostBase.Assembly.GetName().Name, StringComparison.OrdinalIgnoreCase));
+            sb.Append("; referencedCore=").Append(referencedCore?.Version?.ToString() ?? "<none>")
+                .Append("; hostCore(version=").Append(hostBase.Assembly.GetName().Version)
+                .Append(", location=").Append(hostBase.Assembly.Location)
+                .Append(", mvid=").Append(hostBase.Assembly.ManifestModule.ModuleVersionId)
+                .Append(')');
+
+            // Candidates that carry the attribute BY NAME but failed a filter:
+            // the smoking gun for identity splits is a base assembly whose
+            // location/MVID differs from the host's.
+            foreach (var type in exportedTypes)
+            {
+                bool namedAttribute = type.GetCustomAttributesData()
+                    .Any(attribute => attribute.AttributeType.Name == nameof(GSharpDiagnosticAnalyzerAttribute));
+                var analyzerBase = FindAnalyzerBase(type, hostBase.FullName);
+                if (!namedAttribute && analyzerBase == null)
+                {
+                    continue;
+                }
+
+                sb.Append("; candidate ").Append(type.FullName)
+                    .Append("(abstract=").Append(type.IsAbstract)
+                    .Append(", namedAttr=").Append(namedAttribute)
+                    .Append(", assignable=").Append(hostBase.IsAssignableFrom(type));
+                if (analyzerBase != null)
+                {
+                    sb.Append(", baseAssembly=").Append(analyzerBase.Assembly.GetName().Version)
+                        .Append('@').Append(analyzerBase.Assembly.Location)
+                        .Append(", baseMvid=").Append(analyzerBase.Assembly.ManifestModule.ModuleVersionId)
+                        .Append(", baseIsHost=").Append(ReferenceEquals(analyzerBase.Assembly, hostBase.Assembly));
+                }
+
+                sb.Append(')');
+            }
+        }
+        catch (Exception forensics) when (forensics is not OutOfMemoryException and not StackOverflowException)
+        {
+            sb.Append("; forensics-failed: ").Append(forensics.GetType().Name).Append(": ").Append(forensics.Message);
+        }
+
+        return sb.ToString();
+    }
+
+    private static Type? FindAnalyzerBase(Type type, string? analyzerBaseFullName)
+    {
+        for (var current = type.BaseType; current != null; current = current.BaseType)
+        {
+            if (current.FullName == analyzerBaseFullName)
+            {
+                return current;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Issue #3617: a load exception's Message alone hid every actionable
+    /// detail (two CI runs produced no data). Surface the exception chain and
+    /// any per-type loader failures.
+    /// </summary>
+    private static string DescribeLoadException(Exception ex)
+    {
+        var sb = new System.Text.StringBuilder();
+        sb.Append(ex.GetType().Name).Append(": ").Append(ex.Message);
+        if (ex is ReflectionTypeLoadException typeLoad)
+        {
+            foreach (var loaderException in typeLoad.LoaderExceptions.Take(5))
+            {
+                if (loaderException != null)
+                {
+                    sb.Append(" | loader: ").Append(loaderException.GetType().Name)
+                        .Append(": ").Append(loaderException.Message);
+                }
+            }
+        }
+
+        for (var inner = ex.InnerException; inner != null; inner = inner.InnerException)
+        {
+            sb.Append(" | inner: ").Append(inner.GetType().Name).Append(": ").Append(inner.Message);
+        }
+
+        return sb.ToString();
     }
 
     private static void CheckCoreVersion(
@@ -156,11 +272,39 @@ public static class GSharpAnalyzerHost
 
         protected override Assembly? Load(AssemblyName assemblyName)
         {
-            foreach (var loaded in Default.Assemblies)
+            // Issue #3617: resolve HOST-OWNED assemblies to the host's own
+            // instances FIRST — typeof(GSharpDiagnosticAnalyzer)'s assembly
+            // and everything loaded beside it in the host's own context. The
+            // analyzer's base type must be identity-equal to the driver's or
+            // discovery reports "no analyzer types"; scanning Default first
+            // left a hole whenever the host itself runs outside the default
+            // context (in-proc hosts, test harnesses, future embeddings).
+            var hostAssembly = typeof(GSharpDiagnosticAnalyzer).Assembly;
+            if (string.Equals(hostAssembly.GetName().Name, assemblyName.Name, StringComparison.OrdinalIgnoreCase))
             {
-                if (string.Equals(loaded.GetName().Name, assemblyName.Name, StringComparison.OrdinalIgnoreCase))
+                return hostAssembly;
+            }
+
+            var hostContext = GetLoadContext(hostAssembly);
+            if (hostContext != null && hostContext != this)
+            {
+                foreach (var loaded in hostContext.Assemblies)
                 {
-                    return loaded;
+                    if (string.Equals(loaded.GetName().Name, assemblyName.Name, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return loaded;
+                    }
+                }
+            }
+
+            if (hostContext != Default)
+            {
+                foreach (var loaded in Default.Assemblies)
+                {
+                    if (string.Equals(loaded.GetName().Name, assemblyName.Name, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return loaded;
+                    }
                 }
             }
 

--- a/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs
@@ -377,11 +377,23 @@ public sealed class MigrationPipeline
                 await Cs2Gs.Translator.Loading.CSharpProjectLoader
                     .LoadProjectWithReferencesAsync(app.ProjectPath, cancellationToken)
                     .ConfigureAwait(false);
+
+            // Issue #3617: the Roslyn loader follows compile references only,
+            // so an analyzer-shaped reference (`OutputItemType="Analyzer"
+            // ReferenceOutputAssembly="false"`, e.g. Core → InternalAnalyzers)
+            // never becomes an ordering edge. Union in the XML-declared
+            // ProjectReference paths so a dependent app cannot build before
+            // its analyzer dependency has translated its sources — building
+            // the dependency from a source-less mirror directory produces a
+            // two-file husk assembly that later fails analyzer discovery
+            // (GS9301).
             references[Path.GetFullPath(app.ProjectPath)] = loaded
                 .Skip(1)
                 .Select(project => project.ProjectPath)
                 .Where(path => !string.IsNullOrEmpty(path))
                 .Select(Path.GetFullPath)
+                .Concat(DeclaredProjectItems.ProjectReferencePaths(app.ProjectPath))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToList();
         }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3617AnalyzerReferenceOrderingTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3617AnalyzerReferenceOrderingTests.cs
@@ -1,0 +1,67 @@
+// <copyright file="Issue3617AnalyzerReferenceOrderingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Regression tests for issue #3617: the repository-layout app ordering must
+/// see analyzer-shaped project references (<c>OutputItemType="Analyzer"
+/// ReferenceOutputAssembly="false"</c>) as dependency edges. The Roslyn
+/// project loader follows compile references only, so the ordering unions in
+/// the XML-declared <c>ProjectReference</c> paths — this suite pins the
+/// contract that declared-path reading surfaces analyzer references, which is
+/// what keeps a consumer app from building its analyzer dependency out of a
+/// source-less mirror directory into a husk assembly that later fails
+/// analyzer discovery (GS9301).
+/// </summary>
+public class Issue3617AnalyzerReferenceOrderingTests
+{
+    [Fact]
+    public void ProjectReferencePaths_IncludesAnalyzerShapedReference()
+    {
+        using var directory = new ScratchDirectory();
+        string appDirectory = Path.Combine(directory.Path, "src", "Core");
+        string analyzerDirectory = Path.Combine(directory.Path, "src", "Analyzers", "InternalAnalyzers");
+        Directory.CreateDirectory(appDirectory);
+        Directory.CreateDirectory(analyzerDirectory);
+        string analyzerProject = Path.Combine(analyzerDirectory, "InternalAnalyzers.csproj");
+        File.WriteAllText(analyzerProject, "<Project></Project>");
+        string appProject = Path.Combine(appDirectory, "Core.csproj");
+        File.WriteAllText(
+            appProject,
+            "<Project><ItemGroup>" +
+            "<ProjectReference Include=\"..\\Analyzers\\InternalAnalyzers\\InternalAnalyzers.csproj\" " +
+            "OutputItemType=\"Analyzer\" ReferenceOutputAssembly=\"false\" PrivateAssets=\"all\" />" +
+            "</ItemGroup></Project>");
+
+        IReadOnlyList<string> paths = DeclaredProjectItems.ProjectReferencePaths(appProject);
+
+        string resolved = Assert.Single(paths);
+        Assert.Equal(Path.GetFullPath(analyzerProject), resolved);
+    }
+
+    private sealed class ScratchDirectory : IDisposable
+    {
+        public ScratchDirectory()
+        {
+            this.Path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                "cs2gs-issue3617-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(this.Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            Directory.Delete(this.Path, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3617.

## Root cause

The selfmig pipeline's repository-layout app ordering (`MigrationPipeline.OrderForSdkBuildAsync`) built its dependency edges from the Roslyn project loader, which follows **compile references only**. An analyzer-shaped reference — `<ProjectReference ... OutputItemType="Analyzer" ReferenceOutputAssembly="false" />`, exactly how `src/Core/Core.csproj` consumes `InternalAnalyzers` — never became an ordering edge. Depending on discovery order, Core could run **before** InternalAnalyzers had translated its sources.

Core's transitive `dotnet build` of `InternalAnalyzers.gsproj` then evaluated a mirror directory containing the project file but **zero `.gs` sources** (they hadn't been emitted yet), compiling only the two synthesized files (`Version.gs` + `AssemblyInfo.gs`) into a 4096-byte husk with 2 exported types and no `GSharp.Core` reference. The analyzer host loaded the husk, found no `[GSharpDiagnosticAnalyzer]` types, and failed with GS9301 — non-deterministically, since it tracked whatever order apps happened to be processed in.

Diagnosed via binlog capture of a failing transitive build: the embedded project file was correct, but the evaluation had zero `Compile` items because the source files' mtimes postdated the consumer's compile.

## Changes

- **`MigrationPipeline.OrderForSdkBuildAsync`**: union the loader's edges with the XML-declared `ProjectReference` paths (`DeclaredProjectItems.ProjectReferencePaths`), which include analyzer references. Analyzer dependencies now always translate before their consumers build.
- **`GSharpAnalyzerHost`** (diagnosability): the GS9301 zero-discovery message now includes forensics — exported-type count, file size, MVID, referenced vs host `GSharp.Core` identities, and per-candidate filter verdicts — so a husk (or an identity-split load) is recognizable from the error alone. Analyzer load failures now surface `ReflectionTypeLoadException` loader exceptions and inner-exception chains.
- **`AnalyzerLoadContext`** (hardening): resolves host-owned assemblies from the host's own load context before probing the analyzer directory, so an analyzer compiled against `GSharp.Core` can never bind a second copy and silently fail the `IsAssignableFrom` filter.
- Regression test pinning that `ProjectReferencePaths` surfaces analyzer-shaped references (the edge source the ordering fix depends on).

## Verification

3-app local repro (`Analyzers.Testing`, `InternalAnalyzers`, `Core`): previously ordered Core first → GS9301 husk failure; with the fix the order is InternalAnalyzers → Core and **Core passes all four stages** (translate/compile/ilverify/test-parity). Analyzers.Testing still fails on the known pre-existing gsc tuple `!=` gap (GS0129), unrelated to this change. Adr0169 analyzer-framework suite: 29/29 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgTBb1VHmEVc8Un3AdfWjG