### PR TITLE
cs2gs: run the redundant-`!!` polish to a real fixed point (#3723)

### DIFF
--- a/.github/workflows/cs2gs-selfmig-nightly.yml
+++ b/.github/workflows/cs2gs-selfmig-nightly.yml
@@ -157,6 +157,9 @@ jobs:
             /tmp/gsharp-cs2gs-selfmig/shard-${{ matrix.name }}/runs/**/*.json
             /tmp/gsharp-cs2gs-selfmig/shard-${{ matrix.name }}/runs/**/report.html
             /tmp/gsharp-cs2gs-selfmig/shard-${{ matrix.name }}/runs/**/sdk.build.log
+            # Issue #3723: what the redundant-`!!` polish loop did per app
+            # (rounds, assertions stripped, whether it hit its round cap).
+            /tmp/gsharp-cs2gs-selfmig/shard-${{ matrix.name }}/runs/**/polish.log
 
   gate:
     runs-on: ubuntu-latest

--- a/tools/cs2gs/Cs2Gs.Pipeline/CompileStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/CompileStage.cs
@@ -97,50 +97,28 @@ public sealed class CompileStage : IMigrationStage
             // Issue #3501 (!! reduction): gsc reports GS0536 on every `!!`
             // whose operand is already non-null — the compiler's own
             // narrowing is the single source of truth. Strip exactly those
-            // spans from the emitted files and recompile, iterating to a
-            // small fixpoint: removing one round of assertions can extend
-            // binding far enough to surface the next round. Defensive: if a
-            // polished recompile regresses a previously passing build,
-            // restore the round's text and keep the prior result.
-            for (var polishRound = 0; polishRound < 3; polishRound++)
-            {
-                if (!sdkResult.IsAvailable
-                    || !sdkResult.Diagnostics.Any(d => d.Id == NullAssertionPolishPass.DiagnosticId))
-                {
-                    break;
-                }
-
-                // The SDK build also compiles project references, so a
-                // dependency whose own compile stage never ran can surface
-                // GS0536 in files outside this app's emitted set — anything
-                // under the shared output root is fair game for the polish.
-                string strippableRoot = context.Options.OutputRoot;
-                Dictionary<string, string> backups = NullAssertionPolishPass
-                    .CandidateFiles(sdkResult.Diagnostics, gsFiles, strippableRoot)
-                    .Concat(gsFiles)
-                    .Where(File.Exists)
-                    .Distinct(StringComparer.Ordinal)
-                    .ToDictionary(f => f, File.ReadAllText, StringComparer.Ordinal);
-                if (NullAssertionPolishPass.Strip(sdkResult.Diagnostics, gsFiles, strippableRoot) == 0)
-                {
-                    break;
-                }
-
-                SdkCompileResult polished = RunSdkCompile();
-                if (polished.IsAvailable && (polished.Succeeded || !sdkResult.Succeeded))
-                {
-                    sdkResult = polished;
-                }
-                else
-                {
-                    foreach (KeyValuePair<string, string> backup in backups)
-                    {
-                        File.WriteAllText(backup.Key, backup.Value);
-                    }
-
-                    break;
-                }
-            }
+            // spans from the emitted files and recompile, repeating until a
+            // compile stops reporting them.
+            //
+            // Issue #3723: this used to stop after three rounds, which is not
+            // a fixed point. A compile reports nothing past the first project
+            // it fails on, so a deep reference graph spends a round per level
+            // before the app's own sources are ever bound; nested assertions
+            // (`a!!.b!!`) then add generations on top. Four apps were red on
+            // the nightly gate with GS0536 as their ONLY diagnostic because
+            // the loop ran out of rounds and said nothing about it.
+            //
+            // The SDK build also compiles project references, so a dependency
+            // whose own compile stage never ran can surface GS0536 in files
+            // outside this app's emitted set — anything under the shared
+            // output root is fair game for the polish.
+            NullAssertionPolishPass.PolishLoopOutcome polish = NullAssertionPolishPass.RunToFixedPoint(
+                sdkResult,
+                RunSdkCompile,
+                gsFiles,
+                context.Options.OutputRoot);
+            sdkResult = polish.Result;
+            ReportPolishOutcome(context, polish);
 
             if (sdkResult.IsAvailable)
             {
@@ -274,6 +252,45 @@ public sealed class CompileStage : IMigrationStage
 
     private static string NormalizeSeparators(string path) =>
         path.Replace('\\', '/');
+
+    /// <summary>
+    /// Issue #3723: records what the redundant-<c>!!</c> polish loop did, and
+    /// says so on stderr when it stopped short of a fixed point. Silently
+    /// giving up is how the non-convergence stayed invisible across several
+    /// nightly runs, so an app that is still reporting GS0536 after the loop
+    /// now always leaves a trace next to its build log.
+    /// </summary>
+    /// <param name="context">The stage context (for the artifact directory and app id).</param>
+    /// <param name="polish">The loop outcome.</param>
+    private static void ReportPolishOutcome(
+        StageExecutionContext context, NullAssertionPolishPass.PolishLoopOutcome polish)
+    {
+        if (polish.Rounds == 0)
+        {
+            return;
+        }
+
+        string summary = $"polish rounds: {polish.Rounds} (cap {NullAssertionPolishPass.DefaultMaxRounds}), " +
+            $"assertions stripped: {polish.Stripped}, " +
+            $"{NullAssertionPolishPass.DiagnosticId} still reported: {polish.RemainingReports}, " +
+            $"cap exhausted: {polish.CapExhausted}";
+
+        try
+        {
+            Directory.CreateDirectory(context.ArtifactDir);
+            File.WriteAllText(Path.Combine(context.ArtifactDir, "polish.log"), summary + Environment.NewLine);
+        }
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+        {
+            // The artifact is advisory; never fail the stage over it.
+        }
+
+        if (polish.RemainingReports > 0)
+        {
+            Console.Error.WriteLine(
+                $"cs2gs: {context.App.Id}: the redundant-'!!' polish pass did not converge — {summary}.");
+        }
+    }
 
     private static StageOutcome BuildFailureOutcome(
         StageExecutionContext context, IReadOnlyList<GscDiagnostic> errors, string syntheticMessageOnNoDiagnostics)

--- a/tools/cs2gs/Cs2Gs.Pipeline/NullAssertionPolishPass.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/NullAssertionPolishPass.cs
@@ -24,6 +24,100 @@ public static class NullAssertionPolishPass
     public const string DiagnosticId = "GS0536";
 
     /// <summary>
+    /// Issue #3723: the round cap <see cref="RunToFixedPoint"/> stops at. One
+    /// round can only strip what the compile it followed actually reported,
+    /// and a compile reports nothing past the first project it fails on — so a
+    /// deep project graph spends one round per level before the app's own
+    /// sources are ever bound, and nested assertions (<c>a!!.b!!</c>) add
+    /// further generations on top of that. The cap only exists so a
+    /// pathological non-converging case cannot loop forever; hitting it is
+    /// reported, never silent.
+    /// </summary>
+    public const int DefaultMaxRounds = 12;
+
+    /// <summary>
+    /// Issue #3723: strips the GS0536 spans of <paramref name="initial"/>,
+    /// recompiles, and repeats until a compile reports no redundant <c>!!</c>
+    /// (or a round finds nothing left it can strip). The recompile is what
+    /// validates each round: a round is only kept when the polished build is
+    /// no worse than the one before it, and otherwise the round's text is
+    /// rolled back and the prior result stands — a <c>!!</c> the compiler
+    /// still needs therefore survives, because the file it was removed from is
+    /// restored wholesale.
+    /// </summary>
+    /// <param name="initial">The first compile's result.</param>
+    /// <param name="recompile">Reruns the same compile over the rewritten files.</param>
+    /// <param name="emittedGsFiles">The emitted .gs file paths owned by this app.</param>
+    /// <param name="strippableRoot">The optional shared emitted-output root.</param>
+    /// <param name="maxRounds">The round cap (see <see cref="DefaultMaxRounds"/>).</param>
+    /// <returns>The final compile result and what the loop did to reach it.</returns>
+    public static PolishLoopOutcome RunToFixedPoint(
+        SdkCompileResult initial,
+        Func<SdkCompileResult> recompile,
+        IReadOnlyCollection<string> emittedGsFiles,
+        string strippableRoot = null,
+        int maxRounds = DefaultMaxRounds)
+    {
+        if (initial is null)
+        {
+            throw new ArgumentNullException(nameof(initial));
+        }
+
+        if (recompile is null)
+        {
+            throw new ArgumentNullException(nameof(recompile));
+        }
+
+        SdkCompileResult result = initial;
+        var rounds = 0;
+        var stripped = 0;
+        while (result.IsAvailable
+            && result.Diagnostics.Any(d => string.Equals(d.Id, DiagnosticId, StringComparison.Ordinal)))
+        {
+            if (rounds >= maxRounds)
+            {
+                return new PolishLoopOutcome(result, rounds, stripped, capExhausted: true);
+            }
+
+            rounds++;
+            Dictionary<string, string> backups = CandidateFiles(result.Diagnostics, emittedGsFiles, strippableRoot)
+                .Concat(emittedGsFiles ?? Array.Empty<string>())
+                .Where(File.Exists)
+                .Distinct(StringComparer.Ordinal)
+                .ToDictionary(f => f, File.ReadAllText, StringComparer.Ordinal);
+
+            int roundStripped = Strip(result.Diagnostics, emittedGsFiles, strippableRoot);
+            if (roundStripped == 0)
+            {
+                // Every reported span was one this pass declines to touch
+                // (a stale coordinate, or a file outside the strippable set):
+                // another round would report the same thing.
+                break;
+            }
+
+            stripped += roundStripped;
+            SdkCompileResult polished = recompile();
+            if (polished.IsAvailable && (polished.Succeeded || !result.Succeeded))
+            {
+                result = polished;
+                continue;
+            }
+
+            // The polished build regressed a previously passing one (or could
+            // not run at all): restore the round's text and keep the result
+            // that stood before it.
+            foreach (KeyValuePair<string, string> backup in backups)
+            {
+                File.WriteAllText(backup.Key, backup.Value);
+            }
+
+            break;
+        }
+
+        return new PolishLoopOutcome(result, rounds, stripped, capExhausted: false);
+    }
+
+    /// <summary>
     /// Deletes every GS0536-flagged <c>!!</c> span from the given emitted
     /// files. Spans are applied bottom-up per file so earlier deletions never
     /// shift later coordinates, and each span is verified to hold exactly
@@ -249,6 +343,45 @@ public static class NullAssertionPolishPass
         }
 
         return directory;
+    }
+
+    /// <summary>
+    /// Issue #3723: what a <see cref="RunToFixedPoint"/> call did — enough for
+    /// the caller to say out loud that the loop gave up, which is how the
+    /// old three-round cap stayed invisible for several nightly runs.
+    /// </summary>
+    public sealed class PolishLoopOutcome
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PolishLoopOutcome"/> class.
+        /// </summary>
+        /// <param name="result">The final compile result.</param>
+        /// <param name="rounds">The number of strip-and-recompile rounds run.</param>
+        /// <param name="stripped">The total number of assertions removed.</param>
+        /// <param name="capExhausted">Whether the round cap stopped the loop.</param>
+        public PolishLoopOutcome(SdkCompileResult result, int rounds, int stripped, bool capExhausted)
+        {
+            this.Result = result;
+            this.Rounds = rounds;
+            this.Stripped = stripped;
+            this.CapExhausted = capExhausted;
+        }
+
+        /// <summary>Gets the final compile result.</summary>
+        public SdkCompileResult Result { get; }
+
+        /// <summary>Gets the number of strip-and-recompile rounds run.</summary>
+        public int Rounds { get; }
+
+        /// <summary>Gets the total number of assertions removed.</summary>
+        public int Stripped { get; }
+
+        /// <summary>Gets a value indicating whether the round cap stopped the loop.</summary>
+        public bool CapExhausted { get; }
+
+        /// <summary>Gets the number of redundant-<c>!!</c> reports still standing.</summary>
+        public int RemainingReports => this.Result.Diagnostics
+            .Count(d => string.Equals(d.Id, DiagnosticId, StringComparison.Ordinal));
     }
 
     private sealed class SpanComparer : IEqualityComparer<GscDiagnostic>

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3723PolishConvergenceTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3723PolishConvergenceTests.cs
@@ -1,0 +1,268 @@
+// <copyright file="Issue3723PolishConvergenceTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3723: the redundant-<c>!!</c> polish loop has to run to a real fixed
+/// point. One compile only reports what it managed to bind — it stops at the
+/// first project that fails, and a nested assertion only becomes visibly
+/// redundant once the one outside it is gone — so a fixed round budget leaves
+/// the app red with GS0536 as its only diagnostic. These tests drive
+/// <see cref="NullAssertionPolishPass.RunToFixedPoint"/> with a stand-in
+/// compiler so the multi-generation and per-project shapes are exercised
+/// without a real <c>dotnet build</c>.
+/// </summary>
+public sealed class Issue3723PolishConvergenceTests
+{
+    [Fact]
+    public void RunToFixedPoint_ConvergesAcrossGenerations_PastTheOldThreeRoundBudget()
+    {
+        using var workspace = new PolishWorkspace();
+        string file = workspace.WriteFile("Nested.gs", "let a = b!!.c!!.d!!.e!!");
+        var compiler = new FakeCompiler(workspace.Files, PerLineFrontier);
+
+        NullAssertionPolishPass.PolishLoopOutcome outcome = NullAssertionPolishPass.RunToFixedPoint(
+            compiler.Compile(),
+            compiler.Compile,
+            workspace.Files);
+
+        Assert.False(outcome.CapExhausted);
+        Assert.Equal(0, outcome.RemainingReports);
+        Assert.Equal(4, outcome.Stripped);
+
+        // Four generations: strictly more than the three rounds the loop used
+        // to allow, which is what left the gate's apps red.
+        Assert.Equal(4, outcome.Rounds);
+        Assert.True(outcome.Result.Succeeded);
+        Assert.Equal("let a = b.c.d.e", File.ReadAllText(file).TrimEnd());
+    }
+
+    [Fact]
+    public void RunToFixedPoint_ConvergesWhenEachCompileOnlyReachesTheNextProject()
+    {
+        using var workspace = new PolishWorkspace();
+
+        // A compile reports nothing past the project it fails on, so the loop
+        // sees one file's worth of assertions at a time however many are left.
+        string[] files = Enumerable.Range(1, 5)
+            .Select(i => workspace.WriteFile("Project" + i + ".gs", "let a = b!!"))
+            .ToArray();
+        var compiler = new FakeCompiler(workspace.Files, FirstFileFrontier);
+
+        NullAssertionPolishPass.PolishLoopOutcome outcome = NullAssertionPolishPass.RunToFixedPoint(
+            compiler.Compile(),
+            compiler.Compile,
+            workspace.Files);
+
+        Assert.False(outcome.CapExhausted);
+        Assert.Equal(0, outcome.RemainingReports);
+        Assert.Equal(5, outcome.Rounds);
+        Assert.All(files, f => Assert.Equal("let a = b", File.ReadAllText(f).TrimEnd()));
+    }
+
+    [Fact]
+    public void RunToFixedPoint_ReportsTheCapInsteadOfGivingUpSilently()
+    {
+        using var workspace = new PolishWorkspace();
+        workspace.WriteFile("Nested.gs", "let a = b!!.c!!.d!!.e!!");
+        var compiler = new FakeCompiler(workspace.Files, PerLineFrontier);
+
+        NullAssertionPolishPass.PolishLoopOutcome outcome = NullAssertionPolishPass.RunToFixedPoint(
+            compiler.Compile(),
+            compiler.Compile,
+            workspace.Files,
+            strippableRoot: null,
+            maxRounds: 2);
+
+        Assert.True(outcome.CapExhausted);
+        Assert.Equal(2, outcome.Rounds);
+        Assert.Equal(2, outcome.Stripped);
+        Assert.True(outcome.RemainingReports > 0);
+        Assert.False(outcome.Result.Succeeded);
+    }
+
+    [Fact]
+    public void RunToFixedPoint_RestoresAnAssertionTheRecompileTurnsOutToNeed()
+    {
+        using var workspace = new PolishWorkspace();
+        string file = workspace.WriteFile("Needed.gs", "let a = b!!");
+        const string original = "let a = b!!";
+
+        // The first build passed (GS0536 is advisory there), so the polished
+        // build that fails to bind is a regression: the assertion goes back.
+        SdkCompileResult initial = SdkCompileResult.Completed(
+            0,
+            output: null,
+            new[] { Diagnostic(NullAssertionPolishPass.DiagnosticId, "warning", file, 1, 10) },
+            emittedAssemblyPath: "app.dll");
+        var recompiles = 0;
+        SdkCompileResult Recompile()
+        {
+            recompiles++;
+            return SdkCompileResult.Completed(
+                1,
+                output: null,
+                new[] { Diagnostic("GS0400", "error", file, 1, 9) },
+                emittedAssemblyPath: null);
+        }
+
+        NullAssertionPolishPass.PolishLoopOutcome outcome = NullAssertionPolishPass.RunToFixedPoint(
+            initial,
+            Recompile,
+            workspace.Files);
+
+        Assert.Equal(1, recompiles);
+        Assert.Equal(1, outcome.Rounds);
+        Assert.Same(initial, outcome.Result);
+        Assert.Equal(original, File.ReadAllText(file).TrimEnd());
+    }
+
+    [Fact]
+    public void RunToFixedPoint_StopsWhenNothingReportedCanBeStripped()
+    {
+        using var workspace = new PolishWorkspace();
+        string file = workspace.WriteFile("Stale.gs", "let a = b");
+        var recompiles = 0;
+        SdkCompileResult Recompile()
+        {
+            recompiles++;
+            return SdkCompileResult.Completed(0, null, Array.Empty<GscDiagnostic>(), "app.dll");
+        }
+
+        // A span that no longer holds `!!` is skipped rather than applied, so
+        // the loop must end instead of spinning to the cap.
+        SdkCompileResult initial = SdkCompileResult.Completed(
+            1,
+            output: null,
+            new[] { Diagnostic(NullAssertionPolishPass.DiagnosticId, "error", file, 1, 10) },
+            emittedAssemblyPath: null);
+
+        NullAssertionPolishPass.PolishLoopOutcome outcome = NullAssertionPolishPass.RunToFixedPoint(
+            initial,
+            Recompile,
+            workspace.Files);
+
+        Assert.Equal(0, recompiles);
+        Assert.False(outcome.CapExhausted);
+        Assert.Equal(1, outcome.Rounds);
+        Assert.Equal(0, outcome.Stripped);
+        Assert.Equal("let a = b", File.ReadAllText(file).TrimEnd());
+    }
+
+    private static GscDiagnostic Diagnostic(string id, string severity, string file, int line, int column) =>
+        new GscDiagnostic(id, "Redundant '!!'…", severity, file, line, column, line, column + 2);
+
+    // Reports the leftmost `!!` of every line of every file — the stand-in
+    // for gsc reporting one generation at a time: a nested assertion only
+    // becomes visibly redundant once the one outside it is gone.
+    private static IEnumerable<(string File, int Line, int Column)> PerLineFrontier(
+        IReadOnlyList<string> files)
+    {
+        foreach (string file in files)
+        {
+            string[] lines = File.ReadAllLines(file);
+            for (var i = 0; i < lines.Length; i++)
+            {
+                int index = lines[i].IndexOf("!!", StringComparison.Ordinal);
+                if (index >= 0)
+                {
+                    yield return (file, i + 1, index + 1);
+                }
+            }
+        }
+    }
+
+    // Reports every `!!` of the FIRST file that still has one: the shape of a
+    // build that never gets past the project it fails on.
+    private static IEnumerable<(string File, int Line, int Column)> FirstFileFrontier(
+        IReadOnlyList<string> files)
+    {
+        foreach (string file in files)
+        {
+            var reports = new List<(string File, int Line, int Column)>();
+            string[] lines = File.ReadAllLines(file);
+            for (var i = 0; i < lines.Length; i++)
+            {
+                for (int index = lines[i].IndexOf("!!", StringComparison.Ordinal);
+                    index >= 0;
+                    index = lines[i].IndexOf("!!", index + 2, StringComparison.Ordinal))
+                {
+                    reports.Add((file, i + 1, index + 1));
+                }
+            }
+
+            if (reports.Count > 0)
+            {
+                return reports;
+            }
+        }
+
+        return Array.Empty<(string File, int Line, int Column)>();
+    }
+
+    private sealed class FakeCompiler
+    {
+        private readonly IReadOnlyList<string> files;
+        private readonly Func<IReadOnlyList<string>, IEnumerable<(string File, int Line, int Column)>> report;
+
+        public FakeCompiler(
+            IReadOnlyList<string> files,
+            Func<IReadOnlyList<string>, IEnumerable<(string File, int Line, int Column)>> report)
+        {
+            this.files = files;
+            this.report = report;
+        }
+
+        public SdkCompileResult Compile()
+        {
+            IReadOnlyList<GscDiagnostic> diagnostics = this.report(this.files)
+                .Select(r => Diagnostic(NullAssertionPolishPass.DiagnosticId, "error", r.File, r.Line, r.Column))
+                .ToList();
+            return diagnostics.Count == 0
+                ? SdkCompileResult.Completed(0, null, diagnostics, "app.dll")
+                : SdkCompileResult.Completed(1, null, diagnostics, null);
+        }
+    }
+
+    private sealed class PolishWorkspace : IDisposable
+    {
+        private readonly string directory;
+        private readonly List<string> files = new List<string>();
+
+        public PolishWorkspace()
+        {
+            this.directory = Path.Combine(
+                Path.GetTempPath(),
+                nameof(Issue3723PolishConvergenceTests),
+                Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(this.directory);
+        }
+
+        public IReadOnlyList<string> Files => this.files;
+
+        public string WriteFile(string name, params string[] lines)
+        {
+            string path = Path.Combine(this.directory, name);
+            File.WriteAllLines(path, lines);
+            this.files.Add(path);
+            return path;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(this.directory))
+            {
+                Directory.Delete(this.directory, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3723.

## Mechanism

Not span mapping, and not a new `!!` shape the pass fails to recognise — **the loop was iterating, but three rounds is not a fixed point**, for two compounding reasons:

1. **One round per project level.** A compile reports nothing past the first project it fails on. `Cs2Gs.Pipeline` sits four projects deep, so rounds 0–2 were spent stripping `src/Core`, `Cs2Gs.CodeModel` and `Cs2Gs.ProjectLoading`; the budget ran out before the app's own sources were ever bound. That is exactly the shape of the nightly evidence: the app's final `sdk.build.log` from run 33358255571 is a compile of the **unmodified** text (all 476 reported spans still hold `!!` in the migrated artifact), and every one of those spans is gone in the shard's `polished.tar.gz` — a later app in the same shard stripped them as a dependency, after `Cs2Gs.Pipeline` had already been recorded as failed.
2. **Generations.** Stripping one assertion makes a neighbouring one redundant (`project!!.LibraryName!!` → `project.LibraryName!!`), so even a single project needs several rounds.

Both were then invisible because exhausting the budget was silent.

## Change

The loop moves into `NullAssertionPolishPass.RunToFixedPoint`, which iterates until a compile reports no `GS0536` (or a round finds nothing it can strip). The cap rises to 12 and is now only a runaway guard: hitting it, and any `GS0536` still standing when the loop ends, is written to a per-app `polish.log` (uploaded with the shard artifacts) and called out on stderr.

The correctness rule is unchanged and still enforced by the recompile, not assumed: only spans gsc itself reported are deleted, each is verified to hold `!!` first, and a round is kept only when the build that follows it is no worse than the one before — otherwise the round's text is restored and the previous result stands. An assertion the compiler still needs therefore comes back.

## Measured

Local reproduction against the migrated tree from run 33358255571 (`cs2gs validate --app …`, gsc 0.4.338). Before/after are the same tree and the same binaries, only the loop differs.

| app | GS0536 before | after | rounds | assertions stripped |
|---|---:|---:|---:|---:|
| `tools/cs2gs/Cs2Gs.Pipeline` | 476 spans (240 triage artifacts on the nightly) | **0** | 6 | 3267 |
| `tools/cs2gs/Cs2Gs.Cli` | 1 | **0** | 4 | 605 |
| `test/Compiler.Tests` | 1 | **0** | 4 | 386 |

No round hit the cap, and the stripped output binds: every project in each graph compiles through binding afterwards. `tools/cs2gs/Cs2Gs.Tests` was not run locally (same code path, and its dependency set is a subset of `Cs2Gs.Cli`'s).

**These apps are not all green yet.** With the `GS0536` wall gone, two blockers it had been masking become visible, and neither is caused by the extra strips:

- `Cs2Gs.Pipeline` and `Cs2Gs.Cli` → `GS9997` "Could not find assembly 'Microsoft.Build.Locator'": a transitive `PackageReference` (through `Cs2Gs.ProjectLoading`) that does not reach gsc's reference set. The package is restored; it just is not passed.
- `Compiler.Tests` → `GS0227` in `src/Repl`, a dependency that is independently red on the nightly.

So the expected gate movement is "at least `Cs2Gs.Tests`, plus whatever those two follow-ups unblock", not the full 39 → 43 the issue projected. The `GS0536`-only failure mode itself is gone.

## Tests

`tools/cs2gs/Cs2Gs.Tests/Issue3723PolishConvergenceTests.cs` drives the loop with a stand-in compiler, so both shapes are covered without a real `dotnet build`:

- four nested assertions on one line, reported one generation per compile — converges in four rounds, past the old budget;
- five files reported one at a time (the "stops at the first failing project" shape) — converges in five rounds;
- the cap is reported rather than swallowed;
- a recompile that regresses puts the assertion back;
- a stale span that no longer holds `!!` ends the loop instead of spinning it.

Existing coverage kept green: `Issue3501NullAssertionPolishPassTests` (5) and the three SDK-backed pipeline tests that depend on the polish pass stripping emitted forgiveness (`Issue2412`, `Issue2514`, `Issue2521`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
