### PR TITLE
gsc: a variadic carrier accepts an argument typed from CLR metadata (GS0266, #3779)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Candidates.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Candidates.cs
@@ -1185,9 +1185,11 @@ internal sealed partial class OverloadResolver
 
             // A single trailing argument already typed as the slice itself is a
             // pass-through (`f(existingSlice)`); accept it as-is.
+            var carrierType = candidate.Parameters[candidate.Parameters.Length - 1].Type;
             var isSlicePassThrough = argumentCount - tailStart == 1
                 && tailStart < boundArguments.Count
-                && boundArguments[tailStart]?.Type == candidate.Parameters[candidate.Parameters.Length - 1].Type;
+                && boundArguments[tailStart]?.Type is { } passThroughArgumentType
+                && IsVariadicCarrierPassThrough(passThroughArgumentType, carrierType);
 
             if (!isSlicePassThrough && !(elementType is TypeParameterSymbol))
             {
@@ -1221,6 +1223,42 @@ internal sealed partial class OverloadResolver
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// True when a single trailing argument already IS the variadic carrier
+    /// (`f(existingSlice)`), so the call binds in NORMAL form and the
+    /// per-element tail check must not run.
+    /// </summary>
+    /// <remarks>
+    /// This was a <c>==</c> test on the two <see cref="TypeSymbol"/>s. Neither
+    /// <see cref="TypeSymbol"/> nor <see cref="Symbol"/> declares an
+    /// <c>operator ==</c>, so that is REFERENCE identity — it only ever
+    /// succeeded when the argument's type symbol was literally the same
+    /// instance as the parameter's. The <c>[]string</c> a carrier is declared
+    /// with and the <c>string[]</c> read back from CLR metadata denote the same
+    /// runtime type but are built on different paths, so
+    /// `f(Environment.GetCommandLineArgs())` failed the pass-through test, fell
+    /// into the element loop, failed `string[] -> string`, and the candidate was
+    /// dropped as non-convertible. When EVERY candidate is dropped the caller
+    /// keeps the unfiltered set and ranks it, so two variadic siblings tie and
+    /// the call is reported ambiguous (GS0266) instead of binding.
+    /// Classify the conversion instead: an identity or implicit conversion to
+    /// the carrier is exactly what "the argument already is the carrier" means,
+    /// and it is the same test the final argument coercion applies.
+    /// </remarks>
+    /// <param name="argumentType">The single trailing argument's type.</param>
+    /// <param name="carrierType">The candidate's variadic carrier parameter type.</param>
+    /// <returns><see langword="true"/> when the argument binds as the carrier itself.</returns>
+    private static bool IsVariadicCarrierPassThrough(TypeSymbol argumentType, TypeSymbol carrierType)
+    {
+        if (ReferenceEquals(argumentType, carrierType))
+        {
+            return true;
+        }
+
+        var conversion = Conversion.Classify(argumentType, carrierType);
+        return conversion.Exists && (conversion.IsIdentity || conversion.IsImplicit);
     }
 
     private bool IsContextuallyApplicableAsyncLambda(

--- a/test/Core.Tests/CodeAnalysis/Issue3779MetadataArgumentVariadicOverloadTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Issue3779MetadataArgumentVariadicOverloadTests.cs
@@ -1,0 +1,164 @@
+// <copyright file="Issue3779MetadataArgumentVariadicOverloadTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis;
+
+/// <summary>
+/// Issue #3779: two variadic overloads that differ only by a leading fixed
+/// parameter tied (GS0266) whenever the single argument's type came from CLR
+/// METADATA — an imported member's return type — rather than from source.
+/// <para>The #1493 variadic-tail applicability check asked whether the argument
+/// already IS the carrier with <c>==</c> on two <see cref="TypeSymbol"/>s.
+/// Neither <c>TypeSymbol</c> nor <c>Symbol</c> declares an <c>operator ==</c>,
+/// so that is REFERENCE identity: the <c>[]string</c> a carrier is declared
+/// with and the <c>string[]</c> read back from metadata denote the same runtime
+/// type but are two different symbol instances. The pass-through went
+/// undetected, the candidate fell into the per-element loop, failed
+/// <c>string[] -&gt; string</c>, and was dropped as non-convertible — and when
+/// EVERY candidate is dropped the resolver deliberately keeps the unfiltered
+/// set and ranks it, so the two variadic siblings tied.</para>
+/// <para>These tests EXECUTE the emitted program: the interesting part is not
+/// merely that the call binds but that it binds in NORMAL form (the array is
+/// passed through) rather than expanded form (the array wrapped as a single
+/// element), which only running can tell apart.</para>
+/// </summary>
+public class Issue3779MetadataArgumentVariadicOverloadTests
+{
+    /// <summary>
+    /// The migrated <c>TranslationTestValidation.AssertBinds</c> shape, reduced:
+    /// a variadic overload pair where the argument is a local inferred from an
+    /// imported member's return type. Fails on <c>origin/main</c> with GS0266.
+    /// </summary>
+    [Fact]
+    public void VariadicOverloadPair_ArgumentTypedByImportedMember_BindsInNormalForm()
+    {
+        var source = @"
+import System
+
+class Holder {}
+
+func Count(sources ...string) int32 { return sources.Length }
+func Count(references Holder?, sources ...string) int32 { return -1 }
+
+func run() int32 {
+    // The type of `three` comes from CLR metadata (Environment.GetCommandLineArgs),
+    // not from a source-written []string. On main this made both candidates
+    // non-convertible and the call ambiguous.
+    let three = Environment.GetCommandLineArgs()
+    let passedThrough = Count(three)
+
+    // Normal form: the array is the carrier, so the count is the array's own
+    // length, NOT 1. Expanded form would wrap it as a single element.
+    if passedThrough != three.Length {
+        return -10
+    }
+
+    // Expanded form still works for genuine element arguments.
+    if Count(""x"", ""y"") != 2 {
+        return -20
+    }
+
+    // The two-parameter sibling is still reachable (it also tied on main).
+    if Count(nil, three) != -1 {
+        return -30
+    }
+
+    return 1
+}
+
+run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(1, result.Value);
+    }
+
+    /// <summary>
+    /// The same defect reached through an imported GENERIC member
+    /// (<c>Enumerable.ToArray</c>) — the exact expression the migrated
+    /// <c>Cs2Gs.Tests</c> call sites use. Fails on <c>origin/main</c>.
+    /// </summary>
+    [Fact]
+    public void VariadicOverloadPair_ArgumentTypedByImportedGenericMember_BindsInNormalForm()
+    {
+        var source = @"
+import System
+import System.Linq
+
+class Holder {}
+
+func Join(sources ...string) string { return string.Join(""|"", sources) }
+func Join(references Holder?, sources ...string) string { return ""two-param"" }
+
+func run() string {
+    let docs []string = []string{""a"", ""b"", ""c""}
+    let printed = docs.Select((d string) -> d.ToUpperInvariant()).ToArray()
+    return Join(printed)
+}
+
+run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal("A|B|C", result.Value);
+    }
+
+    /// <summary>
+    /// Anti-vacuity guard: this one PASSES on <c>origin/main</c> and must keep
+    /// passing. A single variadic candidate given an argument that genuinely
+    /// does not fit its only fixed parameter must still be rejected — the fix
+    /// widens a pass-through test, and must not make inapplicable overloads
+    /// applicable.
+    /// </summary>
+    [Fact]
+    public void SingleCandidate_MetadataArgumentAgainstUnrelatedFixedParameter_StillRejected()
+    {
+        var source = @"
+import System
+
+class Holder {}
+
+func Only(references Holder?, sources ...string) int32 { return -1 }
+
+func run() int32 {
+    let three = Environment.GetCommandLineArgs()
+    return Only(three)
+}
+
+run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.IsError && d.Id == "GS0154");
+    }
+
+    /// <summary>
+    /// Anti-vacuity guard: this one PASSES on <c>origin/main</c> too. The
+    /// source-written carrier spelling was never broken, and the fix must not
+    /// disturb it.
+    /// </summary>
+    [Fact]
+    public void VariadicOverloadPair_SourceDeclaredArgument_StillBindsInNormalForm()
+    {
+        var source = @"
+class Holder {}
+
+func Count(sources ...string) int32 { return sources.Length }
+func Count(references Holder?, sources ...string) int32 { return -1 }
+
+func run() int32 {
+    let docs []string = []string{""a"", ""b"", ""c""}
+    return Count(docs)
+}
+
+run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(3, result.Value);
+    }
+}


### PR DESCRIPTION
Closes #3779. Found triaging the migrated `tools/cs2gs/Cs2Gs.Tests` compile wall
for #3501, where this accounts for 5 of the app's substantive errors through the
`TranslationTestValidation.AssertBinds` overload pair.

## The bug

Two variadic overloads that differ only by a leading fixed parameter were
reported ambiguous (GS0266) whenever the single argument's type came from **CLR
metadata** — an imported member's return type — rather than from source.

```gs
func Count(sources ...string) int32 { return sources.Length }
func Count(references Holder?, sources ...string) int32 { return -1 }

let three = Environment.GetCommandLineArgs()   // metadata string[]
Count(three)                                   // GS0266 on main
```

## Root cause

The #1493 variadic-tail applicability check asked whether the argument already
IS the carrier with `==` on two `TypeSymbol`s. Neither `TypeSymbol` nor `Symbol`
declares an `operator ==`, so that is **reference identity**: the `[]string` a
carrier is declared with and the `string[]` read back from metadata denote the
same runtime type but are two different symbol instances.

The pass-through therefore went undetected, the candidate fell into the
per-element loop, failed `string[] -> string`, and was dropped as
non-convertible. The two-parameter sibling is (correctly) dropped too — and when
**every** candidate is dropped the resolver deliberately keeps the unfiltered set
and ranks it, so the two variadic siblings tie.

Instrumenting `IsConvertibilityApplicable` on `origin/main` shows both candidates
rejected, and the two spellings of the one type:

```
[trace] cand=Count([]string)         convertible=False argTypes=string[]
[trace] cand=Count(Holder?,[]string) convertible=False argTypes=string[]
```

## The fix

Classify the conversion instead of comparing references. An identity or implicit
conversion to the carrier is exactly what "the argument already is the carrier"
means, and it is the same test the final argument coercion applies.

## Why the discriminator is metadata-vs-source, not genericity

One axis at a time, on `origin/main`:

| argument expression | main |
|---|---|
| `let x []string = []string{"a"}` (source-declared) | binds |
| `let x = []string{"a"}` (inferred from an array literal) | binds |
| `let x = Make()`, `Make() []string` source-declared | binds |
| `let x []string = Environment.GetCommandLineArgs()` (annotated) | binds |
| `let x = Environment.GetCommandLineArgs()` (imported, non-generic) | **GS0266** |
| `let x = docs.ToArray()` (imported generic) | **GS0266** |

An ordinary imported *non-generic* member reproduces it, so this is not the
imported-generic-inference family. The conversion machinery itself was never
wrong (`var h Holder? = Environment.GetCommandLineArgs()` correctly reports
GS0155), and each overload **alone** already behaved correctly — the 1-parameter
one binds, the 2-parameter one correctly reports GS0154. Only the pair tied.

## Tests

The tests **execute** the emitted program, because the interesting property is
not that the call binds but that it binds in **normal** form — the array passed
through, not wrapped as a single element. Binding-only assertions cannot tell
those apart.

```
Count(three)      => 3    (normal form; expanded form would give 1)
Count("x","y")    => 2    (expanded form still works)
Count(nil, three) => -1   (2-param sibling still reachable; also tied on main)
```

Honest labelling of the four tests:

| test | on `origin/main` | with fix |
|---|---|---|
| `..._ArgumentTypedByImportedMember_BindsInNormalForm` | **fails** (GS0266) | passes |
| `..._ArgumentTypedByImportedGenericMember_BindsInNormalForm` | **fails** (GS0266) | passes |
| `SingleCandidate_...StillRejected` | passes | passes — anti-vacuity: an inapplicable overload must still report GS0154 |
| `..._SourceDeclaredArgument_StillBindsInNormalForm` | passes | passes — anti-vacuity: the never-broken spelling must not regress |

Failing-on-main proof, with the fix reverted and the test files kept:

```
Failed VariadicOverloadPair_ArgumentTypedByImportedMember_BindsInNormalForm
Failed VariadicOverloadPair_ArgumentTypedByImportedGenericMember_BindsInNormalForm
Failed!  - Failed: 2, Passed: 2, Skipped: 0, Total: 4
```

`test/Core.Tests` is green with the fix: **8563 passed, 0 failed** (8559 before
these four).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
