### PR TITLE
gsc: every member kind agrees on friend-assembly `internal` visibility (audit of #3705)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
@@ -642,20 +642,16 @@ internal sealed partial class ExpressionBinder
                     // Issue #529: use interface-aware lookup so that members
                     // declared on a base interface (e.g. IReadOnlyCollection<T>.Count
                     // surfaced through IReadOnlyList<T>) are found.
-                    var prop = ClrTypeUtilities.SafeGetPropertyIncludingInterfaces(clrReceiverType, memberName, BindingFlags.Public | BindingFlags.Instance);
-                    if (prop == null && scope.References.CanAccessInternalMembers(clrReceiverType.Assembly))
-                    {
-                        var internalCandidate = ClrTypeUtilities.SafeGetPropertyIncludingInterfaces(
-                            clrReceiverType,
-                            memberName,
-                            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-                        if (internalCandidate?.GetMethod?.IsAssembly == true)
-                        {
-                            prop = internalCandidate;
-                        }
-                    }
+                    // Issue #3705: the read and the write path share one probe
+                    // so the friend-`internal` widening cannot drift apart
+                    // between them again (#3693 / #3702). The getter gate is
+                    // the visible one — a `{ private get; … }` property is not
+                    // readable here however the property itself was found.
+                    var prop = SafeGetVisibleInstanceProperty(clrReceiverType, memberName);
 
-                    if (prop != null && prop.GetIndexParameters().Length == 0 && prop.CanRead)
+                    if (prop != null
+                        && prop.GetIndexParameters().Length == 0
+                        && GetVisibleGetter(prop) != null)
                     {
                         // Issue #504 follow-up: properties with NRT
                         // annotations (e.g. `DirectoryInfo.Parent` is
@@ -681,19 +677,7 @@ internal sealed partial class ExpressionBinder
                         return ConversionClassifier.AutoDereferenceRefReturn(new BoundClrPropertyAccessExpression(null, receiver!, prop, propType));
                     }
 
-                    var fld = ClrTypeUtilities.SafeGetFieldIncludingInterfaces(clrReceiverType, memberName, BindingFlags.Public | BindingFlags.Instance);
-                    if (fld == null && scope.References.CanAccessInternalMembers(clrReceiverType.Assembly))
-                    {
-                        var internalCandidate = ClrTypeUtilities.SafeGetFieldIncludingInterfaces(
-                            clrReceiverType,
-                            memberName,
-                            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-                        if (internalCandidate?.IsAssembly == true)
-                        {
-                            fld = internalCandidate;
-                        }
-                    }
-
+                    var fld = SafeGetVisibleInstanceField(clrReceiverType, memberName);
                     if (fld != null)
                     {
                         var fieldType = NormalizeImportedSemanticAggregate(
@@ -1353,7 +1337,7 @@ internal sealed partial class ExpressionBinder
                     out var idxProp,
                     out var resolvedIdxArgs))
                 {
-                    if (idxProp!.GetGetMethod(nonPublic: false) == null)
+                    if (ClrMemberVisibility.GetVisibleGetter(idxProp!, CanAccessInternalsOf(idxProp!.DeclaringType)) == null)
                     {
                         Diagnostics.ReportTypeNotIndexable(targetLocation, target.Type);
                         return new BoundErrorExpression(null);
@@ -1389,7 +1373,7 @@ internal sealed partial class ExpressionBinder
             if (this.memberLookup.TryResolveClrIndexer(target.Type, clrAnnotIdx, idxArgsAnnot, out var idxPropAnnot, out var resolvedIdxArgsAnnot))
             {
                 // A successful CLR indexer resolution establishes a non-null property.
-                if (idxPropAnnot!.GetGetMethod(nonPublic: false) == null)
+                if (ClrMemberVisibility.GetVisibleGetter(idxPropAnnot!, CanAccessInternalsOf(idxPropAnnot!.DeclaringType)) == null)
                 {
                     Diagnostics.ReportTypeNotIndexable(targetLocation, target.Type);
                     return new BoundErrorExpression(null);
@@ -1413,7 +1397,7 @@ internal sealed partial class ExpressionBinder
             if (this.memberLookup.TryResolveClrIndexer(target.Type, clrTarget, idxArgs, out var idxProp, out var resolvedIdxArgs))
             {
                 // A successful CLR indexer resolution establishes a non-null property.
-                if (idxProp!.GetGetMethod(nonPublic: false) == null)
+                if (ClrMemberVisibility.GetVisibleGetter(idxProp!, CanAccessInternalsOf(idxProp!.DeclaringType)) == null)
                 {
                     Diagnostics.ReportTypeNotIndexable(targetLocation, target.Type);
                     return new BoundErrorExpression(null);
@@ -2097,7 +2081,7 @@ internal sealed partial class ExpressionBinder
                     out var idxProp,
                     out var resolvedIdxArgs))
                 {
-                    if (idxProp!.GetSetMethod(nonPublic: false) == null)
+                    if (ClrMemberVisibility.GetVisibleSetter(idxProp!, CanAccessInternalsOf(idxProp!.DeclaringType)) == null)
                     {
                         Diagnostics.ReportTypeNotIndexable(diagnosticLocation, targetType);
                         return new BoundErrorExpression(null);
@@ -2129,7 +2113,7 @@ internal sealed partial class ExpressionBinder
             if (this.memberLookup.TryResolveClrIndexer(targetType, clrAnnotWr, idxArgsAnnotWr, out var idxPropAnnotWr, out var resolvedIdxArgsAnnotWr))
             {
                 // A successful CLR indexer resolution establishes a non-null property.
-                if (idxPropAnnotWr!.GetSetMethod(nonPublic: false) == null)
+                if (ClrMemberVisibility.GetVisibleSetter(idxPropAnnotWr!, CanAccessInternalsOf(idxPropAnnotWr!.DeclaringType)) == null)
                 {
                     Diagnostics.ReportTypeNotIndexable(diagnosticLocation, targetType);
                     return new BoundErrorExpression(null);
@@ -2168,9 +2152,9 @@ internal sealed partial class ExpressionBinder
                 // managed pointer. Detect the ref-returning getter and store through
                 // it. A `ReadOnlySpan[T]` getter is `ref readonly T` — writing is a
                 // hard error (GS0226).
-                if (idxProp!.GetSetMethod(nonPublic: false) == null)
+                if (ClrMemberVisibility.GetVisibleSetter(idxProp!, CanAccessInternalsOf(idxProp!.DeclaringType)) == null)
                 {
-                    var refGetter = idxProp.GetGetMethod(nonPublic: false);
+                    var refGetter = GetVisibleGetter(idxProp);
                     if (refGetter != null && refGetter.ReturnType.IsByRef)
                     {
                         if (IsReadOnlyRefReturn(idxProp, refGetter))
@@ -2795,7 +2779,7 @@ internal sealed partial class ExpressionBinder
             }
 
             // Either indexer lookup succeeded, so the property is present here.
-            var getter = indexer!.GetGetMethod(nonPublic: false);
+            var getter = ClrMemberVisibility.GetVisibleGetter(indexer!, CanAccessInternalsOf(indexer!.DeclaringType));
             var valueType = ResolveIndexerElementType(targetType, indexer);
             if (!indexer.CanWrite)
             {

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -500,13 +500,13 @@ internal sealed partial class ExpressionBinder
         if (receiverType is not StructSymbol && receiverType is not NullableTypeSymbol && receiverType.ClrType != null)
         {
             var clrReceiverType = receiverType.ClrType;
-            MemberInfo? instanceMember = ClrTypeUtilities.SafeGetPropertyIncludingInterfaces(clrReceiverType, propertyName, BindingFlags.Public | BindingFlags.Instance);
+            MemberInfo? instanceMember = SafeGetVisibleInstanceProperty(clrReceiverType, propertyName);
             if (instanceMember is PropertyInfo idxProp && idxProp.GetIndexParameters().Length != 0)
             {
                 instanceMember = null;
             }
 
-            instanceMember ??= ClrTypeUtilities.SafeGetFieldIncludingInterfaces(clrReceiverType, propertyName, BindingFlags.Public | BindingFlags.Instance);
+            instanceMember ??= SafeGetVisibleInstanceField(clrReceiverType, propertyName);
             if (instanceMember == null)
             {
                 Diagnostics.ReportUnableToFindMember(initSyntax.PropertyIdentifier.Location, propertyName);
@@ -860,13 +860,13 @@ internal sealed partial class ExpressionBinder
         {
             var clrReceiverType = assignmentReceiverType.ClrType;
             var fieldName = syntax.FieldIdentifier.ValueText;
-            MemberInfo? instanceMember = ClrTypeUtilities.SafeGetPropertyIncludingInterfaces(clrReceiverType, fieldName, BindingFlags.Public | BindingFlags.Instance);
+            MemberInfo? instanceMember = SafeGetVisibleInstanceProperty(clrReceiverType, fieldName);
             if (instanceMember is PropertyInfo prop && prop.GetIndexParameters().Length != 0)
             {
                 instanceMember = null;
             }
 
-            instanceMember ??= ClrTypeUtilities.SafeGetFieldIncludingInterfaces(clrReceiverType, fieldName, BindingFlags.Public | BindingFlags.Instance);
+            instanceMember ??= SafeGetVisibleInstanceField(clrReceiverType, fieldName);
             if (instanceMember == null)
             {
                 Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, fieldName);
@@ -1845,13 +1845,13 @@ internal sealed partial class ExpressionBinder
         }
         else
         {
-            instanceMember = ClrTypeUtilities.SafeGetPropertyIncludingInterfaces(clrReceiverType, memberName, BindingFlags.Public | BindingFlags.Instance);
+            instanceMember = SafeGetVisibleInstanceProperty(clrReceiverType, memberName);
             if (instanceMember is PropertyInfo propInfo && propInfo.GetIndexParameters().Length != 0)
             {
                 instanceMember = null;
             }
 
-            instanceMember ??= ClrTypeUtilities.SafeGetFieldIncludingInterfaces(clrReceiverType, memberName, BindingFlags.Public | BindingFlags.Instance);
+            instanceMember ??= SafeGetVisibleInstanceField(clrReceiverType, memberName);
         }
 
         if (instanceMember == null)
@@ -2822,13 +2822,13 @@ internal sealed partial class ExpressionBinder
         if (CanBindClrInstanceMember(receiver))
         {
             var clrReceiverType = Invariant.Required(receiverType.ClrType, "a CLR member receiver has a CLR type");
-            MemberInfo? instanceMember = ClrTypeUtilities.SafeGetPropertyIncludingInterfaces(clrReceiverType, fieldName, BindingFlags.Public | BindingFlags.Instance);
+            MemberInfo? instanceMember = SafeGetVisibleInstanceProperty(clrReceiverType, fieldName);
             if (instanceMember is PropertyInfo propInfo && propInfo.GetIndexParameters().Length != 0)
             {
                 instanceMember = null;
             }
 
-            instanceMember ??= ClrTypeUtilities.SafeGetFieldIncludingInterfaces(clrReceiverType, fieldName, BindingFlags.Public | BindingFlags.Instance);
+            instanceMember ??= SafeGetVisibleInstanceField(clrReceiverType, fieldName);
             if (instanceMember == null)
             {
                 Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, fieldName);
@@ -3313,13 +3313,13 @@ internal sealed partial class ExpressionBinder
 
         var clrReceiverType = globalType.ClrType;
         var memberName = syntax.FieldIdentifier.ValueText;
-        MemberInfo? instanceMember = ClrTypeUtilities.SafeGetPropertyIncludingInterfaces(clrReceiverType, memberName, BindingFlags.Public | BindingFlags.Instance);
+        MemberInfo? instanceMember = SafeGetVisibleInstanceProperty(clrReceiverType, memberName);
         if (instanceMember is PropertyInfo indexedProperty && indexedProperty.GetIndexParameters().Length != 0)
         {
             instanceMember = null;
         }
 
-        instanceMember ??= ClrTypeUtilities.SafeGetFieldIncludingInterfaces(clrReceiverType, memberName, BindingFlags.Public | BindingFlags.Instance);
+        instanceMember ??= SafeGetVisibleInstanceField(clrReceiverType, memberName);
         if (instanceMember == null)
         {
             Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, memberName);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
@@ -399,9 +399,19 @@ internal sealed partial class ExpressionBinder
         EventInfo? eventInfo = null;
         if (isEventCapableOperator && receiverClrType != null)
         {
+            // Issue #3705: friend-visible `internal` events are candidates
+            // here exactly as friend-visible methods/properties/fields are.
+            var eventsIncludeInternal = CanAccessInternalsOf(receiverClrType);
             eventInfo = boundReceiver != null
-                ? MemberLookup.SafeGetEventIncludingSelfAndInterfaces(receiverClrType, eventName)
-                : ClrTypeUtilities.SafeGetEvent(receiverClrType, eventName, flags);
+                ? MemberLookup.SafeGetEventIncludingSelfAndInterfaces(receiverClrType, eventName, eventsIncludeInternal)
+                : ClrTypeUtilities.SafeGetEvent(
+                    receiverClrType,
+                    eventName,
+                    ClrMemberVisibility.Widen(flags, eventsIncludeInternal));
+            if (!ClrMemberVisibility.IsVisible(eventInfo, eventsIncludeInternal))
+            {
+                eventInfo = null;
+            }
         }
 
         if (eventInfo == null)

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
@@ -3115,7 +3115,7 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
-        var getter = clrProp.GetGetMethod(nonPublic: false);
+        var getter = GetVisibleGetter(clrProp);
         if (getter == null)
         {
             return false;
@@ -3187,7 +3187,7 @@ internal sealed partial class ExpressionBinder
             return true;
         }
 
-        var setter = clrProp.GetSetMethod(nonPublic: false);
+        var setter = GetVisibleSetter(clrProp);
         if (setter == null)
         {
             Diagnostics.ReportCannotAssign(equalsLocation, memberName);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -1291,8 +1291,7 @@ internal sealed partial class ExpressionBinder
                         receiverType,
                         p,
                         projectOnlyWhenSymbolicallyRequired: true);
-                writable = p.CanWrite
-                    && (p.GetSetMethod(nonPublic: false) != null || IsFriendVisibleInternalSetter(p));
+                writable = p.CanWrite && GetVisibleSetter(p) != null;
                 return writable;
             case FieldInfo f:
                 targetType = f.FieldType;
@@ -1310,30 +1309,90 @@ internal sealed partial class ExpressionBinder
     }
 
     /// <summary>
-    /// Issue #3684: whether <paramref name="property"/>'s setter is an
-    /// <c>internal</c> (metadata <c>assembly</c>) accessor declared by an
-    /// assembly that named this compilation in an
-    /// <c>InternalsVisibleTo</c> — i.e. a setter this compilation may legally
-    /// call, exactly as C# lets a friend assembly write
-    /// <c>{ get; internal set; }</c>.
-    /// <para>
-    /// #3693 widened the CLR instance-call and imported-static probes the same
-    /// way; the writability test kept <c>GetSetMethod(nonPublic: false)</c>, so
-    /// a friend could READ an internal-set property but never write it — in a
-    /// plain assignment or an object initializer alike (GS0127). Only
-    /// <c>assembly</c> accessibility is admitted: <c>private</c>,
-    /// <c>protected</c>, <c>protected internal</c> and <c>private protected</c>
-    /// setters stay unwritable however the friendship is declared.
-    /// </para>
+    /// Issue #3705: whether this compilation may see the <c>internal</c>
+    /// members declared by <paramref name="clrType"/>'s assembly.
+    /// </summary>
+    /// <param name="clrType">The declaring CLR type.</param>
+    /// <returns><see langword="true"/> when friend internals are visible.</returns>
+    private bool CanAccessInternalsOf(Type? clrType)
+        => clrType?.Assembly is { } assembly && scope.References.CanAccessInternalMembers(assembly);
+
+    /// <summary>
+    /// Issue #3705: the property's getter when this compilation may call it —
+    /// public, or <c>internal</c> in a friend assembly. Member-lookup gates
+    /// should use this rather than <c>GetGetMethod(nonPublic: false)</c>, which
+    /// silently rejects a friend-visible accessor.
     /// </summary>
     /// <param name="property">The imported CLR property.</param>
-    /// <returns><see langword="true"/> when the internal setter is visible here.</returns>
-    private bool IsFriendVisibleInternalSetter(PropertyInfo property)
+    /// <returns>The callable getter, or <see langword="null"/>.</returns>
+    private MethodInfo? GetVisibleGetter(PropertyInfo property)
+        => ClrMemberVisibility.GetVisibleGetter(property, CanAccessInternalsOf(property.DeclaringType));
+
+    /// <summary>
+    /// Issue #3705: the setter sibling of <see cref="GetVisibleGetter"/>.
+    /// </summary>
+    /// <param name="property">The imported CLR property.</param>
+    /// <returns>The callable setter, or <see langword="null"/>.</returns>
+    private MethodInfo? GetVisibleSetter(PropertyInfo property)
+        => ClrMemberVisibility.GetVisibleSetter(property, CanAccessInternalsOf(property.DeclaringType));
+
+    /// <summary>
+    /// Issue #3705: the shared instance-property probe for CLR member lookup.
+    /// <para>
+    /// #3693 widened the method probes and #3702 the writability test, but the
+    /// property/field <em>lookups</em> on the assignment paths still ran
+    /// <c>BindingFlags.Public</c>-only, so a friend assembly could read
+    /// <c>internal T P { get; set; }</c> and never write it (GS0130). Both the
+    /// read and the write path now come through here, so the two cannot drift
+    /// apart again. Only metadata <c>assembly</c> accessibility is admitted —
+    /// <c>private</c>, <c>protected</c>, <c>protected internal</c> and
+    /// <c>private protected</c> stay invisible.
+    /// </para>
+    /// </summary>
+    /// <param name="clrReceiverType">The receiver's CLR type.</param>
+    /// <param name="name">The member name to find.</param>
+    /// <returns>The visible property, or <see langword="null"/>.</returns>
+    private PropertyInfo? SafeGetVisibleInstanceProperty(Type clrReceiverType, string name)
     {
-        var setter = property.GetSetMethod(nonPublic: true);
-        return setter is { IsAssembly: true }
-            && setter.DeclaringType?.Assembly is { } declaringAssembly
-            && scope.References.CanAccessInternalMembers(declaringAssembly);
+        var property = ClrTypeUtilities.SafeGetPropertyIncludingInterfaces(
+            clrReceiverType,
+            name,
+            BindingFlags.Public | BindingFlags.Instance);
+        if (property != null || !CanAccessInternalsOf(clrReceiverType))
+        {
+            return property;
+        }
+
+        var candidate = ClrTypeUtilities.SafeGetPropertyIncludingInterfaces(
+            clrReceiverType,
+            name,
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        return ClrMemberVisibility.IsVisible(candidate, includeInternal: true) ? candidate : null;
+    }
+
+    /// <summary>
+    /// Issue #3705: the shared instance-field probe for CLR member lookup —
+    /// the field sibling of <see cref="SafeGetVisibleInstanceProperty"/>.
+    /// </summary>
+    /// <param name="clrReceiverType">The receiver's CLR type.</param>
+    /// <param name="name">The member name to find.</param>
+    /// <returns>The visible field, or <see langword="null"/>.</returns>
+    private FieldInfo? SafeGetVisibleInstanceField(Type clrReceiverType, string name)
+    {
+        var field = ClrTypeUtilities.SafeGetFieldIncludingInterfaces(
+            clrReceiverType,
+            name,
+            BindingFlags.Public | BindingFlags.Instance);
+        if (field != null || !CanAccessInternalsOf(clrReceiverType))
+        {
+            return field;
+        }
+
+        var candidate = ClrTypeUtilities.SafeGetFieldIncludingInterfaces(
+            clrReceiverType,
+            name,
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        return ClrMemberVisibility.IsVisible(candidate, includeInternal: true) ? candidate : null;
     }
 
     /// <summary>ADR-0039: Determines whether an expression is an lvalue (can have its address taken).</summary>

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -462,24 +462,29 @@ internal sealed class MemberLookup
         return null;
     }
 
-    /// <summary>Finds a public instance event on a CLR type or any implemented interface.</summary>
+    /// <summary>
+    /// Finds a visible instance event on a CLR type or any implemented
+    /// interface. Issue #3705: <c>event</c> was the member kind #3693 and
+    /// #3702 never reached, so a friend assembly's <c>internal event</c> was
+    /// invisible while its <c>internal</c> methods, properties and fields were
+    /// not. Only metadata <c>assembly</c> accessibility is admitted.
+    /// </summary>
     /// <param name="clrType">The CLR type to probe.</param>
     /// <param name="name">The event name to match.</param>
+    /// <param name="includeInternal">Whether friend internals are visible.</param>
     /// <returns>The matching <see cref="EventInfo"/>, or <c>null</c>.</returns>
-    public static EventInfo? SafeGetEventIncludingSelfAndInterfaces(Type clrType, string name)
+    public static EventInfo? SafeGetEventIncludingSelfAndInterfaces(Type clrType, string name, bool includeInternal = false)
     {
         if (clrType == null)
         {
             return null;
         }
 
+        var flags = ClrMemberVisibility.Widen(BindingFlags.Public | BindingFlags.Instance, includeInternal);
         foreach (var type in EnumerateSelfAndInterfaces(clrType))
         {
-            var eventInfo = ClrTypeUtilities.SafeGetEvent(
-                type,
-                name,
-                BindingFlags.Public | BindingFlags.Instance);
-            if (eventInfo != null)
+            var eventInfo = ClrTypeUtilities.SafeGetEvent(type, name, flags);
+            if (ClrMemberVisibility.IsVisible(eventInfo, includeInternal))
             {
                 return eventInfo;
             }
@@ -3384,7 +3389,9 @@ internal sealed class MemberLookup
         var hasSetOnlyIndexer = false;
         foreach (var property in properties)
         {
-            hasSetOnlyIndexer |= property.GetGetMethod(nonPublic: false) == null;
+            hasSetOnlyIndexer |= ClrMemberVisibility.GetVisibleGetter(
+                property,
+                this.binderCtx.References.CanAccessInternalMembers(property.DeclaringType?.Assembly)) == null;
         }
 
         if (hasSymbolicArgument || hasSetOnlyIndexer)
@@ -4541,17 +4548,24 @@ internal sealed class MemberLookup
         return elementType != null && elementType != TypeSymbol.Error;
     }
 
-    private static PropertyInfo[] CollectVisibleClrIndexers(TypeSymbol targetType, Type clrTarget)
+    private PropertyInfo[] CollectVisibleClrIndexers(TypeSymbol targetType, Type clrTarget)
     {
         var declaringTypes = clrTarget.IsInterface
             ? EnumerateSelfAndInterfaces(clrTarget)
             : new List<Type> { clrTarget };
+
+        // Issue #3705: the indexer was the member kind #3693 / #3702 never
+        // reached, so a friend assembly's `internal this[…]` — or a
+        // `{ get; internal set; }` indexer — was invisible while its
+        // methods, properties and fields were not. Only metadata `assembly`
+        // accessibility is admitted.
+        var includeInternal = this.binderCtx.References.CanAccessInternalMembers(clrTarget.Assembly);
         var collected = new List<PropertyInfo>();
         foreach (var declaringType in declaringTypes)
         {
             foreach (var property in ClrTypeUtilities.SafeGetProperties(
                 declaringType,
-                BindingFlags.Public | BindingFlags.Instance))
+                ClrMemberVisibility.Widen(BindingFlags.Public | BindingFlags.Instance, includeInternal)))
             {
                 var alreadyCollected = false;
                 foreach (var existing in collected)
@@ -4566,8 +4580,7 @@ internal sealed class MemberLookup
                 }
 
                 if (property.GetIndexParameters().Length == 0
-                    || (property.GetGetMethod(nonPublic: false) == null
-                        && property.GetSetMethod(nonPublic: false) == null)
+                    || !ClrMemberVisibility.IsVisible(property, includeInternal)
                     || alreadyCollected)
                 {
                     continue;

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
@@ -566,13 +566,16 @@ internal sealed partial class MethodBodyEmitter
             this.EmitExpression(subscription.Handler);
         }
 
+        // Issue #3705: the binder decides accessibility (including a friend
+        // assembly's `internal` event); emit must not re-derive it with a
+        // narrower probe, or a bound subscription would fail here.
         var accessor = subscription.IsAdd
-            ? subscription.Event.GetAddMethod(nonPublic: false)
-            : subscription.Event.GetRemoveMethod(nonPublic: false);
+            ? subscription.Event.GetAddMethod(nonPublic: true)
+            : subscription.Event.GetRemoveMethod(nonPublic: true);
         if (accessor == null)
         {
             throw new InvalidOperationException(
-                $"Event '{subscription.Event.DeclaringType?.FullName}.{subscription.Event.Name}' has no public {(subscription.IsAdd ? "add" : "remove")} accessor.");
+                $"Event '{subscription.Event.DeclaringType?.FullName}.{subscription.Event.Name}' has no {(subscription.IsAdd ? "add" : "remove")} accessor.");
         }
 
         if (subscription.IsConstrainedTypeParameterAccess)

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
@@ -1343,9 +1343,13 @@ internal sealed partial class MethodBodyEmitter
             this.EmitExpression(arg);
         }
 
+        // Issue #3705: fall back to the non-public accessor exactly as the
+        // plain-property arms above do — the binder has already decided that a
+        // friend assembly's `internal` indexer accessor is callable here.
         var getter = ImportedMemberRefFactory.GetTypeBuilderSafePropertyAccessor(idx.Indexer, wantSetter: false)
+            ?? ImportedMemberRefFactory.GetTypeBuilderSafePropertyAccessor(idx.Indexer, wantSetter: false, nonPublic: true)
             ?? throw new InvalidOperationException(
-                $"Indexer on '{idx.Indexer.DeclaringType?.FullName}' has no public getter.");
+                $"Indexer on '{idx.Indexer.DeclaringType?.FullName}' has no getter.");
         var receiverIsValueType = ReflectionMetadataEmitter.IsValueTypeSymbol(idx.Target.Type);
         this.il.OpCode(receiverIsValueType ? ILOpCode.Call : ILOpCode.Callvirt);
         // Issue #671: route through the receiver-aware overload so the indexer
@@ -1374,7 +1378,10 @@ internal sealed partial class MethodBodyEmitter
 
     private void EmitClrIndexAssignment(BoundClrIndexAssignmentExpression ixa)
     {
-        var setter = ImportedMemberRefFactory.GetTypeBuilderSafePropertyAccessor(ixa.Indexer, wantSetter: true);
+        // Issue #3705: see EmitClrIndexAccess — the indexer arm honours a
+        // friend-visible `internal` accessor like its property siblings.
+        var setter = ImportedMemberRefFactory.GetTypeBuilderSafePropertyAccessor(ixa.Indexer, wantSetter: true)
+            ?? ImportedMemberRefFactory.GetTypeBuilderSafePropertyAccessor(ixa.Indexer, wantSetter: true, nonPublic: true);
 
         if (ixa.IsConstrainedTypeParameterAccess)
         {
@@ -1415,8 +1422,9 @@ internal sealed partial class MethodBodyEmitter
         if (setter == null)
         {
             var refGetter = ImportedMemberRefFactory.GetTypeBuilderSafePropertyAccessor(ixa.Indexer, wantSetter: false)
+                ?? ImportedMemberRefFactory.GetTypeBuilderSafePropertyAccessor(ixa.Indexer, wantSetter: false, nonPublic: true)
                 ?? throw new InvalidOperationException(
-                    $"Indexer on '{ixa.Indexer.DeclaringType?.FullName}' has no public setter or getter.");
+                    $"Indexer on '{ixa.Indexer.DeclaringType?.FullName}' has no setter or getter.");
             BoundExpression receiver = ixa.TargetExpression ?? new BoundVariableExpression(null, BoundNodeForm.VariableTarget(ixa));
             var tmp = this.indexAssignmentValueSlots[ixa];
 

--- a/src/Core/CodeAnalysis/Symbols/ClrMemberVisibility.cs
+++ b/src/Core/CodeAnalysis/Symbols/ClrMemberVisibility.cs
@@ -1,0 +1,113 @@
+// <copyright file="ClrMemberVisibility.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Reflection;
+
+namespace GSharp.Core.CodeAnalysis.Symbols;
+
+/// <summary>
+/// Issue #3705: the single place that decides whether an imported CLR member
+/// is visible to the compilation currently being bound.
+/// <para>
+/// Member-lookup probes across the binder each hand-rolled their own
+/// <see cref="BindingFlags"/> and <c>nonPublic:</c> arguments, and the result
+/// was a family of "inconsistent sibling probe" defects (#3693, #3702, #3703):
+/// a friend assembly's <c>internal</c> method was a candidate while its
+/// <c>internal</c> property was not, an <c>internal</c> setter was readable
+/// but not writable, and so on. Every probe that participates in member lookup
+/// should ask these helpers instead, passing the one bit that decides the
+/// answer — whether
+/// <see cref="ReferenceResolver.CanAccessInternalMembers(Assembly?)"/> holds
+/// for the declaring assembly.
+/// </para>
+/// <para>
+/// Only metadata <c>assembly</c> accessibility is ever admitted:
+/// <c>private</c>, <c>protected</c>, <c>protected internal</c> and
+/// <c>private protected</c> members stay invisible however the friendship is
+/// declared, and a consumer that was not named in an
+/// <c>InternalsVisibleTo</c> sees none of them.
+/// </para>
+/// </summary>
+public static class ClrMemberVisibility
+{
+    /// <summary>
+    /// Widens <paramref name="flags"/> to include
+    /// <see cref="BindingFlags.NonPublic"/> when friend-assembly internals are
+    /// visible. The caller must still filter the returned members through the
+    /// per-member predicates below: <see cref="BindingFlags.NonPublic"/> also
+    /// admits <c>private</c> and <c>protected</c>.
+    /// </summary>
+    /// <param name="flags">The public-only binding flags.</param>
+    /// <param name="includeInternal">Whether friend internals are visible.</param>
+    /// <returns>The widened flags.</returns>
+    public static BindingFlags Widen(BindingFlags flags, bool includeInternal)
+        => includeInternal ? flags | BindingFlags.NonPublic : flags;
+
+    /// <summary>Whether a method/accessor is visible to the consuming compilation.</summary>
+    /// <param name="method">The candidate method, or <see langword="null"/>.</param>
+    /// <param name="includeInternal">Whether friend internals are visible.</param>
+    /// <returns><see langword="true"/> when the method may be bound here.</returns>
+    public static bool IsVisible(MethodBase? method, bool includeInternal)
+        => method != null && (method.IsPublic || (includeInternal && method.IsAssembly));
+
+    /// <summary>Whether a field is visible to the consuming compilation.</summary>
+    /// <param name="field">The candidate field, or <see langword="null"/>.</param>
+    /// <param name="includeInternal">Whether friend internals are visible.</param>
+    /// <returns><see langword="true"/> when the field may be bound here.</returns>
+    public static bool IsVisible(FieldInfo? field, bool includeInternal)
+        => field != null && (field.IsPublic || (includeInternal && field.IsAssembly));
+
+    /// <summary>
+    /// Whether a property is visible — i.e. at least one of its accessors is.
+    /// A <c>{ get; internal set; }</c> property is visible to a friend and to
+    /// a non-friend alike; only the setter differs, which is
+    /// <see cref="GetVisibleSetter"/>'s business.
+    /// </summary>
+    /// <param name="property">The candidate property, or <see langword="null"/>.</param>
+    /// <param name="includeInternal">Whether friend internals are visible.</param>
+    /// <returns><see langword="true"/> when the property may be bound here.</returns>
+    public static bool IsVisible(PropertyInfo? property, bool includeInternal)
+        => property != null
+            && (GetVisibleGetter(property, includeInternal) != null
+                || GetVisibleSetter(property, includeInternal) != null);
+
+    /// <summary>Whether an event is visible — i.e. its <c>add</c> accessor is.</summary>
+    /// <param name="eventInfo">The candidate event, or <see langword="null"/>.</param>
+    /// <param name="includeInternal">Whether friend internals are visible.</param>
+    /// <returns><see langword="true"/> when the event may be bound here.</returns>
+    public static bool IsVisible(EventInfo? eventInfo, bool includeInternal)
+        => eventInfo != null && GetVisibleAddMethod(eventInfo, includeInternal) != null;
+
+    /// <summary>Returns the property's getter when it is visible here.</summary>
+    /// <param name="property">The property to inspect.</param>
+    /// <param name="includeInternal">Whether friend internals are visible.</param>
+    /// <returns>The visible getter, or <see langword="null"/>.</returns>
+    public static MethodInfo? GetVisibleGetter(PropertyInfo property, bool includeInternal)
+        => Visible(property.GetGetMethod(nonPublic: true), includeInternal);
+
+    /// <summary>Returns the property's setter when it is visible here.</summary>
+    /// <param name="property">The property to inspect.</param>
+    /// <param name="includeInternal">Whether friend internals are visible.</param>
+    /// <returns>The visible setter, or <see langword="null"/>.</returns>
+    public static MethodInfo? GetVisibleSetter(PropertyInfo property, bool includeInternal)
+        => Visible(property.GetSetMethod(nonPublic: true), includeInternal);
+
+    /// <summary>Returns the event's <c>add</c> accessor when it is visible here.</summary>
+    /// <param name="eventInfo">The event to inspect.</param>
+    /// <param name="includeInternal">Whether friend internals are visible.</param>
+    /// <returns>The visible accessor, or <see langword="null"/>.</returns>
+    public static MethodInfo? GetVisibleAddMethod(EventInfo eventInfo, bool includeInternal)
+        => Visible(eventInfo.GetAddMethod(nonPublic: true), includeInternal);
+
+    /// <summary>Returns the event's <c>remove</c> accessor when it is visible here.</summary>
+    /// <param name="eventInfo">The event to inspect.</param>
+    /// <param name="includeInternal">Whether friend internals are visible.</param>
+    /// <returns>The visible accessor, or <see langword="null"/>.</returns>
+    public static MethodInfo? GetVisibleRemoveMethod(EventInfo eventInfo, bool includeInternal)
+        => Visible(eventInfo.GetRemoveMethod(nonPublic: true), includeInternal);
+
+    private static MethodInfo? Visible(MethodInfo? accessor, bool includeInternal)
+        => IsVisible(accessor, includeInternal) ? accessor : null;
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3705MemberKindAccessibilityDifferentialTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3705MemberKindAccessibilityDifferentialTests.cs
@@ -1,0 +1,276 @@
+// <copyright file="Issue3705MemberKindAccessibilityDifferentialTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Text;
+using GsCompilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
+using GsSyntaxTree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #3705: the "inconsistent sibling probe" differential gate.
+/// <para>
+/// Seven defects in one week (#3693, #3702, #3703 ×2, #3680, #3667, #3697)
+/// shared one shape — a metadata probe omitting something a sibling probe a
+/// few lines away already did. Three of them were literally the same omission
+/// found three times: a member-lookup probe that enumerated
+/// <c>BindingFlags.Public</c> only, so a friend assembly's <c>internal</c>
+/// member of ONE kind was invisible while the same member of ANOTHER kind
+/// resolved fine. Each site looked locally reasonable; only the disagreement
+/// between kinds was wrong.
+/// </para>
+/// <para>
+/// So rather than one test per site, this fixture asserts the INVARIANT the
+/// sites are supposed to share: across method / property / field / event /
+/// indexer, read and write, the answer to "can this compilation see the
+/// member?" depends only on the member's accessibility and on whether the
+/// declaring assembly named this one in an <c>InternalsVisibleTo</c> — never
+/// on the member's kind. It is issue #3705's prevention option (3), and it
+/// fails on <c>main</c> for the event, indexer and property/field-write rows
+/// while passing for the method and property/field-read rows.
+/// </para>
+/// <para>
+/// The guard rails are half the point: <c>private</c> and <c>protected</c>
+/// must stay invisible to a friend, and a non-friend must see neither those
+/// nor <c>internal</c>.
+/// </para>
+/// </summary>
+public sealed class Issue3705MemberKindAccessibilityDifferentialTests
+{
+    private const string FriendAssemblyName = "Issue3705.Friend";
+    private const string StrangerAssemblyName = "Issue3705.Stranger";
+    private const string LibraryAssemblyName = "Issue3705.Library";
+
+    /// <summary>
+    /// One member of every kind at every accessibility. Indexer accessibility
+    /// is discriminated by the index parameter type, since a type may declare
+    /// only one indexer per signature.
+    /// </summary>
+    private const string CSharpLibrarySource = """
+        using System;
+        using System.Runtime.CompilerServices;
+
+        [assembly: InternalsVisibleTo("Issue3705.Friend")]
+
+        namespace Issue3705.Library;
+
+        public class Surface
+        {
+            public int PublicField;
+            internal int InternalField;
+            private int PrivateField;
+            protected int ProtectedField;
+
+            public event Action PublicEvent;
+            internal event Action InternalEvent;
+            private event Action PrivateEvent;
+            protected event Action ProtectedEvent;
+
+            public int PublicProperty { get; set; }
+            internal int InternalProperty { get; set; }
+            private int PrivateProperty { get; set; }
+            protected int ProtectedProperty { get; set; }
+
+            public int PublicMethod() => 1;
+            internal int InternalMethod() => 1;
+            private int PrivateMethod() => 1;
+            protected int ProtectedMethod() => 1;
+
+            public int this[int index] { get => 0; set { } }
+            internal int this[string index] { get => 0; set { } }
+            private int this[bool index] { get => 0; set { } }
+            protected int this[double index] { get => 0; set { } }
+
+            public int Touch()
+                => PrivateField + PrivateProperty + PrivateMethod() + this[true]
+                    + (PrivateEvent == null ? 0 : 1);
+        }
+        """;
+
+    /// <summary>
+    /// The differential matrix: member kind × accessibility × friend-vs-not.
+    /// Every row's expectation is computed from accessibility and friendship
+    /// ALONE — the member kind never appears in the expectation.
+    /// </summary>
+    /// <returns>The theory rows.</returns>
+    public static IEnumerable<object[]> Matrix()
+    {
+        string[] accessibilities = { "Public", "Internal", "Private", "Protected" };
+        string[] kinds =
+        {
+            "MethodCall",
+            "PropertyRead",
+            "PropertyWrite",
+            "FieldRead",
+            "FieldWrite",
+            "EventSubscribe",
+            "IndexerRead",
+            "IndexerWrite",
+        };
+
+        foreach (var kind in kinds)
+        {
+            foreach (var accessibility in accessibilities)
+            {
+                foreach (var isFriend in new[] { true, false })
+                {
+                    var visible = accessibility == "Public"
+                        || (accessibility == "Internal" && isFriend);
+                    yield return new object[] { kind, accessibility, isFriend, visible };
+                }
+            }
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(Matrix))]
+    public void MemberKinds_Agree_On_FriendAssembly_Visibility(
+        string kind,
+        string accessibility,
+        bool isFriend,
+        bool expectedVisible)
+    {
+        var directory = CreateOutputDirectory();
+        try
+        {
+            var libraryPath = EmitCSharpLibrary(directory, LibraryAssemblyName, CSharpLibrarySource);
+            var consumer = isFriend ? FriendAssemblyName : StrangerAssemblyName;
+            var result = CompileGSharp(BuildSource(kind, accessibility, consumer), consumer, libraryPath);
+
+            if (expectedVisible)
+            {
+                Assert.True(
+                    result.Success,
+                    $"{kind}/{accessibility}/friend={isFriend} should bind: {Describe(result)}");
+            }
+            else
+            {
+                Assert.False(
+                    result.Success,
+                    $"{kind}/{accessibility}/friend={isFriend} must NOT bind, but it did.");
+            }
+        }
+        finally
+        {
+            DeleteOutputDirectory(directory);
+        }
+    }
+
+    private static string BuildSource(string kind, string accessibility, string consumer)
+    {
+        // The index argument selects the overload whose accessibility is under
+        // test; each literal converts to exactly one of the four index types.
+        var indexArgument = accessibility switch
+        {
+            "Public" => "1",
+            "Internal" => "\"key\"",
+            "Private" => "true",
+            "Protected" => "1.5",
+            _ => throw new ArgumentOutOfRangeException(nameof(accessibility)),
+        };
+
+        var body = kind switch
+        {
+            "MethodCall" => $"    let value = surface.{accessibility}Method()",
+            "PropertyRead" => $"    let value = surface.{accessibility}Property",
+            "PropertyWrite" => $"    surface.{accessibility}Property = 7",
+            "FieldRead" => $"    let value = surface.{accessibility}Field",
+            "FieldWrite" => $"    surface.{accessibility}Field = 7",
+            "EventSubscribe" => $"    surface.{accessibility}Event += () -> {{ }}",
+            "IndexerRead" => $"    let value = surface[{indexArgument}]",
+            "IndexerWrite" => $"    surface[{indexArgument}] = 7",
+            _ => throw new ArgumentOutOfRangeException(nameof(kind)),
+        };
+
+        return $$"""
+            package {{consumer}}
+            import Issue3705.Library
+
+            func Run() {
+                let surface = Surface()
+            {{body}}
+            }
+            """;
+    }
+
+    private static string Describe(CompileResult result)
+        => string.Join(Environment.NewLine, result.Diagnostics.Select(d => d.Id + ": " + d.Message));
+
+    private static CompileResult CompileGSharp(
+        string source,
+        string assemblyName,
+        params string[] references)
+    {
+        using var resolver = ReferenceResolver.WithReferences(references);
+        resolver.CurrentAssemblyName = assemblyName;
+        var compilation = new GsCompilation(
+            resolver,
+            GsSyntaxTree.Parse(SourceText.From(source)))
+        {
+            AssemblyName = assemblyName,
+        };
+
+        using var output = new MemoryStream();
+        var emit = compilation.Emit(
+            output,
+            pdbStream: null,
+            refStream: null,
+            assemblyName: assemblyName);
+        return new CompileResult(
+            emit.Success,
+            emit.Diagnostics.Select(d => new DiagnosticInfo(d.Id, d.Message)).ToArray());
+    }
+
+    private static string EmitCSharpLibrary(string directory, string assemblyName, string source)
+    {
+        var references = ((AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string)
+                ?.Split(Path.PathSeparator)
+                ?? Array.Empty<string>())
+            .Where(File.Exists)
+            .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path));
+        var compilation = CSharpCompilation.Create(
+            assemblyName,
+            new[] { CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest)) },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        var path = Path.Combine(directory, assemblyName + ".dll");
+        using var output = File.Create(path);
+        var emit = compilation.Emit(output);
+        Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
+        return path;
+    }
+
+    private static string CreateOutputDirectory()
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            nameof(Issue3705MemberKindAccessibilityDifferentialTests),
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
+    private static void DeleteOutputDirectory(string directory)
+    {
+        try
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    private readonly record struct CompileResult(bool Success, DiagnosticInfo[] Diagnostics);
+
+    private readonly record struct DiagnosticInfo(string Id, string Message);
+}


### PR DESCRIPTION
Ask 1 of #3705 — the audit — plus the accessibility third of its fix. The full triage of all three families (with per-site reachability, what was cleared and why, and the Ask 2 recommendation) is posted as a comment on #3705: https://github.com/DavidObando/gsharp/issues/3705#issuecomment-5471546238

## What was wrong

#3693 widened the method probes; #3702 widened the property writability test. Both patched one site at a time, so the same omission survived in five more places — each of which looked locally reasonable:

| Site | The omission | The sibling that was already right |
|---|---|---|
| the five write paths in `ExpressionBinder.Assignments.cs` (10 probes) | `BindingFlags.Public`-only *lookup*, so a wholly-`internal` member of a friend assembly was never found | the READ path at `ExpressionBinder.Access.MemberLookup.cs:645/684`, widened by #3693 |
| `MemberLookup.CollectVisibleClrIndexers` — the single indexer funnel — and its 8 downstream accessor gates | `Public`-only + `nonPublic: false` | the method/property/field probes; `IsFriendVisibleInternalSetter` (#3702) |
| `MemberLookup.SafeGetEventIncludingSelfAndInterfaces` | ditto — event was a member kind neither fix reached | ditto |
| `Emit/MethodBodyEmitter.Closures.cs` (event) and `Emit/MethodBodyEmitter.MemberAccess.cs` (indexer) | emit re-derived accessibility with a narrower probe than the binder | `MemberAccess.cs:1111/1238`, the *plain-property* arms, which already fell back to `nonPublic: true` |
| `ExpressionBinder.Calls.Arguments.cs:3118/3190` (`base.P`) | `nonPublic: false` | same |

Concretely, on `main`, against a friend assembly: `x.Count` reads but `x.Count = 1` reports "unable to find member"; `internal T this[int]` is invisible; `x.E += () -> {}` on an `internal event` fails.

Also fixed on the way: the read path gated on `prop.CanRead`, which is `true` for `public T P { private get; set; }` — it would have bound a call to a **private** getter. It now requires a *visible* getter.

## The shape of the fix

Rather than repeat the widening at 18 sites, they go through a new `Symbols/ClrMemberVisibility.cs` — `Widen(flags, includeInternal)`, `IsVisible(method|field|property|event, …)`, `GetVisibleGetter/Setter/AddMethod/RemoveMethod`. This is the accessibility slice of #3705's Ask 2 option (1), and it paid for itself inside this PR: `IsFriendVisibleInternalSetter` (#3702's bespoke helper) is deleted in its favour, and emit now asks the binder's question instead of a narrower one of its own.

Guard rails: only metadata `assembly` accessibility is ever admitted. `private`, `protected`, `protected internal` and `private protected` stay invisible however the friendship is declared, and a consumer not named in an `InternalsVisibleTo` sees none of them.

## Verification

`Issue3705MemberKindAccessibilityDifferentialTests` is #3705's prevention option (3): 64 rows over member kind (method / property-read / property-write / field-read / field-write / event / indexer-read / indexer-write) × accessibility (public / internal / private / protected) × friend-vs-non-friend. **Its expectation is computed from accessibility and friendship alone — the member kind never appears on the right-hand side, so the test *is* the invariant.**

- On `main`: exactly 5 of 64 fail — `PropertyWrite`, `FieldWrite`, `EventSubscribe`, `IndexerRead`, `IndexerWrite`, all `Internal/friend=True`.
- Here: 64/64 pass.
- It would have caught #3693 and #3702 as one group, before either was filed.

Regression: 5766 binding/indexer/event tests green; 998 emit + samples-baseline tests green — **no IL baseline movement**, as expected, since the change only *adds* candidates and only for friend assemblies.

## Not in this PR (triaged, with evidence, in the issue comment)

- **Nullability family** — 13 reachable sites, plus two systematic sub-patterns worth more than the individual sites (fallback-slot drift across `MemberLookup`'s five member-type helpers; `MergeDeclarationNullability` applied on the field path only). Deferred because `ClrNullability` also implements the #1354 oblivious-default rule, so every swap widens *unannotated* metadata too — corpus-wide `!!` churn, and exactly the class of change that produced the #3704 gate regression.
- **Asymmetric-arm family** — the member-kind sweep came back clean, but the #3697 load-context shape did not. **`Lowering/Lowerer.cs:1224` deserves its own bug now**: one arm of a single `if` is the MLC-safe `ClrTypeUtilities.IsByRefLike` and the other is `typeof(IDisposable).IsAssignableFrom(clrType)`, which is unconditionally `false` for MetadataLoadContext types — so `for line in File.ReadLines(p) { break }` emits no `try`/`finally` and **never disposes the enumerator**. Deferred here only because it moves emitted IL and wants its own baseline audit.

Fixes the accessibility family of #3705; the issue stays open for the other two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
