### PR TITLE
gsc + cs2gs: four root causes from the migrated Core.Tests long tail (#3684)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -1781,6 +1781,22 @@ public sealed class Conversion
     }
 
     /// <summary>
+    /// Returns whether <c>to(fromValue)</c> is a checked CLR <em>unboxing</em>
+    /// cast — the value-type mirror of
+    /// <see cref="HasCheckedReferenceConversion"/>. Issue #3684 (family F8):
+    /// the conversion-call spelling <c>T(expr)</c> over a value-typed <c>T</c>
+    /// (e.g. <c>ImmutableArray[P](method.Invoke(…))</c>, the G# form of a C#
+    /// <c>(ImmutableArray&lt;P&gt;)</c> cast) needs this alongside the
+    /// reference case, because the constructor-overload fallback in
+    /// <c>ExpressionBinder</c> can only offer a conversion it can name.
+    /// </summary>
+    /// <param name="from">Static source type.</param>
+    /// <param name="to">Requested target type.</param>
+    /// <returns><see langword="true"/> for an explicit checked unboxing conversion.</returns>
+    internal static bool HasCheckedUnboxingConversion(TypeSymbol? from, TypeSymbol? to)
+        => HasExplicitUnboxingConversion(from, to);
+
+    /// <summary>
     /// Returns whether <c>to(fromValue)</c> is a checked CLR reference cast.
     /// The conversion preserves a null reference, returns the target reference
     /// on success, and throws <see cref="InvalidCastException"/> for an

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Attributes.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Attributes.cs
@@ -905,6 +905,29 @@ internal sealed partial class DeclarationBinder
                 }
 
                 return false;
+
+            // Issue #3684 (family F11): a flags-enum combination —
+            // `@AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)`
+            // — is the single most common attribute argument in the BCL's own
+            // surface, and it is a compile-time constant per ECMA-335 II.23.3
+            // (the blob carries the folded underlying primitive). It parses as
+            // a binary expression, so like the unary case above it never
+            // reached the enum-literal fallthrough. Fold it with the same
+            // constant evaluator the `const`-field binder uses and accept only
+            // serialisable (primitive / string / enum) results.
+            case BinaryExpressionSyntax binarySyntax:
+                if (bindExpression(binarySyntax) is { } boundBinary
+                    && boundBinary.Type is { } binaryType
+                    && ConstantExpressionEvaluator.TryEvaluate(boundBinary, out var foldedBinary)
+                    && foldedBinary is not null
+                    && IsSerialisableAttributeConstant(binaryType))
+                {
+                    value = foldedBinary;
+                    type = binaryType;
+                    return true;
+                }
+
+                return false;
         }
 
         // Issue #177: accept BoundLiteralExpression whose static type is an
@@ -969,7 +992,19 @@ internal sealed partial class DeclarationBinder
         // values via Array.GetValue — so a runtime-equivalent container
         // element type is exact.
         var containerElementType = ResolveRuntimeContainerElementType(elementClrType);
-        var result = Array.CreateInstance(containerElementType, elements.Count);
+
+        // Issue #3684 (family F11): bind every element FIRST, because a
+        // `typeof(T)` naming a type declared in THIS compilation has no CLR
+        // `Type` yet — `TryBindAttributeArgument` hands back the `TypeSymbol`
+        // placeholder instead (the same placeholder the SCALAR `typeof`
+        // argument position has always carried, and which
+        // `CustomAttributeEncoder.WriteCustomAttributeFixedArg` already
+        // serialises). A `Type[]` container cannot hold that placeholder, so
+        // `SetValue` threw and `@Property(Arbitrary: []Type{typeof(Local)})`
+        // was rejected as non-constant. Widen the CONTAINER to `object[]` in
+        // that case; the blob is written from the SIGNATURE's element type, so
+        // the container's own element type never reaches metadata.
+        var elementValues = new object?[elements.Count];
         for (int i = 0; i < elements.Count; i++)
         {
             if (!TryBindAttributeArgument(elements[i], out var elementValue, out _))
@@ -977,9 +1012,19 @@ internal sealed partial class DeclarationBinder
                 return false;
             }
 
+            elementValues[i] = elementValue;
+            if (elementValue is TypeSymbol)
+            {
+                containerElementType = typeof(object);
+            }
+        }
+
+        var result = Array.CreateInstance(containerElementType, elements.Count);
+        for (int i = 0; i < elements.Count; i++)
+        {
             try
             {
-                result.SetValue(CoerceAttributeElement(elementValue, containerElementType), i);
+                result.SetValue(CoerceAttributeElement(elementValues[i], containerElementType), i);
             }
             catch
             {

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -1492,7 +1492,39 @@ internal sealed partial class ExpressionBinder
             }
 
             var argument = boundArguments[0];
-            if (Conversion.HasCheckedReferenceConversion(argument.Type, conversionTarget))
+
+            // Issue #3684 (family F8): the same fallback must cover the
+            // value-typed target. `ImmutableArray[ParameterSymbol](method.Invoke(…))`
+            // is a G# conversion call over an IMPORTED GENERIC value type — a
+            // plain C# `(ImmutableArray<ParameterSymbol>)` cast — but the type
+            // name binds as a constructor call, no `.ctor` takes a single
+            // `object?`, and the reference-cast fallback below rejects a value
+            // type outright, so the whole shape reported GS0267. An unboxing
+            // cast from `object`/`ValueType`/`Enum`/a implemented interface is
+            // exactly as checked (and as runtime-throwing) as the reference
+            // case, so it belongs on the same fallback.
+            if (Conversion.HasCheckedReferenceConversion(argument.Type, conversionTarget)
+                || Conversion.HasCheckedUnboxingConversion(argument.Type, conversionTarget))
+            {
+                result = conversions.BindConversion(
+                    syntax.Arguments[0].Location,
+                    argument,
+                    conversionTarget,
+                    allowExplicit: true);
+                return true;
+            }
+
+            // Issue #3684 (family F8), third shape: a DELEGATE target —
+            // `Func[TypeSymbol, TypeSymbol]((e TypeSymbol) -> …)`, the G# form
+            // of a C# `(Func<TypeSymbol, TypeSymbol>)(e => …)` cast. The CLR
+            // delegate `.ctor` takes `(object, IntPtr)`, so a one-argument call
+            // never resolves and the whole conversion reported GS0267. Bind it
+            // as the conversion it is, but only when one genuinely exists —
+            // an argument that cannot convert still falls through to GS0267.
+            if (conversionTarget.ClrType is { } targetClr
+                && ClrTypeUtilities.IsDelegateType(targetClr)
+                && argument.Type is { } argumentType
+                && Conversion.Classify(argumentType, conversionTarget).Exists)
             {
                 result = conversions.BindConversion(
                     syntax.Arguments[0].Location,

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -47,6 +47,23 @@ internal sealed partial class ExpressionBinder
             return BindDereferenceExpression(syntax);
         }
 
+        // Issue #3684 (family F14) / ECMA-334 §12.9.3: the lexer types a
+        // decimal literal one past int.MaxValue as `uint32` (it does not fit
+        // int32), so `-2147483648` — plain `int32.MinValue`, and how every C#
+        // corpus spells it — bound as a negation of uint32 and was rejected
+        // outright with GS0128 (`-` is not defined for uint32). C# resolves
+        // this at the token level: a decimal literal whose value is exactly
+        // 2^31 and which sits IMMEDIATELY under a unary minus is an `int32`.
+        // The enum-member folder (DeclarationBinder.TryFoldEnumMemberValue,
+        // issue #1912) already carried this rule; mirror it for the general
+        // expression position so the two agree.
+        if (syntax.OperatorToken.Kind == SyntaxKind.MinusToken
+            && syntax.Operand is LiteralExpressionSyntax { Value: uint negatedMagnitude }
+            && negatedMagnitude == (uint)int.MaxValue + 1)
+        {
+            return new BoundLiteralExpression(null, int.MinValue, TypeSymbol.Int32);
+        }
+
         var boundOperand = BindExpression(syntax.Operand);
 
         if (boundOperand.Type == TypeSymbol.Error)

--- a/test/Core.Tests/CodeAnalysis/Binding/AttributeBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/AttributeBinderTests.cs
@@ -1073,6 +1073,68 @@ struct Point {
     }
 
     [Fact]
+    public void AttributeArgument_EnumFlagsOr_IsFoldedAsConstant()
+    {
+        // Issue #3684 (family F11): `AttributeTargets.Method |
+        // AttributeTargets.Class` is a compile-time constant per ECMA-335
+        // II.23.3 (the blob carries the folded underlying primitive), but it
+        // parses as a binary expression and so missed the enum-literal
+        // fallthrough in TryBindAttributeArgument — GS0202.
+        var source = """
+            import System
+
+            @Attribute
+            @AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple: true, Inherited: true)
+            class Marker {
+            }
+
+            @Marker
+            func Foo() {
+            }
+
+            @Marker
+            class Boxed {
+            }
+            """;
+
+        var globalScope = BindSource(source);
+        Assert.DoesNotContain(GetBinderDiagnostics(globalScope), d => d.Id == "GS0202");
+
+        // The folded ValidOn must actually cover BOTH targets — a fold that
+        // silently kept only the first operand would report GS0209 on one of
+        // the two applications.
+        Assert.DoesNotContain(GetBinderDiagnostics(globalScope), d => d.Id == "GS0209");
+    }
+
+    [Fact]
+    public void AttributeArgument_ArrayOfTypeOfSameCompilationType_IsFoldedAsConstant()
+    {
+        // Issue #3684 (family F11): a 1-D array of `typeof` is explicitly
+        // legal, but an element naming a type declared in THIS compilation has
+        // no CLR `Type` yet — the binder hands back the `TypeSymbol`
+        // placeholder, which a `Type[]` container could not hold, so
+        // `Array.SetValue` threw and the whole argument was rejected (GS0202).
+        var source = """
+            import System
+
+            class Generators {
+            }
+
+            @Attribute
+            @AttributeUsage(AttributeTargets.All)
+            class ArbitraryAttribute {
+            }
+
+            @Arbitrary([]Type{typeof(Generators), typeof(string)})
+            func Foo() {
+            }
+            """;
+
+        var globalScope = BindSource(source);
+        Assert.DoesNotContain(GetBinderDiagnostics(globalScope), d => d.Id == "GS0202");
+    }
+
+    [Fact]
     public void Conditional_On_Non_Void_Function_Reports_GS0212()
     {
         // Issue #176 / ADR-0047 §6: `[Conditional]` requires a void return

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1912ExplicitEnumMemberValueTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1912ExplicitEnumMemberValueTests.cs
@@ -147,6 +147,20 @@ StatusCode.DefaultError == StatusCode.ServerError
         return Assert.Single(globalScope.Enums);
     }
 
+    [Fact]
+    public void MinValueLiteral_InExpressionPosition_BindsAndEvaluatesAsInt32()
+    {
+        // Issue #3684 (family F14): the same lattice quirk applies OUTSIDE an
+        // enum-member initializer — the enum folder special-cased
+        // `-2147483648` but the general expression binder still saw a negation
+        // of `uint32` and reported GS0128, so every migrated
+        // `Assert.Equal(-2147483648, …)` failed to compile.
+        var result = Evaluate("-2147483648");
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(int.MinValue, result.Value);
+    }
+
     private static ImmutableArray<Diagnostic> BindDiagnostics(string source)
     {
         var tree = SyntaxTree.Parse(SourceText.From(source));

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2621ImportedGenericConstructorTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2621ImportedGenericConstructorTests.cs
@@ -65,6 +65,63 @@ public sealed class Issue2621ImportedGenericConstructorTests
         Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.Id is "GS0130" or "GS0267");
     }
 
+    [Fact]
+    public void ImportedGenericValueType_ConversionCallFromObject_Unboxes()
+    {
+        // Issue #3684 (family F8): `ImmutableArray[int32](o)` is the G#
+        // spelling of a C# `(ImmutableArray<int>)o` CAST, not a construction —
+        // there is no single-`object` `.ctor`. The constructor-overload
+        // fallback offered a checked REFERENCE conversion only, which a value
+        // type can never satisfy, so the whole shape reported GS0267.
+        const string source = """
+            package Demo
+            import System.Collections.Immutable
+
+            func Take(o object) ImmutableArray[int32] {
+                return ImmutableArray[int32](o)
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void ImportedGenericValueType_ConversionCallFromUnrelatedValue_StillReportsNoOverload()
+    {
+        // The unboxing fallback must not swallow a genuinely impossible
+        // conversion: an `int32` source is not a box, so there is nothing to
+        // unbox and GS0267 still stands.
+        const string source = """
+            package Demo
+            import System.Collections.Immutable
+
+            func Take(n int32) {
+                let taken = ImmutableArray[int32](n)
+            }
+            """;
+
+        Assert.Contains(Bind(source), diagnostic => diagnostic.Id == "GS0267");
+    }
+
+    [Fact]
+    public void ImportedGenericDelegate_ConversionCallFromLambda_Binds()
+    {
+        // Issue #3684 (family F8), third shape: `Func[int32, int32](lambda)` is
+        // the G# form of a C# `(Func<int, int>)(e => …)` cast. The CLR delegate
+        // `.ctor` takes `(object, IntPtr)`, so the one-argument call never
+        // resolved and the cast reported GS0267.
+        const string source = """
+            package Demo
+            import System
+
+            func Wrap() Func[int32, int32] {
+                return Func[int32, int32](((e int32) -> e + 1))
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
     private static ImmutableArray<Diagnostic> Bind(string source)
     {
         return EmittedOracle.Evaluate(source).Diagnostics;

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -1819,14 +1819,23 @@ public static class GSharpPrinter
         var sb = new StringBuilder();
         sb.Append(RenderAttributeBlock(declaration.Attributes, indent));
         sb.Append(pad);
+        sb.Append(RenderVisibility(declaration.Visibility));
         if (declaration.IsUnsafe)
         {
-            // ADR-0122 / issue #1014: the `unsafe` contextual modifier precedes
-            // the accessibility keyword (`unsafe public class …`).
+            // ADR-0122 / issue #1202 (issue #3684, family F9): the canonical
+            // aggregate head is `[visibility]? [unsafe]? [open|sealed]? …` —
+            // `ParseMember` consumes the accessibility keyword BEFORE
+            // `TryDetectAggregateDeclarationHead` runs, so an `unsafe` that
+            // precedes the visibility keyword is not recognised as a
+            // declaration head at all and the token parses as an expression
+            // statement (GS0125 `Variable 'unsafe' doesn't exist`). Emitting
+            // it AFTER the visibility keyword matches the grammar; the
+            // modifier then actually establishes the unsafe context, which is
+            // what makes a `*T` member signature legal (otherwise `*T` means a
+            // managed by-ref and GS0243 rejects it as a parameter type).
             sb.Append("unsafe ");
         }
 
-        sb.Append(RenderVisibility(declaration.Visibility));
         if (declaration.IsOpen)
         {
             sb.Append("open ");

--- a/tools/cs2gs/Cs2Gs.Tests/FaithfulUnsafeFormTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/FaithfulUnsafeFormTranslationTests.cs
@@ -147,8 +147,13 @@ namespace Demo
     }
 
     /// <summary>
-    /// Issue #1026: a C# <c>unsafe class</c> maps to a G# <c>unsafe class</c> (the
-    /// <c>unsafe</c> modifier precedes the visibility on the type declaration).
+    /// Issue #1026: a C# <c>unsafe class</c> maps to a G# <c>unsafe class</c>.
+    /// Issue #3684 (family F9): the <c>unsafe</c> modifier FOLLOWS the
+    /// visibility keyword — ADR-0078's aggregate head is
+    /// <c>[visibility]? [unsafe]? [open|sealed]? class …</c> and gsc's
+    /// <c>ParseMember</c> consumes the accessibility keyword before it probes
+    /// for a declaration head, so <c>unsafe internal class</c> does not parse
+    /// at all.
     /// </summary>
     [Fact]
     public void UnsafeClass_TranslatesToUnsafeClassModifier()
@@ -162,7 +167,39 @@ namespace Demo
     }
 }");
 
+        // `public` is G#'s default visibility, so the rendered head is bare
+        // `unsafe class` — what matters is that no accessibility keyword ever
+        // follows the `unsafe` modifier.
         Assert.Contains("unsafe class Native", printed);
+        Assert.DoesNotContain("unsafe public", printed);
+    }
+
+    /// <summary>
+    /// Issue #3684 (family F9): a C# <c>file unsafe sealed class</c> with a
+    /// pointer-typed member parameter. The type's visibility is `internal`, so
+    /// the modifier order regression showed up as `unsafe internal class`; with
+    /// the canonical order the `unsafe` modifier actually takes effect and the
+    /// <c>*T</c> parameter binds as an UNMANAGED pointer rather than a managed
+    /// by-ref (which gsc rejects as a parameter type with GS0243).
+    /// </summary>
+    [Fact]
+    public void UnsafeInternalClassWithPointerParameter_EmitsVisibilityBeforeUnsafe()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    internal unsafe sealed class Fixture<T>
+        where T : unmanaged
+    {
+        public void AcceptPointer(T* value) => _ = value;
+    }
+}");
+
+        // G# classes are sealed by default (`open` is the opt-in), so `sealed`
+        // is dropped; the load-bearing part is that `unsafe` follows `internal`.
+        Assert.Contains("internal unsafe class Fixture[T unmanaged]", printed);
+        Assert.DoesNotContain("unsafe internal", printed);
+        Assert.Contains("value *T", printed);
     }
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Tests/OahuFoundationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuFoundationTranslationTests.cs
@@ -511,6 +511,29 @@ namespace Demo
     }
 
     /// <summary>
+    /// Issue #3684 (family F14): `-2147483648` is `int.MinValue` in C#
+    /// (§12.9.3 types the decimal literal 2147483648 as `int` when it sits
+    /// immediately after a unary minus), but the LITERAL TOKEN's lexed value is
+    /// the `uint` 2147483648. Deriving the width suffix from the token value
+    /// emitted `-2147483648U`, and G# has no unary `-` on uint32 (GS0128).
+    /// </summary>
+    [Fact]
+    public void NegatedIntMinValueLiteral_GetsNoUnsignedSuffix()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public static class Bounds
+    {
+        public static int Min() => -2147483648;
+    }
+}");
+
+        Assert.Contains("-2147483648", printed);
+        Assert.DoesNotContain("2147483648U", printed);
+    }
+
+    /// <summary>
     /// ADR-0115 §B: a bare catch-all `catch { }` (no declaration) has no G# form;
     /// the translator synthesizes the required typed binder
     /// `catch (__caught Exception) { }`.

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -438,6 +438,26 @@ public sealed partial class CSharpToGSharpTranslator
                 return text;
             }
 
+            // Issue #3684 (family F14): the width suffix must come from the type
+            // of the NEGATED expression, not the bare literal. C# §12.9.3 gives
+            // `-2147483648` the type `int` (value int.MinValue) even though the
+            // literal `2147483648` on its own is `uint`, and Roslyn records that
+            // only on the enclosing unary node. Suffixing off the literal
+            // produced `-2147483648U`, which G# rejects outright — it has no
+            // unary `-` on uint32 (GS0128). Take the negated expression's own
+            // bound type instead, and never emit an UNSIGNED suffix under a
+            // minus: an unsigned operand is exactly what makes the operator
+            // undefined.
+            if (literal.Parent is PrefixUnaryExpressionSyntax negation
+                && negation.IsKind(SyntaxKind.UnaryMinusExpression))
+            {
+                return this.context.GetTypeInfo(negation).Type?.SpecialType switch
+                {
+                    SpecialType.System_Int64 => text + "L",
+                    _ => text,
+                };
+            }
+
             switch (value)
             {
                 case ulong:


### PR DESCRIPTION
Part of #3684 — four of the long tail's root-cause families, re-measured against
current `main`. The issue's counts were stale: a great deal has merged since it
was filed (#3687, #3690, #3692, #3693, #3696, #3697, #3698), so the first thing
this branch did was a whole-repository translate plus
`cs2gs validate --app test/Core.Tests/Core.Tests.csproj` to establish what
actually survives. Family **F18** (`TypeBuilder.DefineMethod` /
`GetILGenerator`, GS0159 ×2) is **already gone** — it was a receiver-typing
cascade off the `typeof` family fixed in #3687, exactly as the issue suspected.

### F9 — `unsafe` type modifier and `*T` parameter (2) — cs2gs

ADR-0078's aggregate head is `[visibility]? [unsafe]? [open|sealed]? class …`,
and gsc's `ParseMember` consumes the accessibility keyword **before** it probes
for a declaration head. The printer emitted the modifier *first*
(`unsafe internal class`), so `TryDetectAggregateDeclarationHead` never
recognised the head at all and the token fell out as an expression statement —
GS0125 `Variable 'unsafe' doesn't exist`. Because the modifier never took
effect, the `*T` member parameter beneath it also bound as a **managed by-ref**
rather than an unmanaged pointer, which the binder rejects as a parameter type
(GS0243). One printer-ordering fix clears both diagnostics; the pre-existing
`unsafe class Native` assertion still holds, since `public` is G#'s default
visibility and renders as nothing.

### F11 — attribute-argument constant folding (2) — gsc

Two shapes ECMA-335 II.23.3 permits but `TryBindAttributeArgument` rejected with
GS0202:

- **`AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, …)`** — a
  flags-enum combination parses as a *binary* expression, so it never reached
  the enum-literal fallthrough. It now folds through the same
  `ConstantExpressionEvaluator` the unary-literal case (#2831) already used, and
  is accepted on the same serialisable-type rule.
- **`@Property(Arbitrary: []Type{typeof(OverloadResolutionGenerators)})`** — a
  1-D `typeof` array whose element names a type declared in *this* compilation.
  That element has no CLR `Type` yet, so the binder hands back the `TypeSymbol`
  placeholder — the same placeholder the **scalar** `typeof` argument position
  has always carried, and which `CustomAttributeEncoder` already serialises —
  but a `Type[]` container cannot hold it, so `Array.SetValue` threw and the
  whole argument was reported non-constant. The container now widens to
  `object[]` in that case only. **Metadata is unchanged**: the blob is written
  from the *signature's* element type, and the container's element type never
  reaches it.

### F14 — `-2147483648` (1) — both layers

Two stacked defects:

- **cs2gs** derived the width suffix from the literal TOKEN's lexed value (the
  `uint` 2147483648) rather than from the negated expression's bound type, and
  emitted `-2147483648U`.
- **gsc** rejected even the correct spelling. Its lexer types the literal as
  `uint32` (it does not fit int32) and there is no unary `-` on uint32, so
  GS0128. ECMA-334 §12.9.3 settles this at the token level: a decimal literal of
  exactly 2^31 sitting *immediately* under a unary minus is an `int32`.
  `DeclarationBinder.TryFoldEnumMemberValue` has carried that rule for enum
  members since #1912; the general expression binder now agrees with it.

### F8 — conversion-call over an imported generic (3 + 3 cascades) — gsc

`T(expr)` is G#'s cast spelling, but a type name binds as a **constructor** call
and `FinishClrConstructorBindingFailure` could only offer a checked *reference*
conversion on failure. Two shapes therefore reported GS0267:

- `ImmutableArray[ParameterSymbol](method.Invoke(…))` and
  `ValueTask[bool](moveNext.Invoke(…))` — plain C# **unboxing** casts, which a
  reference-only fallback can never satisfy for a value type;
- `Func[TypeSymbol, TypeSymbol]((e TypeSymbol) -> …)` — a delegate target, whose
  CLR `.ctor` takes `(object, IntPtr)` and so never matches a one-argument call.

The fallback now also offers a checked unboxing conversion, and for a delegate
target any conversion that genuinely exists. An argument that cannot convert
still falls through to GS0267 — covered by a negative test.

## Verification

- `test/Core.Tests`: `AttributeBinderTests`, `Issue2621ImportedGenericConstructorTests`,
  `Issue1912ExplicitEnumMemberValueTests`, `Issue1881*`, `Issue2023*` — 128
  passed. The three new gsc tests fail on `main` and pass here (measured by
  reverting only the binder files and rebuilding).
- `tools/cs2gs/Cs2Gs.Tests`: `FaithfulUnsafeFormTranslationTests`,
  `OahuFoundationTranslationTests`, `Issue1910PartialTypeMergeTranslationTests`
  — 40 passed, including the two new translation tests (which fail on `main`).
- **`Samples_EmittedPE_Match_Baseline` was not regenerated and is not expected to
  move.** Every gsc change here only admits a shape that previously produced a
  *compile error*, so no program that used to emit can emit differently: the
  attribute folder accepts arguments that were rejected, the negation rule binds
  a literal that was rejected, and the conversion-call fallback fires only on
  the `noApplicableOverload` path that already returned an error.

## Measured before/after — migrated `test/Core.Tests`

Whole-repository `cs2gs migrate` (50/51 apps translate; the one failure is the
unrelated `out/scratch/ildump` scratch project) followed by
`cs2gs validate --app test/Core.Tests/Core.Tests.csproj` against the freshly
packed SDK. No project the app project-references was excluded.

Both runs report a large, steady block of `GS0536` "redundant `!!`" entries
(104 → 105). Those are **first-compile artifacts**: stage 2's polish pass strips
them and recompiles — this run rewrote 166 `.gs` files that way — and the count
is flat across before/after, so the substantive figure is the non-`GS0536` one.

| | before | after |
|---|---:|---:|
| all compile errors | 159 | **127** |
| excluding the `GS0536` polish artifacts | 55 | **22** |

Before = `ff6a84ed` (this branch's original base). After = `069167e7` + this
branch, so the 33-error drop also contains #3696, #3697 and #3698, which merged
mid-measurement. The four families **this** PR owns are unambiguous at
site level, and all 11 of their errors are gone:

| family | before | after |
|---|---|---|
| F8 `ImmutableArray[P](…)`, `ValueTask[bool](…)`, `Func[T, T](lambda)` | GS0267 ×3 | — |
| F8 cascades — `vt.AsTask()`, `parameter.Name`, `parameter.Type` | GS0159 ×1, GS0158 ×2 | — |
| F9 `unsafe internal class` + `*T` parameter | GS0125 ×1, GS0243 ×1 | — |
| F11 enum `\|` and `[]Type{typeof(…)}` in an attribute | GS0202 ×2 | — |
| F14 `-2147483648` | GS0128 ×1 | — |

**No diagnostic id increased and no new id appeared** — the after-run's id set is
a strict subset of the before-run's. `GS0128`, `GS0202`, `GS0243` and `GS0267`
are now absent from the app entirely.

## What remains in #3684

The issue stays open. Its remaining families, with **current** evidence from the
after-run (so the issue is actionable rather than stale):

| family | now | site | layer |
|---|---|---|---|
| **F7** read-only property in a `{ … }` initializer | GS0127 ×3 | `Issue3258BoundSyntaxDiagnosticTests.gs(98,25)` and `(101,34)`; `BoundTreeRewriterClonePreservationTests.gs(39,36)` | gsc — the target properties are `{ get; internal set; }` in `src/Core`, and Core.Tests is now a friend assembly (#3693), so the object-initializer path is not honouring a non-public setter across assemblies |
| **F10** one interface at two instantiations | GS0264 + GS0187 | `Issue3465InferenceTests.gs(1079,7)` / `(1081,10)` | gsc — genuine language gap; needs an explicit-interface-implementation spelling, not a binder patch |
| **F12** async golden test loses its `catch` binding | GS0157 ×2, GS0125 ×1 | `AsyncEmitGoldenTests.gs(348,32)`, `(360,27)`, `(360,49)` | cs2gs — C# `catch (TargetInvocationException ex) when (ex.InnerException is AggregateException agg)`: the filter's rethrow lowering hoists the pattern designation's spill OUT of the catch body, where neither `ex` nor `agg` is in scope |
| **F13** method group to a nullable function type | GS0218 ×1 | `Issue1958InterfaceMemberGenericSubstitutionTests.gs(78,46)` — `let mapClrType ((Type?) -> Type?)? = resolver.MapClrTypeToReferences` | undetermined; either cs2gs should not annotate a method-group target nullable, or gsc should accept the method-group→`F?` conversion |
| **F15** `.index` on a while-let tuple binding | GS0158 ×1 | `Issue3352WhileLetBindingTests.gs(109,14)` | cs2gs |
| **F16** `[]T{…}` at an `ImmutableArray[T]` target | GS0155 ×1 | `OverloadResolutionGenerators.gs(16,58)` | cs2gs — a C# collection expression whose target carries `[CollectionBuilder]` must emit the builder's factory call (`ImmutableArray.Create[T](…)`), not a slice literal |
| **F1b** `typeof` qualifier dropped | GS0113 ×1 | `ImportedExtensionMethodTests.gs(303,110)` — C# `typeof(Fixtures.Handler322Extensions)` lost its `Fixtures.` qualifier and no import replaces it | cs2gs |
| **F18** `TypeBuilder.DefineMethod` / `GetILGenerator` | **gone** | — | was a receiver-typing cascade off the `typeof` family fixed in #3687 |

Two things worth carrying forward that are **not** part of #3684:

- `Issue3673NullableReceiverExtensionInferenceTests.gs(92,52)` / `(92,59)` —
  GS0159 + GS0113 on `List[string]{ typeof(Issue3673NullableReceiverExtensions).Assembly.Location }`.
  This is a NEW site of the #3677 source-declared-`typeof` family (a `typeof`
  of a same-compilation type inside a *collection initializer*), which #3698
  did not reach.
- `DebugInformationOptionsTests.gs(27,91)` and
  `ImportedEnumAttributeEmitTests.gs(99,24)` — the two residual #3682 `nil`
  sites that #3696 did not cover: an object-initializer member (`{DebugInformation = nil}`)
  and a bare `return nil` on a reference-returning method, neither of which is
  an array/slice literal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
