### PR TITLE
cs2gs: preserve designations on nested untyped property patterns (selfmig nightly regression)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/NestedPatternDesignationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/NestedPatternDesignationTranslationTests.cs
@@ -1,0 +1,134 @@
+// <copyright file="NestedPatternDesignationTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// A designation on a NESTED untyped property pattern
+/// (<c>{ ClrType: { IsGenericType: true } closedClr }</c>) must survive
+/// translation as G#'s native ADR-0166 after-brace designator. The untyped
+/// recursive-pattern branch used to drop <c>Designation</c> entirely,
+/// orphaning every body reference to the binder (GS0125/GS0159) — the
+/// 2026-08-29 selfmig nightly regression on
+/// <c>TupleElementNamesReader.cs</c> that cascaded migrated
+/// <c>src/Core</c> compile failures into 18 downstream apps.
+/// </summary>
+public class NestedPatternDesignationTranslationTests
+{
+    private const string HolderSource = """
+        using System;
+
+        namespace Demo
+        {
+            public sealed class Holder
+            {
+                public Type? ClrType { get; init; }
+            }
+
+            public static class Repro
+            {
+        """;
+
+    [Fact]
+    public void SwitchStatement_NestedPropertyPatternDesignation_Preserved()
+    {
+        string printed = Translate(HolderSource + """
+                public static int Classify(Holder holder)
+                {
+                    switch (holder)
+                    {
+                        case { ClrType: { IsGenericType: true, IsGenericTypeDefinition: false } closedClr }:
+                            return closedClr.GetGenericArguments().Length;
+
+                        default:
+                            return -1;
+                    }
+                }
+
+                public static int Run()
+                {
+                    var generic = new Holder { ClrType = typeof(System.Collections.Generic.List<int>) };
+                    return (Classify(generic) * 10) + Classify(new Holder()) + 1;
+                }
+            }
+        }
+        """);
+
+        Assert.Contains(
+            "case { ClrType: { IsGenericType: true, IsGenericTypeDefinition: false } closedClr }",
+            printed,
+            StringComparison.Ordinal);
+        Assert.Contains("closedClr.GetGenericArguments().Length", printed, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(printed);
+
+        LocalFunctionHoistTranslationTests.CompileAndRun(
+            printed,
+            "System.Console.WriteLine(Demo.Repro.Run())",
+            "10");
+    }
+
+    [Fact]
+    public void IsPattern_NestedPropertyPatternDesignation_Preserved()
+    {
+        string printed = Translate(HolderSource + """
+                public static int ViaIs(Holder holder)
+                {
+                    if (holder is { ClrType: { IsGenericType: true } closedClr })
+                    {
+                        return closedClr.GetGenericArguments().Length;
+                    }
+
+                    return -1;
+                }
+            }
+        }
+        """);
+
+        Assert.Contains(
+            "is { ClrType: { IsGenericType: true } closedClr }",
+            printed,
+            StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(printed);
+    }
+
+    [Fact]
+    public void SwitchExpression_NestedPropertyPatternDesignation_Preserved()
+    {
+        string printed = Translate(HolderSource + """
+                public static int Via(Holder holder) => holder switch
+                {
+                    { ClrType: { IsGenericType: true } closedClr } => closedClr.GetGenericArguments().Length,
+                    _ => -1,
+                };
+            }
+        }
+        """);
+
+        Assert.Contains(
+            "case { ClrType: { IsGenericType: true } closedClr }:",
+            printed,
+            StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(printed);
+    }
+
+    private static string Translate(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
@@ -1956,7 +1956,40 @@ public sealed partial class CSharpToGSharpTranslator
                     }
                 }
 
-                return new PropertyPattern(fields);
+                // A designation on the (possibly nested) untyped property
+                // pattern (`{ ClrType: { IsGenericType: true } closedClr }`)
+                // maps to G#'s native ADR-0166 designator after the closing
+                // brace — dropping it orphans every body reference to the
+                // binder (the nightly selfmig regression on
+                // TupleElementNamesReader.cs).
+                string propertyDesignator = null;
+                if (recursive.Designation is SingleVariableDesignationSyntax propertyVariable)
+                {
+                    propertyDesignator = this.EmittedName(propertyVariable, propertyVariable.Identifier);
+                    if (mutableBindings != null
+                        && this.context.GetDeclaredSymbol(propertyVariable) is ILocalSymbol propertySymbol
+                        && this.IsSymbolReassigned(
+                            propertySymbol,
+                            this.state.CurrentBodyScope ?? recursive.SyntaxTree.GetRoot()))
+                    {
+                        string captureName =
+                            this.NewMutableSwitchPatternCaptureName(recursive, usedDesignators);
+                        mutableBindings.Add((propertySymbol, new IdentifierExpression(captureName)));
+                        propertyDesignator = captureName;
+                    }
+                    else
+                    {
+                        usedDesignators?.Add(propertyDesignator);
+                    }
+                }
+                else if (recursive.Designation is ParenthesizedVariableDesignationSyntax)
+                {
+                    this.context.ReportUnsupported(
+                        recursive,
+                        "property pattern with tuple designation has no canonical G# form yet (ADR-0115 §B).");
+                }
+
+                return new PropertyPattern(fields, propertyDesignator);
             }
 
             // Typed recursive pattern: synthesize a designator named after the type


### PR DESCRIPTION
Fixes the systemic failure in the 2026-08-29 selfmig nightly ([run 33234797980](https://github.com/DavidObando/gsharp/actions/runs/33234797980)): 18 apps shared the same two compile fingerprints (`GS0159 Cannot find function GetGenericArguments` / `GS0125 Variable 'closedClr' doesn't exist`), all cascading from migrated `src/Core` failing to compile — which dropped the gate to 28/52 green against floor 33.

## Root cause

`TranslateRecursivePattern`'s untyped branch returned `new PropertyPattern(fields)` without ever consulting `recursive.Designation`. A designation on a **nested** untyped property pattern was silently dropped while the body still referenced the binder:

```csharp
// TupleElementNamesReader.cs:202 (added by #3622) — the trigger
case { ClrType: { IsGenericType: true, IsGenericTypeDefinition: false } closedClr }:
    ... closedClr.GetGenericArguments() ...
```

translated to a pattern without `closedClr`, orphaning the body references.

## Fix

G# natively supports the after-brace designator (ADR-0166, `PropertyPattern identifier?` in the spec grammar), and the code model + printer already carry a `Designator` — the translator now populates it, with reassigned-binder capture mirroring the existing var-pattern path, and an explicit unsupported report for tuple designations. Verified that gsc compiles and runs the nested-designation form correctly (narrowed non-nil binding, parity with C# semantics).

## Tests

`NestedPatternDesignationTranslationTests` — switch statement (with compile+run parity witness: generic vs nil holder), boolean `is`-pattern, and switch expression. Full pattern-related Cs2Gs.Tests family green (188/188).

Note: this is independent of #3630; the C# trigger shape came from #3622 (merged), so the regression exists on main regardless of the variadic-carriers branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs