### PR TITLE
cs2gs + Core: a null-accepting setter says [AllowNull], and G# renders it T? (#3694)

### DIFF
--- a/docs/adr/0155-incremental-nullable-adoption.md
+++ b/docs/adr/0155-incremental-nullable-adoption.md
@@ -246,3 +246,17 @@ A6's `classify` split — annotation-only versus behaviour-capable — is the ri
 `test/Core.Tests/Baselines/refactoring-baseline.json` is the cheapest strong oracle available: a byte-for-byte PE comparison that an annotation-only change cannot move. It stayed unchanged across the entire migration, which is what makes the emit-side claim credible.
 
 Finally: any detector written to audit these shapes needs a mutation witness (ADR-0154). A first attempt at auditing the migration's 588 `Invariant.Required` sites reported zero hits and was simply broken — its method segmenter mis-parsed, and re-introducing a known defect failed to trip it. **A zero from an unwitnessed detector carries no information.**
+
+## Amendment (2026-08-30)
+
+### A9 — A null-accepting setter must say `[AllowNull]`; G# has only one contract per declaration
+
+A5 leaves production annotated and the ~489k-line test tree oblivious, and A4 records the *read* direction of what that costs. Issue #3694 is the **write** direction, and it is the sharper one.
+
+`Compilation.DebugInformation` is declared `DebugInformationOptions` — non-nullable — and its setter is `value ?? new DebugInformationOptions()`, i.e. it deliberately accepts `null`. Its own doc comment says so. An oblivious test writes `DebugInformation = null` and the C# compiler reports **nothing**: the write crosses a nullable-context boundary, so nothing ever checks the annotation against the code that contradicts it. The annotation is simply wrong, and the build cannot say so — a fifth entry in A8's catalogue of what the build cannot check, differing from the other four in that the *evidence* lives in a project the checker does not check.
+
+> **Rule.** A setter that normalises `null` states that with `[AllowNull]` (`System.Diagnostics.CodeAnalysis`). C# splits a declaration into an input and an output contract; `[AllowNull] T P { get; set; }` is exactly "the setter takes `T?`, the getter returns `T`". Writing `T` alone claims a contract the setter does not enforce and the compiler will not test.
+
+This is not only hygiene. G#, like Kotlin (ADR-0001), has **one** nullability per declaration — there is no separate write contract to widen, and no `!!` that can bridge "assign `nil` to a non-`nil` target"; `!!` forgives a nullable *value*, and a literal `nil` has nothing to forgive. So a null-accepting C# setter has exactly one faithful G# rendering, `T?`, and cs2gs promotes any source declaration carrying `[AllowNull]` to it (`ObliviousNullabilityAnalyzer.HasAllowNullWriteContract`). The getter widens with it and reads across the corpus pick up `!!` through the existing use-site pass; that is sound precisely because the setter's normalisation means the getter never returns `nil`.
+
+The alternative — inferring the same promotion from the fact that *some oblivious consumer somewhere* writes `null` — was rejected. It makes a library's migrated public surface depend on its consumers, it can disagree between the project that emits the declaration and the project that writes to it, and it re-derives, from weaker evidence, a fact the author can simply state. The attribute is decided by the declaration alone, so every compilation in a migration run computes the same answer. Metadata-only declarations are excluded for the same reason: a referenced assembly's contract is already emitted, and gsc imports `[AllowNull] T` as plain `T`.

--- a/src/Core/CodeAnalysis/Compilation/Compilation.cs
+++ b/src/Core/CodeAnalysis/Compilation/Compilation.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -103,6 +104,7 @@ public class Compilation
     /// conditional methods are elided by default unless the embedder opts
     /// in. Setting <c>null</c> is normalised to the empty set.
     /// </summary>
+    [AllowNull]
     public ImmutableHashSet<string> PreprocessorSymbols
     {
         get => preprocessorSymbols;
@@ -117,6 +119,7 @@ public class Compilation
     /// opt in produce bit-for-bit identical PE output. Setting
     /// <see langword="null"/> is normalised to a fresh default instance.
     /// </summary>
+    [AllowNull]
     public DebugInformationOptions DebugInformation
     {
         get => debugInformation;

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3694AllowNullWriteContractTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3694AllowNullWriteContractTranslationTests.cs
@@ -1,0 +1,266 @@
+// <copyright file="Issue3694AllowNullWriteContractTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translator-fidelity tests for issue #3694: the WRITE direction of the
+/// cross-nullable-context problem whose read direction is #3683/#3687.
+///
+/// <para>
+/// A nullable-<em>oblivious</em> consumer (every <c>test/*</c> project sets
+/// <c>&lt;Nullable&gt;disable&lt;/Nullable&gt;</c>) writes <c>null</c> into a
+/// property declared non-nullable by an <em>annotated</em> library
+/// (<c>src/Core</c>) whose setter deliberately normalises <c>null</c>. C#
+/// reports nothing — the write crosses a nullable-context boundary — so no
+/// forgiveness or promotion predicate fires, and gsc then rejects the
+/// <c>nil</c> at a non-nullable target (GS0155).
+/// </para>
+///
+/// <para>
+/// The repair is the declaration-local one: C# spells "the setter accepts
+/// <c>null</c>, the getter never returns it" with
+/// <see cref="System.Diagnostics.CodeAnalysis.AllowNullAttribute"/>, and G#
+/// — which, like Kotlin, has a single nullability per declaration rather than
+/// separate input and output contracts — can only honour that by rendering the
+/// declaration <c>T?</c>. So an <c>[AllowNull]</c> reference declaration is
+/// promoted, in every compilation that sees it, on the strength of the
+/// attribute alone. No consumer evidence, and no cross-project taint, is
+/// consulted: the answer is a property of the declaration and is therefore the
+/// same whichever project is being translated.
+/// </para>
+/// </summary>
+public class Issue3694AllowNullWriteContractTranslationTests
+{
+    private const string AnnotatedLibrary = @"
+using System.Diagnostics.CodeAnalysis;
+
+namespace Library
+{
+    public class Options
+    {
+        public int Format { get; set; }
+    }
+
+    public class Host
+    {
+        private Options options = new Options();
+
+        /// <summary>Setting null is normalised to a fresh default instance.</summary>
+        [AllowNull]
+        public Options Debug
+        {
+            get => this.options;
+            set => this.options = value ?? new Options();
+        }
+    }
+}";
+
+    [Fact]
+    public void AnnotatedAllowNullProperty_RendersNullableDeclaration()
+    {
+        // The library itself is nullable-ENABLED, so nothing in #2113's
+        // oblivious taint machinery runs for it. `[AllowNull]` alone decides:
+        // the write contract admits nil, and G# has only one contract per
+        // declaration, so the declaration is `Options?`.
+        (string library, _) = TranslateLibraryAndConsumer(@"
+using Library;
+
+namespace App
+{
+    public static class Use
+    {
+        public static Host Make() => new Host();
+    }
+}");
+
+        Assert.Contains("Debug Options?", library);
+    }
+
+    [Fact]
+    public void ObliviousConsumer_WritesNilIntoAllowNullProperty_NeedsNoBridge()
+    {
+        // The #3694 site itself: an oblivious test writes `null` into the
+        // annotated property through an object initializer. Once the
+        // declaration is `Options?` the `nil` binds directly — there is no
+        // `!!` that could bridge "assign nil to a non-nil target" anyway, and
+        // forcing one would turn a deliberate, supported C# assignment into a
+        // runtime throw.
+        (_, string consumer) = TranslateLibraryAndConsumer(@"
+using Library;
+
+namespace App
+{
+    public static class Use
+    {
+        public static Host Make() => new Host { Debug = null };
+    }
+}");
+
+        Assert.Contains("Host{Debug: nil}", Compact(consumer));
+        Assert.DoesNotContain("nil!!", Compact(consumer));
+    }
+
+    [Fact]
+    public void ObliviousConsumer_ReadsAllowNullProperty_ForgivesTheNullableGetter()
+    {
+        // Promoting the declaration widens the GETTER too, so every read of it
+        // across the corpus has to be forgiven. That cascade is the existing
+        // use-site forgiveness pass — the same predicate decides both — and it
+        // is sound here because the setter's normalisation means the getter
+        // never actually observes nil.
+        (_, string consumer) = TranslateLibraryAndConsumer(@"
+using Library;
+
+namespace App
+{
+    public static class Use
+    {
+        public static int Read(Host host) { return host.Debug.Format; }
+    }
+}");
+
+        Assert.Contains("host.Debug!!.Format", Compact(consumer));
+    }
+
+    [Fact]
+    public void AnnotatedPropertyWithoutAllowNull_StaysNonNullable()
+    {
+        // The negative control that keeps this narrow: an ordinary annotated
+        // non-nullable property is untouched. Only the attribute that states
+        // the null-accepting write contract promotes.
+        const string library = @"
+namespace Library
+{
+    public class Options
+    {
+        public int Format { get; set; }
+    }
+
+    public class Host
+    {
+        public Options Debug { get; set; } = new Options();
+    }
+}";
+        LoadedCSharpProject projectLibrary = LoadEnabled(library, "Library");
+        string printed = TranslateProject(projectLibrary, new[] { projectLibrary.Compilation });
+
+        Assert.Contains("Debug Options", printed);
+        Assert.DoesNotContain("Debug Options?", printed);
+    }
+
+    [Fact]
+    public void AllowNullParameter_RendersNullableParameter()
+    {
+        // The attribute is legal on parameters too, and means exactly the same
+        // thing there: the caller may pass null.
+        const string library = @"
+using System.Diagnostics.CodeAnalysis;
+
+namespace Library
+{
+    public class Host
+    {
+        public string Normalise([AllowNull] string value) => value ?? string.Empty;
+    }
+}";
+        LoadedCSharpProject projectLibrary = LoadEnabled(library, "Library");
+        string printed = TranslateProject(projectLibrary, new[] { projectLibrary.Compilation });
+
+        Assert.Contains("Normalise(@AllowNull value string?) string", printed);
+    }
+
+    // ---- Helpers -------------------------------------------------------------
+
+    // The two-compilation idiom of Issue2113ObliviousNullableTranslationTests /
+    // Issue2412CrossProjectObliviousNullabilityTranslationTests: an ANNOTATED
+    // library plus an OBLIVIOUS consumer, translated in one run so both see the
+    // same repository compilations.
+    private static (string Library, string Consumer) TranslateLibraryAndConsumer(string consumerSource)
+    {
+        LoadedCSharpProject projectLibrary = LoadEnabled(AnnotatedLibrary, "Library");
+        LoadedCSharpProject projectApp = LoadOblivious(
+            consumerSource,
+            "App",
+            new MetadataReference[] { projectLibrary.Compilation.ToMetadataReference() });
+
+        var repository = new[] { projectLibrary.Compilation, projectApp.Compilation };
+        return (
+            TranslateProject(projectLibrary, repository),
+            TranslateProject(projectApp, repository));
+    }
+
+    private static LoadedCSharpProject LoadOblivious(
+        string source, string assemblyName, IReadOnlyList<MetadataReference> extraReferences = null)
+    {
+        IReadOnlyList<MetadataReference> references = extraReferences is null
+            ? CSharpProjectLoader.RuntimeReferences()
+            : CSharpProjectLoader.RuntimeReferences().Concat(extraReferences).ToList();
+
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { (assemblyName + ".cs", source) }, references, assemblyName);
+        Assert.True(
+            project.BoundWithoutErrors,
+            $"{assemblyName} should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        Assert.Equal(NullableContextOptions.Disable, project.Compilation.Options.NullableContextOptions);
+        return project;
+    }
+
+    // `CSharpProjectLoader.LoadInMemory` always builds an oblivious
+    // compilation, so a genuinely ANNOTATED library has to be constructed
+    // directly with `WithNullableContextOptions(Enable)`.
+    private static LoadedCSharpProject LoadEnabled(string source, string assemblyName)
+    {
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(
+            source, new CSharpParseOptions(LanguageVersion.Latest), path: assemblyName + ".cs");
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            assemblyName,
+            new[] { tree },
+            CSharpProjectLoader.RuntimeReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Enable));
+
+        var diagnostics = compilation.GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .ToList();
+        Assert.True(
+            diagnostics.Count == 0,
+            $"{assemblyName} should bind with no C# errors: " +
+                string.Join(Environment.NewLine, diagnostics));
+
+        var document = new LoadedDocument(assemblyName + ".cs", tree, compilation.GetSemanticModel(tree));
+        return new LoadedCSharpProject(compilation, new[] { document }, Array.Empty<Diagnostic>());
+    }
+
+    private static string TranslateProject(
+        LoadedCSharpProject project, IReadOnlyList<CSharpCompilation> repositoryCompilations)
+    {
+        var translator = new CSharpToGSharpTranslator();
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(
+            project.Compilation,
+            document.SemanticModel,
+            document.FilePath,
+            repositoryCompilations,
+            repositoryCompilations);
+        CompilationUnit unit = translator.TranslateDocument(document, context);
+        return GSharpPrinter.Print(unit);
+    }
+
+    private static string Compact(string printed) =>
+        string.Join(" ", printed.Split(
+            new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries));
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
@@ -848,6 +848,28 @@ public sealed partial class CSharpToGSharpTranslator
                 return false;
             }
 
+            // Issue #3694: C# gives a declaration two nullability contracts, an
+            // INPUT and an OUTPUT one, and `[AllowNull]` keeps the output
+            // non-nullable while widening the input — `[AllowNull] T P { get;
+            // set; }` is exactly "the setter takes T?, the getter returns T",
+            // the shape of a property whose setter normalises `null` to a
+            // default. G# has a SINGLE nullability per declaration (ADR-0155,
+            // Kotlin-style), so the only rendering that still accepts the
+            // writes the C# accepts is `T?`; anything else turns a supported
+            // assignment into an unrepresentable one (gsc GS0155 at the write —
+            // and there is no `!!` for "assign nil to a non-nil target", so
+            // there is nothing to bridge with at the use site).
+            //
+            // Being attribute-driven, this is decided by the DECLARATION alone:
+            // no consumer evidence, no taint fixpoint, the same answer in every
+            // compilation of a run. That is what makes it safe across projects,
+            // where a consumer's promotion decision could otherwise disagree
+            // with the contract the referenced project actually emitted.
+            if (ObliviousNullabilityAnalyzer.HasAllowNullWriteContract(symbol))
+            {
+                return true;
+            }
+
             // EF Core treats reference properties from nullable-oblivious C#
             // entity types as optional. Preserve that model when translating
             // DbSet<T> entities; emitting a non-nullable G# property would make
@@ -1059,6 +1081,17 @@ public sealed partial class CSharpToGSharpTranslator
             // the target never remains non-nullable and nullable arguments
             // need no `!!` bridge.
             if (this.InAnalyzerApiMode && Analyzers.RoslynAnalyzerApiMap.IsNamespaceSymbolType(targetType))
+            {
+                return false;
+            }
+
+            // Issue #3694: an `[AllowNull]` target is promoted from its own
+            // declaration, so it widens in the project that emits it whether or
+            // not that project is the one being translated here. Unlike the
+            // evidence-driven promotions below, this one needs no
+            // same-compilation gate — the referenced project's migrated
+            // declaration is nullable too, so a nullable value needs no bridge.
+            if (ObliviousNullabilityAnalyzer.HasAllowNullWriteContract(targetSymbol))
             {
                 return false;
             }

--- a/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
@@ -55,6 +55,12 @@ namespace Cs2Gs.Translator;
 /// </summary>
 internal static class ObliviousNullabilityAnalyzer
 {
+    // Issue #3694: the metadata name of the attribute that states "null is an
+    // accepted input for this declaration" (`System.Diagnostics.CodeAnalysis`).
+    // Matched by name rather than by symbol so the lookup needs no compilation
+    // and answers identically in every compilation a migration run loads.
+    private const string AllowNullAttributeName = "AllowNullAttribute";
+
     // Keyed by Compilation identity so an edited/new compilation naturally gets
     // a fresh entry and stale ones are collectible — same pattern as the
     // subclassed-base-types / partial-type-parts caches in the translator.
@@ -227,6 +233,58 @@ internal static class ObliviousNullabilityAnalyzer
                 {
                     return true;
                 }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Issue #3694: whether <paramref name="symbol"/> declares — with
+    /// <see cref="AllowNullAttributeName"/> — that <c>null</c> is an accepted
+    /// INPUT even though its type is annotated non-nullable. C# splits a
+    /// declaration's nullability into an input and an output contract, so
+    /// <c>[AllowNull] T P { get; set; }</c> means "the setter takes
+    /// <c>T?</c>, the getter returns <c>T</c>". G#, like Kotlin, has ONE
+    /// nullability per declaration, so the only rendering that admits the
+    /// writes the C# genuinely accepts is <c>T?</c>.
+    ///
+    /// <para>
+    /// The answer is a property of the DECLARATION alone — no consumer
+    /// evidence and no taint fixpoint — so every compilation in a run that
+    /// sees the symbol computes the same result, which is what lets a
+    /// cross-project write site trust that the referenced project's migrated
+    /// declaration really will be nullable.
+    /// </para>
+    ///
+    /// <para>
+    /// The attribute is looked up on the symbol itself, on a property setter's
+    /// <c>value</c> parameter (where the C# compiler also accepts it), and on
+    /// the SOURCE base or interface declaration an overriding/implementing
+    /// member inherits its signature from — a member whose base is
+    /// <c>[AllowNull]</c> must be promoted with it or the two G# signatures no
+    /// longer match (gsc GS0185/GS0386).
+    /// </para>
+    /// </summary>
+    /// <param name="symbol">The declaration symbol to test.</param>
+    /// <returns><see langword="true"/> when null is an accepted input for the declaration.</returns>
+    public static bool HasAllowNullWriteContract(ISymbol symbol)
+    {
+        // Scoped to declarations this migration EMITS. A metadata-only symbol
+        // (the BCL, a NuGet package) keeps whatever contract its assembly
+        // already carries — gsc imports `[AllowNull] T` as plain `T` — so
+        // widening the translator's view of it would only manufacture
+        // mismatches at sites gsc still binds non-nullably.
+        if (symbol == null || symbol.OriginalDefinition.DeclaringSyntaxReferences.Length == 0)
+        {
+            return false;
+        }
+
+        foreach (ISymbol candidate in AllowNullContractSites(symbol.OriginalDefinition))
+        {
+            if (candidate != null && CarriesAllowNull(candidate))
+            {
+                return true;
             }
         }
 
@@ -818,6 +876,124 @@ internal static class ObliviousNullabilityAnalyzer
         symbol is IMethodSymbol { MethodKind: MethodKind.PropertyGet, AssociatedSymbol: { } property }
             ? property
             : symbol;
+
+    // Every declaration whose `[AllowNull]` binds `symbol`'s write contract:
+    // the symbol itself, a property setter's `value` parameter, and the base or
+    // interface declaration an inherited signature comes from.
+    private static IEnumerable<ISymbol> AllowNullContractSites(ISymbol symbol)
+    {
+        switch (symbol)
+        {
+            case IPropertySymbol property:
+                yield return property;
+                if (property.SetMethod is { Parameters.Length: > 0 } setter)
+                {
+                    yield return setter.Parameters[0];
+                }
+
+                foreach (ISymbol inherited in InheritedDeclarations(property))
+                {
+                    yield return inherited;
+                    if (inherited is IPropertySymbol { SetMethod.Parameters.Length: > 0 } inheritedProperty)
+                    {
+                        yield return inheritedProperty.SetMethod.Parameters[0];
+                    }
+                }
+
+                break;
+
+            case IParameterSymbol parameter:
+                yield return parameter;
+                if (parameter.ContainingSymbol is IMethodSymbol owner)
+                {
+                    foreach (ISymbol inherited in InheritedDeclarations(owner))
+                    {
+                        if (inherited is IMethodSymbol inheritedMethod
+                            && parameter.Ordinal < inheritedMethod.Parameters.Length)
+                        {
+                            yield return inheritedMethod.Parameters[parameter.Ordinal];
+                        }
+                    }
+                }
+
+                break;
+
+            case IFieldSymbol field:
+                yield return field;
+                break;
+        }
+    }
+
+    // The base-class overrides and interface members `member` inherits its
+    // signature from.
+    private static IEnumerable<ISymbol> InheritedDeclarations(ISymbol member)
+    {
+        for (ISymbol current = OverriddenDeclaration(member); current != null; current = OverriddenDeclaration(current))
+        {
+            yield return current;
+        }
+
+        foreach (ISymbol explicitImplementation in ExplicitImplementations(member))
+        {
+            yield return explicitImplementation;
+        }
+
+        INamedTypeSymbol containing = member.ContainingType;
+        if (containing == null)
+        {
+            yield break;
+        }
+
+        foreach (INamedTypeSymbol contract in containing.AllInterfaces)
+        {
+            foreach (ISymbol candidate in contract.GetMembers(member.Name))
+            {
+                if (SymbolEqualityComparer.Default.Equals(
+                    containing.FindImplementationForInterfaceMember(candidate), member))
+                {
+                    yield return candidate;
+                }
+            }
+        }
+    }
+
+    private static ISymbol OverriddenDeclaration(ISymbol member) =>
+        member switch
+        {
+            IMethodSymbol method => method.OverriddenMethod,
+            IPropertySymbol property => property.OverriddenProperty,
+            _ => null,
+        };
+
+    private static IEnumerable<ISymbol> ExplicitImplementations(ISymbol member) =>
+        member switch
+        {
+            IMethodSymbol method => method.ExplicitInterfaceImplementations,
+            IPropertySymbol property => property.ExplicitInterfaceImplementations,
+            _ => Enumerable.Empty<ISymbol>(),
+        };
+
+    private static bool CarriesAllowNull(ISymbol symbol)
+    {
+        // A metadata base declaration is already emitted as plain `T`, so an
+        // `[AllowNull]` there must not repaint a source override that has to
+        // keep matching it.
+        ISymbol declaring = symbol is IParameterSymbol parameter ? parameter.ContainingSymbol : symbol;
+        if (declaring == null || declaring.DeclaringSyntaxReferences.Length == 0)
+        {
+            return false;
+        }
+
+        foreach (AttributeData attribute in symbol.GetAttributes())
+        {
+            if (attribute.AttributeClass?.Name == AllowNullAttributeName)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     // Whether the member owning `symbol`'s type position inherits that position
     // from a base class or interface declaration, so its nullability is not the


### PR DESCRIPTION
Fixes #3694. The **write** direction of the cross-nullable-context problem whose read direction was #3687 (F6) and #3701 (F5). Triage for the wider wall: https://github.com/DavidObando/gsharp/issues/3501#issuecomment-5469492729

## The gap

`test/Core.Tests` is nullable-**oblivious**, `src/Core` is **annotated** (ADR-0155 migrated production only). `Compilation.DebugInformation` is declared non-nullable, and its setter normalises `null`:

```csharp
/// Setting <see langword="null"/> is normalised to a fresh default instance.
public DebugInformationOptions DebugInformation
{
    get => debugInformation;
    set => debugInformation = value ?? new DebugInformationOptions();
}
```

An oblivious test writes `DebugInformation = null`. C# reports **nothing** — the write crosses a nullable-context boundary, so no forgiveness or promotion predicate ever fires — and gsc, which has no such suppression, rejects the `nil`:

```
DebugInformationOptionsTests.gs(27,91): error GS0155: Cannot convert type 'nil' to '…DebugInformationOptions'.
```

## The judgement call the issue asked for

The issue frames this as possibly needing a **cross-project declaration promotion**: teach `ShouldPromoteToNullableReference` that an annotated `NotAnnotated` declaration is null-tainted when a sibling oblivious compilation writes `null` into it. I don't think that is the right instrument, and I don't think this needs one.

**The C# annotation is simply wrong, and C# already has the word for what this setter does.** `[AllowNull]` (`System.Diagnostics.CodeAnalysis`) states precisely "the setter takes `T?`, the getter returns `T`" — C# gives every declaration an *input* and an *output* nullability contract, and writing plain `T` here claims an input contract the setter does not enforce and that, because every consumer that violates it is oblivious, nothing ever checks. The doc comment has said so in prose since the property was written.

The three options weighed:

- **(a) Promote from consumer evidence.** Faithful to what the code does, but it makes a library's migrated public surface a function of its consumers; the answer can differ between the project that *emits* the declaration and the project that *writes* to it (which is exactly the assumption `TargetWillRemainNonNullableReference` encodes today, issue #2521); and it re-derives from weak evidence a fact the author can state in one attribute.
- **(b) Bridge at the write site.** Not expressible. `!!` forgives a nullable *value*; a literal `nil` has nothing to forgive, and forcing one would turn an assignment the setter deliberately supports into a runtime throw.
- **(c) Report an unsupported gap.** Refuses to migrate legal C# whose meaning G# *can* express.

So: **fix the annotation, and teach the translator the annotation.** `[AllowNull]` on a **source** declaration promotes it to `T?`. G#, like Kotlin (ADR-0001), has **one** nullability per declaration — there is no separate write contract to widen — so `T?` is the only rendering that admits the writes the C# accepts. The getter widens with it and reads pick up `!!` through the existing use-site pass, which is sound precisely because the setter's normalisation means the getter never returns `nil`.

Crucially, this is decided by the **declaration alone** — no consumer evidence, no taint fixpoint — so every compilation in a migration run computes the same answer. That is what lets `TargetWillRemainNonNullableReference` drop its same-compilation gate for such a target: the referenced project's migrated declaration really will be nullable. Metadata-only declarations are excluded — a referenced assembly's contract is already emitted, and gsc imports `[AllowNull] T` as plain `T`, so widening the translator's view of one would only manufacture mismatches at sites gsc still binds non-nullably.

`PreprocessorSymbols` has the identical `value ?? …` shape and is annotated too; no consumer currently writes `null` to it, but the annotation was equally untrue.

## Verification — measured end to end

`dotnet build GSharp.sln -c Release -graph` (so the gate compiles through the **packed** SDK nupkg), whole-repository `build/run-cs2gs-selfmig-migrate.sh`, then `build/run-cs2gs-selfmig-validate.sh core test/Core.Tests/Core.Tests.csproj`. Baseline and treatment measured the same way on `5cf391be` (`gscVersion` 0.4.325), counting unique compile-error sites after the stage-2 `!!` polish pass reached its fixed point.

**Migrated `test/Core.Tests`: 18 → 17 substantive compile errors.** The GS0536 "redundant `!!`" first-compile artifacts (105, unchanged) are excluded — stage 2's polish pass strips them; raw totals were 123 → 122.

The diff of the two error lists is **purely subtractive** — one line removed, none added, no id increased, no new id, no line-number drift:

```
< DebugInformationOptionsTests.gs(27,91)  GS0155 Cannot convert type 'nil' to '…DebugInformationOptions'
```

Whole-repository translate is unchanged at **50/51 apps** with identical readability metrics (`labels=0 __local_=29 lines>300=568 bangs=21492`), and the migrated declaration is now:

```gs
@AllowNull
prop DebugInformation DebugInformationOptions? {
    get -> debugInformation
    set -> debugInformation = value ?? DebugInformationOptions()
}
```

Targeted suites (ADR-0155 A6 — `nullable_hygiene.py` classifies the two translator files and the new test as behaviour-capable, `Compilation.cs` as annotation-only):

- `Cs2Gs.Tests` filtered to every nullability/oblivious/forgiveness class — **457 passed, 0 failed**.
- `Core.Tests` `DebugInformation`/`Preprocessor` — **6 passed, 0 failed**.
- `build/nullable_hygiene.py --base origin/main --head HEAD` — OK.

New `Issue3694AllowNullWriteContractTranslationTests` uses the two-compilation idiom (annotated library + oblivious consumer): the declaration renders `T?`, the oblivious write emits a bare `nil` with no bridge, a read gets its `!!`, an `[AllowNull]` parameter renders `T?`, and — the negative control that keeps this narrow — an ordinary annotated non-nullable property is untouched.

## Also worth knowing

While bisecting the measurement I confirmed a **first draft of this rule that did not exclude metadata declarations crashed the translator** (`IndexOutOfRangeException`) on 14 of 51 apps, including `src/Core`. The source-only scoping is not just conservatism — promoting BCL `[AllowNull]` members is actively destructive.

ADR-0155 gains **A9**, recording the rule ("a setter that normalises `null` says `[AllowNull]`") and the finding: this is a fifth entry in A8's catalogue of what the build cannot check, differing from the other four in that the evidence lives in a project the checker does not check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
