### PR TITLE
cs2gs: bridge annotated-context null flows at lambda-result and expanded-params seams (#3644)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue3644AnnotatedNullFlowBridgingTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3644AnnotatedNullFlowBridgingTests.cs
@@ -1,0 +1,226 @@
+// <copyright file="Issue3644AnnotatedNullFlowBridgingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translator-fidelity tests for issue #3644: an OBLIVIOUS compilation binding
+/// an annotated `T?` value (declared `string?` in BCL metadata, e.g.
+/// <c>Path.GetDirectoryName</c>) into a slot the C# source compiled as
+/// non-null `T`. Two shapes slipped through the established #1072/#2113
+/// bridging and produced GS0154/GS0155 walls in migrated
+/// <c>Cs2Gs.Pipeline</c>:
+/// <list type="number">
+/// <item>an expression-bodied runtime lambda forwarding a flat
+/// declared-annotated member read as its result (the
+/// <c>PrepareTemporaryBuildProps</c>
+/// <c>Select(path =&gt; Path.GetDirectoryName(...))</c> shape) — the lambda
+/// result seam bailed on ANY <c>IsNullableInitializer</c> value, so gsc
+/// inferred the lambda result `string?` and the divergence cascaded into
+/// every downstream sink;</item>
+/// <item>an argument in the EXPANDED tail of a classic `params T[]` call
+/// (the <c>FindNupkgForVersion</c>
+/// <c>Path.Combine(RepoRoot, "out", ...)</c> shape) — Roslyn wraps the tail
+/// in one synthesized array-creation argument, so the per-argument
+/// <c>IArgumentOperation</c>-driven bridge never saw a bound
+/// parameter.</item>
+/// </list>
+/// </summary>
+public class Issue3644AnnotatedNullFlowBridgingTests
+{
+    /// <summary>
+    /// The migrated Cs2Gs.Pipeline <c>PrepareTemporaryBuildProps</c> wall
+    /// (GS0154 at SdkCompileRunner.gs): a runtime lambda whose body is a flat
+    /// annotated-BCL invocation (`string?`) targeting an oblivious
+    /// `Func&lt;string, string&gt;` return contract must assert `!!` so the
+    /// `Select(...)` element type — and the foreach variable inferred from it
+    /// — stays non-null for the downstream non-null parameter.
+    /// </summary>
+    [Fact]
+    public void RuntimeLambdaResult_FlatAnnotatedBclValue_AssertsNonNull()
+    {
+        string printed = TranslateOblivious(@"
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Demo
+{
+    public static class Props
+    {
+        public static void Prepare(IEnumerable<string> generatedProjectPaths)
+        {
+            foreach (string projectDirectory in generatedProjectPaths
+                .Select(path => Path.GetDirectoryName(Path.GetFullPath(path)))
+                .Distinct(StringComparer.OrdinalIgnoreCase))
+            {
+                Consume(projectDirectory);
+            }
+        }
+
+        private static void Consume(string directory)
+        {
+            Console.WriteLine(directory);
+        }
+    }
+}");
+
+        Assert.Contains("Path.GetDirectoryName(Path.GetFullPath(path))!!", printed);
+    }
+
+    /// <summary>
+    /// The migrated Cs2Gs.Pipeline <c>FindNupkgForVersion</c> wall (GS0155 at
+    /// GsharpTestProjectRunner.gs:118): a promoted-nullable property
+    /// (`string?` on the G# side) flowing into the expanded tail of
+    /// `Path.Combine(params string[])` must assert `!!` against the non-null
+    /// params ELEMENT contract.
+    /// </summary>
+    [Fact]
+    public void ExpandedParamsArgument_PromotedProperty_AssertsNonNull()
+    {
+        string printed = TranslateOblivious(@"
+using System.IO;
+
+namespace Demo
+{
+    public class Runner
+    {
+        public Runner(string repoRoot)
+        {
+            RepoRoot = repoRoot ?? FindRepoRoot();
+        }
+
+        public string RepoRoot { get; }
+
+        public string Candidate(string version)
+        {
+            return Path.Combine(RepoRoot, ""out"", ""bin"", ""nupkgs"", version + "".nupkg"");
+        }
+
+        private static string FindRepoRoot()
+        {
+            return null;
+        }
+    }
+}");
+
+        Assert.Contains("prop RepoRoot string?", printed);
+        Assert.Contains("RepoRoot!!", printed.Substring(printed.IndexOf("Path.Combine", StringComparison.Ordinal)));
+    }
+
+    /// <summary>
+    /// Precision guard: a SYNTACTICALLY nullable lambda result (`x?.Member`)
+    /// keeps its deliberate nullability — no `!!` is forced onto the
+    /// conditional access.
+    /// </summary>
+    [Fact]
+    public void RuntimeLambdaResult_ConditionalAccessShape_StaysBare()
+    {
+        string printed = TranslateOblivious(@"
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Demo
+{
+    public static class Trimmer
+    {
+        public static List<string> TrimAll(IEnumerable<string> values)
+        {
+            return values.Select(value => value?.Trim()).ToList();
+        }
+    }
+}");
+
+        Assert.DoesNotContain("Trim()!!", printed);
+    }
+
+    /// <summary>
+    /// Precision guard: a non-nullable value in the expanded params tail grows
+    /// no assertion.
+    /// </summary>
+    [Fact]
+    public void ExpandedParamsArgument_NonNullableValue_StaysBare()
+    {
+        string printed = TranslateOblivious(@"
+using System.IO;
+
+namespace Demo
+{
+    public static class Combiner
+    {
+        public static string Build(string root)
+        {
+            return Path.Combine(root, ""a"", ""b"", ""c"", ""d"");
+        }
+    }
+}");
+
+        Assert.DoesNotContain("root!!", printed);
+    }
+
+    /// <summary>
+    /// Regression guard for the already-working sibling shape: a LOCAL
+    /// initialized from an annotated-BCL `string?` value renders the promoted
+    /// `string?` declaration with `!!` at the non-null use site, and the whole
+    /// document still binds.
+    /// </summary>
+    [Fact]
+    public void AnnotatedBclLocalInitializer_PromotesAndAssertsAtUse()
+    {
+        string printed = TranslateOblivious(@"
+using System.IO;
+
+namespace Demo
+{
+    public static class Dirs
+    {
+        public static void Ensure(string generatedProjectPath)
+        {
+            string projectDirectory = Path.GetDirectoryName(Path.GetFullPath(generatedProjectPath));
+            Directory.CreateDirectory(projectDirectory);
+        }
+    }
+}");
+
+        Assert.Contains("projectDirectory string?", printed);
+        Assert.Contains("projectDirectory!!", printed);
+    }
+
+    private static string TranslateOblivious(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        Assert.Equal(
+            NullableContextOptions.Disable,
+            project.Compilation.Options.NullableContextOptions);
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+
+    private static string PrintAndValidate(CompilationUnit unit)
+    {
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -2927,8 +2927,21 @@ public sealed partial class CSharpToGSharpTranslator
 
         private bool IsUnguardedForwardOfTaintedValueAsRuntimeLambdaResult(ExpressionSyntax use)
         {
+            // Issue #3644: only a SYNTACTICALLY nullable result shape (`a?.b`,
+            // `a ?? nullableFallback`, `cond ? a : b` with a nullable arm) keeps
+            // its nullable lambda result unasserted — those forms introduce
+            // nullability the C# author wrote deliberately. A value whose
+            // nullability comes solely from the DECLARED `T?` annotation of the
+            // bound member (e.g. the annotated-BCL `Path.GetDirectoryName(...)`)
+            // was compiled by oblivious C# under the target delegate's NON-NULL
+            // return contract (`Func<string, string>`), so it must be bridged
+            // with `!!` like every other tainted forward — otherwise gsc infers
+            // the lambda result `T?` and the divergence cascades into every
+            // downstream sink (`Select(...)` element flows, `foreach` variables,
+            // non-null arguments: the migrated Cs2Gs.Pipeline
+            // `PrepareTemporaryBuildProps` GS0154 walls).
             if (IsNullOrSuppressedNull(use)
-                || this.IsNullableInitializer(use)
+                || this.IsSyntacticallyNullableResultShape(use)
                 || !this.IsObliviousCompilation()
                 || this.IsWithinExpressionTreeLambda(use)
                 || this.FindResultLambda(use) is not { } lambda

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -1588,8 +1588,80 @@ public sealed partial class CSharpToGSharpTranslator
                     parameter,
                     includePromotedValue: true);
             }
+            else if (!IsNameOfArgument(argument)
+                && !isXunitNullAssertion
+                && argumentOperation is null
+                && this.TryGetExpandedParamsElementTarget(
+                    argument,
+                    out ITypeSymbol paramsElementType,
+                    out IParameterSymbol paramsParameter))
+            {
+                // Issue #3644: an argument in the EXPANDED tail of a params
+                // call (`params T[]` or the C#13 `params ReadOnlySpan<T>`,
+                // e.g. `Path.Combine(a, b, c, d, e)` binding
+                // `Path.Combine(params ReadOnlySpan<string>)`) has no
+                // IArgumentOperation of its own — Roslyn wraps the whole tail
+                // in one synthesized collection argument — so the
+                // parameter-targeted bridge above never sees it and a
+                // promoted/declared-nullable value flowed into the non-null
+                // element slot bare (GS0154/GS0155, the migrated
+                // Cs2Gs.Pipeline `FindNupkgForVersion` wall). Bridge against
+                // the params ELEMENT contract instead.
+                translated = this.ForgiveNullableReferenceValue(
+                    argument.Expression,
+                    translated,
+                    paramsElementType,
+                    paramsParameter,
+                    includePromotedValue: true);
+            }
 
             return translated;
+        }
+
+        // Issue #3644: resolves the element contract an argument binds to when
+        // it sits in the EXPANDED tail of a `params T[]` /
+        // `params ReadOnlySpan<T>` (or other single-type-argument params
+        // collection) parameter. The single-argument DIRECT collection form
+        // (`Path.Combine(paths)`) binds the parameter itself and is excluded.
+        private bool TryGetExpandedParamsElementTarget(
+            ArgumentSyntax argument,
+            out ITypeSymbol elementType,
+            out IParameterSymbol paramsParameter)
+        {
+            elementType = null;
+            paramsParameter = null;
+            if (argument.NameColon != null
+                || argument.Parent is not BaseArgumentListSyntax { Parent: ExpressionSyntax call } argumentList
+                || this.context.GetSymbolInfo(call).Symbol is not IMethodSymbol method
+                || method.Parameters.Length == 0)
+            {
+                return false;
+            }
+
+            IParameterSymbol lastParameter = method.Parameters[^1];
+            ITypeSymbol candidateElementType = lastParameter.Type switch
+            {
+                IArrayTypeSymbol arrayType => arrayType.ElementType,
+                INamedTypeSymbol { TypeArguments.Length: 1 } spanLike => spanLike.TypeArguments[0],
+                _ => null,
+            };
+            if (!lastParameter.IsParams
+                || candidateElementType == null
+                || argumentList.Arguments.IndexOf(argument) < method.Parameters.Length - 1)
+            {
+                return false;
+            }
+
+            ITypeSymbol convertedType = this.context.GetTypeInfo(argument.Expression).ConvertedType;
+            if (convertedType != null
+                && SymbolEqualityComparer.Default.Equals(convertedType, lastParameter.Type))
+            {
+                return false;
+            }
+
+            elementType = candidateElementType;
+            paramsParameter = lastParameter;
+            return true;
         }
 
         // ADR-0060: whether this argument binds (implicitly, in C#) to an `in`

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
@@ -650,6 +650,37 @@ public sealed partial class CSharpToGSharpTranslator
                 && symbolType.NullableAnnotation == NullableAnnotation.Annotated;
         }
 
+        // Issue #3644: the subset of <see cref="IsNullableInitializer"/> whose
+        // nullability is written into the EXPRESSION SHAPE itself (`a?.b`,
+        // `a ?? nullableFallback`, `cond ? a : b` with a nullable arm) rather
+        // than inherited from a bound member's declared `T?` annotation. The
+        // runtime-lambda result seam keeps these shapes unasserted (their
+        // nullability is deliberate) while a flat declared-annotated member
+        // read forwarded as the lambda result is bridged with `!!` to preserve
+        // the oblivious C# delegate's non-null return contract.
+        private bool IsSyntacticallyNullableResultShape(ExpressionSyntax expression)
+        {
+            switch (expression)
+            {
+                case ParenthesizedExpressionSyntax paren:
+                    return this.IsSyntacticallyNullableResultShape(paren.Expression);
+
+                case ConditionalAccessExpressionSyntax:
+                    return true;
+
+                case BinaryExpressionSyntax coalesce
+                    when coalesce.IsKind(SyntaxKind.CoalesceExpression):
+                    return this.IsNullableInitializer(coalesce.Right);
+
+                case ConditionalExpressionSyntax ternary:
+                    return this.IsNullableInitializer(ternary.WhenTrue)
+                        || this.IsNullableInitializer(ternary.WhenFalse);
+
+                default:
+                    return false;
+            }
+        }
+
         // Issue #1072/#2113/#914: the single translator-side promotion decision
         // for a reference-typed symbol position. Declaration rendering and sink
         // `!!` insertion both route through this helper so a tainted interface/


### PR DESCRIPTION
Fixes #3644 — the GS0154/GS0155 walls in migrated `Cs2Gs.Pipeline` (`SdkCompileRunner.gs` 546/568, `GsharpTestProjectRunner.gs` 118).

## Root cause

Two seams let a value whose nullability comes from a **declared `T?` annotation** reach a non-null slot without a `!!` bridge, so gsc rejected output the C# compiler had accepted under its own contracts:

1. **Runtime-lambda result forwards.** The seam treated *any* nullable-initializer shape as deliberate authored nullability. But only a **syntactically** nullable result (`a?.b`, `a ?? nullableFallback`, a ternary with a nullable arm) is authored; a flat read like the annotated-BCL `Path.GetDirectoryName(...)` was compiled under the target delegate's non-null return contract (`Func<string, string>`). Left unasserted, gsc infers the lambda result as `T?` and the divergence cascades into every downstream sink (`Select` element flows, `foreach` variables, non-null arguments).

2. **Expanded-params arguments.** An argument in the expanded tail of a `params T[]` / C#13 `params ReadOnlySpan<T>` call (e.g. `Path.Combine(a, b, c, d, e)`) has **no `IArgumentOperation` of its own** — Roslyn wraps the whole tail in one synthesized collection argument — so the parameter-targeted bridge never saw it and promoted/declared-nullable values flowed into the non-null element slot bare. These now bridge against the params **element** contract; the single-argument direct-collection form (`Path.Combine(paths)`) still binds the parameter itself and is excluded.

## Verification

- New `Issue3644AnnotatedNullFlowBridgingTests` (5 tests) covering both seams.
- Regression families green: nullability / `Issue1072` / `Forgive` / oblivious / `Issue2113` / params — **427/427**.
- Rebased onto current main (post-#3647/#3650).

Note: this PR was completed from an interrupted agent session; the code and tests are as authored, re-verified end to end after rebasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs