### PR TITLE
gsc: attach doc comments to `deinit` declarations (GS0227, #3739)

### DIFF
--- a/src/Core/CodeAnalysis/Syntax/DocumentationAttacher.cs
+++ b/src/Core/CodeAnalysis/Syntax/DocumentationAttacher.cs
@@ -227,6 +227,14 @@ internal static class DocumentationAttacher
             }
         }
 
+        // A `deinit` block is a member declaration in its own right (the CLR
+        // finalizer), so a `///` block above it attaches to it rather than
+        // floating (GS0227).
+        if (structDecl.Deinitializer != null)
+        {
+            result.Add(structDecl.Deinitializer);
+        }
+
         // ADR-0053: members declared inside a `shared { … }` block are still
         // documentable. The block itself is not a documentable declaration,
         // but each contained field/property/event/method is.

--- a/test/Core.Tests/CodeAnalysis/Documentation/DocumentationValidatorTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Documentation/DocumentationValidatorTests.cs
@@ -111,6 +111,23 @@ public class DocumentationValidatorTests
         Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0231");
     }
 
+    [Fact]
+    public void DocCommentOnDeinit_DoesNotProduceGS0227()
+    {
+        var result = Compile(
+            """
+            package Lib
+
+            class Widget {
+                /// Finalizes an instance of the Widget class.
+                deinit {
+                }
+            }
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0227");
+    }
+
     private static EmitResult Compile(string source, bool warnOnMissingDocs = false)
     {
         var tree = SyntaxTree.Parse(source);


### PR DESCRIPTION
Fixes #3739.

## The defect

Migrated `src/Repl` failed to compile with a single substantive error:

```
GS0227 Documentation comment is not attached to a declaration.
  src/Repl/Shell/ConsoleInputReader.gs:28
```

Line 28 is the `///` block above a `deinit` member — the finalizer of `ConsoleInputReader`, translated from the C# `~ConsoleInputReader()` and its StyleCop-mandated `<summary>Finalizes an instance of the …</summary>`:

```gs
/// Finalizes an instance of the (cref:ConsoleInputReader) class.
deinit {
    this.Restore()
}
```

## Layer at fault: gsc, not cs2gs

The emitted G# is well-formed — the comment does abut a real member declaration, exactly as C# permits on `~Type()`. The fault is in the attachment pass.

`DocumentationAttacher.CollectFromStructBody` (`src/Core/CodeAnalysis/Syntax/DocumentationAttacher.cs`) enumerates fields, properties, events, methods, constructors, `shared { … }` members and nested types, but never adds `StructDeclarationSyntax.Deinitializer`. With the finalizer absent from the documentable-declaration list, the ADR-0057 §7 position-based pass finds nothing on the line following the block, and `DocumentationValidator.ValidateFloatingDocComments` reports GS0227. ADR-0057 §8 predates ADR-0068's `deinit`, so the omission is a gap rather than a deliberate rule.

The fix adds the deinitializer to the collected declarations. Nothing else consumes the attachment table for this node, so the change is confined to making the block attach instead of float.

## Verification

- Minimal repro added to `test/Core.Tests/.../DocumentationValidatorTests.cs` (`DocCommentOnDeinit_DoesNotProduceGS0227`): fails on `origin/main`, passes with the fix. All 102 `Documentation`-filtered Core.Tests pass.
- Repo-wide, this shape occurs exactly once, so the blast radius is `src/Repl`.

### Measured before/after (whole-repo `cs2gs migrate` + `cs2gs validate`, packed Release SDK, both apps in one run so neither masks the other)

| app | before (`origin/main` @ 50314f0be0) | after |
|---|---|---|
| `src/Repl/Repl.csproj` | FAIL(1) — GS0227 at `ConsoleInputReader.gs:28` | **PASS** (compile, ILVerify, test-parity all green) |
| `test/Compiler.Tests/Compiler.Tests.csproj` | FAIL(1) — the same GS0227, inherited from its `src/Repl` project reference | FAIL(20) |

`src/Repl`'s error list is purely subtractive: one error to zero, no new diagnostic id.

`test/Compiler.Tests` is a different story worth stating plainly. Its single "before" error *was* Repl's GS0227 — the dependency never produced an assembly, so the app never got far enough to surface anything of its own. With Repl green it now compiles against a real Repl and reports its own 20 errors: 12× GS0159, 4× GS0158, 3× GS0155, 1× GS0113. These are pre-existing translator gaps that the red dependency was hiding, not regressions from this change; they are separate follow-ups. So this PR turns one gate app green and unmasks the real work remaining in the other.

(GS0536 excluded from all substantive counts throughout.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
