### PR TITLE
cs2gs: make the migrated mirror a repository, not a bag of projects (#3772)

### DIFF
--- a/build/selfmig-common.sh
+++ b/build/selfmig-common.sh
@@ -18,7 +18,11 @@
 # permanently-C# extension via linked sources. Gsharp.Extensions is excluded
 # because it is ALREADY G# (all-.gs sources bootstrapped by the latest
 # compiler without a gsproj) — there is nothing to migrate, and feeding its
-# .gs sources through the C# parser only produces phantom gaps.
+# .gs sources through the C# parser only produces phantom gaps. Excluded from
+# TRANSLATION is not excluded from the MIRROR: issue #3772 keeps its .csproj in
+# the migrated tree (with references retargeted), because its .gs sources are
+# mirrored verbatim and four migrated projects — Extensions.Tests,
+# Compiler.Tests, Interpreter.Tests and Repl — project-reference it.
 #
 # INVARIANT (issue #3668): --exclude is NOT a sharding mechanism. Excluding a
 # project that another app project-references breaks reference resolution and

--- a/docs/adr/0115-csharp-to-gsharp-migration-tool.md
+++ b/docs/adr/0115-csharp-to-gsharp-migration-tool.md
@@ -34,8 +34,11 @@ Build `cs2gs` as a **Roslyn-based, offline, deterministic** translator feeding a
 `cs2gs migrate` produces a maintainable repository mirror by default. The
 destination preserves repository-relative directories and non-C# files,
 translates each checked-in `.cs` to the corresponding `.gs`, transforms each
-`.csproj` to a same-location `.gsproj`, and replaces `.sln` files with `.slnx`
-while preserving project coverage. Literal Nerdbank.GitVersioning versions
+`.csproj` to a same-location `.gsproj`, and mirrors each `.sln` under its own
+name with a `.slnx` conversion beside it, all while preserving project coverage
+(issue #3772: the mirror is a repository, so code in it that walks up to a
+repository root named `GSharp.sln` finds one, and a project excluded from
+translation because it has nothing to translate keeps its project file). Literal Nerdbank.GitVersioning versions
 below the G#-compatible `3.11.13-beta` floor are upgraded in transformed
 projects and shared MSBuild props. Validation still runs through the four-stage
 pipeline, but logs, triage records, reports, and build intermediates are written

--- a/tools/cs2gs/Cs2Gs.Pipeline/GSharpProjectTransformer.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/GSharpProjectTransformer.cs
@@ -210,6 +210,16 @@ internal static class GSharpProjectTransformer
                 Path.Combine(sourceProjectDirectory, NormalizeDirectorySeparators(include.Value)));
             if (!generatedProjectPaths.TryGetValue(sourceReferencePath, out string generatedProjectPath))
             {
+                // Issue #3772: the run translated no project here, so the mirror
+                // carries the ORIGINAL project (when it had nothing to
+                // translate) or nothing at all. Either way its output is not
+                // this project's reference: the pinned SDK already supplies the
+                // assembly, and taking a second copy from the mirrored build
+                // hands gsc two assemblies with one identity (GS9200). Keep the
+                // reference so the project still gets BUILT — repository code
+                // looks for the built assembly on disk — and drop only its
+                // contribution to the reference set.
+                projectReference.SetAttributeValue("ReferenceOutputAssembly", "false");
                 continue;
             }
 

--- a/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs
@@ -192,6 +192,9 @@ public sealed class MigrationPipeline
                     SanitizeAppId(app.Id),
                     Path.GetFileNameWithoutExtension(app.ProjectPath) + ".gsproj"),
             StringComparer.OrdinalIgnoreCase);
+        RepositoryExcludedScope excludedScope = repositoryLayout
+            ? RepositoryExcludedScope.Compute(this.options.SourceRoot, this.options.ExcludedProjectPaths)
+            : null;
         if (repositoryLayout)
         {
             string sdkMoniker = SdkCompileRunner.ResolveSdkMoniker(this.options.Config);
@@ -214,6 +217,19 @@ public sealed class MigrationPipeline
                 transformed.Save(
                     generatedProjectPath,
                     System.Xml.Linq.SaveOptions.DisableFormatting);
+            }
+
+            // Issue #3772: an excluded project with nothing to translate still
+            // belongs in the mirror — dropping only its project file leaves a
+            // half project its consumers cannot reference.
+            foreach (string mirroredProject in RepositoryMirror.MirrorExcludedProjects(
+                this.options.SourceRoot,
+                destinationRoot,
+                repositoryFiles,
+                excludedScope,
+                this.options.GeneratedProjectPaths))
+            {
+                this.options.RepositoryAdditionalFiles.Add(mirroredProject);
             }
 
             var loadedProjects = new Dictionary<string, LoadedCSharpProject>(StringComparer.OrdinalIgnoreCase);
@@ -266,9 +282,6 @@ public sealed class MigrationPipeline
 
         if (repositoryLayout)
         {
-            RepositoryExcludedScope excludedScope = RepositoryExcludedScope.Compute(
-                this.options.SourceRoot,
-                this.options.ExcludedProjectPaths);
             if (runResult.Succeeded)
             {
                 // Issue #3580: an orphan-mirror failure marks the run failed

--- a/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs
@@ -227,7 +227,8 @@ public sealed class MigrationPipeline
                 destinationRoot,
                 repositoryFiles,
                 excludedScope,
-                this.options.GeneratedProjectPaths))
+                this.options.GeneratedProjectPaths,
+                sdkMoniker))
             {
                 this.options.RepositoryAdditionalFiles.Add(mirroredProject);
             }

--- a/tools/cs2gs/Cs2Gs.Pipeline/RepositoryMirror.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/RepositoryMirror.cs
@@ -71,13 +71,15 @@ internal static class RepositoryMirror
     /// <param name="sourceFiles">The repository inventory, relative to <paramref name="sourceRoot"/>.</param>
     /// <param name="excludedScope">The run's excluded scope.</param>
     /// <param name="generatedProjectPaths">Source project path to generated project path.</param>
+    /// <param name="sdkMoniker">The pinned <c>Gsharp.NET.Sdk</c> moniker every mirrored project builds with.</param>
     /// <returns>The mirror-relative paths of the project files written.</returns>
     internal static IReadOnlyList<string> MirrorExcludedProjects(
         string sourceRoot,
         string destinationRoot,
         IReadOnlyList<string> sourceFiles,
         RepositoryExcludedScope excludedScope,
-        IReadOnlyDictionary<string, string> generatedProjectPaths)
+        IReadOnlyDictionary<string, string> generatedProjectPaths,
+        string sdkMoniker)
     {
         excludedScope ??= RepositoryExcludedScope.None;
         string source = Path.GetFullPath(sourceRoot);
@@ -117,6 +119,7 @@ internal static class RepositoryMirror
                 Path.Combine(source, path.Replace('/', Path.DirectorySeparatorChar)),
                 LoadOptions.PreserveWhitespace);
             RetargetProjectReferences(project, source, destination, path, generatedProjectPaths);
+            RebindToPinnedSdk(project, sdkMoniker);
             project.Save(target, SaveOptions.DisableFormatting);
             written.Add(path.Replace('/', Path.DirectorySeparatorChar));
         }
@@ -274,6 +277,61 @@ internal static class RepositoryMirror
                 include.Value = Path.GetRelativePath(destinationDirectory, generated)
                     .Replace('\\', '/');
             }
+        }
+    }
+
+    /// <summary>
+    /// Rebinds a mirrored project onto the pinned <c>Gsharp.NET.Sdk</c>, the way
+    /// every other project in the mirror is built.
+    /// </summary>
+    /// <remarks>
+    /// The one project this applies to today, <c>src/Sdk/Gsharp.Extensions</c>,
+    /// is built in the source repository by the BOOTSTRAP SDK: it resolves
+    /// <c>gsc.dll</c> and the build task out of <c>out/bin/&lt;cfg&gt;/</c> at
+    /// project-evaluation time, which exists there only because the repo build
+    /// orders the compiler first. A mirror has no such ordering — the shards
+    /// build one app each on a clean runner — so the bootstrap's
+    /// <c>UsingTask</c> condition is false and the build dies with MSB4036
+    /// before anything is compiled. The mirror does not need the bootstrap at
+    /// all: it exists to break a cycle (an assembly cannot reference itself
+    /// while being built) that a PINNED SDK package does not have. Rebinding
+    /// costs the toolchain-only project references, which are exactly the
+    /// bootstrap's build-ordering arrows.
+    /// </remarks>
+    private static void RebindToPinnedSdk(XDocument project, string sdkMoniker)
+    {
+        if (string.IsNullOrEmpty(sdkMoniker) || project.Root is null)
+        {
+            return;
+        }
+
+        if (project.Root.Attribute("Sdk") is not null)
+        {
+            return;
+        }
+
+        // The Sdk ATTRIBUTE, not <Import Sdk="…"/>: only the attribute form
+        // carries a "Name/Version" moniker, and the mirror has to pin the exact
+        // package it built the rest of the tree against.
+        project.Root.SetAttributeValue("Sdk", sdkMoniker);
+
+        foreach (XElement import in project.Root.Descendants()
+            .Where(element => element.Name.LocalName.Equals("Import", StringComparison.OrdinalIgnoreCase))
+            .ToList())
+        {
+            import.Remove();
+        }
+
+        foreach (XElement reference in project.Root.Descendants()
+            .Where(element =>
+                element.Name.LocalName.Equals("ProjectReference", StringComparison.OrdinalIgnoreCase)
+                && string.Equals(
+                    element.Attribute("ReferenceOutputAssembly")?.Value?.Trim(),
+                    "false",
+                    StringComparison.OrdinalIgnoreCase))
+            .ToList())
+        {
+            reference.Remove();
         }
     }
 

--- a/tools/cs2gs/Cs2Gs.Pipeline/RepositoryMirror.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/RepositoryMirror.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Xml.Linq;
 using Cs2Gs.Translator.Loading;
 
 namespace Cs2Gs.Pipeline;
@@ -42,6 +43,87 @@ internal static class RepositoryMirror
         return files;
     }
 
+    /// <summary>
+    /// Issue #3772: mirrors the project files of excluded projects that have
+    /// nothing to translate.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="Prepare"/> skips every <c>.csproj</c> because the translated
+    /// <c>.gsproj</c> normally replaces it. For a project the run excluded
+    /// there is no <c>.gsproj</c>, so the mirror ends up with the project's
+    /// directory but no project — a half project. That is fine when the
+    /// sources are missing too (they were <c>.cs</c> files nobody translated),
+    /// but wrong when they are all still there, which is the case for a
+    /// project excluded because it is ALREADY G# (<c>src/Sdk/Gsharp.Extensions</c>):
+    /// the mirror carries its complete <c>.gs</c> source set and drops only the
+    /// file that makes it buildable, breaking every consumer that references it.
+    /// </para>
+    /// <para>
+    /// The rule is therefore "the mirror never contains a half project": an
+    /// excluded project whose sources are all mirrored verbatim (it declares no
+    /// <c>.cs</c> file under its own directory) keeps its project file, with
+    /// project references retargeted to the generated projects.
+    /// </para>
+    /// </remarks>
+    /// <param name="sourceRoot">The repository source root.</param>
+    /// <param name="destinationRoot">The mirror root.</param>
+    /// <param name="sourceFiles">The repository inventory, relative to <paramref name="sourceRoot"/>.</param>
+    /// <param name="excludedScope">The run's excluded scope.</param>
+    /// <param name="generatedProjectPaths">Source project path to generated project path.</param>
+    /// <returns>The mirror-relative paths of the project files written.</returns>
+    internal static IReadOnlyList<string> MirrorExcludedProjects(
+        string sourceRoot,
+        string destinationRoot,
+        IReadOnlyList<string> sourceFiles,
+        RepositoryExcludedScope excludedScope,
+        IReadOnlyDictionary<string, string> generatedProjectPaths)
+    {
+        excludedScope ??= RepositoryExcludedScope.None;
+        string source = Path.GetFullPath(sourceRoot);
+        string destination = Path.GetFullPath(destinationRoot);
+
+        var csharpSourceDirectories = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (string path in sourceFiles)
+        {
+            if (Path.GetExtension(path).Equals(".cs", StringComparison.OrdinalIgnoreCase))
+            {
+                string directory = DirectoryOf(path);
+                while (directory.Length > 0)
+                {
+                    if (!csharpSourceDirectories.Add(directory))
+                    {
+                        break;
+                    }
+
+                    directory = DirectoryOf(directory);
+                }
+            }
+        }
+
+        var written = new List<string>();
+        foreach (string path in sourceFiles)
+        {
+            if (!Path.GetExtension(path).Equals(".csproj", StringComparison.OrdinalIgnoreCase)
+                || !excludedScope.IsExcluded(path)
+                || csharpSourceDirectories.Contains(DirectoryOf(path)))
+            {
+                continue;
+            }
+
+            string target = Path.Combine(destination, path.Replace('/', Path.DirectorySeparatorChar));
+            Directory.CreateDirectory(Path.GetDirectoryName(target));
+            XDocument project = XDocument.Load(
+                Path.Combine(source, path.Replace('/', Path.DirectorySeparatorChar)),
+                LoadOptions.PreserveWhitespace);
+            RetargetProjectReferences(project, source, destination, path, generatedProjectPaths);
+            project.Save(target, SaveOptions.DisableFormatting);
+            written.Add(path.Replace('/', Path.DirectorySeparatorChar));
+        }
+
+        return written;
+    }
+
     internal static void ValidateCompleted(
         string sourceRoot,
         string destinationRoot,
@@ -65,7 +147,7 @@ internal static class RepositoryMirror
                         || extension.Equals(".csproj", StringComparison.OrdinalIgnoreCase);
                     return !translated || !excludedScope.IsExcluded(path);
                 })
-                .Select(DestinationRelativePath),
+                .SelectMany(DestinationRelativePaths),
             StringComparer.OrdinalIgnoreCase);
         if (additionalFiles is not null)
         {
@@ -137,14 +219,61 @@ internal static class RepositoryMirror
         var destinations = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         foreach (string source in files)
         {
-            string destination = DestinationRelativePath(source);
-            if (destinations.TryGetValue(destination, out string prior))
+            foreach (string destination in DestinationRelativePaths(source))
             {
-                throw new InvalidOperationException(
-                    $"Migration output collision: '{prior}' and '{source}' both map to '{destination}'.");
+                if (destinations.TryGetValue(destination, out string prior))
+                {
+                    throw new InvalidOperationException(
+                        $"Migration output collision: '{prior}' and '{source}' both map to '{destination}'.");
+                }
+
+                destinations[destination] = source;
+            }
+        }
+    }
+
+    private static string DirectoryOf(string relativePath)
+    {
+        int separator = relativePath.LastIndexOfAny(new[] { '/', Path.DirectorySeparatorChar });
+        return separator < 0 ? string.Empty : relativePath.Substring(0, separator);
+    }
+
+    private static void RetargetProjectReferences(
+        XDocument project,
+        string sourceRoot,
+        string destinationRoot,
+        string relativeProjectPath,
+        IReadOnlyDictionary<string, string> generatedProjectPaths)
+    {
+        if (generatedProjectPaths is null || generatedProjectPaths.Count == 0)
+        {
+            return;
+        }
+
+        string sourceDirectory = Path.GetDirectoryName(
+            Path.Combine(sourceRoot, relativeProjectPath.Replace('/', Path.DirectorySeparatorChar)));
+        string destinationDirectory = Path.GetDirectoryName(
+            Path.Combine(destinationRoot, relativeProjectPath.Replace('/', Path.DirectorySeparatorChar)));
+
+        foreach (XElement reference in project.Descendants()
+            .Where(element => element.Name.LocalName.Equals("ProjectReference", StringComparison.OrdinalIgnoreCase))
+            .ToList())
+        {
+            XAttribute include = reference.Attribute("Include");
+            if (include is null || include.Value.Contains("$(", StringComparison.Ordinal))
+            {
+                continue;
             }
 
-            destinations[destination] = source;
+            string referenced = Path.GetFullPath(Path.Combine(
+                sourceDirectory,
+                include.Value.Replace('\\', Path.DirectorySeparatorChar)
+                    .Replace('/', Path.DirectorySeparatorChar)));
+            if (generatedProjectPaths.TryGetValue(referenced, out string generated))
+            {
+                include.Value = Path.GetRelativePath(destinationDirectory, generated)
+                    .Replace('\\', '/');
+            }
         }
     }
 
@@ -165,25 +294,34 @@ internal static class RepositoryMirror
         File.Copy(source, destination);
     }
 
-    private static string DestinationRelativePath(string source)
+    // A legacy `.sln` produces TWO mirrored files, not a rename: the solution
+    // keeps its own name (issue #3772 — the repository's own sources anchor
+    // the repository root by that file name, so renaming it makes the mirror
+    // internally inconsistent) and the `.slnx` conversion is emitted beside it
+    // because only the XML format can type-tag a `.gsproj`.
+    private static IEnumerable<string> DestinationRelativePaths(string source)
     {
         string extension = Path.GetExtension(source);
         if (extension.Equals(".cs", StringComparison.OrdinalIgnoreCase))
         {
-            return Path.ChangeExtension(source, ".gs");
+            yield return Path.ChangeExtension(source, ".gs");
+            yield break;
         }
 
         if (extension.Equals(".csproj", StringComparison.OrdinalIgnoreCase))
         {
-            return Path.ChangeExtension(source, ".gsproj");
+            yield return Path.ChangeExtension(source, ".gsproj");
+            yield break;
         }
 
         if (extension.Equals(".sln", StringComparison.OrdinalIgnoreCase))
         {
-            return Path.ChangeExtension(source, ".slnx");
+            yield return source;
+            yield return Path.ChangeExtension(source, ".slnx");
+            yield break;
         }
 
-        return source;
+        yield return source;
     }
 
     private static bool IsUnderDirectory(string path, string directory)

--- a/tools/cs2gs/Cs2Gs.Pipeline/RepositorySolutionGenerator.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/RepositorySolutionGenerator.cs
@@ -73,18 +73,26 @@ public static class RepositorySolutionGenerator
             projectMapping,
             fullSourceRoot,
             fullDestinationRoot);
-        List<(string SourcePath, string RelativeDestinationPath)> plans =
-            DiscoverSolutions(fullSourceRoot, sourceFiles)
-                .Select(sourcePath =>
-                {
-                    string relativePath = Path.GetRelativePath(fullSourceRoot, sourcePath);
-                    string relativeDestinationPath =
-                        Path.GetExtension(sourcePath).Equals(".sln", StringComparison.OrdinalIgnoreCase)
-                            ? Path.ChangeExtension(relativePath, ".slnx")
-                            : relativePath;
-                    return (sourcePath, relativeDestinationPath);
-                })
-                .ToList();
+
+        // Issue #3772: a legacy `.sln` is MIRRORED as well as converted. The
+        // repository's own sources anchor the repository root by the solution's
+        // file name, so a mirror that renames GSharp.sln to GSharp.slnx is not
+        // the same repository; the `.slnx` conversion is emitted beside it
+        // because only the XML format can type-tag a `.gsproj`.
+        var plans = new List<(string SourcePath, string RelativeDestinationPath)>();
+        foreach (string sourcePath in DiscoverSolutions(fullSourceRoot, sourceFiles))
+        {
+            string relativePath = Path.GetRelativePath(fullSourceRoot, sourcePath);
+            if (Path.GetExtension(sourcePath).Equals(".sln", StringComparison.OrdinalIgnoreCase))
+            {
+                plans.Add((sourcePath, relativePath));
+                plans.Add((sourcePath, Path.ChangeExtension(relativePath, ".slnx")));
+            }
+            else
+            {
+                plans.Add((sourcePath, relativePath));
+            }
+        }
 
         DetectDestinationCollisions(plans);
 
@@ -110,7 +118,11 @@ public static class RepositorySolutionGenerator
             string destinationDirectory = Path.GetDirectoryName(destinationPath);
             Directory.CreateDirectory(destinationDirectory);
 
-            if (Path.GetExtension(sourcePath).Equals(".sln", StringComparison.OrdinalIgnoreCase))
+            if (Path.GetExtension(destinationPath).Equals(".sln", StringComparison.OrdinalIgnoreCase))
+            {
+                MirrorLegacySolution(sourcePath, destinationPath, canonicalMapping);
+            }
+            else if (Path.GetExtension(sourcePath).Equals(".sln", StringComparison.OrdinalIgnoreCase))
             {
                 ConvertLegacySolution(sourcePath, destinationPath, canonicalMapping);
             }
@@ -224,6 +236,62 @@ public static class RepositorySolutionGenerator
 
             destinations.Add(relativeDestinationPath, sourcePath);
         }
+    }
+
+    /// <summary>
+    /// Copies a legacy <c>.sln</c> to the mirror under its own name, retargeting
+    /// its project paths at the generated projects and leaving every other byte —
+    /// GUIDs, folders, configuration blocks — exactly as authored.
+    /// </summary>
+    private static void MirrorLegacySolution(
+        string sourceSolutionPath,
+        string destinationPath,
+        IReadOnlyDictionary<string, string> projectMapping)
+    {
+        string sourceSolutionDirectory = Path.GetDirectoryName(Path.GetFullPath(sourceSolutionPath));
+        string destinationDirectory = Path.GetDirectoryName(Path.GetFullPath(destinationPath));
+        string[] lines = File.ReadAllLines(sourceSolutionPath);
+
+        for (int index = 0; index < lines.Length; index++)
+        {
+            string line = lines[index];
+            if (!line.StartsWith("Project(", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            // Project("{type-guid}") = "Name", "relative\path.csproj", "{guid}"
+            // The path is the fourth quoted field; solution folders name a
+            // folder there instead of a file, and simply never match the map.
+            List<int> quotes = new List<int>();
+            for (int position = 0; position < line.Length; position++)
+            {
+                if (line[position] == '"')
+                {
+                    quotes.Add(position);
+                }
+            }
+
+            if (quotes.Count < 6)
+            {
+                continue;
+            }
+
+            int start = quotes[4] + 1;
+            int length = quotes[5] - start;
+            string projectPath = line.Substring(start, length);
+            string canonicalSourceProject = CanonicalizePath(projectPath, sourceSolutionDirectory);
+            if (!projectMapping.TryGetValue(canonicalSourceProject, out string generatedProject))
+            {
+                continue;
+            }
+
+            string mirrored = Path.GetRelativePath(destinationDirectory, generatedProject)
+                .Replace('/', '\\');
+            lines[index] = line.Substring(0, start) + mirrored + line.Substring(quotes[5]);
+        }
+
+        File.WriteAllLines(destinationPath, lines);
     }
 
     private static void ConvertLegacySolution(

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3772MirrorFidelityTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3772MirrorFidelityTests.cs
@@ -1,0 +1,206 @@
+// <copyright file="Issue3772MirrorFidelityTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3772: the migrated tree is a repository, not a bag of projects. Code
+/// in the mirror probes the repository layout it was written against — the
+/// solution that names the repository root, and the projects its own project
+/// files reference — so the mirror has to reproduce both.
+/// </summary>
+public sealed class Issue3772MirrorFidelityTests : IDisposable
+{
+    private readonly string root;
+
+    /// <summary>Initializes a new isolated test directory.</summary>
+    public Issue3772MirrorFidelityTests()
+    {
+        this.root = Path.Combine(
+            Path.GetTempPath(),
+            "issue-3772-mirror-fidelity",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(this.root);
+    }
+
+    /// <summary>Removes the isolated test directory.</summary>
+    public void Dispose()
+    {
+        Directory.Delete(this.root, recursive: true);
+    }
+
+    /// <summary>
+    /// An excluded project with nothing to translate keeps its project file, so
+    /// the mirror never holds a project directory without its project.
+    /// </summary>
+    [Fact]
+    public void MirrorExcludedProjects_AlreadyGsharpProject_IsMirroredWithRetargetedReferences()
+    {
+        string source = Path.Combine(this.root, "source");
+        string destination = Path.Combine(this.root, "destination");
+        string extensionsDirectory = Path.Combine(source, "src", "Sdk", "Gsharp.Extensions");
+        Directory.CreateDirectory(extensionsDirectory);
+        Directory.CreateDirectory(Path.Combine(source, "src", "Compiler"));
+        File.WriteAllText(Path.Combine(source, "src", "Compiler", "Compiler.csproj"), "<Project />");
+        File.WriteAllText(Path.Combine(extensionsDirectory, "Optional.gs"), "func none() {}");
+        File.WriteAllText(
+            Path.Combine(extensionsDirectory, "Gsharp.Extensions.csproj"),
+            """
+            <Project>
+              <!-- keep me -->
+              <ItemGroup>
+                <ProjectReference Include="..\..\Compiler\Compiler.csproj" />
+              </ItemGroup>
+            </Project>
+            """);
+
+        var scope = ExcludedScope(source, Path.Combine(extensionsDirectory, "Gsharp.Extensions.csproj"));
+        IReadOnlyList<string> written = RepositoryMirror.MirrorExcludedProjects(
+            source,
+            destination,
+            new[]
+            {
+                "src/Compiler/Compiler.csproj",
+                "src/Sdk/Gsharp.Extensions/Gsharp.Extensions.csproj",
+                "src/Sdk/Gsharp.Extensions/Optional.gs",
+            },
+            scope,
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [Path.Combine(source, "src", "Compiler", "Compiler.csproj")] =
+                    Path.Combine(destination, "src", "Compiler", "Compiler.gsproj"),
+            });
+
+        Assert.Equal(
+            new[] { Path.Combine("src", "Sdk", "Gsharp.Extensions", "Gsharp.Extensions.csproj") },
+            written.ToArray());
+        string mirrored = Path.Combine(
+            destination, "src", "Sdk", "Gsharp.Extensions", "Gsharp.Extensions.csproj");
+        XDocument document = XDocument.Load(mirrored, LoadOptions.PreserveWhitespace);
+        Assert.Equal(
+            "../../Compiler/Compiler.gsproj",
+            document.Descendants("ProjectReference").Single().Attribute("Include").Value);
+        Assert.Contains("keep me", File.ReadAllText(mirrored), StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// An excluded project whose C# sources were left untranslated stays out of
+    /// the mirror: mirroring it would produce a project with no sources.
+    /// </summary>
+    [Fact]
+    public void MirrorExcludedProjects_ProjectWithCSharpSources_IsNotMirrored()
+    {
+        string source = Path.Combine(this.root, "source");
+        string destination = Path.Combine(this.root, "destination");
+        string extensionDirectory = Path.Combine(source, "src", "vs-gsharp", "src", "VsGsharp");
+        Directory.CreateDirectory(extensionDirectory);
+        File.WriteAllText(Path.Combine(extensionDirectory, "VsGsharp.csproj"), "<Project />");
+        File.WriteAllText(Path.Combine(extensionDirectory, "Package.cs"), "class Package {}");
+
+        var scope = ExcludedScope(source, Path.Combine(extensionDirectory, "VsGsharp.csproj"));
+        IReadOnlyList<string> written = RepositoryMirror.MirrorExcludedProjects(
+            source,
+            destination,
+            new[]
+            {
+                "src/vs-gsharp/src/VsGsharp/Package.cs",
+                "src/vs-gsharp/src/VsGsharp/VsGsharp.csproj",
+            },
+            scope,
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
+
+        Assert.Empty(written);
+    }
+
+    /// <summary>
+    /// A legacy solution is mirrored under its own name — the file name the
+    /// repository's own sources use to find the repository root — with its
+    /// project paths retargeted, and the buildable `.slnx` lands beside it.
+    /// </summary>
+    [Fact]
+    public void Generate_LegacySolution_MirrorsSlnAndEmitsSlnx()
+    {
+        string source = Path.Combine(this.root, "source");
+        string destination = Path.Combine(this.root, "destination");
+        Directory.CreateDirectory(Path.Combine(source, "src", "App"));
+        string sourceProject = Path.Combine(source, "src", "App", "App.csproj");
+        File.WriteAllText(
+            sourceProject,
+            "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup>" +
+            "<TargetFramework>net10.0</TargetFramework></PropertyGroup></Project>");
+        File.WriteAllText(
+            Path.Combine(source, "Product.sln"),
+            """
+            Microsoft Visual Studio Solution File, Format Version 12.00
+            Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "App", "src\App\App.csproj", "{2E0F0D1B-5E52-4A2A-9C7C-1E5B0F6A7B31}"
+            EndProject
+            Global
+            	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+            		Debug|Any CPU = Debug|Any CPU
+            	EndGlobalSection
+            	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+            		{2E0F0D1B-5E52-4A2A-9C7C-1E5B0F6A7B31}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+            	EndGlobalSection
+            EndGlobal
+
+            """);
+
+        IReadOnlyList<string> written = RepositorySolutionGenerator.Generate(
+            source,
+            destination,
+            new Dictionary<string, string>
+            {
+                [sourceProject] = Path.Combine(destination, "src", "App", "App.gsproj"),
+            });
+
+        string mirroredSln = Path.Combine(destination, "Product.sln");
+        string convertedSlnx = Path.Combine(destination, "Product.slnx");
+        Assert.Equal(
+            new[] { mirroredSln, convertedSlnx }.OrderBy(path => path, StringComparer.Ordinal).ToArray(),
+            written.OrderBy(path => path, StringComparer.Ordinal).ToArray());
+
+        string legacy = File.ReadAllText(mirroredSln);
+        Assert.Contains(@"""src\App\App.gsproj""", legacy, StringComparison.Ordinal);
+        Assert.DoesNotContain("App.csproj", legacy, StringComparison.Ordinal);
+        Assert.Contains("{2E0F0D1B-5E52-4A2A-9C7C-1E5B0F6A7B31}", legacy, StringComparison.Ordinal);
+        Assert.Contains("GlobalSection(ProjectConfigurationPlatforms)", legacy, StringComparison.Ordinal);
+
+        Assert.Equal(
+            "src/App/App.gsproj",
+            XDocument.Load(convertedSlnx).Descendants("Project").Single().Attribute("Path").Value);
+    }
+
+    /// <summary>
+    /// The completeness contract expects both mirrored solution files, so a
+    /// mirror that reproduces the repository's own layout validates clean.
+    /// </summary>
+    [Fact]
+    public void ValidateCompleted_MirroredSlnAndSlnx_AreBothExpected()
+    {
+        string source = Path.Combine(this.root, "source");
+        string destination = Path.Combine(this.root, "destination");
+        Directory.CreateDirectory(source);
+        Directory.CreateDirectory(destination);
+        File.WriteAllText(Path.Combine(destination, "Product.sln"), "legacy");
+        File.WriteAllText(Path.Combine(destination, "Product.slnx"), "<Solution />");
+
+        RepositoryMirror.ValidateCompleted(source, destination, new[] { "Product.sln" });
+
+        File.Delete(Path.Combine(destination, "Product.sln"));
+        InvalidOperationException missing = Assert.Throws<InvalidOperationException>(
+            () => RepositoryMirror.ValidateCompleted(source, destination, new[] { "Product.sln" }));
+        Assert.Contains("Product.sln", missing.Message, StringComparison.Ordinal);
+    }
+
+    private static RepositoryExcludedScope ExcludedScope(string sourceRoot, string excludedProject) =>
+        RepositoryExcludedScope.Compute(sourceRoot, new[] { excludedProject });
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3772MirrorFidelityTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3772MirrorFidelityTests.cs
@@ -57,9 +57,15 @@ public sealed class Issue3772MirrorFidelityTests : IDisposable
             """
             <Project>
               <!-- keep me -->
+              <PropertyGroup>
+                <AssemblyName>Gsharp.Extensions</AssemblyName>
+              </PropertyGroup>
               <ItemGroup>
                 <ProjectReference Include="..\..\Compiler\Compiler.csproj" />
+                <ProjectReference Include="..\Gsharp.NET.Sdk\Gsharp.NET.Sdk.csproj" ReferenceOutputAssembly="false" />
               </ItemGroup>
+              <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
+              <Import Project="..\Gsharp.NET.Sdk.Bootstrap\build\Gsharp.NET.Sdk.Bootstrap.targets" />
             </Project>
             """);
 
@@ -78,7 +84,8 @@ public sealed class Issue3772MirrorFidelityTests : IDisposable
             {
                 [Path.Combine(source, "src", "Compiler", "Compiler.csproj")] =
                     Path.Combine(destination, "src", "Compiler", "Compiler.gsproj"),
-            });
+            },
+            "Gsharp.NET.Sdk/9.9.9-test");
 
         Assert.Equal(
             new[] { Path.Combine("src", "Sdk", "Gsharp.Extensions", "Gsharp.Extensions.csproj") },
@@ -90,6 +97,14 @@ public sealed class Issue3772MirrorFidelityTests : IDisposable
             "../../Compiler/Compiler.gsproj",
             document.Descendants("ProjectReference").Single().Attribute("Include").Value);
         Assert.Contains("keep me", File.ReadAllText(mirrored), StringComparison.Ordinal);
+
+        // Rebound onto the pinned SDK: no bootstrap imports and none of the
+        // bootstrap's toolchain-only build-ordering references.
+        Assert.Equal("Gsharp.NET.Sdk/9.9.9-test", document.Root.Attribute("Sdk").Value);
+        Assert.Empty(document.Descendants("Import"));
+        Assert.Equal(
+            "Gsharp.Extensions",
+            document.Descendants("AssemblyName").Single().Value);
     }
 
     /// <summary>
@@ -116,7 +131,8 @@ public sealed class Issue3772MirrorFidelityTests : IDisposable
                 "src/vs-gsharp/src/VsGsharp/VsGsharp.csproj",
             },
             scope,
-            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            "Gsharp.NET.Sdk/9.9.9-test");
 
         Assert.Empty(written);
     }

--- a/tools/cs2gs/README.md
+++ b/tools/cs2gs/README.md
@@ -86,8 +86,13 @@ repository's own sources anchor the repository root by that file name — and th
 type-tag a `.gsproj`. A project `--exclude` removed from the run keeps its
 project file too when it has no `.cs` sources of its own (it was already G#, so
 the mirror carries its complete source set); dropping it would leave a project
-directory whose consumers reference a project that is not there. As a
-compatibility rewrite, literal
+directory whose consumers reference a project that is not there. Such a project
+is rebound onto the same pinned `Gsharp.NET.Sdk` as every other mirrored
+project — a mirror has no in-tree bootstrap toolchain to resolve — and a
+`ProjectReference` the run did not translate becomes
+`ReferenceOutputAssembly="false"`: the reference exists to get the project
+BUILT, while the assembly the consumer compiles against comes from the SDK. As
+a compatibility rewrite, literal
 Nerdbank.GitVersioning versions below `3.11.13-beta` are upgraded in projects
 and shared MSBuild props. Build outputs, logs, triage records,
 `run.json`, `report.html`, and `summary.json` stay outside the destination under

--- a/tools/cs2gs/README.md
+++ b/tools/cs2gs/README.md
@@ -78,8 +78,16 @@ dotnet out/bin/Release/Cs2Gs.Cli/cs2gs.dll migrate \
 | `--translate-only` | Repository mode: run stage 1 only, then stop (see `validate`). |
 
 Repository mode preserves relative directories, copies non-C# files, translates
-checked-in `.cs` files to `.gs`, transforms `.csproj` files to `.gsproj`, and
-replaces `.sln` files with `.slnx`. As a compatibility rewrite, literal
+checked-in `.cs` files to `.gs`, and transforms `.csproj` files to `.gsproj`.
+The mirror is a repository, not a bag of projects (issue #3772): every `.sln`
+is mirrored under its own name with its project paths retargeted — the
+repository's own sources anchor the repository root by that file name — and the
+`.slnx` conversion is written beside it, because only the XML format can
+type-tag a `.gsproj`. A project `--exclude` removed from the run keeps its
+project file too when it has no `.cs` sources of its own (it was already G#, so
+the mirror carries its complete source set); dropping it would leave a project
+directory whose consumers reference a project that is not there. As a
+compatibility rewrite, literal
 Nerdbank.GitVersioning versions below `3.11.13-beta` are upgraded in projects
 and shared MSBuild props. Build outputs, logs, triage records,
 `run.json`, `report.html`, and `summary.json` stay outside the destination under


### PR DESCRIPTION
Fixes the mirror-fidelity half of #3772 by making the migrated tree a **repository**, not a bag of projects. Neither of the two options that loosen the probe (accept `.slnx` in `LocateGsharpExtensionsAssembly`, or exclude the tests) is taken: the layout is fixed so the probe passes because the layout is right.

## Both causes, reproduced

A whole-repo migrate + `cs2gs validate --app test/Extensions.Tests/...` reproduces the gate's fingerprint `sha256:146ec6a1d0e9` exactly — `Failed: 2, Passed: 171, Total: 173`, both failures `Gsharp.Extensions.dll must be built before running this test`:

1. **No root anchor.** The mirror root had only `GSharp.slnx`. 37 files across `test/Core.Tests`, `test/Compiler.Tests`, `test/Interpreter.Tests`, `test/LanguageServer.Tests` and `test/Extensions.Tests` walk up looking for a file literally named `GSharp.sln`; in the mirror every one of them returns `null`. Most are masked today by apps that are red earlier.
2. **No project.** `RepositoryMirror.Prepare` skips every `.csproj` on the assumption that a translated `.gsproj` replaces it — false for an `--exclude`d project. `src/Sdk/Gsharp.Extensions` is excluded because it is *already G#*, so the mirror carried its complete `.gs` source set and dropped only the file that builds it, leaving four migrated projects (Extensions.Tests, Compiler.Tests, Interpreter.Tests, Repl) pointing a `ProjectReference` at a file that is not there.

## Fixed as rules, not as file names

- **Solutions are mirrored, not renamed.** Every `.sln` is now written to the mirror under its own name with its project paths retargeted at the generated projects, and the `.slnx` conversion lands beside it (only the XML format can type-tag a `.gsproj`). This also stops the `gsharp-xunit` template shipping a `.slnx` where it authored a `.sln`.
- **The mirror never contains a half project.** An excluded project with no `.cs` sources of its own — its sources are all mirrored verbatim — keeps its project file.
- **Every mirrored project builds with the pinned SDK.** The mirrored `Gsharp.Extensions` is rebound off the in-tree bootstrap (which resolves `gsc.dll` from `out/bin/<cfg>/` at *evaluation* time, a thing no clean shard runner has) onto the same `Gsharp.NET.Sdk` moniker as every other mirrored project.
- **An untranslated `ProjectReference` is a build-only reference.** `ReferenceOutputAssembly="false"`: its job in the mirror is to get the project built, while the assembly the consumer compiles against comes from the SDK. Without this, gsc sees two assemblies with one identity (GS9200).

## Before / after (whole-repo migrate, then `validate --app`)

| | `test/Extensions.Tests` | `src/Repl` |
|---|---|---|
| before | compile PASS, ilverify PASS, **test-parity FAIL** — `146ec6a1d0e9`, 2/173 failed, *"Gsharp.Extensions.dll must be built before running this test"* | PASS/PASS/PASS |
| after | compile PASS, ilverify PASS, **test-parity FAIL** — 2/173 failed, `error GS9998: NullReferenceException` from the migrated gsc | PASS/PASS/PASS |

The mirror now produces `out/bin/Release/Gsharp.Extensions/Gsharp.Extensions.dll` and the harness locates it: the assertion the two tests fail on is no longer the missing artifact, it is the compiler output. Repl — which project-references the same project and is in `greenApps` — stays green through the change.

## The fix unmasked a real defect

With the artifact present the two tests finally exercise the migrated compiler, and it fails where the C# compiler does not:

```
$ dotnet <mirror>/out/bin/Release/Compiler/gsc.dll /r:.../Gsharp.Extensions.dll snippet.gs
error GS9998: NullReferenceException: Object reference not set to an instance of an object.
$ dotnet out/bin/Release/Compiler/gsc.dll     /r:.../Gsharp.Extensions.dll snippet.gs
Wrote snippet2.dll
```

Same snippet, same reference assembly, opposite outcome — a silent runtime divergence in the same family as #3770/#3771, filed separately. `Extensions.Tests` therefore stays a `test-parity` failure, but for a real reason now rather than a missing build artifact.

## Baseline

No `greenFloor` or `greenApps` movement: the app was red before and is red after (for a different, genuine reason), Repl is unchanged, and no app is added to or removed from the corpus (`Gsharp.Extensions` is mirrored, not discovered).

## Tests

`Issue3772MirrorFidelityTests` (4) covers the mirrored `.sln` + `.slnx` pair, the completeness contract expecting both, the mirrored excluded project with its retargeted references and SDK rebind, and the excluded project with C# sources that must *not* be mirrored. `GSharpProjectTransformerTests`, `Issue2317ProjectReferenceTests`, `Adr0169AnalyzerProjectTransformTests`, `RepositoryMirrorTests`, `RepositorySolutionGeneratorTests`, `Issue3580OrphanMirrorRobustnessTests`, `Issue2868MirroredArtifactLayoutTests` all pass (41 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
