### PR TITLE
gsc: friend assemblies can call a referenced assembly's internal methods (#3679)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -3446,8 +3446,18 @@ internal sealed partial class ExpressionBinder
         var instSymbolicArgs = MemberLookup.BuildSymbolicArgTypeVector(
             receiverType: null,
             ImmutableArray.CreateRange(arguments.Select(a => a.Type)));
+
+        // Issue #3679: an `internal` instance method of a referenced assembly
+        // that named this compilation in an `InternalsVisibleTo` is a legal
+        // candidate — the msbuild `<InternalsVisibleTo>` item the SDK turns
+        // into that attribute is how every migrated test app reaches the
+        // internals of the project under test.
+        var receiverGrantsInternals = scope.References.CanAccessInternalMembers(clrType.Assembly);
         var candidates = MemberLookup.ExcludeErasureOnlyEnumCandidates(
-            MemberLookup.SafeGetMethodsIncludingSelfAndInterfaces(clrType, methodName),
+            MemberLookup.SafeGetMethodsIncludingSelfAndInterfaces(
+                clrType,
+                methodName,
+                includeInternal: receiverGrantsInternals),
             instSymbolicArgs,
             argumentNames.IsDefault ? null : (IReadOnlyList<string>)argumentNames,
             effectiveReceiverType).ToList();

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -44,11 +44,19 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// </remarks>
 internal sealed class MemberLookup
 {
+    /// <summary>
+    /// Issue #3679: distinguishes the internal-inclusive candidate set from the
+    /// public-only one inside <see cref="methodsIncludingSelfAndInterfacesCache"/>.
+    /// A NUL is not a legal metadata method name, so no probed name can collide
+    /// with a suffixed key.
+    /// </summary>
+    private const string InternalCandidatesCacheKeySuffix = "\0internal";
+
     private static readonly ConditionalWeakTable<MethodInfo, MethodInfo> OpenMethodsByMappedMethod = new();
     private readonly BinderContext binderCtx;
 
     /// <summary>
-    /// Process-wide memoization backing <see cref="SafeGetMethodsIncludingSelfAndInterfaces"/>,
+    /// Process-wide memoization backing <see cref="SafeGetMethodsIncludingSelfAndInterfaces(Type, string, bool)"/>,
     /// keyed on the CLR <see cref="Type"/> plus the probed method name.
     /// Cleared via <see cref="ClearCache"/> (wired into
     /// <see cref="ReferenceResolver.Dispose"/>) so entries keyed on a disposed
@@ -259,6 +267,36 @@ internal sealed class MemberLookup
     /// <param name="name">The method name to match.</param>
     /// <returns>The candidate list with self-slot methods first.</returns>
     public static IReadOnlyList<MethodInfo> SafeGetMethodsIncludingSelfAndInterfaces(Type clrType, string name)
+        => SafeGetMethodsIncludingSelfAndInterfaces(clrType, name, includeInternal: false);
+
+    /// <summary>
+    /// Issue #3679: the <paramref name="includeInternal"/> variant of
+    /// <see cref="SafeGetMethodsIncludingSelfAndInterfaces(Type, string)"/>,
+    /// which also surfaces <c>internal</c> (metadata <c>assembly</c>) instance
+    /// methods declared by <paramref name="clrType"/> or its base chain.
+    /// Callers pass <see langword="true"/> only when the declaring assembly
+    /// grants this compilation internal access — i.e. when
+    /// <see cref="ReferenceResolver.CanAccessInternalMembers"/> says so for an
+    /// <c>InternalsVisibleTo</c> friend — mirroring the property/field probes
+    /// in <c>ExpressionBinder.Access.MemberLookup</c>, which already widen to
+    /// <see cref="BindingFlags.NonPublic"/> under that same condition. Without
+    /// it a friend assembly could reach a referenced assembly's internal
+    /// fields and properties but never its internal methods.
+    /// <para>
+    /// The result is cached under a distinct key so the public-only and
+    /// internal-inclusive candidate sets never overwrite one another. Neither
+    /// set depends on WHICH consumer is asking — only on the members' declared
+    /// accessibility — so the process-wide cache stays consumer-independent.
+    /// </para>
+    /// </summary>
+    /// <param name="clrType">The CLR type (concrete class or interface) to probe.</param>
+    /// <param name="name">The method name to match.</param>
+    /// <param name="includeInternal">Whether to also return <c>internal</c> instance methods.</param>
+    /// <returns>The candidate list with self-slot methods first.</returns>
+    public static IReadOnlyList<MethodInfo> SafeGetMethodsIncludingSelfAndInterfaces(
+        Type clrType,
+        string name,
+        bool includeInternal)
     {
         static Type? GetBaseTypeSafe(Type type)
         {
@@ -289,8 +327,11 @@ internal sealed class MemberLookup
         // ClrTypeUtilities.ClearCache() clearing the caches it reads from.
         return methodsIncludingSelfAndInterfacesCache
             .GetValue(clrType, static _ => new System.Collections.Concurrent.ConcurrentDictionary<string, IReadOnlyList<MethodInfo>>(StringComparer.Ordinal))
-            .GetOrAdd(name, n =>
+            .GetOrAdd(includeInternal ? name + InternalCandidatesCacheKeySuffix : name, _ =>
         {
+            // The cache key may carry the internal-inclusive suffix; the probe
+            // itself always matches on the bare method name.
+            var n = name;
             var selfMethods = ClrTypeUtilities.SafeGetMethods(clrType, BindingFlags.Public | BindingFlags.Instance);
             var result = new List<MethodInfo>();
             foreach (var m in selfMethods)
@@ -311,6 +352,27 @@ internal sealed class MemberLookup
                     BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
                 {
                     if (ClrTypeUtilities.EmittedMemberNameMatches(m, n)
+                        && !IsMethodHiddenByExisting(result, m))
+                    {
+                        result.Add(m);
+                    }
+                }
+
+                // Issue #3679: an `internal` instance method of a friend
+                // assembly is a legal candidate. Only `assembly` accessibility
+                // is admitted — `private`/`protected`/`private protected`
+                // members stay invisible however the friendship is declared.
+                if (!includeInternal)
+                {
+                    continue;
+                }
+
+                foreach (var m in ClrTypeUtilities.SafeGetMethods(
+                    current,
+                    BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+                {
+                    if (m.IsAssembly
+                        && ClrTypeUtilities.EmittedMemberNameMatches(m, n)
                         && !IsMethodHiddenByExisting(result, m))
                     {
                         result.Add(m);
@@ -3495,11 +3557,22 @@ internal sealed class MemberLookup
         if (staticClassType != null)
         {
             var statics = new List<MethodInfo>();
-            foreach (var method in ClrTypeUtilities.SafeGetMethods(
-                         staticClassType,
-                         BindingFlags.Static | BindingFlags.Public))
+
+            // Issue #3679: widen to the `internal` statics as well when the
+            // declaring assembly named this compilation in an
+            // `InternalsVisibleTo`; only `assembly` accessibility is admitted.
+            var staticFlags = BindingFlags.Static | BindingFlags.Public;
+            var staticsIncludeInternal =
+                this.binderCtx.References.CanAccessInternalMembers(staticClassType.Assembly);
+            if (staticsIncludeInternal)
             {
-                if (ClrTypeUtilities.EmittedMemberNameMatches(method, methodName))
+                staticFlags |= BindingFlags.NonPublic;
+            }
+
+            foreach (var method in ClrTypeUtilities.SafeGetMethods(staticClassType, staticFlags))
+            {
+                if ((method.IsPublic || (staticsIncludeInternal && method.IsAssembly))
+                    && ClrTypeUtilities.EmittedMemberNameMatches(method, methodName))
                 {
                     statics.Add(method);
                 }
@@ -3515,7 +3588,13 @@ internal sealed class MemberLookup
 
         if (receiverClrType != null)
         {
-            var instance = new List<MethodInfo>(SafeGetMethodsIncludingSelfAndInterfaces(receiverClrType, methodName));
+            // Issue #3679: friend-visible `internal` instance methods are
+            // candidates here too, exactly as they are on the final CLR
+            // instance-call path.
+            var instance = new List<MethodInfo>(SafeGetMethodsIncludingSelfAndInterfaces(
+                receiverClrType,
+                methodName,
+                includeInternal: this.binderCtx.References.CanAccessInternalMembers(receiverClrType.Assembly)));
             if (instance.Count > 0)
             {
                 result.Add(new ImportedMethodProbe(instance, receiverParameterOffset: 0));

--- a/test/Compiler.Tests/ResourceLeakRegressionTests.cs
+++ b/test/Compiler.Tests/ResourceLeakRegressionTests.cs
@@ -134,7 +134,15 @@ public class ResourceLeakRegressionTests
     private static object InvokeMemberLookupCache(Type type)
     {
         var memberLookup = typeof(ReferenceResolver).Assembly.GetType("GSharp.Core.CodeAnalysis.Binding.MemberLookup");
-        var method = memberLookup?.GetMethod("SafeGetMethodsIncludingSelfAndInterfaces", BindingFlags.Public | BindingFlags.Static);
+
+        // Issue #3679 added an `includeInternal` overload, so the probe must
+        // name the parameter types instead of matching on the name alone.
+        var method = memberLookup?.GetMethod(
+            "SafeGetMethodsIncludingSelfAndInterfaces",
+            BindingFlags.Public | BindingFlags.Static,
+            binder: null,
+            new[] { typeof(Type), typeof(string) },
+            modifiers: null);
         return method?.Invoke(null, new object[] { type, "ToString" });
     }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3679InternalsVisibleToMemberAccessTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3679InternalsVisibleToMemberAccessTests.cs
@@ -1,0 +1,318 @@
+// <copyright file="Issue3679InternalsVisibleToMemberAccessTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Text;
+using GsCompilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
+using GsSyntaxTree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #3679: a friend assembly must reach the <c>internal</c> METHODS of a
+/// referenced assembly, not just its internal fields and properties.
+/// <para>
+/// The .NET SDK turns every <c>&lt;InternalsVisibleTo Include="X" /&gt;</c>
+/// msbuild item into an <c>@(AssemblyAttribute)</c> item, which
+/// <c>Gsharp.NET.Sdk</c>'s <c>WriteGsharpAssemblyInfoTask</c> renders as the
+/// file-level annotation <c>@assembly: System.Runtime.CompilerServices.InternalsVisibleTo("X")</c>
+/// and the emitter writes as a real <c>InternalsVisibleToAttribute</c> row. All
+/// of that already worked; what did not was the consumer side. The CLR
+/// instance-call candidate walk
+/// (<c>MemberLookup.SafeGetMethodsIncludingSelfAndInterfaces</c>) and the
+/// imported static-class probe enumerated <c>BindingFlags.Public</c> only, so
+/// an internal method of a friend assembly was never even a candidate and the
+/// call dead-ended at GS0159 "Cannot find function" — while an internal
+/// property or field on the same type resolved fine, because those probes
+/// already widened to <c>NonPublic</c> under the same friendship test. That
+/// asymmetry is why every migrated <c>*.Tests</c> app lost cross-assembly
+/// internal access to the project under test.
+/// </para>
+/// </summary>
+public sealed class Issue3679InternalsVisibleToMemberAccessTests
+{
+    private const string CSharpLibrarySource = """
+        using System.Runtime.CompilerServices;
+
+        [assembly: InternalsVisibleTo("Issue3679.Friend")]
+
+        namespace Issue3679.Library;
+
+        public class Bag
+        {
+            public int Report() => 1;
+
+            internal int BeginTransaction() => 42;
+
+            internal int Hidden => 3;
+
+            internal static int MapToReferenceClrType() => 7;
+
+            private int Secret() => 9;
+        }
+        """;
+
+    [Fact]
+    public void FriendAssembly_Calls_Internal_Instance_Method_Of_Imported_CSharp_Class()
+    {
+        var directory = CreateOutputDirectory();
+        try
+        {
+            var libraryPath = EmitCSharpLibrary(directory, "Issue3679.Library", CSharpLibrarySource);
+            var result = CompileGSharp(
+                """
+                package Issue3679.Friend
+                import Issue3679.Library
+
+                func Run() int32 {
+                    let bag = Bag()
+                    return bag.BeginTransaction()
+                }
+                """,
+                "Issue3679.Friend",
+                libraryPath);
+
+            Assert.True(result.Success, Describe(result));
+        }
+        finally
+        {
+            DeleteOutputDirectory(directory);
+        }
+    }
+
+    [Fact]
+    public void FriendAssembly_Calls_Internal_Static_Method_Of_Imported_CSharp_Class()
+    {
+        var directory = CreateOutputDirectory();
+        try
+        {
+            var libraryPath = EmitCSharpLibrary(directory, "Issue3679.Library", CSharpLibrarySource);
+            var result = CompileGSharp(
+                """
+                package Issue3679.Friend
+                import Issue3679.Library
+
+                func Run() int32 -> Bag.MapToReferenceClrType()
+                """,
+                "Issue3679.Friend",
+                libraryPath);
+
+            Assert.True(result.Success, Describe(result));
+        }
+        finally
+        {
+            DeleteOutputDirectory(directory);
+        }
+    }
+
+    [Fact]
+    public void NonFriendAssembly_Still_Cannot_Call_An_Internal_Method()
+    {
+        var directory = CreateOutputDirectory();
+        try
+        {
+            var libraryPath = EmitCSharpLibrary(directory, "Issue3679.Library", CSharpLibrarySource);
+            var result = CompileGSharp(
+                """
+                package Issue3679.Stranger
+                import Issue3679.Library
+
+                func Run() int32 {
+                    let bag = Bag()
+                    return bag.BeginTransaction()
+                }
+                """,
+                "Issue3679.Stranger",
+                libraryPath);
+
+            Assert.False(result.Success);
+            Assert.Contains(result.Diagnostics, d => d.Id == "GS0159");
+        }
+        finally
+        {
+            DeleteOutputDirectory(directory);
+        }
+    }
+
+    [Fact]
+    public void FriendAssembly_Still_Cannot_Call_A_Private_Method()
+    {
+        var directory = CreateOutputDirectory();
+        try
+        {
+            var libraryPath = EmitCSharpLibrary(directory, "Issue3679.Library", CSharpLibrarySource);
+            var result = CompileGSharp(
+                """
+                package Issue3679.Friend
+                import Issue3679.Library
+
+                func Run() int32 {
+                    let bag = Bag()
+                    return bag.Secret()
+                }
+                """,
+                "Issue3679.Friend",
+                libraryPath);
+
+            Assert.False(result.Success);
+            Assert.Contains(result.Diagnostics, d => d.Id == "GS0159");
+        }
+        finally
+        {
+            DeleteOutputDirectory(directory);
+        }
+    }
+
+    /// <summary>
+    /// The producer half of the SDK path: the friend declaration a
+    /// <c>&lt;InternalsVisibleTo&gt;</c> item becomes is the FULLY QUALIFIED,
+    /// suffix-less <c>System.Runtime.CompilerServices.InternalsVisibleTo</c>
+    /// spelling <c>WriteGsharpAssemblyInfoTask</c> renders from
+    /// <c>@(AssemblyAttribute)</c> — not the bare <c>InternalsVisibleTo</c> a
+    /// hand-written G# source uses. Both must grant the same access.
+    /// </summary>
+    [Fact]
+    public void SdkGeneratedQualifiedAnnotation_Grants_Internal_Method_Access()
+    {
+        var directory = CreateOutputDirectory();
+        try
+        {
+            var libraryPath = EmitGSharpLibrary(
+                directory,
+                "Issue3679.GsLibrary",
+                """
+                package Issue3679.GsLibrary
+
+                @assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Issue3679.Friend")
+
+                public class DiagnosticBag {
+                  public func Report() int32 -> 1
+
+                  internal func BeginTransaction() int32 -> 42
+                }
+                """);
+            var result = CompileGSharp(
+                """
+                package Issue3679.Friend
+                import Issue3679.GsLibrary
+
+                func Run() int32 {
+                    let bag = DiagnosticBag()
+                    return bag.BeginTransaction()
+                }
+                """,
+                "Issue3679.Friend",
+                libraryPath);
+
+            Assert.True(result.Success, Describe(result));
+        }
+        finally
+        {
+            DeleteOutputDirectory(directory);
+        }
+    }
+
+    private static string Describe(CompileResult result)
+        => string.Join(Environment.NewLine, result.Diagnostics.Select(d => d.Id + ": " + d.Message));
+
+    private static CompileResult CompileGSharp(
+        string source,
+        string assemblyName,
+        params string[] references)
+    {
+        using var resolver = references.Length == 0
+            ? ReferenceResolver.Default()
+            : ReferenceResolver.WithReferences(references);
+        resolver.CurrentAssemblyName = assemblyName;
+        var compilation = new GsCompilation(
+            resolver,
+            GsSyntaxTree.Parse(SourceText.From(source)))
+        {
+            AssemblyName = assemblyName,
+        };
+
+        using var output = new MemoryStream();
+        var emit = compilation.Emit(
+            output,
+            pdbStream: null,
+            refStream: null,
+            assemblyName: assemblyName);
+        return new CompileResult(
+            emit.Success,
+            emit.Diagnostics.Select(d => new DiagnosticInfo(d.Id, d.Message)).ToArray());
+    }
+
+    private static string EmitGSharpLibrary(string directory, string assemblyName, string source)
+    {
+        var path = Path.Combine(directory, assemblyName + ".dll");
+        using var resolver = ReferenceResolver.Default();
+        resolver.CurrentAssemblyName = assemblyName;
+        var compilation = new GsCompilation(
+            resolver,
+            GsSyntaxTree.Parse(SourceText.From(source)))
+        {
+            AssemblyName = assemblyName,
+            IsLibrary = true,
+        };
+
+        using var output = File.Create(path);
+        var emit = compilation.Emit(
+            output,
+            pdbStream: null,
+            refStream: null,
+            assemblyName: assemblyName);
+        Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
+        return path;
+    }
+
+    private static string EmitCSharpLibrary(string directory, string assemblyName, string source)
+    {
+        var references = ((AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string)
+                ?.Split(Path.PathSeparator)
+                ?? Array.Empty<string>())
+            .Where(File.Exists)
+            .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path));
+        var compilation = CSharpCompilation.Create(
+            assemblyName,
+            new[] { CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest)) },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        var path = Path.Combine(directory, assemblyName + ".dll");
+        using var output = File.Create(path);
+        var emit = compilation.Emit(output);
+        Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
+        return path;
+    }
+
+    private static string CreateOutputDirectory()
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            nameof(Issue3679InternalsVisibleToMemberAccessTests),
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
+    private static void DeleteOutputDirectory(string directory)
+    {
+        try
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    private readonly record struct CompileResult(bool Success, DiagnosticInfo[] Diagnostics);
+
+    private readonly record struct DiagnosticInfo(string Id, string Message);
+}

--- a/test/Sdk.Tests/Issue2814GenerateAssemblyInfoTests.cs
+++ b/test/Sdk.Tests/Issue2814GenerateAssemblyInfoTests.cs
@@ -37,6 +37,27 @@ public class Issue2814GenerateAssemblyInfoTests
             StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// Issue #3679: the .NET SDK's <c>GetAssemblyAttributes</c> target turns
+    /// every <c>&lt;InternalsVisibleTo Include="X" /&gt;</c> msbuild item into
+    /// an <c>@(AssemblyAttribute)</c> item whose identity is the suffix-less
+    /// <c>System.Runtime.CompilerServices.InternalsVisibleTo</c>. Rendering it
+    /// is how a <c>.gsproj</c> declares a friend assembly without hand-writing
+    /// the annotation, so the exact spelling is a contract with the binder —
+    /// see <c>Issue3679InternalsVisibleToMemberAccessTests</c>.
+    /// </summary>
+    [Fact]
+    public void Render_InternalsVisibleToItem_EmitsFriendAssemblyAnnotation()
+    {
+        var item = new TaskItem("System.Runtime.CompilerServices.InternalsVisibleTo");
+        item.SetMetadata("_Parameter1", "GSharp.Core.Tests");
+
+        Assert.Contains(
+            "@assembly: System.Runtime.CompilerServices.InternalsVisibleTo(\"GSharp.Core.Tests\")",
+            WriteGsharpAssemblyInfoTask.Render(new ITaskItem[] { item }),
+            StringComparison.Ordinal);
+    }
+
     [Fact]
     public void Render_MultiplePositionalParameters_KeepsDeclaredOrder()
     {


### PR DESCRIPTION
Fixes #3679.

## Where it actually broke

The issue proposed an SDK or cs2gs fix. Neither layer was at fault — I checked all three before changing anything:

- **SDK.** `Gsharp.NET.Sdk`'s `_GsharpGenerateAssemblyInfo` already runs the standard `GetAssemblyAttributes` target, which turns every `<InternalsVisibleTo Include="X" />` item into an `@(AssemblyAttribute)`, and `WriteGsharpAssemblyInfoTask` renders it as `@assembly: System.Runtime.CompilerServices.InternalsVisibleTo("X")`. Confirmed on a real `.gsproj` build: `obj/Debug/net10.0/Lib.AssemblyInfo.gs` carries the annotation.
- **gsc emit.** That annotation becomes a real `InternalsVisibleToAttribute` row — in both the runtime assembly and the `/refout:` reference assembly. Confirmed on the emitted metadata.
- **gsc bind — the actual defect.** The consumer never saw the internal *methods*. `MemberLookup.SafeGetMethodsIncludingSelfAndInterfaces` (the CLR instance-call candidate walk) and the imported static-class probe in `CollectImportedMethodProbes` enumerated `BindingFlags.Public` only, so an `internal` method of a friend assembly was never even a candidate and the call dead-ended at `GS0159 Cannot find function`. An internal *property* or *field* on the same type resolved fine, because those probes (`ExpressionBinder.Access.MemberLookup`) already widen to `NonPublic` under exactly the same `ReferenceResolver.CanAccessInternalMembers` test. The bug was that asymmetry.

Reproduced minimally end to end through the G# SDK — a `Lib.gsproj` declaring `<InternalsVisibleTo Include="Consumer" />` plus a `Consumer.gsproj` that project-references it and calls `bag.Secret()` — which failed with the exact `GS0159` shape from the #3501 triage, and passes after the fix. It reproduces identically with a C#-compiled producer, so this was never specific to gsc-emitted metadata.

## The fix

Both probes widen to `NonPublic` when — and only when — the declaring assembly grants this compilation internal access, and admit `assembly` accessibility alone: `private` / `protected` / `private protected` members stay invisible however the friendship is declared. The instance-candidate memo keys the internal-inclusive set under a distinct key so it can never overwrite the public-only one; neither set depends on *which* consumer is asking (only on declared accessibility), so the process-wide cache stays consumer-independent.

## Tests

`test/Core.Tests/.../Issue3679InternalsVisibleToMemberAccessTests.cs` — sibling-assembly binder tests over a Roslyn-compiled C# library plus a gsc-emitted G# one:

- friend calls an `internal` instance method ✅
- friend calls an `internal` static method ✅
- non-friend consumer still gets `GS0159` ✅
- friend still cannot call a `private` method ✅
- the SDK's fully-qualified, suffix-less `@assembly: System.Runtime.CompilerServices.InternalsVisibleTo(...)` spelling grants the same access as the bare one ✅

Plus one `Sdk.Tests` fact pinning the exact annotation `WriteGsharpAssemblyInfoTask` renders for an `InternalsVisibleTo` `@(AssemblyAttribute)` item, which is the contract the binder tests depend on.

Full `Core.Tests` is green locally: **8313 passed, 0 failed**.

## Expected effect on the self-migration

This removes family F2 from the `test/Core.Tests` triage — 12 of that app's errors (10 `GS0159` on `internal` members of `GSharp.Core` plus 2 `GS0119` cascades) — and the same class in every other migrated `*.Tests` app that reaches an internal. The measured tally will land at the next nightly translate; I did not run a full local self-migration for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
