### PR TITLE
gsc: List[T].Sort with a comparison lambda no longer reports GS0159 (#3659)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -1304,7 +1304,22 @@ internal sealed partial class ExpressionBinder
         foreach (var probe in probes)
         {
             var offset = probe.ReceiverParameterOffset;
-            var methods = probe.Methods;
+
+            // Issue #3659: narrow the candidate set to the overloads that can
+            // actually receive a lambda in every deferred slot before probing.
+            // The probe below passes `null` for a deferred slot, which generic
+            // inference skips and treats as reference-convertible to any
+            // parameter — so an overload set like `List[T].Sort`'s (no-arg,
+            // `IComparer[T]`, `Comparison[T]`, `(int32, int32, IComparer[T])`)
+            // stays ambiguous and the untyped lambda never gets a target.
+            // A lambda of known arity can only convert to a delegate-shaped
+            // parameter with the same parameter count, so the other overloads
+            // are not viable receivers for it.
+            var methods = FilterCandidatesByDeferredLambdaShape(
+                probe.Methods,
+                offset,
+                ce,
+                deferredIndices);
             var argTypes = new System.Type?[boundArgs.Length + offset];
             if (offset == 1)
             {
@@ -1466,6 +1481,188 @@ internal sealed partial class ExpressionBinder
         }
 
         return names;
+    }
+
+    /// <summary>
+    /// Issue #3659: narrows a deferred arrow-lambda probe's candidate set to the
+    /// overloads whose deferred-lambda parameters can actually receive a lambda,
+    /// i.e. are delegate-shaped (or <c>Expression&lt;TDelegate&gt;</c>-wrapped)
+    /// with exactly the lambda's parameter count. Without this, an overload set
+    /// whose other members take a non-delegate in the same slot (e.g.
+    /// <c>List[T].Sort(IComparer[T])</c> alongside
+    /// <c>List[T].Sort(Comparison[T])</c>) probes as ambiguous — the deferred
+    /// slot is passed as <c>null</c>, which is applicable to everything — so the
+    /// lambda never receives a target type and binds untargeted (GS0304), which
+    /// in turn fails the whole call (GS0159).
+    /// <para>This is only a narrowing of the best-effort target-type probe; the
+    /// call is re-resolved for real once every argument is bound. The filter
+    /// declines (returning <paramref name="methods"/> unchanged) whenever a
+    /// candidate's slot shape cannot be determined — a bare generic-parameter
+    /// slot, a non-lambda deferred argument, or a metadata load failure — so no
+    /// existing overload-resolution behaviour is loosened.</para>
+    /// </summary>
+    /// <param name="methods">The probe's candidate methods.</param>
+    /// <param name="offset">The probe's receiver parameter offset.</param>
+    /// <param name="ce">The call being bound.</param>
+    /// <param name="deferredIndices">The deferred arrow-lambda argument indices.</param>
+    /// <returns>The narrowed candidates, or <paramref name="methods"/> when no
+    /// narrowing applies.</returns>
+    private static IReadOnlyList<MethodInfo> FilterCandidatesByDeferredLambdaShape(
+        IReadOnlyList<MethodInfo> methods,
+        int offset,
+        CallExpressionSyntax ce,
+        List<int> deferredIndices)
+    {
+        var arities = new int[deferredIndices.Count];
+        for (var i = 0; i < deferredIndices.Count; i++)
+        {
+            var inner = OverloadResolver.UnwrapNamedArgumentValue(ce.Arguments[deferredIndices[i]]);
+            if (inner is not LambdaExpressionSyntax lambda)
+            {
+                return methods;
+            }
+
+            arities[i] = lambda.Parameters.Count;
+        }
+
+        List<MethodInfo>? filtered = null;
+        foreach (var method in methods)
+        {
+            if (method == null)
+            {
+                continue;
+            }
+
+            ParameterInfo[] parameters;
+            try
+            {
+                parameters = method.GetParameters();
+            }
+            catch (Exception ex) when (ClrTypeUtilities.IsMetadataLoadFailure(ex))
+            {
+                return methods;
+            }
+
+            var viable = true;
+            for (var i = 0; i < deferredIndices.Count; i++)
+            {
+                var paramIndex = MapSourceArgumentToParameter(
+                    parameters,
+                    ce,
+                    deferredIndices[i],
+                    offset);
+                if (paramIndex < 0 || paramIndex >= parameters.Length)
+                {
+                    viable = false;
+                    break;
+                }
+
+                if (!CanParameterReceiveLambdaOfArity(parameters[paramIndex], arities[i], out var determined))
+                {
+                    if (!determined)
+                    {
+                        // The slot's shape is unknowable from metadata alone —
+                        // decline to narrow rather than drop a viable candidate.
+                        return methods;
+                    }
+
+                    viable = false;
+                    break;
+                }
+            }
+
+            if (viable)
+            {
+                (filtered ??= new List<MethodInfo>()).Add(method);
+            }
+        }
+
+        return filtered ?? methods;
+    }
+
+    /// <summary>
+    /// Issue #3659: decides whether <paramref name="parameter"/> can receive an
+    /// arrow lambda with <paramref name="arity"/> parameters — that is, whether
+    /// its type is a delegate (possibly wrapped in <c>Expression&lt;T&gt;</c>, or
+    /// reached through the <c>params</c> array element type) whose
+    /// <c>Invoke</c> takes exactly that many parameters.
+    /// </summary>
+    /// <param name="parameter">The candidate parameter.</param>
+    /// <param name="arity">The lambda's parameter count.</param>
+    /// <param name="determined">Set to <see langword="false"/> when the shape
+    /// cannot be decided from metadata (an open type-parameter slot or a
+    /// metadata load failure), in which case the caller must not narrow.</param>
+    /// <returns><see langword="true"/> when the slot can receive the lambda.</returns>
+    private static bool CanParameterReceiveLambdaOfArity(
+        ParameterInfo parameter,
+        int arity,
+        out bool determined)
+    {
+        determined = true;
+
+        var parameterType = parameter.ParameterType;
+        if (parameterType == null)
+        {
+            determined = false;
+            return false;
+        }
+
+        if (parameterType.IsByRef)
+        {
+            parameterType = parameterType.GetElementType();
+            if (parameterType == null)
+            {
+                determined = false;
+                return false;
+            }
+        }
+
+        if (parameterType.IsGenericParameter)
+        {
+            // A bare method/type parameter slot (e.g. `TDelegate`) says nothing
+            // about the delegate shape it will close over.
+            determined = false;
+            return false;
+        }
+
+        try
+        {
+            if (MatchesDelegateArity(parameterType, arity))
+            {
+                return true;
+            }
+
+            // A `params Func[...][]` slot receives the lambda through the array
+            // element type in expanded form.
+            return parameterType.IsArray
+                && parameterType.GetElementType() is { } elementType
+                && MatchesDelegateArity(elementType, arity);
+        }
+        catch (Exception ex) when (ClrTypeUtilities.IsMetadataLoadFailure(ex))
+        {
+            determined = false;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Issue #3659: reports whether <paramref name="type"/> is a delegate (or an
+    /// <c>Expression&lt;TDelegate&gt;</c> wrapping one) whose <c>Invoke</c>
+    /// signature takes exactly <paramref name="arity"/> parameters.
+    /// </summary>
+    /// <param name="type">The candidate slot type.</param>
+    /// <param name="arity">The required parameter count.</param>
+    /// <returns><see langword="true"/> when the arity matches.</returns>
+    private static bool MatchesDelegateArity(System.Type type, int arity)
+    {
+        var delegateType = type;
+        if (MemberLookup.TryGetExpressionTreeDelegateType(delegateType, out var unwrapped))
+        {
+            delegateType = unwrapped;
+        }
+
+        var invoke = delegateType?.GetMethodSafe("Invoke");
+        return invoke != null && invoke.GetParameters().Length == arity;
     }
 
     private static int MapSourceArgumentToParameter(
@@ -1789,8 +1986,15 @@ internal sealed partial class ExpressionBinder
 
             MethodInfo openMethod;
             ParameterInfo[] openParameters;
+
+            // Issue #3659: the candidate as reflected off the receiver's own
+            // (erased) closed CLR type — its parameter types are already in the
+            // receiver's erasure domain, which is what the rebound lambda's
+            // argument type must land in.
+            ParameterInfo[] closedParameters;
             try
             {
+                closedParameters = method.GetParameters();
                 if (receiverOpenDefinition != null
                     && TryResolveOpenMethodByToken(
                         receiverOpenDefinition,
@@ -1988,6 +2192,40 @@ internal sealed partial class ExpressionBinder
                     {
                         candidateUsable = false;
                         break;
+                    }
+
+                    // Issue #3659: re-anchor the mapped delegate's ERASED CLR
+                    // shape on this candidate's own closed parameter type.
+                    // `MapOpenClrTypeToSymbolic` re-erases the symbolic type
+                    // arguments through the inference-oriented erasure, which
+                    // does not always agree with the erasure the receiver was
+                    // closed with — a same-compilation enum rides through as
+                    // `Int32` there but as `object` in the receiver
+                    // (`List[TokMod]` is `List<object>`, so its `Sort` candidate
+                    // takes `Comparison<object>` while the mapped target claimed
+                    // `Comparison<Int32>`), and a slice of a same-compilation
+                    // type collapses to `object` there but stays `object[]` in
+                    // the receiver. Either divergence makes the rebound lambda's
+                    // argument type unassignable to EVERY candidate, so the call
+                    // dead-ends at GS0159 "Cannot find function Sort". The
+                    // candidate's own parameter type is by construction in the
+                    // receiver's erasure domain; keep the symbolic arguments
+                    // (which carry the real element identity for emit) and swap
+                    // only the erased CLR shape.
+                    if (mappedDelegate is ImportedTypeSymbol { OpenDefinition: { } mappedOpenDefinition } mappedImported
+                        && paramIndex < closedParameters.Length
+                        && closedParameters[paramIndex].ParameterType is { } closedParameterType
+                        && !closedParameterType.ContainsGenericParameters
+                        && !closedParameterType.IsSameAs(mappedImported.ClrType)
+                        && closedParameterType.IsGenericType
+                        && ClrTypeUtilities.AreSame(
+                            closedParameterType.GetGenericTypeDefinition(),
+                            mappedOpenDefinition))
+                    {
+                        mappedDelegate = ImportedTypeSymbol.GetConstructed(
+                            closedParameterType,
+                            mappedOpenDefinition,
+                            mappedImported.TypeArguments);
                     }
 
                     var returnClrType = invoke.ReturnType;

--- a/test/Core.Tests/CodeAnalysis/Issue3659ListSortComparisonLambdaTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Issue3659ListSortComparisonLambdaTests.cs
@@ -1,0 +1,150 @@
+// <copyright file="Issue3659ListSortComparisonLambdaTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis;
+
+/// <summary>
+/// Issue #3659: <c>List[T].Sort(lambda)</c> reported GS0159 "Cannot find
+/// function Sort" — the symptom that blocked the migrated
+/// <c>src/LanguageServer</c> for #3501 — for two distinct reasons.
+/// <para>When the element type is a same-compilation enum, or a tuple carrying
+/// a slice of a same-compilation type, the deferred arrow-lambda's symbolic
+/// delegate target was closed through the inference-oriented erasure
+/// (enum → <c>Int32</c>, slice → <c>object</c>) while the receiver was closed
+/// through the type-clause erasure (enum → <c>object</c>, slice →
+/// <c>object[]</c>). The rebound lambda's argument type then matched none of
+/// the receiver's own candidates, so every <c>Sort</c> overload was rejected.
+/// The target's erased CLR shape is now re-anchored on the candidate's own
+/// closed parameter type.</para>
+/// <para>When the lambda's parameters are untyped, the CLR probe that
+/// discovers their target type passed <c>null</c> for the lambda slot, which
+/// is applicable to every overload — so <c>Sort</c>'s four-way overload set
+/// probed as ambiguous and the parameters never got a target (GS0304, then
+/// GS0159). The probe now narrows to the overloads whose lambda slot is
+/// actually delegate-shaped with the lambda's arity.</para>
+/// <para>Each test asserts the <em>correct</em> overload was selected by
+/// checking the list is really reordered by the comparison, not merely that
+/// the call binds.</para>
+/// </summary>
+public class Issue3659ListSortComparisonLambdaTests
+{
+    [Fact]
+    public void SortComparisonLambda_SameCompilationEnumElement_SortsDescending()
+    {
+        var source = @"
+import System.Collections.Generic
+
+enum Tok { A, B, C }
+
+func run() int32 {
+    let xs = List[Tok]()
+    xs.Add(Tok.C)
+    xs.Add(Tok.A)
+    xs.Add(Tok.B)
+    xs.Sort((a Tok, b Tok) -> int32(b) - int32(a))
+    var acc = 0
+    for x in xs {
+        acc = acc * 10 + int32(x)
+    }
+    return acc
+}
+
+run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+
+        // C(2), B(1), A(0) — the Comparison[Tok] overload really ran.
+        Assert.Equal(210, result.Value);
+    }
+
+    [Fact]
+    public void SortComparisonLambda_TupleElementWithUserTypeSlice_SortsAscending()
+    {
+        var source = @"
+import System.Collections.Generic
+
+struct Sp { var Start int32 }
+
+func run() int32 {
+    let xs = List[(A int32, B []Sp)]()
+    xs.Add((3, []Sp{}))
+    xs.Add((1, []Sp{}))
+    xs.Add((2, []Sp{}))
+    xs.Sort((p (A int32, B []Sp), q (A int32, B []Sp)) -> p.A.CompareTo(q.A))
+    var acc = 0
+    for t in xs {
+        acc = acc * 10 + t.A
+    }
+    return acc
+}
+
+run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(123, result.Value);
+    }
+
+    [Fact]
+    public void SortComparisonLambda_UntypedParameters_TargetTypeFromComparisonOverload()
+    {
+        var source = @"
+import System.Collections.Generic
+
+func run() int32 {
+    let xs = List[int32]()
+    xs.Add(1)
+    xs.Add(3)
+    xs.Add(2)
+    xs.Sort((a, b) -> b.CompareTo(a))
+    var acc = 0
+    for x in xs {
+        acc = acc * 10 + x
+    }
+    return acc
+}
+
+run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+
+        // Descending — the untyped `a`/`b` inferred int32 from Comparison[int32].
+        Assert.Equal(321, result.Value);
+    }
+
+    [Fact]
+    public void SortComparisonLambda_ImportedStructElement_StillSorts()
+    {
+        // The shape from the migrated SemanticTokensHandler: an imported
+        // (metadata) struct element sorted by one of its members.
+        var source = @"
+import System
+import System.Collections.Generic
+
+func run() int32 {
+    let xs = List[TimeSpan]()
+    xs.Add(TimeSpan.FromTicks(30))
+    xs.Add(TimeSpan.FromTicks(10))
+    xs.Add(TimeSpan.FromTicks(20))
+    xs.Sort((a TimeSpan, b TimeSpan) -> a.Ticks.CompareTo(b.Ticks))
+    var acc = 0
+    for t in xs {
+        acc = acc * 10 + int32(t.Ticks) / 10
+    }
+    return acc
+}
+
+run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(123, result.Value);
+    }
+}


### PR DESCRIPTION
Fixes #3659

Blocks the #3501 self-migration of `src/LanguageServer`, whose migrated `SemanticTokensHandler.gs` failed with `GS0159 Cannot find function Sort` on the translation of `holeTokens.Sort((a, b) => a.Span.Start.CompareTo(b.Span.Start))`. cs2gs emits explicitly-typed lambda parameters here, so the translation is correct — gsc rejected it.

Two independent root causes, both in the deferred arrow-lambda machinery of `ExpressionBinder.ResolveDeferredArrowLambdaArguments`.

## 1. Erasure-domain divergence on the symbolic delegate target

`TryMapDeferredLambdaTargetsSymbolic` recovers the lambda's delegate target with `MemberLookup.MapOpenClrTypeToSymbolic`, which re-erases the receiver's symbolic type arguments through the *inference-oriented* erasure (`ProjectSymbolicArgToErasedClr`: same-compilation enum → `Int32` per #2391; slice of a same-compilation type → `object`, for want of an arm). The receiver itself is closed through the *type-clause* erasure (`Binder.ProjectGenericArgument`: enum → `object`; `[]Sp` → `object[]`).

The two disagree:

| receiver | its `Sort` candidate | rebound lambda's argument |
|---|---|---|
| `List[Tok]` (source enum) | `Sort(Comparison<object>)` | `Comparison<Int32>` |
| `List[(int32, []Sp)]` | `Sort(Comparison<ValueTuple<Int32, Object[]>>)` | `Comparison<ValueTuple<Int32, Object>>` |

No candidate accepts the argument, resolution returns `NoneApplicable`, and the call dead-ends at GS0159 — the same failure family as #3646, where an argument whose CLR shape cannot match makes *every* imported candidate fail and surfaces as "cannot find function" rather than a conversion error.

**Fix:** re-anchor the mapped delegate target's *erased CLR shape* on the candidate's own closed parameter type, which is by construction already in the receiver's erasure domain. The symbolic type arguments (which carry the real element identity for emit) are preserved, and the swap is a no-op whenever the two erasures already agree.

An earlier attempt that aligned the two erasure functions globally was rejected: it fixed these cases but regressed `List[[]Tok]` (whose receiver erases the whole slice to `object`). Anchoring on the candidate's own parameter type is exact rather than re-derived, and handles all shapes uniformly.

## 2. Untyped lambda parameters against an overloaded imported method

```gs
let xs = List[int32]()
xs.Sort((a, b) -> a.CompareTo(b))   // GS0304 x2, then GS0159
```

The CLR probe that discovers an untyped lambda's target type passes `null` in the deferred slot, which generic inference skips and treats as reference-convertible to anything — so all four `List<T>.Sort` overloads stayed applicable, the probe was ambiguous, and the parameters never received a target. (The single-overload case, `xs.ForEach((v) -> …)`, already worked.)

**Fix:** narrow the probe's candidate set to the overloads whose deferred lambda slots are delegate-shaped (or `Expression<TDelegate>`-wrapped) with the lambda's arity. This narrows only the best-effort target-type probe — the call is re-resolved for real once every argument is bound — and declines to narrow whenever a slot's shape cannot be determined (bare generic-parameter slot, non-lambda deferred argument, metadata load failure), so no existing overload-resolution rule is loosened.

## Verification

- Recompiled the emitted `src/LanguageServer` G# against `GSharp.Core.dll` with the fresh `gsc`: `SemanticTokensHandler.gs` went from exactly one error (`GS0159` at 143) to none. (Compiling the emitted sources directly avoids the packed-SDK staleness trap — it uses the locally built compiler.) Residual LS errors belong to #3661 / #3662 and a separate nullable-conversion issue.
- New `test/Core.Tests/CodeAnalysis/Issue3659ListSortComparisonLambdaTests.cs` — four `EmittedOracle` end-to-end tests (same-compilation enum element, tuple element carrying a slice of a same-compilation struct, untyped parameters, imported struct element). Each asserts the **correct** overload was selected by evaluating the resulting order (`210` / `123` / `321` / `123`), not merely that the call binds.
- Full `test/Core.Tests` in Release: 8263 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs