### PR TITLE
gsc: TypeRefs are scoped to the compilation's reference closure, not the host runtime (#3718)

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
+++ b/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
@@ -595,11 +595,89 @@ internal sealed class ImportedMemberRefFactory
             || fullName == "System.Collections.Generic.IAsyncEnumerator`1";
     }
 
+    /// <summary>
+    /// Issue #3718: projects a host-runtime <see cref="Type"/> — one produced by
+    /// a compiler-internal <c>typeof(...)</c> rather than resolved from the
+    /// compilation's references — onto the equivalent type from
+    /// <paramref name="references"/>, so its TypeRef is scoped to the reference
+    /// closure's contract assembly instead of the hosting runtime's
+    /// implementation assembly.
+    /// </summary>
+    /// <remarks>
+    /// Returns <see langword="false"/> — leaving the caller on the host identity
+    /// — whenever projection is unnecessary or impossible: the type already came
+    /// from a <see cref="System.Reflection.MetadataLoadContext"/> (reflection-only
+    /// assemblies are by construction inside the closure), the resolver has no
+    /// load context at all (the in-process/TPA path, where the host type *is* the
+    /// reference type), the type is a shape with no resolvable full name
+    /// (generic parameter, array/byref/pointer, constructed generic — those are
+    /// projected element-wise by their own encoders), or the references simply do
+    /// not carry the type.
+    /// </remarks>
+    /// <param name="references">The compilation's reference resolver.</param>
+    /// <param name="type">The candidate host type.</param>
+    /// <param name="projected">The reference-set type, when one was found.</param>
+    /// <returns><see langword="true"/> when <paramref name="projected"/> was set.</returns>
+    private static bool TryProjectOntoReferences(
+        ReferenceResolver references,
+        Type type,
+        [NotNullWhen(true)] out Type? projected)
+    {
+        projected = null;
+
+        if (type.Assembly.ReflectionOnly
+            || type.IsGenericParameter
+            || type.HasElementType
+            || type.IsConstructedGenericType)
+        {
+            return false;
+        }
+
+        if (type.FullName is not { Length: > 0 } fullName)
+        {
+            return false;
+        }
+
+        if (!references.TryResolveType(fullName, requireExternalVisibility: false, out var resolved)
+            || ReferenceEquals(resolved, type))
+        {
+            return false;
+        }
+
+        // A non-reflection-only answer means the resolver searched the host's
+        // own runtime assemblies (ReferenceResolver.Default). Projecting there
+        // would be a no-op at best and a cross-identity swap at worst.
+        if (!resolved.Assembly.ReflectionOnly)
+        {
+            return false;
+        }
+
+        projected = resolved;
+        return true;
+    }
+
     internal TypeReferenceHandle GetTypeReference(Type type)
     {
         if (this.cache.TypeRefs.TryGetValue(type, out var existing))
         {
             return existing;
+        }
+
+        // Issue #3718: a lowering or emit site that names a well-known BCL type
+        // with a host `typeof(...)` hands us a *runtime* Type whose assembly is
+        // whichever corlib happens to be hosting gsc (System.Private.CoreLib).
+        // Scoping the TypeRef to that assembly leaks an implementation-assembly
+        // AssemblyRef into a compilation whose reference closure only ever named
+        // the targeting pack. Project the type onto the compilation's own
+        // reference set first so the row is scoped to the contract assembly that
+        // actually declares it. The host type remains the fallback for the
+        // in-process/TPA path, where the resolver has no MetadataLoadContext and
+        // the host identity is already the right one.
+        if (TryProjectOntoReferences(this.emitCtx.References, type, out var projected))
+        {
+            var projectedHandle = this.GetTypeReference(projected);
+            this.cache.TypeRefs[type] = projectedHandle;
+            return projectedHandle;
         }
 
         // Nested types: resolution scope is the TypeRef of the declaring type,

--- a/test/Compiler.Tests/LanguageConformance/DifferentialReferenceClosureTests.cs
+++ b/test/Compiler.Tests/LanguageConformance/DifferentialReferenceClosureTests.cs
@@ -59,18 +59,6 @@ public class DifferentialReferenceClosureTests
     private const string ContractCorlib = "System.Runtime";
 
     /// <summary>
-    /// The reason shared by every <see cref="KnownRefPackCorlibLeaks"/> entry:
-    /// compiler-synthesised references to well-known BCL types (the
-    /// interpolation handler, the async state-machine plumbing, record
-    /// <c>ToString</c>/<c>GetHashCode</c> helpers, the variadic
-    /// <c>System.Array</c> path, …) are resolved with a host <c>typeof</c>
-    /// rather than through the compilation's reference closure, so the emitted
-    /// assembly names the implementation corlib.
-    /// </summary>
-    private const string Issue3718 =
-        "#3718 — synthesised well-known-type reference resolved through the host runtime";
-
-    /// <summary>
     /// The per-PR subset: samples whose codegen goes through imported types in
     /// the ways this defect family attacks — <c>for … in</c> over an imported
     /// enumerable (the #3708 shape), imported delegates and events (#3697),
@@ -108,80 +96,24 @@ public class DifferentialReferenceClosureTests
     /// <summary>
     /// Samples whose ref-pack compile still emits an <c>AssemblyRef</c> to
     /// <c>System.Private.CoreLib</c>, keyed by file with the reason — the
-    /// #3716 guard-rail idiom again. Every entry here is a <b>known defect</b>
-    /// (#3718), not an accepted behaviour; the list is a burn-down, and the
-    /// assertion fails in <em>both</em> directions — an unlisted leak and a
-    /// listed sample that has stopped leaking — so fixing a lowering site
-    /// forces the corresponding entries out.
+    /// #3716 guard-rail idiom again. Every entry here is a <b>known defect</b>,
+    /// not an accepted behaviour; the list is a burn-down, and the assertion
+    /// fails in <em>both</em> directions — an unlisted leak and a listed sample
+    /// that has stopped leaking — so fixing a lowering site forces the
+    /// corresponding entries out.
+    /// <para>
+    /// The list is <b>empty</b>: #3718 burned down all 65 original entries at
+    /// once, because every leak funnelled through the single
+    /// <c>ImportedMemberRefFactory.GetTypeReference(Type)</c> row producer,
+    /// which now projects a host <c>typeof</c> onto the compilation's reference
+    /// closure before choosing the TypeRef's resolution scope. It stays here as
+    /// a burn-down, not as dead code: a new lowering site that names a
+    /// well-known type in a way the projection cannot see re-populates it.
+    /// </para>
     /// </summary>
     private static readonly Dictionary<string, string> KnownRefPackCorlibLeaks =
         new(StringComparer.Ordinal)
         {
-            ["AddressBook.gs"] = Issue3718,
-            ["AnonymousVariadicFunctionType.gs"] = Issue3718,
-            ["ArrowFunctionTypeClause.gs"] = Issue3718,
-            ["AsyncAwaitInLoop.gs"] = Issue3718,
-            ["AsyncAwaitInNestedLoop.gs"] = Issue3718,
-            ["AsyncClassMethod.gs"] = Issue3718,
-            ["AsyncGoScopeJoin.gs"] = Issue3718,
-            ["AsyncMultiAwaitInLoop.gs"] = Issue3718,
-            ["AsyncTask.gs"] = Issue3718,
-            ["AsyncValueReturns.gs"] = Issue3718,
-            ["Channels.gs"] = Issue3718,
-            ["CountWords.gs"] = Issue3718,
-            ["DataStruct.gs"] = Issue3718,
-            ["DataStructErgonomics.gs"] = Issue3718,
-            ["DefaultExpression.gs"] = Issue3718,
-            ["DefaultInterfaceMethods.gs"] = Issue3718,
-            ["DiscriminatedUnion.gs"] = Issue3718,
-            ["Exhaustiveness.gs"] = Issue3718,
-            ["ExpressionEval.gs"] = Issue3718,
-            ["GenericMethodUserTypeArg.gs"] = Issue3718,
-            ["GenericNamedDelegate.gs"] = Issue3718,
-            ["GenericTypeParameterAsTypeArgument.gs"] = Issue3718,
-            ["GoBuiltinsGated.gs"] = Issue3718,
-            ["GoChannelsGated.gs"] = Issue3718,
-            ["GoScope.gs"] = Issue3718,
-            ["GsharpExtensionsMixed.gs"] = Issue3718,
-            ["GsharpExtensionsOptional.gs"] = Issue3718,
-            ["GsharpExtensionsSequences.gs"] = Issue3718,
-            ["IfLetGuardLet.gs"] = Issue3718,
-            ["InterfaceUpcast.gs"] = Issue3718,
-            ["InterpolatedString.gs"] = Issue3718,
-            ["InterpolatedStringFormat.gs"] = Issue3718,
-            ["InterpolatedStringFormattable.gs"] = Issue3718,
-            ["InterpolatedStringRichHoles.gs"] = Issue3718,
-            ["Loop.gs"] = Issue3718,
-            ["MapForIn.gs"] = Issue3718,
-            ["NamedArguments.gs"] = Issue3718,
-            ["NamedTupleElements.gs"] = Issue3718,
-            ["NullableFlow.gs"] = Issue3718,
-            ["NullCoalescingAssignment.gs"] = Issue3718,
-            ["ParenthesizedReceiver.gs"] = Issue3718,
-            ["Patterns.gs"] = Issue3718,
-            ["PatternSwitch.gs"] = Issue3718,
-            ["PInvokeLibraryImport.gs"] = Issue3718,
-            ["PInvokeLibraryImportStringReturn.gs"] = Issue3718,
-            ["PortScan.gs"] = Issue3718,
-            ["PrimaryCtorVariadic.gs"] = Issue3718,
-            ["Records.gs"] = Issue3718,
-            ["ReifiedGenerics.gs"] = Issue3718,
-            ["Sealed.gs"] = Issue3718,
-            ["Select.gs"] = Issue3718,
-            ["SliceLinqUntypedLambda.gs"] = Issue3718,
-            ["SlicePattern.gs"] = Issue3718,
-            ["SpanComprehensive.gs"] = Issue3718,
-            ["SwitchExpression.gs"] = Issue3718,
-            ["TupleArrowElements.gs"] = Issue3718,
-            ["TupleEquality.gs"] = Issue3718,
-            ["TupleSequenceIterators.gs"] = Issue3718,
-            ["UserRefStruct.gs"] = Issue3718,
-            ["ValueTypeObjectMethods.gs"] = Issue3718,
-            ["Variadic.gs"] = Issue3718,
-            ["VariadicDelegate.gs"] = Issue3718,
-            ["VariadicMethods.gs"] = Issue3718,
-            ["WhileAndLabeledLoops.gs"] = Issue3718,
-            ["ZeroValues.gs"] = Issue3718,
         };
 
     public static IEnumerable<object[]> DifferentialSamples()

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue3718TypeRefScopeFunnelGuardTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue3718TypeRefScopeFunnelGuardTests.cs
@@ -1,0 +1,155 @@
+// <copyright file="Issue3718TypeRefScopeFunnelGuardTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #3718, the TypeRef-resolution-scope funnel's guard rail — the sibling
+/// of <c>Issue3705LoadContextFunnelGuardTests</c>. That one forbids
+/// <em>comparing</em> against a live host <c>typeof</c>; this one keeps the
+/// compiler from <em>emitting</em> one.
+/// <para>
+/// A compiler-internal <c>typeof(X)</c> yields a runtime <see cref="Type"/>
+/// whose assembly is whichever corlib hosts gsc. Turning that type into a
+/// <c>TypeRef</c> row scoped to <c>type.Assembly</c> writes an
+/// <c>AssemblyRef</c> to <c>System.Private.CoreLib</c> into an assembly whose
+/// reference closure only ever named the targeting pack — 65 of the 128
+/// conformance samples did exactly that before #3718. The defect is invisible
+/// to an IL comparison (the opcode stream is unchanged) and to the build (the
+/// row is well-formed), so the only durable protection is structural: exactly
+/// one place in the compiler may write a <c>TypeRef</c> or an
+/// <c>AssemblyRef</c>, and that place projects the type onto the compilation's
+/// reference closure first.
+/// </para>
+/// </summary>
+public class Issue3718TypeRefScopeFunnelGuardTests
+{
+    /// <summary>
+    /// The sole sanctioned producer of <c>TypeRef</c> / <c>AssemblyRef</c>
+    /// rows: <c>ImportedMemberRefFactory.GetTypeReference(Type)</c> projects a
+    /// host type onto <c>EmitContext.References</c> before choosing the row's
+    /// resolution scope, and <c>GetAssemblyReference</c> is reached only from
+    /// there. A second producer would bypass the projection.
+    /// </summary>
+    private static readonly Dictionary<string, string> AllowedFiles = new(StringComparer.Ordinal)
+    {
+        ["src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs"] =
+            "#3718 — the funnel itself: projects host types onto the reference closure before scoping the row",
+    };
+
+    private static readonly string[] ScannedRoots = new[]
+    {
+        "src/Core/CodeAnalysis/Binding",
+        "src/Core/CodeAnalysis/Lowering",
+        "src/Core/CodeAnalysis/Emit",
+        "src/Core/CodeAnalysis/Symbols",
+    };
+
+    private static readonly Regex ForbiddenPattern = new(
+        @"\.\s*Add(Type|Assembly)Reference\s*\(",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// Fails when a <c>TypeRef</c> or <c>AssemblyRef</c> row is written
+    /// anywhere but the funnel.
+    /// </summary>
+    [Fact]
+    public void No_TypeRef_Or_AssemblyRef_Rows_Outside_The_Funnel()
+    {
+        var repoRoot = LocateRepoRoot();
+        var offenders = new List<string>();
+
+        foreach (var root in ScannedRoots)
+        {
+            var rootDir = Path.Combine(repoRoot, root);
+            if (!Directory.Exists(rootDir))
+            {
+                continue;
+            }
+
+            foreach (var file in Directory.EnumerateFiles(rootDir, "*.cs", SearchOption.AllDirectories))
+            {
+                var relative = Path.GetRelativePath(repoRoot, file).Replace('\\', '/');
+                if (AllowedFiles.ContainsKey(relative))
+                {
+                    continue;
+                }
+
+                var lines = File.ReadAllLines(file);
+                for (var i = 0; i < lines.Length; i++)
+                {
+                    var code = StripCommentAndStrings(lines[i]);
+                    if (ForbiddenPattern.IsMatch(code))
+                    {
+                        offenders.Add($"{relative}:{i + 1}: {lines[i].Trim()}");
+                    }
+                }
+            }
+        }
+
+        Assert.True(
+            offenders.Count == 0,
+            "A TypeRef / AssemblyRef row is written outside ImportedMemberRefFactory (issue #3718).\n"
+                + "Rows created elsewhere skip the projection of host `typeof` types onto the\n"
+                + "compilation's reference closure, which leaks a System.Private.CoreLib AssemblyRef\n"
+                + "into ref-pack builds. Route through ImportedMemberRefFactory.GetTypeReference, or\n"
+                + "add the file to AllowedFiles with a reason:\n  "
+                + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>
+    /// The funnel must keep doing the projection: a rewrite that drops the
+    /// call turns this whole guard into a no-op that still passes.
+    /// </summary>
+    [Fact]
+    public void The_Funnel_Still_Projects_Onto_The_Reference_Closure()
+    {
+        var repoRoot = LocateRepoRoot();
+        var funnel = Path.Combine(repoRoot, "src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs");
+        Assert.True(File.Exists(funnel), $"the funnel moved: {funnel} does not exist");
+
+        var text = File.ReadAllText(funnel);
+        Assert.Contains("TryProjectOntoReferences", text, StringComparison.Ordinal);
+        Assert.Contains("TryResolveType", text, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Removes line comments and string literals so the pattern only matches
+    /// code position — doc comments naming the forbidden idiom (there are
+    /// several) must not trip it.
+    /// </summary>
+    /// <param name="line">The source line.</param>
+    /// <returns>The line with comment / literal text blanked out.</returns>
+    private static string StripCommentAndStrings(string line)
+    {
+        var trimmed = line.TrimStart();
+        if (trimmed.StartsWith("//", StringComparison.Ordinal)
+            || trimmed.StartsWith("*", StringComparison.Ordinal))
+        {
+            return string.Empty;
+        }
+
+        var commentIndex = line.IndexOf("//", StringComparison.Ordinal);
+        var code = commentIndex >= 0 ? line.Substring(0, commentIndex) : line;
+        return Regex.Replace(code, "\"[^\"]*\"", "\"\"");
+    }
+
+    private static string LocateRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !File.Exists(Path.Combine(dir.FullName, "GSharp.sln")))
+        {
+            dir = dir.Parent;
+        }
+
+        Assert.True(dir != null, "could not locate the repository root (GSharp.sln)");
+        return dir!.FullName;
+    }
+}


### PR DESCRIPTION
Fixes #3718.

## The defect

65 of the 128 single-file conformance samples, compiled **entirely against
the `Microsoft.NETCore.App.Ref` targeting pack**, still emitted an
`AssemblyRef` row for `System.Private.CoreLib`. Every such row came from a
compiler-internal `typeof(X)` — a host runtime `Type` whose `Assembly` is
whichever corlib happens to be hosting gsc — handed to the TypeRef producer
and used verbatim as the row's resolution scope.

It is invisible to the #3717 IL differential (that comparison normalises
assembly identity away) and invisible to the build (the row is well-formed).
Only the non-vacuity guard the same suite added could see it.

## The fix: one funnel, not 30 sites

The issue's aggregate — `DefaultInterpolatedStringHandler` ×28,
`System.Exception` ×14, `System.String` ×12, `Task`/`TaskAwaiter`/`Int32` ×9
each, and ~25 more — reads like a list of lowering sites. It is not.
`ImportedMemberRefFactory.GetTypeReference(Type)` is the **sole** producer of
`TypeRef` and `AssemblyRef` rows in the compiler (verified: no other
`AddTypeReference` / `AddAssemblyReference` call exists in `src/`), so every
leaking type flowed through that one method.

It now projects a host type onto `EmitContext.References` by full name — the
existing `ReferenceResolver.TryResolveType(fullName, requireExternalVisibility: false, …)`
machinery, the same call `EmitContext.ResolveCoreType` already uses — before
choosing the resolution scope, so the row names the contract assembly that
actually declares the type. This generalises the hand-maintained
`IsCoreLibBaseType` name list (#242/#806), which routed a fixed set of corlib
types through `System.Runtime` for exactly this reason and had to be extended
by hand each time a new one surfaced.

Projection is skipped — leaving the host identity untouched — whenever it is
unnecessary or impossible:

- the type is already reflection-only (it came from the compilation's
  `MetadataLoadContext`, so it is by construction inside the closure);
- the resolver answers with a non-reflection-only type, meaning it searched
  the host's own runtime assemblies (`ReferenceResolver.Default` — the
  in-process/TPA path the conformance harness's first mode and the
  interpreter use, where the host type *is* the reference type);
- the type is a shape with no resolvable full name (generic parameter,
  array/byref/pointer, constructed generic) — those are projected
  element-wise by their own encoders.

The `InterpolatedStringHandlerLowerer.HandlerType` host `typeof` named in the
issue is left in place: it no longer reaches metadata, and rebinding the
lowerer's member lookups (`AppendLiteral`, `AppendFormatted<T>`, …) onto the
target framework's shape is the separate cross-targeting concern the issue's
third bullet describes. Worth its own issue; not needed to close the
AssemblyRef leak.

## Verification

- **All 65 `KnownRefPackCorlibLeaks` entries removed** — the burn-down goes
  to zero. The full corpus under `GSHARP_DIFFERENTIAL_CONFORMANCE=1` is
  **130/130 green with the list empty**, so all three differential levels
  hold: (a) diagnostics, (b) normalised IL, (c) runtime output — plus the
  `AssemblyRef` closure assertion, which fails in both directions.
- **`Samples_EmittedPE_Match_Baseline` did not move.** No regeneration, no
  audit needed: the baseline compiles in-process, where the resolver has no
  `MetadataLoadContext` and the new path is a no-op by construction. This is
  why the skip conditions above are worth their length.
- Manual repro from the issue is clean: `ZeroValues.dll` built against the
  ref pack now carries `System.Runtime` and `System.Console` and nothing
  else — no `System.Private.CoreLib`, and no `mscorlib`/`netstandard` facade
  substituted in its place (the resolver follows type forwarders to the
  defining assembly).
- Core.Tests 8467/8467, Compiler.Tests 4585/4585, Sdk.Tests 82/82,
  `sdk-e2e.sh` and `foreign-cs-e2e.sh` PASS.

## Guard rail

`Issue3718TypeRefScopeFunnelGuardTests` is the sibling the issue asks for:
#3716 forbids *comparing* against a live `typeof`, this forbids *emitting*
one. The "a host `typeof` reaches metadata" shape is not syntactically
expressible, but the structural invariant that makes it impossible is: it
fails the build on a `TypeRef`/`AssemblyRef` row written anywhere but the
funnel, and — so the guard cannot decay into a no-op that still passes — on a
funnel that has stopped projecting.

`KnownRefPackCorlibLeaks` stays as an empty burn-down rather than being
deleted, so a future lowering site that names a well-known type in a way the
projection cannot see re-populates it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
