### PR TITLE
cs2gs + gsc: [InlineData(null)] taint and nil-comparing a generic imported result (#3724 families C and D)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -1989,6 +1989,20 @@ internal sealed partial class ExpressionBinder
 
     private static bool IsExplicitlyNonNullImportedResult(BoundExpression expression)
     {
+        // Issue #3727: the metadata answer describes the DECLARED return type,
+        // which for a generic method is the open type parameter — `T Read<T>(ref
+        // T location)` carries no nullable annotation there, because its
+        // nullability is supplied by the type argument at each call site. The
+        // binder has already substituted it: `Volatile.Read(&x)` over an `x C?`
+        // really does produce a `C?`, and comparing that against `nil` is the
+        // whole point of the call. So an operand the binder itself typed
+        // nullable is never an "explicitly non-null" result, whatever the open
+        // declaration says.
+        if (expression.Type is NullableTypeSymbol)
+        {
+            return false;
+        }
+
         MethodInfo? method = expression switch
         {
             BoundImportedInstanceCallExpression instanceCall => instanceCall.Method,

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3727GenericImportedResultNilCompareTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3727GenericImportedResultNilCompareTests.cs
@@ -1,0 +1,148 @@
+// <copyright file="Issue3727GenericImportedResultNilCompareTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #3727: <c>Volatile.Read(&amp;x) != nil</c> over a nullable reference
+/// reported <c>GS0129</c>. The nil-comparison table itself was never consulted:
+/// an earlier arm in the binary-operator binder rejects
+/// <c>importedCall == nil</c> when the imported method's METADATA declares a
+/// non-null reference return (so a genuine <c>string</c> result is not
+/// pointlessly compared against nil), and that check asked
+/// <c>ClrNullability.GetReturnTypeSymbol</c> about the DECLARED return type.
+/// For <c>T Read&lt;T&gt;(ref T location)</c> the declared return type is the
+/// open type parameter, which carries no nullable annotation — its nullability
+/// comes from the type argument at the call site. Inference had already
+/// substituted <c>C?</c>, so the binder's own result type was nullable while
+/// the metadata check said "explicitly non-null", and the comparison the call
+/// exists for was rejected. <c>GS0154</c> at the enclosing lambda
+/// (<c>() -&gt; ?</c> against <c>() -&gt; bool</c>) was pure cascade.
+/// </summary>
+public class Issue3727GenericImportedResultNilCompareTests
+{
+    [Fact]
+    public void VolatileRead_OverANullableClass_ComparesAgainstNil()
+    {
+        const string source = @"
+package P
+
+import System.Threading
+
+class Result {
+    var Value int32
+}
+
+func Guard() bool {
+    var r Result? = nil
+    return Volatile.Read(&r) != nil
+}
+";
+        Assert.Empty(GetErrors(source));
+    }
+
+    [Fact]
+    public void VolatileRead_OverANullableString_ComparesAgainstNil()
+    {
+        const string source = @"
+package P
+
+import System.Threading
+
+func Guard() bool {
+    var s string? = nil
+    return Volatile.Read(&s) == nil
+}
+";
+        Assert.Empty(GetErrors(source));
+    }
+
+    [Fact]
+    public void VolatileReadNilCompare_BindsInsideALambdaArgument()
+    {
+        // The reported shape: `await WaitForAsync(() -> Volatile.Read(&x) !=
+        // nil)`. A failed body degraded the lambda to `() -> ?` and cascaded
+        // into GS0154 at the `() -> bool` parameter.
+        const string source = @"
+package P
+
+import System.Threading
+
+class Result {
+    var Value int32
+}
+
+func Wait(condition () -> bool) bool {
+    return condition()
+}
+
+func Guard() bool {
+    var r Result? = nil
+    return Wait(() -> Volatile.Read(&r) != nil)
+}
+";
+        Assert.Empty(GetErrors(source));
+    }
+
+    [Fact]
+    public void AnExplicitlyNonNullImportedResult_StillRejectsANilComparison()
+    {
+        // The guard the fix narrows is otherwise unchanged: a NON-generic
+        // imported member whose metadata declares a non-null reference return
+        // is still not comparable against nil.
+        const string source = @"
+package P
+
+func Guard() bool {
+    return ""abc"".ToUpperInvariant() != nil
+}
+";
+        Assert.Contains(GetErrors(source), d => d.Id == "GS0129");
+    }
+
+    [Fact]
+    public void VolatileReadNilCompare_EvaluatesTheRealNullState()
+    {
+        const string source = @"
+package P
+
+import System.Threading
+
+class Result {
+    var Value int32
+}
+
+func Read(value Result?) bool {
+    var slot = value
+    return Volatile.Read(&slot) != nil
+}
+
+let empty Result? = nil
+(Read(empty), Read(Result()))
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal((false, true), result.Value);
+    }
+
+    private static ImmutableArray<Diagnostic> GetErrors(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree) { IsLibrary = true };
+        return tree.Diagnostics
+            .Concat(compilation.GlobalScope.Diagnostics)
+            .Concat(compilation.BoundProgram.Diagnostics)
+            .Where(d => d.IsError)
+            .ToImmutableArray();
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3726InlineDataNullArgumentTaintTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3726InlineDataNullArgumentTaintTests.cs
@@ -1,0 +1,155 @@
+// <copyright file="Issue3726InlineDataNullArgumentTaintTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3726: a data-driving attribute is a null-WRITING site. An xunit
+/// theory declared <c>[InlineData(null, null)] void T(string a, string b)</c>
+/// really is called with <c>null</c> for both parameters, but the attribute
+/// argument was not part of the taint-source set, so oblivious parameters kept
+/// their non-nullable <c>string</c> rendering while cs2gs emitted
+/// <c>@InlineData(nil, nil)</c> beside them — an internally inconsistent file
+/// gsc correctly rejected (GS0274).
+/// <para>
+/// The repair follows #3706's shape: an attribute-driven, DECLARATION-only
+/// promotion. A <c>null</c> in a positional <c>params object[]</c> data
+/// attribute taints the parameter it lines up with, and the existing edge
+/// machinery carries that taint onward — bridging the emitted <c>nil</c> with
+/// <c>!!</c> instead would convert clean behaviour into a runtime throw.
+/// </para>
+/// </summary>
+public class Issue3726InlineDataNullArgumentTaintTests
+{
+    // A stand-in for xunit's `[InlineData]`: the mechanical shape the rule
+    // keys off is a `params object[]` constructor, not the xunit name.
+    private const string DataAttributeDeclarations = @"
+using System;
+
+namespace Demo
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    public sealed class InlineDataAttribute : Attribute
+    {
+        public InlineDataAttribute(params object[] data)
+        {
+            this.Data = data;
+        }
+
+        public object[] Data { get; }
+    }
+
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class TheoryAttribute : Attribute
+    {
+    }
+}";
+
+    [Fact]
+    public void NullInlineDataArgument_PromotesThePositionallyMatchingParameter()
+    {
+        string printed = Translate(
+            @"
+namespace Demo
+{
+    public class ProgramTests
+    {
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData("""", null)]
+        [InlineData(""  protocol.log  "", ""protocol.log"")]
+        public void GetLogPath(string tracePath, string expected)
+        {
+            System.Console.WriteLine(tracePath);
+            System.Console.WriteLine(expected);
+        }
+    }
+}",
+            out string declarations);
+
+        Assert.Contains("GetLogPath(tracePath string?, expected string?)", printed);
+        TranslationTestValidation.AssertBinds(declarations, printed);
+    }
+
+    [Fact]
+    public void ANonNullInlineDataColumn_LeavesItsParameterNonNullable()
+    {
+        // Only the columns that actually carry a `null` are evidence: the
+        // second parameter is never supplied null, so it must stay `string`.
+        string printed = Translate(
+            @"
+namespace Demo
+{
+    public class ProgramTests
+    {
+        [Theory]
+        [InlineData(null, ""a"")]
+        [InlineData(""b"", ""c"")]
+        public void Check(string maybe, string always)
+        {
+            System.Console.WriteLine(maybe);
+            System.Console.WriteLine(always);
+        }
+    }
+}",
+            out string declarations);
+
+        Assert.Contains("Check(maybe string?, always string)", printed);
+        TranslationTestValidation.AssertBinds(declarations, printed);
+    }
+
+    [Fact]
+    public void ValueTypedColumns_AreNotPromoted()
+    {
+        // `T?` for a value type means `Nullable<T>` — a different declaration
+        // entirely — so the reference-type guard must keep an `int` column out.
+        string printed = Translate(
+            @"
+namespace Demo
+{
+    public class ProgramTests
+    {
+        [Theory]
+        [InlineData(null, 1)]
+        public void Check(string text, int count)
+        {
+            System.Console.WriteLine(text);
+            System.Console.WriteLine(count);
+        }
+    }
+}",
+            out string declarations);
+
+        Assert.Contains("Check(text string?, count int32)", printed);
+        TranslationTestValidation.AssertBinds(declarations, printed);
+    }
+
+    // Returns the printed consumer file, and hands back the printed attribute
+    // declarations too so callers can bind the pair.
+    private static string Translate(string source, out string printedDeclarations)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Attributes.cs", DataAttributeDeclarations), ("Tests.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " + string.Join("\n", project.ErrorDiagnostics));
+
+        printedDeclarations = Print(project, 0);
+        return Print(project, 1);
+    }
+
+    private static string Print(LoadedCSharpProject project, int documentIndex)
+    {
+        LoadedDocument document = project.Documents[documentIndex];
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3726InlineDataNullArgumentTaintTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3726InlineDataNullArgumentTaintTests.cs
@@ -131,6 +131,42 @@ namespace Demo
         TranslationTestValidation.AssertBinds(declarations, printed);
     }
 
+    [Fact]
+    public void ANullDataRowValue_WidensAnArrayLiteralElementInsteadOfBridgingIt()
+    {
+        // The #3704 shape the promotion could otherwise create: the row really
+        // does pass null, and the C# filters it out afterwards, so bridging the
+        // array element with `!!` would throw before the filter ever ran. An
+        // array literal's element type is inferred AT the literal (#3682), so
+        // widening it is the faithful repair.
+        string printed = Translate(
+            @"
+using System.Linq;
+
+namespace Demo
+{
+    public class ProgramTests
+    {
+        [Theory]
+        [InlineData(null, ""/target:library"")]
+        [InlineData(""/optimize+"", ""/target:library"")]
+        public void Check(string flag, string target)
+        {
+            var arguments = new[] { target, flag }
+                .Where(argument => argument is not null)
+                .ToArray();
+            System.Console.WriteLine(arguments.Length);
+        }
+    }
+}",
+            out string declarations);
+
+        Assert.Contains("Check(flag string?, target string)", printed);
+        Assert.Contains("[]string?{", printed);
+        Assert.DoesNotContain("flag!!", printed);
+        TranslationTestValidation.AssertBinds(declarations, printed);
+    }
+
     // Returns the printed consumer file, and hands back the printed attribute
     // declarations too so callers can bind the pair.
     private static string Translate(string source, out string printedDeclarations)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
@@ -870,6 +870,18 @@ public sealed partial class CSharpToGSharpTranslator
                 return true;
             }
 
+            // Issue #3726: a data-driving attribute is a null-WRITING site. An
+            // xunit theory declared `[InlineData(null, …)] void T(string a, …)`
+            // genuinely receives `null` for `a` at runtime, and cs2gs emits the
+            // attribute — `@InlineData(nil, …)` — right beside the parameter
+            // list it renders, so a non-nullable `a` contradicts the file's own
+            // attribute (gsc GS0274). Attribute-driven and therefore decided by
+            // the DECLARATION alone, exactly like `[AllowNull]` above.
+            if (ObliviousNullabilityAnalyzer.HasNullDataRowArgument(symbol))
+            {
+                return true;
+            }
+
             // EF Core treats reference properties from nullable-oblivious C#
             // entity types as optional. Preserve that model when translating
             // DbSet<T> entities; emitting a non-nullable G# property would make

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
@@ -671,13 +671,36 @@ public sealed partial class CSharpToGSharpTranslator
 
             foreach (ExpressionSyntax element in elements)
             {
-                if (element != null && IsNullOrDefaultLiteral(element))
+                if (element != null
+                    && (IsNullOrDefaultLiteral(element) || this.IsNullDataRowRead(element)))
                 {
                     return MakeNullable(elementType);
                 }
             }
 
             return elementType;
+        }
+
+        // Issue #3726: #3682's rule stated for a value that is KNOWN nil rather
+        // than the literal `nil`. A theory parameter a data row supplies `null`
+        // for (`[InlineData(null, …)]`) really does arrive nil on that row, and
+        // the element type is still inferred AT the literal — so widening it is
+        // the same faithful repair #3682 makes. Bridging with `!!` instead is
+        // exactly the "clean C# turned into a runtime throw" that rule rejects:
+        // `new[] { flag, … }.Where(a => a is not null)` deliberately tolerates
+        // the null, and `flag!!` would throw before the filter ever ran.
+        //
+        // Deliberately scoped to that attribute-stated evidence rather than to
+        // every promoted declaration: generalizing it to the whole taint
+        // fixpoint rewrites ~50 files across the corpus (an array literal's
+        // element type is load-bearing for what the literal converts to), which
+        // is its own decision.
+        private bool IsNullDataRowRead(ExpressionSyntax expression)
+        {
+            ISymbol symbol = this.context.GetSymbolInfo(expression).Symbol;
+            return symbol is IParameterSymbol
+                && ObliviousNullabilityAnalyzer.HasNullDataRowArgument(symbol)
+                && this.ShouldPromoteToNullableReference(symbol);
         }
 
         // Issue #914: whether <paramref name="expression"/> is a bare `null` /

--- a/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
@@ -292,6 +292,71 @@ internal static class ObliviousNullabilityAnalyzer
     }
 
     /// <summary>
+    /// Issue #3726: whether <paramref name="symbol"/> is a parameter some
+    /// DATA-DRIVING attribute on its own method supplies <c>null</c> for. An
+    /// xunit theory's <c>[InlineData(null, "x")]</c> states outright that the
+    /// theory really is invoked with <c>null</c> for its first parameter, so
+    /// the parameter is nullable however its type is spelled — and cs2gs emits
+    /// the attribute with a literal <c>nil</c> beside the declaration it
+    /// renders, so leaving the parameter non-nullable makes the two sides of
+    /// one file contradict each other (gsc GS0274).
+    ///
+    /// <para>
+    /// The match is mechanical rather than xunit-specific: an attribute whose
+    /// constructor is a single <c>params</c> array, applied to a method, lines
+    /// its arguments up with that method's parameters positionally — the shape
+    /// every data-row attribute has. <c>[MemberData]</c>/<c>[ClassData]</c>
+    /// carry no literal arguments and are unaffected. A whole-array <c>null</c>
+    /// (<c>[InlineData(null)]</c>, which C# binds as "the array itself is
+    /// null") names no position and is likewise no evidence.
+    /// </para>
+    ///
+    /// <para>
+    /// Like <see cref="HasAllowNullWriteContract"/> this is a property of the
+    /// DECLARATION alone — no consumer evidence, no taint fixpoint — so every
+    /// compilation in a run computes the same answer for it.
+    /// </para>
+    /// </summary>
+    /// <param name="symbol">The declaration symbol to test.</param>
+    /// <returns><see langword="true"/> when a data attribute supplies null for the parameter.</returns>
+    public static bool HasNullDataRowArgument(ISymbol symbol)
+    {
+        // Scoped to declarations this migration EMITS, for the same reason
+        // HasAllowNullWriteContract is: a metadata-only method keeps whatever
+        // contract its assembly already carries.
+        if (symbol is not IParameterSymbol { ContainingSymbol: IMethodSymbol method } parameter
+            || method.OriginalDefinition.DeclaringSyntaxReferences.Length == 0)
+        {
+            return false;
+        }
+
+        foreach (AttributeData attribute in method.GetAttributes())
+        {
+            if (attribute.AttributeConstructor is not { Parameters.Length: 1 } constructor
+                || !constructor.Parameters[0].IsParams
+                || attribute.ConstructorArguments.Length != 1)
+            {
+                continue;
+            }
+
+            TypedConstant row = attribute.ConstructorArguments[0];
+            if (row.Kind != TypedConstantKind.Array
+                || row.IsNull
+                || parameter.Ordinal >= row.Values.Length)
+            {
+                continue;
+            }
+
+            if (row.Values[parameter.Ordinal].IsNull)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Whether <paramref name="tree"/> opens with an <c>&lt;auto-generated&gt;</c>
     /// marker, matching the leading-trivia test the C# compiler itself uses to
     /// decide a tree is generated code. Memoized per tree.

--- a/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
@@ -340,8 +340,15 @@ internal static class ObliviousNullabilityAnalyzer
             }
 
             TypedConstant row = attribute.ConstructorArguments[0];
+
+            // A data ROW never supplies more values than the method has
+            // parameters; a params attribute that means something else — e.g.
+            // `[MemberNotNull("Field")]`, whose strings name members rather
+            // than line up with parameters — is filtered out by that shape
+            // check plus the "the value must be a literal null" test below.
             if (row.Kind != TypedConstantKind.Array
                 || row.IsNull
+                || row.Values.Length > method.Parameters.Length
                 || parameter.Ordinal >= row.Values.Length)
             {
                 continue;


### PR DESCRIPTION
Fixes #3726
Fixes #3727

Families **C** and **D** of the #3724 `test/LanguageServer.Tests` triage — 2 errors each, independent, one in cs2gs and one in gsc.

## #3726 (cs2gs) — a data-driving attribute is a null-writing site

```csharp
[Theory]
[InlineData(null, null)]
[InlineData("", null)]
public void GetLogPath_UsesOptInProtocolTraceEnvironment(string tracePath, string expected)
```

The parameters are oblivious and their only null evidence is an **attribute argument**, which was not in the taint-source set — so cs2gs emitted `@InlineData(nil, nil)` beside `tracePath string, expected string`, a file contradicting itself, and gsc correctly rejected the `nil` (GS0274 ×2).

`ObliviousNullabilityAnalyzer.HasNullDataRowArgument` now states the rule mechanically rather than for xunit by name: an attribute whose constructor is a single `params` array lines its arguments up with the decorated method's parameters positionally, so a `null` at position *i* promotes parameter *i*. `[MemberData]`/`[ClassData]` carry no literal nulls; `[MemberNotNull("Field")]` is filtered out by the "a row never has more values than the method has parameters" shape check plus the "the value must be a literal null" test. `[InlineData(null)]` with a single argument is C#'s "the array itself is null" and names no position, so it is no evidence.

Like #3706's `[AllowNull]`, this is decided by the **declaration alone** — no consumer evidence, no taint fixpoint — so every compilation in a run agrees, which is what makes it safe across projects. And as #3726 asks, the DECLARATION is promoted rather than the value bridged: a `!!` on a value that is genuinely null converts clean behaviour into a runtime throw.

### The one `!!` it would have created, and why it doesn't

Measured whole-repo, the promotion made `test/Compiler.Tests/Issue2920ReleaseJitOptimizerTests` emit `optimizeFlag!!` inside `new[] { …, optimizeFlag, … }.Where(a => a is not null)` — exactly the #3704 mode: the null row would throw before the filter it was written for ever ran. #3682 already answers this shape for a literal `nil` (widen the element type — it is inferred AT the literal, and the value really is nil); a parameter a data row supplies `null` for is the same evidence at one remove, so it joins that rule and the element renders `[]string?`. Scoped to that attribute-stated evidence on purpose: generalizing the element widening to every promoted declaration rewrote ~50 files across the corpus and is its own decision.

Also checked, as the issue asks: no `[Attr(Prop = null)]`-shaped named argument occurs in the corpus, and such an argument targets a metadata property of the attribute type — not a declaration this migration emits — so it is out of this rule's scope either way.

## #3727 (gsc) — the metadata answer is about the OPEN return type

```
await WaitForAsync(() -> Volatile.Read(&projectBind) != nil)
```

The nil-comparison table was never consulted. An earlier arm in the binary-operator binder rejects `importedCall == nil` when the imported method's METADATA declares a non-null reference return, and it asked `ClrNullability.GetReturnTypeSymbol` about the DECLARED return type. For `T Read<T>(ref T location)` that is the open type parameter, which carries no nullable annotation because its nullability is supplied by the type argument at the call site. Inference had already substituted `DiagnosticComputationResult?`, so the binder's own result type was nullable while the metadata check said "explicitly non-null". An operand the binder itself typed nullable is no longer an "explicitly non-null imported result".

Reproduced standalone before the fix (`Volatile.Read(&r) != nil` for both a class and a `string?`); the `&x` ref binding and the generic inference were both fine, so this is not the #3731 seam. `GS0154` at the lambda was pure cascade. The guard is otherwise unchanged — `"abc".ToUpperInvariant() != nil` still reports GS0129, pinned by a test.

## Verification

* Both reproduced minimally first; Release gsc rebuilt before every manual run.
* `tools/cs2gs/Cs2Gs.Tests --filter Issue3726`: 3 failing → 4 passing (targeted run; the neighbouring #3682/#2113/#3714/#914 suites pass: 107/107).
* `test/Core.Tests --filter Issue3727`: 4 of 5 failing → 5 passing (the GS0129 pin passes either way); #796/#2300/nil-compare neighbours: 61/61.
* `dotnet build GSharp.sln -c Release -graph` green; whole-repo `cs2gs migrate --translate-only` translates 50/51 apps both before and after (the one failure, `test/Interpreter.Tests`, is pre-existing and unrelated).
* `cs2gs validate --app src/Core/Core.csproj --app src/LanguageServer/LanguageServer.csproj --app test/LanguageServer.Tests/LanguageServer.Tests.csproj` (dependencies in the app list, per #3724): **6 → 2** substantive errors on the app. `src/Core` and `src/LanguageServer` are PASS/PASS/PASS. The diff is purely subtractive — the four that went are exactly families C (GS0274 ×2) and D (GS0129 + GS0154), no new diagnostic id — and the two that remain are family B (#3725, `Cannot find function DoesNotContain`/`Where`), which is someone else's issue.
* Repo-wide `!!` delta: **0**. The whole migrated-tree diff against main is three `.gs` files: the two promoted parameter pairs and the one widened array element.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
