### PR TITLE
gsc: a generic instance/static call on a symbolic receiver keeps its own type arguments (#3712)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
@@ -1246,10 +1246,19 @@ internal sealed partial class ExpressionBinder
                 // parameter list, so the method-type-argument inference vector must
                 // not carry the receiver as slot 0 — otherwise lambda-only-inferable
                 // method type parameters never unify and erase to `<object>`.
+                // Issue #3712 (instance calls): refine the pre-resolution vector
+                // for method-group arguments now that the winning overload pins
+                // each group's target delegate — the same refinement the
+                // extension-call and direct-instance paths apply.
+                var refinedInheritedSymbolicArgs = RefineSymbolicArgsForMethodGroups(
+                    best,
+                    arguments,
+                    inheritedSymbolicArgs,
+                    receiverArgCount: 0);
                 var inheritedSymbolicTypeArgs = MemberLookup.BuildSymbolicMethodTypeArgs(
                     best,
                     typeArgSymbols,
-                    inheritedSymbolicArgs,
+                    refinedInheritedSymbolicArgs,
                     resolution.IsExpanded);
                 var inheritedTypeArgSymbolsForCall = !inheritedSymbolicTypeArgs.IsDefault
                     ? inheritedSymbolicTypeArgs

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -414,9 +414,50 @@ internal sealed partial class ExpressionBinder
             return null;
         }
 
-        var mapped = MemberLookup.MapOpenClrTypeToSymbolic(openReturn, imp.OpenDefinition, imp.TypeArguments);
+        // Issue #3712 follow-up: the receiver only closes the DECLARING TYPE's
+        // parameters. When the selected method is itself generic its own
+        // (method-level) parameters must be substituted from the closed method,
+        // or the projection returns the open shape — `List<TOutput>` for
+        // `List[Token].ConvertAll(...)` — and, because this override is
+        // consulted BEFORE the plain CLR return type, that open shape became
+        // the call's bound type and every use of it reported GS0156.
+        var mapped = MemberLookup.MapOpenClrTypeToSymbolic(
+            openReturn,
+            imp.OpenDefinition,
+            imp.TypeArguments,
+            openMethod,
+            BuildMethodTypeArgSymbolsFromClosedMethod(closedMethod));
 
         return mapped;
+    }
+
+    /// <summary>
+    /// Issue #3712 follow-up: projects a closed generic method's own CLR type
+    /// arguments onto symbols, for use as the method-level substitution vector
+    /// of <see cref="MemberLookup.MapOpenClrTypeToSymbolic(Type, Type, ImmutableArray{TypeSymbol}, System.Reflection.MethodInfo, ImmutableArray{TypeSymbol})"/>.
+    /// Returns <see langword="default"/> for a non-generic (or still open)
+    /// method, which leaves the method-level substitution disabled exactly as
+    /// before.
+    /// </summary>
+    /// <param name="closedMethod">The closed method selected by overload resolution.</param>
+    /// <returns>The per-MVar symbol vector, or default when there is nothing to substitute.</returns>
+    private static ImmutableArray<TypeSymbol?> BuildMethodTypeArgSymbolsFromClosedMethod(System.Reflection.MethodInfo? closedMethod)
+    {
+        if (closedMethod == null
+            || !closedMethod.IsGenericMethod
+            || closedMethod.IsGenericMethodDefinition)
+        {
+            return default;
+        }
+
+        var closedTypeArgs = closedMethod.GetGenericArguments();
+        var builder = ImmutableArray.CreateBuilder<TypeSymbol?>(closedTypeArgs.Length);
+        foreach (var closedTypeArg in closedTypeArgs)
+        {
+            builder.Add(MemberLookup.MapOpenClrTypeToSymbolic(closedTypeArg, openDefinition: null, typeArguments: default));
+        }
+
+        return builder.MoveToImmutable();
     }
 
     /// <summary>
@@ -471,10 +512,18 @@ internal sealed partial class ExpressionBinder
             return null;
         }
 
+        // Issue #3712 follow-up (sibling of
+        // `ResolveInstanceReturnTypeFromReceiver`, #3705): substitute the
+        // method's OWN generic parameters too, so an `out` parameter of a
+        // generic method on a symbolically-constructed receiver (e.g.
+        // `Dictionary[K, V].TryAdd`-shaped generic members) does not project to
+        // the open method type parameter.
         return MemberLookup.MapOpenClrTypeToSymbolic(
             openPointee,
             imp.OpenDefinition,
-            imp.TypeArguments);
+            imp.TypeArguments,
+            openMethod,
+            BuildMethodTypeArgSymbolsFromClosedMethod(closedMethod));
     }
 
     /// <summary>
@@ -2909,7 +2958,7 @@ internal sealed partial class ExpressionBinder
 
         if (classSymbol != null)
         {
-            if (classSymbol.TryLookupFunction(methodName, ce, arguments, out var staticFn, out var staticMapping, out var staticAmbiguous, out var staticAmbiguousMethods, out var staticIsExpanded, explicitTypeArgs, typeArgSymbols, scope.References.MapClrTypeToReferences, argumentNames.IsDefault ? null : (IReadOnlyList<string>)argumentNames))
+            if (classSymbol.TryLookupFunction(methodName, ce, arguments, out var staticFn, out var staticMapping, out var staticAmbiguous, out var staticAmbiguousMethods, out var staticIsExpanded, explicitTypeArgs, typeArgSymbols, scope.References.MapClrTypeToReferences, argumentNames.IsDefault ? null : (IReadOnlyList<string>)argumentNames, (closed, vector) => RefineSymbolicArgsForMethodGroups(closed, arguments, vector, receiverArgCount: 0)))
             {
                 // Issue #1538: now that the imported static overload is chosen,
                 // re-bind any inline `out var`/`out let`/`out _` placeholders
@@ -2950,10 +2999,22 @@ internal sealed partial class ExpressionBinder
                 var staticSymbolicArgs = MemberLookup.BuildSymbolicArgTypeVector(
                     receiverType: null,
                     ImmutableArray.CreateRange(arguments.Select(a => a.Type)));
+
+                // Issue #3712 (static calls): the same method-group refinement
+                // the extension- and instance-call paths apply — a user method
+                // group reaches the vector without a natural type, so its
+                // same-compilation return type would otherwise be lost and the
+                // call closed over `object` (`Array.ConvertAll` then reports
+                // GS0155 against the real element type).
+                var refinedStaticSymbolicArgs = RefineSymbolicArgsForMethodGroups(
+                    staticFn.Method,
+                    arguments,
+                    staticSymbolicArgs,
+                    receiverArgCount: 0);
                 var staticSymbolicTypeArgs = MemberLookup.BuildSymbolicMethodTypeArgs(
                     staticFn.Method,
                     typeArgSymbols,
-                    staticSymbolicArgs,
+                    refinedStaticSymbolicArgs,
                     staticIsExpanded);
                 var staticTypeArgSymbolsForCall = !staticSymbolicTypeArgs.IsDefault ? staticSymbolicTypeArgs : AsNullableElements(typeArgSymbols);
                 var staticParameters = staticFn.Method.GetParameters();
@@ -3660,10 +3721,22 @@ internal sealed partial class ExpressionBinder
                         // never unified and the call collapsed to `<object>`. The
                         // receiver still drives return-type Var substitution via
                         // `ResolveCallReturnTypeFromSymbolicTypeArgs` below.
+                        // Issue #3712 (instance calls): a user method group has
+                        // no natural type until the target delegate is known,
+                        // so the pre-resolution vector above reached here as
+                        // `Error` and the group's same-compilation return type
+                        // was never recovered. Now that `method` is known its
+                        // delegate parameter pins the group's arity — refine
+                        // the vector exactly as the extension-call path does.
+                        var refinedInstSymbolicArgs = RefineSymbolicArgsForMethodGroups(
+                            method,
+                            arguments,
+                            instSymbolicArgs,
+                            receiverArgCount: 0);
                         var instSymbolicTypeArgs = MemberLookup.BuildSymbolicMethodTypeArgs(
                             method,
                             typeArgSymbols,
-                            instSymbolicArgs,
+                            refinedInstSymbolicArgs,
                             resolution.IsExpanded);
                         var instTypeArgSymbolsForCall = !instSymbolicTypeArgs.IsDefault ? instSymbolicTypeArgs : AsNullableElements(typeArgSymbols);
                         var returnType = ResolveImportedGenericReturnType(method, typeArgSymbols)

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -1059,13 +1059,22 @@ internal sealed partial class ExpressionBinder
 
     /// <summary>
     /// Issue #3712: refines a pre-resolution symbolic argument vector once the
-    /// winning CLR overload is known, replacing each overloaded user
-    /// method-group slot with the symbolic function type of the candidate whose
-    /// arity matches the target delegate parameter. The erased CLR vector
-    /// resolves such a group's return type to <c>object</c> when the return type
-    /// is a same-compilation user type; without this refinement the generic
-    /// method is emitted closed over <c>object</c> and the assembly fails IL
-    /// verification with <c>StackUnexpected</c>.
+    /// winning CLR overload is known, replacing each user method-group slot that
+    /// carries no symbolic function type with the symbolic function type of the
+    /// candidate whose arity matches the target delegate parameter. The erased
+    /// CLR vector resolves such a group's return type to <c>object</c> when the
+    /// return type is a same-compilation user type; without this refinement the
+    /// generic method is emitted closed over <c>object</c> and the assembly
+    /// fails IL verification with <c>StackUnexpected</c>.
+    /// <para>
+    /// Issue #3712 follow-up (instance calls): the slot is refined for a
+    /// SINGLE-candidate group too. A single-candidate group only acquires a
+    /// natural type when that type is expressible in CLR terms, so a group
+    /// returning a same-compilation user class reaches this vector as
+    /// <see cref="TypeSymbol.Error"/> exactly like an overloaded one. The
+    /// <see cref="FunctionTypeSymbol"/> guard below keeps every slot that
+    /// already carries symbolic information untouched.
+    /// </para>
     /// </summary>
     /// <param name="resolved">The winning (possibly closed generic) CLR method.</param>
     /// <param name="arguments">The bound user arguments, in source order.</param>
@@ -1093,7 +1102,7 @@ internal sealed partial class ExpressionBinder
                 continue;
             }
 
-            if (arguments[i] is not BoundMethodGroupExpression group || group.Candidates.Length <= 1)
+            if (arguments[i] is not BoundMethodGroupExpression group)
             {
                 continue;
             }
@@ -1103,9 +1112,14 @@ internal sealed partial class ExpressionBinder
                 continue;
             }
 
-            var invoke = parameters[slot].ParameterType.GetMethodSafe("Invoke");
-            if (invoke == null
-                || !TryGetSymbolicUserMethodGroupType(group, out var symbolicGroupType, invoke.GetParameters().Length))
+            // Issue #3752/#3753: read the target delegate's shape through the
+            // load-context funnel rather than a bare `Invoke` probe — the
+            // direct probe throws (and would silently skip the refinement)
+            // whenever the closed delegate is a `TypeBuilderInstantiation`,
+            // which is exactly what closing `Converter`/`Func` over a
+            // MetadataLoadContext type argument produces.
+            if (!ClrLoadContext.TryGetDelegateSignature(parameters[slot].ParameterType, out var delegateParameters, out _)
+                || !TryGetSymbolicUserMethodGroupType(group, out var symbolicGroupType, delegateParameters.Length))
             {
                 continue;
             }

--- a/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
@@ -204,8 +204,9 @@ public sealed class ImportedClassSymbol : Symbol
     /// <param name="typeArgSymbols">Explicit type-argument symbols in source order, or default.</param>
     /// <param name="projectTypeArgument">Projects an inferred type argument onto the reference load context, or <see langword="null"/>.</param>
     /// <param name="argumentNames">Per-source-argument names parallel to <paramref name="arguments"/>.</param>
+    /// <param name="refineSymbolicMethodGroupArgs">Issue #3712: given the selected method and the pre-resolution symbolic argument vector, returns the vector with each user method-group slot replaced by the symbolic function type the winning overload's delegate parameter selects. <see langword="null"/> leaves the vector unrefined.</param>
     /// <returns>Whether we found a matching function or not.</returns>
-    public bool TryLookupFunction(string text, CallExpressionSyntax callExpression, ImmutableArray<BoundExpression> arguments, [NotNullWhen(true)] out ImportedFunctionSymbol? function, out ImmutableArray<int> parameterMapping, out bool isAmbiguous, out ImmutableArray<MethodInfo> ambiguousMethods, out bool isExpanded, Type[]? explicitTypeArgs = null, ImmutableArray<TypeSymbol> typeArgSymbols = default, Func<Type, Type>? projectTypeArgument = null, IReadOnlyList<string>? argumentNames = null)
+    public bool TryLookupFunction(string text, CallExpressionSyntax callExpression, ImmutableArray<BoundExpression> arguments, [NotNullWhen(true)] out ImportedFunctionSymbol? function, out ImmutableArray<int> parameterMapping, out bool isAmbiguous, out ImmutableArray<MethodInfo> ambiguousMethods, out bool isExpanded, Type[]? explicitTypeArgs = null, ImmutableArray<TypeSymbol> typeArgSymbols = default, Func<Type, Type>? projectTypeArgument = null, IReadOnlyList<string>? argumentNames = null, Func<MethodInfo, ImmutableArray<TypeSymbol>, ImmutableArray<TypeSymbol>>? refineSymbolicMethodGroupArgs = null)
     {
         function = null;
         parameterMapping = default;
@@ -394,7 +395,7 @@ public sealed class ImportedClassSymbol : Symbol
                 return MemberLookup.BuildSymbolicMethodTypeArgs(
                     closed,
                     typeArgSymbols,
-                    symbolicArgVector,
+                    refineSymbolicMethodGroupArgs?.Invoke(closed, symbolicArgVector) ?? symbolicArgVector,
                     isExpanded);
             },
             supplementaryInterfaceCheck: supplementaryInterfaceCheck,
@@ -432,10 +433,16 @@ public sealed class ImportedClassSymbol : Symbol
                 // the type-erased `IEnumerable<object>`.
                 if (returnOverride == null)
                 {
+                    // Issue #3712: a user method group has no natural type
+                    // before the target delegate is known, so its slot in
+                    // `symbolicArgVector` is the Error sentinel. Refine it
+                    // against the winning candidate, or a group whose return
+                    // type is a same-compilation user class leaves the call
+                    // closed over that type's `object` erasure.
                     var symbolicMethodTypeArgs = MemberLookup.BuildSymbolicMethodTypeArgs(
                         bestMethod,
                         typeArgSymbols,
-                        symbolicArgVector,
+                        refineSymbolicMethodGroupArgs?.Invoke(bestMethod, symbolicArgVector) ?? symbolicArgVector,
                         result.IsExpanded);
                     returnOverride = MemberLookup.ResolveCallReturnTypeFromSymbolicTypeArgs(bestMethod, symbolicMethodTypeArgs, receiverType: null);
                 }

--- a/test/Compiler.Tests/Emit/Issue3712InstanceGenericCallMethodGroupEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3712InstanceGenericCallMethodGroupEmitTests.cs
@@ -1,0 +1,536 @@
+// <copyright file="Issue3712InstanceGenericCallMethodGroupEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #3712, "Related (distinct, not fixed here)": the INSTANCE generic-call
+/// path (<c>tokens.ConvertAll(Helper.ToRange)</c>).
+///
+/// <para>
+/// Two independent defects met on that path, and only the second is the one
+/// #3712 predicted:
+/// </para>
+///
+/// <list type="number">
+///   <item>
+///     <description>
+///     <c>ResolveInstanceReturnTypeFromReceiver</c> (issue #794) projects the
+///     OPEN declaring type's return type through the receiver's symbolic type
+///     arguments, but never substituted the selected method's OWN generic
+///     parameters. For <c>List&lt;T&gt;.ConvertAll&lt;TOutput&gt;</c> that
+///     yields the open <c>List[TOutput]</c>, and because the override is
+///     consulted BEFORE the plain CLR return type it became the call's bound
+///     type — <c>GS0156: Cannot convert type 'List[TOutput]' to …</c>. This has
+///     nothing to do with method groups: it fires for a plain lambda argument
+///     too, and even with an explicit <c>[string]</c> type-argument list. The
+///     discriminator is a receiver whose type arguments are symbolic (a
+///     same-compilation user class such as <c>List[Token]</c>).
+///     </description>
+///   </item>
+///   <item>
+///     <description>
+///     the #3712 gap proper: a user method group has no natural type until the
+///     target delegate is known, so its slot in the pre-resolution symbolic
+///     vector is the Error sentinel and the group's same-compilation return
+///     type is lost. The extension-call path recovers it (#3713); the instance,
+///     inherited-instance and imported-static paths did not. With defect 1
+///     fixed but this one still open the same programs would compile clean and
+///     emit <c>ConvertAll&lt;object&gt;</c> into an <c>IEnumerable[Range]</c>
+///     slot — silently unverifiable IL — so every test here runs ilverify AND
+///     executes the program.
+///     </description>
+///   </item>
+/// </list>
+/// </summary>
+public class Issue3712InstanceGenericCallMethodGroupEmitTests
+{
+    /// <summary>
+    /// The issue's own instance-path repro: an overloaded <c>shared</c> group
+    /// returning a same-compilation class, projected by <c>List[T].ConvertAll</c>
+    /// over a receiver whose element type is also same-compilation.
+    /// </summary>
+    [Fact]
+    public void InstanceGenericCall_OverloadedGroup_ReturningSameCompilationClass_EmitsClosedOverRealType()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            class Token {
+                var Text string
+                init(text string) { Text = text }
+            }
+
+            class Range {
+                var Label string
+                init(label string) { Label = label }
+            }
+
+            class Holder {
+                var Items IEnumerable[Range]
+            }
+
+            class Helper {
+                shared {
+                    func ToRange(token Token) Range { return Range(token.Text) }
+                    func ToRange(text string, extra int32) Range { return Range(text) }
+                }
+            }
+
+            func Build(tokens List[Token]) Holder {
+                return Holder{Items: tokens.ConvertAll(Helper.ToRange)}
+            }
+
+            var tokens = List[Token]()
+            tokens.Add(Token("a"))
+            tokens.Add(Token("b"))
+            for item in Build(tokens).Items {
+                Console.WriteLine(item.Label)
+            }
+            """;
+
+        Assert.Equal($"a{Environment.NewLine}b{Environment.NewLine}", CompileAndRun(source));
+    }
+
+    /// <summary>
+    /// The same shape with a SINGLE-candidate group. #3712 framed the instance
+    /// gap as the overloaded case; it is not — a single-candidate group whose
+    /// return type is a same-compilation class also has no CLR-expressible
+    /// natural type, so it reaches the symbolic vector erased exactly like an
+    /// overloaded one.
+    /// </summary>
+    [Fact]
+    public void InstanceGenericCall_SingleCandidateGroup_ReturningSameCompilationClass_EmitsClosedOverRealType()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            class Token {
+                var Text string
+                init(text string) { Text = text }
+            }
+
+            class Range {
+                var Label string
+                init(label string) { Label = label }
+            }
+
+            class Holder {
+                var Items IEnumerable[Range]
+            }
+
+            class Helper {
+                shared {
+                    func ToRange(token Token) Range { return Range(token.Text) }
+                }
+            }
+
+            func Build(tokens List[Token]) Holder {
+                return Holder{Items: tokens.ConvertAll(Helper.ToRange)}
+            }
+
+            var tokens = List[Token]()
+            tokens.Add(Token("a"))
+            for item in Build(tokens).Items {
+                Console.WriteLine(item.Label)
+            }
+            """;
+
+        Assert.Equal($"a{Environment.NewLine}", CompileAndRun(source));
+    }
+
+    /// <summary>
+    /// Defect 1 in isolation: no method group at all — a plain lambda whose
+    /// return type is a BCL type. The receiver's symbolic element type is the
+    /// only unusual ingredient, and the call still failed to bind, which is
+    /// what disproves the issue's method-group framing for this path.
+    /// </summary>
+    [Fact]
+    public void InstanceGenericCall_LambdaArgument_SymbolicReceiver_BindsAndRuns()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            class Token {
+                var Text string
+                init(text string) { Text = text }
+            }
+
+            func Build(tokens List[Token]) IEnumerable[string] {
+                return tokens.ConvertAll(func(t Token) string { return t.Text })
+            }
+
+            var tokens = List[Token]()
+            tokens.Add(Token("a"))
+            for item in Build(tokens) {
+                Console.WriteLine(item)
+            }
+            """;
+
+        Assert.Equal($"a{Environment.NewLine}", CompileAndRun(source));
+    }
+
+    /// <summary>
+    /// Defect 1 with an EXPLICIT type-argument list. Inference is bypassed
+    /// entirely here, so this pins the failure on the receiver-driven
+    /// return-type override rather than on any inference step.
+    /// </summary>
+    [Fact]
+    public void InstanceGenericCall_ExplicitTypeArgument_SymbolicReceiver_BindsAndRuns()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            class Token {
+                var Text string
+                init(text string) { Text = text }
+            }
+
+            func Build(tokens List[Token]) IEnumerable[string] {
+                return tokens.ConvertAll[string](func(t Token) string { return t.Text })
+            }
+
+            var tokens = List[Token]()
+            tokens.Add(Token("a"))
+            for item in Build(tokens) {
+                Console.WriteLine(item)
+            }
+            """;
+
+        Assert.Equal($"a{Environment.NewLine}", CompileAndRun(source));
+    }
+
+    /// <summary>
+    /// Defect 1 with a value-type result, so the projected type argument is a
+    /// struct rather than a reference type (a wrong instantiation here would
+    /// box and fail verification instead of merely mistyping).
+    /// </summary>
+    [Fact]
+    public void InstanceGenericCall_ValueTypeResult_SymbolicReceiver_BindsAndRuns()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            class Token {
+                var Text string
+                init(text string) { Text = text }
+            }
+
+            func Build(tokens List[Token]) IEnumerable[int32] {
+                return tokens.ConvertAll(func(t Token) int32 { return t.Text.Length })
+            }
+
+            var tokens = List[Token]()
+            tokens.Add(Token("ab"))
+            for item in Build(tokens) {
+                Console.WriteLine(item)
+            }
+            """;
+
+        Assert.Equal($"2{Environment.NewLine}", CompileAndRun(source));
+    }
+
+    /// <summary>
+    /// The imported-STATIC sibling of the #3712 gap
+    /// (<c>ImportedClassSymbol.TryLookupFunction</c>): the same overloaded group
+    /// through <c>Array.ConvertAll</c> reported
+    /// <c>GS0155: Cannot convert type 'object[]' to '[]Range'</c> because the
+    /// group's symbolic slot was never refined there either.
+    /// </summary>
+    [Fact]
+    public void ImportedStaticGenericCall_OverloadedGroup_ReturningSameCompilationClass_EmitsClosedOverRealType()
+    {
+        var source = """
+            package P
+            import System
+
+            class Range {
+                var Label string
+                init(label string) { Label = label }
+            }
+
+            class Helper {
+                shared {
+                    func ToRange(value int32) Range { return Range(value.ToString()) }
+                    func ToRange(text string, extra int32) Range { return Range(text) }
+                }
+            }
+
+            func Build(values []int32) []Range {
+                return Array.ConvertAll(values, Helper.ToRange)
+            }
+
+            for item in Build([]int32{1, 2}) {
+                Console.WriteLine(item.Label)
+            }
+            """;
+
+        Assert.Equal($"1{Environment.NewLine}2{Environment.NewLine}", CompileAndRun(source));
+    }
+
+    /// <summary>
+    /// The SILENT half of the instance gap. With a BCL element type in the
+    /// receiver (<c>List[int32]</c>) defect 1 never fires, so the program
+    /// compiled clean on main — and emitted <c>ConvertAll&lt;object&gt;</c>,
+    /// storing a <c>List&lt;object&gt;</c> into an <c>IEnumerable&lt;Range&gt;</c>
+    /// slot. On <c>origin/main</c> this test fails only at the ilverify step
+    /// (<c>StackUnexpected</c>), which is why these tests must verify and
+    /// execute rather than count diagnostics.
+    /// </summary>
+    [Fact]
+    public void InstanceGenericCall_ClrReceiverElement_OverloadedGroup_EmitsClosedOverRealType()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            class Range {
+                var Label string
+                init(label string) { Label = label }
+            }
+
+            class Helper {
+                shared {
+                    func ToRange(value int32) Range { return Range(value.ToString()) }
+                    func ToRange(text string, extra int32) Range { return Range(text) }
+                }
+            }
+
+            func Build(values List[int32]) IEnumerable[Range] {
+                return values.ConvertAll(Helper.ToRange)
+            }
+
+            var values = List[int32]()
+            values.Add(7)
+            for item in Build(values) {
+                Console.WriteLine(item.Label)
+            }
+            """;
+
+        Assert.Equal($"7{Environment.NewLine}", CompileAndRun(source));
+    }
+
+    /// <summary>
+    /// Anti-vacuity control: an overloaded group whose candidates all share
+    /// the target arity stays ambiguous by arity alone, so the refinement must
+    /// decline it and leave the existing erasure path to decide. The program
+    /// must still bind and pick the <c>int32</c> candidate.
+    /// </summary>
+    [Fact]
+    public void InstanceGenericCall_SameArityOverloads_StayOnTheErasurePath()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            class Helper {
+                shared {
+                    func Describe(value int32) string { return "i" + value.ToString() }
+                    func Describe(value string) string { return "s" + value }
+                }
+            }
+
+            func Build(values List[int32]) List[string] {
+                return values.ConvertAll(Helper.Describe)
+            }
+
+            var values = List[int32]()
+            values.Add(3)
+            for item in Build(values) {
+                Console.WriteLine(item)
+            }
+            """;
+
+        Assert.Equal($"i3{Environment.NewLine}", CompileAndRun(source));
+    }
+
+    /// <summary>
+    /// Anti-vacuity guard-rail: a genuinely inapplicable method group must
+    /// still be REJECTED. The refinement widens what the symbolic vector can
+    /// recover; it must not make an incompatible group bind. <c>ToRange</c> has
+    /// no one-parameter candidate that accepts a <c>Token</c>, so the call has
+    /// to report a diagnostic rather than silently pick something.
+    /// </summary>
+    [Fact]
+    public void InstanceGenericCall_IncompatibleGroup_StillFailsToBind()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            class Token {
+                var Text string
+                init(text string) { Text = text }
+            }
+
+            class Range {
+                var Label string
+                init(label string) { Label = label }
+            }
+
+            class Helper {
+                shared {
+                    func ToRange(first Range, second Range) Range { return first }
+                }
+            }
+
+            func Build(tokens List[Token]) IEnumerable[Range] {
+                return tokens.ConvertAll(Helper.ToRange)
+            }
+
+            Console.WriteLine(Build(List[Token]()))
+            """;
+
+        var (exitCode, output) = Compile(source);
+        Assert.True(exitCode != 0, "an inapplicable method group must not bind; got a clean compile:\n" + output);
+    }
+
+    private static (int ExitCode, string Output) Compile(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_3712_inst_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            try
+            {
+                return (Program.Main(args), compileOut.ToString() + compileErr.ToString());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+        }
+        finally
+        {
+            TryDelete(tempDir);
+        }
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_3712_inst_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+
+            // (a) A generic call closed over the `object` erasure binds and
+            // compiles clean — only IL verification catches it.
+            IlVerifier.Verify(outPath);
+
+            // (b) Verifiable-but-wrong is worse than the bug, so the program
+            // must also produce the right values.
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi) ?? throw new Xunit.Sdk.XunitException("failed to start dotnet exec");
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.ReplaceLineEndings(Environment.NewLine);
+        }
+        finally
+        {
+            TryDelete(tempDir);
+        }
+    }
+
+    private static void TryDelete(string tempDir)
+    {
+        try
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Refs #3712 (the "Related (distinct, not fixed here)" section).

## The issue's framing does not hold

#3712 parked the instance path with:

> `tokens.ConvertAll(Helper.ToRange)` with the same shapes fails earlier and louder, with `GS0156` — a compile error, not bad IL, so it is not a verification hazard.

Reproducing it in-process contradicts both halves. Full correction posted to the issue: https://github.com/DavidObando/gsharp/issues/3712#issuecomment-5488598518

**The `GS0156` has nothing to do with method groups.** It reproduces with a plain lambda, and survives an explicit `[string]` type-argument list that bypasses inference entirely:

```go
return tokens.ConvertAll(func(t Token) string { return t.Text })       // GS0156: 'List[TOutput]'
return tokens.ConvertAll[string](func(t Token) string { return t.Text })  // GS0156: 'List[TOutput]'
```

The discriminator is a receiver whose type arguments are **symbolic** (`List[Token]` where `Token` is same-compilation). `List[int32]` never fails.

**And the path is not safe from bad IL.** With a BCL element type in the receiver the projection defect stays quiet and the #3712 gap proper takes over — this compiled clean on `main`:

```go
func Build(values List[int32]) IEnumerable[Range] {
    return values.ConvertAll(Helper.ToRange)   // Helper.ToRange overloaded, returns same-compilation Range
}
```

```
[IL]: Error [StackUnexpected]: [P.<Program>::Build(List`1<int32>)] [offset 0x00000012]
  [found ref 'List`1<object>'] [expected ref 'IEnumerable`1<P.Range>']
```

Same signature as the original report, on the path the issue declared safe.

## Diagnosis

Two independent defects met here.

**1. Method-level type arguments dropped by the receiver projection** (the loud one, and a distinct pre-existing bug, not a regression of #3753/#3756). `ExpressionBinder.ResolveInstanceReturnTypeFromReceiver` (#794) maps the *open declaring type's* return type through the receiver's symbolic type arguments, but never substituted the selected method's **own** generic parameters. `List<T>.ConvertAll<TOutput>` therefore projected to the open `List[TOutput]`, and because the override sits **before** the plain CLR return type in the chain

```csharp
var returnType = ResolveImportedGenericReturnType(...)
    ?? MemberLookup.ResolveCallReturnTypeFromSymbolicTypeArgs(...)   // inactive: nothing symbolic to recover
    ?? ResolveInstanceReturnTypeFromReceiver(...)                    // ← the open `List[TOutput]`
    ?? MapClrMethodReturnType(method);                               // ← had the correct `List[string]`
```

the open shape won. This is the #3705 inconsistent-sibling shape: `MemberLookup.ResolveCallReturnTypeFromSymbolicTypeArgs` passes the method-level vector to the very same `MapOpenClrTypeToSymbolic`; this probe and its by-ref twin `ResolveInstanceParameterPointeeTypeFromReceiver` (#1107) omitted it.

**2. The #3712 gap proper, on three more paths** (the silent one; a genuine incompleteness of the #3713 fix, which only wired the extension-call path). A user method group has no natural type until the target delegate is known, so its slot in the pre-resolution symbolic vector is the `Error` sentinel and a same-compilation return type is lost.

## Changes

`src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs`
- `ResolveInstanceReturnTypeFromReceiver` and `ResolveInstanceParameterPointeeTypeFromReceiver` now pass the method-level substitution vector, built by the new `BuildMethodTypeArgSymbolsFromClosedMethod` from the closed method's own generic arguments.
- `RefineSymbolicArgsForMethodGroups` wired into the direct-instance path and the imported-static path.

`src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs`
- same refinement on the inherited-instance path.

`src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs`
- `TryLookupFunction` takes the refiner as an optional callback and applies it where it builds the symbolic method type args, fixing `Array.ConvertAll(values, Helper.ToRange)` (`GS0155: Cannot convert type 'object[]' to '[]Range'`).

`src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs` — two sibling omissions inside the refinement itself:
- it skipped **single-candidate** groups. A group only acquires a natural type when that type is CLR-expressible, so one returning a same-compilation class arrives erased exactly like an overloaded one. The existing `is FunctionTypeSymbol` guard keeps every already-symbolic slot untouched.
- it probed the target delegate with a bare `GetMethodSafe("Invoke")` where its neighbours use `ClrLoadContext.TryGetDelegateSignature` (#3752/#3753). The direct probe throws on the `TypeBuilderInstantiation` that closing `Converter`/`Func` over a MetadataLoadContext argument produces — which would have silently skipped the refinement rather than failing loudly.

## Tests

`test/Compiler.Tests/Emit/Issue3712InstanceGenericCallMethodGroupEmitTests.cs` — every case **compiles, runs ilverify, and executes** the program and asserts its stdout, because the silent variant binds with zero diagnostics.

On `origin/main` (`src/` checked out at main, tests kept): **7 of 9 fail**.

| test | on main |
|---|---|
| `InstanceGenericCall_OverloadedGroup_ReturningSameCompilationClass_…` | FAIL (GS0156) |
| `InstanceGenericCall_SingleCandidateGroup_ReturningSameCompilationClass_…` | FAIL (GS0156) |
| `InstanceGenericCall_LambdaArgument_SymbolicReceiver_BindsAndRuns` | FAIL (GS0156) |
| `InstanceGenericCall_ExplicitTypeArgument_SymbolicReceiver_BindsAndRuns` | FAIL (GS0156) |
| `InstanceGenericCall_ValueTypeResult_SymbolicReceiver_BindsAndRuns` | FAIL (GS0156) |
| `InstanceGenericCall_ClrReceiverElement_OverloadedGroup_…` | FAIL — **compiles clean, ilverify `StackUnexpected`** |
| `ImportedStaticGenericCall_OverloadedGroup_…` | FAIL (GS0155) |
| `InstanceGenericCall_SameArityOverloads_StayOnTheErasurePath` | **passes** (anti-vacuity) |
| `InstanceGenericCall_IncompatibleGroup_StillFailsToBind` | **passes** (anti-vacuity) |

The two passing on main are the guard-rails: an overloaded group ambiguous by arity alone must keep binding through the existing erasure path, and a genuinely inapplicable group must still be rejected — the refinement widens what the symbolic vector can recover and must not make an incompatible group bind.

## Local runs

- `Compiler.Tests --filter Issue3712` — 13/13 pass (4 pre-existing from #3713 + 9 new).
- `Core.Tests` — 8516/8516 pass.
- `LanguageServer.Tests` — 486/486 pass.
- Full `Compiler.Tests` running; CI covers the rest.

## Follow-up filed

#3760 — a **user-declared** generic function cannot take a method group in a delegate-typed parameter at all: `GS0151` when inferred, and a `GS9998` internal compiler error when the type argument is supplied explicitly. Distinct path (user-generic inference, not the imported-call binder), so not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
