### PR TITLE
cs2gs: propagate null taint into tuple elements under generic type arguments (#3641)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue3641NullArmInitializedLocalTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3641NullArmInitializedLocalTranslationTests.cs
@@ -1,0 +1,217 @@
+// <copyright file="Issue3641NullArmInitializedLocalTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translator-fidelity tests for issue #3641: a value initialized through a
+/// conditional expression whose false (or true) arm is <c>null</c> is really
+/// nullable — it observably holds <c>null</c> on that path, and the source
+/// typically null-checks it later, which trips GS0523 (ADR-0159) when the
+/// declaration renders bare.
+/// <para>
+/// The four SIMPLE-local shapes below already promoted correctly through the
+/// issue-#1072 used-as-nullable analysis and are locked here as regression
+/// probes. The real wall (the selfmig one at SdkCompileRunner.gs) is the fifth:
+/// the null-bearing value is packed into a TUPLE ELEMENT that lives under a
+/// generic type argument — <c>List&lt;(string Path, byte[] Original)&gt;</c> — and is
+/// handed across three signatures. Because G# tuple types agree structurally,
+/// the element has to render nullable at every one of those occurrences or at
+/// none of them.
+/// </para>
+/// </summary>
+public class Issue3641NullArmInitializedLocalTranslationTests
+{
+    [Fact]
+    public void TernaryNullArmByteArrayLocal_WithLaterIsNullCheck_PromotesToNullable()
+    {
+        // The exact SdkCompileRunner shape: `byte[] x = cond ? bytes : null;`
+        // followed by `if (x is null)`.
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public void F(string path)
+        {
+            byte[] originalNugetConfig = System.IO.File.Exists(path)
+                ? System.IO.File.ReadAllBytes(path)
+                : null;
+            if (originalNugetConfig is null)
+            {
+                System.Console.WriteLine(""missing"");
+            }
+            else
+            {
+                System.IO.File.WriteAllBytes(path, originalNugetConfig);
+            }
+        }
+    }
+}");
+
+        Assert.Contains("originalNugetConfig []?uint8 =", printed);
+        Assert.DoesNotContain("originalNugetConfig []uint8 =", printed);
+    }
+
+    [Fact]
+    public void TernaryNullArmLocalIntoTupleElement_TaintsTupleElementAcrossMembers()
+    {
+        // The surviving SdkCompileRunner wall (the .gs GS0523): a ternary-null
+        // local packed into a tuple element that lives under a generic type
+        // argument, handed across three signatures — the producer's
+        // `IReadOnlyList<...>` return, an intermediate local, and a SIBLING
+        // method's `IEnumerable<...>` parameter that null-checks the element
+        // (`temporary.Original == null`). G# tuple types agree structurally, so
+        // `Original` must render `[]?uint8` at EVERY one of those occurrences.
+        string printed = TranslateUnit(@"
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Demo
+{
+    public static class C
+    {
+        public static void Run(IEnumerable<string> paths)
+        {
+            IReadOnlyList<(string Path, byte[] Original)> temporaryBuildProps = Prepare(paths);
+            Restore(temporaryBuildProps);
+        }
+
+        public static IReadOnlyList<(string Path, byte[] Original)> Prepare(IEnumerable<string> paths)
+        {
+            var prepared = new List<(string Path, byte[] Original)>();
+            foreach (string path in paths)
+            {
+                byte[] original = System.IO.File.Exists(path)
+                    ? System.IO.File.ReadAllBytes(path)
+                    : null;
+                prepared.Add((path, original));
+            }
+
+            return prepared;
+        }
+
+        public static void Restore(IEnumerable<(string Path, byte[] Original)> temporaryBuildProps)
+        {
+            foreach (var temporary in temporaryBuildProps.Reverse())
+            {
+                if (temporary.Original == null)
+                {
+                    System.IO.File.Delete(temporary.Path);
+                }
+                else
+                {
+                    System.IO.File.WriteAllBytes(temporary.Path, temporary.Original);
+                }
+            }
+        }
+    }
+}");
+
+        Assert.DoesNotContain("Original []uint8)", printed);
+        Assert.Contains("temporaryBuildProps IEnumerable[(Path string, Original []?uint8)]", printed);
+        Assert.Contains("IReadOnlyList[(Path string, Original []?uint8)]", printed);
+        Assert.Contains("List[(Path string, Original []?uint8)]", printed);
+    }
+
+    [Fact]
+    public void TernaryNullArmStringLocal_WithLaterIsNullCheck_PromotesToNullable()
+    {
+        // Reference-type variant of the same shape.
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public void F(bool cond)
+        {
+            string s = cond ? ""x"" : null;
+            if (s is null)
+            {
+                System.Console.WriteLine(""nil"");
+            }
+            else
+            {
+                System.Console.WriteLine(s);
+            }
+        }
+    }
+}");
+
+        Assert.Contains("s string? =", printed);
+    }
+
+    [Fact]
+    public void TernaryNullArmLocal_NeverNullChecked_StillPromotesToNullable()
+    {
+        // Even without a later null check, the null arm alone proves the local
+        // can hold nil, so the declared type must be nullable for the
+        // initializer itself to bind.
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class Box { }
+    public class C
+    {
+        public void F(bool cond)
+        {
+            Box b = cond ? new Box() : null;
+            System.Console.WriteLine(b);
+        }
+    }
+}");
+
+        Assert.Contains("b Box? =", printed);
+    }
+
+    [Fact]
+    public void TernaryNonNullArms_LocalStaysNonNullable()
+    {
+        // Precision guard: a conditional initializer with two non-null arms
+        // must not be over-promoted.
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public void F(bool cond)
+        {
+            string s = cond ? ""x"" : ""y"";
+            System.Console.WriteLine(s);
+        }
+    }
+}");
+
+        Assert.DoesNotContain("string?", printed);
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip and bind. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -2238,6 +2238,7 @@ public sealed partial class CSharpToGSharpTranslator
             GTypeReference type = typeSymbol != null
                 ? this.typeMapper.Map(typeSymbol, this.context, creation.GetLocation())
                 : new NamedTypeReference(creation.Type.ToString());
+            type = this.PromoteCreationTupleArguments(type, typeSymbol, creation);
 
             var arguments = this.TranslateCallArguments(
                 creation,

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
@@ -252,6 +252,71 @@ public sealed partial class CSharpToGSharpTranslator
             return this.PromoteTupleTypeArguments(mapped, returnType, symbol, new List<int>());
         }
 
+        // Issue #3641: `var prepared = new List<(string, byte[])>()` renders the
+        // CREATED type, not the local's declared type, so promoting only the
+        // declaration would leave the initializer's `List[(string, []uint8)]`
+        // unconvertible to the promoted `List[(string, []?uint8)]`. G# tuple
+        // types agree structurally: the construction that feeds a promoted sink
+        // has to be spelled with the same elements. The sink's own element paths
+        // are reused directly — the mapper walks the CREATED type's arguments,
+        // which coincide with the sink's for the covariant collection hand-offs
+        // this shape uses (`List<T>` stored as `IReadOnlyList<T>`) and simply ask
+        // an untainted key otherwise.
+        private GTypeReference PromoteCreationTupleArguments(
+            GTypeReference type,
+            ITypeSymbol typeSymbol,
+            BaseObjectCreationExpressionSyntax creation)
+        {
+            if (type == null || typeSymbol == null || !this.IsObliviousCompilation())
+            {
+                return type;
+            }
+
+            ISymbol sink = this.ResolveValueSink(creation);
+            return sink == null
+                ? type
+                : this.PromoteTupleTypeArguments(type, typeSymbol, sink, new List<int>());
+        }
+
+        // The declaration a freshly built value flows into: the local/field being
+        // initialized, the assignment target, the invoked parameter, or the
+        // enclosing member whose return it is. Mirrors the sinks the analyzer's
+        // tuple-flow collectors record edges for, so both sides agree on which
+        // declaration owns the element key.
+        private ISymbol ResolveValueSink(ExpressionSyntax value)
+        {
+            SyntaxNode node = value;
+            while (node.Parent is ParenthesizedExpressionSyntax or CastExpressionSyntax)
+            {
+                node = node.Parent;
+            }
+
+            switch (node.Parent)
+            {
+                case EqualsValueClauseSyntax { Parent: VariableDeclaratorSyntax declarator }:
+                    return this.context.GetDeclaredSymbol(declarator);
+
+                case AssignmentExpressionSyntax assignment
+                    when assignment.IsKind(SyntaxKind.SimpleAssignmentExpression)
+                        && assignment.Right == node:
+                    return this.context.GetSymbolInfo(assignment.Left).Symbol;
+
+                case ArgumentSyntax argument:
+                    return (this.context.SemanticModel.GetOperation(argument) as IArgumentOperation)
+                        ?.Parameter;
+
+                case ReturnStatementSyntax returnStatement:
+                    return this.context.SemanticModel
+                        .GetEnclosingSymbol(returnStatement.SpanStart) as IMethodSymbol;
+
+                case ArrowExpressionClauseSyntax arrow:
+                    return this.context.SemanticModel.GetDeclaredSymbol(arrow.Parent);
+
+                default:
+                    return null;
+            }
+        }
+
         private GTypeReference PromoteTupleTypeArguments(
             GTypeReference mapped,
             ITypeSymbol declaredType,

--- a/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
@@ -1080,14 +1080,13 @@ internal static class ObliviousNullabilityAnalyzer
                 case VariableDeclaratorSyntax declarator
                     when declarator.Initializer?.Value is ExpressionSyntax initializer:
                     ISymbol declared = model.GetDeclaredSymbol(declarator);
-                    if (TryGetTupleType(declared, out INamedTypeSymbol declaredTuple))
+                    if (declared != null && SymbolValueType(declared) is ITypeSymbol declaredType)
                     {
-                        CollectTupleValueFlow(
+                        CollectDeclarationTupleFlow(
                             Canonical(declared),
-                            declaredTuple,
+                            declaredType,
                             initializer,
                             model,
-                            string.Empty,
                             tupleTainted,
                             tupleEdges,
                             tupleScalarEdges);
@@ -1098,14 +1097,13 @@ internal static class ObliviousNullabilityAnalyzer
                 case AssignmentExpressionSyntax assignment
                     when assignment.IsKind(SyntaxKind.SimpleAssignmentExpression):
                     ISymbol target = ResolveAssignable(assignment.Left, model);
-                    if (TryGetTupleType(target, out INamedTypeSymbol targetTuple))
+                    if (target != null && SymbolValueType(target) is ITypeSymbol assignedType)
                     {
-                        CollectTupleValueFlow(
+                        CollectDeclarationTupleFlow(
                             target,
-                            targetTuple,
+                            assignedType,
                             assignment.Right,
                             model,
-                            string.Empty,
                             tupleTainted,
                             tupleEdges,
                             tupleScalarEdges);
@@ -1148,7 +1146,9 @@ internal static class ObliviousNullabilityAnalyzer
         List<(TupleElementKey Target, TupleElementKey Source)> tupleEdges,
         List<(TupleElementKey Target, ISymbol Source)> tupleScalarEdges)
     {
-        if (!TryGetTupleType(method, out INamedTypeSymbol tupleType))
+        ITypeSymbol returnType = SymbolValueType(method);
+        if (returnType is not INamedTypeSymbol { IsTupleType: true }
+            && NestedTupleSlots(returnType).Count == 0)
         {
             return;
         }
@@ -1156,12 +1156,11 @@ internal static class ObliviousNullabilityAnalyzer
         ISymbol target = Canonical(method);
         if (arrowBody != null)
         {
-            CollectTupleValueFlow(
+            CollectDeclarationTupleFlow(
                 target,
-                tupleType,
+                returnType,
                 arrowBody,
                 model,
-                string.Empty,
                 tupleTainted,
                 tupleEdges,
                 tupleScalarEdges);
@@ -1171,12 +1170,11 @@ internal static class ObliviousNullabilityAnalyzer
         {
             if (statement.Expression != null)
             {
-                CollectTupleValueFlow(
+                CollectDeclarationTupleFlow(
                     target,
-                    tupleType,
+                    returnType,
                     statement.Expression,
                     model,
-                    string.Empty,
                     tupleTainted,
                     tupleEdges,
                     tupleScalarEdges);
@@ -1258,14 +1256,13 @@ internal static class ObliviousNullabilityAnalyzer
         {
             if (argument.Parameter is IParameterSymbol parameter
                 && argument.Value?.Syntax is ExpressionSyntax value
-                && TryGetTupleType(parameter, out INamedTypeSymbol tupleType))
+                && parameter.Type is ITypeSymbol parameterType)
             {
-                CollectTupleValueFlow(
+                CollectDeclarationTupleFlow(
                     Canonical(parameter),
-                    tupleType,
+                    parameterType,
                     value,
                     model,
-                    string.Empty,
                     tupleTainted,
                     tupleEdges,
                     tupleScalarEdges);
@@ -1302,16 +1299,23 @@ internal static class ObliviousNullabilityAnalyzer
         };
 
         ISymbol target = receiver == null ? null : model.GetSymbolInfo(receiver).Symbol;
+
+        // Issue #3641: a LOCAL collection is just as much a declaration sink as
+        // a field/property — `var prepared = new List<(string, byte[])>();
+        // prepared.Add((path, original))` is where the null-bearing element
+        // enters the tuple that the enclosing method then returns.
         ITypeSymbol targetType = target switch
         {
             IFieldSymbol field => field.Type,
             IPropertySymbol property => property.Type,
+            ILocalSymbol local => local.Type,
+            IParameterSymbol receiverParameter => receiverParameter.Type,
             _ => null,
         };
 
         // Scalar flow already treats out as callee-to-caller and deliberately
         // excludes ref, so neither is receiver-directed here.
-        if (target is not (IFieldSymbol or IPropertySymbol)
+        if (target is not (IFieldSymbol or IPropertySymbol or ILocalSymbol or IParameterSymbol)
             || targetType is not INamedTypeSymbol receiverType
             || argument.Parameter is not IParameterSymbol parameter
             || parameter.RefKind is RefKind.Out or RefKind.Ref
@@ -1334,6 +1338,137 @@ internal static class ObliviousNullabilityAnalyzer
             tupleTainted,
             tupleEdges,
             tupleScalarEdges);
+    }
+
+    /// <summary>
+    /// Issue #3641: routes a value flowing into a declaration to the bare-tuple
+    /// collector or to the nested (generic type argument) one, so a tuple that
+    /// lives under `List&lt;T&gt;` / `IReadOnlyList&lt;T&gt;` / `IEnumerable&lt;T&gt;` is the same
+    /// declaration sink as a bare tuple. G# tuple types agree structurally, so a
+    /// producer's return, the intermediate locals and the consumer's parameter
+    /// must all render an element identically or none of them may.
+    /// </summary>
+    /// <param name="target">The declaration receiving the value.</param>
+    /// <param name="targetType">The declaration's declared (or awaited) type.</param>
+    /// <param name="value">The flowing value expression.</param>
+    /// <param name="model">The semantic model for <paramref name="value"/>.</param>
+    /// <param name="tupleTainted">Directly tainted tuple leaves.</param>
+    /// <param name="tupleEdges">Tuple-leaf to tuple-leaf edges.</param>
+    /// <param name="tupleScalarEdges">Tuple-leaf to scalar-declaration edges.</param>
+    private static void CollectDeclarationTupleFlow(
+        ISymbol target,
+        ITypeSymbol targetType,
+        ExpressionSyntax value,
+        SemanticModel model,
+        HashSet<TupleElementKey> tupleTainted,
+        List<(TupleElementKey Target, TupleElementKey Source)> tupleEdges,
+        List<(TupleElementKey Target, ISymbol Source)> tupleScalarEdges)
+    {
+        if (target == null)
+        {
+            return;
+        }
+
+        if (targetType is INamedTypeSymbol { IsTupleType: true } tuple)
+        {
+            CollectTupleValueFlow(
+                target,
+                tuple,
+                value,
+                model,
+                string.Empty,
+                tupleTainted,
+                tupleEdges,
+                tupleScalarEdges);
+            return;
+        }
+
+        CollectNestedTupleValueFlow(target, targetType, value, model, tupleTainted, tupleEdges);
+    }
+
+    // Issue #3641: pairs the nested tuple slots of the target's declared type
+    // with those of the source's, positionally and only when both sides expose
+    // the same number of slots with the same element arity. That keeps the
+    // pairing sound across the covariant hand-offs the shape actually uses
+    // (`List<T>` returned as `IReadOnlyList<T>`, passed as `IEnumerable<T>`)
+    // without inventing a second cross-signature keying model: each side keeps
+    // the element path of ITS OWN rendered type.
+    private static void CollectNestedTupleValueFlow(
+        ISymbol target,
+        ITypeSymbol targetType,
+        ExpressionSyntax value,
+        SemanticModel model,
+        HashSet<TupleElementKey> tupleTainted,
+        List<(TupleElementKey Target, TupleElementKey Source)> tupleEdges)
+    {
+        List<(string Path, INamedTypeSymbol Tuple)> targetSlots = NestedTupleSlots(targetType);
+        if (targetSlots.Count == 0)
+        {
+            return;
+        }
+
+        value = UnwrapTupleValue(value);
+        switch (value)
+        {
+            case null:
+                return;
+
+            case ConditionalExpressionSyntax conditional:
+                CollectNestedTupleValueFlow(
+                    target, targetType, conditional.WhenTrue, model, tupleTainted, tupleEdges);
+                CollectNestedTupleValueFlow(
+                    target, targetType, conditional.WhenFalse, model, tupleTainted, tupleEdges);
+                return;
+
+            case SwitchExpressionSyntax switchExpression:
+                foreach (SwitchExpressionArmSyntax arm in switchExpression.Arms)
+                {
+                    CollectNestedTupleValueFlow(
+                        target, targetType, arm.Expression, model, tupleTainted, tupleEdges);
+                }
+
+                return;
+        }
+
+        ISymbol source = value switch
+        {
+            InvocationExpressionSyntax or IdentifierNameSyntax or MemberAccessExpressionSyntax =>
+                model.GetSymbolInfo(value).Symbol,
+            _ => null,
+        };
+
+        if (source == null)
+        {
+            return;
+        }
+
+        List<(string Path, INamedTypeSymbol Tuple)> sourceSlots = NestedTupleSlots(SymbolValueType(source));
+        if (sourceSlots.Count != targetSlots.Count)
+        {
+            return;
+        }
+
+        for (int i = 0; i < targetSlots.Count; i++)
+        {
+            if (targetSlots[i].Tuple.TupleElements.Length != sourceSlots[i].Tuple.TupleElements.Length)
+            {
+                return;
+            }
+        }
+
+        ISymbol canonicalSource = Canonical(source);
+        for (int i = 0; i < targetSlots.Count; i++)
+        {
+            AddTupleShapeEdges(
+                target,
+                targetSlots[i].Tuple,
+                targetSlots[i].Path,
+                canonicalSource,
+                sourceSlots[i].Tuple,
+                sourceSlots[i].Path,
+                tupleTainted,
+                tupleEdges);
+        }
     }
 
     private static void CollectTupleValueFlow(
@@ -1855,18 +1990,68 @@ internal static class ObliviousNullabilityAnalyzer
 
     private static bool TryGetTupleType(ISymbol symbol, out INamedTypeSymbol tupleType)
     {
-        ITypeSymbol type = symbol switch
-        {
-            IMethodSymbol method => UnwrapAwaitedType(method.ReturnType),
-            IPropertySymbol property => property.Type,
-            IFieldSymbol field => field.Type,
-            ILocalSymbol local => local.Type,
-            IParameterSymbol parameter => parameter.Type,
-            _ => null,
-        };
-
-        tupleType = type as INamedTypeSymbol;
+        tupleType = SymbolValueType(symbol) as INamedTypeSymbol;
         return tupleType is { IsTupleType: true };
+    }
+
+    /// <summary>
+    /// The type of the value a declaration symbol denotes — a method's
+    /// (awaited) return type, otherwise the declared type. Returns
+    /// <see langword="null"/> for symbols that are not value declarations.
+    /// </summary>
+    /// <param name="symbol">The candidate declaration symbol.</param>
+    /// <returns>The denoted value type, or <see langword="null"/>.</returns>
+    private static ITypeSymbol SymbolValueType(ISymbol symbol) => symbol switch
+    {
+        IMethodSymbol method => UnwrapAwaitedType(method.ReturnType),
+        IPropertySymbol property => property.Type,
+        IFieldSymbol field => field.Type,
+        ILocalSymbol local => local.Type,
+        IParameterSymbol parameter => parameter.Type,
+        _ => null,
+    };
+
+    /// <summary>
+    /// Issue #3641: the tuple positions reachable from <paramref name="type"/>
+    /// through generic type ARGUMENTS (`List&lt;(string, byte[])&gt;`), keyed by the
+    /// very path the type mapper walks when it renders the declaration
+    /// (<c>PromoteTupleTypeArguments</c>): type-argument indexes first, tuple
+    /// element indexes after. Bare tuple types are excluded — those already own
+    /// the empty-prefix key — so the two collectors never key the same leaf twice.
+    /// </summary>
+    /// <param name="type">The declared type to scan.</param>
+    /// <returns>The nested tuple slots, outermost type argument first.</returns>
+    private static List<(string Path, INamedTypeSymbol Tuple)> NestedTupleSlots(ITypeSymbol type)
+    {
+        var slots = new List<(string Path, INamedTypeSymbol Tuple)>();
+        if (type is INamedTypeSymbol { IsTupleType: false })
+        {
+            CollectNestedTupleSlots(type, string.Empty, slots);
+        }
+
+        return slots;
+    }
+
+    private static void CollectNestedTupleSlots(
+        ITypeSymbol type,
+        string prefix,
+        List<(string Path, INamedTypeSymbol Tuple)> slots)
+    {
+        if (type is not INamedTypeSymbol named)
+        {
+            return;
+        }
+
+        if (named.IsTupleType)
+        {
+            slots.Add((prefix, named));
+            return;
+        }
+
+        for (int i = 0; i < named.TypeArguments.Length; i++)
+        {
+            CollectNestedTupleSlots(named.TypeArguments[i], AppendTuplePath(prefix, i), slots);
+        }
     }
 
     private static bool TryResolveReceiverTypeParameterPath(
@@ -1968,15 +2153,7 @@ internal static class ObliviousNullabilityAnalyzer
 
     private static bool IsEligibleScalarTarget(ISymbol symbol)
     {
-        ITypeSymbol type = symbol switch
-        {
-            IMethodSymbol method => UnwrapAwaitedType(method.ReturnType),
-            IPropertySymbol property => property.Type,
-            IFieldSymbol field => field.Type,
-            ILocalSymbol local => local.Type,
-            IParameterSymbol parameter => parameter.Type,
-            _ => null,
-        };
+        ITypeSymbol type = SymbolValueType(symbol);
 
         return type is { IsReferenceType: true }
             && type.NullableAnnotation != NullableAnnotation.Annotated;


### PR DESCRIPTION
Fixes #3641

## Corrected root cause

The shape quoted in the issue body — `byte[] x = cond ? bytes : null;` followed by `if (x is null)` — **already promoted correctly on main**, via the #1072 used-as-nullable analysis (its `IsPatternExpressionSyntax` + null-constant-pattern case fires). Four probe tests in this PR lock that existing behaviour in as regressions; they pass unmodified against `main`.

The real selfmig wall at `SdkCompileRunner.gs` is a **tuple ELEMENT** that holds the null:

```csharp
internal static IReadOnlyList<(string Path, byte[] Original)> PrepareTemporaryBuildProps(...)
{
    var prepared = new List<(string Path, byte[] Original)>();
    ...
    byte[] original = File.Exists(propsPath) ? File.ReadAllBytes(propsPath) : null;  // null flows in
    prepared.Add((propsPath, original));
    ...
    return prepared;
}

internal static void RestoreTemporaryBuildProps(IEnumerable<(string Path, byte[] Original)> temporaryBuildProps)
{
    foreach ((string Path, byte[] Original) temporary in temporaryBuildProps.Reverse())
    {
        if (temporary.Original is null) { ... }   // GS0523 on the emitted `== nil`
    }
}
```

The element rendered non-nullable — `List[(Path string, Original []uint8)]` — so the consumer's `temporary.Original == nil` tripped `GS0523`, fatal under the via-sdk `/warnaserror`.

## The fix

`ObliviousNullabilityAnalyzer` already tracks tuple leaves independently, keyed by `(declaration symbol, element path)`, and the type mapper's `PromoteTupleTypeArguments` already walks generic type arguments *before* tuple element indexes when it renders a declaration. What was missing is that every tuple-flow **collector** only recognised a symbol whose type **is** a tuple, so a tuple living under a type argument was never a sink. This extends that existing fixpoint rather than adding a parallel mechanism:

- **`NestedTupleSlots`** enumerates the tuple positions reachable through generic type arguments, keyed by the very path the mapper walks — so the seeding side and the rendering side agree without a second cross-signature keying model. Bare tuple types keep their existing empty-prefix key, so no leaf is keyed twice.
- Declaration / assignment / return / argument flows now route through a shared **`CollectDeclarationTupleFlow`**, which pairs nested slots positionally and only when both sides expose the same slot count and the same element arity. That stays sound across the covariant hand-offs this shape actually uses (`List<T>` returned as `IReadOnlyList<T>`, passed as `IEnumerable<T>`), and each side keeps the element path of its own rendered type.
- The generic-receiver flow (#3564) now accepts a **local or parameter** receiver, not just a field/property — `prepared.Add((path, original))` on a local `List<...>` is exactly where the null-bearing element enters the tuple.
- `var prepared = new List<(string, byte[])>()` renders the **created** type, not the local's declared type, so the object creation is promoted at its sink as well; otherwise the initializer would no longer convert to the promoted declaration.

Because G# tuple types must agree structurally, the element now renders `[]?uint8` consistently at *every* occurrence of that tuple type: the producer's return, the intermediate locals, and the consumer's parameter.

## Verification

- New `Issue3641NullArmInitializedLocalTranslationTests` (5 tests): 4 simple-local probes plus the cross-signature tuple-element case, which asserts the promoted spelling on the `List`, the `IReadOnlyList` return and the `IEnumerable` parameter, and round-trips/binds the emitted G#.
- Regression families `Nullable|Issue1072|Oblivious|Issue2157|Tuple`: 414 passed, 0 failed.
- Additional `Deconstruct|Collection|Dictionary|Issue3564|Issue2469|Issue2490|Issue2504|ObjectCreation|Initializer`: 264 passed, 0 failed. Golden tests: 47 passed.
- End to end: migrating `Cs2Gs.Pipeline` alone with a Release `gsc`/`cs2gs` removes **exactly one** diagnostic versus the same run on `main` — the `SdkCompileRunner.gs` `GS0523` (136 → 135 compile errors) — and introduces nothing new. The remaining errors there belong to separate issues (#3640/#3643/#3644).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
