### PR TITLE
gsc: bind constructed-generic receivers with dotted type arguments (#3658)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
@@ -3143,8 +3143,9 @@ internal sealed partial class ExpressionBinder
 
     /// <summary>
     /// ADR-0089 / issue #1030: reshapes a type-name expression (a simple name
-    /// such as <c>int32</c> or a nested generic such as <c>IBox[int32]</c>) into
-    /// a <see cref="TypeClauseSyntax"/> so it can be bound by the shared
+    /// such as <c>int32</c> or a dotted name such as
+    /// <c>System.Collections.Immutable.ImmutableArray</c>) into a
+    /// <see cref="TypeClauseSyntax"/> so it can be bound by the shared
     /// type-clause binder. Returns <c>false</c> for non-type shapes.
     /// </summary>
     /// <param name="expr">The candidate type expression.</param>
@@ -3161,7 +3162,90 @@ internal sealed partial class ExpressionBinder
             return true;
         }
 
+        // Issue #3658: a type argument written as a dotted name
+        // (`ImmutableArray[GSharp.Core.CodeAnalysis.Diagnostic].Empty`) reaches
+        // the binder as an accessor chain, not a bare name. Flatten the chain
+        // into the type clause's qualifier tokens so it binds exactly as the
+        // same spelling does in type position.
+        if (expr is AccessorExpressionSyntax accessor)
+        {
+            return TryBuildQualifiedTypeClauseFromAccessor(accessor, out typeClause);
+        }
+
         return false;
+    }
+
+    /// <summary>
+    /// Issue #3658: flattens a dotted accessor chain whose every segment is a
+    /// plain identifier (<c>A.B.C</c>) into a qualified
+    /// <see cref="TypeClauseSyntax"/>. Returns <c>false</c> when any segment is
+    /// null-conditional or is not a simple name, so genuine value expressions
+    /// fall back to ordinary expression binding.
+    /// </summary>
+    /// <param name="accessor">The candidate dotted type name.</param>
+    /// <param name="typeClause">The synthesized qualified type clause on success.</param>
+    /// <returns>Whether the accessor chain spells a dotted type name.</returns>
+    private static bool TryBuildQualifiedTypeClauseFromAccessor(
+        AccessorExpressionSyntax accessor,
+        [NotNullWhen(true)] out TypeClauseSyntax? typeClause)
+    {
+        typeClause = null;
+        var dots = ImmutableArray.CreateBuilder<SyntaxToken>();
+        var segments = ImmutableArray.CreateBuilder<SyntaxToken>();
+        if (!TryCollectDottedNameSegments(accessor, dots, segments) || segments.Count < 2)
+        {
+            return false;
+        }
+
+        var head = segments[0];
+        segments.RemoveAt(0);
+        typeClause = new TypeClauseSyntax(
+            accessor.SyntaxTree,
+            openBracketToken: null,
+            lengthToken: null,
+            closeBracketToken: null,
+            head,
+            dots.ToImmutable(),
+            segments.ToImmutable(),
+            typeArgumentOpenBracketToken: null,
+            typeArguments: default,
+            typeArgumentCloseBracketToken: null,
+            questionToken: null);
+        return true;
+    }
+
+    /// <summary>
+    /// Issue #3658: appends the identifier tokens of a dotted-name expression to
+    /// <paramref name="segments"/> in source order, and the <c>.</c> tokens that
+    /// separate them to <paramref name="dots"/>. The parser nests accessor
+    /// chains to the right (<c>A.B.C</c> is <c>A.(B.C)</c>) in expression
+    /// position but to the left elsewhere, so both leanings are walked.
+    /// </summary>
+    /// <param name="expr">The candidate dotted name.</param>
+    /// <param name="dots">Receives the separating <c>.</c> tokens.</param>
+    /// <param name="segments">Receives the identifier tokens.</param>
+    /// <returns>Whether every node in the chain is a plain identifier or a non-null-conditional dot.</returns>
+    private static bool TryCollectDottedNameSegments(
+        ExpressionSyntax expr,
+        ImmutableArray<SyntaxToken>.Builder dots,
+        ImmutableArray<SyntaxToken>.Builder segments)
+    {
+        switch (expr)
+        {
+            case NameExpressionSyntax name when !name.IdentifierToken.IsMissing:
+                segments.Add(name.IdentifierToken);
+                return true;
+            case AccessorExpressionSyntax step when !step.IsNullConditional:
+                if (!TryCollectDottedNameSegments(step.LeftPart, dots, segments))
+                {
+                    return false;
+                }
+
+                dots.Add(step.DotToken);
+                return TryCollectDottedNameSegments(step.RightPart, dots, segments);
+            default:
+                return false;
+        }
     }
 
     /// <summary>

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3658QualifiedTypeArgumentReceiverTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3658QualifiedTypeArgumentReceiverTests.cs
@@ -1,0 +1,177 @@
+// <copyright file="Issue3658QualifiedTypeArgumentReceiverTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #3658 — a constructed generic type used as a member-access receiver
+/// must bind when its type argument is spelled as a <em>dotted</em> name
+/// (<c>ImmutableArray[System.String].Empty</c>,
+/// <c>ImmutableArray[App.Thing].Empty</c>). The reshape from index-expression
+/// brackets to a type clause previously accepted only a bare identifier, so a
+/// dotted argument abandoned the constructed-generic-receiver interpretation and
+/// fell back to element access — reporting
+/// <c>GS0125 Variable 'ImmutableArray' doesn't exist</c> plus a bogus member
+/// lookup on the trailing segment. The same spelling in type position always
+/// bound, which is why the defect only surfaced on the initializer side.
+/// </summary>
+public class Issue3658QualifiedTypeArgumentReceiverTests
+{
+    [Fact]
+    public void ImportedGenericReceiver_WithQualifiedTypeArgument_Binds()
+    {
+        var source = """
+            package App
+            import System.Collections.Immutable
+
+            class Thing {
+            }
+
+            class Holder {
+                private var items ImmutableArray[App.Thing] = ImmutableArray[App.Thing].Empty
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void ImportedGenericReceiver_WithFrameworkQualifiedTypeArgument_Binds()
+    {
+        var source = """
+            package App
+            import System.Collections.Immutable
+
+            class Holder {
+                private var names ImmutableArray[System.String] = ImmutableArray[System.String].Empty
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void ImportedGenericReceiver_WithDeepQualifiedTypeArgument_Binds()
+    {
+        // Three or more segments nest to the *right* in expression position
+        // (`System.(Text.StringBuilder)`), unlike the two-segment case, so the
+        // flattening walk has to handle both leanings.
+        var source = """
+            package App
+            import System.Collections.Immutable
+
+            class Holder {
+                private var builders ImmutableArray[System.Text.StringBuilder] = ImmutableArray[System.Text.StringBuilder].Empty
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void FullyQualifiedGenericReceiver_WithQualifiedTypeArgument_Binds()
+    {
+        var source = """
+            package App
+
+            class Thing {
+            }
+
+            class Holder {
+                private var items System.Collections.Immutable.ImmutableArray[App.Thing] =
+                    System.Collections.Immutable.ImmutableArray[App.Thing].Empty
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void UserGenericReceiver_WithNestedTypeArgument_Binds()
+    {
+        var source = """
+            package App
+
+            class Outer {
+                class Inner {
+                }
+            }
+
+            class Box[T] {
+                shared {
+                    let Default int32 = 0
+                }
+            }
+
+            func F() int32 {
+                return Box[Outer.Inner].Default
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void GenuineIndexing_WithQualifiedIndexExpression_StillBindsAsElementAccess()
+    {
+        // The dotted-name reshape must not steal genuine indexing: `values` is a
+        // value in scope, so `values[Keys.First]` remains element access.
+        var source = """
+            package App
+            import System.Collections.Generic
+
+            class Keys {
+                shared {
+                    let First int32 = 0
+                }
+            }
+
+            func F() string {
+                var values = List[string]()
+                values.Add("a")
+                return values[Keys.First]
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    private static ReferenceResolver MetadataLoadContextResolver()
+    {
+        var paths = new[]
+        {
+            typeof(object).Assembly.Location,
+            typeof(System.Collections.Generic.List<>).Assembly.Location,
+            typeof(ImmutableArray<>).Assembly.Location,
+            typeof(System.Console).Assembly.Location,
+            typeof(System.Linq.Enumerable).Assembly.Location,
+        }
+        .Where(p => !string.IsNullOrEmpty(p))
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .ToArray();
+
+        return ReferenceResolver.WithReferences(paths);
+    }
+
+    private static ImmutableArray<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var globalScope = Binder.BindGlobalScope(
+            previous: null,
+            ImmutableArray.Create(tree),
+            MetadataLoadContextResolver());
+        var program = Binder.BindProgram(globalScope, MetadataLoadContextResolver());
+        return globalScope.Diagnostics.AddRange(program.Diagnostics);
+    }
+}


### PR DESCRIPTION
## Root cause

The #3501 self-migration of `src/LanguageServer` reported, at `ProjectState.gs` lines 45 and 289:

```
GS0125 Variable 'ImmutableArray' doesn't exist.
GS0158 Cannot find member Diagnostic.
```

cs2gs is **not** at fault — the emitted G# is well formed and idiomatic:

```
private var gsAnalyzerLoadDiagnostics ImmutableArray[GSharp.Core.CodeAnalysis.Diagnostic] = ImmutableArray[GSharp.Core.CodeAnalysis.Diagnostic].Empty
```

The type clause on the left binds; the identical spelling on the initializer side does not.

The parser shapes `Name[Arg]` in expression position as an index expression. `ExpressionBinder.TryResolveConstructedGenericTypeReceiver` recovers the constructed-generic *type* interpretation by reshaping the bracket contents into a `TypeClauseSyntax` through `TryBuildTypeClauseFromExpression` — which accepted only a bare `NameExpressionSyntax`. A **dotted** type argument (`App.Thing`, `System.Text.StringBuilder`, `GSharp.Core.CodeAnalysis.Diagnostic`) arrives as an `AccessorExpressionSyntax` chain, so the reshape returned `false`, the constructed-generic-receiver interpretation was abandoned, and the whole expression fell back to element access on a non-existent variable — producing GS0125 on the receiver plus a bogus member lookup on the trailing segment.

Minimal repro (pre-fix):

```gs
package Repro
import System.Collections.Immutable

class Thing {
}

class Holder {
    private var ok  ImmutableArray[Thing] = ImmutableArray[Thing].Empty              // binds
    private var bad ImmutableArray[Repro.Thing] = ImmutableArray[Repro.Thing].Empty  // GS0125 + GS0157
    private var deep ImmutableArray[System.Text.StringBuilder] =
        ImmutableArray[System.Text.StringBuilder].Empty                              // GS0125 + GS0158
}
```

## Fix

Flatten a dotted accessor chain whose every segment is a plain, non-null-conditional identifier into the type clause's qualifier tokens (`Identifier` + `QualifierDotTokens`/`QualifierIdentifierTokens`), so a dotted type argument binds in expression position exactly as it does in type position.

The walk is recursive because the parser nests accessor chains of three or more segments to the **right** in expression position (`System.(Text.StringBuilder)`), unlike the two-segment case. A left-only walk fixes `A.B` and silently leaves `A.B.C` broken — which is precisely the shape the LanguageServer hit.

Chains containing null-conditional steps or non-name segments still return `false`, so genuine indexing (`values[Keys.First]`, `arr[i]`) stays on the element-access path.

## Verification

- New binder tests: `test/Core.Tests/CodeAnalysis/Binding/Issue3658QualifiedTypeArgumentReceiverTests.cs` — 6 passing, covering the imported-generic receiver with a two-segment argument, a deep (three-segment, right-leaning) argument, a fully qualified receiver, a user generic with a nested-type argument, and a genuine-indexing guard.
- `dotnet test test/Core.Tests --filter FullyQualifiedName~CodeAnalysis.Binding` → **5537 passed, 0 failed**.
- `src/LanguageServer` migration re-run (after repacking the local `Gsharp.NET.Sdk` nupkg so the SDK build path picks up the new gsc): the GS0125/GS0158 fingerprints at `ProjectState.gs` 45 and 289 are **gone**; distinct ProjectState errors drop 128 → 124. The residual `ImmutableArray[GSharpDiagnosticAnalyzer]` failure at line 290 has an unrelated root cause (`GSharpDiagnosticAnalyzer` itself does not resolve, same family as `ReferenceResolver`/`GSharpAnalyzerHost` at lines 41/301) and is out of scope here.

Fixes #3658

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
