### PR TITLE
gsc: awaited imported Task[(named)] keeps element names (ADR-0172, #3501)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -1580,6 +1580,20 @@ internal sealed partial class ExpressionBinder
     {
         element = null;
 
+        // ADR-0172: an imported awaitable whose signature carries reference-
+        // nullability metadata arrives wrapped in a
+        // NullabilityAnnotatedTypeSymbol, hiding the symbolic constructed
+        // base from the fast path below — and the CLR fallback would erase a
+        // named-tuple element's names (they share the unnamed CLR backing).
+        // Unwrap to the symbolic base exactly when names are at stake; the
+        // base's arguments already carry their element nullability.
+        if (type is NullabilityAnnotatedTypeSymbol annotatedAwaitable
+            && annotatedAwaitable.BaseType is ImportedTypeSymbol { TypeArguments.IsDefaultOrEmpty: false } symbolicAwaitable
+            && symbolicAwaitable.TypeArguments.Any(TypeSymbol.ContainsNamedTupleElements))
+        {
+            type = symbolicAwaitable;
+        }
+
         // Issue #2195: for an imported generic awaitable (e.g. `Task[T]`,
         // `ValueTask[T]`) recover the awaited ELEMENT type from the SYMBOLIC
         // type argument rather than the awaiter's CLR `GetResult()` return

--- a/test/Compiler.Tests/Emit/NamedTupleMetadataEmitTests.cs
+++ b/test/Compiler.Tests/Emit/NamedTupleMetadataEmitTests.cs
@@ -173,6 +173,57 @@ public class NamedTupleMetadataEmitTests
         Assert.Equal($"3{Environment.NewLine}5{Environment.NewLine}3{Environment.NewLine}", output);
     }
 
+    [Fact]
+    public void GsToGsRoundTrip_AwaitedTaskOfNamedTuple_KeepsNames()
+    {
+        // The imported awaitable arrives wrapped in nullability metadata
+        // (NullabilityAnnotatedTypeSymbol); the await element derivation must
+        // unwrap to the symbolic Task so `t.line` still binds — and the
+        // nullable named tuple (`(line int32, gitRef string?)?`) must survive
+        // an if-let unwrap of the awaited value.
+        var libSource = """
+            package NamedAsyncLib
+            import System.Threading.Tasks
+
+            class Fetcher {
+                shared {
+                    async func Find() (line int32, column int32) {
+                        await Task.Delay(1)
+                        return (3, 5)
+                    }
+
+                    async func TryFind(ok bool) (line int32, gitRef string?)? {
+                        await Task.Delay(1)
+                        if ok {
+                            return (7, "main")
+                        }
+
+                        return nil
+                    }
+                }
+            }
+            """;
+        var appSource = """
+            package App
+            import System
+            import NamedAsyncLib
+
+            async func run() {
+                let t = await Fetcher.Find()
+                Console.WriteLine(t.line)
+                if let r = await Fetcher.TryFind(true) {
+                    Console.WriteLine(r.line)
+                    Console.WriteLine(r.gitRef)
+                }
+            }
+
+            run().Wait()
+            """;
+
+        var output = CompileAndRunWithLibrary(libSource, appSource, libraryName: "NamedAsyncLib");
+        Assert.Equal($"3{Environment.NewLine}7{Environment.NewLine}main{Environment.NewLine}", output);
+    }
+
     private static string[] ReadNames(ICustomAttributeProvider provider)
     {
         var data = FindAttribute(provider);
@@ -205,13 +256,13 @@ public class NamedTupleMetadataEmitTests
         return Assembly.Load(File.ReadAllBytes(outPath));
     }
 
-    private static string CompileAndRunWithLibrary(string libSource, string appSource)
+    private static string CompileAndRunWithLibrary(string libSource, string appSource, string libraryName = "namedlib")
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_ntuple_rt_").FullName;
         try
         {
             var libSrc = Path.Combine(tempDir, "lib.gs");
-            var libDll = Path.Combine(tempDir, "namedlib.dll");
+            var libDll = Path.Combine(tempDir, libraryName + ".dll");
             var appSrc = Path.Combine(tempDir, "app.gs");
             var appDll = Path.Combine(tempDir, "app.dll");
             File.WriteAllText(libSrc, libSource);


### PR DESCRIPTION
## Summary

Follow-up to #3622: the code-exploder gate's `GS0158: Cannot find member AnalysisId` family. An imported awaitable whose signature carries reference-nullability metadata arrives wrapped in `NullabilityAnnotatedTypeSymbol`, hiding the symbolic constructed `Task` from `TryGetTaskElementType`'s #2195 fast path — the CLR fallback rebuilt the element from the closed `ValueTuple` and erased its names, so `(await store.RetryAsync(id)).AnalysisId` failed to bind. Fix: unwrap to the symbolic base exactly when a type argument carries named-tuple content (`ContainsNamedTupleElements` gate, matching the #3622 projection-gate family); the base's arguments already carry their element nullability.

Verified on the pinned code-exploder `Task<(Guid AnalysisId, string? GitRef)?>` shape reduced to a minimal cross-assembly repro (compiles + runs), plus a new round-trip test covering `await` element access and an if-let unwrap of an awaited nullable named tuple. Async/await suites green (Compiler.Tests 326, Core.Tests 453).

**Known follow-up (pre-existing, reproduced without this change):** an async-function `if let` over a *non-awaited* imported call returning `Nullable<ValueTuple<…>>`-with-names emits invalid IL — ILVerify `StackUnexpected: found Nullobjref, expected Nullable<ValueTuple<int32,string>>` in `MoveNext` — filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs