### PR TITLE
gsc: honour a delegate's nullable return annotation in arrow-lambda target typing (#3695)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
@@ -439,7 +439,7 @@ internal sealed partial class ExpressionBinder
         var handlerType = Invariant.Required(eventInfo.EventHandlerType, "a CLR event has an event-handler type");
         var handlerTypeSymbol = importedEventTarget != null
             ? MemberLookup.GetClrEventHandlerTypeSymbol(importedEventTarget, eventInfo)
-            : TypeSymbol.FromClrType(handlerType);
+            : MemberLookup.GetClrEventHandlerTypeSymbol(eventInfo);
         var boundHandler = BindEventSubscriptionHandler(syntax.Value, handlerTypeSymbol);
 
         // The handler is most useful when expressed as a function literal of

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -2708,11 +2708,18 @@ internal sealed class MemberLookup
             anyVariadic |= paramArray;
         }
 
+        // Issue #3695: the return position must read its reference-type
+        // nullability from metadata exactly as the parameter positions above
+        // already do (ClrNullability.GetParameterTypeSymbol). Dropping it here
+        // made a delegate whose C# signature returns `T?` (e.g.
+        // `ResolveEventHandler`, whose Invoke returns `Assembly?`) present a
+        // non-null `T` target return to lambda binding, so an arrow lambda
+        // body's `return nil` was rejected with GS0155.
         var returnType = invoke.ReturnType.IsSameAs(typeof(void))
             ? TypeSymbol.Void
             : invoke.ReturnType.ContainsGenericParameters
                 ? TypeSymbol.Object
-                : TypeSymbol.FromClrType(invoke.ReturnType);
+                : ClrNullability.GetReturnTypeSymbol(invoke);
         var variadicFlags = anyVariadic ? variadicBuilder.ToImmutable() : default;
         functionType = FunctionTypeSymbol.Get(parameterTypes.ToImmutable(), variadicFlags, returnType);
         return true;
@@ -3999,12 +4006,32 @@ internal sealed class MemberLookup
                     declaringTypeArguments);
                 if (mapped.ClrType?.ContainsGenericParameters != true)
                 {
-                    return mapped;
+                    return ApplyEventDeclarationNullability(mapped, openEvent, openDefinition);
                 }
             }
         }
 
-        return TypeSymbol.FromClrType(closedEvent.EventHandlerType);
+        return GetClrEventHandlerTypeSymbol(closedEvent);
+    }
+
+    /// <summary>
+    /// Issue #3695: the reflected handler type of an event reached WITHOUT a
+    /// symbolic receiver (an imported static event, say), with the event
+    /// declaration's <c>[Nullable]</c> metadata applied.
+    /// </summary>
+    /// <param name="closedEvent">The reflected event.</param>
+    /// <returns>The handler type with declaration-site nullability applied.</returns>
+    internal static TypeSymbol GetClrEventHandlerTypeSymbol(EventInfo closedEvent)
+    {
+        var handlerType = TypeSymbol.FromClrType(closedEvent.EventHandlerType);
+
+        // A constructed generic declaring type would need its flags projected
+        // through the substitution first (the symbolic path above does exactly
+        // that); leave those alone rather than misalign the byte positions.
+        return closedEvent.DeclaringType is { } declaringType
+            && !declaringType.IsConstructedGenericType
+            ? ApplyEventDeclarationNullability(handlerType, closedEvent, declaringType)
+            : handlerType;
     }
 
     /// <summary>
@@ -6400,6 +6427,41 @@ internal sealed class MemberLookup
     /// <returns>The pointee type for a by-ref member; the type unchanged otherwise.</returns>
     private static Type DereferenceByRefElement(Type elementType) =>
         elementType.IsByRef ? elementType.GetElementType() ?? elementType : elementType;
+
+    /// <summary>
+    /// Issue #3695: folds an event declaration's <c>[Nullable]</c> metadata
+    /// into the symbolic handler type, mirroring the field path's
+    /// <see cref="NullableFlagsBuilder.MergeDeclarationNullability"/> call.
+    /// Without it a handler declared <c>Func&lt;…, Assembly?&gt;</c> presented
+    /// a non-null <c>Assembly</c> return to lambda target typing, so an arrow
+    /// lambda subscribing to the event could not <c>return nil</c>.
+    /// The event slot's own top-level nullability is deliberately dropped: it
+    /// describes the delegate field, not the handler shape a lambda is
+    /// converted to (and a nullable target suppresses lambda target typing).
+    /// </summary>
+    /// <param name="mapped">The symbolically-substituted handler type.</param>
+    /// <param name="openEvent">The event as declared on the open definition.</param>
+    /// <param name="openDefinition">The open declaring type, for <c>[NullableContext]</c> lookup.</param>
+    /// <returns>The handler type with declaration-site nullability applied.</returns>
+    private static TypeSymbol ApplyEventDeclarationNullability(
+        TypeSymbol mapped,
+        EventInfo openEvent,
+        Type openDefinition)
+    {
+        if (openEvent.EventHandlerType is not Type handlerLayout)
+        {
+            return mapped;
+        }
+
+        var declarationFlags = ClrNullability.ReadNullableFlags(openEvent, openDefinition);
+        var merged = NullableFlagsBuilder.MergeDeclarationNullability(
+            mapped,
+            handlerLayout,
+            declarationFlags);
+        return merged is NullableTypeSymbol nullableHandler
+            ? nullableHandler.UnderlyingType
+            : merged;
+    }
 
     /// <summary>
     /// Issue #985: a single CLR interface method slot that an implementing type

--- a/test/Compiler.Tests/Emit/Issue3695NullableDelegateReturnEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3695NullableDelegateReturnEmitTests.cs
@@ -1,0 +1,257 @@
+// <copyright file="Issue3695NullableDelegateReturnEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #3695: an arrow lambda subscribed to a CLR event whose delegate
+/// returns a NULLABLE reference type (<c>AssemblyLoadContext.Resolving</c> is
+/// <c>Func&lt;AssemblyLoadContext, AssemblyName, Assembly?&gt;?</c>) inferred
+/// its return type from the body's first <c>return</c> (<c>Assembly</c>) and
+/// then rejected the other branch's <c>return nil</c> with GS0155. The event's
+/// declared <c>[Nullable]</c> metadata never reached lambda target typing:
+/// <c>MemberLookup.GetClrEventHandlerTypeSymbol</c> dropped the declaration
+/// flags when substituting the handler type symbolically, and
+/// <c>TryGetDelegateFunctionType</c> read nullability for the delegate's
+/// parameter positions but not for its return position.
+///
+/// These tests compile AND RUN the emitted program so the fix is verified at
+/// runtime, not merely at bind time: the installed handler must actually
+/// return <see langword="null"/> to the runtime's resolution machinery.
+/// </summary>
+public class Issue3695NullableDelegateReturnEmitTests
+{
+    [Fact]
+    public void ArrowLambda_ReturningNil_OnGenericFuncEvent_CompilesRunsAndIlVerifies()
+    {
+        // AssemblyLoadContext.Resolving: a CLOSED GENERIC Func<> event whose
+        // last type argument is annotated nullable. The program installs the
+        // exact two-branch shape from the issue, then forces a resolution
+        // failure so the `return nil` branch runs for real — the load throws
+        // only because the handler's null actually reached the runtime.
+        const string source = """
+            package Issue3695.App
+
+            import System
+            import System.Reflection
+            import System.Runtime.Loader
+
+            func Main() {
+                var seen = ""
+                let ctx = AssemblyLoadContext.Default
+                ctx.Resolving += (c AssemblyLoadContext, name AssemblyName) -> {
+                    seen = name.Name!!
+                    if name.Name == "Issue3695.Present" {
+                        return typeof(string).Assembly
+                    }
+
+                    return nil
+                }
+
+                try {
+                    ctx.LoadFromAssemblyName(AssemblyName("Issue3695.Absent"))
+                    Console.WriteLine("loaded")
+                } catch (e Exception) {
+                    Console.WriteLine("nil-honoured")
+                }
+
+                Console.WriteLine(seen)
+            }
+            """;
+
+        using var artifacts = Compile(source);
+        IlVerifier.Verify(artifacts.OutputPath);
+        Assert.Equal(
+            $"nil-honoured{Environment.NewLine}Issue3695.Absent{Environment.NewLine}",
+            Run(artifacts.OutputPath));
+    }
+
+    [Fact]
+    public void ArrowLambda_ReturningNil_OnNamedDelegateEvent_CompilesAndIlVerifies()
+    {
+        // AppDomain.AssemblyResolve is a NON-generic named delegate
+        // (ResolveEventHandler) whose Invoke returns `Assembly?`. That
+        // nullability lives on the delegate's own Invoke return parameter, so
+        // it exercises the second half of the fix (the return position in
+        // MemberLookup.TryGetDelegateFunctionType).
+        const string source = """
+            package Issue3695.Named
+
+            import System
+            import System.Reflection
+
+            func Main() {
+                AppDomain.CurrentDomain.AssemblyResolve += (sender object, args ResolveEventArgs) -> {
+                    if args.Name == "Issue3695.Present" {
+                        return typeof(string).Assembly
+                    }
+
+                    return nil
+                }
+
+                Console.WriteLine("subscribed")
+            }
+            """;
+
+        using var artifacts = Compile(source);
+        IlVerifier.Verify(artifacts.OutputPath);
+        Assert.Equal($"subscribed{Environment.NewLine}", Run(artifacts.OutputPath));
+    }
+
+    [Fact]
+    public void ArrowLambda_ReturningNil_OnNonNullDelegateEvent_StillRejected()
+    {
+        // Conservatism control: only an EXPLICIT nullable annotation widens the
+        // target return type. A source-declared event whose handler returns a
+        // non-null `string` must keep rejecting `return nil`, so the fix cannot
+        // be mistaken for "every delegate return became nullable".
+        const string source = """
+            package Issue3695.Strict
+
+            import System
+
+            class Box {
+                event Transform (int32) -> string
+            }
+
+            func Main() {
+                let b = Box()
+                b.Transform += (x int32) -> {
+                    if x > 0 {
+                        return "positive"
+                    }
+
+                    return nil
+                }
+            }
+            """;
+
+        using var artifacts = Compile(source, expectSuccess: false);
+        Assert.NotEqual(0, artifacts.ExitCode);
+        var output = artifacts.Stdout + artifacts.Stderr;
+        Assert.True(output.Contains("GS0155", StringComparison.Ordinal), output);
+    }
+
+    private static CompilationArtifacts Compile(string source, bool expectSuccess = true)
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            "issue3695-artifacts",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+
+        var sourcePath = Path.Combine(directory, "test.gs");
+        var outputPath = Path.Combine(directory, "Issue3695.App.dll");
+        File.WriteAllText(sourcePath, source);
+
+        var result = RunCompiler(new[]
+        {
+            "/out:" + outputPath,
+            "/target:exe",
+            "/targetframework:net10.0",
+            sourcePath,
+        });
+
+        if (expectSuccess)
+        {
+            Assert.True(
+                result.ExitCode == 0,
+                $"compile failed\n{result.Stdout}\n{result.Stderr}");
+        }
+
+        return new CompilationArtifacts(
+            directory,
+            outputPath,
+            result.ExitCode,
+            result.Stdout,
+            result.Stderr);
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) RunCompiler(string[] args)
+    {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            return (Program.Main(args), stdout.ToString(), stderr.ToString());
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+    }
+
+    private static string Run(string assemblyPath)
+    {
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = Path.GetDirectoryName(assemblyPath)!,
+        };
+        startInfo.ArgumentList.Add("exec");
+        startInfo.ArgumentList.Add("--runtimeconfig");
+        startInfo.ArgumentList.Add(Path.ChangeExtension(assemblyPath, ".runtimeconfig.json"));
+        startInfo.ArgumentList.Add(assemblyPath);
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start dotnet exec.");
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), "dotnet exec timed out.");
+        Assert.True(
+            process.ExitCode == 0,
+            $"exited {process.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout.ReplaceLineEndings(Environment.NewLine);
+    }
+
+    private sealed class CompilationArtifacts : IDisposable
+    {
+        public CompilationArtifacts(
+            string directory,
+            string outputPath,
+            int exitCode,
+            string stdout,
+            string stderr)
+        {
+            this.Directory = directory;
+            this.OutputPath = outputPath;
+            this.ExitCode = exitCode;
+            this.Stdout = stdout;
+            this.Stderr = stderr;
+        }
+
+        public string Directory { get; }
+
+        public string OutputPath { get; }
+
+        public int ExitCode { get; }
+
+        public string Stdout { get; }
+
+        public string Stderr { get; }
+
+        public void Dispose()
+        {
+            try
+            {
+                System.IO.Directory.Delete(this.Directory, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3695NullableDelegateReturnLambdaTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3695NullableDelegateReturnLambdaTests.cs
@@ -1,0 +1,276 @@
+// <copyright file="Issue3695NullableDelegateReturnLambdaTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using GsCompilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GsSyntaxTree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree;
+using GSharp.Core.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #3695: an arrow lambda subscribed to an imported event whose delegate
+/// RETURNS a nullable reference type inferred its return type from the body's
+/// first <c>return</c> and then rejected the other branch's <c>return nil</c>
+/// with GS0155 — the target's declared nullability never reached lambda return
+/// inference. Two independent metadata paths dropped it:
+/// <list type="bullet">
+/// <item><description>a closed generic handler (<c>Func&lt;int, string?&gt;</c>)
+/// carries its nullability on the EVENT declaration, which
+/// <c>MemberLookup.GetClrEventHandlerTypeSymbol</c> discarded while
+/// substituting the handler type symbolically;</description></item>
+/// <item><description>a named delegate (<c>delegate string? Resolver(int)</c>)
+/// carries it on the delegate's own <c>Invoke</c> return parameter, which
+/// <c>MemberLookup.TryGetDelegateFunctionType</c> ignored even though it
+/// already read nullability for every PARAMETER position.</description></item>
+/// </list>
+/// The negative controls matter as much as the positive ones: the fix widens
+/// the target return type only for an EXPLICIT <c>?</c> annotation, so an
+/// unannotated/non-null delegate return must keep rejecting <c>return nil</c>,
+/// and a non-null delegate PARAMETER must stay non-null (no new <c>!!</c>
+/// noise at the lambda's use sites).
+/// </summary>
+public class Issue3695NullableDelegateReturnLambdaTests
+{
+    private static readonly string LibraryPath = EmitCSharpLibrary();
+
+    [Fact]
+    public void GenericFuncEvent_NullableReturn_ArrowLambdaReturnsNil_Binds()
+    {
+        Assert.Empty(Bind("""
+            package App
+            import Lib3695
+
+            func Main() {
+                let r = Resolver()
+                r.Transform += (x int32) -> {
+                    if x > 0 {
+                        return "positive"
+                    }
+
+                    return nil
+                }
+            }
+            """));
+    }
+
+    [Fact]
+    public void GenericFuncEvent_NullableReturn_ArrowLambdaReturnsOnlyNil_Binds()
+    {
+        // Expression-bodied form: the lambda has no non-null candidate at all,
+        // so the target return type is the ONLY source of a shape.
+        Assert.Empty(Bind("""
+            package App
+            import Lib3695
+
+            func Main() {
+                let r = Resolver()
+                r.Transform += (x int32) -> nil
+            }
+            """));
+    }
+
+    [Fact]
+    public void StaticGenericFuncEvent_NullableReturn_ArrowLambdaReturnsNil_Binds()
+    {
+        // A STATIC event is reached without a symbolic receiver, so its handler
+        // type comes from the reflected fallback rather than the symbolic
+        // substitution — the declaration flags must be applied there too.
+        Assert.Empty(Bind("""
+            package App
+            import Lib3695
+
+            func Main() {
+                Resolver.StaticTransform += (x int32) -> {
+                    if x > 0 {
+                        return "positive"
+                    }
+
+                    return nil
+                }
+            }
+            """));
+    }
+
+    [Fact]
+    public void NamedDelegateEvent_NullableReturn_ArrowLambdaReturnsNil_Binds()
+    {
+        Assert.Empty(Bind("""
+            package App
+            import Lib3695
+
+            func Main() {
+                let r = Resolver()
+                r.Resolve += (x int32) -> {
+                    if x > 0 {
+                        return "positive"
+                    }
+
+                    return nil
+                }
+            }
+            """));
+    }
+
+    [Fact]
+    public void GenericFuncEvent_NonNullReturn_ArrowLambdaReturnsNil_ReportsDiagnostic()
+    {
+        // Conservatism control: `Func<int, string>` (NOT annotated nullable)
+        // must still reject `return nil`.
+        var diagnostics = Bind("""
+            package App
+            import Lib3695
+
+            func Main() {
+                let r = Resolver()
+                r.Strict += (x int32) -> {
+                    if x > 0 {
+                        return "positive"
+                    }
+
+                    return nil
+                }
+            }
+            """);
+
+        Assert.NotEmpty(diagnostics);
+        Assert.Contains(diagnostics, d => d.Id == "GS0155");
+    }
+
+    [Fact]
+    public void NamedDelegateEvent_NonNullReturn_ArrowLambdaReturnsNil_ReportsDiagnostic()
+    {
+        var diagnostics = Bind("""
+            package App
+            import Lib3695
+
+            func Main() {
+                let r = Resolver()
+                r.ResolveStrict += (x int32) -> {
+                    if x > 0 {
+                        return "positive"
+                    }
+
+                    return nil
+                }
+            }
+            """);
+
+        Assert.NotEmpty(diagnostics);
+        Assert.Contains(diagnostics, d => d.Id == "GS0155");
+    }
+
+    [Fact]
+    public void GenericFuncEvent_NonNullParameter_StaysNonNull()
+    {
+        // The declaration flags annotate the return position only; the
+        // parameter position stays non-null, so it is dereferenced without a
+        // `!!` bridge exactly as before the fix.
+        Assert.Empty(Bind("""
+            package App
+            import Lib3695
+
+            func Main() {
+                let r = Resolver()
+                r.Describe += (text string) -> text.Length.ToString()
+            }
+            """));
+    }
+
+    [Fact]
+    public void GenericFuncEvent_NullableReturn_ArrowLambdaReturnsWrongType_StillReportsDiagnostic()
+    {
+        // Shape control: widening the return to `string?` must not make the
+        // target return type permissive about unrelated types.
+        Assert.NotEmpty(Bind("""
+            package App
+            import Lib3695
+
+            func Main() {
+                let r = Resolver()
+                r.Transform += (x int32) -> 42
+            }
+            """));
+    }
+
+    private static System.Collections.Generic.IReadOnlyList<GSharp.Core.CodeAnalysis.Diagnostic> Bind(string source)
+    {
+        using var resolver = ReferenceResolver.WithReferences(new[] { LibraryPath });
+        var tree = GsSyntaxTree.Parse(SourceText.From(source));
+        var compilation = new GsCompilation(resolver, tree);
+
+        // Mirrors Issue2389ImportedDelegateLambdaEventTests: the imported
+        // library is loaded reflection-only, so bind (and lower) the program to
+        // surface body-level diagnostics without executing anything.
+        return tree.Diagnostics
+            .Concat(compilation.GlobalScope.Diagnostics)
+            .Concat(compilation.BoundProgram.Diagnostics)
+            .ToList();
+    }
+
+    private static string EmitCSharpLibrary()
+    {
+        var outputDir = Path.Combine(AppContext.BaseDirectory, "Issue3695Binding");
+        Directory.CreateDirectory(outputDir);
+        var libraryPath = Path.Combine(outputDir, "Lib3695.dll");
+
+        const string csharpSource = """
+            #nullable enable
+            using System;
+
+            namespace Lib3695
+            {
+                public delegate string? NullableResolver(int x);
+
+                public delegate string StrictResolver(int x);
+
+                public class Resolver
+                {
+                    public event Func<int, string?>? Transform;
+
+                    public event Func<int, string>? Strict;
+
+                    public event Func<string, string?>? Describe;
+
+                    public event NullableResolver? Resolve;
+
+                    public event StrictResolver? ResolveStrict;
+
+                    public static event Func<int, string?>? StaticTransform;
+                }
+            }
+            """;
+
+        var syntaxTree = CSharpSyntaxTree.ParseText(csharpSource, new CSharpParseOptions(LanguageVersion.Latest));
+
+        var referencePaths = (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string)
+            ?.Split(Path.PathSeparator)
+            ?? Array.Empty<string>();
+
+        var references = referencePaths
+            .Where(File.Exists)
+            .Select(p => (MetadataReference)MetadataReference.CreateFromFile(p))
+            .ToList();
+
+        var compilation = CSharpCompilation.Create(
+            "Lib3695",
+            new[] { syntaxTree },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using (var peStream = File.Create(libraryPath))
+        {
+            var emitResult = compilation.Emit(peStream);
+            Assert.True(emitResult.Success, string.Join(Environment.NewLine, emitResult.Diagnostics));
+        }
+
+        return libraryPath;
+    }
+}


### PR DESCRIPTION
Fixes #3695.

## The defect

An arrow lambda subscribed to a CLR event whose delegate **returns a nullable reference type** inferred its return type from the body's first `return` and then rejected the other branch's `return nil`:

```gs
loadContext.Resolving += (ctx AssemblyLoadContext, name AssemblyName) -> {
    if name.Name == "…" {
        return typeof(string).Assembly
    }
    return nil          // error GS0155: Cannot convert type 'nil' to 'System.Reflection.Assembly'.
}
```

`InferLambdaReturnType` already prefers the target's return type when every candidate converts to it — the target it was handed simply said `Assembly`, not `Assembly?`. So this is not an inference-rule change: the **metadata** was being dropped on the way in, on two independent paths.

## The fix

* **Closed generic handler** (`Func<AssemblyLoadContext, AssemblyName, Assembly?>?`) — the nullability lives on the *event declaration*, and `MemberLookup.GetClrEventHandlerTypeSymbol` discarded it while substituting the handler type symbolically. It now folds the declaration's flags in through `NullableFlagsBuilder.MergeDeclarationNullability`, exactly as the sibling *field* path already did a few lines above. The same helper covers the reflected fallback used by imported **static** events.
* **Named delegate** (`ResolveEventHandler`, whose `Invoke` returns `Assembly?`) — the nullability lives on the delegate's own `Invoke` return parameter. `MemberLookup.TryGetDelegateFunctionType` read nullability for every *parameter* position (`ClrNullability.GetParameterTypeSymbol`) but used a bare `TypeSymbol.FromClrType` for the *return* position. It now uses `ClrNullability.GetReturnTypeSymbol`, removing that asymmetry.

The event slot's own top-level nullability is deliberately dropped: it describes the delegate field, not the handler shape a lambda converts to (and a `NullableTypeSymbol` target suppresses lambda target typing outright).

### Deliberately conservative

Widening is driven by an **explicit** `?` only — `MergeDeclarationNullability` annotates on nullable byte `2`. An unannotated / non-null delegate return keeps rejecting `return nil`, and non-null delegate *parameters* stay non-null (no new `!!` noise at lambda use sites). Both are covered by negative controls.

`cs2gs` needs no follow-up here: G#'s arrow form carries no return-type annotation, so the translator had no way to spell `Assembly?`; with the target honoured, the emitted G# is correct as written.

## Verification

New tests, each failing before / passing after:

* `test/Core.Tests/…/Issue3695NullableDelegateReturnLambdaTests.cs` — binder tests against a Roslyn-compiled `#nullable enable` sibling assembly: generic `Func<int, string?>` event (block body and expression body), named `delegate string? Resolver(int)` event, static generic event, plus negative controls (`Func<int, string>` and `delegate string StrictResolver(int)` still report GS0155; a non-null parameter stays non-null; a wrong-typed body is still rejected). 3 of the 8 failed before the fix.
* `test/Compiler.Tests/Emit/Issue3695NullableDelegateReturnEmitTests.cs` — **executing** coverage: the `AssemblyLoadContext.Resolving` program is compiled, IL-verified, and run out-of-process; the assertion is on its stdout, so the installed handler must actually hand `null` back to the runtime's resolution machinery (the load fails only because it does). Plus the named-delegate program and a compile-negative control. 2 of the 3 failed before the fix.

Targeted suites (full output captured to logs, then grepped):

* `test/Core.Tests --filter "…~Lambda|…~Delegate|…~Invocation|…~Event|…~Nullable|…~Overload|…~RefactoringBaseline"` → 1341 passed, 0 failed.
* `test/Compiler.Tests --filter "…~Lambda|…~Delegate|…~Event|…~Overload|…~Nullable"` → 1229 passed, 0 failed.
* `Samples_EmittedPE_Match_Baseline` passes unchanged — no sample IL moved, so no baseline regeneration.

The recent neighbouring fixes (#3664, #3667, #3697, #3646) are covered by those filters and stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
