### PR TITLE
gsc: keep named-tuple-bearing generic arguments symbolic at every projection gate (ADR-0172)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -4988,9 +4988,14 @@ public sealed class Binder
     {
         // #313 / #671 / #3560: preserve symbolic type parameters, user types,
         // and tuple conversion semantics beside their CLR form.
+        // ADR-0172: a named-tuple-bearing argument at ANY nesting depth
+        // (`List[(a int32, b string)]`, `[](a int32, b string)`) shares its
+        // CLR backing with the unnamed shape — only the symbolic argument
+        // preserves the names on projected members.
         if (TypeSymbol.RequiresSymbolicProjection(type)
             || type.ClrType == null
-            || type is TupleTypeSymbol)
+            || type is TupleTypeSymbol
+            || TypeSymbol.ContainsNamedTupleElements(type))
         {
             hasSymbolicArgument = true;
 

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -1520,7 +1520,8 @@ internal sealed class ConversionClassifier
         return mapped != null
             && mapped != TypeSymbol.Error
             && (TypeSymbol.RequiresSymbolicProjection(mapped)
-                || mapped is TupleTypeSymbol)
+                || mapped is TupleTypeSymbol
+                || TypeSymbol.ContainsNamedTupleElements(mapped))
             ? mapped
             : null;
     }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
@@ -3056,7 +3056,11 @@ internal sealed partial class ExpressionBinder
             // `Comparer<!TResult>` TypeSpec instead of the erased
             // `Comparer<object>` — yielding verifiable IL exactly as the
             // concrete-argument receiver does.
-            var symbolicReceiver = typeArgs.Any(TypeSymbol.RequiresSymbolicProjection)
+            // ADR-0172: a named-tuple-bearing argument at any nesting depth
+            // (`List[List[(a int32, b string)]]`) shares its CLR backing with
+            // the unnamed shape — only the symbolic view preserves the names.
+            var symbolicReceiver = typeArgs.Any(static a =>
+                TypeSymbol.RequiresSymbolicProjection(a) || TypeSymbol.ContainsNamedTupleElements(a))
                 ? ImportedTypeSymbol.GetConstructed(closed, openClrType, typeArgs)
                 : null;
             constructedImported = new ImportedClassSymbol(closed, receiverSyntax, symbolicReceiver, scope.References);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
@@ -2288,7 +2288,14 @@ internal sealed partial class ExpressionBinder
         // (e.g. `outer[0]` on `List[List[MyGs]]` -> `List[MyGs]`); without
         // this the element would type-erase to `List<object>` and downstream
         // member access on the result would emit against the wrong parent.
-        if (target.HasSubstitutableTypeArgument
+        // ADR-0172: `HasSubstitutableTypeArgument` only counts a DIRECT named
+        // tuple argument; a named tuple nested deeper in the argument
+        // (`List[[](a int32, b string)]`) still needs the substitution to
+        // surface its names, so widen the gate here without changing the
+        // property's broader (conversion/lowering) meaning.
+        if ((target.HasSubstitutableTypeArgument
+                || (!target.TypeArguments.IsDefaultOrEmpty
+                    && target.TypeArguments.Any(TypeSymbol.ContainsNamedTupleElements)))
             && target.OpenDefinition is System.Type openDefinition)
         {
             try
@@ -2328,7 +2335,8 @@ internal sealed partial class ExpressionBinder
                             target.TypeArguments);
                         if (projected != null
                             && projected != TypeSymbol.Error
-                            && TypeSymbol.RequiresSymbolicProjection(projected))
+                            && (TypeSymbol.RequiresSymbolicProjection(projected)
+                                || TypeSymbol.ContainsNamedTupleElements(projected)))
                         {
                             return openElement.IsByRef ? ByRefTypeSymbol.Get(projected) : projected;
                         }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -1585,7 +1585,12 @@ internal sealed partial class ExpressionBinder
 
             // Issues #2664/#3560: preserve symbolic shapes and tuple conversion
             // semantics so member arguments can recover their language target.
-            if (TypeSymbol.RequiresSymbolicProjection(ta) || ta is TupleTypeSymbol)
+            // ADR-0172: a named-tuple-bearing argument at ANY nesting depth
+            // (`List[(a int32, b string)]`) shares its CLR backing with the
+            // unnamed shape — only the symbolic argument preserves the names.
+            if (TypeSymbol.RequiresSymbolicProjection(ta)
+                || ta is TupleTypeSymbol
+                || TypeSymbol.ContainsNamedTupleElements(ta))
             {
                 hasSymbolicArg = true;
             }

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -1193,7 +1193,12 @@ internal sealed class MemberLookup
                 // receiver keep the `Check` element identity instead of
                 // collapsing to the type-erased `IEnumerable<object>` (which
                 // for a value-type element is not even a legal up-cast).
+                // ADR-0172: a named-tuple-bearing argument (at any nesting
+                // depth — `List[(a int32, b string)]` as the argument of an
+                // outer generic) shares its CLR backing with the unnamed
+                // shape, so collapsing to FromClrType would erase the names.
                 if (TypeSymbol.RequiresSymbolicProjection(mapped)
+                    || TypeSymbol.ContainsNamedTupleElements(mapped)
                     || (a.ContainsGenericParameters
                         && mapped.ClrType?.ContainsGenericParameters == false))
                 {
@@ -3797,7 +3802,8 @@ internal sealed class MemberLookup
                 if (!projectOnlyWhenSymbolicallyRequired
                     || openProperty.PropertyType.IsGenericParameter
                     || (openProperty.PropertyType.ContainsGenericParameters
-                        && TypeSymbol.RequiresSymbolicProjection(mapped)))
+                        && (TypeSymbol.RequiresSymbolicProjection(mapped)
+                            || TypeSymbol.ContainsNamedTupleElements(mapped))))
                 {
                     return mapped;
                 }

--- a/test/Core.Tests/CodeAnalysis/Binding/NestedNamedTupleProjectionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/NestedNamedTupleProjectionTests.cs
@@ -1,0 +1,104 @@
+// <copyright file="NestedNamedTupleProjectionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// ADR-0172 projection-gate family: a named tuple nested INSIDE a generic
+/// type argument (`List[List[(a int32, b string)]]`, `List[[](a, b)]`)
+/// shares its CLR backing with the unnamed shape, so every keep-symbolic
+/// decision along the construction/indexing chain must treat
+/// named-tuple-bearing arguments as symbolic — otherwise the element names
+/// erase and member access by name fails GS0158. This was the 2026-08-29
+/// selfmig nightly wall: cs2gs (post-#3623) emits `candidate[0].Symbol`
+/// against `List[List[(syntax …, symbol …)]]` in
+/// CSharpToGSharpTranslator.Constructors.gs, which cascaded compile
+/// failures into every app referencing migrated Cs2Gs projects.
+/// </summary>
+public class NestedNamedTupleProjectionTests
+{
+    [Fact]
+    public void ListOfListOfNamedTuple_IndexChain_ResolvesNames()
+    {
+        var result = EmittedOracle.Evaluate(@"
+import System.Collections.Generic
+
+func run() int32 {
+    let groups = List[List[(a int32, b string)]]()
+    let inner = List[(a int32, b string)]()
+    inner.Add((a: 1, b: ""x""))
+    groups.Add(inner)
+    let picked = groups[0]
+    return groups[0][0].a + picked[0].a
+}
+run()
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(2, result.Value);
+    }
+
+    [Fact]
+    public void ListOfSliceOfNamedTuple_IndexChain_ResolvesNames()
+    {
+        var result = EmittedOracle.Evaluate(@"
+import System.Collections.Generic
+
+func run() int32 {
+    let a = List[[](a int32, b string)]()
+    a.Add([](a int32, b string){(a: 41, b: ""x"")})
+    return a[0][0].a
+}
+run()
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(41, result.Value);
+    }
+
+    [Fact]
+    public void ForInOverListOfListOfNamedTuple_MemberOnIndexedElement_Resolves()
+    {
+        // The exact selfmig shape: iterate the outer list, index the inner,
+        // read a named element, then use the result as a typed receiver.
+        var result = EmittedOracle.Evaluate(@"
+import System
+import System.Collections.Generic
+
+func run() int32 {
+    let groups = List[List[(syntax string, symbol IComparable)]]()
+    let inner = List[(syntax string, symbol IComparable)]()
+    inner.Add((syntax: ""s"", symbol: 3))
+    groups.Add(inner)
+    var found = 0
+    for candidate in groups {
+        let head = candidate[0].symbol
+        found = found + head.CompareTo(3)
+    }
+    return found
+}
+run()
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(0, result.Value);
+    }
+
+    [Fact]
+    public void DictionaryOfNamedTupleValues_IndexerResolvesNames()
+    {
+        var result = EmittedOracle.Evaluate(@"
+import System.Collections.Generic
+
+func run() int32 {
+    let table = Dictionary[string, (count int32, label string)]()
+    table[""k""] = (count: 7, label: ""x"")
+    return table[""k""].count
+}
+run()
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(7, result.Value);
+    }
+}


### PR DESCRIPTION
Fixes the remaining systemic failure in the second 2026-08-29 selfmig nightly ([run 33260247720](https://github.com/DavidObando/gsharp/actions/runs/33260247720), which already included #3630/#3631): 32/52 green against floor 33, with migrated **Cs2Gs.Translator** failing `GS0158 Cannot find member Symbol` / `GS0159 Cannot find function Contains` / `GS0116 not indexable` at `CSharpToGSharpTranslator.Constructors.gs:1537-38` — `candidate[0].Symbol` and `reach[head].Contains(symbol)` over `List[List[(syntax …, symbol …)]]` — cascading into 11 downstream apps.

## Root cause

A named tuple nested **inside** a generic type argument shares its CLR backing with the unnamed shape (`ValueTuple<…>`), so any keep-symbolic gate that consults only `RequiresSymbolicProjection` (or a direct `is TupleTypeSymbol`) collapses the constructed type to its erased CLR form — and the element names vanish, so member access by name fails. The #3622 projection-gate family covered *direct* named-tuple arguments (`List[(a, b)]`, one level), but not `List[List[(a, b)]]`, `List[[](a, b)]`, or `Dictionary[K, (a, b)]` reached through construction, indexing, or iteration. Minimal repro (failed before, runs now):

```gs
let groups = List[List[(a int32, b string)]]()
…
groups[0][0].a          // was GS0158: Cannot find member a
```

## Fix

Widened six keep-symbolic gates with `TypeSymbol.ContainsNamedTupleElements` (already recursive through every constructor shape): the generic ctor-call type-argument resolution (the erasure at the root), the constructed-generic receiver form, the indexer element substitution + its #2365 recursive projection filter, the generic-return construction and indexer property projection in MemberLookup, the conversion-classifier parameter substitution, and the type-clause `ProjectGenericArgument`. Deliberately did **not** widen `ImportedTypeSymbol.HasSubstitutableTypeArgument` itself — it feeds conversion/lowering decisions with broader meaning, and widening it regressed working cases during investigation.

## Verification

- New `NestedNamedTupleProjectionTests` (4 end-to-end oracle tests) pin all shapes, including the exact selfmig iteration+index+member chain with an imported interface element type.
- Full Core.Tests: **8218/8218 passed**.
- Local selfmig proof over the cs2gs subtree: Cs2Gs.Translator's three real compile errors are gone (the only remaining local failures are the known subtree-proof artifact — `GSharpRoundTrip.gs` referencing GSharp.Core, which the subtree run excludes from migration; the nightly migrates it).

With this plus #3630/#3631, the next nightly should clear the `b7a89d8f22f8`/`0a665d0d062c`/`ebe7e1f2f6f8` fingerprint family. The `!!` ceiling breach (17516 vs 17400) is a separate ratchet question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs