### PR TITLE
gsc: receiver substitution keeps declaration nullability (#3705 family 2)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -4106,14 +4106,34 @@ internal sealed class MemberLookup
             var openMethod = TryGetOpenMethodOnDeclaringType(openDefinition, closedMethod);
             if (openMethod != null)
             {
-                return MapOpenClrTypeToSymbolic(
+                // Issue #3705 (family 2): the symbolic branch returned the
+                // receiver-substituted type RAW. Substitution recovers the
+                // shape but not the declaration's `[Nullable]` metadata, so an
+                // imported `string?` return reached the binder as non-null
+                // `string`. GetClrFieldTypeSymbol's symbolic branch folds the
+                // declaration flags back in; this one now does the same.
+                var mapped = MapOpenClrTypeToSymbolic(
                     openMethod.ReturnType,
                     openDefinition,
                     declaringTypeArguments);
+                var declarationFlags = ClrNullability.ReadNullableFlags(
+                    openMethod.ReturnParameter,
+                    openMethod);
+                return NullableFlagsBuilder.MergeDeclarationNullability(
+                    mapped,
+                    openMethod.ReturnType,
+                    declarationFlags);
             }
         }
 
-        return TypeSymbol.FromClrType(closedMethod.ReturnType);
+        // Issue #3705 (family 2, the #3703 shape): the reflected fallback slot
+        // of the three sibling helpers above — GetClrPropertyTypeSymbol,
+        // GetClrFieldTypeSymbol and GetClrIndexerParameterTypeSymbol — each end
+        // in a `ClrNullability` read. This one ended in a bare `FromClrType`,
+        // which drops the declaration's `[Nullable]` metadata and binds an
+        // imported `string?` return as non-null `string` — the unsound
+        // direction. Route it through the same reader the siblings use.
+        return ClrNullability.GetReturnTypeSymbol(closedMethod);
     }
 
     /// <summary>Resolves an imported method parameter through a symbolic receiver.</summary>
@@ -4138,23 +4158,50 @@ internal sealed class MemberLookup
             var openParameters = openMethod?.GetParameters();
             if (openParameters != null && (uint)parameterIndex < (uint)openParameters.Length)
             {
-                var openParameterType = openParameters[parameterIndex].ParameterType;
+                // Issue #3705 (family 2): as with the return slot above, the
+                // receiver substitution recovers the shape but drops the
+                // declaration's `[Nullable]` metadata. `[Nullable]` on a by-ref
+                // parameter annotates the POINTEE (by-ref contributes no
+                // nullability byte), which is why the flags are merged after
+                // peeling and before re-wrapping.
+                var openParameter = openParameters[parameterIndex];
+                var openParameterType = openParameter.ParameterType;
+                var parameterFlags = ClrNullability.ReadNullableFlags(openParameter, openMethod);
                 if (openParameterType.IsByRef)
                 {
-                    return ByRefTypeSymbol.Get(MapOpenClrTypeToSymbolic(
+                    var pointeeType = Invariant.Required(
                         openParameterType.GetElementType(),
-                        openDefinition,
-                        declaringTypeArguments));
+                        "a by-ref parameter type has an element type");
+                    return ByRefTypeSymbol.Get(NullableFlagsBuilder.MergeDeclarationNullability(
+                        MapOpenClrTypeToSymbolic(
+                            pointeeType,
+                            openDefinition,
+                            declaringTypeArguments),
+                        pointeeType,
+                        parameterFlags));
                 }
 
-                return MapOpenClrTypeToSymbolic(
+                return NullableFlagsBuilder.MergeDeclarationNullability(
+                    MapOpenClrTypeToSymbolic(
+                        openParameterType,
+                        openDefinition,
+                        declaringTypeArguments),
                     openParameterType,
-                    openDefinition,
-                    declaringTypeArguments);
+                    parameterFlags);
             }
         }
 
-        return TypeSymbol.FromClrType(closedMethod.GetParameters()[parameterIndex].ParameterType);
+        // Issue #3705 (family 2): same omission as GetClrMethodReturnTypeSymbol,
+        // compounded — the bare `FromClrType` also failed to peel `ByRef`, so an
+        // `out T` parameter reached callers as an `ImportedTypeSymbol` wrapping
+        // `T&` rather than the `ByRefTypeSymbol` the symbolic branch above
+        // returns. Callers that switch on `ByRefTypeSymbol` therefore took the
+        // wrong arm on the reflected path only.
+        var reflectedParameter = closedMethod.GetParameters()[parameterIndex];
+        var reflectedType = ClrNullability.GetParameterTypeSymbol(reflectedParameter);
+        return reflectedParameter.ParameterType.IsByRef
+            ? ByRefTypeSymbol.Get(reflectedType)
+            : reflectedType;
     }
 
     internal static MethodInfo GetImportedMethodForEmission(MethodInfo method)

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
@@ -2178,15 +2178,21 @@ internal sealed partial class StatementBinder
 
             for (var i = 0; i < identifiers.Count; i++)
             {
+                // Issue #3705 (family 2): the extension-`Deconstruct` arm used a
+                // bare `FromClrType`, so a synthesised deconstruction local took
+                // its type from an `out T` parameter with the declaration's
+                // `[Nullable]` metadata dropped — while the instance arm reads it
+                // through MemberLookup. `GetParameterTypeSymbol` peels `ByRef`
+                // itself, so the element type falls out of both arms directly.
                 var parameterType = receiverOffset == 0
                     ? MemberLookup.GetClrMethodParameterTypeSymbol(
                         Invariant.Required(receiver.Type, "a deconstruction receiver has a type"),
                         method,
                         i)
-                    : TypeSymbol.FromClrType(parameters[i + receiverOffset].ParameterType);
+                    : ClrNullability.GetParameterTypeSymbol(parameters[i + receiverOffset]);
                 var elementType = parameterType is ByRefTypeSymbol byRef
                     ? byRef.PointeeType
-                    : TypeSymbol.FromClrType(parameters[i + receiverOffset].ParameterType.GetElementType());
+                    : parameterType;
                 var temp = new LocalVariableSymbol(
                     $"<deconstruct{System.Threading.Interlocked.Increment(ref binderCtx.SyntheticLocalCounter)}>",
                     isReadOnly: false,

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3705MemberKindNullabilityDifferentialTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3705MemberKindNullabilityDifferentialTests.cs
@@ -1,0 +1,480 @@
+// <copyright file="Issue3705MemberKindNullabilityDifferentialTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Text;
+using GsCompilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
+using GsSyntaxTree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #3705, family 2 — the nullability differential gate.
+/// <para>
+/// The companion of <see cref="Issue3705MemberKindAccessibilityDifferentialTests"/>
+/// (member kind × accessibility) and of
+/// <c>Issue3705LoadContextDifferentialTests</c> (compiler query × load context).
+/// The family-2 shape is #3703: a signature position read with a bare
+/// <c>TypeSymbol.FromClrType</c> where the sibling position one line away used
+/// the nullability-aware <c>ClrNullability</c> reader — so an imported
+/// <c>string?</c> bound as non-null <c>string</c>, the unsound direction.
+/// </para>
+/// <para>
+/// So rather than one test per site, this fixture asserts the INVARIANT: for a
+/// reference-typed signature position on an imported member, whether the bound
+/// type is nullable depends only on the DECLARATION's annotation state —
+/// annotated non-null, annotated nullable, or unannotated/oblivious — and never
+/// on the member kind through which the position was reached. The member kind
+/// never appears on the right-hand side of the expectation; the table IS the
+/// invariant.
+/// </para>
+/// <para>
+/// The oblivious row is deliberately part of the contract rather than an
+/// accident: issue #1354 fixed the import default so an unannotated imported
+/// reference type reads as nullable. Every kind must apply that rule too, and a
+/// swap that only fixed the explicitly-annotated positions would leave the
+/// kinds disagreeing again.
+/// </para>
+/// <para>
+/// Guard rails, and they are half the point: the <c>NonNull</c> rows are the
+/// negative controls. They fail if a fix widens an annotated non-null position
+/// to nullable — the #3704-shaped regression the family-2 triage warned about,
+/// where a widened declaration reaches a position that consumes it as non-null.
+/// <see cref="Fixture_Really_Presents_Three_Distinct_AnnotationStates"/> is the
+/// anti-vacuity assertion: it reads the emitted metadata directly and proves
+/// the three states carry genuinely different <c>[Nullable]</c> bytes, so the
+/// table cannot go green because every row secretly tested the same thing.
+/// </para>
+/// </summary>
+public sealed class Issue3705MemberKindNullabilityDifferentialTests
+{
+    private const string ConsumerAssemblyName = "Issue3705.NullabilityConsumer";
+    private const string LibraryAssemblyName = "Issue3705.NullabilityLibrary";
+
+    /// <summary>
+    /// One reference-typed signature position of every kind, in each of the
+    /// three annotation states. <c>#nullable disable</c> is what makes the
+    /// <c>Oblivious</c> members carry no <c>[Nullable]</c> metadata at all.
+    /// </summary>
+    private const string CSharpLibrarySource = """
+        #nullable enable
+        using System;
+        using System.Collections.Generic;
+
+        namespace Issue3705.NullabilityLibrary;
+
+        public class Surface
+        {
+            public string NonNullField = string.Empty;
+            public string? NullableField = null;
+
+            public string NonNullProperty { get; set; } = string.Empty;
+            public string? NullableProperty { get; set; }
+
+            public string NonNullMethod() => string.Empty;
+            public string? NullableMethod() => null;
+
+            public string this[int index] => string.Empty;
+            public string? this[long index] => null;
+
+            public void Deconstruct(out string first, out int second)
+            {
+                first = string.Empty;
+                second = 0;
+            }
+        }
+
+        public class NullableDeconstructSurface
+        {
+            public void Deconstruct(out string? first, out int second)
+            {
+                first = null;
+                second = 0;
+            }
+        }
+
+        public interface IConstrained
+        {
+            string NonNullMethod();
+
+            string? NullableMethod();
+        }
+
+        public class Constrained : IConstrained
+        {
+            public string NonNullMethod() => string.Empty;
+
+            public string? NullableMethod() => null;
+        }
+
+        #nullable disable
+
+        public class ObliviousSurface
+        {
+            public string ObliviousField;
+
+            public string ObliviousProperty { get; set; }
+
+            public string ObliviousMethod() => string.Empty;
+
+            public string this[int index] => string.Empty;
+
+            public void Deconstruct(out string first, out int second)
+            {
+                first = string.Empty;
+                second = 0;
+            }
+        }
+
+        public interface IObliviousConstrained
+        {
+            string ObliviousMethod();
+        }
+
+        public class ObliviousConstrained : IObliviousConstrained
+        {
+            public string ObliviousMethod() => string.Empty;
+        }
+        """;
+
+    /// <summary>
+    /// Gets the signature-position kinds under test. Each names a distinct
+    /// reader inside the compiler; the invariant is that they all give the
+    /// same answer for the same declaration.
+    /// </summary>
+    private static string[] Kinds => new[]
+    {
+        "Field",
+        "Property",
+        "MethodReturn",
+        "IndexerElement",
+        "ConstrainedMethodReturn",
+        "DeconstructOut",
+    };
+
+    /// <summary>
+    /// Gets the differential matrix: signature-position kind × ANNOTATED
+    /// state. The expectation ("does this bind as non-null?") is computed
+    /// from the annotation state ALONE — the kind never appears on the
+    /// right-hand side.
+    /// </summary>
+    /// <returns>The theory rows.</returns>
+    public static IEnumerable<object[]> AnnotatedMatrix()
+    {
+        foreach (var kind in Kinds)
+        {
+            foreach (var state in new[] { "NonNull", "Nullable" })
+            {
+                yield return new object[] { kind, state, state == "NonNull" };
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the UNANNOTATED (oblivious) half of the matrix, with each kind's
+    /// answer as the compiler gives it today. Issue #1354 says every row here
+    /// should be nullable; three are not. See
+    /// <see cref="ObliviousPositions_Diverge_Where_Receiver_Substitution_Runs"/>
+    /// for why this half is pinned rather than asserted.
+    /// </summary>
+    /// <returns>The theory rows.</returns>
+    public static IEnumerable<object[]> ObliviousMatrix()
+    {
+        // The three that diverge are exactly the readers whose symbolic
+        // (receiver-substituted) branch routes through
+        // NullableFlagsBuilder.MergeDeclarationNullability, which returns the
+        // projected type unchanged when the declaration carries no flags at
+        // all. The three that agree take the plain ClrNullability readers,
+        // which apply the #1354 default.
+        var divergent = new HashSet<string>
+        {
+            "Field",
+            "ConstrainedMethodReturn",
+            "DeconstructOut",
+        };
+
+        foreach (var kind in Kinds)
+        {
+            yield return new object[] { kind, divergent.Contains(kind) };
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(AnnotatedMatrix))]
+    public void SignaturePositions_Agree_On_DeclarationNullability(
+        string kind,
+        string state,
+        bool expectedNonNull)
+    {
+        var directory = CreateOutputDirectory();
+        try
+        {
+            var libraryPath = EmitCSharpLibrary(directory, LibraryAssemblyName, CSharpLibrarySource);
+
+            // The probe binds the position to a NON-NULL `string` local, which
+            // succeeds only when the position itself bound as non-null.
+            var strict = CompileGSharp(BuildSource(kind, state, nullableTarget: false), libraryPath);
+
+            // …and to a `string?` local, which must succeed either way. This
+            // arm is what distinguishes "bound nullable" from "did not bind at
+            // all" — without it a lookup regression would read as a passing row.
+            var lenient = CompileGSharp(BuildSource(kind, state, nullableTarget: true), libraryPath);
+
+            Assert.True(
+                lenient.Success,
+                $"{kind}/{state}: the position must bind at all: {Describe(lenient)}");
+
+            if (expectedNonNull)
+            {
+                Assert.True(
+                    strict.Success,
+                    $"{kind}/{state} should bind NON-NULL, but assigning it to a "
+                    + $"non-null local failed: {Describe(strict)}");
+            }
+            else
+            {
+                Assert.False(
+                    strict.Success,
+                    $"{kind}/{state} should bind NULLABLE, but it assigned to a "
+                    + "non-null local without a diagnostic.");
+            }
+        }
+        finally
+        {
+            DeleteOutputDirectory(directory);
+        }
+    }
+
+    /// <summary>
+    /// The deferred half, pinned rather than asserted.
+    /// <para>
+    /// Issue #1354 made an unannotated imported reference type read as
+    /// nullable, and the plain <c>ClrNullability</c> readers implement it. The
+    /// receiver-substituting readers do not: <c>MergeDeclarationNullability</c>
+    /// short-circuits on <c>declarationFlags.IsDefaultOrEmpty</c> and returns
+    /// the projected (non-null) type, so a member reached through a symbolic
+    /// receiver keeps the pre-#1354 answer.
+    /// </para>
+    /// <para>
+    /// Closing that hole is a semantic change, not a probe fix: it would flip
+    /// every unannotated imported field / constrained call / deconstruction in
+    /// the corpus to nullable at once, which is the #3704 shape the family-2
+    /// triage flagged. So this fixture pins the divergence — three kinds
+    /// disagree with the other three, and the set is named explicitly. When
+    /// the rule is settled and the hole closed, this test fails and forces the
+    /// review; until then it stops the set drifting.
+    /// </para>
+    /// </summary>
+    /// <param name="kind">The signature-position kind.</param>
+    /// <param name="bindsNonNullToday">The answer the compiler gives today.</param>
+    [Theory]
+    [MemberData(nameof(ObliviousMatrix))]
+    public void ObliviousPositions_Diverge_Where_Receiver_Substitution_Runs(
+        string kind,
+        bool bindsNonNullToday)
+    {
+        var directory = CreateOutputDirectory();
+        try
+        {
+            var libraryPath = EmitCSharpLibrary(directory, LibraryAssemblyName, CSharpLibrarySource);
+            var strict = CompileGSharp(BuildSource(kind, "Oblivious", nullableTarget: false), libraryPath);
+            var lenient = CompileGSharp(BuildSource(kind, "Oblivious", nullableTarget: true), libraryPath);
+
+            Assert.True(
+                lenient.Success,
+                $"{kind}/Oblivious: the position must bind at all: {Describe(lenient)}");
+            Assert.Equal(bindsNonNullToday, strict.Success);
+        }
+        finally
+        {
+            DeleteOutputDirectory(directory);
+        }
+    }
+
+    /// <summary>
+    /// Anti-vacuity. #3716's load-context table nearly shipped a fixture that
+    /// would have passed even if its "MLC twin" had silently been the host
+    /// type; the analogous trap here is a fixture whose three annotation states
+    /// all carry the same metadata, which would make every row above assert the
+    /// same thing. Read the emitted <c>[Nullable]</c> bytes back through the
+    /// same reader the binder uses and prove the states really differ.
+    /// </summary>
+    [Fact]
+    public void Fixture_Really_Presents_Three_Distinct_AnnotationStates()
+    {
+        var directory = CreateOutputDirectory();
+        try
+        {
+            var libraryPath = EmitCSharpLibrary(directory, LibraryAssemblyName, CSharpLibrarySource);
+            using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+            Assert.True(resolver.TryResolveType("Issue3705.NullabilityLibrary.Surface", out var surface));
+            Assert.True(resolver.TryResolveType("Issue3705.NullabilityLibrary.ObliviousSurface", out var oblivious));
+
+            var nonNull = ClrNullability.GetFieldTypeSymbol(surface!.GetField("NonNullField")!);
+            var nullable = ClrNullability.GetFieldTypeSymbol(surface.GetField("NullableField")!);
+            var unannotated = ClrNullability.GetFieldTypeSymbol(oblivious!.GetField("ObliviousField")!);
+
+            // Annotated non-null is the only one of the three that is not
+            // nullable — if this ever collapses, every "Nullable"/"Oblivious"
+            // row above becomes vacuous.
+            Assert.IsNotType<NullableTypeSymbol>(nonNull);
+            Assert.IsType<NullableTypeSymbol>(nullable);
+            Assert.IsType<NullableTypeSymbol>(unannotated);
+
+            // …and the two nullable states must not be nullable for the SAME
+            // reason: the annotated one carries an explicit `[Nullable(2)]`,
+            // the oblivious one carries no nullability metadata at all.
+            Assert.Equal(
+                new byte[] { 1 },
+                ClrNullability.ReadNullableFlags(surface.GetField("NonNullField")!, surface).ToArray());
+            Assert.Equal(
+                new byte[] { 2 },
+                ClrNullability.ReadNullableFlags(surface.GetField("NullableField")!, surface).ToArray());
+            Assert.Empty(
+                ClrNullability.ReadNullableFlags(oblivious.GetField("ObliviousField")!, oblivious));
+        }
+        finally
+        {
+            DeleteOutputDirectory(directory);
+        }
+    }
+
+    private static string BuildSource(string kind, string state, bool nullableTarget)
+    {
+        var target = nullableTarget ? "string?" : "string";
+
+        // `Oblivious` members live on a separate `#nullable disable` type, so
+        // the receiver varies with the state rather than with the kind.
+        var isOblivious = state == "Oblivious";
+        var receiverType = isOblivious ? "ObliviousSurface" : "Surface";
+        var memberPrefix = isOblivious ? "Oblivious" : state;
+        var indexArgument = state == "Nullable" ? "1L" : "1";
+        var constrainedInterface = isOblivious ? "IObliviousConstrained" : "IConstrained";
+        var constrainedImpl = isOblivious ? "ObliviousConstrained" : "Constrained";
+        var deconstructReceiver = state switch
+        {
+            "NonNull" => "Surface",
+            "Nullable" => "NullableDeconstructSurface",
+            _ => "ObliviousSurface",
+        };
+
+        var body = kind switch
+        {
+            "Field" => $"    let receiver = {receiverType}()\n"
+                + $"    let probe {target} = receiver.{memberPrefix}Field",
+            "Property" => $"    let receiver = {receiverType}()\n"
+                + $"    let probe {target} = receiver.{memberPrefix}Property",
+            "MethodReturn" => $"    let receiver = {receiverType}()\n"
+                + $"    let probe {target} = receiver.{memberPrefix}Method()",
+            "IndexerElement" => $"    let receiver = {receiverType}()\n"
+                + $"    let probe {target} = receiver[{indexArgument}]",
+
+            // Reaches MemberLookup.GetClrMethodReturnTypeSymbol — the reflected
+            // fallback slot whose three siblings already read nullability.
+            "ConstrainedMethodReturn" => $"    let probe {target} = ViaConstraint({constrainedImpl}())",
+
+            // Reaches MemberLookup.GetClrMethodParameterTypeSymbol and the
+            // synthesised deconstruction local in StatementBinder.Narrowing.
+            "DeconstructOut" => $"    let receiver = {deconstructReceiver}()\n"
+                + "    let (first, second) = receiver\n"
+                + $"    let probe {target} = first",
+            _ => throw new ArgumentOutOfRangeException(nameof(kind)),
+        };
+
+        var helper = kind == "ConstrainedMethodReturn"
+            ? $$"""
+
+                func ViaConstraint[T {{constrainedInterface}}](value T) {{target}} {
+                    return value.{{memberPrefix}}Method()
+                }
+                """
+            : string.Empty;
+
+        return $$"""
+            package {{ConsumerAssemblyName}}
+            import Issue3705.NullabilityLibrary
+
+            func Run() {
+            {{body}}
+            }
+            {{helper}}
+            """;
+    }
+
+    private static string Describe(CompileResult result)
+        => string.Join(Environment.NewLine, result.Diagnostics.Select(d => d.Id + ": " + d.Message));
+
+    private static CompileResult CompileGSharp(string source, params string[] references)
+    {
+        using var resolver = ReferenceResolver.WithReferences(references);
+        resolver.CurrentAssemblyName = ConsumerAssemblyName;
+        var compilation = new GsCompilation(
+            resolver,
+            GsSyntaxTree.Parse(SourceText.From(source)))
+        {
+            AssemblyName = ConsumerAssemblyName,
+        };
+
+        using var output = new MemoryStream();
+        var emit = compilation.Emit(
+            output,
+            pdbStream: null,
+            refStream: null,
+            assemblyName: ConsumerAssemblyName);
+        return new CompileResult(
+            emit.Success,
+            emit.Diagnostics.Select(d => new DiagnosticInfo(d.Id, d.Message)).ToArray());
+    }
+
+    private static string EmitCSharpLibrary(string directory, string assemblyName, string source)
+    {
+        var references = ((AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string)
+                ?.Split(Path.PathSeparator)
+                ?? Array.Empty<string>())
+            .Where(File.Exists)
+            .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path));
+        var compilation = CSharpCompilation.Create(
+            assemblyName,
+            new[] { CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest)) },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        var path = Path.Combine(directory, assemblyName + ".dll");
+        using var output = File.Create(path);
+        var emit = compilation.Emit(output);
+        Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
+        return path;
+    }
+
+    private static string CreateOutputDirectory()
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            nameof(Issue3705MemberKindNullabilityDifferentialTests),
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
+    private static void DeleteOutputDirectory(string directory)
+    {
+        try
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    private readonly record struct CompileResult(bool Success, DiagnosticInfo[] Diagnostics);
+
+    private readonly record struct DiagnosticInfo(string Id, string Message);
+}


### PR DESCRIPTION
Family 2 of the #3705 audit — the nullability family, the one the original triage deliberately deferred. Follows #3707 (accessibility) and #3716 (load context). Full triage, including everything cleared and everything left open, is [in a comment on #3705](https://github.com/DavidObando/gsharp/issues/3705#issuecomment-5484668929).

## The grep could not see the bug

The family was scoped as *"~149 bare `TypeSymbol.FromClrType` in `Binding/` versus 17 nullability-aware reads"*, and the Ask 1 triage ranked the fix as: the two `MemberLookup` fallback slots that end in a bare `FromClrType` while their three siblings end in a `ClrNullability` read. That is a real #3703 instance and it is in this PR — but on its own it changes **nothing observable**.

`TryGetSymbolicDeclaringContext` succeeds for a plain non-generic imported receiver too, so the reader that actually runs is the **symbolic branch**, and the defective line there is

```csharp
return MapOpenClrTypeToSymbolic(openMethod.ReturnType, openDefinition, declaringTypeArguments);
```

Receiver substitution recovers the member's *shape* and silently discards the declaration's `[Nullable]` metadata. There is no `FromClrType` on that line. `GetClrFieldTypeSymbol`'s symbolic branch has folded the flags back in via `NullableFlagsBuilder.MergeDeclarationNullability` since #3695; the return and parameter branches now do the same.

Worth recording for the Ask 2 discussion: rule 3 of the [proposed analyzer set](https://github.com/DavidObando/gsharp/issues/3705#issuecomment-5474427968) — "bare `FromClrType` in a signature position" — would have flagged neither of the two bugs fixed here.

## Reachable, and in the unsound direction

Both bind an imported `string?` as non-null `string`, with no diagnostic:

```gs
// imported: string? NullableMethod()  on interface IC
func Via[T IC](v T) string { return v.NullableMethod() }
```

```gs
// imported: void Deconstruct(out string? a, out int b)
let (a, b) = surface        // `a` is non-null `string`
```

## Fixed

| Site | Slot | Sibling that was already right |
|---|---|---|
| `MemberLookup.GetClrMethodReturnTypeSymbol` — symbolic branch | constrained-call return | `GetClrFieldTypeSymbol`'s symbolic branch |
| `MemberLookup.GetClrMethodParameterTypeSymbol` — symbolic branch | `Deconstruct` out-parameter | same |
| both helpers' reflected fallbacks | as above | `GetClrPropertyTypeSymbol` / `GetClrFieldTypeSymbol` / `GetClrIndexerParameterTypeSymbol` fallback slots |
| `StatementBinder.Narrowing.TryBindImportedDeconstruct` — extension arm | synthesised deconstruction local | the instance arm of the same ternary |

The parameter fallback also failed to peel `ByRef`, unlike the symbolic branch directly above it, so an `out T` parameter reached callers as an `ImportedTypeSymbol` wrapping `T&` and every caller that switches on `ByRefTypeSymbol` took the wrong arm on the reflected path only. `[Nullable]` on a by-ref parameter annotates the **pointee** (by-ref contributes no nullability byte), so the flags merge after peeling and before re-wrapping.

## Not fixed, on purpose — and it is a decision, not a swap

`NullableFlagsBuilder.MergeDeclarationNullability` opens with `if (declarationFlags.IsDefaultOrEmpty) { return projectedType; }`, so a member reached through a receiver-substituting reader keeps the pre-#1354 answer when its declaration carries no nullability metadata at all. The plain `ClrNullability` readers implement #1354's "unannotated imported reference types are nullable"; these do not. The kinds therefore disagree **only in the oblivious column**:

| kind | annotated non-null | annotated nullable | unannotated |
|---|---|---|---|
| Property / MethodReturn / IndexerElement | non-null | nullable | nullable ✓ |
| Field / ConstrainedMethodReturn / DeconstructOut | non-null | nullable | **non-null ✗** |

Closing it is one `return` away and it is not in this PR, because it flips every unannotated imported field read, constrained call and deconstruction in the corpus to nullable at once — the widened-declaration-meets-non-null-consumer shape that produced the #3704 gate regression. It wants its own PR with a corpus measurement. The consequence direction supports waiting: that is the *safe* direction (nullable-when-not — noisy, needs `!!`), where the five sites fixed here were the unsound one.

## Prevention — option (3), third of three

`Issue3705MemberKindNullabilityDifferentialTests`, 19 rows:

- **12** over signature-position kind × annotation state. The expectation is computed from the annotation state **alone** — the kind never appears on the right-hand side, so the table *is* the invariant, as in #3707's and #3716's.
- **6** pinning the oblivious divergence with the divergent set named explicitly, so it cannot drift and closing the hole fails the test and forces the review.
- **1** anti-vacuity fact. #3716 flagged this trap for whoever did family 2: its first fixture would have passed even if the "MLC twin" had silently been the host type. The analogue here is three annotation states that are secretly the same declaration, so the fact reads the emitted `[Nullable]` bytes back out of the fixture assembly and asserts they are `[1]`, `[2]` and absent respectively.

The table earned its keep twice: it **reversed the fix ranking** (the Ask 1 triage's first-ranked fix turned out to be a no-op, and the table is what said so before the sweep shipped it), and it **found the oblivious split**, which is the same "member kinds disagree and nothing in the code says so" signature that #3693 / #3702 / #3707 kept re-discovering one kind at a time.

## Verification

- The two annotated rows for `ConstrainedMethodReturn` and `DeconstructOut` fail on `main` and pass here; the `NonNull` rows are the negative controls for the direction not being changed, and the six oblivious rows are the negative control for the widening deliberately **not** shipped.
- `Core.Tests` 8494/8494, `Compiler.Tests` 4587/4587.
- No emitted-IL movement. `Samples_EmittedPE_Match_Baseline` lives in `Core.Tests` and is green with no baseline regeneration: the sample corpus does not reach a constrained call or a CLR `Deconstruct` over an annotated-nullable imported member, so no baseline moved and none needed auditing.

Refs #3705 — the issue stays open. Remaining: the #1354 oblivious rule through receiver substitution (a decision), the base-member group (`e.StackTrace` on a G# class deriving from an imported base — cheap once the oblivious rule is settled), and the element-type sub-pattern, which needs `GetNullableFlagsForSubtree` rather than a reader swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
