### PR TITLE
gsc: skip unresolvable types in the extension-class scan (netstandard2.0 selfmig crash); exclude Gsharp.Extensions from the gate

### DIFF
--- a/build/run-cs2gs-selfmig.sh
+++ b/build/run-cs2gs-selfmig.sh
@@ -20,7 +20,10 @@
 # extension stays in TypeScript), so all three vs-gsharp apps are excluded:
 # VsGsharp and VsGsharp.CodeLens build only under the Windows-only VSSDK
 # toolchain (VSCT compile, pkgdef), and VsGsharp.UnitTests tests the
-# permanently-C# extension via linked sources.
+# permanently-C# extension via linked sources. Gsharp.Extensions is excluded
+# because it is ALREADY G# (all-.gs sources bootstrapped by the latest
+# compiler without a gsproj) — there is nothing to migrate, and feeding its
+# .gs sources through the C# parser only produces phantom gaps.
 set -euo pipefail
 
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
@@ -62,6 +65,7 @@ dotnet "$repo_root/out/bin/Release/Cs2Gs.Cli/cs2gs.dll" migrate \
   --exclude src/vs-gsharp/src/VsGsharp/VsGsharp.csproj \
   --exclude src/vs-gsharp/src/VsGsharp.CodeLens/VsGsharp.CodeLens.csproj \
   --exclude src/vs-gsharp/test/VsGsharp.UnitTests \
+  --exclude src/Sdk/Gsharp.Extensions \
   --exclude tools/cs2gs/corpus/CompileGap-Library \
   | tee "$work_root/migrate.log"
 migrate_exit=${PIPESTATUS[0]}

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -3645,7 +3645,24 @@ internal sealed class MemberLookup
                         continue;
                     }
 
-                    if (!IsStaticClass(type) || !HasExtensionAttribute(type) || !IsVisibleImportedType(type))
+                    // The probes below walk base types and attributes, which
+                    // under MetadataLoadContext can throw for types whose
+                    // dependency closure is unresolvable in the compile's
+                    // reference set — e.g. a HOST-fallback net10 BCL assembly
+                    // scanned during a netstandard2.0 compile, whose typerefs
+                    // target assembly versions the netstandard facade set
+                    // cannot satisfy. Such a type can never be a usable
+                    // extension holder here; skip it instead of failing the
+                    // whole compilation (the GS9998 TypeLoadException wall on
+                    // the migrated netstandard2.0 Gsharp.NET.Sdk, #3501).
+                    try
+                    {
+                        if (!IsStaticClass(type) || !HasExtensionAttribute(type) || !IsVisibleImportedType(type))
+                        {
+                            continue;
+                        }
+                    }
+                    catch (Exception ex) when (ClrTypeUtilities.IsMetadataLoadFailure(ex))
                     {
                         continue;
                     }


### PR DESCRIPTION
Root-causes the "GS9999 quartet" from the 2026-08-29 nightly ([run 33260247720](https://github.com/DavidObando/gsharp/actions/runs/33260247720)). The four apps' `sdk.build.log`s actually contained structured errors the gate failed to surface (filed as #3634); they decompose into **two** causes:

- **3 apps — Gsharp.NET.Sdk, Sdk.Tests, Extensions.Tests** (the latter two die building the Sdk project transitively): `error GS9998: TypeLoadException: Could not find type 'System.IO.Stream' / 'System.Text.Encoding' in assembly ''` — fixed here.
- **1 app — Core.Tests**: a separate gsgen `GS9200` MetadataLoadContext/runtime type-mix crash — filed as #3633.

## Root cause (stack captured via direct gsc run on the harness rsp)

`MemberLookup.GetImportedExtensionClasses` probes every namespace-matching candidate type with `IsStaticClass` → `Type.IsClass` → base-type resolution. The migrated `Gsharp.NET.Sdk.gsproj` targets **netstandard2.0** (MSBuild task assembly), and `ReferenceResolver.WithReferences` adds the *host's net10 BCL* as fallback assemblies. The sources import `System.IO`/`System.Text`, so the scan reaches types from those net10 fallbacks — whose typerefs cannot resolve against the netstandard facade set — and the unguarded probe turned the resulting `TypeLoadException` into a whole-compilation GS9998 abort. The failing type varied by file (`Stream` vs `Encoding`) because it tracked whichever imported namespace matched first.

## Fix

Wrap the three candidate probes in a `catch when (ClrTypeUtilities.IsMetadataLoadFailure(ex))` → skip. A type whose dependency closure is unresolvable in the compile's reference set can never be a usable extension holder, so skipping is semantically exact — no behavior change for resolvable types.

## Gate change

`build/run-cs2gs-selfmig.sh` now excludes `src/Sdk/Gsharp.Extensions`: it is an all-`.gs` bootstrap project (produces a G# DLL with the latest compiler, no gsproj) and is not a migration target; parsing its `.gs` sources as C# produced 13 phantom translate gaps. This removes one always-red app from the denominator (it was red, so `greenFloor` is unaffected).

## Verification

- Direct gsc on the failing response file: GS9998 gone; compilation proceeds to the real (pre-existing) diagnostics.
- Harness rerun with the repacked SDK: Gsharp.NET.Sdk **translate PASS**; compile now fails only on the two oblivious-nullability defects the crash had masked (`bool.TrueString` as `string?`, `Array.Empty[T]()` as `T[]?` under unannotated netstandard refs) — filed as #3635, same GS0155 family as the LanguageServer wall.
- Extension-lookup tests 193/193; full Core.Tests **8231/8231**.

Expected gate effect once #3635 lands too: +3 apps (Sdk family); with #3633: +1 more (Core.Tests). Gsharp.Extensions exclusion removes a permanent red row immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs