### PR TITLE
cs2gs: null-forgiveness for a nullable call result read from an oblivious file (#3683)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue3683ObliviousCallResultForgivenessTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3683ObliviousCallResultForgivenessTests.cs
@@ -1,0 +1,178 @@
+// <copyright file="Issue3683ObliviousCallResultForgivenessTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3683, family F5: a CALL RESULT whose declared return is an annotated
+/// <c>T?</c> reference, read from an OBLIVIOUS file. This is the sibling of the
+/// cast-receiver half (family F6, fixed in #3687) — the same
+/// cross-nullable-context read through a different syntactic door.
+/// <c>test/Core.Tests</c> declares no <c>Nullable</c> setting while
+/// <c>src/Core</c> is annotated, so Roslyn erases the annotation at the call
+/// site (the expression's type reports <c>NullableAnnotation.None</c> and the
+/// flow state is <c>None</c>); none of the ordinary forgiveness predicates
+/// fire, and the chained dereference reached gsc as a <c>T?</c> receiver
+/// (GS0158 on a member, GS0116 on an index).
+/// </summary>
+public class Issue3683ObliviousCallResultForgivenessTests
+{
+    // Deliberately ABSTRACT members: an annotated declaration with no body can
+    // seed no evidence in the whole-program taint fixpoint, so these tests
+    // exercise the ANNOTATION path only and never the (already-covered)
+    // oblivious promotion path.
+    private const string AnnotatedDeclarations = @"
+#nullable enable
+using System.Threading.Tasks;
+
+namespace Demo
+{
+    public abstract class Node
+    {
+        private Node? slot;
+
+        public string Name { get; set; } = string.Empty;
+
+        public abstract Node? Child();
+
+        public abstract Node Required();
+
+        public abstract Node[]? Children();
+
+        public abstract Task<Node> LoadAsync();
+
+        // Concrete on purpose: gsc has no `open prop this[...]` form yet, so an
+        // abstract indexer could not be bound back by AssertBinds.
+        public Node? this[int index] => this.slot;
+    }
+}";
+
+    [Fact]
+    public void ObliviousCallOfAnnotatedNullableReturn_MemberAccessReceiver_IsForgiven()
+    {
+        string printed = Translate(@"
+namespace Demo
+{
+    public class Holder
+    {
+        public string Read(Node node)
+        {
+            return node.Child().Name;
+        }
+    }
+}", out string declarations);
+
+        Assert.Contains("node.Child()!!.Name", printed);
+        TranslationTestValidation.AssertBinds(declarations, printed);
+    }
+
+    [Fact]
+    public void ObliviousCallOfAnnotatedNullableArrayReturn_ElementAccessReceiver_IsForgiven()
+    {
+        string printed = Translate(@"
+namespace Demo
+{
+    public class Holder
+    {
+        public Node Read(Node node)
+        {
+            return node.Children()[0];
+        }
+    }
+}", out string declarations);
+
+        Assert.Contains("node.Children()!![0]", printed);
+        TranslationTestValidation.AssertBinds(declarations, printed);
+    }
+
+    [Fact]
+    public void ObliviousReadOfAnnotatedNullableIndexer_MemberAccessReceiver_IsForgiven()
+    {
+        string printed = Translate(@"
+namespace Demo
+{
+    public class Holder
+    {
+        public string Read(Node node)
+        {
+            return node[0].Name;
+        }
+    }
+}", out string declarations);
+
+        Assert.Contains("node[0]!!.Name", printed);
+        TranslationTestValidation.AssertBinds(declarations, printed);
+    }
+
+    [Fact]
+    public void ObliviousCallOfNonNullableReturn_StaysUnforgiven()
+    {
+        string printed = Translate(@"
+namespace Demo
+{
+    public class Holder
+    {
+        public string Read(Node node)
+        {
+            return node.Required().Name;
+        }
+    }
+}", out string declarations);
+
+        Assert.Contains("node.Required().Name", printed);
+        Assert.DoesNotContain("Required()!!", printed);
+        TranslationTestValidation.AssertBinds(declarations, printed);
+    }
+
+    [Fact]
+    public void ObliviousAwaitOfNonNullableTaskReturn_EnvelopeStaysUnforgiven()
+    {
+        // A `Task<T>` envelope is itself non-null; nothing here is annotated, so
+        // the new rule must not manufacture an assertion on the awaited call.
+        string printed = Translate(@"
+using System.Threading.Tasks;
+
+namespace Demo
+{
+    public class Holder
+    {
+        public async Task<string> ReadAsync(Node node)
+        {
+            return (await node.LoadAsync()).Name;
+        }
+    }
+}", out _);
+
+        Assert.DoesNotContain("LoadAsync()!!", printed);
+    }
+
+    // Returns the printed consumer file, and hands back the printed ANNOTATED
+    // declarations too so callers can bind the pair with
+    // <see cref="TranslationTestValidation.AssertBinds(string[])"/>.
+    private static string Translate(string obliviousSource, out string printedDeclarations)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Annotated.cs", AnnotatedDeclarations), ("Oblivious.cs", obliviousSource) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " + string.Join("\n", project.ErrorDiagnostics));
+
+        printedDeclarations = Print(project, 0);
+        return Print(project, 1);
+    }
+
+    private static string Print(LoadedCSharpProject project, int documentIndex)
+    {
+        LoadedDocument document = project.Documents[documentIndex];
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -2257,6 +2257,15 @@ public sealed partial class CSharpToGSharpTranslator
                 return true;
             }
 
+            // Issue #3683 (family F5): the sibling of the promoted-value rule
+            // above for a declaration that was never promoted because it was
+            // ANNOTATED `T?` all along, read from an OBLIVIOUS file. Same
+            // receiver-only gate, same faithfulness argument.
+            if (isDereferenceReceiver && this.ReceiverValueIsObliviouslyReadAnnotatedResult(recv))
+            {
+                return true;
+            }
+
             // Issue #2164: the classic lazy-singleton pattern initializes a
             // nullable static/instance field (or auto-property) under a null
             // guard (`if (F == null) { F = new(); } ... return F;` / `F ??= …;`),
@@ -2445,6 +2454,66 @@ public sealed partial class CSharpToGSharpTranslator
             // too, so its flow-proven uses need the same assertion for consistency.
             return declared.NullableAnnotation == NullableAnnotation.Annotated
                 || this.ShouldPromoteToNullableReference(symbol);
+        }
+
+        /// <summary>
+        /// Issue #3683 (family F5): true when <paramref name="expression"/> is a
+        /// CALL RESULT — an invocation or an indexer read — whose <em>declared</em>
+        /// return is an annotated <c>T?</c> reference, evaluated inside a
+        /// nullable-OBLIVIOUS compilation.
+        /// </summary>
+        /// <remarks>
+        /// This is the call-result door onto the same cross-nullable-context read
+        /// that issue #3683's cast-receiver half (family F6) closed. When an
+        /// oblivious file (<c>test/Core.Tests</c> declares no <c>Nullable</c>
+        /// setting) calls an ANNOTATED API (<c>src/Core</c>, or the annotated BCL:
+        /// <c>Type? Type.GetElementType()</c>), Roslyn erases the annotation at the
+        /// call site — <c>GetTypeInfo(...).Type.NullableAnnotation</c> reads
+        /// <c>None</c> and the flow state is <c>None</c> too — so neither
+        /// <see cref="NullableReferenceValueMayBeNull"/> nor the flow-gated tail of
+        /// <see cref="ReceiverNeedsNullForgiveness"/> can see anything nullable.
+        /// The declaring symbol's own return type still carries the annotation, and
+        /// gsc maps it to <c>T?</c>, so the chained dereference was rejected
+        /// (GS0158 on a member, GS0116 on an index). A nullable-ENABLED compilation
+        /// needs none of this: there the annotation survives on the expression's
+        /// type and the existing predicates already fire, so this stays gated to
+        /// oblivious.
+        /// <para>
+        /// Asserting is faithful and stays receiver-only: C# raises a
+        /// <see cref="System.NullReferenceException"/> at exactly this dereference,
+        /// and <c>!!</c> raises at exactly the same point. A call result forwarded
+        /// as a return value or an argument is NOT covered here — that value must
+        /// keep its <c>T?</c> and reach the declaration-promotion path instead.
+        /// </para>
+        /// </remarks>
+        private bool ReceiverValueIsObliviouslyReadAnnotatedResult(ExpressionSyntax expression)
+        {
+            if (!this.IsObliviousCompilation())
+            {
+                return false;
+            }
+
+            switch (expression)
+            {
+                case ParenthesizedExpressionSyntax parenthesized:
+                    return this.ReceiverValueIsObliviouslyReadAnnotatedResult(parenthesized.Expression);
+
+                case InvocationExpressionSyntax invocation:
+                    // A `Task<T>`/`ValueTask<T>` envelope is itself non-null; its
+                    // annotation belongs to the awaited T (see
+                    // AwaitedReceiverValueIsPromotedNullable), never to the
+                    // receiver being dereferenced here.
+                    return this.context.GetSymbolInfo(invocation).Symbol is IMethodSymbol method
+                        && !IsTaskLikeEnvelope(method.ReturnType)
+                        && IsAnnotatedNullableReference(method.ReturnType);
+
+                case ElementAccessExpressionSyntax elementAccess:
+                    return this.context.GetSymbolInfo(elementAccess).Symbol is IPropertySymbol indexer
+                        && IsAnnotatedNullableReference(indexer.Type);
+
+                default:
+                    return false;
+            }
         }
 
         private bool ReceiverValueIsPromotedNullable(ExpressionSyntax expression)


### PR DESCRIPTION
Fixes #3683. Family **F5**; family F6 of the same issue was closed by #3687. Triage for the wider wall is on #3501: https://github.com/DavidObando/gsharp/issues/3501#issuecomment-5469492729

## The gap

A call whose **declared** return is an annotated `T?` reference, invoked from a nullable-**oblivious** file. This is the sibling of the cast-receiver half #3687 fixed — the same cross-nullable-context read through a different syntactic door.

`test/Core.Tests` declares no `<Nullable>` setting while `src/Core` is annotated (the NRT migration was production-only), and the annotated BCL is in the same position (`Type? Type.GetElementType()`). At the call site Roslyn **erases** the annotation — probed directly on the semantic model:

```
node.Child() | Type=Demo.Node ann=None | flow=None nullAnn=None | ret=Annotated
```

`GetTypeInfo(...).Type.NullableAnnotation` is `None` and the flow state is `None`, so neither `NullableReferenceValueMayBeNull` nor the flow-gated tail of `ReceiverNeedsNullForgiveness` can see anything nullable. The declaring symbol's own return type still carries `Annotated`, and gsc maps it to `T?` — so the chained dereference was rejected:

```csharp
// C# — Type? GetElementType(); warning only
Assert.NotEqual(typeof(int).Assembly.FullName, mapped.GetElementType().Assembly.FullName);
```
```gs
// before — the VARIABLE got its `!!`, the call result did not
Assert.NotEqual(typeof(int32).Assembly.FullName!!, mapped!!.GetElementType().Assembly.FullName!!)
//                                                                          ^ GS0158 Cannot find member Assembly
// after
Assert.NotEqual(typeof(int32).Assembly.FullName!!, mapped!!.GetElementType()!!.Assembly.FullName!!)
```

## The fix

`ReceiverNeedsNullForgiveness` now consults a new `ReceiverValueIsObliviouslyReadAnnotatedResult` immediately after the existing `ReceiverValueIsPromotedNullable` call, under the **same receiver-only gate** — deliberately reusing that seam rather than adding a parallel path. It answers true for an invocation or an indexer read whose declared result is an annotated `T?` reference, inside an oblivious compilation. `Task<T>`/`ValueTask<T>` envelopes are excluded exactly as the promoted-value rule excludes them: the annotation there belongs to the awaited `T`, not to the non-null envelope.

Judgement per the issue's instruction not to blanket-`!!`:

- **Bridging the value is right here, and only here.** The rule fires only at a **dereference receiver**. C# raises a `NullReferenceException` at exactly that dereference and `!!` raises at exactly the same point, so behaviour is unchanged. A call result forwarded as a return value or a call argument is *not* covered — that value keeps its `T?` and must reach the declaration-promotion path instead.
- **Gated to oblivious.** A nullable-ENABLED compilation needs none of this: there the annotation survives on the expression's type, `NullableReferenceValueMayBeNull` already fires, and the emitted output is byte-identical to before.
- Two of the sites originally filed under F5 are **not** this shape and are deliberately left alone — see "What is left" below. One of them would have been actively wrong to `!!`.

## Verification — measured end to end

`dotnet build GSharp.sln -c Release -graph`, whole-repository translate (`build/run-cs2gs-selfmig-migrate.sh`), then `cs2gs validate --app test/Core.Tests/Core.Tests.csproj` against the freshly packed SDK. Baseline and treatment were measured the same way on the same commit (`cb69490d`, `gscVersion` 0.4.318), counting unique `file(line,col): error GSxxxx` sites in the migrated app after the stage-2 `!!` polish pass had reached its fixed point.

**Migrated `test/Core.Tests`: 153 → 143 compile errors.**

| id | before | after |
|---|---:|---:|
| GS0158 | 11 | **6** |
| GS0116 | 5 | **0** |
| everything else | 137 | 137 |

The diff of the two error lists is **purely subtractive** — ten lines removed, none added, no id increased, no new id, and no line-number drift anywhere else:

```
< Issue2325ArrayPointerByRefRemapEmitTests.gs(50,86)  GS0158 Cannot find member Assembly
< Issue2325ArrayPointerByRefRemapEmitTests.gs(124,86) GS0158 Cannot find member Assembly
< Issue2325ArrayPointerByRefRemapEmitTests.gs(138,86) GS0158 Cannot find member Assembly
< PortablePdbEmitTests.gs(374,44)                     GS0158 Cannot find member Length
< ReferenceResolverTests.gs(251,75)                   GS0158 Cannot find member FullName
< Issue1506PerSegmentTypeArgumentParserTests.gs(67,34)  GS0116 not indexable
< Issue1506PerSegmentTypeArgumentParserTests.gs(69,34)  GS0116 not indexable
< Issue1506PerSegmentTypeArgumentParserTests.gs(81,34)  GS0116 not indexable
< Issue1506PerSegmentTypeArgumentParserTests.gs(86,34)  GS0116 not indexable
< Issue1506PerSegmentTypeArgumentParserTests.gs(130,38) GS0116 not indexable
```

Repository-wide `!!` count moved 21418 → 21431 (+13) across the whole 50-app migrated tree, which is the scale this rule should have.

Tests:

- New `Issue3683ObliviousCallResultForgivenessTests` (5) — an oblivious consumer file over an in-memory annotated compilation (the `Issue2113Oblivious…` two-document idiom), one minimal fixture per distinct shape: member-access receiver, indexed nullable-array return, nullable indexer read, plus two negatives (a non-nullable return stays unforgiven; a `Task<T>` envelope gains nothing). Each positive asserts the emitted G# **binds** via `TranslationTestValidation.AssertBinds`, binding the translated annotated declarations alongside the consumer. The annotated members are deliberately `abstract` so they can seed no evidence in the whole-program taint fixpoint — the tests therefore exercise the annotation path and not the already-covered promotion path.
- `Issue3683ObliviousCastReceiverForgivenessTests` (the F6 tests from #3687) still green — 8/8 for the pair.
- 362-test nullable / `Issue1072` / `Issue3644` / oblivious / `Issue2113` regression subset: all green.
- All 42 `GoldenTests`: green.

## What is left, and why it is not in here

Two of the six sites the triage listed under F5 survive, and neither is the call-result shape — filed with evidence as **#3700**:

1. `Issue3354RectangularArrayParserTests.gs(20,72)` — the un-forgiven receiver sits **inside a `?.` / `?[` continuation**, which the conditional-access lowering translates through its own path, so no forgiveness predicate is reachable there at all. A general gap, worth its own fix.
2. `Issue1675SyntaxNodeChildEnumerationTests.gs(361,59)` — the oblivious taint fixpoint promotes an iterator's return **element** to `SyntaxNode?` from a `yield return` that is dominated by `if (child != null)`. Here the correct repair is at the **declaration** (do not promote a guarded yield), not at the value: asserting the argument would paper over a promotion that should never have happened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs