### PR TITLE
cs2gs: escape keyword-named packages on the namespace-split path (ADR-0170, #3610)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue3461IdentifierSanitizationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3461IdentifierSanitizationTests.cs
@@ -1182,6 +1182,56 @@ public sealed class Issue3461IdentifierSanitizationTests
         Assert.False(match.Success, $"raw identifier '{identifier}' leaked into translated G#:\n{rendered}");
     }
 
+    /// <summary>Issue #3610 / ADR-0170 follow-up: the repository-mode
+    /// package-split path resolves each split unit's package through
+    /// <c>ResolvePackageName</c> with the C# DISPLAY spelling of the
+    /// namespace (<c>@class</c> from <c>ToDisplayString</c>). The symbol
+    /// walk must compare the bare metadata name so a keyword-named
+    /// namespace prints as the G# <c>$class</c> escape — the raw <c>@</c>
+    /// text does not round-trip-parse (the Cs2Gs.Tests selfmig AtToken
+    /// wall in the 2026-08-28 nightly).</summary>
+    [Fact]
+    public void PackageSplit_KeywordNamespace_PrintsEscapedPackage()
+    {
+        const string source = """
+            namespace @class
+            {
+                public sealed class @defer
+                {
+                    public int Value => 19;
+                }
+            }
+
+            namespace Other
+            {
+                public sealed class Marker
+                {
+                }
+            }
+            """;
+
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Issue3461Split.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+
+        // The pipeline hands the split translator ToDisplayString packages.
+        IReadOnlyList<string> packages = CSharpToGSharpTranslator.GetDeclaredPackages(document);
+        Assert.Contains("@class", packages);
+
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        var splitTranslator = new CSharpToGSharpTranslator(packageFilter: "@class");
+        string printed = GSharpPrinter.Print(splitTranslator.TranslateDocument(document, context));
+
+        Assert.Contains("package $class", printed);
+        Assert.DoesNotContain("@class", printed);
+        Assert.Contains("class $defer", printed);
+    }
+
     private static string Render(
         string source,
         IReadOnlyList<MetadataReference> references = null)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -1097,8 +1097,18 @@ public sealed partial class CSharpToGSharpTranslator
         EmittedNameAllocator nameAllocator)
     {
         INamespaceSymbol current = context.Compilation.GlobalNamespace;
-        foreach (string segment in packageName.Split('.'))
+        foreach (string rawSegment in packageName.Split('.'))
         {
+            // Issue #3610 / ADR-0170: a keyword-named namespace arrives in its
+            // C# display spelling (`@class`) — from ToDisplayString on the
+            // package-split path — while the SYMBOL's Name is the bare
+            // metadata name (`class`). Compare the bare spelling so the walk
+            // succeeds and the allocator can hand back the G# `$class`
+            // escape; falling through returned the raw `@` text, which does
+            // not round-trip-parse (the Cs2Gs.Tests selfmig AtToken wall).
+            string segment = rawSegment.Length > 1 && rawSegment[0] == '@'
+                ? rawSegment.Substring(1)
+                : rawSegment;
             current = current.GetNamespaceMembers()
                 .FirstOrDefault(candidate => candidate.Name == segment);
             if (current == null)


### PR DESCRIPTION
## Summary

Root-causes and fixes the residual **`AtToken` round-trip wall** from the 2026-08-28 selfmig nightly ([run 33217212584](https://github.com/DavidObando/gsharp/actions/runs/33217212584)), pinned to `Issue3461ReservedMetadataFixtures.cs`.

**Root cause:** the repository-mode **namespace-split** path feeds `ResolvePackageName` the C# *display* spelling of the package (`ToDisplayString()` → `@class` for `namespace @class`), but the resolver's namespace-symbol walk compared segments against the bare metadata name (`class`). The mismatch fell through to returning the raw text, so the split unit printed `package @class` — which gsc's parser rejects (`GS0005: Unexpected token <AtToken>`), failing the translator's round-trip validation. Class names were unaffected (`class $defer` printed correctly); only the package line missed the ADR-0170 escape.

**Fix:** strip a leading `@` from each dotted segment before the symbol comparison, so the walk reaches the namespace symbol and the emitted-name allocator returns the G# `$class` escape.

## Verification

- New pinning test `PackageSplit_KeywordNamespace_PrintsEscapedPackage` (drives the exact pipeline shape: `GetDeclaredPackages` display spelling → `packageFilter` translator → asserts `package $class`, no `@`). All 35 Issue3461 suites green.
- Reproduced the nightly failure locally first (repo-mode migrate of the cs2gs subtree at nightly tip 81e8685c → same `translate-9dd020ef25f2` AtToken fingerprint), then re-ran with the fix: the fingerprint disappears, the emitted file reads `package $class`, and Cs2Gs.Tests' only remaining translate gap is the known `params ReadOnlySpan<int>` CS2GS-GAP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs