### PR TITLE
selfmig harness: surface MSBuild-relayed GSxxxx errors instead of synthetic GS9999 (#3634)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Pipeline/SdkCompileRunner.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/SdkCompileRunner.cs
@@ -36,6 +36,19 @@ public sealed class SdkCompileRunner
         @":\s+error\s+(?<code>[A-Za-z]+\d+):\s*(?<msg>.*)$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
+    // Matches an MSBuild-relayed GSxxxx error line (issue #3634). Unlike gsc's
+    // own four-coordinate `<file>(l,c,el,ec):` shape that
+    // GscInvoker.ParseDiagnostics recognizes, MSBuild task/target errors carry
+    // a two-coordinate location whose path is not a .gs source at all — e.g.
+    // `.../build/Gsharp.NET.Core.Sdk.targets(505,5): error GS9998: ... [App.gsproj]`
+    // or `gsgen(1,1): error GS9200: ...` — and may append a `[project]` suffix.
+    // The location prefix is optional so a bare `error GSxxxx: message` line
+    // still surfaces with a best-effort location.
+    private static readonly Regex RelayedGsErrorPattern = new Regex(
+        @"^(?:(?<file>.+?)\((?<line>\d+),(?<col>\d+)(?:,(?<eline>\d+),(?<ecol>\d+))?\)\s*:\s*)?" +
+        @"error\s+(?<id>GS\d{4}):\s*(?<msg>.*)$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
     // The well-known NuGet package-asset directories that follow an
     // `{id}/{version}/` pair under a packages cache root (generic detector,
     // not specific to any single package).
@@ -115,6 +128,14 @@ public sealed class SdkCompileRunner
             File.WriteAllText(Path.Combine(artifactDirectory, "sdk.build.log"), result.Output ?? string.Empty);
 
             IReadOnlyList<GscDiagnostic> diagnostics = GscInvoker.ParseDiagnostics(result.Output);
+            if (result.ExitCode != 0 && !diagnostics.Any(d => d.IsError))
+            {
+                // Issue #3634: surface MSBuild-relayed GSxxxx errors (.targets-
+                // or gsgen-anchored lines the source-anchored parser misses)
+                // instead of letting the caller synthesize an opaque GS9999.
+                diagnostics = diagnostics.Concat(ParseRelayedGsErrors(result.Output)).ToList();
+            }
+
             string assemblyPath = result.ExitCode == 0
                 ? ResolveTargetPath(
                     generatedProjectPath,
@@ -352,10 +373,21 @@ public sealed class SdkCompileRunner
         IReadOnlyList<GscDiagnostic> diagnostics = GscInvoker.ParseDiagnostics(result.Output);
         if (result.ExitCode != 0 && diagnostics.Count(d => d.IsError) == 0)
         {
-            GscDiagnostic synthetic = SynthesizeFallbackDiagnostic(result, gsFilePaths);
-            if (synthetic is not null)
+            // Issue #3634: before synthesizing an opaque fallback, surface any
+            // MSBuild-relayed GSxxxx errors (.targets- or gsgen-anchored) that
+            // the source-anchored parser cannot see.
+            IReadOnlyList<GscDiagnostic> relayed = ParseRelayedGsErrors(result.Output);
+            if (relayed.Count > 0)
             {
-                diagnostics = diagnostics.Append(synthetic).ToList();
+                diagnostics = diagnostics.Concat(relayed).ToList();
+            }
+            else
+            {
+                GscDiagnostic synthetic = SynthesizeFallbackDiagnostic(result, gsFilePaths);
+                if (synthetic is not null)
+                {
+                    diagnostics = diagnostics.Append(synthetic).ToList();
+                }
             }
         }
 
@@ -951,6 +983,59 @@ public sealed class SdkCompileRunner
         string referencePath,
         IReadOnlyList<DeclaredProjectItem> projectReferences) =>
         IsRepresentedByProjectReference(referencePath, projectReferences);
+
+    /// <summary>
+    /// Scans <c>dotnet build</c> output for MSBuild-relayed <c>GSxxxx</c> error
+    /// lines that <see cref="GscInvoker.ParseDiagnostics"/> cannot recognize
+    /// (issue #3634): task/target errors anchored to a non-<c>.gs</c> path such
+    /// as a <c>.targets</c> file or the literal <c>gsgen</c> tool name, with a
+    /// two-coordinate location and an optional trailing <c>[project]</c>
+    /// suffix. The id and full message are surfaced verbatim (including any
+    /// <c>[project]</c> suffix) so the nightly table and fingerprint carry the
+    /// real error instead of the synthetic GS9999. Identical repeated lines are
+    /// deduplicated — MSBuild prints each error again in its final summary.
+    /// </summary>
+    /// <param name="output">The combined stdout+stderr of the <c>dotnet build</c> run.</param>
+    /// <returns>The distinct relayed error diagnostics in output order; empty when none match.</returns>
+    internal static IReadOnlyList<GscDiagnostic> ParseRelayedGsErrors(string output)
+    {
+        var diagnostics = new List<GscDiagnostic>();
+        if (string.IsNullOrEmpty(output))
+        {
+            return diagnostics;
+        }
+
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (string rawLine in output.Replace("\r\n", "\n").Split('\n'))
+        {
+            Match match = RelayedGsErrorPattern.Match(rawLine.Trim());
+            if (!match.Success)
+            {
+                continue;
+            }
+
+            string file = match.Groups["file"].Success ? match.Groups["file"].Value.Trim() : "unknown";
+            int line = match.Groups["line"].Success ? int.Parse(match.Groups["line"].Value) : 1;
+            int column = match.Groups["col"].Success ? int.Parse(match.Groups["col"].Value) : 1;
+            int endLine = match.Groups["eline"].Success ? int.Parse(match.Groups["eline"].Value) : line;
+            int endColumn = match.Groups["ecol"].Success ? int.Parse(match.Groups["ecol"].Value) : column;
+            var diagnostic = new GscDiagnostic(
+                match.Groups["id"].Value,
+                match.Groups["msg"].Value.Trim(),
+                "error",
+                file,
+                line,
+                column,
+                endLine,
+                endColumn);
+            if (seen.Add(diagnostic.Id + "|" + diagnostic.File + "|" + diagnostic.Line + "," + diagnostic.Column + "|" + diagnostic.Message))
+            {
+                diagnostics.Add(diagnostic);
+            }
+        }
+
+        return diagnostics;
+    }
 
     private static string FindInheritedBuildProps(string projectDirectory)
     {

--- a/tools/cs2gs/Cs2Gs.Tests/SdkCompileRunnerTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/SdkCompileRunnerTests.cs
@@ -476,6 +476,98 @@ public class SdkCompileRunnerTests
         }
     }
 
+    [Fact]
+    public void ParseRelayedGsErrors_ParsesTargetsRelayedError_WithTrailingProjectSuffix()
+    {
+        const string Output =
+            "Determining projects to restore...\n" +
+            "/Users/dev/.nuget-packages/gsharp.net.sdk/1.2.3/build/Gsharp.NET.Core.Sdk.targets(505,5): " +
+            "error GS9998: TypeLoadException: Could not load type 'X'. [/Users/dev/out/App.gsproj]\n" +
+            "Build FAILED.\n";
+
+        var diagnostics = SdkCompileRunner.ParseRelayedGsErrors(Output);
+
+        GscDiagnostic diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("GS9998", diagnostic.Id);
+        Assert.Equal(
+            "TypeLoadException: Could not load type 'X'. [/Users/dev/out/App.gsproj]",
+            diagnostic.Message);
+        Assert.Equal("error", diagnostic.Severity);
+        Assert.Equal(
+            "/Users/dev/.nuget-packages/gsharp.net.sdk/1.2.3/build/Gsharp.NET.Core.Sdk.targets",
+            diagnostic.File);
+        Assert.Equal(505, diagnostic.Line);
+        Assert.Equal(5, diagnostic.Column);
+    }
+
+    [Fact]
+    public void ParseRelayedGsErrors_ParsesGsgenAnchoredError()
+    {
+        const string Output =
+            "gsgen(1,1): error GS9200: Type must be a type provided by the runtime. (Parameter 'elementType')\n";
+
+        var diagnostics = SdkCompileRunner.ParseRelayedGsErrors(Output);
+
+        GscDiagnostic diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("GS9200", diagnostic.Id);
+        Assert.Equal(
+            "Type must be a type provided by the runtime. (Parameter 'elementType')",
+            diagnostic.Message);
+        Assert.Equal("gsgen", diagnostic.File);
+        Assert.Equal(1, diagnostic.Line);
+        Assert.Equal(1, diagnostic.Column);
+    }
+
+    [Fact]
+    public void ParseRelayedGsErrors_DeduplicatesIdenticalRepeatedLines()
+    {
+        // MSBuild prints each error once inline and again in the final
+        // "Build FAILED" summary — the harness must not double-report it.
+        const string ErrorLine =
+            "/sdk/build/Gsharp.NET.Core.Sdk.targets(505,5): error GS9998: TypeLoadException: boom. [/out/App.gsproj]";
+        const string Output =
+            ErrorLine + "\n" +
+            "gsgen(1,1): error GS9200: Type must be a type provided by the runtime.\n" +
+            "Build FAILED.\n" +
+            "    " + ErrorLine + "\n" +
+            "gsgen(1,1): error GS9200: Type must be a type provided by the runtime.\n";
+
+        var diagnostics = SdkCompileRunner.ParseRelayedGsErrors(Output);
+
+        Assert.Equal(2, diagnostics.Count);
+        Assert.Equal("GS9998", diagnostics[0].Id);
+        Assert.Equal("GS9200", diagnostics[1].Id);
+    }
+
+    [Fact]
+    public void ParseRelayedGsErrors_ParsesLocationlessErrorLine_WithBestEffortLocation()
+    {
+        var diagnostics = SdkCompileRunner.ParseRelayedGsErrors("error GS9200: something went wrong\n");
+
+        GscDiagnostic diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("GS9200", diagnostic.Id);
+        Assert.Equal("something went wrong", diagnostic.Message);
+        Assert.Equal("unknown", diagnostic.File);
+        Assert.Equal(1, diagnostic.Line);
+        Assert.Equal(1, diagnostic.Column);
+    }
+
+    [Fact]
+    public void ParseRelayedGsErrors_ReturnsEmpty_ForGenuinelyUnparseableOutput()
+    {
+        // No GSxxxx error line at all: the caller keeps the synthetic GS9999
+        // fallback as the true last resort.
+        const string Output =
+            "MSBUILD : error MSB1009: Project file does not exist.\n" +
+            "/src/App.cs(3,1): error CS0246: The type or namespace name 'Foo' could not be found\n" +
+            "/src/App.gs(3,1,3,4): warning GS0100: not an error\n" +
+            "Build FAILED.\n";
+
+        Assert.Empty(SdkCompileRunner.ParseRelayedGsErrors(Output));
+        Assert.Empty(SdkCompileRunner.ParseRelayedGsErrors(string.Empty));
+        Assert.Empty(SdkCompileRunner.ParseRelayedGsErrors(null));
+    }
+
     /// <summary>
     /// A scratch directory populated with one fake shared-framework assembly
     /// file, so <see cref="SdkCompileRunner.PartitionReferences"/>'s runtime-dir


### PR DESCRIPTION
## Root cause

`GscInvoker.ParseDiagnostics` only recognizes gsc's own four-coordinate diagnostic shape `<file>(l,c,el,ec): <sev> GSxxxx: <msg>`. Errors relayed through `dotnet build --via-sdk` by MSBuild tasks/targets use a **two-coordinate** location anchored to a **non-`.gs` path**, e.g.

```
.../gsharp.net.sdk/<ver>/build/Gsharp.NET.Core.Sdk.targets(505,5): error GS9998: TypeLoadException: ... [App.gsproj]
gsgen(1,1): error GS9200: Type must be a type provided by the runtime. (Parameter 'elementType')
```

so zero errors parsed, `SynthesizeFallbackDiagnostic` fired, and every affected app was labeled `GS9999: dotnet build (--via-sdk) exited with code 1 and no parseable diagnostic` — the real error hidden from the nightly table and truncated in the fingerprint json (this week's opaque quartet).

## Fix

- New `SdkCompileRunner.ParseRelayedGsErrors`: when the build exits non-zero and no source-anchored error-severity diagnostic parsed, scan the output for `error GS\d{4}: <message>` lines with any (optional) `path(l,c)` / `path(l,c,el,ec)` prefix and surface them verbatim — id + full message (including the trailing `[project]` suffix), best-effort location.
- Wired into **both** build paths: corpus-mode `Compile` (before the `SynthesizeFallbackDiagnostic` last resort) and repo-mode `CompileMirroredProject` (which previously had no fallback scan at all and left GS9999 synthesis to `CompileStage`).
- Identical repeated lines are deduplicated — MSBuild reprints each error in its `Build FAILED` summary.
- The synthetic GS9999 remains the true last resort for genuinely unparseable output. Fingerprints are content-derived, so the newly surfaced ids/messages yield actionable fingerprints by design.

## Verification

New unit tests in `SdkCompileRunnerTests` cover: the `.targets`-relayed GS9998 shape with trailing `[project]`, the `gsgen(1,1)` GS9200 shape, dedup of MSBuild's duplicate summary lines, a locationless `error GSxxxx:` line, and genuinely unparseable output (MSB/CS/GS-warning lines) still returning empty so GS9999 fires.

- `dotnet test tools/cs2gs/Cs2Gs.Tests --filter "FullyQualifiedName~ParseRelayedGsErrors"` — 5/5 passed
- `dotnet test tools/cs2gs/Cs2Gs.Tests --filter "FullyQualifiedName~SdkCompileRunnerTests"` — 34/34 passed

Fixes #3634

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs