### PR TITLE
gsc: object initializers honour a friend assembly's internal setter (#3684 F7)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -1271,10 +1271,10 @@ internal sealed partial class ExpressionBinder
         return fnRetClr == invoke.ReturnType;
     }
 
-    private static bool TryGetWritableClrMember(MemberInfo? member, [NotNullWhen(true)] out Type? targetType, [NotNullWhen(true)] out TypeSymbol? targetTypeSymbol, out bool writable)
+    private bool TryGetWritableClrMember(MemberInfo? member, [NotNullWhen(true)] out Type? targetType, [NotNullWhen(true)] out TypeSymbol? targetTypeSymbol, out bool writable)
         => TryGetWritableClrMember(member, receiverType: null, out targetType, out targetTypeSymbol, out writable);
 
-    private static bool TryGetWritableClrMember(
+    private bool TryGetWritableClrMember(
         MemberInfo? member,
         TypeSymbol? receiverType,
         [NotNullWhen(true)] out Type? targetType,
@@ -1291,7 +1291,8 @@ internal sealed partial class ExpressionBinder
                         receiverType,
                         p,
                         projectOnlyWhenSymbolicallyRequired: true);
-                writable = p.CanWrite && p.GetSetMethod(nonPublic: false) != null;
+                writable = p.CanWrite
+                    && (p.GetSetMethod(nonPublic: false) != null || IsFriendVisibleInternalSetter(p));
                 return writable;
             case FieldInfo f:
                 targetType = f.FieldType;
@@ -1306,6 +1307,33 @@ internal sealed partial class ExpressionBinder
                 writable = false;
                 return false;
         }
+    }
+
+    /// <summary>
+    /// Issue #3684: whether <paramref name="property"/>'s setter is an
+    /// <c>internal</c> (metadata <c>assembly</c>) accessor declared by an
+    /// assembly that named this compilation in an
+    /// <c>InternalsVisibleTo</c> — i.e. a setter this compilation may legally
+    /// call, exactly as C# lets a friend assembly write
+    /// <c>{ get; internal set; }</c>.
+    /// <para>
+    /// #3693 widened the CLR instance-call and imported-static probes the same
+    /// way; the writability test kept <c>GetSetMethod(nonPublic: false)</c>, so
+    /// a friend could READ an internal-set property but never write it — in a
+    /// plain assignment or an object initializer alike (GS0127). Only
+    /// <c>assembly</c> accessibility is admitted: <c>private</c>,
+    /// <c>protected</c>, <c>protected internal</c> and <c>private protected</c>
+    /// setters stay unwritable however the friendship is declared.
+    /// </para>
+    /// </summary>
+    /// <param name="property">The imported CLR property.</param>
+    /// <returns><see langword="true"/> when the internal setter is visible here.</returns>
+    private bool IsFriendVisibleInternalSetter(PropertyInfo property)
+    {
+        var setter = property.GetSetMethod(nonPublic: true);
+        return setter is { IsAssembly: true }
+            && setter.DeclaringType?.Assembly is { } declaringAssembly
+            && scope.References.CanAccessInternalMembers(declaringAssembly);
     }
 
     /// <summary>ADR-0039: Determines whether an expression is an lvalue (can have its address taken).</summary>

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3684InternalSetterObjectInitializerTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3684InternalSetterObjectInitializerTests.cs
@@ -52,6 +52,32 @@ public sealed class Issue3684InternalSetterObjectInitializerTests
         }
         """;
 
+    /// <summary>
+    /// The exact shape #3684 hit: FOUR members in one literal, every one of
+    /// them <c>{ get; internal set; }</c> — modelled on <c>BoundProgram</c>'s
+    /// <c>Imports</c> / <c>FriendAssemblies</c> / <c>AssemblyAttributes</c> /
+    /// <c>ModuleAttributes</c>.
+    /// </summary>
+    private const string MultiMemberLibrarySource = """
+        using System.Collections.Immutable;
+        using System.Runtime.CompilerServices;
+
+        [assembly: InternalsVisibleTo("Issue3684.Friend")]
+
+        namespace Issue3684.Library;
+
+        public class Program
+        {
+            public ImmutableArray<string> Imports { get; internal set; } = ImmutableArray<string>.Empty;
+
+            public ImmutableArray<string> FriendAssemblies { get; internal set; } = ImmutableArray<string>.Empty;
+
+            public ImmutableArray<string> AssemblyAttributes { get; internal set; } = ImmutableArray<string>.Empty;
+
+            public ImmutableArray<string> ModuleAttributes { get; internal set; } = ImmutableArray<string>.Empty;
+        }
+        """;
+
     [Fact]
     public void FriendAssembly_ObjectInitializer_Assigns_Internal_Setter()
     {
@@ -202,28 +228,7 @@ public sealed class Issue3684InternalSetterObjectInitializerTests
         var directory = CreateOutputDirectory();
         try
         {
-            var libraryPath = EmitCSharpLibrary(
-                directory,
-                "Issue3684.Library",
-                """
-                using System.Collections.Immutable;
-                using System.Runtime.CompilerServices;
-
-                [assembly: InternalsVisibleTo("Issue3684.Friend")]
-
-                namespace Issue3684.Library;
-
-                public class Program
-                {
-                    public ImmutableArray<string> Imports { get; internal set; } = ImmutableArray<string>.Empty;
-
-                    public ImmutableArray<string> FriendAssemblies { get; internal set; } = ImmutableArray<string>.Empty;
-
-                    public ImmutableArray<string> AssemblyAttributes { get; internal set; } = ImmutableArray<string>.Empty;
-
-                    public ImmutableArray<string> ModuleAttributes { get; internal set; } = ImmutableArray<string>.Empty;
-                }
-                """);
+            var libraryPath = EmitCSharpLibrary(directory, "Issue3684.Library", MultiMemberLibrarySource);
             var result = CompileGSharp(
                 """
                 package Issue3684.Friend
@@ -237,6 +242,45 @@ public sealed class Issue3684InternalSetterObjectInitializerTests
                         AssemblyAttributes: source.AssemblyAttributes,
                         ModuleAttributes: source.ModuleAttributes,
                     }
+                }
+                """,
+                "Issue3684.Friend",
+                libraryPath);
+
+            Assert.True(result.Success, Describe(result));
+        }
+        finally
+        {
+            DeleteOutputDirectory(directory);
+        }
+    }
+
+    /// <summary>
+    /// The literal spelling the migrated `test/Core.Tests` carries: cs2gs
+    /// renders a C# object initializer with `=` and a trailing constructor
+    /// argument list — `T(args){A = x, B = y}` — which is why the reported
+    /// GS0127 locations in #3684 sit on the `=` tokens rather than the member
+    /// names. Every member must bind.
+    /// </summary>
+    [Fact]
+    public void FriendAssembly_EqualsSpelledInitializer_Assigns_Every_Internal_Setter()
+    {
+        var directory = CreateOutputDirectory();
+        try
+        {
+            var libraryPath = EmitCSharpLibrary(directory, "Issue3684.Library", MultiMemberLibrarySource);
+            var result = CompileGSharp(
+                """
+                package Issue3684.Friend
+                import Issue3684.Library
+                import System.Collections.Immutable
+
+                func Run(source Program) Program {
+                    return Program(){
+                        Imports = source.Imports,
+                        FriendAssemblies = source.FriendAssemblies,
+                        AssemblyAttributes = source.AssemblyAttributes,
+                        ModuleAttributes = source.ModuleAttributes}
                 }
                 """,
                 "Issue3684.Friend",

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3684InternalSetterObjectInitializerTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3684InternalSetterObjectInitializerTests.cs
@@ -1,0 +1,354 @@
+// <copyright file="Issue3684InternalSetterObjectInitializerTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+using GsCompilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
+using GsSyntaxTree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #3684 (family F7): an object initializer must honour a friend-visible
+/// <c>internal</c> setter of a referenced assembly's property.
+/// <para>
+/// #3693 taught the CLR instance-call and imported-static probes to admit
+/// <c>assembly</c> accessibility when the declaring assembly names this
+/// compilation in an <c>InternalsVisibleTo</c>. The object-initializer member
+/// path kept its own writability test — <c>GetSetMethod(nonPublic: false)</c>
+/// — so <c>{ get; internal set; }</c> still reported GS0127 "read-only and
+/// cannot be assigned to" across a friend boundary. Only <c>assembly</c>
+/// accessibility is admitted: <c>private</c>, <c>protected</c> and
+/// <c>private protected</c> setters stay rejected however the friendship is
+/// declared, and a non-friend consumer sees none of them.
+/// </para>
+/// </summary>
+public sealed class Issue3684InternalSetterObjectInitializerTests
+{
+    private const string CSharpLibrarySource = """
+        using System.Runtime.CompilerServices;
+
+        [assembly: InternalsVisibleTo("Issue3684.Friend")]
+
+        namespace Issue3684.Library;
+
+        public class Bag
+        {
+            public int Open { get; set; }
+
+            public int Restricted { get; internal set; }
+
+            public int Secret { get; private set; }
+
+            public int Guarded { get; protected set; }
+        }
+        """;
+
+    [Fact]
+    public void FriendAssembly_ObjectInitializer_Assigns_Internal_Setter()
+    {
+        RunFriend(
+            "Restricted",
+            result =>
+            {
+                Assert.True(result.Success, Describe(result));
+
+                // Binding alone is not the contract: the emitted body must
+                // actually CALL the internal accessor, not silently drop the
+                // member. The setter's name is interned in the image's string
+                // heap by the memberref the assignment emits.
+                Assert.Contains("set_Restricted", Encoding.UTF8.GetString(result.Image), StringComparison.Ordinal);
+            });
+    }
+
+    /// <summary>
+    /// The same widening on the PLAIN assignment path — a friend writing
+    /// <c>bag.Restricted = 1</c> — which shares the binder's writability test
+    /// with the object-initializer path and was equally rejected.
+    /// </summary>
+    [Fact]
+    public void FriendAssembly_Assignment_Writes_Internal_Setter()
+    {
+        var directory = CreateOutputDirectory();
+        try
+        {
+            var libraryPath = EmitCSharpLibrary(directory, "Issue3684.Library", CSharpLibrarySource);
+            var result = CompileGSharp(
+                """
+                package Issue3684.Friend
+                import Issue3684.Library
+
+                func Run() Bag {
+                    let bag = Bag()
+                    bag.Restricted = 1
+                    return bag
+                }
+                """,
+                "Issue3684.Friend",
+                libraryPath);
+
+            Assert.True(result.Success, Describe(result));
+        }
+        finally
+        {
+            DeleteOutputDirectory(directory);
+        }
+    }
+
+    /// <summary>
+    /// The plain-assignment counterpart of the accessibility guard: a
+    /// <c>private</c> setter is not writable even for a friend.
+    /// </summary>
+    [Fact]
+    public void FriendAssembly_Assignment_Still_Rejects_Private_Setter()
+    {
+        var directory = CreateOutputDirectory();
+        try
+        {
+            var libraryPath = EmitCSharpLibrary(directory, "Issue3684.Library", CSharpLibrarySource);
+            var result = CompileGSharp(
+                """
+                package Issue3684.Friend
+                import Issue3684.Library
+
+                func Run() Bag {
+                    let bag = Bag()
+                    bag.Secret = 1
+                    return bag
+                }
+                """,
+                "Issue3684.Friend",
+                libraryPath);
+
+            Assert.False(result.Success, Describe(result));
+            Assert.Contains(result.Diagnostics, d => d.Id == "GS0127");
+        }
+        finally
+        {
+            DeleteOutputDirectory(directory);
+        }
+    }
+
+    [Fact]
+    public void FriendAssembly_ObjectInitializer_Assigns_Public_Setter()
+    {
+        RunFriend(
+            "Open",
+            result => Assert.True(result.Success, Describe(result)));
+    }
+
+    [Fact]
+    public void FriendAssembly_ObjectInitializer_Still_Rejects_Private_Setter()
+    {
+        RunFriend(
+            "Secret",
+            result =>
+            {
+                Assert.False(result.Success, Describe(result));
+                Assert.Contains(result.Diagnostics, d => d.Id == "GS0127");
+            });
+    }
+
+    [Fact]
+    public void FriendAssembly_ObjectInitializer_Still_Rejects_Protected_Setter()
+    {
+        RunFriend(
+            "Guarded",
+            result =>
+            {
+                Assert.False(result.Success, Describe(result));
+                Assert.Contains(result.Diagnostics, d => d.Id == "GS0127");
+            });
+    }
+
+    [Fact]
+    public void NonFriendAssembly_ObjectInitializer_Still_Rejects_Internal_Setter()
+    {
+        var directory = CreateOutputDirectory();
+        try
+        {
+            var libraryPath = EmitCSharpLibrary(directory, "Issue3684.Library", CSharpLibrarySource);
+            var result = CompileGSharp(
+                Consumer("Issue3684.Stranger", "Restricted"),
+                "Issue3684.Stranger",
+                libraryPath);
+
+            Assert.False(result.Success, Describe(result));
+            Assert.Contains(result.Diagnostics, d => d.Id == "GS0127");
+        }
+        finally
+        {
+            DeleteOutputDirectory(directory);
+        }
+    }
+
+    /// <summary>
+    /// The shape #3684 actually hit: FOUR initializer members in one literal,
+    /// every one of them <c>{ get; internal set; }</c>. Every member must bind;
+    /// the original defect reported on some and not others purely because the
+    /// binder's per-member fallbacks differ.
+    /// </summary>
+    [Fact]
+    public void FriendAssembly_ObjectInitializer_Assigns_Every_Internal_Setter_In_One_Literal()
+    {
+        var directory = CreateOutputDirectory();
+        try
+        {
+            var libraryPath = EmitCSharpLibrary(
+                directory,
+                "Issue3684.Library",
+                """
+                using System.Collections.Immutable;
+                using System.Runtime.CompilerServices;
+
+                [assembly: InternalsVisibleTo("Issue3684.Friend")]
+
+                namespace Issue3684.Library;
+
+                public class Program
+                {
+                    public ImmutableArray<string> Imports { get; internal set; } = ImmutableArray<string>.Empty;
+
+                    public ImmutableArray<string> FriendAssemblies { get; internal set; } = ImmutableArray<string>.Empty;
+
+                    public ImmutableArray<string> AssemblyAttributes { get; internal set; } = ImmutableArray<string>.Empty;
+
+                    public ImmutableArray<string> ModuleAttributes { get; internal set; } = ImmutableArray<string>.Empty;
+                }
+                """);
+            var result = CompileGSharp(
+                """
+                package Issue3684.Friend
+                import Issue3684.Library
+                import System.Collections.Immutable
+
+                func Run(source Program) Program {
+                    return Program{
+                        Imports: source.Imports,
+                        FriendAssemblies: source.FriendAssemblies,
+                        AssemblyAttributes: source.AssemblyAttributes,
+                        ModuleAttributes: source.ModuleAttributes,
+                    }
+                }
+                """,
+                "Issue3684.Friend",
+                libraryPath);
+
+            Assert.True(result.Success, Describe(result));
+        }
+        finally
+        {
+            DeleteOutputDirectory(directory);
+        }
+    }
+
+    private static string Consumer(string assemblyName, string memberName)
+        => $$"""
+            package {{assemblyName}}
+            import Issue3684.Library
+
+            func Run() Bag {
+                return Bag{{{memberName}}: 1}
+            }
+            """;
+
+    private static void RunFriend(string memberName, Action<CompileResult> assert)
+    {
+        var directory = CreateOutputDirectory();
+        try
+        {
+            var libraryPath = EmitCSharpLibrary(directory, "Issue3684.Library", CSharpLibrarySource);
+            assert(CompileGSharp(
+                Consumer("Issue3684.Friend", memberName),
+                "Issue3684.Friend",
+                libraryPath));
+        }
+        finally
+        {
+            DeleteOutputDirectory(directory);
+        }
+    }
+
+    private static string Describe(CompileResult result)
+        => string.Join(Environment.NewLine, result.Diagnostics.Select(d => d.Id + ": " + d.Message));
+
+    private static CompileResult CompileGSharp(
+        string source,
+        string assemblyName,
+        params string[] references)
+    {
+        using var resolver = references.Length == 0
+            ? ReferenceResolver.Default()
+            : ReferenceResolver.WithReferences(references);
+        resolver.CurrentAssemblyName = assemblyName;
+        var compilation = new GsCompilation(
+            resolver,
+            GsSyntaxTree.Parse(SourceText.From(source)))
+        {
+            AssemblyName = assemblyName,
+        };
+
+        using var output = new MemoryStream();
+        var emit = compilation.Emit(
+            output,
+            pdbStream: null,
+            refStream: null,
+            assemblyName: assemblyName);
+        return new CompileResult(
+            emit.Success,
+            emit.Diagnostics.Select(d => new DiagnosticInfo(d.Id, d.Message)).ToArray(),
+            output.ToArray());
+    }
+
+    private static string EmitCSharpLibrary(string directory, string assemblyName, string source)
+    {
+        var references = ((AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string)
+                ?.Split(Path.PathSeparator)
+                ?? Array.Empty<string>())
+            .Where(File.Exists)
+            .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path));
+        var compilation = CSharpCompilation.Create(
+            assemblyName,
+            new[] { CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest)) },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        var path = Path.Combine(directory, assemblyName + ".dll");
+        using var output = File.Create(path);
+        var emit = compilation.Emit(output);
+        Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
+        return path;
+    }
+
+    private static string CreateOutputDirectory()
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            nameof(Issue3684InternalSetterObjectInitializerTests),
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
+    private static void DeleteOutputDirectory(string directory)
+    {
+        try
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    private readonly record struct CompileResult(bool Success, DiagnosticInfo[] Diagnostics, byte[] Image);
+
+    private readonly record struct DiagnosticInfo(string Id, string Message);
+}


### PR DESCRIPTION
Part of #3684 — family **F7** (`GS0127` "read-only and cannot be assigned to" on an object-initializer member). The other families in that issue stay open.

## Where it actually broke

The issue's original triage put F7 on cs2gs; the re-measurement comment corrected it to gsc, and that is right. The migrated `test/Core.Tests` faithfully renders `BoundProgram`'s `{ get; internal set; }` members, and since #3693 `test/Core.Tests` is a real friend assembly of `src/Core` — so the assignment is legal C# and must be legal G#.

#3693 widened `MemberLookup.SafeGetMethodsIncludingSelfAndInterfaces` and the imported static-class probe from `BindingFlags.Public` to include `NonPublic` under the existing `ReferenceResolver.CanAccessInternalMembers` test. This is the same class of omission at a **third** site, and I verified rather than assumed it: instrumenting `DiagnosticBag.ReportCannotAssign` put the failing frame at `ExpressionBinder.BindImportedTypeObjectInitializer`, whose writability test is the shared helper

```csharp
writable = p.CanWrite && p.GetSetMethod(nonPublic: false) != null;
```

in `ExpressionBinder.TryGetWritableClrMember`. `GetSetMethod(nonPublic: false)` returns `null` for an `internal` accessor, so the member was declared unwritable and GS0127 followed. Because the helper is shared, the *plain* assignment path (`bag.Restricted = 1`) was broken in exactly the same way — a friend could read an internal-set property but never write it, in either spelling. Both are fixed here.

## The fix

`TryGetWritableClrMember` also accepts a setter that is `internal` (metadata `assembly`) when — and only when — the declaring assembly grants this compilation internal access. It becomes an instance method so it can consult `scope.References`. Only `assembly` accessibility is admitted, matching #3693 exactly: `private`, `protected`, `protected internal` and `private protected` setters stay unwritable however the friendship is declared, and a non-friend consumer sees none of them.

No emit change was needed: `MethodBodyEmitter.MemberAccess` already resolves a property accessor with a `nonPublic: true` fallback, so the memberref is written correctly once binding admits the member. The new test asserts that directly rather than trusting it — it greps the emitted image for `set_Restricted`, so a silently-dropped assignment would fail the test.

## Tests

`test/Core.Tests/CodeAnalysis/Binding/Issue3684InternalSetterObjectInitializerTests.cs`, in the sibling-assembly binder idiom #3693 established (a Roslyn-compiled C# library with an `InternalsVisibleTo`, consumed by a gsc compilation):

- friend assigns an `internal` setter in an object initializer ✅ (plus the emitted-IL assertion)
- friend assigns an `internal` setter in a plain assignment ✅
- friend assigns a `public` setter — unchanged ✅
- friend still cannot assign a `private` setter, initializer or assignment (GS0127) ✅
- friend still cannot assign a `protected` setter (GS0127) ✅
- a **non-friend** consumer still cannot assign the `internal` setter (GS0127) ✅
- the shape #3684 actually hit: four `{ get; internal set; }` members in one literal, all of which must bind ✅
- the same four in the **`=` spelling** cs2gs actually emits (below) ✅

4 of the 9 fail on `origin/main`'s binder and pass with it; the other 5 are the guard rails and pass either way.

Full `test/Core.Tests` is green locally: **8347 passed, 0 failed**.

## On the "only 2 of the 4 members report" clue

It does not reproduce, and chasing it turned up something more useful. I ran a whole-repository `cs2gs migrate` and read the three sites the triage names:

```
// migrated test/Core.Tests/.../Issue3258BoundSyntaxDiagnosticTests.gs
 97:                program.Delegates){
 98:                Imports = program.Imports,
 99:                FriendAssemblies = program.FriendAssemblies,
100:                AssemblyAttributes = program.AssemblyAttributes,
101:                ModuleAttributes = program.ModuleAttributes}
```

Two things follow. First, cs2gs renders the initializer with `=`, not the `Member: value` spelling — and the reported columns are the `=` tokens, not the member names: `Imports`'s `=` is at column 25 and `ModuleAttributes`'s at column 34, exactly the (98,25) / (101,34) in the triage. `BoundTreeRewriterClonePreservationTests.gs(39,36)` is the `=` of `StaticGenericOwnerType = owner` on `BoundCallExpression`, also `{ get; internal set; }` — the same family. So all three sites are this defect.

Second, the four members are *identical* in every respect that matters — the migrated `src/Core/.../BoundProgram.gs` renders all four as `prop … { get { … } internal set { … } }` — and gsc reports GS0127 on **all four**, which the new four-member tests confirm in both spellings. The "2 of 4" reads as the triage listing the first and last of a run rather than a real asymmetry; there is no narrowing condition to isolate. All four clear with this change.

I did not complete a full `cs2gs validate --app test/Core.Tests` before/after tally — another self-migration run was occupying the machine — so I am not quoting a migrated-app error delta. The site-level evidence above is direct: every GS0127 the triage attributes to F7 is a `{ get; internal set; }` target across the friend boundary, and each is covered by a test that fails without this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
