### PR TITLE
Differential TPA-vs-reference-closure conformance (#3717)

### DIFF
--- a/.github/workflows/differential-conformance-nightly.yml
+++ b/.github/workflows/differential-conformance-nightly.yml
@@ -1,0 +1,77 @@
+name: differential-conformance-nightly
+
+# Issue #3717: the full-corpus differential TPA-versus-reference-closure run.
+#
+# Every sample is compiled twice — once with no `/reference:` closure (gsc
+# resolves imports from the host's trusted platform assemblies, so imported
+# types are live runtime types) and once against the whole
+# `Microsoft.NETCore.App.Ref` targeting pack (gsc builds a
+# MetadataLoadContext, as every real SDK build does) — and the two are
+# required to agree on diagnostics, on normalised IL and on runtime output.
+# A load-context defect (#3708/#3715, #3697, #3637, #3636, #3666) is by
+# definition a disagreement between those compiles.
+#
+# The PR gate (build.yml) runs the same suite with the environment variable
+# unset, which restricts it to the curated `AlwaysOnSamples` subset — about
+# seven samples, ~7 s. Setting GSHARP_DIFFERENTIAL_CONFORMANCE=1 widens it to
+# the whole single-file corpus (~130 samples, ~2 min of test time on top of
+# the solution build), which is why it lives here rather than on every PR.
+
+on:
+  schedule:
+    - cron: '43 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  # Parallel MSBuild nodes corrupt $GITHUB_ENV via Nerdbank.GitVersioning's
+  # GitBuildVersion* emission; nothing consumes those variables, so disable
+  # it (see build.yml for the full rationale).
+  NBGV_SetCloudBuildVersionVars: false
+
+jobs:
+  differential:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v5
+        with:
+          global-json-file: global.json
+
+      - name: Restore
+        run: dotnet restore GSharp.sln --locked-mode
+
+      - name: Restore .NET local tools
+        run: dotnet tool restore
+
+      - name: Build
+        run: dotnet build GSharp.sln --configuration Release --no-restore -graph
+
+      - name: Differential conformance (full corpus)
+        env:
+          MSBUILDDISABLENODEREUSE: 1
+          GSHARP_DIFFERENTIAL_CONFORMANCE: '1'
+        run: |
+          dotnet test test/Compiler.Tests/Compiler.Tests.csproj \
+            --configuration Release \
+            --no-build \
+            --no-restore \
+            --filter "FullyQualifiedName~DifferentialReferenceClosureTests" \
+            --logger "trx" \
+            --results-directory TestResults
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: differential-conformance-results
+          path: TestResults
+          if-no-files-found: ignore

--- a/test/Compiler.Tests/LanguageConformance/DifferentialReferenceClosureTests.cs
+++ b/test/Compiler.Tests/LanguageConformance/DifferentialReferenceClosureTests.cs
@@ -1,0 +1,399 @@
+// <copyright file="DifferentialReferenceClosureTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using GSharp.Tests.LanguageConformance;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.LanguageConformance;
+
+/// <summary>
+/// Issue #3717: differential TPA-versus-reference-closure conformance.
+///
+/// <para>
+/// Every other sample suite compiles with no <c>/reference:</c> closure, so
+/// gsc resolves imports from the host's trusted platform assemblies and every
+/// imported type is a live runtime <see cref="Type"/>. The
+/// <see cref="System.Reflection.MetadataLoadContext"/> that a real
+/// <c>/reference:</c> build constructs — every SDK build — is never entered.
+/// A whole defect family (#3708/#3715, #3697, #3637, #3636, #3666) is
+/// therefore structurally invisible: a host
+/// <c>typeof(X).IsAssignableFrom(clrType)</c> answers correctly for runtime
+/// types and is unconditionally <see langword="false"/> for MLC types, so the
+/// wrong arm is silently taken and nothing throws.
+/// </para>
+///
+/// <para>
+/// This suite compiles each sample twice — once as today, once against the
+/// full <c>Microsoft.NETCore.App.Ref</c> closure — and asserts the two agree
+/// on diagnostics, on normalised IL and on runtime output. A load-context
+/// defect is by definition a disagreement between those two compiles, so the
+/// detector needs nobody to anticipate the specific defect: with the #3708 fix
+/// reverted this suite fails on the samples that iterate an imported
+/// enumerable, naming the method whose <c>finally</c> went missing.
+/// </para>
+///
+/// <para>
+/// <b>Where it runs.</b> The differential doubles conformance compile time and
+/// the ref-pack compile is itself the slower of the two (a ~160-assembly
+/// closure through a MetadataLoadContext instead of the host TPA), so the full
+/// corpus is <b>nightly</b>, gated on <c>GSHARP_DIFFERENTIAL_CONFORMANCE=1</c>.
+/// A curated always-on subset — the samples that actually iterate, dispose or
+/// reflect over imported types, which is where this family lands — runs on
+/// every PR so the mechanism cannot rot between nightlies.
+/// </para>
+/// </summary>
+public class DifferentialReferenceClosureTests
+{
+    private const string FullCorpusEnvironmentVariable = "GSHARP_DIFFERENTIAL_CONFORMANCE";
+
+    /// <summary>The runtime's implementation corlib — only a host-TPA compile should name it.</summary>
+    private const string ImplementationCorlib = "System.Private.CoreLib";
+
+    /// <summary>The targeting pack's corlib contract — a ref-pack compile must name it.</summary>
+    private const string ContractCorlib = "System.Runtime";
+
+    /// <summary>
+    /// The reason shared by every <see cref="KnownRefPackCorlibLeaks"/> entry:
+    /// compiler-synthesised references to well-known BCL types (the
+    /// interpolation handler, the async state-machine plumbing, record
+    /// <c>ToString</c>/<c>GetHashCode</c> helpers, the variadic
+    /// <c>System.Array</c> path, …) are resolved with a host <c>typeof</c>
+    /// rather than through the compilation's reference closure, so the emitted
+    /// assembly names the implementation corlib.
+    /// </summary>
+    private const string Issue3718 =
+        "#3718 — synthesised well-known-type reference resolved through the host runtime";
+
+    /// <summary>
+    /// The per-PR subset: samples whose codegen goes through imported types in
+    /// the ways this defect family attacks — <c>for … in</c> over an imported
+    /// enumerable (the #3708 shape), imported delegates and events (#3697),
+    /// attribute arguments (#3637), and imported generic instantiations.
+    /// The remaining samples run nightly.
+    /// </summary>
+    private static readonly string[] AlwaysOnSamples =
+    {
+        "CountWords.gs",
+        "EventSubscription.gs",
+        "ForIn.gs",
+        "LinqExtensions.gs",
+        "MapForIn.gs",
+        "Select.gs",
+        "TupleSequenceIterators.gs",
+    };
+
+    /// <summary>
+    /// Samples whose two compiles legitimately disagree, keyed by file with
+    /// the reason — the #3716 guard-rail idiom (a set keyed by file, not an
+    /// ordered line-numbered list) so concurrent edits cannot leave a stale
+    /// entry that breaks an unrelated PR. The assertion below only ever fails
+    /// on an <em>unlisted</em> divergence.
+    /// <para>
+    /// A difference that is a compiler defect does not belong here: file an
+    /// issue and reference it. Entries must name what about the sample makes
+    /// the two closures genuinely different, not merely that they are.
+    /// </para>
+    /// </summary>
+    private static readonly Dictionary<string, string> KnownDifferences =
+        new(StringComparer.Ordinal)
+        {
+        };
+
+    /// <summary>
+    /// Samples whose ref-pack compile still emits an <c>AssemblyRef</c> to
+    /// <c>System.Private.CoreLib</c>, keyed by file with the reason — the
+    /// #3716 guard-rail idiom again. Every entry here is a <b>known defect</b>
+    /// (#3718), not an accepted behaviour; the list is a burn-down, and the
+    /// assertion fails in <em>both</em> directions — an unlisted leak and a
+    /// listed sample that has stopped leaking — so fixing a lowering site
+    /// forces the corresponding entries out.
+    /// </summary>
+    private static readonly Dictionary<string, string> KnownRefPackCorlibLeaks =
+        new(StringComparer.Ordinal)
+        {
+            ["AddressBook.gs"] = Issue3718,
+            ["AnonymousVariadicFunctionType.gs"] = Issue3718,
+            ["ArrowFunctionTypeClause.gs"] = Issue3718,
+            ["AsyncAwaitInLoop.gs"] = Issue3718,
+            ["AsyncAwaitInNestedLoop.gs"] = Issue3718,
+            ["AsyncClassMethod.gs"] = Issue3718,
+            ["AsyncGoScopeJoin.gs"] = Issue3718,
+            ["AsyncMultiAwaitInLoop.gs"] = Issue3718,
+            ["AsyncTask.gs"] = Issue3718,
+            ["AsyncValueReturns.gs"] = Issue3718,
+            ["Channels.gs"] = Issue3718,
+            ["CountWords.gs"] = Issue3718,
+            ["DataStruct.gs"] = Issue3718,
+            ["DataStructErgonomics.gs"] = Issue3718,
+            ["DefaultExpression.gs"] = Issue3718,
+            ["DefaultInterfaceMethods.gs"] = Issue3718,
+            ["DiscriminatedUnion.gs"] = Issue3718,
+            ["Exhaustiveness.gs"] = Issue3718,
+            ["ExpressionEval.gs"] = Issue3718,
+            ["GenericMethodUserTypeArg.gs"] = Issue3718,
+            ["GenericNamedDelegate.gs"] = Issue3718,
+            ["GenericTypeParameterAsTypeArgument.gs"] = Issue3718,
+            ["GoBuiltinsGated.gs"] = Issue3718,
+            ["GoChannelsGated.gs"] = Issue3718,
+            ["GoScope.gs"] = Issue3718,
+            ["GsharpExtensionsMixed.gs"] = Issue3718,
+            ["GsharpExtensionsOptional.gs"] = Issue3718,
+            ["GsharpExtensionsSequences.gs"] = Issue3718,
+            ["IfLetGuardLet.gs"] = Issue3718,
+            ["InterfaceUpcast.gs"] = Issue3718,
+            ["InterpolatedString.gs"] = Issue3718,
+            ["InterpolatedStringFormat.gs"] = Issue3718,
+            ["InterpolatedStringFormattable.gs"] = Issue3718,
+            ["InterpolatedStringRichHoles.gs"] = Issue3718,
+            ["Loop.gs"] = Issue3718,
+            ["MapForIn.gs"] = Issue3718,
+            ["NamedArguments.gs"] = Issue3718,
+            ["NamedTupleElements.gs"] = Issue3718,
+            ["NullableFlow.gs"] = Issue3718,
+            ["NullCoalescingAssignment.gs"] = Issue3718,
+            ["ParenthesizedReceiver.gs"] = Issue3718,
+            ["Patterns.gs"] = Issue3718,
+            ["PatternSwitch.gs"] = Issue3718,
+            ["PInvokeLibraryImport.gs"] = Issue3718,
+            ["PInvokeLibraryImportStringReturn.gs"] = Issue3718,
+            ["PortScan.gs"] = Issue3718,
+            ["PrimaryCtorVariadic.gs"] = Issue3718,
+            ["Records.gs"] = Issue3718,
+            ["ReifiedGenerics.gs"] = Issue3718,
+            ["Sealed.gs"] = Issue3718,
+            ["Select.gs"] = Issue3718,
+            ["SliceLinqUntypedLambda.gs"] = Issue3718,
+            ["SlicePattern.gs"] = Issue3718,
+            ["SpanComprehensive.gs"] = Issue3718,
+            ["SwitchExpression.gs"] = Issue3718,
+            ["TupleArrowElements.gs"] = Issue3718,
+            ["TupleEquality.gs"] = Issue3718,
+            ["TupleSequenceIterators.gs"] = Issue3718,
+            ["UserRefStruct.gs"] = Issue3718,
+            ["ValueTypeObjectMethods.gs"] = Issue3718,
+            ["Variadic.gs"] = Issue3718,
+            ["VariadicDelegate.gs"] = Issue3718,
+            ["VariadicMethods.gs"] = Issue3718,
+            ["WhileAndLabeledLoops.gs"] = Issue3718,
+            ["ZeroValues.gs"] = Issue3718,
+        };
+
+    public static IEnumerable<object[]> DifferentialSamples()
+    {
+        string samplesDirectory = LocateSamplesDirectory();
+        if (samplesDirectory is null)
+        {
+            yield break;
+        }
+
+        if (!ReferenceClosure.IsRefPackAvailable())
+        {
+            // Degrade gracefully rather than emitting an empty theory (which
+            // xUnit reports as an error): one row that reports the missing
+            // prerequisite by name.
+            yield return new object[] { null };
+            yield break;
+        }
+
+        bool fullCorpus = string.Equals(
+            Environment.GetEnvironmentVariable(FullCorpusEnvironmentVariable),
+            "1",
+            StringComparison.Ordinal);
+
+        foreach (string sample in SampleConformanceData.GetSingleFileSamples(samplesDirectory))
+        {
+            if (!fullCorpus && !AlwaysOnSamples.Contains(sample, StringComparer.Ordinal))
+            {
+                continue;
+            }
+
+            if (OperatingSystem.IsWindows() && sample.StartsWith("PInvoke", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            yield return new object[] { sample };
+        }
+    }
+
+    /// <summary>
+    /// Compiles the sample against both reference closures and fails on any
+    /// unlisted divergence.
+    /// </summary>
+    /// <param name="sampleName">The sample file name.</param>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Theory]
+    [MemberData(nameof(DifferentialSamples))]
+    public async Task Sample_AgreesAcrossReferenceClosures(string sampleName)
+    {
+        if (sampleName is null)
+        {
+            Assert.True(
+                ReferenceClosure.UnavailableReason is not null,
+                "the differential was skipped without a recorded reason");
+            return;
+        }
+
+        string samplesDirectory = LocateSamplesDirectory();
+        Assert.NotNull(samplesDirectory);
+        string sourcePath = Path.Combine(samplesDirectory, sampleName);
+        string goldenPath = Path.ChangeExtension(sourcePath, ".golden");
+
+        DriverConformanceHarness.DifferentialOutcome outcome =
+            await DriverConformanceHarness.RunDifferentialAsync(
+                sampleName,
+                new[] { sourcePath },
+                File.Exists(goldenPath) ? goldenPath : null);
+
+        AssertBothClosuresWereRealised(outcome);
+        AssertRefPackCompileStaysInItsClosure(outcome);
+
+        if (KnownDifferences.TryGetValue(sampleName, out string reason))
+        {
+            Assert.True(
+                outcome.Differences.Count > 0,
+                $"{sampleName} is listed in KnownDifferences ({reason}) but the two reference "
+                    + "closures now agree. Remove the entry.");
+            return;
+        }
+
+        Assert.True(
+            outcome.Differences.Count == 0,
+            $"{sampleName} compiles differently against the host TPA and against the "
+                + "Microsoft.NETCore.App.Ref closure. This is the load-context defect signature "
+                + "(issue #3717): a host `typeof(X).IsAssignableFrom(clrType)` or equivalent is "
+                + "taking a different arm for MetadataLoadContext types. Triage it — file an "
+                + "issue if it is a defect; only add it to KnownDifferences with a reason if the "
+                + "divergence is legitimate.\n\n"
+                + string.Join("\n\n", outcome.Differences));
+    }
+
+    /// <summary>
+    /// The vacuity guard the differential itself needs: a green run proves
+    /// nothing if the "ref-pack" compile silently resolved from the host TPA
+    /// anyway — the same concern the #3705 load-context differential tests
+    /// caught in themselves.
+    /// <para>
+    /// The evidence is in the emitted <c>AssemblyRef</c> table. A compile that
+    /// bound against live runtime types names the implementation assembly
+    /// <c>System.Private.CoreLib</c>; a compile that bound through a
+    /// <see cref="System.Reflection.MetadataLoadContext"/> over the targeting
+    /// pack names the <c>System.Runtime</c> contract. Both must be present, on
+    /// their respective sides, or the two modes were not two modes.
+    /// </para>
+    /// </summary>
+    /// <param name="outcome">The differential outcome.</param>
+    private static void AssertBothClosuresWereRealised(
+        DriverConformanceHarness.DifferentialOutcome outcome)
+    {
+        Assert.True(
+            outcome.HostTpaAssemblyReferences.Contains(ImplementationCorlib, StringComparer.Ordinal),
+            $"{outcome.Sample}: the host-TPA compile did not reference {ImplementationCorlib} "
+                + $"(refs: [{string.Join(", ", outcome.HostTpaAssemblyReferences)}]), so it did "
+                + "not bind against live runtime types and the differential is vacuous.");
+        Assert.True(
+            outcome.RefPackAssemblyReferences.Contains(ContractCorlib, StringComparer.Ordinal),
+            $"{outcome.Sample}: the ref-pack compile did not reference {ContractCorlib} "
+                + $"(refs: [{string.Join(", ", outcome.RefPackAssemblyReferences)}]), so it did "
+                + "not bind through the targeting pack and the differential is vacuous.");
+    }
+
+    /// <summary>
+    /// The ref-pack compile must not reach past its reference closure into the
+    /// host runtime. An <c>AssemblyRef</c> to <c>System.Private.CoreLib</c> in
+    /// an assembly compiled entirely against the targeting pack means some
+    /// compiler path resolved a well-known type with a host <c>typeof</c>
+    /// instead of the compilation's load context — the #3717 family's other
+    /// face, invisible to the IL comparison because that comparison
+    /// deliberately normalises assembly identity away.
+    /// </summary>
+    /// <param name="outcome">The differential outcome.</param>
+    private static void AssertRefPackCompileStaysInItsClosure(
+        DriverConformanceHarness.DifferentialOutcome outcome)
+    {
+        if (!outcome.RefPackAssemblyReferences.Contains(ImplementationCorlib, StringComparer.Ordinal))
+        {
+            Assert.False(
+                KnownRefPackCorlibLeaks.ContainsKey(outcome.Sample),
+                $"{outcome.Sample} is listed in KnownRefPackCorlibLeaks but its ref-pack compile "
+                    + $"no longer references {ImplementationCorlib}. Remove the entry.");
+            return;
+        }
+
+        Assert.True(
+            KnownRefPackCorlibLeaks.ContainsKey(outcome.Sample),
+            $"{outcome.Sample}: the ref-pack compile emitted an AssemblyRef to "
+                + $"{ImplementationCorlib} even though it was compiled entirely against the "
+                + "Microsoft.NETCore.App.Ref closure (refs: "
+                + $"[{string.Join(", ", outcome.RefPackAssemblyReferences)}]). Some compiler path "
+                + "resolved a well-known type through the host runtime instead of the "
+                + "compilation's MetadataLoadContext. Fix it, or record it here with an issue "
+                + "number.");
+    }
+
+    /// <summary>
+    /// Guards the per-PR subset against silent shrinkage, and against listing
+    /// a sample that no longer exists.
+    /// </summary>
+    [Fact]
+    public void AlwaysOnSubset_IsPresentAndNonVacuous()
+    {
+        string samplesDirectory = LocateSamplesDirectory();
+        Assert.NotNull(samplesDirectory);
+
+        var available = SampleConformanceData.GetSingleFileSamples(samplesDirectory)
+            .ToHashSet(StringComparer.Ordinal);
+        string[] missing = AlwaysOnSamples
+            .Where(sample => !available.Contains(sample))
+            .ToArray();
+        Assert.True(
+            missing.Length == 0,
+            "AlwaysOnSamples names samples that no longer exist: " + string.Join(", ", missing));
+
+        // The subset must keep covering the shapes this defect family attacks,
+        // or it would run green forever while the nightly does the real work.
+        string[] sources = AlwaysOnSamples
+            .Select(sample => File.ReadAllText(Path.Combine(samplesDirectory, sample)))
+            .ToArray();
+        Assert.True(
+            sources.Count(text => text.Contains("for ", StringComparison.Ordinal)) >= 4,
+            "AlwaysOnSamples must keep at least four `for … in` samples — the #3708 shape.");
+        Assert.Contains(sources, text => text.Contains("+=", StringComparison.Ordinal));
+        Assert.Contains(sources, text => text.Contains("Gsharp.Extensions", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// Every allow-listed entry must carry a reason and name a sample that
+    /// still exists, so neither list can rot into a set of stale keys that
+    /// silently stop guarding anything.
+    /// </summary>
+    [Fact]
+    public void AllowLists_CarryReasonsAndNameLiveSamples()
+    {
+        string samplesDirectory = LocateSamplesDirectory();
+        Assert.NotNull(samplesDirectory);
+        var available = SampleConformanceData.GetSingleFileSamples(samplesDirectory)
+            .ToHashSet(StringComparer.Ordinal);
+
+        foreach (KeyValuePair<string, string> entry in
+            KnownDifferences.Concat(KnownRefPackCorlibLeaks))
+        {
+            Assert.False(
+                string.IsNullOrWhiteSpace(entry.Value),
+                $"{entry.Key} is allow-listed without a reason.");
+            Assert.True(
+                available.Contains(entry.Key),
+                $"{entry.Key} is allow-listed but is not a sample any more.");
+        }
+    }
+
+    private static string LocateSamplesDirectory()
+        => SampleConformanceData.LocateSamplesDirectory(
+            typeof(DifferentialReferenceClosureTests).Assembly);
+}

--- a/test/Compiler.Tests/LanguageConformance/DriverConformanceHarness.cs
+++ b/test/Compiler.Tests/LanguageConformance/DriverConformanceHarness.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -19,6 +20,12 @@ internal static class DriverConformanceHarness
 {
     private static readonly Regex DiagnosticIdPattern =
         new(@"\b(?:GS\d{4}|GSI\d{3})\b", RegexOptions.CultureInvariant);
+
+    // IL offsets in the normalised dump (issue #3717). Blanked out when two
+    // method bodies are compared so a single dropped instruction does not read
+    // as a wholesale rewrite.
+    private static readonly Regex IlOffsetPattern =
+        new(@"IL_[0-9A-F]{4}", RegexOptions.CultureInvariant);
 
     public static async Task AssertSingleFileConformsAsync(
         string displayName,
@@ -74,9 +81,250 @@ internal static class DriverConformanceHarness
         GoldenFile.AssertMatches(goldenPath, emitted.Output, $"{displayName} emitted output changed.");
     }
 
+    /// <summary>
+    /// Issue #3717: compiles the sample twice — once as the rest of this
+    /// harness does (no <c>/reference:</c>, so gsc resolves imports from the
+    /// host's trusted platform assemblies and every imported type is a live
+    /// runtime <see cref="Type"/>) and once against the full
+    /// <c>Microsoft.NETCore.App.Ref</c> closure (so gsc builds a
+    /// <see cref="System.Reflection.MetadataLoadContext"/>, as every SDK build
+    /// does) — and asserts the two agree.
+    /// <para>
+    /// A load-context defect is by definition a case where those two
+    /// compilations disagree, so this assertion detects the whole family
+    /// without anyone having to anticipate a specific defect. Agreement is
+    /// checked strongest-first: diagnostics, then normalised IL, then runtime
+    /// output against the sample's golden.
+    /// </para>
+    /// </summary>
+    /// <param name="displayName">The sample name, for failure messages.</param>
+    /// <param name="sourcePaths">The sample's source files.</param>
+    /// <param name="goldenPath">The sample's golden file, or <see langword="null"/>.</param>
+    /// <returns>The differential outcome, for the caller to triage.</returns>
+    public static async Task<DifferentialOutcome> RunDifferentialAsync(
+        string displayName,
+        string[] sourcePaths,
+        string goldenPath)
+    {
+        string assemblyName = Path.GetFileNameWithoutExtension(displayName.TrimEnd('/'));
+        DriverResult tpa = await RunEmittedAsync(
+            sourcePaths,
+            assemblyName,
+            ReferenceClosureMode.HostTrustedPlatform,
+            captureIl: true);
+        DriverResult refPack = await RunEmittedAsync(
+            sourcePaths,
+            assemblyName,
+            ReferenceClosureMode.ReferencePack,
+            captureIl: true);
+
+        var differences = new List<string>();
+
+        // (a) Diagnostics — ids and the raw compiler text, which carries the
+        // locations. Catches the "member not found / throws under MLC" shapes.
+        if (!tpa.DiagnosticIds.SequenceEqual(refPack.DiagnosticIds, StringComparer.Ordinal)
+            || !string.Equals(tpa.CompilerOutput, refPack.CompilerOutput, StringComparison.Ordinal))
+        {
+            differences.Add(
+                "diagnostics differ between reference closures:\n"
+                + $"  host-TPA:  [{string.Join(", ", tpa.DiagnosticIds)}]\n"
+                + $"{Indent(tpa.CompilerOutput)}\n"
+                + $"  ref-pack:  [{string.Join(", ", refPack.DiagnosticIds)}]\n"
+                + $"{Indent(refPack.CompilerOutput)}");
+        }
+
+        // (b) Emitted IL, modulo assembly-reference tokens and ordering.
+        if (!string.Equals(tpa.IlDump, refPack.IlDump, StringComparison.Ordinal))
+        {
+            differences.Add("emitted IL differs between reference closures:\n"
+                + DescribeIlDifference(tpa.IlDump, refPack.IlDump));
+        }
+
+        // (c) Runtime output, against the existing golden.
+        if (!string.Equals(tpa.Output, refPack.Output, StringComparison.Ordinal)
+            || tpa.ExitCode != refPack.ExitCode)
+        {
+            differences.Add(
+                "runtime output differs between reference closures:\n"
+                + $"  host-TPA:  {Format(tpa)}\n"
+                + $"  ref-pack:  {Format(refPack)}");
+        }
+        else if (goldenPath is not null)
+        {
+            GoldenFile.AssertMatches(
+                goldenPath,
+                refPack.Output,
+                $"{displayName} ref-pack runtime output does not match the golden.");
+        }
+
+        return new DifferentialOutcome(
+            displayName,
+            differences,
+            tpa.AssemblyReferences,
+            refPack.AssemblyReferences);
+    }
+
+    private static string Indent(string text)
+        => string.Join(
+            "\n",
+            (text ?? string.Empty).Split('\n').Select(line => "    " + line));
+
+    /// <summary>
+    /// Describes how two normalised IL dumps diverge, per method rather than
+    /// per line. A naive line diff is useless here: one dropped protected
+    /// region shifts every subsequent IL offset, so the real finding (#3708 —
+    /// two missing <c>.region Finally</c> rows) is buried under a hundred
+    /// spurious lines. This reports, for each differing method, the
+    /// offset-insensitive exception-region difference first and then the first
+    /// divergence in the opcode sequence.
+    /// </summary>
+    /// <param name="expected">The host-TPA dump.</param>
+    /// <param name="actual">The ref-pack dump.</param>
+    /// <returns>A bounded description of the divergence.</returns>
+    private static string DescribeIlDifference(string expected, string actual)
+    {
+        Dictionary<string, string[]> left = SplitMethods(expected);
+        Dictionary<string, string[]> right = SplitMethods(actual);
+        var report = new List<string>();
+
+        foreach (string only in left.Keys.Except(right.Keys, StringComparer.Ordinal)
+            .OrderBy(key => key, StringComparer.Ordinal).Take(5))
+        {
+            report.Add($"  emitted only by the host-TPA compile: {only}");
+        }
+
+        foreach (string only in right.Keys.Except(left.Keys, StringComparer.Ordinal)
+            .OrderBy(key => key, StringComparer.Ordinal).Take(5))
+        {
+            report.Add($"  emitted only by the ref-pack compile: {only}");
+        }
+
+        int shown = 0;
+        foreach (string key in left.Keys.Intersect(right.Keys, StringComparer.Ordinal)
+            .OrderBy(key => key, StringComparer.Ordinal))
+        {
+            if (left[key].SequenceEqual(right[key], StringComparer.Ordinal) || shown >= 5)
+            {
+                continue;
+            }
+
+            shown++;
+            report.Add($"  {key}");
+            report.AddRange(DescribeMethodDifference(left[key], right[key]));
+        }
+
+        if (report.Count == 0)
+        {
+            report.Add("  dumps differ only in method ordering or whitespace");
+        }
+
+        return string.Join("\n", report);
+    }
+
+    private static IEnumerable<string> DescribeMethodDifference(string[] left, string[] right)
+    {
+        string[] leftRegions = OffsetInsensitive(left, "  .region ");
+        string[] rightRegions = OffsetInsensitive(right, "  .region ");
+        foreach (string missing in leftRegions.Except(rightRegions, StringComparer.Ordinal))
+        {
+            yield return $"    protected region present under host-TPA, absent under ref-pack: {missing}";
+        }
+
+        foreach (string extra in rightRegions.Except(leftRegions, StringComparer.Ordinal))
+        {
+            yield return $"    protected region present under ref-pack, absent under host-TPA: {extra}";
+        }
+
+        if (leftRegions.Length != rightRegions.Length)
+        {
+            yield return $"    region count: host-TPA {leftRegions.Length}, ref-pack {rightRegions.Length}";
+        }
+
+        string leftLocals = left.FirstOrDefault(
+            line => line.StartsWith("  .locals ", StringComparison.Ordinal));
+        string rightLocals = right.FirstOrDefault(
+            line => line.StartsWith("  .locals ", StringComparison.Ordinal));
+        if (!string.Equals(leftLocals, rightLocals, StringComparison.Ordinal))
+        {
+            yield return "    locals differ:"
+                + $"\n      host-TPA: {leftLocals?.Trim() ?? "<none>"}"
+                + $"\n      ref-pack: {rightLocals?.Trim() ?? "<none>"}";
+        }
+
+        string[] leftCode = OffsetInsensitive(left, "  IL_");
+        string[] rightCode = OffsetInsensitive(right, "  IL_");
+        for (int i = 0; i < Math.Max(leftCode.Length, rightCode.Length); i++)
+        {
+            string leftLine = i < leftCode.Length ? leftCode[i] : "<end of method>";
+            string rightLine = i < rightCode.Length ? rightCode[i] : "<end of method>";
+            if (!string.Equals(leftLine, rightLine, StringComparison.Ordinal))
+            {
+                yield return $"    first opcode divergence at instruction {i}:";
+                yield return $"      host-TPA: {leftLine}";
+                yield return $"      ref-pack: {rightLine}";
+                yield break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Selects the dump lines with the given prefix and blanks out IL offsets,
+    /// so a shifted body does not read as a wholly different one.
+    /// </summary>
+    /// <param name="lines">The method's dump lines.</param>
+    /// <param name="prefix">The line prefix to select.</param>
+    /// <returns>Offset-insensitive lines.</returns>
+    private static string[] OffsetInsensitive(string[] lines, string prefix)
+        => lines
+            .Where(line => line.StartsWith(prefix, StringComparison.Ordinal))
+            .Select(line => IlOffsetPattern.Replace(line, "IL_x"))
+            .Select(line => line.TrimStart())
+            .ToArray();
+
+    private static Dictionary<string, string[]> SplitMethods(string dump)
+    {
+        var methods = new Dictionary<string, string[]>(StringComparer.Ordinal);
+        string current = null;
+        var body = new List<string>();
+        foreach (string line in (dump ?? string.Empty).Split('\n'))
+        {
+            if (line.StartsWith("method ", StringComparison.Ordinal))
+            {
+                if (current is not null)
+                {
+                    methods[current] = body.ToArray();
+                }
+
+                // Compiler-generated closures can share a header line;
+                // disambiguate so the two dumps still pair up entry for entry.
+                string candidate = line;
+                for (int occurrence = 2; methods.ContainsKey(candidate); occurrence++)
+                {
+                    candidate = line + " #" + occurrence.ToString(CultureInfo.InvariantCulture);
+                }
+
+                current = candidate;
+                body = new List<string>();
+            }
+            else
+            {
+                body.Add(line);
+            }
+        }
+
+        if (current is not null)
+        {
+            methods[current] = body.ToArray();
+        }
+
+        return methods;
+    }
+
     private static async Task<DriverResult> RunEmittedAsync(
         string[] sourcePaths,
-        string assemblyName)
+        string assemblyName,
+        ReferenceClosureMode referenceMode = ReferenceClosureMode.HostTrustedPlatform,
+        bool captureIl = false)
     {
         string testDirectory = Path.GetDirectoryName(typeof(DriverConformanceHarness).Assembly.Location);
         Assert.NotNull(testDirectory);
@@ -112,13 +360,24 @@ internal static class DriverConformanceHarness
                 arguments.Add("/r:" + extensionsAssemblyPath);
             }
 
+            if (referenceMode == ReferenceClosureMode.ReferencePack)
+            {
+                // Issue #3717: the closure the .NET SDK passes. Supplying it
+                // makes gsc bind imports through a MetadataLoadContext instead
+                // of the host's live runtime types.
+                foreach (string reference in ReferenceClosure.RefPackAssemblies())
+                {
+                    arguments.Add("/reference:" + reference);
+                }
+            }
+
             arguments.AddRange(sourcePaths);
             DriverResult compile = CaptureConsole(
                 () => GSharp.Compiler.Program.Main(arguments.ToArray()),
                 compilerProtocol: true);
             Assert.True(
                 compile.ExitCode == 0,
-                $"gsc failed for {assemblyName}: {Format(compile)}");
+                $"gsc failed for {assemblyName} ({referenceMode}): {Format(compile)}");
             Assert.Equal(string.Empty, compile.StandardError);
             Assert.True(File.Exists(outputPath), $"Expected emitted assembly at {outputPath}.");
 
@@ -129,6 +388,10 @@ internal static class DriverConformanceHarness
                 ignoredErrorCodes: knownIlIssues.ErrorCodes,
                 ignoredErrorScope: knownIlIssues.Scope);
             Assembly.Load(File.ReadAllBytes(outputPath)).GetTypes();
+            string ilDump = captureIl ? NormalizedIlDump.Create(outputPath) : null;
+            IReadOnlyList<string> assemblyReferences = captureIl
+                ? NormalizedIlDump.AssemblyReferenceNames(outputPath)
+                : null;
 
             ProcessResult runtime = await RunProcessAsync(
                 "dotnet",
@@ -141,8 +404,13 @@ internal static class DriverConformanceHarness
                 runtime.ExitCode,
                 GoldenFile.Normalize(runtime.StandardOutput),
                 compile.DiagnosticIds,
-                GoldenFile.Normalize(runtime.StandardError));
-            Assert.True(result.ExitCode == 0, $"{assemblyName} emitted runtime failed: {Format(result)}");
+                GoldenFile.Normalize(runtime.StandardError),
+                compile.CompilerOutput.Replace(outputDirectory, "<output>", StringComparison.Ordinal),
+                ilDump,
+                assemblyReferences);
+            Assert.True(
+                result.ExitCode == 0,
+                $"{assemblyName} emitted runtime failed ({referenceMode}): {Format(result)}");
             Assert.Equal(string.Empty, result.StandardError);
             return result;
         }
@@ -216,7 +484,12 @@ internal static class DriverConformanceHarness
             exitCode,
             CleanCliStream(stdout, compilerProtocol),
             diagnosticIds,
-            CleanCliStream(stderr, compilerProtocol));
+            CleanCliStream(stderr, compilerProtocol),
+            CompilerOutput: string.Join(
+                "\n",
+                GoldenFile.Normalize(stdout + "\n" + stderr)
+                    .Split('\n')
+                    .Where(line => line is not "Success." and not "Failed.")));
     }
 
     private static string CleanCliStream(string value, bool compilerProtocol)
@@ -297,7 +570,26 @@ internal static class DriverConformanceHarness
         int ExitCode,
         string Output,
         string[] DiagnosticIds,
-        string StandardError);
+        string StandardError,
+        string CompilerOutput = "",
+        string IlDump = null,
+        IReadOnlyList<string> AssemblyReferences = null);
+
+    /// <summary>
+    /// The result of one differential comparison (issue #3717): the sample,
+    /// every level at which the two reference closures disagreed, and the
+    /// <c>AssemblyRef</c> sets each compile produced (the non-vacuity
+    /// evidence that the two modes really used different reflection contexts).
+    /// </summary>
+    /// <param name="Sample">The sample name.</param>
+    /// <param name="Differences">Human-readable divergence reports; empty when the modes agree.</param>
+    /// <param name="HostTpaAssemblyReferences">AssemblyRef names emitted by the host-TPA compile.</param>
+    /// <param name="RefPackAssemblyReferences">AssemblyRef names emitted by the ref-pack compile.</param>
+    public sealed record DifferentialOutcome(
+        string Sample,
+        IReadOnlyList<string> Differences,
+        IReadOnlyList<string> HostTpaAssemblyReferences,
+        IReadOnlyList<string> RefPackAssemblyReferences);
 
     private sealed record ProcessResult(
         int ExitCode,

--- a/test/Compiler.Tests/LanguageConformance/NormalizedIlDump.cs
+++ b/test/Compiler.Tests/LanguageConformance/NormalizedIlDump.cs
@@ -1,0 +1,479 @@
+// <copyright file="NormalizedIlDump.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection.Emit;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using System.Text;
+
+namespace GSharp.Compiler.Tests.LanguageConformance;
+
+/// <summary>
+/// Issue #3717: renders an emitted assembly as a text dump that is stable
+/// across reference closures, so two compilations of the same source — one
+/// against the host's trusted platform assemblies, one against the
+/// <c>Microsoft.NETCore.App.Ref</c> targeting pack — can be diffed for
+/// codegen divergence.
+/// <para>
+/// The two PEs are never byte-identical: they carry different
+/// <c>AssemblyRef</c> rows (<c>System.Private.CoreLib</c> versus the facade
+/// set), in a different order, so every <c>TypeRef</c> / <c>MemberRef</c>
+/// token differs numerically. The dump therefore resolves every metadata
+/// token to a <em>name</em> — <c>Namespace.Type::Member(signature)</c> with
+/// the defining assembly deliberately dropped — and orders methods by that
+/// name rather than by table row. What survives is exactly the thing the
+/// differential is about: the opcode stream, the exception-handling regions
+/// and the local-variable types.
+/// </para>
+/// <para>
+/// This is the <c>System.Reflection.Metadata</c> dumper model established by
+/// PR #3692's baseline audit, extended with EH regions because the defect
+/// class it is aimed at (#3708 — the missing <c>for … in</c> disposal
+/// <c>finally</c>) is precisely a missing protected region.
+/// </para>
+/// </summary>
+internal static class NormalizedIlDump
+{
+    private static readonly Dictionary<short, OpCode> OpCodesByValue = typeof(OpCodes)
+        .GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
+        .Where(field => field.FieldType == typeof(OpCode))
+        .Select(field => (OpCode)field.GetValue(null))
+        .ToDictionary(opcode => opcode.Value);
+
+    /// <summary>
+    /// Produces the normalised dump of the assembly at
+    /// <paramref name="assemblyPath"/>.
+    /// </summary>
+    /// <param name="assemblyPath">Path to the emitted .dll.</param>
+    /// <returns>A deterministic, reference-closure-independent text dump.</returns>
+    public static string Create(string assemblyPath)
+    {
+        using var stream = File.OpenRead(assemblyPath);
+        using var pe = new PEReader(stream);
+        MetadataReader reader = pe.GetMetadataReader();
+        var provider = new NameTypeProvider();
+
+        var methods = new List<(string Key, string Body)>();
+        foreach (MethodDefinitionHandle handle in reader.MethodDefinitions)
+        {
+            MethodDefinition method = reader.GetMethodDefinition(handle);
+            string signature = SafeDecode(
+                () => Describe(method.DecodeSignature(provider, null)),
+                "<bad-signature>");
+            string key = TypeName(reader, method.GetDeclaringType(), provider)
+                + "::" + reader.GetString(method.Name) + signature;
+
+            var builder = new StringBuilder();
+            builder.Append("method ").Append(key).Append(" [")
+                .Append(method.Attributes).Append('|').Append(method.ImplAttributes).Append("]\n");
+            AppendBody(builder, pe, reader, provider, method);
+            methods.Add((key, builder.ToString()));
+        }
+
+        return string.Concat(methods
+            .OrderBy(entry => entry.Key, StringComparer.Ordinal)
+            .ThenBy(entry => entry.Body, StringComparer.Ordinal)
+            .Select(entry => entry.Body));
+    }
+
+    /// <summary>
+    /// The <c>AssemblyRef</c> names of an emitted assembly. Used by the
+    /// differential suite's non-vacuity check: a TPA compile references
+    /// <c>System.Private.CoreLib</c>, a ref-pack compile references the
+    /// facades, so two dumps that agree while these sets are identical would
+    /// mean the second mode silently fell back to runtime types.
+    /// </summary>
+    /// <param name="assemblyPath">Path to the emitted .dll.</param>
+    /// <returns>The referenced assembly simple names, ordered.</returns>
+    public static IReadOnlyList<string> AssemblyReferenceNames(string assemblyPath)
+    {
+        using var stream = File.OpenRead(assemblyPath);
+        using var pe = new PEReader(stream);
+        MetadataReader reader = pe.GetMetadataReader();
+        return reader.AssemblyReferences
+            .Select(handle => reader.GetString(reader.GetAssemblyReference(handle).Name))
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static void AppendBody(
+        StringBuilder builder,
+        PEReader pe,
+        MetadataReader reader,
+        NameTypeProvider provider,
+        MethodDefinition method)
+    {
+        int rva = method.RelativeVirtualAddress;
+        if (rva == 0)
+        {
+            builder.Append("  <no body>\n");
+            return;
+        }
+
+        MethodBodyBlock body = pe.GetMethodBody(rva);
+
+        if (!body.LocalSignature.IsNil)
+        {
+            ImmutableArray<string> locals = SafeDecode(
+                () => reader.GetStandaloneSignature(body.LocalSignature)
+                    .DecodeLocalSignature(provider, null),
+                ImmutableArray<string>.Empty);
+            builder.Append("  .locals (").Append(string.Join(", ", locals)).Append(")\n");
+        }
+
+        foreach (ExceptionRegion region in body.ExceptionRegions
+            .OrderBy(region => region.TryOffset)
+            .ThenBy(region => region.HandlerOffset))
+        {
+            builder.Append("  .region ").Append(region.Kind)
+                .Append(" try IL_").Append(Hex(region.TryOffset))
+                .Append("..IL_").Append(Hex(region.TryOffset + region.TryLength))
+                .Append(" handler IL_").Append(Hex(region.HandlerOffset))
+                .Append("..IL_").Append(Hex(region.HandlerOffset + region.HandlerLength));
+            if (region.Kind == ExceptionRegionKind.Catch)
+            {
+                builder.Append(" catch ").Append(RenderHandle(reader, provider, region.CatchType));
+            }
+            else if (region.Kind == ExceptionRegionKind.Filter)
+            {
+                builder.Append(" filter IL_").Append(Hex(region.FilterOffset));
+            }
+
+            builder.Append('\n');
+        }
+
+        foreach (string instruction in ReadInstructions(body.GetILBytes(), reader, provider))
+        {
+            builder.Append("  ").Append(instruction).Append('\n');
+        }
+    }
+
+    private static IEnumerable<string> ReadInstructions(
+        byte[] il,
+        MetadataReader reader,
+        NameTypeProvider provider)
+    {
+        var lines = new List<string>();
+        int offset = 0;
+        while (offset < il.Length)
+        {
+            int instructionOffset = offset;
+            short value = il[offset++] == 0xFE
+                ? unchecked((short)(0xFE00 | il[offset++]))
+                : unchecked((short)il[instructionOffset]);
+            if (!OpCodesByValue.TryGetValue(value, out OpCode opcode))
+            {
+                lines.Add($"IL_{Hex(instructionOffset)}: <unknown 0x{value:X4}>");
+                break;
+            }
+
+            string operand = string.Empty;
+            switch (opcode.OperandType)
+            {
+                case OperandType.InlineNone:
+                    break;
+                case OperandType.ShortInlineBrTarget:
+                    operand = " IL_" + Hex(offset + 1 + unchecked((sbyte)il[offset]));
+                    offset += 1;
+                    break;
+                case OperandType.InlineBrTarget:
+                    operand = " IL_" + Hex(offset + 4 + BitConverter.ToInt32(il, offset));
+                    offset += 4;
+                    break;
+                case OperandType.InlineSwitch:
+                    int count = BitConverter.ToInt32(il, offset);
+                    offset += 4;
+                    int baseOffset = offset + (count * 4);
+                    var targets = new List<string>(count);
+                    for (int i = 0; i < count; i++)
+                    {
+                        targets.Add("IL_" + Hex(baseOffset + BitConverter.ToInt32(il, offset)));
+                        offset += 4;
+                    }
+
+                    operand = " (" + string.Join(", ", targets) + ")";
+                    break;
+                case OperandType.ShortInlineI:
+                    operand = " " + unchecked((sbyte)il[offset]).ToString(CultureInfo.InvariantCulture);
+                    offset += 1;
+                    break;
+                case OperandType.ShortInlineVar:
+                    operand = " " + il[offset].ToString(CultureInfo.InvariantCulture);
+                    offset += 1;
+                    break;
+                case OperandType.InlineVar:
+                    operand = " " + BitConverter.ToUInt16(il, offset).ToString(CultureInfo.InvariantCulture);
+                    offset += 2;
+                    break;
+                case OperandType.InlineI:
+                    operand = " " + BitConverter.ToInt32(il, offset).ToString(CultureInfo.InvariantCulture);
+                    offset += 4;
+                    break;
+                case OperandType.ShortInlineR:
+                    operand = " " + BitConverter.ToSingle(il, offset).ToString("R", CultureInfo.InvariantCulture);
+                    offset += 4;
+                    break;
+                case OperandType.InlineI8:
+                    operand = " " + BitConverter.ToInt64(il, offset).ToString(CultureInfo.InvariantCulture);
+                    offset += 8;
+                    break;
+                case OperandType.InlineR:
+                    operand = " " + BitConverter.ToDouble(il, offset).ToString("R", CultureInfo.InvariantCulture);
+                    offset += 8;
+                    break;
+                case OperandType.InlineMethod:
+                case OperandType.InlineField:
+                case OperandType.InlineType:
+                case OperandType.InlineTok:
+                case OperandType.InlineSig:
+                case OperandType.InlineString:
+                    operand = " " + RenderToken(reader, provider, BitConverter.ToInt32(il, offset));
+                    offset += 4;
+                    break;
+                default:
+                    throw new InvalidOperationException(
+                        $"Unsupported IL operand type {opcode.OperandType}.");
+            }
+
+            lines.Add($"IL_{Hex(instructionOffset)}: {opcode.Name}{operand}");
+        }
+
+        return lines;
+    }
+
+    /// <summary>
+    /// Resolves a metadata token to a name. This is the normalisation that
+    /// makes the two closures comparable: the numeric token, the row order and
+    /// the defining assembly are all discarded, only the member's fully
+    /// qualified name and signature survive.
+    /// </summary>
+    /// <param name="reader">The metadata reader.</param>
+    /// <param name="provider">The signature type provider.</param>
+    /// <param name="token">The raw metadata token from the IL stream.</param>
+    /// <returns>A closure-independent rendering of the token.</returns>
+    private static string RenderToken(MetadataReader reader, NameTypeProvider provider, int token)
+    {
+        // 0x70 is the UserString heap, which is not an EntityHandle.
+        if ((token >>> 24) == 0x70)
+        {
+            string literal = SafeDecode(
+                () => reader.GetUserString(MetadataTokens.UserStringHandle(token)),
+                "<bad-string>");
+            return "\"" + literal.Replace("\\", "\\\\", StringComparison.Ordinal)
+                .Replace("\"", "\\\"", StringComparison.Ordinal)
+                .Replace("\n", "\\n", StringComparison.Ordinal)
+                .Replace("\r", "\\r", StringComparison.Ordinal) + "\"";
+        }
+
+        return RenderHandle(reader, provider, MetadataTokens.EntityHandle(token));
+    }
+
+    private static string RenderHandle(
+        MetadataReader reader,
+        NameTypeProvider provider,
+        EntityHandle handle)
+    {
+        if (handle.IsNil)
+        {
+            return "<nil>";
+        }
+
+        return SafeDecode(() => RenderHandleCore(reader, provider, handle), "<unresolved>");
+    }
+
+    private static string RenderHandleCore(
+        MetadataReader reader,
+        NameTypeProvider provider,
+        EntityHandle handle)
+    {
+        switch (handle.Kind)
+        {
+            case HandleKind.TypeDefinition:
+            case HandleKind.TypeReference:
+            case HandleKind.TypeSpecification:
+                return TypeName(reader, handle, provider);
+
+            case HandleKind.MethodDefinition:
+            {
+                MethodDefinition method = reader.GetMethodDefinition((MethodDefinitionHandle)handle);
+                return TypeName(reader, method.GetDeclaringType(), provider)
+                    + "::" + reader.GetString(method.Name)
+                    + Describe(method.DecodeSignature(provider, null));
+            }
+
+            case HandleKind.FieldDefinition:
+            {
+                FieldDefinition field = reader.GetFieldDefinition((FieldDefinitionHandle)handle);
+                return TypeName(reader, field.GetDeclaringType(), provider)
+                    + "::" + reader.GetString(field.Name)
+                    + " : " + field.DecodeSignature(provider, null);
+            }
+
+            case HandleKind.MemberReference:
+            {
+                MemberReference member = reader.GetMemberReference((MemberReferenceHandle)handle);
+                string parent = member.Parent.Kind == HandleKind.ModuleReference
+                    ? "<module>"
+                    : TypeName(reader, member.Parent, provider);
+                string signature = member.GetKind() == MemberReferenceKind.Field
+                    ? " : " + member.DecodeFieldSignature(provider, null)
+                    : Describe(member.DecodeMethodSignature(provider, null));
+                return parent + "::" + reader.GetString(member.Name) + signature;
+            }
+
+            case HandleKind.MethodSpecification:
+            {
+                MethodSpecification spec = reader.GetMethodSpecification((MethodSpecificationHandle)handle);
+                ImmutableArray<string> arguments = spec.DecodeSignature(provider, null);
+                return RenderHandle(reader, provider, spec.Method)
+                    + "<" + string.Join(", ", arguments) + ">";
+            }
+
+            case HandleKind.StandaloneSignature:
+            {
+                StandaloneSignature signature =
+                    reader.GetStandaloneSignature((StandaloneSignatureHandle)handle);
+                return "sig" + Describe(signature.DecodeMethodSignature(provider, null));
+            }
+
+            default:
+                return handle.Kind.ToString();
+        }
+    }
+
+    private static string TypeName(
+        MetadataReader reader,
+        EntityHandle handle,
+        NameTypeProvider provider)
+    {
+        switch (handle.Kind)
+        {
+            case HandleKind.TypeDefinition:
+            {
+                TypeDefinition definition = reader.GetTypeDefinition((TypeDefinitionHandle)handle);
+                string name = reader.GetString(definition.Name);
+                if (definition.IsNested)
+                {
+                    return TypeName(reader, definition.GetDeclaringType(), provider) + "+" + name;
+                }
+
+                string ns = reader.GetString(definition.Namespace);
+                return string.IsNullOrEmpty(ns) ? name : ns + "." + name;
+            }
+
+            case HandleKind.TypeReference:
+            {
+                TypeReference reference = reader.GetTypeReference((TypeReferenceHandle)handle);
+                string name = reader.GetString(reference.Name);
+
+                // The resolution scope is deliberately ignored when it is an
+                // AssemblyRef: that is exactly the axis the two closures differ
+                // on (System.Private.CoreLib versus the facade set).
+                if (reference.ResolutionScope.Kind == HandleKind.TypeReference)
+                {
+                    return TypeName(reader, reference.ResolutionScope, provider) + "+" + name;
+                }
+
+                string ns = reader.GetString(reference.Namespace);
+                return string.IsNullOrEmpty(ns) ? name : ns + "." + name;
+            }
+
+            case HandleKind.TypeSpecification:
+                return reader.GetTypeSpecification((TypeSpecificationHandle)handle)
+                    .DecodeSignature(provider, null);
+
+            default:
+                return handle.Kind.ToString();
+        }
+    }
+
+    private static string Describe(MethodSignature<string> signature)
+    {
+        string generics = signature.GenericParameterCount > 0
+            ? "`" + signature.GenericParameterCount.ToString(CultureInfo.InvariantCulture)
+            : string.Empty;
+        return generics + "(" + string.Join(", ", signature.ParameterTypes) + ") : "
+            + signature.ReturnType;
+    }
+
+    private static string Hex(int offset)
+        => offset.ToString("X4", CultureInfo.InvariantCulture);
+
+    private static T SafeDecode<T>(Func<T> decode, T fallback)
+    {
+        try
+        {
+            return decode();
+        }
+        catch (BadImageFormatException)
+        {
+            return fallback;
+        }
+        catch (InvalidOperationException)
+        {
+            return fallback;
+        }
+    }
+
+    /// <summary>
+    /// Renders signature blobs as assembly-agnostic type names.
+    /// </summary>
+    private sealed class NameTypeProvider : ISignatureTypeProvider<string, object>
+    {
+        public string GetArrayType(string elementType, ArrayShape shape)
+            => elementType + "[" + new string(',', Math.Max(0, shape.Rank - 1)) + "]";
+
+        public string GetByReferenceType(string elementType) => elementType + "&";
+
+        public string GetFunctionPointerType(MethodSignature<string> signature)
+            => "method " + signature.ReturnType + " *("
+                + string.Join(", ", signature.ParameterTypes) + ")";
+
+        public string GetGenericInstantiation(string genericType, ImmutableArray<string> typeArguments)
+            => genericType + "<" + string.Join(", ", typeArguments) + ">";
+
+        public string GetGenericMethodParameter(object genericContext, int index)
+            => "!!" + index.ToString(CultureInfo.InvariantCulture);
+
+        public string GetGenericTypeParameter(object genericContext, int index)
+            => "!" + index.ToString(CultureInfo.InvariantCulture);
+
+        public string GetModifiedType(string modifier, string unmodifiedType, bool isRequired)
+            => unmodifiedType + (isRequired ? " modreq(" : " modopt(") + modifier + ")";
+
+        public string GetPinnedType(string elementType) => elementType + " pinned";
+
+        public string GetPointerType(string elementType) => elementType + "*";
+
+        public string GetPrimitiveType(PrimitiveTypeCode typeCode) => typeCode.ToString();
+
+        public string GetSZArrayType(string elementType) => elementType + "[]";
+
+        public string GetTypeFromDefinition(
+            MetadataReader metadataReader,
+            TypeDefinitionHandle handle,
+            byte rawTypeKind)
+            => TypeName(metadataReader, handle, this);
+
+        public string GetTypeFromReference(
+            MetadataReader metadataReader,
+            TypeReferenceHandle handle,
+            byte rawTypeKind)
+            => TypeName(metadataReader, handle, this);
+
+        public string GetTypeFromSpecification(
+            MetadataReader metadataReader,
+            object genericContext,
+            TypeSpecificationHandle handle,
+            byte rawTypeKind)
+            => metadataReader.GetTypeSpecification(handle).DecodeSignature(this, genericContext);
+    }
+}

--- a/test/Compiler.Tests/ReferenceClosure.cs
+++ b/test/Compiler.Tests/ReferenceClosure.cs
@@ -1,0 +1,166 @@
+// <copyright file="ReferenceClosure.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace GSharp.Compiler.Tests;
+
+/// <summary>
+/// The two reference closures gsc can be driven with, and the helpers that
+/// materialise them. Extracted from <c>XunitAssertOverloadResolutionTests</c>
+/// (issue #504-reopen) so issue #3717's differential conformance mode can
+/// reuse exactly the same closures rather than re-deriving them.
+/// <para>
+/// The distinction matters because it decides which reflection context gsc
+/// binds against. With no <c>/reference:</c> switch gsc resolves imports from
+/// the host's trusted platform assemblies and every imported type is a live
+/// runtime <see cref="Type"/>; with the <c>Microsoft.NETCore.App.Ref</c>
+/// targeting-pack facades gsc constructs a
+/// <see cref="System.Reflection.MetadataLoadContext"/> — which is what every
+/// real SDK build does. Defects that take the wrong arm of a
+/// <c>typeof(X).IsAssignableFrom(clrType)</c> test (#3708, #3697, #3637,
+/// #3636, #3666) are visible only in the second configuration.
+/// </para>
+/// </summary>
+internal enum ReferenceClosureMode
+{
+    /// <summary>
+    /// No <c>/reference:</c> switches: gsc falls back to the host's trusted
+    /// platform assemblies and imported types are live runtime types.
+    /// </summary>
+    HostTrustedPlatform,
+
+    /// <summary>
+    /// The full <c>Microsoft.NETCore.App.Ref</c> targeting-pack closure passed
+    /// via <c>/reference:</c>, as the .NET SDK does — imported types come from
+    /// a <see cref="System.Reflection.MetadataLoadContext"/>.
+    /// </summary>
+    ReferencePack,
+}
+
+/// <summary>
+/// Resolves the reference closures described by <see cref="ReferenceClosureMode"/>.
+/// </summary>
+internal static class ReferenceClosure
+{
+    /// <summary>
+    /// Assembles the same reference closure the .NET SDK would pass to gsc —
+    /// the <c>Microsoft.NETCore.App.Ref</c> targeting-pack facades for the
+    /// running runtime. Each facade resolves to a different
+    /// <see cref="System.Reflection.Assembly"/> identity than the host's
+    /// <c>System.Private.CoreLib</c>, so imported types are
+    /// <c>MetadataLoadContext</c> types rather than runtime types.
+    /// </summary>
+    /// <returns>The ref-pack reference assemblies.</returns>
+    public static IEnumerable<string> RefPackAssemblies()
+    {
+        string refDir = LocateRefPackDirectory()
+            ?? throw new Xunit.Sdk.XunitException(
+                "prerequisite missing: " + (UnavailableReason ?? "ref pack not resolvable"));
+        return Directory.EnumerateFiles(refDir, "*.dll");
+    }
+
+    /// <summary>
+    /// The host's trusted platform assemblies — the set gsc falls back to when
+    /// no <c>/reference:</c> switch is supplied.
+    /// </summary>
+    /// <returns>Existing TPA paths.</returns>
+    public static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        if (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") is not string tpa
+            || string.IsNullOrEmpty(tpa))
+        {
+            yield break;
+        }
+
+        foreach (string path in tpa.Split(Path.PathSeparator))
+        {
+            if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
+            {
+                yield return path;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Trusted platform assemblies whose file name starts with
+    /// <paramref name="prefix"/>. Used to graft host-resolved packages (for
+    /// example xUnit) onto the ref-pack closure; their identity is stable
+    /// across both reflection contexts and is not what the differential is
+    /// exercising.
+    /// </summary>
+    /// <param name="prefix">Case-insensitive file-name prefix.</param>
+    /// <returns>Matching TPA paths.</returns>
+    public static IEnumerable<string> TrustedPlatformAssembliesStartingWith(string prefix)
+        => TrustedPlatformAssemblies()
+            .Where(path => Path.GetFileName(path)
+                .StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// Gets a human-readable reason the ref pack could not be located, or
+    /// <see langword="null"/> when it was found. Callers that must degrade
+    /// gracefully (rather than fail) consult this before enumerating.
+    /// </summary>
+    public static string UnavailableReason { get; private set; }
+
+    /// <summary>
+    /// Gets a value indicating whether the ref pack is present on this machine.
+    /// </summary>
+    /// <returns><see langword="true"/> when <see cref="RefPackAssemblies"/> will succeed.</returns>
+    public static bool IsRefPackAvailable() => LocateRefPackDirectory() is not null;
+
+    private static string LocateRefPackDirectory()
+    {
+        string runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        if (string.IsNullOrEmpty(runtimeDir))
+        {
+            return Unavailable("host runtime directory not resolvable");
+        }
+
+        string dotnetRoot = Directory.GetParent(runtimeDir)?.Parent?.Parent?.FullName;
+        if (string.IsNullOrEmpty(dotnetRoot))
+        {
+            return Unavailable("dotnet root not resolvable");
+        }
+
+        string packsRoot = Path.Combine(dotnetRoot, "packs", "Microsoft.NETCore.App.Ref");
+        if (!Directory.Exists(packsRoot))
+        {
+            return Unavailable($"ref pack root '{packsRoot}' missing");
+        }
+
+        string tfm = $"net{Environment.Version.Major}.0";
+
+        // Match the targeting-pack version to the running runtime (e.g. 10.0.X).
+        string refDir = Path.Combine(packsRoot, Environment.Version.ToString(3), "ref", tfm);
+        if (Directory.Exists(refDir))
+        {
+            UnavailableReason = null;
+            return refDir;
+        }
+
+        // Fall back to the newest installed ref pack matching the major version.
+        string major = Environment.Version.Major.ToString();
+        string candidate = Directory.EnumerateDirectories(packsRoot, major + ".*")
+            .OrderByDescending(directory => directory, StringComparer.Ordinal)
+            .Select(directory => Path.Combine(directory, "ref", tfm))
+            .FirstOrDefault(Directory.Exists);
+        if (string.IsNullOrEmpty(candidate))
+        {
+            return Unavailable($"no ref pack for net{major}.0 under '{packsRoot}'");
+        }
+
+        UnavailableReason = null;
+        return candidate;
+    }
+
+    private static string Unavailable(string reason)
+    {
+        UnavailableReason = reason;
+        return null;
+    }
+}

--- a/test/Compiler.Tests/XunitAssertOverloadResolutionTests.cs
+++ b/test/Compiler.Tests/XunitAssertOverloadResolutionTests.cs
@@ -748,99 +748,17 @@ public class XunitAssertOverloadResolutionTests
     /// through the MetadataLoadContext (e.g. <c>Nullable&lt;bool&gt;</c>) carry
     /// assembly-qualified type-arg names that diverge from the host's. This is
     /// the exact configuration where the binder's identity-by-FullName check
-    /// silently fails. Skips the test gracefully when the ref-pack is absent.
+    /// silently fails. Fails with a clear prerequisite message when the
+    /// ref-pack is absent.
     /// </summary>
     /// <returns>The set of reference assemblies to pass to gsc.</returns>
     private static IEnumerable<string> RefPackReferences()
-    {
-        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
-        Skip.IfNull(runtimeDir, "host runtime directory not resolvable");
-        var sharedDir = Directory.GetParent(runtimeDir)?.Parent;
-        var dotnetRoot = sharedDir?.Parent?.FullName;
-        Skip.IfNullOrEmpty(dotnetRoot, "dotnet root not resolvable");
-        var tfm = $"net{Environment.Version.Major}.0";
-        var packsRoot = Path.Combine(dotnetRoot, "packs", "Microsoft.NETCore.App.Ref");
-        Skip.IfFalse(Directory.Exists(packsRoot), $"ref pack root '{packsRoot}' missing");
-
-        // Match the targeting-pack version to the running runtime (e.g. 10.0.X).
-        var version = Environment.Version.ToString(3);
-        var refDir = Path.Combine(packsRoot, version, "ref", tfm);
-        if (!Directory.Exists(refDir))
-        {
-            // Fall back to the newest installed ref-pack matching the major version.
-            var major = Environment.Version.Major.ToString();
-            var candidate = Directory.EnumerateDirectories(packsRoot, major + ".*")
-                .OrderByDescending(d => d, StringComparer.Ordinal)
-                .Select(d => Path.Combine(d, "ref", tfm))
-                .FirstOrDefault(Directory.Exists);
-            Skip.IfNullOrEmpty(candidate, $"no ref pack for net{major}.0 under '{packsRoot}'");
-            refDir = candidate;
-        }
-
-        foreach (var path in Directory.EnumerateFiles(refDir, "*.dll"))
-        {
-            yield return path;
-        }
-
-        // xUnit is consumed from the host's TPA — its identity is stable across
-        // both reflection contexts and is not what the bug is exercising.
-        foreach (var path in TrustedPlatformAssemblies())
-        {
-            var name = Path.GetFileName(path);
-            if (name.StartsWith("xunit.", StringComparison.OrdinalIgnoreCase))
-            {
-                yield return path;
-            }
-        }
-    }
-
-    /// <summary>
-    /// Tiny in-test skip-if helper. xUnit's <c>SkipException</c> is not part
-    /// of the v2 runner used here, so use <see cref="Xunit.Sdk.XunitException"/>
-    /// to surface a missing-prerequisite condition as a test failure with a
-    /// clear message rather than a silent pass.
-    /// </summary>
-    private static class Skip
-    {
-        public static void IfNull(object value, string reason)
-        {
-            if (value == null)
-            {
-                throw new Xunit.Sdk.XunitException($"prerequisite missing: {reason}");
-            }
-        }
-
-        public static void IfNullOrEmpty(string value, string reason)
-        {
-            if (string.IsNullOrEmpty(value))
-            {
-                throw new Xunit.Sdk.XunitException($"prerequisite missing: {reason}");
-            }
-        }
-
-        public static void IfFalse(bool condition, string reason)
-        {
-            if (!condition)
-            {
-                throw new Xunit.Sdk.XunitException($"prerequisite missing: {reason}");
-            }
-        }
-    }
+        => ReferenceClosure.RefPackAssemblies()
+            // xUnit is consumed from the host's TPA — its identity is stable
+            // across both reflection contexts and is not what the bug is
+            // exercising.
+            .Concat(ReferenceClosure.TrustedPlatformAssembliesStartingWith("xunit."));
 
     private static IEnumerable<string> TrustedPlatformAssemblies()
-    {
-        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
-        if (string.IsNullOrEmpty(tpa))
-        {
-            yield break;
-        }
-
-        foreach (var path in tpa.Split(Path.PathSeparator))
-        {
-            if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
-            {
-                yield return path;
-            }
-        }
-    }
+        => ReferenceClosure.TrustedPlatformAssemblies();
 }


### PR DESCRIPTION
Fixes #3717.

## What this adds

Every sample suite today compiles with **no `/reference:` closure**, so gsc resolves imports from the host's trusted platform assemblies and every imported type is a live runtime `Type`. The `MetadataLoadContext` that a real `/reference:` build constructs — every SDK build, and the entire self-migration corpus — is never entered. That is why #3708/#3715 was invisible in-process, and the same is true of #3697, #3637, #3636 and #3666.

This adds a **differential mode** to `DriverConformanceHarness`: each sample is compiled twice — once as today, once against the full `Microsoft.NETCore.App.Ref` closure — and the two are required to agree, strongest-first:

1. **Diagnostics** — ids *and* the raw compiler text, which carries the locations.
2. **Emitted IL**, modulo assembly-reference tokens and ordering.
3. **Runtime output**, and the ref-pack build's output is checked against the existing `.golden` too.

Nothing is forked: sample discovery, ILVerify, the golden comparison and the `dotnet exec` oracle are the harness's existing ones. `RefPackReferences()` / `TrustedPlatformAssemblies()` moved out of `XunitAssertOverloadResolutionTests` into a shared `ReferenceClosure`, which both suites now use.

### IL normalisation

The two PEs are never byte-identical — different `AssemblyRef` rows (`System.Private.CoreLib` versus the facade set), in a different order, so every `TypeRef`/`MemberRef` token differs numerically. `NormalizedIlDump` (the `System.Reflection.Metadata` dumper model from #3692's baseline audit) resolves every metadata token to a **name** — `Namespace.Type::Member(signature)`, with the defining assembly deliberately dropped — and orders methods by that name rather than by table row. It also emits **exception-handling regions**, because the family's flagship defect is a missing protected region.

Failures are reported per method and offset-insensitively; a naive line diff would bury one dropped `finally` under a hundred shifted offsets.

## Proof the detector actually works

A green differential proves nothing if the second mode silently used runtime types, so:

**Non-vacuity, asserted per sample.** The host-TPA compile must emit an `AssemblyRef` to `System.Private.CoreLib` (the signature of binding against live runtime types) and the ref-pack compile must emit one to `System.Runtime` (the targeting-pack contract). If either is missing the test fails as vacuous rather than passing.

**The reverted-#3708 check.** With `git checkout 8babae79^ -- src/Core/CodeAnalysis/Lowering/Lowerer.cs` (dropping the `for … in` disposal fix) and nothing else changed, the full corpus goes **127 passed / 3 failed**:

```
LinqExtensions.gs compiles differently against the host TPA and against the
Microsoft.NETCore.App.Ref closure. ...

emitted IL differs between reference closures:
  method GSharp.Example.LinqExtensions.<Program>::<Main>$(String[]) : Void
    protected region present under host-TPA, absent under ref-pack:
      .region Finally try IL_x..IL_x handler IL_x..IL_x
    region count: host-TPA 2, ref-pack 0
    first opcode divergence at instruction 38:
      host-TPA: IL_x: leave IL_x
      ref-pack: IL_x: ldsfld ...::list : System.Collections.Generic.List`1<Int32>
```

Same shape for `OptionalExtensionArgs.gs` (1 region) and `SliceLinqUntypedLambda.gs` (1 region). Restoring `Lowerer.cs` returns the run to **130 passed / 0 failed**. `LinqExtensions.gs` is in the always-on subset, so the per-PR run catches it too.

No sample had to be added — the existing corpus already carries `for … in` over an imported `IEnumerator` that really implements `IDisposable`.

## First-run triage

**Agreement levels 1–3: zero divergences across all 128 single-file samples.** Diagnostics, normalised IL and runtime output are identical under both closures on `main`. `KnownDifferences` is therefore **empty** — nothing was allow-listed to make the suite pass.

**The non-vacuity guard found a real defect, filed as #3718.** 65 of the 128 samples emit an `AssemblyRef` to `System.Private.CoreLib` *even when compiled entirely against the targeting pack*. That row can only come from resolving a well-known type through the host runtime rather than the compilation's load context — the same root cause as #3708/#3697/#3637, but invisible to the IL comparison precisely because that comparison normalises assembly identity away.

Aggregating the `TypeRef` rows scoped to `System.Private.CoreLib` across those 65 ref-pack builds:

| Type | Samples |
| --- | --- |
| `DefaultInterpolatedStringHandler` | 28 |
| `System.Exception` | 14 |
| `System.String` | 12 |
| `System.Int32`, `Task`, `TaskAwaiter` | 9 each |
| `Convert`, `CultureInfo`, `HashCode`, `IFormatProvider`, `IAsyncStateMachine` | 8 each |
| `System.Array`, `List<>`, `CancellationTokenSource` | 7 each |
| `ValueTask`, `ValueTask<>`, `Task<>`, `TaskAwaiter<>`, `CancellationToken`, `InvalidOperationException` | 6 each |
| … 15 more (`Marshal`, `FormattableStringFactory`, `Dictionary<,>`, `Action`, `Func<>`, …) | 1–5 each |

The most concentrated site is confirmed in source:

```csharp
// src/Core/CodeAnalysis/Lowering/InterpolatedStringHandlerLowerer.cs:45
private static readonly System.Type HandlerType = typeof(DefaultInterpolatedStringHandler);
```

A `static readonly` host `typeof` cannot, by construction, ever be the compilation's type. The user-visible consequence is that every SDK-built G# assembly using interpolation, `async`, records, pattern matching or variadics names an *implementation* assembly rather than the `System.Runtime` contract — which Roslyn never does, and which is wrong for any runtime whose corlib identity differs, and for trimming/AOT dependency graphs.

**These are not allow-listed as legitimate.** They are pinned in `KnownRefPackCorlibLeaks`, keyed by **file + reason** (the #3716 guard-rail idiom, not line numbers, so concurrent edits cannot leave a stale entry), with every entry pointing at #3718. The assertion fails in *both* directions — an unlisted leak, and a listed sample that has stopped leaking — so it is a burn-down list that cannot rot: fixing a lowering site forces the corresponding entries out.

**Summary of the backlog:** 0 legitimate differences allow-listed, 0 defects silently allow-listed, 1 real defect filed (#3718) with a 65-entry burn-down.

## Cost, and where it is wired

- **Full corpus:** 130 tests, **1 m 54 s** of test time (measured locally, Debug).
- **Always-on subset:** 9 tests, **7 s**.

The differential roughly doubles conformance compile time and the ref-pack compile is the slower half (a ~270-assembly closure through a `MetadataLoadContext` instead of the host TPA). So:

- **Per PR**, the existing `build.yml` Compiler.Tests shard runs the suite with `GSHARP_DIFFERENTIAL_CONFORMANCE` unset, which restricts the theory to a curated `AlwaysOnSamples` subset — the samples that iterate, subscribe to or reflect over imported types, which is where this family lands. ~7 s, no workflow change needed. `LinqExtensions.gs` is in it, so the #3708 shape is guarded on every PR.
- **Nightly**, a new `differential-conformance-nightly.yml` sets `GSHARP_DIFFERENTIAL_CONFORMANCE=1` and runs the whole corpus.

`AlwaysOnSubset_IsPresentAndNonVacuous` keeps the subset from silently shrinking or drifting off the shapes it is meant to cover, so the per-PR half cannot rot between nightlies.

## Verification

- `DifferentialReferenceClosureTests`, full corpus: **130 passed, 0 failed** (1 m 54 s).
- `DifferentialReferenceClosureTests` + `SampleConformanceTests` + `XunitAssertOverloadResolutionTests` + `Issue3708*`: **173 passed, 0 failed** (2 m 48 s) — the existing conformance gate and the extracted-helper consumer are unaffected.
- With #3708 reverted: **3 failed**, all naming the missing `.region Finally`; restored: green.
- No goldens changed, no ILVerify suppressions added, no baselines regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
