### PR TITLE
gsc: infer T from a lifted Nullable<T> extension receiver (#3673)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
@@ -1630,22 +1630,55 @@ internal sealed partial class ExpressionBinder
             argumentIndex > 0
             && argumentIndex - 1 < arguments.Length
             && arguments[argumentIndex - 1] is BoundFunctionLiteralExpression;
-        var resolution = ClrOverloadResolution.Resolve(
-            candidates,
-            argTypes,
-            explicitTypeArgs,
-            scope.References.MapClrTypeToReferences,
-            ComputeInterpolatedStringArgFlags(ce.Arguments, argTypes.Length, receiverArgCount: 1),
-            argumentNames: extensionArgumentNames,
-            recoverTypeArgSymbols: recoverExtensionTypeArgs,
-            supplementaryInterfaceCheck: supplementaryInterfaceCheck,
-            constantNarrowingArgumentCheck: MakeConstantNarrowingArgumentCheck(arguments, argumentOffset: 1),
-            structuralProjectionArgumentCheck: ExtensionStructuralProjectionCheck,
-            delegateRefKindArgumentCheck: MakeDelegateRefKindArgumentCheck(arguments, argumentOffset: 1),
-            methodGroupInference: MakeMethodGroupInference(arguments, GetEffectiveArgumentClrTypeForOverloadResolution, argumentOffset: 1),
-            methodGroupArgumentCheck: MakeMethodGroupArgumentCheck(arguments, argumentOffset: 1),
-            deferredInferenceArgs: deferredInferenceArgs,
-            functionLiteralArgumentCheck: functionLiteralArgumentCheck);
+        ClrOverloadResolution.Result<MethodInfo> ResolveExtensionCandidates() =>
+            ClrOverloadResolution.Resolve(
+                candidates,
+                argTypes,
+                explicitTypeArgs,
+                scope.References.MapClrTypeToReferences,
+                ComputeInterpolatedStringArgFlags(ce.Arguments, argTypes.Length, receiverArgCount: 1),
+                argumentNames: extensionArgumentNames,
+                recoverTypeArgSymbols: recoverExtensionTypeArgs,
+                supplementaryInterfaceCheck: supplementaryInterfaceCheck,
+                constantNarrowingArgumentCheck: MakeConstantNarrowingArgumentCheck(arguments, argumentOffset: 1),
+                structuralProjectionArgumentCheck: ExtensionStructuralProjectionCheck,
+                delegateRefKindArgumentCheck: MakeDelegateRefKindArgumentCheck(arguments, argumentOffset: 1),
+                methodGroupInference: MakeMethodGroupInference(arguments, GetEffectiveArgumentClrTypeForOverloadResolution, argumentOffset: 1),
+                methodGroupArgumentCheck: MakeMethodGroupArgumentCheck(arguments, argumentOffset: 1),
+                deferredInferenceArgs: deferredInferenceArgs,
+                functionLiteralArgumentCheck: functionLiteralArgumentCheck);
+
+        var resolution = ResolveExtensionCandidates();
+
+        // Issue #3673: `NullableTypeSymbol.ClrType` is the *underlying* CLR type
+        // (`Int32` for `int32?`), so slot 0 above presents a value-typed nullable
+        // receiver unlifted. A candidate whose `this` parameter is
+        // `Nullable<T>` — for example
+        // `Gsharp.Extensions.Optional.OrThrow[T struct](self T?, message string)` —
+        // then has no evidence to infer `T` from, because none of the user
+        // arguments mention it, and the whole call dead-ends at GS0159. (Sibling
+        // helpers such as `OrElse`/`OrCompute` are unaffected only because their
+        // user argument independently pins `T`.) Retry once with the lifted
+        // `Nullable<T>` receiver shape so `Nullable<T>` self-parameters unify.
+        // The retry runs only after the unlifted shape has already failed, so
+        // extensions that legitimately match the underlying type keep binding
+        // exactly as before.
+        if (resolution.Outcome == ClrOverloadResolution.ResolutionOutcome.NoneApplicable
+            && receiver.Type is NullableTypeSymbol
+            && NullableLifting.GetEffectiveClrType(receiver.Type) is { } liftedReceiverClrType
+            && !ClrTypeUtilities.AreSame(liftedReceiverClrType, receiverClrType))
+        {
+            argTypes[0] = liftedReceiverClrType;
+            var liftedResolution = ResolveExtensionCandidates();
+            if (liftedResolution.Outcome != ClrOverloadResolution.ResolutionOutcome.NoneApplicable)
+            {
+                resolution = liftedResolution;
+            }
+            else
+            {
+                argTypes[0] = receiverClrType;
+            }
+        }
 
         switch (resolution.Outcome)
         {

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3673NullableReceiverExtensionInferenceTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3673NullableReceiverExtensionInferenceTests.cs
@@ -1,0 +1,133 @@
+// <copyright file="Issue3673NullableReceiverExtensionInferenceTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #3673: an imported generic extension method whose <c>this</c>
+/// parameter is <c>Nullable&lt;T&gt;</c> must infer <c>T</c> from a value-typed
+/// nullable receiver even when no user argument mentions <c>T</c>. The
+/// extension-call argument vector presents slot 0 as
+/// <c>NullableTypeSymbol.ClrType</c>, which is the *underlying* CLR type, so
+/// the binder additionally retries with the lifted <c>Nullable&lt;T&gt;</c>
+/// shape. This is what <c>Gsharp.Extensions.Optional.OrThrow</c> needs.
+/// </summary>
+public class Issue3673NullableReceiverExtensionInferenceTests
+{
+    [Fact]
+    public void ReceiverOnlyInference_ValueTypedNullable_Binds()
+    {
+        const string source = """
+            package Probe
+            import GSharp.Core.Tests.Fixtures
+
+            func Run() {
+                let v int32? = 7
+                let unwrapped = v.UnwrapOrThrow3673("missing")
+            }
+            """;
+
+        AssertBindsWithoutErrors(source);
+    }
+
+    [Fact]
+    public void ReceiverOnlyInference_ReferenceTypedNullable_Binds()
+    {
+        const string source = """
+            package Probe
+            import GSharp.Core.Tests.Fixtures
+
+            func Run() {
+                let s string? = "x"
+                let unwrapped = s.UnwrapOrThrow3673("missing")
+            }
+            """;
+
+        AssertBindsWithoutErrors(source);
+    }
+
+    [Fact]
+    public void ArgumentDrivenInference_ValueTypedNullable_StillBinds()
+    {
+        const string source = """
+            package Probe
+            import GSharp.Core.Tests.Fixtures
+
+            func Run() {
+                let v int32? = 7
+                let value = v.UnwrapOrElse3673(1)
+            }
+            """;
+
+        AssertBindsWithoutErrors(source);
+    }
+
+    [Fact]
+    public void UnderlyingTypedExtension_OnNullableReceiver_StillBinds()
+    {
+        // The lifted retry runs only after the unlifted receiver shape has
+        // already failed, so an extension declared over the underlying value
+        // type keeps binding exactly as it did before issue #3673.
+        const string source = """
+            package Probe
+            import GSharp.Core.Tests.Fixtures
+
+            func Run() {
+                let v int32? = 7
+                let doubled = v.Double3673()
+            }
+            """;
+
+        AssertBindsWithoutErrors(source);
+    }
+
+    [Fact]
+    public void UnknownExtensionName_OnNullableReceiver_StillReportsError()
+    {
+        const string source = """
+            package Probe
+            import GSharp.Core.Tests.Fixtures
+
+            func Run() {
+                let v int32? = 7
+                let missing = v.NoSuchExtension3673("missing")
+            }
+            """;
+
+        Assert.Contains(BindDiagnostics(source), d => d.IsError);
+    }
+
+    private static void AssertBindsWithoutErrors(string source)
+        => Assert.DoesNotContain(BindDiagnostics(source), d => d.IsError);
+
+    private static ImmutableArray<Diagnostic> BindDiagnostics(string source)
+    {
+        // Load the test assembly (which carries the issue #3673 fixture) plus
+        // the BCL through a MetadataLoadContext, matching how the migrated
+        // Extensions.Tests app sees Gsharp.Extensions.dll.
+        List<string> paths = [typeof(Fixtures.Issue3673NullableReceiverExtensions).Assembly.Location];
+        if (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") is string tpa && !string.IsNullOrEmpty(tpa))
+        {
+            paths.AddRange(tpa.Split(Path.PathSeparator).Where(p => !string.IsNullOrWhiteSpace(p) && File.Exists(p)));
+        }
+
+        using var resolver = ReferenceResolver.WithReferences(paths.Distinct(StringComparer.OrdinalIgnoreCase));
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree), resolver);
+        var program = Binder.BindProgram(globalScope, resolver);
+        return globalScope.Diagnostics.AddRange(program.Diagnostics);
+    }
+}

--- a/test/Core.Tests/Fixtures/Issue3673NullableReceiverExtensions.cs
+++ b/test/Core.Tests/Fixtures/Issue3673NullableReceiverExtensions.cs
@@ -1,0 +1,48 @@
+// <copyright file="Issue3673NullableReceiverExtensions.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.Tests.Fixtures;
+
+/// <summary>
+/// Issue #3673 fixture: mirrors the shape of
+/// <c>Gsharp.Extensions.Optional.OrThrow</c> — an imported generic extension
+/// method whose only inference site for <c>T</c> is a <c>Nullable&lt;T&gt;</c>
+/// <c>this</c> parameter, plus a sibling whose ordinary argument also mentions
+/// <c>T</c>. Calling the former with instance syntax on a value-typed nullable
+/// receiver must infer <c>T</c> from the receiver alone.
+/// </summary>
+public static class Issue3673NullableReceiverExtensions
+{
+    /// <summary>Unwraps a present value or throws; <c>T</c> is inferable only from the receiver.</summary>
+    /// <typeparam name="T">The underlying value type.</typeparam>
+    /// <param name="self">The nullable receiver.</param>
+    /// <param name="message">The exception message used when the receiver has no value.</param>
+    /// <returns>The receiver's value when present.</returns>
+    public static T UnwrapOrThrow3673<T>(this T? self, string message)
+        where T : struct
+        => self ?? throw new System.InvalidOperationException(message);
+
+    /// <summary>Unwraps a present reference or throws; <c>T</c> is inferable only from the receiver.</summary>
+    /// <typeparam name="T">The underlying reference type.</typeparam>
+    /// <param name="self">The nullable receiver.</param>
+    /// <param name="message">The exception message used when the receiver is null.</param>
+    /// <returns>The receiver's value when present.</returns>
+    public static T UnwrapOrThrow3673<T>(this T self, string message)
+        where T : class
+        => self ?? throw new System.InvalidOperationException(message);
+
+    /// <summary>Returns the receiver's value, or <paramref name="fallback"/>; <c>T</c> is also inferable from the argument.</summary>
+    /// <typeparam name="T">The underlying value type.</typeparam>
+    /// <param name="self">The nullable receiver.</param>
+    /// <param name="fallback">The value returned when the receiver has no value.</param>
+    /// <returns>The receiver's value when present, otherwise <paramref name="fallback"/>.</returns>
+    public static T UnwrapOrElse3673<T>(this T? self, T fallback)
+        where T : struct
+        => self ?? fallback;
+
+    /// <summary>Takes the underlying value type directly, so a nullable receiver must not match it.</summary>
+    /// <param name="self">The receiver.</param>
+    /// <returns>The receiver, doubled.</returns>
+    public static int Double3673(this int self) => self * 2;
+}


### PR DESCRIPTION
Fixes #3673.

## The wall

Migrated `test/Extensions.Tests` failed the self-migration gate (#3501) with exactly two errors:

```
OptionalExtensionsTests.gs:256   GS0159 Cannot find function OrThrow.
OptionalExtensionsTests.gs:263   GS0159 Cannot find function OrThrow.
```

## Minimal repro

Hand-written G#, compiled with `gsc` against the built `Gsharp.Extensions.dll`:

```gs
package repro

import Gsharp.Extensions.Optional

func Run() {
    let s string? = "x"
    let a = s.OrThrow("missing")   // OK
    let v int32? = 7
    let b = v.OrThrow("missing")   // error GS0159: Cannot find function OrThrow.
    let c = s.OrElse("y")          // OK
    let d = v.OrElse(1)            // OK
}
```

`v.OrThrow[int32]("missing")` binds, so this is generic inference, not extension-method discovery.

## Root cause

`NullableTypeSymbol.ClrType` is the *underlying* CLR type (`Int32` for `int32?`) — exactly why `NullableLifting.GetEffectiveClrType` exists. `TryBindImportedExtensionCall` ran every *user* argument through `GetEffectiveArgumentClrTypeForOverloadResolution`, but filled the receiver ("this") slot straight from `receiver.Type.ClrType`. A candidate declaring `this Nullable<T>` therefore saw `Int32` in slot 0, `UnifyForInference` found no `Nullable<>` in that hierarchy, `T` was never bound, and the candidate was dropped.

`Gsharp.Extensions.Optional.OrThrow[T struct](self T?, message string)` is the shape that breaks, because the receiver is its only inference site for `T`. The sibling helpers survive only incidentally: `OrElse`/`OrCompute` take a `T` / `() -> T` argument that pins `T` independently, after which the unlifted `Int32` receiver is accepted by a NullableWrap conversion. `Gsharp.Extensions` is an all-G# project deliberately excluded from migration (#3636), so the call crosses an assembly boundary and lands on the imported-extension path.

## The fix

gsc, not cs2gs — the emitted G# is the obvious `value.OrThrow("missing")`. `TryBindImportedExtensionCall` now retries extension overload resolution once with the lifted `Nullable<T>` receiver shape, and only after the unlifted shape has already resolved to `NoneApplicable`. Extensions declared over the underlying value type still win on the first pass, so their binding is untouched.

## Verification

- The repro above compiles clean, and a runnable variant prints `value=7` / `ref=x` / `caught=boom` — the `[T struct]` overload is selected and unwraps correctly.
- New `test/Core.Tests/CodeAnalysis/Binding/Issue3673NullableReceiverExtensionInferenceTests.cs` (+ a C# fixture mirroring the `OrThrow` shape): 5 tests, covering receiver-only inference for both the value- and reference-typed nullable receiver, argument-driven inference, an extension over the underlying value type still binding, and an unknown name still erroring. Confirmed 1 of the 5 fails on `origin/main` and all 5 pass with the fix.
- `Core.Tests` `~Binding` (5590 passed) and `~Emit|~Overload|~Extension` (1465 passed): no regressions.
- Full solution rebuilt with `dotnet build GSharp.sln -c Release -graph` so the packed `Gsharp.NET.Sdk` nupkg carries the new compiler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
