### PR TITLE
Shard the cs2gs self-migration gate: one whole-repo translate pass + N validate shards

### DIFF
--- a/.github/workflows/cs2gs-selfmig-nightly.yml
+++ b/.github/workflows/cs2gs-selfmig-nightly.yml
@@ -151,7 +151,7 @@ jobs:
           name: cs2gs-selfmig-shard-${{ matrix.name }}
           retention-days: 3
           path: |
-            /tmp/gsharp-cs2gs-selfmig/shard-${{ matrix.name }}/run.json
+            /tmp/gsharp-cs2gs-selfmig/shard-${{ matrix.name }}/shard-run.json
             /tmp/gsharp-cs2gs-selfmig/shard-${{ matrix.name }}/polished.tar.gz
             /tmp/gsharp-cs2gs-selfmig/shard-${{ matrix.name }}/validate.log
             /tmp/gsharp-cs2gs-selfmig/shard-${{ matrix.name }}/runs/**/*.json

--- a/.github/workflows/cs2gs-selfmig-nightly.yml
+++ b/.github/workflows/cs2gs-selfmig-nightly.yml
@@ -3,13 +3,34 @@ name: cs2gs-selfmig-nightly
 # Issue #3501 Track C: the repo self-migration gate. Migrates the entire
 # GSharp repository C# → G# nightly and enforces the ratcheting baseline in
 # tools/cs2gs/selfmig-baseline.json — a green-count floor plus readability
-# ceilings (synthetic labels, __local_ lifts, >300-char lines) over the
-# migrated output. Track A/B improvements tighten the baseline in the same
-# PR, so the migration goal ratchets instead of drifting.
+# ceilings (synthetic labels, __local_ lifts, >300-char lines, !! assertions)
+# over the migrated output. Track A/B improvements tighten the baseline in the
+# same PR, so the migration goal ratchets instead of drifting.
 #
-# Too expensive for the PR gates (~40+ minutes: 55 projects through
-# translate + SDK compile + ilverify + parity); scheduled clear of
-# cs2gs-nightly (07:17), windows-nightly (09:23), macos-nightly (11:23).
+# Issue #3668: the gate outgrew a single job. Once a cascade clears, apps stop
+# short-circuiting at translate and start paying for compile + ILVerify +
+# test-parity, and the serial run blew past two hours after 23 of 51 apps.
+# It now runs as three jobs:
+#
+#   migrate  — ONE whole-repository translate pass. Translation is NOT
+#              sharded: linked sources (e.g. test/Shared/EmittedOracle.cs) are
+#              compiled into several projects and TranslateStage cross-checks
+#              that they translate identically in all of them; that guard only
+#              exists when every project translates in the same run.
+#   validate — N shards, each downloading the migrated tree and running
+#              compile/ILVerify/test-parity for its own apps. These stages are
+#              independent per app, which is what makes them shardable. Shards
+#              are selected with `cs2gs validate --app`, NEVER with --exclude:
+#              excluding a project another app project-references breaks
+#              reference resolution and manufactures phantom cascades.
+#   gate     — merges the shard results with the migrate pass's translate
+#              results, replays the shards' `!!` polish rewrites onto the
+#              migrated tree, re-measures the readability metrics and applies
+#              the baseline. Runs even when shards fail, so a red run still
+#              reports a number.
+#
+# build/run-cs2gs-selfmig.sh remains the equivalent single-job reference path
+# for local proofs.
 
 on:
   schedule:
@@ -20,17 +41,21 @@ env:
   # See build.yml: parallel MSBuild nodes corrupt $GITHUB_ENV via
   # Nerdbank.GitVersioning's GitBuildVersion* emission.
   NBGV_SetCloudBuildVersionVars: false
+  SELFMIG_SHARDS: '6'
+  # Pinned rather than left to the scripts' ${TMPDIR:-/tmp} default: the
+  # artifact paths below are absolute, and the migrate job's run directory is
+  # handed to the shards as an absolute path, so all three jobs must agree.
+  SELFMIG_GATE_ROOT: /tmp/gsharp-cs2gs-selfmig
 
 jobs:
-  selfmig:
+  migrate:
     runs-on: ubuntu-latest
-    # Issue #3668: an app that fails at TRANSLATE costs seconds; one that gets
-    # past it pays for compile + ILVerify + test-parity. Clearing the #3666
-    # cascade (PR #3667) moved ~19 apps from "fails immediately" to "runs the
-    # full pipeline", so the run blew through the old 120-minute budget after
-    # only 23 of 51 apps and was cancelled with no verdict. Raised so the gate
-    # can report at all; a sharded matrix is the durable fix (#3668).
-    timeout-minutes: 360
+    # Generous by design: this is the one job that cannot be split, and a
+    # nightly's wall time is cheap. PR #3669 raised the old single job to 360;
+    # the translate pass alone is a fraction of that, but keep the headroom.
+    timeout-minutes: 240
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
 
     steps:
       - uses: actions/checkout@v5
@@ -51,17 +76,122 @@ jobs:
       - name: Build cs2gs (Release)
         run: dotnet build tools/cs2gs/Cs2Gs.Cli/Cs2Gs.Cli.csproj --configuration Release --no-restore -graph
 
-      - name: Run self-migration gate
-        run: ./build/run-cs2gs-selfmig.sh
+      - name: Translate the repository
+        run: ./build/run-cs2gs-selfmig-migrate.sh
 
-      - name: Upload run artifacts
+      - name: Plan validation shards
+        id: matrix
+        run: |
+          run_dir=$(cat /tmp/gsharp-cs2gs-selfmig/migrate-run-dir.txt)
+          matrix=$(python3 build/generate-selfmig-shard-matrix.py \
+            --run-dir "$run_dir" --shards "$SELFMIG_SHARDS")
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+      - name: Upload migrated tree
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: cs2gs-selfmig-migrated
+          retention-days: 3
+          include-hidden-files: true
+          path: |
+            /tmp/gsharp-cs2gs-selfmig/migrated/**
+            /tmp/gsharp-cs2gs-selfmig/runs/**
+            /tmp/gsharp-cs2gs-selfmig/migrate.log
+            /tmp/gsharp-cs2gs-selfmig/metrics.json
+            /tmp/gsharp-cs2gs-selfmig/migrate-run-dir.txt
+
+  validate:
+    name: validate (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    needs: migrate
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.migrate.outputs.matrix) }}
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v5
+        with:
+          global-json-file: global.json
+
+      - name: Restore
+        run: dotnet restore GSharp.sln --locked-mode
+
+      - name: Restore .NET local tools
+        run: dotnet tool restore
+
+      - name: Build cs2gs (Release)
+        run: dotnet build tools/cs2gs/Cs2Gs.Cli/Cs2Gs.Cli.csproj --configuration Release --no-restore -graph
+
+      - name: Download migrated tree
+        uses: actions/download-artifact@v5
+        with:
+          name: cs2gs-selfmig-migrated
+          path: /tmp/gsharp-cs2gs-selfmig
+
+      - name: Validate shard
+        env:
+          SHARD_NAME: ${{ matrix.name }}
+          SHARD_APPS: ${{ matrix.apps }}
+        # SHARD_APPS is a space-separated app-id list and is deliberately
+        # unquoted so it splits into one argument per app.
+        # shellcheck disable=SC2086
+        run: ./build/run-cs2gs-selfmig-validate.sh "$SHARD_NAME" $SHARD_APPS
+
+      - name: Upload shard result
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: cs2gs-selfmig-shard-${{ matrix.name }}
+          retention-days: 3
+          path: |
+            /tmp/gsharp-cs2gs-selfmig/shard-${{ matrix.name }}/run.json
+            /tmp/gsharp-cs2gs-selfmig/shard-${{ matrix.name }}/polished.tar.gz
+            /tmp/gsharp-cs2gs-selfmig/shard-${{ matrix.name }}/validate.log
+            /tmp/gsharp-cs2gs-selfmig/shard-${{ matrix.name }}/runs/**/*.json
+            /tmp/gsharp-cs2gs-selfmig/shard-${{ matrix.name }}/runs/**/report.html
+            /tmp/gsharp-cs2gs-selfmig/shard-${{ matrix.name }}/runs/**/sdk.build.log
+
+  gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: [migrate, validate]
+    # Report even when a shard failed: the whole point of the gate is to
+    # produce a number, and a shard that errored out must not silently leave
+    # the run verdict-less (which is exactly what the timeout did in #3668).
+    # The merge itself fails loudly if a translated app has no shard result.
+    if: always() && needs.migrate.result == 'success'
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Download migrated tree
+        uses: actions/download-artifact@v5
+        with:
+          name: cs2gs-selfmig-migrated
+          path: /tmp/gsharp-cs2gs-selfmig
+
+      - name: Download shard results
+        uses: actions/download-artifact@v5
+        with:
+          pattern: cs2gs-selfmig-shard-*
+          path: /tmp/gsharp-cs2gs-selfmig-shards
+
+      - name: Apply the baseline
+        run: ./build/run-cs2gs-selfmig-gate.sh /tmp/gsharp-cs2gs-selfmig /tmp/gsharp-cs2gs-selfmig-shards
+
+      - name: Upload merged run
         if: always()
         uses: actions/upload-artifact@v5
         with:
           name: cs2gs-selfmig-run
           path: |
+            /tmp/gsharp-cs2gs-selfmig/run.merged.json
+            /tmp/gsharp-cs2gs-selfmig/metrics.json
             /tmp/gsharp-cs2gs-selfmig/migrate.log
-            /tmp/gsharp-cs2gs-selfmig/runs/**/run.json
-            /tmp/gsharp-cs2gs-selfmig/runs/**/report.html
-            /tmp/gsharp-cs2gs-selfmig/runs/**/*.json
-            /tmp/gsharp-cs2gs-selfmig/runs/**/sdk.build.log

--- a/build/generate-selfmig-shard-matrix.py
+++ b/build/generate-selfmig-shard-matrix.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Assign the self-migration gate's translated apps to N validation shards.
+
+Issue #3668. The gate's cost is dominated by stages 2-4 (SDK compile, ILVerify,
+``dotnet test`` parity), which are independent per app; translation stays one
+whole-repository pass. This emits the GitHub Actions matrix the ``validate`` job
+consumes, in the same shape ``build/generate-ci-test-matrix.py`` produces for
+the unit-test shards.
+
+Only apps that PASSED translate are assigned: an app that failed translate cost
+seconds in the migrate job and already has its verdict, so scheduling it would
+just move an empty result around.
+
+Shards are balanced by estimated cost rather than round-robin, because the
+distribution is extremely skewed — a test project pays for a full ``dotnet
+test`` run while a small library pays for one compile. The estimate uses the
+emitted G# file count from each app's ``validation-context.json`` plus a flat
+test-project surcharge, and packs greedily longest-first (LPT), which keeps the
+slowest shard close to optimal.
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+# A test project additionally restores, builds and runs xUnit under `dotnet
+# test`; empirically that dwarfs the per-file compile cost, so it is modelled as
+# a flat surcharge in "file-equivalents".
+TEST_PROJECT_SURCHARGE = 400
+
+
+def app_weight(run_dir: Path, artifact_dir_name: str) -> int:
+    manifest_path = run_dir / artifact_dir_name / "validation-context.json"
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return 1
+
+    weight = len(manifest.get("emittedFiles", []))
+    if manifest.get("isTestProject"):
+        weight += TEST_PROJECT_SURCHARGE
+    return max(weight, 1)
+
+
+def artifact_dir_names(run_dir: Path) -> dict[str, str]:
+    """Maps app id to the artifact directory the migrate pass wrote for it.
+
+    The name is ``<sanitized-id>-<8 hex of sha256(id)>`` (see
+    ``MigrationPipeline.ArtifactDirectoryName``); rather than recompute the
+    hash here, read each manifest's own ``appId`` so the two never drift.
+    """
+    names: dict[str, str] = {}
+    for manifest_path in sorted(run_dir.glob("*/validation-context.json")):
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        app_id = manifest.get("appId")
+        if app_id:
+            names[app_id] = manifest_path.parent.name
+    return names
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--run-dir", required=True, help="the migrate pass's run directory")
+    parser.add_argument("--shards", type=int, default=6, help="number of validation shards")
+    args = parser.parse_args()
+
+    if args.shards < 1:
+        raise SystemExit("generate-selfmig-shard-matrix: --shards must be >= 1.")
+
+    run_dir = Path(args.run_dir)
+    run = json.loads((run_dir / "run.json").read_text(encoding="utf-8"))
+    names = artifact_dir_names(run_dir)
+
+    translated = []
+    for app in run.get("apps", []):
+        app_id = app["appId"]
+        passed = any(
+            stage.get("stage") == "translate" and stage.get("status") == "passed"
+            for stage in app.get("stages", [])
+        )
+        if not passed:
+            continue
+        if " " in app_id:
+            raise SystemExit(
+                f"generate-selfmig-shard-matrix: app id '{app_id}' contains a space; "
+                "shard app lists are space-separated."
+            )
+        translated.append((app_id, app_weight(run_dir, names.get(app_id, ""))))
+
+    shard_count = min(args.shards, max(len(translated), 1))
+    buckets: list[list[str]] = [[] for _ in range(shard_count)]
+    loads = [0] * shard_count
+    for app_id, weight in sorted(translated, key=lambda item: (-item[1], item[0])):
+        target = loads.index(min(loads))
+        buckets[target].append(app_id)
+        loads[target] += weight
+
+    include = [
+        {"name": str(index + 1), "apps": " ".join(sorted(apps))}
+        for index, apps in enumerate(buckets)
+        if apps
+    ]
+    print(json.dumps({"include": include}, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/build/merge-selfmig-runs.py
+++ b/build/merge-selfmig-runs.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Merge a translate-only migrate run.json with N validation shard run.jsons.
+
+Issue #3668. The sharded self-migration gate splits one whole run into a single
+whole-repository translate pass plus N per-app validation shards. This script
+puts the pieces back together so the gate sees exactly the per-app verdicts a
+single whole run would have produced:
+
+  * the ``translate`` stage result always comes from the migrate pass (it is the
+    only pass that ran it, and it must stay whole-repository so the linked
+    source cross-check keeps working);
+  * stages ``compile``/``ilverify``/``test-parity`` come from the shard that
+    owned the app;
+  * an app that failed translate was never handed to a shard, so its later
+    stages are filled in as ``skipped`` — the same shape the whole run's
+    short-circuit produces;
+  * ``succeeded`` is the conjunction, ``unverified`` is recomputed with the
+    whole run's rule (nothing failed, but something was skipped);
+  * an app that translated but that no shard reported on is a sharding bug, not
+    a green app: the merge fails loudly rather than silently shrinking the
+    denominator or inflating the green count.
+"""
+
+import argparse
+import json
+import sys
+
+TRANSLATE = "translate"
+VALIDATION_STAGES = ("compile", "ilverify", "test-parity")
+
+
+def load(path: str) -> dict:
+    with open(path, encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def stage_status(app: dict, name: str) -> str | None:
+    for stage in app.get("stages", []):
+        if stage.get("stage") == name:
+            return stage.get("status")
+    return None
+
+
+def merge_app(migrate_app: dict, shard_app: dict | None) -> dict:
+    stages = [s for s in migrate_app.get("stages", []) if s.get("stage") == TRANSLATE]
+    translated = stage_status(migrate_app, TRANSLATE) == "passed"
+
+    merged = {
+        "appId": migrate_app["appId"],
+        "succeeded": bool(migrate_app.get("succeeded", False)),
+        "unverified": False,
+        "failureCategory": migrate_app.get("failureCategory"),
+        "stages": stages,
+        "artifacts": list(migrate_app.get("artifacts", [])),
+        "fingerprints": list(migrate_app.get("fingerprints", [])),
+    }
+
+    if not translated:
+        # The whole run short-circuits after a failed stage; mirror that shape
+        # so downstream report tooling sees the familiar four-stage row.
+        merged["stages"] = stages + [
+            {"stage": name, "status": "skipped", "artifactCount": 0}
+            for name in VALIDATION_STAGES
+        ]
+        return merged
+
+    if shard_app is None:
+        raise SystemExit(
+            f"merge-selfmig-runs: app '{migrate_app['appId']}' translated but no shard "
+            "reported a result for it. Every translated app must be assigned to exactly "
+            "one shard; a missing shard result would silently shrink the gate."
+        )
+
+    merged["stages"] = stages + list(shard_app.get("stages", []))
+    merged["succeeded"] = bool(shard_app.get("succeeded", False))
+    merged["artifacts"] += list(shard_app.get("artifacts", []))
+    merged["fingerprints"] += list(shard_app.get("fingerprints", []))
+    if not merged["succeeded"]:
+        merged["failureCategory"] = shard_app.get("failureCategory")
+    else:
+        merged["failureCategory"] = None
+    merged["unverified"] = merged["succeeded"] and any(
+        stage.get("status") == "skipped" for stage in merged["stages"]
+    )
+    return merged
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--migrate", required=True, help="the translate-only run.json")
+    parser.add_argument("--out", required=True, help="the merged run.json to write")
+    parser.add_argument("shards", nargs="+", help="one run.json per validation shard")
+    args = parser.parse_args()
+
+    migrate = load(args.migrate)
+
+    shard_apps: dict[str, dict] = {}
+    for path in args.shards:
+        for app in load(path).get("apps", []):
+            app_id = app["appId"]
+            if app_id in shard_apps:
+                raise SystemExit(
+                    f"merge-selfmig-runs: app '{app_id}' was validated by more than one "
+                    "shard; shard assignments must partition the app set."
+                )
+            shard_apps[app_id] = app
+
+    merged_apps = [
+        merge_app(app, shard_apps.pop(app["appId"], None)) for app in migrate.get("apps", [])
+    ]
+
+    if shard_apps:
+        raise SystemExit(
+            "merge-selfmig-runs: shards reported apps the migrate pass never saw: "
+            + ", ".join(sorted(shard_apps))
+        )
+
+    merged = {
+        "runId": migrate.get("runId"),
+        "timestamp": migrate.get("timestamp"),
+        "gscVersion": migrate.get("gscVersion"),
+        "gscPath": migrate.get("gscPath"),
+        # The migrate pass's own verdict still gates: it also covers the
+        # repository-wide orphan-mirror and mirror-completeness checks, which
+        # no shard can see.
+        "succeeded": bool(migrate.get("succeeded", False))
+        and all(app["succeeded"] for app in merged_apps),
+        "unverified": False,
+        "apps": merged_apps,
+    }
+    merged["unverified"] = merged["succeeded"] and any(
+        app["unverified"] for app in merged_apps
+    )
+
+    with open(args.out, "w", encoding="utf-8") as handle:
+        json.dump(merged, handle, indent=2)
+        handle.write("\n")
+
+    green = sum(1 for app in merged_apps if app["succeeded"])
+    print(
+        f"merge-selfmig-runs: {len(merged_apps)} apps merged from "
+        f"{len(args.shards)} shard(s); {green} green.",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/build/run-cs2gs-selfmig-gate.sh
+++ b/build/run-cs2gs-selfmig-gate.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Issue #3668, stage 3 of the sharded self-migration gate: merge the shard
+# results and apply the ratcheting baseline in tools/cs2gs/selfmig-baseline.json.
+#
+# Usage: run-cs2gs-selfmig-gate.sh <migrate-artifact-dir> <shards-dir>
+#
+#   <migrate-artifact-dir>  the unpacked migrate artifact: migrated/, runs/,
+#                           metrics.json, migrate-run-dir.txt
+#   <shards-dir>            a directory containing one subdirectory per shard,
+#                           each holding run.json and (optionally)
+#                           polished.tar.gz
+#
+# The merge reconstructs exactly the per-app verdicts a single whole run would
+# have produced: the translate stage comes from the migrate pass, stages 2-4
+# from the shard that owned the app, and an app that failed translate keeps the
+# whole run's shape (translate FAIL, the rest skipped) without ever having been
+# handed to a shard. The polish deltas are replayed over the migrated tree
+# before the readability metrics are re-measured, because stage 2 strips `!!`
+# spans that gsc proved redundant and a whole run measures the tree AFTER that.
+#
+# Output format is a contract: the summary line, the step-summary table and the
+# `GATE: ...` lines are identical to the classic single-job gate.
+set -euo pipefail
+
+if (( $# != 2 )); then
+  echo "usage: $0 <migrate-artifact-dir> <shards-dir>" >&2
+  exit 2
+fi
+
+migrate_dir=$(cd "$1" && pwd -P)
+shards_dir=$(cd "$2" && pwd -P)
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+# shellcheck source=build/selfmig-common.sh
+source "$repo_root/build/selfmig-common.sh"
+baseline="$repo_root/tools/cs2gs/selfmig-baseline.json"
+migrated_dir="$migrate_dir/migrated"
+
+migrate_run_json=$(find "$migrate_dir/runs" -maxdepth 2 -name run.json | sort | tail -1)
+if [[ -z "$migrate_run_json" ]]; then
+  echo "self-migration gate: the migrate artifact carries no run.json." >&2
+  exit 1
+fi
+
+shard_run_jsons=()
+while IFS= read -r path; do
+  shard_run_jsons+=("$path")
+done < <(find "$shards_dir" -name run.json | sort)
+
+if (( ${#shard_run_jsons[@]} == 0 )); then
+  echo "self-migration gate: no shard results found under $shards_dir." >&2
+  exit 1
+fi
+
+merged="$migrate_dir/run.merged.json"
+python3 "$repo_root/build/merge-selfmig-runs.py" \
+  --migrate "$migrate_run_json" \
+  --out "$merged" \
+  "${shard_run_jsons[@]}"
+
+# Replay each shard's stage-2 `!!` polish rewrites onto the migrated tree.
+# Overlapping rewrites of a shared file are last-one-wins, exactly as they are
+# within a single whole run, where whichever app compiles last leaves the file.
+shopt -s nullglob
+for polished in "$shards_dir"/*/polished.tar.gz; do
+  echo "gate: replaying polish delta $polished"
+  tar -xzf "$polished" -C "$migrated_dir"
+done
+shopt -u nullglob
+
+green=$(jq '[.apps[] | select(.succeeded)] | length' "$merged")
+total=$(jq '.apps | length' "$merged")
+
+selfmig_measure "$migrated_dir"
+selfmig_apply_baseline "$baseline" "$green" "$total"

--- a/build/run-cs2gs-selfmig-gate.sh
+++ b/build/run-cs2gs-selfmig-gate.sh
@@ -7,7 +7,7 @@
 #   <migrate-artifact-dir>  the unpacked migrate artifact: migrated/, runs/,
 #                           metrics.json, migrate-run-dir.txt
 #   <shards-dir>            a directory containing one subdirectory per shard,
-#                           each holding run.json and (optionally)
+#                           each holding shard-run.json and (optionally)
 #                           polished.tar.gz
 #
 # The merge reconstructs exactly the per-app verdicts a single whole run would
@@ -45,10 +45,10 @@ fi
 shard_run_jsons=()
 while IFS= read -r path; do
   shard_run_jsons+=("$path")
-done < <(find "$shards_dir" -name run.json | sort)
+done < <(find "$shards_dir" -name shard-run.json | sort)
 
 if (( ${#shard_run_jsons[@]} == 0 )); then
-  echo "self-migration gate: no shard results found under $shards_dir." >&2
+  echo "self-migration gate: no shard-run.json found under $shards_dir." >&2
   exit 1
 fi
 

--- a/build/run-cs2gs-selfmig-migrate.sh
+++ b/build/run-cs2gs-selfmig-migrate.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Issue #3668, stage 1 of the sharded self-migration gate: ONE whole-repository
+# translate pass.
+#
+# Translation deliberately is NOT sharded. Linked sources (e.g.
+# test/Shared/EmittedOracle.cs) are compiled into several projects, and
+# TranslateStage cross-checks that each such file translates identically in all
+# of them ("translates differently in multiple projects"). That guard only
+# exists when every project translates in the same process, so this job
+# migrates the whole repo exactly as the classic single-job gate does — it just
+# stops after stage 1 and hands stages 2-4 to `cs2gs validate` shards.
+#
+# Outputs, all under $SELFMIG_GATE_ROOT (default /tmp/gsharp-cs2gs-selfmig):
+#   migrated/        the migrated G# tree (uploaded for the shards and the gate)
+#   runs/<runId>/    per-app validation-context.json manifests + run.json
+#   migrate.log      the translate log
+#   metrics.json     the readability metrics measured on the freshly-translated
+#                    tree, as the pre-validation baseline for the gate job
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+# shellcheck source=build/selfmig-common.sh
+source "$repo_root/build/selfmig-common.sh"
+work_root=${SELFMIG_GATE_ROOT:-"${TMPDIR:-/tmp}/gsharp-cs2gs-selfmig"}
+
+case "$work_root" in
+  ""|"/"|"$repo_root")
+    echo "Refusing unsafe self-migration gate root: '$work_root'" >&2
+    exit 2
+    ;;
+esac
+
+rm -rf "$work_root"
+mkdir -p "$work_root"
+work_root=$(cd "$work_root" && pwd -P)
+migrated_dir="$work_root/migrated"
+runs_dir="$work_root/runs"
+
+selfmig_build_prerequisites
+
+set +e
+dotnet "$repo_root/out/bin/Release/Cs2Gs.Cli/cs2gs.dll" migrate \
+  --corpus "$repo_root" \
+  --out "$migrated_dir" \
+  --artifacts "$runs_dir" \
+  --config Release \
+  --translate-only \
+  "${selfmig_excludes[@]}" \
+  | tee "$work_root/migrate.log"
+migrate_exit=${PIPESTATUS[0]}
+set -e
+
+run_json=$(find "$runs_dir" -maxdepth 2 -name run.json | sort | tail -1)
+if [[ -z "$run_json" ]]; then
+  echo "self-migration gate: no run.json produced (migrate exit $migrate_exit)." >&2
+  exit 1
+fi
+
+run_dir=$(dirname "$run_json")
+echo "$run_dir" > "$work_root/migrate-run-dir.txt"
+
+# The metrics are measured here, on the just-translated tree, because that is
+# the tree the shards start from. Stage 2's `!!` polish pass then rewrites some
+# files in each shard's own copy; the shards ship those rewrites back as a
+# small delta and the gate job replays them before re-measuring, so the final
+# numbers match a single whole run.
+selfmig_measure "$migrated_dir"
+jq -n \
+  --argjson labels "$labels" \
+  --argjson lifts "$lifts" \
+  --argjson longLines "$long_lines" \
+  --argjson bangs "$bangs" \
+  '{labels: $labels, lifts: $lifts, longLines: $longLines, bangs: $bangs}' \
+  > "$work_root/metrics.json"
+
+translated=$(jq '[.apps[] | select(.succeeded)] | length' "$run_json")
+total=$(jq '.apps | length' "$run_json")
+echo "self-migration translate: $translated/$total apps translated (migrate exit $migrate_exit)."
+echo "pre-validation metrics: labels=$labels __local_=$lifts lines>300=$long_lines bangs=$bangs"

--- a/build/run-cs2gs-selfmig-validate.sh
+++ b/build/run-cs2gs-selfmig-validate.sh
@@ -16,7 +16,9 @@
 #   runs/<runId>/           per-app validation-context.json manifests
 #   migrate-run-dir.txt     the manifest run directory
 # Outputs under $SELFMIG_GATE_ROOT/shard-<name>/:
-#   run.json                this shard's partial run result
+#   shard-run.json          this shard's partial run result (named distinctly from
+#                           the inner runs/<runId>/run.json so the gate's merge
+#                           cannot pick up the same result twice)
 #   polished.tar.gz         the .gs files stage 2's `!!` polish pass rewrote
 set -euo pipefail
 
@@ -89,7 +91,7 @@ if [[ -z "$shard_run_json" ]]; then
   echo "self-migration shard $shard_name: no run.json produced." >&2
   exit 1
 fi
-cp "$shard_run_json" "$shard_out/run.json"
+cp "$shard_run_json" "$shard_out/shard-run.json"
 
 selfmig_hash_tree "$migrated_dir" > "$shard_out/post.sha256"
 
@@ -103,6 +105,6 @@ if (( polished_count > 0 )); then
   tar -czf "$shard_out/polished.tar.gz" -C "$migrated_dir" -T "$shard_out/polished.txt"
 fi
 
-green=$(jq '[.apps[] | select(.succeeded)] | length' "$shard_out/run.json")
-total=$(jq '.apps | length' "$shard_out/run.json")
+green=$(jq '[.apps[] | select(.succeeded)] | length' "$shard_out/shard-run.json")
+total=$(jq '.apps | length' "$shard_out/shard-run.json")
 echo "self-migration shard $shard_name: $green/$total apps green."

--- a/build/run-cs2gs-selfmig-validate.sh
+++ b/build/run-cs2gs-selfmig-validate.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Issue #3668, stage 2 of the sharded self-migration gate: validate ONE shard's
+# apps against the already-migrated tree produced by
+# run-cs2gs-selfmig-migrate.sh.
+#
+# Usage: run-cs2gs-selfmig-validate.sh <shard-name> <app-id> [<app-id> ...]
+#
+# Compile, ILVerify and test-parity are independent per app — that is the axis
+# this shards on. The DISCOVERED app set stays the whole repository (identical
+# --exclude list): `cs2gs validate --app` narrows what is executed, never what
+# exists, because excluding a project another app project-references breaks
+# reference resolution and manufactures phantom cascades.
+#
+# Inputs (from the migrate artifact, unpacked under $SELFMIG_GATE_ROOT):
+#   migrated/               the migrated tree
+#   runs/<runId>/           per-app validation-context.json manifests
+#   migrate-run-dir.txt     the manifest run directory
+# Outputs under $SELFMIG_GATE_ROOT/shard-<name>/:
+#   run.json                this shard's partial run result
+#   polished.tar.gz         the .gs files stage 2's `!!` polish pass rewrote
+set -euo pipefail
+
+if (( $# < 2 )); then
+  echo "usage: $0 <shard-name> <app-id> [<app-id> ...]" >&2
+  exit 2
+fi
+
+shard_name=$1
+shift
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+# shellcheck source=build/selfmig-common.sh
+source "$repo_root/build/selfmig-common.sh"
+work_root=${SELFMIG_GATE_ROOT:-"${TMPDIR:-/tmp}/gsharp-cs2gs-selfmig"}
+work_root=$(cd "$work_root" && pwd -P)
+migrated_dir="$work_root/migrated"
+manifest_run_dir=$(cat "$work_root/migrate-run-dir.txt")
+shard_out="$work_root/shard-$shard_name"
+
+if [[ ! -d "$migrated_dir" ]]; then
+  echo "self-migration shard $shard_name: no migrated tree at $migrated_dir." >&2
+  exit 1
+fi
+
+# The migrate artifact records absolute paths from the migrate runner; on a
+# fresh runner the run directory lands at the same absolute location, but be
+# explicit rather than trusting that.
+if [[ ! -d "$manifest_run_dir" ]]; then
+  manifest_run_dir=$(find "$work_root/runs" -maxdepth 2 -name run.json | sort | tail -1)
+  manifest_run_dir=${manifest_run_dir%/run.json}
+fi
+
+rm -rf "$shard_out"
+mkdir -p "$shard_out"
+
+selfmig_build_prerequisites
+
+# Snapshot the tree so stage 2's `!!` polish rewrites can be shipped back to
+# the gate job as a delta (see run-cs2gs-selfmig-gate.sh).
+selfmig_hash_tree "$migrated_dir" > "$shard_out/pre.sha256"
+
+app_args=()
+for app in "$@"; do
+  app_args+=(--app "$app")
+done
+
+set +e
+dotnet "$repo_root/out/bin/Release/Cs2Gs.Cli/cs2gs.dll" validate \
+  --corpus "$repo_root" \
+  --migrated "$migrated_dir" \
+  --artifacts "$shard_out/runs" \
+  --manifests "$manifest_run_dir" \
+  --config Release \
+  "${selfmig_excludes[@]}" \
+  "${app_args[@]}" \
+  | tee "$shard_out/validate.log"
+validate_exit=${PIPESTATUS[0]}
+set -e
+
+# Exit 1 means "apps failed a stage", which is exactly what the gate job is
+# there to judge; only exit 2 (tool error) fails the shard job itself.
+if (( validate_exit >= 2 )); then
+  echo "self-migration shard $shard_name: cs2gs validate errored (exit $validate_exit)." >&2
+  exit "$validate_exit"
+fi
+
+shard_run_json=$(find "$shard_out/runs" -maxdepth 2 -name run.json | sort | tail -1)
+if [[ -z "$shard_run_json" ]]; then
+  echo "self-migration shard $shard_name: no run.json produced." >&2
+  exit 1
+fi
+cp "$shard_run_json" "$shard_out/run.json"
+
+selfmig_hash_tree "$migrated_dir" > "$shard_out/post.sha256"
+
+# Files whose hash changed (or that appeared) during validation — i.e. what the
+# polish pass rewrote. Almost always a small handful.
+awk 'NR==FNR { before[$2] = $1; next } (!($2 in before)) || before[$2] != $1 { print $2 }' \
+  "$shard_out/pre.sha256" "$shard_out/post.sha256" > "$shard_out/polished.txt"
+polished_count=$(wc -l < "$shard_out/polished.txt" | tr -d ' ')
+echo "self-migration shard $shard_name: $polished_count .gs file(s) rewritten by the polish pass."
+if (( polished_count > 0 )); then
+  tar -czf "$shard_out/polished.tar.gz" -C "$migrated_dir" -T "$shard_out/polished.txt"
+fi
+
+green=$(jq '[.apps[] | select(.succeeded)] | length' "$shard_out/run.json")
+total=$(jq '.apps | length' "$shard_out/run.json")
+echo "self-migration shard $shard_name: $green/$total apps green."

--- a/build/run-cs2gs-selfmig.sh
+++ b/build/run-cs2gs-selfmig.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# Issue #3501 Track C: the repo self-migration gate. Migrates the ENTIRE
-# GSharp repository from C# to G# (translate + compile + ilverify + parity
-# per project) and enforces the ratcheting baseline in
+# Issue #3501 Track C: the repo self-migration gate, CLASSIC SINGLE-JOB path.
+# Migrates the ENTIRE GSharp repository from C# to G# (translate + compile +
+# ilverify + parity per project) and enforces the ratcheting baseline in
 # tools/cs2gs/selfmig-baseline.json:
 #
 #   - greenFloor:            minimum fully-green apps (run fails below it)
@@ -15,18 +15,16 @@
 # When a Track A/B improvement lands, tighten the corresponding number in the
 # baseline within the same PR so progress ratchets.
 #
-# E2E fixtures that are not migration targets are excluded via --exclude.
-# The Visual Studio extension stays in C# by decision (like the VSCode
-# extension stays in TypeScript), so all three vs-gsharp apps are excluded:
-# VsGsharp and VsGsharp.CodeLens build only under the Windows-only VSSDK
-# toolchain (VSCT compile, pkgdef), and VsGsharp.UnitTests tests the
-# permanently-C# extension via linked sources. Gsharp.Extensions is excluded
-# because it is ALREADY G# (all-.gs sources bootstrapped by the latest
-# compiler without a gsproj) — there is nothing to migrate, and feeding its
-# .gs sources through the C# parser only produces phantom gaps.
+# Issue #3668: the NIGHTLY runs the sharded pipeline instead
+# (run-cs2gs-selfmig-migrate.sh + run-cs2gs-selfmig-validate.sh +
+# run-cs2gs-selfmig-gate.sh), which is the same work split across runners.
+# This script stays the reference implementation and the local proof path: it
+# is what the sharded pipeline is verified to be equivalent to.
 set -euo pipefail
 
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+# shellcheck source=build/selfmig-common.sh
+source "$repo_root/build/selfmig-common.sh"
 baseline="$repo_root/tools/cs2gs/selfmig-baseline.json"
 work_root=${SELFMIG_GATE_ROOT:-"${TMPDIR:-/tmp}/gsharp-cs2gs-selfmig"}
 
@@ -43,16 +41,7 @@ work_root=$(cd "$work_root" && pwd -P)
 migrated_dir="$work_root/migrated"
 runs_dir="$work_root/runs"
 
-# MSBuildWorkspace design-time project loads evaluate in Debug regardless of
-# --config Release, and Gsharp.Extensions.csproj's Bootstrap SDK import
-# hard-errors when out/bin/Debug/{Compiler/gsc.dll, Gsharp.NET.Sdk/
-# Gsharp.NET.Sdk.dll} are missing — which fails ProjectLoad (CS2GS0001) for
-# every app that transitively references Gsharp.Extensions (Repl, the
-# Compiler/Extensions/Interpreter test projects, ...). Build both Debug
-# prerequisites up front; the Compiler must come first because the SDK build
-# compiles Gsharp.Extensions' .gs sources with the bootstrap gsc.
-dotnet build "$repo_root/src/Compiler/Compiler.csproj" -c Debug -graph
-dotnet build "$repo_root/src/Sdk/Gsharp.NET.Sdk/Gsharp.NET.Sdk.csproj" -c Debug -graph
+selfmig_build_prerequisites
 
 set +e
 dotnet "$repo_root/out/bin/Release/Cs2Gs.Cli/cs2gs.dll" migrate \
@@ -60,13 +49,7 @@ dotnet "$repo_root/out/bin/Release/Cs2Gs.Cli/cs2gs.dll" migrate \
   --out "$migrated_dir" \
   --artifacts "$runs_dir" \
   --config Release \
-  --exclude samples/ProjectRef/CSharpApp \
-  --exclude samples/PropertyRef/CSharpApp \
-  --exclude src/vs-gsharp/src/VsGsharp/VsGsharp.csproj \
-  --exclude src/vs-gsharp/src/VsGsharp.CodeLens/VsGsharp.CodeLens.csproj \
-  --exclude src/vs-gsharp/test/VsGsharp.UnitTests \
-  --exclude src/Sdk/Gsharp.Extensions \
-  --exclude tools/cs2gs/corpus/CompileGap-Library \
+  "${selfmig_excludes[@]}" \
   | tee "$work_root/migrate.log"
 migrate_exit=${PIPESTATUS[0]}
 set -e
@@ -80,69 +63,5 @@ fi
 green=$(jq '[.apps[] | select(.succeeded)] | length' "$run_json")
 total=$(jq '.apps | length' "$run_json")
 
-# Metrics count CODE, not fixtures: migrated test sources embed expected-output
-# strings (and docs quote constructs), so lines containing a string quote or
-# leading with a comment marker are excluded before counting.
-code_grep() {
-  # A ZERO-match metric is success, not failure: without the || true, the
-  # no-match grep's exit 1 kills the script under `set -eo pipefail` before
-  # the ceilings are ever checked (exactly what happened once the synthetic
-  # label count reached 0).
-  local count
-  count=$(grep -rhE "$1" "$migrated_dir" --include='*.gs' 2>/dev/null \
-    | grep -v '"' | grep -vE '^[[:space:]]*//' | grep -oE "$1" | wc -l | tr -d ' ') || true
-  echo "${count:-0}"
-}
-labels=$(code_grep '__(switchExit|iteratorExit|gotoCase|gotoDefault|patternGuardEnd)')
-lifts=$(code_grep '__local_')
-long_lines=$(find "$migrated_dir" -name '*.gs' -exec awk 'length($0)>300' {} + 2>/dev/null | wc -l | tr -d ' ')
-bangs=$(code_grep '!!')
-
-green_floor=$(jq -r '.greenFloor' "$baseline")
-label_ceiling=$(jq -r '.syntheticLabelCeiling' "$baseline")
-lift_ceiling=$(jq -r '.liftedLocalCeiling' "$baseline")
-long_ceiling=$(jq -r '.longLineCeiling' "$baseline")
-bang_ceiling=$(jq -r '.nullAssertionCeiling' "$baseline")
-
-summary="self-migration: $green/$total green (floor $green_floor); labels=$labels (ceiling $label_ceiling); __local_=$lifts (ceiling $lift_ceiling); lines>300=$long_lines (ceiling $long_ceiling); bangs=$bangs (ceiling $bang_ceiling)"
-echo "$summary"
-if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
-  {
-    echo "### cs2gs self-migration gate"
-    echo ''
-    echo "| metric | value | baseline |"
-    echo "|---|---|---|"
-    echo "| green apps | $green/$total | floor $green_floor |"
-    echo "| synthetic labels | $labels | ceiling $label_ceiling |"
-    echo "| \`__local_\` lifts | $lifts | ceiling $lift_ceiling |"
-    echo "| lines >300 chars | $long_lines | ceiling $long_ceiling |"
-    echo "| \`!!\` assertions | $bangs | ceiling $bang_ceiling |"
-  } >> "$GITHUB_STEP_SUMMARY"
-fi
-
-status=0
-if (( green < green_floor )); then
-  echo "GATE: green count $green fell below floor $green_floor." >&2
-  status=1
-fi
-if (( labels > label_ceiling )); then
-  echo "GATE: synthetic label count $labels exceeded ceiling $label_ceiling." >&2
-  status=1
-fi
-if (( lifts > lift_ceiling )); then
-  echo "GATE: __local_ count $lifts exceeded ceiling $lift_ceiling." >&2
-  status=1
-fi
-if (( long_lines > long_ceiling )); then
-  echo "GATE: >300-char line count $long_lines exceeded ceiling $long_ceiling." >&2
-  status=1
-fi
-if (( bangs > bang_ceiling )); then
-  echo "GATE: !! null-assertion count $bangs exceeded ceiling $bang_ceiling." >&2
-  status=1
-fi
-
-if (( status == 0 )); then
-  echo "Self-migration gate PASSED."
-fi
-exit "$status"
+selfmig_measure "$migrated_dir"
+selfmig_apply_baseline "$baseline" "$green" "$total"

--- a/build/selfmig-common.sh
+++ b/build/selfmig-common.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Issue #3501 Track C / issue #3668: the pieces of the repo self-migration gate
+# that BOTH the classic single-job path (build/run-cs2gs-selfmig.sh) and the
+# sharded path (run-cs2gs-selfmig-{migrate,validate,gate}.sh) must agree on:
+#
+#   - the --exclude set (it defines the DISCOVERED app set, so every stage of
+#     the sharded pipeline has to pass the identical list; see below),
+#   - the readability metric definitions,
+#   - the baseline threshold evaluation and its output format.
+#
+# Sourced, never executed. Callers set `repo_root` before sourcing.
+
+# E2E fixtures that are not migration targets are excluded via --exclude.
+# The Visual Studio extension stays in C# by decision (like the VSCode
+# extension stays in TypeScript), so all three vs-gsharp apps are excluded:
+# VsGsharp and VsGsharp.CodeLens build only under the Windows-only VSSDK
+# toolchain (VSCT compile, pkgdef), and VsGsharp.UnitTests tests the
+# permanently-C# extension via linked sources. Gsharp.Extensions is excluded
+# because it is ALREADY G# (all-.gs sources bootstrapped by the latest
+# compiler without a gsproj) — there is nothing to migrate, and feeding its
+# .gs sources through the C# parser only produces phantom gaps.
+#
+# INVARIANT (issue #3668): --exclude is NOT a sharding mechanism. Excluding a
+# project that another app project-references breaks reference resolution and
+# manufactures phantom cascades (dropping src/Core from a LanguageServer run
+# yielded ~794 bogus errors). Every job in the sharded pipeline therefore
+# passes this exact list; shards are selected with `cs2gs validate --shard`,
+# which narrows what is EXECUTED, never what is discovered.
+selfmig_excludes=(
+  --exclude samples/ProjectRef/CSharpApp
+  --exclude samples/PropertyRef/CSharpApp
+  --exclude src/vs-gsharp/src/VsGsharp/VsGsharp.csproj
+  --exclude src/vs-gsharp/src/VsGsharp.CodeLens/VsGsharp.CodeLens.csproj
+  --exclude src/vs-gsharp/test/VsGsharp.UnitTests
+  --exclude src/Sdk/Gsharp.Extensions
+  --exclude tools/cs2gs/corpus/CompileGap-Library
+)
+
+# MSBuildWorkspace design-time project loads evaluate in Debug regardless of
+# --config Release, and Gsharp.Extensions.csproj's Bootstrap SDK import
+# hard-errors when out/bin/Debug/{Compiler/gsc.dll, Gsharp.NET.Sdk/
+# Gsharp.NET.Sdk.dll} are missing — which fails ProjectLoad (CS2GS0001) for
+# every app that transitively references Gsharp.Extensions (Repl, the
+# Compiler/Extensions/Interpreter test projects, ...). Build both Debug
+# prerequisites up front; the Compiler must come first because the SDK build
+# compiles Gsharp.Extensions' .gs sources with the bootstrap gsc.
+selfmig_build_prerequisites() {
+  dotnet build "$repo_root/src/Compiler/Compiler.csproj" -c Debug -graph
+  dotnet build "$repo_root/src/Sdk/Gsharp.NET.Sdk/Gsharp.NET.Sdk.csproj" -c Debug -graph
+}
+
+# Metrics count CODE, not fixtures: migrated test sources embed expected-output
+# strings (and docs quote constructs), so lines containing a string quote or
+# leading with a comment marker are excluded before counting.
+selfmig_code_grep() {
+  local migrated_dir=$1 pattern=$2
+  # A ZERO-match metric is success, not failure: without the || true, the
+  # no-match grep's exit 1 kills the script under `set -eo pipefail` before
+  # the ceilings are ever checked (exactly what happened once the synthetic
+  # label count reached 0).
+  local count
+  count=$(grep -rhE "$pattern" "$migrated_dir" --include='*.gs' 2>/dev/null \
+    | grep -v '"' | grep -vE '^[[:space:]]*//' | grep -oE "$pattern" | wc -l | tr -d ' ') || true
+  echo "${count:-0}"
+}
+
+# Hashes every .gs file in a migrated tree as "<hash>  <tree-relative path>",
+# sorted by path. Used by the shards to ship stage 2's `!!` polish rewrites
+# back to the gate job as a delta, so the gate re-measures the same tree a
+# single whole run would have produced.
+selfmig_hash_tree() {
+  local tree=$1 hasher
+  # sha256sum on Linux runners, shasum -a 256 on macOS; both print
+  # "<hash>  <path>".
+  if command -v sha256sum >/dev/null 2>&1; then
+    hasher=(sha256sum)
+  else
+    hasher=(shasum -a 256)
+  fi
+  ( cd "$tree" && find . -name '*.gs' -type f -print0 \
+      | xargs -0 -n 200 "${hasher[@]}" | sort -k2 )
+}
+
+# Computes the four readability metrics over a migrated tree, into the caller's
+# `labels`, `lifts`, `long_lines` and `bangs` variables.
+selfmig_measure() {
+  local migrated_dir=$1
+  labels=$(selfmig_code_grep "$migrated_dir" '__(switchExit|iteratorExit|gotoCase|gotoDefault|patternGuardEnd)')
+  lifts=$(selfmig_code_grep "$migrated_dir" '__local_')
+  long_lines=$(find "$migrated_dir" -name '*.gs' -exec awk 'length($0)>300' {} + 2>/dev/null | wc -l | tr -d ' ')
+  bangs=$(selfmig_code_grep "$migrated_dir" '!!')
+}
+
+# Applies the ratcheting baseline to a green count and the measured metrics,
+# printing the canonical one-line summary, the step-summary table, and one
+# `GATE: ...` line per breach. Returns 1 when any threshold is breached.
+#
+# The output format is a contract: humans and tooling parse these exact lines.
+selfmig_apply_baseline() {
+  local baseline=$1 green=$2 total=$3
+
+  local green_floor label_ceiling lift_ceiling long_ceiling bang_ceiling
+  green_floor=$(jq -r '.greenFloor' "$baseline")
+  label_ceiling=$(jq -r '.syntheticLabelCeiling' "$baseline")
+  lift_ceiling=$(jq -r '.liftedLocalCeiling' "$baseline")
+  long_ceiling=$(jq -r '.longLineCeiling' "$baseline")
+  bang_ceiling=$(jq -r '.nullAssertionCeiling' "$baseline")
+
+  local summary
+  summary="self-migration: $green/$total green (floor $green_floor); labels=$labels (ceiling $label_ceiling); __local_=$lifts (ceiling $lift_ceiling); lines>300=$long_lines (ceiling $long_ceiling); bangs=$bangs (ceiling $bang_ceiling)"
+  echo "$summary"
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    {
+      echo "### cs2gs self-migration gate"
+      echo ''
+      echo "| metric | value | baseline |"
+      echo "|---|---|---|"
+      echo "| green apps | $green/$total | floor $green_floor |"
+      echo "| synthetic labels | $labels | ceiling $label_ceiling |"
+      echo "| \`__local_\` lifts | $lifts | ceiling $lift_ceiling |"
+      echo "| lines >300 chars | $long_lines | ceiling $long_ceiling |"
+      echo "| \`!!\` assertions | $bangs | ceiling $bang_ceiling |"
+    } >> "$GITHUB_STEP_SUMMARY"
+  fi
+
+  local status=0
+  if (( green < green_floor )); then
+    echo "GATE: green count $green fell below floor $green_floor." >&2
+    status=1
+  fi
+  if (( labels > label_ceiling )); then
+    echo "GATE: synthetic label count $labels exceeded ceiling $label_ceiling." >&2
+    status=1
+  fi
+  if (( lifts > lift_ceiling )); then
+    echo "GATE: __local_ count $lifts exceeded ceiling $lift_ceiling." >&2
+    status=1
+  fi
+  if (( long_lines > long_ceiling )); then
+    echo "GATE: >300-char line count $long_lines exceeded ceiling $long_ceiling." >&2
+    status=1
+  fi
+  if (( bangs > bang_ceiling )); then
+    echo "GATE: !! null-assertion count $bangs exceeded ceiling $bang_ceiling." >&2
+    status=1
+  fi
+
+  if (( status == 0 )); then
+    echo "Self-migration gate PASSED."
+  fi
+  return "$status"
+}

--- a/tools/cs2gs/Cs2Gs.Cli/Program.cs
+++ b/tools/cs2gs/Cs2Gs.Cli/Program.cs
@@ -60,6 +60,19 @@ internal static class Program
             }
         }
 
+        if (verb is "validate")
+        {
+            try
+            {
+                return await ValidateCommand.RunAsync(args.Skip(1).ToArray()).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine("cs2gs: " + ex.Message);
+                return 2;
+            }
+        }
+
         if (verb is "report")
         {
             try
@@ -152,15 +165,69 @@ internal static class Program
         }
     }
 
+    /// <summary>
+    /// Prints the per-app × per-stage status matrix and the green-count verdict.
+    /// Shared by <c>migrate</c> and <c>validate</c> so a shard's log reads
+    /// exactly like a whole run's.
+    /// </summary>
+    /// <param name="result">The (possibly partial) run result.</param>
+    /// <param name="stages">The stages the run executed, in order.</param>
+    internal static void PrintSummary(RunResult result, IReadOnlyList<IMigrationStage> stages)
+    {
+        var stageNames = stages.Select(s => TriageSerialization.StageName(s.Kind)).ToList();
+
+        Console.WriteLine();
+        Console.WriteLine($"cs2gs migrate — run {result.RunId}");
+        Console.WriteLine($"gsc: {result.GscVersion}");
+        Console.WriteLine();
+
+        int idWidth = Math.Max(3, result.Apps.Select(a => a.AppId.Length).DefaultIfEmpty(3).Max());
+        string header = "app".PadRight(idWidth) + "  " +
+            string.Join("  ", stageNames.Select(n => n.PadRight(12)));
+        Console.WriteLine(header);
+        Console.WriteLine(new string('-', header.Length));
+
+        foreach (AppResult app in result.Apps)
+        {
+            var cells = new List<string>();
+            foreach (string stageName in stageNames)
+            {
+                StageResult stage = app.Stages.FirstOrDefault(s => s.Stage == stageName);
+                cells.Add(FormatCell(stage).PadRight(12));
+            }
+
+            Console.WriteLine(app.AppId.PadRight(idWidth) + "  " + string.Join("  ", cells));
+            if (!app.Succeeded)
+            {
+                foreach (string artifact in app.Artifacts)
+                {
+                    Console.WriteLine($"    -> {app.FailureCategory}: {artifact}");
+                }
+            }
+        }
+
+        Console.WriteLine();
+
+        // Same precedence as the report (issue #1831): a run-level failure
+        // always wins; otherwise call out unverified apps rather than
+        // rendering them as a plain pass.
+        int passed = result.Apps.Count(a => a.Succeeded && !a.Unverified);
+        int unverified = result.Apps.Count(a => a.Unverified);
+        string verdict = !result.Succeeded
+            ? "FAILED"
+            : unverified > 0 ? $"PASSED ({unverified} unverified)" : "PASSED";
+        Console.WriteLine($"{passed}/{result.Apps.Count} apps green; run {verdict}.");
+    }
+
     private static async Task<int> RunMigrateAsync(string[] args)
     {
-        (string Corpus, List<string> AppIds, PipelineOptions Options, string BaselinePath, bool BaselineStrict)? parsed = ParseMigrateArgs(args, out bool helpRequested);
+        MigrateArguments? parsed = ParseMigrateArgs(args, out bool helpRequested);
         if (parsed is null)
         {
             return helpRequested ? 0 : 1;
         }
 
-        (string corpus, List<string> appIds, PipelineOptions options, string baselinePath, bool baselineStrict) = parsed.Value;
+        (string corpus, List<string> appIds, PipelineOptions options, string baselinePath, bool baselineStrict, bool translateOnly) = parsed.Value;
         options.SourceRoot = Path.GetFullPath(corpus);
 
         IReadOnlyList<CorpusApp> apps;
@@ -240,7 +307,19 @@ internal static class Program
             return 1;
         }
 
-        var pipeline = new MigrationPipeline(options);
+        if (translateOnly && options.OutputLayout != MigrationOutputLayout.Repository)
+        {
+            Console.Error.WriteLine("cs2gs: --translate-only applies to repository migration only.");
+            return 1;
+        }
+
+        // Issue #3668: --translate-only keeps the whole-repository translate
+        // pass (and its cross-project linked-source guard) intact while
+        // deferring the per-app compile/ilverify/test-parity work to
+        // `cs2gs validate` shards.
+        var pipeline = translateOnly
+            ? new MigrationPipeline(options, new IMigrationStage[] { new TranslateStage() })
+            : new MigrationPipeline(options);
         RunResult result = await pipeline.RunAsync(apps).ConfigureAwait(false);
 
         PrintSummary(result, pipeline.Stages);
@@ -441,12 +520,13 @@ internal static class Program
         return Path.Combine(root, runId);
     }
 
-    private static (string Corpus, List<string> AppIds, PipelineOptions Options, string BaselinePath, bool BaselineStrict)? ParseMigrateArgs(string[] args, out bool helpRequested)
+    private static MigrateArguments? ParseMigrateArgs(string[] args, out bool helpRequested)
     {
         helpRequested = false;
         string corpus = null;
         string baselinePath = null;
         bool baselineStrict = false;
+        bool translateOnly = false;
         var appIds = new List<string>();
         var options = new PipelineOptions { OutputLayout = MigrationOutputLayout.Repository };
 
@@ -496,6 +576,9 @@ internal static class Program
                     case "--baseline-strict":
                         baselineStrict = true;
                         break;
+                    case "--translate-only":
+                        translateOnly = true;
+                        break;
                     case "--via-sdk":
                         options.CompileViaSdk = true;
                         break;
@@ -526,7 +609,7 @@ internal static class Program
             }
         }
 
-        return (corpus, appIds, options, baselinePath, baselineStrict);
+        return new MigrateArguments(corpus, appIds, options, baselinePath, baselineStrict, translateOnly);
     }
 
     /// <summary>
@@ -569,53 +652,6 @@ internal static class Program
         return null;
     }
 
-    private static void PrintSummary(RunResult result, IReadOnlyList<IMigrationStage> stages)
-    {
-        var stageNames = stages.Select(s => TriageSerialization.StageName(s.Kind)).ToList();
-
-        Console.WriteLine();
-        Console.WriteLine($"cs2gs migrate — run {result.RunId}");
-        Console.WriteLine($"gsc: {result.GscVersion}");
-        Console.WriteLine();
-
-        int idWidth = Math.Max(3, result.Apps.Select(a => a.AppId.Length).DefaultIfEmpty(3).Max());
-        string header = "app".PadRight(idWidth) + "  " +
-            string.Join("  ", stageNames.Select(n => n.PadRight(12)));
-        Console.WriteLine(header);
-        Console.WriteLine(new string('-', header.Length));
-
-        foreach (AppResult app in result.Apps)
-        {
-            var cells = new List<string>();
-            foreach (string stageName in stageNames)
-            {
-                StageResult stage = app.Stages.FirstOrDefault(s => s.Stage == stageName);
-                cells.Add(FormatCell(stage).PadRight(12));
-            }
-
-            Console.WriteLine(app.AppId.PadRight(idWidth) + "  " + string.Join("  ", cells));
-            if (!app.Succeeded)
-            {
-                foreach (string artifact in app.Artifacts)
-                {
-                    Console.WriteLine($"    -> {app.FailureCategory}: {artifact}");
-                }
-            }
-        }
-
-        Console.WriteLine();
-
-        // Same precedence as the report (issue #1831): a run-level failure
-        // always wins; otherwise call out unverified apps rather than
-        // rendering them as a plain pass.
-        int passed = result.Apps.Count(a => a.Succeeded && !a.Unverified);
-        int unverified = result.Apps.Count(a => a.Unverified);
-        string verdict = !result.Succeeded
-            ? "FAILED"
-            : unverified > 0 ? $"PASSED ({unverified} unverified)" : "PASSED";
-        Console.WriteLine($"{passed}/{result.Apps.Count} apps green; run {verdict}.");
-    }
-
     private static string FormatCell(StageResult stage)
     {
         if (stage is null)
@@ -638,6 +674,7 @@ internal static class Program
         Console.WriteLine();
         Console.WriteLine("Usage:");
         Console.WriteLine("  cs2gs migrate [options]");
+        Console.WriteLine("  cs2gs validate --corpus <repo-root> --migrated <dir> [--shard i/N | --app <id>...]");
         Console.WriteLine("  cs2gs report --run <runDir> [--out <file-or-dir>]");
         Console.WriteLine("  cs2gs coverage [--write] [--repo-root <dir>]");
         Console.WriteLine("  cs2gs triage list --run <runDir> [--gaps <file>]");
@@ -661,6 +698,11 @@ internal static class Program
         Console.WriteLine("  --baseline-strict Also fail on STALE ledger entries (nightly mode).");
         Console.WriteLine("  --via-sdk         Build emitted G# via 'dotnet build' + Gsharp.NET.Sdk (default).");
         Console.WriteLine("  --no-via-sdk      Use the legacy direct-gsc compile path.");
+        Console.WriteLine("  --translate-only  Repository migration only (issue #3668): run stage 1 across the WHOLE");
+        Console.WriteLine("                    repository and stop, writing a per-app validation-context.json so");
+        Console.WriteLine("                    'cs2gs validate' shards can run stages 2-4 in parallel elsewhere.");
+        Console.WriteLine();
+        Console.WriteLine("validate options: run 'cs2gs validate --help'.");
         Console.WriteLine();
         Console.WriteLine("report options:");
         Console.WriteLine("  --run <dir>       Existing run directory containing run.json (required).");
@@ -680,6 +722,23 @@ internal static class Program
         Console.WriteLine();
         Console.WriteLine("Exit code is non-zero if any app fails a stage (so CI can gate).");
     }
+
+    /// <summary>
+    /// The parsed <c>migrate</c> command line.
+    /// </summary>
+    /// <param name="Corpus">The source repository root.</param>
+    /// <param name="AppIds">Explicit <c>--app</c> ids (diagnostic runs only).</param>
+    /// <param name="Options">The pipeline options.</param>
+    /// <param name="BaselinePath">The gap-ledger path, or <see langword="null"/>.</param>
+    /// <param name="BaselineStrict">Whether stale ledger entries fail the gate.</param>
+    /// <param name="TranslateOnly">Whether to run the translate stage only (issue #3668).</param>
+    private readonly record struct MigrateArguments(
+        string Corpus,
+        List<string> AppIds,
+        PipelineOptions Options,
+        string BaselinePath,
+        bool BaselineStrict,
+        bool TranslateOnly);
 
     /// <summary>
     /// Sentinel exception thrown by <see cref="NextValue"/> when an option's

--- a/tools/cs2gs/Cs2Gs.Cli/Program.cs
+++ b/tools/cs2gs/Cs2Gs.Cli/Program.cs
@@ -172,12 +172,16 @@ internal static class Program
     /// </summary>
     /// <param name="result">The (possibly partial) run result.</param>
     /// <param name="stages">The stages the run executed, in order.</param>
-    internal static void PrintSummary(RunResult result, IReadOnlyList<IMigrationStage> stages)
+    /// <param name="verb">The verb to label the run with (<c>migrate</c> or <c>validate</c>).</param>
+    internal static void PrintSummary(
+        RunResult result,
+        IReadOnlyList<IMigrationStage> stages,
+        string verb = "migrate")
     {
         var stageNames = stages.Select(s => TriageSerialization.StageName(s.Kind)).ToList();
 
         Console.WriteLine();
-        Console.WriteLine($"cs2gs migrate — run {result.RunId}");
+        Console.WriteLine($"cs2gs {verb} — run {result.RunId}");
         Console.WriteLine($"gsc: {result.GscVersion}");
         Console.WriteLine();
 

--- a/tools/cs2gs/Cs2Gs.Cli/ValidateCommand.cs
+++ b/tools/cs2gs/Cs2Gs.Cli/ValidateCommand.cs
@@ -154,7 +154,7 @@ internal static class ValidateCommand
             .ValidateAsync(allApps, selected, manifests)
             .ConfigureAwait(false);
 
-        Program.PrintSummary(result, pipeline.Stages);
+        Program.PrintSummary(result, pipeline.Stages, "validate");
 
         string runDir = Path.Combine(options.ArtifactRoot, result.RunId);
         Console.WriteLine($"partial run: {Path.Combine(runDir, "run.json")}");

--- a/tools/cs2gs/Cs2Gs.Cli/ValidateCommand.cs
+++ b/tools/cs2gs/Cs2Gs.Cli/ValidateCommand.cs
@@ -1,0 +1,318 @@
+// <copyright file="ValidateCommand.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+
+namespace Cs2Gs.Cli;
+
+/// <summary>
+/// The <c>validate</c> verb (issue #3668): run the post-translate stages —
+/// compile → ilverify → test-parity — for a SUBSET of apps against a tree that
+/// a previous whole-repository <c>migrate --translate-only</c> pass already
+/// migrated, and write a partial <c>run.json</c>.
+/// <para>
+/// This is the shardable half of the self-migration gate. Translation itself
+/// deliberately stays one whole-repository pass: linked sources compiled into
+/// several projects are cross-checked for identical translations, and that
+/// guard only exists when every project translates in the same run. Stages 2–4
+/// read the migrated tree and are independent per app, so they parallelize.
+/// </para>
+/// <para>
+/// Sharding NEVER narrows the discovered app set: <c>--exclude</c> must match
+/// the migrate pass exactly, because excluding a project another app
+/// project-references breaks reference resolution and produces large phantom
+/// cascades. <c>--app</c>/<c>--shard</c> select which apps are EXECUTED, not
+/// which exist.
+/// </para>
+/// </summary>
+internal static class ValidateCommand
+{
+    /// <summary>
+    /// Parses the <c>validate</c> arguments and runs the shard.
+    /// </summary>
+    /// <param name="args">The arguments following the verb.</param>
+    /// <returns>0 when every selected app is green, 1 on failures, 2 on usage errors.</returns>
+    internal static async Task<int> RunAsync(string[] args)
+    {
+        string corpus = null;
+        string migrated = null;
+        string manifests = null;
+        int shardIndex = -1;
+        int shardCount = 0;
+        var appIds = new List<string>();
+        var options = new PipelineOptions { OutputLayout = MigrationOutputLayout.Repository };
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            string arg = args[i];
+            switch (arg)
+            {
+                case "-h":
+                case "--help":
+                    PrintUsage();
+                    return 0;
+                case "--corpus":
+                    corpus = Next(args, ref i, arg);
+                    break;
+                case "--migrated":
+                    migrated = Next(args, ref i, arg);
+                    break;
+                case "--artifacts":
+                    options.ArtifactRoot = Next(args, ref i, arg);
+                    break;
+                case "--manifests":
+                    manifests = Next(args, ref i, arg);
+                    break;
+                case "--app":
+                    appIds.Add(Next(args, ref i, arg).Replace('\\', '/'));
+                    break;
+                case "--shard":
+                    if (!TryParseShard(Next(args, ref i, arg), out shardIndex, out shardCount))
+                    {
+                        Console.Error.WriteLine("cs2gs: --shard expects <index>/<count> with 1 <= index <= count.");
+                        return 1;
+                    }
+
+                    break;
+                case "--exclude":
+                    options.ExcludeAppIdPrefixes.Add(Next(args, ref i, arg).Replace('\\', '/').TrimEnd('/'));
+                    break;
+                case "--config":
+                    options.Config = Next(args, ref i, arg);
+                    break;
+                case "--gsc":
+                    options.GscPath = Next(args, ref i, arg);
+                    break;
+                case "--gsgen":
+                    options.GsgenPath = Next(args, ref i, arg);
+                    break;
+                default:
+                    Console.Error.WriteLine($"cs2gs: unknown option '{arg}'.");
+                    PrintUsage();
+                    return 1;
+            }
+        }
+
+        if (string.IsNullOrEmpty(corpus))
+        {
+            Console.Error.WriteLine("cs2gs: validate requires --corpus <repo-root>.");
+            return 1;
+        }
+
+        if (string.IsNullOrEmpty(migrated))
+        {
+            Console.Error.WriteLine("cs2gs: validate requires --migrated <migrated-tree>.");
+            return 1;
+        }
+
+        options.SourceRoot = Path.GetFullPath(corpus);
+        options.OutputRoot = Path.GetFullPath(migrated);
+        options.ArtifactRoot = string.IsNullOrEmpty(options.ArtifactRoot)
+            ? options.OutputRoot + ".cs2gs-runs"
+            : Path.GetFullPath(options.ArtifactRoot);
+
+        manifests = string.IsNullOrEmpty(manifests)
+            ? FindLatestRunDir(options.ArtifactRoot)
+            : Path.GetFullPath(manifests);
+        if (string.IsNullOrEmpty(manifests) || !Directory.Exists(manifests))
+        {
+            Console.Error.WriteLine(
+                "cs2gs: validate requires --manifests <migrate-run-dir> (no run directory could be inferred).");
+            return 1;
+        }
+
+        // The FULL discovered set, with exactly the migrate pass's exclusions:
+        // the mirrored-project reference map has to stay repository-wide.
+        IReadOnlyList<CorpusApp> allApps = ApplyExclusions(
+            RepositoryDiscovery.Discover(options.SourceRoot), options);
+        if (allApps.Count == 0)
+        {
+            Console.Error.WriteLine($"cs2gs: no projects discovered under {options.SourceRoot}.");
+            return 1;
+        }
+
+        IReadOnlyList<CorpusApp> selected = SelectApps(allApps, appIds, shardIndex, shardCount, out string error);
+        if (error is not null)
+        {
+            Console.Error.WriteLine("cs2gs: " + error);
+            return 1;
+        }
+
+        Console.WriteLine(
+            $"cs2gs validate: {selected.Count} of {allApps.Count} app(s) selected; " +
+            $"migrated tree {options.OutputRoot}; manifests {manifests}.");
+
+        var pipeline = new MigrationPipeline(options, ValidationStages());
+        RunResult result = await pipeline
+            .ValidateAsync(allApps, selected, manifests)
+            .ConfigureAwait(false);
+
+        Program.PrintSummary(result, pipeline.Stages);
+
+        string runDir = Path.Combine(options.ArtifactRoot, result.RunId);
+        Console.WriteLine($"partial run: {Path.Combine(runDir, "run.json")}");
+        Program.GenerateReport(runDir);
+
+        return result.Succeeded ? 0 : 1;
+    }
+
+    /// <summary>
+    /// Gets the stages a validation shard runs: everything after translate.
+    /// Translate is excluded by construction, not by a runtime skip, so a shard
+    /// can never silently re-translate a subset of the repository.
+    /// </summary>
+    /// <returns>The ordered post-translate stages.</returns>
+    internal static IReadOnlyList<IMigrationStage> ValidationStages() => new IMigrationStage[]
+    {
+        new CompileStage(),
+        new IlVerifyStage(),
+        new TestParityStage(),
+    };
+
+    /// <summary>
+    /// Selects the apps a shard executes: an explicit <c>--app</c> list, or a
+    /// deterministic <c>--shard i/N</c> stripe over the discovered order.
+    /// </summary>
+    /// <param name="allApps">The full discovered app list.</param>
+    /// <param name="appIds">Explicit app ids (may be empty).</param>
+    /// <param name="shardIndex">The 1-based shard index, or -1.</param>
+    /// <param name="shardCount">The shard count, or 0.</param>
+    /// <param name="error">Set to a message when the selection is invalid.</param>
+    /// <returns>The selected apps, in discovered order.</returns>
+    internal static IReadOnlyList<CorpusApp> SelectApps(
+        IReadOnlyList<CorpusApp> allApps,
+        IReadOnlyList<string> appIds,
+        int shardIndex,
+        int shardCount,
+        out string error)
+    {
+        error = null;
+        if (appIds.Count > 0 && shardCount > 0)
+        {
+            error = "--app and --shard are mutually exclusive.";
+            return Array.Empty<CorpusApp>();
+        }
+
+        if (appIds.Count > 0)
+        {
+            var selected = new List<CorpusApp>();
+            foreach (string id in appIds)
+            {
+                CorpusApp app = allApps.FirstOrDefault(a =>
+                    string.Equals(a.Id, id, StringComparison.OrdinalIgnoreCase));
+                if (app is null)
+                {
+                    error = $"app '{id}' is not in the discovered (post-exclude) app set.";
+                    return Array.Empty<CorpusApp>();
+                }
+
+                selected.Add(app);
+            }
+
+            return selected;
+        }
+
+        if (shardCount > 0)
+        {
+            return allApps.Where((_, index) => (index % shardCount) == (shardIndex - 1)).ToList();
+        }
+
+        return allApps;
+    }
+
+    /// <summary>Parses an <c>i/N</c> shard specification.</summary>
+    /// <param name="value">The raw option value.</param>
+    /// <param name="index">The parsed 1-based index.</param>
+    /// <param name="count">The parsed shard count.</param>
+    /// <returns><see langword="true"/> when the specification is well formed.</returns>
+    internal static bool TryParseShard(string value, out int index, out int count)
+    {
+        index = -1;
+        count = 0;
+        string[] parts = (value ?? string.Empty).Split('/');
+        return parts.Length == 2
+            && int.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out index)
+            && int.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out count)
+            && count > 0
+            && index >= 1
+            && index <= count;
+    }
+
+    private static IReadOnlyList<CorpusApp> ApplyExclusions(
+        IReadOnlyList<CorpusApp> apps,
+        PipelineOptions options)
+    {
+        if (options.ExcludeAppIdPrefixes.Count == 0)
+        {
+            return apps;
+        }
+
+        var kept = new List<CorpusApp>(apps.Count);
+        foreach (CorpusApp app in apps)
+        {
+            if (options.ExcludeAppIdPrefixes.Any(prefix =>
+                app.Id.StartsWith(prefix, StringComparison.Ordinal)))
+            {
+                options.ExcludedProjectPaths.Add(app.ProjectPath);
+            }
+            else
+            {
+                kept.Add(app);
+            }
+        }
+
+        return kept;
+    }
+
+    private static string FindLatestRunDir(string artifactRoot)
+    {
+        if (!Directory.Exists(artifactRoot))
+        {
+            return null;
+        }
+
+        return Directory.EnumerateDirectories(artifactRoot)
+            .Where(dir => File.Exists(Path.Combine(dir, "run.json")))
+            .OrderBy(dir => new DirectoryInfo(dir).Name, StringComparer.Ordinal)
+            .LastOrDefault();
+    }
+
+    private static string Next(string[] args, ref int index, string flag)
+    {
+        if (index + 1 >= args.Length)
+        {
+            throw new ArgumentException($"option '{flag}' requires a value.");
+        }
+
+        return args[++index];
+    }
+
+    private static void PrintUsage()
+    {
+        Console.WriteLine("cs2gs validate - validate an already-migrated tree for a subset of apps (issue #3668)");
+        Console.WriteLine();
+        Console.WriteLine("Usage:");
+        Console.WriteLine("  cs2gs validate --corpus <repo-root> --migrated <dir> [options]");
+        Console.WriteLine();
+        Console.WriteLine("options:");
+        Console.WriteLine("  --corpus <dir>     The ORIGINAL repository root the tree was migrated from (required).");
+        Console.WriteLine("  --migrated <dir>   The already-migrated tree to validate (required).");
+        Console.WriteLine("  --artifacts <dir>  Runs root for this shard's logs/triage (default: <migrated>.cs2gs-runs).");
+        Console.WriteLine("  --manifests <dir>  The migrate run directory holding per-app validation-context.json");
+        Console.WriteLine("                     (default: the newest run directory under --artifacts).");
+        Console.WriteLine("  --app <id>         Validate this app (repeatable).");
+        Console.WriteLine("  --shard <i>/<N>    Validate every Nth app starting at i (1-based); excludes --app.");
+        Console.WriteLine("  --exclude <path>   MUST match the migrate pass exactly — it defines the discovered set,");
+        Console.WriteLine("                     not the executed subset. Narrowing it breaks reference resolution.");
+        Console.WriteLine("  --config <name>    Build config used to find gsc and the SDK package (default: Release).");
+        Console.WriteLine("  --gsc <path>       Override gsc.dll.");
+        Console.WriteLine("  --gsgen <path>     Override gsgen.dll.");
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs
@@ -69,6 +69,22 @@ public sealed class MigrationPipeline
     public static string SanitizeAppId(string id) => id.Replace('/', '_').Replace('\\', '_');
 
     /// <summary>
+    /// The artifact directory name for one app under a run directory. In
+    /// repository layout it is suffixed with a hash of the app id so two
+    /// projects with the same sanitized id cannot collide. Deterministic from
+    /// the app id alone, so a <c>validate</c> shard can locate the manifest
+    /// written by the whole-repository translate pass (issue #3668).
+    /// </summary>
+    /// <param name="appId">The corpus app id.</param>
+    /// <param name="layout">The migration output layout.</param>
+    /// <returns>The artifact directory name.</returns>
+    public static string ArtifactDirectoryName(string appId, MigrationOutputLayout layout) =>
+        layout == MigrationOutputLayout.Repository
+            ? SanitizeAppId(appId) + "-" + Convert.ToHexString(
+                SHA256.HashData(Encoding.UTF8.GetBytes(appId))).Substring(0, 8).ToLowerInvariant()
+            : SanitizeAppId(appId);
+
+    /// <summary>
     /// Executes the pipeline over the supplied apps, writing all artifacts and
     /// the run summary, and returns the machine-readable run result.
     /// </summary>
@@ -319,6 +335,163 @@ public sealed class MigrationPipeline
         return runResult;
     }
 
+    /// <summary>
+    /// Validates an ALREADY-migrated repository tree for a subset of its apps
+    /// (issue #3668). Runs this pipeline's stages — normally compile →
+    /// ilverify → test-parity — against the migrated tree at
+    /// <see cref="PipelineOptions.OutputRoot"/>, rehydrating each app's
+    /// translate-derived state from the <see cref="ValidationManifest"/> the
+    /// whole-repository <c>migrate</c> pass wrote, and returns a PARTIAL
+    /// <see cref="RunResult"/> covering only <paramref name="selectedApps"/>.
+    /// <para>
+    /// <paramref name="allApps"/> must be the COMPLETE app list of the migrate
+    /// run (same <c>--exclude</c> set), because the mirrored project map every
+    /// stage resolves <c>ProjectReference</c>s through is repository-wide.
+    /// Narrowing it — for instance by excluding the projects a shard does not
+    /// own — breaks reference resolution and manufactures phantom cascades.
+    /// </para>
+    /// </summary>
+    /// <param name="allApps">Every app in the migrated tree, in discovery order.</param>
+    /// <param name="selectedApps">The subset this shard validates.</param>
+    /// <param name="manifestRunDir">The migrate run directory holding the per-app manifests.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The partial run result for <paramref name="selectedApps"/>.</returns>
+    /// <exception cref="InvalidOperationException">No <c>gsc.dll</c> could be resolved.</exception>
+    public async Task<RunResult> ValidateAsync(
+        IReadOnlyList<CorpusApp> allApps,
+        IReadOnlyList<CorpusApp> selectedApps,
+        string manifestRunDir,
+        CancellationToken cancellationToken = default)
+    {
+        if (allApps is null)
+        {
+            throw new ArgumentNullException(nameof(allApps));
+        }
+
+        if (selectedApps is null)
+        {
+            throw new ArgumentNullException(nameof(selectedApps));
+        }
+
+        if (string.IsNullOrWhiteSpace(this.options.OutputRoot))
+        {
+            throw new InvalidOperationException("Validation requires --migrated <existing-migrated-tree>.");
+        }
+
+        string migratedRoot = Path.GetFullPath(this.options.OutputRoot);
+        if (!Directory.Exists(migratedRoot))
+        {
+            throw new InvalidOperationException($"Migrated tree '{migratedRoot}' does not exist.");
+        }
+
+        this.options.OutputLayout = MigrationOutputLayout.Repository;
+
+        string gscPath = GscInvoker.Resolve(
+            this.options.GscPath,
+            this.options.Config,
+            Directory.GetCurrentDirectory());
+        if (gscPath is null)
+        {
+            throw new InvalidOperationException(
+                "Could not resolve gsc.dll. Build GSharp.sln or pass --gsc <path>.");
+        }
+
+        string gsgenPath = GscInvoker.ResolveGsgenTool(
+            this.options.GsgenPath,
+            this.options.Config,
+            Directory.GetCurrentDirectory());
+        var gsc = new GscInvoker(gscPath, gsgenPath);
+        string gscVersion = gsc.GetVersion();
+
+        DateTime nowUtc = DateTime.UtcNow;
+        string runId = NewRunId(nowUtc);
+        string timestamp = nowUtc.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+
+        string outputRoot = Path.GetFullPath(
+            this.options.ArtifactRoot ?? migratedRoot + ".cs2gs-runs");
+        string runDir = Path.Combine(outputRoot, runId);
+        Directory.CreateDirectory(runDir);
+
+        // The mirrored-project map is repository-wide by construction: it is
+        // the same map the migrate pass built, computed from the full app list
+        // and the migrated tree root.
+        this.options.GeneratedProjectPaths = allApps.ToDictionary(
+            app => Path.GetFullPath(app.ProjectPath),
+            app => Path.Combine(
+                migratedRoot,
+                Path.ChangeExtension(
+                    app.RelativeProjectPath ?? Path.GetRelativePath(this.options.SourceRoot, app.ProjectPath),
+                    ".gsproj")),
+            StringComparer.OrdinalIgnoreCase);
+        this.options.ProjectsReferencedByOtherApps =
+            DeclaredProjectItems.CollectCompileReferencedProjectPaths(
+                allApps.Select(app => app.ProjectPath));
+
+        IReadOnlyDictionary<string, List<TriageRetryEntry>> priorHistory =
+            LoadPriorRetryEntries(outputRoot, runId);
+
+        var runResult = new RunResult
+        {
+            RunId = runId,
+            Timestamp = timestamp,
+            GscVersion = gscVersion,
+            GscPath = gscPath,
+            Succeeded = true,
+        };
+
+        foreach (CorpusApp app in selectedApps)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            StageExecutionContext context = this.CreateAppContext(
+                app, gsc, gscVersion, runId, timestamp, runDir, out string artifactDir);
+
+            ValidationManifest manifest = ValidationManifest.Read(
+                Path.Combine(
+                    manifestRunDir ?? string.Empty,
+                    ArtifactDirectoryName(app.Id, MigrationOutputLayout.Repository)));
+            if (manifest is null)
+            {
+                throw new InvalidOperationException(
+                    $"No {ValidationManifest.FileName} for app '{app.Id}' under '{manifestRunDir}'. " +
+                    "Validation shards must run against the artifacts of the migrate pass that " +
+                    "produced the migrated tree.");
+            }
+
+            if (!manifest.Translated)
+            {
+                // The app never got past stage 1, so it has no migrated sources
+                // to compile and its verdict already exists in the migrate run.
+                // Reporting it here would render an empty compile as a PASS and
+                // inflate the green count; the merge takes the translate
+                // failure from the migrate pass instead.
+                Console.WriteLine($"cs2gs validate: skipping '{app.Id}' — it did not translate.");
+                continue;
+            }
+
+            manifest.Hydrate(context, migratedRoot);
+
+            AppResult appResult = await this.RunStagesAsync(
+                app, context, artifactDir, runDir, priorHistory, cancellationToken).ConfigureAwait(false);
+            runResult.Apps.Add(appResult);
+            if (!appResult.Succeeded)
+            {
+                runResult.Succeeded = false;
+            }
+        }
+
+        if (runResult.Succeeded && runResult.Apps.Any(a => a.Unverified))
+        {
+            runResult.Unverified = true;
+        }
+
+        File.WriteAllText(
+            Path.Combine(runDir, "run.json"),
+            JsonSerializer.Serialize(runResult, TriageSerialization.Options));
+
+        return runResult;
+    }
+
     private IReadOnlyList<CorpusApp> OrderForSdkBuild(IReadOnlyList<CorpusApp> apps)
     {
         if (!this.options.CompileViaSdk || apps.Count <= 1)
@@ -524,6 +697,27 @@ public sealed class MigrationPipeline
         }
     }
 
+    private StageExecutionContext CreateAppContext(
+        CorpusApp app,
+        GscInvoker gsc,
+        string gscVersion,
+        string runId,
+        string timestamp,
+        string runDir,
+        out string artifactDir)
+    {
+        artifactDir = Path.Combine(runDir, ArtifactDirectoryName(app.Id, this.options.OutputLayout));
+        string projectOutputDir = this.options.OutputLayout == MigrationOutputLayout.Repository
+            ? Path.GetDirectoryName(this.options.GeneratedProjectPaths[Path.GetFullPath(app.ProjectPath)])
+            : artifactDir;
+        Directory.CreateDirectory(artifactDir);
+        Directory.CreateDirectory(projectOutputDir);
+
+        var triage = new TriageBuilder(runId, timestamp, gscVersion, app.Id);
+        return new StageExecutionContext(
+            app, this.options, gsc, projectOutputDir, artifactDir, triage);
+    }
+
     private async Task<AppResult> RunAppAsync(
         CorpusApp app,
         GscInvoker gsc,
@@ -534,21 +728,36 @@ public sealed class MigrationPipeline
         IReadOnlyDictionary<string, List<TriageRetryEntry>> priorHistory,
         CancellationToken cancellationToken)
     {
-        string artifactDirectoryName = this.options.OutputLayout == MigrationOutputLayout.Repository
-            ? SanitizeAppId(app.Id) + "-" + Convert.ToHexString(
-                SHA256.HashData(Encoding.UTF8.GetBytes(app.Id))).Substring(0, 8).ToLowerInvariant()
-            : SanitizeAppId(app.Id);
-        string artifactDir = Path.Combine(runDir, artifactDirectoryName);
-        string projectOutputDir = this.options.OutputLayout == MigrationOutputLayout.Repository
-            ? Path.GetDirectoryName(this.options.GeneratedProjectPaths[Path.GetFullPath(app.ProjectPath)])
-            : artifactDir;
-        Directory.CreateDirectory(artifactDir);
-        Directory.CreateDirectory(projectOutputDir);
+        StageExecutionContext context = this.CreateAppContext(
+            app, gsc, gscVersion, runId, timestamp, runDir, out string artifactDir);
 
-        var triage = new TriageBuilder(runId, timestamp, gscVersion, app.Id);
-        var context = new StageExecutionContext(
-            app, this.options, gsc, projectOutputDir, artifactDir, triage);
+        AppResult appResult = await this.RunStagesAsync(
+            app, context, artifactDir, runDir, priorHistory, cancellationToken).ConfigureAwait(false);
 
+        if (this.options.OutputLayout == MigrationOutputLayout.Repository &&
+            !string.IsNullOrWhiteSpace(this.options.OutputRoot))
+        {
+            // Issue #3668: hand the translate-derived state of this app to any
+            // later `cs2gs validate` shard over the same migrated tree.
+            bool translated = appResult.Stages
+                .Any(s => s.Stage == TriageSerialization.StageName(MigrationStageKind.Translate)
+                    && s.Status == "passed");
+            ValidationManifest.Write(
+                ValidationManifest.Capture(context, translated, this.options.OutputRoot),
+                artifactDir);
+        }
+
+        return appResult;
+    }
+
+    private async Task<AppResult> RunStagesAsync(
+        CorpusApp app,
+        StageExecutionContext context,
+        string artifactDir,
+        string runDir,
+        IReadOnlyDictionary<string, List<TriageRetryEntry>> priorHistory,
+        CancellationToken cancellationToken)
+    {
         var appResult = new AppResult { AppId = app.Id, Succeeded = true };
         bool shortCircuited = false;
 
@@ -577,7 +786,7 @@ public sealed class MigrationPipeline
             }
             catch (Exception ex)
             {
-                outcome = StageOutcome.Failed(new[] { StageCrashArtifact(triage, stage.Kind, ex) });
+                outcome = StageOutcome.Failed(new[] { StageCrashArtifact(context.Triage, stage.Kind, ex) });
             }
 
             if (outcome.Status == StageStatus.Passed)

--- a/tools/cs2gs/Cs2Gs.Pipeline/ValidationManifest.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/ValidationManifest.cs
@@ -1,0 +1,283 @@
+// <copyright file="ValidationManifest.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Cs2Gs.Pipeline;
+
+/// <summary>
+/// The per-app hand-off between a translate-only <c>migrate</c> run and a later
+/// <c>validate</c> run over the same migrated tree (issue #3668).
+/// <para>
+/// Sharding the self-migration gate splits it into ONE whole-repository
+/// translate pass and N independent per-app validation shards. Translation must
+/// stay whole-repository — linked sources (e.g. <c>test/Shared/*.cs</c>) are
+/// compiled into several projects and <see cref="PipelineOptions.RepositoryTranslations"/>
+/// cross-checks that they translate identically everywhere; splitting the
+/// translate pass would silently disable that guard. Stages 2–4 (compile,
+/// ilverify, test-parity), by contrast, only read the migrated tree, so they
+/// shard cleanly.
+/// </para>
+/// <para>
+/// The only translate-derived state stages 2–4 consume in repository layout is
+/// captured here: the emitted <c>.gs</c> file set (compile-error attribution and
+/// the <c>!!</c> polish pass), the external reference paths (ilverify's
+/// <c>-r</c> set), and the project classification flags. The G# source text
+/// itself is NOT stored — it is read back from the migrated tree, which is
+/// exactly what a whole run would have on disk at that point.
+/// </para>
+/// </summary>
+public sealed class ValidationManifest
+{
+    /// <summary>The manifest file name written into each app's artifact directory.</summary>
+    public const string FileName = "validation-context.json";
+
+    /// <summary>Gets or sets the corpus app id.</summary>
+    [JsonPropertyName("appId")]
+    [JsonPropertyOrder(0)]
+    public string AppId { get; set; }
+
+    /// <summary>Gets or sets a value indicating whether the translate stage passed for this app.</summary>
+    [JsonPropertyName("translated")]
+    [JsonPropertyOrder(1)]
+    public bool Translated { get; set; }
+
+    /// <summary>Gets or sets a value indicating whether the source project is a test project.</summary>
+    [JsonPropertyName("isTestProject")]
+    [JsonPropertyOrder(2)]
+    public bool IsTestProject { get; set; }
+
+    /// <summary>Gets or sets a value indicating whether the app targets the G# analyzer API.</summary>
+    [JsonPropertyName("isAnalyzerProject")]
+    [JsonPropertyOrder(3)]
+    public bool IsAnalyzerProject { get; set; }
+
+    /// <summary>Gets or sets the source project's root namespace.</summary>
+    [JsonPropertyName("rootNamespace")]
+    [JsonPropertyOrder(4)]
+    public string RootNamespace { get; set; }
+
+    /// <summary>Gets or sets the source project's assembly name.</summary>
+    [JsonPropertyName("assemblyName")]
+    [JsonPropertyOrder(5)]
+    public string AssemblyName { get; set; }
+
+    /// <summary>Gets or sets the friend assemblies contributed by generated sources.</summary>
+    [JsonPropertyName("generatedFriendAssemblies")]
+    [JsonPropertyOrder(6)]
+    public List<string> GeneratedFriendAssemblies { get; set; } = new List<string>();
+
+    /// <summary>
+    /// Gets or sets the absolute external (NuGet package) assembly paths the C#
+    /// compilation resolved against. Consumed by the IL-verify stage. A shard
+    /// filters out any path that does not exist on its own runner; ilverify
+    /// already scans the emitted assembly's output directory, so a package copy
+    /// that a shard cannot see is additive, never load-bearing.
+    /// </summary>
+    [JsonPropertyName("externalReferences")]
+    [JsonPropertyOrder(7)]
+    public List<string> ExternalReferences { get; set; } = new List<string>();
+
+    /// <summary>Gets or sets the emitted G# files, relative to the migrated tree root.</summary>
+    [JsonPropertyName("emittedFiles")]
+    [JsonPropertyOrder(8)]
+    public List<ValidationManifestFile> EmittedFiles { get; set; } = new List<ValidationManifestFile>();
+
+    /// <summary>
+    /// Captures the translate-derived state of one app into a manifest.
+    /// </summary>
+    /// <param name="context">The app's stage execution context after translate.</param>
+    /// <param name="translated">Whether the translate stage passed.</param>
+    /// <param name="migratedRoot">The migrated tree root, used to relativize emitted paths.</param>
+    /// <returns>The populated manifest.</returns>
+    public static ValidationManifest Capture(
+        StageExecutionContext context,
+        bool translated,
+        string migratedRoot)
+    {
+        if (context is null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        string root = Path.GetFullPath(migratedRoot ?? throw new ArgumentNullException(nameof(migratedRoot)));
+        var manifest = new ValidationManifest
+        {
+            AppId = context.App.Id,
+            Translated = translated,
+            IsTestProject = context.IsTestProject,
+            IsAnalyzerProject = context.IsAnalyzerProject,
+            RootNamespace = context.RootNamespace,
+            AssemblyName = context.AssemblyName,
+        };
+
+        foreach (string friend in context.GeneratedFriendAssemblies)
+        {
+            manifest.GeneratedFriendAssemblies.Add(friend);
+        }
+
+        manifest.GeneratedFriendAssemblies.Sort(StringComparer.Ordinal);
+
+        var seenReferences = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (string reference in context.ExternalReferencePaths)
+        {
+            if (!string.IsNullOrEmpty(reference) && seenReferences.Add(reference))
+            {
+                manifest.ExternalReferences.Add(reference);
+            }
+        }
+
+        foreach (EmittedGsFile file in context.EmittedFiles)
+        {
+            manifest.EmittedFiles.Add(new ValidationManifestFile
+            {
+                Path = Relativize(root, file.GsPath),
+                RelativeGsPath = file.RelativeGsPath,
+                CsFilePath = file.CsFilePath,
+                FromReferencedProject = file.IsFromReferencedProject,
+            });
+        }
+
+        return manifest;
+    }
+
+    /// <summary>
+    /// Writes the manifest into an app's artifact directory.
+    /// </summary>
+    /// <param name="manifest">The manifest to write.</param>
+    /// <param name="artifactDir">The app's artifact directory.</param>
+    public static void Write(ValidationManifest manifest, string artifactDir)
+    {
+        if (manifest is null)
+        {
+            throw new ArgumentNullException(nameof(manifest));
+        }
+
+        Directory.CreateDirectory(artifactDir);
+        File.WriteAllText(
+            Path.Combine(artifactDir, FileName),
+            JsonSerializer.Serialize(manifest, TriageSerialization.Options));
+    }
+
+    /// <summary>
+    /// Reads a manifest from an app's artifact directory.
+    /// </summary>
+    /// <param name="artifactDir">The app's artifact directory.</param>
+    /// <returns>The manifest, or <see langword="null"/> when absent or unreadable.</returns>
+    public static ValidationManifest Read(string artifactDir)
+    {
+        string path = Path.Combine(artifactDir ?? string.Empty, FileName);
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<ValidationManifest>(
+                File.ReadAllText(path), TriageSerialization.Options);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Rehydrates the translate-derived state of this manifest onto a stage
+    /// execution context, reading each emitted file's current text from the
+    /// migrated tree. Files that no longer exist are dropped: a whole run would
+    /// equally have nothing to attribute a diagnostic to.
+    /// </summary>
+    /// <param name="context">The context to populate.</param>
+    /// <param name="migratedRoot">The migrated tree root.</param>
+    public void Hydrate(StageExecutionContext context, string migratedRoot)
+    {
+        if (context is null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        string root = Path.GetFullPath(migratedRoot ?? throw new ArgumentNullException(nameof(migratedRoot)));
+        context.IsTestProject = this.IsTestProject;
+        context.IsAnalyzerProject = this.IsAnalyzerProject;
+        context.RootNamespace = this.RootNamespace;
+        context.AssemblyName = this.AssemblyName;
+
+        foreach (string friend in this.GeneratedFriendAssemblies)
+        {
+            context.GeneratedFriendAssemblies.Add(friend);
+        }
+
+        foreach (string reference in this.ExternalReferences)
+        {
+            // A shard runs on a different machine than the translate pass: a
+            // package path that is not present here is dropped rather than
+            // handed to ilverify as a dangling -r (which it reports as a load
+            // error). The emitted assembly's own output directory is scanned
+            // by IlVerifyRunner regardless, so real dependencies still resolve.
+            if (File.Exists(reference))
+            {
+                context.ExternalReferencePaths.Add(reference);
+            }
+        }
+
+        foreach (ValidationManifestFile file in this.EmittedFiles)
+        {
+            string gsPath = Path.GetFullPath(Path.Combine(root, file.Path));
+            if (!File.Exists(gsPath))
+            {
+                continue;
+            }
+
+            context.EmittedFiles.Add(new EmittedGsFile(
+                gsPath,
+                file.RelativeGsPath,
+                file.CsFilePath,
+                File.ReadAllText(gsPath))
+            {
+                IsFromReferencedProject = file.FromReferencedProject,
+            });
+        }
+    }
+
+    private static string Relativize(string root, string path)
+    {
+        string full = Path.GetFullPath(path);
+        string relative = Path.GetRelativePath(root, full);
+        return relative.Replace('\\', '/');
+    }
+}
+
+/// <summary>One emitted G# file recorded in a <see cref="ValidationManifest"/>.</summary>
+public sealed class ValidationManifestFile
+{
+    /// <summary>Gets or sets the migrated-tree-relative path of the emitted <c>.gs</c> file.</summary>
+    [JsonPropertyName("path")]
+    [JsonPropertyOrder(0)]
+    public string Path { get; set; }
+
+    /// <summary>Gets or sets the run-relative path used in triage artifacts.</summary>
+    [JsonPropertyName("relativeGsPath")]
+    [JsonPropertyOrder(1)]
+    public string RelativeGsPath { get; set; }
+
+    /// <summary>Gets or sets the originating C# file path.</summary>
+    [JsonPropertyName("csFilePath")]
+    [JsonPropertyOrder(2)]
+    public string CsFilePath { get; set; }
+
+    /// <summary>Gets or sets a value indicating whether the file came from a referenced project.</summary>
+    [JsonPropertyName("fromReferencedProject")]
+    [JsonPropertyOrder(3)]
+    public bool FromReferencedProject { get; set; }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3668ShardedValidationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3668ShardedValidationTests.cs
@@ -1,0 +1,405 @@
+// <copyright file="Issue3668ShardedValidationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using Cs2Gs.Cli;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3668: the self-migration gate now runs as ONE whole-repository
+/// translate pass plus N independent validation shards. These tests pin the
+/// three pieces that make that split safe:
+/// <list type="bullet">
+/// <item><description>
+/// the <see cref="ValidationManifest"/> hand-off carries exactly the
+/// translate-derived state stages 2–4 consume, and rehydrates it from a
+/// migrated tree;
+/// </description></item>
+/// <item><description>
+/// shard selection narrows what is EXECUTED, never what is discovered
+/// (<c>--exclude</c> must stay identical across jobs, or reference resolution
+/// breaks and phantom cascades appear);
+/// </description></item>
+/// <item><description>
+/// the merge reconstructs the same per-app verdicts a single whole run would
+/// have produced, and refuses to silently drop an app.
+/// </description></item>
+/// </list>
+/// </summary>
+public class Issue3668ShardedValidationTests
+{
+    /// <summary>
+    /// The manifest round-trips the translate-derived state and rehydrates the
+    /// emitted G# set by re-reading the migrated tree — so a shard sees the
+    /// same <c>EmittedFiles</c> the whole run's compile stage would.
+    /// </summary>
+    [Fact]
+    public void ManifestRoundTripsTranslateDerivedState()
+    {
+        using var temp = new TempDirectory();
+        string migrated = Path.Combine(temp.Path, "migrated");
+        string projectDir = Path.Combine(migrated, "src", "Lib");
+        Directory.CreateDirectory(projectDir);
+        string gsPath = Path.Combine(projectDir, "Widget.gs");
+        File.WriteAllText(gsPath, "package Lib\n");
+
+        string reference = Path.Combine(temp.Path, "Some.Package.dll");
+        File.WriteAllText(reference, string.Empty);
+
+        var app = new CorpusApp("src/Lib/Lib.csproj", Path.Combine(temp.Path, "Lib.csproj"), TargetKind.Library);
+        var options = new PipelineOptions { OutputLayout = MigrationOutputLayout.Repository };
+        var context = new StageExecutionContext(
+            app,
+            options,
+            NullGsc(),
+            projectDir,
+            Path.Combine(temp.Path, "artifacts"),
+            new TriageBuilder("run", "ts", "gsc", app.Id));
+        context.IsTestProject = true;
+        context.IsAnalyzerProject = true;
+        context.RootNamespace = "Lib";
+        context.AssemblyName = "Lib";
+        context.GeneratedFriendAssemblies.Add("Lib.Tests");
+        context.ExternalReferencePaths.Add(reference);
+        context.ExternalReferencePaths.Add(Path.Combine(temp.Path, "Absent.dll"));
+        context.EmittedFiles.Add(new EmittedGsFile(gsPath, "src_Lib/Widget.gs", "Widget.cs", "package Lib\n"));
+
+        string artifactDir = Path.Combine(temp.Path, "artifacts");
+        ValidationManifest.Write(ValidationManifest.Capture(context, translated: true, migrated), artifactDir);
+
+        ValidationManifest read = ValidationManifest.Read(artifactDir);
+        Assert.NotNull(read);
+        Assert.True(read.Translated);
+        Assert.Equal("src/Lib/Lib.csproj", read.AppId);
+
+        // Emitted paths are stored relative to the migrated tree so the tree
+        // can be re-rooted onto a shard runner.
+        Assert.Equal("src/Lib/Widget.gs", Assert.Single(read.EmittedFiles).Path);
+
+        var rehydrated = new StageExecutionContext(
+            app,
+            new PipelineOptions { OutputLayout = MigrationOutputLayout.Repository },
+            NullGsc(),
+            projectDir,
+            artifactDir,
+            new TriageBuilder("run2", "ts", "gsc", app.Id));
+        read.Hydrate(rehydrated, migrated);
+
+        Assert.True(rehydrated.IsTestProject);
+        Assert.True(rehydrated.IsAnalyzerProject);
+        Assert.Equal("Lib", rehydrated.RootNamespace);
+        Assert.Equal("Lib", rehydrated.AssemblyName);
+        Assert.Equal(new[] { "Lib.Tests" }, rehydrated.GeneratedFriendAssemblies.ToArray());
+
+        // A package path the shard cannot see is dropped rather than handed to
+        // ilverify as a dangling -r; ilverify scans the output directory anyway.
+        Assert.Equal(new[] { reference }, rehydrated.ExternalReferencePaths.ToArray());
+
+        EmittedGsFile emitted = Assert.Single(rehydrated.EmittedFiles);
+        Assert.Equal(Path.GetFullPath(gsPath), Path.GetFullPath(emitted.GsPath));
+        Assert.Equal("src_Lib/Widget.gs", emitted.RelativeGsPath);
+        Assert.Equal("package Lib\n", emitted.GSharpSource);
+    }
+
+    /// <summary>
+    /// The manifest is looked up by the same deterministic artifact directory
+    /// name the migrate pass writes, so a shard on a different machine finds it
+    /// from the app id alone.
+    /// </summary>
+    [Fact]
+    public void ArtifactDirectoryNameIsDeterministicPerLayout()
+    {
+        string repository = MigrationPipeline.ArtifactDirectoryName(
+            "src/Core/Core.csproj", MigrationOutputLayout.Repository);
+        Assert.Equal(repository, MigrationPipeline.ArtifactDirectoryName(
+            "src/Core/Core.csproj", MigrationOutputLayout.Repository));
+        Assert.StartsWith("src_Core_Core.csproj-", repository, StringComparison.Ordinal);
+
+        // Two apps whose sanitized ids collide must not share a directory.
+        Assert.NotEqual(
+            repository,
+            MigrationPipeline.ArtifactDirectoryName("src/Core/Core.csproj ", MigrationOutputLayout.Repository));
+
+        Assert.Equal(
+            "corpus_L1-Console",
+            MigrationPipeline.ArtifactDirectoryName("corpus/L1-Console", MigrationOutputLayout.DiagnosticRun));
+    }
+
+    /// <summary>
+    /// A shard runs stages 2–4 only. Translate is absent by CONSTRUCTION, not
+    /// by a runtime skip, so a shard can never re-translate a subset of the
+    /// repository behind the linked-source cross-check's back.
+    /// </summary>
+    [Fact]
+    public void ValidationStagesExcludeTranslate()
+    {
+        MigrationStageKind[] kinds = ValidateCommand.ValidationStages().Select(s => s.Kind).ToArray();
+        Assert.Equal(
+            new[] { MigrationStageKind.Compile, MigrationStageKind.IlVerify, MigrationStageKind.TestParity },
+            kinds);
+        Assert.DoesNotContain(MigrationStageKind.Translate, kinds);
+    }
+
+    /// <summary>
+    /// <c>--shard i/N</c> partitions the discovered app set: every app lands in
+    /// exactly one shard, and the union is the whole set.
+    /// </summary>
+    [Fact]
+    public void ShardSelectionPartitionsTheAppSet()
+    {
+        IReadOnlyList<CorpusApp> apps = Enumerable.Range(0, 11)
+            .Select(i => new CorpusApp($"src/P{i}/P{i}.csproj", $"/repo/src/P{i}/P{i}.csproj", TargetKind.Library))
+            .ToList();
+
+        var seen = new List<string>();
+        for (var shard = 1; shard <= 4; shard++)
+        {
+            IReadOnlyList<CorpusApp> selected = ValidateCommand.SelectApps(
+                apps, Array.Empty<string>(), shard, 4, out string error);
+            Assert.Null(error);
+            seen.AddRange(selected.Select(a => a.Id));
+        }
+
+        Assert.Equal(
+            apps.Select(a => a.Id).OrderBy(id => id, StringComparer.Ordinal),
+            seen.OrderBy(id => id, StringComparer.Ordinal));
+        Assert.Equal(seen.Count, seen.Distinct(StringComparer.Ordinal).Count());
+    }
+
+    /// <summary>
+    /// An <c>--app</c> id outside the discovered (post-exclude) set is a hard
+    /// error, not a silently empty shard: an app quietly dropped would shrink
+    /// the gate's denominator and hide a regression.
+    /// </summary>
+    [Fact]
+    public void UnknownAppIsRejected()
+    {
+        IReadOnlyList<CorpusApp> apps = new[]
+        {
+            new CorpusApp("src/A/A.csproj", "/repo/src/A/A.csproj", TargetKind.Library),
+        };
+
+        ValidateCommand.SelectApps(apps, new[] { "src/B/B.csproj" }, -1, 0, out string error);
+        Assert.Contains("not in the discovered", error, StringComparison.Ordinal);
+
+        ValidateCommand.SelectApps(apps, new[] { "src/A/A.csproj" }, 1, 2, out string conflict);
+        Assert.Contains("mutually exclusive", conflict, StringComparison.Ordinal);
+    }
+
+    /// <summary>Shard specifications are validated, not silently coerced.</summary>
+    /// <param name="value">The raw <c>--shard</c> value.</param>
+    /// <param name="expected">Whether it should parse.</param>
+    [Theory]
+    [InlineData("1/6", true)]
+    [InlineData("6/6", true)]
+    [InlineData("0/6", false)]
+    [InlineData("7/6", false)]
+    [InlineData("1/0", false)]
+    [InlineData("1", false)]
+    [InlineData("a/b", false)]
+    public void ShardSpecificationIsValidated(string value, bool expected)
+    {
+        Assert.Equal(expected, ValidateCommand.TryParseShard(value, out _, out _));
+    }
+
+    /// <summary>
+    /// The merge reconstructs a whole run: translate from the migrate pass,
+    /// stages 2–4 from the owning shard, a translate-failed app keeping the
+    /// whole run's short-circuit shape, and the green count matching.
+    /// </summary>
+    [Fact]
+    public void MergeReconstructsWholeRunVerdicts()
+    {
+        using var temp = new TempDirectory();
+        string migratePath = Path.Combine(temp.Path, "migrate.json");
+        string shardPath = Path.Combine(temp.Path, "shard.json");
+        string outPath = Path.Combine(temp.Path, "merged.json");
+
+        File.WriteAllText(migratePath, """
+        {
+          "runId": "r1", "timestamp": "t", "gscVersion": "v", "gscPath": "p",
+          "succeeded": false,
+          "apps": [
+            { "appId": "src/Green/Green.csproj", "succeeded": true,
+              "stages": [ { "stage": "translate", "status": "passed", "artifactCount": 0 } ],
+              "artifacts": [], "fingerprints": [] },
+            { "appId": "src/Red/Red.csproj", "succeeded": true,
+              "stages": [ { "stage": "translate", "status": "passed", "artifactCount": 0 } ],
+              "artifacts": [], "fingerprints": [] },
+            { "appId": "src/NoTranslate/NoTranslate.csproj", "succeeded": false,
+              "failureCategory": "translation-unsupported",
+              "stages": [ { "stage": "translate", "status": "failed", "artifactCount": 1 } ],
+              "artifacts": [ "a/translate-1.json" ], "fingerprints": [ "sha256:aa" ] }
+          ]
+        }
+        """);
+
+        File.WriteAllText(shardPath, """
+        {
+          "runId": "r2", "timestamp": "t", "gscVersion": "v", "gscPath": "p",
+          "succeeded": false,
+          "apps": [
+            { "appId": "src/Green/Green.csproj", "succeeded": true,
+              "stages": [
+                { "stage": "compile", "status": "passed", "artifactCount": 0 },
+                { "stage": "ilverify", "status": "passed", "artifactCount": 0 },
+                { "stage": "test-parity", "status": "passed", "artifactCount": 0 } ],
+              "artifacts": [], "fingerprints": [] },
+            { "appId": "src/Red/Red.csproj", "succeeded": false,
+              "failureCategory": "compile-error",
+              "stages": [
+                { "stage": "compile", "status": "failed", "artifactCount": 2 },
+                { "stage": "ilverify", "status": "skipped", "artifactCount": 0 },
+                { "stage": "test-parity", "status": "skipped", "artifactCount": 0 } ],
+              "artifacts": [ "b/compile-2.json" ], "fingerprints": [ "sha256:bb" ] }
+          ]
+        }
+        """);
+
+        RunMerge(migratePath, outPath, shardPath);
+
+        using JsonDocument merged = JsonDocument.Parse(File.ReadAllText(outPath));
+        JsonElement apps = merged.RootElement.GetProperty("apps");
+        Assert.Equal(3, apps.GetArrayLength());
+
+        JsonElement green = apps[0];
+        Assert.True(green.GetProperty("succeeded").GetBoolean());
+        Assert.False(green.GetProperty("unverified").GetBoolean());
+        Assert.Equal(
+            new[] { "translate", "compile", "ilverify", "test-parity" },
+            green.GetProperty("stages").EnumerateArray()
+                .Select(s => s.GetProperty("stage").GetString()).ToArray());
+
+        JsonElement red = apps[1];
+        Assert.False(red.GetProperty("succeeded").GetBoolean());
+        Assert.Equal("compile-error", red.GetProperty("failureCategory").GetString());
+        Assert.Equal("b/compile-2.json", Assert.Single(
+            red.GetProperty("artifacts").EnumerateArray().Select(a => a.GetString())));
+
+        // A translate failure never reaches a shard, but keeps the whole run's
+        // four-stage shape with the later stages skipped.
+        JsonElement untranslated = apps[2];
+        Assert.False(untranslated.GetProperty("succeeded").GetBoolean());
+        Assert.Equal(
+            new[] { "passed_or_failed", "skipped", "skipped", "skipped" },
+            untranslated.GetProperty("stages").EnumerateArray()
+                .Select((s, index) => index == 0 ? "passed_or_failed" : s.GetProperty("status").GetString())
+                .ToArray());
+
+        Assert.False(merged.RootElement.GetProperty("succeeded").GetBoolean());
+        Assert.Equal(1, apps.EnumerateArray().Count(a => a.GetProperty("succeeded").GetBoolean()));
+    }
+
+    /// <summary>
+    /// An app that translated but that no shard reported on fails the merge.
+    /// Silently treating it as absent would shrink the denominator; silently
+    /// treating it as green would inflate the floor. Both hide regressions —
+    /// which is precisely the failure mode issue #3668 exists to end.
+    /// </summary>
+    [Fact]
+    public void MergeFailsWhenATranslatedAppHasNoShardResult()
+    {
+        using var temp = new TempDirectory();
+        string migratePath = Path.Combine(temp.Path, "migrate.json");
+        string shardPath = Path.Combine(temp.Path, "shard.json");
+        string outPath = Path.Combine(temp.Path, "merged.json");
+
+        File.WriteAllText(migratePath, """
+        {
+          "runId": "r1", "timestamp": "t", "gscVersion": "v", "gscPath": "p", "succeeded": true,
+          "apps": [
+            { "appId": "src/Orphan/Orphan.csproj", "succeeded": true,
+              "stages": [ { "stage": "translate", "status": "passed", "artifactCount": 0 } ],
+              "artifacts": [], "fingerprints": [] }
+          ]
+        }
+        """);
+        File.WriteAllText(shardPath, """
+        { "runId": "r2", "timestamp": "t", "gscVersion": "v", "gscPath": "p",
+          "succeeded": true, "apps": [] }
+        """);
+
+        (int exit, string output) = TryRunMerge(migratePath, outPath, shardPath);
+        Assert.NotEqual(0, exit);
+        Assert.Contains("no shard reported a result", output, StringComparison.Ordinal);
+    }
+
+    private static void RunMerge(string migratePath, string outPath, params string[] shardPaths)
+    {
+        (int exit, string output) = TryRunMerge(migratePath, outPath, shardPaths);
+        Assert.True(exit == 0, "merge-selfmig-runs.py failed: " + output);
+    }
+
+    private static (int Exit, string Output) TryRunMerge(
+        string migratePath, string outPath, params string[] shardPaths)
+    {
+        string script = Path.Combine(RepoRoot(), "build", "merge-selfmig-runs.py");
+        var startInfo = new ProcessStartInfo("python3")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        startInfo.ArgumentList.Add(script);
+        startInfo.ArgumentList.Add("--migrate");
+        startInfo.ArgumentList.Add(migratePath);
+        startInfo.ArgumentList.Add("--out");
+        startInfo.ArgumentList.Add(outPath);
+        foreach (string shardPath in shardPaths)
+        {
+            startInfo.ArgumentList.Add(shardPath);
+        }
+
+        using Process process = Process.Start(startInfo);
+        string output = process.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        return (process.ExitCode, output);
+    }
+
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, "build")))
+        {
+            dir = dir.Parent;
+        }
+
+        Assert.NotNull(dir);
+        return dir.FullName;
+    }
+
+    private static GscInvoker NullGsc() => new GscInvoker("/nonexistent/gsc.dll");
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public TempDirectory()
+        {
+            this.Path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(), "cs2gs-3668-" + Guid.NewGuid().ToString("n"));
+            Directory.CreateDirectory(this.Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(this.Path, recursive: true);
+            }
+            catch (IOException)
+            {
+                // Best-effort cleanup.
+            }
+        }
+    }
+}

--- a/tools/cs2gs/README.md
+++ b/tools/cs2gs/README.md
@@ -23,7 +23,7 @@ oracle, §F reporting). This README is the operational quick start.
 | `Cs2Gs.Translator` | Roslyn C# front end. `CSharpToGSharpTranslator` + `CSharpTypeMapper` map C# syntax/semantics to the code model (the only project that references `Microsoft.CodeAnalysis.CSharp`). |
 | `Cs2Gs.Pipeline` | The four ordered, short-circuiting migration stages, the triage builder + fingerprint, corpus discovery, and the `gsc` invoker. |
 | `Cs2Gs.Report` | Aggregates a run into a self-contained `report.html` + `summary.json`. |
-| `Cs2Gs.Cli` | The `cs2gs` command-line front end (`migrate` / `report` verbs). |
+| `Cs2Gs.Cli` | The `cs2gs` command-line front end (`migrate` / `validate` / `report` verbs). |
 | `Cs2Gs.Tests` | Unit + golden + live tests for all of the above. |
 | `corpus/` | The curated C# **input** corpus (L1–L5) plus xUnit oracles. Isolated from `GSharp.sln`; see [`corpus/README.md`](corpus/README.md). |
 
@@ -75,6 +75,7 @@ dotnet out/bin/Release/Cs2Gs.Cli/cs2gs.dll migrate \
 | `--app <id>` | Diagnostic-run only; migrate one app (repeatable). |
 | `--gsc <path>` | Override `gsc.dll` (default `out/bin/<Config>/Compiler/gsc.dll`). |
 | `--config <name>` | Build config used to locate `gsc` (default `Release`). |
+| `--translate-only` | Repository mode: run stage 1 only, then stop (see `validate`). |
 
 Repository mode preserves relative directories, copies non-C# files, translates
 checked-in `.cs` files to `.gs`, transforms `.csproj` files to `.gsproj`, and
@@ -91,6 +92,43 @@ cs2gs migrate --diagnostic-run \
   --corpus tools/cs2gs/corpus \
   --out cs2gs-runs
 ```
+
+### `validate` — run stages 2–4 for a subset of an already-migrated tree
+
+The self-migration gate outgrew a single CI job (issue #3668): once a cascade
+clears, apps stop short-circuiting at translate and start paying for compile +
+ILVerify + test-parity. `migrate --translate-only` plus N `validate` shards is
+the same work split across runners.
+
+```sh
+# One whole-repository translate pass.
+cs2gs migrate --corpus "$repo" --out /tmp/migrated --artifacts /tmp/runs \
+  --config Release --translate-only --exclude ...
+
+# N independent shards over the SAME migrated tree.
+cs2gs validate --corpus "$repo" --migrated /tmp/migrated \
+  --artifacts /tmp/shard1 --manifests /tmp/runs/<runId> \
+  --config Release --exclude ... --shard 1/6
+```
+
+Two invariants make this safe, and both are load-bearing:
+
+* **Translation stays ONE whole-repository pass.** Linked sources (e.g.
+  `test/Shared/EmittedOracle.cs`) are compiled into several projects, and
+  `TranslateStage` cross-checks that such a file translates identically in all
+  of them. That guard only exists when every project translates in the same
+  run, so `validate` never runs the translate stage — it is absent from the
+  shard's stage list by construction, not skipped at runtime.
+* **`--exclude` is never a sharding mechanism.** It defines the *discovered*
+  app set, and every job must pass the identical list; excluding a project that
+  another app project-references breaks reference resolution and manufactures
+  phantom cascades. `--app` / `--shard` narrow what is *executed*.
+
+Each shard writes a partial `run.json`; `build/merge-selfmig-runs.py` merges
+them with the translate pass's results back into a single whole-run shape.
+See `build/run-cs2gs-selfmig-{migrate,validate,gate}.sh` and
+`.github/workflows/cs2gs-selfmig-nightly.yml`; `build/run-cs2gs-selfmig.sh`
+remains the equivalent single-job reference path for local proofs.
 
 ### `report` — regenerate a report from an existing run
 


### PR DESCRIPTION
Fixes #3668.

The nightly self-migration gate stopped reporting: run
[33303426077](https://github.com/DavidObando/gsharp/actions/runs/33303426077) was
cancelled by its 120-minute timeout after processing 23 of 51 apps. That is a
consequence of progress, not a hang — clearing the #3666 cascade (PR #3667)
pushed ~19 apps out of "fails at translate in seconds" and into "pays for
compile + ILVerify + test-parity". With no summary line and no green count,
`greenFloor` / `nullAssertionCeiling` cannot be ratcheted and regressions cannot
be detected. PR #3669 raised the timeout as a stopgap; this is the durable fix.

## Design, and the invariants it preserves

**1. Translation stays ONE whole-repository pass.** Linked sources (e.g.
`test/Shared/EmittedOracle.cs`) are compiled into several projects, and
`TranslateStage` cross-checks via `RepositoryTranslations` that each such file
translates identically in all of them ("translates differently in multiple
projects"). That guard only exists when every project translates in the same
run, so sharding translation would silently disable it. `cs2gs migrate
--translate-only` runs stage 1 across the whole repo exactly as before, then
stops.

**2. Sharding is never done with `--exclude`.** `--exclude` defines the
*discovered* app set; excluding a project that another app project-references
breaks reference resolution and manufactures phantom cascades (dropping
`src/Core` from a LanguageServer run yielded ~794 bogus errors). Every job now
passes the identical exclude list — defined once in `build/selfmig-common.sh` —
and shards are selected with `cs2gs validate --app` / `--shard i/N`, which
narrows what is EXECUTED, never what exists. Each shard rebuilds the
repository-wide mirrored-project map from the full app list.

**3. Compile / ILVerify / test-parity only read the migrated tree and are
independent per app.** That is the axis parallelized.

## The new `cs2gs validate` verb

cs2gs had no way to validate an already-migrated tree, so this adds one:

```
cs2gs validate --corpus <repo> --migrated <dir> --artifacts <dir>
               --manifests <migrate-run-dir> [--app <id>... | --shard i/N]
```

The seam turned out small. In repository layout the only translate-derived state
stages 2–4 consume is the emitted `.gs` file set (compile-error attribution and
the `!!` polish pass), the external reference paths (ilverify's `-r` set), and
the project classification flags. `migrate` now writes that per app as
`validation-context.json` (`ValidationManifest`); a shard rehydrates it,
re-reading the G# text from the migrated tree rather than carrying it. A shard's
stage list omits `TranslateStage` **by construction**, not by a runtime skip, so
it cannot re-translate a subset behind the cross-check's back.
`MigrationPipeline`'s stage loop is factored into `CreateAppContext` +
`RunStagesAsync` and shared by both entry points, so a shard's per-app semantics
are literally the whole run's.

`migrate`'s existing end-to-end behaviour is unchanged — the `cs2gs-corpus` job
and local subtree proofs depend on it, and `build/run-cs2gs-selfmig.sh` remains
the equivalent single-job reference path.

## Preserving the gate's numbers

Stage 2 strips `!!` spans that gsc proved redundant (GS0536), rewriting files in
the migrated tree, and a whole run measures the tree *after* that. So each shard
hashes the tree before and after validating and ships back only the rewritten
`.gs` files; the gate job replays those deltas before re-measuring. Because the
polish pass is scoped to the whole output root, a shard also polishes the
dependencies it builds, making it self-healing rather than order-dependent.

`build/merge-selfmig-runs.py` reassembles a whole-run-shaped `run.json`:
translate from the migrate pass, stages 2–4 from the owning shard, and an app
that failed translate keeps the short-circuit shape (translate FAIL, the rest
skipped) without ever being scheduled. It **fails loudly** if a translated app
has no shard result, or if two shards claim one app — silently shrinking the
denominator or inflating the green count is exactly the failure mode this issue
is about. The gate then applies `greenFloor` / `syntheticLabelCeiling` /
`liftedLocalCeiling` / `longLineCeiling` / `nullAssertionCeiling` and prints the
same summary line, the same step-summary table and the same `GATE: ...` lines as
before; that output format is a contract and is now defined once.

## Workflow

Three jobs mirroring `build.yml`'s `discover-tests` idiom: `migrate` (whole-repo
translate; emits the shard matrix via `build/generate-selfmig-shard-matrix.py`,
which balances by estimated cost rather than round-robin and only schedules apps
that actually translated), `validate` (matrix, `fail-fast: false`), and `gate`
(`if: always()`, so a red or errored shard still produces a verdict). The long
jobs keep a generous 240-minute timeout — the point is that no single job can be
starved again.

## Verification

**Equivalence on corpus slices.** Both paths were run over the same slice with
the *identical* exclude list, so any exclusion artefact is common to both and the
comparison isolates the sharding change:

**Slice 1** (`L1-Console`, `L2-Library`, `L2-Library.Tests`, `G01`, `G03` — one
executable with a stdout golden, one mirrored `dotnet test` project):

```
=== per-app verdicts ===   VERDICTS IDENTICAL
=== metrics ===            A: labels=0 lifts=0 lines>300=0 bangs=0
                           B: labels=0 lifts=0 lines>300=0 bangs=0   METRICS IDENTICAL
A green: 5/5   B green: 5/5
```

**Slice 2** exercises the *full* CI mechanism — each shard got its own copy of
the migrated tree, shipped back a real polish delta, and the gate replayed the
deltas before measuring — over a slice with a genuinely red app
(`CompileGap-Library`, whose compile FAILs and whose ilverify/test-parity are
skipped) plus `src/Core`, `InternalAnalyzers`, `Analyzers.Testing`,
`L2-Library`, `L2-Library.Tests`:

```
=== path A: classic whole run ===        A exit=1
=== path B: translate-only ===           B migrate exit=0
=== path B: shard 1 (own copy) ===       B shard1 exit=0    polished files: 166
=== path B: shard 2 (own copy) ===       B shard2 exit=1    polished files: 2
=== gate: merge + replay polish deltas ===
merge-selfmig-runs: 6 apps merged from 2 shard(s); 5 green.

=== per-app verdicts ===   VERDICTS IDENTICAL
=== metrics ===            A: labels=0 lifts=22 lines>300=250 bangs=3065
                           B: labels=0 lifts=22 lines>300=250 bangs=3065   METRICS IDENTICAL
A green: 5/6   B green: 5/6
```

The verdict comparison is over `{appId, succeeded, unverified, failureCategory,
stages:[{stage,status}]}` for every app — 24 stage statuses across the six apps,
byte-identical — so the `FAIL(1)` / `skip` / `skip` short-circuit shape and the
`compile-error` category are reproduced by the merge, not just the green count.
The 168 replayed polish files are what keep `bangs` and `lines>300` from drifting.

**Unit tests.** `tools/cs2gs/Cs2Gs.Tests/Issue3668ShardedValidationTests.cs`
covers the manifest hand-off (capture → write → read → hydrate, including
dropping references a shard cannot see), the deterministic artifact-directory
naming a shard uses to find its manifest, the translate-free stage list, shard
partitioning and rejection of unknown/conflicting selections, and the merge's
reconstruction plus its refusal to drop an app. 150 targeted tests pass
(`Issue3668`, `IlVerifyStageTests`, `Pipeline`, `ExitCode`, `Report` filters);
the full suite is left to CI.

**Workflow.** YAML parsed and reviewed by hand (`actionlint` unavailable here);
all scripts pass `bash -n`. Artifact names line up
(`cs2gs-selfmig-migrated` → both consumers; `cs2gs-selfmig-shard-*` → the gate's
`pattern:` download). The shard's partial result is deliberately named
`shard-run.json` so the gate's `find` cannot also pick up the inner
`runs/<runId>/run.json` and double-count every app.

## Expected wall-time

Historical durations: 1h40m for a complete run (36/52 green), then a hard
2h00m timeout at 23/51 once the #3666 cascade cleared — so a complete run at
today's stage coverage is roughly **4 hours** serial.

Split, the critical path becomes `migrate` + slowest `validate` shard + `gate`:

* `migrate` is stage 1 only over 51 apps — roughly 40 minutes, based on the
  51m run (33288891845) in which most apps short-circuited at translate;
* the `validate` leg is the ~3h of compile/ILVerify/test-parity spread over 6
  cost-balanced shards. It is not a clean 6× because each shard rebuilds the
  mirrored dependencies of its own apps, and because one app (`src/Core`, and
  the larger test projects) sets a floor — call it **50–75 minutes** for the
  slowest shard;
* `gate` is a merge, a tar replay and four greps: **under 5 minutes**.

That is roughly **4h → 1h35m–2h wall**, a ~2–2.5× improvement, with the
important property that it is now *tunable*: `SELFMIG_SHARDS` is a workflow-level
env var, so the validate leg shrinks further as the corpus grows, and no single
job can be starved into producing no verdict again. Total runner-minutes go up
(each shard restores and builds cs2gs, and rebuilds shared dependencies) — a
deliberate trade for a nightly, exactly as `build.yml` already makes for the
unit-test shards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
