### PR TITLE
selfmig gate: raise the job timeout so the run can report again (#3668)

### DIFF
--- a/.github/workflows/cs2gs-selfmig-nightly.yml
+++ b/.github/workflows/cs2gs-selfmig-nightly.yml
@@ -24,7 +24,13 @@ env:
 jobs:
   selfmig:
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    # Issue #3668: an app that fails at TRANSLATE costs seconds; one that gets
+    # past it pays for compile + ILVerify + test-parity. Clearing the #3666
+    # cascade (PR #3667) moved ~19 apps from "fails immediately" to "runs the
+    # full pipeline", so the run blew through the old 120-minute budget after
+    # only 23 of 51 apps and was cancelled with no verdict. Raised so the gate
+    # can report at all; a sharded matrix is the durable fix (#3668).
+    timeout-minutes: 360
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Run [33303426077](https://github.com/DavidObando/gsharp/actions/runs/33303426077) was **cancelled by the 120-minute job timeout** after processing only 23 of 51 apps — no summary line, no green count, no verdict. That blocks the ratcheting workflow (`greenFloor` / `nullAssertionCeiling` can't be updated without a complete run) and would hide regressions.

## This is progress, not a hang

An app that fails at **translate** costs seconds; one that gets past translate pays for compile, ILVerify and test-parity. Clearing the #3666 cascade (PR #3667) moved ~19 apps from "fails immediately" into "runs the full pipeline":

| run | duration | outcome |
|---|---|---|
| 33266052490 | 1h40m | 36/52 green |
| 33288891845 | 51m | 32/51 — many apps short-circuited at translate |
| 33294795512 | 55m | 28/51 — the #3666 cascade failed apps early and cheaply |
| 33303426077 | **2h00m (cancelled)** | cascade fixed → apps run the full pipeline |

So the earlier "fast" runs were fast because the corpus was broken.

## Change

`timeout-minutes: 120` → `360`, with a comment recording why. It's a nightly, so wall time is cheap. The durable fix — a sharded matrix plus an aggregation step that applies the thresholds to merged results — is tracked in #3668.

## Partial results from the cancelled run (worth noting)

13 of the 23 processed apps had **zero diagnostics**, including `src/Core`, `src/Compiler`, `Cs2Gs.Translator`, `Cs2Gs.ProjectLoading`, `Cs2Gs.CodeModel`, `Gsgen.Cli` and `GSharp.GeneratorHost` — confirming #3667 cleared the cascade. `LanguageServer` is down to 5 errors, all the GS0155 `nil`/`T?` family, confirming PRs #3661/#3662/#3664 cleared the other three families.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs