### PR TITLE
cs2gs: catch-filter seams, inferred tuple names, [CollectionBuilder] targets (#3684)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue3684MigratedCoreTestsTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3684MigratedCoreTestsTranslationTests.cs
@@ -1,0 +1,153 @@
+// <copyright file="Issue3684MigratedCoreTestsTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Regression tests for the cs2gs root-cause families issue #3684 tracked in
+/// migrated <c>test/Core.Tests</c>.
+/// </summary>
+public class Issue3684MigratedCoreTestsTranslationTests
+{
+    /// <summary>
+    /// Family F12: an exception filter that introduces a PATTERN DESIGNATION.
+    /// The #1724 rethrow lowering translates the filter into the catch body,
+    /// but the designation's storage and the scrutinee spill were hoisted to
+    /// the seam enclosing the whole <c>try</c> — outside the catch, where
+    /// neither the catch binder nor the designation is in scope.
+    /// </summary>
+    [Fact]
+    public void CatchFilterWithPatternDesignation_KeepsItsSpillsInsideTheCatch()
+    {
+        string printed = TranslateUnit(@"
+using System;
+
+namespace Demo
+{
+    public static class Runner
+    {
+        public static string Run(Action body)
+        {
+            try
+            {
+                body();
+            }
+            catch (InvalidOperationException ex) when (ex.InnerException is ArgumentException arg)
+            {
+                return arg.ParamName;
+            }
+
+            return string.Empty;
+        }
+    }
+}
+");
+
+        int catchIndex = printed.IndexOf("} catch (", StringComparison.Ordinal);
+        Assert.True(catchIndex >= 0, "expected a translated catch clause in:\n" + printed);
+        Assert.DoesNotContain("ex.InnerException", printed.Substring(0, catchIndex), StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Family F15: C# 7.1 infers tuple element names from the element
+    /// expressions (<c>(statement, index)</c>), and ADR-0172 deliberately does
+    /// NOT adopt that inference — so the translated literal prints unlabeled,
+    /// its type is the unnamed shape, and a later <c>pair.index</c> read failed
+    /// GS0158. Such a read normalizes to the positional element instead. An
+    /// element whose name is DECLARED in a tuple type still keeps it.
+    /// </summary>
+    [Fact]
+    public void InferredTupleElementRead_NormalizesToThePositionalElement()
+    {
+        string printed = TranslateUnit(@"
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Demo
+{
+    public static class Indexer
+    {
+        public static int FirstEmpty(IReadOnlyList<string> values)
+        {
+            return values
+                .Select((value, index) => (value, index))
+                .First(pair => pair.value.Length == 0)
+                .index;
+        }
+
+        public static int DeclaredNamesSurvive((int Line, int Column) at)
+        {
+            return at.Line;
+        }
+    }
+}
+");
+
+        Assert.Contains(".Item2", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain(".index", printed, StringComparison.Ordinal);
+        Assert.Contains("at.Line", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Family F16: a <c>[CollectionBuilder]</c> target that is a STRUCT
+    /// (<c>ImmutableArray&lt;T&gt;</c>) never took the collection-initializer
+    /// path — which only fires for a constructible class — and the slice
+    /// literal it fell through to has no conversion to it (GS0155). C# lowers
+    /// such a collection expression to the declared builder factory, so cs2gs
+    /// emits that call.
+    /// </summary>
+    [Fact]
+    public void CollectionExpressionAtCollectionBuilderStructTarget_CallsTheBuilderFactory()
+    {
+        string printed = TranslateUnit(
+            @"
+using System.Collections.Immutable;
+
+namespace Demo
+{
+    public static class Names
+    {
+        public static readonly ImmutableArray<string> All = [""a"", ""b""];
+    }
+}
+",
+            roundTripOnlyReason: "gsc binds the printed factory call only against a reference set carrying System.Collections.Immutable.");
+
+        Assert.Contains(
+            @"ImmutableArray.Create[string]([]string{""a"", ""b""})",
+            printed,
+            StringComparison.Ordinal);
+    }
+
+    private static string TranslateUnit(string source, string roundTripOnlyReason = null)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = roundTripOnlyReason is null
+            ? TranslationTestValidation.AssertBinds(printed)
+            : TranslationTestValidation.ValidateRoundTripOnly(printed, roundTripOnlyReason);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -789,9 +789,18 @@ public sealed partial class CSharpToGSharpTranslator
                 field.ContainingType is { IsTupleType: true })
             {
                 IFieldSymbol positional = field.CorrespondingTupleField ?? field;
-                if (SymbolEqualityComparer.Default.Equals(positional, field))
+                if (SymbolEqualityComparer.Default.Equals(positional, field)
+                    || IsInferredTupleElementName(field))
                 {
-                    // Default positional access (`item.Item2`) stays positional.
+                    // Default positional access (`item.Item2`) stays positional,
+                    // and so does an INFERRED one (issue #3684 F15): ADR-0172
+                    // deliberately does not adopt C# 7.1 name inference, so a
+                    // name C# derived from an element EXPRESSION
+                    // (`(statement, index)` typing as `(… statement, … index)`)
+                    // exists nowhere in the translated G# — the literal prints
+                    // unlabeled and the tuple type is the unnamed shape. Reading
+                    // it back by that name is GS0158; the positional spelling is
+                    // always valid.
                     memberName = positional.Name;
                     memberSymbol = positional;
                 }
@@ -927,6 +936,36 @@ public sealed partial class CSharpToGSharpTranslator
 
             return unwrapped is CastExpressionSyntax cast
                 && this.CastLowersToNullPreservingSafeCast(cast);
+        }
+
+        /// <summary>
+        /// Whether a named tuple element's name was INFERRED by C# 7.1 from the
+        /// element expression rather than written down. A declared name — in a
+        /// tuple TYPE (<c>(int Line, int Column)</c>) or carried on a metadata
+        /// signature — has a <see cref="TupleElementSyntax"/> declaring
+        /// reference or none at all; an inferred one points back at the tuple
+        /// literal's own <see cref="ArgumentSyntax"/>, the only spelling that
+        /// does not survive translation (ADR-0172 does not infer names).
+        /// </summary>
+        /// <param name="element">The tuple element field symbol.</param>
+        /// <returns><see langword="true"/> when the name exists only by inference.</returns>
+        private static bool IsInferredTupleElementName(IFieldSymbol element)
+        {
+            ImmutableArray<SyntaxReference> references = element.DeclaringSyntaxReferences;
+            if (references.IsDefaultOrEmpty)
+            {
+                return false;
+            }
+
+            foreach (SyntaxReference reference in references)
+            {
+                if (reference.GetSyntax() is TupleElementSyntax)
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         private bool ImportedGenericTupleElementRequiresAssertion(ExpressionSyntax receiver)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -2581,7 +2581,75 @@ public sealed partial class CSharpToGSharpTranslator
                 }
             }
 
-            return new ArrayLiteralExpression(sliceElementType, elements);
+            var slice = new ArrayLiteralExpression(sliceElementType, elements);
+
+            // Issue #3684 (F16): a `[CollectionBuilder]` target that is not a
+            // constructible CLASS — `ImmutableArray<T>` and friends are STRUCTS,
+            // so the collection-initializer path above never sees them — has no
+            // conversion from the slice literal either (GS0155). C# itself
+            // lowers such a collection expression to a call of the declared
+            // builder factory, so emit that call directly, handing it the slice
+            // (gsc's existing `[]T` → `ReadOnlySpan[T]` implicit conversion
+            // covers the factory's span parameter).
+            if (TryGetCollectionBuilder(target, out INamedTypeSymbol builderType, out string builderMethodName)
+                && this.typeMapper.Map(builderType, this.context, collection.GetLocation())
+                    is NamedTypeReference builderRef)
+            {
+                return new InvocationExpression(
+                    new MemberAccessExpression(
+                        new IdentifierExpression(builderRef.Name),
+                        builderMethodName),
+                    new List<GExpression> { slice },
+                    new List<GTypeReference> { sliceElementType });
+            }
+
+            return slice;
+        }
+
+        /// <summary>
+        /// The <c>[CollectionBuilder(typeof(B), "M")]</c> factory declared on a
+        /// collection-expression target, when the target carries one and the
+        /// named factory is a single-type-parameter generic method (the only
+        /// shape whose call cs2gs can spell without inferring anything).
+        /// </summary>
+        /// <param name="target">The collection expression's target type.</param>
+        /// <param name="builderType">Receives the builder type.</param>
+        /// <param name="methodName">Receives the factory method name.</param>
+        /// <returns><see langword="true"/> when a usable builder was found.</returns>
+        private static bool TryGetCollectionBuilder(
+            ITypeSymbol target,
+            out INamedTypeSymbol builderType,
+            out string methodName)
+        {
+            builderType = null;
+            methodName = null;
+            if (target is not INamedTypeSymbol named)
+            {
+                return false;
+            }
+
+            foreach (AttributeData attribute in named.OriginalDefinition.GetAttributes())
+            {
+                if (attribute.AttributeClass?.Name != "CollectionBuilderAttribute"
+                    || attribute.ConstructorArguments is not
+                        [{ Value: INamedTypeSymbol declaredBuilder }, { Value: string declaredMethod }])
+                {
+                    continue;
+                }
+
+                if (!declaredBuilder.GetMembers(declaredMethod)
+                    .OfType<IMethodSymbol>()
+                    .Any(m => m.IsStatic && m.Arity == 1))
+                {
+                    continue;
+                }
+
+                builderType = declaredBuilder;
+                methodName = declaredMethod;
+                return true;
+            }
+
+            return false;
         }
 
         private GExpression CoerceCollectionElement(

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
@@ -1860,8 +1860,12 @@ public sealed partial class CSharpToGSharpTranslator
                 this.state.CurrentCatchVariable = variableName;
                 try
                 {
-                    BlockStatement body = this.TranslateBlock(catchClause.Block);
-                    if (catchClause.Filter != null)
+                    BlockStatement body;
+                    if (catchClause.Filter == null)
+                    {
+                        body = this.TranslateBlock(catchClause.Block);
+                    }
+                    else
                     {
                         // No overlapping later sibling here by construction
                         // (loopEnd stops before mergeStartIndex, the first index
@@ -1875,13 +1879,42 @@ public sealed partial class CSharpToGSharpTranslator
                         // silently swallowed (issue #1724). Note: unlike a real
                         // CLR exception filter, this runs after the stack has
                         // already unwound into the handler.
-                        GExpression filter = this.TranslateExpression(catchClause.Filter.FilterExpression);
+                        //
+                        // Issue #3684 (F12): the filter is translated under its
+                        // OWN statement seam. A filter may need hoisted
+                        // statements — a scrutinee spill, or storage for a
+                        // pattern designation it introduces
+                        // (`when (ex.InnerException is AggregateException agg)`)
+                        // — and the ambient seam at this point is the one
+                        // enclosing the whole `try`, which is outside the catch
+                        // where neither the catch binder nor the designation is
+                        // in scope. Those statements belong at the head of the
+                        // catch body, ahead of the rethrow test, which is
+                        // exactly where the filter runs. Translating the filter
+                        // BEFORE the body also registers the designation's
+                        // binding, so body references to it (`throw
+                        // agg.InnerException ?? agg`) see the materialized
+                        // local.
+                        List<GStatement> outerSpillPrologue = this.state.PendingSpillPrologue;
+                        var filterPrologue = new List<GStatement>();
+                        this.state.PendingSpillPrologue = filterPrologue;
+                        GExpression filter;
+                        try
+                        {
+                            filter = this.TranslateExpression(catchClause.Filter.FilterExpression);
+                        }
+                        finally
+                        {
+                            this.state.PendingSpillPrologue = outerSpillPrologue;
+                        }
+
+                        BlockStatement filteredBody = this.TranslateBlock(catchClause.Block);
                         var rethrowIfFalse = new IfStatement(
                             new UnaryExpression("!", filter),
                             new BlockStatement(new List<GStatement> { new ThrowStatement(new IdentifierExpression(variableName)) }));
-                        var statements = new List<GStatement> { rethrowIfFalse };
-                        statements.AddRange(body.Statements);
-                        body = new BlockStatement(statements, body.IsUnsafe);
+                        var statements = new List<GStatement>(filterPrologue) { rethrowIfFalse };
+                        statements.AddRange(filteredBody.Statements);
+                        body = new BlockStatement(statements, filteredBody.IsUnsafe);
                     }
 
                     catches.Add(new CatchClause(variableName, exceptionType, body));


### PR DESCRIPTION
Three of the root-cause families issue #3684 tracks in migrated
`test/Core.Tests`, all cs2gs-side. Re-measured first, because a great deal
merged since the issue's last comment.

## Measurement

Whole-repository `cs2gs migrate`, then
`cs2gs validate --app test/Core.Tests/Core.Tests.csproj` with **both** projects
Core.Tests project-references also in the `--app` list (`src/Core`,
`src/Analyzers/GSharp.CodeAnalysis.Analyzers.Testing`), against the freshly
packed SDK. Before = `cec369958` (`origin/main` at branch point);
after = this branch.

**migrated `test/Core.Tests`: 11 → 6 compile errors.** No `GS0536` in either
run — the `!!` polish convergence from #3728 has held, so this is the whole
substantive figure, not a filtered one. The after-run's fingerprint set is a
strict SUBSET of the before-run's: **purely subtractive**, no diagnostic id
increased and no new id appeared. `src/Core` and
`GSharp.CodeAnalysis.Analyzers.Testing` are PASS/PASS/PASS (compile, ILVerify,
test-parity) in both runs.

Repo-wide readability metrics on the freshly-translated tree (pre-polish):
**`!!` 21335 → 21356 (+21)**, long lines 567 → 568, synthetic labels 0 → 0,
lifts 29 → 29. The `!!` movement is F12's: a designation that used to print as
an unbound bare name now prints as the materialized `(spill as T)!!` value, two
per filtered-catch clause that introduces one (about ten such clauses across the
corpus). Nothing else in this change can emit a `!!`.

The issue's last comment reported 22 non-`GS0536` errors. Eleven of those were
already gone before this branch touched anything — see the issue comment for
which.

## What this fixes

| family | before | after |
|---|---|---|
| **F12** filtered catch with a pattern designation | `GS0157` ×2, `GS0125` ×1 | — |
| **F15** `.index` on an inferred-name tuple | `GS0158` ×1 | — |
| **F16** `[]T{…}` at an `ImmutableArray[T]` target | `GS0155` ×1 | — |

`GS0125`, `GS0155` and `GS0157` are now absent from the app entirely.

### F12 — an exception filter that introduces a pattern designation

The #1724 rethrow lowering translates
`catch (X ex) when (ex.Inner is Y agg)` into the catch body, but it translated
the filter under the statement seam enclosing the whole `try`. A filter that
needs hoisted statements — a scrutinee spill, or storage for a designation it
introduces — put them OUTSIDE the catch, where neither the catch binder nor the
designation is in scope:

```gs
let __spill0 = ex.InnerException          // outside the try: `ex` unknown
try { … } catch (ex TargetInvocationException) {
    if !(__spill0 is AggregateException) { throw ex }
    throw agg.InnerException ?? agg       // `agg` never declared
}
```

The filter now gets its own seam whose statements open the catch body, ahead of
the rethrow test — which is exactly where the filter runs. Translating the
filter *before* the body also registers the designation's binding, so body
references to it resolve to the materialized value instead of a bare name.

### F15 — a tuple element name that exists only by C# 7.1 inference

ADR-0172 §"Tuple literals" deliberately does not adopt name inference from
expressions, so `(statement, index)` prints unlabeled and types as the *unnamed*
shape; reading `pair.index` back off it was `GS0158`. Such a read normalizes to
the positional element (`pair.Item2`), which is always valid.

Only the *inferred* case moves: an element name declared in a tuple TYPE
(`(int Line, int Column)`) has a `TupleElementSyntax` declaring reference and
keeps printing `at.Line`, and a name carried on a metadata signature has no
declaring reference at all and is likewise untouched. Labelling the literal
instead was tried and rejected — it rewrites every tuple literal whose elements
are identifiers, and a C#-inferred name that is a G# keyword (`(…, scope: …)`)
does not even parse.

### F16 — a `[CollectionBuilder]` target that is a struct

`TranslateCollectionExpression` only takes the collection-initializer path for a
`TypeKind.Class` target, so `ImmutableArray<T>` — a struct — fell through to the
slice literal, which has no conversion to it (`GS0155`). C# itself lowers such a
collection expression to a call of the type's declared builder factory, so
cs2gs emits that call and hands it the slice; gsc's existing
`[]T` → `ReadOnlySpan[T]` implicit conversion covers the factory's span
parameter, and spread elements ride along inside the slice unchanged.

```gs
private let ArgumentTypes ImmutableArray[Type] = ImmutableArray.Create[Type]([]Type{typeof(bool), …})
```

## Tests

`tools/cs2gs/Cs2Gs.Tests/Issue3684MigratedCoreTestsTranslationTests.cs` — one
test per family, each failing on `origin/main` and passing here. F12 and F15
assert through `TranslationTestValidation.AssertBinds`, so gsc binds the printed
G#, not just the printer's text.

Re-ran the neighbouring Cs2Gs.Tests suites most exposed to these paths
(`~Tuple`, `~Catch`, `~Collection`, `~Try`, `~Oahu`, `~Golden`, `~Pattern`,
`~Exception`, `~Immutable`, `~Slice`, `~Array`): 573 passed, 0 failed.

## What is left, with current evidence

Six errors, and one of them is re-diagnosed. Detail is in the issue comment;
in short:

- **F1b is not a dropped qualifier.** `typeof(Fixtures.Handler322Extensions)`
  fails because cs2gs's owned-extension lowering ERASES the extension container
  class into free `func (recv T) M()` declarations — the type it names no longer
  exists in the translated program. The `Issue3673NullableReceiverExtensions`
  site the last comment filed under the #3677 `typeof` family is the same defect,
  not a `typeof` one. 2 × `GS0113` + 1 × `GS0159` cascade.
- **F13 is not about nullability.** `let mapClrType ((Type?) -> Type?)? =
  resolver.MapClrTypeToReferences` fails identically at the NON-nullable
  spelling `(Type) -> Type`, and at every combination of inner annotations —
  so neither "cs2gs should not annotate the target" nor "gsc should accept
  method-group → `F?`" is the bug. It reproduces only under a
  `MetadataLoadContext`-rooted resolver and only for a signature over an
  MLC-projected type; the same conversion over `string`/`bool` binds. It is a
  cross-reflection-context projection defect in the #1958 family.
- **F10** (`GS0264` + `GS0187`) is unchanged: one interface at two
  instantiations, a genuine language gap needing an explicit-interface-
  implementation spelling.

Refs #3684.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
