### PR TITLE
cs2gs: survey the whole graph in one polish build instead of one project per round (#3782)

### DIFF
--- a/src/Sdk/Gsharp.NET.Sdk.Bootstrap/build/Gsharp.NET.Sdk.Bootstrap.targets
+++ b/src/Sdk/Gsharp.NET.Sdk.Bootstrap/build/Gsharp.NET.Sdk.Bootstrap.targets
@@ -68,6 +68,7 @@
       <_GsharpCoreCompileInputsToHash Include="$(NoWarn)" />
       <_GsharpCoreCompileInputsToHash Include="$(TreatWarningsAsErrors)" />
       <_GsharpCoreCompileInputsToHash Include="$(WarningsAsErrors)" />
+      <_GsharpCoreCompileInputsToHash Include="$(WarningsNotAsErrors)" />
       <_GsharpCoreCompileInputsToHash Include="$(OutputType)" />
       <_GsharpCoreCompileInputsToHash Include="$(Optimize)" />
       <_GsharpCoreCompileInputsToHash Include="$(SourceLink)" />
@@ -131,6 +132,7 @@
         NoWarn="$(NoWarn)"
         TreatWarningsAsErrors="$(TreatWarningsAsErrors)"
         WarningsAsErrors="$(WarningsAsErrors)"
+        WarningsNotAsErrors="$(WarningsNotAsErrors)"
         Compile="@(Compile)"
         References="@(ReferencePathWithRefAssemblies)"
         ResponseFilePath="$(IntermediateOutputPath)$(TargetName).rsp" />

--- a/src/Sdk/Gsharp.NET.Sdk/BuildTask.cs
+++ b/src/Sdk/Gsharp.NET.Sdk/BuildTask.cs
@@ -105,6 +105,16 @@ public class BuildTask : Microsoft.Build.Utilities.Task, ICancelableTask
     /// <summary>Gets or sets the comma-separated list of diagnostic IDs to promote to errors (WarningsAsErrors MSBuild property).</summary>
     public string? WarningsAsErrors { get; set; }
 
+    /// <summary>
+    /// Gets or sets the comma-separated list of diagnostic IDs that stay
+    /// warnings even under <see cref="TreatWarningsAsErrors"/> — the standard
+    /// <c>WarningsNotAsErrors</c> MSBuild property, forwarded as
+    /// <c>gsc /warnaserror-:</c>. Issue #3782: cs2gs's redundant-<c>!!</c>
+    /// polish loop sets it to survey a whole project graph in one build
+    /// instead of one project per round.
+    /// </summary>
+    public string? WarningsNotAsErrors { get; set; }
+
     /// <summary>Gets or sets the Compile item group (the .gs sources).</summary>
     public ITaskItem[] Compile { get; set; } = Array.Empty<ITaskItem>();
 
@@ -230,6 +240,11 @@ public class BuildTask : Microsoft.Build.Utilities.Task, ICancelableTask
         if (string.Equals(this.TreatWarningsAsErrors, "true", StringComparison.OrdinalIgnoreCase))
         {
             args.Add("/warnaserror");
+        }
+
+        if (!string.IsNullOrEmpty(this.WarningsNotAsErrors))
+        {
+            args.Add($"/warnaserror-:{this.WarningsNotAsErrors}");
         }
 
         foreach (var r in this.References)

--- a/src/Sdk/Gsharp.NET.Sdk/build/Gsharp.NET.Core.Sdk.targets
+++ b/src/Sdk/Gsharp.NET.Sdk/build/Gsharp.NET.Core.Sdk.targets
@@ -207,6 +207,7 @@
       <_GsharpCoreCompileInputsToHash Include="$(NoWarn)" />
       <_GsharpCoreCompileInputsToHash Include="$(TreatWarningsAsErrors)" />
       <_GsharpCoreCompileInputsToHash Include="$(WarningsAsErrors)" />
+      <_GsharpCoreCompileInputsToHash Include="$(WarningsNotAsErrors)" />
       <_GsharpCoreCompileInputsToHash Include="$(OutputType)" />
       <_GsharpCoreCompileInputsToHash Include="$(TargetFramework)" />
       <_GsharpCoreCompileInputsToHash Include="$(Optimize)" />
@@ -522,6 +523,7 @@
         NoWarn="$(NoWarn)"
         TreatWarningsAsErrors="$(TreatWarningsAsErrors)"
         WarningsAsErrors="$(WarningsAsErrors)"
+        WarningsNotAsErrors="$(WarningsNotAsErrors)"
         Compile="@(Compile)"
         References="@(ReferencePathWithRefAssemblies)"
         GsAnalyzers="@(GsharpCodeAnalyzer)"

--- a/test/Sdk.Tests/Issue3782WarningsNotAsErrorsTests.cs
+++ b/test/Sdk.Tests/Issue3782WarningsNotAsErrorsTests.cs
@@ -1,0 +1,113 @@
+// <copyright file="Issue3782WarningsNotAsErrorsTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Gsharp.NET.Sdk.Tools;
+using Microsoft.Build.Utilities;
+using Xunit;
+
+namespace GSharp.Sdk.Tests;
+
+/// <summary>
+/// Issue #3782: <c>WarningsNotAsErrors</c> is the standard MSBuild property for
+/// "keep this id a warning even under <c>TreatWarningsAsErrors</c>", and gsc has
+/// always understood the switch it maps to (<c>/warnaserror-:</c>) — only the
+/// SDK never plumbed the two together. cs2gs's redundant-<c>!!</c> polish loop
+/// needs it: a warnings-as-errors build reports nothing past the first project
+/// it fails on, so without a way to demote GS0536 for a survey build the loop
+/// advances one project per round and cannot converge on a deep graph.
+/// </summary>
+public sealed class Issue3782WarningsNotAsErrorsTests : IDisposable
+{
+    private readonly DirectoryInfo root = Directory.CreateDirectory(
+        Path.Combine(Path.GetTempPath(), "gs-3782-" + Guid.NewGuid().ToString("N")));
+
+    [Fact]
+    public void BuildTask_ForwardsWarningsNotAsErrors_AsWarnAsErrorMinus()
+    {
+        string[] arguments = this.Arguments(warningsNotAsErrors: "GS0536");
+
+        Assert.Contains("/warnaserror", arguments);
+        Assert.Contains("/warnaserror-:GS0536", arguments);
+    }
+
+    [Fact]
+    public void BuildTask_OmitsTheSwitchWhenNothingIsDemoted()
+    {
+        string[] arguments = this.Arguments(warningsNotAsErrors: null);
+
+        Assert.Contains("/warnaserror", arguments);
+        Assert.DoesNotContain(arguments, a => a.StartsWith("/warnaserror-:", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("src/Sdk/Gsharp.NET.Sdk/build/Gsharp.NET.Core.Sdk.targets")]
+    [InlineData("src/Sdk/Gsharp.NET.Sdk.Bootstrap/build/Gsharp.NET.Sdk.Bootstrap.targets")]
+    public void Targets_PassTheProperty_AndHashItIntoTheCompileInputs(string relativePath)
+    {
+        XDocument targets = XDocument.Load(Path.Combine(RepoRoot(), relativePath));
+
+        // Passed to the task, or the switch never reaches gsc...
+        Assert.Contains(
+            targets.Descendants().Where(e => e.Name.LocalName == "BuildTask"),
+            task => (string)task.Attribute("WarningsNotAsErrors") == "$(WarningsNotAsErrors)");
+
+        // ...and hashed into the CoreCompile inputs, or toggling it between two
+        // builds of the same tree is a property-only change that MSBuild's
+        // up-to-date check skips (issue #1666) — the strict confirmation build
+        // would then silently reuse the survey build's output and report
+        // nothing at all.
+        Assert.Contains(
+            targets.Descendants().Where(e => e.Name.LocalName == "_GsharpCoreCompileInputsToHash"),
+            item => (string)item.Attribute("Include") == "$(WarningsNotAsErrors)");
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (this.root.Exists)
+        {
+            this.root.Delete(recursive: true);
+        }
+    }
+
+    private static string RepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "GSharp.sln")))
+        {
+            directory = directory.Parent;
+        }
+
+        Assert.NotNull(directory);
+        return directory!.FullName;
+    }
+
+    private string[] Arguments(string warningsNotAsErrors)
+    {
+        var task = new BuildTask
+        {
+            GsharpCompilerFullPath = "missing-gsc.dll",
+            OutputPath = ".",
+            OutputName = "Demote",
+            TempOutputPath = ".",
+            TargetFramework = "net10.0",
+            BasePath = this.root.FullName,
+            OutputType = "Library",
+            TreatWarningsAsErrors = "true",
+            WarningsNotAsErrors = warningsNotAsErrors,
+            Compile = new[] { new TaskItem("Program.gs") },
+            References = Array.Empty<TaskItem>(),
+            ResponseFilePath = Path.Combine(this.root.FullName, "demote.rsp"),
+            SkipCompilerExecution = "true",
+            ProvideCommandLineArgs = "true",
+        };
+
+        Assert.True(task.Execute());
+        return task.CommandLineArgs.Select(item => item.ItemSpec).ToArray();
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Pipeline/CompileStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/CompileStage.cs
@@ -67,14 +67,22 @@ public sealed class CompileStage : IMigrationStage
         if (context.Options.CompileViaSdk)
         {
             var runner = new SdkCompileRunner();
-            SdkCompileResult RunSdkCompile() =>
+
+            // Issue #3782: `survey` demotes GS0536 to a warning for this build
+            // only, so one compile walks the WHOLE project graph and reports
+            // every redundant `!!` in it. Without it a warnings-as-errors build
+            // stops at the first project holding one and the polish loop
+            // advances a single project per round. The gate's verdict always
+            // comes from a survey: false build.
+            SdkCompileResult RunSdkCompile(bool survey) =>
                 context.Options.OutputLayout == MigrationOutputLayout.Repository
                     ? runner.CompileMirroredProject(
                         context.App.ProjectPath,
                         context.Options.GeneratedProjectPaths[Path.GetFullPath(context.App.ProjectPath)],
                         context.ArtifactDir,
                         context.Options.Config,
-                        context.Options.GeneratedProjectPaths)
+                        context.Options.GeneratedProjectPaths,
+                        survey ? NullAssertionPolishPass.SurveyWarningsNotAsErrors : null)
                     : runner.Compile(
                         context.ProjectOutputDir,
                         Path.GetFileNameWithoutExtension(context.App.ProjectPath),
@@ -90,9 +98,10 @@ public sealed class CompileStage : IMigrationStage
                         context.ProjectReferences,
                         context.Options.GeneratedProjectPaths,
                         context.UsesCentralPackageManagement,
-                        assemblyName: context.AssemblyName);
+                        assemblyName: context.AssemblyName,
+                        warningsNotAsErrors: survey ? NullAssertionPolishPass.SurveyWarningsNotAsErrors : null);
 
-            SdkCompileResult sdkResult = RunSdkCompile();
+            SdkCompileResult sdkResult = RunSdkCompile(survey: false);
 
             // Issue #3501 (!! reduction): gsc reports GS0536 on every `!!`
             // whose operand is already non-null — the compiler's own
@@ -112,6 +121,14 @@ public sealed class CompileStage : IMigrationStage
             // whose own compile stage never ran can surface GS0536 in files
             // outside this app's emitted set — anything under the shared
             // output root is fair game for the polish.
+            //
+            // Issue #3782: raising the cap was the wrong lever — one round per
+            // project is a ~40-build bill for `tools/cs2gs/Cs2Gs.Tests` and its
+            // twelve-project graph, and it made the corpus-wide `!!` count
+            // depend on how the gate happened to pack its shards. The rounds
+            // after the first now SURVEY (GS0536 demoted to a warning) so a
+            // single build reports the whole graph at once; the loop then ends
+            // on a strict build, which is the verdict below.
             NullAssertionPolishPass.PolishLoopOutcome polish = NullAssertionPolishPass.RunToFixedPoint(
                 sdkResult,
                 RunSdkCompile,
@@ -270,7 +287,11 @@ public sealed class CompileStage : IMigrationStage
             return;
         }
 
+        // Issue #3782: `builds` is the cost the gate actually pays (the strip
+        // recompiles plus the closing strict confirmation); it stopped equalling
+        // `rounds` when survey mode landed, so both are recorded.
         string summary = $"polish rounds: {polish.Rounds} (cap {NullAssertionPolishPass.DefaultMaxRounds}), " +
+            $"polish builds: {polish.Builds}, " +
             $"assertions stripped: {polish.Stripped}, " +
             $"{NullAssertionPolishPass.DiagnosticId} still reported: {polish.RemainingReports}, " +
             $"cap exhausted: {polish.CapExhausted}";

--- a/tools/cs2gs/Cs2Gs.Pipeline/NullAssertionPolishPass.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/NullAssertionPolishPass.cs
@@ -24,14 +24,36 @@ public static class NullAssertionPolishPass
     public const string DiagnosticId = "GS0536";
 
     /// <summary>
-    /// Issue #3723: the round cap <see cref="RunToFixedPoint"/> stops at. One
-    /// round can only strip what the compile it followed actually reported,
-    /// and a compile reports nothing past the first project it fails on — so a
-    /// deep project graph spends one round per level before the app's own
-    /// sources are ever bound, and nested assertions (<c>a!!.b!!</c>) add
-    /// further generations on top of that. The cap only exists so a
-    /// pathological non-converging case cannot loop forever; hitting it is
-    /// reported, never silent.
+    /// The MSBuild property, and its value, that demotes <see cref="DiagnosticId"/>
+    /// back to a warning for the duration of a survey round (issue #3782). The
+    /// migrated tree inherits the repository's <c>TreatWarningsAsErrors</c>, so
+    /// without this a build stops at the first project holding a redundant
+    /// <c>!!</c> and reports nothing about the projects behind it.
+    /// </summary>
+    public const string SurveyWarningsNotAsErrors = DiagnosticId;
+
+    /// <summary>
+    /// Issue #3723: the round cap <c>RunToFixedPoint</c> stops at.
+    /// <para>
+    /// The loop cannot actually run forever — <see cref="Strip"/> only ever
+    /// DELETES <c>!!</c> tokens and a round that strips none breaks out, so the
+    /// number of rounds is bounded by the number of assertions in the tree. The
+    /// cap is a cost guard, not a termination guard, and hitting it is reported
+    /// rather than silent.
+    /// </para>
+    /// <para>
+    /// Issue #3782: it used to be the binding constraint on any deep graph. One
+    /// round can only strip what the compile it followed reported, and a
+    /// warnings-as-errors compile reports nothing past the first project it
+    /// fails on — so <c>tools/cs2gs/Cs2Gs.Tests</c>, which pulls twelve
+    /// projects into its build, needed roughly one round per project (~40) and
+    /// exhausted the cap with 14752 <c>GS0536</c> still standing. The loop now
+    /// SURVEYS instead: every round after the first demotes <c>GS0536</c> to a
+    /// warning (<see cref="SurveyWarningsNotAsErrors"/>), so a single build
+    /// walks the whole graph and reports every redundant assertion in it at
+    /// once. Convergence is then a function of assertion NESTING
+    /// (<c>a!!.b!!</c>), not of graph depth, and the cap stops being reachable.
+    /// </para>
     /// </summary>
     public const int DefaultMaxRounds = 12;
 
@@ -44,9 +66,43 @@ public static class NullAssertionPolishPass
     /// rolled back and the prior result stands — a <c>!!</c> the compiler
     /// still needs therefore survives, because the file it was removed from is
     /// restored wholesale.
+    /// <para>
+    /// Issue #3782: the first round's recompile is strict, exactly as before,
+    /// so an app that converges in one round does exactly one build and nothing
+    /// changes for it. Only when that round leaves reports standing — the
+    /// signature of a build that stopped part-way up a project graph — do
+    /// subsequent rounds switch to survey mode, and a final STRICT build then
+    /// produces the result the caller acts on. A survey build's verdict is
+    /// never returned: it saw GS0536 as a warning, so its success would mean
+    /// nothing.
+    /// </para>
     /// </summary>
     /// <param name="initial">The first compile's result.</param>
-    /// <param name="recompile">Reruns the same compile over the rewritten files.</param>
+    /// <param name="recompile">
+    /// Reruns the same compile over the rewritten files. The argument asks for
+    /// SURVEY mode: <see langword="true"/> demotes <see cref="DiagnosticId"/>
+    /// to a warning (see <see cref="SurveyWarningsNotAsErrors"/>) so the build
+    /// reports the whole project graph instead of stopping at the first
+    /// offender; <see langword="false"/> is the gate's own strict compile.
+    /// </param>
+    /// <param name="emittedGsFiles">The emitted .gs file paths owned by this app.</param>
+    /// <param name="strippableRoot">The optional shared emitted-output root.</param>
+    /// <param name="maxRounds">The round cap (see <see cref="DefaultMaxRounds"/>).</param>
+    /// <returns>The final compile result and what the loop did to reach it.</returns>
+    public static PolishLoopOutcome RunToFixedPoint(
+        SdkCompileResult initial,
+        Func<bool, SdkCompileResult> recompile,
+        IReadOnlyCollection<string> emittedGsFiles,
+        string strippableRoot = null,
+        int maxRounds = DefaultMaxRounds) =>
+        Run(initial, recompile, emittedGsFiles, strippableRoot, maxRounds, surveyAvailable: true);
+
+    /// <summary>
+    /// Convenience overload for callers with no survey-mode compile to offer
+    /// (the unit tests, and any direct-gsc path): every round compiles strictly.
+    /// </summary>
+    /// <param name="initial">The first compile's result.</param>
+    /// <param name="recompile">Reruns the same strict compile.</param>
     /// <param name="emittedGsFiles">The emitted .gs file paths owned by this app.</param>
     /// <param name="strippableRoot">The optional shared emitted-output root.</param>
     /// <param name="maxRounds">The round cap (see <see cref="DefaultMaxRounds"/>).</param>
@@ -58,63 +114,12 @@ public static class NullAssertionPolishPass
         string strippableRoot = null,
         int maxRounds = DefaultMaxRounds)
     {
-        if (initial is null)
-        {
-            throw new ArgumentNullException(nameof(initial));
-        }
-
         if (recompile is null)
         {
             throw new ArgumentNullException(nameof(recompile));
         }
 
-        SdkCompileResult result = initial;
-        var rounds = 0;
-        var stripped = 0;
-        while (result.IsAvailable
-            && result.Diagnostics.Any(d => string.Equals(d.Id, DiagnosticId, StringComparison.Ordinal)))
-        {
-            if (rounds >= maxRounds)
-            {
-                return new PolishLoopOutcome(result, rounds, stripped, capExhausted: true);
-            }
-
-            rounds++;
-            Dictionary<string, string> backups = CandidateFiles(result.Diagnostics, emittedGsFiles, strippableRoot)
-                .Concat(emittedGsFiles ?? Array.Empty<string>())
-                .Where(File.Exists)
-                .Distinct(StringComparer.Ordinal)
-                .ToDictionary(f => f, File.ReadAllText, StringComparer.Ordinal);
-
-            int roundStripped = Strip(result.Diagnostics, emittedGsFiles, strippableRoot);
-            if (roundStripped == 0)
-            {
-                // Every reported span was one this pass declines to touch
-                // (a stale coordinate, or a file outside the strippable set):
-                // another round would report the same thing.
-                break;
-            }
-
-            stripped += roundStripped;
-            SdkCompileResult polished = recompile();
-            if (polished.IsAvailable && (polished.Succeeded || !result.Succeeded))
-            {
-                result = polished;
-                continue;
-            }
-
-            // The polished build regressed a previously passing one (or could
-            // not run at all): restore the round's text and keep the result
-            // that stood before it.
-            foreach (KeyValuePair<string, string> backup in backups)
-            {
-                File.WriteAllText(backup.Key, backup.Value);
-            }
-
-            break;
-        }
-
-        return new PolishLoopOutcome(result, rounds, stripped, capExhausted: false);
+        return Run(initial, _ => recompile(), emittedGsFiles, strippableRoot, maxRounds, surveyAvailable: false);
     }
 
     /// <summary>
@@ -218,6 +223,123 @@ public static class NullAssertionPolishPass
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToList();
     }
+
+    private static PolishLoopOutcome Run(
+        SdkCompileResult initial,
+        Func<bool, SdkCompileResult> recompile,
+        IReadOnlyCollection<string> emittedGsFiles,
+        string strippableRoot,
+        int maxRounds,
+        bool surveyAvailable)
+    {
+        if (initial is null)
+        {
+            throw new ArgumentNullException(nameof(initial));
+        }
+
+        if (recompile is null)
+        {
+            throw new ArgumentNullException(nameof(recompile));
+        }
+
+        SdkCompileResult result = initial;
+        var rounds = 0;
+        var stripped = 0;
+        var builds = 0;
+        var surveyBuilds = 0;
+
+        // Set once a round has been kept, so round 2 onwards surveys. Cleared
+        // for good if a strict confirmation proves surveying changed nothing —
+        // an SDK too old to understand WarningsNotAsErrors degrades to the
+        // pre-#3782 strict loop rather than paying for a confirmation per round.
+        var survey = false;
+        bool surveyWorks = surveyAvailable;
+        var capExhausted = false;
+        var abandoned = false;
+
+        while (true)
+        {
+            while (result.IsAvailable && Reports(result.Diagnostics))
+            {
+                if (rounds >= maxRounds)
+                {
+                    capExhausted = true;
+                    break;
+                }
+
+                rounds++;
+                Dictionary<string, string> backups = CandidateFiles(result.Diagnostics, emittedGsFiles, strippableRoot)
+                    .Concat(emittedGsFiles ?? Array.Empty<string>())
+                    .Where(File.Exists)
+                    .Distinct(StringComparer.Ordinal)
+                    .ToDictionary(f => f, File.ReadAllText, StringComparer.Ordinal);
+
+                int roundStripped = Strip(result.Diagnostics, emittedGsFiles, strippableRoot);
+                if (roundStripped == 0)
+                {
+                    // Every reported span was one this pass declines to touch
+                    // (a stale coordinate, or a file outside the strippable set):
+                    // another round would report the same thing.
+                    break;
+                }
+
+                stripped += roundStripped;
+                bool surveyThisRound = survey && surveyWorks;
+                SdkCompileResult polished = recompile(surveyThisRound);
+                builds++;
+                if (surveyThisRound)
+                {
+                    surveyBuilds++;
+                }
+
+                if (polished.IsAvailable && (polished.Succeeded || !result.Succeeded))
+                {
+                    result = polished;
+                    survey = true;
+                    continue;
+                }
+
+                // The polished build regressed a previously passing one (or could
+                // not run at all): restore the round's text and keep the result
+                // that stood before it.
+                foreach (KeyValuePair<string, string> backup in backups)
+                {
+                    File.WriteAllText(backup.Key, backup.Value);
+                }
+
+                abandoned = true;
+                break;
+            }
+
+            if (surveyBuilds == 0 || !result.IsAvailable)
+            {
+                break;
+            }
+
+            // `result` came from a build that saw GS0536 as a warning, so it is
+            // not a verdict. Recompile strictly over the same text; that build
+            // is what the caller gets, and it is also the proof that the polish
+            // converged.
+            result = recompile(false);
+            builds++;
+            surveyBuilds = 0;
+            survey = false;
+            if (abandoned || capExhausted || !result.IsAvailable || !Reports(result.Diagnostics))
+            {
+                break;
+            }
+
+            // Surveying bought nothing (the property never reached gsc): fall
+            // back to the strict round-per-project loop for whatever budget is
+            // left, and never pay for another confirmation.
+            surveyWorks = false;
+        }
+
+        return new PolishLoopOutcome(result, rounds, stripped, capExhausted, builds);
+    }
+
+    private static bool Reports(IReadOnlyList<GscDiagnostic> diagnostics) =>
+        diagnostics.Any(d => string.Equals(d.Id, DiagnosticId, StringComparison.Ordinal));
 
     // Indexes the app-owned emitted files by BOTH the raw full path and the
     // symlink-canonical path, so a diagnostic echoing either spelling matches.
@@ -346,7 +468,7 @@ public static class NullAssertionPolishPass
     }
 
     /// <summary>
-    /// Issue #3723: what a <see cref="RunToFixedPoint"/> call did — enough for
+    /// Issue #3723: what a <c>RunToFixedPoint</c> call did — enough for
     /// the caller to say out loud that the loop gave up, which is how the
     /// old three-round cap stayed invisible for several nightly runs.
     /// </summary>
@@ -359,12 +481,15 @@ public static class NullAssertionPolishPass
         /// <param name="rounds">The number of strip-and-recompile rounds run.</param>
         /// <param name="stripped">The total number of assertions removed.</param>
         /// <param name="capExhausted">Whether the round cap stopped the loop.</param>
-        public PolishLoopOutcome(SdkCompileResult result, int rounds, int stripped, bool capExhausted)
+        /// <param name="builds">The number of recompiles the loop paid for.</param>
+        public PolishLoopOutcome(
+            SdkCompileResult result, int rounds, int stripped, bool capExhausted, int builds = 0)
         {
             this.Result = result;
             this.Rounds = rounds;
             this.Stripped = stripped;
             this.CapExhausted = capExhausted;
+            this.Builds = builds;
         }
 
         /// <summary>Gets the final compile result.</summary>
@@ -379,9 +504,23 @@ public static class NullAssertionPolishPass
         /// <summary>Gets a value indicating whether the round cap stopped the loop.</summary>
         public bool CapExhausted { get; }
 
-        /// <summary>Gets the number of redundant-<c>!!</c> reports still standing.</summary>
+        /// <summary>
+        /// Gets the number of recompiles the loop paid for — the honest cost
+        /// unit, since a round and a build stopped being the same thing when
+        /// #3782 added the strict confirmation compile.
+        /// </summary>
+        public int Builds { get; }
+
+        /// <summary>
+        /// Gets the number of redundant-<c>!!</c> reports still standing,
+        /// counted by distinct source span: MSBuild echoes each diagnostic
+        /// again in its end-of-build summary, so the raw count double-counts.
+        /// </summary>
         public int RemainingReports => this.Result.Diagnostics
-            .Count(d => string.Equals(d.Id, DiagnosticId, StringComparison.Ordinal));
+            .Where(d => string.Equals(d.Id, DiagnosticId, StringComparison.Ordinal))
+            .Select(d => (d.File, d.Line, d.Column))
+            .Distinct()
+            .Count();
     }
 
     private sealed class SpanComparer : IEqualityComparer<GscDiagnostic>

--- a/tools/cs2gs/Cs2Gs.Pipeline/SdkCompileRunner.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/SdkCompileRunner.cs
@@ -79,13 +79,20 @@ public sealed class SdkCompileRunner
     /// <param name="artifactDirectory">The external build and log directory.</param>
     /// <param name="config">The build configuration.</param>
     /// <param name="generatedProjectPaths">The complete source-to-generated project map.</param>
+    /// <param name="warningsNotAsErrors">
+    /// Issue #3782: diagnostic ids to keep at warning severity for this build
+    /// despite the mirror's <c>TreatWarningsAsErrors</c>. The redundant-<c>!!</c>
+    /// polish loop passes <c>GS0536</c> so one build surveys the whole project
+    /// graph; <see langword="null"/> is the gate's own strict compile.
+    /// </param>
     /// <returns>The SDK compile result.</returns>
     public SdkCompileResult CompileMirroredProject(
         string sourceProjectPath,
         string generatedProjectPath,
         string artifactDirectory,
         string config,
-        IReadOnlyDictionary<string, string> generatedProjectPaths)
+        IReadOnlyDictionary<string, string> generatedProjectPaths,
+        string warningsNotAsErrors = null)
     {
         string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
         string sdkMoniker = ResolveSdkMoniker(config);
@@ -125,7 +132,8 @@ public sealed class SdkCompileRunner
                 generatedProjectPath,
                 artifactDirectory,
                 config,
-                projectNugetConfig);
+                projectNugetConfig,
+                warningsNotAsErrors);
             ProcessRunResult result = ProcessRunner.Run(
                 "dotnet",
                 args,
@@ -224,6 +232,11 @@ public sealed class SdkCompileRunner
     /// NuGet's restore fails (NU1008) if both are present.
     /// </param>
     /// <param name="assemblyName">The source project's assembly name.</param>
+    /// <param name="warningsNotAsErrors">
+    /// Issue #3782: diagnostic ids to keep at warning severity for this build
+    /// despite <c>TreatWarningsAsErrors</c> — the redundant-<c>!!</c> polish
+    /// loop's survey mode. <see langword="null"/> is the strict compile.
+    /// </param>
     /// <returns>The compile result, or an unavailable result when no local SDK nupkg can be found.</returns>
     public SdkCompileResult Compile(
         string appRunDir,
@@ -240,7 +253,8 @@ public sealed class SdkCompileRunner
         IReadOnlyList<DeclaredProjectItem> projectReferences = null,
         IReadOnlyDictionary<string, string> generatedProjectPaths = null,
         bool usesCentralPackageManagement = false,
-        string assemblyName = null)
+        string assemblyName = null,
+        string warningsNotAsErrors = null)
     {
         if (string.IsNullOrEmpty(appRunDir))
         {
@@ -368,6 +382,11 @@ public sealed class SdkCompileRunner
 
         var args = new List<string> { "build", projectPath, "-c", config ?? "Release" };
         args.Add("-p:RestorePackagesPath=" + Path.Combine(appRunDir, ".nuget-packages"));
+        if (!string.IsNullOrEmpty(warningsNotAsErrors))
+        {
+            args.Add("-p:WarningsNotAsErrors=" + warningsNotAsErrors);
+        }
+
         string repoNugetConfig = Path.Combine(repoRoot, "nuget.config");
         if (File.Exists(repoNugetConfig))
         {
@@ -1054,13 +1073,24 @@ public sealed class SdkCompileRunner
     /// <param name="artifactDirectory">The external build and log directory.</param>
     /// <param name="config">The build configuration.</param>
     /// <param name="projectNugetConfig">The nuget.config written beside the generated project.</param>
+    /// <param name="warningsNotAsErrors">
+    /// Issue #3782: diagnostic ids to keep at warning severity despite the
+    /// mirror's <c>TreatWarningsAsErrors</c>. The property is global, so it
+    /// applies to every project in the graph — which is the point: the
+    /// redundant-<c>!!</c> polish loop uses it to make ONE build report the
+    /// whole graph's <c>GS0536</c> instead of stopping at the first project
+    /// that would otherwise error out. <see langword="null"/> (the default)
+    /// leaves the mirror's strict settings exactly as they are.
+    /// </param>
     /// <returns>The <c>dotnet</c> arguments.</returns>
     internal static IReadOnlyList<string> BuildMirroredBuildArguments(
         string generatedProjectPath,
         string artifactDirectory,
         string config,
-        string projectNugetConfig) =>
-        new List<string>
+        string projectNugetConfig,
+        string warningsNotAsErrors = null)
+    {
+        var args = new List<string>
         {
             "build",
             generatedProjectPath,
@@ -1071,6 +1101,14 @@ public sealed class SdkCompileRunner
             "-p:Cs2GsArtifactRoot=" + artifactDirectory,
             "-p:GeneratePackageOnBuild=false",
         };
+
+        if (!string.IsNullOrEmpty(warningsNotAsErrors))
+        {
+            args.Add("-p:WarningsNotAsErrors=" + warningsNotAsErrors);
+        }
+
+        return args;
+    }
 
     private static IReadOnlyList<GscDiagnostic> ParseRelayedErrors(string output, Regex pattern)
     {

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3723PolishConvergenceTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3723PolishConvergenceTests.cs
@@ -17,7 +17,7 @@ namespace Cs2Gs.Tests;
 /// first project that fails, and a nested assertion only becomes visibly
 /// redundant once the one outside it is gone — so a fixed round budget leaves
 /// the app red with GS0536 as its only diagnostic. These tests drive
-/// <see cref="NullAssertionPolishPass.RunToFixedPoint"/> with a stand-in
+/// <c>NullAssertionPolishPass.RunToFixedPoint</c>'s strict overload with a stand-in
 /// compiler so the multi-generation and per-project shapes are exercised
 /// without a real <c>dotnet build</c>.
 /// </summary>

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3782PolishSurveyTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3782PolishSurveyTests.cs
@@ -1,0 +1,274 @@
+// <copyright file="Issue3782PolishSurveyTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3782: the redundant-<c>!!</c> polish loop used to advance ONE project
+/// per round, because the migrated tree builds warnings-as-errors and such a
+/// build reports nothing past the first project it fails on.
+/// <c>tools/cs2gs/Cs2Gs.Tests</c> pulls twelve projects into its graph, so it
+/// needed ~40 rounds against a cap of 12 and finished with 14752 GS0536 still
+/// standing — the only app in the corpus that failed to converge, and the reason
+/// the corpus-wide <c>!!</c> count moved with shard packing.
+/// <para>
+/// The fix is SURVEY mode: from the second round on, the recompile demotes
+/// GS0536 back to a warning so one build walks the whole graph and reports every
+/// redundant assertion at once. Convergence then depends on assertion NESTING,
+/// not on graph depth. These tests drive the loop with a stand-in compiler that
+/// models both build shapes.
+/// </para>
+/// </summary>
+public sealed class Issue3782PolishSurveyTests
+{
+    [Fact]
+    public void DeepGraph_WithoutSurvey_ExhaustsTheCap()
+    {
+        // The pre-#3782 behaviour, kept as the control: twenty project levels
+        // against the default cap of twelve leaves the app red with GS0536 as
+        // its only diagnostic. This is exactly the Cs2Gs.Tests shape.
+        using var workspace = new PolishWorkspace();
+        var compiler = new GraphCompiler(WriteGraph(workspace, projects: 20));
+
+        NullAssertionPolishPass.PolishLoopOutcome outcome = NullAssertionPolishPass.RunToFixedPoint(
+            compiler.Compile(survey: false),
+            () => compiler.Compile(survey: false),
+            workspace.Files);
+
+        Assert.True(outcome.CapExhausted);
+        Assert.Equal(NullAssertionPolishPass.DefaultMaxRounds, outcome.Rounds);
+        Assert.True(outcome.RemainingReports > 0);
+        Assert.False(outcome.Result.Succeeded);
+    }
+
+    [Fact]
+    public void DeepGraph_WithSurvey_ConvergesWellInsideTheCap()
+    {
+        using var workspace = new PolishWorkspace();
+        var compiler = new GraphCompiler(WriteGraph(workspace, projects: 20));
+
+        NullAssertionPolishPass.PolishLoopOutcome outcome = NullAssertionPolishPass.RunToFixedPoint(
+            compiler.Compile(survey: false),
+            compiler.Compile,
+            workspace.Files);
+
+        Assert.False(outcome.CapExhausted);
+        Assert.Equal(0, outcome.RemainingReports);
+        Assert.True(outcome.Result.Succeeded);
+        Assert.All(workspace.Files, f => Assert.DoesNotContain("!!", File.ReadAllText(f), StringComparison.Ordinal));
+
+        // Depth stops being a cost. Round 1 strips what the strict compile saw
+        // (project 1) and recompiles strictly, which surfaces project 2; round 2
+        // strips that and SURVEYS, which surfaces the remaining eighteen at
+        // once; round 3 strips them all. Three rounds and a closing strict
+        // confirmation for a twenty-project graph — the strict loop needs
+        // twenty rounds for the same tree and the cap only allows twelve.
+        Assert.Equal(3, outcome.Rounds);
+        Assert.Equal(4, outcome.Builds);
+    }
+
+    [Fact]
+    public void ShallowGraph_DoesNoMoreWorkThanBefore()
+    {
+        // The guard on the fix: an app whose whole graph is reported by its
+        // first compile must not pay for survey mode or for a confirmation
+        // build. One round, one build — byte for byte the old cost.
+        using var workspace = new PolishWorkspace();
+        var compiler = new GraphCompiler(WriteGraph(workspace, projects: 1));
+
+        NullAssertionPolishPass.PolishLoopOutcome outcome = NullAssertionPolishPass.RunToFixedPoint(
+            compiler.Compile(survey: false),
+            compiler.Compile,
+            workspace.Files);
+
+        Assert.False(outcome.CapExhausted);
+        Assert.Equal(0, outcome.RemainingReports);
+        Assert.Equal(1, outcome.Rounds);
+        Assert.Equal(1, outcome.Builds);
+
+        // Two compiles all told: the stage's own first build, which the loop
+        // does not pay for, and the one recompile the single round needed.
+        Assert.Equal(2, compiler.Compiles);
+        Assert.Empty(compiler.SurveyCompiles);
+    }
+
+    [Fact]
+    public void TheResultAlwaysComesFromAStrictBuild()
+    {
+        // A survey build sees GS0536 as a warning, so its success proves
+        // nothing about the gate's warnings-as-errors bar. Whatever the loop
+        // returns must have been produced with the demotion OFF.
+        using var workspace = new PolishWorkspace();
+        var compiler = new GraphCompiler(WriteGraph(workspace, projects: 6));
+
+        NullAssertionPolishPass.PolishLoopOutcome outcome = NullAssertionPolishPass.RunToFixedPoint(
+            compiler.Compile(survey: false),
+            compiler.Compile,
+            workspace.Files);
+
+        Assert.Contains(true, compiler.SurveyRequests);
+        Assert.False(compiler.SurveyRequests[compiler.SurveyRequests.Count - 1]);
+        Assert.Same(compiler.LastStrictResult, outcome.Result);
+        Assert.Equal(0, outcome.RemainingReports);
+    }
+
+    [Fact]
+    public void AnSdkThatIgnoresTheDemotion_FallsBackToTheStrictLoop()
+    {
+        // WarningsNotAsErrors is plumbed through the packed SDK, so a stale
+        // nupkg can silently ignore it. The loop must then behave exactly like
+        // the pre-#3782 one — and in particular must NOT keep paying for a
+        // strict confirmation build after every survey attempt.
+        using var workspace = new PolishWorkspace();
+        var compiler = new GraphCompiler(WriteGraph(workspace, projects: 4))
+        {
+            HonoursSurvey = false,
+        };
+
+        NullAssertionPolishPass.PolishLoopOutcome outcome = NullAssertionPolishPass.RunToFixedPoint(
+            compiler.Compile(survey: false),
+            compiler.Compile,
+            workspace.Files);
+
+        Assert.False(outcome.CapExhausted);
+        Assert.Equal(0, outcome.RemainingReports);
+        Assert.Equal(4, outcome.Rounds);
+
+        // One strip round per project, as before, plus ONE closing strict
+        // confirmation — not one confirmation per attempted survey.
+        Assert.Equal(5, outcome.Builds);
+    }
+
+    [Fact]
+    public void RemainingReportsCountsDistinctSpans()
+    {
+        // MSBuild echoes every diagnostic again in its end-of-build summary, so
+        // the raw diagnostic count double-reports once GS0536 arrives as a
+        // warning. The number the gate publishes has to be spans, not lines.
+        var diagnostic = new GscDiagnostic(
+            NullAssertionPolishPass.DiagnosticId, "Redundant '!!'…", "warning", "/x/A.gs", 3, 7, 3, 9);
+        var outcome = new NullAssertionPolishPass.PolishLoopOutcome(
+            SdkCompileResult.Completed(0, null, new[] { diagnostic, diagnostic }, "app.dll"),
+            rounds: 1,
+            stripped: 0,
+            capExhausted: false,
+            builds: 1);
+
+        Assert.Equal(1, outcome.RemainingReports);
+    }
+
+    // One `!!` per project file, which the strict build reports one project at
+    // a time and the survey build reports all at once.
+    private static IReadOnlyList<string> WriteGraph(PolishWorkspace workspace, int projects) =>
+        Enumerable.Range(1, projects)
+            .Select(i => workspace.WriteFile("Project" + i + ".gs", "let a = b!!"))
+            .ToList();
+
+    /// <summary>
+    /// A stand-in for the mirrored SDK build. A STRICT compile stops at the
+    /// first file still holding a <c>!!</c> and reports only that one (the
+    /// warnings-as-errors shape); a SURVEY compile reports every file's, and
+    /// succeeds, because GS0536 is a warning there.
+    /// </summary>
+    private sealed class GraphCompiler
+    {
+        private readonly IReadOnlyList<string> files;
+
+        public GraphCompiler(IReadOnlyList<string> files) => this.files = files;
+
+        /// <summary>Gets or sets a value indicating whether survey mode has any effect.</summary>
+        public bool HonoursSurvey { get; set; } = true;
+
+        public List<bool> SurveyRequests { get; } = new List<bool>();
+
+        public int Compiles => this.SurveyRequests.Count;
+
+        public IEnumerable<bool> SurveyCompiles => this.SurveyRequests.Where(r => r);
+
+        public SdkCompileResult LastStrictResult { get; private set; }
+
+        public SdkCompileResult Compile(bool survey)
+        {
+            this.SurveyRequests.Add(survey);
+            bool wide = survey && this.HonoursSurvey;
+            var reports = new List<GscDiagnostic>();
+            foreach (string file in this.files)
+            {
+                string[] lines = File.ReadAllLines(file);
+                for (var i = 0; i < lines.Length; i++)
+                {
+                    int index = lines[i].IndexOf("!!", StringComparison.Ordinal);
+                    if (index >= 0)
+                    {
+                        reports.Add(new GscDiagnostic(
+                            NullAssertionPolishPass.DiagnosticId,
+                            "Redundant '!!'…",
+                            wide ? "warning" : "error",
+                            file,
+                            i + 1,
+                            index + 1,
+                            i + 1,
+                            index + 3));
+                    }
+                }
+
+                if (reports.Count > 0 && !wide)
+                {
+                    break;
+                }
+            }
+
+            // A survey build never fails on GS0536; a strict one always does.
+            SdkCompileResult result = reports.Count == 0 || wide
+                ? SdkCompileResult.Completed(0, null, reports, "app.dll")
+                : SdkCompileResult.Completed(1, null, reports, null);
+            if (!survey)
+            {
+                this.LastStrictResult = result;
+            }
+
+            return result;
+        }
+    }
+
+    private sealed class PolishWorkspace : IDisposable
+    {
+        private readonly string directory;
+        private readonly List<string> files = new List<string>();
+
+        public PolishWorkspace()
+        {
+            this.directory = Path.Combine(
+                Path.GetTempPath(),
+                nameof(Issue3782PolishSurveyTests),
+                Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(this.directory);
+        }
+
+        public IReadOnlyList<string> Files => this.files;
+
+        public string WriteFile(string name, params string[] lines)
+        {
+            string path = Path.Combine(this.directory, name);
+            File.WriteAllLines(path, lines);
+            this.files.Add(path);
+            return path;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(this.directory))
+            {
+                Directory.Delete(this.directory, recursive: true);
+            }
+        }
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/SdkCompileRunnerTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/SdkCompileRunnerTests.cs
@@ -643,6 +643,27 @@ public class SdkCompileRunnerTests
         Assert.Contains("-p:GeneratePackageOnBuild=false", args);
         Assert.Contains("-p:Cs2GsArtifactRoot=/artifacts/app", args);
         Assert.Contains("-p:RestoreConfigFile=/out/nuget.config", args);
+
+        // Issue #3782: the strict compile — the one whose verdict the gate acts
+        // on — must not carry the polish loop's demotion.
+        Assert.DoesNotContain(args, a => a.StartsWith("-p:WarningsNotAsErrors=", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void BuildMirroredBuildArguments_DemotesTheRequestedWarnings()
+    {
+        // Issue #3782: survey mode. WarningsNotAsErrors is a GLOBAL property, so
+        // it reaches every project in the graph — which is the whole point: one
+        // build then reports every redundant `!!` instead of erroring out at the
+        // first project that holds one.
+        IReadOnlyList<string> args = SdkCompileRunner.BuildMirroredBuildArguments(
+            "/out/App.gsproj",
+            "/artifacts/app",
+            "Release",
+            "/out/nuget.config",
+            NullAssertionPolishPass.SurveyWarningsNotAsErrors);
+
+        Assert.Contains("-p:WarningsNotAsErrors=GS0536", args);
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #3782.

The redundant-`!!` polish loop advanced **one project per round**. The migrated
tree inherits the repository's `TreatWarningsAsErrors`, so a compile reports
nothing past the first project it fails on — a deep graph therefore spends a
round per level before the app's own sources are ever bound, and the round cap
is a budget on graph depth rather than on the thing that actually needs
bounding.

## The fix: survey, don't raise the cap

`gsc` has always understood `/warnaserror-:<ids>`; the SDK just never plumbed
MSBuild's standard `WarningsNotAsErrors` property to it. This PR adds that
plumbing (`BuildTask` + both targets files, hashed into the CoreCompile inputs
so toggling it cannot be skipped by the up-to-date check), and the polish loop
uses it:

- round 1 recompiles **strictly**, exactly as before — an app that converges in
  one round does exactly one build and nothing about it changes;
- if reports are still standing after that round — the signature of a build that
  stopped part-way up a graph — every later round **surveys**: `GS0536` is
  demoted to a warning for that build only, so one compile walks the whole graph
  and reports every redundant assertion in it at once;
- the loop then ends on a **strict** build, and that build is the verdict the
  stage acts on. A survey build's success is never returned: it saw `GS0536` as
  a warning, so it would prove nothing.

`GS0536` is **not** suppressed and no `NoWarn` is added. The gate's bar is
unchanged; the last compile of every polished app is still a
warnings-as-errors build that must report zero `GS0536`.

Convergence is now a function of assertion **nesting** (`a!!.b!!`), not of graph
depth — which is what makes the count independent of shard packing. The cap
stays at 12 as a runaway guard (and it is a cost guard only: `Strip` never adds
a `!!`, so the loop's termination was never in question).

Why not the two options the issue named:

- **Per-project round budget** solves the same problem by paying for depth
  instead of removing it — ~40 full SDK builds of a twelve-project graph for one
  app. Survey mode removes the depth cost outright and makes every multi-project
  app cheaper, not just the worst one.
- **Shard co-location in dependency order** is a scheduling workaround for a
  loop defect, it perturbs the LPT makespan balance the packer was tuned for
  (#3721), and it leaves the `!!` metric a function of packing — the exact
  property blocking the ratchet. Not needed once the loop is depth-independent;
  worth revisiting only as a pure cost optimisation.

## Measured

One `--translate-only` mirror, snapshotted and restored byte-for-byte before
every run; one packed SDK (`0.4.368-g1ca30278eb`) for both sides, so the only
axis varied is the loop.

| app | before rounds/builds | after rounds/builds | stripped | GS0536 left |
|---|---|---|---|---|
| `tools/cs2gs/Cs2Gs.Cli` (10-project graph) | 7 / 7 | **3 / 4** | 3802 both | 0 both |
| `src/Repl` | 5 / 5 | **3 / 4** | 2890 both | 0 both |
| `src/Sdk/Gsharp.HotReload.Runtime` (1 round) | 1 / 1 | **1 / 1** | 3 both | 0 both |

Identical strip counts and identical compile verdicts on both sides — the fix
changes the cost of reaching the fixed point, not the fixed point. The app that
already converged in one round does **no** extra work.

Round count is invariant to how much of the graph a previous app already
polished: `Cs2Gs.Cli` takes 3 rounds whether it strips 3802 assertions (pristine
tree) or 1249 (dependencies pre-polished). That invariance is the packing
independence. Two packings of the same three apps in one shard, each from a
pristine tree:

| packing | order | polish builds | tree-wide `!!` |
|---|---|---|---|
| A | HotReload, Repl, Cs2Gs.Cli | 9 | **17509** |
| B | Cs2Gs.Cli, Repl, HotReload | 8 | **17509** |

## Premise correction (please read before ratcheting)

The issue's headline numbers no longer reproduce. In gate run `33463929797`
`tools/cs2gs/Cs2Gs.Tests` reported `rounds 12/12 … 14752 … cap exhausted: True`.
In the two most recent runs — `33499698666` (the one the 10976 `!!` figure comes
from) and `33513731258` — the same app reports:

```
polish rounds: 8 (cap 12), assertions stripped: 8785, GS0536 still reported: 0, cap exhausted: False
```

and its compile wall is `FAIL(14)`, not `FAIL(521)`. Every one of the 26 apps
that emitted a `polish.log` in `33499698666` converged. So cap exhaustion is
**intermittent and packing-dependent**, not permanent: with the dependencies
spread across shards the app needed more rounds than the cap allowed; with some
co-resident it fit in 8 of 12. That is the same defect the issue describes, but
it means the `!!` number can silently swing between runs rather than being
persistently wrong — which is exactly why the ratchet was held.

`tools/cs2gs/Cs2Gs.Tests` could not be measured locally: it now fails
**translate** on `main` (98 gaps, first `Roslyn API type
'Microsoft.CodeAnalysis.MetadataReference' has no G# analyzer-API mapping`),
introduced by 16fd62ef7 (#3777), which landed after those gate runs. Unrelated
to this change; the deep-graph measurements use the next-deepest app instead.

Because of that, `nullAssertionCeiling` is **not** tightened here — the honest
post-fix corpus number has to come from a full gate run on this branch. The
mechanism that made it packing-dependent is gone, so it can be ratcheted on the
next nightly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
