### PR TITLE
gsc: deferred lambda returning a slice of a type parameter no longer erases to object[] (#3666)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -2090,6 +2090,18 @@ internal sealed partial class ExpressionBinder
                 var openParameterType = openParameters[paramIndex].ParameterType;
                 TypeSymbol? mappedDelegate;
                 FunctionTypeSymbol? functionType;
+
+                // Issue #3666: set when the delegate's RETURN shape was closed
+                // entirely by this unification — every method type parameter it
+                // mentions was resolved — even though it still mentions an
+                // enclosing type parameter carried by the receiver's symbolic
+                // arguments (e.g. `[]TMember` from
+                // `MemberCache[TMember].Cache : ConcurrentDictionary[(Type,
+                // BindingFlags), []TMember]`). Such a return cannot be recorded
+                // as an *exact* target return (the lambda body still has to
+                // infer it), but it does prove the reflected CLR target would be
+                // erased, so this symbolic path must win over the CLR probe.
+                var returnGroundedInReceiver = false;
                 if (openParameterType.IsGenericParameter)
                 {
                     if (!TryBuildSymbolicDelegateTarget(
@@ -2238,6 +2250,8 @@ internal sealed partial class ExpressionBinder
                             openMethod,
                             methodTypeArgs);
                     functionType = FunctionTypeSymbol.Get(parameterTypes.ToImmutable(), mappedReturnType);
+                    returnGroundedInReceiver = returnClrType != null
+                        && AllMethodTypeParametersResolved(returnClrType, openMethod, inferred);
                 }
 
                 foreach (var parameterType in functionType.ParameterTypes)
@@ -2265,6 +2279,26 @@ internal sealed partial class ExpressionBinder
                     {
                         candidateHasSymbolicType = true;
                     }
+                }
+                else if (returnGroundedInReceiver
+                    && mappedReturn != null
+                    && mappedReturn != TypeSymbol.Error
+                    && TypeSymbol.RequiresSymbolicProjection(mappedReturn))
+                {
+                    // Issue #3666: the return shape is fully determined by the
+                    // receiver's symbolic arguments yet still mentions a type
+                    // parameter, so it stays a placeholder (the body infers it)
+                    // — but the shape IS symbolic information reflection cannot
+                    // represent, so this candidate must count toward the success
+                    // gate below. Otherwise the whole symbolic recovery declines
+                    // and the CLR probe binds the lambda against the receiver's
+                    // erased target instead: `MemberCache[TMember].Cache
+                    // .GetOrAdd(key, k -> …)` got `Func[…, object[]]`, and the
+                    // body's genuine `[]TMember` result failed to convert
+                    // (GS0155). This slot deliberately does NOT enter
+                    // `slotReturnTypes`, so the lambda still infers its own
+                    // return type from the body.
+                    candidateHasSymbolicType = true;
                 }
             }
 

--- a/test/Core.Tests/CodeAnalysis/Issue3666GenericMemberArrayErasureTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Issue3666GenericMemberArrayErasureTests.cs
@@ -1,0 +1,123 @@
+// <copyright file="Issue3666GenericMemberArrayErasureTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis;
+
+/// <summary>
+/// Issue #3666: a deferred arrow lambda whose target return type is closed by
+/// the receiver's symbolic type arguments but still mentions an enclosing type
+/// parameter — the shape of migrated
+/// <c>ClrTypeUtilities.SafeEnumerate[TMember]</c>, whose body is
+/// <c>MemberCache[TMember].Cache.GetOrAdd(key, k -> … usable.ToArray())</c> —
+/// bound against the receiver's ERASED CLR target
+/// (<c>Func[…, object[]]</c>), so the body's genuine <c>[]TMember</c> result
+/// failed to convert with <c>GS0155</c>.
+/// <para>The symbolic recovery in
+/// <c>TryMapDeferredLambdaTargetsSymbolic</c> had produced the correct
+/// <c>[]TMember</c> return, but declined the candidate for want of symbolic
+/// information: a return type that still mentions a type parameter cannot be
+/// recorded as an exact target return, and no other slot on this call is
+/// symbolic. The success gate now counts such a return, so the symbolic path
+/// wins over the CLR probe and the lambda infers its own <c>[]TMember</c>
+/// return.</para>
+/// </summary>
+public class Issue3666GenericMemberArrayErasureTests
+{
+    [Fact]
+    public void DeferredLambdaReturningSliceOfMethodTypeParameter_ThroughNestedGenericStaticField_Binds()
+    {
+        // The migrated src/Core shape, reduced: a constrained generic function
+        // whose cache factory lambda returns []TMember, reached through a
+        // nested generic type's static ConcurrentDictionary field.
+        var source = @"
+import System
+import System.Collections.Concurrent
+import System.Collections.Generic
+import System.Reflection
+
+class MemberCache[TMember MemberInfo] {
+    shared {
+        var Cache ConcurrentDictionary[(Type, BindingFlags), []TMember] = ConcurrentDictionary[(Type, BindingFlags), []TMember]()
+    }
+}
+
+func SafeEnumerate[TMember MemberInfo](t Type, flags BindingFlags, getAll (Type) -> []TMember) []TMember {
+    return MemberCache[TMember].Cache.GetOrAdd((t, flags), (key (Type, BindingFlags)) -> {
+        let all = getAll(key.Item1)
+        let usable = List[TMember](all.Length)
+        for m in all {
+            usable.Add(m)
+        }
+        return usable.ToArray()
+    })
+}
+
+func run() int32 {
+    let flags = BindingFlags.Public | BindingFlags.Instance
+    let first = SafeEnumerate[MethodInfo](typeof(String), flags, (tt Type) -> tt.GetMethods())
+    let cached = SafeEnumerate[MethodInfo](typeof(String), flags, (tt Type) -> tt.GetMethods())
+    if first.Length == 0 {
+        return -1
+    }
+
+    // The second call must come back from the cache with the same array.
+    if !Object.ReferenceEquals(first, cached) {
+        return -2
+    }
+
+    return 1
+}
+
+run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(1, result.Value);
+    }
+
+    [Fact]
+    public void DeferredLambdaReturningSliceOfTypeParameter_ThroughGenericClassField_Binds()
+    {
+        // The same erasure domain reached through a generic *class* type
+        // parameter rather than a generic function's, with a same-compilation
+        // element type so the element identity really has to survive.
+        var source = @"
+import System.Collections.Concurrent
+import System.Collections.Generic
+
+class Item {
+    var Id int32
+}
+
+class Store[T] {
+    var Cache ConcurrentDictionary[int32, []T] = ConcurrentDictionary[int32, []T]()
+
+    func GetOrBuild(key int32, seed T) []T {
+        return Cache.GetOrAdd(key, (k int32) -> {
+            let acc = List[T]()
+            acc.Add(seed)
+            return acc.ToArray()
+        })
+    }
+}
+
+func run() int32 {
+    let store = Store[Item]()
+    let it = Item()
+    it.Id = 7
+    let built = store.GetOrBuild(1, it)
+    return built[0].Id
+}
+
+run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(7, result.Value);
+    }
+}


### PR DESCRIPTION
Fixes #3666

Migrated `src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.gs` failed with
`GS0155 Cannot convert type '[]TMember' to 'object[]'` — one error that was
the *sole* failure of 18 further apps in the #3501 self-migration gate
(19 of 23 reds).

## Bisect — causing PR is #3664

Minimal hand-written repro (`MemberCache[TMember].Cache` is a nested generic
type's static `ConcurrentDictionary`, exactly the `SafeEnumerate<TMember>`
shape):

```gs
class MemberCache[TMember MemberInfo] {
    shared {
        var Cache ConcurrentDictionary[(Type, BindingFlags), []TMember] = ConcurrentDictionary[(Type, BindingFlags), []TMember]()
    }
}

func SafeEnumerate[TMember MemberInfo](t Type, flags BindingFlags, getAll (Type) -> []TMember) []TMember {
    return MemberCache[TMember].Cache.GetOrAdd((t, flags), (key (Type, BindingFlags)) -> {
        let all = getAll(key.Item1)
        let usable = List[TMember](all.Length)
        for m in all { usable.Add(m) }
        return usable.ToArray()
    })
}
```

| commit | result |
|---|---|
| `bba1dc55` — #3662, the merge-base before #3664 | **compiles** |
| `0f9e6713` — #3664 | `GS0155: Cannot convert type '[]TMember' to 'object[]'` |
| this branch | **compiles and runs** correctly (cache identity preserved) |

## Root cause

Not #3664's erasure re-anchoring — its *other* half.

#3664 added `FilterCandidatesByDeferredLambdaShape`, which narrows the deferred
arrow-lambda target-type probe to overloads whose lambda slot is
delegate-shaped with the lambda's arity. On `ConcurrentDictionary.GetOrAdd`
that turns a previously **ambiguous** probe (`GetOrAdd(TKey, TValue)` /
`(TKey, Func[TKey, TValue])` / `[TArg](TKey, Func[TKey, TArg, TValue], TArg)`)
into a resolved one. Resolving is correct — but that CLR probe builds the
lambda's target from the receiver's *reflected, erased* closed parameter type,
`Func<ValueTuple<Type, BindingFlags>, object[]>`. The lambda was therefore
bound with an `object[]` return slot and its genuine `[]TMember` result failed
to convert. Before #3664 the ambiguous probe fell through to the
partial-inference path, which leaves the return type to the body.

The symbolic path (`TryMapDeferredLambdaTargetsSymbolic`, which runs first) had
*already recovered the correct `[]TMember` return* — but then declined the
candidate. Its success gate only counts symbolic information coming from a
lambda **parameter** type, or from a return type that is fully closed (mentions
no type parameter). Here the only symbolic slot is a return type that still
mentions `TMember`, so `anySymbolicType` stayed `false` and the whole recovery
was discarded.

## Fix

The gate now also counts a return type that is **grounded in the receiver's
symbolic arguments** — every *method* type parameter it mentions was resolved
by this unification (`AllMethodTypeParametersResolved`) — yet still mentions an
enclosing type parameter. Such a return is genuine symbolic information that
reflection cannot represent, so the symbolic path must win over the erased CLR
probe.

The slot deliberately does **not** enter `slotReturnTypes`, so the lambda keeps
inferring its own return type from the body; only the delegate identity and
parameter types come from the recovered target.

The `AllMethodTypeParametersResolved` requirement is what keeps
`Select[TSource, TResult](…, Func[TSource, TResult])`-shaped calls — whose
return type is a method type parameter inferable only from the lambda body — on
their existing path. No revert of #3664 was needed and no requirement conflicts.

## Verification

Built through the packed `Gsharp.NET.Sdk` nupkg (`dotnet build GSharp.sln -c
Release -graph`) before re-running any migration, and no project was excluded
that a migrated app project-references.

- **Migrated `src/Core`: 0 errors.** The `[]TMember`/`object[]` family is gone.
- **#3664's fingerprint has NOT returned**: migrated
  `src/LanguageServer/SemanticTokensHandler.gs` reports no `GS0159` on the
  `List.Sort` translation. LanguageServer's residual `GS0155`s are the
  pre-existing `nil`-to-non-nullable family that #3664 already called out
  (`LspServer.gs`, `Models.gs`, `TestDiscoveryComputer.gs`), not this one.
- `test/Core.Tests` `Lambda|Generic|Invocation|Issue3659|Issue3666`:
  **1412 passed, 0 failed** — including #3664's own
  `Issue3659ListSortComparisonLambdaTests`.
- `test/Compiler.Tests` `Lambda|Overload|Generic|Invocation`:
  **1081 passed, 0 failed**.
- New `test/Core.Tests/CodeAnalysis/Issue3666GenericMemberArrayErasureTests.cs`
  — two `EmittedOracle` end-to-end tests (the generic-function shape, asserting
  the cached array comes back by reference; and a generic-*class* variant over
  a same-compilation element type, asserting element identity survives).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
