### PR TITLE
cs2gs + LS: preserve C# tuple element names + completion (ADR-0172 Phases C+D, #3501)

### DIFF
--- a/docs/cs2gs-coverage-matrix.md.actual
+++ b/docs/cs2gs-coverage-matrix.md.actual
@@ -92,7 +92,7 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | EmptyStatement | EmptyStatementSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/EmptyStatement.cs |  |  |
 | EnumDeclaration | EnumDeclarationSyntax | ADR-0115 §B.11 |  | tools/cs2gs/corpus/grid/G06-Types-Console/Constructs/EnumDeclaration.cs |  | Member values (explicit or implicit) and [Flags] are preserved (issue #1912, fixed). |
 | EnumMemberDeclaration | EnumMemberDeclarationSyntax | ADR-0115 §B.11 |  | tools/cs2gs/corpus/grid/G06-Types-Console/Constructs/EnumMemberDeclaration.cs |  | Explicit/negative/[Flags] bit-shift-or/alias values resolve via the semantic model's IFieldSymbol.ConstantValue and are emitted as an explicit G# `= value` (new language feature, issue #1912, fixed). |
-| EqualsExpression | BinaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/EqualsExpression.cs |  | Tuple operands compare element-wise via gsc tuple equality (ADR-0171, issue #3501); element names never affect equality. |
+| EqualsExpression | BinaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/EqualsExpression.cs |  | Tuple operands compare element-wise via gsc tuple equality (ADR-0171, issue #3501); C# element names are ignored, matching the positional G# lowering. |
 | EqualsValueClause | EqualsValueClauseSyntax | ADR-0115 §B.3 |  |  |  |  |
 | EventDeclaration | EventDeclarationSyntax | ADR-0052 |  | tools/cs2gs/corpus/grid/G07-Members-Console/Constructs/EventDeclaration.cs |  | Explicit add/remove accessor event maps to the G# event declaration's explicit-accessor form (ADR-0052 §2); a source-declared named delegate handler type keeps its name (issue #1960 item 3) instead of the anonymous arrow form. |
 | EventFieldDeclaration | EventFieldDeclarationSyntax | ADR-0052 |  | tools/cs2gs/corpus/grid/G07-Members-Console/Constructs/EventFieldDeclaration.cs |  | Field-like event maps to the G# field-like event declaration (ADR-0052 §2); a source-declared named delegate handler type keeps its name (issue #1960 item 3) instead of the anonymous arrow form. |
@@ -159,7 +159,7 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | NameColon | NameColonSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G09-Functions-Console/Constructs/NameColon.cs |  | Named arguments use the G# name: value form (ADR-0080). |
 | NameEquals | NameEqualsSyntax | ADR-0115 §B.16 |  |  |  |  |
 | NamespaceDeclaration | NamespaceDeclarationSyntax | ADR-0115 §B.1 |  |  |  |  |
-| NotEqualsExpression | BinaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/NotEqualsExpression.cs |  | Tuple operands compare element-wise via gsc tuple equality (ADR-0171, issue #3501); element names never affect equality. |
+| NotEqualsExpression | BinaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/NotEqualsExpression.cs |  | Tuple operands compare element-wise via gsc tuple equality (ADR-0171, issue #3501); C# element names are ignored, matching the positional G# lowering. |
 | NotPattern | UnaryPatternSyntax | ADR-0115 §B.22 |  | tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/NotPattern.cs |  |  |
 | NullLiteralExpression | LiteralExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G01-Literals-Console/Constructs/NullLiteralExpression.cs |  |  |
 | NullableType | NullableTypeSyntax | ADR-0115 §B.12 |  |  |  | T? maps to G# nullable spelling. |
@@ -226,9 +226,9 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | ThrowStatement | ThrowStatementSyntax | ADR-0115 §B.27 |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/ThrowStatement.cs |  |  |
 | TrueLiteralExpression | LiteralExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G01-Literals-Console/Constructs/TrueLiteralExpression.cs |  |  |
 | TryStatement | TryStatementSyntax | ADR-0115 §B.27 |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/TryStatement.cs |  |  |
-| TupleElement | TupleElementSyntax | ADR-0115 §B.12 |  |  |  | G# tuple types; ADR-0172: C# element names are preserved name-first ((Line int32, Column int32)), and named access stays by-name. |
-| TupleExpression | TupleExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/TupleExpression.cs |  | ADR-0172: C# element labels ((Line: 1, …)) are preserved as G# labeled elements. |
-| TupleType | TupleTypeSyntax | ADR-0115 §B.12 |  |  |  | G# tuple types; ADR-0172: element names preserved (was: dropped with an Info diagnostic). |
+| TupleElement | TupleElementSyntax | ADR-0115 §B.12 |  |  |  | G# tuple types (T1, T2). |
+| TupleExpression | TupleExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/TupleExpression.cs |  |  |
+| TupleType | TupleTypeSyntax | ADR-0115 §B.12 |  |  |  | G# tuple types (T1, T2). |
 | TypeArgumentList | TypeArgumentListSyntax | ADR-0115 §B.7 |  | tools/cs2gs/corpus/grid/G08-Generics-Console/Constructs/TypeArgumentList.cs |  |  |
 | TypeConstraint | TypeConstraintSyntax | ADR-0115 §B.7 |  | tools/cs2gs/corpus/grid/G08-Generics-Console/Constructs/TypeConstraint.cs |  |  |
 | TypeOfExpression | TypeOfExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/TypeOfExpression.cs |  |  |

--- a/src/LanguageServer/HoverComputer.cs
+++ b/src/LanguageServer/HoverComputer.cs
@@ -2187,6 +2187,40 @@ public static class CompletionComputer
 
     private static void AddInstanceTypeMembers(List<CompletionItem> items, HashSet<string> seen, TypeSymbol type)
     {
+        // ADR-0172: a tuple receiver offers its declared element names first,
+        // then the positional ItemN spellings (both resolve).
+        if (type is TupleTypeSymbol tupleType)
+        {
+            for (var i = 0; i < tupleType.Arity; i++)
+            {
+                var elementDetail = SymbolDisplay.ToTypeDisplayString(tupleType.ElementTypes[i]);
+                if (tupleType.HasNames
+                    && tupleType.ElementNames[i] is { } elementName
+                    && seen.Add(elementName))
+                {
+                    items.Add(new CompletionItem
+                    {
+                        Label = elementName,
+                        Kind = CompletionItemKind.Field,
+                        Detail = elementDetail,
+                    });
+                }
+
+                var positional = "Item" + (i + 1).ToString(System.Globalization.CultureInfo.InvariantCulture);
+                if (seen.Add(positional))
+                {
+                    items.Add(new CompletionItem
+                    {
+                        Label = positional,
+                        Kind = CompletionItemKind.Field,
+                        Detail = elementDetail,
+                    });
+                }
+            }
+
+            return;
+        }
+
         if (type is StructSymbol structType)
         {
             AddStructInstanceMembers(items, seen, structType);

--- a/test/LanguageServer.Tests/CompletionHandlerTests.cs
+++ b/test/LanguageServer.Tests/CompletionHandlerTests.cs
@@ -116,6 +116,35 @@ public class CompletionHandlerTests
     }
 
     [Fact]
+    public void ComputeCompletions_AfterDotOnNamedTuple_OffersElementNamesAndItemN()
+    {
+        // ADR-0172: a named-tuple receiver offers its declared element names
+        // plus the positional ItemN spellings, and suppresses the global soup.
+        const string source = "let pos (line int32, column int32) = (3, 5)\npos.\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        var items = CompletionComputer.ComputeCompletions(content, After(source, "pos."));
+
+        Assert.Contains(items, i => i.Label == "line" && i.Kind == CompletionItemKind.Field);
+        Assert.Contains(items, i => i.Label == "column" && i.Kind == CompletionItemKind.Field);
+        Assert.Contains(items, i => i.Label == "Item1" && i.Kind == CompletionItemKind.Field);
+        Assert.Contains(items, i => i.Label == "Item2" && i.Kind == CompletionItemKind.Field);
+        Assert.DoesNotContain(items, i => i.Kind == CompletionItemKind.Keyword);
+    }
+
+    [Fact]
+    public void ComputeCompletions_AfterDotOnUnnamedTuple_OffersItemN()
+    {
+        const string source = "let pair = (1, \"x\")\npair.\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        var items = CompletionComputer.ComputeCompletions(content, After(source, "pair."));
+
+        Assert.Contains(items, i => i.Label == "Item1" && i.Kind == CompletionItemKind.Field);
+        Assert.Contains(items, i => i.Label == "Item2" && i.Kind == CompletionItemKind.Field);
+    }
+
+    [Fact]
     public void ComputeCompletions_AfterDotOnConsole_OffersStaticMembers()
     {
         const string source = "import System\nfunc main() {\nConsole.\n}\n";

--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GExpression.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GExpression.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Cs2Gs.CodeModel.Ast;
 
@@ -669,7 +670,8 @@ public sealed class WithExpression : GExpression
 }
 
 /// <summary>
-/// A tuple literal <c>(a, b, c)</c> (spec §Primary expressions, <c>TupleLiteral</c>).
+/// A tuple literal <c>(a, b, c)</c> (spec §Primary expressions,
+/// <c>TupleLiteral</c>) — or, with ADR-0172 labels, <c>(line: 1, column: 2)</c>.
 /// A tuple literal always has at least two elements.
 /// </summary>
 public sealed class TupleLiteralExpression : GExpression
@@ -678,13 +680,18 @@ public sealed class TupleLiteralExpression : GExpression
     /// Initializes a new instance of the <see cref="TupleLiteralExpression"/> class.
     /// </summary>
     /// <param name="elements">The tuple element expressions.</param>
-    public TupleLiteralExpression(IReadOnlyList<GExpression> elements)
+    /// <param name="elementNames">Optional per-element labels parallel to <paramref name="elements"/>, null where unlabeled; pass null for a fully unlabeled literal.</param>
+    public TupleLiteralExpression(IReadOnlyList<GExpression> elements, IReadOnlyList<string> elementNames = null)
     {
         Elements = elements ?? new List<GExpression>();
+        ElementNames = elementNames != null && elementNames.Any(n => n != null) ? elementNames : null;
     }
 
     /// <summary>Gets the tuple element expressions.</summary>
     public IReadOnlyList<GExpression> Elements { get; }
+
+    /// <summary>Gets the per-element labels parallel to <see cref="Elements"/> (<see langword="null"/> entries where unlabeled), or <see langword="null"/> when fully unlabeled (ADR-0172).</summary>
+    public IReadOnlyList<string> ElementNames { get; }
 }
 
 /// <summary>

--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GTypeReference.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GTypeReference.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.InteropServices;
 
 namespace Cs2Gs.CodeModel.Ast;
@@ -79,11 +80,11 @@ public sealed class ArrayTypeReference : GTypeReference
 }
 
 /// <summary>
-/// A positional tuple type rendered as <c>(T1, T2, …)</c> (spec §Type syntax,
-/// the <c>"(" TypeClause { "," TypeClause } ")"</c> production). C# value tuples
-/// (named or unnamed) map to this form; G# tuples are positional, so C# element
-/// names are dropped and named element access lowers to <c>.Item1</c>/<c>.Item2</c>
-/// (ADR-0115 §B.4). At least two element types are required for a tuple type.
+/// A tuple type rendered as <c>(T1, T2, …)</c> — or, when element names are
+/// present, the ADR-0172 name-first form <c>(line int32, column int32)</c>.
+/// C# value tuples (named or unnamed) map to this form with their element
+/// names preserved; access by name stays by-name in the output (ADR-0115
+/// §B.4 as amended by ADR-0172). At least two element types are required.
 /// </summary>
 public sealed class TupleTypeReference : GTypeReference
 {
@@ -91,13 +92,18 @@ public sealed class TupleTypeReference : GTypeReference
     /// Initializes a new instance of the <see cref="TupleTypeReference"/> class.
     /// </summary>
     /// <param name="elementTypes">The ordered element types.</param>
-    public TupleTypeReference(IReadOnlyList<GTypeReference> elementTypes)
+    /// <param name="elementNames">Optional element names parallel to <paramref name="elementTypes"/>, null where unnamed; pass null for a fully unnamed tuple.</param>
+    public TupleTypeReference(IReadOnlyList<GTypeReference> elementTypes, IReadOnlyList<string> elementNames = null)
     {
         ElementTypes = elementTypes ?? new List<GTypeReference>();
+        ElementNames = elementNames != null && elementNames.Any(n => n != null) ? elementNames : null;
     }
 
     /// <summary>Gets the ordered element types.</summary>
     public IReadOnlyList<GTypeReference> ElementTypes { get; }
+
+    /// <summary>Gets the element names parallel to <see cref="ElementTypes"/> (<see langword="null"/> entries for unnamed positions), or <see langword="null"/> when fully unnamed (ADR-0172).</summary>
+    public IReadOnlyList<string> ElementNames { get; }
 }
 
 /// <summary>

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -176,7 +176,11 @@ public static class GSharpPrinter
                 return $"*{RenderType(pointer.ElementType)}";
 
             case TupleTypeReference tuple:
-                return $"({string.Join(", ", tuple.ElementTypes.Select(RenderType))})";
+                // ADR-0172: element names render name-first — `(line int32, column int32)`.
+                return "(" + string.Join(", ", tuple.ElementTypes.Select((t, i) =>
+                    tuple.ElementNames?[i] is { } elementName
+                        ? $"{elementName} {RenderType(t)}"
+                        : RenderType(t))) + ")";
 
             case ArrowTypeReference arrow:
                 var prefix = arrow.IsAsync ? "async " : string.Empty;
@@ -685,7 +689,11 @@ public static class GSharpPrinter
                     : $"{allocation}{{{string.Join(", ", arrayAllocation.Elements.Select(e => RenderExpression(e, indent)))}}}";
 
             case TupleLiteralExpression tuple:
-                var tupleElements = string.Join(", ", tuple.Elements.Select(e => RenderExpression(e, indent)));
+                // ADR-0172: labeled elements render as `label: value`.
+                var tupleElements = string.Join(", ", tuple.Elements.Select((e, i) =>
+                    tuple.ElementNames?[i] is { } label
+                        ? $"{label}: {RenderExpression(e, indent)}"
+                        : RenderExpression(e, indent)));
                 return $"({tupleElements})";
 
             case UnaryExpression unary:

--- a/tools/cs2gs/Cs2Gs.Tests/Adr0172NamedTupleTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Adr0172NamedTupleTranslationTests.cs
@@ -1,0 +1,154 @@
+// <copyright file="Adr0172NamedTupleTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// ADR-0172 Phase C: cs2gs preserves C# tuple element names end-to-end —
+/// types print name-first (<c>(Line int32, Column int32)</c>), literal labels
+/// survive (<c>(Line: 1, Column: 2)</c>), and a named element ACCESS stays
+/// by-name instead of lowering to <c>.ItemN</c> (amending ADR-0115 §B.4).
+/// Every translated snippet must re-bind through the real G# compiler, which
+/// exercises gsc's own ADR-0172 front end. Witness of discrimination: before
+/// Phase C the printed output contained <c>(int32, int32)</c> and
+/// <c>.Item1</c>/<c>.Item2</c> for every case below.
+/// </summary>
+public class Adr0172NamedTupleTranslationTests
+{
+    [Fact]
+    public void NamedTupleType_PrintsNameFirst()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public sealed class C
+    {
+        public (int Line, int Column) Find() => (3, 5);
+    }
+}");
+
+        Assert.Contains("(Line int32, Column int32)", printed);
+        Assert.DoesNotContain("Item1", printed);
+    }
+
+    [Fact]
+    public void NamedElementAccess_StaysByName()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public sealed class C
+    {
+        public int Total()
+        {
+            (string Name, int Price, int Quantity) item = (""x"", 2, 3);
+            return item.Price * item.Quantity;
+        }
+    }
+}");
+
+        Assert.Contains("item.Price * item.Quantity", printed);
+        Assert.DoesNotContain("Item2", printed);
+        Assert.DoesNotContain("Item3", printed);
+    }
+
+    [Fact]
+    public void PositionalAccessOnNamedTuple_StaysPositional()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public sealed class C
+    {
+        public int First()
+        {
+            (int Line, int Column) pos = (3, 5);
+            return pos.Item1;
+        }
+    }
+}");
+
+        Assert.Contains("pos.Item1", printed);
+    }
+
+    [Fact]
+    public void LiteralLabels_ArePreserved()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public sealed class C
+    {
+        public (int Count, string Name) Make() => (Count: 3, Name: ""three"");
+    }
+}");
+
+        Assert.Contains("(Count: 3, Name: \"three\")", printed);
+    }
+
+    [Fact]
+    public void UnnamedTuples_Unchanged()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public sealed class C
+    {
+        public (int, string) Make() => (1, ""x"");
+        public int First() => Make().Item1;
+    }
+}");
+
+        Assert.Contains("(int32, string)", printed);
+        Assert.Contains(".Item1", printed);
+    }
+
+    [Fact]
+    public void NamedTupleInsideGeneric_PrintsNames()
+    {
+        string printed = TranslateUnit(@"
+using System.Collections.Generic;
+
+namespace Demo
+{
+    public sealed class C
+    {
+        public List<(int Line, int Column)> All() => new List<(int Line, int Column)>();
+        public int FirstLine() => All()[0].Line;
+    }
+}");
+
+        Assert.Contains("List[(Line int32, Column int32)]", printed);
+        Assert.Contains(".Line", printed);
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1914TupleAliasDirectiveTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1914TupleAliasDirectiveTests.cs
@@ -45,7 +45,8 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("let pair (int32, string) = (1, \"a\")", printed);
+        // ADR-0172: the alias's element names are preserved name-first.
+        Assert.Contains("let pair (Number int32, Word string) = (1, \"a\")", printed);
     }
 
     [Fact]
@@ -65,7 +66,8 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("func Make(seed (int32, string)) (int32, string)", printed);
+        // ADR-0172: the alias's element names are preserved name-first.
+        Assert.Contains("func Make(seed (Number int32, Word string)) (Number int32, Word string)", printed);
     }
 
     private static string TranslateUnit(string source)

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2469TupleElementNullabilityTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2469TupleElementNullabilityTranslationTests.cs
@@ -43,9 +43,9 @@ public static class Parser
 }");
 
         Assert.Contains(
-            "func Parse(text string) (string?, string?, Dictionary[string, string]?)",
+            "func Parse(text string) (Action string?, Method string?, Inputs Dictionary[string, string]?)",
             printed);
-        Assert.Contains("let method string? = parsed.Item2", printed);
+        Assert.Contains("let method string? = parsed.Method", printed);
         Assert.DoesNotContain("nil!!", printed);
     }
 
@@ -70,7 +70,7 @@ public static class Parser
 }");
 
         Assert.Contains(
-            "func Pick(flag bool, value int32) ((string?, string?), int32, string, int32?)",
+            "func Pick(flag bool, value int32) (Names (Left string?, Right string?), Count int32, Keep string, Maybe int32?)",
             printed);
     }
 
@@ -103,10 +103,10 @@ public sealed class Parser : ParserBase, IParser
     }
 }");
 
-        Assert.Contains("func ParseAsync() Task[(string?, string)];", printed);
-        Assert.Contains("async func ParseAsync() (string?, string)", printed);
-        Assert.Contains("open func Parse() (string?, string);", printed);
-        Assert.Contains("override func Parse() (string?, string)", printed);
+        Assert.Contains("func ParseAsync() Task[(Action string?, Method string)];", printed);
+        Assert.Contains("async func ParseAsync() (Action string?, Method string)", printed);
+        Assert.Contains("open func Parse() (Action string?, Method string);", printed);
+        Assert.Contains("override func Parse() (Action string?, Method string)", printed);
     }
 
     [Fact]
@@ -132,8 +132,8 @@ public static class Parser
     }
 }");
 
-        Assert.Contains("func Generic[T class]() (T?, int32, int32?)", printed);
-        Assert.Contains("func Get() (string?, string)", printed);
+        Assert.Contains("func Generic[T class]() (Value T?, Count int32, Maybe int32?)", printed);
+        Assert.Contains("func Get() (First string?, Second string)", printed);
         Assert.Contains("func Forward() string?", printed);
     }
 
@@ -151,8 +151,8 @@ public static class Parser
     }
 }");
 
-        Assert.Contains("func Parse() (string, string?, int32, int32?)", printed);
-        Assert.DoesNotContain("(string?, string?, int32, int32?)", printed);
+        Assert.Contains("func Parse() (Required string, Optional string?, Count int32, Maybe int32?)", printed);
+        Assert.DoesNotContain("Required string?", printed);
     }
 
     [Fact]
@@ -196,8 +196,8 @@ namespace LibA
             siblings,
             "Consumer fixture omits the sibling Parser declaration from its emitted G# binding input.");
 
-        Assert.Contains("func Parse() (string?, string)", printedB);
-        Assert.Contains("func Parse() (string?, string)", printedA);
+        Assert.Contains("func Parse() (Action string?, Method string)", printedB);
+        Assert.Contains("func Parse() (Action string?, Method string)", printedA);
     }
 
     private static string TranslateOblivious(string source)

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3615TupleReceiverPromotionProbeTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3615TupleReceiverPromotionProbeTests.cs
@@ -87,7 +87,7 @@ public sealed class Registry
 ";
         string printed = Render(source);
         Assert.DoesNotContain("(SyntaxTree?", printed, StringComparison.Ordinal);
-        Assert.Contains("HashSet[(SyntaxTree, int32, int32)]", printed, StringComparison.Ordinal);
+        Assert.Contains("HashSet[(Tree SyntaxTree, Start int32, Length int32)]", printed, StringComparison.Ordinal);
         AssertRoundTripParses(printed);
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/ObliviousPromotionSinkCompilationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/ObliviousPromotionSinkCompilationTests.cs
@@ -121,7 +121,7 @@ namespace Demo
         Assert.Contains("Field:", printed);
         Assert.Contains("default(string?)", printed);
         Assert.Contains(
-            "Parse(text string) (string?, string?, Dictionary[string, string]?)",
+            "Parse(text string) (Action string?, Method string?, Inputs Dictionary[string, string]?)",
             printed);
         CompileWithGsc(printed);
     }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.ControlFlow.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.ControlFlow.cs
@@ -1532,7 +1532,7 @@ public sealed partial class CSharpToGSharpTranslator
                 PointerTypeReference pointer =>
                     new PointerTypeReference(pointer.ElementType) { IsNullable = true },
                 TupleTypeReference tuple =>
-                    new TupleTypeReference(tuple.ElementTypes) { IsNullable = true },
+                    new TupleTypeReference(tuple.ElementTypes, tuple.ElementNames) { IsNullable = true },
                 ArrowTypeReference arrow =>
                     new ArrowTypeReference(arrow.ParameterTypes, arrow.ReturnTypes, arrow.IsAsync)
                     {

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -690,17 +690,21 @@ public sealed partial class CSharpToGSharpTranslator
             // avoids entirely.)
             bool isArrow = member.IsKind(SyntaxKind.PointerMemberAccessExpression);
 
-            // A C# tuple element access (`item.Name`, `item.Price`) lowers to the
-            // positional G# tuple field `.Item1`/`.Item2`, because G# tuples are
-            // positional and carry no element names (ADR-0115 §B.4). The default
-            // `.ItemN` access already resolves; only named-element access needs the
-            // rewrite, detected via the bound tuple-element field symbol.
+            // ADR-0172 (amending ADR-0115 §B.4): G# now has named tuple
+            // elements, so an explicitly named C# element access (`item.Price`)
+            // KEEPS its name in the output — the translated tuple type carries
+            // the same names. The symbol still normalizes to the positional
+            // field for downstream taint/typing; only the printed name differs.
             if (memberSymbol is IFieldSymbol field &&
                 field.ContainingType is { IsTupleType: true })
             {
                 IFieldSymbol positional = field.CorrespondingTupleField ?? field;
-                memberName = positional.Name;
-                memberSymbol = positional;
+                if (SymbolEqualityComparer.Default.Equals(positional, field))
+                {
+                    // Default positional access (`item.Item2`) stays positional.
+                    memberName = positional.Name;
+                    memberSymbol = positional;
+                }
             }
 
             // Issue #2282 (was #2224): an anonymous-typed value (`new { A = 1,

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
@@ -335,7 +335,7 @@ public sealed partial class CSharpToGSharpTranslator
             }
 
             return changed
-                ? new TupleTypeReference(elements) { IsNullable = tuple.IsNullable }
+                ? new TupleTypeReference(elements, tuple.ElementNames) { IsNullable = tuple.IsNullable }
                 : tuple;
         }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -162,8 +162,11 @@ public sealed partial class CSharpToGSharpTranslator
                     return this.TranslateInterpolatedString(interpolated);
 
                 case TupleExpressionSyntax tuple:
+                    // ADR-0172: preserve C# element labels (`(Line: 1, …)`)
+                    // as G# labeled tuple-literal elements.
                     return new TupleLiteralExpression(
-                        tuple.Arguments.Select(a => this.TranslateValueWithNullForgiveness(a.Expression)).ToList());
+                        tuple.Arguments.Select(a => this.TranslateValueWithNullForgiveness(a.Expression)).ToList(),
+                        tuple.Arguments.Select(a => a.NameColon?.Name.Identifier.ValueText).ToList());
 
                 case AnonymousObjectCreationExpressionSyntax anonymous:
                     return this.TranslateAnonymousObjectCreation(anonymous);

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -1333,7 +1333,7 @@ public sealed class CSharpTypeMapper
             case PointerTypeReference pointer:
                 return new PointerTypeReference(pointer.ElementType) { IsNullable = isNullable };
             case TupleTypeReference tuple:
-                return new TupleTypeReference(tuple.ElementTypes) { IsNullable = isNullable };
+                return new TupleTypeReference(tuple.ElementTypes, tuple.ElementNames) { IsNullable = isNullable };
             case ArrowTypeReference arrow:
                 return new ArrowTypeReference(arrow.ParameterTypes, arrow.ReturnTypes, arrow.IsAsync)
                 {
@@ -1408,21 +1408,23 @@ public sealed class CSharpTypeMapper
 
         if (type is INamedTypeSymbol named)
         {
-            // Value tuples / named tuples map to the canonical G# positional
-            // tuple type `(T1, T2, …)` (spec §Type syntax). G# tuples are
-            // positional, so C# element names are dropped here and named element
-            // access lowers to `.Item1`/`.Item2` at the use site (ADR-0115 §B.4).
+            // Value tuples map to the native G# tuple type. ADR-0172: G#
+            // now has named tuple elements, so C# element names are
+            // PRESERVED name-first — `(int Line, int Column)` becomes
+            // `(Line int32, Column int32)` — and named access stays by-name
+            // at the use site (ADR-0115 §B.4 as amended). A default
+            // positional name (`Item1` at position 1, …) counts as unnamed.
             if (named.IsTupleType)
             {
                 List<GTypeReference> elementTypes = named.TupleElements
                     .Select(e => this.Map(e.Type, context, location))
                     .ToList();
-                context.Report(new TranslationDiagnostic(
-                    named.ToDisplayString(),
-                    "C# value-tuple / named-tuple type mapped to the canonical G# positional tuple type; element names are dropped and named access lowers to '.ItemN' (ADR-0115 §B.4).",
-                    location,
-                    TranslationSeverity.Info));
-                return new TupleTypeReference(elementTypes);
+                List<string> elementNames = named.TupleElements
+                    .Select((e, i) => e.IsImplicitlyDeclared || e.Name == "Item" + (i + 1)
+                        ? null
+                        : e.Name)
+                    .ToList();
+                return new TupleTypeReference(elementTypes, elementNames);
             }
 
             // Issue #2282 (was #1934): an anonymous type (`new { A = 1, B = 2 }`)
@@ -2258,7 +2260,7 @@ public sealed class CSharpTypeMapper
             }
 
             return changed
-                ? new TupleTypeReference(elements) { IsNullable = mappedTuple.IsNullable }
+                ? new TupleTypeReference(elements, mappedTuple.ElementNames) { IsNullable = mappedTuple.IsNullable }
                 : mapped;
         }
 

--- a/tools/cs2gs/coverage/csharp-construct-inventory.json
+++ b/tools/cs2gs/coverage/csharp-construct-inventory.json
@@ -749,7 +749,7 @@
     "rule": "ADR-0115 \u00A7B",
     "rationale": "None",
     "fixture": "tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/EqualsExpression.cs",
-    "notes": "Tuple operands compare element-wise via gsc tuple equality (ADR-0171, issue #3501); C# element names are ignored, matching the positional G# lowering."
+    "notes": "Tuple operands compare element-wise via gsc tuple equality (ADR-0171, issue #3501); element names never affect equality."
   },
   {
     "kind": "EqualsValueClause",
@@ -1500,7 +1500,7 @@
     "rule": "ADR-0115 \u00A7B",
     "rationale": "None",
     "fixture": "tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/NotEqualsExpression.cs",
-    "notes": "Tuple operands compare element-wise via gsc tuple equality (ADR-0171, issue #3501); C# element names are ignored, matching the positional G# lowering."
+    "notes": "Tuple operands compare element-wise via gsc tuple equality (ADR-0171, issue #3501); element names never affect equality."
   },
   {
     "kind": "NotPattern",
@@ -2213,7 +2213,7 @@
     "status": "Translated",
     "rule": "ADR-0115 \u00A7B.12",
     "rationale": "None",
-    "notes": "G# tuple types (T1, T2)."
+    "notes": "G# tuple types; ADR-0172: C# element names are preserved name-first ((Line int32, Column int32)), and named access stays by-name."
   },
   {
     "kind": "TupleExpression",
@@ -2221,7 +2221,8 @@
     "status": "Translated",
     "rule": "ADR-0115 \u00A7B",
     "rationale": "None",
-    "fixture": "tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/TupleExpression.cs"
+    "fixture": "tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/TupleExpression.cs",
+    "notes": "ADR-0172: C# element labels ((Line: 1, \u2026)) are preserved as G# labeled elements."
   },
   {
     "kind": "TupleType",
@@ -2229,7 +2230,7 @@
     "status": "Translated",
     "rule": "ADR-0115 \u00A7B.12",
     "rationale": "None",
-    "notes": "G# tuple types (T1, T2)."
+    "notes": "G# tuple types; ADR-0172: element names preserved (was: dropped with an Info diagnostic)."
   },
   {
     "kind": "TypeArgumentList",


### PR DESCRIPTION
## Summary

**Stacked on #3622** (named tuple elements, Phases A+B) — Phase C of ADR-0172: cs2gs stops erasing C# tuple element names, delivering the #3501 readability win across the ~830 named-tuple declaration lines in the self-migration corpus.

- **Types** print name-first: `(int Line, int Column)` → `(Line int32, Column int32)` (`CSharpTypeMapper` keeps Roslyn's `TupleElements` names; a default `ItemN`-at-position counts as unnamed; the ADR-0115 §B.4 name-drop Info diagnostic is retired). Names survive the nullability-promotion rebuild sites too (oblivious promotion, whole-type nullable wraps).
- **Literal labels** survive: `(Count: 3, Name: "three")` via `NameColon`.
- **Named element access stays by-name**: `item.Price * item.Quantity` round-trips verbatim where it previously lowered to `item.Item2 * item.Item3`; default positional `.ItemN` access still normalizes positionally.
- `TupleTypeReference` / `TupleLiteralExpression` gain optional element-name lists; the printer renders both forms.

### Verification

- New `Adr0172NamedTupleTranslationTests` (6): name-first types, by-name access, positional access unchanged, literal labels, unnamed tuples unchanged, names inside generics — every snippet re-binds through the real gsc (exercising the #3622 front end).
- Existing tuple-behavior tests updated to the named surface (Issue1914 alias, Issue2469 nullability ×6, Issue3615 receiver probe, oblivious-promotion sinks); coverage-matrix notes moved into the inventory and `docs/cs2gs-coverage-matrix.md` regenerated via `cs2gs coverage --write`.
- **Full Cs2Gs.Tests green** (2454 tests; the two last local failures were a stale `out/bin/Release` gsc found by `FindCompiler` — rebuilt — and a stale expectation).
- **Corpus diagnostic-run 18/20 green** with the branch gsc (CompileGap-Library is the known wontfix; L3-Library's test-parity failure is the documented stale-SDK-nupkg trap — the parity stage rebuilds with the packaged gsc, which predates ADR-0172; CI builds the SDK from the same commit). Translated L1 now reads `total += item.Price * item.Quantity` with `List[(Name string, Price int32, Quantity int32)]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs