### PR TITLE
gsc: funnel the load-context family through ClrLoadContext (audit of #3705, family 3)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -6362,7 +6362,11 @@ public sealed class Binder
         {
             if (typeArgument.ClrType is { } argClr)
             {
-                return constraintClr.IsAssignableFrom(argClr);
+                // Issue #3705 (family 3): the constraint comes from imported
+                // metadata (MetadataLoadContext) while the argument may be a
+                // well-known TypeSymbol singleton wrapping a host `typeof(T)`.
+                // Raw IsAssignableFrom is silently false across that boundary.
+                return ClrLoadContext.IsAssignable(constraintClr, argClr);
             }
 
             // Issue #3501: a SOURCE class deriving (possibly through source
@@ -6375,7 +6379,7 @@ public sealed class Binder
                 for (var current = sourceClass; current != null; current = current.BaseClass)
                 {
                     if (current.ImportedBaseType?.ClrType is { } importedBaseClr
-                        && constraintClr.IsAssignableFrom(importedBaseClr))
+                        && ClrLoadContext.IsAssignable(constraintClr, importedBaseClr))
                     {
                         return true;
                     }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -1240,20 +1240,38 @@ internal sealed partial class ExpressionBinder
         return BindNameExpression(syntax);
     }
 
+    /// <summary>
+    /// Issue #3705 (family 3): whether a structural function type has exactly
+    /// the signature of <paramref name="delegateType"/>.
+    /// <para>
+    /// Every operand here can come from the compilation's
+    /// <see cref="System.Reflection.MetadataLoadContext"/> — both callers pass
+    /// an <c>EventInfo.EventHandlerType</c>, which is always imported metadata
+    /// — so all three questions must be asked across load contexts:
+    /// <c>typeof(Delegate).IsAssignableFrom</c> answers <see langword="false"/>
+    /// for an MLC delegate (<see cref="ClrTypeUtilities.IsDelegateType"/> is
+    /// the by-name walk that does not), the constructed <c>Invoke</c> may be
+    /// unreachable (#3697 — <see cref="ClrLoadContext.TryGetDelegateSignature"/>
+    /// carries the open-definition fallback), and a raw <c>!=</c> on
+    /// <see cref="Type"/> is reference identity, never true across contexts
+    /// (#835 — <see cref="ClrTypeUtilities.IsSameAs"/> compares structurally).
+    /// </para>
+    /// </summary>
+    /// <param name="fn">The structural function type.</param>
+    /// <param name="delegateType">The candidate delegate type, typically imported.</param>
+    /// <returns><see langword="true"/> when the signatures match exactly.</returns>
     private static bool IsSignatureCompatibleWithDelegate(FunctionTypeSymbol fn, Type delegateType)
     {
-        if (delegateType == null || !typeof(Delegate).IsAssignableFrom(delegateType))
+        if (!ClrTypeUtilities.IsDelegateType(delegateType))
         {
             return false;
         }
 
-        var invoke = delegateType.GetMethodSafe("Invoke");
-        if (invoke == null)
+        if (!ClrLoadContext.TryGetDelegateSignature(delegateType, out var parms, out var invokeReturn))
         {
             return false;
         }
 
-        var parms = invoke.GetParameters();
         if (parms.Length != fn.ParameterTypes.Length)
         {
             return false;
@@ -1261,14 +1279,14 @@ internal sealed partial class ExpressionBinder
 
         for (var i = 0; i < parms.Length; i++)
         {
-            if (fn.ParameterTypes[i]?.ClrType != parms[i].ParameterType)
+            if (!ClrTypeUtilities.IsSameAs(fn.ParameterTypes[i]?.ClrType, parms[i]))
             {
                 return false;
             }
         }
 
         var fnRetClr = fn.ReturnType == TypeSymbol.Void ? typeof(void) : fn.ReturnType?.ClrType;
-        return fnRetClr == invoke.ReturnType;
+        return ClrTypeUtilities.IsSameAs(fnRetClr, invokeReturn);
     }
 
     private bool TryGetWritableClrMember(MemberInfo? member, [NotNullWhen(true)] out Type? targetType, [NotNullWhen(true)] out TypeSymbol? targetTypeSymbol, out bool writable)

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -911,8 +911,12 @@ internal sealed class MemberLookup
             }
         }
 
-        // Non-generic IEnumerable falls back to object.
-        if (typeof(System.Collections.IEnumerable).IsAssignableFrom(clrType))
+        // Non-generic IEnumerable falls back to object. Issue #3705 (family 3):
+        // the generic arm above walks the interface closure by FullName (#2859)
+        // but this fallback used `typeof(IEnumerable).IsAssignableFrom`, which
+        // is unconditionally false for a MetadataLoadContext type — i.e. for
+        // every `/reference:`-compiled program. Ask the load-context funnel.
+        if (ClrLoadContext.Satisfies(clrType, typeof(System.Collections.IEnumerable)))
         {
             elementType = typeof(object);
             return true;

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/ClrOverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/ClrOverloadResolution.cs
@@ -1478,7 +1478,7 @@ internal static class ClrOverloadResolution
         Dictionary<string, Type> bounds,
         Func<int, IReadOnlyList<Type>, (Type[] Parameters, Type Return)?> methodGroupInference)
     {
-        if (!TryGetDelegateSignature(delegateType, out var delegateParameters, out var delegateReturn))
+        if (!ClrLoadContext.TryGetDelegateSignature(delegateType, out var delegateParameters, out var delegateReturn))
         {
             return false;
         }
@@ -1919,7 +1919,7 @@ internal static class ClrOverloadResolution
     /// types are compared by name to remain safe across reflection contexts
     /// (the target may be loaded through a <c>MetadataLoadContext</c> while the
     /// literal's natural <c>Func&lt;...&gt;</c> is a live-runtime type), and
-    /// both signatures are read through <see cref="TryGetDelegateSignature"/>
+    /// both signatures are read through <see cref="ClrLoadContext.TryGetDelegateSignature"/>
     /// so a constructed delegate whose <c>Invoke</c> is unreachable across
     /// those contexts still decomposes (issue #3681).
     /// </summary>
@@ -1950,8 +1950,8 @@ internal static class ClrOverloadResolution
         // closed generic delegate through its open definition, and the two
         // sibling delegate predicates (#908 covariance, #1150 return
         // widening) already go through it — this one was the outlier.
-        if (!TryGetDelegateSignature(target, out var targetParams, out var targetReturn)
-            || !TryGetDelegateSignature(source, out var sourceParams, out var sourceReturn))
+        if (!ClrLoadContext.TryGetDelegateSignature(target, out var targetParams, out var targetReturn)
+            || !ClrLoadContext.TryGetDelegateSignature(source, out var sourceParams, out var sourceReturn))
         {
             return false;
         }
@@ -2008,8 +2008,8 @@ internal static class ClrOverloadResolution
             return false;
         }
 
-        if (!TryGetDelegateSignature(target, out var targetParams, out var targetReturn)
-            || !TryGetDelegateSignature(source, out var sourceParams, out var sourceReturn))
+        if (!ClrLoadContext.TryGetDelegateSignature(target, out var targetParams, out var targetReturn)
+            || !ClrLoadContext.TryGetDelegateSignature(source, out var sourceParams, out var sourceReturn))
         {
             return false;
         }
@@ -2035,7 +2035,7 @@ internal static class ClrOverloadResolution
             return false;
         }
 
-        if (!IsReferencePreservingUpcast(targetReturn, sourceReturn))
+        if (!ClrLoadContext.Satisfies(sourceReturn, targetReturn))
         {
             return false;
         }
@@ -2082,8 +2082,8 @@ internal static class ClrOverloadResolution
             return false;
         }
 
-        if (!TryGetDelegateSignature(target, out var targetParams, out var targetReturn)
-            || !TryGetDelegateSignature(source, out var sourceParams, out var sourceReturn))
+        if (!ClrLoadContext.TryGetDelegateSignature(target, out var targetParams, out var targetReturn)
+            || !ClrLoadContext.TryGetDelegateSignature(source, out var sourceParams, out var sourceReturn))
         {
             return false;
         }
@@ -2160,8 +2160,8 @@ internal static class ClrOverloadResolution
             return false;
         }
 
-        if (!TryGetDelegateSignature(target, out var targetParams, out var targetReturn)
-            || !TryGetDelegateSignature(source, out var sourceParams, out var sourceReturn))
+        if (!ClrLoadContext.TryGetDelegateSignature(target, out var targetParams, out var targetReturn)
+            || !ClrLoadContext.TryGetDelegateSignature(source, out var sourceParams, out var sourceReturn))
         {
             return false;
         }
@@ -2291,8 +2291,8 @@ internal static class ClrOverloadResolution
     /// </summary>
     private static bool IsLambdaBodyConvertibleToDelegate(Type targetDelegate, Type source, Func<Type, Type, bool>? supplementaryInterfaceCheck)
     {
-        if (!TryGetDelegateSignature(targetDelegate, out var targetParams, out var targetReturn)
-            || !TryGetDelegateSignature(source, out var sourceParams, out var sourceReturn)
+        if (!ClrLoadContext.TryGetDelegateSignature(targetDelegate, out var targetParams, out var targetReturn)
+            || !ClrLoadContext.TryGetDelegateSignature(source, out var sourceParams, out var sourceReturn)
             || targetReturn is null
             || sourceReturn is null
             || targetParams.Length != sourceParams.Length)
@@ -2318,223 +2318,6 @@ internal static class ClrOverloadResolution
 
         var returnConversion = ClassifyImplicit(targetReturn, sourceReturn, supplementaryInterfaceCheck);
         return returnConversion != ImplicitConversionKind.None;
-    }
-
-    /// <summary>
-    /// Issue #908: extracts a delegate type's parameter types and return type.
-    /// Prefers the <c>Invoke</c> method, but falls back to decomposing the
-    /// generic arguments of a closed <c>System.Func`N</c> / <c>System.Action`N</c>
-    /// shape. The fallback is required because a <c>func</c>/arrow literal's
-    /// natural delegate type is built by <c>FunctionTypeSymbol.BuildClrType</c>
-    /// as a host-runtime <c>Func&lt;&gt;</c> closed over
-    /// <see cref="System.Reflection.MetadataLoadContext"/> type arguments, on
-    /// which <see cref="Type.GetMethod(string)"/> throws.
-    /// </summary>
-    private static bool TryGetDelegateSignature(Type delegateType, out Type[] parameterTypes, [NotNullWhen(true)] out Type? returnType)
-    {
-        parameterTypes = Array.Empty<Type>();
-        returnType = null;
-
-        try
-        {
-            var invoke = delegateType.GetMethodSafe("Invoke");
-            if (invoke != null)
-            {
-                var ps = invoke.GetParameters();
-                var result = new Type[ps.Length];
-                for (var i = 0; i < ps.Length; i++)
-                {
-                    var parameterType = GetDelegateCompatibilityParameterType(ps[i]);
-                    if (parameterType is null)
-                    {
-                        return false;
-                    }
-
-                    result[i] = parameterType;
-                }
-
-                parameterTypes = result;
-                returnType = invoke.ReturnType;
-                return true;
-            }
-        }
-        catch (Exception)
-        {
-            // Cross-context constructed Func<>/Action<> — fall back to the
-            // generic-argument decomposition below.
-        }
-
-        var fullName = delegateType.FullName;
-        if (fullName == null || !delegateType.IsGenericType)
-        {
-            return false;
-        }
-
-        Type[] genericArgs;
-        try
-        {
-            genericArgs = delegateType.GetGenericArguments();
-        }
-        catch (Exception)
-        {
-            return false;
-        }
-
-        if (fullName.StartsWith("System.Func`", StringComparison.Ordinal) && genericArgs.Length >= 1)
-        {
-            // Func<T1,...,Tn,TResult>: trailing argument is the return type.
-            var ps = new Type[genericArgs.Length - 1];
-            Array.Copy(genericArgs, ps, ps.Length);
-            parameterTypes = ps;
-            returnType = genericArgs[genericArgs.Length - 1];
-            return true;
-        }
-
-        if (fullName.StartsWith("System.Action`", StringComparison.Ordinal))
-        {
-            // Action<T1,...,Tn>: void return, all generic arguments are parameters.
-            parameterTypes = genericArgs;
-            returnType = typeof(void);
-            return true;
-        }
-
-        // Issue #932: any other closed generic delegate (e.g.
-        // System.Predicate<T>, System.Comparison<T>, System.Converter<TIn,TOut>)
-        // whose constructed Invoke is unreachable across reflection contexts.
-        // Read the Invoke signature off the open generic definition — which is
-        // always in metadata — then substitute the closed type arguments into
-        // each generic-parameter slot. This generalises the Func/Action special
-        // cases above to the whole delegate surface a func/arrow literal may
-        // target.
-        try
-        {
-            var definition = delegateType.GetGenericTypeDefinition();
-            var defInvoke = definition.GetMethodSafe("Invoke");
-            if (defInvoke == null)
-            {
-                return false;
-            }
-
-            var defParams = defInvoke.GetParameters();
-            var resolvedParams = new Type[defParams.Length];
-            for (var i = 0; i < defParams.Length; i++)
-            {
-                var resolved = SubstituteGenericParameter(
-                    GetDelegateCompatibilityParameterType(defParams[i]),
-                    genericArgs);
-                if (resolved is null)
-                {
-                    return false;
-                }
-
-                resolvedParams[i] = resolved;
-            }
-
-            parameterTypes = resolvedParams;
-            var resolvedReturn = SubstituteGenericParameter(defInvoke.ReturnType, genericArgs);
-            if (resolvedReturn is null)
-            {
-                return false;
-            }
-
-            returnType = resolvedReturn;
-            return true;
-        }
-        catch (Exception)
-        {
-            return false;
-        }
-    }
-
-    private static Type? GetDelegateCompatibilityParameterType(ParameterInfo parameter)
-    {
-        var parameterType = parameter.ParameterType;
-
-        // Issue #2802: a by-ref slot's function shape is its pointee type;
-        // ref/out/in remain parameter metadata, not managed-pointer value types.
-        if (!parameterType.IsByRef)
-        {
-            return parameterType;
-        }
-
-        return parameterType.GetElementType();
-    }
-
-    /// <summary>
-    /// Issue #932: maps a (possibly generic-parameter) type drawn from a
-    /// delegate's open-definition <c>Invoke</c> signature to the corresponding
-    /// closed type argument. A bare generic parameter <c>T</c> is replaced by
-    /// <paramref name="genericArgs"/> at its <see cref="Type.GenericParameterPosition"/>;
-    /// every other type is returned unchanged. Only the direct-parameter case
-    /// is needed for the BCL delegates a func/arrow literal targets
-    /// (<c>Predicate&lt;T&gt;</c>, <c>Comparison&lt;T&gt;</c>,
-    /// <c>Converter&lt;TIn,TOut&gt;</c>).
-    /// </summary>
-    /// <param name="type">A type from the open definition's Invoke signature.</param>
-    /// <param name="genericArgs">The closed delegate's type arguments.</param>
-    /// <returns>The substituted type.</returns>
-    private static Type? SubstituteGenericParameter(Type? type, Type[] genericArgs)
-    {
-        if (type != null && type.IsGenericParameter
-            && type.GenericParameterPosition >= 0
-            && type.GenericParameterPosition < genericArgs.Length)
-        {
-            return genericArgs[type.GenericParameterPosition];
-        }
-
-        return type;
-    }
-
-    /// <summary>
-    /// Issue #908: determines whether <paramref name="source"/> is
-    /// reference-convertible (an upcast) to <paramref name="target"/> — i.e.
-    /// <paramref name="target"/> is the same type, an interface implemented by
-    /// <paramref name="source"/>, or a base class of <paramref name="source"/>.
-    /// Compared by name so it is robust across reflection contexts.
-    /// </summary>
-    private static bool IsReferencePreservingUpcast(Type target, Type source)
-    {
-        if (ClrTypeUtilities.AreSame(target, source))
-        {
-            return true;
-        }
-
-        if (string.Equals(target.FullName, "System.Object", StringComparison.Ordinal))
-        {
-            return true;
-        }
-
-        if (target.IsInterface && ClrTypeUtilities.ImplementsInterfaceByName(source, target))
-        {
-            return true;
-        }
-
-        for (var baseType = SafeBaseType(source); baseType != null; baseType = SafeBaseType(baseType))
-        {
-            if (ClrTypeUtilities.AreSame(baseType, target))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /// <summary>
-    /// Issue #908: returns <see cref="Type.BaseType"/>, swallowing the reflection
-    /// load failures that cross-context constructed generics can throw during a
-    /// base-type walk.
-    /// </summary>
-    private static Type? SafeBaseType(Type type)
-    {
-        try
-        {
-            return type.BaseType;
-        }
-        catch (Exception ex) when (ClrTypeUtilities.IsMetadataLoadFailure(ex))
-        {
-            return null;
-        }
     }
 
     /// <summary>
@@ -2860,7 +2643,7 @@ internal static class ClrOverloadResolution
                     && methodGroupInference != null
                     && methodGroupArgumentCheck?.Invoke(i) == true)
                 {
-                    if (!TryGetDelegateSignature(paramTypes[i], out var delegateParameters, out var delegateReturn)
+                    if (!ClrLoadContext.TryGetDelegateSignature(paramTypes[i], out var delegateParameters, out var delegateReturn)
                         || !IsMethodGroupSignatureCompatible(
                             methodGroupInference(i, delegateParameters),
                             delegateParameters,
@@ -3982,7 +3765,7 @@ internal static class ClrOverloadResolution
             return TaskLambdaDelegateShape.Other;
         }
 
-        if (!TryGetDelegateSignature(openParamType, out _, out var openReturn) || openReturn == null)
+        if (!ClrLoadContext.TryGetDelegateSignature(openParamType, out _, out var openReturn) || openReturn == null)
         {
             return TaskLambdaDelegateShape.Other;
         }
@@ -4012,7 +3795,7 @@ internal static class ClrOverloadResolution
             return false;
         }
 
-        return TryGetDelegateSignature(type, out _, out var returnType)
+        return ClrLoadContext.TryGetDelegateSignature(type, out _, out var returnType)
             && IsTaskType(returnType);
     }
 
@@ -4233,9 +4016,9 @@ internal static class ClrOverloadResolution
             // this tiebreak yields no preference -- the same `return 0` the
             // TryGetDelegateSignature failures below already produce.
             if (source is not null
-                && TryGetDelegateSignature(paramA, out _, out var retA)
-                && TryGetDelegateSignature(paramB, out _, out var retB)
-                && TryGetDelegateSignature(source, out _, out var retSource)
+                && ClrLoadContext.TryGetDelegateSignature(paramA, out _, out var retA)
+                && ClrLoadContext.TryGetDelegateSignature(paramB, out _, out var retB)
+                && ClrLoadContext.TryGetDelegateSignature(source, out _, out var retSource)
                 && retA != null && retB != null && retSource != null)
             {
                 return CompareNumericTargets(retA, retB, retSource);
@@ -5294,14 +5077,12 @@ internal static class ClrOverloadResolution
             return false;
         }
 
-        try
-        {
-            return target.IsAssignableFrom(source);
-        }
-        catch (NotSupportedException)
-        {
-            return false;
-        }
+        // Issue #3705 (family 3): both operands are method-group / delegate
+        // signature slots, so one can be a host `typeof(...)` while the other
+        // came from the compilation's MetadataLoadContext. Raw
+        // IsAssignableFrom answers a silent `false` there, dropping the
+        // candidate; the funnel falls back to the by-name walk.
+        return ClrLoadContext.IsAssignable(target, source);
     }
 
     /// <summary>
@@ -5456,8 +5237,8 @@ internal static class ClrOverloadResolution
 
         if (IsStructurallyInferrableDelegate(parameterType, argumentType))
         {
-            if (!TryGetDelegateSignature(parameterType, out var parameterDelegateParameters, out var parameterDelegateReturn)
-                || !TryGetDelegateSignature(argumentType, out var argumentDelegateParameters, out var argumentDelegateReturn)
+            if (!ClrLoadContext.TryGetDelegateSignature(parameterType, out var parameterDelegateParameters, out var parameterDelegateReturn)
+                || !ClrLoadContext.TryGetDelegateSignature(argumentType, out var argumentDelegateParameters, out var argumentDelegateReturn)
                 || parameterDelegateParameters.Length != argumentDelegateParameters.Length)
             {
                 return true;

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
@@ -1302,7 +1302,12 @@ internal sealed partial class MethodBodyEmitter
             && idx.Target.Type.ClrType is System.Type erasedClr
             && idx.Arguments.Length == 1)
         {
-            if (typeof(System.Collections.IList).IsAssignableFrom(erasedClr)
+            // Issue #3705 (family 3): `erasedClr` is an imported type, so it is
+            // a MetadataLoadContext type on every `/reference:` compile — a
+            // host `typeof(IList).IsAssignableFrom(...)` is silently false
+            // there and the erasure below is skipped, emitting a
+            // `callvirt List<object>::get_Item` that cannot bind at runtime.
+            if (ClrLoadContext.Satisfies(erasedClr, typeof(System.Collections.IList))
                 && idx.Arguments[0].Type == TypeSymbol.Int32)
             {
                 this.EmitInstanceReceiver(idx.Target);
@@ -1316,7 +1321,7 @@ internal sealed partial class MethodBodyEmitter
                 return;
             }
 
-            if (typeof(System.Collections.IDictionary).IsAssignableFrom(erasedClr))
+            if (ClrLoadContext.Satisfies(erasedClr, typeof(System.Collections.IDictionary)))
             {
                 this.EmitInstanceReceiver(idx.Target);
                 this.il.OpCode(ILOpCode.Castclass);

--- a/src/Core/CodeAnalysis/Symbols/ClrLoadContext.cs
+++ b/src/Core/CodeAnalysis/Symbols/ClrLoadContext.cs
@@ -1,0 +1,303 @@
+// <copyright file="ClrLoadContext.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+
+namespace GSharp.Core.CodeAnalysis.Symbols;
+
+/// <summary>
+/// Issue #3705 (family 3): the single place that answers "does this CLR type —
+/// which may have been materialised through a
+/// <see cref="System.Reflection.MetadataLoadContext"/> — satisfy a well-known
+/// shape the compiler cares about?".
+/// <para>
+/// <c>gsc</c> creates one <c>MetadataLoadContext</c> per compilation
+/// (<see cref="ImportedAssemblySemantics"/>) and never normalises the
+/// <see cref="Type"/>s it hands back to host <c>RuntimeType</c>s. A
+/// <c>typeof(X).IsAssignableFrom(importedType)</c> in the binder, lowerer or
+/// emitter is therefore not merely imprecise: it is <em>unconditionally
+/// false</em>, silently, for every program compiled with <c>/reference:</c> —
+/// which is every production compile. That is what produced #3708 (a <c>for</c>
+/// loop over an imported enumerable emitted no <c>Dispose</c>) and the
+/// <c>Delegate</c> arm of #3697.
+/// </para>
+/// <para>
+/// The rule this type exists to enforce: a load-context-crossing question is
+/// asked here, never hand-rolled at the call site. The guard-rail test
+/// <c>Issue3705LoadContextFunnelGuardTests</c> fails the build when a new
+/// <c>typeof(X).IsAssignableFrom(…)</c> appears in <c>Binding/</c>,
+/// <c>Lowering/</c>, <c>Emit/</c> or <c>Symbols/</c>.
+/// </para>
+/// </summary>
+public static class ClrLoadContext
+{
+    /// <summary>
+    /// Cross-reflection-context replacement for
+    /// <c>typeof(WellKnown).IsAssignableFrom(candidate)</c>: returns whether
+    /// <paramref name="candidate"/> <em>is</em>, derives from, or implements
+    /// <paramref name="wellKnown"/>, comparing by logical CLR identity rather
+    /// than by reference.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="wellKnown"/> is expected to be a host <c>typeof(…)</c>
+    /// literal for a BCL type whose <see cref="Type.FullName"/> is stable
+    /// across contexts (<c>System.IDisposable</c>,
+    /// <c>System.Collections.IEnumerable</c>, …). Constructed generics are
+    /// compared structurally by <see cref="ClrTypeUtilities.IsSameAs"/>, so
+    /// <c>Satisfies(x, typeof(IEnumerable&lt;string&gt;))</c> is meaningful;
+    /// an <em>open</em> definition is not a shape any concrete type satisfies
+    /// and always answers <see langword="false"/>.
+    /// </remarks>
+    /// <param name="candidate">The candidate type, typically drawn from imported metadata. May be <see langword="null"/>.</param>
+    /// <param name="wellKnown">The well-known target shape, typically a host <c>typeof(…)</c> literal.</param>
+    /// <returns><see langword="true"/> when <paramref name="candidate"/> satisfies <paramref name="wellKnown"/>.</returns>
+    public static bool Satisfies(Type? candidate, Type? wellKnown)
+    {
+        if (candidate is null || wellKnown is null)
+        {
+            return false;
+        }
+
+        if (ClrTypeUtilities.IsSameAs(candidate, wellKnown))
+        {
+            return true;
+        }
+
+        // Every type is (or boxes to) System.Object, including interfaces —
+        // whose Type.BaseType is null, so the base walk below cannot see it.
+        if (string.Equals(wellKnown.FullName, "System.Object", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        if (wellKnown.IsInterface)
+        {
+            return ClrTypeUtilities.ImplementsInterfaceByName(candidate, wellKnown);
+        }
+
+        for (var baseType = SafeBaseType(candidate); baseType != null; baseType = SafeBaseType(baseType))
+        {
+            if (ClrTypeUtilities.IsSameAs(baseType, wellKnown))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Cross-reflection-context replacement for
+    /// <c>target.IsAssignableFrom(source)</c> where <em>either</em> operand may
+    /// have come from a <c>MetadataLoadContext</c>. Uses the same-context
+    /// <see cref="Type.IsAssignableFrom"/> fast path when it is trustworthy and
+    /// falls back to the reference-context-independent by-name walk otherwise.
+    /// </summary>
+    /// <param name="target">The assignment target type.</param>
+    /// <param name="source">The assignment source type.</param>
+    /// <returns><see langword="true"/> when a reference assignment is permissible.</returns>
+    public static bool IsAssignable(Type? target, Type? source)
+        => ClrTypeUtilities.IsAssignableByName(target, source);
+
+    /// <summary>
+    /// Issue #932 / #3697: reads a delegate type's <c>Invoke</c> signature in a
+    /// way that survives every reflection context the compiler can produce one
+    /// in.
+    /// <para>
+    /// The direct <c>GetMethod("Invoke")</c> is tried first, then two
+    /// fallbacks: the <c>System.Func`n</c> / <c>System.Action`n</c>
+    /// generic-argument decomposition, and — for any other closed generic
+    /// delegate (<c>Predicate&lt;T&gt;</c>, <c>Comparison&lt;T&gt;</c>,
+    /// <c>Converter&lt;TIn,TOut&gt;</c>, an imported user delegate) — reading
+    /// <c>Invoke</c> off the <em>open</em> definition, which is always in
+    /// metadata, and substituting the closed type arguments. The direct probe
+    /// fails whenever the closed type is a
+    /// <c>System.Reflection.Emit.TypeBuilderInstantiation</c> (a structural
+    /// function type closed over an in-flight <c>TypeBuilder</c>, or over a
+    /// <c>MetadataLoadContext</c>-loaded argument), which throws
+    /// <see cref="NotSupportedException"/>.
+    /// </para>
+    /// </summary>
+    /// <param name="delegateType">The delegate type whose signature to read.</param>
+    /// <param name="parameterTypes">On success, the <c>Invoke</c> parameter types with by-ref slots reduced to their pointee.</param>
+    /// <param name="returnType">On success, the <c>Invoke</c> return type.</param>
+    /// <returns><see langword="true"/> when the signature was recovered.</returns>
+    public static bool TryGetDelegateSignature(
+        Type? delegateType,
+        out Type[] parameterTypes,
+        [NotNullWhen(true)] out Type? returnType)
+    {
+        parameterTypes = Array.Empty<Type>();
+        returnType = null;
+
+        if (delegateType is null)
+        {
+            return false;
+        }
+
+        try
+        {
+            var invoke = delegateType.GetMethodSafe("Invoke");
+            if (invoke != null)
+            {
+                var ps = invoke.GetParameters();
+                var result = new Type[ps.Length];
+                for (var i = 0; i < ps.Length; i++)
+                {
+                    var parameterType = GetDelegateCompatibilityParameterType(ps[i]);
+                    if (parameterType is null)
+                    {
+                        return false;
+                    }
+
+                    result[i] = parameterType;
+                }
+
+                parameterTypes = result;
+                returnType = invoke.ReturnType;
+                return true;
+            }
+        }
+        catch (Exception)
+        {
+            // Cross-context constructed Func<>/Action<> — fall back to the
+            // generic-argument decomposition below.
+        }
+
+        var fullName = delegateType.FullName;
+        if (fullName == null || !delegateType.IsGenericType)
+        {
+            return false;
+        }
+
+        Type[] genericArgs;
+        try
+        {
+            genericArgs = delegateType.GetGenericArguments();
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+
+        if (fullName.StartsWith("System.Func`", StringComparison.Ordinal) && genericArgs.Length >= 1)
+        {
+            // Func<T1,...,Tn,TResult>: trailing argument is the return type.
+            var ps = new Type[genericArgs.Length - 1];
+            Array.Copy(genericArgs, ps, ps.Length);
+            parameterTypes = ps;
+            returnType = genericArgs[genericArgs.Length - 1];
+            return true;
+        }
+
+        if (fullName.StartsWith("System.Action`", StringComparison.Ordinal))
+        {
+            // Action<T1,...,Tn>: void return, all generic arguments are parameters.
+            parameterTypes = genericArgs;
+            returnType = typeof(void);
+            return true;
+        }
+
+        // Issue #932: any other closed generic delegate whose constructed
+        // Invoke is unreachable across reflection contexts. Read the Invoke
+        // signature off the open generic definition — which is always in
+        // metadata — then substitute the closed type arguments into each
+        // generic-parameter slot.
+        try
+        {
+            var definition = delegateType.GetGenericTypeDefinition();
+            var defInvoke = definition.GetMethodSafe("Invoke");
+            if (defInvoke == null)
+            {
+                return false;
+            }
+
+            var defParams = defInvoke.GetParameters();
+            var resolvedParams = new Type[defParams.Length];
+            for (var i = 0; i < defParams.Length; i++)
+            {
+                var resolved = SubstituteGenericParameter(
+                    GetDelegateCompatibilityParameterType(defParams[i]),
+                    genericArgs);
+                if (resolved is null)
+                {
+                    return false;
+                }
+
+                resolvedParams[i] = resolved;
+            }
+
+            parameterTypes = resolvedParams;
+            var resolvedReturn = SubstituteGenericParameter(defInvoke.ReturnType, genericArgs);
+            if (resolvedReturn is null)
+            {
+                return false;
+            }
+
+            returnType = resolvedReturn;
+            return true;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Issue #2802: a by-ref slot's function shape is its pointee type;
+    /// <c>ref</c>/<c>out</c>/<c>in</c> remain parameter metadata, not managed-
+    /// pointer value types.
+    /// </summary>
+    /// <param name="parameter">The <c>Invoke</c> parameter.</param>
+    /// <returns>The parameter's function-shape type.</returns>
+    private static Type? GetDelegateCompatibilityParameterType(ParameterInfo parameter)
+    {
+        var parameterType = parameter.ParameterType;
+        return parameterType.IsByRef ? parameterType.GetElementType() : parameterType;
+    }
+
+    /// <summary>
+    /// Issue #932: maps a (possibly generic-parameter) type drawn from a
+    /// delegate's open-definition <c>Invoke</c> signature to the corresponding
+    /// closed type argument. A bare generic parameter <c>T</c> is replaced by
+    /// <paramref name="genericArgs"/> at its
+    /// <see cref="Type.GenericParameterPosition"/>; every other type is
+    /// returned unchanged.
+    /// </summary>
+    /// <param name="type">The open-definition signature type.</param>
+    /// <param name="genericArgs">The closed type arguments.</param>
+    /// <returns>The substituted type.</returns>
+    private static Type? SubstituteGenericParameter(Type? type, Type[] genericArgs)
+    {
+        if (type != null && type.IsGenericParameter
+            && type.GenericParameterPosition >= 0
+            && type.GenericParameterPosition < genericArgs.Length)
+        {
+            return genericArgs[type.GenericParameterPosition];
+        }
+
+        return type;
+    }
+
+    /// <summary>
+    /// Reads <see cref="Type.BaseType"/>, tolerating the metadata-load
+    /// failures a reference-only context can raise when the base type lives in
+    /// an assembly that was not supplied via <c>/r:</c>.
+    /// </summary>
+    /// <param name="type">The type whose base to read.</param>
+    /// <returns>The base type, or <see langword="null"/>.</returns>
+    private static Type? SafeBaseType(Type type)
+    {
+        try
+        {
+            return type.BaseType;
+        }
+        catch (Exception ex) when (ClrTypeUtilities.IsMetadataLoadFailure(ex))
+        {
+            return null;
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Symbols/Issue3705LoadContextDifferentialTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/Issue3705LoadContextDifferentialTests.cs
@@ -1,0 +1,242 @@
+// <copyright file="Issue3705LoadContextDifferentialTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Symbols;
+
+/// <summary>
+/// Issue #3705, family 3 — the load-context family — and #3705's prevention
+/// option (3), the differential gate, applied to it.
+/// <para>
+/// <c>gsc</c> creates one <see cref="System.Reflection.MetadataLoadContext"/>
+/// per compilation and never normalises the <see cref="Type"/>s it hands back
+/// to host <c>RuntimeType</c>s. Every type-shape query the binder, lowerer and
+/// emitter ask therefore has two possible operands for the same logical CLR
+/// type, and the answer must not depend on which one it gets. That is the
+/// whole invariant, and — exactly as with
+/// <c>Issue3705MemberKindAccessibilityDifferentialTests</c> — the load context
+/// never appears on the right-hand side of the expectation: each row states
+/// one answer, and it is asserted for both contexts.
+/// </para>
+/// <para>
+/// A silently-wrong site in this family is worse than an imprecise one: a
+/// <c>typeof(X).IsAssignableFrom(importedType)</c> is unconditionally
+/// <see langword="false"/>, so the compiler takes the wrong arm without
+/// diagnosing anything (#3708 emitted no <c>Dispose</c>; the
+/// <c>typeof(Delegate)</c> arm of #3697 dropped every event-handler
+/// candidate). <see cref="NaiveIsAssignableFrom_IsSilentlyWrong_AcrossContexts"/>
+/// pins that hazard directly, and doubles as proof that this fixture's MLC
+/// really is a distinct reflection context rather than the host handing back
+/// its own types.
+/// </para>
+/// </summary>
+public class Issue3705LoadContextDifferentialTests
+{
+    /// <summary>
+    /// The compiler queries in this family. Each is a "what shape is this CLR
+    /// type?" question asked from <c>Binding/</c>, <c>Lowering/</c> or
+    /// <c>Emit/</c> about a type that can have come from either context.
+    /// </summary>
+    public enum Query
+    {
+        /// <summary><c>ClrLoadContext.Satisfies(t, typeof(IDisposable))</c> — #3708's disposal predicate.</summary>
+        SatisfiesIDisposable,
+
+        /// <summary><c>ClrLoadContext.Satisfies(t, typeof(IEnumerable))</c> — the non-generic enumerable fallback.</summary>
+        SatisfiesIEnumerable,
+
+        /// <summary><c>ClrLoadContext.Satisfies(t, typeof(IList))</c> — #313's erased-generic indexer erasure.</summary>
+        SatisfiesIList,
+
+        /// <summary><c>ClrLoadContext.Satisfies(t, typeof(IDictionary))</c> — ditto, the map arm.</summary>
+        SatisfiesIDictionary,
+
+        /// <summary><c>ClrLoadContext.Satisfies(t, typeof(object))</c> — the universal arm.</summary>
+        SatisfiesObject,
+
+        /// <summary><c>ClrTypeUtilities.IsDelegateType(t)</c> — #3697's <c>typeof(Delegate)</c> arm.</summary>
+        IsDelegate,
+
+        /// <summary><c>MemberLookup.TryGetClrEnumerableElementType(t)</c> — the <c>for x in …</c> element type.</summary>
+        EnumerableElement,
+
+        /// <summary><c>ClrLoadContext.TryGetDelegateSignature(t)</c> — #932/#3697's signature decomposition.</summary>
+        DelegateSignature,
+    }
+
+    /// <summary>
+    /// The differential table. Every row is <c>(host type, query, the one
+    /// answer)</c>; the reflection context is deliberately absent from the
+    /// expectation.
+    /// </summary>
+    /// <returns>The xUnit member-data rows.</returns>
+    public static TheoryData<string, Query, string> Rows()
+    {
+        var data = new TheoryData<string, Query, string>();
+
+        void Add(Type hostType, Query query, string expected)
+            => data.Add(hostType.AssemblyQualifiedName!, query, expected);
+
+        // --- IDisposable: #3708's predicate. The `for x in imported` disposal
+        // arm read `typeof(IDisposable).IsAssignableFrom(clrType)`.
+        Add(typeof(List<int>.Enumerator), Query.SatisfiesIDisposable, "True");
+        Add(typeof(MemoryStream), Query.SatisfiesIDisposable, "True");
+        Add(typeof(IEnumerator<int>), Query.SatisfiesIDisposable, "True");
+        Add(typeof(IDisposable), Query.SatisfiesIDisposable, "True");
+        Add(typeof(StringBuilder), Query.SatisfiesIDisposable, "False");
+        Add(typeof(int), Query.SatisfiesIDisposable, "False");
+
+        // --- Non-generic IEnumerable: MemberLookup's fallback arm.
+        Add(typeof(ArrayList), Query.SatisfiesIEnumerable, "True");
+        Add(typeof(Hashtable), Query.SatisfiesIEnumerable, "True");
+        Add(typeof(string), Query.SatisfiesIEnumerable, "True");
+        Add(typeof(List<int>), Query.SatisfiesIEnumerable, "True");
+        Add(typeof(int[]), Query.SatisfiesIEnumerable, "True");
+        Add(typeof(StringBuilder), Query.SatisfiesIEnumerable, "False");
+
+        // --- IList / IDictionary: emit's #313 erased-generic indexer erasure.
+        Add(typeof(List<object>), Query.SatisfiesIList, "True");
+        Add(typeof(ArrayList), Query.SatisfiesIList, "True");
+        Add(typeof(Dictionary<string, object>), Query.SatisfiesIList, "False");
+        Add(typeof(Dictionary<string, object>), Query.SatisfiesIDictionary, "True");
+        Add(typeof(Hashtable), Query.SatisfiesIDictionary, "True");
+        Add(typeof(List<object>), Query.SatisfiesIDictionary, "False");
+
+        // --- The universal arm. Interfaces have a null BaseType, so a bare
+        // base-chain walk misses them; value types reach object by boxing.
+        Add(typeof(StringBuilder), Query.SatisfiesObject, "True");
+        Add(typeof(IDisposable), Query.SatisfiesObject, "True");
+        Add(typeof(int), Query.SatisfiesObject, "True");
+        Add(typeof(object), Query.SatisfiesObject, "True");
+
+        // --- Delegate-ness: #3697's `typeof(Delegate).IsAssignableFrom` arm.
+        Add(typeof(Action), Query.IsDelegate, "True");
+        Add(typeof(Action<int>), Query.IsDelegate, "True");
+        Add(typeof(Func<int, string>), Query.IsDelegate, "True");
+        Add(typeof(Predicate<string>), Query.IsDelegate, "True");
+        Add(typeof(EventHandler), Query.IsDelegate, "True");
+        Add(typeof(Comparison<int>), Query.IsDelegate, "True");
+        Add(typeof(Delegate), Query.IsDelegate, "True");
+        Add(typeof(StringBuilder), Query.IsDelegate, "False");
+        Add(typeof(IDisposable), Query.IsDelegate, "False");
+
+        // --- The `for x in …` element type. The generic arm walks the
+        // interface closure by FullName (#2859); the non-generic fallback did
+        // not, until #3705.
+        Add(typeof(List<string>), Query.EnumerableElement, "System.String");
+        Add(typeof(int[]), Query.EnumerableElement, "System.Int32");
+        Add(typeof(IReadOnlyCollection<int>), Query.EnumerableElement, "System.Int32");
+        Add(typeof(ArrayList), Query.EnumerableElement, "System.Object");
+        Add(typeof(Hashtable), Query.EnumerableElement, "System.Object");
+        Add(typeof(StringBuilder), Query.EnumerableElement, "<none>");
+
+        // --- Delegate signature decomposition.
+        Add(typeof(Action), Query.DelegateSignature, "() -> System.Void");
+        Add(typeof(Action<int>), Query.DelegateSignature, "(System.Int32) -> System.Void");
+        Add(typeof(Func<int, string>), Query.DelegateSignature, "(System.Int32) -> System.String");
+        Add(typeof(Predicate<string>), Query.DelegateSignature, "(System.String) -> System.Boolean");
+        Add(typeof(Comparison<int>), Query.DelegateSignature, "(System.Int32, System.Int32) -> System.Int32");
+        Add(typeof(EventHandler), Query.DelegateSignature, "(System.Object, System.EventArgs) -> System.Void");
+
+        return data;
+    }
+
+    /// <summary>
+    /// The invariant: the answer is a property of the logical CLR type, not of
+    /// the reflection context the <see cref="Type"/> was materialised in.
+    /// </summary>
+    /// <param name="hostTypeName">Assembly-qualified name of the host type under test.</param>
+    /// <param name="query">The compiler query to ask.</param>
+    /// <param name="expected">The single expected answer, for both contexts.</param>
+    [Theory]
+    [MemberData(nameof(Rows))]
+    public void SameAnswer_ForRuntimeType_AndMetadataLoadContextTwin(string hostTypeName, Query query, string expected)
+    {
+        var hostType = Type.GetType(hostTypeName, throwOnError: true)!;
+
+        using var resolver = CreateMetadataLoadContextResolver();
+        var mlcType = resolver.MapClrTypeToReferences(hostType);
+        Assert.True(mlcType != null, $"no MetadataLoadContext twin for '{hostType.FullName}'");
+        Assert.False(
+            ReferenceEquals(hostType, mlcType),
+            $"'{hostType.FullName}' resolved to the host type — the fixture is not exercising two contexts");
+
+        var hostAnswer = Ask(query, hostType);
+        var mlcAnswer = Ask(query, mlcType!);
+
+        Assert.Equal(expected, hostAnswer);
+        Assert.Equal(expected, mlcAnswer);
+    }
+
+    /// <summary>
+    /// The hazard this family exists for, pinned directly: a host
+    /// <c>typeof(X).IsAssignableFrom(y)</c> is not merely imprecise for a
+    /// MetadataLoadContext <c>y</c> — it is silently, unconditionally
+    /// <see langword="false"/>. This is why every such site had to move behind
+    /// <see cref="ClrLoadContext"/>, and why the guard-rail test forbids new
+    /// ones.
+    /// </summary>
+    [Fact]
+    public void NaiveIsAssignableFrom_IsSilentlyWrong_AcrossContexts()
+    {
+        using var resolver = CreateMetadataLoadContextResolver();
+
+        var mlcArrayList = resolver.MapClrTypeToReferences(typeof(ArrayList));
+        var mlcEnumerator = resolver.MapClrTypeToReferences(typeof(List<int>.Enumerator));
+        Assert.NotNull(mlcArrayList);
+        Assert.NotNull(mlcEnumerator);
+
+        // What the sites did before #3705: false, with no diagnostic.
+        Assert.False(typeof(IEnumerable).IsAssignableFrom(mlcArrayList));
+        Assert.False(typeof(IDisposable).IsAssignableFrom(mlcEnumerator));
+
+        // The same questions asked in the host context: true.
+        Assert.True(typeof(IEnumerable).IsAssignableFrom(typeof(ArrayList)));
+        Assert.True(typeof(IDisposable).IsAssignableFrom(typeof(List<int>.Enumerator)));
+
+        // Through the funnel: true in both.
+        Assert.True(ClrLoadContext.Satisfies(mlcArrayList, typeof(IEnumerable)));
+        Assert.True(ClrLoadContext.Satisfies(mlcEnumerator, typeof(IDisposable)));
+    }
+
+    private static string Ask(Query query, Type type) => query switch
+    {
+        Query.SatisfiesIDisposable => ClrLoadContext.Satisfies(type, typeof(IDisposable)).ToString(),
+        Query.SatisfiesIEnumerable => ClrLoadContext.Satisfies(type, typeof(IEnumerable)).ToString(),
+        Query.SatisfiesIList => ClrLoadContext.Satisfies(type, typeof(IList)).ToString(),
+        Query.SatisfiesIDictionary => ClrLoadContext.Satisfies(type, typeof(IDictionary)).ToString(),
+        Query.SatisfiesObject => ClrLoadContext.Satisfies(type, typeof(object)).ToString(),
+        Query.IsDelegate => ClrTypeUtilities.IsDelegateType(type).ToString(),
+        Query.EnumerableElement => MemberLookup.TryGetClrEnumerableElementType(type, out var element)
+            ? element.FullName ?? element.Name
+            : "<none>",
+        Query.DelegateSignature => ClrLoadContext.TryGetDelegateSignature(type, out var ps, out var ret)
+            ? "(" + string.Join(", ", ps.Select(p => p.FullName ?? p.Name)) + ") -> " + (ret.FullName ?? ret.Name)
+            : "<none>",
+        _ => throw new ArgumentOutOfRangeException(nameof(query)),
+    };
+
+    /// <summary>
+    /// Builds the reference-assembly-backed resolver <c>gsc</c> uses on every
+    /// real <c>/reference:</c> compile — the same construction
+    /// <c>Issue2348NotNullWhenMetadataLoadContextTests</c> relies on.
+    /// </summary>
+    /// <returns>A MetadataLoadContext-backed resolver.</returns>
+    private static ReferenceResolver CreateMetadataLoadContextResolver()
+    {
+        var runtimeDir = RuntimeEnvironment.GetRuntimeDirectory();
+        var refPaths = Directory.EnumerateFiles(runtimeDir, "*.dll", SearchOption.TopDirectoryOnly);
+        return ReferenceResolver.WithReferences(refPaths);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Symbols/Issue3705LoadContextFunnelGuardTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/Issue3705LoadContextFunnelGuardTests.cs
@@ -1,0 +1,141 @@
+// <copyright file="Issue3705LoadContextFunnelGuardTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Symbols;
+
+/// <summary>
+/// Issue #3705 (family 3), the load-context funnel's guard rail — the
+/// companion to <c>Issue835TypeofIdentityRegressionGuardTests</c>, which
+/// forbids <c>clrType == typeof(X)</c> for the same reason.
+/// <para>
+/// A host <c>typeof(X).IsAssignableFrom(candidate)</c> in the binder, lowerer
+/// or emitter is unconditionally <see langword="false"/> whenever
+/// <paramref name="candidate"/> came from the compilation's
+/// <see cref="System.Reflection.MetadataLoadContext"/> — that is, on every
+/// production <c>/reference:</c> compile. It never throws and never
+/// diagnoses, so the wrong arm is simply taken: #3708 emitted no
+/// <c>Dispose</c> for a <c>for</c> loop over an imported enumerable, and the
+/// <c>typeof(Delegate)</c> arm of #3697 dropped every imported event-handler
+/// candidate. New sites must ask
+/// <c>GSharp.Core.CodeAnalysis.Symbols.ClrLoadContext.Satisfies</c> (well-known
+/// target shape) or <c>ClrLoadContext.IsAssignable</c> (two arbitrary types).
+/// </para>
+/// </summary>
+public class Issue3705LoadContextFunnelGuardTests
+{
+    /// <summary>
+    /// Sites that legitimately compare against a well-known host type, with
+    /// the reason. Kept as a set rather than an ordered, line-numbered list
+    /// (which is what #835's guard uses) because these directories are edited
+    /// concurrently; the assertion below only ever fails on an <em>unlisted</em>
+    /// offender, so a stale entry cannot break an unrelated PR.
+    /// </summary>
+    private static readonly Dictionary<string, string> AllowedFiles = new(StringComparer.Ordinal)
+    {
+        // #3708, fixed separately: the disposal predicate in
+        // TryBuildEnumeratorDisposeCall. Listed so this guard can land
+        // alongside that fix rather than racing it.
+        ["src/Core/CodeAnalysis/Lowering/Lowerer.cs"] = "#3708 — enumerator disposal predicate, fixed under its own issue",
+    };
+
+    private static readonly string[] ScannedRoots = new[]
+    {
+        "src/Core/CodeAnalysis/Binding",
+        "src/Core/CodeAnalysis/Lowering",
+        "src/Core/CodeAnalysis/Emit",
+        "src/Core/CodeAnalysis/Symbols",
+    };
+
+    // `typeof(...).IsAssignableFrom(...)`. The inner group forbids nested
+    // parentheses so a `typeof(Foo<Bar>)` still matches (angle brackets are
+    // not parentheses) while a method call is not mistaken for a typeof.
+    private static readonly Regex ForbiddenPattern = new(
+        @"typeof\s*\([^()]*\)\s*\.\s*IsAssignableFrom\s*\(",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// Fails when a load-context-crossing assignability probe is hand-rolled
+    /// instead of routed through the funnel.
+    /// </summary>
+    [Fact]
+    public void No_Host_TypeofIsAssignableFrom_In_Binding_Lowering_Emit_Or_Symbols()
+    {
+        var repoRoot = LocateRepoRoot();
+        var offenders = new List<string>();
+
+        foreach (var root in ScannedRoots)
+        {
+            var rootDir = Path.Combine(repoRoot, root);
+            if (!Directory.Exists(rootDir))
+            {
+                continue;
+            }
+
+            foreach (var file in Directory.EnumerateFiles(rootDir, "*.cs", SearchOption.AllDirectories))
+            {
+                var relative = Path.GetRelativePath(repoRoot, file).Replace('\\', '/');
+                if (AllowedFiles.ContainsKey(relative))
+                {
+                    continue;
+                }
+
+                var lines = File.ReadAllLines(file);
+                for (var i = 0; i < lines.Length; i++)
+                {
+                    var code = StripCommentAndStrings(lines[i]);
+                    if (ForbiddenPattern.IsMatch(code))
+                    {
+                        offenders.Add($"{relative}:{i + 1}: {lines[i].Trim()}");
+                    }
+                }
+            }
+        }
+
+        Assert.True(
+            offenders.Count == 0,
+            "Hand-rolled host `typeof(X).IsAssignableFrom(y)` is unconditionally false for a\n"
+                + "MetadataLoadContext `y` (issue #3705, family 3). Use ClrLoadContext.Satisfies /\n"
+                + "ClrLoadContext.IsAssignable, or add the file to AllowedFiles with a reason:\n  "
+                + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>
+    /// Removes line comments and string literals so the pattern only matches
+    /// code position — doc comments describing the forbidden idiom (there are
+    /// several, including on <c>ClrLoadContext</c> itself) must not trip it.
+    /// </summary>
+    /// <param name="line">The source line.</param>
+    /// <returns>The line with comment / literal text blanked out.</returns>
+    private static string StripCommentAndStrings(string line)
+    {
+        var trimmed = line.TrimStart();
+        if (trimmed.StartsWith("//", StringComparison.Ordinal)
+            || trimmed.StartsWith("*", StringComparison.Ordinal))
+        {
+            return string.Empty;
+        }
+
+        var commentIndex = line.IndexOf("//", StringComparison.Ordinal);
+        var code = commentIndex >= 0 ? line.Substring(0, commentIndex) : line;
+        return Regex.Replace(code, "\"[^\"]*\"", "\"\"");
+    }
+
+    private static string LocateRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !File.Exists(Path.Combine(dir.FullName, "GSharp.sln")))
+        {
+            dir = dir.Parent;
+        }
+
+        Assert.True(dir != null, "could not locate the repository root (GSharp.sln)");
+        return dir!.FullName;
+    }
+}


### PR DESCRIPTION
Family 3 of #3705 — the load-context family — plus the funnel seam and differential gate the audit recommended for it. The full per-site triage (reachability, consequence, and what was cleared and why) is posted as a comment on the issue: https://github.com/DavidObando/gsharp/issues/3705#issuecomment-5472308357

#3707 closed family 1. This is the stage that PR's triage flagged as next, on the grounds that it is **the only family where a bad site is silently *wrong* rather than merely imprecise**. That held up: of the eight probes fixed here, not one throws. Every bad answer is a silent `false` that sends the compiler down the wrong arm with no diagnostic.

## What was wrong

gsc creates **one `MetadataLoadContext` per compilation** (`ImportedAssemblySemantics.cs:48`) and never normalises the `Type`s it hands back to host `RuntimeType`s. So a `typeof(X).IsAssignableFrom(importedType)` in the binder, lowerer or emitter is not imprecise — it is unconditionally `false`, on every program compiled with `/reference:`, which is every production compile.

| Site | The omission | The sibling that was already right |
|---|---|---|
| `ExpressionBinder.IsSignatureCompatibleWithDelegate` | **three** independent cross-context faults in one 25-line predicate: `typeof(Delegate).IsAssignableFrom`, a raw `GetMethodSafe("Invoke")` on the *closed* type, and `!=` reference identity on every parameter and the return type | `ConversionClassifier.BindClrMethodGroupConversion`, which uses `ClrTypeUtilities.IsDelegateType`; and the three delegate predicates in `ClrOverloadResolution`, which go through `TryGetDelegateSignature` |
| `MemberLookup.TryGetClrEnumerableElementType` — the non-generic `IEnumerable` fallback | `typeof(IEnumerable).IsAssignableFrom(clrType)` | the **generic arm 15 lines above**, which walks the interface closure by `FullName` and was hardened for MLC in #2859 |
| `Emit/MethodBodyEmitter.MemberAccess` — #313's erased-generic `IList` / `IDictionary` indexer erasure | ditto; `erasedClr` is an `ImportedTypeSymbol.ClrType`, so the erasure was skipped and emit fell through to a `callvirt List<object>::get_Item` on a receiver that is really a `List<int32>` | — |
| `Binder.SatisfiesClassConstraint` (2 probes) | unguarded `constraintClr.IsAssignableFrom(argClr)` — imported constraint vs. a well-known `TypeSymbol` singleton wrapping a **host** `typeof(T)` | — |
| `ClrOverloadResolution.IsVariantAssignable` | unguarded `target.IsAssignableFrom(source)`, `catch (NotSupportedException)` only | its two neighbours in the same file (`ClassifyImplicit`, `UnifyForInference`) each carry a same-context guard **and** a by-name fallback |

Concretely, on `main`, compiled with `/reference:`: `let h = func(sender object, e EventArgs) { … }` then `t.Changed += h` on an imported event reports GS0155, because `IsSignatureCompatibleWithDelegate` cannot answer `true` for any imported handler type.

## The shape of the fix

A new `Symbols/ClrLoadContext.cs` — `Satisfies(candidate, wellKnown)` (replaces `typeof(X).IsAssignableFrom(y)`), `IsAssignable(target, source)` (replaces `a.IsAssignableFrom(b)` across contexts), and `TryGetDelegateSignature`.

This is #3705's Ask 2 option (1) for the load-context slice, and — as with #3707 — it paid for itself inside the PR. `TryGetDelegateSignature` and its two helpers were **hoisted out of `ClrOverloadResolution`**, where they had sat as `private static` since #932. That is exactly why `ExpressionBinder` hand-rolled its own broken version instead of reusing them: the primitive existed, was correct, and was unreachable from the file that needed it. `IsReferencePreservingUpcast` — a near-duplicate of `Satisfies` — and its `SafeBaseType` are deleted in the funnel's favour too.

`Lowering/Lowerer.cs`'s disposal predicate (#3708) is deliberately untouched and explicitly allow-listed in the guard rail, so the two can land in either order.

## Verification

`Issue3705LoadContextDifferentialTests` is #3705's prevention option (3) applied to this family: **44 rows over 8 compiler queries × well-known BCL types**, each asserting the same answer for a host runtime `Type` and its `MetadataLoadContext` twin — built through `ReferenceResolver.WithReferences`, the resolver gsc actually uses. **The load context never appears on the right-hand side of the expectation: each row states one answer and it is asserted for both contexts, so the test *is* the invariant.**

- On `main`: 2 of 44 fail (`ArrayList` and `Hashtable`, query `EnumerableElement`).
- Here: 44/44.
- It would have caught #3708 and the `typeof(Delegate)` half of #3697 as one group.

Two findings came out of the table rather than the sweep, both recorded in the issue comment:

1. `Satisfies(x, typeof(object))` cannot be answered by a base-chain walk when `x` is an **interface** (`Type.BaseType` is `null` for interfaces). The sweep would have shipped without that arm — a latent behaviour change in a *refactor*, caught by the four `SatisfiesObject` rows.
2. A vacuity trap worth flagging for whoever does family 2: the first draft of the fixture would have passed unchanged even if the "MLC twin" had silently been the host type. `NaiveIsAssignableFrom_IsSilentlyWrong_AcrossContexts` now pins the hazard directly and doubles as proof the fixture really exercises two contexts.

`Issue3705LoadContextFunnelGuardTests` is the boundary: it fails the build when a new `typeof(X).IsAssignableFrom(…)` appears in `Binding/`, `Lowering/`, `Emit/` or `Symbols/`. This is the cheap form of Ask 2's option (2) that the family-1 triage predicted would only become affordable *after* the funnel landed. It allow-lists by file plus reason and fails only on *unlisted* offenders, so a stale entry cannot break an unrelated PR in these concurrently-edited directories.

Regression: full `Core.Tests` and `Compiler.Tests` green, including the samples emitted-PE baseline — no IL baseline movement.

## Not in this PR

**Family 2 (nullability)** — still deferred, for the reason the family-1 triage gave: `ClrNullability` also implements #1354's oblivious-default rule, so every swap widens *unannotated* metadata too, and a naive sweep recreates a #3704-shaped gate regression. Staging recommendation unchanged.

Two family-3 sites are listed rather than guessed at: `StructLayoutBinder.TryGetClrStorageSize` (`Marshal.SizeOf` needs a runtime `Type`; the correct MLC answer means walking field layout — a feature, not a swap) and `DeclarationBinder.Attributes`' `Array.CreateInstance` (the #3637 shape; needs an attribute-argument corpus).

Closes the load-context family of #3705; the issue stays open for family 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
