### PR TITLE
cs2gs + gsc: a base class subclassed only from a referencing project (#3724 family A)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
@@ -2644,13 +2644,7 @@ internal sealed partial class ExpressionBinder
             return new BoundErrorExpression(null);
         }
 
-        var boundArguments = ImmutableArray.CreateBuilder<BoundExpression>(ce.Arguments.Count);
-        foreach (var argument in ce.Arguments)
-        {
-            boundArguments.Add(BindExpression(OverloadResolver.UnwrapNamedArgumentValue(argument)));
-        }
-
-        var arguments = boundArguments.ToImmutable();
+        var arguments = BindBaseCallArguments(ce);
         var method = overloads.SelectInstanceOverloadOrReport(baseOverloads, arguments, ce, methodName, argumentNames);
         if (method == null)
         {
@@ -2689,6 +2683,44 @@ internal sealed partial class ExpressionBinder
     }
 
     /// <summary>
+    /// Issue #3724: binds the argument list of a <c>base.M(args)</c> call.
+    /// <para>
+    /// Both base-call paths used to bind every argument with the plain
+    /// <c>BindExpression</c>, which has no <c>ref</c>/<c>out</c> arm —
+    /// it reaches the "an inline out declaration is only allowed at an out
+    /// parameter position" guard (GS0236) and answers a bound error. That error
+    /// then failed overload resolution, so a user base call surfaced GS0130 and
+    /// an imported base call surfaced GS0384 ("does not declare an accessible
+    /// method"), each followed by a GS0238 definite-assignment cascade on the
+    /// caller's own <c>out</c> parameter. Every other call site in the binder
+    /// routes a <see cref="RefArgumentExpressionSyntax"/> through
+    /// <see cref="BindRefArgumentExpression"/>; base calls now do the same.
+    /// </para>
+    /// <para>
+    /// The parameter is not known during this first pass (the overload is picked
+    /// from the resulting argument types), so inline <c>out var</c>/<c>out let</c>
+    /// payloads bind against their declared type and are patched up by the shared
+    /// instance-call pipeline afterwards — exactly as in
+    /// <c>OverloadResolver.BindCallExpression</c>.
+    /// </para>
+    /// </summary>
+    /// <param name="ce">The method-call syntax whose arguments to bind.</param>
+    /// <returns>The bound arguments, in source order.</returns>
+    private ImmutableArray<BoundExpression> BindBaseCallArguments(CallExpressionSyntax ce)
+    {
+        var boundArguments = ImmutableArray.CreateBuilder<BoundExpression>(ce.Arguments.Count);
+        foreach (var argument in ce.Arguments)
+        {
+            var argSyntax = OverloadResolver.UnwrapNamedArgumentValue(argument);
+            boundArguments.Add(argSyntax is RefArgumentExpressionSyntax refArgument
+                ? BindRefArgumentExpression(refArgument, parameter: null)
+                : BindExpression(argSyntax));
+        }
+
+        return boundArguments.ToImmutable();
+    }
+
+    /// <summary>
     /// Issue #1260: binds a <c>base.M(args)</c> call into an imported/BCL base
     /// class. Resolves the overload set against <paramref name="clrBase"/>
     /// (which walks the CLR base chain), runs the shared imported-instance
@@ -2723,13 +2755,7 @@ internal sealed partial class ExpressionBinder
             return true;
         }
 
-        var boundArguments = ImmutableArray.CreateBuilder<BoundExpression>(ce.Arguments.Count);
-        foreach (var argument in ce.Arguments)
-        {
-            boundArguments.Add(BindExpression(OverloadResolver.UnwrapNamedArgumentValue(argument)));
-        }
-
-        var arguments = boundArguments.ToImmutable();
+        var arguments = BindBaseCallArguments(ce);
         if (function?.ThisParameter is not { } thisParameter)
         {
             return false;

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3724BaseCallOutArgumentTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3724BaseCallOutArgumentTests.cs
@@ -1,0 +1,103 @@
+// <copyright file="Issue3724BaseCallOutArgumentTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #3724: <c>base.M(..., out x)</c> did not bind. Both base-call paths
+/// (<c>BindBaseClassCall</c> for a G# base, <c>TryBindBaseClrInstanceCall</c>
+/// for an imported one) bound every argument with the plain expression binder,
+/// which has no <c>ref</c>/<c>out</c> arm — the argument hit the GS0236 guard
+/// and bound to an error, overload resolution then failed with GS0130/GS0384,
+/// and the caller's own <c>out</c> parameter cascaded into GS0238.
+///
+/// Found in migrated <c>test/LanguageServer.Tests</c>, whose
+/// <c>ThrowingDocumentContentService.TryGet</c> forwards to
+/// <c>base.TryGet(key, out content)</c>.
+/// </summary>
+public class Issue3724BaseCallOutArgumentTests
+{
+    [Fact]
+    public void BaseCall_ForwardsOutArgument()
+    {
+        var source = @"
+open class Store {
+    open func TryGet(key string, out value string) bool {
+        value = key + ""!""
+        return true
+    }
+}
+
+class Logging() : Store {
+    override func TryGet(key string, out value string) bool {
+        return base.TryGet(key, out value)
+    }
+}
+
+var s = Logging()
+var ok = s.TryGet(""a"", out var found)
+found
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("a!", result.Value);
+    }
+
+    [Fact]
+    public void BaseCall_ForwardsInlineOutDeclaration()
+    {
+        var source = @"
+open class Store {
+    open func TryGet(key string, out value string) bool {
+        value = key + ""!""
+        return true
+    }
+}
+
+class Logging() : Store {
+    override func TryGet(key string, out value string) bool {
+        let ok = base.TryGet(key, out var inner)
+        value = inner + ""?""
+        return ok
+    }
+}
+
+var s = Logging()
+var ok = s.TryGet(""a"", out var found)
+found
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("a!?", result.Value);
+    }
+
+    [Fact]
+    public void BaseCall_ForwardsRefArgument()
+    {
+        var source = @"
+open class Store {
+    open func Bump(ref value int32) int32 {
+        value = value + 1
+        return value
+    }
+}
+
+class Logging() : Store {
+    override func Bump(ref value int32) int32 {
+        return base.Bump(ref value) + 100
+    }
+}
+
+var s = Logging()
+var n = 1
+s.Bump(ref n)
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(102, result.Value);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3724CrossProjectVirtualOpennessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3724CrossProjectVirtualOpennessTranslationTests.cs
@@ -1,0 +1,109 @@
+// <copyright file="Issue3724CrossProjectVirtualOpennessTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3724: openness was inferred from <c>CollectSubclassedBaseTypes</c>,
+/// which only walks the CURRENT project's assembly. A base class whose only
+/// subclass lives in a referencing project — <c>src/LanguageServer</c>'s
+/// <c>DocumentContentService</c>, derived by <c>test/LanguageServer.Tests</c>'s
+/// <c>ThrowingDocumentContentService</c> — was therefore emitted as a plain
+/// (CLR-sealed) <c>class</c> whose <c>virtual</c> members lost <c>open</c>, and
+/// the derived project failed to compile with GS0157 on the base clause plus
+/// GS0183 on the <c>override</c>.
+///
+/// A C# <c>virtual</c>/<c>abstract</c> member on a non-sealed type states the
+/// inheritance intent outright, so the translator now carries it across the
+/// assembly boundary instead of re-deriving it from in-project subclasses.
+/// </summary>
+public class Issue3724CrossProjectVirtualOpennessTranslationTests
+{
+    /// <summary>
+    /// The shape of <c>DocumentContentService</c>: a public, non-sealed, concrete
+    /// class with a <c>virtual</c> method and NO subclass anywhere in its own
+    /// assembly.
+    /// </summary>
+    private const string VirtualWithoutLocalSubclass = @"
+namespace Corpus.Issue3724
+{
+    public class ContentService
+    {
+        public virtual bool TryGet(string key, out string? content)
+        {
+            content = key;
+            return true;
+        }
+    }
+
+    public sealed class SealedService
+    {
+        public bool TryGet(string key) => key.Length > 0;
+    }
+
+    public class PlainService
+    {
+        public bool TryGet(string key) => key.Length > 0;
+    }
+}
+";
+
+    [Fact]
+    public void VirtualMemberWithoutLocalSubclass_ForcesOpenClass()
+    {
+        TypeDeclaration service = TranslateType(VirtualWithoutLocalSubclass, "ContentService");
+        Assert.True(service.IsOpen);
+    }
+
+    [Fact]
+    public void VirtualMemberWithoutLocalSubclass_KeepsOpenOnTheMember()
+    {
+        TypeDeclaration service = TranslateType(VirtualWithoutLocalSubclass, "ContentService");
+        MethodDeclaration tryGet = service.Members.OfType<MethodDeclaration>().Single(m => m.Name == "TryGet");
+        Assert.True(tryGet.IsOpen);
+    }
+
+    [Fact]
+    public void VirtualMemberWithoutLocalSubclass_RendersOpenClass()
+    {
+        string rendered = GSharpPrinter.Print(Translate(VirtualWithoutLocalSubclass));
+        Assert.Contains("open class ContentService", rendered, StringComparison.Ordinal);
+        Assert.Contains("open func TryGet", rendered, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ClassWithoutVirtualMembers_StaysClosed()
+    {
+        // The rule keys off declared inheritance intent, not visibility: a class
+        // with nothing overridable must not be widened.
+        Assert.False(TranslateType(VirtualWithoutLocalSubclass, "PlainService").IsOpen);
+        Assert.False(TranslateType(VirtualWithoutLocalSubclass, "SealedService").IsOpen);
+    }
+
+    private static TypeDeclaration TranslateType(string source, string name) =>
+        Translate(source).Members.OfType<TypeDeclaration>().Single(t => t.Name == name);
+
+    private static CompilationUnit Translate(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("ContentService.cs", source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        return new CSharpToGSharpTranslator().TranslateDocument(document, context);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Declarations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Declarations.cs
@@ -567,6 +567,52 @@ public sealed partial class CSharpToGSharpTranslator
         }
 
         /// <summary>
+        /// Issue #3724: returns <see langword="true"/> when <paramref name="type"/>
+        /// declares a <c>virtual</c> or <c>abstract</c> member that another assembly
+        /// could override.
+        /// <para>
+        /// <c>CollectSubclassedBaseTypes</c> only walks
+        /// <c>compilation.Assembly.GlobalNamespace</c>, so a base class whose only
+        /// subclass lives in a *referencing* project — the
+        /// <c>src/LanguageServer</c> / <c>test/LanguageServer.Tests</c> split, and
+        /// every other "the test project derives a fake from the production type"
+        /// pattern — was emitted as a plain (that is, CLR-sealed) <c>class</c> with
+        /// non-<c>open</c> members. The derived project then failed to compile:
+        /// GS0157 on the base clause, GS0183 on the <c>override</c>.
+        /// </para>
+        /// <para>
+        /// A C# author who writes <c>virtual</c> on a non-sealed type has already
+        /// declared the inheritance intent explicitly, so carry that intent across
+        /// the assembly boundary rather than re-deriving it from the in-project
+        /// subclasses that happen to be visible. Only members that are already
+        /// virtual in C# gain <c>open</c> (<see cref="IsMemberEmittedOpen"/> gates on
+        /// the same predicate), so the emitted vtable shape is unchanged.
+        /// </para>
+        /// </summary>
+        private static bool DeclaresOverridableMember(INamedTypeSymbol type)
+        {
+            foreach (ISymbol member in type.GetMembers())
+            {
+                if (member.IsSealed
+                    || member.DeclaredAccessibility == Accessibility.Private
+                    || !(member.IsVirtual || member.IsAbstract))
+                {
+                    continue;
+                }
+
+                switch (member.Kind)
+                {
+                    case SymbolKind.Method:
+                    case SymbolKind.Property:
+                    case SymbolKind.Event:
+                        return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Determines whether <paramref name="type"/> will be emitted as an
         /// <c>open class</c> in G#. Mirrors the class-declaration openness logic in
         /// <see cref="VisitAggregate"/> so member-level <c>open</c> is only emitted
@@ -586,7 +632,9 @@ public sealed partial class CSharpToGSharpTranslator
                 return true;
             }
 
-            return !type.IsSealed && this.subclassedBases.Contains(type.OriginalDefinition);
+            return !type.IsSealed
+                && (this.subclassedBases.Contains(type.OriginalDefinition)
+                    || DeclaresOverridableMember(type));
         }
 
         /// <summary>
@@ -1407,6 +1455,11 @@ public sealed partial class CSharpToGSharpTranslator
                 !symbol.IsStatic &&
                 ((!symbol.IsSealed && this.subclassedBases.Contains(symbol.OriginalDefinition))
                     || HasProtectedMember(symbol)
+
+                    // Issue #3724: a `virtual`/`abstract` member declares inheritance
+                    // intent that `subclassedBases` cannot see when the only subclass
+                    // lives in a referencing project — see DeclaresOverridableMember.
+                    || (!symbol.IsSealed && DeclaresOverridableMember(symbol))
                     || (!symbol.IsSealed && this.efEntityTypes.Contains(symbol.OriginalDefinition)));
 
             // G# has no `abstract` class modifier (the keyword is not recognized by


### PR DESCRIPTION
Family **A** of the [#3724](https://github.com/DavidObando/gsharp/issues/3724) `test/LanguageServer.Tests` triage (#3501 Track C) — 8 of the app's 14 compile errors, from the ordinary "the test project derives a fake from the production type" shape:

```csharp
// src/LanguageServer/DocumentContentService.cs
public class DocumentContentService {
    public virtual bool TryGet(string key, out DocumentContent? content) => …;
}

// test/LanguageServer.Tests/Issue816HandlerExceptionTests.cs
private sealed class ThrowingDocumentContentService : DocumentContentService {
    public override bool TryGet(string key, out DocumentContent content) { …; return base.TryGet(key, out content); }
}
```

Two independent root causes, both required to compile it.

## (a) cs2gs — `open` was inferred from in-assembly subclasses only

`CollectSubclassedBaseTypes` walks `compilation.Assembly.GlobalNamespace`. `DocumentContentService`'s only subclass lives in the *referencing* project, so it was invisible and the base came out as a plain — that is, CLR-**sealed** — class with a non-`open` member:

```
class DocumentContentService {
    func TryGet(key string, out content DocumentContent?) bool { … }
}
```

Minimal two-assembly repro against pre-fix `gsc`:

```
// lib.gs
class Base { func TryGet(key string, out content string?) bool { content = key; return true } }
// app.gs — /r:lib.dll
class Derived : Base { override func TryGet(key string, out content string?) bool { … } }
```
→ `GS0157` on the base clause, `GS0183` on the `override`; marking the base `open class`/`open func` clears both.

The rest of the family is cascade: the erroring base clause error-types `ThrowingDocumentContentService`, which error-types `LspServer(contentService, …)` (`GS0130`), which error-types `server` and turns every `server.XxxAsync(…)` into `GS0159 Cannot find function` — the three reports that look like LSP handler-lookup failures but are not.

A C# author who writes `virtual`/`abstract` on a non-sealed type has stated the inheritance intent outright, so `IsTypeEmittedOpen` and the class-declaration openness now carry that intent across the assembly boundary instead of re-deriving it from the subclasses that happen to share a compilation. Only members already virtual in C# gain `open`, so the emitted vtable shape is unchanged — over the whole 51-app corpus this adds exactly **two** `open class` and **two** `open func`.

Known residual, recorded in #3724: a base with *no* virtual members subclassed only cross-project is still emitted closed. Not present in this corpus; the fully faithful rule ("every non-sealed C# class is an `open` G# class") is a much larger diff and a separate decision.

## (b) gsc — `base.M(…, out x)` never bound its `out` argument

Independent of (a) and reproducible **in a single assembly**:

```
open class Base2 { open func TryGet(key string, out content string?) bool { content = key; return true } }
class Derived2 : Base2 { override func TryGet(key string, out content string?) bool { return base.TryGet(key, out content) } }
```
→ `GS0236` + `GS0238`; cross-assembly the same input adds `GS0384`.

Both base-call paths — `BindBaseClassCall` (G# base) and `TryBindBaseClrInstanceCall` (imported base) — bound every argument with the plain `BindExpression`, which has no `ref`/`out` arm. The argument reached the "an inline out declaration is only allowed at an out parameter position" guard (GS0236) and bound to an error, overload resolution then failed (GS0130 for a user base, GS0384 for an imported one), and the caller's own `out` parameter cascaded into GS0238. Every other call site in the binder routes a `RefArgumentExpressionSyntax` through `BindRefArgumentExpression`; base calls now do the same, via one shared `BindBaseCallArguments` helper.

## Measured

Whole-repo `cs2gs migrate --translate-only`, then `cs2gs validate --app src/Core/Core.csproj --app src/LanguageServer/LanguageServer.csproj --app test/LanguageServer.Tests/LanguageServer.Tests.csproj`, with a full `dotnet build GSharp.sln -c Release -graph` between the two runs so the packed SDK nupkg carries the change:

| | before | after |
|---|---|---|
| `test/LanguageServer.Tests` compile errors | **14** | **6** |
| `src/Core` | PASS / PASS / PASS | PASS / PASS / PASS |
| `src/LanguageServer` | PASS / PASS / PASS | PASS / PASS / PASS |

The 6 that remain are families B, C and D of the triage — #3725, #3726, #3727 — untouched by this PR:

```
GS0159 DocumentSyncHandlerTests.gs:20      Cannot find function DoesNotContain.
GS0159 DocumentSyncHandlerTests.gs:72      Cannot find function Where.
GS0274 ProgramTests.gs:18                  'nil' cannot be assigned to parameter 'tracePath' …
GS0274 ProgramTests.gs:19                  'nil' cannot be assigned to parameter 'expected' …
GS0129 LspServerParityContractTests.gs:100 Binary operator '!=' is not defined for … and 'nil'.
GS0154 LspServerParityContractTests.gs:100 Parameter 'condition' requires a value of type '() -> bool' …
```

Unit tests: `Issue3724CrossProjectVirtualOpennessTranslationTests` (4, cs2gs — including a negative case pinning that a class with nothing overridable stays closed) and `Issue3724BaseCallOutArgumentTests` (3, gsc — `out`, inline `out var`, and `ref` through a base call). Both green; `Issue986BaseClassCallBinderTests` and `Issue2534BaseClassCallBinderTests` stay green alongside them.

Closes the family-A half of #3724.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
