### PR TITLE
gsc: params-element nullability and dotted conversion calls (#3747, #3749)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -249,6 +249,14 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
+        // Issue #3749: the sibling omission is the final argument below. Every
+        // other caller of `FinishClrConstructorBindingFailure` supplies the
+        // conversion target, which is what lets a one-argument `T(x)` that
+        // matched no constructor fall back to the ADR-0047 §6 conversion-call
+        // reading. This caller — the DOTTED form, and therefore the only route
+        // a NESTED type can take — passed none, so
+        // `DebuggableAttribute.DebuggingModes(2)` had no conversion arm to land
+        // on and reported GS0159 instead.
         var handled = TryBindClrConstructorFromType(
             clrType,
             terminalCall,
@@ -262,7 +270,8 @@ internal sealed partial class ExpressionBinder
                 typeSimpleName,
                 noApplicableOverload,
                 boundArguments,
-                ref result);
+                ref result,
+                TypeSymbol.FromClrType(clrType));
         if (handled && terminalObjectCreation != null)
         {
             result = BindObjectInitializerSuffix(

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -1533,6 +1533,28 @@ internal sealed partial class ExpressionBinder
                     allowExplicit: true);
                 return true;
             }
+
+            // Issue #3749, fourth shape: an ENUM (or any other) target reached
+            // through the dotted spelling. The three arms above enumerate
+            // particular conversion kinds; the simple-name conversion-call path
+            // in `OverloadResolver.BindCallExpression` instead applies the
+            // ADR-0047 §6 rule generally — a one-argument `T(x)` over a
+            // non-constructible `T` IS the explicit conversion. Mirror that
+            // here so `DebuggableAttribute.DebuggingModes(2)` reads the same as
+            // the unnested `SomeEnum(2)`. Gated on an existing conversion, so a
+            // genuinely unconvertible argument still falls through to the
+            // not-found/overload diagnostics rather than a new one.
+            if (argument.Type is { } sourceType
+                && sourceType != TypeSymbol.Error
+                && Conversion.Classify(sourceType, conversionTarget).Exists)
+            {
+                result = conversions.BindConversion(
+                    syntax.Arguments[0].Location,
+                    argument,
+                    conversionTarget,
+                    allowExplicit: true);
+                return true;
+            }
         }
 
         if (syntax.TypeArgumentList == null)

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Arguments.cs
@@ -51,7 +51,7 @@ internal sealed partial class OverloadResolver
         var elementClrType = paramArrayType.GetElementType();
         var elementTypeSymbol = elementClrType == null
             ? TypeSymbol.Object
-            : TypeSymbol.FromClrType(elementClrType);
+            : GetParamsElementTypeSymbol(parameters[paramsIndex], elementClrType);
         if (!symbolicMethodTypeArgs.IsDefaultOrEmpty
             && parameters[paramsIndex].Member is MethodInfo method
             && method.IsGenericMethod)
@@ -142,6 +142,43 @@ internal sealed partial class OverloadResolver
 
         result.Add(arrayExpr);
         return result.MoveToImmutable();
+    }
+
+    /// <summary>
+    /// Issue #3747: resolves the ELEMENT type of an imported <c>params T[]</c>
+    /// parameter with the declaration's <c>[Nullable]</c> metadata applied.
+    /// <para>
+    /// The inconsistent-sibling shape of #3705 family 2: this site read the
+    /// element with a bare <see cref="TypeSymbol.FromClrType"/>, which sees only
+    /// the erased CLR shape, so every <c>params T?[]</c> element bound as
+    /// non-null <c>T</c> and <c>nil</c> in an expanded position was rejected
+    /// with GS0155 — while every other element-of-an-imported-position reader in
+    /// the binder (<c>GetArraySliceElementType</c>,
+    /// <c>TryGetCollectionSpreadElementType</c>, the indexer readers) already
+    /// goes through <see cref="NullabilityAnnotatedTypeSymbol"/>. Note this was
+    /// never specific to a nullable params ARRAY (<c>params object?[]?</c>): a
+    /// plain <c>params object?[]</c> lost its element annotation identically.
+    /// </para>
+    /// </summary>
+    /// <param name="parameter">The <c>params</c> parameter.</param>
+    /// <param name="elementClrType">The params array's CLR element type.</param>
+    /// <returns>The element type symbol, nullability-annotated where the declaration says so.</returns>
+    private static TypeSymbol GetParamsElementTypeSymbol(
+        System.Reflection.ParameterInfo parameter,
+        Type elementClrType)
+    {
+        // The parameter's own type carries the flags; the array may itself be
+        // nullable (`params object?[]?`), so peel that wrapper before reading
+        // the element position out of the annotation.
+        var parameterType = ClrNullability.GetParameterTypeSymbol(parameter);
+        if (parameterType is NullableTypeSymbol nullableArray)
+        {
+            parameterType = nullableArray.UnderlyingType;
+        }
+
+        return parameterType is NullabilityAnnotatedTypeSymbol annotated
+            ? annotated.GetTypeArgumentSymbolForClrType(elementClrType)
+            : TypeSymbol.FromClrType(elementClrType);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/VariadicCarriers.cs
+++ b/src/Core/CodeAnalysis/Binding/VariadicCarriers.cs
@@ -107,6 +107,17 @@ internal static class VariadicCarriers
         SliceTypeSymbol slice => slice.ElementType,
         ArrayTypeSymbol array => array.ElementType,
         ImportedTypeSymbol { TypeArguments: [var symbolicElement] } => symbolicElement,
+
+        // Issue #3747 (sibling of the params-array element site in
+        // `OverloadResolver.ExpandParamsArguments`): an imported carrier that
+        // carries `[Nullable]` metadata must yield its element THROUGH that
+        // metadata. The `FromClrType` fallback below sees only the erased CLR
+        // shape, so a `...List[string?]` element would arrive as non-null
+        // `string` — the same annotation loss, one type-shape over.
+        NullabilityAnnotatedTypeSymbol { ClrType: { IsArray: true } annotatedArray } annotatedCarrier
+            => annotatedCarrier.GetTypeArgumentSymbolForClrType(annotatedArray.GetElementType()),
+        NullabilityAnnotatedTypeSymbol { ClrType: { IsGenericType: true, IsGenericTypeDefinition: false } } annotatedGeneric
+            => annotatedGeneric.GetTypeArgumentSymbol(0),
         _ when carrierType.ClrType is { IsGenericType: true, IsGenericTypeDefinition: false } clr
             => TypeSymbol.FromClrType(clr.GetGenericArguments()[0]),
         _ => TypeSymbol.Error,

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3747NullableParamsElementTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3747NullableParamsElementTests.cs
@@ -1,0 +1,115 @@
+// <copyright file="Issue3747NullableParamsElementTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #3747 — <c>nil</c> in an expanded <c>params</c> position.
+/// <para>
+/// <c>OverloadResolver.ExpandParamsArguments</c> derived the params ELEMENT
+/// type with a bare <c>TypeSymbol.FromClrType(paramArrayType.GetElementType())</c>,
+/// which sees only the erased CLR shape. The declaration's <c>[Nullable]</c>
+/// metadata was therefore dropped and every <c>params T?[]</c> element bound as
+/// non-null <c>T</c>, so <c>nil</c> in an expanded position failed
+/// <c>GS0155 Cannot convert type 'nil' to 'object'</c> — note the target prints
+/// as <c>object</c>, not <c>object?</c>, which is the annotation loss showing
+/// through the diagnostic.
+/// </para>
+/// <para>
+/// The issue as filed believed the defect was specific to a NULLABLE params
+/// ARRAY (<c>params object?[]?</c>, as on <c>Delegate.DynamicInvoke</c>), citing
+/// <c>string.Format("{0} {1}", "x", nil)</c> as a working control over a
+/// non-nullable <c>params object?[]</c>. That control was not a control: two
+/// trailing arguments bind the NON-params overload
+/// <c>Format(string, object?, object?)</c> and never expand at all.
+/// <see cref="PlainNullableElement_ArrayNotNullable_AlsoBinds"/> forces genuine
+/// expansion with five arguments and fails on <c>main</c> identically, so the
+/// defect was never about the array's own nullability. Both spellings are kept
+/// here because they are the two halves of that correction.
+/// </para>
+/// <para>
+/// This is the #3705-family "inconsistent sibling probe" shape but a distinct
+/// site from PR #3741's — that PR fixed the signature-position readers in
+/// <c>MemberLookup</c>; this is the params-expansion element reader. It is NOT
+/// a regression of #3741.
+/// </para>
+/// </summary>
+public class Issue3747NullableParamsElementTests
+{
+    /// <summary>
+    /// The issue's own repro: <c>Delegate.DynamicInvoke(params object?[]? args)</c>.
+    /// Executed, not merely bound — the packed array must still emit as
+    /// <c>object[]</c> with a null slot, and the invoked delegate returns it.
+    /// </summary>
+    [Fact]
+    public void NullableParamsArray_AcceptsNilElement_AndRoundTrips()
+    {
+        var result = EmittedOracle.Evaluate(@"
+import System
+
+let d Func[object?, object?, object?] = func (a object?, b object?) object? {
+    return b
+}
+let del Delegate = d
+del.DynamicInvoke(""x"", nil)
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.Value);
+    }
+
+    /// <summary>
+    /// The array itself is NOT nullable here (<c>string.Format(string, params object?[])</c>),
+    /// and five arguments force real expansion past every fixed overload. This
+    /// is the assertion that disproves the issue's stated isolation.
+    /// </summary>
+    [Fact]
+    public void PlainNullableElement_ArrayNotNullable_AlsoBinds()
+    {
+        var result = EmittedOracle.Evaluate(@"
+import System
+
+string.Format(""{0}|{1}|{2}|{3}|{4}"", ""a"", ""b"", ""c"", ""d"", nil)
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("a|b|c|d|", result.Value);
+    }
+
+    /// <summary>
+    /// The negative control, and the reason the fix reads the declaration rather
+    /// than blanket-nullifying every params element: a <c>params string[]</c>
+    /// whose element is annotated NON-null must still reject <c>nil</c>. A fix
+    /// that simply widened the element type would turn this green and lose the
+    /// soundness the annotation buys.
+    /// </summary>
+    [Fact]
+    public void NonNullParamsElement_StillRejectsNil()
+    {
+        var result = EmittedOracle.Evaluate(@"
+import System.IO
+
+Path.Combine(""a"", ""b"", ""c"", nil)
+");
+        Assert.NotEmpty(result.Diagnostics);
+    }
+
+    /// <summary>
+    /// Anti-vacuity: an ordinary non-nil element still flows through the
+    /// expanded position unchanged, so the fix cannot be passing above merely by
+    /// erasing the element type to something that accepts anything.
+    /// </summary>
+    [Fact]
+    public void NonNilElements_StillPackAndFormat()
+    {
+        var result = EmittedOracle.Evaluate(@"
+import System
+
+string.Format(""{0}|{1}|{2}|{3}|{4}"", 1, 2, 3, 4, 5)
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("1|2|3|4|5", result.Value);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3749NestedTypeConversionCallTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3749NestedTypeConversionCallTests.cs
@@ -1,0 +1,120 @@
+// <copyright file="Issue3749NestedTypeConversionCallTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #3749 — the conversion-call form <c>T(expr)</c> over a DOTTED type name.
+/// <para>
+/// The simple-name form (<c>SomeEnum(2)</c>) is bound by
+/// <c>OverloadResolver.BindCallExpression</c>, which applies the ADR-0047 §6
+/// rule directly: a one-argument call on a non-constructible type IS the
+/// explicit conversion. The dotted form parses as an accessor chain and is
+/// bound instead by <c>ExpressionBinder.TryBindQualifiedClrConstructorCall</c>,
+/// which only ever tried CONSTRUCTORS: it called
+/// <c>FinishClrConstructorBindingFailure</c> without the
+/// <c>conversionTarget</c> argument that all four sibling call sites supply, so
+/// the conversion fallback was unreachable and the call reported
+/// <c>GS0159 Cannot find function DebuggingModes</c>.
+/// </para>
+/// <para>
+/// Nesting is what makes the gap visible rather than what causes it — the
+/// dotted spelling is the only route a nested type can take, but a
+/// namespace-qualified enum takes it too (see
+/// <see cref="NamespaceQualifiedEnum_ConversionCall_AlsoBinds"/>, which also
+/// fails on <c>main</c>). Adjacent to but distinct from #3660 / PR #3662, which
+/// was nested-type bodies calling an enclosing type's <c>shared</c> members; it
+/// is NOT a regression of that work.
+/// </para>
+/// </summary>
+public class Issue3749NestedTypeConversionCallTests
+{
+    /// <summary>The issue's own repro: a nested imported enum, executed.</summary>
+    [Fact]
+    public void NestedImportedEnum_ConversionCall_Binds()
+    {
+        var result = EmittedOracle.Evaluate(@"
+import System
+import System.Diagnostics
+
+let flags = DebuggableAttribute.DebuggingModes(2)
+flags.ToString()
+");
+        Assert.Empty(result.Diagnostics);
+
+        // DebuggingModes.IgnoreSymbolStoreSequencePoints == 2.
+        Assert.Equal("IgnoreSymbolStoreSequencePoints", result.Value);
+    }
+
+    /// <summary>
+    /// The same defect without any nesting: a namespace-qualified enum. Proves
+    /// the gap belongs to the DOTTED binding path, not to nested-type
+    /// resolution — nested-type resolution (issue #569) already worked.
+    /// </summary>
+    [Fact]
+    public void NamespaceQualifiedEnum_ConversionCall_AlsoBinds()
+    {
+        var result = EmittedOracle.Evaluate(@"
+let d = System.DayOfWeek(2)
+d.ToString()
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("Tuesday", result.Value);
+    }
+
+    /// <summary>
+    /// The differential the fix is really about: the unnested spelling of the
+    /// very same conversion already bound on <c>main</c>. Both spellings must
+    /// now agree.
+    /// </summary>
+    [Fact]
+    public void UnnestedEnum_ConversionCall_StillBinds()
+    {
+        var result = EmittedOracle.Evaluate(@"
+import System
+
+let d = DayOfWeek(2)
+d.ToString()
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("Tuesday", result.Value);
+    }
+
+    /// <summary>
+    /// Guard rail: the conversion arm is gated on a conversion that actually
+    /// exists, so a dotted call over a type with no applicable constructor AND
+    /// no conversion from the argument still reports an error rather than
+    /// silently binding.
+    /// </summary>
+    [Fact]
+    public void DottedCall_WithNoConversion_StillErrors()
+    {
+        var result = EmittedOracle.Evaluate(@"
+import System
+import System.Diagnostics
+
+let flags = DebuggableAttribute.DebuggingModes(""not-a-number"")
+flags
+");
+        Assert.NotEmpty(result.Diagnostics);
+    }
+
+    /// <summary>
+    /// Anti-regression for the path the fix touches: a dotted CONSTRUCTOR call
+    /// must keep resolving as construction, not be hijacked into a conversion.
+    /// </summary>
+    [Fact]
+    public void DottedConstructorCall_StillConstructs()
+    {
+        var result = EmittedOracle.Evaluate(@"
+let sb = System.Text.StringBuilder(16)
+sb.Append(""ok"").ToString()
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("ok", result.Value);
+    }
+}


### PR DESCRIPTION
Fixes #3747. Fixes #3749.

Two independent binder gaps split out of the #3745 triage (families F3 and F5). Both turned out to be the **inconsistent sibling probe** class tracked in #3705: a probe that omits what a neighbouring probe one line away already does correctly. **Neither is a regression** of its adjacent solved work — see the section at the bottom.

---

## #3747 — `nil` rejected in an expanded `params` position

### Diagnosis

`OverloadResolver.ExpandParamsArguments` derived the params **element** type with a bare

```csharp
TypeSymbol.FromClrType(paramArrayType.GetElementType())
```

which sees only the erased CLR shape. The declaration's `[Nullable]` metadata was therefore dropped, every `params T?[]` element bound as non-null `T`, and `nil` in an expanded position failed `GS0155 Cannot convert type 'nil' to 'object'`. The target printing as `object` rather than `object?` *is* the annotation loss showing through the diagnostic.

Every other element-of-an-imported-position reader in the binder (`GetArraySliceElementType`, `TryGetCollectionSpreadElementType`, the indexer readers) already goes through `NullabilityAnnotatedTypeSymbol`. This one didn't.

### The issue's premise was wrong — and the correction is load-bearing

The issue states the defect is isolated to a **nullable params array** (`params object?[]?`, as on `Delegate.DynamicInvoke`), citing this as a working control over a non-nullable `params object?[]`:

```gs
string.Format("{0} {1}", "x", nil)   // "binds today"
```

That is not a control. Two trailing arguments bind the **non-params** overload `Format(string, object?, object?)` and never expand at all. Forcing genuine expansion:

```gs
string.Format("{0}|{1}|{2}|{3}|{4}", "a", "b", "c", "d", nil)
```

fails on `main` with the identical `GS0155`, over a params array that is **not** nullable. The defect was never about the array's own nullability — it is every `params T?[]`. Both spellings are kept in the fixture as the two halves of that correction.

### Fix

`src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Arguments.cs` — new `GetParamsElementTypeSymbol` reads the params parameter through `ClrNullability.GetParameterTypeSymbol`, peels the array's own `NullableTypeSymbol` wrapper (`params object?[]?`), and takes the element out of the `NullabilityAnnotatedTypeSymbol`.

### Sibling omission found and fixed alongside

`src/Core/CodeAnalysis/Binding/VariadicCarriers.cs` — `GetElementType` had the same omission one type-shape over: an ADR-0173 collection carrier arriving as a `NullabilityAnnotatedTypeSymbol` matched none of the symbolic cases and fell through to the erased `FromClrType` fallback, so a `...List[string?]` element would arrive as non-null `string`. Added the array and closed-generic annotated cases.

---

## #3749 — conversion call on a dotted type name

### Diagnosis

The simple-name conversion call `SomeEnum(2)` is bound by `OverloadResolver.BindCallExpression`, which applies the ADR-0047 §6 rule directly: a one-argument call on a non-constructible type **is** the explicit conversion.

The dotted form parses as an accessor chain and is bound instead by `ExpressionBinder.TryBindQualifiedClrConstructorCall`, which only ever tried **constructors**: it called `FinishClrConstructorBindingFailure` *without* the `conversionTarget` argument that **all four** of its sibling call sites supply. The conversion fallback was therefore unreachable and `DebuggableAttribute.DebuggingModes(2)` reported `GS0159 Cannot find function DebuggingModes`.

Nesting made the gap **visible** rather than **causing** it. Nested-type resolution (issue #569, `TryResolveAsNestedTypeChain`) already worked and resolved the type fine; the dotted spelling is simply the only route a nested type can take. The purely namespace-qualified spelling `System.DayOfWeek(2)` fails on `main` too, and is asserted here.

### Fix

- `ExpressionBinder.Access.cs` — pass `TypeSymbol.FromClrType(clrType)` as the conversion target, matching the four siblings.
- `ExpressionBinder.Calls.cs` — `FinishClrConstructorBindingFailure`'s three arms enumerate specific conversion *kinds* (checked reference, unboxing, delegate); an enum target matched none. Added the general ADR-0047 §6 arm the simple-name path already applies, gated on `Conversion.Classify(...).Exists` so a genuinely unconvertible argument still falls through to the existing diagnostics rather than a new one.

---

## Explicitly: neither is a regression

- **#3747 vs #3705 family 2 / PR #3741** — same *class* (bare `FromClrType` next to a nullability-aware sibling), **different site**. #3741 fixed the signature-position readers `GetClrMethodReturnTypeSymbol` / `GetClrMethodParameterTypeSymbol` in `MemberLookup` and the extension-`Deconstruct` arm. This is the params-expansion element reader in `OverloadResolver`, which #3741 never touched. Not a regression.
- **#3749 vs #3660 / PR #3662** — #3662 added lexical outward walking so a nested type's *body* can call an enclosing type's `shared` members from `BindCallExpression`. This is the opposite direction (a nested type named as a conversion *target* from outside) in a different file. Not a regression.

---

## Test evidence

Two new fixtures, 9 cases, all executing (not merely binding):

- `test/Core.Tests/CodeAnalysis/Binding/Issue3747NullableParamsElementTests.cs`
- `test/Core.Tests/CodeAnalysis/Binding/Issue3749NestedTypeConversionCallTests.cs`

**Failing on `origin/main`** (test files present, `src/` at `origin/main`) — 4 of 9, with exactly the reported diagnostics:

```
NestedImportedEnum_ConversionCall_Binds            FAIL  [Cannot find function DebuggingModes., …]
NamespaceQualifiedEnum_ConversionCall_AlsoBinds    FAIL  [Cannot find type System. …]
PlainNullableElement_ArrayNotNullable_AlsoBinds    FAIL  [Cannot convert type 'nil' to 'object'.]
NullableParamsArray_AcceptsNilElement_AndRoundTrips FAIL [Cannot convert type 'nil' to 'object'.]
```

The other 5 pass on `main` **by design** — they are the negative controls and differentials that a careless widening would break:

- `NonNullParamsElement_StillRejectsNil` — `Path.Combine(params string[])` must still reject `nil`. A fix that blanket-widened the element type turns this green and loses the soundness the annotation buys.
- `NonNilElements_StillPackAndFormat` — anti-vacuity: ordinary elements still pack and format.
- `UnnestedEnum_ConversionCall_StillBinds` — the differential #3749 is really about; both spellings must now agree.
- `DottedCall_WithNoConversion_StillErrors` — the new general conversion arm must not swallow real errors.
- `DottedConstructorCall_StillConstructs` — `System.Text.StringBuilder(16)` must stay construction, not be hijacked into a conversion.

**With the fix:** all 9 pass, and the **full `Core.Tests` suite is green — 8504 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
