### PR TITLE
cs2gs: two silent runtime divergences behind the #3501 test-parity failures (#3770, #3771)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue3770SilentRuntimeDivergenceTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3770SilentRuntimeDivergenceTests.cs
@@ -1,0 +1,235 @@
+// <copyright file="Issue3770SilentRuntimeDivergenceTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issues #3770 / #3771: two translations that TRANSLATE, COMPILE and ILVerify
+/// clean but behave differently from the C# original at run time — the
+/// <c>test-parity-failure</c> profile from the #3501 self-migration gate, where
+/// no diagnostic points at the defect.
+/// <para>
+/// #3770 — a C# 12 primary constructor plus a get-only auto-property
+/// initializer emitted BOTH a primary-constructor parameter list and a
+/// synthesized <b>parameterless</b> <c>init()</c> carrying the assignments. The
+/// parameterless initializer is unreachable, so every such property was silently
+/// left at its default. This is what broke <c>DocumentContent</c> and, through
+/// it, 151 of the 259 migrated <c>LanguageServer.Tests</c> failures with a
+/// <c>NullReferenceException</c> on <c>content.SyntaxTree</c>.
+/// </para>
+/// <para>
+/// #3771 — <c>for (var c = x; c != null; c = Parent(c))</c> emitted a <c>!!</c>
+/// on the incrementor. C#'s <c>!</c> is erased at compile time; G#'s <c>!!</c> is
+/// a CHECKED assertion that THROWS on nil, so the loop's normal termination
+/// became a guaranteed <c>NullReferenceException</c>. This broke
+/// <c>BoundScope.TryLookupLexicalNestedTypeAlias</c> in the migrated compiler and
+/// with it 6 of the 13 migrated <c>GSharp.GeneratorHost.Tests</c> failures.
+/// </para>
+/// <para>
+/// Both are invisible to a binding-only assertion, so each is asserted by
+/// EXECUTING the translated G#.
+/// </para>
+/// </summary>
+public sealed class Issue3770SilentRuntimeDivergenceTests
+{
+    private const string PrimaryConstructorSource = @"
+    public class Doc(string tree, int n)
+    {
+        public string Tree { get; } = tree;
+
+        public int N { get; } = n;
+    }
+";
+
+    private const string NullableLoopSource = @"
+    public class Walker
+    {
+        private readonly Walker? parent;
+
+        public Walker(Walker? parent) => this.parent = parent;
+
+        public static Walker? Parent(Walker w) => w.parent;
+
+        public static int Depth(Walker start)
+        {
+            var d = 0;
+            for (var current = start; current != null; current = Parent(current))
+            {
+                d++;
+            }
+
+            return d;
+        }
+    }
+";
+
+    /// <summary>
+    /// The property initializers must land on a constructor that is actually
+    /// reached: the primary-constructor parameters move onto the synthesized
+    /// designated <c>init(...)</c> and the class header is left parameterless.
+    /// </summary>
+    [Fact]
+    public void PrimaryConstructorWithPropertyInitializers_DoesNotEmitAnUnreachableParameterlessInit()
+    {
+        string printed = Translate(PrimaryConstructorSource);
+
+        Assert.DoesNotContain("init() {", printed, StringComparison.Ordinal);
+        Assert.Contains("init(tree string, n int32)", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The executing half of <see
+    /// cref="PrimaryConstructorWithPropertyInitializers_DoesNotEmitAnUnreachableParameterlessInit"/>.
+    /// On the pre-fix translation this printed <c>|0</c> — the properties were
+    /// silently left at their defaults — with a clean compile.
+    /// </summary>
+    [Fact]
+    public void PrimaryConstructorWithPropertyInitializers_ConstructedValuesReachTheProperties()
+    {
+        string printed = Translate(PrimaryConstructorSource);
+        string stdout = CompileAndRun(
+            printed,
+            "let d = Doc(\"hello\", 7)\nConsole.WriteLine(d.Tree + \"|\" + d.N.ToString())");
+
+        Assert.Equal("hello|7", stdout.Trim());
+    }
+
+    /// <summary>
+    /// A <c>var</c> local widened to <c>T?</c> at its declaration must not also
+    /// receive a <c>!!</c> bridge on assignments into it.
+    /// </summary>
+    [Fact]
+    public void NullableLoopIncrementor_DoesNotAssertTheNullableAssignment()
+    {
+        string printed = Translate(NullableLoopSource);
+
+        // Asserted on the whole for-header, not on a `Parent(current)!!`
+        // substring: the pre-fix output was `Parent(current!!)!!`, so a substring
+        // assertion would have passed vacuously. The ARGUMENT's `!!` is faithful
+        // — `current` is flow-narrowed non-null there and `Parent` takes a
+        // non-nullable `Walker` — it is the assertion on the assigned VALUE that
+        // is wrong.
+        Assert.Contains(
+            "for var current Walker? = start; current != nil; current = Parent(current!!) {",
+            printed,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The executing half of <see
+    /// cref="NullableLoopIncrementor_DoesNotAssertTheNullableAssignment"/>. On the
+    /// pre-fix translation this threw <c>NullReferenceException</c> at the loop's
+    /// normal exit, with a clean compile and a clean ILVerify.
+    /// </summary>
+    [Fact]
+    public void NullableLoopIncrementor_LoopTerminatesInsteadOfThrowing()
+    {
+        string printed = Translate(NullableLoopSource);
+        string stdout = CompileAndRun(
+            printed,
+            "Console.WriteLine(Walker.Depth(Walker(Walker(Walker(nil)))).ToString())");
+
+        Assert.Equal("3", stdout.Trim());
+    }
+
+    private static string Translate(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Snippet.cs", "#nullable enable\nusing System;\n\nnamespace Demo\n{\n" + source + "\n}\n") });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: "
+                + string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        Assert.DoesNotContain(
+            context.Diagnostics,
+            d => d.Severity == TranslationSeverity.Unsupported);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" + string.Join("\n", result.Errors)
+                + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+
+    private static string CompileAndRun(string printed, string entryStatements)
+    {
+        string compiler = FindCompiler();
+        Assert.True(compiler != null, "gsc.dll must be built (dotnet build GSharp.sln) before running this test.");
+
+        string workDir = Path.Combine(AppContext.BaseDirectory, "issue-3770-e2e", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workDir);
+        string gsPath = Path.Combine(workDir, "Snippet.gs");
+        string dllPath = Path.Combine(workDir, "Snippet.dll");
+        File.WriteAllText(gsPath, printed + Environment.NewLine + entryStatements + Environment.NewLine);
+
+        (int compileExit, string compileOut) = RunDotnet(
+            $"\"{compiler}\" /target:exe /out:\"{dllPath}\" \"{gsPath}\"");
+        Assert.True(
+            compileExit == 0 && !compileOut.Contains("error", StringComparison.OrdinalIgnoreCase),
+            "gsc must compile the translated snippet with zero errors. Output:\n" + compileOut
+                + "\n\nTranslated G#:\n" + printed);
+
+        (int runExit, string stdout) = RunDotnet($"\"{dllPath}\"");
+        Assert.True(
+            runExit == 0,
+            "Translated snippet must run successfully. Output:\n" + stdout
+                + "\n\nTranslated G#:\n" + printed);
+        return stdout;
+    }
+
+    private static (int Exit, string Output) RunDotnet(string arguments)
+    {
+        var psi = new ProcessStartInfo("dotnet", arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        using Process process = Process.Start(psi);
+        var output = new StringBuilder();
+        output.Append(process.StandardOutput.ReadToEnd());
+        output.Append(process.StandardError.ReadToEnd());
+        process.WaitForExit();
+        return (process.ExitCode, output.ToString());
+    }
+
+    private static string FindCompiler()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            foreach (string config in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(dir.FullName, "out", "bin", config, "Compiler", "gsc.dll");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Declarations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Declarations.cs
@@ -841,6 +841,70 @@ public sealed partial class CSharpToGSharpTranslator
         /// the same type via <c>: this(...)</c>. Such a constructor is the place
         /// into which get-only auto-property initializers are injected (OD-T1).
         /// </summary>
+        /// <summary>
+        /// Issue #3770: whether a C# 12 primary constructor's parameters are read
+        /// ONLY by get-only auto-property initializers, so they can move from the
+        /// G# class header onto the synthesized designated <c>init(...)</c> that
+        /// carries those initializers.
+        /// </summary>
+        /// <remarks>
+        /// A capture anywhere else — a method or accessor body, a field or
+        /// non-get-only property initializer, or a <c>: Base(param)</c> forward —
+        /// needs the parameter to remain a primary-constructor parameter field, so
+        /// the move is unsafe. Partial types are refused outright: another part
+        /// this method cannot see may capture the parameter.
+        /// </remarks>
+        private bool CanMovePrimaryParametersToSynthesizedInit(TypeDeclarationSyntax node)
+        {
+            if (node.ParameterList == null || node.Modifiers.Any(SyntaxKind.PartialKeyword))
+            {
+                return false;
+            }
+
+            // `class C(int a) : Base(a)` forwards a parameter to the base
+            // constructor from the header itself, which only a primary
+            // constructor can express.
+            if (node.BaseList?.Types.Any(t => t is PrimaryConstructorBaseTypeSyntax) == true)
+            {
+                return false;
+            }
+
+            var parameters = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+            foreach (ParameterSyntax parameter in node.ParameterList.Parameters)
+            {
+                if (this.context.GetDeclaredSymbol(parameter) is not IParameterSymbol symbol)
+                {
+                    return false;
+                }
+
+                parameters.Add(symbol);
+            }
+
+            foreach (MemberDeclarationSyntax member in node.Members)
+            {
+                // The get-only auto-property initializers are exactly what moves
+                // into the `init(...)` body, so reads there are fine.
+                if (member is PropertyDeclarationSyntax property
+                    && property.Initializer != null
+                    && !property.Modifiers.Any(SyntaxKind.StaticKeyword)
+                    && IsGetOnlyAutoProperty(property))
+                {
+                    continue;
+                }
+
+                foreach (IdentifierNameSyntax identifier in member.DescendantNodesAndSelf().OfType<IdentifierNameSyntax>())
+                {
+                    if (this.context.GetSymbolInfo(identifier).Symbol is { } referenced
+                        && parameters.Contains(referenced))
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+
         private static bool HasDesignatedInstanceConstructor(IReadOnlyList<MemberDeclarationSyntax> members)
         {
             return members
@@ -1404,9 +1468,54 @@ public sealed partial class CSharpToGSharpTranslator
                 var initStatements = propertyCtorInits
                     .Select(p => (GStatement)new AssignmentStatement(new IdentifierExpression(p.Name), p.Value))
                     .ToList();
-                instanceMembers.Insert(0, new ConstructorDeclaration(
-                    new List<Parameter>(),
-                    new BlockStatement(initStatements)));
+
+                // Issue #3770: when the type ALSO carries a C# 12 primary
+                // constructor, a *parameterless* `init()` is unreachable — every
+                // construction goes through the primary constructor, so the
+                // initializer assignments never run and every such property is
+                // silently left at its default (this compiles and ILVerifies
+                // clean, so only a runtime test sees it). The T2 explicit-ctor
+                // lift already refuses to emit this conflicting pair; the
+                // C# 12 primary-ctor path had no such guard.
+                //
+                // The faithful shape is a single designated `init(<primary
+                // parameters>)` carrying the assignments, with the class header
+                // left parameterless — a C# primary constructor whose parameters
+                // are only read by member initializers has exactly that meaning.
+                // When a parameter is captured anywhere else (a method body, a
+                // field initializer, a `: Base(...)` forward), it must stay a
+                // primary-constructor parameter field, so the move is skipped and
+                // the conflict is reported instead of being emitted silently.
+                var initParameters = new List<Parameter>();
+                if (primaryCtor is { Count: > 0 })
+                {
+                    if (this.CanMovePrimaryParametersToSynthesizedInit(node))
+                    {
+                        initParameters.AddRange(primaryCtor);
+                        primaryCtor = null;
+                    }
+                    else
+                    {
+                        string conflictMessage =
+                            $"'{node.Identifier.Text}' has a C# 12 primary constructor and get-only auto-property "
+                            + "initializer(s), but a primary-constructor parameter is also captured elsewhere in "
+                            + "the type, so the initializers cannot be moved into a designated 'init(...)'. The "
+                            + "property initializer(s) are dropped.";
+                        this.context.Report(new TranslationDiagnostic(
+                            nameof(SyntaxKind.PropertyDeclaration),
+                            conflictMessage,
+                            node.Identifier.GetLocation(),
+                            TranslationSeverity.Unsupported));
+                        initStatements = null;
+                    }
+                }
+
+                if (initStatements != null)
+                {
+                    instanceMembers.Insert(0, new ConstructorDeclaration(
+                        initParameters,
+                        new BlockStatement(initStatements)));
+                }
             }
 
             var members = new List<GMember>(instanceMembers);

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
@@ -200,9 +200,7 @@ public sealed partial class CSharpToGSharpTranslator
                 }
                 else if (initializer != null &&
                     this.context.GetDeclaredSymbol(declarator) is ILocalSymbol inferredLocal &&
-                    (this.ShouldPromoteToNullableReference(inferredLocal)
-                        || (IsAnnotatedNullableReference(inferredLocal.Type)
-                            && this.IsUsedAsNullable(inferredLocal, this.GetNullabilityScope(inferredLocal)))))
+                    this.InferredLocalDeclarationIsNullable(inferredLocal))
                 {
                     // Issue #1072/#2305 (inferred-type form): a `var x = e` local
                     // whose uses prove it nullable needs an explicit `T?`.
@@ -223,6 +221,22 @@ public sealed partial class CSharpToGSharpTranslator
 
             return results;
         }
+
+        /// <summary>
+        /// Issue #1072/#2305/#3771: whether a <c>var</c> local's emitted G#
+        /// declaration is widened to <c>T?</c>.
+        /// </summary>
+        /// <remarks>
+        /// This is the single rule shared by the declaration site (which emits the
+        /// explicit <c>T?</c> clause) and by the assignment-RHS forgiveness, which
+        /// must NOT bridge an assignment into a target that is nullable in G#:
+        /// unlike C#'s erased <c>!</c>, G#'s <c>!!</c> is a checked assertion that
+        /// THROWS on nil.
+        /// </remarks>
+        private bool InferredLocalDeclarationIsNullable(ILocalSymbol local) =>
+            this.ShouldPromoteToNullableReference(local)
+            || (IsAnnotatedNullableReference(local.Type)
+                && this.IsUsedAsNullable(local, this.GetNullabilityScope(local)));
 
         /// <summary>
         /// Translates every declarator of a ref-local declaration (<c>ref int r =
@@ -2420,6 +2434,22 @@ public sealed partial class CSharpToGSharpTranslator
                 && declarator.Ancestors().OfType<VariableDeclarationSyntax>()
                     .FirstOrDefault()?.Type.IsVar == true)
             {
+                // Issue #3771: substituting the INITIALIZER's type for the
+                // target's and dropping `promotionTarget` also drops the #1072
+                // promotion check, so a `var` local whose emitted G# declaration
+                // was widened to `T?` (TranslateLocalDeclaration's inferred-type
+                // branch) still looks like a non-nullable sink here and the RHS
+                // gets a `!!`. C#'s `!` is erased at compile time; G#'s `!!` is a
+                // CHECKED assertion that THROWS on nil, so the assertion turns
+                // `for (var c = x; c != null; c = Parent(c))` into a guaranteed
+                // NullReferenceException at the loop's normal exit — compiling
+                // and ILVerifying clean the whole way. Keep the promotion target
+                // so a widened declaration vetoes the assertion.
+                if (this.InferredLocalDeclarationIsNullable(inferredAssignmentLocal))
+                {
+                    return value;
+                }
+
                 assignmentTargetType = this.context.GetTypeInfo(initializer).Type;
                 promotionTarget = null;
             }


### PR DESCRIPTION
Closes #3770. Closes #3771.

Triage of the three `test-parity-failure` apps in gate run 33463929797. These apps **translate, compile and ILVerify clean**, then behave differently from their C# originals at run time — no diagnostic points at them anywhere in the chain.

### The premise this replaces

The two apps sharing fingerprint `sha256:146ec6a1d0e9…` (`Extensions.Tests`, `GeneratorHost.Tests`) are **not** one root cause. That fingerprint is derived from the stage/diagnostic id (`LIBRARY-TESTS-FAILED` / `LibraryTestRun`), not from the failure text, so it does not discriminate causes at all. The actual grouping runs the other way: `GeneratorHost.Tests` and `LanguageServer.Tests` — which carry *different* fingerprints — share a cause (#3771), while `Extensions.Tests` is not a translation defect at all (#3772, filed; it needs a harness-policy call).

Three distinct root causes, two of them fixed here.

### #3770 — an unreachable parameterless `init()`

A C# 12 primary constructor combined with a get-only auto-property initializer emitted BOTH a primary-constructor parameter list AND a synthesized *parameterless* `init()` carrying the assignments. The parameterless initializer is unreachable, so every such property was silently left at its default.

```gsharp
class Doc(tree string, n int32) {
    init() { Tree = tree; N = n }     // never reached
    prop Tree string { get; init; }
}
```

The sibling T2 explicit-constructor lift already refuses to emit this conflicting pair ("cannot coexist with a primary constructor that carries parameters"); the C# 12 primary-constructor path had no equivalent guard. The primary parameters now move onto the synthesized designated `init(...)` with the class header left parameterless, which is exactly what the C# shape means. The move is refused — and reported as an `Unsupported` gap rather than emitted silently — when a primary-constructor parameter is captured anywhere else (a member body, a field initializer, a `: Base(param)` forward) or the type is partial.

`src/LanguageServer/DocumentContent.cs` is this shape, so every migrated `DocumentContent` had a null `SyntaxTree`: **151 of the 259** failures in the migrated `LanguageServer.Tests`.

### #3771 — a `!!` that turns loop termination into a throw

`ForgiveAssignmentRhs` substitutes the initializer's type for a `var` target's and drops `promotionTarget`, which also drops the #1072 promotion check — so a local whose emitted G# declaration was *already* widened to `T?` still read as a non-nullable sink and its assigned value got a `!!`.

C#'s `!` is erased at compile time. **G#'s `!!` is a checked assertion that throws on nil.** So:

```gsharp
for var current Walker? = start; current != nil; current = Parent(current!!)!! {
```

gained a guaranteed `NullReferenceException` at the loop's normal exit. (The *argument's* `!!` is faithful — `current` is flow-narrowed non-null there; the trailing one is not.) The widening rule is extracted into one predicate consulted at both the declaration site and the forgiveness site.

`BoundScope.TryLookupLexicalNestedTypeAlias` is this shape: **6 of the 13** failures in the migrated `GSharp.GeneratorHost.Tests`, plus more in `LanguageServer.Tests`.

### Test evidence

Both defects are definitionally invisible to a binding-only assertion, so two of the four tests **execute** the translated G# through the real `gsc`.

On `origin/main`, 3 of the 4 fail:

| test | on main |
|---|---|
| `PrimaryConstructorWithPropertyInitializers_DoesNotEmitAnUnreachableParameterlessInit` | fails |
| `PrimaryConstructorWithPropertyInitializers_ConstructedValuesReachTheProperties` (executes) | fails — prints `\|0`, expected `hello\|7` |
| `NullableLoopIncrementor_DoesNotAssertTheNullableAssignment` | fails |
| `NullableLoopIncrementor_LoopTerminatesInsteadOfThrowing` (executes) | fails — `NullReferenceException`, expected `3` |

All four pass on this branch.

Anti-vacuity note: the first draft of `NullableLoopIncrementor_DoesNotAssertTheNullableAssignment` asserted `DoesNotContain("Parent(current)!!")` and passed **vacuously** on main, because main emits `Parent(current!!)!!`. It now asserts the whole for-header and fails on main as it should.

### Not fixed here

`Extensions.Tests` — filed as #3772. Its two failures are a mirror-fidelity gap, not a translation defect: the migrated repository root has `GSharp.slnx` and no `GSharp.sln`, so the test's upward walk for the repo root returns null; and separately the mirror has no `Gsharp.Extensions` project at all, so the artifact the test wants is never built. 171 of its 173 tests pass. That needs a harness-policy decision (classify as not-applicable vs. mirror more faithfully), so it is filed with the options weighed rather than patched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
