### PR TITLE
gsc: infer imported generic type args through a user class's implemented interface (#3745)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
@@ -1825,8 +1825,13 @@ internal sealed partial class ExpressionBinder
     /// methods declared on the richer interface remain reachable. Falls back to
     /// the first implemented CLR interface so non-collection extensions can
     /// still match an interface receiver.
+    /// <para>
+    /// Issue #3745: the same projection is reused for ORDINARY arguments by
+    /// <see cref="TryProjectUserClassArgumentInterfaces"/>, but only after
+    /// overload resolution has already failed with the erased shapes.
+    /// </para>
     /// </summary>
-    /// <param name="userClass">The user-declared class receiver.</param>
+    /// <param name="userClass">The user-declared class receiver or argument.</param>
     /// <param name="clrInterface">The projected CLR interface type, on success.</param>
     /// <returns><see langword="true"/> when an implemented CLR interface was found.</returns>
     private static bool TryProjectUserClassReceiverInterface(StructSymbol userClass, [NotNullWhen(true)] out Type? clrInterface)
@@ -1864,6 +1869,50 @@ internal sealed partial class ExpressionBinder
 
         clrInterface = bestEnumerable ?? firstInterface;
         return clrInterface != null;
+    }
+
+    /// <summary>
+    /// Issue #3745: rewrites, IN PLACE, every argument slot holding a
+    /// user-declared class that erased to <c>System.Object</c> so it carries the
+    /// implemented imported interface instead. An imported generic method whose
+    /// type parameter occurs solely inside an interface-typed parameter — e.g.
+    /// <c>MethodDefinition.DecodeSignature&lt;TType, TGenericContext&gt;(
+    /// ISignatureTypeProvider&lt;TType, TGenericContext&gt;, TGenericContext)</c>
+    /// called with a G#-declared <c>NameSignatureProvider :
+    /// ISignatureTypeProvider[string, object]</c> — gets no bound at all from an
+    /// <c>object</c> argument, so inference fails and the call reports
+    /// <c>GS0159 Cannot find function</c>.
+    /// <para>
+    /// This runs ONLY after resolution with the erased shapes has already
+    /// failed. The <c>object</c> ride-through is load-bearing on its own — it is
+    /// what makes a parameter whose type is an erased type parameter applicable
+    /// (issue #2840's <c>Do(ctx T, …)</c> on an imported <c>Jobb[T]</c>) — so a
+    /// caller must restore the original vector when the retry does not resolve.
+    /// </para>
+    /// </summary>
+    /// <param name="arguments">The bound arguments, positionally aligned with <paramref name="argTypes"/>.</param>
+    /// <param name="argTypes">The CLR argument-type vector, rewritten in place.</param>
+    /// <returns><see langword="true"/> when at least one slot was rewritten.</returns>
+    private static bool TryProjectUserClassArgumentInterfaces(
+        ImmutableArray<BoundExpression> arguments,
+        Type?[] argTypes)
+    {
+        var projected = false;
+        for (var i = 0; i < arguments.Length && i < argTypes.Length; i++)
+        {
+            if (arguments[i].Type is not StructSymbol { IsClass: true } userClass
+                || argTypes[i] is not { } erased
+                || !erased.IsSameAs(typeof(object))
+                || !TryProjectUserClassReceiverInterface(userClass, out var clrInterface))
+            {
+                continue;
+            }
+
+            argTypes[i] = clrInterface;
+            projected = true;
+        }
+
+        return projected;
     }
 
     private static bool ImplementsGenericEnumerable(Type clr)

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -3564,6 +3564,50 @@ internal sealed partial class ExpressionBinder
                     delegateRefKindArgumentCheck: MakeDelegateRefKindArgumentCheck(arguments),
                     methodGroupInference: MakeMethodGroupInference(arguments, GetEffectiveArgumentClrTypeForOverloadResolution),
                     methodGroupArgumentCheck: MakeMethodGroupArgumentCheck(arguments));
+
+                // Issue #3745: a user-declared class argument erases to
+                // `System.Object`, which gives an imported generic method no
+                // evidence for a type parameter that occurs solely inside an
+                // interface-typed parameter (`DecodeSignature<TType,
+                // TGenericContext>(ISignatureTypeProvider<TType,
+                // TGenericContext>, TGenericContext)`), so inference fails and
+                // the call reports GS0159. Retry ONCE with each such argument
+                // projected onto the imported interface it implements. The
+                // retry is on the failure path only, and the original vector is
+                // restored when it does not resolve, because the `object`
+                // ride-through is itself load-bearing for erased type-parameter
+                // parameters (#2840).
+                if (resolution.Outcome != ClrOverloadResolution.ResolutionOutcome.Resolved
+                    && hasUserClassArg)
+                {
+                    var erasedArgTypes = (Type?[])argTypes.Clone();
+                    if (TryProjectUserClassArgumentInterfaces(arguments, argTypes))
+                    {
+                        var projectedResolution = ClrOverloadResolution.Resolve(
+                            candidates,
+                            argTypes,
+                            explicitTypeArgs,
+                            scope.References.MapClrTypeToReferences,
+                            ComputeInterpolatedStringArgFlags(ce.Arguments, arguments.Length),
+                            argumentNames.IsDefault ? null : (IReadOnlyList<string>)argumentNames,
+                            recoverTypeArgSymbols: recoverTypeArgSymbols,
+                            supplementaryInterfaceCheck: supplementaryInterfaceCheck,
+                            constantNarrowingArgumentCheck: MakeConstantNarrowingArgumentCheck(arguments),
+                            structuralProjectionArgumentCheck: MakeStructuralProjectionArgumentCheck(arguments),
+                            delegateRefKindArgumentCheck: MakeDelegateRefKindArgumentCheck(arguments),
+                            methodGroupInference: MakeMethodGroupInference(arguments, GetEffectiveArgumentClrTypeForOverloadResolution),
+                            methodGroupArgumentCheck: MakeMethodGroupArgumentCheck(arguments));
+                        if (projectedResolution.Outcome == ClrOverloadResolution.ResolutionOutcome.Resolved)
+                        {
+                            resolution = projectedResolution;
+                        }
+                        else
+                        {
+                            Array.Copy(erasedArgTypes, argTypes, argTypes.Length);
+                        }
+                    }
+                }
+
                 switch (resolution.Outcome)
                 {
                     case ClrOverloadResolution.ResolutionOutcome.Resolved:

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -2180,6 +2180,13 @@ internal sealed partial class ExpressionBinder
         // and the supplementary interface check handle the rest).
         if (typeSymbol is StructSymbol { IsClass: true } ss)
         {
+            // Issue #3745: the implemented imported INTERFACES a user class
+            // carries are deliberately NOT surfaced here. The `object`
+            // ride-through is what makes an erased type-parameter parameter
+            // (`Do(ctx T, …)` on an imported `Jobb[T]`) applicable, so
+            // projecting an interface unconditionally breaks calls that bind
+            // today (#2840). The projection is applied only on the FAILURE path
+            // — see TryProjectUserClassArgumentInterfaces.
             return ss.ImportedBaseType?.ClrType ?? typeof(object);
         }
 

--- a/test/Compiler.Tests/Emit/Issue3745UserClassInterfaceArgumentInferenceEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3745UserClassInterfaceArgumentInferenceEmitTests.cs
@@ -1,0 +1,188 @@
+// <copyright file="Issue3745UserClassInterfaceArgumentInferenceEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection.Metadata;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #3745 — a user-declared G# class has no CLR <c>Type</c> while it is
+/// being compiled, so <c>GetEffectiveArgumentClrTypeForOverloadResolution</c>
+/// erased it to the imported BASE type, or to <c>System.Object</c> when it has
+/// no imported base. The implemented imported INTERFACES were dropped, and they
+/// are the only evidence an imported generic method has for inferring a type
+/// parameter that occurs solely inside an interface-typed parameter. The
+/// canonical case is
+/// <c>MethodDefinition.DecodeSignature&lt;TType, TGenericContext&gt;(
+/// ISignatureTypeProvider&lt;TType, TGenericContext&gt;, TGenericContext)</c>
+/// called with a G#-declared provider: <c>TType</c> received no bound at all,
+/// inference failed, and the whole call reported
+/// <c>GS0159 Cannot find function DecodeSignature.</c>
+/// <para>
+/// Issue #1423 already projected a user class to its most-derived implemented
+/// CLR interface for an extension method's RECEIVER; this extends the identical
+/// projection to ORDINARY arguments. It is the largest family in the migrated
+/// <c>test/Compiler.Tests</c> compile wall (13 of 20 errors, counting the
+/// <c>GS0158</c> member lookups that cascade off the failed call's error type).
+/// </para>
+/// </summary>
+public class Issue3745UserClassInterfaceArgumentInferenceEmitTests
+{
+    /// <summary>
+    /// The minimal repro reduced from
+    /// <c>test/Compiler.Tests/LanguageConformance/NormalizedIlDump.cs</c>: a G#
+    /// class implementing <c>ISignatureTypeProvider[string, object]</c> passed
+    /// as an ordinary argument to the imported generic instance method
+    /// <c>MethodDefinition.DecodeSignature</c>. The test EXECUTES the decode
+    /// against this test assembly's own metadata, so it proves the inferred
+    /// <c>TType = string</c> reaches emit and not merely the binder.
+    /// </summary>
+    [Fact]
+    public void UserClassImplementingImportedInterface_InfersGenericArgument_Runs()
+    {
+        const string source = """
+            package i3745provider
+            import System
+            import System.Collections.Immutable
+            import System.IO
+            import System.Reflection.Metadata
+            import System.Reflection.PortableExecutable
+
+            class NameProvider3745 : ISignatureTypeProvider[string, object] {
+                func GetArrayType(elementType string, shape ArrayShape) string -> elementType + "[]"
+                func GetByReferenceType(elementType string) string -> "ref " + elementType
+                func GetFunctionPointerType(signature MethodSignature[string]) string -> "fnptr"
+                func GetGenericInstantiation(genericType string, typeArguments ImmutableArray[string]) string -> genericType + "<...>"
+                func GetGenericMethodParameter(genericContext object, index int32) string -> "m" + index.ToString()
+                func GetGenericTypeParameter(genericContext object, index int32) string -> "t" + index.ToString()
+                func GetModifiedType(modifier string, unmodifiedType string, isRequired bool) string -> unmodifiedType
+                func GetPinnedType(elementType string) string -> elementType
+                func GetPointerType(elementType string) string -> elementType + "*"
+                func GetPrimitiveType(typeCode PrimitiveTypeCode) string -> typeCode.ToString()
+                func GetSZArrayType(elementType string) string -> elementType + "[]"
+                func GetTypeFromDefinition(metadataReader MetadataReader, handle TypeDefinitionHandle, rawTypeKind uint8) string -> "def"
+                func GetTypeFromReference(metadataReader MetadataReader, handle TypeReferenceHandle, rawTypeKind uint8) string -> "ref"
+
+                func GetTypeFromSpecification(
+                    metadataReader MetadataReader,
+                    genericContext object,
+                    handle TypeSpecificationHandle,
+                    rawTypeKind uint8) string -> "spec"
+            }
+
+            func Main() {
+                let path = Environment.GetCommandLineArgs()[0]
+                using let stream = File.OpenRead(path)
+                using let pe = PEReader(stream)
+                let reader = pe.GetMetadataReader()
+                let provider = NameProvider3745()
+                for handle in reader.MethodDefinitions {
+                    let method = reader.GetMethodDefinition(handle)
+                    if reader.GetString(method.Name) == "Main" {
+                        // `sig` is MethodSignature[string] only when TType was
+                        // inferred from the provider's implemented interface.
+                        let sig = method.DecodeSignature(provider, nil)
+                        Console.WriteLine(sig.ReturnType)
+                        return
+                    }
+                }
+
+                Console.WriteLine("not-found")
+            }
+            """;
+
+        Assert.Equal($"Void{Environment.NewLine}", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_3745_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            // System.Reflection.Metadata is not in gsc's default reference set.
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+                "/r:" + typeof(MetadataReader).Assembly.Location,
+                "/r:" + typeof(System.Collections.Immutable.ImmutableArray).Assembly.Location,
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add(dllPath);
+
+            using var process = Process.Start(psi);
+            Assert.NotNull(process);
+            var stdout = process.StandardOutput.ReadToEnd();
+            var stderr = process.StandardError.ReadToEnd();
+            Assert.True(process.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(process.ExitCode == 0, $"exited {process.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+            return stdout.ReplaceLineEndings(Environment.NewLine);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
Triage and first fix for #3745 — the 20 errors `test/Compiler.Tests` reports now that #3744 unmasked it. Full triage posted as https://github.com/DavidObando/gsharp/issues/3745#issuecomment-5486810106.

## Triage: 20 errors → 6 root-cause families, **0 regressions**

| # | root cause | errors | layer | status |
|---|---|---|---|---|
| F1 | user class → imported interface lost for **ordinary arguments** | **13** | gsc | **fixed here** |
| F2 | named tuple element names lost across `await` | 2 | gsc | filed #3746 |
| F3 | `nil` rejected as an element of a **nullable** params array | 2 | gsc | filed #3747 |
| F4 | named tuple → `object?` boxing in a **lambda** return | 1 | gsc | filed #3748 |
| F5 | conversion-call on a **nested** imported enum type | 1 | gsc | filed #3749 |
| F6 | cs2gs drops the static extension-**holder class** | 1 | cs2gs | filed #3750 |

Three of the 20 are pure cascades off F1's failed lookups. Every family was checked against the ~22 already-solved ones: **none is a reappearance**. F3 and F5 are *adjacent* to solved work (signature-position nullability #3705/PR #3741, and nested-type → enclosing-`shared` calls #3660/PR #3662) but are distinct defects; called out explicitly in the triage comment.

## The fix (F1)

A user-declared G# class has no CLR `Type` while it is being compiled, so `GetEffectiveArgumentClrTypeForOverloadResolution` erases it to its imported base type, or to `System.Object` when it has none. The implemented imported **interfaces** are dropped — and they are the only evidence an imported generic method has for inferring a type parameter that occurs solely inside an interface-typed parameter:

```csharp
MethodDefinition.DecodeSignature<TType, TGenericContext>(
    ISignatureTypeProvider<TType, TGenericContext> provider,
    TGenericContext genericContext)
```

called with a G#-declared `NameSignatureProvider : ISignatureTypeProvider[string, object]`. With `provider` erased to `object`, `FindClosedGeneric` matches nothing, `TType` gets no bound, `TryInferTypeArguments` fails, and the call reports `GS0159 Cannot find function DecodeSignature`. That is 10 sites across `LanguageConformance/NormalizedIlDump.cs` and `Emit/Issue1208SafeHandlePInvokeEmitTests.cs`, plus 3 `GS0158`/`GS0159` member lookups cascading off the error-typed results.

Issue #1423 already projects a user class to its most-derived implemented CLR interface — but only for an extension method's **receiver**. This reuses that projection for ordinary arguments.

**It runs on the failure path only.** Projecting unconditionally in the mapper is *not* correct and I measured that: the `object` ride-through is itself load-bearing for a parameter whose type is an erased type parameter, and the blunt version regressed #2840's cross-assembly `Do(ctx T, …)` on an imported `Jobb[T]` (`GS0159 Cannot find function Do`). So resolution runs first with the erased shapes; only when it fails is each user-class argument that erased to `object` projected onto its implemented interface and resolution retried once, with the erased vector restored if the retry also fails.

## Verification

- New `Issue3745UserClassInterfaceArgumentInferenceEmitTests` — **fails on `main`** (`GS0159 Cannot find function DecodeSignature`), passes here. It EXECUTES: the compiled program decodes a real method signature out of its own metadata and prints the return type, so it proves the inferred `TType = string` reaches emit, not just the binder.
- `test/Compiler.Tests` `Emit` suite: **4209/4209 pass** (33 m 48 s). The blunt mapper-level variant failed 1 of those; this one fails none.

## Measured before/after on the corpus

Both runs are whole-repo `cs2gs migrate` followed by `cs2gs validate` with `test/Compiler.Tests` **and every project it references** in the `--app` list (`src/Core`, `src/Compiler`, `src/LanguageServer`, `src/Repl`, `tools/gsgen/GSharp.GeneratorHost`, `tools/gsgen/Gsgen.Cli`, `test/Compiler.Tests`) — nothing the target references is excluded. Both go through the packed SDK from a full `dotnet build GSharp.sln -c Release -graph`, and because the fix is a real commit the two runs pin genuinely different SDK versions (`0.4.349-gcec369958b` → `0.4.350-g419aa39ac4`), not the same one twice.

| | before | after |
|---|---|---|
| apps green | 6/7 | 6/7 |
| `test/Compiler.Tests` errors | **20** | **7** |
| GS0159 | 12 | 1 |
| GS0158 | 4 | 2 |
| GS0155 | 3 | 3 |
| GS0113 | 1 | 1 |

**The error-list diff is purely subtractive**: the 7 survivors are identical in id, file, line, column and message to their "before" counterparts. **No diagnostic id increased, and none appeared.** The other six apps in the list stayed green throughout. Translation was 50/51 both times, the single failure being the known `test/Interpreter.Tests` `translation-unsupported`.

Repo-wide `!!` delta: 21325 → 21329, **+4 — all four from the new test file this PR adds** (its own migrated `.gs` contributes exactly those occurrences). `lines>300` 567 → 568, likewise the new test file's one long source line. `labels` 0 → 0 and `__local_` 29 → 29, unchanged. No `GS0536` in any substantive count.

Note on timings: another agent was running `cs2gs migrate` on the same machine during part of this work, so the wall-clock figures above are contended and should not be read as cost measurements. The error counts are unaffected by that.

Not `Fixes #3745` — 7 of the 20 remain, tracked by #3746–#3750.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
