### PR TITLE
gsc: an imported `string?` bound as non-null `string` through a constrained receiver (#3705 family 2)

### DIFF
--- a/docs/adr/0136-nullable-by-default-for-unannotated-imports.md
+++ b/docs/adr/0136-nullable-by-default-for-unannotated-imports.md
@@ -65,7 +65,7 @@ The single principle: **only an explicit `1` (NotAnnotated) means non-null `T`;
 `[NullableContext(1)]` makes **all** nested reference positions non-null, and a
 `[Nullable(2)]` makes them all nullable — matching Roslyn's compaction.
 
-The rule is applied uniformly in both reading paths:
+The rule is applied uniformly in all three reading paths:
 
 - `ApplyReferenceNullabilityFull` — top-level field / property / parameter /
   return reading (previously keyed off `topFlag == 2`).
@@ -74,6 +74,38 @@ The rule is applied uniformly in both reading paths:
   beyond-length positions to `0`). Beyond-length handling now follows the same
   rule: length-1 flags apply `flags[0]` to all positions, empty flags are
   nullable, otherwise index directly.
+- `NullableFlagsBuilder.MergeDeclarationNullability` — the receiver-substituting
+  path (issue #3705 family 2), which folds a declaration's flags back onto a type
+  recovered by generic substitution. It reaches imported fields, constrained
+  calls, `Deconstruct` out-parameters and event handler types.
+
+`IsFlagNonNull(byte)` is the single predicate all three defer to. It exists
+because the two open-codings of this one-line rule are what let the paths drift:
+C# reads "nullable iff the byte is `2`", G# reads "non-null iff the byte is `1`",
+and the two agree on `1` and `2` while disagreeing on `0` and on absence. A
+reader that spells the rule itself will sooner or later spell C#'s.
+
+#### The scope of "reference position": open type parameters are excluded
+
+The rule above is about **concrete** reference positions. An **open type-parameter**
+position is not one, and issue #3705 family 2 makes that explicit after a first
+attempt at uniformity made `map[K, V].Keys` iterate as `K?`:
+
+- A type parameter's nullability arrives with the type **argument** at
+  substitution, and the argument carries its own annotation. Applying the
+  declaration's *missing* byte overwrites the caller's answer with a guess.
+- It is unsound in a way the concrete case is not. An unconstrained `K` may be
+  substituted with a **value type**, where `K?` silently means `Nullable<K>` and
+  changes the contract.
+
+So an open parameter slot keeps the pre-#1354 reading: widen only for an
+explicit `[Nullable(2)]`, which is the declarer genuinely writing `K?`. Absent
+and oblivious leave the projected type alone.
+
+This distinction needs care because `ExpandNullableFlags` fills absent positions
+with `2` — that fill *is* the rule above — so the expanded array cannot tell
+"declared `T?`" from "declared nothing". The `absentFill` overload gives the
+literal reading; only the type-parameter arm uses it.
 
 **Value types are unaffected.** A value-type position contributes no byte and
 stays non-null; `Nullable<T>` value types are already lowered in
@@ -207,3 +239,19 @@ its flag byte), which is a deeper change than this fix warrants. The common case
 (a non-generic instance method returning a plain reference type) is fully fixed;
 the generic-substituted-return nullability is the only remaining call-return gap
 and is tracked here as best-effort follow-up.
+
+**Resolved.** That threading is `NullableFlagsBuilder.MergeDeclarationNullability`,
+which walks the open declaration's layout and the substituted symbol in lockstep
+so each substituted position recovers its flag byte. Issue #3695 applied it to
+fields and event handlers, #3741 (issue #3705 family 2) to constrained-call
+returns and `Deconstruct` out-parameters, and #3705 family 2's second half to the
+oblivious column: `MergeDeclarationNullability` used to return the projected type
+unchanged when the declaration's flags were empty, and to key its annotation off
+`flag == 2` when they were not — so a member reached through a substituting
+receiver kept the pre-#1354 answer for *both* shapes of oblivious. Both are gone;
+the path now defers to `IsFlagNonNull` like the other two.
+
+`Issue3705MemberKindNullabilityDifferentialTests` is the standing gate: six
+signature-position kinds × four annotation states, with the expectation computed
+from the annotation state alone, so the table *is* this ADR's uniformity claim
+rather than a restatement of the current implementation.

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -3919,7 +3919,23 @@ internal sealed class MemberLookup
                         && (TypeSymbol.RequiresSymbolicProjection(mapped)
                             || TypeSymbol.ContainsNamedTupleElements(mapped))))
                 {
-                    return mapped;
+                    // Issue #3705 (family 2): this branch returned the
+                    // receiver-substituted type RAW, exactly as
+                    // GetClrMethodReturnTypeSymbol's did before #3741 — and
+                    // #3741 fixed the return and parameter branches but not this
+                    // one. Substitution recovers the member's shape and silently
+                    // discards the declaration's `[Nullable]`, so an imported
+                    // `string?` property or indexer read through a constrained
+                    // generic receiver bound as non-null `string` with no
+                    // diagnostic: the unsound direction. Fold the declaration
+                    // flags back in like every sibling reader.
+                    var declarationFlags = ClrNullability.ReadNullableFlags(
+                        openProperty,
+                        openProperty.DeclaringType);
+                    return NullableFlagsBuilder.MergeDeclarationNullability(
+                        mapped,
+                        openProperty.PropertyType,
+                        declarationFlags);
                 }
             }
         }

--- a/src/Core/CodeAnalysis/Emit/NullableFlagsBuilder.cs
+++ b/src/Core/CodeAnalysis/Emit/NullableFlagsBuilder.cs
@@ -78,14 +78,27 @@ internal static class NullableFlagsBuilder
         Type layoutType,
         ImmutableArray<byte> declarationFlags)
     {
-        if (declarationFlags.IsDefaultOrEmpty)
-        {
-            return projectedType;
-        }
-
+        // Issue #3705 family 2: no short-circuit on empty flags. An absent
+        // `[Nullable]` is not "no information" in G# — issue #1354 makes it
+        // mean `T?`, and `ExpandNullableFlags` already expands empty metadata
+        // to a full array of `2`s for exactly that reason. Returning
+        // `projectedType` here is what made a member reached through a
+        // receiver-substituting reader (field, constrained call, deconstruct
+        // out-parameter) keep the pre-#1354 non-null answer while its
+        // ClrNullability-read siblings said `T?`.
         var declaredFlags = ClrNullability.ExpandNullableFlags(
             layoutType,
             declarationFlags);
+
+        // The same expansion read LITERALLY: absent positions stay oblivious
+        // instead of defaulting to `2`. Only the open-type-parameter carve-out
+        // below consults this, because it is the one position where "the
+        // declaration was silent" must not be read as "the declaration said
+        // `T?`" — and the default expansion cannot tell those apart.
+        var literalFlags = ClrNullability.ExpandNullableFlags(
+            layoutType,
+            declarationFlags,
+            absentFill: Oblivious);
         var position = 0;
         return Merge(projectedType, layoutType);
 
@@ -98,7 +111,36 @@ internal static class NullableFlagsBuilder
 
             if (layout.IsGenericParameter)
             {
-                return ApplyRootAnnotation(projected, declaredFlags[position++]);
+                // Issue #3705 family 2 — the ONE carve-out from the #1354 rule,
+                // and it is principled rather than pragmatic.
+                //
+                // #1354 is a statement about CONCRETE reference positions in
+                // imported metadata: "unannotated means the declarer told us
+                // nothing, so assume `T?`". An OPEN type-parameter position is
+                // not such a position. Its nullability is supplied by the type
+                // ARGUMENT at substitution — which carries its own annotation —
+                // so reading the declaration's missing byte as `K?` would
+                // overwrite the caller's answer with a guess.
+                //
+                // It is also unsound in a way the concrete case is not: an
+                // unconstrained `K` may be substituted with a VALUE type, where
+                // `K?` silently means `Nullable<K>` and changes the contract.
+                // (`ApplyRootAnnotation`'s value-type guard cannot catch this —
+                // it inspects the still-open parameter, which has no `struct`
+                // constraint to see.) This is what `Issue3311…GenericFunc_Keys_
+                // FullyOpen_ReturnsFirstKey_As_K` pins: `map[K, V].Keys` must
+                // iterate as `K`, not `K?`.
+                //
+                // So an open parameter slot keeps the pre-#1354 reading: widen
+                // only for an EXPLICIT `[Nullable(2)]`, which is the declarer
+                // genuinely saying `K?`. Absent and oblivious leave it alone.
+                // Read LITERALLY: `declaredFlags` would show a fabricated `2`
+                // here for a declaration that said nothing at all, which is the
+                // very case the carve-out exists to leave alone.
+                var parameterFlag = literalFlags[position++];
+                return parameterFlag == Annotated
+                    ? ApplyRootAnnotation(projected, parameterFlag)
+                    : projected;
             }
 
             if (layout.IsArray)
@@ -204,7 +246,12 @@ internal static class NullableFlagsBuilder
 
         static TypeSymbol ApplyRootAnnotation(TypeSymbol projected, byte flag)
         {
-            if (flag != Annotated || projected is NullableTypeSymbol)
+            // Issue #3705 family 2: ask the single #1354 predicate rather than
+            // open-coding `flag != Annotated`. The two differ on the oblivious
+            // byte `0`, which csc emits explicitly for a `#nullable disable`
+            // member of a `[NullableContext(1)]` type — a NON-empty flags array
+            // the removed short-circuit above never even saw.
+            if (ClrNullability.IsFlagNonNull(flag) || projected is NullableTypeSymbol)
             {
                 return projected;
             }

--- a/src/Core/CodeAnalysis/Symbols/ClrNullability.cs
+++ b/src/Core/CodeAnalysis/Symbols/ClrNullability.cs
@@ -432,6 +432,35 @@ public static class ClrNullability
     /// <param name="flags">Physical nullable flags, possibly scalar or empty.</param>
     /// <returns>One byte per CLR nullable-metadata position.</returns>
     internal static ImmutableArray<byte> ExpandNullableFlags(Type type, ImmutableArray<byte> flags)
+        => ExpandNullableFlags(type, flags, absentFill: 2);
+
+    /// <summary>
+    /// Issue #3705 family 2: <see cref="ExpandNullableFlags(Type, ImmutableArray{byte})"/>
+    /// with an explicit fill for positions the declaration did not supply.
+    /// <para>
+    /// The default fill of <c>2</c> IS the #1354 rule — "the declarer said
+    /// nothing, so assume nullable". That is right for a concrete reference
+    /// position and wrong for an OPEN type-parameter position, whose
+    /// nullability comes from the substituted argument instead. A caller that
+    /// must distinguish "the declaration explicitly said <c>2</c>" from "the
+    /// declaration was silent and we defaulted to <c>2</c>" cannot do it from
+    /// the default expansion, because both look identical. Passing
+    /// <c>absentFill: 0</c> yields the literal reading.
+    /// </para>
+    /// <para>
+    /// A scalar or context byte is a genuine statement about every position and
+    /// is preserved under both fills; only truly absent and beyond-length
+    /// positions differ.
+    /// </para>
+    /// </summary>
+    /// <param name="type">CLR type tree to expand.</param>
+    /// <param name="flags">Physical nullable flags, possibly scalar or empty.</param>
+    /// <param name="absentFill">Byte to use for positions the declaration did not supply.</param>
+    /// <returns>One byte per CLR nullable-metadata position.</returns>
+    internal static ImmutableArray<byte> ExpandNullableFlags(
+        Type type,
+        ImmutableArray<byte> flags,
+        byte absentFill)
     {
         var builder = ImmutableArray.CreateBuilder<byte>(CountNullabilityBytes(type));
         var index = 0;
@@ -484,7 +513,7 @@ public static class ClrNullability
         {
             if (flags.IsDefaultOrEmpty)
             {
-                return 2;
+                return absentFill;
             }
 
             if (flags.Length == 1)
@@ -492,7 +521,7 @@ public static class ClrNullability
                 return flags[0];
             }
 
-            return position < flags.Length ? flags[position] : (byte)2;
+            return position < flags.Length ? flags[position] : absentFill;
         }
     }
 
@@ -526,12 +555,32 @@ public static class ClrNullability
         if (flags.Length == 1)
         {
             // Scalar/context byte applies to every position.
-            return flags[0] == 1;
+            return IsFlagNonNull(flags[0]);
         }
 
         // Per-position array: index directly; beyond-length positions are nullable.
-        return index < flags.Length && flags[index] == 1;
+        return index < flags.Length && IsFlagNonNull(flags[index]);
     }
+
+    /// <summary>
+    /// Issue #1354, issue #3705 family 2 — <b>the</b> predicate that turns one
+    /// C# nullable-metadata byte into G#'s answer, and the only place in the
+    /// compiler allowed to decide it.
+    /// <para>
+    /// G#'s import rule is the inverse of C#'s. C# reads "nullable iff the byte
+    /// is <c>2</c>", so oblivious (<c>0</c>) and absent metadata mean non-null.
+    /// G# reads "non-null iff the byte is <c>1</c>", so oblivious <b>and</b>
+    /// absent both mean <c>T?</c>. Two readers open-coding the two rules is
+    /// exactly how the #3705 nullability family kept producing member kinds
+    /// that disagreed about the same declaration, so the rule lives here and
+    /// <see cref="IsPositionNonNull"/> and
+    /// <c>NullableFlagsBuilder.MergeDeclarationNullability</c> both defer to it
+    /// rather than comparing bytes themselves.
+    /// </para>
+    /// </summary>
+    /// <param name="flag">A single C# nullable-metadata byte (0, 1 or 2).</param>
+    /// <returns><c>true</c> only for <c>1</c> (not-annotated).</returns>
+    internal static bool IsFlagNonNull(byte flag) => flag == 1;
 
     /// <summary>
     /// Constructs a <see cref="TypeSymbol"/> for <paramref name="clrType"/> by

--- a/test/Compiler.Tests/Emit/Issue1418GenericUserElementErasureEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1418GenericUserElementErasureEmitTests.cs
@@ -94,6 +94,17 @@ public class Issue1418GenericUserElementErasureEmitTests
         // `LinkedListNode[object]`, so `node.Value` bound as `object` and
         // `node.Value.V` failed GS0158. (`LinkedList` itself is enumerable, but
         // the `.First` PROPERTY type — `LinkedListNode<T>` — is not.)
+        //
+        // Issue #3705 family 2: the `nil` guard is new and it is a CORRECTION,
+        // not a workaround. `LinkedList<T>.First` is declared `[Nullable(2)]`
+        // in the BCL — it returns null for an empty list — so the guard is what
+        // the declaration always required. This test used to bind it as non-null
+        // only because `GetClrPropertyTypeSymbol`'s symbolic branch dropped the
+        // declaration's nullability, which is the unsound direction #3705
+        // family 2 exists to close. The test's actual subject — that a
+        // constructed generic property type does not erase to
+        // `LinkedListNode[object]`, so `.Value.V` resolves to the user member —
+        // is unchanged and still asserted by the `11` below.
         var source = """
             package P
             import System
@@ -106,7 +117,11 @@ public class Issue1418GenericUserElementErasureEmitTests
             a.V = 11
             ll.AddLast(a)
             let node = ll.First
-            Console.WriteLine(node.Value.V)
+            if node == nil {
+                Console.WriteLine("empty")
+            } else {
+                Console.WriteLine(node.Value.V)
+            }
             """;
 
         Assert.Equal($"11{Environment.NewLine}", CompileAndRun(source));

--- a/test/Compiler.Tests/Emit/Issue2514ImportedInterfaceConstraintMemberTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2514ImportedInterfaceConstraintMemberTests.cs
@@ -20,7 +20,18 @@ namespace GSharp.Compiler.Tests.Emit;
 /// </summary>
 public sealed class Issue2514ImportedInterfaceConstraintMemberTests
 {
+    // Issue #3705 family 2: `#nullable enable` is load-bearing, not tidying.
+    // This fixture is about member REACHABILITY through an imported interface
+    // constraint, and the G# side assigns every read to a non-null `string`. In
+    // an oblivious compilation those members carry no `[Nullable]` metadata, and
+    // per #1354 / ADR-0136 gsc imports an unannotated reference position as
+    // `T?` — so the assignments were only legal while the constrained-receiver
+    // readers still dropped declaration nullability. Annotating the fixture
+    // states the contract the test always meant (these members really are
+    // non-null) instead of relying on that gap. The `EventHandler?` /
+    // `Action<T>?` declarations below were already written in nullable style.
     private const string ContractsSource = """
+        #nullable enable
         using System;
 
         namespace Issue2514.Contracts

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3705MemberKindNullabilityDifferentialTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3705MemberKindNullabilityDifferentialTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.Loader;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Text;
 using GsCompilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
@@ -30,28 +31,48 @@ namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 /// <para>
 /// So rather than one test per site, this fixture asserts the INVARIANT: for a
 /// reference-typed signature position on an imported member, whether the bound
-/// type is nullable depends only on the DECLARATION's annotation state —
-/// annotated non-null, annotated nullable, or unannotated/oblivious — and never
-/// on the member kind through which the position was reached. The member kind
-/// never appears on the right-hand side of the expectation; the table IS the
-/// invariant.
+/// type is nullable depends only on the DECLARATION's annotation state, and
+/// never on the member kind through which the position was reached. The member
+/// kind never appears on the right-hand side of either expectation; the table
+/// IS the invariant.
 /// </para>
 /// <para>
-/// The oblivious row is deliberately part of the contract rather than an
-/// accident: issue #1354 fixed the import default so an unannotated imported
-/// reference type reads as nullable. Every kind must apply that rule too, and a
-/// swap that only fixed the explicitly-annotated positions would leave the
-/// kinds disagreeing again.
+/// There are FOUR annotation states, not three, and the fourth is the one the
+/// original family-2 deferral missed. Issue #1354 says a reference position is
+/// non-null only for an explicit <c>1</c>; oblivious reaches the compiler in two
+/// physically different shapes and a fix that only handles the first leaves the
+/// kinds disagreeing:
+/// <list type="bullet">
+/// <item><c>ObliviousAbsent</c> — no <c>[Nullable]</c> and no
+/// <c>[NullableContext]</c> anywhere, so the flags array is EMPTY.</item>
+/// <item><c>ObliviousZero</c> — a <c>#nullable disable</c> member of a
+/// <c>[NullableContext(1)]</c> type, which csc annotates with an explicit
+/// <c>[Nullable(0)]</c>: a NON-empty flags array holding the oblivious byte.
+/// <c>MergeDeclarationNullability</c>'s empty-flags short-circuit never saw
+/// this one at all; it fell through to an <c>ApplyRootAnnotation</c> that
+/// open-coded C#'s "nullable iff the byte is 2" instead of G#'s "non-null iff
+/// the byte is 1".</item>
+/// </list>
 /// </para>
 /// <para>
 /// Guard rails, and they are half the point: the <c>NonNull</c> rows are the
 /// negative controls. They fail if a fix widens an annotated non-null position
 /// to nullable — the #3704-shaped regression the family-2 triage warned about,
 /// where a widened declaration reaches a position that consumes it as non-null.
-/// <see cref="Fixture_Really_Presents_Three_Distinct_AnnotationStates"/> is the
+/// <see cref="Fixture_Really_Presents_Four_Distinct_AnnotationStates"/> is the
 /// anti-vacuity assertion: it reads the emitted metadata directly and proves
-/// the three states carry genuinely different <c>[Nullable]</c> bytes, so the
-/// table cannot go green because every row secretly tested the same thing.
+/// the four states carry genuinely different <c>[Nullable]</c> bytes, so the
+/// table cannot go green because every row secretly tested the same thing. In
+/// particular it pins <c>ObliviousZero</c> to the byte <c>[0]</c>, because if
+/// csc ever chose a different <c>[NullableContext]</c> for that type the state
+/// would silently collapse into <c>ObliviousAbsent</c> and stop testing the
+/// second mechanism.
+/// </para>
+/// <para>
+/// Every row also EXECUTES its emitted assembly. A nullability edit changes the
+/// types the emitter sees, and binding cleanly with zero diagnostics is not
+/// evidence that the emitted IL runs; the marker each program prints is derived
+/// from the annotation state alone, exactly like the bind expectation.
 /// </para>
 /// </summary>
 public sealed class Issue3705MemberKindNullabilityDifferentialTests
@@ -61,8 +82,19 @@ public sealed class Issue3705MemberKindNullabilityDifferentialTests
 
     /// <summary>
     /// One reference-typed signature position of every kind, in each of the
-    /// three annotation states. <c>#nullable disable</c> is what makes the
-    /// <c>Oblivious</c> members carry no <c>[Nullable]</c> metadata at all.
+    /// four annotation states.
+    /// <para>
+    /// Every position that is not <c>Nullable</c> holds a non-null value at
+    /// runtime and every <c>Nullable</c> position holds <c>null</c>, so the
+    /// executed marker is a function of the annotation state alone.
+    /// </para>
+    /// <para>
+    /// <c>#nullable disable</c> alone is what makes the <c>Oblivious*</c>
+    /// members oblivious; whether that shows up as absent metadata or as an
+    /// explicit <c>[Nullable(0)]</c> is decided by the enclosing type's
+    /// <c>[NullableContext]</c>, which is why the <c>ObliviousZero</c> types
+    /// carry enough non-null anchors to push csc's majority vote to <c>1</c>.
+    /// </para>
     /// </summary>
     private const string CSharpLibrarySource = """
         #nullable enable
@@ -73,21 +105,21 @@ public sealed class Issue3705MemberKindNullabilityDifferentialTests
 
         public class Surface
         {
-            public string NonNullField = string.Empty;
+            public string NonNullField = "V";
             public string? NullableField = null;
 
-            public string NonNullProperty { get; set; } = string.Empty;
+            public string NonNullProperty { get; set; } = "V";
             public string? NullableProperty { get; set; }
 
-            public string NonNullMethod() => string.Empty;
+            public string NonNullMethod() => "V";
             public string? NullableMethod() => null;
 
-            public string this[int index] => string.Empty;
+            public string this[int index] => "V";
             public string? this[long index] => null;
 
             public void Deconstruct(out string first, out int second)
             {
-                first = string.Empty;
+                first = "V";
                 second = 0;
             }
         }
@@ -106,42 +138,185 @@ public sealed class Issue3705MemberKindNullabilityDifferentialTests
             string NonNullMethod();
 
             string? NullableMethod();
+
+            string NonNullProperty { get; }
+
+            string? NullableProperty { get; }
+
+            string this[int index] { get; }
+
+            string? this[long index] { get; }
         }
 
         public class Constrained : IConstrained
         {
-            public string NonNullMethod() => string.Empty;
+            public string NonNullMethod() => "V";
 
             public string? NullableMethod() => null;
+
+            public string NonNullProperty => "V";
+
+            public string? NullableProperty => null;
+
+            public string this[int index] => "V";
+
+            public string? this[long index] => null;
+        }
+
+        // ObliviousZero: a `[NullableContext(1)]` type whose `#nullable disable`
+        // members therefore carry an explicit `[Nullable(0)]`. The anchors exist
+        // only to win csc's per-type majority vote.
+        public class ObliviousZeroSurface
+        {
+            public string Anchor1 = "V";
+            public string Anchor2 = "V";
+            public string Anchor3 = "V";
+            public string Anchor4 = "V";
+            public string Anchor5 = "V";
+            public string Anchor6 = "V";
+            public string Anchor7 = "V";
+            public string Anchor8 = "V";
+            public string Anchor9 = "V";
+            public string Anchor10 = "V";
+            public string Anchor11 = "V";
+            public string Anchor12 = "V";
+
+        #nullable disable
+            public string ObliviousZeroField = "V";
+
+            public string ObliviousZeroProperty { get; set; } = "V";
+
+            public string ObliviousZeroMethod() => "V";
+
+            public string this[int index] => "V";
+
+            public void Deconstruct(out string first, out int second)
+            {
+                first = "V";
+                second = 0;
+            }
+        #nullable enable
+        }
+
+        public interface IObliviousZeroConstrained
+        {
+            string Anchor1();
+
+            string Anchor2();
+
+            string Anchor3();
+
+            string Anchor4();
+
+            string Anchor5();
+
+            string Anchor6();
+
+            string Anchor7();
+
+            string Anchor8();
+
+            string Anchor9();
+
+            string Anchor10();
+
+        #nullable disable
+            string ObliviousZeroMethod();
+
+            string ObliviousZeroProperty { get; }
+
+            string this[int index] { get; }
+        #nullable enable
+        }
+
+        public class ObliviousZeroConstrained : IObliviousZeroConstrained
+        {
+            public string Anchor1() => "V";
+
+            public string Anchor2() => "V";
+
+            public string Anchor3() => "V";
+
+            public string Anchor4() => "V";
+
+            public string Anchor5() => "V";
+
+            public string Anchor6() => "V";
+
+            public string Anchor7() => "V";
+
+            public string Anchor8() => "V";
+
+            public string Anchor9() => "V";
+
+            public string Anchor10() => "V";
+
+        #nullable disable
+            public string ObliviousZeroMethod() => "V";
+
+            public string ObliviousZeroProperty => "V";
+
+            public string this[int index] => "V";
+        #nullable enable
         }
 
         #nullable disable
 
-        public class ObliviousSurface
+        // ObliviousAbsent: no `[Nullable]` and no `[NullableContext]` reaches
+        // these members at all, so the flags array the binder reads is empty.
+        public class ObliviousAbsentSurface
         {
-            public string ObliviousField;
+            public string ObliviousAbsentField = "V";
 
-            public string ObliviousProperty { get; set; }
+            public string ObliviousAbsentProperty { get; set; } = "V";
 
-            public string ObliviousMethod() => string.Empty;
+            public string ObliviousAbsentMethod() => "V";
 
-            public string this[int index] => string.Empty;
+            public string this[int index] => "V";
 
             public void Deconstruct(out string first, out int second)
             {
-                first = string.Empty;
+                first = "V";
                 second = 0;
             }
         }
 
-        public interface IObliviousConstrained
+        public interface IObliviousAbsentConstrained
         {
-            string ObliviousMethod();
+            string ObliviousAbsentMethod();
+
+            string ObliviousAbsentProperty { get; }
+
+            string this[int index] { get; }
         }
 
-        public class ObliviousConstrained : IObliviousConstrained
+        // The open-type-parameter carve-out, declared in an OBLIVIOUS region —
+        // which is exactly where the #1354 default would otherwise fire and
+        // rewrite the declaration's `T` into `T?`. `Value`'s metadata slot is
+        // an OPEN `T` with no nullability byte at all.
+        public class ObliviousBox<T>
         {
-            public string ObliviousMethod() => string.Empty;
+            public ObliviousBox(T value)
+            {
+                Value = value;
+            }
+
+            public T Value { get; }
+        }
+
+        public class ObliviousAbsentConstrained : IObliviousAbsentConstrained
+        {
+            public string ObliviousAbsentMethod() => "V";
+
+            public string ObliviousAbsentProperty => "V";
+
+            public string this[int index] => "V";
+        }
+
+        // The soundness demonstration: oblivious AND genuinely null at runtime.
+        public class ObliviousNullAtRuntimeSurface
+        {
+            public string ObliviousField;
         }
         """;
 
@@ -157,21 +332,36 @@ public sealed class Issue3705MemberKindNullabilityDifferentialTests
         "MethodReturn",
         "IndexerElement",
         "ConstrainedMethodReturn",
+        "ConstrainedProperty",
+        "ConstrainedIndexer",
         "DeconstructOut",
     };
 
     /// <summary>
-    /// Gets the differential matrix: signature-position kind × ANNOTATED
-    /// state. The expectation ("does this bind as non-null?") is computed
-    /// from the annotation state ALONE — the kind never appears on the
-    /// right-hand side.
+    /// Gets the annotation states. <c>ObliviousAbsent</c> and
+    /// <c>ObliviousZero</c> are the two physical shapes of "unannotated"; #1354
+    /// gives them the same answer and so must every kind.
+    /// </summary>
+    private static string[] States => new[]
+    {
+        "NonNull",
+        "Nullable",
+        "ObliviousAbsent",
+        "ObliviousZero",
+    };
+
+    /// <summary>
+    /// Gets the differential matrix: signature-position kind × annotation
+    /// state. Both expectations — "does this bind as non-null?" and "what does
+    /// the emitted program print?" — are computed from the annotation state
+    /// ALONE. The kind never appears on the right-hand side.
     /// </summary>
     /// <returns>The theory rows.</returns>
-    public static IEnumerable<object[]> AnnotatedMatrix()
+    public static IEnumerable<object[]> Matrix()
     {
         foreach (var kind in Kinds)
         {
-            foreach (var state in new[] { "NonNull", "Nullable" })
+            foreach (var state in States)
             {
                 yield return new object[] { kind, state, state == "NonNull" };
             }
@@ -179,36 +369,28 @@ public sealed class Issue3705MemberKindNullabilityDifferentialTests
     }
 
     /// <summary>
-    /// Gets the UNANNOTATED (oblivious) half of the matrix, with each kind's
-    /// answer as the compiler gives it today. Issue #1354 says every row here
-    /// should be nullable; three are not. See
-    /// <see cref="ObliviousPositions_Diverge_Where_Receiver_Substitution_Runs"/>
-    /// for why this half is pinned rather than asserted.
+    /// The family-2 invariant, over all four annotation states.
+    /// <para>
+    /// Rows that pass on <c>origin/main</c> and are here as guard rails: every
+    /// <c>NonNull</c> and <c>Nullable</c> row (#3741 landed those), and the
+    /// <c>Oblivious*</c> rows for <c>Property</c>, <c>MethodReturn</c> and
+    /// <c>IndexerElement</c>, which already took the plain
+    /// <c>ClrNullability</c> readers.
+    /// </para>
+    /// <para>
+    /// Rows that FAIL on <c>origin/main</c>: the <c>Oblivious*</c> rows for
+    /// <c>Field</c>, <c>ConstrainedMethodReturn</c> and <c>DeconstructOut</c>,
+    /// the three kinds that route through
+    /// <c>NullableFlagsBuilder.MergeDeclarationNullability</c>. On main they
+    /// bind an unannotated imported reference position as non-null, which is
+    /// the pre-#1354 answer.
+    /// </para>
     /// </summary>
-    /// <returns>The theory rows.</returns>
-    public static IEnumerable<object[]> ObliviousMatrix()
-    {
-        // The three that diverge are exactly the readers whose symbolic
-        // (receiver-substituted) branch routes through
-        // NullableFlagsBuilder.MergeDeclarationNullability, which returns the
-        // projected type unchanged when the declaration carries no flags at
-        // all. The three that agree take the plain ClrNullability readers,
-        // which apply the #1354 default.
-        var divergent = new HashSet<string>
-        {
-            "Field",
-            "ConstrainedMethodReturn",
-            "DeconstructOut",
-        };
-
-        foreach (var kind in Kinds)
-        {
-            yield return new object[] { kind, divergent.Contains(kind) };
-        }
-    }
-
+    /// <param name="kind">The signature-position kind.</param>
+    /// <param name="state">The declaration's annotation state.</param>
+    /// <param name="expectedNonNull">Whether the position must bind non-null.</param>
     [Theory]
-    [MemberData(nameof(AnnotatedMatrix))]
+    [MemberData(nameof(Matrix))]
     public void SignaturePositions_Agree_On_DeclarationNullability(
         string kind,
         string state,
@@ -246,6 +428,14 @@ public sealed class Issue3705MemberKindNullabilityDifferentialTests
                     $"{kind}/{state} should bind NULLABLE, but it assigned to a "
                     + "non-null local without a diagnostic.");
             }
+
+            // Binding cleanly is not the same as emitting something that runs.
+            // The marker is a function of the annotation state alone: every
+            // position that is not `Nullable` holds a non-null value.
+            var expectedMarker = state == "Nullable" ? "nil" : "value";
+            Assert.Equal(
+                expectedMarker,
+                RunGSharp(lenient, libraryPath, $"{kind}-{state}").Trim());
         }
         finally
         {
@@ -254,44 +444,126 @@ public sealed class Issue3705MemberKindNullabilityDifferentialTests
     }
 
     /// <summary>
-    /// The deferred half, pinned rather than asserted.
+    /// The soundness case, executed. An oblivious imported field that really is
+    /// <c>null</c> at run time.
     /// <para>
-    /// Issue #1354 made an unannotated imported reference type read as
-    /// nullable, and the plain <c>ClrNullability</c> readers implement it. The
-    /// receiver-substituting readers do not: <c>MergeDeclarationNullability</c>
-    /// short-circuits on <c>declarationFlags.IsDefaultOrEmpty</c> and returns
-    /// the projected (non-null) type, so a member reached through a symbolic
-    /// receiver keeps the pre-#1354 answer.
-    /// </para>
-    /// <para>
-    /// Closing that hole is a semantic change, not a probe fix: it would flip
-    /// every unannotated imported field / constrained call / deconstruction in
-    /// the corpus to nullable at once, which is the #3704 shape the family-2
-    /// triage flagged. So this fixture pins the divergence — three kinds
-    /// disagree with the other three, and the set is named explicitly. When
-    /// the rule is settled and the hole closed, this test fails and forces the
-    /// review; until then it stops the set drifting.
+    /// The local is INFERRED rather than annotated, so on <c>origin/main</c>
+    /// it infers non-null <c>string</c> and the <c>nil</c> guard is rejected —
+    /// which is the whole defect: main hands a null to a position it has typed
+    /// as non-null and offers no way to check. With the #1354 rule applied
+    /// through receiver substitution the guard binds, the program runs, and the
+    /// guard fires.
     /// </para>
     /// </summary>
-    /// <param name="kind">The signature-position kind.</param>
-    /// <param name="bindsNonNullToday">The answer the compiler gives today.</param>
-    [Theory]
-    [MemberData(nameof(ObliviousMatrix))]
-    public void ObliviousPositions_Diverge_Where_Receiver_Substitution_Runs(
-        string kind,
-        bool bindsNonNullToday)
+    [Fact]
+    public void ObliviousField_That_Is_Null_At_Runtime_Is_Guardable_And_Runs()
     {
         var directory = CreateOutputDirectory();
         try
         {
             var libraryPath = EmitCSharpLibrary(directory, LibraryAssemblyName, CSharpLibrarySource);
-            var strict = CompileGSharp(BuildSource(kind, "Oblivious", nullableTarget: false), libraryPath);
-            var lenient = CompileGSharp(BuildSource(kind, "Oblivious", nullableTarget: true), libraryPath);
+            var source = $$"""
+                package {{ConsumerAssemblyName}}
+                import Issue3705.NullabilityLibrary
 
+                func Main() {
+                    let surface = ObliviousNullAtRuntimeSurface()
+                    let probe = surface.ObliviousField
+                    if probe == nil {
+                        Console.WriteLine("guarded")
+                    } else {
+                        Console.WriteLine("leaked")
+                    }
+                }
+                """;
+
+            var compiled = CompileGSharp(source, libraryPath);
             Assert.True(
-                lenient.Success,
-                $"{kind}/Oblivious: the position must bind at all: {Describe(lenient)}");
-            Assert.Equal(bindsNonNullToday, strict.Success);
+                compiled.Success,
+                "an oblivious imported field must bind nullable, so a nil guard "
+                + $"over it binds: {Describe(compiled)}");
+            Assert.Equal("guarded", RunGSharp(compiled, libraryPath, "NullAtRuntime").Trim());
+        }
+        finally
+        {
+            DeleteOutputDirectory(directory);
+        }
+    }
+
+    /// <summary>
+    /// The one carve-out from the uniformity above, pinned so it stays a
+    /// decision rather than decaying into "we gave up".
+    /// <para>
+    /// #1354 is a rule about CONCRETE reference positions in imported metadata.
+    /// An OPEN type-parameter position is not one: its nullability arrives with
+    /// the type ARGUMENT at substitution. Applying the declaration's missing
+    /// byte there would overwrite the caller's answer with a guess, and for an
+    /// unconstrained <c>T</c> substituted with a value type it would silently
+    /// mean <c>Nullable&lt;T&gt;</c>.
+    /// </para>
+    /// <para>
+    /// So <c>Box&lt;string&gt;.Value</c> read off an oblivious holder must be
+    /// <c>string</c> — the argument's own nullability — and NOT <c>string?</c>,
+    /// even though the holder carries no nullability metadata at all and every
+    /// concrete position on it does widen. <c>Box&lt;int&gt;.Value</c> is the
+    /// value-type control: it must stay a plain <c>int32</c>.
+    /// </para>
+    /// <para>
+    /// The in-tree guard rail for the same rule is
+    /// <c>Issue3311OpenMapMemberLookupEmitTests.GenericFunc_Keys_FullyOpen_ReturnsFirstKey_As_K</c>
+    /// (<c>map[K, V].Keys</c> must iterate as <c>K</c>); this row is the
+    /// imported-metadata twin of it, and both fail if the carve-out is dropped.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void OpenTypeParameterPositions_Take_Nullability_From_The_Argument()
+    {
+        var directory = CreateOutputDirectory();
+        try
+        {
+            var libraryPath = EmitCSharpLibrary(directory, LibraryAssemblyName, CSharpLibrarySource);
+
+            // A reference type argument: `ObliviousBox[string].Value` is
+            // `string`, not `string?`, despite the declaration being fully
+            // oblivious. The receiver is constructed in G# so that its OWN
+            // nullability is not in question — the only thing under test is the
+            // open `T` slot.
+            var reference = CompileGSharp(
+                $$"""
+                package {{ConsumerAssemblyName}}
+                import Issue3705.NullabilityLibrary
+
+                func Main() {
+                    let boxed = ObliviousBox[string]("V")
+                    let probe string = boxed.Value
+                    Console.WriteLine(probe)
+                }
+                """,
+                libraryPath);
+            Assert.True(
+                reference.Success,
+                "an open type-parameter position must take the ARGUMENT's "
+                + $"nullability, not the declaration's: {Describe(reference)}");
+            Assert.Equal("V", RunGSharp(reference, libraryPath, "OpenTypeParamRef").Trim());
+
+            // A value type argument: the case where widening would not merely
+            // be noisy but would change the type to `Nullable<int>`.
+            var value = CompileGSharp(
+                $$"""
+                package {{ConsumerAssemblyName}}
+                import Issue3705.NullabilityLibrary
+
+                func Main() {
+                    let boxed = ObliviousBox[int32](7)
+                    let probe int32 = boxed.Value
+                    Console.WriteLine(probe)
+                }
+                """,
+                libraryPath);
+            Assert.True(
+                value.Success,
+                $"a value-type argument must not become nullable: {Describe(value)}");
+            Assert.Equal("7", RunGSharp(value, libraryPath, "OpenTypeParamValue").Trim());
         }
         finally
         {
@@ -302,13 +574,13 @@ public sealed class Issue3705MemberKindNullabilityDifferentialTests
     /// <summary>
     /// Anti-vacuity. #3716's load-context table nearly shipped a fixture that
     /// would have passed even if its "MLC twin" had silently been the host
-    /// type; the analogous trap here is a fixture whose three annotation states
-    /// all carry the same metadata, which would make every row above assert the
+    /// type; the analogous trap here is a fixture whose annotation states all
+    /// carry the same metadata, which would make every row above assert the
     /// same thing. Read the emitted <c>[Nullable]</c> bytes back through the
-    /// same reader the binder uses and prove the states really differ.
+    /// same reader the binder uses and prove the four states really differ.
     /// </summary>
     [Fact]
-    public void Fixture_Really_Presents_Three_Distinct_AnnotationStates()
+    public void Fixture_Really_Presents_Four_Distinct_AnnotationStates()
     {
         var directory = CreateOutputDirectory();
         try
@@ -316,30 +588,50 @@ public sealed class Issue3705MemberKindNullabilityDifferentialTests
             var libraryPath = EmitCSharpLibrary(directory, LibraryAssemblyName, CSharpLibrarySource);
             using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
             Assert.True(resolver.TryResolveType("Issue3705.NullabilityLibrary.Surface", out var surface));
-            Assert.True(resolver.TryResolveType("Issue3705.NullabilityLibrary.ObliviousSurface", out var oblivious));
+            Assert.True(resolver.TryResolveType("Issue3705.NullabilityLibrary.ObliviousAbsentSurface", out var absent));
+            Assert.True(resolver.TryResolveType("Issue3705.NullabilityLibrary.ObliviousZeroSurface", out var zero));
 
-            var nonNull = ClrNullability.GetFieldTypeSymbol(surface!.GetField("NonNullField")!);
-            var nullable = ClrNullability.GetFieldTypeSymbol(surface.GetField("NullableField")!);
-            var unannotated = ClrNullability.GetFieldTypeSymbol(oblivious!.GetField("ObliviousField")!);
+            var nonNullField = surface!.GetField("NonNullField")!;
+            var nullableField = surface.GetField("NullableField")!;
+            var absentField = absent!.GetField("ObliviousAbsentField")!;
+            var zeroField = zero!.GetField("ObliviousZeroField")!;
 
-            // Annotated non-null is the only one of the three that is not
-            // nullable — if this ever collapses, every "Nullable"/"Oblivious"
-            // row above becomes vacuous.
-            Assert.IsNotType<NullableTypeSymbol>(nonNull);
-            Assert.IsType<NullableTypeSymbol>(nullable);
-            Assert.IsType<NullableTypeSymbol>(unannotated);
+            // Annotated non-null is the only one of the four that is not
+            // nullable — if this ever collapses, every non-`NonNull` row above
+            // becomes vacuous.
+            Assert.IsNotType<NullableTypeSymbol>(ClrNullability.GetFieldTypeSymbol(nonNullField));
+            Assert.IsType<NullableTypeSymbol>(ClrNullability.GetFieldTypeSymbol(nullableField));
+            Assert.IsType<NullableTypeSymbol>(ClrNullability.GetFieldTypeSymbol(absentField));
+            Assert.IsType<NullableTypeSymbol>(ClrNullability.GetFieldTypeSymbol(zeroField));
 
-            // …and the two nullable states must not be nullable for the SAME
-            // reason: the annotated one carries an explicit `[Nullable(2)]`,
-            // the oblivious one carries no nullability metadata at all.
+            // …and the three nullable states must not be nullable for the SAME
+            // reason. `ObliviousZero` in particular must be a NON-empty `[0]`:
+            // if csc ever picked a different `[NullableContext]` for that type
+            // it would collapse into `ObliviousAbsent` and silently stop
+            // covering the second divergence mechanism.
             Assert.Equal(
                 new byte[] { 1 },
-                ClrNullability.ReadNullableFlags(surface.GetField("NonNullField")!, surface).ToArray());
+                ClrNullability.ReadNullableFlags(nonNullField, surface).ToArray());
             Assert.Equal(
                 new byte[] { 2 },
-                ClrNullability.ReadNullableFlags(surface.GetField("NullableField")!, surface).ToArray());
-            Assert.Empty(
-                ClrNullability.ReadNullableFlags(oblivious.GetField("ObliviousField")!, oblivious));
+                ClrNullability.ReadNullableFlags(nullableField, surface).ToArray());
+            Assert.Empty(ClrNullability.ReadNullableFlags(absentField, absent));
+            Assert.Equal(
+                new byte[] { 0 },
+                ClrNullability.ReadNullableFlags(zeroField, zero).ToArray());
+
+            // The constrained rows read off an INTERFACE, whose `[NullableContext]`
+            // majority vote is computed separately from the surface class's. Pin
+            // it too, or the constrained ObliviousZero rows could silently
+            // degrade into ObliviousAbsent while the table stayed green.
+            Assert.True(resolver.TryResolveType(
+                "Issue3705.NullabilityLibrary.IObliviousZeroConstrained",
+                out var zeroConstrained));
+            Assert.Equal(
+                new byte[] { 0 },
+                ClrNullability.ReadNullableFlags(
+                    zeroConstrained!.GetProperty("ObliviousZeroProperty")!,
+                    zeroConstrained).ToArray());
         }
         finally
         {
@@ -351,19 +643,19 @@ public sealed class Issue3705MemberKindNullabilityDifferentialTests
     {
         var target = nullableTarget ? "string?" : "string";
 
-        // `Oblivious` members live on a separate `#nullable disable` type, so
-        // the receiver varies with the state rather than with the kind.
-        var isOblivious = state == "Oblivious";
-        var receiverType = isOblivious ? "ObliviousSurface" : "Surface";
-        var memberPrefix = isOblivious ? "Oblivious" : state;
+        // The oblivious members live on their own types, so the receiver varies
+        // with the state rather than with the kind.
+        var isOblivious = state.StartsWith("Oblivious", StringComparison.Ordinal);
+        var receiverType = isOblivious ? state + "Surface" : "Surface";
+        var memberPrefix = state;
         var indexArgument = state == "Nullable" ? "1L" : "1";
-        var constrainedInterface = isOblivious ? "IObliviousConstrained" : "IConstrained";
-        var constrainedImpl = isOblivious ? "ObliviousConstrained" : "Constrained";
+        var constrainedInterface = isOblivious ? "I" + state + "Constrained" : "IConstrained";
+        var constrainedImpl = isOblivious ? state + "Constrained" : "Constrained";
         var deconstructReceiver = state switch
         {
             "NonNull" => "Surface",
             "Nullable" => "NullableDeconstructSurface",
-            _ => "ObliviousSurface",
+            _ => state + "Surface",
         };
 
         var body = kind switch
@@ -381,6 +673,11 @@ public sealed class Issue3705MemberKindNullabilityDifferentialTests
             // fallback slot whose three siblings already read nullability.
             "ConstrainedMethodReturn" => $"    let probe {target} = ViaConstraint({constrainedImpl}())",
 
+            // The SAME receiver shape as the row above, one member kind over.
+            // Reaches MemberLookup.GetClrPropertyTypeSymbol / the indexer path.
+            "ConstrainedProperty" => $"    let probe {target} = ViaConstraint({constrainedImpl}())",
+            "ConstrainedIndexer" => $"    let probe {target} = ViaConstraint({constrainedImpl}())",
+
             // Reaches MemberLookup.GetClrMethodParameterTypeSymbol and the
             // synthesised deconstruction local in StatementBinder.Narrowing.
             "DeconstructOut" => $"    let receiver = {deconstructReceiver}()\n"
@@ -389,21 +686,48 @@ public sealed class Issue3705MemberKindNullabilityDifferentialTests
             _ => throw new ArgumentOutOfRangeException(nameof(kind)),
         };
 
-        var helper = kind == "ConstrainedMethodReturn"
-            ? $$"""
+        // Only the nullable-target arm can ask the `nil` question; on the
+        // non-null arm the comparison would be rejected on its own merits.
+        var report = nullableTarget
+            ? """
+                  if probe == nil {
+                      Console.WriteLine("nil")
+                  } else {
+                      Console.WriteLine("value")
+                  }
+              """
+            : "    Console.WriteLine(\"value\")";
+
+        // The constrained rows all use the SAME generic helper shape and differ
+        // only in which member kind they read off the constrained receiver `T`.
+        var constrainedRead = kind switch
+        {
+            "ConstrainedMethodReturn" => $"value.{memberPrefix}Method()",
+            "ConstrainedProperty" => $"value.{memberPrefix}Property",
+
+            // The annotated interface distinguishes its two indexers by argument
+            // type, exactly as `Surface` does; the oblivious interfaces declare
+            // only `this[int]`.
+            "ConstrainedIndexer" => $"value[{(state == "Nullable" ? "1L" : "1")}]",
+            _ => null,
+        };
+
+        var helper = constrainedRead == null
+            ? string.Empty
+            : $$"""
 
                 func ViaConstraint[T {{constrainedInterface}}](value T) {{target}} {
-                    return value.{{memberPrefix}}Method()
+                    return {{constrainedRead}}
                 }
-                """
-            : string.Empty;
+                """;
 
         return $$"""
             package {{ConsumerAssemblyName}}
             import Issue3705.NullabilityLibrary
 
-            func Run() {
+            func Main() {
             {{body}}
+            {{report}}
             }
             {{helper}}
             """;
@@ -431,7 +755,53 @@ public sealed class Issue3705MemberKindNullabilityDifferentialTests
             assemblyName: ConsumerAssemblyName);
         return new CompileResult(
             emit.Success,
-            emit.Diagnostics.Select(d => new DiagnosticInfo(d.Id, d.Message)).ToArray());
+            emit.Diagnostics.Select(d => new DiagnosticInfo(d.Id, d.Message)).ToArray(),
+            emit.Success ? output.ToArray() : Array.Empty<byte>());
+    }
+
+    /// <summary>
+    /// Loads and runs the emitted assembly, capturing stdout. A nullability
+    /// edit moves the types the emitter sees, so "it bound with no diagnostics"
+    /// is not evidence the emitted IL is executable.
+    /// </summary>
+    private static string RunGSharp(CompileResult compiled, string libraryPath, string contextName)
+    {
+        var loadContext = new AssemblyLoadContext(
+            nameof(Issue3705MemberKindNullabilityDifferentialTests) + "-" + contextName,
+            isCollectible: true);
+        loadContext.Resolving += (context, name) =>
+            string.Equals(name.Name, LibraryAssemblyName, StringComparison.Ordinal)
+                ? context.LoadFromAssemblyPath(libraryPath)
+                : null;
+
+        try
+        {
+            using var peStream = new MemoryStream(compiled.PeBytes);
+            var assembly = loadContext.LoadFromStream(peStream);
+            var entry = assembly.EntryPoint;
+            Assert.NotNull(entry);
+
+            var stdout = Console.Out;
+            var captured = new StringWriter();
+            Console.SetOut(captured);
+            try
+            {
+                var arguments = entry.GetParameters().Length == 0
+                    ? null
+                    : new object[] { Array.Empty<string>() };
+                entry.Invoke(null, arguments);
+            }
+            finally
+            {
+                Console.SetOut(stdout);
+            }
+
+            return captured.ToString();
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
     }
 
     private static string EmitCSharpLibrary(string directory, string assemblyName, string source)
@@ -474,7 +844,10 @@ public sealed class Issue3705MemberKindNullabilityDifferentialTests
         }
     }
 
-    private readonly record struct CompileResult(bool Success, DiagnosticInfo[] Diagnostics);
+    private readonly record struct CompileResult(
+        bool Success,
+        DiagnosticInfo[] Diagnostics,
+        byte[] PeBytes);
 
     private readonly record struct DiagnosticInfo(string Id, string Message);
 }


### PR DESCRIPTION
**An imported `string?` read through a constrained generic receiver bound as non-null `string`, with no diagnostic.** Not against a synthetic fixture — against the fully-annotated BCL. `LinkedList<T>.First` is declared `[Nullable(2)]` (it returns `null` for an empty list) and gsc handed it to callers as non-null:

```gs
// imported, nullable-enabled: string? NullableProperty { get; }  on interface IC
func Via[T IC](v T) string { return v.NullableProperty }   // bound clean on main
```

`MemberLookup.GetClrPropertyTypeSymbol`'s symbolic branch ended in a bare `return mapped;` — receiver substitution recovers the member's *shape* and silently discards its `[Nullable]` metadata. #3741 called that exact line out by name as *"the defective line … contains no `FromClrType` at all"*, the shape a grep cannot see, and then fixed two of its three occurrences: the method-return and parameter branches. This is the third.

It stayed invisible because the differential matrix's axis was wrong. It varied *member kind* while holding receiver shape ≈ plain, so "constrained receiver" was only ever probed through a method return. The axis is now (member kind × **receiver shape**), and the two new kinds fail on `main` in the annotated-`Nullable` column — the unsound direction, not the noisy one.

This PR is family 2 of the #3705 audit — the half #3741 deferred as *"a decision, not a swap"*. The deferred question was about the oblivious default; answering it properly turned up the unsoundness above, two further defects, and the one position where the #1354 rule must **not** apply.

## 2. The deferral's own description of the defect was incomplete

> `MergeDeclarationNullability` opens with `if (declarationFlags.IsDefaultOrEmpty) { return projectedType; }` … Closing it is one `return` away.

It is two. `MergeDeclarationNullability` annotates through `ApplyRootAnnotation`, which read `if (flag != Annotated) return projected;` — **C#'s** rule ("nullable iff the byte is `2`"). G#'s rule (#1354 / ADR-0136) is the inverse ("non-null iff the byte is `1`"). They agree on `1` and `2` and disagree on `0`, and `0` is not hypothetical: csc emits an explicit `[Nullable(0)]` for a `#nullable disable` member of a `[NullableContext(1)]` type. Probed:

```
TYPEATTR  NullableContextAttribute 1
FIELD A     flags=[1]  ->  string    (annotated non-null)
FIELD Zero  flags=[0]  ->  string?   (#nullable disable member, EXPLICIT [Nullable(0)])
```

`flags=[0]` is **non-empty**, so the empty-flags short-circuit never saw it. Deleting that one `return` would have left this shape divergent.

## 3. …and one position where #1354 must NOT apply

Making every position obey #1354 broke 12 tests across 6 CI shards, all one defect: `map[K, V].Keys` iterated as `K?`. That is wrong, and not merely noisy — an unconstrained `K` may be substituted with a **value type**, where `K?` silently means `Nullable<K>`.

So the carve-out is principled: **#1354 is a rule about concrete reference positions in imported metadata.** An OPEN type-parameter position is not one — its nullability arrives with the type **argument** at substitution, which carries its own annotation. An open parameter slot keeps the pre-#1354 reading: widen only for an explicit `[Nullable(2)]`.

This has a sharp edge worth recording, because the next person will otherwise rediscover it the hard way. `ExpandNullableFlags` fills absent positions with `2` — that fill **is** the #1354 rule — so the expanded array cannot distinguish "declared `T?`" from "declared nothing, defaulted". An `absentFill` overload gives the literal reading; only the carve-out uses it. Without that, 3 of the 12 stayed red.

## 4. The decision: uniformity over concrete positions, and ADR-0136 already required it

ADR-0136 §2 states the rule and its intended blast radius:

> **only an explicit `1` (NotAnnotated) means non-null `T`; `2` (Annotated), `0` (oblivious), and an absent attribute all mean nullable `T?`.**

> Only genuinely unannotated/oblivious assemblies — **and oblivious positions within otherwise-annotated assemblies** — become nullable.

The rule is applied "uniformly in **both** reading paths". Receiver substitution is a **third** path, added after the ADR, that never got it. The divergent set was never a semantic grouping — it was exactly the readers routing through `MergeDeclarationNullability`, plus the one that skipped it. Mechanism, not intent.

### The measured matrix — `main` / with fix

| kind | ann. non-null | ann. nullable | ObliviousAbsent | ObliviousZero `[0]` |
|---|---|---|---|---|
| Property / MethodReturn / IndexerElement | non-null / same | nullable / same | nullable / same | nullable / same |
| Field / ConstrainedMethodReturn / DeconstructOut | non-null / same | nullable / same | **non-null** → nullable | **non-null** → nullable |
| **ConstrainedProperty / ConstrainedIndexer** | non-null / same | **non-null** → nullable | **non-null** → nullable | **non-null** → nullable |

## 5. Fixed

| Site | Symptom |
|---|---|
| `MemberLookup.GetClrPropertyTypeSymbol` — symbolic branch | **imported `string?` property/indexer bound non-null through a constrained receiver** |
| `NullableFlagsBuilder.MergeDeclarationNullability` — empty-flags short-circuit | oblivious-with-no-metadata kept the pre-#1354 answer |
| `NullableFlagsBuilder.ApplyRootAnnotation` — `flag != Annotated` | explicit `[Nullable(0)]` kept the pre-#1354 answer |
| `MergeDeclarationNullability` — generic-parameter arm | *carve-out*: open `K` must not become `K?` |

Funnel, per #3707's `ClrMemberVisibility` and #3716's `ClrLoadContext`: `ClrNullability.IsFlagNonNull(byte)` is the only place that decides what a nullability byte means. (The surviving `flag != Annotated` in `AppendAnnotatedTail` is an emit-side scalar-compression check asking a different question, and is correct.)

## 6. Two test repairs, both corrections rather than accommodations

- **`Issue2514ImportedInterfaceConstraintMemberTests`** — its C# contracts were nullable-**oblivious**, so every member now imports `T?` while the G# side assigns to non-null `string`. Those assignments were only legal because the constrained-receiver readers dropped nullability. The fixture gets `#nullable enable`, stating the contract the test always meant. Chosen over `!!` deliberately: `!!` would make the fixture depend on the very gap being closed, and uncommented `!!` is a review defect under ADR-0155.
- **`Issue1418…LinkedListNodeProperty_UserElement_ChainedAccessBindsAndRuns`** — gains a `nil` guard. This is the live BCL instance of §1: `LinkedList<T>.First` is `[Nullable(2)]`, so the guard is what the declaration always required. Its actual subject — that a constructed generic property type does not erase to `LinkedListNode[object]` — is unchanged and still asserted.

## 7. Gate

`Issue3705MemberKindNullabilityDifferentialTests`: 19 rows → **8 kinds × 4 states + 3 = 35**, with **zero pinned exceptions**. #3741 wrote *"when the rule is settled and the hole closed, this test fails and forces the review"*; this is that review, and the pin is deleted rather than re-pointed.

- `ConstrainedProperty` / `ConstrainedIndexer` make the axis (member kind × **receiver shape**) — the blind spot that hid §1.
- `ObliviousZero` is a first-class state; anti-vacuity pins it to byte `[0]` on **both** the surface class and the constrained interface, since csc's `[NullableContext]` vote is per-type and either could silently decay into `ObliviousAbsent`.
- `OpenTypeParameterPositions_Take_Nullability_From_The_Argument` pins §3 with a reference-type **and** a value-type argument, both executed.
- **Every row executes its emitted assembly.** Binding clean is not evidence the IL runs.
- `ObliviousField_That_Is_Null_At_Runtime_Is_Guardable_And_Runs`: an oblivious imported field that really is `null`, read into an **inferred** local (inferred deliberately — with an explicit `string?` it compiles on `main` too and proves nothing), guarded, executed, guard asserted to fire.

## 8. Observable behaviour change

Stated rather than left to be discovered. Two categories are user-visible, both intended:

1. **Source-breaking, desired.** Code reading an imported `string?` property/indexer through a constrained generic receiver compiled silently before and now correctly requires a null check. The old behaviour handed out a `string` that could be null.
2. **Source-breaking, noisier, also intended.** Reading a member of a nullable-**oblivious** assembly through the receiver-substituting readers now yields `T?`. ADR-0136 named this consequence: *"code that … relied on the old oblivious→non-null default now sees `T?` and must null-check or null-forgive. This is the intended, safer behavior."*
3. **Emitted metadata does not move.** G# requires explicit types on function signatures, so public surface carries declared (not inferred) nullability; only inferred locals change, and those contribute no metadata. Checked, not assumed: `Samples_EmittedPE_Match_Baseline` hashes the **metadata stream** — where `[Nullable]` attributes live — plus every method body's IL, and is green with no baseline regeneration.

## 9. Verification

| measurement | result |
|---|---|
| `Core.Tests` (full) | **8559 / 8559** |
| `Compiler.Tests` (full) | **4609 / 4609** |
| CI, final SHA | **35 pass, 0 fail** |
| failing-on-`origin/main` | **12 of 35 rows fail**, 23 pass as labelled guard rails |
| emitted PE baseline | green, no regeneration |
| nullable hygiene (ADR-0155) | clean |

ADR-0136 updated: the third reading path named, `IsFlagNonNull` recorded as the single predicate, the open-type-parameter exclusion documented with both reasons, and the "generic-substituted returns" deferral marked resolved.

## Still open on #3705

- **Base-member group** — `e.StackTrace` on a G# class deriving from an imported base; needs a G# class declaration rather than an expression, so its own matrix row.
- **Element-type sub-pattern** — needs `GetNullableFlagsForSubtree`, not a reader swap. #3758 (#3747) hit two more after #3741 landed; the live sub-family.
- **cs2gs `Deconstruct` out-parameter prediction** — `IsImportedObliviousNullableMember` keys on a member's return/type, so a `void`-returning `Deconstruct` never matches. Translator-side prediction gap, not unsoundness.

Refs #3705.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
