### PR TITLE
cs2gs: conditional-index continuation seam and guarded-yield element promotion (#3700)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue3700RemainingNullableValueShapesTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3700RemainingNullableValueShapesTests.cs
@@ -1,0 +1,190 @@
+// <copyright file="Issue3700RemainingNullableValueShapesTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3700: the two nullable-value shapes family F5 (#3683) deliberately
+/// left alone, neither of which is the call-result receiver #3701 closed.
+/// <list type="number">
+/// <item>A conditional-access continuation rooted at a null-conditional INDEX.
+/// gsc parses <c>?.</c> and <c>?[</c> asymmetrically — the member form swallows
+/// the whole trailing chain into its guarded branch, the index form is one
+/// postfix step whose result is <c>T?</c> — so the flat C# shape
+/// <c>a?[i].B</c> reaches gsc as <c>(a?[i]).B</c> and is rejected (GS0158 /
+/// GS0116). Asserting the index result would be actively wrong: it throws when
+/// the receiver itself is nil, which is the case <c>?[</c> exists to
+/// short-circuit.</item>
+/// <item>An iterator whose element was promoted nullable by a <c>yield
+/// return</c> that a null-check guard already proves non-null. The repair is at
+/// the DECLARATION: the element must not be promoted at all.</item>
+/// </list>
+/// </summary>
+public class Issue3700RemainingNullableValueShapesTests
+{
+    // Deliberately ABSTRACT members (mirroring #3683's fixture): an annotated
+    // declaration with no body seeds no evidence in the whole-program taint
+    // fixpoint, so these tests exercise the ANNOTATION path, not the
+    // already-covered oblivious promotion path.
+    private const string AnnotatedDeclarations = @"
+#nullable enable
+
+namespace Demo
+{
+    public abstract class Node
+    {
+        public string Name { get; set; } = string.Empty;
+
+        public abstract Node? Child();
+
+        public abstract Node[]? Children();
+
+        public abstract string Describe();
+    }
+}";
+
+    [Fact]
+    public void ConditionalIndexContinuation_MemberAccess_GetsItsOwnGuardedSeam()
+    {
+        string printed = Translate(@"
+namespace Demo
+{
+    public class Holder
+    {
+        public string Read(Node node)
+        {
+            var name = node.Children()?[0].Name;
+            return name ?? string.Empty;
+        }
+    }
+}", out string declarations);
+
+        Assert.Contains("?[0]?.Name", printed);
+        TranslationTestValidation.AssertBinds(declarations, printed);
+    }
+
+    [Fact]
+    public void ConditionalIndexContinuation_Invocation_GetsItsOwnGuardedSeam()
+    {
+        string printed = Translate(@"
+namespace Demo
+{
+    public class Holder
+    {
+        public string Read(Node node)
+        {
+            var text = node.Children()?[0].Describe();
+            return text ?? string.Empty;
+        }
+    }
+}", out string declarations);
+
+        Assert.Contains("?[0]?.Describe()", printed);
+        TranslationTestValidation.AssertBinds(declarations, printed);
+    }
+
+    [Fact]
+    public void ConditionalIndexWithoutContinuation_KeepsTheSingleSeam()
+    {
+        string printed = Translate(@"
+namespace Demo
+{
+    public class Holder
+    {
+        public Node Read(Node node)
+        {
+            var first = node.Children()?[0];
+            return first;
+        }
+    }
+}", out string declarations);
+
+        Assert.Contains("node.Children()?[0]", printed);
+        Assert.DoesNotContain("?[0]?", printed);
+        TranslationTestValidation.AssertBinds(declarations, printed);
+    }
+
+    [Fact]
+    public void GuardedYield_DoesNotPromoteTheIteratorElement()
+    {
+        string printed = Translate(@"
+using System.Collections.Generic;
+
+namespace Demo
+{
+    public class Walker
+    {
+        public IEnumerable<Node> Children(Node node)
+        {
+            Node child = node.Child();
+            if (child != null)
+            {
+                yield return child;
+            }
+        }
+    }
+}", out string declarations);
+
+        Assert.Contains("sequence[Node]", printed);
+        Assert.DoesNotContain("sequence[Node?]", printed);
+        TranslationTestValidation.AssertBinds(declarations, printed);
+    }
+
+    [Fact]
+    public void UnguardedYieldAlongsideAGuardedOne_StillPromotesTheElement()
+    {
+        // The exclusion is per-yield evidence, not per-iterator: one unguarded
+        // nullable yield still widens the element.
+        string printed = Translate(@"
+using System.Collections.Generic;
+
+namespace Demo
+{
+    public class Walker
+    {
+        public IEnumerable<Node> Children(Node node)
+        {
+            Node child = node.Child();
+            if (child != null)
+            {
+                yield return child;
+            }
+
+            yield return null;
+        }
+    }
+}", out _);
+
+        Assert.Contains("sequence[Node?]", printed);
+    }
+
+    // Returns the printed consumer file, and hands back the printed ANNOTATED
+    // declarations too so callers can bind the pair with
+    // <see cref="TranslationTestValidation.AssertBinds(string[])"/>.
+    private static string Translate(string obliviousSource, out string printedDeclarations)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Annotated.cs", AnnotatedDeclarations), ("Oblivious.cs", obliviousSource) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " + string.Join("\n", project.ErrorDiagnostics));
+
+        printedDeclarations = Print(project, 0);
+        return Print(project, 1);
+    }
+
+    private static string Print(LoadedCSharpProject project, int documentIndex)
+    {
+        LoadedDocument document = project.Documents[documentIndex];
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -843,6 +843,17 @@ public sealed partial class CSharpToGSharpTranslator
         private GExpression TranslateReceiverWithNullForgiveness(ExpressionSyntax recv)
         {
             GExpression translated = this.TranslateExpression(recv);
+
+            // Issue #3700: a `?.` / `?[` CONDITIONAL RECEIVER is null-guarded by
+            // the seam that produced it, so an assertion there is at best
+            // redundant and at worst masks the guard — and it is not even
+            // printable, since the receiver renders as the empty string and the
+            // assertion would split the `?.` token (`[i]?!!.B`).
+            if (translated is ConditionalReceiverExpression)
+            {
+                return translated;
+            }
+
             bool iteratorForeachReceiverRequiresAssertion =
                 this.IteratorForeachReceiverRequiresAssertion(recv);
             bool importedGenericTupleElementRequiresAssertion =

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -301,9 +301,33 @@ public sealed partial class CSharpToGSharpTranslator
                             this.TranslateExpression(conditionalAccess.Expression));
                     }
 
+                    // Issue #3700: gsc's `?[i]` is a single postfix STEP whose
+                    // result is `T?`, unlike `?.` — which swallows the whole
+                    // continuation into its guarded branch. A C# `a?[i].B`
+                    // therefore cannot be printed flat: gsc reads it as
+                    // `(a?[i]).B` and rejects the dereference of a `T?`
+                    // (GS0158 / GS0116). Re-split it at the index so the
+                    // continuation hangs off a second `?` seam instead.
+                    if (TryFindConditionalIndexContinuation(
+                            conditionalAccess.WhenNotNull,
+                            out ElementBindingExpressionSyntax chainedIndexBinding))
+                    {
+                        return this.TranslateConditionalIndexWithContinuation(
+                            conditionalAccess,
+                            chainedIndexBinding);
+                    }
+
                     return new ConditionalAccessExpression(
                         this.TranslateExpression(conditionalAccess.Expression),
                         this.TranslateExpression(conditionalAccess.WhenNotNull));
+
+                case ElementBindingExpressionSyntax replacedBinding
+                    when this.state.ConditionalElementBindingReplacements.TryGetValue(
+                        replacedBinding,
+                        out GExpression bindingReplacement):
+                    // Issue #3700: the index step is already the inner `?` seam's
+                    // target; the rest of the chain reads the conditional receiver.
+                    return bindingReplacement;
 
                 case MemberBindingExpressionSyntax memberBinding:
                     // Issue #1879: `word?.DoubledLength` binds to the same
@@ -589,6 +613,110 @@ public sealed partial class CSharpToGSharpTranslator
             {
                 this.state.ConditionalElementReceivers.Remove(elementBinding);
             }
+        }
+
+        /// <summary>
+        /// Issue #3700: matches a conditional-access continuation that is rooted
+        /// at a null-conditional INDEX (<c>a?[i].B</c>, <c>a?[i].M()</c>,
+        /// <c>a?[i][j]</c>) and carries at least one further postfix step.
+        /// </summary>
+        /// <remarks>
+        /// gsc parses <c>?.</c> and <c>?[</c> asymmetrically: the member form
+        /// takes the whole trailing chain as its guarded continuation, while the
+        /// index form is one postfix step whose result is <c>T?</c>. Printing the
+        /// C# shape flat therefore says <c>(a?[i]).B</c> to gsc, which rejects
+        /// the dereference. Asserting the index result instead
+        /// (<c>a?[i]!!.B</c>) would be actively wrong: it throws when <c>a</c>
+        /// itself is nil, which is the case <c>?[</c> exists to short-circuit.
+        /// </remarks>
+        /// <param name="whenNotNull">The conditional-access continuation.</param>
+        /// <param name="elementBinding">The leading <c>?[i]</c> binding when matched.</param>
+        /// <returns><see langword="true"/> when the continuation must be re-split.</returns>
+        private static bool TryFindConditionalIndexContinuation(
+            ExpressionSyntax whenNotNull,
+            out ElementBindingExpressionSyntax elementBinding)
+        {
+            elementBinding = null;
+            for (ExpressionSyntax current = whenNotNull; current != null;)
+            {
+                switch (current)
+                {
+                    case ParenthesizedExpressionSyntax parenthesized:
+                        current = parenthesized.Expression;
+                        continue;
+
+                    // A nested `?.` further along the chain keeps its own seam;
+                    // keep walking to the index at the root of the continuation.
+                    case ConditionalAccessExpressionSyntax nested:
+                        current = nested.Expression;
+                        continue;
+
+                    case InvocationExpressionSyntax invocation:
+                        current = invocation.Expression;
+                        continue;
+
+                    case MemberAccessExpressionSyntax memberAccess:
+                        current = memberAccess.Expression;
+                        continue;
+
+                    case ElementAccessExpressionSyntax elementAccess:
+                        current = elementAccess.Expression;
+                        continue;
+
+                    case ElementBindingExpressionSyntax binding:
+                        elementBinding = binding;
+                        current = null;
+                        continue;
+
+                    default:
+                        return false;
+                }
+            }
+
+            // Fire only when the step DIRECTLY after the index is an ordinary
+            // `.` / `[`. A bare `a?[i]` needs no second seam, and `a?[i]?.b`
+            // already has one (re-splitting it would print `[i]??.b`).
+            return elementBinding != null
+                && ((elementBinding.Parent is MemberAccessExpressionSyntax member
+                        && member.Expression == elementBinding)
+                    || (elementBinding.Parent is ElementAccessExpressionSyntax element
+                        && element.Expression == elementBinding));
+        }
+
+        /// <summary>
+        /// Issue #3700: emits <c>a?[i]?<em>rest</em></c> for a C# <c>a?[i].rest</c>,
+        /// giving the continuation its own guarded seam (see
+        /// <see cref="TryFindConditionalIndexContinuation"/>).
+        /// </summary>
+        /// <param name="conditionalAccess">The C# conditional access.</param>
+        /// <param name="elementBinding">Its leading <c>?[i]</c> binding.</param>
+        /// <returns>The nested conditional-access form.</returns>
+        private GExpression TranslateConditionalIndexWithContinuation(
+            ConditionalAccessExpressionSyntax conditionalAccess,
+            ElementBindingExpressionSyntax elementBinding)
+        {
+            GExpression receiver = this.TranslateExpression(conditionalAccess.Expression);
+
+            // Translate the index step first, while the binding still renders as
+            // the index itself; it becomes the inner seam's target.
+            GExpression indexStep = this.TranslateExpression(elementBinding);
+
+            this.state.ConditionalElementBindingReplacements.Add(
+                elementBinding,
+                new ConditionalReceiverExpression());
+            GExpression continuation;
+            try
+            {
+                continuation = this.TranslateExpression(conditionalAccess.WhenNotNull);
+            }
+            finally
+            {
+                this.state.ConditionalElementBindingReplacements.Remove(elementBinding);
+            }
+
+            return new ConditionalAccessExpression(
+                receiver,
+                new ConditionalAccessExpression(indexStep, continuation));
         }
 
         private bool ConditionalIndexReceiverIsNullable(ExpressionSyntax receiver)

--- a/tools/cs2gs/Cs2Gs.Translator/DocumentTranslationState.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/DocumentTranslationState.cs
@@ -223,6 +223,13 @@ internal sealed class DocumentTranslationState
     public Dictionary<ElementBindingExpressionSyntax, GExpression> ConditionalElementReceivers { get; } =
         new Dictionary<ElementBindingExpressionSyntax, GExpression>();
 
+    // Issue #3700: while re-splitting a `?[i]`-rooted continuation into a second
+    // `?` seam, the element binding itself has already been emitted as the inner
+    // seam's TARGET, so the rest of the chain must translate against the
+    // conditional receiver instead of re-emitting the index.
+    public Dictionary<ElementBindingExpressionSyntax, GExpression> ConditionalElementBindingReplacements { get; } =
+        new Dictionary<ElementBindingExpressionSyntax, GExpression>();
+
     // Issue #1902: numbers the `__qN` tuple parameter synthesized to carry a
     // query's transparent identifier (multiple in-scope range variables)
     // through a lambda that C#'s query-translation spec (§12.19.3) would bind

--- a/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
@@ -2744,6 +2744,23 @@ internal static class ObliviousNullabilityAnalyzer
             if (descendant is YieldStatementSyntax { Expression: { } yielded }
                 && descendant.IsKind(SyntaxKind.YieldReturnStatement))
             {
+                // Issue #3700: a yield that a syntactic null-check guard proves
+                // non-null yields no evidence about the ELEMENT. The canonical
+                // shape is `var child = (T)p.GetValue(o); if (child != null) {
+                // yield return child; }` — the local is nullable because the
+                // reflective read lowers to `as`, but the element never is.
+                // Promoting it anyway widens the iterator's element to `T?`,
+                // and that `T?` then escapes through every `foreach` variable
+                // and recursive call the sequence feeds (gsc GS0154). The
+                // repair belongs at the DECLARATION, exactly as it does for a
+                // guarded constructor argument above: gsc's own smart-cast
+                // narrows the same guarded read at the yield seam, so standing
+                // the promotion down reintroduces no `T? -> T`.
+                if (IsNullGuardDominatedRead(yielded, model))
+                {
+                    continue;
+                }
+
                 ApplyReturnValue(
                     canonicalReturn,
                     yielded,


### PR DESCRIPTION
Fixes #3700. These are the two shapes family **F5** (#3683 / #3701) deliberately left alone — neither is the call-result receiver that PR closed, and, as suspected there, neither wanted a `!!`.

## 1. Conditional-access continuation rooted at a null-conditional INDEX

gsc parses `?.` and `?[` **asymmetrically**. `ParseNullConditionalContinuation` hands `?.` the whole trailing chain, which `BindNullConditionalAccessExpressionCore` then binds against the guarded capture — C# semantics. `?[` is not a continuation carrier at all: `ParsePostfixChainCore` builds one `IndexExpressionSyntax { IsNullConditional = true }` step whose result is `T?`, and anything after it hangs off *that*. Probed directly against `gsc`:

```gs
var items []?Item = []Item{Item{Tokens: 5}}
var chained = items?[0].Tokens
// probe.gs(14,25): error GS0158: Cannot find member Tokens.
```

So the flat print was never the C# meaning — gsc reads `a?[i].B` as `(a?[i]).B`.

Forgiving the index result would have been **actively wrong**, which is why #3701 declined it. `items?[0]!!.B` throws when `items` itself is nil — exactly the case `?[` exists to short-circuit. Probed on the same fixture with `items = nil`:

```
items?[0]?.Tokens   -> b-nil
items?[0]!!.Tokens  -> Unhandled exception. System.NullReferenceException
```

The continuation now gets its **own guarded seam** instead:

```gs
// before — un-bindable
Assert.Single((function.Parameters[2].Type!!.TypeArguments?[0].ArrayCommaTokens)!!)
// after
Assert.Single((function.Parameters[2].Type!!.TypeArguments?[0]?.ArrayCommaTokens)!!)
```

It fires only when the step **directly** after the index is an ordinary `.`/`[`: a bare `a?[i]` needs no second seam, and `a?[i]?.b` already has one (re-splitting that would print `[i]??.b`). A nested `?.` further along the chain keeps its own seam and composes — `a?[i].b?.c` prints `a?[i]?.b?.c`. There is exactly **one** such site in the whole repository corpus, the reported one.

A `?.`/`?[` **conditional receiver** is also now exempt from receiver forgiveness: it is null-guarded by the seam that produced it, so an assertion there is redundant at best and unprintable at worst (it renders as the empty string, so `!!` would split the `?.` token into `[i]?!!.B`).

## 2. A guarded `yield return` no longer promotes the iterator's element

The oblivious taint fixpoint saw a `SyntaxNode?` local reaching `yield return child` under a dominating `if (child != null)` and widened the iterator's return **element** to `sequence[SyntaxNode?]`, which then escaped through `expected`, the `foreach` variable and the recursive call (GS0154). The repair is at the **declaration**, not the value — the yielded value is provably non-null, so asserting the argument would paper over a promotion that should never have happened.

This reuses `IsNullGuardDominatedRead` exactly as the guarded-constructor-argument rule (#3501) already does, and it stays **per-yield**: one unguarded nullable yield still widens the element (covered by a negative test). gsc's own smart-cast narrows the same guarded read at the yield seam — and `ForgiveNullableReferenceValue` stands its promoted-value bridge down for a flow-narrowed local — so standing the promotion down reintroduces no `T? -> T`.

```gs
// before
private func LegacyGetChildren(node SyntaxNode) sequence[SyntaxNode?]
let expected = LegacyGetChildren(node)!!.ToList()
// after
private func LegacyGetChildren(node SyntaxNode) sequence[SyntaxNode]
let expected = LegacyGetChildren(node).ToList()
```

Note this **narrows** a declaration; it cannot widen one into a position that consumes it as non-nullable (the failure mode of #3704).

## Verification — measured end to end

`dotnet build GSharp.sln -c Release -graph` (the gate compiles through the PACKED SDK nupkg), whole-repository translate via `build/run-cs2gs-selfmig-migrate.sh`, then `cs2gs validate --app test/Core.Tests/Core.Tests.csproj`. Baseline and treatment measured identically on `5cf391be`, `gscVersion` 0.4.325, with no project excluded that the target app project-references.

**Migrated `test/Core.Tests`, excluding the GS0536 "redundant `!!`" first-compile artifacts stage 2's polish pass strips: 18 → 16 compile errors.**

| id | before | after |
|---|---:|---:|
| GS0154 | 1 | **0** |
| GS0158 | 2 | **1** |
| everything else | 15 | 15 |

The diff of the two error lists is **purely subtractive** — two lines removed, none added, no id increased, no new id, no line-number drift:

```
< Issue1675SyntaxNodeChildEnumerationTests.gs(361,59)  GS0154 Parameter 'node' requires ... SyntaxNode but was given ... SyntaxNode?
< Issue3354RectangularArrayParserTests.gs(20,72)       GS0158 Cannot find member ArrayCommaTokens
```

GS0536 moved 105 → 104, also purely subtractive (the now-unneeded `LegacyGetChildren(node)!!`).

Repository-wide `!!` across the whole 50-app migrated tree, excluding the self-migrated copies of this change's own sources: **17835 → 17834 (−1)**. The entire whole-corpus output delta is those **two files and three lines** shown above — nothing else in the tree moved.

Tests:

- New `Issue3700RemainingNullableValueShapesTests` (5) on the two-compilation oblivious-consumer fixture (the `Issue2113Oblivious…` idiom #3701 used): member-access continuation, invocation continuation, a bare `a?[i]` negative, the guarded iterator, and a mixed guarded/unguarded iterator negative. Each positive asserts the emitted G# **binds** via `TranslationTestValidation.AssertBinds`, binding the translated annotated declarations alongside the consumer.
- 597-test nullable / oblivious / conditional-access / iterator / `Issue2113` / `Issue3683` / `Issue3501` / `Issue914` / `GoldenTests` regression subset: all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
