### PR TITLE
gsc: recover the symbolic return type of an overloaded user method group (fixes migrated src/LanguageServer ilverify)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
@@ -1711,10 +1711,21 @@ internal sealed partial class ExpressionBinder
         // method-type-args may then surface a symbolic return like
         // `[]T` from `[]T{}.ToArray()` instead of the erased
         // `object[]`.
+        // Issue #3712: an OVERLOADED user method group has no natural type, so
+        // the pre-resolution symbolic vector above kept the argument's erased
+        // shape. Now that `best` is known its delegate parameter pins the
+        // group's arity — refine the vector so the symbolic type arguments
+        // (and therefore the emitted generic instantiation) recover the
+        // same-compilation return type instead of its `object` erasure.
+        var refinedExtensionSymbolicArgs = RefineSymbolicArgsForMethodGroups(
+            best,
+            arguments,
+            extensionSymbolicArgs,
+            receiverArgCount: 1);
         var extensionSymbolicTypeArgs = MemberLookup.BuildSymbolicMethodTypeArgs(
             best,
             typeArgSymbols,
-            extensionSymbolicArgs,
+            refinedExtensionSymbolicArgs,
             resolution.IsExpanded);
         var extensionTypeArgSymbolsForCall = !extensionSymbolicTypeArgs.IsDefault
             ? extensionSymbolicTypeArgs

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -1014,13 +1014,27 @@ internal sealed partial class ExpressionBinder
         => TryGetSymbolicUserMethodGroupType(group, out naturalType)
             && naturalType.ClrType != null;
 
+    /// <summary>
+    /// Issue #3712: recovers the symbolic (pre-erasure) function type of a
+    /// user-declared method group. When <paramref name="expectedParameterCount"/>
+    /// is supplied the group's candidates are first narrowed to the single
+    /// candidate of that arity, so an OVERLOADED group still yields a symbolic
+    /// type once the target delegate's shape is known. Without the filter an
+    /// overloaded group has no natural type and the symbolic argument vector
+    /// falls back to the erased CLR shape, which silently instantiates a
+    /// generic call over <c>object</c>.
+    /// </summary>
+    /// <param name="group">The bound method group.</param>
+    /// <param name="naturalType">The recovered symbolic function type, on success.</param>
+    /// <param name="expectedParameterCount">Optional target-delegate arity used to disambiguate an overloaded group.</param>
+    /// <returns><see langword="true"/> when a single symbolic candidate was recovered.</returns>
     private bool TryGetSymbolicUserMethodGroupType(
         BoundMethodGroupExpression group,
-        [NotNullWhen(true)] out FunctionTypeSymbol? naturalType)
+        [NotNullWhen(true)] out FunctionTypeSymbol? naturalType,
+        int? expectedParameterCount = null)
     {
         naturalType = null;
-        if (group.Candidates.Length != 1
-            || group.Candidates[0] is not { IsGeneric: false } candidate)
+        if (!TryGetUniqueSymbolicMethodGroupCandidate(group, expectedParameterCount, out var candidate))
         {
             return false;
         }
@@ -1041,6 +1055,120 @@ internal sealed partial class ExpressionBinder
             parameterTypes.MoveToImmutable(),
             MethodGroupObservableReturnType(candidate));
         return true;
+    }
+
+    /// <summary>
+    /// Issue #3712: refines a pre-resolution symbolic argument vector once the
+    /// winning CLR overload is known, replacing each overloaded user
+    /// method-group slot with the symbolic function type of the candidate whose
+    /// arity matches the target delegate parameter. The erased CLR vector
+    /// resolves such a group's return type to <c>object</c> when the return type
+    /// is a same-compilation user type; without this refinement the generic
+    /// method is emitted closed over <c>object</c> and the assembly fails IL
+    /// verification with <c>StackUnexpected</c>.
+    /// </summary>
+    /// <param name="resolved">The winning (possibly closed generic) CLR method.</param>
+    /// <param name="arguments">The bound user arguments, in source order.</param>
+    /// <param name="symbolicArgs">The pre-resolution symbolic vector, receiver-first when <paramref name="receiverArgCount"/> is 1.</param>
+    /// <param name="receiverArgCount">Number of leading receiver slots in <paramref name="symbolicArgs"/>.</param>
+    /// <returns>The refined vector, or <paramref name="symbolicArgs"/> when nothing changed.</returns>
+    private ImmutableArray<TypeSymbol> RefineSymbolicArgsForMethodGroups(
+        MethodInfo resolved,
+        ImmutableArray<BoundExpression> arguments,
+        ImmutableArray<TypeSymbol> symbolicArgs,
+        int receiverArgCount)
+    {
+        if (symbolicArgs.IsDefaultOrEmpty || arguments.IsDefaultOrEmpty)
+        {
+            return symbolicArgs;
+        }
+
+        var parameters = resolved.GetParameters();
+        ImmutableArray<TypeSymbol>.Builder? refined = null;
+        for (var i = 0; i < arguments.Length; i++)
+        {
+            var slot = i + receiverArgCount;
+            if (slot >= symbolicArgs.Length || slot >= parameters.Length)
+            {
+                continue;
+            }
+
+            if (arguments[i] is not BoundMethodGroupExpression group || group.Candidates.Length <= 1)
+            {
+                continue;
+            }
+
+            if (symbolicArgs[slot] is FunctionTypeSymbol)
+            {
+                continue;
+            }
+
+            var invoke = parameters[slot].ParameterType.GetMethodSafe("Invoke");
+            if (invoke == null
+                || !TryGetSymbolicUserMethodGroupType(group, out var symbolicGroupType, invoke.GetParameters().Length))
+            {
+                continue;
+            }
+
+            refined ??= symbolicArgs.ToBuilder();
+            refined[slot] = symbolicGroupType;
+        }
+
+        return refined?.ToImmutable() ?? symbolicArgs;
+    }
+
+    /// <summary>
+    /// Issue #3712: picks the single non-generic candidate of a user method
+    /// group. A group with one candidate resolves unconditionally; an
+    /// overloaded group resolves only when <paramref name="expectedParameterCount"/>
+    /// selects exactly one candidate by arity.
+    /// </summary>
+    /// <param name="group">The bound method group.</param>
+    /// <param name="expectedParameterCount">Optional target-delegate arity.</param>
+    /// <param name="candidate">The selected candidate, on success.</param>
+    /// <returns><see langword="true"/> when exactly one candidate was selected.</returns>
+    private static bool TryGetUniqueSymbolicMethodGroupCandidate(
+        BoundMethodGroupExpression group,
+        int? expectedParameterCount,
+        [NotNullWhen(true)] out FunctionSymbol? candidate)
+    {
+        candidate = null;
+        if (group.Candidates.Length == 1)
+        {
+            candidate = group.Candidates[0] is { IsGeneric: false } single ? single : null;
+            return candidate != null;
+        }
+
+        if (expectedParameterCount is not { } arity)
+        {
+            return false;
+        }
+
+        foreach (var groupCandidate in group.Candidates)
+        {
+            if (groupCandidate.IsGeneric)
+            {
+                continue;
+            }
+
+            var offset = groupCandidate.IsExtension && group.Receiver != null ? 1 : 0;
+            if (groupCandidate.Parameters.Length - offset != arity)
+            {
+                continue;
+            }
+
+            if (candidate != null)
+            {
+                // Ambiguous by arity alone — leave the group unresolved so the
+                // existing erasure path decides.
+                candidate = null;
+                return false;
+            }
+
+            candidate = groupCandidate;
+        }
+
+        return candidate != null;
     }
 
     /// <summary>

--- a/test/Compiler.Tests/Emit/Issue3712OverloadedMethodGroupInferenceEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3712OverloadedMethodGroupInferenceEmitTests.cs
@@ -1,0 +1,282 @@
+// <copyright file="Issue3712OverloadedMethodGroupInferenceEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #3712: an OVERLOADED user method group passed to a generic imported
+/// extension method (<c>list.Select(Helper.ToRange)</c>) had no natural type,
+/// so the symbolic type-argument vector kept the argument's erased CLR shape
+/// and the generic call was emitted closed over <c>object</c> —
+/// <c>Enumerable::Select&lt;Token, object&gt;</c> feeding a
+/// <c>List&lt;object&gt;</c> into an <c>IEnumerable&lt;Range&gt;</c> slot. The
+/// binder still typed the expression symbolically, so nothing was reported and
+/// the assembly failed IL verification with <c>StackUnexpected</c>. This was
+/// the sole ilverify failure of the migrated <c>src/LanguageServer</c>
+/// (<c>LspServer::ComputeLinkedEditingRanges</c>).
+/// </summary>
+public class Issue3712OverloadedMethodGroupInferenceEmitTests
+{
+    /// <summary>
+    /// The reduced <c>LspServer::ComputeLinkedEditingRanges</c> shape: an
+    /// overloaded <c>shared</c> group whose return type is a same-compilation
+    /// class, projected over a <c>List[T]</c> and stored into an
+    /// <c>IEnumerable[T]</c> field.
+    /// </summary>
+    [Fact]
+    public void OverloadedSharedGroup_ReturningSameCompilationClass_EmitsClosedOverRealType()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            class Token {
+                var Text string
+                init(text string) { Text = text }
+            }
+
+            class Range {
+                var Label string
+                init(label string) { Label = label }
+            }
+
+            class Holder {
+                var Items IEnumerable[Range]
+            }
+
+            class Helper {
+                shared {
+                    func ToRange(token Token) Range { return Range(token.Text) }
+                    func ToRange(text string, extra int32) Range { return Range(text) }
+                }
+            }
+
+            func Build(tokens List[Token]) Holder {
+                return Holder{Items: tokens.Select(Helper.ToRange).ToList()}
+            }
+
+            var tokens = List[Token]()
+            tokens.Add(Token("a"))
+            tokens.Add(Token("b"))
+            for item in Build(tokens).Items {
+                Console.WriteLine(item.Label)
+            }
+            """;
+
+        Assert.Equal($"a{Environment.NewLine}b{Environment.NewLine}", CompileAndRun(source));
+    }
+
+    /// <summary>
+    /// The same defect with an imported element type: only the group's RETURN
+    /// type is same-compilation, so the erasure enters inference through the
+    /// output position alone.
+    /// </summary>
+    [Fact]
+    public void OverloadedSharedGroup_ImportedSource_SameCompilationResult_EmitsClosedOverRealType()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            class Range {
+                var Label string
+                init(label string) { Label = label }
+            }
+
+            class Holder {
+                var Items IEnumerable[Range]
+            }
+
+            class Helper {
+                shared {
+                    func ToRange(value int32) Range { return Range(value.ToString()) }
+                    func ToRange(text string, extra int32) Range { return Range(text) }
+                }
+            }
+
+            func Build(values List[int32]) Holder {
+                return Holder{Items: values.Select(Helper.ToRange).ToList()}
+            }
+
+            var values = List[int32]()
+            values.Add(1)
+            values.Add(2)
+            for item in Build(values).Items {
+                Console.WriteLine(item.Label)
+            }
+            """;
+
+        Assert.Equal($"1{Environment.NewLine}2{Environment.NewLine}", CompileAndRun(source));
+    }
+
+    /// <summary>
+    /// Regression guard for the pre-existing single-candidate path, which
+    /// already recovered the symbolic return type — the refinement must not
+    /// disturb it.
+    /// </summary>
+    [Fact]
+    public void SingleCandidateGroup_ReturningSameCompilationClass_StillEmitsClosedOverRealType()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            class Range {
+                var Label string
+                init(label string) { Label = label }
+            }
+
+            class Helper {
+                shared {
+                    func ToRange(value int32) Range { return Range(value.ToString()) }
+                }
+            }
+
+            func Build(values List[int32]) IEnumerable[Range] {
+                return values.Select(Helper.ToRange).ToList()
+            }
+
+            var values = List[int32]()
+            values.Add(7)
+            for item in Build(values) {
+                Console.WriteLine(item.Label)
+            }
+            """;
+
+        Assert.Equal($"7{Environment.NewLine}", CompileAndRun(source));
+    }
+
+    /// <summary>
+    /// An overloaded group whose candidates share the target arity stays
+    /// ambiguous by arity alone and must keep binding through the existing
+    /// CLR-erasure path — here both candidates take one parameter and the
+    /// argument type selects between them.
+    /// </summary>
+    [Fact]
+    public void OverloadedSharedGroup_SameArityCandidates_StillBindsAndRuns()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            class Helper {
+                shared {
+                    func Describe(value int32) string { return "i" + value.ToString() }
+                    func Describe(value string) string { return "s" + value }
+                }
+            }
+
+            func Build(values List[int32]) List[string] {
+                return values.Select(Helper.Describe).ToList()
+            }
+
+            var values = List[int32]()
+            values.Add(3)
+            for item in Build(values) {
+                Console.WriteLine(item)
+            }
+            """;
+
+        Assert.Equal($"i3{Environment.NewLine}", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_3712_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new System.Collections.Generic.List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+
+            // (a) Static verification: the erased `object` closure produced
+            // unverifiable IL, so ilverify is the primary assertion.
+            IlVerifier.Verify(outPath);
+
+            // (b) Dynamic verification: verifiable-but-wrong lowering would be
+            // worse than the bug, so the program must also produce the right
+            // values.
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.ReplaceLineEndings(Environment.NewLine);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3712

## What broke

`src/LanguageServer` is the first #3501 corpus app to translate AND compile and then fail **ilverify** — the first substantial "it builds, and the IL is wrong" sample. It gates four apps (LanguageServer, Repl, LanguageServer.Tests, Compiler.Tests).

From run [33331139589](https://github.com/DavidObando/gsharp/actions/runs/33331139589), the run's **only** verifier error:

```
[IL]: Error [StackUnexpected]: [GSharp.LanguageServer.dll :
  LspServer::ComputeLinkedEditingRanges(DocumentContent, LinkedEditingRangeParams, CancellationToken)]
  [offset 0x000000A7]
  [found ref    'List`1<object>']
  [expected ref 'IEnumerable`1<GSharp.LanguageServer.Protocol.Range>']
```

It is **not** a surviving variant of #3689/PR #3692 — no state machine is involved. It is a new, distinct root cause.

## Root cause

`LspServer.gs:1206`: `references.Select(SemanticLookup.ToRange).ToList()`.

`SemanticLookup.ToRange` is an **overloaded** `shared` group (`ToRange(SyntaxToken)` / `ToRange(SourceText, TextSpan)`) whose return type `Protocol.Range` is a **same-compilation** class. Such types have no CLR `Type` during binding and ride through overload resolution erased to `object` (ADR-0004 / #313, #658). The erasure is normally undone by the symbolic type-argument vector, which the emitter uses to re-close the generic call over the real symbols — but that vector is populated by `TryGetSymbolicUserMethodGroupType`, which **bails out for a group with more than one candidate** (an overloaded group has no natural type until the target delegate is known).

So a single-candidate group emits `Select<Token, Range>` and verifies, while the *overloaded* group emits `Select<Token, object>` + `ToList<object>` and stores a `List<object>` into an `IEnumerable<Range>` field. The binder still typed the expression symbolically, so **no diagnostic was reported** — the failure is silent until ilverify.

Reduced repro (no LanguageServer, no state machine):

```go
class Range { var Label string; init(label string) { Label = label } }
class Holder { var Items IEnumerable[Range] }
class Helper {
    shared {
        func ToRange(token Token) Range { return Range(token.Text) }
        func ToRange(text string, extra int32) Range { return Range(text) }
    }
}
func Build(tokens List[Token]) Holder {
    return Holder{Items: tokens.Select(Helper.ToRange).ToList()}
}
```

Deleting the second overload makes the same program verify.

## The fix

Once overload resolution has picked a candidate, its delegate parameter pins the group's arity. `RefineSymbolicArgsForMethodGroups` re-runs the symbolic method-group lookup at that point with an arity filter, selecting the single candidate of that arity and feeding its symbolic function type into `BuildSymbolicMethodTypeArgs`, so the emitter re-closes the generic call over the real types.

Deliberately conservative: the refinement fires only for a group that is (a) overloaded, (b) matched to a delegate parameter, and (c) unambiguous by arity. A group whose candidates share the target arity keeps binding exactly as before through the existing erasure path.

Scope note: the *instance* generic-call path (`preResolutionSymbolicArgs`) never applies the method-group symbolic case at all — `tokens.ConvertAll(Helper.ToRange)` fails earlier with `GS0156`, a compile error rather than bad IL, so it is not a verification hazard. Documented in #3712, not fixed here.

ILVerify was not weakened or skipped anywhere.

## Verification

**On the real migrated assembly** (migrated `src/LanguageServer` tree compiled with Release gsc, built from a genuine checkout of the parent commit for the "before"):

| gsc | ilverify |
| --- | --- |
| `origin/main` | `1 Error(s)` — `StackUnexpected`, `ComputeLinkedEditingRanges`, offset `0x000000A7`, byte-identical to the CI artifact |
| this branch | `All Classes and Methods … Verified.` |

**New tests** — `test/Compiler.Tests/Emit/Issue3712OverloadedMethodGroupInferenceEmitTests.cs`, 4 cases, each compiling the shape, running `IlVerifier.Verify`, **and executing** the result asserting the right values (verifiable-but-wrong lowering would be worse than the bug):

- overloaded group, same-compilation source and result — the `ComputeLinkedEditingRanges` shape;
- overloaded group, imported source, same-compilation result — erasure enters via the output position alone;
- single-candidate group — regression guard for the path that already worked;
- overloaded group with same-arity candidates — must keep binding through the unchanged erasure path.

All 4 pass; cases 1–2 fail on `origin/main`.

**Suites** (full output to logs, then grepped): `Core.Tests` `~MethodGroup|~Overload|~Extension` 544/544 pass; `~Sample|~Golden|~Baseline` 22/22 pass; `Compiler.Tests` `~Iterator|~Async|~StateMachine|~Emit` pass.

**`Samples_EmittedPE_Match_Baseline` did NOT move** — it passes unchanged, so no baseline regeneration was needed. That is the expected result and is itself evidence of tight scope: no sample carries an overloaded shared method group passed to a generic extension with a same-compilation return type, and nothing unrelated drifted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
