### PR TITLE
cs2gs: nullable element type for an array/slice literal that writes nil (#3682)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue3682NullElementTargetTypeTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3682NullElementTargetTypeTests.cs
@@ -1,0 +1,198 @@
+// <copyright file="Issue3682NullElementTargetTypeTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3682: a C# array / slice literal that literally writes <c>null</c>
+/// into a non-nullable reference element type. The C# is legal — the literal
+/// lives in an oblivious file, so nothing is reported — but G#'s element type
+/// really is non-nullable and gsc rejects the emitted <c>nil</c> (GS0155,
+/// <c>Cannot convert type 'nil' to 'object'</c>). The literal's element type is
+/// inferred AT the literal rather than pinned by a declaration, so the faithful
+/// repair is to widen it to <c>T?</c>; a <c>!!</c> bridge would turn a clean C#
+/// <c>new object[] { a, null }</c> into a runtime throw.
+/// </summary>
+public class Issue3682NullElementTargetTypeTests
+{
+    [Fact]
+    public void ExplicitObjectArrayWithNullElements_RendersNullableElementType()
+    {
+        string printed = TranslateUnit(@"
+using System.Reflection;
+
+namespace Demo
+{
+    public class C
+    {
+        public object F(ConstructorInfo ctor, object program)
+        {
+            return ctor.Invoke(new object[] { program, null, false, null });
+        }
+    }
+}");
+
+        Assert.Contains("[]object?{program, nil, false, nil}", printed);
+    }
+
+    [Fact]
+    public void ObjectArrayLocalWithNullElement_RendersNullableElementType()
+    {
+        string printed = TranslateUnit(@"
+using System;
+using System.Reflection;
+
+namespace Demo
+{
+    public class C
+    {
+        public object F(MethodInfo method, object cache, Type type)
+        {
+            var args = new object[] { type, null };
+            return method.Invoke(cache, args);
+        }
+    }
+}");
+
+        Assert.Contains("[]object?{type, nil}", printed);
+    }
+
+    [Fact]
+    public void ImplicitlyTypedArrayWithNullElements_RendersNullableElementType()
+    {
+        string printed = TranslateUnit(@"
+using System.Collections.Generic;
+
+namespace Demo
+{
+    public class C
+    {
+        public void Check<T>(IEnumerable<T> items)
+        {
+        }
+
+        public void F()
+        {
+            this.Check(new[] { null, null, ""d"" });
+        }
+    }
+}");
+
+        Assert.Contains(@"[]string?{nil, nil, ""d""}", printed);
+    }
+
+    [Fact]
+    public void CollectionExpressionWithNullElements_RendersNullableElementType()
+    {
+        string printed = TranslateUnit(@"
+using System.Collections.Generic;
+
+namespace Demo
+{
+    public class C
+    {
+        public void Check<T>(IEnumerable<T> items)
+        {
+        }
+
+        public void F()
+        {
+            this.Check<string>([null, null, ""d""]);
+        }
+    }
+}");
+
+        Assert.Contains(@"[]string?{nil, nil, ""d""}", printed);
+    }
+
+    [Fact]
+    public void RectangularArrayWithNullElement_RendersNullableElementType()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public object F(object a)
+        {
+            var grid = new object[,] { { a, null }, { a, a } };
+            return grid[0, 0];
+        }
+    }
+}");
+
+        Assert.Contains("[2, 2]object?", printed);
+    }
+
+    [Fact]
+    public void ArrayWithoutNullElements_KeepsNonNullableElementType()
+    {
+        string printed = TranslateUnit(@"
+using System.Reflection;
+
+namespace Demo
+{
+    public class C
+    {
+        public object F(ConstructorInfo ctor, object program)
+        {
+            return ctor.Invoke(new object[] { program, false });
+        }
+    }
+}");
+
+        Assert.Contains("[]object{program, false}", printed);
+        Assert.DoesNotContain("[]object?", printed);
+    }
+
+    [Fact]
+    public void AnnotatedNullableElementArray_IsUnchanged()
+    {
+        string printed = TranslateUnit(@"
+#nullable enable
+using System.Reflection;
+
+namespace Demo
+{
+    public class C
+    {
+        public object F(ConstructorInfo ctor, object program)
+        {
+            return ctor.Invoke(new object?[] { program, null });
+        }
+    }
+}");
+
+        Assert.Contains("[]object?{program, nil}", printed);
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
@@ -639,6 +639,47 @@ public sealed partial class CSharpToGSharpTranslator
                 : nested;
         }
 
+        // Issue #3682: the element type of an array / slice literal that
+        // literally writes `null` (or `default`) into a NON-nullable reference
+        // element. C# accepts the write — the literal sits in an oblivious file
+        // (`test/Core.Tests` has no `<Nullable>` setting), or its element type
+        // was inferred from an oblivious/unannotated target — but G#'s element
+        // type is genuinely non-nullable and gsc rejects the `nil` (GS0155,
+        // `Cannot convert type 'nil' to 'object'`).
+        //
+        // The right repair is the DECLARATION, not the value: the `nil` really
+        // is nil, so `!!` would turn a clean C# `new object[] { a, null }` into
+        // a runtime throw. A literal's element type is inferred AT the literal
+        // rather than pinned by a declaration, so widening it to `T?` is both
+        // faithful and local — the array genuinely holds a nil.
+        //
+        // Restricted to reference elements whose annotation is not already
+        // `Annotated` (those already render `T?`); value-typed elements never
+        // receive a `nil` in the first place.
+        private GTypeReference PromoteElementTypeForNullElements(
+            GTypeReference elementType,
+            ITypeSymbol elementTypeSymbol,
+            IEnumerable<ExpressionSyntax> elements)
+        {
+            if (elementType == null
+                || elementType.IsNullable
+                || elementTypeSymbol is not { IsReferenceType: true }
+                || elementTypeSymbol.NullableAnnotation == NullableAnnotation.Annotated)
+            {
+                return elementType;
+            }
+
+            foreach (ExpressionSyntax element in elements)
+            {
+                if (element != null && IsNullOrDefaultLiteral(element))
+                {
+                    return MakeNullable(elementType);
+                }
+            }
+
+            return elementType;
+        }
+
         // Issue #914: whether <paramref name="expression"/> is a bare `null` /
         // `null!` literal or a `default` / `default(T)` expression — the direct
         // null-argument forms used to detect a null flowing into a delegate

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -1885,11 +1885,15 @@ public sealed partial class CSharpToGSharpTranslator
                             leaves);
                     }
 
+                    GTypeReference leafElementType = this.PromoteElementTypeForNullElements(
+                        elementType, elementTypeSymbol, leaves);
+                    bool leafPromoted = !ReferenceEquals(leafElementType, elementType);
                     return new ArrayAllocationExpression(
-                        elementType,
+                        leafElementType,
                         dimensions,
                         leaves.Select(expression =>
-                            this.TranslateArrayInitializerElement(expression, elementTypeSymbol)).ToList());
+                            this.TranslateArrayInitializerElement(
+                                expression, elementTypeSymbol, leafPromoted)).ToList());
                 }
 
                 return new ArrayAllocationExpression(
@@ -1903,11 +1907,15 @@ public sealed partial class CSharpToGSharpTranslator
             {
                 // `new T[]{a, b}` / `new T[0]` (with an explicit, possibly empty,
                 // initializer) → the slice literal `[]T{a, b}`.
+                GTypeReference literalElementType = this.PromoteElementTypeForNullElements(
+                    elementType, elementTypeSymbol, creation.Initializer.Expressions);
+                bool literalPromoted = !ReferenceEquals(literalElementType, elementType);
                 return new ArrayLiteralExpression(
-                    elementType,
+                    literalElementType,
                     creation.Initializer.Expressions
                         .Select(expression =>
-                            this.TranslateArrayInitializerElement(expression, elementTypeSymbol))
+                            this.TranslateArrayInitializerElement(
+                                expression, elementTypeSymbol, literalPromoted))
                         .ToList());
             }
 
@@ -2081,9 +2089,20 @@ public sealed partial class CSharpToGSharpTranslator
 
         private GExpression TranslateArrayInitializerElement(
             ExpressionSyntax expression,
-            ITypeSymbol elementType)
+            ITypeSymbol elementType,
+            bool elementTypePromotedToNullable = false)
         {
             GExpression translated = this.TranslateExpression(expression);
+
+            // Issue #3682: the literal's element type was widened to `T?`
+            // because the literal writes a `nil` into it, so no element needs
+            // (or may take) a `!!` bridge against a non-nullable element — the
+            // slot accepts nil by construction now.
+            if (elementTypePromotedToNullable)
+            {
+                return translated;
+            }
+
             translated = this.ForgiveNullableReferenceValue(
                 expression,
                 translated,
@@ -2137,19 +2156,27 @@ public sealed partial class CSharpToGSharpTranslator
                     rank: arrayType.Rank,
                     dims,
                     leaves);
+                GTypeReference leafElementType = this.PromoteElementTypeForNullElements(
+                    elementType, elementTypeSymbol, leaves);
+                bool leafPromoted = !ReferenceEquals(leafElementType, elementType);
                 return new ArrayAllocationExpression(
-                    elementType,
+                    leafElementType,
                     dims.Select(d => (GExpression)LiteralExpression.Int(
                         d.ToString(CultureInfo.InvariantCulture))).ToList(),
                     leaves.Select(expression =>
-                        this.TranslateArrayInitializerElement(expression, elementTypeSymbol)).ToList());
+                        this.TranslateArrayInitializerElement(
+                            expression, elementTypeSymbol, leafPromoted)).ToList());
             }
 
+            GTypeReference literalElementType = this.PromoteElementTypeForNullElements(
+                elementType, elementTypeSymbol, creation.Initializer.Expressions);
+            bool literalPromoted = !ReferenceEquals(literalElementType, elementType);
             return new ArrayLiteralExpression(
-                elementType,
+                literalElementType,
                 creation.Initializer.Expressions
                     .Select(expression =>
-                        this.TranslateArrayInitializerElement(expression, elementTypeSymbol))
+                        this.TranslateArrayInitializerElement(
+                            expression, elementTypeSymbol, literalPromoted))
                     .ToList());
         }
 
@@ -2398,6 +2425,15 @@ public sealed partial class CSharpToGSharpTranslator
             // canonical G# slice literal `[]T{ … }` (ADR-0115 §B). Spreads map
             // directly to native G# ellipsis elements, with no statement-hosted
             // build/append temporary (issue #3096).
+            //
+            // Issue #3682: `[null, null, "d"]` writes a `nil` into the slice's
+            // element type, which the C# target left non-nullable.
+            GTypeReference sliceElementType = this.PromoteElementTypeForNullElements(
+                elementType,
+                elementTypeSymbol,
+                collection.Elements.OfType<ExpressionElementSyntax>().Select(e => e.Expression));
+            bool slicePromoted = !ReferenceEquals(sliceElementType, elementType);
+
             var elements = new List<GExpression>();
             foreach (CollectionElementSyntax element in collection.Elements)
             {
@@ -2408,14 +2444,16 @@ public sealed partial class CSharpToGSharpTranslator
                 else
                 {
                     var expressionElement = (ExpressionElementSyntax)element;
-                    elements.Add(this.CoerceCollectionElement(
-                        expressionElement.Expression,
-                        elementType,
-                        elementTypeSymbol));
+                    elements.Add(slicePromoted
+                        ? this.TranslateExpression(expressionElement.Expression)
+                        : this.CoerceCollectionElement(
+                            expressionElement.Expression,
+                            elementType,
+                            elementTypeSymbol));
                 }
             }
 
-            return new ArrayLiteralExpression(elementType, elements);
+            return new ArrayLiteralExpression(sliceElementType, elements);
         }
 
         private GExpression CoerceCollectionElement(


### PR DESCRIPTION
Family **F3** of the [#3501 `test/Core.Tests` triage](https://github.com/DavidObando/gsharp/issues/3501#issuecomment-5469492729): a C# array or slice literal that literally writes `null` at a **non-nullable reference element type**.

```csharp
// C# — test/Core.Tests is nullable-OBLIVIOUS, so nothing is reported
ctor.Invoke(new object[] { program, references, null, false, null })
```
```gs
// before — error GS0155: Cannot convert type 'nil' to 'object'
ctor.Invoke([]object{program, references, nil, false, nil})
// after
ctor.Invoke([]object?{program, references, nil, false, nil})
```

### Why widen the declaration rather than bridge the value

Per-site, the C# is legal because the literal sits in an oblivious file (`build/gsharp.build.props` sets `<Nullable>disable</Nullable>` for test projects) or its element type was inferred from an unannotated target. The `nil` really **is** nil, so `ForgiveNullableReferenceValue`/`!!` is the wrong tool here — asserting a value that can genuinely be null converts clean C# behaviour into a runtime throw. And unlike a field or parameter, a literal's element type is inferred **at the literal**, not pinned by a declaration, so widening it to `T?` is both faithful and local.

`PromoteElementTypeForNullElements` (in `CSharpToGSharpTranslator.Nullability.cs`, alongside the existing `PromoteIfUsedAsNullable` / `ShouldPromoteToNullableReference` machinery) does that widening for the explicit (`new T[]{…}`), implicit (`new[]{…}`), rectangular and C# 12 collection-expression literal forms. It is guarded to reference elements whose annotation is not already `Annotated`, using the same `IsNullOrDefaultLiteral` null-form predicate #914 already relies on, so a `new object?[]` or a value-typed element is untouched.

When the widening fires, `TranslateArrayInitializerElement` skips its element bridge: the slot accepts nil by construction now, so no element needs — or may take — a `!!` against a non-nullable element.

### Measured before/after

Whole-repository `build/run-cs2gs-selfmig-migrate.sh` (Release Compiler + Cs2Gs.Cli rebuilt, SDK repacked) followed by `cs2gs validate --app test/Core.Tests/Core.Tests.csproj`, run once on `origin/main` and once with this change:

| | before | after |
|---|---:|---:|
| compile artifacts | 170 | 165 |
| ‑ of which GS0536 (polish-loop transients) | 103 | 103 |
| **real compile errors** | **67** | **62** |
| `GS0155` | 8 | 3 |
| every other diagnostic id | — | unchanged |

No diagnostic id increased and no new id appeared. Five of the seven F3 sites are gone — `Issue2325ArrayPointerByRefRemapEmitTests`, `GenericRemapPrecedenceTests`, `Issue1679TypeIdentityAqnCacheTests`, `PortablePdbEmitTests`, `Issue3409PatternDesignationParserTests`.

### The two F3 sites this does not fix

Filed with evidence rather than half-fixed, because each needs a different layer:

- **#3694** — `Compilation(…){DebugInformation = nil}`. An oblivious test writes `null` into an **annotated** non-nullable property in `src/Core` whose setter normalises it. This is the mirror of the F6 cross-context *read* fixed in #3687, in the *write* direction, where no `!!` bridge exists. The only faithful repair promotes a declaration in another project, which cascades `!!` into every read of that property; that needs its own design pass.
- **#3695** — a `gsc` defect. An arrow lambda bound to `Func<…, Assembly?>` infers its return type from the body instead of the target delegate, so `return nil` is rejected. G#'s arrow form carries no return-type annotation at all (`LambdaExpression.ReturnType` is documented as null for it), so cs2gs cannot spell the fix.

### Tests

`tools/cs2gs/Cs2Gs.Tests/Issue3682NullElementTargetTypeTests.cs` — seven minimal repros, one per distinct shape (explicit `object[]` invoke argument, `var` local, implicit `new[]`, collection expression, rectangular array) plus two negatives (no null element → unchanged; an already-`object?[]` annotated literal → unchanged). Every case asserts the emitted G# binds via `TranslationTestValidation.AssertBinds`.

Ran `--filter "FullyQualifiedName~Nullable|FullyQualifiedName~Issue1072|FullyQualifiedName~Issue3644|FullyQualifiedName~Oblivious|FullyQualifiedName~Issue3682|FullyQualifiedName~Array|FullyQualifiedName~Collection"`: **448 passed, 0 failed**.

Fixes #3682

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
