### PR TITLE
gsc: build attribute constant arrays with runtime container element types (#3633)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Attributes.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Attributes.cs
@@ -958,7 +958,18 @@ internal sealed partial class DeclarationBinder
             return false;
         }
 
-        var result = Array.CreateInstance(elementClrType, elements.Count);
+        // Array.CreateInstance / Convert.ChangeType demand RUNTIME types, but
+        // when the compile carries a /r: reference set the element type may be
+        // a MetadataLoadContext type (e.g. an imported enum in
+        // `@Days([]DayOfWeek{...})`), which threw ArgumentException "Type must
+        // be a type provided by the runtime" and aborted the compilation
+        // (GS9998; GS9200 through gsgen — issue #3633). The array built here
+        // is only a CONTAINER for the constant values — the custom-attribute
+        // encoder writes the blob from the SIGNATURE's element type and reads
+        // values via Array.GetValue — so a runtime-equivalent container
+        // element type is exact.
+        var containerElementType = ResolveRuntimeContainerElementType(elementClrType);
+        var result = Array.CreateInstance(containerElementType, elements.Count);
         for (int i = 0; i < elements.Count; i++)
         {
             if (!TryBindAttributeArgument(elements[i], out var elementValue, out _))
@@ -968,7 +979,7 @@ internal sealed partial class DeclarationBinder
 
             try
             {
-                result.SetValue(CoerceAttributeElement(elementValue, elementClrType), i);
+                result.SetValue(CoerceAttributeElement(elementValue, containerElementType), i);
             }
             catch
             {
@@ -1034,6 +1045,35 @@ internal sealed partial class DeclarationBinder
                     }
                 }
             }
+        }
+    }
+
+    /// <summary>
+    /// Maps a possibly-MetadataLoadContext array element type onto the
+    /// runtime type used for the constant-container array: MLC-loaded enums
+    /// map to their (runtime) underlying integral, other MLC types map to
+    /// their runtime twin by full name, and anything unmappable falls back to
+    /// <see cref="object"/> (always a valid container element).
+    /// </summary>
+    /// <param name="elementClrType">The signature's array element type.</param>
+    /// <returns>A runtime-provided element type for the container array.</returns>
+    private static Type ResolveRuntimeContainerElementType(Type elementClrType)
+    {
+        if (!elementClrType.Assembly.ReflectionOnly)
+        {
+            return elementClrType;
+        }
+
+        try
+        {
+            var lookupType = elementClrType.IsEnum
+                ? Enum.GetUnderlyingType(elementClrType)
+                : elementClrType;
+            return Type.GetType(lookupType.FullName ?? string.Empty) ?? typeof(object);
+        }
+        catch (Exception ex) when (ClrTypeUtilities.IsMetadataLoadFailure(ex))
+        {
+            return typeof(object);
         }
     }
 

--- a/test/Compiler.Tests/Issue3633AttributeArrayMlcTests.cs
+++ b/test/Compiler.Tests/Issue3633AttributeArrayMlcTests.cs
@@ -1,0 +1,60 @@
+// <copyright file="Issue3633AttributeArrayMlcTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using Xunit;
+
+namespace GSharp.Compiler.Tests;
+
+/// <summary>
+/// Issue #3633: an attribute array whose element type resolves through the
+/// MetadataLoadContext (a <c>/reference:</c> compile — the SDK/gsgen path)
+/// crashed the whole compilation with
+/// <c>ArgumentException: Type must be a type provided by the runtime
+/// (Parameter 'elementType')</c>: the binder built the constant-container
+/// array via <c>Array.CreateInstance</c> with the MLC element type. This was
+/// the gsgen <c>GS9200</c> wall on migrated Core.Tests in the selfmig
+/// nightly. The container now uses a runtime-equivalent element type (the
+/// blob is written from the signature's element type, so the container shape
+/// is immaterial).
+/// </summary>
+public class Issue3633AttributeArrayMlcTests
+{
+    [Fact]
+    public void ImportedEnumArrayAttributeArgument_CompilesUnderRefPack()
+    {
+        XunitAssertOverloadResolutionTests.AssertGsCompilesCleanlyAgainstRefPack("""
+            package P
+
+            import System
+
+            class DaysAttribute : Attribute {
+                init(days []DayOfWeek) {
+                }
+            }
+
+            @Days([]DayOfWeek{DayOfWeek.Monday, DayOfWeek.Friday})
+            class Holder {
+            }
+            """);
+    }
+
+    [Fact]
+    public void PrimitiveAndStringArrayAttributeArguments_CompileUnderRefPack()
+    {
+        XunitAssertOverloadResolutionTests.AssertGsCompilesCleanlyAgainstRefPack("""
+            package P
+
+            import System
+
+            class TagsAttribute : Attribute {
+                init(tags []string, codes []int32) {
+                }
+            }
+
+            @Tags([]string{"a", "b"}, []int32{1, 2})
+            class Holder {
+            }
+            """);
+    }
+}

--- a/test/Compiler.Tests/XunitAssertOverloadResolutionTests.cs
+++ b/test/Compiler.Tests/XunitAssertOverloadResolutionTests.cs
@@ -458,7 +458,7 @@ public class XunitAssertOverloadResolutionTests
     /// names than the host's runtime types.
     /// </summary>
     /// <param name="source">G# source to compile.</param>
-    private static void AssertGsCompilesCleanlyAgainstRefPack(string source)
+    internal static void AssertGsCompilesCleanlyAgainstRefPack(string source)
         => CompileGsAgainstReferences(source, ReferenceModeRefPack);
 
     private const int ReferenceModeTpa = 0;


### PR DESCRIPTION
Fixes #3633 — the gsgen `GS9200` member of the selfmig quartet (migrated Core.Tests).

## Root cause

`TryBindAttributeArrayArgument` builds the bound constant array with `Array.CreateInstance(elementClrType, …)` and coerces elements via `Convert.ChangeType(…, elementClrType)`. Under any `/reference:` compile (the SDK build path and gsgen both run this way), `elementClrType` can be a **MetadataLoadContext** type — e.g. an imported enum in `@Days([]DayOfWeek{…})` — and both APIs demand runtime types: `ArgumentException: Type must be a type provided by the runtime (Parameter 'elementType')`, escalating to a whole-compilation GS9998 (gsc) / GS9200 (gsgen). Third instance of the MLC/runtime type-mix genus (#3630's pack helper, the probe in #3636's investigation).

## Fix

The array is only a *container* for the constant values — the custom-attribute encoder writes the blob from the **signature's** element type and reads values via `Array.GetValue`, so the container's element type is immaterial. `ResolveRuntimeContainerElementType` maps MLC enums to their runtime underlying integral, other MLC types to their runtime twin by full name, and falls back to `object`. Runtime-typed compiles are untouched (early return).

## Verification

- Minimal repro (imported-enum attribute array compiled against the `Microsoft.NETCore.App.Ref` closure) failed with the exact crash before, compiles now, and the emitted blob decodes byte-correct via runtime reflection: `System.DayOfWeek[] { Monday(1), Friday(5) }`.
- New `Issue3633AttributeArrayMlcTests` (enum-array + primitive/string-array shapes) reuse the existing ref-pack compile helper (widened to `internal`); they fail without the fix.
- Attribute suites green: 39 Compiler.Tests + 128 Core.Tests.

Expected gate effect: clears migrated Core.Tests' gsgen wall (+1 app once its remaining stages hold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs