### PR TITLE
cs2gs: rewrite nested-build project paths in the migrated project

### DIFF
--- a/tools/cs2gs/Cs2Gs.Pipeline/GSharpProjectTransformer.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/GSharpProjectTransformer.cs
@@ -78,6 +78,12 @@ internal static class GSharpProjectTransformer
             sourceProjectDirectory,
             fullDestinationDirectory,
             generatedProjectPaths);
+        RewriteNestedProjectPaths(
+            document,
+            sourceProjectDirectory,
+            fullDestinationDirectory,
+            generatedProjectPaths);
+        RewriteGeneratePackageOnBuild(document);
         RewriteOutputType(document);
         RewriteCompileItems(document);
         RewriteCSharpMetadata(document);
@@ -211,6 +217,202 @@ internal static class GSharpProjectTransformer
                     destinationProjectDirectory,
                     Path.GetFullPath(generatedProjectPath))
                 .Replace('\\', '/');
+        }
+    }
+
+    // Issue #3674: a project can name sibling projects outside
+    // ProjectReference — the <MSBuild Projects="…"/> task and the
+    // PropertyGroup properties that feed it (this repo's own
+    // Gsharp.NET.Sdk.csproj does both in its Pack* targets). Those specs are
+    // relative to the SOURCE repository, so in a mirror they resolve to a
+    // project that is either absent or present only as .gsproj, and the
+    // nested build dies with MSB3202 for a reason unrelated to translation.
+    //
+    // The rewrite is deliberately narrow: a spec is redirected to its
+    // generated counterpart only when it resolves to a project that is in
+    // the migration set. Anything else is left verbatim. In particular an
+    // unmapped project (excluded from the run, or simply outside it) is NOT
+    // re-anchored at the real repository: doing so would make a mirror build
+    // write into the source tree's obj/bin and would compile unmigrated C#
+    // inside a run whose whole purpose is to exercise migrated code.
+    private static void RewriteNestedProjectPaths(
+        XDocument document,
+        string sourceProjectDirectory,
+        string destinationProjectDirectory,
+        IReadOnlyDictionary<string, string> generatedProjectPaths)
+    {
+        if (generatedProjectPaths is null || generatedProjectPaths.Count == 0)
+        {
+            return;
+        }
+
+        foreach (XElement task in ElementsNamed(document, "MSBuild"))
+        {
+            XAttribute projects = AttributeNamed(task, "Projects");
+            if (projects is null || string.IsNullOrWhiteSpace(projects.Value))
+            {
+                continue;
+            }
+
+            string rewritten = RewriteProjectPathList(
+                projects.Value,
+                sourceProjectDirectory,
+                destinationProjectDirectory,
+                generatedProjectPaths);
+            if (!string.Equals(rewritten, projects.Value, StringComparison.Ordinal))
+            {
+                projects.Value = rewritten;
+            }
+        }
+
+        foreach (XElement propertyGroup in ElementsNamed(document, "PropertyGroup"))
+        {
+            foreach (XElement property in propertyGroup.Elements())
+            {
+                if (property.HasElements)
+                {
+                    continue;
+                }
+
+                string rewritten = RewriteProjectPathList(
+                    property.Value,
+                    sourceProjectDirectory,
+                    destinationProjectDirectory,
+                    generatedProjectPaths);
+                if (!string.Equals(rewritten, property.Value, StringComparison.Ordinal))
+                {
+                    property.Value = rewritten;
+                }
+            }
+        }
+    }
+
+    private static string RewriteProjectPathList(
+        string value,
+        string sourceProjectDirectory,
+        string destinationProjectDirectory,
+        IReadOnlyDictionary<string, string> generatedProjectPaths)
+    {
+        if (value.IndexOf(".csproj", StringComparison.OrdinalIgnoreCase) < 0)
+        {
+            return value;
+        }
+
+        string[] specs = value.Split(';');
+        bool changed = false;
+        for (int i = 0; i < specs.Length; i++)
+        {
+            if (TryMapProjectPathSpec(
+                specs[i],
+                sourceProjectDirectory,
+                destinationProjectDirectory,
+                generatedProjectPaths,
+                out string mapped))
+            {
+                specs[i] = mapped;
+                changed = true;
+            }
+        }
+
+        return changed ? string.Join(";", specs) : value;
+    }
+
+    // Maps one path spec to its generated counterpart, preserving the leading
+    // MSBuild directory expression (the only two that can be expanded without
+    // evaluating the project) and any surrounding whitespace. Returns false —
+    // leaving the spec untouched — for anything that cannot be resolved
+    // statically or that is not part of the migration set.
+    private static bool TryMapProjectPathSpec(
+        string spec,
+        string sourceProjectDirectory,
+        string destinationProjectDirectory,
+        IReadOnlyDictionary<string, string> generatedProjectPaths,
+        out string mapped)
+    {
+        mapped = null;
+        string value = spec.Trim();
+        if (value.Length == 0 || !value.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        int start = 0;
+        while (char.IsWhiteSpace(spec[start]))
+        {
+            start++;
+        }
+
+        string leading = spec.Substring(0, start);
+        string trailing = spec.Substring(start + value.Length);
+
+        string prefix = string.Empty;
+        string remainder = value;
+        if (value.StartsWith("$(", StringComparison.Ordinal))
+        {
+            int close = value.IndexOf(')');
+            if (close < 0)
+            {
+                return false;
+            }
+
+            prefix = value.Substring(0, close + 1);
+            if (!IsAnchorExpression(prefix))
+            {
+                return false;
+            }
+
+            remainder = value.Substring(close + 1).TrimStart('/', '\\');
+        }
+
+        // Anything still holding an unexpanded expression or a wildcard
+        // cannot be resolved to a single project path here.
+        if (remainder.Length == 0
+            || remainder.Contains("$(", StringComparison.Ordinal)
+            || remainder.Contains("@(", StringComparison.Ordinal)
+            || remainder.Contains('*'))
+        {
+            return false;
+        }
+
+        string sourceReferencePath = Path.GetFullPath(
+            Path.Combine(sourceProjectDirectory, NormalizeDirectorySeparators(remainder)));
+        if (!generatedProjectPaths.TryGetValue(sourceReferencePath, out string generatedProjectPath))
+        {
+            return false;
+        }
+
+        string relative = Path.GetRelativePath(
+                destinationProjectDirectory,
+                Path.GetFullPath(generatedProjectPath))
+            .Replace('\\', '/');
+
+        // $(MSBuildThisFileDirectory) already expands with a trailing
+        // separator; $(MSBuildProjectDirectory) does not.
+        string separator = prefix.Equals("$(MSBuildProjectDirectory)", StringComparison.OrdinalIgnoreCase)
+            ? "/"
+            : string.Empty;
+        mapped = leading + prefix + separator + relative + trailing;
+        return true;
+    }
+
+    private static bool IsAnchorExpression(string expression) =>
+        expression.Equals("$(MSBuildThisFileDirectory)", StringComparison.OrdinalIgnoreCase)
+        || expression.Equals("$(MSBuildProjectDirectory)", StringComparison.OrdinalIgnoreCase);
+
+    // Issue #3674, the other half of the MSB3202 story: packaging is
+    // repository infrastructure a mirror cannot reproduce. Pack targets reach
+    // for projects outside the migration set and for repository assets
+    // (READMEs, icons, prebuilt output directories) that the mirror does not
+    // carry, and a mirrored build has no reason to produce a NuGet package at
+    // all. Neutralize pack-on-build in the emitted project so the mirror is
+    // self-consistent for anyone building it directly — the compile stage
+    // additionally passes the same property globally
+    // (SdkCompileRunner.BuildMirroredBuildArguments).
+    private static void RewriteGeneratePackageOnBuild(XDocument document)
+    {
+        foreach (XElement generatePackageOnBuild in ElementsNamed(document, "GeneratePackageOnBuild"))
+        {
+            generatePackageOnBuild.Value = "false";
         }
     }
 

--- a/tools/cs2gs/Cs2Gs.Pipeline/SdkCompileRunner.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/SdkCompileRunner.cs
@@ -1041,6 +1041,14 @@ public sealed class SdkCompileRunner
     /// project) or exist only as <c>.gsproj</c>, failing the build with MSB3202
     /// for a reason that has nothing to do with the translation. The property is
     /// global, so it also applies to every project reference in the graph.
+    /// <para>
+    /// Issue #3674 taught <see cref="GSharpProjectTransformer"/> to redirect
+    /// those literal paths at their migrated counterparts, but the suppression
+    /// stays: paths outside the migration set stay dangling by design, pack
+    /// targets also consume repository assets a partial mirror does not carry
+    /// (READMEs, icons, prebuilt output directories), and a mirror has no
+    /// reason to spend a compiler publish on producing a NuGet package.
+    /// </para>
     /// </summary>
     /// <param name="generatedProjectPath">The mirrored G# project to build.</param>
     /// <param name="artifactDirectory">The external build and log directory.</param>

--- a/tools/cs2gs/Cs2Gs.Tests/GSharpProjectTransformerTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/GSharpProjectTransformerTests.cs
@@ -196,6 +196,155 @@ public sealed class GSharpProjectTransformerTests
         }
     }
 
+    // Issue #3674: the Pack* targets of this repo's own Gsharp.NET.Sdk.csproj
+    // drive nested builds through <MSBuild Projects="…"/> and through
+    // PropertyGroup properties holding project paths. Both shapes must follow
+    // the migration set or the mirrored build fails with MSB3202.
+    [Fact]
+    public void Transform_RewritesNestedBuildProjectPathsForMigratedProjects()
+    {
+        using var scratch = new ScratchDirectory();
+        string sourceProject = Path.Combine(scratch.Path, "source", "Sdk", "Sdk.csproj");
+        string sourceCompiler = Path.Combine(scratch.Path, "source", "Compiler", "Compiler.csproj");
+        string sourceTool = Path.Combine(scratch.Path, "source", "tools", "Gsgen", "Gsgen.csproj");
+        string destinationDirectory = Path.Combine(scratch.Path, "generated", "Sdk");
+        string generatedCompiler = Path.Combine(scratch.Path, "generated", "Compiler", "Compiler.gsproj");
+        string generatedTool = Path.Combine(scratch.Path, "generated", "tools", "Gsgen", "Gsgen.gsproj");
+        Directory.CreateDirectory(Path.GetDirectoryName(sourceProject));
+        Directory.CreateDirectory(destinationDirectory);
+        File.WriteAllText(
+            sourceProject,
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <_CompilerProject>$(MSBuildThisFileDirectory)..\Compiler\Compiler.csproj</_CompilerProject>
+                <_ExtensionsProject>$(MSBuildThisFileDirectory)..\Extensions\Extensions.csproj</_ExtensionsProject>
+                <_ToolProject>$(MSBuildProjectDirectory)\..\tools\Gsgen\Gsgen.csproj</_ToolProject>
+                <_Unrelated>net10.0</_Unrelated>
+              </PropertyGroup>
+              <Target Name="PackEverything">
+                <MSBuild Projects="$(MSBuildThisFileDirectory)..\Compiler\Compiler.csproj" Targets="Publish" />
+                <MSBuild Projects="..\tools\Gsgen\Gsgen.csproj; ..\Extensions\Extensions.csproj" Targets="Build" />
+                <MSBuild Projects="$(_CompilerProject)" Targets="Build" />
+              </Target>
+            </Project>
+            """);
+
+        XDocument transformed = GSharpProjectTransformer.Transform(
+            sourceProject,
+            destinationDirectory,
+            "Gsharp.NET.Sdk/1.0.0",
+            new Dictionary<string, string>
+            {
+                [Path.GetFullPath(sourceCompiler)] = generatedCompiler,
+                [Path.GetFullPath(sourceTool)] = generatedTool,
+            });
+
+        Assert.Equal(
+            "$(MSBuildThisFileDirectory)../Compiler/Compiler.gsproj",
+            SingleElement(transformed, "_CompilerProject").Value);
+        Assert.Equal(
+            "$(MSBuildProjectDirectory)/../tools/Gsgen/Gsgen.gsproj",
+            SingleElement(transformed, "_ToolProject").Value);
+
+        // Not in the migration set: left verbatim rather than re-anchored at
+        // the source repository.
+        Assert.Equal(
+            "$(MSBuildThisFileDirectory)..\\Extensions\\Extensions.csproj",
+            SingleElement(transformed, "_ExtensionsProject").Value);
+        Assert.Equal("net10.0", SingleElement(transformed, "_Unrelated").Value);
+
+        XElement[] nestedBuilds = ElementsNamed(transformed, "MSBuild").ToArray();
+        Assert.Equal(
+            "$(MSBuildThisFileDirectory)../Compiler/Compiler.gsproj",
+            nestedBuilds[0].Attribute("Projects")?.Value);
+        Assert.Equal("Publish", nestedBuilds[0].Attribute("Targets")?.Value);
+        Assert.Equal(
+            "../tools/Gsgen/Gsgen.gsproj; ..\\Extensions\\Extensions.csproj",
+            nestedBuilds[1].Attribute("Projects")?.Value);
+
+        // The property it names was rewritten, so the indirection needs no edit.
+        Assert.Equal("$(_CompilerProject)", nestedBuilds[2].Attribute("Projects")?.Value);
+    }
+
+    [Fact]
+    public void Transform_TurnsOffPackOnBuild()
+    {
+        using var scratch = new ScratchDirectory();
+        string sourceProject = Path.Combine(scratch.Path, "Sdk.csproj");
+        File.WriteAllText(
+            sourceProject,
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+                <IsPackable>true</IsPackable>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        XDocument transformed = GSharpProjectTransformer.Transform(
+            sourceProject,
+            scratch.Path,
+            "Gsharp.NET.Sdk/1.0.0",
+            new Dictionary<string, string>());
+
+        Assert.Equal("false", SingleElement(transformed, "GeneratePackageOnBuild").Value);
+        Assert.Equal("true", SingleElement(transformed, "IsPackable").Value);
+    }
+
+    [Fact]
+    public void Transform_LeavesUnresolvableNestedBuildProjectPathsUntouched()
+    {
+        using var scratch = new ScratchDirectory();
+        string sourceProject = Path.Combine(scratch.Path, "source", "Sdk", "Sdk.csproj");
+        string sourceCompiler = Path.Combine(scratch.Path, "source", "Compiler", "Compiler.csproj");
+        string destinationDirectory = Path.Combine(scratch.Path, "generated", "Sdk");
+        Directory.CreateDirectory(Path.GetDirectoryName(sourceProject));
+        Directory.CreateDirectory(destinationDirectory);
+        File.WriteAllText(
+            sourceProject,
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <_FromUnknownRoot>$(RepoRoot)Compiler\Compiler.csproj</_FromUnknownRoot>
+                <_ThroughProperty>$(MSBuildThisFileDirectory)..\$(Leaf)\Compiler.csproj</_ThroughProperty>
+                <_Glob>$(MSBuildThisFileDirectory)..\**\*.csproj</_Glob>
+                <_NotAProject>$(MSBuildThisFileDirectory)..\Compiler\Compiler.props</_NotAProject>
+              </PropertyGroup>
+              <Target Name="Pack">
+                <MSBuild Projects="@(CompilerProjects)" Targets="Build" />
+              </Target>
+            </Project>
+            """);
+
+        XDocument transformed = GSharpProjectTransformer.Transform(
+            sourceProject,
+            destinationDirectory,
+            "Gsharp.NET.Sdk/1.0.0",
+            new Dictionary<string, string>
+            {
+                [Path.GetFullPath(sourceCompiler)] =
+                    Path.Combine(scratch.Path, "generated", "Compiler", "Compiler.gsproj"),
+            });
+
+        Assert.Equal(
+            "$(RepoRoot)Compiler\\Compiler.csproj",
+            SingleElement(transformed, "_FromUnknownRoot").Value);
+        Assert.Equal(
+            "$(MSBuildThisFileDirectory)..\\$(Leaf)\\Compiler.csproj",
+            SingleElement(transformed, "_ThroughProperty").Value);
+        Assert.Equal(
+            "$(MSBuildThisFileDirectory)..\\**\\*.csproj",
+            SingleElement(transformed, "_Glob").Value);
+        Assert.Equal(
+            "$(MSBuildThisFileDirectory)..\\Compiler\\Compiler.props",
+            SingleElement(transformed, "_NotAProject").Value);
+        Assert.Equal(
+            "@(CompilerProjects)",
+            SingleElement(transformed, "MSBuild").Attribute("Projects")?.Value);
+    }
+
     [Fact]
     public void Transform_PropagatesMalformedXmlException()
     {


### PR DESCRIPTION
Fixes #3674.

## The gap

`GSharpProjectTransformer` mapped `ProjectReference/@Include` through the source→generated project map and nothing else. A project that drives a **nested** build names its targets some other way, and those names survived verbatim into the emitted `.gsproj`. This repo's own `src/Sdk/Gsharp.NET.Sdk/Gsharp.NET.Sdk.csproj` does both shapes in its `Pack*` targets:

```xml
<MSBuild Projects="$(MSBuildThisFileDirectory)..\..\Compiler\Compiler.csproj" Targets="Publish" />
<_GsharpCompilerProject>$(MSBuildThisFileDirectory)..\..\Compiler\Compiler.csproj</_GsharpCompilerProject>
```

In a partial mirror those siblings are absent or exist only as `.gsproj`, so the nested `<MSBuild>` died with `MSB3202` — the wall #3672 diagnosed for four apps. #3675 unblocked the gate by not packing during the mirrored compile; this PR is the durable fix.

## The rewrite rules, and why these ones

**1. Redirect what the migration set owns.** `<MSBuild Projects="…">` attributes and `PropertyGroup` property values whose spec resolves to a project in `generatedProjectPaths` are rewritten to the destination-relative generated `.gsproj`. The leading MSBuild anchor is preserved rather than flattened — `$(MSBuildThisFileDirectory)` (expands with a trailing separator) and `$(MSBuildProjectDirectory)` (does not) are the only two expressions that can be expanded without evaluating the project, and in the mirrored project they hold the same relationship to the file as in the source. `;`-lists are handled per-spec, so a mixed list keeps its unmapped neighbours untouched.

**2. Leave everything else verbatim — do NOT re-anchor at the real repository.** A spec is skipped when it cannot be resolved statically (unknown property root, embedded `$(…)`/`@(…)`, a wildcard, a bare `@(item)` list, a non-`.csproj` value) or when it resolves outside the migration set. The tempting alternative — pointing unmapped paths back at the source repo so they at least resolve — is wrong twice over: a mirrored build would write into the real repository's `obj`/`bin` (racing the gate's own build) and would compile **unmigrated C#** inside a run whose entire purpose is to exercise migrated code. It is also exactly the contract `RewriteProjectReferences` has always honoured for excluded projects, so the two paths now agree. A `<MSBuild Projects="$(_SomeProject)">` indirection needs no edit at all once the property that defines it is rewritten.

**3. Neutralize packaging in the emitted project.** `<GeneratePackageOnBuild>` is forced to `false`. Packaging is repository infrastructure a mirror structurally cannot reproduce: the pack targets consume `--exclude`d projects (`Gsharp.Extensions`), repo assets (`assets/PACKAGE_README.md`, `assets/gsharp-icon.png`), and prebuilt output directories the mirror does not carry — and a mirror has no reason to spend a compiler publish on a NuGet package. `<IsPackable>` is left alone; only pack-*on-build* is disarmed.

## The suppression stays

`-p:GeneratePackageOnBuild=false` in `SdkCompileRunner.BuildMirroredBuildArguments` (#3675) is kept, and the reason is now documented next to it. Rule 3 makes the emitted tree self-consistent for anyone building it by hand; the global property additionally covers every project in the graph, including any that grows a pack-on-build in future. The rewrite is still worth doing on its own: the suppression only disarms *packaging*, while rule 1 fixes any migrated project that drives a nested build from a non-pack target — which is precisely the case #3674 was filed for.

Out of scope, noted in #3674 and unchanged here: the copied `build/gsharp.props` hard-codes repo `.csproj` paths and emits `warning : Gsharp project does not exist` noise. That is a mirrored *props* file, not a transformed project, and it warns rather than fails.

## Verification

- `dotnet build GSharp.sln -c Release -graph` — clean (the packed-SDK-nupkg trap).
- `dotnet test tools/cs2gs/Cs2Gs.Tests --filter GSharpProjectTransformerTests|Adr0169AnalyzerProjectTransformTests|MigrationPipelineTests|SdkCompileRunnerTests` — 66/66 pass, including three new transformer tests: one per rewrite class, one asserting every unresolvable/unmapped shape is byte-identical after transform.
- End-to-end `build/run-cs2gs-selfmig-migrate.sh` (whole repo, real `--exclude` set). The emitted `src/Sdk/Gsharp.NET.Sdk/Gsharp.NET.Sdk.gsproj` now reads:

```xml
<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
<MSBuild Projects="$(MSBuildThisFileDirectory)../../Compiler/Compiler.gsproj" Targets="Publish" … />
<MSBuild Projects="$(MSBuildThisFileDirectory)../../../tools/gsgen/Gsgen.Cli/Gsgen.Cli.gsproj" Targets="Publish" … />
<_GsharpCompilerProject>$(MSBuildThisFileDirectory)../../Compiler/Compiler.gsproj</_GsharpCompilerProject>
```

  Both rewritten targets exist in the mirror. A tree-wide scan of every emitted `.gsproj` finds exactly one residual project-path class — `src/Sdk/Gsharp.Extensions`, which is `--exclude`d, so it is unmapped by design and is why rules 2 and 3 must coexist.
- Translate result unchanged at 50/51 apps; the single `FAIL(1)` is `test/Interpreter.Tests` on a pre-existing `translation-unsupported` gap, not a project-file issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
