### PR TITLE
cs2gs: bridge deconstructed foreach reads of a promoted tuple element (#3663)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue3663DeconstructedForEachElementBridgingTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3663DeconstructedForEachElementBridgingTests.cs
@@ -1,0 +1,229 @@
+// <copyright file="Issue3663DeconstructedForEachElementBridgingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Regression tests for issue #3663 — the selfmig wall in migrated
+/// <c>Cs2Gs.Translator</c> (<c>CollectOwnedExtensions</c>): a Try-pattern
+/// <c>out</c> variable, promoted to <c>T?</c> by the #1072/#3501 analysis, is
+/// stored into a LOCAL <c>List&lt;(T, …)&gt;</c> and read back through a
+/// deconstructing <c>foreach</c>.
+/// <para>
+/// #3657 widened the nested-tuple flow collectors so a local collection is a
+/// declaration sink, which correctly renders the element <c>T?</c>. But a
+/// deconstructing <c>foreach</c> variable has no declaration of its own on the
+/// G# side — <c>for (a, b) in items</c> infers each name from the sequence's
+/// element tuple — so every read of the variable became a <c>T?</c> the
+/// translator still believed was a <c>T</c>: <c>GS0158 Cannot find member …</c>
+/// at a dereference and <c>GS0154</c> at every non-null argument sink.
+/// </para>
+/// </summary>
+public class Issue3663DeconstructedForEachElementBridgingTests
+{
+    /// <summary>
+    /// The migrated <c>CollectOwnedExtensions</c> wall: the promoted tuple
+    /// element's deconstructed reads assert <c>!!</c> at a dereference and at a
+    /// non-null argument position, while the sibling untainted element stays
+    /// bare.
+    /// </summary>
+    [Fact]
+    public void PromotedTupleElement_TypedForEachDeconstruction_AssertsNonNull()
+    {
+        string printed = TranslateOblivious(@"
+using System.Collections.Generic;
+
+namespace Demo
+{
+    public class Registry
+    {
+        public int Rank { get; set; }
+    }
+
+    public static class Collector
+    {
+        public static int Collect(IEnumerable<string> names)
+        {
+            var candidates = new List<(Registry Owner, string Name)>();
+            foreach (string name in names)
+            {
+                if (!TryGetOwner(name, out Registry owner))
+                {
+                    continue;
+                }
+
+                candidates.Add((owner, name));
+            }
+
+            int total = 0;
+            foreach ((Registry o, string n) in candidates)
+            {
+                total += Describe(o).Length + o.Rank + n.Length;
+            }
+
+            return total;
+        }
+
+        private static string Describe(Registry owner)
+        {
+            return owner.ToString();
+        }
+
+        private static bool TryGetOwner(string name, out Registry owner)
+        {
+            owner = null;
+            if (name == null)
+            {
+                return false;
+            }
+
+            owner = new Registry();
+            return true;
+        }
+    }
+}");
+
+        Assert.Contains("List[(Owner Registry?, Name string)]", printed);
+        Assert.Contains("Describe(o!!)", printed);
+        Assert.Contains("o!!.Rank", printed);
+        Assert.Contains("n.Length", printed);
+    }
+
+    /// <summary>
+    /// The <c>var (a, b)</c> header spelling nests its designations differently
+    /// from the explicitly typed one and must resolve to the same tuple leaf.
+    /// </summary>
+    [Fact]
+    public void PromotedTupleElement_VarForEachDeconstruction_AssertsNonNull()
+    {
+        string printed = TranslateOblivious(@"
+using System.Collections.Generic;
+
+namespace Demo
+{
+    public class Registry
+    {
+        public int Rank { get; set; }
+    }
+
+    public static class Collector
+    {
+        public static int Collect(IEnumerable<string> names)
+        {
+            var candidates = new List<(Registry Owner, string Name)>();
+            foreach (string name in names)
+            {
+                if (!TryGetOwner(name, out Registry owner))
+                {
+                    continue;
+                }
+
+                candidates.Add((owner, name));
+            }
+
+            int total = 0;
+            foreach (var (o, n) in candidates)
+            {
+                total += o.Rank + n.Length;
+            }
+
+            return total;
+        }
+
+        private static bool TryGetOwner(string name, out Registry owner)
+        {
+            owner = null;
+            if (name == null)
+            {
+                return false;
+            }
+
+            owner = new Registry();
+            return true;
+        }
+    }
+}");
+
+        Assert.Contains("o!!.Rank", printed);
+        Assert.Contains("n.Length", printed);
+    }
+
+    /// <summary>
+    /// Precision guard: when no null ever reaches the tuple element, neither the
+    /// element nor its deconstructed reads grow an assertion.
+    /// </summary>
+    [Fact]
+    public void UntaintedTupleElement_ForEachDeconstruction_StaysBare()
+    {
+        string printed = TranslateOblivious(@"
+using System.Collections.Generic;
+
+namespace Demo
+{
+    public class Registry
+    {
+        public int Rank { get; set; }
+    }
+
+    public static class Collector
+    {
+        public static int Collect(IEnumerable<string> names)
+        {
+            var candidates = new List<(Registry Owner, string Name)>();
+            foreach (string name in names)
+            {
+                candidates.Add((new Registry(), name));
+            }
+
+            int total = 0;
+            foreach ((Registry o, string n) in candidates)
+            {
+                total += o.Rank + n.Length;
+            }
+
+            return total;
+        }
+    }
+}");
+
+        Assert.Contains("List[(Owner Registry, Name string)]", printed);
+        Assert.DoesNotContain("o!!", printed);
+    }
+
+    private static string TranslateOblivious(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        Assert.Equal(
+            NullableContextOptions.Disable,
+            project.Compilation.Options.NullableContextOptions);
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+
+    private static string PrintAndValidate(CompilationUnit unit)
+    {
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -2378,6 +2378,19 @@ public sealed partial class CSharpToGSharpTranslator
 
                 case IdentifierNameSyntax:
                 case MemberAccessExpressionSyntax:
+                    // Issue #3663: a DECONSTRUCTING `foreach` variable carries no
+                    // taint of its own — it aliases a tuple leaf of the enumerated
+                    // sequence, and G# infers its type from that leaf. A promoted
+                    // leaf therefore makes the dereference `T? -> T` (GS0158).
+                    if (ObliviousNullabilityAnalyzer.IsDeconstructedForEachElementTainted(
+                        this.context.Compilation,
+                        expression,
+                        this.context.SemanticModel,
+                        this.context.SiblingCompilations))
+                    {
+                        return true;
+                    }
+
                     ISymbol symbol = this.context.GetSymbolInfo(expression).Symbol;
                     if (symbol is ILocalSymbol local
                         && !this.ShouldPromoteToNullableReference(local)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
@@ -445,6 +445,21 @@ public sealed partial class CSharpToGSharpTranslator
                 return true;
             }
 
+            // Issue #3663: a DECONSTRUCTING `foreach` variable aliases a tuple
+            // leaf without ever naming it, and G#'s `for (a, b) in items` infers
+            // each name from the sequence's element tuple. When #3641's
+            // nested-tuple promotion renders that element `T?`, the variable IS
+            // a nullable value even though its own declaration symbol carries no
+            // taint of its own — bridge its reads like any other promoted value.
+            if (ObliviousNullabilityAnalyzer.IsDeconstructedForEachElementTainted(
+                this.context.Compilation,
+                expression,
+                this.context.SemanticModel,
+                this.context.SiblingCompilations))
+            {
+                return true;
+            }
+
             ISymbol symbol = this.context.GetSymbolInfo(expression).Symbol;
             if (symbol is ILocalSymbol local
                 && !this.ShouldPromoteToNullableReference(local)

--- a/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
@@ -248,6 +248,49 @@ internal static class ObliviousNullabilityAnalyzer
             new HashSet<TupleElementQuery>(TupleElementQueryComparer.Instance));
     }
 
+    /// <summary>
+    /// Issue #3663: whether <paramref name="expression"/> reads a variable bound
+    /// by a DECONSTRUCTING <c>foreach</c> header
+    /// (<c>foreach ((A a, B b) in items)</c>) whose corresponding tuple leaf is
+    /// null-tainted. Such a variable has no declared type of its own on the G#
+    /// side — <c>for (a, b) in items</c> infers each name from the sequence's
+    /// element tuple — so when #3641's nested-tuple promotion renders that
+    /// element <c>A?</c>, every read of the variable is a nullable value the
+    /// translator must bridge with <c>!!</c> at its non-null sinks. The sibling
+    /// <see cref="IsTupleElementTainted(CSharpCompilation, ExpressionSyntax, SemanticModel, IReadOnlyList{CSharpCompilation})"/>
+    /// only recognizes an explicit member read (<c>pair.Item1</c>), which a
+    /// deconstruction never writes.
+    /// </summary>
+    /// <param name="compilation">The compilation containing the expression.</param>
+    /// <param name="expression">A read of a deconstruction-bound variable.</param>
+    /// <param name="model">The semantic model for the expression.</param>
+    /// <param name="siblingCompilations">Other compilations loaded in the same translation run.</param>
+    /// <returns><see langword="true"/> when the bound tuple leaf is null-tainted.</returns>
+    public static bool IsDeconstructedForEachElementTainted(
+        CSharpCompilation compilation,
+        ExpressionSyntax expression,
+        SemanticModel model,
+        IReadOnlyList<CSharpCompilation> siblingCompilations)
+    {
+        if (compilation == null
+            || expression == null
+            || model == null
+            || compilation.Options.NullableContextOptions != NullableContextOptions.Disable
+            || !TryResolveForEachDeconstructionSource(expression, model, out TupleElementKey source))
+        {
+            return false;
+        }
+
+        RegisterSourceAssemblies(compilation, siblingCompilations);
+        return IsTupleElementTaintedCore(
+            compilation,
+            source.Symbol,
+            source.Path,
+            siblingCompilations,
+            new HashSet<ScalarQuery>(ScalarQueryComparer.Instance),
+            new HashSet<TupleElementQuery>(TupleElementQueryComparer.Instance));
+    }
+
     public static HashSet<INamedTypeSymbol> CollectEfEntityTypes(Compilation compilation)
     {
         var entities = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
@@ -1969,6 +2012,103 @@ internal static class ObliviousNullabilityAnalyzer
 
         source = default;
         return false;
+    }
+
+    // Issue #3663: resolves a read of a variable declared by a DECONSTRUCTING
+    // `foreach` header back to the leaf it aliases — the enumerated collection's
+    // declaration symbol plus the element path the type mapper walks when it
+    // renders that declaration (`PromoteTupleTypeArguments`: type-argument
+    // indexes first, tuple element indexes after). Both header spellings climb
+    // the same way: `var (a, b)` nests SingleVariableDesignations inside a
+    // ParenthesizedVariableDesignation, while the explicitly typed `(A a, B b)`
+    // nests DeclarationExpressions inside a TupleExpression.
+    private static bool TryResolveForEachDeconstructionSource(
+        ExpressionSyntax expression,
+        SemanticModel model,
+        out TupleElementKey source)
+    {
+        source = default;
+        if (model.GetSymbolInfo(expression).Symbol is not ILocalSymbol local
+            || local.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax()
+                is not SingleVariableDesignationSyntax designation)
+        {
+            return false;
+        }
+
+        var indexes = new List<int>();
+        SyntaxNode current = designation;
+        bool climbing = true;
+        while (climbing)
+        {
+            switch (current.Parent)
+            {
+                case ParenthesizedVariableDesignationSyntax nested
+                    when current is VariableDesignationSyntax variable:
+                    int nestedIndex = nested.Variables.IndexOf(variable);
+                    if (nestedIndex < 0)
+                    {
+                        return false;
+                    }
+
+                    indexes.Insert(0, nestedIndex);
+                    current = nested;
+                    break;
+
+                case DeclarationExpressionSyntax declaration:
+                    current = declaration;
+                    break;
+
+                case ArgumentSyntax { Parent: TupleExpressionSyntax tuple } argument:
+                    int tupleIndex = tuple.Arguments.IndexOf(argument);
+                    if (tupleIndex < 0)
+                    {
+                        return false;
+                    }
+
+                    indexes.Insert(0, tupleIndex);
+                    current = tuple;
+                    break;
+
+                default:
+                    climbing = false;
+                    break;
+            }
+        }
+
+        if (indexes.Count == 0
+            || current.Parent is not ForEachVariableStatementSyntax forEach
+            || forEach.Variable != current)
+        {
+            return false;
+        }
+
+        if (model.GetForEachStatementInfo(forEach).ElementType
+                is not INamedTypeSymbol { IsTupleType: true } elementTuple
+            || model.GetSymbolInfo(forEach.Expression).Symbol is not { } collection
+            || SymbolValueType(collection) is not { } collectionType)
+        {
+            return false;
+        }
+
+        // The enumerated element tuple has to sit at exactly ONE position of the
+        // collection's rendered type; an ambiguous match (two identical tuple
+        // slots) would key the leaf arbitrarily, so leave those unbridged.
+        List<(string Path, INamedTypeSymbol Tuple)> slots = NestedTupleSlots(collectionType)
+            .Where(slot => SymbolEqualityComparer.Default.Equals(slot.Tuple, elementTuple))
+            .ToList();
+        if (slots.Count != 1)
+        {
+            return false;
+        }
+
+        string path = slots[0].Path;
+        foreach (int index in indexes)
+        {
+            path = AppendTuplePath(path, index);
+        }
+
+        source = new TupleElementKey(Canonical(collection), path);
+        return true;
     }
 
     private static int TupleElementIndex(INamedTypeSymbol tupleType, IFieldSymbol field)


### PR DESCRIPTION
Fixes #3663 — the regression that put the #3501 selfmig gate below its floor (32/51 vs floor 33). `Cs2Gs.Translator`, `Cs2Gs.ProjectLoading`, `GSharp.GeneratorHost` and `Gsgen.Cli` went from fully green to red, and the same family blocked all ten apps that compile migrated `Cs2Gs.Translator`.

## Which PR introduced it — #3657

**#3657** (`73feb864`, *cs2gs: propagate null taint into tuple elements under generic type arguments*), specifically its widening of the generic-receiver tuple flow to accept a **local** collection as a declaration sink.

Bisect evidence — the minimal repro added here (`PromotedTupleElement_TypedForEachDeconstruction_AssertsNonNull`), run unmodified at each commit:

| commit | rendered element type | binds? |
| --- | --- | --- |
| `2df9abbc` (#3657's parent, = #3656) | `List[(Owner Registry, Name string)]` | ✅ |
| `73feb864` (#3657) | `List[(Owner Registry?, Name string)]` | ❌ `Parameter 'owner' requires 'Registry' but was given 'Registry?'` |

#3650 and #3656 are cleared: neither touches tuple-element promotion, and the shape reproduces with #3656 in place.

## Root cause

`CollectOwnedExtensions` (`CSharpToGSharpTranslator.cs:531`) stores a Try-pattern `out` variable into a **local** `List<(INamedTypeSymbol, MethodDeclarationSyntax, IMethodSymbol)>` and reads it back through a deconstructing `foreach`:

```csharp
if (!TryGetOwnedExtensionReceiver(method, out INamedTypeSymbol receiverDefinition)) { continue; }
candidates.Add((receiverDefinition, methodDeclaration, method));
...
foreach ((INamedTypeSymbol receiver, MethodDeclarationSyntax syntax, IMethodSymbol method) in candidates)
```

`TryGetOwnedExtensionReceiver` assigns `receiverDefinition = null` at entry, so the established #1072/#3501 analysis promotes the out parameter — and, through the out-var back-edge, the caller's local. #3657 then correctly made the local `List<…>` a declaration sink, so the element renders `INamedTypeSymbol?`.

But a deconstructing `foreach` variable has **no declaration of its own** on the G# side: `for (receiver, syntax, method) in candidates` infers each name from the sequence's element tuple. The variable's own symbol carries no taint, so the translator still believed it held a non-null `INamedTypeSymbol` and left every read bare — the exact three diagnostics in the issue, at migrated `CSharpToGSharpTranslator.gs` 836-841:

```
GS0158 Cannot find member TypeKind.                              ← receiver.TypeKind
GS0154 Parameter 'type' requires 'INamedTypeSymbol' …            ← HasApplicableInstanceMember(receiver, method)
GS0154 Parameter 'receiver' requires 'INamedTypeSymbol' …        ← result.Add(receiver, syntax)
```

## Fix

`ObliviousNullabilityAnalyzer.IsDeconstructedForEachElementTainted` resolves a read of a deconstruction-bound variable back to the leaf it aliases — the enumerated collection's declaration symbol plus the element path the type mapper already walks in `PromoteTupleTypeArguments` (type-argument indexes first, tuple element indexes after) — and asks the existing tuple-leaf fixpoint about it. Both header spellings climb to the same key: `var (a, b)` nests designations, the explicitly typed `(A a, B b)` nests declaration expressions inside a tuple expression. The enumerated element tuple must occupy exactly one slot of the collection's rendered type, otherwise the leaf is left unbridged.

The translator consults it from the two seams that decide `!!`: `IsNullablePromotedValue` (argument / return / initializer sinks) and `ReceiverValueIsPromotedNullable` (dereference receivers).

#3657's promotion itself is untouched — it is right, and its regression tests keep passing. **Soundness of the false-return path** is preserved: the `!!` only lands on reads the original C# already dereferenced or passed to a non-null slot, so it restores exactly the throw-on-null the C# had. The `TryGetOwnedExtensionReceiver == false` path `continue`s before `candidates.Add`, so a genuinely-null value never reaches these reads; and the promoted `out` declaration itself (`out receiverDefinition INamedTypeSymbol?`) is unchanged, so a caller that ignores the `false` return still sees a nullable type.

## Verification

- New `Issue3663DeconstructedForEachElementBridgingTests` — 3 tests: the typed `foreach ((A a, B b) in …)` header, the `foreach (var (a, b) in …)` header, and a precision guard that an untainted element renders bare on both the declaration and its reads.
- `Nullable|Issue1072|Oblivious|Issue3641|Issue3644|Issue3635|Tuple|Issue3501|Issue3564|Issue3615|Deconstruct`: **501 passed, 0 failed**. Golden tests: **42 passed**.
- End to end, after a full `dotnet build GSharp.sln -c Release -graph` (so the packed `Gsharp.NET.Sdk` nupkg carries the new compiler), migrating the cs2gs subtree emits

  ```
  if (receiver!!.TypeKind is TypeKind.Class or TypeKind.Struct) &&
      …
      !HasApplicableInstanceMember(receiver!!, method) {
      result.Add(receiver!!, syntax)
  ```

  and **`Cs2Gs.Translator` compiles with 0 errors** (44 warnings). `Cs2Gs.ProjectLoading`, `Cs2Gs.Pipeline`, `Cs2Gs.Cli`, `Cs2Gs.CodeModel`, `Cs2Gs.Report`, `Core`, `Compiler`, `Gsharp.NET.Sdk`, `Gsharp.HotReload.Runtime`, `Gsharp.Templates`, both analyzer apps: 0 errors. `LanguageServer`'s 40 remaining errors are the unrelated pre-existing `ImmutableArray` / `FindNodes` / `nil -> T` family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
