### PR TITLE
gsc: a user-declared generic function accepts a method group in a delegate-typed parameter (GS0151 + GS9998, #3760)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
@@ -45,6 +45,203 @@ internal sealed partial class OverloadResolver
         return false;
     }
 
+    /// <summary>
+    /// Issue #3760: whether at least one of <paramref name="typeParameters"/>
+    /// is still without a bound after the positional inference pass.
+    /// </summary>
+    private static bool HasUnboundTypeParameter(
+        ImmutableArray<TypeParameterSymbol> typeParameters,
+        Dictionary<TypeParameterSymbol, TypeSymbol> substitution)
+    {
+        foreach (var typeParameter in typeParameters)
+        {
+            if (!substitution.ContainsKey(typeParameter))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Issue #3760: the user-generic counterpart of
+    /// <c>ClrOverloadResolution.TryInferMethodGroupArgument</c>. A method group
+    /// argument carries no type, so a type parameter reachable only through
+    /// the target delegate's RETURN position never receives a bound from the
+    /// positional pass. Close the delegate's input types from the bounds
+    /// gathered so far, resolve the group against that closed input list, and
+    /// unify the selected candidate's return type back into
+    /// <paramref name="substitution"/>. A group that stays ambiguous under the
+    /// closed inputs contributes nothing, leaving the established GS0151.
+    /// </summary>
+    private void InferFromUserMethodGroupArgument(
+        TypeSymbol parameterType,
+        BoundExpression argument,
+        Dictionary<TypeParameterSymbol, TypeSymbol> substitution)
+    {
+        if (argument is not BoundMethodGroupExpression and not BoundClrMethodGroupExpression
+            || !MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(parameterType, out var target)
+            || !TypeSymbol.ContainsTypeParameter(target.ReturnType))
+        {
+            return;
+        }
+
+        var closedInputs = new TypeSymbol[target.ParameterTypes.Length];
+        for (var i = 0; i < closedInputs.Length; i++)
+        {
+            var closedInput = substituteType(target.ParameterTypes[i], substitution);
+            if (closedInput == null
+                || closedInput == TypeSymbol.Error
+                || TypeSymbol.ContainsTypeParameter(closedInput))
+            {
+                // An input the first pass could not close gives the group no
+                // signature to resolve against.
+                return;
+            }
+
+            closedInputs[i] = closedInput;
+        }
+
+        var selectedReturn = argument is BoundClrMethodGroupExpression clrGroup
+            ? ResolveClrMethodGroupReturn(clrGroup, closedInputs)
+            : ResolveUserMethodGroupReturn((BoundMethodGroupExpression)argument, closedInputs);
+
+        if (selectedReturn != null)
+        {
+            inferTypeArguments(target.ReturnType, selectedReturn, substitution);
+        }
+    }
+
+    /// <summary>
+    /// Issue #3760: resolves a user method group against a fully closed input
+    /// list, returning the single applicable candidate's return type (or
+    /// <see langword="null"/> when none or several apply).
+    /// </summary>
+    private static TypeSymbol? ResolveUserMethodGroupReturn(
+        BoundMethodGroupExpression group,
+        TypeSymbol[] closedInputs)
+    {
+        if (group.Candidates.IsDefaultOrEmpty)
+        {
+            return null;
+        }
+
+        TypeSymbol? selectedReturn = null;
+        foreach (var candidate in group.Candidates)
+        {
+            var candidateOwner = group.StaticOwnerType != null && candidate.StaticOwnerType is StructSymbol declaredOwner
+                ? TypeMemberModel.ResolveStaticMemberOwner(group.StaticOwnerType, declaredOwner)
+                : null;
+            if (!ExpressionBinder.TryCloseMethodGroupCandidate(
+                    candidate,
+                    group.Receiver,
+                    candidateOwner,
+                    closedInputs,
+                    out var closedParameters,
+                    out var closedReturn,
+                    out _))
+            {
+                continue;
+            }
+
+            // The candidate must ACCEPT what the delegate provides — the same
+            // contravariant admissibility the CLR sibling applies (#3501 A5).
+            var applicable = true;
+            for (var i = 0; i < closedInputs.Length; i++)
+            {
+                if (closedParameters[i] != closedInputs[i]
+                    && !Conversion.Classify(closedInputs[i], closedParameters[i]).IsImplicit)
+                {
+                    applicable = false;
+                    break;
+                }
+            }
+
+            if (!applicable || closedReturn == TypeSymbol.Void || closedReturn == TypeSymbol.Error)
+            {
+                continue;
+            }
+
+            if (selectedReturn != null && selectedReturn != closedReturn)
+            {
+                // Two applicable candidates disagree on the return type: the
+                // group is ambiguous at this slot, so it must not bind.
+                return null;
+            }
+
+            selectedReturn = closedReturn;
+        }
+
+        return selectedReturn;
+    }
+
+    /// <summary>
+    /// Issue #3760: the imported (CLR) sibling of
+    /// <see cref="ResolveUserMethodGroupReturn"/>. Projects the closed input
+    /// types to CLR, runs the ordinary CLR overload selection over the group's
+    /// candidates, and maps the winner's return type back to a symbol.
+    /// </summary>
+    private TypeSymbol? ResolveClrMethodGroupReturn(
+        BoundClrMethodGroupExpression group,
+        TypeSymbol[] closedInputs)
+    {
+        if (group.Candidates.IsDefaultOrEmpty)
+        {
+            return null;
+        }
+
+        // A group whose receiver is present but whose candidates are all
+        // static is an extension group: slot 0 of the CLR signature is the
+        // receiver, and the delegate's inputs start at slot 1.
+        var closesExtensionReceiver = group.Receiver != null;
+        foreach (var candidate in group.Candidates)
+        {
+            closesExtensionReceiver &= candidate.IsStatic;
+        }
+
+        var offset = closesExtensionReceiver ? 1 : 0;
+        var resolutionArguments = new Type[closedInputs.Length + offset];
+        if (closesExtensionReceiver)
+        {
+            var receiverType = Invariant.Required(
+                group.Receiver,
+                "an extension method group has a receiver").Type;
+            if (receiverType.ClrType is not { } receiverClr)
+            {
+                return null;
+            }
+
+            resolutionArguments[0] = binderCtx.References.MapClrTypeToReferences(receiverClr);
+        }
+
+        for (var i = 0; i < closedInputs.Length; i++)
+        {
+            if (closedInputs[i].ClrType is not { } inputClr)
+            {
+                // A same-compilation input has no CLR backing to resolve an
+                // imported overload against.
+                return null;
+            }
+
+            resolutionArguments[i + offset] = binderCtx.References.MapClrTypeToReferences(inputClr);
+        }
+
+        // #835/#3753: `IsSameAs` rather than reference identity — the
+        // candidate may come from a MetadataLoadContext, where the host
+        // `typeof(void)` is a different Type instance.
+        var resolution = ClrOverloadResolution.Resolve(group.Candidates, resolutionArguments);
+        if (resolution.Outcome != ClrOverloadResolution.ResolutionOutcome.Resolved
+            || resolution.Best is not { } best
+            || best.IsGenericMethodDefinition
+            || best.ReturnType.IsSameAs(typeof(void)))
+        {
+            return null;
+        }
+
+        return TypeSymbol.FromClrType(binderCtx.References.MapClrTypeToReferences(best.ReturnType));
+    }
+
     private bool TryResolveImplicitInheritedTypeArguments(
         TypeArgumentListSyntax? typeArgumentList,
         out Type[]? clrTypeArguments,
@@ -1657,6 +1854,30 @@ internal sealed partial class OverloadResolver
                     inferTypeArguments(paramType, boundArguments[i].Type, substitution);
                 }
 
+                // Issue #3760: a method group has no type of its own, so the
+                // loop above contributes nothing from a `f Func[int32, TOut]`
+                // slot and `TOut` — reachable ONLY through the group's return
+                // type — never receives a bound (GS0151). The imported-call
+                // binder already runs this second step
+                // (ClrOverloadResolution.TryInferMethodGroupArgument); the
+                // user-generic path had no equivalent (the #3705
+                // "inconsistent sibling probe" class). Mirror it here: close
+                // the target delegate's INPUT types from the bounds the first
+                // pass established, resolve the group against them, and unify
+                // the resulting return type back in. Per #3756 this runs ONLY
+                // when the first pass left a type parameter unbound, so no
+                // call that already infers can change shape.
+                if (HasUnboundTypeParameter(function.TypeParameters, substitution))
+                {
+                    for (var i = 0; i < function.Parameters.Length && i < boundArguments.Count; i++)
+                    {
+                        InferFromUserMethodGroupArgument(
+                            function.Parameters[i].Type,
+                            boundArguments[i],
+                            substitution);
+                    }
+                }
+
                 foreach (var tp in function.TypeParameters)
                 {
                     if (!substitution.ContainsKey(tp))
@@ -1950,9 +2171,22 @@ internal sealed partial class OverloadResolver
             // selection. Route it through BindConversion — which performs the
             // signature-directed pick — instead of the type-equality / implicit
             // conversion checks below (which would reject the Error-typed group).
+            // Issue #3760: the generic guard below must look at the SUBSTITUTED
+            // target (`expectedType`), not the declared `parameter.Type`. A
+            // generic callee's delegate parameter — `func Map[TOut](value
+            // int32, f Func[int32, TOut])` — always mentions a type parameter
+            // in its declared form, so testing the declared type skipped this
+            // branch even when the call site had already pinned `TOut` (by
+            // inference or an explicit `[string]`) and `expectedType` was the
+            // fully closed `Func[int32, string]`. The group then fell through
+            // every branch below still unresolved and Error-typed, and reached
+            // the emitter as GS9998 (internal compiler error). Only a target
+            // that is STILL open after substitution has no signature to drive
+            // the pick, and only that case may skip.
             if ((argument is BoundMethodGroupExpression { FunctionType: null }
                     || argument is BoundClrMethodGroupExpression { ResolvedMethod: null })
-                && !(substitution != null && TypeSymbol.ContainsTypeParameter(parameter.Type)))
+                && !(substitution != null
+                    && (expectedType == null || TypeSymbol.ContainsTypeParameter(expectedType))))
             {
                 var groupLoc = i < parameterSyntax.Length
                     ? Invariant.Required(parameterSyntax[i], "a method group argument has source syntax").Location

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Invocations.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Invocations.cs
@@ -1638,6 +1638,24 @@ internal sealed partial class OverloadResolver
                     inferTypeArguments(paramType, permutedArguments[i].Type, substitution);
                 }
 
+                // Issue #3760: sibling of the free-function path — a method
+                // group argument gives the loop above nothing to unify, so a
+                // type parameter reachable only through the target delegate's
+                // return position stays unbound. Retry the unbound ones
+                // through the method group's own signature. Runs ONLY after
+                // the positional pass failed (#3756), so no call that already
+                // infers changes shape.
+                if (HasUnboundTypeParameter(method.TypeParameters, substitution))
+                {
+                    for (var i = 0; i < permutedArguments.Length && i + parameterOffset < method.Parameters.Length; i++)
+                    {
+                        InferFromUserMethodGroupArgument(
+                            method.Parameters[i + parameterOffset].Type,
+                            permutedArguments[i],
+                            substitution);
+                    }
+                }
+
                 foreach (var tp in method.TypeParameters)
                 {
                     if (!substitution.ContainsKey(tp))

--- a/test/Compiler.Tests/Emit/Issue3760UserGenericMethodGroupEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3760UserGenericMethodGroupEmitTests.cs
@@ -1,0 +1,370 @@
+// <copyright file="Issue3760UserGenericMethodGroupEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #3760: a <em>user-declared</em> generic function could not accept a
+/// method group in a delegate-typed parameter.
+/// <para>
+/// Two distinct defects sat on the same path, and both are covered here:
+/// </para>
+/// <list type="number">
+///   <item>Inference — a method group carries no type of its own, so the
+///   positional inference pass contributed nothing from an
+///   <c>f Func[int32, TOut]</c> slot and <c>TOut</c> (reachable only through
+///   the group's return type) never received a bound: GS0151. The
+///   imported-call binder already ran a deferred method-group inference step
+///   (<c>ClrOverloadResolution.TryInferMethodGroupArgument</c>); the
+///   user-generic path had no equivalent — the #3705 "inconsistent sibling
+///   probe" class.</item>
+///   <item>Conversion — the argument-conversion loop skipped the
+///   method-group-to-delegate branch whenever the <em>declared</em> parameter
+///   type mentioned a type parameter, which for a generic callee is always.
+///   Even a call site that had already pinned the type argument (explicitly,
+///   or from another argument) left the group unresolved and Error-typed, and
+///   it reached the emitter as <c>GS9998</c> — an internal compiler error on
+///   valid user code.</item>
+/// </list>
+/// <para>
+/// Every positive case is compiled, IL-verified and RUN, asserting stdout: a
+/// method group that binds to the wrong overload — or to the right one over
+/// the wrong instantiation — compiles clean and only misbehaves at runtime.
+/// </para>
+/// </summary>
+public class Issue3760UserGenericMethodGroupEmitTests
+{
+    private const string Preamble = """
+        package P
+        import System
+
+        class Helper {
+            shared {
+                func ToText(value int32) string { return value.ToString() }
+                func Twice(value int32) int32 { return value * 2 }
+                func Emit(value int32) { Console.WriteLine("emit" + value.ToString()) }
+                func Show(value int32) string { return "i" + value.ToString() }
+                func Show(value string) int32 { return value.Length }
+            }
+        }
+
+        class Box {
+            var Tag string = "box"
+
+            func Decorate(value int32) string { return Tag + value.ToString() }
+
+            func Map[TOut](value int32, f Func[int32, TOut]) TOut { return f(value) }
+        }
+
+        func Map[TOut](value int32, f Func[int32, TOut]) TOut { return f(value) }
+        func RunG[TIn](value TIn, a Action[TIn]) { a(value) }
+
+        """;
+
+    /// <summary>
+    /// The issue's headline repro (free function, inferred type argument).
+    /// Reported GS0151 on origin/main.
+    /// </summary>
+    [Fact]
+    public void FreeGenericFunction_InfersTOut_FromUserMethodGroup()
+    {
+        string output = CompileAndRun(Preamble + """
+            Console.WriteLine(Map(5, Helper.ToText))
+            """);
+
+        // "5" — not "10": the STRING-returning overload of the two `Helper`
+        // one-argument int32 members had to win the slot.
+        Assert.Equal($"5{Environment.NewLine}", output);
+    }
+
+    /// <summary>
+    /// A non-string <c>TOut</c>, so the assertion cannot pass by accident on a
+    /// group that erased to <c>object</c> and round-tripped through
+    /// <c>ToString</c>.
+    /// </summary>
+    [Fact]
+    public void FreeGenericFunction_InfersNonStringTOut_FromUserMethodGroup()
+    {
+        string output = CompileAndRun(Preamble + """
+            let doubled = Map(5, Helper.Twice)
+            Console.WriteLine(doubled + 1)
+            """);
+
+        // `doubled` is int32, so `+ 1` is arithmetic (11), not concatenation
+        // ("101") — proving TOut inferred as int32 and not string/object.
+        Assert.Equal($"11{Environment.NewLine}", output);
+    }
+
+    /// <summary>
+    /// The GS9998 half: an explicit type argument closed the parameter, and
+    /// the conversion branch still refused the group because the DECLARED
+    /// parameter type mentioned <c>TOut</c>. The unresolved group reached code
+    /// emission as an internal compiler error.
+    /// </summary>
+    [Fact]
+    public void ExplicitTypeArgument_MethodGroup_NoLongerReachesTheEmitterUnresolved()
+    {
+        string output = CompileAndRun(Preamble + """
+            Console.WriteLine(Map[string](7, Helper.ToText))
+            """);
+
+        Assert.Equal($"7{Environment.NewLine}", output);
+    }
+
+    /// <summary>
+    /// The same crash reached through successful inference rather than an
+    /// explicit type argument: <c>TIn</c> is pinned by the first argument, so
+    /// inference never failed — only the conversion did. This case is the
+    /// clearest proof the two defects are independent.
+    /// </summary>
+    [Fact]
+    public void TypeParameterInDelegateInputPosition_MethodGroup_Runs()
+    {
+        string output = CompileAndRun(Preamble + """
+            RunG(13, Helper.Emit)
+            """);
+
+        Assert.Equal($"emit13{Environment.NewLine}", output);
+    }
+
+    /// <summary>
+    /// The issue's second repro: a generic INSTANCE member of a user class.
+    /// That call binds through a different site
+    /// (<c>OverloadResolver.Invocations</c>), which needed the same
+    /// method-group inference step.
+    /// </summary>
+    [Fact]
+    public void GenericInstanceMember_InfersTOut_FromUserMethodGroup()
+    {
+        string output = CompileAndRun(Preamble + """
+            Console.WriteLine(Box().Map(9, Helper.ToText))
+            """);
+
+        Assert.Equal($"9{Environment.NewLine}", output);
+    }
+
+    /// <summary>
+    /// An INSTANCE method group as the argument: the emitted delegate must
+    /// carry the receiver, so the assertion reads a value only the bound
+    /// instance's field can produce.
+    /// <para>
+    /// ANTI-VACUITY GUARD RAIL — this one already passed on origin/main. A
+    /// single-candidate instance group (<c>b.Decorate</c>) binds with a
+    /// resolved function type, so the positional pass could unify it; only
+    /// the shapes that reach the binder still unresolved were broken. Kept
+    /// so a regression on the working half is caught too.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void InstanceMethodGroupArgument_KeepsItsReceiver()
+    {
+        string output = CompileAndRun(Preamble + """
+            let b = Box()
+            b.Tag = "tag"
+            Console.WriteLine(Map(3, b.Decorate))
+            """);
+
+        Assert.Equal($"tag3{Environment.NewLine}", output);
+    }
+
+    /// <summary>
+    /// An overloaded group is picked by the delegate's CLOSED input type, and
+    /// the winner's return type is what <c>TOut</c> binds to. `Show` has an
+    /// <c>(int32) string</c> and a <c>(string) int32</c> overload, so a
+    /// mis-picked candidate produces a different value AND a different type.
+    /// </summary>
+    [Fact]
+    public void OverloadedMethodGroup_ResolvedByTheClosedDelegateInput()
+    {
+        string output = CompileAndRun(Preamble + """
+            Console.WriteLine(Map(4, Helper.Show))
+            """);
+
+        // "i4" from `Show(int32) string`, not "1" from `Show(string) int32`.
+        Assert.Equal($"i4{Environment.NewLine}", output);
+    }
+
+    /// <summary>
+    /// The imported (CLR) sibling of the group above: <c>Convert.ToString</c>
+    /// is a large imported overload set that must resolve against the closed
+    /// <c>int32</c> input and contribute <c>string</c> as <c>TOut</c>.
+    /// </summary>
+    [Fact]
+    public void ImportedMethodGroup_InfersTOut_ForAUserGenericFunction()
+    {
+        string output = CompileAndRun(Preamble + """
+            Console.WriteLine(Map(11, Convert.ToString) + "!")
+            """);
+
+        // The `+ "!"` is string concatenation, so TOut really is `string`.
+        Assert.Equal($"11!{Environment.NewLine}", output);
+    }
+
+    /// <summary>
+    /// ANTI-VACUITY GUARD RAIL — passes on origin/main too. A lambda in the
+    /// same slot always inferred; if this ever fails, the fix broke the
+    /// working control rather than the reverse.
+    /// </summary>
+    [Fact]
+    public void GuardRail_LambdaInTheSameSlot_StillInfers()
+    {
+        string output = CompileAndRun(Preamble + """
+            Console.WriteLine(Map(5, func(v int32) string { return v.ToString() }))
+            """);
+
+        Assert.Equal($"5{Environment.NewLine}", output);
+    }
+
+    /// <summary>
+    /// ANTI-VACUITY GUARD RAIL — passes on origin/main too. A NON-generic user
+    /// function always accepted a method group; the guard that broke the
+    /// generic case never applied here.
+    /// </summary>
+    [Fact]
+    public void GuardRail_NonGenericFunction_StillAcceptsAMethodGroup()
+    {
+        string output = CompileAndRun(Preamble + """
+            func MapS(value int32, f Func[int32, string]) string { return f(value) }
+
+            Console.WriteLine(MapS(5, Helper.ToText))
+            """);
+
+        Assert.Equal($"5{Environment.NewLine}", output);
+    }
+
+    /// <summary>
+    /// The new inference step is a RETRY on the failure path only, and it must
+    /// stay a diagnostic — never a crash — when the group genuinely cannot be
+    /// resolved. Here the delegate's INPUT type is itself an un-inferable type
+    /// parameter, so there is no closed signature to resolve the group
+    /// against: GS0151 stands, and no GS9998 follows it.
+    /// <para>
+    /// ANTI-VACUITY GUARD RAIL — this also passed on origin/main; it pins that
+    /// the retry did not turn an honest diagnostic into a crash or a wrong
+    /// binding.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void UnresolvableMethodGroup_StillReportsTheInferenceDiagnostic()
+    {
+        (int exitCode, string output) = Compile(Preamble + """
+            func Both[TIn, TOut](f Func[TIn, TOut]) TOut { return f(default) }
+
+            Console.WriteLine(Both(Helper.ToText))
+            """);
+
+        Assert.True(exitCode != 0, "expected the un-inferable call to be rejected:\n" + output);
+        Assert.Contains("GS0151", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("GS9998", output, StringComparison.Ordinal);
+    }
+
+    private static (int ExitCode, string Output) Compile(string source)
+    {
+        string tempDir = Directory.CreateTempSubdirectory("gs_issue3760_").FullName;
+        try
+        {
+            return CompileTo(source, tempDir, out _);
+        }
+        finally
+        {
+            TryDelete(tempDir);
+        }
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        string tempDir = Directory.CreateTempSubdirectory("gs_issue3760_").FullName;
+        try
+        {
+            (int compileExit, string compileOutput) = CompileTo(source, tempDir, out string outPath);
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOutput}");
+
+            // #3712 landed a bug that compiled clean on main and was caught
+            // only here, so verification is not optional for this family.
+            IlVerifier.Verify(outPath);
+
+            string runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add(outPath);
+
+            using Process proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("failed to start dotnet exec");
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(60_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+            return stdout.ReplaceLineEndings(Environment.NewLine);
+        }
+        finally
+        {
+            TryDelete(tempDir);
+        }
+    }
+
+    private static (int ExitCode, string Output) CompileTo(string source, string tempDir, out string outPath)
+    {
+        string srcPath = Path.Combine(tempDir, "test.gs");
+        outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        TextWriter prevOut = Console.Out;
+        TextWriter prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        try
+        {
+            int exitCode = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+            return (exitCode, compileOut.ToString() + compileErr.ToString());
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+    }
+
+    private static void TryDelete(string directory)
+    {
+        try
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3760. Follow-up gap filed as #3766.

## The issue's framing held — and understated the problem by one defect

I reproduced both reported symptoms in-process before touching code, then varied
one axis at a time. Both reproduce exactly as filed. What the issue reads as one
defect ("inference is only where the failure first surfaces") is actually **two
independent defects** on the same path, and the ICE is not downstream of the
inference failure:

| shape | on `origin/main` |
|---|---|
| `Map(5, Helper.ToText)` — `TOut` from the group's return | GS0151 |
| `Map[string](5, Helper.ToText)` — `TOut` given explicitly | **GS9998** |
| `MapIn(5, Helper.ToText)` where `func MapIn[TIn](value TIn, f Func[TIn, string]) string` | **GS9998** |
| `MapS(5, Helper.ToText)` — same call, NON-generic callee | compiles and runs |
| `Map(5, func(v int32) string { … })` — lambda in the same slot | compiles and runs |
| `Map(5, g)` where `g Func[int32, string]` is a local | compiles and runs |

Row 3 is the discriminator the issue did not have: `TIn` is pinned by the FIRST
argument, so inference **succeeds** — and the call still crashes the compiler.
The conversion defect is therefore not "a consequence of inference never getting
that far"; it stands on its own and would still crash every explicitly-typed
call even if inference were perfect.

### Not a regression

`git log -S` puts the offending guard at `3cf814fc7` — *"methodgroups: bind
user-type static/instance method groups (ADR-0112 phase 6)"*, i.e. it has been
there since user method groups existed. It is untouched by #3753, #3756 and
#3761 (the last of which is still open and not in this base). **Distinct
pre-existing gap, not a regression of the just-landed work.**

## Fix

### 1. Conversion — the GS9998 (`OverloadResolver.CallBinding`)

The argument-conversion loop's method-group branch was guarded by

```csharp
&& !(substitution != null && TypeSymbol.ContainsTypeParameter(parameter.Type))
```

`parameter.Type` is the **declared** type. For a generic callee it always
mentions a type parameter (`f Func[int32, TOut]`), so the branch was skipped
even when `expectedType` — the substituted target one line above — was the fully
closed `Func[int32, string]`. The group fell through every remaining branch
still unresolved and `Error`-typed and reached the emitter as GS9998.

The guard now tests `expectedType`. Only a target that is **still open after
substitution** genuinely has no signature to drive the pick, and only that case
skips. `substitution == null` keeps its previous behaviour exactly (a
non-generic callee whose parameter mentions an enclosing class type parameter
still routes through `BindConversion` as before).

### 2. Inference — the GS0151 (both generic call sites)

A method group carries no type, so the positional pass contributes nothing from
a delegate slot and a type parameter reachable only through the group's RETURN
type never receives a bound. The imported-call binder already runs a deferred
method-group inference step (`ClrOverloadResolution.TryInferMethodGroupArgument`
fed by `ExpressionBinder.MakeMethodGroupInference`); the user-generic path had no
equivalent — squarely the #3705 "inconsistent sibling probe" class, as the issue
diagnosed.

`InferFromUserMethodGroupArgument` mirrors the CLR sibling at the symbol level:
close the target delegate's INPUT types from the bounds the first pass
established, resolve the group against that closed input list, unify the
winner's return type back in. User candidates go through the existing
`ExpressionBinder.TryCloseMethodGroupCandidate`; imported (`BoundClrMethodGroup`)
candidates go through the ordinary `ClrOverloadResolution.Resolve`, including the
extension-receiver slot-0 convention its `ResolveMethodGroupInferenceSignature`
sibling uses.

Following **#3756**, it is a **retry on the failure path only** — gated on
`HasUnboundTypeParameter`, so no call that already infers can change shape.
Ambiguity is conservative: if two applicable candidates disagree on the return
type, nothing is contributed and the established GS0151 stands.

#3760 reproduces on free functions *and* generic instance members, which bind
through two different sites, so both `OverloadResolver.CallBinding` (free /
static) and `OverloadResolver.Invocations` (instance / shared member) get the
step.

### Sibling probes checked

* `ClrOverloadResolution.Resolve` candidates can come from a
  `MetadataLoadContext`, so the void check uses `IsSameAs(typeof(void))`, not
  reference identity (#835 / #3753). `Issue835TypeofIdentityRegressionGuardTests`
  caught the first draft — the guard works.
* The two other `ContainsTypeParameter(parameter.Type)` tests in the same loop
  (the #1150 literal-widening branch and the #2335 general implicit-conversion
  branch) look like the same omission. I probed the widening one
  (`Map2[int64](5, func(v int32) int32 { return v })`) directly: it compiles,
  verifies and runs correctly, because the erased-function-literal adapter
  branch above it already handles the substituted target. **No omission there —
  left untouched.**

## Test evidence

`test/Compiler.Tests/Emit/Issue3760UserGenericMethodGroupEmitTests.cs`, 11 tests.
Every positive case is **compile → ilverify → run → assert stdout**: #3712's real
bug compiled clean on main and was caught only by ilverify, and a sibling agent's
method-group fix bound with zero diagnostics while emitting over the wrong
instantiation. Assertions are chosen so a wrong binding changes the output — a
non-string `TOut` (`doubled + 1` is `11`, not `"101"`), an overloaded `Show` whose
two candidates return different types, an instance group whose receiver field
value is read back.

**Failing-on-`origin/main` proof** (ADR-0154 witness): with the test file kept and
`git checkout origin/main -- src/`:

```
Failed!  - Failed: 7, Passed: 4, Skipped: 0, Total: 11
  FreeGenericFunction_InfersTOut_FromUserMethodGroup                    [FAIL]  GS0151
  FreeGenericFunction_InfersNonStringTOut_FromUserMethodGroup           [FAIL]  GS0151
  ExplicitTypeArgument_MethodGroup_NoLongerReachesTheEmitterUnresolved  [FAIL]  GS9998
  TypeParameterInDelegateInputPosition_MethodGroup_Runs                 [FAIL]  GS9998
  GenericInstanceMember_InfersTOut_FromUserMethodGroup                  [FAIL]  GS0151
  OverloadedMethodGroup_ResolvedByTheClosedDelegateInput                [FAIL]  GS0151
  ImportedMethodGroup_InfersTOut_ForAUserGenericFunction                [FAIL]  GS0151
```

The 4 that pass on main are labelled in-file as **anti-vacuity guard rails**:
the lambda control, the non-generic-callee control, a single-candidate instance
group (`b.Decorate` — it binds with a resolved function type, so the positional
pass could already unify it), and the negative case pinning that an
un-inferable group still reports GS0151 and **not** GS9998.

With the fix: 11/11 pass.

Rebased onto `origin/main` **after #3761 and #3755 landed**, and the
failing-on-main proof re-run against that newer base: byte-identical 7-fail /
4-pass split, so #3761 neither caused nor fixes any of this. `Issue3712…` (13
tests) and `Issue3760…` (11 tests) pass together: 24/24.

Also run locally: full `Core.Tests` (8536 tests — the only failure was
`Issue835TypeofIdentityRegressionGuardTests` catching the draft's
`== typeof(void)`, fixed and re-verified green), and `Compiler.Tests` filtered
to `MethodGroup|Generic|Delegate|Lambda`.

## Known remaining gap — filed, not fixed here

Inferring a type parameter from a method group's **parameter** positions still
fails:

```go
func RunOnly[TIn](a Action[TIn]) { }
RunOnly(Helper.Emit)   // GS0151
```

This needs the closed-input list the whole approach depends on, so it is a
genuinely different mechanism (the CLR sibling has the same limitation). It is a
clean diagnostic, never a crash — `RunOnly[int32](Helper.Emit, 21)` compiles,
verifies and runs on this branch. Filed separately with this repro rather than
rushed in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
