### PR TITLE
cs2gs: value-position true-discard assignment yields its RHS instead of writing to '_' (#3640)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue3640LambdaDiscardTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3640LambdaDiscardTranslationTests.cs
@@ -1,0 +1,200 @@
+// <copyright file="Issue3640LambdaDiscardTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using GSharp.Tests;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3640: a true-discard assignment used as an EXPRESSION — canonically an
+/// expression-lambda body (`t => _ = t.Exception`, which binds to the
+/// value-returning <c>Func</c> overload) — must not emit a reference to a
+/// nonexistent <c>_</c> variable (GS0125). Its value is the RHS value and the
+/// write is a no-op, so the RHS alone is the faithful translation. Statement-level
+/// discards keep their existing <c>let _ = …</c> lowering (issue #3462).
+/// </summary>
+public sealed class Issue3640LambdaDiscardTranslationTests
+{
+    [Fact]
+    public void ContinueWithExpressionLambdaDiscard_EmitsNoBareUnderscoreReference()
+    {
+        string rendered = Render("""
+            using System.Threading.Tasks;
+
+            public static class Probe
+            {
+                public static void Observe(Task task)
+                {
+                    _ = task.ContinueWith(t => _ = t.Exception, TaskScheduler.Default);
+                }
+            }
+            """);
+
+        // The outer statement-level discard keeps its native lowering; the
+        // in-lambda discard reduces to the RHS read.
+        Assert.Contains("let _ = task.ContinueWith(", rendered, StringComparison.Ordinal);
+        Assert.Contains("t.Exception", rendered, StringComparison.Ordinal);
+        AssertNoBareUnderscoreReference(rendered);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+
+    [Fact]
+    public void VoidDelegateExpressionLambdaDiscard_EmitsNoBareUnderscoreReference()
+    {
+        string rendered = Render("""
+            using System;
+
+            public static class Probe
+            {
+                public static void Run()
+                {
+                    Action<int> a = x => _ = x.ToString();
+                    a(1);
+                }
+            }
+            """);
+
+        Assert.Contains("x.ToString()", rendered, StringComparison.Ordinal);
+        AssertNoBareUnderscoreReference(rendered);
+        TranslationTestValidation.AssertBinds(rendered);
+    }
+
+    [Fact]
+    public void ValueReturningLambdaDiscard_YieldsRhsValueAndRunsSideEffects()
+    {
+        string rendered = Render("""
+            using System;
+
+            public sealed class Probe
+            {
+                private int state;
+
+                private int Touch(int value)
+                {
+                    state = (state * 10) + value;
+                    return state;
+                }
+
+                public int Run()
+                {
+                    Func<int, int> f = x => _ = Touch(x);
+                    int first = f(4);
+                    int second = f(5);
+                    return (state * 100) + first + second;
+                }
+            }
+            """);
+
+        AssertNoBareUnderscoreReference(rendered);
+        TranslationTestValidation.AssertBinds(rendered);
+
+        EmittedOracleResult result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Probe().Run()");
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(4549, result.Value);
+    }
+
+    [Fact]
+    public void NestedDiscardAssignment_UnwindsToInnermostRhs()
+    {
+        string rendered = Render("""
+            using System;
+
+            public sealed class Probe
+            {
+                private int state;
+
+                private int Touch(int value)
+                {
+                    state = (state * 10) + value;
+                    return state;
+                }
+
+                public int Run()
+                {
+                    Func<int, int> f = x => _ = (_ = Touch(x));
+                    return f(7);
+                }
+            }
+            """);
+
+        AssertNoBareUnderscoreReference(rendered);
+        TranslationTestValidation.AssertBinds(rendered);
+
+        EmittedOracleResult result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Probe().Run()");
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(7, result.Value);
+    }
+
+    [Fact]
+    public void ShortCircuitOperandDiscard_KeepsConditionalEvaluationAndValue()
+    {
+        string rendered = Render("""
+            public sealed class Probe
+            {
+                private int state;
+
+                private int Touch(int value)
+                {
+                    state = (state * 10) + value;
+                    return state;
+                }
+
+                public int Run()
+                {
+                    bool taken = true && (_ = Touch(3)) > 0;
+                    bool skipped = false && (_ = Touch(9)) > 0;
+                    return (state * 100) + (taken ? 10 : 0) + (skipped ? 1 : 0);
+                }
+            }
+            """);
+
+        AssertNoBareUnderscoreReference(rendered);
+        TranslationTestValidation.AssertBinds(rendered);
+
+        EmittedOracleResult result = EmittedOracle.Evaluate(
+            rendered + Environment.NewLine + "Probe().Run()");
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(310, result.Value);
+    }
+
+    // A bare `_` identifier is legal in G# only as a `let _ = …` discard
+    // declaration's target (and as a discard parameter). Any other standalone
+    // `_` token in the rendered output is a reference to a variable that does
+    // not exist (GS0125).
+    private static void AssertNoBareUnderscoreReference(string rendered)
+    {
+        string withoutDiscardDeclarations = rendered.Replace("let _ =", "let __DISCARD__ =");
+        Match bareUnderscore = Regex.Match(withoutDiscardDeclarations, @"(?<![\w$])_(?![\w])");
+        Assert.False(
+            bareUnderscore.Success,
+            "Rendered G# contains a bare '_' identifier reference:" + Environment.NewLine + rendered);
+    }
+
+    private static string Render(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -2210,6 +2210,23 @@ public sealed partial class CSharpToGSharpTranslator
                 return this.TranslateCoalescingAssignmentAsExpression(assignment);
             }
 
+            // Issue #3640: a true-discard assignment (`_ = e`) in VALUE position —
+            // e.g. an expression-lambda body `t => _ = t.Exception`, which binds
+            // to a value-returning delegate, so it reaches here rather than the
+            // statement-level discard lowering in TranslateExpressionStatements.
+            // G# has no discard assignment target (`_` would be an undeclared
+            // identifier, GS0125). C# defines the value of `_ = e` as the value
+            // of `e` and the write itself is a no-op, so the faithful translation
+            // is the RHS alone; a nested discard (`_ = (_ = e)`) unwinds through
+            // the same branch recursively. Only a simple assignment can target a
+            // discard (C# rejects compound forms like `_ += e`).
+            if (assignment.IsKind(SyntaxKind.SimpleAssignmentExpression) &&
+                assignment.Left is IdentifierNameSyntax { Identifier.ValueText: "_" } discardTarget &&
+                this.IsTrueDiscard(discardTarget))
+            {
+                return this.TranslateExpression(assignment.Right);
+            }
+
             GExpression result = new AssignmentExpression(
                 this.TranslateAssignmentTarget(assignment.Left),
                 this.TranslateAssignmentValue(assignment),


### PR DESCRIPTION
## Root cause

A true-discard assignment used as an **expression** — canonically an expression-lambda body, e.g. `tools/cs2gs/Cs2Gs.Pipeline/ProcessRunner.cs:185`:

```csharp
_ = task.ContinueWith(t => _ = t.Exception, TaskScheduler.Default);
```

binds to the **value-returning** `Func` overload of `ContinueWith` (C# betterness prefers the non-void delegate when the lambda body has a value), so the inner `_ = t.Exception` never reaches the statement-level discard lowering in `TranslateExpressionStatements` (which correctly emits `let _ = …`). `CollectEmbeddedAssignments` deliberately skips lambda bodies, so the node fell through to `TranslateAssignmentAsExpression`, which emitted a literal assignment to an undeclared `_` identifier — `ProcessRunner.gs(142): GS0125 Variable '_' doesn't exist`.

## Fix

`TranslateAssignmentAsExpression` now recognizes a simple assignment whose target is a true discard (`IsTrueDiscard`, the issue #1741 symbol check — a real variable named `_` is untouched) and translates it as its RHS alone: C# defines the value of `_ = e` as the value of `e`, and the discard write is a no-op. This covers:

- expression-lambda bodies converted to value-returning delegates (the `ContinueWith` shape),
- nested discards `_ = (_ = e)` (unwinds recursively),
- any other value position with no statement seam (e.g. short-circuited `&&`/`||` operands).

Statement-level discards keep their existing `let _ = …` / drop-inert-reads lowering (issue #3462), unchanged.

## Verification

New `Issue3640LambdaDiscardTranslationTests` (5 tests): the exact `ContinueWith` + `TaskScheduler.Default` shape, `Action<int> a = x => _ = x.ToString();`, a value-returning lambda discard verified end-to-end via `EmittedOracle`, the nested-discard shape, and short-circuit operand discards — each asserting the printed G# contains no bare `_` identifier reference (regex, `let _ =` targets excluded) and binds via `TranslationTestValidation.AssertBinds`. Without the translator change, 4 of 5 fail (the void-`Action` shape already worked and stays as regression coverage). Full `FullyQualifiedName~Discard` filter: 57/57 pass.

Fixes #3640

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs