### PR TITLE
cs2gs: canonicalize migration roots so a symlinked tree keeps its package closure (#3732)

### DIFF
--- a/e2etests/packageref-e2e.sh
+++ b/e2etests/packageref-e2e.sh
@@ -1,7 +1,17 @@
 #!/usr/bin/env bash
-# Validates transitive PackageReference: a .gsproj that depends on a NuGet
-# package (Newtonsoft.Json) and calls into it at compile time. Verifies that
-# @(ReferencePath) correctly flows package assemblies to gsc via /r: flags.
+# Validates PackageReference flow into gsc's /r: set, in two shapes:
+#
+#   1. DIRECT — a .gsproj that declares the package (Newtonsoft.Json) and calls
+#      into it at compile time.
+#   2. TRANSITIVE (issue #3732) — a .gsproj that declares NO package and reaches
+#      one only through a ProjectReference to a library that does, where the
+#      library never names the package in its public surface. csc does not need
+#      such an assembly downstream; gsc's MetadataLoadContext does, so an
+#      incomplete reference set surfaces as `GS9997 Could not find assembly`
+#      rather than an unresolved-symbol error. NuGet puts the referenced
+#      project's packages in the referencing project's assets file and
+#      Gsharp.NET.Core.Sdk.targets hands @(ReferencePathWithRefAssemblies) to
+#      gsc verbatim — this pins that the closure survives both hops.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -41,4 +51,102 @@ if [[ "$ACTUAL" != "$EXPECTED" ]]; then
     exit 1
 fi
 
-echo "PASS: transitive PackageReference (Newtonsoft.Json) flows through to gsc and produces a runnable assembly."
+echo "PASS: direct PackageReference (Newtonsoft.Json) flows through to gsc and produces a runnable assembly."
+
+# --- Issue #3732: a package reached ONLY through a ProjectReference ---
+# Scaffolded outside the repository so it restores exactly like an end-user
+# graph: no repo Directory.Build.props, no committed lock file, its own feed.
+WORK=$(cd "$(mktemp -d)" && pwd -P)
+trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$WORK/Lib" "$WORK/App"
+
+cat > "$WORK/global.json" <<EOF
+{
+  "msbuild-sdks": {
+    "Gsharp.NET.Sdk": "$VER"
+  }
+}
+EOF
+
+cat > "$WORK/nuget.config" <<EOF
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+    <add key="gsharp-local" value="$ROOT/.nugs" />
+  </packageSources>
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
+</configuration>
+EOF
+
+cat > "$WORK/Lib/Lib.gsproj" <<'EOF'
+<Project Sdk="Gsharp.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>TransitivePackageLib</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+</Project>
+EOF
+
+# The package type appears only inside a method BODY: Encode's signature is
+# `string`, so nothing in Lib's public surface names Newtonsoft.Json.
+cat > "$WORK/Lib/Encoder.gs" <<'EOF'
+package TransitivePackageLib
+
+import Newtonsoft.Json
+
+class Encoder(Value string) {
+    func Encode() string {
+        return JsonConvert.SerializeObject(Value)
+    }
+}
+EOF
+
+cat > "$WORK/App/App.gsproj" <<'EOF'
+<Project Sdk="Gsharp.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>TransitivePackageApp</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Lib/Lib.gsproj" />
+  </ItemGroup>
+</Project>
+EOF
+
+cat > "$WORK/App/Program.gs" <<'EOF'
+package TransitivePackageApp
+
+import System
+import TransitivePackageLib
+
+var encoder = Encoder("transitive")
+Console.WriteLine(encoder.Encode())
+EOF
+
+echo "==> dotnet build (package reached only through a ProjectReference)"
+dotnet build "$WORK/App/App.gsproj" --nologo
+
+RSP="$WORK/App/obj/Debug/net10.0/App.rsp"
+if ! grep -qi 'newtonsoft\.json' "$RSP"; then
+    echo "FAIL: Newtonsoft.Json is absent from the downstream gsc reference set ($RSP)"
+    exit 1
+fi
+echo "    PASS: the transitive package assembly reached gsc as a /r: reference"
+
+ACTUAL=$(dotnet "$WORK/App/bin/Debug/net10.0/App.dll")
+EXPECTED='"transitive"'
+if [[ "$ACTUAL" != "$EXPECTED" ]]; then
+    echo "FAIL: expected '$EXPECTED', got '$ACTUAL'"
+    exit 1
+fi
+
+echo "PASS: a PackageReference reached only through a ProjectReference flows through to gsc (issue #3732)."

--- a/tools/cs2gs/Cs2Gs.Cli/Program.cs
+++ b/tools/cs2gs/Cs2Gs.Cli/Program.cs
@@ -232,7 +232,17 @@ internal static class Program
         }
 
         (string corpus, List<string> appIds, PipelineOptions options, string baselinePath, bool baselineStrict, bool translateOnly) = parsed.Value;
-        options.SourceRoot = Path.GetFullPath(corpus);
+
+        // Issue #3732: canonicalize, not merely absolutize. A root reached
+        // through a symlink (`/tmp` and `$TMPDIR` are both links on macOS)
+        // splits every mirrored project's NuGet identity between the link
+        // spelling and the real one, restore drops the ProjectReference
+        // closure, and gsc dies with GS9997 on the first transitively-reached
+        // package assembly it needs. See CanonicalRootPath.
+        options.SourceRoot = CanonicalRootPath.Resolve(corpus);
+        corpus = options.SourceRoot;
+        options.OutputRoot = CanonicalRootPath.Resolve(options.OutputRoot);
+        options.ArtifactRoot = CanonicalRootPath.Resolve(options.ArtifactRoot);
 
         IReadOnlyList<CorpusApp> apps;
         if (options.OutputLayout == MigrationOutputLayout.Repository)
@@ -256,7 +266,7 @@ internal static class Program
                 return 1;
             }
 
-            options.ArtifactRoot ??= Path.GetFullPath(options.OutputRoot) + ".cs2gs-runs";
+            options.ArtifactRoot ??= options.OutputRoot + ".cs2gs-runs";
             apps = RepositoryDiscovery.Discover(corpus);
             if (options.ExcludeAppIdPrefixes.Count > 0)
             {

--- a/tools/cs2gs/Cs2Gs.Cli/ValidateCommand.cs
+++ b/tools/cs2gs/Cs2Gs.Cli/ValidateCommand.cs
@@ -112,15 +112,21 @@ internal static class ValidateCommand
             return 1;
         }
 
-        options.SourceRoot = Path.GetFullPath(corpus);
-        options.OutputRoot = Path.GetFullPath(migrated);
+        // Issue #3732: canonicalize, not merely absolutize. A `--migrated`
+        // tree reached through a symlink (`/tmp` and `$TMPDIR` are both links
+        // on macOS) splits every mirrored project's NuGet identity between the
+        // link spelling and the real one, restore drops the ProjectReference
+        // closure, and gsc dies with GS9997 on the first transitively-reached
+        // package assembly it needs. See CanonicalRootPath.
+        options.SourceRoot = CanonicalRootPath.Resolve(corpus);
+        options.OutputRoot = CanonicalRootPath.Resolve(migrated);
         options.ArtifactRoot = string.IsNullOrEmpty(options.ArtifactRoot)
             ? options.OutputRoot + ".cs2gs-runs"
-            : Path.GetFullPath(options.ArtifactRoot);
+            : CanonicalRootPath.Resolve(options.ArtifactRoot);
 
         manifests = string.IsNullOrEmpty(manifests)
             ? FindLatestRunDir(options.ArtifactRoot)
-            : Path.GetFullPath(manifests);
+            : CanonicalRootPath.Resolve(manifests);
         if (string.IsNullOrEmpty(manifests) || !Directory.Exists(manifests))
         {
             Console.Error.WriteLine(

--- a/tools/cs2gs/Cs2Gs.Pipeline/CanonicalRootPath.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/CanonicalRootPath.cs
@@ -1,0 +1,116 @@
+// <copyright file="CanonicalRootPath.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+
+namespace Cs2Gs.Pipeline;
+
+/// <summary>
+/// Resolves a migration root to its real, symlink-free absolute path
+/// (issue #3732).
+/// <para>
+/// <see cref="Path.GetFullPath(string)"/> normalizes <c>.</c>/<c>..</c> and
+/// makes a path absolute, but it does NOT follow symbolic links, so a root
+/// given as <c>/tmp/…</c> on macOS (where <c>/tmp</c> and <c>$TMPDIR</c> are
+/// both links) stays spelled through the link. Every path the pipeline derives
+/// from that root — the mirrored <c>.gsproj</c> files and the
+/// <c>ProjectReference</c> paths between them — then inherits that spelling,
+/// while MSBuild/NuGet reach the same files through their real path. NuGet
+/// keys restore graph nodes by absolute path, so the two spellings become two
+/// nodes: the referencing project's <c>project.assets.json</c> comes back with
+/// an EMPTY <c>projectReferences</c>/<c>libraries</c> set and none of the
+/// referenced project's packages flow to it.
+/// </para>
+/// <para>
+/// C# survives that silently — <c>csc</c> only needs the assemblies a
+/// compilation actually names — but <c>gsc</c> reads referenced assemblies
+/// through a <see cref="System.Reflection.MetadataLoadContext"/>, which must
+/// resolve the whole <c>AssemblyRef</c> closure of every reference. A package
+/// that a referenced project uses only inside a method body is therefore
+/// mandatory for gsc and absent from csc's needs, and the split root surfaces
+/// as <c>GS9997 Could not find assembly '&lt;package&gt;'</c> on exactly the
+/// projects whose only route to that package is a <c>ProjectReference</c>.
+/// </para>
+/// <para>
+/// The gate scripts already canonicalize their work root with <c>pwd -P</c>
+/// (<c>build/run-cs2gs-selfmig-migrate.sh</c>); this does the same for a
+/// hand-run <c>cs2gs migrate --out /tmp/…</c> / <c>cs2gs validate
+/// --migrated /tmp/…</c>, which is the documented reproduction recipe.
+/// </para>
+/// </summary>
+public static class CanonicalRootPath
+{
+    /// <summary>
+    /// Returns <paramref name="path"/> as an absolute path with every existing
+    /// directory/file component resolved through its symbolic links.
+    /// Components that do not exist yet (a not-yet-created <c>--out</c>
+    /// destination) are appended verbatim, and any resolution failure degrades
+    /// to <see cref="Path.GetFullPath(string)"/> — a root that cannot be
+    /// canonicalized must not fail the run.
+    /// </summary>
+    /// <param name="path">The user-supplied root, absolute or relative.</param>
+    /// <returns>The canonical absolute path, or <paramref name="path"/> unchanged when it is null or empty.</returns>
+    public static string Resolve(string path)
+    {
+        if (string.IsNullOrEmpty(path))
+        {
+            return path;
+        }
+
+        string full = Path.GetFullPath(path);
+        try
+        {
+            string root = Path.GetPathRoot(full);
+            if (string.IsNullOrEmpty(root))
+            {
+                return full;
+            }
+
+            string current = root;
+            foreach (string segment in full.Substring(root.Length).Split(
+                new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar },
+                StringSplitOptions.RemoveEmptyEntries))
+            {
+                current = Path.Combine(current, segment);
+                current = ResolveComponent(current);
+            }
+
+            return current;
+        }
+        catch (Exception exception) when (
+            exception is IOException
+                or UnauthorizedAccessException
+                or NotSupportedException
+                or ArgumentException)
+        {
+            return full;
+        }
+    }
+
+    private static string ResolveComponent(string component)
+    {
+        // ResolveLinkTarget throws when the component does not exist, and
+        // returns null when it exists but is not a link — both mean "keep the
+        // spelling we already have".
+        FileSystemInfo target = null;
+        if (Directory.Exists(component))
+        {
+            target = Directory.ResolveLinkTarget(component, returnFinalTarget: true);
+        }
+        else if (File.Exists(component))
+        {
+            target = File.ResolveLinkTarget(component, returnFinalTarget: true);
+        }
+
+        if (target is null)
+        {
+            return component;
+        }
+
+        return Path.IsPathRooted(target.FullName)
+            ? target.FullName
+            : Path.GetFullPath(Path.Combine(Path.GetDirectoryName(component) ?? string.Empty, target.FullName));
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3732TransitivePackageReferenceTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3732TransitivePackageReferenceTests.cs
@@ -1,0 +1,225 @@
+// <copyright file="Issue3732TransitivePackageReferenceTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Regression coverage for issue #3732: <c>Cs2Gs.Pipeline</c> and
+/// <c>Cs2Gs.Cli</c> reach <c>Microsoft.Build.Locator</c> only transitively —
+/// <c>Cs2Gs.ProjectLoading</c> declares the <c>PackageReference</c> and they
+/// hold a <c>ProjectReference</c> to it — and the report was that the assembly
+/// never reached <c>gsc</c>'s reference set (<c>GS9997 Could not find assembly
+/// 'Microsoft.Build.Locator'</c>).
+/// <para>
+/// The transitive flow is NuGet's, not the pipeline's: the mirrored
+/// <c>.gsproj</c> graph restores exactly like the C# graph, so the referenced
+/// project's package lands in the referencing project's
+/// <c>project.assets.json</c> and from there in
+/// <c>@(ReferencePathWithRefAssemblies)</c>, which
+/// <c>Gsharp.NET.Core.Sdk.targets</c> hands to <c>gsc</c> verbatim as
+/// <c>/r:</c>. For that to hold, the migration must preserve two things about
+/// the source graph, and those are what this fixture pins:
+/// </para>
+/// <list type="number">
+/// <item>the referenced project's <c>PackageReference</c> items survive the
+/// transform verbatim (id, version and metadata), so its generated project
+/// restores the same package set; and</item>
+/// <item>the referencing project's <c>ProjectReference</c> is retargeted at
+/// that generated project, so restore walks into it — a referencing project
+/// that declares no package of its own still inherits the closure.</item>
+/// </list>
+/// <para>
+/// The end-to-end half of the same invariant — that the package assembly
+/// actually reaches <c>gsc</c>'s <c>/r:</c> set for a downstream project that
+/// never names the package — lives in <c>e2etests/packageref-e2e.sh</c>.
+/// </para>
+/// </summary>
+public sealed class Issue3732TransitivePackageReferenceTests
+{
+    /// <summary>
+    /// The migrated graph keeps the source graph's package/project shape: the
+    /// library carries the <c>PackageReference</c>, the app carries only a
+    /// <c>ProjectReference</c> retargeted at the library's generated project.
+    /// </summary>
+    [Fact]
+    public void Transform_KeepsPackageReferenceOnTheLibraryAndRetargetsTheConsumer()
+    {
+        using var scratch = new ScratchDirectory();
+        string sourceLibrary = Path.Combine(scratch.Path, "source", "Lib", "Lib.csproj");
+        string sourceApp = Path.Combine(scratch.Path, "source", "App", "App.csproj");
+        string generatedLibrary = Path.Combine(scratch.Path, "generated", "Lib", "Lib.gsproj");
+        string generatedAppDirectory = Path.Combine(scratch.Path, "generated", "App");
+        Directory.CreateDirectory(Path.GetDirectoryName(sourceLibrary));
+        Directory.CreateDirectory(Path.GetDirectoryName(sourceApp));
+        Directory.CreateDirectory(Path.GetDirectoryName(generatedLibrary));
+        Directory.CreateDirectory(generatedAppDirectory);
+
+        File.WriteAllText(
+            sourceLibrary,
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <ItemGroup>
+                <PackageReference Include="Microsoft.Build.Locator" Version="1.7.8" />
+              </ItemGroup>
+            </Project>
+            """);
+        File.WriteAllText(
+            sourceApp,
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <ItemGroup>
+                <ProjectReference Include="..\Lib\Lib.csproj" />
+              </ItemGroup>
+            </Project>
+            """);
+
+        var generatedProjectPaths = new Dictionary<string, string>
+        {
+            [Path.GetFullPath(sourceLibrary)] = generatedLibrary,
+        };
+
+        XDocument transformedLibrary = GSharpProjectTransformer.Transform(
+            sourceLibrary,
+            Path.GetDirectoryName(generatedLibrary),
+            "Gsharp.NET.Sdk/1.0.0",
+            generatedProjectPaths);
+        XElement packageReference = Single(transformedLibrary, "PackageReference");
+        Assert.Equal("Microsoft.Build.Locator", packageReference.Attribute("Include")?.Value);
+        Assert.Equal("1.7.8", packageReference.Attribute("Version")?.Value);
+
+        XDocument transformedApp = GSharpProjectTransformer.Transform(
+            sourceApp,
+            generatedAppDirectory,
+            "Gsharp.NET.Sdk/1.0.0",
+            generatedProjectPaths);
+
+        // The consumer declares no package of its own: the closure has to come
+        // from the retargeted ProjectReference, or nothing supplies it.
+        Assert.Empty(Named(transformedApp, "PackageReference"));
+        Assert.Equal(
+            Path.GetRelativePath(generatedAppDirectory, generatedLibrary).Replace('\\', '/'),
+            Single(transformedApp, "ProjectReference").Attribute("Include")?.Value);
+    }
+
+    /// <summary>
+    /// Issue #3501's analyzer-project transform drops every
+    /// <c>Microsoft.CodeAnalysis*</c> <c>PackageReference</c>, which is exactly
+    /// the shape that WOULD strand a downstream project. It is gated on the
+    /// analyzer marker (<c>EnforceExtendedAnalyzerRules</c>, or a
+    /// <c>PrivateAssets="all"</c> Roslyn package), and
+    /// <c>Cs2Gs.ProjectLoading</c> — an ordinary library that consumes Roslyn
+    /// at runtime alongside <c>Microsoft.Build.Locator</c> — must not trip it.
+    /// </summary>
+    [Fact]
+    public void Transform_DoesNotStripRuntimeRoslynPackagesFromANonAnalyzerLibrary()
+    {
+        using var scratch = new ScratchDirectory();
+        string sourceProject = Path.Combine(scratch.Path, "Lib.csproj");
+        File.WriteAllText(
+            sourceProject,
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <ItemGroup>
+                <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
+                <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.6.0" />
+                <PackageReference Include="Microsoft.Build.Locator" Version="1.7.8" />
+              </ItemGroup>
+            </Project>
+            """);
+
+        XDocument transformed = GSharpProjectTransformer.Transform(
+            sourceProject,
+            scratch.Path,
+            "Gsharp.NET.Sdk/1.0.0",
+            new Dictionary<string, string>());
+
+        Assert.Equal(
+            new[]
+            {
+                "Microsoft.CodeAnalysis.CSharp",
+                "Microsoft.CodeAnalysis.Workspaces.MSBuild",
+                "Microsoft.Build.Locator",
+            },
+            Named(transformed, "PackageReference")
+                .Select(reference => reference.Attribute("Include")?.Value)
+                .ToArray());
+    }
+
+    /// <summary>
+    /// The root cause: a migration root spelled through a symlink. NuGet keys
+    /// restore graph nodes by absolute path, so the link spelling and the real
+    /// one become two nodes and the referencing project's assets file loses the
+    /// whole <c>ProjectReference</c> closure — which is how a transitively
+    /// reached package goes missing from gsc's <c>/r:</c> set.
+    /// <see cref="CanonicalRootPath"/> resolves the link before any generated
+    /// project path is derived from it.
+    /// </summary>
+    [Fact]
+    public void Resolve_FollowsASymlinkedRootComponent()
+    {
+        using var scratch = new ScratchDirectory();
+        string real = Path.Combine(scratch.Path, "real");
+        string link = Path.Combine(scratch.Path, "link");
+        Directory.CreateDirectory(Path.Combine(real, "App"));
+        Directory.CreateSymbolicLink(link, real);
+
+        // Both the link itself and a not-yet-created leaf under it resolve
+        // onto the real root (`--out` names a destination that does not exist).
+        Assert.Equal(
+            CanonicalRootPath.Resolve(real),
+            CanonicalRootPath.Resolve(link));
+        Assert.Equal(
+            Path.Combine(CanonicalRootPath.Resolve(real), "App", "App.gsproj"),
+            CanonicalRootPath.Resolve(Path.Combine(link, "App", "App.gsproj")));
+    }
+
+    /// <summary>A plain, link-free root is returned exactly as <see cref="Path.GetFullPath(string)"/> would.</summary>
+    [Fact]
+    public void Resolve_LeavesALinkFreeRootAlone()
+    {
+        using var scratch = new ScratchDirectory();
+        string nested = Path.Combine(scratch.Path, "a", "b");
+        Directory.CreateDirectory(nested);
+
+        Assert.Equal(
+            CanonicalRootPath.Resolve(nested),
+            CanonicalRootPath.Resolve(Path.Combine(scratch.Path, "a", ".", "b")));
+        Assert.True(Path.IsPathRooted(CanonicalRootPath.Resolve(nested)));
+        Assert.Null(CanonicalRootPath.Resolve(null));
+    }
+
+    private static IEnumerable<XElement> Named(XDocument document, string localName) =>
+        document.Descendants().Where(element => element.Name.LocalName == localName);
+
+    private static XElement Single(XDocument document, string localName) =>
+        Assert.Single(Named(document, localName));
+
+    private sealed class ScratchDirectory : IDisposable
+    {
+        public ScratchDirectory()
+        {
+            this.Path = System.IO.Path.Combine(
+                AppContext.BaseDirectory,
+                "scratch-projects",
+                "issue-3732",
+                Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(this.Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            Directory.Delete(this.Path, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3732.

## Answer to the first question: neither

It is **not** "all transitive package references are dropped", and it is **not**
"`Microsoft.Build.Locator` is special". Under a canonical migration root
*nothing* is dropped — `Microsoft.Build.Locator` reaches `gsc` through the
`ProjectReference` to `Cs2Gs.ProjectLoading` exactly like every other
transitive package. Verified directly in the mirrored build's response file:

```
$ grep -iE 'locator|CodeAnalysis.CSharp.dll' <artifacts>/obj/tools/cs2gs/Cs2Gs.Pipeline/obj/Release/GSharp.Cs2Gs.Pipeline.rsp
/r:…/.nuget-packages/microsoft.build.locator/1.7.8/lib/net6.0/Microsoft.Build.Locator.dll
/r:…/.nuget-packages/microsoft.codeanalysis.csharp/5.6.0/lib/net10.0/Microsoft.CodeAnalysis.CSharp.dll
```

Under a **symlinked** root, *all* of them are lost at once —
`Microsoft.Build.Locator` was simply the first one `gsc` actually needed.

## Layer at fault: the cs2gs CLI's root resolution (not the transformer, not the SDK)

`cs2gs migrate --out /tmp/x` / `cs2gs validate --migrated /tmp/x` — the issue's
own reproduction recipe — resolved its roots with `Path.GetFullPath`. That
normalizes `.`/`..` and makes a path absolute but does **not** follow symbolic
links, and on macOS both `/tmp` and `$TMPDIR` are links. Every mirrored
`.gsproj` and every `ProjectReference` between them therefore carried the link
spelling while MSBuild/NuGet reached the same files through the real path.

NuGet keys restore-graph nodes by absolute path, so the two spellings become
two nodes and the referencing project's `project.assets.json` comes back with
an **empty** `projectReferences` *and* `libraries` set. Minimal repro, same
files, only the root spelling differs:

| root | `App/obj/project.assets.json` → `libraries` |
|---|---|
| `/private/tmp/…` (real) | `['Newtonsoft.Json/13.0.3', 'Lib/1.0.0']` |
| `/tmp/…` (symlink) | `[]` |

C# survives that silently — `csc` only needs the assemblies a compilation
actually names. `gsc` does not: it reads references through a
`MetadataLoadContext`, which must resolve the whole `AssemblyRef` closure of
every reference. A package the referenced project uses **only inside a method
body** (`CSharpProjectLoader` calls `MSBuildLocator.RegisterDefaults()` and
never names the type in its public surface) is therefore mandatory for `gsc`
and invisible to `csc`. Hence the reported symptom appearing on exactly the two
apps whose only route to the package is a `ProjectReference`:

```
gsc: error GS9997: Fatal compiler I/O error: Could not find assembly
'Newtonsoft.Json, Version=13.0.0.0, …'. Either explicitly load this assembly …
```

(reproduced verbatim with a two-project `.gsproj` graph under `/tmp`, and
passing byte-identically under `/private/tmp`).

`build/run-cs2gs-selfmig-migrate.sh` already canonicalizes its work root with
`pwd -P`, which is why the nightly never saw this and why the reds in the last
nightly (`Cs2Gs.Pipeline` FAIL(240), `Cs2Gs.Cli` FAIL(1)) were all `GS0536`,
cleared by #3728.

## The fix

`CanonicalRootPath.Resolve` walks a root component by component and follows
each existing symlink, appending not-yet-created components verbatim (an
`--out` destination does not exist yet) and degrading to `Path.GetFullPath` on
any I/O failure — a root that cannot be canonicalized must not fail the run.
`migrate` applies it to `--corpus`/`--out`/`--artifacts`; `validate` to
`--corpus`/`--migrated`/`--artifacts`/`--manifests`.

## Measured before/after

Whole-repo migrate (50/51 translated), then
`cs2gs validate --app tools/cs2gs/Cs2Gs.Pipeline/… --app tools/cs2gs/Cs2Gs.Cli/…`
with the full `--exclude` set — never excluding a dependency. `GS0536` entries
are excluded from the counts below (there were none; the polish pass converged
and rewrote 233 files).

| run | `Cs2Gs.Pipeline` | `Cs2Gs.Cli` |
|---|---|---|
| symlinked `--migrated`, before this change | FAIL(1) compile | — |
| symlinked `--migrated`, after this change | PASS / PASS / PASS | — |
| canonical root, `6d53c629` (pre-#3731) | PASS / PASS / PASS | PASS / PASS / PASS |
| canonical root, `origin/main` (fc8eaca6) | PASS / PASS / PASS | PASS / PASS / PASS |
| canonical root, this branch | PASS / PASS / PASS | PASS / PASS / PASS |

So the gate path is unchanged (both apps were already green on `main` once
#3728 let the polish pass converge — the `GS9997` in the issue came from a
hand-run against a `/tmp` root), and the hand-run path is now green too.

## Tests

- `Issue3732TransitivePackageReferenceTests` (4, `Cs2Gs.Tests`): the resolver
  over a symlinked root and over a link-free one; that a library's
  `PackageReference` survives the transform verbatim while its consumer's
  `ProjectReference` is retargeted at the generated project — the only route a
  consumer that declares no package has to the closure; and that the
  analyzer-project transform's `Microsoft.CodeAnalysis*` stripping does **not**
  fire for an ordinary Roslyn consumer like `Cs2Gs.ProjectLoading` (it would
  strand a downstream project in exactly this way).
- `e2etests/packageref-e2e.sh` gains the end-to-end leg the suite was missing:
  a package reached **only** through a `ProjectReference`, named only inside
  the library's method bodies, must appear in the downstream project's `gsc`
  `.rsp` and the app must run.

Targeted suites green: `Issue3732*`, `GSharpProjectTransformerTests`,
`SdkCompileRunnerTests`, `Adr0169AnalyzerProject*`, `Issue2317ProjectReference*`,
`CentralPackageManagementPolicy*`, `DeclaredProjectItems*` (73 tests), plus
`e2etests/packageref-e2e.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
