### PR TITLE
cs2gs + ADR-0169 M5: translate an analyzer's TEST project against the G# analyzer API (#3686)

### DIFF
--- a/docs/adr/0169-gsharp-analyzer-framework.md
+++ b/docs/adr/0169-gsharp-analyzer-framework.md
@@ -152,6 +152,15 @@ running the driver — deliberately shaped like the internal
 `AnalyzerTestHelper` so cs2gs can translate existing Roslyn analyzer tests
 mechanically.
 
+Amended 2026-09-01 (issue #3686, M5): the same library also exposes the
+non-generic `GSharpAnalyzerVerifier.VerifyAnalyzer(analyzer, markedSource,
+ids…)`. A translated harness holds an analyzer *value* — its parameter is
+`GSharpDiagnosticAnalyzer` and the concrete analyzer is chosen at the call
+site — so the generic, `new()`-constrained form cannot receive it without
+turning an argument into a type argument. Hand-written G# analyzer tests keep
+using the generic form; the instance overload exists so the cs2gs harness
+rewrite is a body substitution rather than a call-site rewrite.
+
 ## Consequences
 
 - The five GSA analyzers gain a migration target: their cs2gs translation is

--- a/docs/cs2gs-analyzer-translation.md
+++ b/docs/cs2gs-analyzer-translation.md
@@ -168,9 +168,46 @@ consumer rewrite is a pure value substitution.
 
 ## Test-harness and snippet translation
 
-`AnalyzerTestHelper.cs` is ordinary C# and translates normally (rules 3/22
-rewrite the Roslyn calls; the `[|...|]` marker-stripping logic is plain string
-code). The hard part is the **embedded C# snippets** — raw strings of analyzed
+Status (2026-09-01, issue #3686): the **harness half is implemented**; the
+**snippet half is not** — see "M5 status" below.
+
+The original plan here — "`AnalyzerTestHelper.cs` is ordinary C# and translates
+normally, rules 3/22 rewrite the Roslyn calls" — did not survive contact with
+the harness body, and rule 22 is now implemented differently than that line
+describes. The harness does not merely *call* Roslyn APIs; it builds a
+`CSharpCompilation` over metadata references pulled from
+`TRUSTED_PLATFORM_ASSEMBLIES` and drives Roslyn's analyzer driver. The G#
+verifier takes **no metadata references at all**, so the faithful translation
+of `GetReferences()` is deletion, not mapping — and translating the remaining
+calls one by one would reimplement, inside the migrated test project, the
+marker-stripping and assertion logic `GSharpAnalyzerVerifier` already owns.
+
+Implemented instead (`CSharpToGSharpTranslator.Analyzers.cs`,
+`IsAnalyzerHarnessEntry` / `TryBuildAnalyzerHarnessBody`): the harness entry
+point — a static method taking an analyzer and a source string — keeps its
+**signature**, so no call site changes, and its **body** becomes a single
+delegation to
+`GSharp.CodeAnalysis.Analyzers.Testing.GSharpAnalyzerVerifier.VerifyAnalyzer`.
+Private members that existed only to serve it are dropped. The substitution is
+reported as `CS2GS-ANALYZER-SHAPE`, never silent.
+
+That required one addition to the framework: ADR-0169 shipped
+`GSharpAnalyzerVerifier<TAnalyzer>` (static, generic, `new()`-constrained),
+but a migrated harness holds an analyzer **value** and has no type parameter to
+bind, so an instance-based overload
+`GSharpAnalyzerVerifier.VerifyAnalyzer(analyzer, markedSource, ids…)` was added
+alongside it. Hand-written G# analyzer tests keep using the generic form.
+
+Detection is per project on both halves: `AnalyzerProjectDetector` gained
+`IsAnalyzerTestProject` (a project that instantiates an analyzer declared in a
+referenced, non-Roslyn assembly), and `GSharpProjectTransformer` recognizes the
+structural counterpart (a `ProjectReference` to an analyzer project that is not
+an `OutputItemType="Analyzer"` consumer reference) to inject the two assemblies
+the migrated tests bind — `GSharp.Core` and the verifier — both copied to the
+test output, because a test assembly is loaded by the test host rather than by
+gsc.
+
+The remaining half is the **embedded C# snippets** — raw strings of analyzed
 code inside tests. For functional equivalence they must become G# snippets.
 
 Approach: nested cs2gs invocation at translation time, not manual porting.
@@ -240,6 +277,19 @@ Order: GSA0001 → GSA0003 → GSA0004 → GSA0002 → GSA0005; harness and pari
   lines).
 - **M5 Test project + snippets** — `SnippetTranslator`, CodeModel `Origin`
   provenance, `CS2GS-ANALYZER-SNIPPET`, goldens of all translated GSA tests.
+
+  **M5 status (2026-09-01, issue #3686).** Done: test-project detection,
+  harness rewrite, the instance-based verifier entry point, and the project
+  transform. Measured on `test/InternalAnalyzers.Tests`, the app was walled at
+  16 `GS0154` errors (3 fingerprints) and now translates, **compiles and
+  ilverifies clean**. Not done: snippet translation. `SnippetTranslator` exists
+  and is unit-tested, but nothing dispatches it during a migration, so the
+  migrated tests still hand **C# snippets** to the G# verifier and all 16 fail
+  — loudly, with the verifier's "the test source does not compile" report, not
+  silently. Two shapes make the wiring more than plumbing: the analyzed source
+  arrives via a `const string` local rather than a literal argument, and
+  several tests compose it (`Model + """…"""`), so the unit to translate is the
+  concatenation, which cannot then be split back into its parts.
 - **M6 Parity + self-migration** — `AnalyzerParityStage`; extend the
   Issue3347-style self-migration ratchet to translate
   `InternalAnalyzers.csproj` live. Exit criterion: all five translated

--- a/src/Analyzers/GSharp.CodeAnalysis.Analyzers.Testing/GSharpAnalyzerVerifier.cs
+++ b/src/Analyzers/GSharp.CodeAnalysis.Analyzers.Testing/GSharpAnalyzerVerifier.cs
@@ -14,28 +14,36 @@ using GSharp.Core.CodeAnalysis.Text;
 namespace GSharp.CodeAnalysis.Analyzers.Testing;
 
 /// <summary>
-/// Test-framework-agnostic verifier for <see cref="GSharpDiagnosticAnalyzer"/>s
-/// (ADR-0169). G# source is annotated with <c>[|</c>…<c>|]</c> span markers at
-/// each expected diagnostic start; the verifier strips the markers, compiles
-/// the source, runs the analyzer through <see cref="GSharpAnalyzerDriver"/>,
-/// and asserts the produced diagnostic IDs (in span order) and their exact
-/// 1-based line/column positions. Mismatches throw
-/// <see cref="GSharpAnalyzerVerificationException"/>. Deliberately shaped like
-/// the repo's Roslyn-side <c>AnalyzerTestHelper.AssertDiagnosticsAsync</c> so
-/// cs2gs can translate existing analyzer tests mechanically.
+/// The instance-based entry point of the ADR-0169 verifier: it takes the
+/// analyzer as a value rather than as a type argument, which is the shape a
+/// translated Roslyn test harness lands on. A migrated
+/// <c>AnalyzerTestHelper.AssertDiagnosticsAsync(DiagnosticAnalyzer analyzer,
+/// …)</c> has an analyzer *instance* in hand and no type parameter to bind, so
+/// <see cref="GSharpAnalyzerVerifier{TAnalyzer}"/> — static, generic, and
+/// <c>new()</c>-constrained — cannot receive it without turning an argument
+/// into a type argument. Hand-written G# analyzer tests should keep using the
+/// generic form; this one exists so cs2gs's harness rewrite (ADR-0169 M5,
+/// issue #3686) is a body substitution rather than a call-site rewrite.
 /// </summary>
-/// <typeparam name="TAnalyzer">The analyzer under test.</typeparam>
-public static class GSharpAnalyzerVerifier<TAnalyzer>
-    where TAnalyzer : GSharpDiagnosticAnalyzer, new()
+public static class GSharpAnalyzerVerifier
 {
     /// <summary>
     /// Compiles <paramref name="markedSource"/> (after stripping the
-    /// <c>[|…|]</c> markers), runs the analyzer, and asserts the produced
-    /// diagnostics match the markers and <paramref name="diagnosticIds"/>.
+    /// <c>[|…|]</c> markers), runs <paramref name="analyzer"/> over it, and
+    /// asserts the produced diagnostics match the markers and
+    /// <paramref name="diagnosticIds"/>.
     /// </summary>
+    /// <param name="analyzer">The analyzer under test.</param>
     /// <param name="markedSource">G# source with expected-diagnostic markers.</param>
     /// <param name="diagnosticIds">Expected diagnostic IDs, one per marker, in span order.</param>
-    public static void VerifyAnalyzer(string markedSource, params string[] diagnosticIds)
+    /// <exception cref="GSharpAnalyzerVerificationException">
+    /// The source does not compile, or the produced diagnostics differ from
+    /// the markers and ids.
+    /// </exception>
+    public static void VerifyAnalyzer(
+        GSharpDiagnosticAnalyzer analyzer,
+        string markedSource,
+        params string[] diagnosticIds)
     {
         var expectedLocations = new List<(int Line, int Column)>();
         var cleanSource = StripMarkers(markedSource, expectedLocations);
@@ -59,7 +67,7 @@ public static class GSharpAnalyzerVerifier<TAnalyzer>
         }
 
         var produced = GSharpAnalyzerDriver
-            .Run(compilation, ImmutableArray.Create<GSharpDiagnosticAnalyzer>(new TAnalyzer()))
+            .Run(compilation, ImmutableArray.Create(analyzer))
             .OrderBy(d => d.Location.Span.Start)
             .ToImmutableArray();
 
@@ -121,4 +129,30 @@ public static class GSharpAnalyzerVerifier<TAnalyzer>
 
         return result.ToString();
     }
+}
+
+/// <summary>
+/// Test-framework-agnostic verifier for <see cref="GSharpDiagnosticAnalyzer"/>s
+/// (ADR-0169). G# source is annotated with <c>[|</c>…<c>|]</c> span markers at
+/// each expected diagnostic start; the verifier strips the markers, compiles
+/// the source, runs the analyzer through <see cref="GSharpAnalyzerDriver"/>,
+/// and asserts the produced diagnostic IDs (in span order) and their exact
+/// 1-based line/column positions. Mismatches throw
+/// <see cref="GSharpAnalyzerVerificationException"/>. Deliberately shaped like
+/// the repo's Roslyn-side <c>AnalyzerTestHelper.AssertDiagnosticsAsync</c> so
+/// cs2gs can translate existing analyzer tests mechanically.
+/// </summary>
+/// <typeparam name="TAnalyzer">The analyzer under test.</typeparam>
+public static class GSharpAnalyzerVerifier<TAnalyzer>
+    where TAnalyzer : GSharpDiagnosticAnalyzer, new()
+{
+    /// <summary>
+    /// Compiles <paramref name="markedSource"/> (after stripping the
+    /// <c>[|…|]</c> markers), runs the analyzer, and asserts the produced
+    /// diagnostics match the markers and <paramref name="diagnosticIds"/>.
+    /// </summary>
+    /// <param name="markedSource">G# source with expected-diagnostic markers.</param>
+    /// <param name="diagnosticIds">Expected diagnostic IDs, one per marker, in span order.</param>
+    public static void VerifyAnalyzer(string markedSource, params string[] diagnosticIds)
+        => GSharpAnalyzerVerifier.VerifyAnalyzer(new TAnalyzer(), markedSource, diagnosticIds);
 }

--- a/src/Compiler/Compiler.csproj
+++ b/src/Compiler/Compiler.csproj
@@ -12,6 +12,15 @@
 
   <ItemGroup>
     <ProjectReference Include="@(GsharpCore)" />
+    <!-- ADR-0169 M5 / issue #3686: the analyzer verifier ships NEXT TO gsc, the
+         same way GSharp.Core does. A migrated analyzer test project references
+         it through $(GsharpCompilerFullPath)'s directory (see
+         GSharpProjectTransformer.CompilerDirectoryExpression), which resolves
+         to the SDK's tools folder for an SDK-driven build and to
+         out/bin/<Config>/Compiler for a direct one. Until the packable
+         GSharp.CodeAnalysis.Analyzers.Testing package is published, co-location
+         with the compiler is the only path that works in both. -->
+    <ProjectReference Include="..\Analyzers\GSharp.CodeAnalysis.Analyzers.Testing\GSharp.CodeAnalysis.Analyzers.Testing.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Compiler/packages.lock.json
+++ b/src/Compiler/packages.lock.json
@@ -53,6 +53,13 @@
         "resolved": "9.0.0",
         "contentHash": "nGdCUVhEQ9/CWYqgaibYEDwIJjokgIinQhCnpmtZfSXdMS6ysLZ8p9xvcJ8VPx6Xpv5OsLIUrho4B9FN+VV/tw=="
       },
+      "gsharp.codeanalysis.analyzers.testing": {
+        "type": "Project",
+        "dependencies": {
+          "GSharp.Core": "[1.0.0, )",
+          "Microsoft.VisualStudio.Validation": "[17.8.8, )"
+        }
+      },
       "GSharp.Core": {
         "type": "Project",
         "dependencies": {

--- a/test/Compiler.Tests/packages.lock.json
+++ b/test/Compiler.Tests/packages.lock.json
@@ -162,6 +162,7 @@
       "gsc": {
         "type": "Project",
         "dependencies": {
+          "GSharp.CodeAnalysis.Analyzers.Testing": "[1.0.0, )",
           "GSharp.Core": "[1.0.0, )",
           "Microsoft.VisualStudio.Validation": "[17.8.8, )"
         }
@@ -170,6 +171,13 @@
         "type": "Project",
         "dependencies": {
           "GSharp.GSharp.GeneratorHost": "[1.0.0, )",
+          "Microsoft.VisualStudio.Validation": "[17.8.8, )"
+        }
+      },
+      "gsharp.codeanalysis.analyzers.testing": {
+        "type": "Project",
+        "dependencies": {
+          "GSharp.Core": "[1.0.0, )",
           "Microsoft.VisualStudio.Validation": "[17.8.8, )"
         }
       },

--- a/test/Core.Tests/CodeAnalysis/Adr0169AnalyzerVerifierTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Adr0169AnalyzerVerifierTests.cs
@@ -76,6 +76,76 @@ func Leak(index int32) int32 {
     }
 
     /// <summary>
+    /// The instance-based entry point (ADR-0169 M5, issue #3686): a migrated
+    /// analyzer test harness holds an analyzer VALUE, not a type argument, so
+    /// the non-generic overload is the shape cs2gs's harness rewrite targets.
+    /// Same source, same markers, same outcome as the generic form above.
+    /// </summary>
+    [Fact]
+    public void InstanceOverload_FlagsIndexReadOutsideResolver_AndHonorsMarkers()
+    {
+        GSharpDiagnosticAnalyzer analyzer = new StructFieldDefsReadAnalogueAnalyzer();
+        GSharpAnalyzerVerifier.VerifyAnalyzer(
+            analyzer,
+            @"package App
+
+var structFieldDefs = []int32{1, 2, 3}
+
+func ResolveFieldToken(index int32) int32 {
+    return structFieldDefs[index]
+}
+
+func Leak(index int32) int32 {
+    return [|structFieldDefs[index]|]
+}
+
+func Populate(index int32) {
+    structFieldDefs[index] = 0
+}
+",
+            "TESTGSA0001");
+    }
+
+    /// <summary>
+    /// Anti-vacuity guard for the overload above: it must still FAIL when the
+    /// analyzer fires and nothing is expected, so a passing verification is
+    /// evidence the analyzer ran rather than evidence it was never invoked.
+    /// </summary>
+    [Fact]
+    public void InstanceOverload_MismatchedExpectation_ThrowsVerificationException()
+    {
+        GSharpDiagnosticAnalyzer analyzer = new StructFieldDefsReadAnalogueAnalyzer();
+        Assert.Throws<GSharpAnalyzerVerificationException>(() =>
+            GSharpAnalyzerVerifier.VerifyAnalyzer(
+                analyzer,
+                @"package App
+
+var structFieldDefs = []int32{1, 2, 3}
+
+func Leak(index int32) int32 {
+    return structFieldDefs[index]
+}
+"));
+    }
+
+    /// <summary>
+    /// The instance overload takes the analyzer through its BASE type, the
+    /// only shape a translated harness can produce: the migrated
+    /// <c>AssertDiagnosticsAsync</c> parameter is
+    /// <c>GSharpDiagnosticAnalyzer</c>, and the concrete analyzer is chosen at
+    /// the call site. A signature that required the concrete type (or a
+    /// <c>new()</c> constraint) would not bind there.
+    /// </summary>
+    [Fact]
+    public void InstanceOverload_AcceptsAnAnalyzerThroughItsBaseType()
+    {
+        var method = typeof(GSharpAnalyzerVerifier).GetMethod(nameof(GSharpAnalyzerVerifier.VerifyAnalyzer));
+        Assert.NotNull(method);
+        Assert.False(method.IsGenericMethod);
+        Assert.Equal(typeof(GSharpDiagnosticAnalyzer), method.GetParameters()[0].ParameterType);
+    }
+
+    /// <summary>
     /// The G# analogue of GSA0001: direct index reads of a member named
     /// <c>structFieldDefs</c> outside <c>ResolveFieldToken</c> /
     /// <c>ResolveInterfaceFieldToken</c> are flagged. Uses

--- a/test/Extensions.Tests/packages.lock.json
+++ b/test/Extensions.Tests/packages.lock.json
@@ -119,6 +119,14 @@
       "gsc": {
         "type": "Project",
         "dependencies": {
+          "GSharp.CodeAnalysis.Analyzers.Testing": "[1.0.0, )",
+          "GSharp.Core": "[1.0.0, )",
+          "Microsoft.VisualStudio.Validation": "[17.8.8, )"
+        }
+      },
+      "gsharp.codeanalysis.analyzers.testing": {
+        "type": "Project",
+        "dependencies": {
           "GSharp.Core": "[1.0.0, )",
           "Microsoft.VisualStudio.Validation": "[17.8.8, )"
         }

--- a/test/Interpreter.Tests/packages.lock.json
+++ b/test/Interpreter.Tests/packages.lock.json
@@ -180,6 +180,14 @@
       "gsc": {
         "type": "Project",
         "dependencies": {
+          "GSharp.CodeAnalysis.Analyzers.Testing": "[1.0.0, )",
+          "GSharp.Core": "[1.0.0, )",
+          "Microsoft.VisualStudio.Validation": "[17.8.8, )"
+        }
+      },
+      "gsharp.codeanalysis.analyzers.testing": {
+        "type": "Project",
+        "dependencies": {
           "GSharp.Core": "[1.0.0, )",
           "Microsoft.VisualStudio.Validation": "[17.8.8, )"
         }

--- a/test/Sdk.Tests/packages.lock.json
+++ b/test/Sdk.Tests/packages.lock.json
@@ -160,6 +160,14 @@
       "gsc": {
         "type": "Project",
         "dependencies": {
+          "GSharp.CodeAnalysis.Analyzers.Testing": "[1.0.0, )",
+          "GSharp.Core": "[1.0.0, )",
+          "Microsoft.VisualStudio.Validation": "[17.8.8, )"
+        }
+      },
+      "gsharp.codeanalysis.analyzers.testing": {
+        "type": "Project",
+        "dependencies": {
           "GSharp.Core": "[1.0.0, )",
           "Microsoft.VisualStudio.Validation": "[17.8.8, )"
         }
@@ -171,7 +179,7 @@
           "System.Reflection.MetadataLoadContext": "[9.0.0, )"
         }
       },
-      "Gsharp.HotReload.Runtime": {
+      "gsharp.hotreload.runtime": {
         "type": "Project",
         "dependencies": {
           "Microsoft.VisualStudio.Validation": "[17.8.8, )"

--- a/tools/cs2gs/Cs2Gs.Pipeline/GSharpProjectTransformer.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/GSharpProjectTransformer.cs
@@ -23,6 +23,10 @@ internal static class GSharpProjectTransformer
     private const string CompilerDirectoryExpression =
         "$([System.IO.Path]::GetDirectoryName('$(GsharpCompilerFullPath)'))";
 
+    // ADR-0169 M5 / issue #3686: the assembly holding GSharpAnalyzerVerifier,
+    // which a migrated Roslyn analyzer test harness delegates to.
+    private const string AnalyzerVerifierAssemblyName = "GSharp.CodeAnalysis.Analyzers.Testing";
+
     private static readonly Regex CSharpSpecSuffix = new Regex(
         "\\.cs(?=\\s*(?:;|$))",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
@@ -73,6 +77,11 @@ internal static class GSharpProjectTransformer
         string sourceProjectDirectory = Path.GetDirectoryName(Path.GetFullPath(sourceProjectPath));
         string fullDestinationDirectory = Path.GetFullPath(destinationProjectDirectory);
 
+        // ADR-0169 M5 / issue #3686: read while the ProjectReference includes
+        // still point at the SOURCE .csproj files — RewriteProjectReferences
+        // below repoints them at the generated .gsproj paths.
+        bool referencesAnalyzerProject = ReferencesAnAnalyzerProject(document, sourceProjectDirectory);
+
         RewriteProjectReferences(
             document,
             sourceProjectDirectory,
@@ -87,7 +96,7 @@ internal static class GSharpProjectTransformer
         RewriteOutputType(document);
         RewriteCompileItems(document);
         RewriteCSharpMetadata(document);
-        RewriteAnalyzerProject(document);
+        RewriteAnalyzerProject(document, referencesAnalyzerProject);
         RewriteAnalyzerConsumerReferences(document);
 
         return document;
@@ -461,22 +470,19 @@ internal static class GSharpProjectTransformer
     // netstandard2.0 does not exist for G#), drops the Roslyn compiler
     // packages and Roslyn-analyzer-authoring properties, and references the
     // G# analyzer API assembly loaded by the compiler host.
-    private static void RewriteAnalyzerProject(XDocument document)
+    private static void RewriteAnalyzerProject(XDocument document, bool referencesAnalyzerProject)
     {
-        // Issue #3501: a plain Microsoft.CodeAnalysis dependency is not enough
-        // (Cs2Gs.Translator needs Roslyn at runtime). Analyzer packages use
-        // PrivateAssets=all; that marker also survives the pipeline's evaluated
-        // project projection when EnforceExtendedAnalyzerRules does not.
-        bool isAnalyzerProject = ElementsNamed(document, "EnforceExtendedAnalyzerRules").Any()
-            || ElementsNamed(document, "PackageReference").Any(reference =>
-                AttributeNamed(reference, "Include")?.Value?.StartsWith(
-                    "Microsoft.CodeAnalysis",
-                    StringComparison.OrdinalIgnoreCase) == true
-                && string.Equals(
-                    AttributeNamed(reference, "PrivateAssets")?.Value?.Trim(),
-                    "all",
-                    StringComparison.OrdinalIgnoreCase));
-        if (!isAnalyzerProject)
+        bool isAnalyzerProject = IsAnalyzerProjectXml(document);
+
+        // ADR-0169 M5 / issue #3686: the analyzer's TEST project gets the same
+        // treatment — it too translates in analyzer-API mode, so its Roslyn
+        // packages are gone and it binds the G# analyzer API plus the verifier.
+        // It is recognized structurally: it project-references an analyzer
+        // project. (The translator's own detector is semantic; the transformer
+        // has no compilation, which is why the two live apart — see
+        // docs/cs2gs-analyzer-translation.md §Detection.)
+        bool isAnalyzerTestProject = !isAnalyzerProject && referencesAnalyzerProject;
+        if (!isAnalyzerProject && !isAnalyzerTestProject)
         {
             return;
         }
@@ -518,6 +524,11 @@ internal static class GSharpProjectTransformer
             }
         }
 
+        // An analyzer assembly is LOADED BY gsc, which already has GSharp.Core
+        // in its own directory — copying it would risk a second, divergent
+        // copy. A test assembly is loaded by the test host instead, with no
+        // gsc in the picture, so it must carry both assemblies into its output
+        // or the analyzer's own types fail to load at run time (#3686).
         var itemGroup = new XElement(
             "ItemGroup",
             new XElement(
@@ -526,8 +537,84 @@ internal static class GSharpProjectTransformer
                 new XElement(
                     "HintPath",
                     CompilerDirectoryExpression + "/GSharp.Core.dll"),
-                new XElement("Private", "false")));
+                new XElement("Private", isAnalyzerTestProject ? "true" : "false")));
+        if (isAnalyzerTestProject)
+        {
+            itemGroup.Add(new XElement(
+                "Reference",
+                new XAttribute("Include", AnalyzerVerifierAssemblyName),
+                new XElement(
+                    "HintPath",
+                    CompilerDirectoryExpression + "/" + AnalyzerVerifierAssemblyName + ".dll"),
+                new XElement("Private", "true")));
+        }
+
         document.Root.Add(itemGroup);
+    }
+
+    // Issue #3501: a plain Microsoft.CodeAnalysis dependency is not enough
+    // (Cs2Gs.Translator needs Roslyn at runtime). Analyzer packages use
+    // PrivateAssets=all; that marker also survives the pipeline's evaluated
+    // project projection when EnforceExtendedAnalyzerRules does not.
+    private static bool IsAnalyzerProjectXml(XDocument document)
+        => ElementsNamed(document, "EnforceExtendedAnalyzerRules").Any()
+            || ElementsNamed(document, "PackageReference").Any(reference =>
+                AttributeNamed(reference, "Include")?.Value?.StartsWith(
+                    "Microsoft.CodeAnalysis",
+                    StringComparison.OrdinalIgnoreCase) == true
+                && string.Equals(
+                    AttributeNamed(reference, "PrivateAssets")?.Value?.Trim(),
+                    "all",
+                    StringComparison.OrdinalIgnoreCase));
+
+    // MSBuild item metadata may be written as an attribute or a child element;
+    // read either.
+    private static string Metadata(XElement item, string name)
+        => AttributeNamed(item, name)?.Value?.Trim()
+            ?? item.Elements().FirstOrDefault(child =>
+                string.Equals(child.Name.LocalName, name, StringComparison.OrdinalIgnoreCase))?.Value?.Trim();
+
+    private static bool ReferencesAnAnalyzerProject(XDocument document, string sourceProjectDirectory)
+    {
+        if (string.IsNullOrEmpty(sourceProjectDirectory))
+        {
+            return false;
+        }
+
+        foreach (XElement reference in ElementsNamed(document, "ProjectReference"))
+        {
+            string include = AttributeNamed(reference, "Include")?.Value;
+            if (string.IsNullOrWhiteSpace(include))
+            {
+                continue;
+            }
+
+            // An analyzer's CONSUMER (src/Core: OutputItemType="Analyzer",
+            // ReferenceOutputAssembly="false") references the analyzer to RUN
+            // it, not to compile against it — it is ordinary C# and must keep
+            // its own Roslyn packages. Only a reference that pulls the
+            // analyzer's assembly in as a library marks a test project.
+            if (string.Equals(Metadata(reference, "OutputItemType"), "Analyzer", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(Metadata(reference, "ReferenceOutputAssembly"), "false", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            string referencedPath = Path.GetFullPath(Path.Combine(
+                sourceProjectDirectory,
+                include.Trim().Replace('\\', Path.DirectorySeparatorChar)));
+            if (!File.Exists(referencedPath))
+            {
+                continue;
+            }
+
+            if (IsAnalyzerProjectXml(XDocument.Parse(File.ReadAllText(referencedPath))))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     // ADR-0169: retain analyzer project references while changing Roslyn's

--- a/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
@@ -325,8 +325,14 @@ public sealed class TranslateStage : IMigrationStage
             // ADR-0169: a project declaring Roslyn diagnostic analyzers is
             // translated in analyzer-API mode — Microsoft.CodeAnalysis usage
             // is rewritten to the G# analyzer API instead of passing through.
+            // Issue #3686 (M5): so is its TEST project. The two halves of one
+            // pair must translate against the SAME analyzer API — otherwise
+            // the migrated tests hand a GSharpDiagnosticAnalyzer to a
+            // parameter still typed Microsoft's DiagnosticAnalyzer (GS0154).
             bool analyzerApiMode = Cs2Gs.Translator.Analyzers.AnalyzerProjectDetector
-                .IsAnalyzerProject(currentProject.Compilation);
+                .IsAnalyzerProject(currentProject.Compilation)
+                || Cs2Gs.Translator.Analyzers.AnalyzerProjectDetector
+                    .IsAnalyzerTestProject(currentProject.Compilation);
             if (!isReferencedProject)
             {
                 context.IsAnalyzerProject = analyzerApiMode;

--- a/tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj
+++ b/tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj
@@ -26,6 +26,11 @@
          against the cs2gs-translated G# analyzers'. -->
     <ProjectReference Include="..\..\..\src\Analyzers\InternalAnalyzers\InternalAnalyzers.csproj" />
 
+    <!-- ADR-0169 M5 (#3686): the harness-rewrite test binds its translated G#
+         against the real verifier assembly, so a delegation to a signature
+         that does not exist fails the test rather than the migration. -->
+    <ProjectReference Include="..\..\..\src\Analyzers\GSharp.CodeAnalysis.Analyzers.Testing\GSharp.CodeAnalysis.Analyzers.Testing.csproj" />
+
     <!-- Issue #1912 review follow-up: the e2e tests shell out to the built
          gsc.dll (see Issue1912ExplicitEnumValueTranslationTests.FindCompiler)
          rather than referencing it as an assembly. Without this reference,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3686AnalyzerTestHarnessTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3686AnalyzerTestHarnessTests.cs
@@ -1,0 +1,407 @@
+// <copyright file="Issue3686AnalyzerTestHarnessTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Analyzers;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// ADR-0169 M5 / issue #3686: an analyzer project and its TEST project must
+/// translate against the SAME analyzer API. Before this, only the project
+/// DECLARING an analyzer entered analyzer mode, so the migrated analyzer became
+/// a <c>GSharpDiagnosticAnalyzer</c> while its migrated tests kept Roslyn's
+/// <c>DiagnosticAnalyzer</c> contract, and every call site failed GS0154.
+/// Covered here: the test-project detection, the harness-body rewrite onto
+/// <c>GSharpAnalyzerVerifier</c> (which the C# pipeline it replaces has no
+/// mapping for at all — the G# verifier takes no metadata references), and the
+/// project-file half that supplies the two assemblies the migrated tests bind.
+/// </summary>
+public class Issue3686AnalyzerTestHarnessTests
+{
+    private const string AnalyzerSource = @"
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Sample;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class SampleAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Rule = new(
+        ""TEST0001"",
+        ""Title"",
+        ""Message"",
+        ""Testing"",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.ElementAccessExpression);
+    }
+
+    private static void Analyze(SyntaxNodeAnalysisContext context)
+    {
+        context.ReportDiagnostic(Diagnostic.Create(Rule, context.Node.GetLocation()));
+    }
+}
+";
+
+    /// <summary>
+    /// The repo's own <c>AnalyzerTestHelper</c> shape, trimmed to the parts
+    /// that matter: the Roslyn compilation pipeline, the metadata-reference
+    /// plumbing, and the marker stripping.
+    /// </summary>
+    private const string HarnessSource = @"
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Sample.Tests;
+
+internal static class AnalyzerTestHelper
+{
+    public static async Task AssertDiagnosticsAsync(DiagnosticAnalyzer analyzer, string source, params string[] diagnosticIds)
+    {
+        var expectedLocations = new List<(int Line, int Column)>();
+        var cleanSource = StripMarkers(source, expectedLocations);
+        var tree = CSharpSyntaxTree.ParseText(cleanSource, new CSharpParseOptions(LanguageVersion.Preview));
+        var compilation = CSharpCompilation.Create(
+            ""AnalyzerTests"",
+            new[] { tree },
+            GetReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var diagnostics = await compilation.WithAnalyzers(ImmutableArray.Create(analyzer)).GetAnalyzerDiagnosticsAsync();
+        if (diagnostics.Length != expectedLocations.Count)
+        {
+            throw new InvalidOperationException(""mismatch"");
+        }
+    }
+
+    private static string StripMarkers(string source, List<(int Line, int Column)> expectedLocations)
+    {
+        expectedLocations.Add((1, 1));
+        return source.Replace(""[|"", string.Empty).Replace(""|]"", string.Empty);
+    }
+
+    private static MetadataReference[] GetReferences()
+    {
+        var trusted = (string)AppContext.GetData(""TRUSTED_PLATFORM_ASSEMBLIES"");
+        return trusted.Split(Path.PathSeparator).Select(p => MetadataReference.CreateFromFile(p)).ToArray();
+    }
+}
+";
+
+    [Fact]
+    public void AnalyzerProject_IsNotItsOwnTestProject()
+    {
+        LoadedCSharpProject analyzer = Load(("Analyzer.cs", AnalyzerSource));
+
+        Assert.True(AnalyzerProjectDetector.IsAnalyzerProject(analyzer.Compilation));
+        Assert.False(AnalyzerProjectDetector.IsAnalyzerTestProject(analyzer.Compilation));
+    }
+
+    /// <summary>
+    /// The detection this issue is about: the tests declare no analyzer, so the
+    /// old "declares one" rule said false and the project translated in
+    /// ordinary mode.
+    /// </summary>
+    [Fact]
+    public void TestProject_InstantiatingAReferencedAnalyzer_IsDetected()
+    {
+        LoadedCSharpProject tests = Load(
+            new[] { ("Harness.cs", HarnessSource), ("Tests.cs", TestsUsing("new Sample.SampleAnalyzer()")) },
+            CSharpProjectLoader.RuntimeReferences().Append(CompileAnalyzerToReference()).ToList());
+
+        Assert.False(AnalyzerProjectDetector.IsAnalyzerProject(tests.Compilation));
+        Assert.True(AnalyzerProjectDetector.IsAnalyzerTestProject(tests.Compilation));
+    }
+
+    /// <summary>
+    /// Anti-vacuity guard, and the real hazard of widening the detector:
+    /// analyzer mode rewrites EVERY Microsoft.CodeAnalysis use in a project,
+    /// so a project that merely consumes Roslyn (cs2gs itself does) must stay
+    /// out of it. Only instantiating an analyzer from another assembly counts.
+    /// </summary>
+    [Fact]
+    public void ProjectThatOnlyUsesRoslyn_IsNotAnAnalyzerTestProject()
+    {
+        LoadedCSharpProject plain = Load((
+            "Plain.cs",
+            @"
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Sample.Plain;
+
+public static class Tool
+{
+    public static int Count(string source)
+        => CSharpSyntaxTree.ParseText(source).GetRoot().DescendantNodes().Count();
+}
+"));
+
+        Assert.False(AnalyzerProjectDetector.IsAnalyzerProject(plain.Compilation));
+        Assert.False(AnalyzerProjectDetector.IsAnalyzerTestProject(plain.Compilation));
+    }
+
+    /// <summary>
+    /// The harness rewrite: the signature (and therefore every call site) is
+    /// preserved, the body delegates to the G# verifier, and the Roslyn
+    /// compilation plumbing — which has no G# counterpart, since the G#
+    /// verifier compiles G# source with no reference set — is gone rather than
+    /// half-mapped. The printed G# is then bound against the real GSharp.Core
+    /// and the real verifier assembly, so a signature that did not exist would
+    /// fail here.
+    /// </summary>
+    [Fact]
+    public void HarnessBody_DelegatesToTheGsharpVerifier_AndBindsAgainstGsCore()
+    {
+        var (printed, diagnostics) = TranslateHarness(HarnessSource);
+
+        Assert.Contains("analyzer GSharpDiagnosticAnalyzer", printed, StringComparison.Ordinal);
+        Assert.Contains(
+            "GSharpAnalyzerVerifier.VerifyAnalyzer(analyzer, source, diagnosticIds)",
+            printed,
+            StringComparison.Ordinal);
+        Assert.Contains("import GSharp.CodeAnalysis.Analyzers.Testing", printed, StringComparison.Ordinal);
+
+        // The Roslyn pipeline and its private plumbing are gone, not mapped.
+        Assert.DoesNotContain("CSharpCompilation", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("GetAnalyzerDiagnosticsAsync", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("MetadataReference", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("GetReferences", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("StripMarkers", printed, StringComparison.Ordinal);
+
+        // The substitution is a declared shape adaptation, never silent.
+        Assert.Contains(
+            diagnostics,
+            d => d.DiagnosticId == "CS2GS-ANALYZER-SHAPE" && d.Message.Contains("VerifyAnalyzer", StringComparison.Ordinal));
+        Assert.DoesNotContain(diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
+
+        AssertBindsAgainstGsCore(printed);
+    }
+
+    /// <summary>
+    /// The dead-code sweep is scoped: a private helper the harness shares with
+    /// another member is still live after the rewrite and must survive.
+    /// </summary>
+    [Fact]
+    public void HarnessSupportMemberUsedElsewhere_IsKept()
+    {
+        string shared = HarnessSource.Replace(
+            "    private static MetadataReference[] GetReferences()",
+            @"    public static string Normalize(string source) => StripMarkers(source, new List<(int Line, int Column)>());
+
+    private static MetadataReference[] GetReferences()",
+            StringComparison.Ordinal);
+
+        var (printed, _) = TranslateHarness(shared);
+
+        Assert.Contains("StripMarkers", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("GetReferences", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The project half: the migrated tests bind GSharp.Core (the analyzer API)
+    /// and the verifier assembly, and — unlike an analyzer, which gsc loads
+    /// beside its own copy — a test assembly must COPY both into its output.
+    /// </summary>
+    [Fact]
+    public void AnalyzerTestProject_GetsCoreAndVerifierReferences_Copied()
+    {
+        XDocument transformed = TransformPair(
+            testProjectXml: @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <ItemGroup>
+    <ProjectReference Include=""..\Analyzer\Analyzer.csproj"" />
+    <PackageReference Include=""Microsoft.CodeAnalysis.CSharp"" Version=""5.6.0"" />
+  </ItemGroup>
+</Project>");
+
+        List<XElement> references = transformed.Descendants()
+            .Where(e => e.Name.LocalName == "Reference")
+            .ToList();
+        Assert.Contains(references, r => r.Attribute("Include")?.Value == "GSharp.Core");
+        Assert.Contains(
+            references,
+            r => r.Attribute("Include")?.Value == "GSharp.CodeAnalysis.Analyzers.Testing");
+        Assert.All(
+            references,
+            r => Assert.Equal(
+                "true",
+                r.Elements().Single(e => e.Name.LocalName == "Private").Value));
+
+        // The Roslyn package the harness no longer needs is dropped.
+        Assert.DoesNotContain(
+            transformed.Descendants().Where(e => e.Name.LocalName == "PackageReference"),
+            p => p.Attribute("Include")?.Value?.StartsWith("Microsoft.CodeAnalysis", StringComparison.Ordinal) == true);
+    }
+
+    /// <summary>
+    /// An analyzer's CONSUMER (the shape of src/Core: OutputItemType="Analyzer",
+    /// ReferenceOutputAssembly="false") references an analyzer project to RUN
+    /// it. It is ordinary C# and must keep its own Roslyn packages — mistaking
+    /// it for a test project would strip them.
+    /// </summary>
+    [Fact]
+    public void AnalyzerConsumerProject_IsNotTreatedAsATestProject()
+    {
+        XDocument transformed = TransformPair(
+            testProjectXml: @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <ItemGroup>
+    <ProjectReference Include=""..\Analyzer\Analyzer.csproj"" OutputItemType=""Analyzer"" ReferenceOutputAssembly=""false"" />
+    <PackageReference Include=""Microsoft.CodeAnalysis.CSharp"" Version=""5.6.0"" />
+  </ItemGroup>
+</Project>");
+
+        Assert.DoesNotContain(
+            transformed.Descendants().Where(e => e.Name.LocalName == "Reference"),
+            r => r.Attribute("Include")?.Value?.StartsWith("GSharp.", StringComparison.Ordinal) == true);
+        Assert.Contains(
+            transformed.Descendants().Where(e => e.Name.LocalName == "PackageReference"),
+            p => p.Attribute("Include")?.Value == "Microsoft.CodeAnalysis.CSharp");
+    }
+
+    private static string TestsUsing(string construction) => @"
+namespace Sample.Tests.Cases;
+
+public sealed class SampleAnalyzerTests
+{
+    public System.Threading.Tasks.Task Reports()
+        => Sample.Tests.AnalyzerTestHelper.AssertDiagnosticsAsync(" + construction + @", ""class C { }"", ""TEST0001"");
+}
+";
+
+    private static LoadedCSharpProject Load((string FileName, string Source) source)
+        => Load(new[] { source }, references: null);
+
+    private static LoadedCSharpProject Load(
+        (string FileName, string Source)[] sources,
+        IReadOnlyList<MetadataReference> references)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(sources, references);
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Fixture should bind with no C# errors: "
+                + string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        return project;
+    }
+
+    private static MetadataReference CompileAnalyzerToReference()
+    {
+        LoadedCSharpProject analyzer = Load(("Analyzer.cs", AnalyzerSource));
+        using var stream = new MemoryStream();
+        Microsoft.CodeAnalysis.Emit.EmitResult result = analyzer.Compilation.Emit(stream);
+        Assert.True(
+            result.Success,
+            "Analyzer fixture should emit: " + string.Join(Environment.NewLine, result.Diagnostics));
+        return MetadataReference.CreateFromImage(stream.ToArray());
+    }
+
+    private static (string Printed, IReadOnlyList<TranslationDiagnostic> Diagnostics) TranslateHarness(string harnessSource)
+    {
+        LoadedCSharpProject project = Load(("Harness.cs", harnessSource));
+        var translator = new CSharpToGSharpTranslator(analyzerApiMode: true);
+        LoadedDocument document = project.Documents.Single(d => Path.GetFileName(d.FilePath) == "Harness.cs");
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = translator.TranslateDocument(document, context);
+        return (GSharpPrinter.Print(unit), context.Diagnostics);
+    }
+
+    private static void AssertBindsAgainstGsCore(string printed)
+    {
+        // Issue #3734/#3767: a translated analyzer's references have all been
+        // retargeted onto the G# analyzer API, so it must import G# namespaces
+        // only — a residual `import Microsoft.CodeAnalysis` would make bare
+        // `Diagnostic`/`SyntaxKind` bind by import order.
+        Assert.DoesNotContain("import Microsoft.", printed, StringComparison.Ordinal);
+
+        var tree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree.Parse(
+            GSharp.Core.CodeAnalysis.Text.SourceText.From(printed, "harness.gs"));
+        Assert.True(
+            tree.Diagnostics.IsEmpty,
+            "Translated harness should parse cleanly:\n"
+                + string.Join("\n", tree.Diagnostics.Select(d => d.Message)) + "\n---\n" + printed);
+
+        string[] referencePaths =
+        {
+            typeof(GSharp.Core.CodeAnalysis.Diagnostic).Assembly.Location,
+            typeof(GSharp.CodeAnalysis.Analyzers.Testing.GSharpAnalyzerVerifier).Assembly.Location,
+        };
+        using var resolver = GSharp.Core.CodeAnalysis.Symbols.ReferenceResolver.WithRuntimeReferences(referencePaths);
+        var compilation = new GSharp.Core.CodeAnalysis.Compilation.Compilation(resolver, tree)
+        {
+            IsLibrary = true,
+        };
+        var errors = compilation.GlobalScope.Diagnostics
+            .Concat(compilation.BoundProgram.Diagnostics)
+            .Where(d => d.IsError)
+            .ToList();
+        Assert.True(
+            errors.Count == 0,
+            "Translated harness should bind against GSharp.Core and the verifier:\n"
+                + string.Join("\n", errors.Select(d => d.Message)) + "\n---\n" + printed);
+    }
+
+    private static XDocument TransformPair(string testProjectXml)
+    {
+        string root = Path.Combine(Path.GetTempPath(), "cs2gs-3686-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            string analyzerDirectory = Path.Combine(root, "Analyzer");
+            string testDirectory = Path.Combine(root, "Analyzer.Tests");
+            Directory.CreateDirectory(analyzerDirectory);
+            Directory.CreateDirectory(testDirectory);
+
+            File.WriteAllText(
+                Path.Combine(analyzerDirectory, "Analyzer.csproj"),
+                @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+  </PropertyGroup>
+</Project>");
+
+            string testProjectPath = Path.Combine(testDirectory, "Analyzer.Tests.csproj");
+            File.WriteAllText(testProjectPath, testProjectXml);
+
+            return Cs2Gs.Pipeline.GSharpProjectTransformer.Transform(
+                testProjectPath,
+                testDirectory,
+                "Gsharp.NET.Sdk/1.0.0",
+                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/packages.lock.json
+++ b/tools/cs2gs/Cs2Gs.Tests/packages.lock.json
@@ -299,6 +299,13 @@
           "xunit.extensibility.core": "[2.9.2]"
         }
       },
+      "gsharp.codeanalysis.analyzers.testing": {
+        "type": "Project",
+        "dependencies": {
+          "GSharp.Core": "[1.0.0, )",
+          "Microsoft.VisualStudio.Validation": "[17.8.8, )"
+        }
+      },
       "GSharp.Core": {
         "type": "Project",
         "dependencies": {

--- a/tools/cs2gs/Cs2Gs.Translator/Analyzers/AnalyzerProjectDetector.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/Analyzers/AnalyzerProjectDetector.cs
@@ -2,6 +2,7 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using System;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -43,6 +44,75 @@ public static class AnalyzerProjectDetector
             .OfType<INamedTypeSymbol>()
             .Any(type => DerivesFrom(type, analyzerBase));
     }
+
+    /// <summary>
+    /// Determines whether <paramref name="compilation"/> is the TEST project
+    /// of an analyzer project (ADR-0169 M5, issue #3686): it declares no
+    /// analyzer of its own, but instantiates one that lives in a referenced
+    /// first-party assembly. Without this, the two halves of one project pair
+    /// are translated against different analyzer APIs — the analyzer becomes a
+    /// <c>GSharpDiagnosticAnalyzer</c> while its tests keep Roslyn's
+    /// <c>DiagnosticAnalyzer</c> contract, and the migrated call sites fail
+    /// with GS0154.
+    /// </summary>
+    /// <remarks>
+    /// The probe is deliberately narrow: an <c>new SomeAnalyzer()</c> in
+    /// source, where the created type derives from
+    /// <c>DiagnosticAnalyzer</c> and comes from an assembly OTHER than this
+    /// compilation's own and other than Roslyn itself. Instantiation is the
+    /// load-bearing shape — a test that verifies an analyzer must construct
+    /// one — and merely *referencing* Roslyn (as most tooling projects here
+    /// do) must not flip a project into analyzer mode, because that mode
+    /// rewrites every Microsoft.CodeAnalysis use in the project.
+    /// </remarks>
+    /// <param name="compilation">The bound C# compilation.</param>
+    /// <returns>True when analyzer translation mode should be enabled.</returns>
+    public static bool IsAnalyzerTestProject(CSharpCompilation compilation)
+    {
+        if (compilation?.GetTypeByMetadataName(DiagnosticAnalyzerMetadataName) is not { } analyzerBase)
+        {
+            return false;
+        }
+
+        if (IsAnalyzerProject(compilation))
+        {
+            return false;
+        }
+
+        foreach (SyntaxTree tree in compilation.SyntaxTrees)
+        {
+            SemanticModel model = compilation.GetSemanticModel(tree);
+            foreach (Microsoft.CodeAnalysis.CSharp.Syntax.BaseObjectCreationExpressionSyntax creation in
+                tree.GetRoot().DescendantNodes()
+                    .OfType<Microsoft.CodeAnalysis.CSharp.Syntax.BaseObjectCreationExpressionSyntax>())
+            {
+                if (model.GetTypeInfo(creation).Type is not INamedTypeSymbol created)
+                {
+                    continue;
+                }
+
+                if (!DerivesFrom(created, analyzerBase))
+                {
+                    continue;
+                }
+
+                IAssemblySymbol declaring = created.ContainingAssembly;
+                if (declaring is null
+                    || SymbolEqualityComparer.Default.Equals(declaring, compilation.Assembly)
+                    || IsRoslynAssembly(declaring))
+                {
+                    continue;
+                }
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsRoslynAssembly(IAssemblySymbol assembly)
+        => assembly.Name.StartsWith("Microsoft.CodeAnalysis", StringComparison.Ordinal);
 
     private static bool DerivesFrom(INamedTypeSymbol type, INamedTypeSymbol candidateBase)
     {

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Analyzers.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Analyzers.cs
@@ -24,6 +24,12 @@ public sealed partial class CSharpToGSharpTranslator
 {
     private sealed partial class DeclarationVisitor
     {
+        /// <summary>
+        /// The G# namespace holding the ADR-0169 verifier package that a
+        /// migrated Roslyn analyzer test harness delegates to.
+        /// </summary>
+        private const string AnalyzerVerifierNamespace = "GSharp.CodeAnalysis.Analyzers.Testing";
+
         private bool InAnalyzerApiMode => this.typeMapper.AnalyzerApiMode;
 
         private static string RoslynTypeMetadataName(INamedTypeSymbol type)
@@ -935,6 +941,153 @@ public sealed partial class CSharpToGSharpTranslator
             this.typeMapper.TrackSubstitutedNamespace("GSharp.Core.CodeAnalysis.Analyzers");
             result = new AttributeUse("GSharpDiagnosticAnalyzer", System.Array.Empty<AttributeArgument>(), target: null);
             return true;
+        }
+
+        /// <summary>
+        /// Recognizes the entry point of a Roslyn analyzer TEST harness
+        /// (ADR-0169 M5, issue #3686): a static method that takes an analyzer
+        /// and a source string, i.e. the repo's
+        /// <c>AnalyzerTestHelper.AssertDiagnosticsAsync</c> shape.
+        /// </summary>
+        /// <remarks>
+        /// The harness body is the one place where a statement-by-statement
+        /// translation would be WRONG rather than merely hard. It builds a
+        /// Roslyn <c>CSharpCompilation</c> over metadata references pulled from
+        /// <c>TRUSTED_PLATFORM_ASSEMBLIES</c> and drives it with Roslyn's
+        /// analyzer driver — a pipeline whose G# counterpart takes NO metadata
+        /// references at all, so the faithful translation of
+        /// <c>GetReferences()</c> is deletion, not mapping. Translating each
+        /// call in isolation would reimplement, inside the migrated test
+        /// project, the marker-stripping and assertion logic that
+        /// <c>GSharpAnalyzerVerifier</c> already owns and tests. The rewrite
+        /// therefore replaces the whole body with a delegation to that
+        /// verifier, keeping the harness's own signature — so every call site
+        /// in the migrated tests is untouched — and reports the substitution as
+        /// a shape adaptation.
+        /// </remarks>
+        /// <param name="symbol">The method being translated.</param>
+        /// <returns>True when this method is the harness entry point.</returns>
+        private bool IsAnalyzerHarnessEntry(IMethodSymbol symbol)
+            => this.InAnalyzerApiMode
+               && symbol is { IsStatic: true }
+               && symbol.Parameters.Length >= 2
+               && DerivesFromDiagnosticAnalyzer(symbol.Parameters[0].Type)
+               && symbol.Parameters[1].Type.SpecialType == SpecialType.System_String;
+
+        /// <summary>
+        /// True when <paramref name="method"/> is private plumbing that exists
+        /// only to serve the harness entry point rewritten above — so once the
+        /// body is a one-line delegation, the member is dead code that would
+        /// still drag unmapped Roslyn types (<c>MetadataReference</c>) into the
+        /// migrated project. Members used from anywhere else are kept.
+        /// </summary>
+        /// <param name="method">The candidate support method.</param>
+        /// <returns>True when the member must not be emitted.</returns>
+        private bool IsAnalyzerHarnessSupportMember(MethodDeclarationSyntax method)
+        {
+            if (!this.InAnalyzerApiMode
+                || this.context.GetDeclaredSymbol(method) is not IMethodSymbol symbol
+                || !symbol.IsStatic
+                || symbol.DeclaredAccessibility != Accessibility.Private
+                || method.Parent is not TypeDeclarationSyntax owner)
+            {
+                return false;
+            }
+
+            var entries = owner.Members
+                .OfType<MethodDeclarationSyntax>()
+                .Where(candidate => this.context.GetDeclaredSymbol(candidate) is IMethodSymbol candidateSymbol
+                    && this.IsAnalyzerHarnessEntry(candidateSymbol))
+                .ToList();
+            if (entries.Count == 0)
+            {
+                return false;
+            }
+
+            var uses = owner.DescendantNodes()
+                .OfType<InvocationExpressionSyntax>()
+                .Where(invocation => SymbolEqualityComparer.Default.Equals(
+                    this.context.GetSymbolInfo(invocation).Symbol?.OriginalDefinition,
+                    symbol))
+                .ToList();
+
+            return uses.Count > 0
+                && uses.All(use => entries.Any(entry => entry.Span.Contains(use.Span)));
+        }
+
+        /// <summary>
+        /// Builds the delegating body for the harness entry point:
+        /// <c>GSharpAnalyzerVerifier.VerifyAnalyzer(analyzer, source, ids)</c>,
+        /// followed by <c>return Task.CompletedTask</c> when the harness kept
+        /// its Task-returning shape (so the migrated <c>[Fact]</c> methods,
+        /// which <c>return</c> the harness call, need no rewrite of their own).
+        /// </summary>
+        /// <param name="symbol">The harness method.</param>
+        /// <param name="parameters">Its already-mapped G# parameters.</param>
+        /// <param name="site">The syntax node to attribute the shape warning to.</param>
+        /// <param name="body">The synthesized body.</param>
+        /// <returns>True when a body was synthesized.</returns>
+        private bool TryBuildAnalyzerHarnessBody(
+            IMethodSymbol symbol,
+            IReadOnlyList<Parameter> parameters,
+            SyntaxNode site,
+            out BlockStatement body)
+        {
+            body = null;
+            if (!this.IsAnalyzerHarnessEntry(symbol) || parameters.Count < 2)
+            {
+                return false;
+            }
+
+            this.typeMapper.TrackSubstitutedNamespace(AnalyzerVerifierNamespace);
+
+            var call = new InvocationExpression(
+                new MemberAccessExpression(
+                    new IdentifierExpression("GSharpAnalyzerVerifier"),
+                    "VerifyAnalyzer"),
+                parameters.Select(parameter => (GExpression)new IdentifierExpression(parameter.Name)).ToList());
+
+            var statements = new List<GStatement> { new ExpressionStatement(call) };
+            if (ReturnsTask(symbol))
+            {
+                statements.Add(new ReturnStatement(
+                    new MemberAccessExpression(new IdentifierExpression("Task"), "CompletedTask")));
+            }
+
+            body = new BlockStatement(statements);
+            string message = $"analyzer test harness '{symbol.Name}' rewritten to delegate to "
+                + $"{AnalyzerVerifierNamespace}.GSharpAnalyzerVerifier.VerifyAnalyzer: the Roslyn compilation "
+                + "pipeline it drove (CSharpCompilation over TRUSTED_PLATFORM_ASSEMBLIES metadata references) "
+                + "has no G# counterpart — the G# verifier compiles G# source with no reference set. The "
+                + "harness signature and every call site are preserved; verify the expected diagnostic "
+                + "locations still hold over the TRANSLATED snippets (ADR-0169 M5, issue #3686).";
+            this.context.Report(new TranslationDiagnostic(
+                "analyzer-api",
+                message,
+                site.GetLocation(),
+                TranslationSeverity.Warning)
+            {
+                DiagnosticId = "CS2GS-ANALYZER-SHAPE",
+            });
+            return true;
+        }
+
+        private static bool ReturnsTask(IMethodSymbol symbol)
+            => symbol.ReturnType is INamedTypeSymbol { Name: "Task" } returnType
+               && returnType.ContainingNamespace?.ToDisplayString() == "System.Threading.Tasks";
+
+        private static bool DerivesFromDiagnosticAnalyzer(ITypeSymbol type)
+        {
+            for (ITypeSymbol current = type; current is not null; current = current.BaseType)
+            {
+                if (current is INamedTypeSymbol named
+                    && RoslynTypeMetadataName(named) == AnalyzerProjectDetector.DiagnosticAnalyzerMetadataName)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private void ReportAnalyzerShapeIfAdapted(

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
@@ -63,6 +63,16 @@ public sealed partial class CSharpToGSharpTranslator
                         break;
                     }
 
+                    // ADR-0169 M5 / issue #3686: private plumbing of a Roslyn
+                    // analyzer test harness whose body is being replaced by a
+                    // delegation to the G# verifier is dead code that would
+                    // otherwise drag unmapped Roslyn types into the migrated
+                    // project (MetadataReference, CSharpCompilationOptions).
+                    if (this.IsAnalyzerHarnessSupportMember(method))
+                    {
+                        break;
+                    }
+
                     (GMember methodMember, bool methodIsStatic) = this.TranslateMethod(
                         method,
                         ownerKind,
@@ -1328,7 +1338,24 @@ public sealed partial class CSharpToGSharpTranslator
 
             bool hasBody = node.Body != null || node.ExpressionBody != null;
             BlockStatement body;
+            bool isAnalyzerHarness = false;
             if (hasBody
+                && this.TryBuildAnalyzerHarnessBody(symbol, parameters, node, out BlockStatement harnessBody))
+            {
+                body = harnessBody;
+                isAnalyzerHarness = true;
+
+                // The C# harness was `async Task`, which G# spells as an
+                // `async func` with NO declared return type (the modifier
+                // synthesizes the envelope). The rewrite drops `async`, so the
+                // Task envelope has to come back explicitly — the migrated
+                // [Fact] methods `return` this call.
+                if (returnType is null && ReturnsTask(symbol))
+                {
+                    returnType = this.typeMapper.Map(symbol.ReturnType, this.context, node.GetLocation());
+                }
+            }
+            else if (hasBody
                 && forceExtensionReceiver
                 && RequiresOwnerScopedExtension(symbol))
             {
@@ -1462,6 +1489,11 @@ public sealed partial class CSharpToGSharpTranslator
                 ? Visibility.Default
                 : MapVisibility(symbol, this.context, node);
 
+            // A rewritten analyzer test harness (#3686) delegates to the
+            // synchronous G# verifier: there is nothing left to await, and an
+            // `async` func returning `Task` cannot `return` a value.
+            bool isEmittedAsync = !isAsyncVoidHandler && !isAnalyzerHarness && symbol != null && symbol.IsAsync;
+
             var method = new MethodDeclaration(
                 this.EmittedName(symbol, node.Identifier.ValueText),
                 parameters: parameters,
@@ -1472,7 +1504,7 @@ public sealed partial class CSharpToGSharpTranslator
                 visibility: explicitInterfaceVisibility,
                 isOpen: isOpen,
                 isOverride: isOverride,
-                isAsync: !isAsyncVoidHandler && symbol != null && symbol.IsAsync,
+                isAsync: isEmittedAsync,
                 attributes: this.MapAttributes(node.AttributeLists),
                 expressionBody: arrowBody,
                 explicitInterfaceType: explicitInterfaceType,


### PR DESCRIPTION
Part of #3501. Closes the harness half of ADR-0169 **M5** (#3686); the snippet half is filed separately (see below).

## The wall

`AnalyzerProjectDetector.IsAnalyzerProject` asked "does this project **declare** an analyzer". `src/Analyzers/InternalAnalyzers` does, so it translated onto `GSharpDiagnosticAnalyzer`. `test/InternalAnalyzers.Tests` does not, so it translated in ordinary mode and kept Roslyn's `DiagnosticAnalyzer` contract verbatim — including a migrated helper that still built a real `CSharpCompilation` and drove Roslyn's analyzer driver over **C#** snippets. Every migrated call site then failed `GS0154`. The two halves of one project pair were translated against two different analyzer APIs.

## Shape decision

The alternative — keep a Roslyn-shaped harness and teach it about `GSharpDiagnosticAnalyzer` — cannot work: Roslyn's driver cannot run a G# analyzer (different API, over G# syntax/bound nodes) and Roslyn cannot parse G# source. Any version of it ends up being the G# driver behind a Roslyn name.

A statement-by-statement translation of the harness body was rejected too. The body pulls metadata references out of `TRUSTED_PLATFORM_ASSEMBLIES`; the G# verifier takes **no** references at all, so the faithful translation of `GetReferences()` is *deletion*, not mapping — and mapping the rest one call at a time would reimplement, inside the migrated test project, the marker-stripping and assertion logic `GSharpAnalyzerVerifier` already owns and tests.

So: **the framework owns the verifier, and cs2gs rewrites the harness body to delegate to it.** The harness keeps its signature, so no call site changes; the substitution is reported as `CS2GS-ANALYZER-SHAPE`, never silent.

## What is in this PR

- **Framework** — `GSharpAnalyzerVerifier` gains a non-generic, instance-based `VerifyAnalyzer(analyzer, markedSource, ids…)`. A migrated harness holds an analyzer *value* with no type parameter to bind, which the static generic `new()`-constrained form cannot receive. Hand-written G# analyzer tests keep the generic form. (ADR-0169 amended.)
- **Detection** — `AnalyzerProjectDetector.IsAnalyzerTestProject`: a project that *instantiates* an analyzer declared in a referenced, non-Roslyn assembly. Deliberately narrow — analyzer mode rewrites every `Microsoft.CodeAnalysis` use in a project, so merely referencing Roslyn (cs2gs itself does) must not flip it. Guarded by a test.
- **Harness rewrite** — `IsAnalyzerHarnessEntry` / `TryBuildAnalyzerHarnessBody`, plus a scoped sweep of private members that existed only to serve the rewritten body.
- **Project transform** — recognizes an analyzer's test project structurally (a `ProjectReference` to an analyzer project that is *not* an `OutputItemType="Analyzer"` consumer reference — src/Core is the counter-example, and has its own test) and injects `GSharp.Core` + the verifier assembly, both **copied**: a test assembly is loaded by the test host, not by gsc. The verifier ships beside gsc so the SDK and direct compile paths both resolve it.

Migrated output:

```
internal class AnalyzerTestHelper {
    shared {
        func AssertDiagnosticsAsync(analyzer GSharpDiagnosticAnalyzer, source string, diagnosticIds ...string) Task {
            GSharpAnalyzerVerifier.VerifyAnalyzer(analyzer, source, diagnosticIds)
            return Task.CompletedTask
        }
    }
}
```

## Measurement — `test/InternalAnalyzers.Tests`

Same targeted 2-app migration, same gsc/SDK build, before at `origin/main` (39e988b3) and after:

| | translate | compile | ilverify | test-parity |
|---|---|---|---|---|
| before | PASS | **FAIL** — 16 `GS0154` (3 fingerprints) | skip | skip |
| after | PASS | **PASS** | **PASS** | FAIL (snippets) |

## What is NOT fixed, and how it fails

Snippet translation. `SnippetTranslator` exists and is unit-tested, but nothing dispatches it during a migration, so the migrated tests still hand **C# snippets** to the G# verifier. All 16 fail — **loudly**, with the verifier's "the test source does not compile" report listing `GS0005` on `public class`/`struct`, not silently passing. Filed as a follow-up with the two shapes that make it more than plumbing (the source arrives via a `const string` local, and several tests compose it with `+`, so the unit to translate is the concatenation, which cannot then be split back).

## Test evidence

7 new cs2gs tests + 3 new framework tests, all executing.

Failing-on-`origin/main` proof, one axis at a time:

- Revert **only** the harness rewrite → exactly `HarnessBody_DelegatesToTheGsharpVerifier_AndBindsAgainstGsCore` and `HarnessSupportMemberUsedElsewhere_IsKept` fail; the other 5 pass.
- Revert **only** the project transform → exactly `AnalyzerTestProject_GetsCoreAndVerifierReferences_Copied` fails; the other 6 pass.

Honest labelling: `AnalyzerConsumerProject_IsNotTreatedAsATestProject` and `ProjectThatOnlyUsesRoslyn_IsNotAnAnalyzerTestProject` pass on main too — they are regression guards on the widened detection, not proof of the fix. The detector tests cannot be run against main at all (`IsAnalyzerTestProject` does not exist there), so their proof is the app-level before/after above.

`HarnessBody_…AndBindsAgainstGsCore` binds the printed G# against the real `GSharp.Core` and the real verifier assembly, so a delegation to a signature that does not exist fails the test rather than the migration — and it holds #3767's invariant that no translated analyzer imports a `Microsoft.` namespace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs