### PR TITLE
gsc: typeof of a source-declared open generic; cs2gs: oblivious cast-receiver forgiveness (#3678, #3683)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -128,6 +128,21 @@ internal sealed partial class ExpressionBinder
                         out isAmbiguous);
                 }
 
+                // Issue #3678: both walks above only ever consult REFERENCED
+                // assemblies, so the explicit-arity spelling could not name a
+                // generic type declared in THIS compilation —
+                // `typeof(Slot[_])` on a source `class Slot[T]` failed with
+                // GS0113 even though the bare `typeof(Slot)` form resolves it
+                // through `bindTypeClause`. Try the declaration table last, so
+                // an imported match still wins exactly as before.
+                if (!resolved
+                    && !isAmbiguous
+                    && !typeClause.HasQualifier
+                    && TryResolveOpenGenericDeclaredType(typeClauseIdentifier.ValueText, arity, out typeSymbol))
+                {
+                    resolved = true;
+                }
+
                 if (!resolved)
                 {
                     // Issue #2012 (N3): "ambiguous across imports" and "no
@@ -226,6 +241,48 @@ internal sealed partial class ExpressionBinder
         type = TypeSymbol.FromClrType(match);
         return true;
     }
+
+    /// <summary>
+    /// Issue #3678: resolves an explicit-arity unbound generic
+    /// (<c>Slot[_]</c>, <c>Pair[_, _]</c>) to a generic type DECLARED IN THIS
+    /// COMPILATION, at the EXACT requested arity. The imported walks
+    /// (<see cref="TryResolveOpenGenericImportedType"/> /
+    /// <see cref="TryResolveOpenGenericImportedTypeWithArity"/>) only search
+    /// referenced assemblies, so without this a source generic was reachable
+    /// through the bare <c>typeof(Slot)</c> spelling but not through the
+    /// arity-bearing one — the only spelling available when the base name is
+    /// shared by several arities.
+    /// </summary>
+    /// <param name="name">The bare generic base name.</param>
+    /// <param name="arity">The exact requested arity.</param>
+    /// <param name="type">The resolved open generic definition on success.</param>
+    /// <returns><see langword="true"/> when a declared generic definition of that arity was found.</returns>
+    private bool TryResolveOpenGenericDeclaredType(string name, int arity, out TypeSymbol? type)
+    {
+        type = null;
+        var candidate = lookupType(name);
+        if (candidate == null || DeclaredGenericDefinitionArity(candidate) != arity)
+        {
+            return false;
+        }
+
+        type = candidate;
+        return true;
+    }
+
+    /// <summary>
+    /// Issue #3678: the type-parameter count of a source generic type
+    /// DEFINITION (never a constructed instantiation, whose type arguments are
+    /// already supplied), or <c>-1</c> for anything else.
+    /// </summary>
+    /// <param name="type">The candidate type.</param>
+    /// <returns>The definition's arity, or <c>-1</c>.</returns>
+    private static int DeclaredGenericDefinitionArity(TypeSymbol type) => type switch
+    {
+        StructSymbol { IsGenericDefinition: true } structSymbol => structSymbol.TypeParameters.Length,
+        InterfaceSymbol { IsGenericDefinition: true } interfaceSymbol => interfaceSymbol.TypeParameters.Length,
+        _ => -1,
+    };
 
     private bool TryGetNestedUnboundGenericReflectionSegments(
         TypeClauseSyntax typeClause,

--- a/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
+++ b/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
@@ -407,7 +407,64 @@ internal sealed class ImportedMemberRefFactory
             return this.GetTypeHandleForMember(nullableType);
         }
 
+        // Issue #3678: `typeof(Slot)` / `typeof(Slot[_])` names the OPEN
+        // generic DEFINITION of a type declared in this compilation, and
+        // `ldtoken` of a definition takes its TypeDef row. The generic-
+        // reference TypeSpec `GetElementTypeToken` builds instead
+        // (`Slot<!0>`) names VAR slots that have no binding in this scope, so
+        // the emitted PE failed to load with BadImageFormatException the
+        // moment the `typeof` ran.
+        if (TryGetOpenGenericDefinition(type, out var definition)
+            && this.TryGetUserTypeDef(definition, out var definitionHandle))
+        {
+            return definitionHandle;
+        }
+
         return this.GetElementTypeToken(type);
+    }
+
+    /// <summary>
+    /// Issue #3678: the user-declared generic DEFINITION behind
+    /// <paramref name="type"/> — a type that declares type parameters and
+    /// supplies no type arguments — or <see langword="false"/> for anything
+    /// else (a constructed instantiation, a non-generic type, an imported
+    /// CLR type, which already carries its own open <see cref="Type"/>).
+    /// </summary>
+    /// <param name="type">The candidate type.</param>
+    /// <param name="definition">The open generic definition on success.</param>
+    /// <returns>Whether <paramref name="type"/> is an open user generic definition.</returns>
+    private static bool TryGetOpenGenericDefinition(TypeSymbol type, [NotNullWhen(true)] out TypeSymbol? definition)
+    {
+        definition = type switch
+        {
+            StructSymbol { IsGenericDefinition: true } structSym => structSym,
+            InterfaceSymbol { IsGenericDefinition: true } interfaceSym => interfaceSym,
+            _ => null,
+        };
+
+        return definition != null;
+    }
+
+    /// <summary>
+    /// Issue #3678: the emitted TypeDef row for a user-declared type.
+    /// </summary>
+    /// <param name="definition">The type definition symbol.</param>
+    /// <param name="handle">The TypeDef handle on success.</param>
+    /// <returns>Whether a TypeDef row has been emitted for the definition.</returns>
+    private bool TryGetUserTypeDef(TypeSymbol definition, out EntityHandle handle)
+    {
+        switch (definition)
+        {
+            case StructSymbol structSym when this.cache.StructTypeDefs.TryGetValue(structSym, out var structHandle):
+                handle = structHandle;
+                return true;
+            case InterfaceSymbol interfaceSym when this.cache.InterfaceTypeDefs.TryGetValue(interfaceSym, out var interfaceHandle):
+                handle = interfaceHandle;
+                return true;
+            default:
+                handle = default;
+                return false;
+        }
     }
 
     private AssemblyReferenceHandle GetAssemblyReference(Assembly assembly)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3678SourceOpenGenericTypeOfTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3678SourceOpenGenericTypeOfTests.cs
@@ -1,0 +1,147 @@
+// <copyright file="Issue3678SourceOpenGenericTypeOfTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #3678: the explicit-arity open-generic <c>typeof(Name[_, …])</c>
+/// spelling (#1989) only ever searched REFERENCED assemblies, so it could not
+/// name a generic type declared in the compilation being built —
+/// <c>typeof(Slot[_])</c> over a source <c>class Slot[T]</c> reported GS0113
+/// "Type 'Slot`1' doesn't exist" even though the bare <c>typeof(Slot)</c> form
+/// bound it. Separately, the <c>ldtoken</c> emitted for ANY open user generic
+/// definition (either spelling) took the generic-reference TypeSpec path,
+/// producing a <c>Slot&lt;!0&gt;</c> TypeSpec whose VAR slot has no binding in
+/// that scope; the PE then failed to load with BadImageFormatException the
+/// moment the <c>typeof</c> ran. Both halves are covered here — the tests
+/// EXECUTE the emitted program, so a metadata regression fails as loudly as a
+/// binder one.
+/// </summary>
+public class Issue3678SourceOpenGenericTypeOfTests
+{
+    [Fact]
+    public void SourceGenericClass_ExplicitArityTypeOf_BindsAndEmitsOpenDefinition()
+    {
+        var source = @"
+class Slot[T] {
+    prop Value int32
+}
+
+typeof(Slot[_]).Name
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("Slot`1", result.Value);
+    }
+
+    [Fact]
+    public void SourceGenericClass_BareTypeOf_EmitsOpenDefinition()
+    {
+        var source = @"
+class Slot[T] {
+    prop Value int32
+}
+
+typeof(Slot).Name
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("Slot`1", result.Value);
+    }
+
+    [Fact]
+    public void SourceGenericInterface_ExplicitArityTypeOf_BindsAndEmitsOpenDefinition()
+    {
+        var source = @"
+interface IQuery[T] {
+}
+
+typeof(IQuery[_]).Name
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("IQuery`1", result.Value);
+    }
+
+    [Fact]
+    public void SourceGenericClass_TwoArityTypeOf_SelectsMatchingArity()
+    {
+        var source = @"
+class Pair[A, B] {
+    prop V int32
+}
+
+typeof(Pair[_, _]).GetGenericArguments().Length
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(2, result.Value);
+    }
+
+    [Fact]
+    public void SourceOpenGenericTypeOf_IsGenericTypeDefinition()
+    {
+        var source = @"
+class Slot[T] {
+    prop Value int32
+}
+
+typeof(Slot[_]).IsGenericTypeDefinition
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(true, result.Value);
+    }
+
+    [Fact]
+    public void SourceOpenGenericTypeOf_MakeGenericType_Constructs()
+    {
+        var source = @"
+class Slot[T] {
+    prop Value int32
+}
+
+typeof(Slot[_]).MakeGenericType(typeof(int32)).GetGenericArguments()[0].Name
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("Int32", result.Value);
+    }
+
+    [Fact]
+    public void SourceGenericClass_WrongArityTypeOf_StillReportsUndefinedTypeGS0113()
+    {
+        var source = @"
+class Slot[T] {
+    prop Value int32
+}
+
+class C {
+    func run() {
+        let t = typeof(Slot[_, _])
+    }
+}
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0113");
+    }
+
+    [Fact]
+    public void ConstructedSourceGenericTypeOf_StaysConstructed()
+    {
+        var source = @"
+class Slot[T] {
+    prop Value int32
+}
+
+typeof(Slot[int32]).GetGenericArguments()[0].Name
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("Int32", result.Value);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3683ObliviousCastReceiverForgivenessTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3683ObliviousCastReceiverForgivenessTests.cs
@@ -1,0 +1,116 @@
+// <copyright file="Issue3683ObliviousCastReceiverForgivenessTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3683: a C# reference cast whose operand is nullable on the G# side
+/// lowers to the null-preserving safe cast <c>expr as T</c> (issue #3501),
+/// whose result is <c>T?</c>. When the operand's nullability comes from an
+/// ANNOTATED declaration read by an OBLIVIOUS file — the shape all of
+/// <c>test/Core.Tests</c> has, since the NRT migration was production-only —
+/// Roslyn reports nothing maybe-null at the dereference, so none of the
+/// ordinary forgiveness predicates fire and the emitted
+/// <c>((x as T)).Member</c> was rejected by gsc with GS0158. The receiver now
+/// carries its <c>!!</c>, which is faithful: C# raises a
+/// NullReferenceException at exactly this dereference.
+/// </summary>
+public class Issue3683ObliviousCastReceiverForgivenessTests
+{
+    private const string AnnotatedDeclarations = @"
+#nullable enable
+namespace Demo
+{
+    public class BoundExpression { }
+
+    public class BoundVariableExpression : BoundExpression
+    {
+        public object? Variable { get; set; }
+    }
+
+    public class BoundFieldAccessExpression : BoundExpression
+    {
+        public BoundExpression? Receiver { get; set; }
+    }
+}";
+
+    [Fact]
+    public void ObliviousReadOfAnnotatedReference_CastReceiver_KeepsNullForgiveness()
+    {
+        string printed = TranslateObliviousConsumer(@"
+namespace Demo
+{
+    public class Holder
+    {
+        public object Read(BoundFieldAccessExpression faExpr)
+        {
+            return ((BoundVariableExpression)faExpr.Receiver).Variable;
+        }
+    }
+}");
+
+        Assert.Contains("((faExpr.Receiver as BoundVariableExpression))!!.Variable", printed);
+    }
+
+    [Fact]
+    public void ObliviousReadOfAnnotatedReference_CastReceiverInLoop_KeepsNullForgiveness()
+    {
+        string printed = TranslateObliviousConsumer(@"
+namespace Demo
+{
+    public class Holder
+    {
+        public void Read(BoundFieldAccessExpression[] items)
+        {
+            for (int i = 0; i < items.Length; i++)
+            {
+                var value = ((BoundVariableExpression)items[i].Receiver).Variable;
+            }
+        }
+    }
+}");
+
+        Assert.Contains("as BoundVariableExpression))!!.Variable", printed);
+    }
+
+    [Fact]
+    public void ObliviousReadOfNonNullableReference_Cast_StaysUnforgiven()
+    {
+        string printed = TranslateObliviousConsumer(@"
+namespace Demo
+{
+    public class Holder
+    {
+        public object Read(BoundVariableExpression variableExpr)
+        {
+            return ((BoundVariableExpression)(BoundExpression)variableExpr).Variable;
+        }
+    }
+}");
+
+        // A provably non-null operand keeps the checked-reference-cast form, so
+        // no safe cast and no assertion are introduced.
+        Assert.DoesNotContain("as BoundVariableExpression))!!", printed);
+    }
+
+    private static string TranslateObliviousConsumer(string obliviousSource)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Annotated.cs", AnnotatedDeclarations), ("Oblivious.cs", obliviousSource) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " + string.Join("\n", project.ErrorDiagnostics));
+
+        LoadedDocument document = project.Documents[1];
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -775,6 +775,21 @@ public sealed partial class CSharpToGSharpTranslator
             {
                 translated = EnsureNonNullAssertion(translated);
             }
+            else if (!this.IsWithinExpressionTreeLambda(recv) && this.ReceiverIsNullPreservingSafeCast(recv))
+            {
+                // Issue #3683: a C# reference cast whose operand is nullable on
+                // the G# side lowers to the null-preserving `expr as T`
+                // (issue #3501), whose result is `T?`. When the operand's
+                // nullability comes from an ANNOTATED declaration read by an
+                // OBLIVIOUS file — `((BoundVariableExpression)faExpr.Receiver)`
+                // in a `#nullable disable` test over an annotated
+                // `BoundExpression? Receiver` — Roslyn reports nothing
+                // maybe-null at this site, so none of the predicates above
+                // fire and the dereference of the `T?` was left un-forgiven
+                // (gsc GS0158 / GS0116). Asserting here is faithful: C# would
+                // raise a NullReferenceException at this same dereference.
+                translated = EnsureNonNullAssertion(translated);
+            }
             else if (!this.IsWithinExpressionTreeLambda(recv) && this.IsLocalBoundFromAsExpression(recv))
             {
                 // ADR-0160: a local bound from a C# `as` (`var p = o as object[];`)
@@ -794,6 +809,23 @@ public sealed partial class CSharpToGSharpTranslator
             }
 
             return ParenthesizeIfBareNumericLiteral(translated);
+        }
+
+        // Issue #3683: true when `recv` is (possibly parenthesized) a C# reference
+        // cast that TranslateCast lowers to the null-preserving safe cast
+        // `expr as T` (issue #3501), so the receiver's G# type is `T?`. See the
+        // dereference assertion in
+        // <see cref="TranslateReceiverWithNullForgiveness"/>.
+        private bool ReceiverIsNullPreservingSafeCast(ExpressionSyntax recv)
+        {
+            ExpressionSyntax unwrapped = recv;
+            while (unwrapped is ParenthesizedExpressionSyntax parenthesized)
+            {
+                unwrapped = parenthesized.Expression;
+            }
+
+            return unwrapped is CastExpressionSyntax cast
+                && this.CastLowersToNullPreservingSafeCast(cast);
         }
 
         private bool ImportedGenericTupleElementRequiresAssertion(ExpressionSyntax receiver)


### PR DESCRIPTION
Fixes #3678. Part of #3683 (family F6 only). Triage for the whole wall is on #3501: https://github.com/DavidObando/gsharp/issues/3501#issuecomment-5469492729

Migrated `test/Core.Tests` failed with 94 compile errors across 18 diagnostic ids. Grouping them by ROOT CAUSE gives 18 families; this PR fixes the largest (31 errors) and one small one (5 errors).

## gsc — `typeof` of an open generic declared in this compilation (#3678)

Two stacked defects.

**Binder.** The explicit-arity open-generic spelling from #1989 (`typeof(Func[_, _])`, G#'s analogue of C#'s comma-count `Name<,>`) resolves through `TryResolveOpenGenericImportedTypeWithArity` / `scope.References.TryResolveType` — both walk the reference set only, so a source-declared generic was never considered:

```gs
class Slot[T] { prop Value int32 }

func A() Type -> typeof(List[_])   // OK — imported
func B() Type -> typeof(Slot[_])   // was: GS0113 Type 'Slot`1' doesn't exist.
```

The bare #1915 spelling `typeof(Slot)` binds because it falls through to `bindTypeClause`, so the arity-bearing form — the only one available when a base name is shared by several arities — was strictly weaker than the bare one. `BindTypeOfExpression` now consults the declaration table **last**, after both imported walks, so an imported match still wins exactly as before and the ambiguity/undefined diagnostics are unchanged.

**Emitter.** Independently, `GetTypeOfToken` forwarded to `GetElementTypeToken`, whose `StructSymbol`/`InterfaceSymbol` branches send anything with type parameters down the generic-*reference* TypeSpec path (`IsUserGenericTypeReference` returns true for a definition — it only checks `TypeParameters`). That encodes `Slot<!0>`, a TypeSpec naming a VAR slot with no binding in that scope. The assembly compiled and then died at run time:

```
Unhandled exception. System.BadImageFormatException: An attempt was made to load a program
with an incorrect format. (0x8007000B)
   at Demo.<Program>.Main()
```

This half reproduces on `main` today through the already-working bare spelling `typeof(Slot).FullName`, so it was a live correctness bug, not only a migration blocker. `ldtoken` of a definition now takes its TypeDef row.

The eight new tests **execute** the emitted program (`EmittedOracle.Evaluate` invokes the entry point), so a metadata regression fails as loudly as a binder one — `typeof(Slot[_]).IsGenericTypeDefinition`, `.MakeGenericType(typeof(int32))`, arity selection, and the wrong-arity GS0113 are all covered.

## cs2gs — cast receiver in an oblivious file reading an annotated declaration (#3683, F6 only)

A C# reference cast whose operand is nullable on the G# side lowers to the null-preserving safe cast `expr as T` (#3501), whose result is `T?`. When the operand's nullability comes from an **annotated declaration read by an oblivious file** — the shape all of `test/Core.Tests` has, since the NRT migration was production-only — Roslyn reports nothing maybe-null at the dereference, so none of the existing forgiveness predicates fire:

```csharp
// Oblivious.cs, over an annotated `BoundExpression? Receiver`
Assert.Same(tempDecl.Variable, ((BoundVariableExpression)faExpr.Receiver).Variable);
```
```gs
// before — gsc GS0158 Cannot find member Variable
Assert.Same(tempDecl.Variable, ((faExpr.Receiver as BoundVariableExpression)).Variable)
// after
Assert.Same(tempDecl.Variable, ((faExpr.Receiver as BoundVariableExpression))!!.Variable)
```

`TranslateReceiverWithNullForgiveness` now recognises the shape directly, next to the existing ADR-0160 `as`-bound-local branch. Asserting here is faithful: C# raises a `NullReferenceException` at this same dereference, and `!!` raises at exactly the same point. Both nullable contexts are covered by the new tests, including the negative case (a provably non-null operand keeps `cast[T](…)` and gains no assertion).

Family F5 of #3683 — the same missing `!!` on a nullable **call result** (`mapped!!.GetElementType().Assembly`) — is NOT fixed here and stays open on that issue.

## Verification

- `dotnet build GSharp.sln -c Release -graph`, then a full repository translate + `cs2gs validate --app test/Core.Tests/Core.Tests.csproj` against the freshly packed SDK.
- Migrated `test/Core.Tests` compile errors **94 → 72**, verified end to end. `GS0113` 16 → 6, `GS0159` 36 → 25, `GS0130` 1 → 0. No diagnostic id increased and no new id appeared. The 22 removed are exactly the unqualified `typeof(X[_])` family plus its cascades; the 6 remaining GS0113 are the qualified/nested spellings (#3677) and one dropped `Fixtures.` qualifier (#3684). The cs2gs half lands at the next translate.
- `test/Core.Tests` — new `Issue3678SourceOpenGenericTypeOfTests` (8) green, plus the existing `Issue1915OpenGenericTypeOfBindingTests` and `Issue1989MultiArityOpenGenericTypeOfBindingTests` (14) still green.
- `tools/cs2gs/Cs2Gs.Tests` — new `Issue3683ObliviousCastReceiverForgivenessTests` (3) green, plus a 494-test nullable / cast / forgiveness / oblivious / `!!` regression subset, all green.

Remaining families from the triage are filed as #3677, #3679, #3681, #3682, #3683 and #3684.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
