### PR TITLE
gsc: method-group conversion reads its target signature through the load-context funnel (GS0218, #3752)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -1715,8 +1715,61 @@ internal sealed class ConversionClassifier
             return new BoundErrorExpression(null);
         }
 
+        // Issue #3752 (#3705, family 3): the direct `Invoke` probe is the fast
+        // path, but it is unreachable whenever the target's CLR type closed a
+        // live `System.Func`n`/`Action`n` over a type projected from the
+        // compilation's MetadataLoadContext — `(Type) -> Type` under any
+        // `/reference:` compile. `MakeGenericType` then yields a
+        // `TypeBuilderInstantiation`, whose `GetMethod("Invoke")` throws
+        // `NotSupportedException` and whose `GetMethodSafe` wrapper answers
+        // null, so EVERY method-group conversion at a function type over an
+        // imported type failed with GS0218 while the same conversion over
+        // `string`/`int32` (host runtime types) succeeded. `ClrLoadContext`
+        // already carries the cross-context decomposition the sibling delegate
+        // probes (#932, #3681, #3697) go through; this one was the outlier.
         var invoke = delegateClr.GetMethodSafe("Invoke");
-        if (invoke == null)
+        Type[] invokeParameterTypes;
+        Type invokeReturnType;
+        ImmutableArray<RefKind> targetParameterRefKinds;
+        if (invoke != null)
+        {
+            var invokeParams = invoke.GetParameters();
+            invokeParameterTypes = new Type[invokeParams.Length];
+            for (var i = 0; i < invokeParams.Length; i++)
+            {
+                invokeParameterTypes[i] = invokeParams[i].ParameterType;
+            }
+
+            invokeReturnType = invoke.ReturnType;
+            targetParameterRefKinds = DelegateRefKindUtilities.GetParameterRefKinds(invoke);
+        }
+        else if (ClrLoadContext.TryGetDelegateSignature(delegateClr, out var crossContextParams, out var crossContextReturn))
+        {
+            targetParameterRefKinds = DelegateRefKindUtilities.GetDelegateParameterRefKinds(
+                delegateClr,
+                crossContextParams.Length,
+                out _);
+            if (targetParameterRefKinds.Length != crossContextParams.Length)
+            {
+                targetParameterRefKinds = ImmutableArray.CreateRange(
+                    Enumerable.Repeat(RefKind.None, crossContextParams.Length));
+            }
+
+            // TryGetDelegateSignature reduces by-ref slots to their pointee
+            // (#2802); candidate `MethodInfo`s still spell them `T&`, so
+            // re-form the managed-pointer shape for the ref-kind-bearing slots
+            // before overload resolution compares them.
+            invokeParameterTypes = new Type[crossContextParams.Length];
+            for (var i = 0; i < crossContextParams.Length; i++)
+            {
+                invokeParameterTypes[i] = targetParameterRefKinds[i] == RefKind.None
+                    ? crossContextParams[i]
+                    : crossContextParams[i].MakeByRefType();
+            }
+
+            invokeReturnType = crossContextReturn;
+        }
+        else
         {
             Diagnostics.ReportCannotConvertMethodGroup(
                 diagnosticLocation,
@@ -1725,15 +1778,13 @@ internal sealed class ConversionClassifier
             return new BoundErrorExpression(null);
         }
 
-        var invokeParams = invoke.GetParameters();
-        var targetParameterRefKinds = DelegateRefKindUtilities.GetParameterRefKinds(invoke);
         var closesExtensionReceiver = group.Receiver != null;
         foreach (var candidate in group.Candidates)
         {
             closesExtensionReceiver &= candidate.IsStatic;
         }
 
-        var argTypes = new Type[invokeParams.Length + (closesExtensionReceiver ? 1 : 0)];
+        var argTypes = new Type[invokeParameterTypes.Length + (closesExtensionReceiver ? 1 : 0)];
         if (closesExtensionReceiver)
         {
             var receiver = Invariant.Required(group.Receiver, "a static method-group extension receiver was established");
@@ -1751,9 +1802,9 @@ internal sealed class ConversionClassifier
             argTypes[0] = receiverClr;
         }
 
-        for (var i = 0; i < invokeParams.Length; i++)
+        for (var i = 0; i < invokeParameterTypes.Length; i++)
         {
-            argTypes[i + (closesExtensionReceiver ? 1 : 0)] = invokeParams[i].ParameterType;
+            argTypes[i + (closesExtensionReceiver ? 1 : 0)] = invokeParameterTypes[i];
         }
 
         var applicable = new List<MethodInfo>();
@@ -1764,7 +1815,7 @@ internal sealed class ConversionClassifier
                 continue;
             }
 
-            if (!IsMethodGroupReturnCompatible(candidate.ReturnType, invoke.ReturnType))
+            if (!IsMethodGroupReturnCompatible(candidate.ReturnType, invokeReturnType))
             {
                 continue;
             }
@@ -3014,28 +3065,21 @@ internal sealed class ConversionClassifier
             return userDelegate.Parameters.Select(parameter => parameter.RefKind).ToImmutableArray();
         }
 
-        var invoke = targetType?.ClrType != null && ClrTypeUtilities.IsDelegateType(targetType.ClrType)
-            ? targetType.ClrType.GetMethodSafe("Invoke")
-            : null;
-        if (invoke == null)
+        // Issue #3752: the sibling of the probe in
+        // `BindClrMethodGroupConversion`, sharing its omission — a direct
+        // `Invoke` reflection that answers null for every cross-reflection-
+        // context closure, here silently degrading a by-ref target signature
+        // to all-by-value rather than failing loudly. Both now read the ref
+        // kinds through the same load-context-tolerant helper.
+        if (targetType?.ClrType == null || !ClrTypeUtilities.IsDelegateType(targetType.ClrType))
         {
             return ImmutableArray.CreateRange(Enumerable.Repeat(RefKind.None, parameterCount));
         }
 
-        returnRefKind = invoke.ReturnType.IsByRef ? RefKind.Ref : RefKind.None;
-        var refKinds = ImmutableArray.CreateBuilder<RefKind>();
-        foreach (var parameter in invoke.GetParameters())
-        {
-            refKinds.Add(!parameter.ParameterType.IsByRef
-                ? RefKind.None
-                : parameter.IsOut
-                    ? RefKind.Out
-                    : parameter.IsIn
-                        ? RefKind.In
-                        : RefKind.Ref);
-        }
-
-        return refKinds.ToImmutable();
+        return DelegateRefKindUtilities.GetDelegateParameterRefKinds(
+            targetType.ClrType,
+            parameterCount,
+            out returnRefKind);
     }
 
     // ADR-0062: an inner ref-kind modifier on a conditional ref-argument branch

--- a/src/Core/CodeAnalysis/Binding/DelegateRefKindUtilities.cs
+++ b/src/Core/CodeAnalysis/Binding/DelegateRefKindUtilities.cs
@@ -41,10 +41,14 @@ internal static class DelegateRefKindUtilities
                 return true;
             case { Type.ClrType: System.Type sourceType }
                 when ClrTypeUtilities.IsDelegateType(sourceType):
-                var sourceInvoke = sourceType.GetMethodSafe("Invoke");
-                if (sourceInvoke != null)
+
+                // Issue #3752: the third sibling of the same probe. A direct
+                // `Invoke` reflection answers null for a delegate closed over
+                // a MetadataLoadContext-projected type, which used to abandon
+                // the source's ref kinds entirely.
+                if (ClrLoadContext.TryGetDelegateSignature(sourceType, out var sourceParameters, out _))
                 {
-                    refKinds = GetParameterRefKinds(sourceInvoke);
+                    refKinds = GetDelegateParameterRefKinds(sourceType, sourceParameters.Length, out _);
                     return true;
                 }
 
@@ -62,6 +66,44 @@ internal static class DelegateRefKindUtilities
 
         refKinds = default;
         return false;
+    }
+
+    /// <summary>
+    /// Issue #3752 (#3705, family 3): reads a delegate type's <c>Invoke</c>
+    /// parameter ref kinds in a way that survives a cross-reflection-context
+    /// closure.
+    /// <para>
+    /// A native function type over a <c>MetadataLoadContext</c>-projected type
+    /// (<c>(Type) -&gt; Type</c> in any compile with <c>/reference:</c>) has a
+    /// <c>System.Reflection.Emit.TypeBuilderInstantiation</c> as its CLR type,
+    /// because <c>typeof(Func&lt;,&gt;).MakeGenericType</c> cannot produce a
+    /// <c>RuntimeType</c> over foreign-context arguments. Reflecting
+    /// <c>Invoke</c> off it throws <see cref="NotSupportedException"/>, so the
+    /// direct probe answers <see langword="null"/>. Ref kinds are stable under
+    /// generic substitution, so the open definition's <c>Invoke</c> — always
+    /// reachable in metadata — answers the same question, exactly as
+    /// <see cref="ClrLoadContext.TryGetDelegateSignature"/> does for the
+    /// parameter and return types.
+    /// </para>
+    /// </summary>
+    /// <param name="delegateType">The delegate (or native function) CLR type.</param>
+    /// <param name="parameterCount">The signature's parameter count, used when no <c>Invoke</c> is reachable at all.</param>
+    /// <param name="returnRefKind">The <c>Invoke</c> return's ref kind.</param>
+    /// <returns>One ref kind per <c>Invoke</c> parameter.</returns>
+    internal static ImmutableArray<RefKind> GetDelegateParameterRefKinds(
+        System.Type? delegateType,
+        int parameterCount,
+        out RefKind returnRefKind)
+    {
+        returnRefKind = RefKind.None;
+        var invoke = delegateType?.GetMethodSafe("Invoke") ?? TryGetOpenDefinitionInvoke(delegateType);
+        if (invoke == null)
+        {
+            return ImmutableArray.CreateRange(Enumerable.Repeat(RefKind.None, parameterCount));
+        }
+
+        returnRefKind = invoke.ReturnType.IsByRef ? RefKind.Ref : RefKind.None;
+        return GetParameterRefKinds(invoke);
     }
 
     internal static ImmutableArray<RefKind> GetParameterRefKinds(
@@ -172,6 +214,30 @@ internal static class DelegateRefKindUtilities
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// Issue #3752: the open generic definition's <c>Invoke</c>, the only one
+    /// reachable when the closed type is a cross-context
+    /// <c>TypeBuilderInstantiation</c>.
+    /// </summary>
+    /// <param name="delegateType">The closed delegate type.</param>
+    /// <returns>The open definition's <c>Invoke</c>, or <see langword="null"/>.</returns>
+    private static MethodInfo? TryGetOpenDefinitionInvoke(System.Type? delegateType)
+    {
+        if (delegateType is null || !delegateType.IsGenericType || delegateType.IsGenericTypeDefinition)
+        {
+            return null;
+        }
+
+        try
+        {
+            return delegateType.GetGenericTypeDefinition().GetMethodSafe("Invoke");
+        }
+        catch (System.Exception)
+        {
+            return null;
+        }
     }
 
     private static RefKind GetParameterRefKind(ParameterInfo parameter) =>

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3752MethodGroupLoadContextDifferentialTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3752MethodGroupLoadContextDifferentialTests.cs
@@ -1,0 +1,246 @@
+// <copyright file="Issue3752MethodGroupLoadContextDifferentialTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #3752 (issue #3705, family 3; #3684's "F13") — a method-group
+/// conversion at a native function type whose signature mentions a type
+/// projected from the compilation's <see cref="System.Reflection.MetadataLoadContext"/>.
+/// <para>
+/// <c>FunctionTypeSymbol.BuildClrType</c> gives <c>(Type) -&gt; Type</c> its
+/// CLR shape by closing the <em>live</em> <c>System.Func`2</c> over the
+/// parameter and return symbols' <c>ClrType</c>s. Under any <c>/reference:</c>
+/// compile those are MLC types, and
+/// <c>typeof(Func&lt;,&gt;).MakeGenericType(mlcType, mlcType)</c> cannot yield
+/// a <c>RuntimeType</c> — the runtime materialises a
+/// <c>System.Reflection.Emit.TypeBuilderInstantiation</c> instead, whose
+/// <c>GetMethod("Invoke")</c> throws <see cref="NotSupportedException"/>.
+/// <c>ConversionClassifier.BindClrMethodGroupConversion</c> reflected
+/// <c>Invoke</c> directly, so it saw "no invoke method" and reported GS0218
+/// for <em>every</em> method group at a function type over an imported type,
+/// while the identical conversion over host runtime types
+/// (<c>(string) -&gt; bool</c>) succeeded.
+/// </para>
+/// <para>
+/// Shaped like <c>Issue3705LoadContextDifferentialTests</c>: the reflection
+/// context never appears on the right-hand side of an expectation. Each row
+/// states one answer and it is asserted for both the default (host runtime)
+/// resolver and the MetadataLoadContext resolver. The rows expecting
+/// <c>GS0218</c> are the anti-vacuity half — they prove the fixture can still
+/// observe the diagnostic it is asserting the absence of elsewhere.
+/// </para>
+/// </summary>
+public class Issue3752MethodGroupLoadContextDifferentialTests
+{
+    /// <summary>
+    /// The differential table: <c>(label, G# source, the one expected
+    /// diagnostic set)</c>, with the reflection context deliberately absent
+    /// from the expectation.
+    /// </summary>
+    /// <returns>The xUnit member-data rows.</returns>
+    public static TheoryData<string, string, string> Rows()
+    {
+        var data = new TheoryData<string, string, string>();
+
+        void Add(string label, string body, string expected)
+            => data.Add(label, body, expected);
+
+        // --- Signatures over `System.Type`, which every MLC projects. These
+        // are the defect: all of them reported GS0218 under the MLC resolver
+        // and bound cleanly under the host one.
+        Add(
+            "static-projected-both-positions",
+            """
+            func probe() {
+                let g (Type) -> Type = Nullable.GetUnderlyingType
+            }
+            """,
+            "<none>");
+
+        Add(
+            "static-projected-nullable-spelling",
+            """
+            func probe() {
+                let g (Type?) -> Type? = Nullable.GetUnderlyingType
+            }
+            """,
+            "<none>");
+
+        Add(
+            "static-projected-optional-function-type",
+            """
+            func probe() {
+                let g ((Type?) -> Type?)? = Nullable.GetUnderlyingType
+            }
+            """,
+            "<none>");
+
+        // Return position alone is enough: `Func<Type>` is just as unreachable
+        // a closure as `Func<Type, Type>`.
+        Add(
+            "instance-projected-return-only",
+            """
+            func probe(t Type) {
+                let g () -> Type = t.MakeArrayType
+            }
+            """,
+            "<none>");
+
+        // Parameter position alone, with a primitive return.
+        Add(
+            "instance-projected-parameter-only",
+            """
+            func probe(t Type) {
+                let g (Type) -> bool = t.IsAssignableFrom
+            }
+            """,
+            "<none>");
+
+        // --- The control that always worked: no projected type in the
+        // signature, so `BuildClrType` closes `Func<string, bool>` over host
+        // runtime types and produces a real `RuntimeType`.
+        Add(
+            "control-no-projected-type",
+            """
+            func probe(t string) {
+                let g (string) -> bool = t.StartsWith
+            }
+            """,
+            "<none>");
+
+        // --- Anti-vacuity: genuinely inapplicable method groups must STILL be
+        // rejected, in both contexts. Without these the rows above could be
+        // satisfied by a binder that stopped diagnosing anything.
+        Add(
+            "reject-arity-mismatch",
+            """
+            func probe() {
+                let g (Type, Type) -> Type = Nullable.GetUnderlyingType
+            }
+            """,
+            "GS0218");
+
+        Add(
+            "reject-return-mismatch",
+            """
+            func probe() {
+                let g (Type) -> string = Nullable.GetUnderlyingType
+            }
+            """,
+            "GS0218");
+
+        Add(
+            "reject-parameter-mismatch",
+            """
+            func probe() {
+                let g (string) -> Type = Nullable.GetUnderlyingType
+            }
+            """,
+            "GS0218");
+
+        return data;
+    }
+
+    /// <summary>
+    /// The invariant: whether a method group converts to a function type is a
+    /// property of the signature, not of the reflection context the
+    /// signature's types were materialised in.
+    /// </summary>
+    /// <param name="label">The row label (diagnostic aid only).</param>
+    /// <param name="body">The G# declaration under test.</param>
+    /// <param name="expected">The single expected answer, for both contexts.</param>
+    [Theory]
+    [MemberData(nameof(Rows))]
+    public void SameAnswer_ForRuntimeResolver_AndMetadataLoadContextResolver(string label, string body, string expected)
+    {
+        var source = "package P\nimport System\n\n" + body;
+
+        var hostAnswer = Compile(source, mlc: false);
+        var mlcAnswer = Compile(source, mlc: true);
+
+        Assert.True(expected == hostAnswer, $"[{label}] host resolver: expected '{expected}', got '{hostAnswer}'");
+        Assert.True(expected == mlcAnswer, $"[{label}] MetadataLoadContext resolver: expected '{expected}', got '{mlcAnswer}'");
+    }
+
+    /// <summary>
+    /// The hazard this family exists for, pinned directly: a native function
+    /// type over an MLC-projected type is not a <c>RuntimeType</c> at all, and
+    /// reflecting <c>Invoke</c> off it throws rather than answering. This is
+    /// why the site had to read its signature through
+    /// <see cref="ClrLoadContext.TryGetDelegateSignature"/>, and it doubles as
+    /// proof that this fixture's MLC really is a distinct reflection context.
+    /// </summary>
+    [Fact]
+    public void FunctionTypeOverProjectedType_HasNoReachableInvoke()
+    {
+        using var resolver = MetadataLoadContextResolver();
+        var mlcType = resolver.MapClrTypeToReferences(typeof(Type));
+        Assert.NotNull(mlcType);
+        Assert.False(
+            ReferenceEquals(typeof(Type), mlcType),
+            "the fixture is not exercising two reflection contexts");
+
+        // What `FunctionTypeSymbol.BuildClrType` produces for `(Type) -> Type`.
+        var functionClr = typeof(Func<,>).MakeGenericType(mlcType!, mlcType!);
+        Assert.False(functionClr.IsGenericTypeDefinition);
+        Assert.Throws<NotSupportedException>(() => functionClr.GetMethod("Invoke"));
+
+        // ... and what the funnel answers for the same type.
+        Assert.True(ClrLoadContext.TryGetDelegateSignature(functionClr, out var parameters, out var returnType));
+        Assert.Equal("System.Type", Assert.Single(parameters).FullName);
+        Assert.Equal("System.Type", returnType.FullName);
+
+        // The host-context twin, for contrast: an ordinary RuntimeType.
+        Assert.NotNull(typeof(Func<Type, Type>).GetMethod("Invoke"));
+    }
+
+    private static string Compile(string source, bool mlc)
+    {
+        var resolver = mlc ? MetadataLoadContextResolver() : null;
+        try
+        {
+            var tree = SyntaxTree.Parse(SourceText.From(source));
+            var globalScope = resolver != null
+                ? Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree), resolver)
+                : Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+            var program = Binder.BindProgram(globalScope, resolver);
+            var ids = globalScope.Diagnostics
+                .AddRange(program.Diagnostics)
+                .Where(d => d.IsError)
+                .Select(d => d.Id)
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(id => id, StringComparer.Ordinal)
+                .ToArray();
+            return ids.Length == 0 ? "<none>" : string.Join(", ", ids);
+        }
+        finally
+        {
+            resolver?.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// The reference-assembly-backed resolver <c>gsc</c> uses on every real
+    /// <c>/reference:</c> compile.
+    /// </summary>
+    /// <returns>A MetadataLoadContext-backed resolver.</returns>
+    private static ReferenceResolver MetadataLoadContextResolver()
+    {
+        var runtimeDir = RuntimeEnvironment.GetRuntimeDirectory();
+        var refPaths = Directory.EnumerateFiles(runtimeDir, "*.dll", SearchOption.TopDirectoryOnly);
+        return ReferenceResolver.WithReferences(refPaths);
+    }
+}


### PR DESCRIPTION
Fixes #3752. This is #3684's **F13**, re-diagnosed: not a nullability question
at all, but a cross-reflection-context defect of the #1958 family and the
#3705 family-3 ("inconsistent sibling probe") shape.

## The defect

`FunctionTypeSymbol.BuildClrType` gives `(Type) -> Type` its CLR shape by
closing the **live** `System.Func`2` over the signature symbols' `ClrType`s.
Under any `/reference:` compile those come from the compilation's
`MetadataLoadContext`, so the closure cannot be a `RuntimeType`:

```
typeof(Func<,>).MakeGenericType(mlcType, mlcType)
  => System.Reflection.Emit.TypeBuilderInstantiation
  => GetMethod("Invoke") throws NotSupportedException
```

`ConversionClassifier.BindClrMethodGroupConversion` reflected `Invoke`
directly, read the `null` its exception wrapper returns as "the target is not
invocable", and reported **GS0218** for *every* method group at a function
type mentioning an imported type — while the identical conversion over host
runtime types (`(string) -> bool`) bound. Verified in-process against both
resolvers before touching anything; every spelling failed, including the fully
non-nullable one, which is what disproves the original nullability hypothesis.

This affects ordinary user code, not just the self-migration: `let f
(SomeImportedType) -> R = obj.Method` never worked in a real compile.

## The fix

`ClrLoadContext.TryGetDelegateSignature` already carries the cross-context
decomposition, and the sibling delegate probes (#932, #3681, #3697) already go
through it — this site was the outlier. The direct `Invoke` stays the fast
path (it alone preserves by-ref parameter spellings) and the funnel is the
fallback, with by-ref slots re-formed from the ref kinds so overload
resolution still compares `T&` against `T&`.

### Sibling probes: yes, two shared the omission, and both are fixed here

- `ConversionClassifier.GetMethodGroupTargetRefKinds` — same direct `Invoke`
  reflection; on `null` it silently degraded a cross-context by-ref target
  signature to all-by-value.
- `DelegateRefKindUtilities.TryGetSourceParameterRefKinds`'s delegate-typed
  arm — abandoned the source's ref kinds outright for the same reason.

Both now read through the new
`DelegateRefKindUtilities.GetDelegateParameterRefKinds`, which falls back to
the open generic definition's `Invoke` (ref kinds are stable under generic
substitution).

## Regression coverage

`Issue3752MethodGroupLoadContextDifferentialTests`, shaped like
`Issue3705LoadContextDifferentialTests`: nine rows, each stating one answer
asserted for **both** the host-runtime and the MetadataLoadContext resolver,
with the reflection context absent from the expectation. Three are
anti-vacuity rows (arity / return / parameter mismatch) that must still report
GS0218 in both contexts, plus a direct pin of the hazard itself.

It did not fit as rows on the existing 44-row matrix: that table asks
`Ask(Type) -> string` questions about a host type and its MLC twin, whereas
the pathological type here (a `Func<,>` closed over MLC arguments) is
constructed by the compiler and is not any type's twin.

**Local evidence** — `dotnet test --filter`:

| filter | result |
|---|---|
| `Issue3752` with this fix | 10/10 pass |
| `Issue3752` with `src/Core` reverted to `origin/main` | **5 fail**, 5 pass (the 5 projected-signature rows; controls, anti-vacuity rows and the hazard pin still pass) |
| Core.Tests `MethodGroup\|Delegate\|Conversion\|RefKind\|Issue3705\|Issue3681\|Issue1958\|Lambda` | 982/982 pass |
| Compiler.Tests `Delegate\|MethodGroup\|RefKind\|Func` | 600/600 pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
