### PR TITLE
cs2gs selfmig: don't pack during the mirrored compile, and relay non-GS build errors

### DIFF
--- a/tools/cs2gs/Cs2Gs.Pipeline/SdkCompileRunner.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/SdkCompileRunner.cs
@@ -49,6 +49,18 @@ public sealed class SdkCompileRunner
         @"error\s+(?<id>GS\d{4}):\s*(?<msg>.*)$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
+    // Issue #3672: the same shape for a build that failed with NO GSxxxx line
+    // at all — an MSBuild task/target error (`error MSB3202:`), a restore
+    // failure (`error NU1101:`), or a csc error from a C# project still in the
+    // graph (`error CS0246:`). Only consulted when the GS scan above found
+    // nothing, so a real G# diagnostic always wins.
+    // The coordinates are optional here as well as the whole prefix, so the
+    // location-free `MSBUILD : error MSB1009: …` shape is recognized too.
+    private static readonly Regex RelayedBuildErrorPattern = new Regex(
+        @"^(?:(?<file>.+?)(?:\((?<line>\d+),(?<col>\d+)(?:,(?<eline>\d+),(?<ecol>\d+))?\))?\s*:\s*)?" +
+        @"error\s+(?<id>[A-Za-z]{2,}\d{2,}):\s*(?<msg>.*)$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
     // The well-known NuGet package-asset directories that follow an
     // `{id}/{version}/` pair under a packages cache root (generic detector,
     // not specific to any single package).
@@ -109,16 +121,11 @@ public sealed class SdkCompileRunner
         try
         {
             temporaryBuildProps = PrepareTemporaryBuildProps(generatedProjectPaths.Values);
-            var args = new List<string>
-            {
-                "build",
+            IReadOnlyList<string> args = BuildMirroredBuildArguments(
                 generatedProjectPath,
-                "-c",
-                config ?? "Release",
-                "-p:RestoreConfigFile=" + projectNugetConfig,
-                "-p:RestorePackagesPath=" + Path.Combine(artifactDirectory, ".nuget-packages"),
-                "-p:Cs2GsArtifactRoot=" + artifactDirectory,
-            };
+                artifactDirectory,
+                config,
+                projectNugetConfig);
             ProcessRunResult result = ProcessRunner.Run(
                 "dotnet",
                 args,
@@ -133,7 +140,16 @@ public sealed class SdkCompileRunner
                 // Issue #3634: surface MSBuild-relayed GSxxxx errors (.targets-
                 // or gsgen-anchored lines the source-anchored parser misses)
                 // instead of letting the caller synthesize an opaque GS9999.
-                diagnostics = diagnostics.Concat(ParseRelayedGsErrors(result.Output)).ToList();
+                // Issue #3672: when the build failed without any GSxxxx line at
+                // all — an MSBuild/NuGet/csc-level failure such as MSB3202 —
+                // relay THAT verbatim for the same reason.
+                IReadOnlyList<GscDiagnostic> relayed = ParseRelayedGsErrors(result.Output);
+                if (relayed.Count == 0)
+                {
+                    relayed = ParseRelayedBuildErrors(result.Output);
+                }
+
+                diagnostics = diagnostics.Concat(relayed).ToList();
             }
 
             string assemblyPath = result.ExitCode == 0
@@ -997,7 +1013,58 @@ public sealed class SdkCompileRunner
     /// </summary>
     /// <param name="output">The combined stdout+stderr of the <c>dotnet build</c> run.</param>
     /// <returns>The distinct relayed error diagnostics in output order; empty when none match.</returns>
-    internal static IReadOnlyList<GscDiagnostic> ParseRelayedGsErrors(string output)
+    internal static IReadOnlyList<GscDiagnostic> ParseRelayedGsErrors(string output) =>
+        ParseRelayedErrors(output, RelayedGsErrorPattern);
+
+    /// <summary>
+    /// Scans <c>dotnet build</c> output for a relayed error of ANY id shape —
+    /// <c>MSB3202</c>, <c>NU1101</c>, <c>CS0246</c> — for the case where the
+    /// build failed without emitting a single <c>GSxxxx</c> line (issue #3672).
+    /// Without this, such a failure reached the caller as an opaque
+    /// <c>GS9999 … no parseable diagnostic</c> whose truncated output excerpt
+    /// routinely captured only leading warning noise, hiding the one real error
+    /// far below it. Only consulted after
+    /// <see cref="ParseRelayedGsErrors"/> comes back empty.
+    /// </summary>
+    /// <param name="output">The combined stdout+stderr of the <c>dotnet build</c> run.</param>
+    /// <returns>The distinct relayed error diagnostics in output order; empty when none match.</returns>
+    internal static IReadOnlyList<GscDiagnostic> ParseRelayedBuildErrors(string output) =>
+        ParseRelayedErrors(output, RelayedBuildErrorPattern);
+
+    /// <summary>
+    /// Issue #3672: the mirrored-build command line. The compile stage measures
+    /// whether the translated G# compiles, so packaging is switched off:
+    /// a source project with <c>&lt;GeneratePackageOnBuild&gt;true</c> (e.g.
+    /// <c>src/Sdk/Gsharp.NET.Sdk</c>) otherwise runs its pack targets, which
+    /// reach out to sibling REPO projects by literal <c>.csproj</c> path —
+    /// paths that in a partial mirror are either absent (an <c>--exclude</c>d
+    /// project) or exist only as <c>.gsproj</c>, failing the build with MSB3202
+    /// for a reason that has nothing to do with the translation. The property is
+    /// global, so it also applies to every project reference in the graph.
+    /// </summary>
+    /// <param name="generatedProjectPath">The mirrored G# project to build.</param>
+    /// <param name="artifactDirectory">The external build and log directory.</param>
+    /// <param name="config">The build configuration.</param>
+    /// <param name="projectNugetConfig">The nuget.config written beside the generated project.</param>
+    /// <returns>The <c>dotnet</c> arguments.</returns>
+    internal static IReadOnlyList<string> BuildMirroredBuildArguments(
+        string generatedProjectPath,
+        string artifactDirectory,
+        string config,
+        string projectNugetConfig) =>
+        new List<string>
+        {
+            "build",
+            generatedProjectPath,
+            "-c",
+            config ?? "Release",
+            "-p:RestoreConfigFile=" + projectNugetConfig,
+            "-p:RestorePackagesPath=" + Path.Combine(artifactDirectory, ".nuget-packages"),
+            "-p:Cs2GsArtifactRoot=" + artifactDirectory,
+            "-p:GeneratePackageOnBuild=false",
+        };
+
+    private static IReadOnlyList<GscDiagnostic> ParseRelayedErrors(string output, Regex pattern)
     {
         var diagnostics = new List<GscDiagnostic>();
         if (string.IsNullOrEmpty(output))
@@ -1008,7 +1075,7 @@ public sealed class SdkCompileRunner
         var seen = new HashSet<string>(StringComparer.Ordinal);
         foreach (string rawLine in output.Replace("\r\n", "\n").Split('\n'))
         {
-            Match match = RelayedGsErrorPattern.Match(rawLine.Trim());
+            Match match = pattern.Match(rawLine.Trim());
             if (!match.Success)
             {
                 continue;

--- a/tools/cs2gs/Cs2Gs.Tests/SdkCompileRunnerTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/SdkCompileRunnerTests.cs
@@ -568,6 +568,83 @@ public class SdkCompileRunnerTests
         Assert.Empty(SdkCompileRunner.ParseRelayedGsErrors(null));
     }
 
+    [Fact]
+    public void ParseRelayedBuildErrors_ParsesMsBuildTaskError()
+    {
+        // Issue #3672: the exact shape that walled four selfmig apps behind an
+        // opaque GS9999 — one MSB3202 line buried under ~80 warning lines.
+        const string Output =
+            "/migrated/build/gsharp.props(24,5): warning : Gsharp project does not exist: '/migrated/src/Core/Core.csproj'\n" +
+            "  Gsharp.NET.Sdk -> /migrated/out/bin/Release/Gsharp.NET.Sdk/Gsharp.NET.Sdk.dll\n" +
+            "/migrated/src/Sdk/Gsharp.NET.Sdk/Gsharp.NET.Sdk.gsproj(104,5): error MSB3202: " +
+            "The project file \"/migrated/src/Compiler/Compiler.csproj\" was not found.\n" +
+            "Build FAILED.\n";
+
+        var diagnostics = SdkCompileRunner.ParseRelayedBuildErrors(Output);
+
+        GscDiagnostic diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MSB3202", diagnostic.Id);
+        Assert.Equal(
+            "The project file \"/migrated/src/Compiler/Compiler.csproj\" was not found.",
+            diagnostic.Message);
+        Assert.Equal("error", diagnostic.Severity);
+        Assert.Equal("/migrated/src/Sdk/Gsharp.NET.Sdk/Gsharp.NET.Sdk.gsproj", diagnostic.File);
+        Assert.Equal(104, diagnostic.Line);
+        Assert.Equal(5, diagnostic.Column);
+    }
+
+    [Fact]
+    public void ParseRelayedBuildErrors_ParsesRestoreAndCsharpAndLocationFreeShapes()
+    {
+        const string Output =
+            "MSBUILD : error MSB1009: Project file does not exist.\n" +
+            "/src/App.csproj : error NU1101: Unable to find package Foo.\n" +
+            "/src/App.cs(3,1): error CS0246: The type or namespace name 'Foo' could not be found\n" +
+            "/src/App.gs(3,1,3,4): warning GS0100: not an error\n" +
+            "Build FAILED.\n";
+
+        var diagnostics = SdkCompileRunner.ParseRelayedBuildErrors(Output);
+
+        Assert.Equal(3, diagnostics.Count);
+        Assert.Equal(new[] { "MSB1009", "NU1101", "CS0246" }, diagnostics.Select(d => d.Id).ToArray());
+        Assert.Equal("MSBUILD", diagnostics[0].File);
+        Assert.Equal(1, diagnostics[0].Line);
+        Assert.Equal("/src/App.cs", diagnostics[2].File);
+        Assert.Equal(3, diagnostics[2].Line);
+    }
+
+    [Fact]
+    public void ParseRelayedBuildErrors_ReturnsEmpty_WhenNoErrorLinePresent()
+    {
+        const string Output =
+            "/src/App.gs(3,1,3,4): warning GS0100: not an error\n" +
+            "    0 Error(s)\n" +
+            "Build succeeded.\n";
+
+        Assert.Empty(SdkCompileRunner.ParseRelayedBuildErrors(Output));
+        Assert.Empty(SdkCompileRunner.ParseRelayedBuildErrors(string.Empty));
+        Assert.Empty(SdkCompileRunner.ParseRelayedBuildErrors(null));
+    }
+
+    [Fact]
+    public void BuildMirroredBuildArguments_DisablesPackagingOnBuild()
+    {
+        // Issue #3672: packing is not what the compile stage measures, and a
+        // source project's pack targets reach out to sibling repo .csproj paths
+        // the mirror never produced (MSB3202).
+        IReadOnlyList<string> args = SdkCompileRunner.BuildMirroredBuildArguments(
+            "/out/App.gsproj",
+            "/artifacts/app",
+            "Release",
+            "/out/nuget.config");
+
+        Assert.Equal("build", args[0]);
+        Assert.Equal("/out/App.gsproj", args[1]);
+        Assert.Contains("-p:GeneratePackageOnBuild=false", args);
+        Assert.Contains("-p:Cs2GsArtifactRoot=/artifacts/app", args);
+        Assert.Contains("-p:RestoreConfigFile=/out/nuget.config", args);
+    }
+
     /// <summary>
     /// A scratch directory populated with one fake shared-framework assembly
     /// file, so <see cref="SdkCompileRunner.PartitionReferences"/>'s runtime-dir


### PR DESCRIPTION
Fixes #3672.

## What the four GS9999 apps were actually hitting

Every one of the four `GS9999: dotnet build (--via-sdk) exited with code 1 and no parseable diagnostic` apps in run [33308959087](https://github.com/DavidObando/gsharp/actions/runs/33308959087) has the same single error in its `sdk.build.log`:

```
/tmp/gsharp-cs2gs-selfmig/migrated/src/Sdk/Gsharp.NET.Sdk/Gsharp.NET.Sdk.gsproj(104,5): error MSB3202:
  The project file ".../migrated/src/Sdk/Gsharp.NET.Sdk/../../Compiler/Compiler.csproj" was not found.
```

The translated G# compiles — the log shows `Gsharp.NET.Sdk -> …/Gsharp.NET.Sdk.dll` succeeding on the line before. The failure comes from packaging: `Gsharp.NET.Sdk.csproj` sets `<GeneratePackageOnBuild>true</GeneratePackageOnBuild>`, so a plain `dotnet build` also runs `Pack`, and its pack targets (`PackGsharpCompiler`, `PackGsgen`, `PackGsharpExtensions`) invoke `<MSBuild Projects="…\Compiler\Compiler.csproj" />` against sibling **repo** project paths. In a partial mirror those siblings are absent (`src/Sdk/Gsharp.Extensions` is deliberately `--exclude`d) or exist only as `.gsproj`, so MSBuild fails with MSB3202 for a reason that has nothing to do with the translation. The other three apps inherit it because the migrated `Gsharp.NET.Sdk.gsproj` is in their build graph.

## Change

1. `SdkCompileRunner.BuildMirroredBuildArguments` (extracted, so the command line is unit-testable) adds `-p:GeneratePackageOnBuild=false`. The compile stage measures compilation, not NuGet packaging, and packaging cannot work in a partial mirror. It is a global property, so it propagates through project references and covers the whole graph.
2. `ParseRelayedBuildErrors` widens the #3634 relay scan to any `error <ID>:` line (`MSB3202`, `NU1101`, `CS0246`, and the location-free `MSBUILD : error MSB1009:` shape) — consulted **only** when `ParseRelayedGsErrors` comes back empty, so a real G# diagnostic always wins. The old behaviour truncated the output excerpt at ~250 chars, which here captured only leading `warning : Gsharp project does not exist` noise and hid the one real error ~80 lines below.

## Which apps this fixes

All four walled apps — `tools/cs2gs/Cs2Gs.Cli`, `tools/cs2gs/Cs2Gs.Tests`, `src/Sdk/Gsharp.NET.Sdk`, `test/Sdk.Tests` — share this single root cause and are fixed by change 1.

Not touched, and already separately diagnosed: `src/Repl` and `test/Compiler.Tests` (each `FAIL(1)`, same fingerprint) fail on the LanguageServer `GS0155 Cannot convert type 'nil' to …` family, which is already relayed correctly and is the LanguageServer wall, not this one.

Follow-up filed: #3674 — `GSharpProjectTransformer` rewrites only `ProjectReference/@Include`, so literal `.csproj` paths inside `<MSBuild Projects=…>` and project-path properties survive into the emitted `.gsproj`. Not needed for the gate now that the mirrored compile does not pack, but it would bite any migrated project that drives a nested build.

## Verification

- `dotnet build GSharp.sln -c Release -graph` — clean (the packed-SDK trap).
- `dotnet test … --filter FullyQualifiedName~SdkCompileRunnerTests` — 38/38 pass, including four new tests covering the MSB3202 relay shape, the `NU`/`CS`/location-free shapes, the no-error case, and the `-p:GeneratePackageOnBuild=false` argument.
- Empirical check that the property actually suppresses the offending targets: `dotnet build src/Sdk/Gsharp.NET.Sdk/Gsharp.NET.Sdk.csproj -c Release -t:Rebuild -v n` matches 44 `gsc-publish`/`PackGsharpCompiler`/`Successfully created package` lines; the same command with `-p:GeneratePackageOnBuild=false` matches 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs