### PR TITLE
gsc: xunit generic-method overload resolution — cross-context delegates and C# bound fixing (#3681)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/ClrOverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/ClrOverloadResolution.cs
@@ -1918,7 +1918,10 @@ internal static class ClrOverloadResolution
     /// <c>System.Action</c> / <c>Action&lt;...&gt;</c>). Parameter and return
     /// types are compared by name to remain safe across reflection contexts
     /// (the target may be loaded through a <c>MetadataLoadContext</c> while the
-    /// literal's natural <c>Func&lt;...&gt;</c> is a live-runtime type).
+    /// literal's natural <c>Func&lt;...&gt;</c> is a live-runtime type), and
+    /// both signatures are read through <see cref="TryGetDelegateSignature"/>
+    /// so a constructed delegate whose <c>Invoke</c> is unreachable across
+    /// those contexts still decomposes (issue #3681).
     /// </summary>
     /// <param name="target">The candidate void-returning delegate parameter type.</param>
     /// <param name="source">The argument's natural delegate type.</param>
@@ -1930,36 +1933,40 @@ internal static class ClrOverloadResolution
             return false;
         }
 
-        MethodInfo? targetInvoke;
-        MethodInfo? sourceInvoke;
-        try
-        {
-            targetInvoke = target.GetMethodSafe("Invoke");
-            sourceInvoke = source.GetMethodSafe("Invoke");
-        }
-        catch (Exception)
-        {
-            return false;
-        }
-
-        if (targetInvoke is null || sourceInvoke is null)
+        // Issue #3681: read both signatures through TryGetDelegateSignature
+        // rather than reflecting `Invoke` directly. A lambda's natural
+        // `Func<...>` is built by closing the live `System.Func`n` over the
+        // bound argument types; whenever any of those came from the reference
+        // load context (every non-primitive imported type — `MemberInfo`,
+        // `Type`, `List<int>`, …) the runtime materialises the closure as a
+        // `TypeBuilderInstantiation`, whose `GetMethod("Invoke")` throws
+        // `NotSupportedException` and whose `GetMethodSafe` wrapper therefore
+        // answers null. This predicate then silently reported "not a discard
+        // conversion" and `Assert.All(items, (x T) -> value)` failed overload
+        // resolution with GS0159 for exactly those element types, while the
+        // same call over `string`/`object`/`int32` (host runtime types)
+        // resolved. `TryGetDelegateSignature` already carries the
+        // cross-context fallback that decomposes `Func`n`/`Action`n`/any
+        // closed generic delegate through its open definition, and the two
+        // sibling delegate predicates (#908 covariance, #1150 return
+        // widening) already go through it — this one was the outlier.
+        if (!TryGetDelegateSignature(target, out var targetParams, out var targetReturn)
+            || !TryGetDelegateSignature(source, out var sourceParams, out var sourceReturn))
         {
             return false;
         }
 
         // Target must return void; source must return a value.
-        if (!string.Equals(targetInvoke.ReturnType.FullName, "System.Void", StringComparison.Ordinal))
+        if (!string.Equals(targetReturn.FullName, "System.Void", StringComparison.Ordinal))
         {
             return false;
         }
 
-        if (string.Equals(sourceInvoke.ReturnType.FullName, "System.Void", StringComparison.Ordinal))
+        if (string.Equals(sourceReturn.FullName, "System.Void", StringComparison.Ordinal))
         {
             return false;
         }
 
-        var targetParams = targetInvoke.GetParameters();
-        var sourceParams = sourceInvoke.GetParameters();
         if (targetParams.Length != sourceParams.Length)
         {
             return false;
@@ -1967,7 +1974,7 @@ internal static class ClrOverloadResolution
 
         for (var i = 0; i < targetParams.Length; i++)
         {
-            if (!ClrTypeUtilities.AreSame(targetParams[i].ParameterType, sourceParams[i].ParameterType))
+            if (!ClrTypeUtilities.AreSame(targetParams[i], sourceParams[i]))
             {
                 return false;
             }
@@ -5297,6 +5304,33 @@ internal static class ClrOverloadResolution
         }
     }
 
+    /// <summary>
+    /// Issue #3681: decides whether <paramref name="source"/> — one lower bound
+    /// collected for a method type parameter — may be absorbed into
+    /// <paramref name="target"/>, the other bound, when fixing that type
+    /// parameter (C# §12.6.3.11). Only the <em>standard</em> implicit
+    /// conversions C# admits at this point are accepted: identity, implicit
+    /// numeric widening, reference upcasts (including interface satisfaction)
+    /// and boxing. Deliberately excludes the contextual conversions
+    /// <see cref="ClassifyImplicit"/> also classifies (user-defined
+    /// <c>op_Implicit</c>, interpolated-string handlers, the lambda/delegate
+    /// shape conversions), none of which participate in fixing — admitting them
+    /// would let genuinely conflicting bounds unify and would widen the
+    /// applicable candidate set beyond what C# resolves.
+    /// </summary>
+    /// <param name="target">The bound being promoted to.</param>
+    /// <param name="source">The bound being absorbed.</param>
+    /// <returns><see langword="true"/> when the promotion is valid.</returns>
+    private static bool IsInferenceBoundPromotion(Type target, Type source) =>
+        ClassifyImplicit(target, source) switch
+        {
+            ImplicitConversionKind.Identity => true,
+            ImplicitConversionKind.NumericWidening => true,
+            ImplicitConversionKind.Reference => true,
+            ImplicitConversionKind.Boxing => true,
+            _ => false,
+        };
+
     private static bool UnifyForInference(Type? parameterType, Type? argumentType, Dictionary<string, Type> bounds)
     {
         if (parameterType is null || argumentType is null)
@@ -5355,8 +5389,32 @@ internal static class ClrOverloadResolution
                 }
                 catch (InvalidOperationException)
                 {
-                    // MLC cross-context: treat as inconclusive.
-                    return false;
+                    // MLC cross-context: fall through to the classifier below,
+                    // which compares by name and is safe across contexts.
+                }
+
+                // Issue #3681: C# fixing (§12.6.3.11) resolves a type parameter
+                // to the unique bound that every other bound converts to
+                // *implicitly* — not merely by reference assignment.
+                // `Type.IsAssignableFrom` above models neither boxing
+                // (`Assert.Equal<T>(TimeSpan, object)`, where C# fixes
+                // T = object) nor implicit numeric widening
+                // (`Assert.Equal<T>(2, byteValue)`, where C# fixes T = int),
+                // and it silently answers false whenever the two bounds were
+                // loaded through different reflection contexts — a host
+                // `System.Object` against a reference-context `TimeSpan`. Retry
+                // through this file's own classifier, which compares by name
+                // (cross-context safe) and is restricted here to the standard
+                // conversions C# admits when fixing.
+                if (IsInferenceBoundPromotion(existing, argumentType))
+                {
+                    return true;
+                }
+
+                if (IsInferenceBoundPromotion(argumentType, existing))
+                {
+                    bounds[parameterType.Name] = argumentType;
+                    return true;
                 }
 
                 return false;

--- a/test/Compiler.Tests/XunitAssertOverloadResolutionTests.cs
+++ b/test/Compiler.Tests/XunitAssertOverloadResolutionTests.cs
@@ -444,8 +444,219 @@ public class XunitAssertOverloadResolutionTests
             """);
     }
 
+    // --- Issue #3681: xunit generic-method overload resolution (family F4) ---
+    //
+    // Two independent gsc defects, both surfaced by migrated `test/Core.Tests`:
+    //
+    // (a) `Assert.All<T>(IEnumerable<T>, Action<T>)` with a VALUE-RETURNING
+    //     typed lambda. The discard conversion `Func<T,TRet>` -> `Action<T>`
+    //     was decided by reflecting `Invoke` off the lambda's natural delegate
+    //     type directly. That natural type is the live `System.Func`n` closed
+    //     over the bound argument types, so as soon as ANY of those came from
+    //     the reference load context — every non-primitive imported type:
+    //     `MemberInfo`, `Type`, `Exception`, `List<int>`, … — the runtime
+    //     materialises it as a `TypeBuilderInstantiation` whose `GetMethod`
+    //     throws and the conversion silently disappeared. The exact same call
+    //     over `string` / `object` / `int32` (host runtime types) resolved,
+    //     which is why a hand-written analogue never reproduced.
+    //
+    // (b) `Assert.Equal<T>(T, T)` where the two arguments give DIFFERENT lower
+    //     bounds for T. C# fixing picks the bound every other bound converts to
+    //     implicitly; gsc only considered `Type.IsAssignableFrom`, which models
+    //     neither boxing nor numeric widening and is false across reflection
+    //     contexts.
+
+    [Fact]
+    public void Issue3681_AssertAll_ValueReturningLambda_ImportedElementType_Resolves()
+    {
+        // (a): `List[MemberInfo]` — the element type comes from the reference
+        // load context, so the lambda's natural `Func<MemberInfo,string>` is a
+        // cross-context instantiation. Before the fix: GS0159 `Cannot find
+        // function All`. The `string` element type in
+        // Issue3681_AssertAll_ValueReturningLambda_HostElementType_Resolves is
+        // the control that always passed.
+        AssertGsCompilesCleanly("""
+            package Probe.Tests
+            import Xunit
+            import System.Collections.Generic
+            import System.Reflection
+
+            class P {
+                @Fact
+                func AllOverImportedElement() {
+                    var items = List[MemberInfo]()
+                    Assert.All(items, (m MemberInfo) -> m.ToString())
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public void Issue3681_AssertAll_ValueReturningLambda_HostElementType_Resolves()
+    {
+        // (a) control: host-runtime element type, which resolved before the fix
+        // too. Guards against the fix regressing the path that already worked.
+        AssertGsCompilesCleanly("""
+            package Probe.Tests
+            import Xunit
+            import System.Collections.Generic
+
+            class P {
+                @Fact
+                func AllOverHostElement() {
+                    var items = List[string]()
+                    Assert.All(items, (m string) -> m.ToString())
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public void Issue3681_AssertAll_ValueReturningLambda_ConstructedGenericElement_Resolves()
+    {
+        // (a): the element type is itself a constructed generic, and the lambda
+        // body is a nested generic xunit assertion whose own type argument is
+        // reference-context too.
+        AssertGsCompilesCleanly("""
+            package Probe.Tests
+            import Xunit
+            import System.Collections.Generic
+
+            class P {
+                @Fact
+                func AllOverConstructedGenericElement() {
+                    var items = List[List[int32]]()
+                    Assert.All(items, (c List[int32]) -> Assert.Single(c))
+                    Assert.All(items, (c List[int32]) -> Assert.IsType[List[int32]](c))
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public void Issue3681_AssertAll_ValueReturningLambda_ArrayCollection_Resolves()
+    {
+        // (a) as it appears in migrated Core.Tests: an array collection plus an
+        // `IsAssignableFrom[T]` body whose explicit type argument is imported.
+        AssertGsCompilesCleanly("""
+            package Probe.Tests
+            import Xunit
+            import System.Reflection
+
+            class P {
+                @Fact
+                func AllOverArray() {
+                    var items = []MemberInfo{}
+                    Assert.All(items, (m MemberInfo) -> Assert.IsAssignableFrom[PropertyInfo](m))
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public void Issue3681_AssertAll_ValueReturningLambda_ImmutableArrayCollection_Resolves()
+    {
+        // (a): `ImmutableArray[T]` reaches `IEnumerable<T>` through an interface
+        // conversion, the shape `AsyncExceptionHandlerRewriterTests.gs` hits.
+        AssertGsCompilesCleanly("""
+            package Probe.Tests
+            import Xunit
+            import System
+            import System.Collections.Immutable
+
+            class P {
+                @Fact
+                func AllOverImmutableArray() {
+                    var items = ImmutableArray[Exception].Empty
+                    Assert.All(items, (e Exception) -> Assert.IsType[InvalidOperationException](e))
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public void Issue3681_AssertEqual_ValueTypeAndObject_FixesToObject()
+    {
+        // (b): `Assert.Equal<T>(T, T)` with a value-type first argument and an
+        // `object`-typed second. C# fixes T = object by boxing the first; gsc
+        // reported GS0159 because the two bounds live in different reflection
+        // contexts, where `IsAssignableFrom` answers false.
+        AssertGsCompilesCleanly("""
+            package Probe.Tests
+            import System
+            import Xunit
+
+            class Holder {
+                var Value object? = nil
+            }
+
+            class P {
+                @Fact
+                func EqualAgainstObject() {
+                    var result = Holder()
+                    Assert.Equal(TimeSpan.FromSeconds(-30), result.Value!!)
+                    Assert.Equal(DateTime(2025, 1, 1), result.Value!!)
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public void Issue3681_AssertEqual_WideningNumericBounds_FixesToWiderType()
+    {
+        // (b): the same fixing rule for a numeric pair. `Assert.Equal(2, aByte)`
+        // has bounds { int32, uint8 }; C# fixes T = int32 because uint8 widens
+        // to it. Reference assignability alone rejects both directions.
+        AssertGsCompilesCleanly("""
+            package Probe.Tests
+            import Xunit
+
+            class RefRecord {
+                var Flags uint8 = 0
+            }
+
+            class P {
+                @Fact
+                func EqualAgainstWiderNumeric() {
+                    var r = RefRecord()
+                    Assert.Equal(2, r.Flags)
+                    Assert.Equal(0x02, r.Flags & uint8(0x02))
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public void Issue3681_AssertEqual_ConflictingBounds_StillFails()
+    {
+        // Guard rail for (b): widening the fixing rule must not make genuinely
+        // conflicting bounds unify. `int32` and `string` convert in neither
+        // direction, so `Assert.Equal<T>(T, T)` stays inapplicable and the call
+        // must still be reported rather than silently binding.
+        AssertGsFailsToCompile("""
+            package Probe.Tests
+            import Xunit
+
+            class P {
+                @Fact
+                func EqualConflicting() {
+                    Assert.Equal(1, "one")
+                }
+            }
+            """);
+    }
+
     private static void AssertGsCompilesCleanly(string source)
         => CompileGsAgainstReferences(source, ReferenceModeTpa);
+
+    /// <summary>
+    /// Issue #3681: negative counterpart to <see cref="AssertGsCompilesCleanly"/>
+    /// — asserts that gsc still rejects a call C# also rejects, so a widened
+    /// inference rule is not silently accepting conflicting bounds.
+    /// </summary>
+    /// <param name="source">G# source expected to fail compilation.</param>
+    private static void AssertGsFailsToCompile(string source)
+        => CompileGsAgainstReferences(source, ReferenceModeTpa, expectSuccess: false);
     /// <summary>
     /// Issue #504-reopen: drives gsc with the same reference-assembly closure
     /// real users get from the SDK (ref-pack facades + xUnit) — NOT the test
@@ -464,7 +675,7 @@ public class XunitAssertOverloadResolutionTests
     private const int ReferenceModeTpa = 0;
     private const int ReferenceModeRefPack = 1;
 
-    private static void CompileGsAgainstReferences(string source, int referenceMode)
+    private static void CompileGsAgainstReferences(string source, int referenceMode, bool expectSuccess = true)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_xunit_overload_").FullName;
         try
@@ -507,6 +718,14 @@ public class XunitAssertOverloadResolutionTests
             {
                 Console.SetOut(prevOut);
                 Console.SetError(prevErr);
+            }
+
+            if (!expectSuccess)
+            {
+                Assert.True(
+                    compileExit != 0,
+                    $"expected gsc to reject the source, but it succeeded:\nstdout:\n{compileOut}");
+                return;
             }
 
             Assert.True(


### PR DESCRIPTION
Family **F4** of the [#3501 `test/Core.Tests` triage](https://github.com/DavidObando/gsharp/issues/3501#issuecomment-5469492729): gsc reported GS0159 `Cannot find function` for public imported generic methods that C# resolves. Two independent defects, both rooted in the same place — a type that came from the **reference load context** rather than the host runtime.

## (a) `Assert.All<T>(IEnumerable<T>, Action<T>)` with a value-returning typed lambda

The `Func<T,TRet>` → `Action<T>` discard conversion (#889) was decided by reflecting `Invoke` off the two delegate types directly. A lambda's natural delegate type is the live `System.Func`n`` closed over the bound argument types — so as soon as **any** of those came from the MetadataLoadContext (that is, every non-primitive imported type: `MemberInfo`, `Type`, `Exception`, `List<int>`, …) the runtime materialises the closure as a `TypeBuilderInstantiation`, whose `GetMethod("Invoke")` throws `NotSupportedException`. `GetMethodSafe` answered `null` — its recovery path only recognises a *literal* `TypeBuilder` type argument — the predicate reported "not a discard conversion", and every `Assert.All` candidate was dropped.

The identical call over `string` / `object` / `int32` resolved, because those are host runtime types. That is exactly why the hand-written analogue in the issue never reproduced:

```gs
Assert.All(List[string](),     (m string)     -> m.ToString())   // always compiled
Assert.All(List[MemberInfo](), (m MemberInfo) -> m.ToString())   // GS0159 before this PR
```

`IsValueReturningDelegateToVoidDelegate` now reads both signatures through `TryGetDelegateSignature`, which already carries the cross-context fallback that decomposes `Func`n``/`Action`n``/any closed generic delegate through its open definition. The two sibling delegate predicates (#908 return covariance, #1150 return widening) already went through it — this one was the outlier.

## (b) `Assert.Equal<T>(T, T)` where the arguments give different lower bounds

C# fixing (§12.6.3.11) resolves a type parameter to the bound every other bound converts to *implicitly*. `UnifyForInference` only consulted `Type.IsAssignableFrom`, which models neither boxing nor implicit numeric widening, and which silently answers `false` whenever the two bounds were loaded through different reflection contexts — a host `System.Object` against a reference-context `TimeSpan`:

```gs
Assert.Equal(TimeSpan.FromSeconds(-30), result.Value!!)   // bounds {TimeSpan, object} → C# fixes T = object
Assert.Equal(2, r.Flags)                                  // bounds {int32, uint8}     → C# fixes T = int32
```

It now falls back to this file's own name-comparing classifier, restricted by the new `IsInferenceBoundPromotion` to the four **standard** conversions C# admits when fixing — identity, numeric widening, reference, boxing. User-defined `op_Implicit`, interpolated-string handlers and the lambda/delegate shape conversions are deliberately excluded, so genuinely conflicting bounds (`Assert.Equal(1, "one")`) still fail; there is a regression test pinning that.

Both changes only ever *add* applicable candidates where resolution previously dead-ended; no ranking or applicability rule was loosened.

## Verification

Measured fresh on this branch, not taken from the issue (whose counts predate several merges): `dotnet build GSharp.sln -c Release -graph`, one full-repository `cs2gs migrate` (51/51 apps translated), then `cs2gs validate --app test/Core.Tests/Core.Tests.csproj` against the packed SDK, before and after the gsc change.

**Migrated `test/Core.Tests`: 67 → 59 compile errors** (gsc-attributable diagnostics; the run's `!!`-polish pass separately clears the GS0536 tail, which is not attributable to this change). **GS0159: 24 → 16.**

The eight removed are exactly the F4 fingerprints:

| file | site |
|---|---|
| `AsyncExceptionHandlerRewriterTests.gs` | (384,16) `Assert.All(typedBody.Statements, (s BoundStatement) -> …)` |
| `Issue2224AnonymousClassExpressionTreeMembersTests.gs` | (53,20) `Assert.All(newExpr.Members!!, (m MemberInfo) -> …)` |
| `Issue2830CollectionLiteralElementParserTests.gs` | (32,16) `Assert.All(…)` |
| `Issue3421CheckedReferenceCastParserTests.gs` | (36,16) `Assert.All(compositeCalls, (call CallExpressionSyntax) -> …)` |
| `PortablePdbEmitTests.gs` | (1190,16) `Assert.All(records, (r RefRecord) -> …)` |
| `ClrConversionTests.gs` | (42,16) `Assert.Equal(BigInteger.Parse("12345"), result.Value!!)` |
| `ClrOperatorTests.gs` | (56,16) `Assert.Equal(TimeSpan.FromSeconds(-30), result.Value!!)` |
| `ClrOperatorTests.gs` | (86,16) `Assert.Equal(DateTime(2025, 1, 1), result.Value!!)` |

No other diagnostic id changed (`GS0113` 7, `GS0155` 8, `GS0158` 7, `GS0267` 3, … all identical) and no new id appeared.

Also:

- Eight new tests in `test/Compiler.Tests/XunitAssertOverloadResolutionTests.cs`, compiled against the real xUnit assemblies — including the host-element-type control that always passed and the conflicting-bounds negative. Each new positive test fails on `main` and passes here.
- The emitted IL was executed (not just compiled) to confirm the newly-accepted conversions are semantically right: the boxed `Assert.Equal(TimeSpan, object)` and the widened `Assert.Equal(2, aByte)` both pass on equal values and both throw on unequal ones, and the `Action<T>` discard lambdas run.
- `dotnet test test/Core.Tests --filter "FullyQualifiedName~Invocation|FullyQualifiedName~GenericMethod|FullyQualifiedName~Overload"` — 463 passed, 0 failed.
- `dotnet test test/Compiler.Tests --filter "FullyQualifiedName~XunitAssert|FullyQualifiedName~Overload|FullyQualifiedName~Lambda"` — 417 passed, 0 failed.

Fixes #3681

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
