### PR TITLE
gsc: keep tuple element names across async widening; box symbolic tuples to object (#3746, #3748)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -923,6 +923,22 @@ public sealed class Conversion
             return Conversion.Implicit;
         }
 
+        // Issue #3748: a tuple is unconditionally a CLR value type
+        // (`System.ValueTuple<…>`) and therefore always boxes to `object`, but
+        // `TupleTypeSymbol.BuildClrType` deliberately leaves `ClrType` null
+        // whenever an element requires symbolic projection — most commonly a
+        // nullable-reference element such as `(A int32, B string?)`, but also a
+        // type parameter or a same-compilation user type. The general
+        // CLR-backed rule above needs a non-null `from.ClrType`, so those
+        // tuples were rejected with GS0155 in every `object` / `object?`
+        // position (argument, return, assignment) while the all-CLR-backed
+        // same-shape tuple boxed fine. Element names are irrelevant here.
+        if (from is TupleTypeSymbol
+            && (to == TypeSymbol.Object || to?.ClrType.IsSameAs(typeof(object)) == true))
+        {
+            return Conversion.Implicit;
+        }
+
         // Issue #3310 / ADR-0159: same-element `[]T → sequence[T]` for the
         // OPEN (null-ClrType) shapes — e.g. `q = []K{}` inside a generic
         // class, and the synthesized empty-sequence zero value for a bare

--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -1518,7 +1518,22 @@ internal sealed class LambdaBinder
             // `Task<Nullable<int>>` rather than `Task<int>`.
             var elementClr = resolveClrTypeForGenericArg(element) ?? Scope.References.MapClrTypeToReferences(clr);
             var closed = taskOpen.MakeGenericType(elementClr);
-            return ImportedTypeSymbol.Get(closed);
+
+            // Issue #3746 / ADR-0172: tuple element names are metadata over the
+            // positional shape, so `ImportedTypeSymbol.Get(closed)` — which
+            // rebuilds its type arguments by reflecting over `closed` — erases
+            // them: `async func F() Task[(Output string, Count int32)]`
+            // normalizes to the awaited named tuple, is re-widened here, and
+            // came back as `Task[(string, int32)]`, making every `await F()
+            // .Output` / `F().Result.Output` a GS0158. Unlike the symbolic
+            // branch above this keeps the EXACT closed CLR type (the awaiter,
+            // the async method builder and the emitted signature all depend on
+            // it) and only attaches the name-bearing symbolic argument, which
+            // AsyncReturnTypeNormalizer.TryUnwrapTaskReturnType and member
+            // lookup read in preference to the reflected one.
+            return TypeSymbol.ContainsNamedTupleElement(element)
+                ? ImportedTypeSymbol.GetConstructed(closed, taskOpen, ImmutableArray.Create(element))
+                : ImportedTypeSymbol.Get(closed);
         }
 
         return element;

--- a/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
@@ -1071,6 +1071,42 @@ public class TypeSymbol : Symbol
             || ContainsReferenceNullableAnnotation(type);
 
     /// <summary>
+    /// Issue #3746 / ADR-0172: returns <c>true</c> when <paramref name="type"/>
+    /// carries tuple element names at any structural position. Like reference
+    /// nullability, element names are metadata over the positional shape and
+    /// have no distinct runtime <see cref="Type"/>, so any projection that
+    /// round-trips a type through its CLR <see cref="Type"/> silently erases
+    /// them. Callers that rebuild a type from reflection must consult this and
+    /// take their symbolic path instead.
+    /// </summary>
+    /// <remarks>
+    /// This deliberately is <em>not</em> folded into
+    /// <see cref="RequiresSymbolicProjection(TypeSymbol)"/>: that predicate also
+    /// gates <see cref="TupleTypeSymbol"/>'s own CLR backing, and a named tuple
+    /// must keep its <c>ValueTuple&lt;…&gt;</c> <see cref="ClrType"/> — names
+    /// never change the runtime type (ADR-0172).
+    /// </remarks>
+    /// <param name="type">The type to inspect.</param>
+    /// <returns><c>true</c> when a named tuple appears anywhere in the type.</returns>
+    public static bool ContainsNamedTupleElement(TypeSymbol type)
+    {
+        if (type is TupleTypeSymbol { HasNames: true })
+        {
+            return true;
+        }
+
+        foreach (var inner in GetWrappedTypes(type))
+        {
+            if (ContainsNamedTupleElement(inner))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Returns true when <paramref name="type"/> — after unwrapping nullable,
     /// slice and array wrappers — is itself a same-compilation user-defined
     /// type (struct/class/enum/interface/delegate with a null <c>ClrType</c>).

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3746AsyncNamedTupleReturnTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3746AsyncNamedTupleReturnTests.cs
@@ -1,0 +1,153 @@
+// <copyright file="Issue3746AsyncNamedTupleReturnTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #3746 (ADR-0172): an <c>async func</c> declaring a named-tuple result
+/// must keep its element names on the observable <c>Task[T]</c> return type.
+/// The declared clause <c>Task[(Output string, Count int32)]</c> is normalized
+/// to the awaited named tuple and re-widened by <c>LambdaBinder.WrapAsTask</c>;
+/// before the fix that re-widening took the CLR path and closed <c>Task`1</c>
+/// over the reflected <c>ValueTuple&lt;string, int&gt;</c>, erasing the names —
+/// so every access on the awaited value reported
+/// <c>GS0158 Cannot find member …</c>.
+/// </summary>
+/// <remarks>
+/// Witness of discrimination: the equivalent non-async func returning
+/// <c>Task[(Output string, Count int32)]</c> always bound (it never goes through
+/// <c>WrapAsTask</c>), and so did an async func whose named tuple carried a
+/// nullable-reference element (that shape already took the symbolic path). The
+/// erasure was specific to a fully CLR-backed named tuple behind
+/// <c>async</c>.
+/// </remarks>
+public class Issue3746AsyncNamedTupleReturnTests
+{
+    [Fact]
+    public void AwaitOfAsyncFuncNamedTupleResult_KeepsElementNames()
+    {
+        var result = EmittedOracle.Evaluate(@"
+import System.Threading.Tasks
+
+async func Produce() Task[(Output string, Count int32)] {
+    return (Output: ""a"", Count: 41)
+}
+
+async func Consume() Task[string] {
+    let t = await Produce()
+    return t.Output.PadLeft(t.Count / 41)
+}
+
+Consume().Result
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("a", result.Value);
+    }
+
+    [Fact]
+    public void ResultOfAsyncFuncNamedTupleResult_KeepsElementNames()
+    {
+        var result = EmittedOracle.Evaluate(@"
+import System.Threading.Tasks
+
+async func Produce() Task[(Output string, Count int32)] {
+    return (Output: ""a"", Count: 41)
+}
+
+Produce().Result.Count
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(41, result.Value);
+    }
+
+    [Fact]
+    public void ImplicitWrapForm_AsyncFuncNamedTupleResult_KeepsElementNames()
+    {
+        // The `async func F() (a, b)` implicit-wrap spelling reaches the same
+        // WrapAsTask widening without any Task clause in the source.
+        var result = EmittedOracle.Evaluate(@"
+import System.Threading.Tasks
+
+async func Produce() (Output string, Count int32) {
+    return (Output: ""a"", Count: 7)
+}
+
+Produce().Result.Output
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("a", result.Value);
+    }
+
+    [Fact]
+    public void ValueTaskWrapper_AsyncFuncNamedTupleResult_KeepsElementNames()
+    {
+        var result = EmittedOracle.Evaluate(@"
+import System.Threading.Tasks
+
+async func Produce() ValueTask[(Output string, Count int32)] {
+    return (Output: ""v"", Count: 3)
+}
+
+async func Consume() Task[int32] {
+    let t = await Produce()
+    return t.Count
+}
+
+Consume().Result
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(3, result.Value);
+    }
+
+    [Fact]
+    public void NestedNamedTupleInsideUnnamedResult_KeepsElementNames()
+    {
+        // The names sit one level down, which is why the guard is the
+        // structural `ContainsNamedTupleElement` rather than a top-level
+        // `TupleTypeSymbol.HasNames` test. (This particular spelling also
+        // passed before the fix — the interning cache happened to alias the
+        // reconstructed outer tuple onto the literal's named one — so it is a
+        // forward-guard, not a failing-on-main witness.)
+        var result = EmittedOracle.Evaluate(@"
+import System.Threading.Tasks
+
+async func Produce() Task[(int32, (Output string, Count int32))] {
+    return (1, (Output: ""n"", Count: 2))
+}
+
+async func Consume() Task[string] {
+    let t = await Produce()
+    return t.Item2.Output
+}
+
+Consume().Result
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("n", result.Value);
+    }
+
+    [Fact]
+    public void UnnamedTupleResult_StillAwaitsPositionally()
+    {
+        var result = EmittedOracle.Evaluate(@"
+import System.Threading.Tasks
+
+async func Produce() Task[(string, int32)] {
+    return (""u"", 5)
+}
+
+async func Consume() Task[int32] {
+    let t = await Produce()
+    return t.Item2
+}
+
+Consume().Result
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(5, result.Value);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3748SymbolicTupleBoxingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3748SymbolicTupleBoxingTests.cs
@@ -1,0 +1,103 @@
+// <copyright file="Issue3748SymbolicTupleBoxingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #3748: a tuple always boxes implicitly to <c>object</c> /
+/// <c>object?</c>. <c>TupleTypeSymbol.BuildClrType</c> deliberately leaves
+/// <c>ClrType</c> null whenever an element requires symbolic projection — most
+/// commonly a nullable-reference element such as <c>(A int32, B string?)</c> —
+/// and the general CLR-backed boxing rule in <c>Conversion</c> requires a
+/// non-null source <c>ClrType</c>, so those tuples were rejected with
+/// <c>GS0155 Cannot convert type '(…)' to 'object?'</c> in every
+/// <c>object</c>-typed position.
+/// </summary>
+/// <remarks>
+/// The reporting issue framed this as named-tuple-plus-lambda; it is neither.
+/// Witness of discrimination: the same shape without the nullable element
+/// (<c>(A int32, B string)</c>) boxed fine, an <em>unnamed</em> tuple with a
+/// nullable element failed identically, and the lambda position was incidental.
+/// The trigger is a null <c>ClrType</c> on the tuple, not its element names.
+/// </remarks>
+public class Issue3748SymbolicTupleBoxingTests
+{
+    [Fact]
+    public void NamedTupleWithNullableElement_BoxesToNullableObject()
+    {
+        var result = EmittedOracle.Evaluate(@"
+let t (A int32, B string?) = (1, ""x"")
+let o object? = t
+o!!.ToString()
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("(1, x)", result.Value);
+    }
+
+    [Fact]
+    public void UnnamedTupleWithNullableElement_BoxesToObject()
+    {
+        var result = EmittedOracle.Evaluate(@"
+let t (int32, string?) = (2, ""y"")
+let o object = t
+o.ToString()
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("(2, y)", result.Value);
+    }
+
+    [Fact]
+    public void NamedTupleWithNullableElement_BoxesInFuncReturnPosition()
+    {
+        var result = EmittedOracle.Evaluate(@"
+func Run(name string) (ExitCode int32, Stdout string?, Stderr string?) {
+    return (ExitCode: 0, Stdout: name, Stderr: nil)
+}
+
+func Box() object? {
+    return Run(""x"")
+}
+
+Box()!!.ToString()
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("(0, x, )", result.Value);
+    }
+
+    [Fact]
+    public void NamedTupleWithNullableElement_BoxesInLambdaReturnPosition()
+    {
+        // The reporting site (test/Compiler.Tests/IlVerifierTests.cs:206):
+        // `Assert.Throws<XunitException>(() => IlVerifier.RunProcess(…))`.
+        var result = EmittedOracle.Evaluate(@"
+func Run(name string) (ExitCode int32, Stdout string?, Stderr string?) {
+    return (ExitCode: 9, Stdout: name, Stderr: nil)
+}
+
+func Invoke(f (() -> object?)) object? -> f()
+
+Invoke(func () object? { return Run(""z"") })!!.ToString()
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("(9, z, )", result.Value);
+    }
+
+    [Fact]
+    public void NamedTupleWithNullableElement_BoxesInArgumentPosition()
+    {
+        var result = EmittedOracle.Evaluate(@"
+import System
+
+func Describe(value object?) string -> string.Format(""{0}"", value)
+
+let t (A int32, B string?) = (4, ""q"")
+Describe(t)
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("(4, q)", result.Value);
+    }
+}


### PR DESCRIPTION
Two defects split out of the #3745 triage. **They do not share a root cause** — and the reproductions **disprove both issues' stated framings**. Two independent one-line fixes, two regression suites.

## #3746 — it is not `await`

The issue claims `await` of a `Task[(named tuple)]` yields the unnamed shape. Probes on `origin/main`:

| repro | main |
|---|---|
| `await Produce()` then `.Output` | **GS0158** |
| `Produce().Result.Output` | **GS0158** — so not `await` |
| non-async `func Produce() Task[(Output string, Count int32)]`, `.Result.Output` | OK |
| `let t Task[(Output string, Count int32)] = Produce()`, `.Result.Output` | OK — the annotation restores the names |

The loss is in the **async return-type re-widening**, and both `await` and `.Result` are downstream victims. `NormalizeAsyncDeclaredReturnType` unwraps the declared clause to the awaited named tuple; `LambdaBinder.WrapAsTask` then re-widens it by closing `Task`1` over `element.ClrType` and calling `ImportedTypeSymbol.Get`, which rebuilds its type arguments **by reflection** — `ValueTuple<string, int>`, names gone.

**Fix** (`src/Core/CodeAnalysis/Binding/LambdaBinder.cs`): attach the name-bearing symbolic argument with `ImportedTypeSymbol.GetConstructed(closed, taskOpen, [element])` while keeping the **exact** closed CLR type. `AsyncReturnTypeNormalizer.TryUnwrapTaskReturnType` already prefers the symbolic argument over the reflected one.

Note for reviewers: the obvious alternative — routing named tuples through the existing symbolic-erasure branch (`Task<object>` + symbolic argument, the path nullable-reference results take) — *binds* but produces an awaiter over the wrong instantiation. `await` then fails at runtime with `Unable to cast object of type 'System.String' to type 'System.ValueTuple`2[System.String,System.Int32]'`, and the `ValueTask` variant faults with an `AccessViolationException`. That approach is deliberately not used.

The guard is a new structural `TypeSymbol.ContainsNamedTupleElement` (`src/Core/CodeAnalysis/Symbols/TypeSymbol.cs`), kept **out of** `RequiresSymbolicProjection`: that predicate also gates `TupleTypeSymbol`'s own CLR backing, and a named tuple must keep its `ValueTuple<…>` type — ADR-0172, names never change the runtime type.

## #3748 — it is neither named tuples nor lambdas

The issue claims named tuple + lambda return. Probes on `origin/main`:

| repro | main |
|---|---|
| named tuple w/ `string?` element, returned from a lambda → `object?` | **GS0155** |
| same named tuple returned from a plain `func` → `object?` | **GS0155** — so not the lambda |
| **unnamed** `(int32, string?)` → `object` | **GS0155** — so not the names |
| named `(A int32, B string)` (no nullable element) → `object?` | OK |
| named tuple *literal* `(ExitCode: 1, Stdout: "a")` in the same lambda | OK |

The trigger is a **nullable-reference element**. `TupleTypeSymbol.BuildClrType` deliberately leaves `ClrType` null whenever an element requires symbolic projection, and `Conversion`'s general boxing rule requires a non-null source `ClrType`, so such tuples were rejected in every `object` / `object?` position (argument, return, assignment). The issue's own diagnostic text is a tell: it prints the target as `object`, and the same failure reproduces with no lambda and no names anywhere.

**Fix** (`src/Core/CodeAnalysis/Binding/Conversion.cs`): an unconditional tuple→`object` arm next to the existing #3303 map arm. A tuple is always a `System.ValueTuple<…>` and always boxes.

## Test evidence

11 new **executing** regression tests (they assert emitted values, not just diagnostics).

- `test/Core.Tests/CodeAnalysis/Binding/Issue3746AsyncNamedTupleReturnTests.cs` — 6 tests: `await`, `.Result`, the implicit-wrap `async func F() (a, b)` spelling, the `ValueTask[T]` wrapper, a nested named tuple, plus an unnamed-tuple control.
- `test/Core.Tests/CodeAnalysis/Binding/Issue3748SymbolicTupleBoxingTests.cs` — 5 tests: named and unnamed nullable-element tuples boxing in local, func-return, lambda-return and argument positions.

Failing-on-main proof (source files reverted to `origin/main`, tests kept): **9 of 11 fail**; the two that pass are the unnamed-tuple control and the nested-tuple forward-guard (that spelling happened to survive on main because the interning cache aliased the reconstructed outer tuple onto the literal's named one — called out in the test comment).

Local runs on this branch: full `Core.Tests` green (**8506** passed), `Compiler.Tests` `Tuple|Async|Await` subset green (**404** passed).

No diagnostic ids added or changed.

Fixes #3746
Fixes #3748

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
