### PR TITLE
cs2gs: sweep every `EnsureNonNullAssertion` site — G# `!!` throws where C# `!` is erased (#3774)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue3774CoalescingAssignmentAssertionTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3774CoalescingAssignmentAssertionTests.cs
@@ -1,0 +1,231 @@
+// <copyright file="Issue3774CoalescingAssignmentAssertionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3774 (sweep of the <c>EnsureNonNullAssertion</c> call sites,
+/// generalized from #3771): C#'s <c>!</c> is ERASED at compile time, but G#'s
+/// <c>!!</c> is a CHECKED assertion that THROWS on nil. Any site that emits
+/// <c>!!</c> onto a value that can genuinely be nil at run time therefore adds a
+/// throw the original program never had — invisible to the compiler, to
+/// ILVerify, and to every binding-only assertion.
+/// <para>
+/// The site fixed here is the value-position <c>??=</c>
+/// (<c>TranslateCoalescingAssignmentAsExpression</c>). The value of
+/// <c>x ??= v</c> is nil exactly when <c>v</c> is, but the assertion's guard
+/// asked only C#'s own annotations — which are empty in a nullable-OBLIVIOUS
+/// compilation, so a same-project member the whole-program taint analysis
+/// promoted to <c>T?</c> read as non-null and earned a <c>!!</c> anyway.
+/// </para>
+/// <para>
+/// Two of the four tests EXECUTE the translated G# through the real
+/// <c>gsc</c>, because this defect class is definitionally invisible to a
+/// text-only assertion. The two "still asserts" tests are anti-vacuity guard
+/// rails: they pass on <c>origin/main</c> too, and exist so a fix that simply
+/// deleted the assertion could not pass this file.
+/// </para>
+/// </summary>
+public class Issue3774CoalescingAssignmentAssertionTests
+{
+    private const string PromotedRightHandSideSource = @"
+using System;
+
+namespace Demo
+{
+    public sealed class C
+    {
+        private static string cache;
+
+        private static string Make()
+        {
+            return null;
+        }
+
+        public static void Run()
+        {
+            string v = (cache ??= Make());
+            Console.WriteLine(v == null ? ""nil"" : v);
+        }
+    }
+}";
+
+    private const string NonNullRightHandSideSource = @"
+using System;
+
+namespace Demo
+{
+    public sealed class C
+    {
+        private static string cache;
+
+        public static void Run()
+        {
+            string v = (cache ??= ""d"");
+            Console.WriteLine(v);
+        }
+    }
+}";
+
+    /// <summary>
+    /// The whole lowered construct is asserted, not a fragment: the #3771 agent
+    /// caught its own first draft asserting a substring that main never emitted,
+    /// so it passed vacuously. Here the exact conditional-expression form is
+    /// pinned and the trailing <c>)!!</c> must be absent from it.
+    /// </summary>
+    [Fact]
+    public void CoalescingAssignmentValue_DoesNotAssertAPromotedNullableRightHandSide()
+    {
+        string printed = TranslateOblivious(PromotedRightHandSideSource);
+
+        Assert.Contains(
+            @"let v string? = (if cache == nil { (cache = Make()) } else { cache })",
+            printed);
+        Assert.DoesNotContain(
+            @"(if cache == nil { (cache = Make()) } else { cache })!!",
+            printed);
+    }
+
+    /// <summary>
+    /// The behavioural half. C# prints <c>nil</c>; on <c>origin/main</c> the
+    /// translated G# throws a <see cref="NullReferenceException"/> instead.
+    /// </summary>
+    [Fact]
+    public void CoalescingAssignmentValue_YieldsNilInsteadOfThrowing()
+    {
+        string printed = TranslateOblivious(PromotedRightHandSideSource);
+        string stdout = CompileAndRun(printed, "C.Run()");
+        Assert.Equal("nil", stdout.Trim());
+    }
+
+    /// <summary>
+    /// Anti-vacuity guard rail (passes on <c>origin/main</c> as well): a
+    /// right-hand side that genuinely cannot be nil keeps its faithful
+    /// assertion, so the fix is a narrowing of the guard rather than a deletion.
+    /// </summary>
+    [Fact]
+    public void CoalescingAssignmentValue_StillAssertsANonNullRightHandSide()
+    {
+        string printed = TranslateOblivious(NonNullRightHandSideSource);
+
+        Assert.Contains(
+            @"(if cache == nil { (cache = ""d"") } else { cache })!!",
+            printed);
+    }
+
+    /// <summary>
+    /// Anti-vacuity guard rail, behavioural half (passes on
+    /// <c>origin/main</c> as well): the retained assertion still runs.
+    /// </summary>
+    [Fact]
+    public void CoalescingAssignmentValue_NonNullRightHandSideStillRuns()
+    {
+        string printed = TranslateOblivious(NonNullRightHandSideSource);
+        string stdout = CompileAndRun(printed, "C.Run()");
+        Assert.Equal("d", stdout.Trim());
+    }
+
+    private static string TranslateOblivious(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        Assert.Equal(
+            NullableContextOptions.Disable,
+            project.Compilation.Options.NullableContextOptions);
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        Assert.DoesNotContain(
+            context.Diagnostics,
+            d => d.Severity == TranslationSeverity.Unsupported);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+
+    private static string CompileAndRun(string printed, string callExpression)
+    {
+        string compiler = FindCompiler();
+        Assert.True(compiler != null, "gsc.dll must be built (dotnet build GSharp.sln) before running this test.");
+
+        string workDir = Path.Combine(AppContext.BaseDirectory, "issue-3774-e2e", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workDir);
+        string gsPath = Path.Combine(workDir, "Snippet.gs");
+        string dllPath = Path.Combine(workDir, "Snippet.dll");
+        File.WriteAllText(gsPath, printed + Environment.NewLine + callExpression + Environment.NewLine);
+
+        (int compileExit, string compileOut) = RunDotnet(
+            $"\"{compiler}\" /target:exe /out:\"{dllPath}\" \"{gsPath}\"");
+        Assert.True(
+            compileExit == 0 && !compileOut.Contains("error", StringComparison.OrdinalIgnoreCase),
+            "gsc must compile the translated snippet with zero errors. Output:\n" + compileOut +
+                "\n\nTranslated G#:\n" + printed);
+
+        (int runExit, string stdout) = RunDotnet($"\"{dllPath}\"");
+        Assert.True(
+            runExit == 0,
+            "Translated snippet must run successfully. Output:\n" + stdout +
+                "\n\nTranslated G#:\n" + printed);
+        return stdout;
+    }
+
+    private static (int Exit, string Output) RunDotnet(string arguments)
+    {
+        var psi = new ProcessStartInfo("dotnet", arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        using var process = Process.Start(psi);
+        var output = new StringBuilder();
+        output.Append(process.StandardOutput.ReadToEnd());
+        output.Append(process.StandardError.ReadToEnd());
+        process.WaitForExit();
+        return (process.ExitCode, output.ToString());
+    }
+
+    private static string FindCompiler()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            foreach (string config in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(dir.FullName, "out", "bin", config, "Compiler", "gsc.dll");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -2418,9 +2418,27 @@ public sealed partial class CSharpToGSharpTranslator
                     target,
                     this.TranslateAssignmentValue(assignment)),
                 current);
+
+            // Issue #3774: G# `!!` is a CHECKED assertion that THROWS on nil, not
+            // C#'s erased `!`, so an assertion here is faithful only when the
+            // `??=` expression's value genuinely cannot be nil — and its value is
+            // nil exactly when the right-hand side is. Roslyn's flow state proves
+            // that in a nullable-ENABLED compilation, and
+            // `NullableReferenceValueMayBeNull` reads the C# annotations. Neither
+            // says anything in an OBLIVIOUS compilation, where a same-project
+            // member the whole-program taint analysis promoted to `T?` still reads
+            // as non-null — so `cache ??= Make()` (C#: yields null) gained a
+            // guaranteed throw. Consult the promotion result too in that mode,
+            // which is the same "can this be nil at runtime in G#" question the
+            // rest of the bridge already asks; a literal / provably non-null RHS
+            // keeps its assertion.
+            bool rightHandSideMayBeNil =
+                this.NullableReferenceValueMayBeNull(assignment.Right)
+                || (this.IsObliviousCompilation()
+                    && this.IsNullablePromotedValue(assignment.Right));
             GExpression result =
                 this.context.GetTypeInfo(assignment).Nullability.FlowState == NullableFlowState.NotNull
-                || !this.NullableReferenceValueMayBeNull(assignment.Right)
+                || !rightHandSideMayBeNil
                 ? EnsureNonNullAssertion(value)
                 : value;
             return statements.Count == 0


### PR DESCRIPTION
Closes #3774. Filed #3775 for the residue.

A sweep of **every** `EnsureNonNullAssertion` call site in `cs2gs`, generalized from #3771 (fixed in the open PR #3773). The premise: C#'s `x!` is **erased**, G#'s `x!!` is a **checked assertion that throws on nil**, so every emission site is a place a translation can silently gain a throw the original never had — invisible to the compiler, to ILVerify and to every binding-only test.

Swept against `origin/main` at `281a9c278`, i.e. **including** the #3705-family-2 change to what gsc considers nullable for imported members.

### Method

The verdicts are not from reading alone. Twenty-six probe programs covering the ranked-risky positions (loop conditions and incrementors, ternary and `??` arms, `??=` value position, `MoveNext`/`Current`, event subscription, index arguments, object/collection initializers, oblivious external members) were translated and inspected for where a `!!` actually lands. Nine of the twenty-six produced any `!!` at all; the rest are the evidence that the target-aware bridges do **not** fire where they should not.

### Site inventory — 20 call sites

**Faithful: `!!` on a dereference receiver (5).** C# would raise a `NullReferenceException` at this same dereference and `!!` raises at exactly the same point.

| site | shape |
|---|---|
| `Statements.cs:2474` | `this.Prop!!.Member = v` (implicit-this assignment target) |
| `Statements.cs:2489` | `recv!!.Member = v` (assignment target) |
| `Expressions.cs:886` | `TranslateReceiverWithNullForgiveness`, main path |
| `Expressions.cs:901` | null-preserving safe-cast receiver (#3683) |
| `Expressions.cs:918` | `as`-bound local receiver (ADR-0160) |

Confirmed by probe: `Parent(w)` → `w!!.parent`, and the `Type` walk → `t!!.BaseType`.

**Faithful: the value is proved non-nil, or the original throws too (3).**

| site | why |
|---|---|
| `Types.cs:1327` | `yield` of a `foreach` variable whose Roslyn flow state is `NotNull` |
| `Invocations.cs:3630` | checked reference cast gated on `IsFlowNarrowedAnnotatedReference` (flow state `NotNull`) |
| `Expressions.cs:723` | `Nullable<T>.Value` → `!!`. Both throw. Only the exception *type* differs (`InvalidOperationException` vs `NullReferenceException`) — noted in #3775 |

**Left alone: target-aware bridges whose gate is sound (7).** Each consults `TargetWillRemainNonNullableReference(targetType, targetSymbol)` — the predicate #3773 consolidated — so a sink that is itself declared or promoted nullable is skipped and no `!!` appears.

`Expressions.cs:1376` (`ForgiveNullableReferenceValue`), `Expressions.cs:2081` (index argument), `Expressions.cs:1285` (value position via `ReceiverNeedsNullForgiveness`), `Patterns.cs:2259` (collection-initializer element), `Patterns.cs:2400` (assignment onto a materialized pattern binder), `Invocations.cs:1559` (argument), `Invocations.cs:2821` (initializer element).

`Expressions.cs:1285` deserves a note because it asserts *before* the target is consulted, which is structurally the #3771 hazard. It survives the sweep because every rule that makes `ReceiverNeedsNullForgiveness` true in value position is either a flow/syntactic non-null proof (`IsLazyInitGuardedFieldUse`, `IsNullGuardNarrowedFieldUse`) or an explicit "this member's return contract was deliberately kept non-null" rule — so the assertion follows the sink's contract rather than an accident. Probes over both shapes emitted no `!!`.

**Deliberately not patched: divergent, but the fix is a contract change, not a deletion (4) — filed as #3775.**

- `Statements.cs:612` — `c.Ticked += h!!`. C#'s `e += null` is a **no-op**; the G# throws. Reproduced by probe. Removing the `!!` produces GS0155 — the real fix is gsc-side (carry the event's metadata annotation onto the arrow type).
- `Statements.cs:659` / `Statements.cs:709` — oblivious sink bridges. The existing comments already state the trade ("a genuinely null oblivious key ... fails at runtime before the index operation"); #3774 is the first time it is named as this defect class.
- `Patterns.cs:504` — the direct `expr!` → `expr!!` mapping (ADR-0115 §B). The purest and highest-volume instance: it fires on every C# null-forgiving operator, including the ones authors wrote *because* the value can be null. Reproduced by probe: `object o = v!;` where `v` is null prints `nil` in C# and throws in G#. #3775 proposes the free subset — drop the assertion when the sink already accepts `T?`.

**Already fixed by the open PR #3773, not duplicated here (1 path).** `ForgiveAssignmentRhs` reaching `Expressions.cs:1376`. The sweep found **two more corpus-shaped instances** beyond #3771's `for` loop, worth adding there:

```gsharp
for var t Type? = typeof(C); t != nil; t = t!!.BaseType!! {   // external Type.BaseType walk
while s != nil { n++; s = Next()!! }                          // while-loop walk
```

Both are guaranteed throws at the loop's designed exit.

### Fixed here: the value-position `??=` (`Patterns.cs:2424`)

The value of `x ??= v` is nil **exactly when `v` is**. The guard asked only Roslyn's flow state and `NullableReferenceValueMayBeNull` — neither of which says anything in a nullable-OBLIVIOUS compilation, where a same-project member the whole-program taint analysis promoted to `T?` still reads as non-null. So:

```csharp
string v = (cache ??= Make());   // C#: v is null, prints "nil"
```

```gsharp
let v string? = ((if cache == nil { (cache = Make()) } else { cache })!!)   // G#: NullReferenceException
```

Note the `!!` is not even load-bearing for binding there — the local is already `string?`. The guard now also consults the promotion result in oblivious mode; a literal or otherwise provably non-null right-hand side keeps its faithful assertion.

### Test evidence

Two of the four tests **execute** the translated G# through the real `gsc`, because this defect class is invisible to text and to binding.

| test | on `origin/main` | on this branch |
|---|---|---|
| `CoalescingAssignmentValue_DoesNotAssertAPromotedNullableRightHandSide` | **fails** | passes |
| `CoalescingAssignmentValue_YieldsNilInsteadOfThrowing` (executes) | **fails** — `System.NullReferenceException`, expected `nil` | passes |
| `CoalescingAssignmentValue_StillAssertsANonNullRightHandSide` | passes (anti-vacuity guard rail) | passes |
| `CoalescingAssignmentValue_NonNullRightHandSideStillRuns` (executes) | passes (anti-vacuity guard rail) | passes |

Failing-on-main proof run with the translator reverted to `origin/main` and the test file kept: 2 failed, 2 passed, exactly as designed. The two guard rails exist so a "fix" that simply deleted the assertion could not pass this file — they pin that a provably non-null RHS still gets its `!!` and that it still runs.

Anti-vacuity: the text assertion pins the **whole** lowered construct (`let v string? = (if cache == nil { (cache = Make()) } else { cache })`) plus a `DoesNotContain` on that same whole construct with `!!` appended — not a fragment that main never emitted, which is how the #3771 draft passed for the wrong reason.

Full `Cs2Gs.Tests`: **2606 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
