### PR TITLE
Lowering: dispose `for … in` enumerators imported through a MetadataLoadContext (#3708)

### DIFF
--- a/src/Core/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/Lowerer.cs
@@ -1220,13 +1220,26 @@ public sealed class Lowerer : BoundTreeRewriter
             // interfaces since .NET 9), but the interface dispatch below
             // boxes — invalid IL for a byref-like type. Roslyn likewise
             // emits no disposal for the span pattern enumerator.
-            if (ClrTypeUtilities.IsByRefLike(clrType)
-                || !typeof(System.IDisposable).IsAssignableFrom(clrType))
+            if (ClrTypeUtilities.IsByRefLike(clrType))
             {
                 return null;
             }
 
-            disposeMethod = typeof(System.IDisposable).GetMethod("Dispose", System.Type.EmptyTypes);
+            // Issue #3708: `typeof(IDisposable).IsAssignableFrom(clrType)` is
+            // unconditionally false when `clrType` comes from a
+            // MetadataLoadContext — i.e. for every imported enumerator in a
+            // `/reference:`-based compile — so this guard used to suppress the
+            // `finally` for `File.ReadLines(...)`, `Directory.EnumerateFiles(...)`,
+            // `xs.Where(...)` and friends, leaking the handle. Resolve
+            // `IDisposable` (and its `Dispose`) out of the receiver's own
+            // reflection context instead, matching the MLC-safe sibling arm above.
+            var disposableInterface = FindDisposableInterface(clrType);
+            if (disposableInterface == null)
+            {
+                return null;
+            }
+
+            disposeMethod = disposableInterface.GetMethodSafe("Dispose", System.Type.EmptyTypes);
         }
 
         if (disposeMethod == null)
@@ -1241,6 +1254,37 @@ public sealed class Lowerer : BoundTreeRewriter
             disposeMethod,
             TypeSymbol.Void,
             ImmutableArray<BoundExpression>.Empty);
+    }
+
+    /// <summary>
+    /// Issue #3708: returns the <c>System.IDisposable</c> interface as seen from
+    /// <paramref name="clrType"/>'s own reflection context, or <see langword="null"/>
+    /// when the type does not implement it. Walking the receiver's transitive
+    /// interface set by name is safe across the live-runtime /
+    /// <see cref="System.Reflection.MetadataLoadContext"/> boundary, where
+    /// <c>typeof(IDisposable).IsAssignableFrom(...)</c> always answers
+    /// <see langword="false"/>, and it yields the interface handle that the
+    /// <c>Dispose</c> lookup must be rooted in so the emitted member reference
+    /// resolves in the same context as the receiver.
+    /// </summary>
+    /// <param name="clrType">The enumerator's CLR type (live or MLC).</param>
+    /// <returns>The context-matched <c>System.IDisposable</c>, or <see langword="null"/>.</returns>
+    private static System.Type? FindDisposableInterface(System.Type clrType)
+    {
+        if (clrType.IsInterface && clrType.FullName == "System.IDisposable")
+        {
+            return clrType;
+        }
+
+        foreach (var iface in ClrTypeUtilities.SafeGetInterfaces(clrType))
+        {
+            if (iface.FullName == "System.IDisposable")
+            {
+                return iface;
+            }
+        }
+
+        return null;
     }
 
     private static bool BodyContainsYieldOrAwait(BoundStatement body)

--- a/test/Compiler.Tests/Emit/Issue3708ForInEnumeratorDisposalEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3708ForInEnumeratorDisposalEmitTests.cs
@@ -1,0 +1,428 @@
+// <copyright file="Issue3708ForInEnumeratorDisposalEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #3708: <c>Lowerer.TryBuildEnumeratorDisposeCall</c> decided whether a
+/// <c>for … in</c> loop needed a <c>try</c>/<c>finally</c> using a live
+/// <c>typeof(IDisposable).IsAssignableFrom(clrType)</c>. That predicate is
+/// unconditionally <see langword="false"/> for types loaded through a
+/// <see cref="System.Reflection.MetadataLoadContext"/> — i.e. every imported
+/// type in a <c>/reference:</c>-based compile, which is every real SDK build —
+/// so no disposal was emitted and the enumerator leaked its resource
+/// (<c>File.ReadLines</c>, <c>Directory.EnumerateFiles</c>, <c>xs.Where(…)</c>).
+/// C# guarantees the <c>finally</c> (ECMA-334 §13.9.5).
+/// <para>
+/// These tests pin the emitted IL rather than mere compilation success: a
+/// "does it compile?" assertion passes on the bug.
+/// </para>
+/// </summary>
+public class Issue3708ForInEnumeratorDisposalEmitTests
+{
+    [Fact]
+    public void ImportedDisposableEnumerator_AgainstRefPack_EmitsTryFinallyWithDisposeCall()
+    {
+        // File.ReadLines returns an imported IEnumerable[string] whose
+        // enumerator is a reference type implementing IDisposable, resolved
+        // entirely out of the MetadataLoadContext.
+        const string source = """
+            package Probe
+            import System
+            import System.IO
+
+            class P {
+                func Run(path string) {
+                    for line in File.ReadLines(path) {
+                        Console.WriteLine(line)
+                        break
+                    }
+                }
+            }
+            """;
+
+        var assemblyPath = CompileLibraryAgainstRefPack(source);
+        try
+        {
+            var body = ReadMethodBody(assemblyPath, "P", "Run");
+            Assert.Contains(body.Regions, region => region.Kind == ExceptionRegionKind.Finally);
+            Assert.Contains(
+                body.Regions.Where(region => region.Kind == ExceptionRegionKind.Finally),
+                region => CalledMethodNames(body, region.HandlerOffset, region.HandlerLength)
+                    .Contains("Dispose"));
+        }
+        finally
+        {
+            DeleteDirectory(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void ImportedDisposableEnumerator_LinqWhere_EmitsTryFinallyWithDisposeCall()
+    {
+        // The LINQ iterator returned by Where is an imported class whose
+        // Dispose is what stops the underlying enumeration — same MLC path.
+        const string source = """
+            package Probe
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            class P {
+                func Run(xs IEnumerable[int32]) int32 {
+                    for x in xs.Where((v int32) -> v > 1) {
+                        return x
+                    }
+                    return 0
+                }
+            }
+            """;
+
+        var assemblyPath = CompileLibraryAgainstRefPack(source);
+        try
+        {
+            var body = ReadMethodBody(assemblyPath, "P", "Run");
+            Assert.Contains(
+                body.Regions.Where(region => region.Kind == ExceptionRegionKind.Finally),
+                region => CalledMethodNames(body, region.HandlerOffset, region.HandlerLength)
+                    .Contains("Dispose"));
+        }
+        finally
+        {
+            DeleteDirectory(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void ByRefLikeEnumerator_Span_EmitsNoDisposal()
+    {
+        // Negative pin for the sibling guard the fix must not weaken: ref
+        // structs implement interfaces since .NET 9, so Span[T].Enumerator
+        // now answers "yes" to IDisposable, but interface dispatch on a
+        // byref-like receiver boxes and is invalid IL. Roslyn likewise emits
+        // no disposal for the span pattern enumerator.
+        const string source = """
+            package Probe
+            import System
+
+            class P {
+                func Run(values []int32) int32 {
+                    var span Span[int32] = values
+                    for v in span {
+                        return v
+                    }
+                    return 0
+                }
+            }
+            """;
+
+        var assemblyPath = CompileLibraryAgainstRefPack(source);
+        try
+        {
+            var body = ReadMethodBody(assemblyPath, "P", "Run");
+            Assert.DoesNotContain(body.Regions, region => region.Kind == ExceptionRegionKind.Finally);
+            Assert.DoesNotContain("Dispose", CalledMethodNames(body, 0, body.Il.Length));
+        }
+        finally
+        {
+            DeleteDirectory(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void UserIteratorEnumerator_StillEmitsTryFinallyWithDisposeCall()
+    {
+        // The symbolic/same-compilation branch (a synthesized iterator state
+        // machine) answered correctly before the fix because its enumerator
+        // type is a live runtime type. Pin that it keeps working.
+        const string source = """
+            package Probe
+            import System
+            import System.Collections.Generic
+
+            class P {
+                func Numbers() IEnumerable[int32] {
+                    yield 1
+                    yield 2
+                }
+
+                func Run() int32 {
+                    for n in Numbers() {
+                        return n
+                    }
+                    return 0
+                }
+            }
+            """;
+
+        var assemblyPath = CompileLibraryAgainstRefPack(source);
+        try
+        {
+            var body = ReadMethodBody(assemblyPath, "P", "Run");
+            Assert.Contains(
+                body.Regions.Where(region => region.Kind == ExceptionRegionKind.Finally),
+                region => CalledMethodNames(body, region.HandlerOffset, region.HandlerLength)
+                    .Contains("Dispose"));
+        }
+        finally
+        {
+            DeleteDirectory(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void ImportedDisposableEnumerator_EarlyBreak_ReleasesTheFileHandle()
+    {
+        // Executing proof: after the loop breaks, the file must be openable
+        // with FileShare.None. While the enumerator's handle leaks (pre-fix,
+        // held until GC) that open throws IOException.
+        const string source = """
+            package Probe
+            import System
+            import System.IO
+
+            let path = Environment.GetCommandLineArgs()[1]
+            for line in File.ReadLines(path) {
+                Console.WriteLine(line)
+                break
+            }
+
+            let exclusive = File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None)
+            exclusive.Dispose()
+            Console.WriteLine("released")
+            """;
+
+        var assemblyPath = CompileExecutableAgainstRefPack(source);
+        var directory = Path.GetDirectoryName(assemblyPath)!;
+        try
+        {
+            var dataPath = Path.Combine(directory, "lines.txt");
+            File.WriteAllText(dataPath, "alpha" + Environment.NewLine + "beta" + Environment.NewLine);
+
+            var result = Run(assemblyPath, dataPath);
+            Assert.True(
+                result.ExitCode == 0,
+                $"the enumerator's file handle was still held after `break` (exit {result.ExitCode}):\n"
+                + $"stdout:\n{result.StandardOutput}\nstderr:\n{result.StandardError}");
+            Assert.Contains("released", result.StandardOutput);
+        }
+        finally
+        {
+            TryDeleteDirectory(directory);
+        }
+    }
+
+    private sealed record MethodBody(
+        byte[] Il,
+        ImmutableArray<ExceptionRegion> Regions,
+        IReadOnlyDictionary<int, string> MethodNamesByToken);
+
+    private static MethodBody ReadMethodBody(string assemblyPath, string typeName, string methodName)
+    {
+        using var stream = File.OpenRead(assemblyPath);
+        using var pe = new PEReader(stream);
+        var metadata = pe.GetMetadataReader();
+        var method = metadata.TypeDefinitions
+            .Select(handle => metadata.GetTypeDefinition(handle))
+            .Where(type => metadata.GetString(type.Name) == typeName)
+            .SelectMany(type => type.GetMethods())
+            .Select(handle => metadata.GetMethodDefinition(handle))
+            .Single(candidate => metadata.GetString(candidate.Name) == methodName);
+        var body = pe.GetMethodBody(method.RelativeVirtualAddress);
+
+        // Resolve the whole call-target name table eagerly: the metadata heaps
+        // are backed by this PEReader's memory block and must not be touched
+        // once it is disposed.
+        var namesByToken = new Dictionary<int, string>();
+        foreach (var handle in metadata.MemberReferences)
+        {
+            namesByToken[MetadataTokens.GetToken(handle)] =
+                metadata.GetString(metadata.GetMemberReference(handle).Name);
+        }
+
+        foreach (var handle in metadata.MethodDefinitions)
+        {
+            namesByToken[MetadataTokens.GetToken(handle)] =
+                metadata.GetString(metadata.GetMethodDefinition(handle).Name);
+        }
+
+        var methodSpecCount = metadata.GetTableRowCount(TableIndex.MethodSpec);
+        for (var row = 1; row <= methodSpecCount; row++)
+        {
+            var handle = MetadataTokens.MethodSpecificationHandle(row);
+            var parent = metadata.GetMethodSpecification(handle).Method;
+            if (namesByToken.TryGetValue(MetadataTokens.GetToken(parent), out var parentName))
+            {
+                namesByToken[MetadataTokens.GetToken(handle)] = parentName;
+            }
+        }
+
+        return new MethodBody(body.GetILBytes()!, body.ExceptionRegions, namesByToken);
+    }
+
+    /// <summary>
+    /// Returns the names of every method targeted by a <c>call</c> /
+    /// <c>callvirt</c> / <c>constrained.</c>-prefixed call inside the given IL
+    /// window. Scanning for the two call opcodes plus a 4-byte token is
+    /// sufficient here because the windows inspected are the tiny bodies the
+    /// lowerer synthesizes, matching the byte-scanning idiom used by the other
+    /// emit tests in this folder.
+    /// </summary>
+    /// <param name="body">The decoded method body.</param>
+    /// <param name="offset">Start of the IL window.</param>
+    /// <param name="length">Length of the IL window.</param>
+    /// <returns>The set of called method names.</returns>
+    private static HashSet<string> CalledMethodNames(MethodBody body, int offset, int length)
+    {
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        var end = Math.Min(body.Il.Length, offset + length);
+        for (var i = offset; i + 5 <= end; i++)
+        {
+            if (body.Il[i] != 0x28 && body.Il[i] != 0x6F)
+            {
+                continue;
+            }
+
+            var token = BinaryPrimitives.ReadInt32LittleEndian(body.Il.AsSpan(i + 1, 4));
+            if (body.MethodNamesByToken.TryGetValue(token, out var name))
+            {
+                names.Add(name);
+            }
+        }
+
+        return names;
+    }
+
+    private static string CompileLibraryAgainstRefPack(string source) => Compile(source, "library");
+
+    private static string CompileExecutableAgainstRefPack(string source) => Compile(source, "exe");
+
+    private static string Compile(string source, string target)
+    {
+        var directory = Directory.CreateTempSubdirectory("gs_issue3708_").FullName;
+        var sourcePath = Path.Combine(directory, "probe.gs");
+        var outputPath = Path.Combine(directory, "probe.dll");
+        File.WriteAllText(sourcePath, source);
+
+        var args = new List<string>
+        {
+            "/out:" + outputPath,
+            "/target:" + target,
+            "/targetframework:net10.0",
+            "/nowarn:GS9100",
+        };
+        foreach (var reference in RefPackReferences())
+        {
+            args.Add("/reference:" + reference);
+        }
+
+        args.Add(sourcePath);
+
+        using var standardOutput = new StringWriter();
+        using var standardError = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(standardOutput);
+        Console.SetError(standardError);
+        try
+        {
+            var exitCode = Program.Main(args.ToArray());
+            Assert.True(exitCode == 0, $"compile failed ({exitCode}):\n{standardOutput}\n{standardError}");
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+
+        IlVerifier.Verify(outputPath);
+        return outputPath;
+    }
+
+    private static (int ExitCode, string StandardOutput, string StandardError) Run(string assemblyPath, string argument)
+    {
+        using var process = Process.Start(new ProcessStartInfo("dotnet")
+        {
+            ArgumentList =
+            {
+                "exec",
+                "--runtimeconfig",
+                Path.ChangeExtension(assemblyPath, ".runtimeconfig.json"),
+                assemblyPath,
+                argument,
+            },
+            WorkingDirectory = Path.GetDirectoryName(assemblyPath)!,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        })!;
+        var standardOutput = process.StandardOutput.ReadToEnd().ReplaceLineEndings(Environment.NewLine);
+        var standardError = process.StandardError.ReadToEnd().ReplaceLineEndings(Environment.NewLine);
+        Assert.True(process.WaitForExit(60_000), "dotnet exec timed out");
+        return (process.ExitCode, standardOutput, standardError);
+    }
+
+    /// <summary>
+    /// Assembles the reference closure the .NET SDK would hand gsc — the
+    /// <c>Microsoft.NETCore.App.Ref</c> targeting-pack facades. Loading through
+    /// these (rather than the test host's TPA) is what puts every imported type
+    /// in a MetadataLoadContext with an assembly identity distinct from the
+    /// host's <c>System.Private.CoreLib</c>, which is the exact configuration
+    /// issue #3708 mis-answered. Mirrors
+    /// <c>XunitAssertOverloadResolutionTests.RefPackReferences</c>.
+    /// </summary>
+    /// <returns>The reference assembly paths.</returns>
+    private static IEnumerable<string> RefPackReferences()
+    {
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        Assert.False(string.IsNullOrEmpty(runtimeDir), "host runtime directory not resolvable");
+        var dotnetRoot = Directory.GetParent(runtimeDir!)?.Parent?.Parent?.FullName;
+        Assert.False(string.IsNullOrEmpty(dotnetRoot), "dotnet root not resolvable");
+        var packsRoot = Path.Combine(dotnetRoot!, "packs", "Microsoft.NETCore.App.Ref");
+        Assert.True(Directory.Exists(packsRoot), $"ref pack root '{packsRoot}' missing");
+
+        var major = Environment.Version.Major.ToString();
+        var refDir = Path.Combine(packsRoot, Environment.Version.ToString(3), "ref", $"net{major}.0");
+        if (!Directory.Exists(refDir))
+        {
+            var candidate = Directory.EnumerateDirectories(packsRoot, major + ".*")
+                .OrderByDescending(d => d, StringComparer.Ordinal)
+                .Select(d => Path.Combine(d, "ref", $"net{major}.0"))
+                .FirstOrDefault(Directory.Exists);
+            Assert.False(string.IsNullOrEmpty(candidate), $"no ref pack for net{major}.0 under '{packsRoot}'");
+            refDir = candidate!;
+        }
+
+        return Directory.EnumerateFiles(refDir, "*.dll");
+    }
+
+    private static void DeleteDirectory(string assemblyPath)
+        => TryDeleteDirectory(Path.GetDirectoryName(assemblyPath)!);
+
+    private static void TryDeleteDirectory(string directory)
+    {
+        try
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3708.

## The defect

`Lowerer.TryBuildEnumeratorDisposeCall` decided whether a `for … in` loop needed a `try`/`finally` to dispose its enumerator with two inconsistent arms of a single `if` (the #3705 sibling-probe pattern):

```csharp
if (ClrTypeUtilities.IsByRefLike(clrType)                       // MLC-safe
    || !typeof(System.IDisposable).IsAssignableFrom(clrType))   // live typeof
{
    return null;   // no disposal emitted
}
```

`typeof(IDisposable).IsAssignableFrom(clrType)` is **unconditionally false** for a type loaded through a `MetadataLoadContext` — i.e. every imported type in a `/reference:`-based compile, which is every real SDK build. The guard returned `null`, no `finally` was emitted, and the enumerator was never disposed:

```gs
for line in File.ReadLines(path) {
    break            // file handle held until GC
}
```

Same for `Directory.EnumerateFiles(...)`, `xs.Where(...)`, and any imported enumerator whose `IDisposable` releases a real resource. C# guarantees the `finally` (ECMA-334 §13.9.5), so this was a correctness divergence in ordinary user code.

## The fix

Both halves, as the issue calls for:

1. **The predicate** — resolve `System.IDisposable` by walking the receiver's transitive interface set by name (`ClrTypeUtilities.SafeGetInterfaces`, the same reference-context-independent walk that backs `ImplementsInterfaceByName` / `IsAssignableByName`), matching the MLC-safe sibling arm one line above.
2. **The `Dispose` resolution** — root the method lookup in that *context-matched* interface handle rather than the live `typeof(IDisposable)`. Fixing only the predicate would emit a member reference from the wrong reflection context.

The byref-like arm is untouched and now stands alone.

## Byref-like guard still holds

`Span[T].Enumerator` still emits **no** disposal — interface dispatch on a ref struct boxes and is invalid IL (Roslyn does the same). `ByRefLikeEnumerator_Span_EmitsNoDisposal` pins it: no `finally` region and no `Dispose` call anywhere in the method body. It is the one new test that passes on **both** `main` and this branch, which is exactly its job.

Struct enumerators are unaffected in the common case: the pattern-based arm above still prefers the type's own public parameterless `Dispose()` (`List[T].Enumerator` etc.), so no boxing is introduced there. A value type implementing `IDisposable` only explicitly falls to the interface arm and is boxed by the emitter's existing `ImportedInstanceReceiverRequiresBoxing` rule — valid IL, and the behaviour the pre-existing code comment already described.

## Verification — IL, not "it compiles"

New `test/Compiler.Tests/Emit/Issue3708ForInEnumeratorDisposalEmitTests.cs` compiles against a real `Microsoft.NETCore.App.Ref` ref-pack closure (the `RefPackReferences()` idiom from `XunitAssertOverloadResolutionTests`) and **decodes the emitted method bodies** — a test that only asserted "compiles" would pass on the bug.

| Test | Asserts |
| --- | --- |
| `ImportedDisposableEnumerator_AgainstRefPack_EmitsTryFinallyWithDisposeCall` | `File.ReadLines` → a `Finally` exception region whose handler calls `Dispose` |
| `ImportedDisposableEnumerator_LinqWhere_EmitsTryFinallyWithDisposeCall` | same for the LINQ `Where` iterator |
| `UserIteratorEnumerator_StillEmitsTryFinallyWithDisposeCall` | the symbolic/same-compilation branch (a G# iterator state machine) still disposes |
| `ByRefLikeEnumerator_Span_EmitsNoDisposal` | **negative** — `Span[int32]` emits no `finally`, no `Dispose` |
| `ImportedDisposableEnumerator_EarlyBreak_ReleasesTheFileHandle` | **executing** — enumerate-then-`break`, then reopen the file with `FileShare.None` |

Decoded IL for the `File.ReadLines` case, on this branch:

```
region: Finally@51+7
calls:  ReadLines | GetEnumerator | get_Current | WriteLine | MoveNext | Dispose
```

On `origin/main` the same method has **no** exception region and **no** `Dispose` memberref at all (`strings probe.dll | grep -i dispos` → empty).

The executing test's failure on `origin/main` is the leak, verbatim:

```
the enumerator's file handle was still held after `break` (exit 134):
Unhandled exception. System.IO.IOException: The process cannot access the file
'…/gs_issue3708_2mFOar/lines.txt' because it is being used by another process.
```

**Pre-fix run of the new suite: 4 failed, 1 passed** (the passing one being the byref-like negative). **Post-fix: 5 passed.**

## Baseline audit — `Samples_EmittedPE_Match_Baseline` did NOT move

The issue predicted this gate would move. It does not, and the reason is specific rather than lucky:

`RefactoringBaselineTests` compiles each sample through `new Compilation(tree)` — *a plain compilation with no extra references* (the test's own comment says so, and that is why the `Gsharp.Extensions.*` samples sit on its known-compile-failure list). Every imported type there is therefore a **live runtime** type, for which `typeof(IDisposable).IsAssignableFrom(...)` already answered correctly. The bug is reachable only through the `MetadataLoadContext` that `/reference:` compiles construct — which the in-process baseline path never builds.

I ran the gate rather than assuming: **green, zero drift, no `refactoring-baseline.json.actual` produced.** No regeneration was performed, so there is no set of "moved samples" to justify and no risk of a regeneration silently absorbing an unintended emit change.

## Targeted suites

- `test/Core.Tests` — `Lower|Foreach|ForIn|Dispose|Iterator`: **374 passed, 0 failed**
- `test/Core.Tests` — `Samples_EmittedPE_Match_Baseline`: **passed** (unchanged)
- `test/Compiler.Tests` — `Foreach|ForIn|Dispose|Iterator|Emit`: **4218 passed, 0 failed** (36 m)
- New `Issue3708` suite: **5 passed** (4 of them failing on `origin/main`)

Each new test also runs `IlVerifier.Verify` on its output, so the added protected regions are verifier-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
