### PR TITLE
gsc: throw-expression lambda to an imported generic method's delegate parameter (#3646)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -2605,8 +2605,19 @@ internal sealed partial class ExpressionBinder
         }
 
         TypeSymbol erasedReturn;
-        if (FunctionTypeSymbol.IsVoidReturn(functionType.ReturnType))
+        if (FunctionTypeSymbol.IsVoidReturn(functionType.ReturnType)
+            || functionType.ReturnType == TypeSymbol.Never)
         {
+            // Issue #3646: a throw-expression lambda's natural return is the
+            // bottom (`never`) type, which has no CLR erasure. It satisfies
+            // every result slot (issue #2716), so erase it like `void` — the
+            // Action<...> shape — for applicability; the winning candidate's
+            // conversion re-shapes the literal to the real delegate target
+            // (ConversionClassifier's never-candidate arm). Without this the
+            // lambda produced no effective CLR type at all, so an imported
+            // generic call taking a delegate (e.g. Roslyn's
+            // `RegisterSourceOutput(provider, (spc, x) -> throw ...)`) never
+            // ran overload resolution and dead-ended with GS0159.
             erasedReturn = TypeSymbol.Void;
         }
         else

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -6017,7 +6017,12 @@ internal sealed class MemberLookup
             paramClr[i] = parameterClr;
         }
 
-        var isVoid = FunctionTypeSymbol.IsVoidReturn(functionType.ReturnType);
+        // Issue #3646: a throw-expression lambda's natural return is the bottom
+        // (`never`) type, which has no CLR erasure but satisfies every result
+        // slot (issue #2716) — erase it like `void` so the Action<...> shape
+        // gates applicability; conversion re-shapes the literal downstream.
+        var isVoid = FunctionTypeSymbol.IsVoidReturn(functionType.ReturnType)
+            || functionType.ReturnType == TypeSymbol.Never;
         Type? returnClr = null;
         if (!isVoid && !TryEraseDelegateComponentClrType(functionType.ReturnType, out returnClr))
         {

--- a/test/Compiler.Tests/Issue3646ThrowLambdaImportedGenericTests.cs
+++ b/test/Compiler.Tests/Issue3646ThrowLambdaImportedGenericTests.cs
@@ -1,0 +1,169 @@
+// <copyright file="Issue3646ThrowLambdaImportedGenericTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GSharp.Compiler.Tests;
+
+/// <summary>
+/// Regression tests for issue #3646: a throw-expression lambda passed to an
+/// imported generic method taking a delegate parameter (e.g. Roslyn's
+/// <c>IncrementalGeneratorInitializationContext.RegisterSourceOutput(provider,
+/// action)</c>, or the BCL's <c>Array.ForEach(array, action)</c>) failed with
+/// GS0159 "Cannot find function". The lambda's natural function type returns
+/// the bottom (<c>never</c>) type, which has no CLR erasure, so the erased
+/// delegate CLR shape used to gate imported-overload applicability could not
+/// be built and every candidate was rejected before overload resolution ran.
+/// The fix erases a <c>never</c> return like <c>void</c> (issue #2716 already
+/// lets a never-returning literal convert to any delegate result slot).
+/// </summary>
+public class Issue3646ThrowLambdaImportedGenericTests
+{
+    [Fact]
+    public void ThrowLambda_ToImportedGenericMethodActionParameter_Compiles()
+    {
+        // Array.ForEach<T>(T[], Action<T>) — T inferred from the array
+        // argument, the throw-expression lambda flows into Action<T>.
+        CompileGsAgainstTpa("""
+            package Probe
+
+            import System
+
+            func main() {
+                var xs = []int32{1, 2, 3}
+                Array.ForEach(xs, (v int32) -> throw InvalidOperationException("boom"))
+            }
+            """);
+    }
+
+    [Fact]
+    public void ThrowLambda_ToRoslynRegisterSourceOutput_Compiles()
+    {
+        // The exact shape from the migrated GeneratorHost tests: a generic
+        // instance method on the imported STRUCT
+        // IncrementalGeneratorInitializationContext, whose T flows from the
+        // IncrementalValueProvider<Compilation> argument into the
+        // Action<SourceProductionContext, T> delegate parameter, with a
+        // throw-expression lambda as the action.
+        CompileGsAgainstTpa(
+            """
+            package Probe
+
+            import System
+            import Microsoft.CodeAnalysis
+
+            public class ThrowingGenerator : IIncrementalGenerator {
+                public func Initialize(context IncrementalGeneratorInitializationContext) {
+                    context.RegisterSourceOutput(
+                        context.CompilationProvider,
+                        (spc SourceProductionContext, _ Compilation) -> throw InvalidOperationException("boom"))
+                }
+            }
+            """,
+            requiredAssemblySimpleName: "Microsoft.CodeAnalysis");
+    }
+
+    /// <summary>
+    /// Drives gsc in-process against the host's trusted-platform-assembly
+    /// closure (which includes the test project's Microsoft.CodeAnalysis
+    /// package assemblies), asserting a clean compile. Mirrors
+    /// <see cref="XunitAssertOverloadResolutionTests"/>' compile helper.
+    /// </summary>
+    /// <param name="source">G# source to compile.</param>
+    /// <param name="requiredAssemblySimpleName">
+    /// Optional assembly simple name that must be present in the reference
+    /// closure; when absent the test surfaces a missing-prerequisite failure
+    /// instead of a misleading compile error.
+    /// </param>
+    private static void CompileGsAgainstTpa(string source, string requiredAssemblySimpleName = null)
+    {
+        var references = TrustedPlatformAssemblies().ToList();
+        if (requiredAssemblySimpleName != null
+            && !references.Any(p => string.Equals(
+                Path.GetFileNameWithoutExtension(p),
+                requiredAssemblySimpleName,
+                StringComparison.OrdinalIgnoreCase)))
+        {
+            throw new Xunit.Sdk.XunitException(
+                $"prerequisite missing: '{requiredAssemblySimpleName}' not present in the host TPA");
+        }
+
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue3646_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "Probe.gs");
+            File.WriteAllText(srcPath, source);
+            var outPath = Path.Combine(tempDir, "Probe.dll");
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+
+            foreach (var reference in references)
+            {
+                args.Add("/reference:" + reference);
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed (exit {compileExit}):\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            Assert.True(File.Exists(outPath), "expected emitted assembly");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+                // Best-effort cleanup only.
+            }
+        }
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (string.IsNullOrEmpty(tpa))
+        {
+            yield break;
+        }
+
+        foreach (var path in tpa.Split(Path.PathSeparator))
+        {
+            if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
+            {
+                yield return path;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3646

## Problem

Migrated `GSharp.GeneratorHost.Tests` failed to compile with `GS0159 Cannot find function RegisterSourceOutput` on:

```
context.RegisterSourceOutput(
    context.CompilationProvider,
    (spc SourceProductionContext, _ Compilation) -> throw InvalidOperationException("boom from ThrowingGenerator"))
```

Minimal repro (no Roslyn needed):

```
Array.ForEach(xs, (v int32) -> throw InvalidOperationException("x"))   // GS0159
```

## Root cause

Not a member-lookup or generic-inference gap: a lambda whose body is a throw expression has the bottom (`never`) return type, which has no CLR erasure. The erased `Func<>`/`Action<>` delegate CLR shape that gates imported-overload applicability could not be built (`TryBuildErasedDelegateClrType` / `TryProjectErasedDelegateClrType` both bail on an unerasable return), so the argument produced no effective CLR type, overload resolution never ran, and every candidate was rejected as GS0159. The same lambda bound fine against source-declared generic functions and concrete delegate targets because the symbolic conversion path already treats `never` as satisfying every result slot (issue #2716).

## Fix

Erase a `never` return like `void` (the `Action<…>` shape) in the two erased-delegate builders:

- `src/Core/CodeAnalysis/Binding/ExpressionBinder.cs` — `TryBuildErasedDelegateClrType`
- `src/Core/CodeAnalysis/Binding/MemberLookup.cs` — `TryProjectErasedDelegateClrType`

The winning candidate's conversion re-shapes the literal to the real delegate target downstream (ConversionClassifier's never-candidate arm), so no overload-resolution rules are loosened — only the applicability gate stops rejecting a shape the conversion machinery already accepts.

## Verification

- New `test/Compiler.Tests/Issue3646ThrowLambdaImportedGenericTests.cs`: compiles the `Array.ForEach` repro and the exact Roslyn `RegisterSourceOutput` generator shape (against real `Microsoft.CodeAnalysis` references from the host TPA, with a clear missing-prerequisite failure if absent) — both green.
- `dotnet test test/Core.Tests --filter "FullyQualifiedName~Invocation|FullyQualifiedName~GenericMethod|FullyQualifiedName~Delegate"`: 296/296 passed.
- `dotnet test test/Compiler.Tests --filter "FullyQualifiedName~XunitAssertOverloadResolution|FullyQualifiedName~Lambda"`: 340/340 passed.
- Manual gsc (Release) run of the generator-shaped repro against `microsoft.codeanalysis.common/csharp 5.6.0`: GS0159 before the fix, clean compile after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
