### PR TITLE
cs2gs: an inferred lambda parameter's namespace joins the imported-homonym scan (#3724 family B)

### DIFF
--- a/test/Compiler.Tests/Issue3725ImportedHomonymLambdaParameterTests.cs
+++ b/test/Compiler.Tests/Issue3725ImportedHomonymLambdaParameterTests.cs
@@ -1,0 +1,260 @@
+// <copyright file="Issue3725ImportedHomonymLambdaParameterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GSharp.Compiler.Tests;
+
+/// <summary>
+/// Issue #3725 (#3724 family B): the gsc half of the contract cs2gs must
+/// satisfy. A bare imported type name is resolved by
+/// <c>BoundScope.TryLookupImportedClassByArity</c> with FIRST-IMPORT-WINS and
+/// no ambiguity report, so when two imported packages export the same simple
+/// name the bare spelling silently picks one — and if the picked one is wrong,
+/// the failure surfaces at the enclosing generic call as
+/// <c>GS0159 Cannot find function Where</c> rather than at the name.
+/// <para>
+/// These tests pin both halves against a real two-package reference assembly
+/// emitted by gsc itself: the bare spelling still fails exactly as the
+/// migrated <c>DocumentSyncHandlerTests.gs</c> did, and the package-qualified
+/// spelling cs2gs now emits binds the INTENDED type — asserted by RUNNING the
+/// program, not merely by compiling it, because a lambda that bound the wrong
+/// homonym and still compiled would be worse than the compile error.
+/// </para>
+/// </summary>
+public class Issue3725ImportedHomonymLambdaParameterTests
+{
+    // `Probe.Alpha` sorts before `Probe.Beta`, so a bare `Item` resolves to
+    // the Alpha type — the wrong one for a Beta-typed collection.
+    private const string AlphaLibrary = """
+        package Probe.Alpha
+
+        class Item {
+            var Label string = "alpha"
+        }
+        """;
+
+    private const string BetaLibrary = """
+        package Probe.Beta
+
+        import System.Collections.Generic
+
+        class Item {
+            var Label string
+
+            init(label string) {
+                Label = label
+            }
+        }
+
+        class Holder {
+            shared {
+                func Make() IReadOnlyList[Item] {
+                    let items = List[Item]()
+                    items.Add(Item("beta"))
+                    items.Add(Item("other"))
+                    return items
+                }
+            }
+        }
+        """;
+
+    [Fact]
+    public void BareHomonymLambdaParameter_FailsTheEnclosingGenericCall()
+    {
+        // The pre-#3725 emitted shape. `Item` binds to `Probe.Alpha.Item`, the
+        // `Func[Alpha.Item, bool]` argument cannot unify with the
+        // `IReadOnlyList[Beta.Item]` receiver, and inference fails at `Where`.
+        (int exitCode, string output) = Compile("""
+            package Probe.App
+
+            import System
+            import System.Linq
+            import Probe.Alpha
+            import Probe.Beta
+
+            let items = Holder.Make()
+            let hits = items.Where((d Item) -> d.Label == "beta").ToList()
+            Console.WriteLine(hits.Count)
+            """);
+
+        Assert.True(exitCode != 0, "expected gsc to reject the bare homonym spelling:\n" + output);
+        Assert.Contains("GS0159", output, StringComparison.Ordinal);
+        Assert.Contains("Where", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void QualifiedHomonymLambdaParameter_BindsAndFiltersTheIntendedType()
+    {
+        // The shape cs2gs now emits. Compiling is not enough: the run pins that
+        // the qualified name selected `Probe.Beta.Item` at RUNTIME — the
+        // predicate reads `Beta.Item.Label`, whose values only that type has.
+        string stdout = CompileAndRun("""
+            package Probe.App
+
+            import System
+            import System.Linq
+            import Probe.Alpha
+            import Probe.Beta
+
+            let items = Holder.Make()
+            let hits = items.Where((d Probe.Beta.Item) -> d.Label == "beta").ToList()
+            Console.WriteLine(hits.Count)
+            Console.WriteLine(hits[0].Label)
+            Console.WriteLine(Item().Label)
+            """);
+
+        // One of the two Beta items matches, and its label round-trips — while
+        // the bare `Item` construction still resolves to Alpha, proving the two
+        // homonyms really are both in scope.
+        Assert.Equal(
+            string.Join(Environment.NewLine, "1", "beta", "alpha") + Environment.NewLine,
+            stdout);
+    }
+
+    private static (int ExitCode, string Output) Compile(string appSource)
+    {
+        (int exitCode, string output) = Build(appSource, out string workDir, out _);
+        TryDelete(workDir);
+        return (exitCode, output);
+    }
+
+    private static string CompileAndRun(string appSource)
+    {
+        (int exitCode, string output) = Build(appSource, out string workDir, out string appPath);
+        try
+        {
+            Assert.True(exitCode == 0, "gsc failed:\n" + output);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = workDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(appPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(appPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("failed to start dotnet exec");
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(60_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+            return stdout.ReplaceLineEndings(Environment.NewLine);
+        }
+        finally
+        {
+            TryDelete(workDir);
+        }
+    }
+
+    private static (int ExitCode, string Output) Build(string appSource, out string workDir, out string appPath)
+    {
+        // Two SEPARATE assemblies, matching the shape the migration hits: the
+        // homonyms come from different referenced projects (GSharp.Core and
+        // GSharp.LanguageServer), never from the app's own compilation.
+        workDir = Directory.CreateTempSubdirectory("gs_issue3725_").FullName;
+        string alphaLibPath = Path.Combine(workDir, "Probe.Alpha.dll");
+        string betaLibPath = Path.Combine(workDir, "Probe.Beta.dll");
+        appPath = Path.Combine(workDir, "Probe.App.dll");
+
+        string alphaPath = Path.Combine(workDir, "Alpha.gs");
+        string betaPath = Path.Combine(workDir, "Beta.gs");
+        string appSourcePath = Path.Combine(workDir, "App.gs");
+        File.WriteAllText(alphaPath, AlphaLibrary);
+        File.WriteAllText(betaPath, BetaLibrary);
+        File.WriteAllText(appSourcePath, appSource);
+
+        (int alphaExit, string alphaOutput) = RunGsc(
+            "/out:" + alphaLibPath,
+            "/target:library",
+            references: Array.Empty<string>(),
+            sources: new[] { alphaPath });
+        Assert.True(alphaExit == 0, "Probe.Alpha failed to compile:\n" + alphaOutput);
+
+        (int betaExit, string betaOutput) = RunGsc(
+            "/out:" + betaLibPath,
+            "/target:library",
+            references: Array.Empty<string>(),
+            sources: new[] { betaPath });
+        Assert.True(betaExit == 0, "Probe.Beta failed to compile:\n" + betaOutput);
+
+        return RunGsc(
+            "/out:" + appPath,
+            "/target:exe",
+            references: new[] { alphaLibPath, betaLibPath },
+            sources: new[] { appSourcePath });
+    }
+
+    private static (int ExitCode, string Output) RunGsc(
+        string outSwitch,
+        string targetSwitch,
+        IReadOnlyList<string> references,
+        IReadOnlyList<string> sources)
+    {
+        var args = new List<string>
+        {
+            outSwitch,
+            targetSwitch,
+            "/targetframework:net10.0",
+            "/nowarn:GS9100",
+        };
+
+        foreach (string reference in TrustedPlatformAssemblies())
+        {
+            args.Add("/reference:" + reference);
+        }
+
+        foreach (string reference in references)
+        {
+            args.Add("/reference:" + reference);
+        }
+
+        args.AddRange(sources);
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        TextWriter previousOut = Console.Out;
+        TextWriter previousErr = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            return (Program.Main(args.ToArray()), stdout.ToString() + stderr);
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousErr);
+        }
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+        => ReferenceClosure.TrustedPlatformAssemblies();
+
+    private static void TryDelete(string directory)
+    {
+        try
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3725InferredLambdaParameterHomonymTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3725InferredLambdaParameterHomonymTests.cs
@@ -1,0 +1,183 @@
+// <copyright file="Issue3725InferredLambdaParameterHomonymTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3725 (#3724 family B): a lambda parameter is the one type position
+/// cs2gs manufactures — C# infers it from the delegate target and writes no
+/// name at all, while the canonical G# arrow lambda always spells it
+/// (ADR-0074). The #2222/#3554 homonym check that decides whether a bare type
+/// name is safe consulted a purely SYNTACTIC pre-scan of the file's name
+/// nodes, so a namespace reached only through such an inferred parameter type
+/// was invisible to it even though the translator still synthesized an
+/// <c>import</c> for it.
+/// <para>
+/// In <c>test/LanguageServer.Tests/DocumentSyncHandlerTests.cs</c> that meant
+/// <c>GSharp.Core.CodeAnalysis.Diagnostic</c> and
+/// <c>GSharp.LanguageServer.Protocol.Diagnostic</c> — both reached only
+/// through <c>d =&gt; d.Message…</c> lambdas — both printed bare while both
+/// namespaces were imported. gsc resolves a bare imported type name by
+/// first-import-wins with no ambiguity report, so every Protocol-typed lambda
+/// silently bound the Core type and the enclosing generic call failed
+/// inference with <c>GS0159 Cannot find function DoesNotContain</c>/<c>Where</c>.
+/// </para>
+/// </summary>
+public class Issue3725InferredLambdaParameterHomonymTests
+{
+    /// <summary>
+    /// The referenced-assembly shape: two namespaces declaring the same simple
+    /// type name, reachable from the test file only through inference. Both
+    /// live in METADATA, so the compilation-wide source census
+    /// (<c>HasSourceHomonym</c>) cannot see the collision either.
+    /// </summary>
+    private const string LibrarySource = @"
+using System.Collections.Generic;
+
+namespace Corpus.Issue3725.Core
+{
+    public sealed class Diagnostic { public string Message { get; set; } }
+
+    public sealed class Scope { public IReadOnlyList<Diagnostic> Diagnostics { get; set; } }
+
+    public sealed class Compilation { public Scope GlobalScope { get; set; } }
+}
+
+namespace Corpus.Issue3725.Protocol
+{
+    public sealed class Diagnostic { public string Message { get; set; } }
+}
+
+namespace Corpus.Issue3725.Server
+{
+    public sealed class Result { public IReadOnlyList<Protocol.Diagnostic> Diagnostics { get; set; } }
+
+    public static class Handler
+    {
+        public static Result Compute() => null;
+
+        public static Core.Compilation Bind() => null;
+    }
+}
+";
+
+    private const string HomonymTestsSource = @"
+using System.Linq;
+using Corpus.Issue3725.Server;
+
+namespace Corpus.Issue3725.Tests
+{
+    public class Probe
+    {
+        public void M()
+        {
+            var protocolDiagnostics = Handler.Compute().Diagnostics;
+            var coreDiagnostics = Handler.Bind().GlobalScope.Diagnostics;
+
+            var a = protocolDiagnostics.Where(d => d.Message.Length > 0).ToList();
+            var b = coreDiagnostics.Where(d => d.Message.Length > 0).ToList();
+        }
+    }
+}
+";
+
+    private const string SingleTypeTestsSource = @"
+using System.Linq;
+using Corpus.Issue3725.Server;
+
+namespace Corpus.Issue3725.Tests
+{
+    public class Probe
+    {
+        public void M()
+        {
+            var protocolDiagnostics = Handler.Compute().Diagnostics;
+
+            var a = protocolDiagnostics.Where(d => d.Message.Length > 0).ToList();
+        }
+    }
+}
+";
+
+    [Fact]
+    public void InferredLambdaParameter_QualifiesTheHomonymReachedOnlyThroughInference()
+    {
+        string rendered = Translate(HomonymTestsSource);
+
+        Assert.Contains(
+            "(d Corpus.Issue3725.Protocol.Diagnostic) ->",
+            rendered,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "(d Corpus.Issue3725.Core.Diagnostic) ->",
+            rendered,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void InferredLambdaParameter_LeavesNoBareHomonymSpelling()
+    {
+        // The bare spelling is what gsc silently mis-binds; neither lambda may
+        // keep it once both namespaces are imported.
+        Assert.DoesNotContain("(d Diagnostic) ->", Translate(HomonymTestsSource), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void InferredLambdaParameter_WithoutHomonym_StaysBare()
+    {
+        // Guard rail: the widened pre-scan only ADDS namespaces the homonym
+        // check may consider — a lambda parameter whose type has no same-named
+        // sibling in another imported namespace must still print bare, or the
+        // fix would qualify the whole corpus.
+        string rendered = Translate(SingleTypeTestsSource);
+
+        Assert.Contains("(d Diagnostic) ->", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("Corpus.Issue3725.Protocol.Diagnostic", rendered, StringComparison.Ordinal);
+    }
+
+    private static string Translate(string testsSource)
+    {
+        IReadOnlyList<MetadataReference> runtime = CSharpProjectLoader.RuntimeReferences();
+
+        var library = CSharpCompilation.Create(
+            "Corpus.Issue3725.Library",
+            new[] { CSharpSyntaxTree.ParseText(LibrarySource) },
+            runtime,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using var peStream = new MemoryStream();
+        Microsoft.CodeAnalysis.Emit.EmitResult emit = library.Emit(peStream);
+        Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
+        peStream.Position = 0;
+
+        var references = new List<MetadataReference>(runtime)
+        {
+            MetadataReference.CreateFromStream(peStream),
+        };
+
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Tests.cs", testsSource) },
+            references);
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        return GSharpPrinter.Print(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -1976,6 +1976,12 @@ public sealed class CSharpTypeMapper
     /// the same namespace set the file will actually end up importing,
     /// regardless of visit order.
     /// </para>
+    /// <para>
+    /// Issue #3725 closes the other half of that blindspot: a lambda parameter
+    /// has NO name node at all in C#, yet cs2gs manufactures one, so its
+    /// inferred type's namespaces are collected from the symbol instead of the
+    /// syntax.
+    /// </para>
     /// Cached per mapper instance: one mapper translates one file, so the
     /// import set never changes across calls.
     /// </summary>
@@ -2013,6 +2019,33 @@ public sealed class CSharpTypeMapper
             // one (see the ordering note above).
             foreach (SyntaxNode node in root.DescendantNodes())
             {
+                // Issue #3725: a lambda parameter is the one type position cs2gs
+                // MANUFACTURES. C# infers it from the delegate target and writes
+                // no name at all (`d => d.Message`), while the canonical G# arrow
+                // lambda always spells it (ADR-0074), so `MapLambdaParameter`
+                // maps the inferred symbol, `TrackShortenedNamespace` records its
+                // namespace, and `Translate` synthesizes the matching `import` —
+                // all without a single name node for the scan below to find.
+                // Left out of this set, the homonym check cannot see that import:
+                // two same-named types reached ONLY through inferred lambda
+                // parameters both printed bare, and gsc's first-import-wins
+                // resolution silently bound both to whichever landed first
+                // (`GSharp.Core.CodeAnalysis.Diagnostic` shadowing
+                // `GSharp.LanguageServer.Protocol.Diagnostic`, surfacing as
+                // GS0159 on the enclosing generic call, never as an ambiguity).
+                if (node is AnonymousFunctionExpressionSyntax lambda)
+                {
+                    foreach (ParameterSyntax parameter in EnumerateLambdaParameters(lambda))
+                    {
+                        if (context.SemanticModel.GetDeclaredSymbol(parameter) is IParameterSymbol { Type: { } parameterType })
+                        {
+                            AddReferencedNamespaces(parameterType, names);
+                        }
+                    }
+
+                    continue;
+                }
+
                 if (node is not (NameSyntax or MemberAccessExpressionSyntax))
                 {
                     continue;
@@ -2038,6 +2071,71 @@ public sealed class CSharpTypeMapper
 
         this.importedNamespaceNames = names;
         return names;
+    }
+
+    /// <summary>
+    /// Issue #3725: the parameters an anonymous function declares, whatever
+    /// spelling it uses. A simple lambda (<c>d =&gt; …</c>) carries one bare
+    /// parameter with no list; parenthesized lambdas and anonymous methods
+    /// carry a (possibly absent) list.
+    /// </summary>
+    /// <param name="lambda">The anonymous function to inspect.</param>
+    /// <returns>The declared parameter syntax nodes.</returns>
+    private static IEnumerable<ParameterSyntax> EnumerateLambdaParameters(AnonymousFunctionExpressionSyntax lambda)
+        => lambda switch
+        {
+            SimpleLambdaExpressionSyntax simple => new[] { simple.Parameter },
+            ParenthesizedLambdaExpressionSyntax parenthesized =>
+                (IEnumerable<ParameterSyntax>)parenthesized.ParameterList.Parameters,
+            AnonymousMethodExpressionSyntax anonymousMethod when anonymousMethod.ParameterList != null =>
+                anonymousMethod.ParameterList.Parameters,
+            _ => System.Array.Empty<ParameterSyntax>(),
+        };
+
+    /// <summary>
+    /// Issue #3725: records the namespace of every top-level named type
+    /// <paramref name="type"/> is spelled out of — itself, its enclosing
+    /// type chain, its type arguments, and the element type of an array or
+    /// pointer. An inferred lambda-parameter type has no name nodes of its
+    /// own, so its constituents are unreachable from the syntactic scan and
+    /// have to be walked here instead.
+    /// </summary>
+    /// <param name="type">The type to walk.</param>
+    /// <param name="names">The namespace-name set to add to.</param>
+    private static void AddReferencedNamespaces(ITypeSymbol type, HashSet<string> names)
+    {
+        switch (type)
+        {
+            case IArrayTypeSymbol array:
+                AddReferencedNamespaces(array.ElementType, names);
+                return;
+
+            case IPointerTypeSymbol pointer:
+                AddReferencedNamespaces(pointer.PointedAtType, names);
+                return;
+
+            case INamedTypeSymbol named:
+                INamedTypeSymbol outermost = named;
+                while (outermost.ContainingType != null)
+                {
+                    outermost = outermost.ContainingType;
+                }
+
+                if (outermost.ContainingNamespace is { IsGlobalNamespace: false } ns)
+                {
+                    names.Add(ns.ToDisplayString());
+                }
+
+                foreach (ITypeSymbol argument in named.TypeArguments)
+                {
+                    AddReferencedNamespaces(argument, names);
+                }
+
+                return;
+
+            default:
+                return;
+        }
     }
 
     private static INamespaceSymbol ResolveNamespace(Compilation compilation, string dottedName)


### PR DESCRIPTION
Family **B** of the [#3724](https://github.com/DavidObando/gsharp/issues/3724) `test/LanguageServer.Tests` triage (#3501 Track C) — 2 of the app's remaining errors.

```
GS0159 test/LanguageServer.Tests/DocumentSyncHandlerTests.gs:20  Cannot find function DoesNotContain.
GS0159 test/LanguageServer.Tests/DocumentSyncHandlerTests.gs:72  Cannot find function Where.
```

## Not a fifth site in the inference family

The issue pointed at generic inference, and the shape looks exactly like #3681/#3697, #3667, #3664, #3713. It is none of them, and it is not in the binder at all. gsc's inference is fine; it was handed the **wrong type**.

The emitted file:

```
package GSharp.LanguageServer.Tests

import System.IO
import System.Linq
import Xunit
import GSharp.Core.CodeAnalysis          // <-- Diagnostic
import GSharp.Core.CodeAnalysis.Syntax
import GSharp.LanguageServer
import GSharp.LanguageServer.Protocol    // <-- Diagnostic
import System
…
        Assert.DoesNotContain(
            fastDiagnostics,
            (d Diagnostic) -> d.Message!!.Contains("Not all code paths", StringComparison.Ordinal))
```

Both imported packages export a `Diagnostic`. `BoundScope.TryLookupImportedClassByArity` resolves a bare imported type name **first-import-wins, with no ambiguity report**, so `Diagnostic` bound to `GSharp.Core.CodeAnalysis.Diagnostic` while `fastDiagnostics` is `IReadOnlyList[GSharp.LanguageServer.Protocol.Diagnostic]`. `Func[Core.Diagnostic, bool]` cannot unify with the receiver's element type, inference fails, and the failure is reported at the enclosing generic call as `GS0159 Cannot find function DoesNotContain`/`Where` — never at the name that is actually wrong. That is why every hand-built repro in the issue passed: they all had exactly one `Diagnostic` in scope.

Reproduced end to end before touching anything, two gsc-emitted reference assemblies plus the real ref-pack/xunit closure, exactly two errors and nothing else:

```
probe.gs(14,16): error GS0159: Cannot find function DoesNotContain.
probe.gs(22,14): error GS0159: Cannot find function Where.
```

## Root cause (cs2gs): the homonym scan cannot see a type it never sees spelled

cs2gs already knows this hazard. `QualifiedTypeName` qualifies a bare top-level name when `HasImportedNamespaceHomonym` finds a distinct same-named type in another of the file's imported namespaces (#2222, extended to metadata/metadata pairs in #3554 — for precisely the `GSharp.Core.CodeAnalysis.Syntax.SyntaxFacts` vs Roslyn `SyntaxFacts` case).

That check consults `GetImportedNamespaceNames`, whose pre-scan walks the file's `using` directives, its declared namespace, and every **name node** bound to a top-level type. A lambda parameter has none of those: C# infers its type from the delegate target and writes no name at all (`d => d.Message`), while the canonical G# arrow lambda must spell it (ADR-0074). So `MapLambdaParameter` maps the inferred symbol, `TrackShortenedNamespace` records its namespace, and `Translate` synthesizes the matching `import` — and the homonym check never learns that any of it happened.

In `DocumentSyncHandlerTests.cs` **both** `Diagnostic`s are reached only that way (`d => d.Message…` over `result.Diagnostics` and over `compilation.GlobalScope.Diagnostics`), so both printed bare while both namespaces were imported. Neither is a source type in the test project, so the compilation-wide source census (`HasSourceHomonym`) could not see the collision either.

**Fix:** the pre-scan now also collects the namespaces of every *inferred lambda-parameter type* — from the symbol rather than the syntax, recursing through type arguments and array/pointer element types, since such a type has no sub-nodes to walk. That closes the other half of the ordering blindspot the pre-scan was introduced for. It only ADDS namespaces the homonym check may consider; a name with no same-named sibling in another imported namespace still prints bare (pinned by a negative test), so the corpus is not blanket-qualified.

Now emitted:

```
(d GSharp.LanguageServer.Protocol.Diagnostic) -> d.Message!!.Contains(…)
```

## Known residual (gsc, not fixed here)

gsc reports a cross-package ambiguity for *source-declared* types (`BoundScope.TryResolveCollidingTypeAliasByImport`) but resolves a bare **imported CLR** name first-import-wins and silently. When the two homonyms have compatible members the mis-binding can compile — strictly worse than this issue's error. Deliberately out of scope: making it an error is a language change with corpus-wide blast radius. `Issue3725ImportedHomonymLambdaParameterTests` pins today's behaviour on both sides so the change is a decision, not a drift.

## Tests

- `Cs2Gs.Tests.Issue3725InferredLambdaParameterHomonymTests` (3) — two homonyms in a **metadata** reference assembly reachable only through inferred lambda parameters; both spellings qualified, no bare spelling left, and the no-homonym case still bare. Two fail before this change, all three pass after.
- `Compiler.Tests.Issue3725ImportedHomonymLambdaParameterTests` (2) — two gsc-emitted reference assemblies exporting the same simple name: the bare spelling still fails with `GS0159` at `Where`, and the qualified spelling **runs**, asserting on stdout that the predicate saw `Probe.Beta.Item` (a lambda that bound the wrong homonym and still compiled would be worse than the compile error).

Closes the family-B half of #3724.

## Gate effect (measured, not inferred)

`dotnet build GSharp.sln -c Release -graph` → whole-repo `cs2gs migrate --translate-only` → `cs2gs validate --app src/Core/Core.csproj --app src/LanguageServer/LanguageServer.csproj --app test/LanguageServer.Tests/LanguageServer.Tests.csproj` (the dependency chain has to be in the `--app` list or `src/LanguageServer`'s own `GS0536` flood masks everything). `GS0536` excluded.

| | before (`0.4.341+fc8eaca621`) | after (`0.4.342+6fa8a6d995`) |
|---|---|---|
| `test/LanguageServer.Tests` | **FAIL(6)** | **FAIL(4)** |
| `src/LanguageServer` | PASS / PASS / PASS | PASS / PASS / PASS |
| `src/Core` | PASS / PASS / PASS | PASS / PASS / PASS |

Both family-B errors are gone; the remaining four are exactly families C (#3726/#3727, `GS0274` ×2 in `ProgramTests.gs`) and D (#3732, `GS0129`+`GS0154` in `LspServerParityContractTests.gs`). Whole-repo translation stayed at 51/51 apps.

## Suites

- `Cs2Gs.Tests` — **2576/2576** green (full suite).
- `Compiler.Tests` `~Xunit|~Overload|~Lambda|~Homonym|~ImportedType` — **437/437** green.
- `Core.Tests` `~Invocation|~GenericMethod|~Overload|~Lambda` — **784/784** green.

No emitted-PE baseline moved: the change is translator-side only.

Fixes #3725

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
