### PR TITLE
gsc: bare calls from a nested type reach the enclosing type's shared members (#3660)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
@@ -984,6 +984,41 @@ internal sealed partial class OverloadResolver
             // not-found paths.
             if (symbol == null)
             {
+                // ADR-0110 / issue #910 nesting: an unqualified call inside a
+                // NESTED type's body may resolve to a `shared` (static) method
+                // of a LEXICALLY ENCLOSING type — C# §7.4 scoping, where a
+                // nested class sees the outer class's static members (including
+                // its private ones) without qualification. The paths above only
+                // consult the nested type's own member set and its base chain,
+                // so `Outer.Inner.M()` calling `Helper(args)` — declared in
+                // `Outer`'s `shared { }` block — reported GS0130. Walk outward
+                // through <c>ContainingType</c> (innermost first, so a nearer
+                // enclosing type shadows a farther one) and finalize through
+                // the shared static-call finalizer for full
+                // private/overload/optional/variadic/generic fidelity. Consulted
+                // before the type-import (`using static`) and imported-CLR
+                // paths because lexical scope outranks imports.
+                if (bindUserTypeStaticCall != null)
+                {
+                    var lexicalSelfType = GetEffectiveThisParameter()?.Type ?? GetImplicitStaticSelfOwner();
+                    for (var enclosing = lexicalSelfType?.ContainingType; enclosing != null; enclosing = enclosing.ContainingType)
+                    {
+                        if (enclosing is not StructSymbol enclosingStruct)
+                        {
+                            continue;
+                        }
+
+                        var enclosingStatics = TypeMemberModel.GetMethods(
+                            enclosingStruct,
+                            syntax.Identifier.ValueText,
+                            MemberQuery.Static(MemberKinds.Method));
+                        if (!enclosingStatics.IsDefaultOrEmpty)
+                        {
+                            return bindUserTypeStaticCall(enclosingStruct, syntax);
+                        }
+                    }
+                }
+
                 // Issue #1201 (C# `using static`): an unqualified call may resolve
                 // to a `shared` (static) method of a type brought into scope by a
                 // type import (`import Ns.Type`). Mirror C#'s using-static

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3660NestedTypeEnclosingStaticBareCallTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3660NestedTypeEnclosingStaticBareCallTests.cs
@@ -1,0 +1,321 @@
+// <copyright file="Issue3660NestedTypeEnclosingStaticBareCallTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #3660: an unqualified (bare-name) call from inside a NESTED type's body
+/// to a <c>shared</c> (static) method of a LEXICALLY ENCLOSING type must resolve
+/// — C# §7.4 scoping, where a nested class sees the outer class's static members
+/// (including its <c>private</c> ones) without qualification. Before the fix the
+/// bare-call binder consulted only the nested type's own member set, its base
+/// chain, package functions and imports, never the enclosing type chain
+/// (<see cref="Symbol.ContainingType"/>, ADR-0110 / issue #910), so such calls
+/// reported <c>GS0130</c> ("Function '…' doesn't exist.") plus a
+/// <c>GS0159</c> cascade off the errored receiver of any chained call.
+/// Every scenario is asserted under BOTH the live-reflection
+/// (<see cref="ReferenceResolver.Default"/>) resolver and the
+/// <see cref="System.Reflection.MetadataLoadContext"/>-backed
+/// (<see cref="ReferenceResolver.WithReferences"/>) resolver, since the SDK
+/// build path uses the latter.
+/// </summary>
+public class Issue3660NestedTypeEnclosingStaticBareCallTests
+{
+    // Instance body of a nested class -> non-generic static of the outer class.
+    [Theory]
+    [MemberData(nameof(Resolvers))]
+    public void NestedInstance_BareCall_OuterStatic_NonGeneric_Resolves(bool withReferences)
+    {
+        var source = @"
+package p
+class Outer {
+    class Inner {
+        func Caller() int32 { return Helper(3) }
+    }
+    shared {
+        private func Helper(value int32) int32 { return value + 1 }
+    }
+}
+";
+        AssertNoErrors(source, withReferences);
+    }
+
+    // The self-migration shape: explicit type arguments plus a chained call on
+    // the result (`FindNodes[T](root).ToArray()` in SemanticLookup.gs).
+    [Theory]
+    [MemberData(nameof(Resolvers))]
+    public void NestedInstance_BareCall_OuterStatic_GenericExplicitTypeArgs_Resolves(bool withReferences)
+    {
+        var source = @"
+package p
+import System.Collections.Generic
+import System.Linq
+class Outer {
+    class Inner {
+        func Caller() []string { return Wrap[string](""a"").ToArray() }
+    }
+    shared {
+        private func Wrap[T](value T) sequence[T] { yield value }
+    }
+}
+";
+        AssertNoErrors(source, withReferences);
+    }
+
+    // Inferred type arguments resolve through the same path.
+    [Theory]
+    [MemberData(nameof(Resolvers))]
+    public void NestedInstance_BareCall_OuterStatic_GenericInferredTypeArgs_Resolves(bool withReferences)
+    {
+        var source = @"
+package p
+class Outer {
+    class Inner {
+        func Caller(x int32) int32 { return Ident(x) }
+    }
+    shared {
+        private func Ident[T](v T) T { return v }
+    }
+}
+";
+        AssertNoErrors(source, withReferences);
+    }
+
+    // An overload set on the enclosing type — the arity-correct member is picked.
+    [Theory]
+    [MemberData(nameof(Resolvers))]
+    public void NestedInstance_BareCall_OuterStaticOverloads_Resolve(bool withReferences)
+    {
+        var source = @"
+package p
+class Outer {
+    class Inner {
+        func Caller() int32 { return Add(1) + Add(1, 2) }
+    }
+    shared {
+        private func Add(a int32) int32 { return a }
+        private func Add(a int32, b int32) int32 { return a + b }
+    }
+}
+";
+        AssertNoErrors(source, withReferences);
+    }
+
+    // A `shared` body of the nested type reaches the enclosing type's statics too
+    // (no `this` in scope; the walk starts from StaticOwnerType).
+    [Theory]
+    [MemberData(nameof(Resolvers))]
+    public void NestedStatic_BareCall_OuterStatic_Resolves(bool withReferences)
+    {
+        var source = @"
+package p
+class Outer {
+    class Inner {
+        shared {
+            func Caller() int32 { return Helper(3) }
+        }
+    }
+    shared {
+        private func Helper(value int32) int32 { return value + 1 }
+    }
+}
+";
+        AssertNoErrors(source, withReferences);
+    }
+
+    // Two levels of nesting — the walk continues outward past the first
+    // enclosing type that does not declare the name.
+    [Theory]
+    [MemberData(nameof(Resolvers))]
+    public void DoublyNested_BareCall_OutermostStatic_Resolves(bool withReferences)
+    {
+        var source = @"
+package p
+class Outer {
+    class Middle {
+        class Inner {
+            func Caller() int32 { return Helper(3) }
+        }
+    }
+    shared {
+        private func Helper(value int32) int32 { return value + 1 }
+    }
+}
+";
+        AssertNoErrors(source, withReferences);
+    }
+
+    // A nearer enclosing type shadows a farther one (innermost-first walk).
+    [Theory]
+    [MemberData(nameof(Resolvers))]
+    public void DoublyNested_NearerEnclosingType_Shadows_Farther(bool withReferences)
+    {
+        var source = @"
+package p
+class Outer {
+    class Middle {
+        class Inner {
+            func Caller() int32 { return Helper() }
+        }
+        shared {
+            private func Helper() int32 { return 2 }
+        }
+    }
+    shared {
+        private func Helper() int32 { return 1 }
+    }
+}
+";
+        AssertNoErrors(source, withReferences);
+    }
+
+    // A struct nested in a class sees the class's statics.
+    [Theory]
+    [MemberData(nameof(Resolvers))]
+    public void NestedStruct_BareCall_OuterStatic_Resolves(bool withReferences)
+    {
+        var source = @"
+package p
+class Outer {
+    struct Inner {
+        func Caller() int32 { return Helper() }
+    }
+    shared {
+        private func Helper() int32 { return 7 }
+    }
+}
+";
+        AssertNoErrors(source, withReferences);
+    }
+
+    // Control — the nested type's own member still wins over the enclosing
+    // type's same-named static.
+    [Theory]
+    [MemberData(nameof(Resolvers))]
+    public void NestedOwnMember_StillWins_OverEnclosingStatic(bool withReferences)
+    {
+        var source = @"
+package p
+class Outer {
+    class Inner {
+        func Caller() int32 { return Helper() }
+        private func Helper() int32 { return 2 }
+    }
+    shared {
+        private func Helper() int32 { return 1 }
+    }
+}
+";
+        AssertNoErrors(source, withReferences);
+    }
+
+    // Control — the qualified `Outer.Helper(...)` form still resolves.
+    [Theory]
+    [MemberData(nameof(Resolvers))]
+    public void QualifiedEnclosingStaticCall_FromNestedType_StillResolves(bool withReferences)
+    {
+        var source = @"
+package p
+class Outer {
+    class Inner {
+        func Caller() int32 { return Outer.Helper(3) }
+    }
+    shared {
+        func Helper(value int32) int32 { return value + 1 }
+    }
+}
+";
+        AssertNoErrors(source, withReferences);
+    }
+
+    // Control — a genuinely undefined bare call from a nested type still reports
+    // GS0130 (the walk must not swallow real "not found" diagnostics).
+    [Theory]
+    [MemberData(nameof(Resolvers))]
+    public void NestedBareCall_UndefinedName_StillReportsGs0130(bool withReferences)
+    {
+        var source = @"
+package p
+class Outer {
+    class Inner {
+        func Caller() int32 { return Nope() }
+    }
+    shared {
+        private func Helper() int32 { return 1 }
+    }
+}
+";
+        var diagnostics = Bind(source, withReferences);
+        Assert.Contains(diagnostics, d => d.IsError && d.Message.Contains("'Nope' doesn't exist"));
+    }
+
+    // Control — an INSTANCE member of the enclosing type is NOT in scope from a
+    // nested type (there is no outer `this`); the call must still fail.
+    [Theory]
+    [MemberData(nameof(Resolvers))]
+    public void NestedBareCall_EnclosingInstanceMember_IsNotInScope(bool withReferences)
+    {
+        var source = @"
+package p
+class Outer {
+    class Inner {
+        func Caller() int32 { return Helper() }
+    }
+    private func Helper() int32 { return 1 }
+}
+";
+        var diagnostics = Bind(source, withReferences);
+        Assert.Contains(diagnostics, d => d.IsError && d.Message.Contains("'Helper' doesn't exist"));
+    }
+
+    public static TheoryData<bool> Resolvers() => new() { false, true };
+
+    private static void AssertNoErrors(string source, bool withReferences)
+    {
+        var diagnostics = Bind(source, withReferences);
+        Assert.Empty(diagnostics.Where(d => d.IsError));
+    }
+
+    private static ImmutableArray<Diagnostic> Bind(string source, bool withReferences)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var globalScope = Binder.BindGlobalScope(
+            previous: null,
+            ImmutableArray.Create(tree),
+            CreateResolver(withReferences));
+        var program = Binder.BindProgram(globalScope, CreateResolver(withReferences));
+        return globalScope.Diagnostics.AddRange(program.Diagnostics);
+    }
+
+    private static ReferenceResolver CreateResolver(bool withReferences)
+    {
+        if (!withReferences)
+        {
+            return ReferenceResolver.Default();
+        }
+
+        var paths = new[]
+        {
+            typeof(object).Assembly.Location,
+            typeof(System.Console).Assembly.Location,
+            typeof(System.Linq.Enumerable).Assembly.Location,
+            typeof(System.Collections.Generic.List<>).Assembly.Location,
+        }
+        .Where(p => !string.IsNullOrEmpty(p))
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .ToArray();
+
+        return ReferenceResolver.WithReferences(paths);
+    }
+}


### PR DESCRIPTION
Fixes #3660. Unblocks two of the twelve remaining `src/LanguageServer` compile errors in the #3501 self-migration.

## Problem

An unqualified call inside a **nested** type's body could not see a `shared` (static) method of a **lexically enclosing** type:

```gs
class Outer {
    class Inner {
        func Caller() []string { return Wrap[string]("a").ToArray() }
    }
    shared {
        private func Wrap[T](value T) sequence[T] { yield value }
    }
}
```

```
error GS0130: Function 'Wrap' doesn't exist.
error GS0159: Cannot find function ToArray.
```

C# §7.4 scoping — which G# follows — puts the outer type's static members, including its `private` ones, in scope inside a nested type without qualification, and the qualified `Outer.Wrap[T](...)` spelling already resolved.

## Root cause

`OverloadResolver.BindCallExpression`'s bare-name ladder consulted the enclosing type's own instance members (#1147), its own `shared` members (#1585), its base chain, then package functions, `using static` type imports and imported CLR statics — but never walked outward through `Symbol.ContainingType` (ADR-0110 / #910). A nested type therefore had **no** path to its enclosing type's `shared { }` block.

## Fix

When nothing nearer matched (inside the `symbol == null` arm, so package functions and extension candidates keep their existing priority), walk the enclosing-type chain innermost-first and, for the first ancestor whose static method group carries the name, finalize through the shared static-call finalizer `bindUserTypeStaticCall` — the same route the qualified and static-self paths use, giving full private/overload/optional/variadic/generic fidelity.

- Innermost-first, so a nearer enclosing type shadows a farther one.
- Placed ahead of the type-import and imported-CLR paths because lexical scope outranks imports.
- Enclosing **instance** members stay out of scope (there is no outer `this`).
- A genuinely undefined name still reports GS0130.

## Self-migration impact

`src/LanguageServer/SemanticLookup.cs` declares `private static IEnumerable<T> FindNodes<T>(…)` on the outer `SemanticLookup` class and calls it unqualified from the nested `SemanticLookup.SemanticModel` class. cs2gs translated that faithfully; gsc then failed at `SemanticLookup.gs:500` with `GS0130` + a `GS0159` cascade. The translator needed no change — the defect was entirely in the gsc binder. Verified by re-running `cs2gs migrate` for `src/Core` + `src/LanguageServer` after repacking the SDK nupkg with the new compiler: the two `SemanticLookup.gs` fingerprints are gone; the remaining errors belong to sibling work (`ImmutableArray<T>.Empty`, `List.Sort`, nullable-conversion shapes).

## Tests

New `test/Core.Tests/CodeAnalysis/Binding/Issue3660NestedTypeEnclosingStaticBareCallTests.cs` — 12 scenarios × both reference resolvers (live reflection and `MetadataLoadContext`): non-generic, explicit and inferred type arguments, overload sets, nested `shared` bodies, double nesting, nearer-shadows-farther, nested struct, plus four controls (own member still wins, qualified form still works, undefined name still GS0130, enclosing instance member still out of scope).

`dotnet test test/Core.Tests -c Release --filter "FullyQualifiedName~Tests.CodeAnalysis.Binding"` → 5555 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs