### PR TITLE
cs2gs: parenthesize non-atomic holes in multiline-interpolation concat lowering (#3638)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue3638InterpolationEscapedQuoteTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3638InterpolationEscapedQuoteTests.cs
@@ -1,0 +1,132 @@
+// <copyright file="Issue3638InterpolationEscapedQuoteTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3638: a MULTILINE interpolated string is lowered to a concatenation
+/// of backtick raw segments and hole values (issue #3501), but a non-atomic
+/// hole expression (<c>{i + 1}</c>) got the synthetic <c>.ToString()</c>
+/// appended without parentheses — <c>i + 1.ToString()</c> — which does not
+/// even parse when the trailing operand is a numeric literal (ADR-0054: no
+/// postfix chain on a bare numeric token, GS0005 on the DotToken) and is
+/// semantically wrong wherever it does. The escaped-quote segments themselves
+/// (<c>\"</c> in the C# literal) render correctly: quote-bearing single-line
+/// chunks keep the escaped double-quoted form and multi-line chunks become
+/// fully-literal backtick raws, both of which the G# lexer accepts.
+/// </summary>
+public class Issue3638InterpolationEscapedQuoteTests
+{
+    [Fact]
+    public void MultilineInterpolation_EscapedQuotesAndExpressionHole_ParenthesizesHoleAndRoundTrips()
+    {
+        // The Adr0158SyncMapSpikeTests shape: escaped quotes, `{{`/`}}` brace
+        // escapes, a plain `{i}` hole, and a non-atomic `{i + 1}` hole.
+        string rendered = Render(@"
+namespace Corpus.Issue3638
+{
+    public class Holder
+    {
+        public string Source(int i)
+        {
+            return $""func setK{i}(m SyncMap) int32 {{\n    m.Store(\""k{i}\"", {i + 1})\n    return 0\n}}"";
+        }
+    }
+}
+");
+
+        Assert.Contains("(i + 1).ToString()", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("1.ToString", rendered.Replace("(i + 1).ToString", string.Empty), StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+
+    [Fact]
+    public void MultilineInterpolation_PlainIdentifierHole_NeedsNoParentheses()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue3638
+{
+    public class Holder
+    {
+        public string Source(int i)
+        {
+            return $""line1 {i}\nline2 \""x\""\nline3"";
+        }
+    }
+}
+");
+
+        Assert.Contains("i.ToString()", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("(i).ToString()", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+
+    [Fact]
+    public void MultilineVerbatimInterpolation_EscapedQuotesAndExpressionHole_ParenthesizesHoleAndRoundTrips()
+    {
+        // Verbatim `$@""...""` uses `""""` quote escapes and real newlines but
+        // flows through the same classic single-dollar machinery.
+        string rendered = Render(@"
+namespace Corpus.Issue3638
+{
+    public class Holder
+    {
+        public string Source(int i)
+        {
+            return $@""b.F{i} = {i + 1} says """"hi""""
+line2
+line3"";
+        }
+    }
+}
+");
+
+        Assert.Contains("(i + 1).ToString()", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+
+    [Fact]
+    public void MultilineInterpolation_UnaryHole_ParenthesizesReceiver()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue3638
+{
+    public class Holder
+    {
+        public string Source(int i)
+        {
+            return $""neg {-i}\nline2\nline3"";
+        }
+    }
+}
+");
+
+        Assert.Contains("(-i).ToString()", rendered, StringComparison.Ordinal);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+
+    private static string Render(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.Empty(context.Diagnostics);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -902,6 +902,18 @@ public sealed partial class CSharpToGSharpTranslator
         private static GExpression ParenthesizeIfBareNumericLiteral(GExpression expr) =>
             IsBareNumericLiteral(expr) ? new ParenthesizedExpression(expr) : expr;
 
+        // Issue #3638: a synthetic member access (e.g. an appended `.ToString()`)
+        // binds tighter than any binary/unary/if operator, so a non-atomic
+        // receiver must be parenthesized or the access silently lands on the
+        // receiver's last operand (`i + 1.ToString()` instead of
+        // `(i + 1).ToString()`). Same predicate as CoerceConcatOperand's
+        // receiver guard, plus prefix unaries (whose numeric-tail case
+        // IsBareNumericLiteral already covered).
+        private static GExpression ParenthesizeForSyntheticMemberAccess(GExpression expr) =>
+            expr is BinaryExpression or IfExpression or UnaryExpression || IsBareNumericLiteral(expr)
+                ? new ParenthesizedExpression(expr)
+                : expr;
+
         /// <summary>
         /// True when a member-/element-access <paramref name="recv"/> receiver is a
         /// nullable-reference <em>field</em> or <em>property</em> (declared <c>T?</c>

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -3814,8 +3814,16 @@ public sealed partial class CSharpToGSharpTranslator
                     ITypeSymbol holeType = this.context.GetTypeInfo(holeSyntax.Expression).Type;
                     if (holeType?.SpecialType != SpecialType.System_String)
                     {
+                        // Issue #3638: a non-atomic hole expression (`{i + 1}`)
+                        // must be parenthesized before the synthetic `.ToString()`
+                        // is appended, or `+` binds looser than `.` and the call
+                        // lands on the last operand (`i + 1.ToString()`) — which
+                        // does not even parse when that operand is a numeric
+                        // literal (ADR-0054, GS0005 on the DotToken).
                         segment = new InvocationExpression(
-                            new MemberAccessExpression(segment, "ToString"),
+                            new MemberAccessExpression(
+                                ParenthesizeForSyntheticMemberAccess(segment),
+                                "ToString"),
                             Array.Empty<GExpression>());
                     }
                 }


### PR DESCRIPTION
## Root cause

The issue #3501 multiline-interpolation lowering (`TryLowerMultilineInterpolationToConcat` in `CSharpToGSharpTranslator.Invocations.cs`) appends a synthetic `.ToString()` to each non-string hole **without parenthesizing the hole expression**. A non-atomic hole like `{i + 1}` printed as `i + 1.ToString()`; member access binds tighter than `+`, so the call lands on the last operand — and when that operand is a bare numeric literal the emitted G# does not even parse (ADR-0054 forbids a postfix chain on a numeric-literal token; gsc reports `GS0005 Unexpected token <DotToken>`). This kept `test/Interpreter.Tests` translate-red on `Adr0158SyncMapSpikeTests.cs` and `Issue1718FrameConcurrencyEmittedOracleTests.cs`.

The escaped-quote half of the reported mangling turns out to be sound emission: quote-bearing single-line chunks keep the escaped double-quoted form (`"\", "`), multiline chunks become fully-literal backtick raws (the lexer accepts embedded `"` there), and the mixed-mode concatenation lexes/parses cleanly once the hole is parenthesized — proven by the new round-trip tests and by gsc on both migrated files.

## Fix

New `ParenthesizeForSyntheticMemberAccess` helper (same receiver guard `CoerceConcatOperand` already uses for string-concat operands — `BinaryExpression`/`IfExpression`/bare numeric literal — plus prefix unaries) wraps the hole before the synthetic `.ToString()`:

- `{i + 1}` → `(i + 1).ToString()`
- `{-i}` → `(-i).ToString()`
- `{i}` → `i.ToString()` (unchanged, no over-parenthesization)

## Verification

- New `Issue3638InterpolationEscapedQuoteTests` (4 tests): the Adr0158 shape (escaped quotes + `{{`/`}}` brace escapes + `{i}`/`{i + 1}` holes), a verbatim `$@"..."` variant, and a unary hole — all assert the parenthesized emission and full round-trip parse+bind.
- `--filter "FullyQualifiedName~Issue3638|FullyQualifiedName~Interpolat"`: 16/16 passed; `GoldenTests`: 42/42 passed (no baseline shifts).
- End-to-end: Release build of gsc + cs2gs, `migrate` over `test/Interpreter.Tests`; the emitted `Adr0158SyncMapSpikeTests.gs` and `Issue1718FrameConcurrencyEmittedOracleTests.gs` now emit `(i + 1).ToString()` and compile with **zero GS0005** (remaining diagnostics are the expected reference-less binder errors, e.g. GS0198 missing xunit attribute types). The app's translate stage still fails only on `Issue2928CallableMaterializationTests.cs` — issue #3639's tuple-of-arrow-types shape, tracked separately.

Fixes #3638

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
