### PR TITLE
gsc: qualified/nested typeof of a source-declared open generic (#3677)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -83,28 +83,38 @@ internal sealed partial class ExpressionBinder
             {
                 TryResolveOpenGenericImportedType(typeClauseIdentifier.ValueText, out typeSymbol);
             }
-            else if (TryGetNestedUnboundGenericReflectionSegments(typeClause, out var reflectionSegments, out var firstGenericSegment))
+            else if (TryGetNestedUnboundGenericReflectionSegments(
+                typeClause,
+                out var reflectionSegments,
+                out var firstGenericSegment,
+                out var segmentNames,
+                out var segmentArities))
             {
                 var qualifiedType = ResolveNestedUnboundGenericType(
                     reflectionSegments,
                     firstGenericSegment,
                     out var reflectionName,
                     out var isAmbiguous);
-                if (qualifiedType == null)
+                if (qualifiedType != null)
                 {
-                    if (isAmbiguous)
-                    {
-                        Diagnostics.ReportAmbiguousImportedType(typeClause.Location, reflectionName);
-                    }
-                    else
-                    {
-                        Diagnostics.ReportUndefinedType(typeClause.Location, reflectionName);
-                    }
-
+                    typeSymbol = TypeSymbol.FromClrType(qualifiedType);
+                }
+                else if (isAmbiguous)
+                {
+                    Diagnostics.ReportAmbiguousImportedType(typeClause.Location, reflectionName);
                     return new BoundErrorExpression(null);
                 }
-
-                typeSymbol = TypeSymbol.FromClrType(qualifiedType);
+                else if (!TryResolveOpenGenericDeclaredNestedType(segmentNames, segmentArities, out typeSymbol))
+                {
+                    // Issue #3677: the reflection walk above only ever consults
+                    // REFERENCED assemblies, so the nested unbound spelling
+                    // (`typeof(Outer[_].Inner[_])`) could not name a type
+                    // declared in THIS compilation. The declaration table is
+                    // consulted last, so an imported match still wins exactly
+                    // as before.
+                    Diagnostics.ReportUndefinedType(typeClause.Location, reflectionName);
+                    return new BoundErrorExpression(null);
+                }
             }
             else if (typeClause.HasTypeArguments
                 && TryGetUnboundGenericArity(typeClause, out var arity))
@@ -135,12 +145,15 @@ internal sealed partial class ExpressionBinder
                 // GS0113 even though the bare `typeof(Slot)` form resolves it
                 // through `bindTypeClause`. Try the declaration table last, so
                 // an imported match still wins exactly as before.
-                if (!resolved
-                    && !isAmbiguous
-                    && !typeClause.HasQualifier
-                    && TryResolveOpenGenericDeclaredType(typeClauseIdentifier.ValueText, arity, out typeSymbol))
+                // Issue #3677: the QUALIFIED spelling (`typeof(A.B[_, _])`)
+                // needs the same fallback, walking the source enclosing-type /
+                // package chain segment by segment rather than by reflection
+                // name.
+                if (!resolved && !isAmbiguous)
                 {
-                    resolved = true;
+                    resolved = typeClause.HasQualifier
+                        ? TryResolveOpenGenericDeclaredQualifiedType(typeClause, arity, out typeSymbol)
+                        : TryResolveOpenGenericDeclaredType(typeClauseIdentifier.ValueText, arity, out typeSymbol);
                 }
 
                 if (!resolved)
@@ -284,12 +297,178 @@ internal sealed partial class ExpressionBinder
         _ => -1,
     };
 
+    /// <summary>
+    /// Issue #3677: whether a segment of a dotted open-generic
+    /// <c>typeof(...)</c> target resolved to a type whose declared shape
+    /// matches what the spelling asked for — a generic DEFINITION of exactly
+    /// <paramref name="arity"/> type parameters when the segment carried
+    /// <c>_</c> placeholders, and a non-generic (or already-constructed) type
+    /// when it carried none. Without the negative half a segment written
+    /// without placeholders could silently pick up a generic homonym.
+    /// </summary>
+    /// <param name="type">The type the segment resolved to.</param>
+    /// <param name="arity">The segment's requested arity, or -1 when it carried no placeholders.</param>
+    /// <returns>Whether the resolved type matches the requested shape.</returns>
+    private static bool DeclaredSegmentShapeMatches(TypeSymbol type, int arity)
+        => arity < 0
+            ? DeclaredGenericDefinitionArity(type) < 0
+            : DeclaredGenericDefinitionArity(type) == arity;
+
+    /// <summary>
+    /// Issue #3677: resolves the QUALIFIED explicit-arity unbound-generic
+    /// spelling (<c>typeof(Fixtures.IQuery[_])</c>,
+    /// <c>typeof(Demo.Fixtures.IChain[_, _])</c>) against types DECLARED IN
+    /// THIS COMPILATION. The qualified branch of
+    /// <see cref="BindTypeOfExpression"/> resolves through
+    /// <c>scope.References.TryResolveType(DottedName + "`" + arity)</c>, a
+    /// reflection-name lookup that only ever sees referenced assemblies, so a
+    /// source-declared nested generic was unreachable through the only
+    /// spelling that can select an arity.
+    /// </summary>
+    /// <param name="typeClause">The <c>typeof(...)</c> target type clause.</param>
+    /// <param name="arity">The requested arity, carried by the deepest segment's <c>_</c> placeholders.</param>
+    /// <param name="type">The resolved open generic definition on success.</param>
+    /// <returns><see langword="true"/> when the dotted name resolved to a declared generic definition of that arity.</returns>
+    private bool TryResolveOpenGenericDeclaredQualifiedType(TypeClauseSyntax typeClause, int arity, out TypeSymbol? type)
+    {
+        type = null;
+        var names = typeClause.DottedName.Split('.');
+        if (names.Length < 2)
+        {
+            return false;
+        }
+
+        var arities = new int[names.Length];
+        Array.Fill(arities, -1);
+        arities[names.Length - 1] = arity;
+        return TryResolveOpenGenericDeclaredNestedType(names, arities, out type);
+    }
+
+    /// <summary>
+    /// Issue #3677: resolves a dotted open-generic <c>typeof(...)</c> target
+    /// against the declaration table by walking SOURCE symbols — the head
+    /// segment through the ordinary source-type lookup (so lexical nesting,
+    /// packages and imports apply), every later segment as a nested type of the
+    /// previously-resolved container. Leading segments that do not name a type
+    /// are skipped — that is how a package qualifier
+    /// (<c>Fixtures2523.IQuery2523[_]</c>) resolves — but only when they spell
+    /// the head's declaring package (see
+    /// <see cref="PrefixMatchesDeclaringPackage"/>); the longest chain (the
+    /// earliest viable head) wins, matching
+    /// <see cref="Binder.TryResolveUserNestedTypeChain"/>.
+    /// Every segment's declared shape is verified against
+    /// <paramref name="arities"/>, so a wrong-arity spelling keeps reporting
+    /// GS0113 rather than silently binding a same-named homonym.
+    /// </summary>
+    /// <param name="names">The raw per-segment names, outermost first.</param>
+    /// <param name="arities">The per-segment requested arity, or -1 for a segment with no <c>_</c> placeholders.</param>
+    /// <param name="type">The resolved type on success.</param>
+    /// <returns><see langword="true"/> when the whole chain resolved to declared types of the requested shapes.</returns>
+    private bool TryResolveOpenGenericDeclaredNestedType(string[] names, int[] arities, out TypeSymbol? type)
+    {
+        type = null;
+        for (var head = 0; head < names.Length; head++)
+        {
+            if (!binderCtx.TryLookupSourceType(
+                    scope,
+                    names[head],
+                    arities[head],
+                    getCurrentFunction(),
+                    out var current,
+                    out _)
+                || !DeclaredSegmentShapeMatches(current, arities[head])
+                || !PrefixMatchesDeclaringPackage(current, names, head))
+            {
+                continue;
+            }
+
+            var resolved = true;
+            for (var i = head + 1; i < names.Length; i++)
+            {
+                var container = (current as StructSymbol)?.Definition ?? current;
+                if (!scope.TryLookupNestedTypeAlias(container, names[i], arities[i], out var nested)
+                    && !(container is StructSymbol containerStruct
+                        && scope.TryLookupNestedTypeAliasIncludingInherited(
+                            containerStruct,
+                            names[i],
+                            arities[i],
+                            out nested,
+                            out _)))
+                {
+                    resolved = false;
+                    break;
+                }
+
+                if (!DeclaredSegmentShapeMatches(nested, arities[i]))
+                {
+                    resolved = false;
+                    break;
+                }
+
+                current = nested;
+            }
+
+            if (resolved)
+            {
+                type = current;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Issue #3677: whether the dotted segments BEFORE the segment that named
+    /// the chain head spell that head's declaring package — either in full
+    /// (<c>Demo.Binding.Fixtures.IQuery[_]</c>) or as the trailing part of it
+    /// (<c>Fixtures.IQuery[_]</c> from inside <c>Demo.Binding</c>), which is the
+    /// relative form C# namespace qualification translates to and the shape
+    /// migrated code overwhelmingly uses. Leading segments have to be skipped
+    /// for a package qualifier to resolve at all, but skipping them unchecked
+    /// would accept any prefix whatsoever
+    /// (<c>typeof(Nonsense.Fixtures.IQuery[_])</c>).
+    /// </summary>
+    /// <param name="head">The type the head segment resolved to.</param>
+    /// <param name="names">The raw per-segment names, outermost first.</param>
+    /// <param name="headIndex">The index of the segment that named <paramref name="head"/>.</param>
+    /// <returns>Whether the skipped prefix names the declaring package.</returns>
+    private static bool PrefixMatchesDeclaringPackage(TypeSymbol head, string[] names, int headIndex)
+    {
+        if (headIndex == 0)
+        {
+            return true;
+        }
+
+        var declaringPackage = head switch
+        {
+            StructSymbol structSymbol => structSymbol.PackageName,
+            InterfaceSymbol interfaceSymbol => interfaceSymbol.PackageName,
+            EnumSymbol enumSymbol => enumSymbol.PackageName,
+            DelegateTypeSymbol delegateSymbol => delegateSymbol.PackageName,
+            _ => null,
+        };
+
+        if (declaringPackage == null)
+        {
+            return false;
+        }
+
+        var prefix = string.Join(".", names, 0, headIndex);
+        return string.Equals(prefix, declaringPackage, StringComparison.Ordinal)
+            || declaringPackage.EndsWith("." + prefix, StringComparison.Ordinal);
+    }
+
     private bool TryGetNestedUnboundGenericReflectionSegments(
         TypeClauseSyntax typeClause,
         out string[] segments,
-        out int firstGenericSegment)
+        out int firstGenericSegment,
+        out string[] names,
+        out int[] arities)
     {
         segments = Array.Empty<string>();
+        names = Array.Empty<string>();
+        arities = Array.Empty<int>();
         firstGenericSegment = -1;
         if (!typeClause.HasQualifier || typeClause.IsArray || typeClause.IsNullable || lookupType("_") != null)
         {
@@ -302,6 +481,13 @@ internal sealed partial class ExpressionBinder
         {
             segments[i] = typeClause.QualifierIdentifierTokens[i - 1].Text;
         }
+
+        // Issue #3677: the source-declaration fallback walks SYMBOLS, not
+        // `+`-joined reflection names, so it needs the raw per-segment name and
+        // arity next to the arity-mangled reflection segments built below.
+        names = (string[])segments.Clone();
+        arities = new int[segments.Length];
+        Array.Fill(arities, -1);
 
         for (var i = 0; i < segments.Length; i++)
         {
@@ -322,6 +508,7 @@ internal sealed partial class ExpressionBinder
             }
 
             firstGenericSegment = firstGenericSegment < 0 ? i : firstGenericSegment;
+            arities[i] = args.Count;
             segments[i] += "`" + args.Count;
         }
 

--- a/test/Compiler.Tests/Emit/Issue3677QualifiedNestedOpenGenericTypeOfEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3677QualifiedNestedOpenGenericTypeOfEmitTests.cs
@@ -1,0 +1,147 @@
+// <copyright file="Issue3677QualifiedNestedOpenGenericTypeOfEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #3677 end-to-end: the qualified (<c>typeof(A.B[_, _])</c>) and nested
+/// (<c>typeof(Outer[_].Inner[_])</c>) open-generic spellings over types declared
+/// in the compilation being built must bind AND emit an <c>ldtoken</c> that
+/// loads. #3678 showed the two halves are independent: an open user generic
+/// definition emitted through the generic-REFERENCE TypeSpec path encodes
+/// <c>Name&lt;!0&gt;</c>, whose VAR slot has no binding in that scope, so the PE
+/// compiles and then dies with <c>BadImageFormatException</c> the moment the
+/// <c>typeof</c> runs. This test verifies the IL mechanically and then EXECUTES
+/// the emitted assembly, asserting the <see cref="Type"/> each spelling yields
+/// is the expected open generic definition.
+/// </summary>
+public class Issue3677QualifiedNestedOpenGenericTypeOfEmitTests
+{
+    [Fact]
+    public void QualifiedAndNestedSourceOpenGenericTypeOf_VerifiesAndRuns()
+    {
+        const string Source = """
+            package Demo
+            import System
+
+            class Fixtures {
+                interface IQuery[T] {}
+                interface IChain[A, B, C, D] {}
+            }
+
+            class Outer[T] {
+                class Inner[U] {}
+                class PlainInner {}
+            }
+
+            Console.WriteLine(typeof(Fixtures.IQuery[_]).FullName)
+            Console.WriteLine(typeof(Fixtures.IQuery[_]).IsGenericTypeDefinition)
+            Console.WriteLine(typeof(Fixtures.IChain[_, _, _, _]).FullName)
+            Console.WriteLine(typeof(Demo.Fixtures.IChain[_, _, _, _]).FullName)
+            Console.WriteLine(typeof(Fixtures.IQuery[_]).MakeGenericType(typeof(int32)).GetGenericArguments()[0].FullName)
+            Console.WriteLine(typeof(Outer[_].Inner[_]).FullName)
+            Console.WriteLine(typeof(Outer[_].Inner[_]).GetGenericArguments().Length)
+            Console.WriteLine(typeof(Outer[_].PlainInner).FullName)
+            Console.WriteLine(typeof(Outer[_].PlainInner).IsGenericTypeDefinition)
+            Console.WriteLine(typeof(Fixtures3677.IPackaged[_]).FullName)
+            Console.WriteLine(typeof(Fixtures3677.PackagedOuter[_].Inner[_]).FullName)
+            """;
+
+        // The shape migrated code actually has: in C# the qualifier is a
+        // NAMESPACE, spelled relative to the referencing one.
+        const string PackagedSource = """
+            package Demo.Fixtures3677
+
+            interface IPackaged[T] {}
+
+            class PackagedOuter[T] {
+                class Inner[U] {}
+            }
+            """;
+
+        var expected = string.Join(
+            Environment.NewLine,
+            "Demo.Fixtures+IQuery`1",
+            "True",
+            "Demo.Fixtures+IChain`4",
+            "Demo.Fixtures+IChain`4",
+            "System.Int32",
+            "Demo.Outer`1+Inner`1",
+            "2",
+            "Demo.Outer`1+PlainInner",
+            "True",
+            "Demo.Fixtures3677.IPackaged`1",
+            "Demo.Fixtures3677.PackagedOuter`1+Inner`1") + Environment.NewLine;
+
+        Assert.Equal(expected, CompileVerifyAndRun(Source, PackagedSource));
+    }
+
+    private static string CompileVerifyAndRun(string source, string packagedSource)
+    {
+        var directory = Directory.CreateTempSubdirectory("gs_issue3677_").FullName;
+        try
+        {
+            var sourcePath = Path.Combine(directory, "test.gs");
+            var packagedPath = Path.Combine(directory, "fixtures.gs");
+            var outputPath = Path.Combine(directory, "test.dll");
+            File.WriteAllText(sourcePath, source);
+            File.WriteAllText(packagedPath, packagedSource);
+
+            using var stdout = new StringWriter();
+            using var stderr = new StringWriter();
+            var previousOut = Console.Out;
+            var previousError = Console.Error;
+            Console.SetOut(stdout);
+            Console.SetError(stderr);
+            int exitCode;
+            try
+            {
+                exitCode = Program.Main(new[]
+                {
+                    "/out:" + outputPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    packagedPath,
+                    sourcePath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+                Console.SetError(previousError);
+            }
+
+            Assert.True(exitCode == 0, $"gsc failed:\n{stdout}\n{stderr}");
+            IlVerifier.Verify(outputPath);
+
+            var startInfo = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = directory,
+            };
+            startInfo.ArgumentList.Add("exec");
+            startInfo.ArgumentList.Add("--runtimeconfig");
+            startInfo.ArgumentList.Add(Path.ChangeExtension(outputPath, ".runtimeconfig.json"));
+            startInfo.ArgumentList.Add(outputPath);
+
+            using var process = Process.Start(startInfo);
+            var runtimeOutput = process!.StandardOutput.ReadToEnd();
+            var runtimeError = process.StandardError.ReadToEnd();
+            Assert.True(process.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(process.ExitCode == 0, $"runtime failed:\n{runtimeOutput}\n{runtimeError}");
+            return runtimeOutput.ReplaceLineEndings(Environment.NewLine);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3677QualifiedNestedOpenGenericTypeOfTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3677QualifiedNestedOpenGenericTypeOfTests.cs
@@ -1,0 +1,187 @@
+// <copyright file="Issue3677QualifiedNestedOpenGenericTypeOfTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #3677: the deferred remainder of #3678. The UNQUALIFIED explicit-arity
+/// open-generic spelling (<c>typeof(Slot[_])</c>) now consults the declaration
+/// table, but the QUALIFIED (<c>typeof(Fixtures.IQuery[_])</c>) and NESTED
+/// (<c>typeof(Outer[_].Inner[_])</c>) spellings still resolved through
+/// reflection names against the reference set alone, so a generic declared in
+/// the compilation being built reported GS0113 "Type 'Fixtures.IQuery`1'
+/// doesn't exist". Both spellings now fall back to a SOURCE walk — the head
+/// segment through the ordinary source-type lookup, every later segment as a
+/// nested type of the previously-resolved container — after the imported walks
+/// miss, so an imported match still wins exactly as before.
+/// <para>
+/// As in #3678 the tests EXECUTE the emitted program, so the second half of
+/// that fix (an <c>ldtoken</c> of an open user generic definition must take its
+/// TypeDef row, not an unbound <c>Name&lt;!0&gt;</c> TypeSpec that fails to
+/// load) is covered for the new spellings too.
+/// </para>
+/// </summary>
+public class Issue3677QualifiedNestedOpenGenericTypeOfTests
+{
+    private const string Fixtures = @"
+class Fixtures {
+    interface IQuery[T] {}
+    interface IChain[A, B, C, D] {}
+    class Plain {}
+}
+
+class Outer[T] {
+    class Inner[U] {}
+    class PlainInner {}
+}
+
+class Slot[T] {
+    prop Value int32
+}
+";
+
+    [Fact]
+    public void QualifiedSourceGeneric_SingleArity_BindsAndEmitsOpenDefinition()
+    {
+        var result = EmittedOracle.Evaluate(Fixtures + "\ntypeof(Fixtures.IQuery[_]).Name\n");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("IQuery`1", result.Value);
+    }
+
+    [Fact]
+    public void QualifiedSourceGeneric_MultiArity_BindsAndEmitsOpenDefinition()
+    {
+        var result = EmittedOracle.Evaluate(Fixtures + "\ntypeof(Fixtures.IChain[_, _, _, _]).Name\n");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("IChain`4", result.Value);
+    }
+
+    [Fact]
+    public void QualifiedSourceGeneric_IsGenericTypeDefinition()
+    {
+        var result = EmittedOracle.Evaluate(Fixtures + "\ntypeof(Fixtures.IQuery[_]).IsGenericTypeDefinition\n");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(true, result.Value);
+    }
+
+    [Fact]
+    public void QualifiedSourceGeneric_MakeGenericType_Constructs()
+    {
+        var result = EmittedOracle.Evaluate(
+            Fixtures + "\ntypeof(Fixtures.IQuery[_]).MakeGenericType(typeof(int32)).GetGenericArguments()[0].Name\n");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("Int32", result.Value);
+    }
+
+    [Fact]
+    public void NestedSourceGenericInsideGeneric_BindsAndEmitsOpenDefinition()
+    {
+        var result = EmittedOracle.Evaluate(Fixtures + "\ntypeof(Outer[_].Inner[_]).Name\n");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("Inner`1", result.Value);
+    }
+
+    [Fact]
+    public void NestedSourceGenericInsideGeneric_CarriesEnclosingTypeParameters()
+    {
+        // The CLR gives a type nested in a generic its enclosing type's
+        // parameters too, so `Outer`1+Inner`1` is an arity-2 definition —
+        // exactly what C#'s `typeof(Outer<>.Inner<>)` yields.
+        var result = EmittedOracle.Evaluate(Fixtures + "\ntypeof(Outer[_].Inner[_]).GetGenericArguments().Length\n");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(2, result.Value);
+    }
+
+    [Fact]
+    public void NonGenericNestedInsideSourceGeneric_BindsAndEmitsOpenDefinition()
+    {
+        var result = EmittedOracle.Evaluate(Fixtures + "\ntypeof(Outer[_].PlainInner).IsGenericTypeDefinition\n");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(true, result.Value);
+    }
+
+    [Fact]
+    public void NonGenericNestedInsideSourceGeneric_NamesTheNestedType()
+    {
+        var result = EmittedOracle.Evaluate(Fixtures + "\ntypeof(Outer[_].PlainInner).Name\n");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("PlainInner", result.Value);
+    }
+
+    [Fact]
+    public void QualifiedSourceGeneric_WrongArity_StillReportsUndefinedTypeGS0113()
+    {
+        var result = EmittedOracle.Evaluate(Fixtures + "\nlet t = typeof(Fixtures.IQuery[_, _])\n");
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0113");
+    }
+
+    [Fact]
+    public void QualifiedNonGenericSourceType_WithArity_StillReportsUndefinedTypeGS0113()
+    {
+        var result = EmittedOracle.Evaluate(Fixtures + "\nlet t = typeof(Fixtures.Plain[_])\n");
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0113");
+    }
+
+    [Fact]
+    public void QualifiedSourceGeneric_BogusQualifier_StillReportsUndefinedTypeGS0113()
+    {
+        var result = EmittedOracle.Evaluate(Fixtures + "\nlet t = typeof(Nonsense.Fixtures.IQuery[_])\n");
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0113");
+    }
+
+    [Fact]
+    public void NestedSourceGeneric_WrongOuterArity_StillReportsUndefinedTypeGS0113()
+    {
+        var result = EmittedOracle.Evaluate(Fixtures + "\nlet t = typeof(Outer[_, _].Inner[_])\n");
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0113");
+    }
+
+    [Fact]
+    public void UnqualifiedSourceGeneric_StillBinds()
+    {
+        var result = EmittedOracle.Evaluate(Fixtures + "\ntypeof(Slot[_]).Name\n");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("Slot`1", result.Value);
+    }
+
+    [Fact]
+    public void BareSourceGeneric_StillBinds()
+    {
+        var result = EmittedOracle.Evaluate(Fixtures + "\ntypeof(Slot).Name\n");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("Slot`1", result.Value);
+    }
+
+    [Fact]
+    public void PackageQualifiedSourceGeneric_BindsThroughRelativeQualifier()
+    {
+        // The shape migrated code actually has: the C# `typeof(Fixtures.IQuery<>)`
+        // qualifier is a NAMESPACE, spelled relative to the referencing package.
+        var result = EmittedOracle.Evaluate(new[]
+        {
+            @"
+package Demo.Fixtures3677
+
+interface IQuery3677[T] {}
+",
+            "\ntypeof(Fixtures3677.IQuery3677[_]).Name\n",
+        });
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("IQuery3677`1", result.Value);
+    }
+
+    [Fact]
+    public void QualifiedImportedGeneric_StillWins()
+    {
+        // The imported reflection-name walk runs first and is unchanged: a
+        // fully-qualified BCL generic keeps resolving from the reference set.
+        var result = EmittedOracle.Evaluate(
+            Fixtures + "\ntypeof(System.Collections.Generic.List[_]).Name\n");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("List`1", result.Value);
+    }
+}


### PR DESCRIPTION
Fixes #3677. The explicitly-deferred remainder of the family #3687 fixed (triage on #3501: https://github.com/DavidObando/gsharp/issues/3501#issuecomment-5469492729).

## The gap

#3687 taught the explicit-arity open-generic spelling from #1989 (`typeof(Name[_, …])`, G#'s analogue of C#'s comma-count `Name<,>`) to consult the declaration table — but only for the UNQUALIFIED form. The other two spellings still resolved through reflection names against the reference set alone, so a generic declared in the compilation being built could not be named at all:

```gs
class Fixtures {
    interface IChain[A, B, C, D] {}
}

class Outer[T] {
    class Inner[U] {}
}

typeof(Fixtures.IChain[_, _, _, _])   // was: GS0113 Type 'Fixtures.IChain`4' doesn't exist
typeof(Outer[_].Inner[_])             // was: GS0113 Type 'Outer`1+Inner`1' doesn't exist
```

The qualified branch used `scope.References.TryResolveType(typeClause.DottedName + "`" + arity, …)`; the nested branch used `ResolveNestedUnboundGenericType` over a `+`-joined reflection name. Neither ever sees a source declaration, which has no CLR representation while binding.

## The fix

Both branches now fall back — **after** the imported walks miss, so an imported match still wins exactly as before and the ambiguity/undefined diagnostics are unchanged — to a SOURCE walk over symbols rather than reflection names: the head segment through the ordinary source-type lookup (`BinderContext.TryLookupSourceType`, so lexical nesting and imports apply), every later segment as a nested type of the previously-resolved container (`TryLookupNestedTypeAlias`, including the inherited-nested variant), which is the same machinery `Binder.TryResolveUserNestedTypeChain` uses for the ordinary bound spelling.

`TryGetNestedUnboundGenericReflectionSegments` now yields the raw per-segment name and arity alongside the arity-mangled reflection segments, so the two paths share one parser and one walk.

**Package qualifiers.** The shape migrated code actually has is a NAMESPACE qualifier spelled relative to the referencing package — `Issue2523Fixtures` in the issue is a namespace, not a class. Leading segments are therefore skipped so the head can be found deeper in the chain, but only when they spell the head's declaring package, either in full (`Demo.Binding.Fixtures.IQuery[_]`) or as its trailing part (`Fixtures.IQuery[_]` for a type in `Demo.Binding.Fixtures`). Unchecked skipping would have accepted `typeof(Nonsense.Fixtures.IQuery[_])`.

**Shape checking.** Every segment's declared shape is verified against the arity that segment asked for — a generic definition of exactly N type parameters where `_` placeholders appeared, a non-generic type where none did. So wrong arity (`Fixtures.IQuery[_, _]`), placeholders on a non-generic segment (`Fixtures.Plain[_]`), a wrong outer arity (`Outer[_, _].Inner[_]`) and a bogus qualifier all keep reporting GS0113 rather than silently binding a homonym.

## The emitter half

The second, live defect #3687 found — `ldtoken` of an open user generic definition taking the generic-*reference* TypeSpec path and encoding `Slot<!0>`, a VAR slot with no binding in that scope, so the PE compiled and then died with `BadImageFormatException` — needed **no further change** for these spellings. `GetTypeOfToken`'s open-definition branch already routes any `StructSymbol`/`InterfaceSymbol` generic definition to its TypeDef row, and that covers the nested definitions the new binder path reaches. This is verified, not assumed: the new tests **execute** the emitted code and assert the resulting `System.Type`, and the Compiler.Tests one runs `IlVerifier.Verify` on the PE first and then the program in a child `dotnet exec`, asserting exact `FullName`s:

```
Demo.Fixtures+IQuery`1                  IsGenericTypeDefinition True
Demo.Fixtures+IChain`4                  (also via Demo.Fixtures.IChain[_, _, _, _])
Demo.Outer`1+Inner`1                    GetGenericArguments().Length == 2
Demo.Outer`1+PlainInner                 IsGenericTypeDefinition True
Demo.Fixtures3677.IPackaged`1           (relative package qualifier)
Demo.Fixtures3677.PackagedOuter`1+Inner`1
```

These match `typeof(Outer<>.Inner<>)` in C# exactly, including the CLR rule that a type nested in a generic inherits its enclosing parameters (so `Outer`1+Inner`1` is an arity-2 definition and `Outer`1+PlainInner` is itself a generic type definition).

## Verification

- Reproduced first on hand-written G# through a rebuilt `out/bin/Release/Compiler/gsc.dll`: four GS0113s before, all six spellings compiling and printing the right `Type` after; the four negative spellings above still error.
- `test/Core.Tests` — new `Issue3677QualifiedNestedOpenGenericTypeOfTests` (16). **9 of them fail on `main` (verified by reverting only the binder file) and pass here**; the other 7 are regression guards (the unqualified `Slot[_]`, bare `Slot`, and qualified imported `System.Collections.Generic.List[_]` spellings, plus the four negatives).
- `test/Compiler.Tests` — new `Issue3677QualifiedNestedOpenGenericTypeOfEmitTests` (ilverify + execute).
- Full `test/Core.Tests`: 8332 passed, 0 failed. `Samples_EmittedPE_Match_Baseline` passes unchanged — **no baseline regeneration**, no emitted PE moved (this change only adds a resolution fallback on a path that previously errored out).
- The `typeof`/`Issue1915`/`Issue1989`/`Issue3678` suites and a 1346-test `Nested`/`Generic`/`Samples` subset are green.

## Migration effect

Not re-measured end to end (the gate's translate + validate through the packed SDK is a whole-repo run). The 5 GS0113 the issue attributes to this family are exactly two shapes — `typeof(Issue2523Fixtures.IChain2523[_, _, _, _])` / `IQuery2523[_]` (a relative NAMESPACE qualifier over a source generic) and `typeof(Issue2851ImportedOuter[_].Inner[_])` (a generic nested in a generic) — and both are reproduced verbatim, compiled and executed here, including the sub-package form. The 4 GS0159 cascades (`MakeGenericType` ×3, `Add` ×1) follow from the error expression they produced; `MakeGenericType` on a qualified open generic is covered by a new test. That leaves the 6th GS0113, the dropped `Fixtures.` qualifier tracked on #3684, untouched — so the expected movement is 6 → 1 GS0113 and 25 → 21 GS0159 at the next migration run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
