### PR TITLE
cs2gs: analyzer mode claims a test project only when it declares a harness (#3789)

### DIFF
--- a/docs/cs2gs-analyzer-translation.md
+++ b/docs/cs2gs-analyzer-translation.md
@@ -199,13 +199,37 @@ bind, so an instance-based overload
 alongside it. Hand-written G# analyzer tests keep using the generic form.
 
 Detection is per project on both halves: `AnalyzerProjectDetector` gained
-`IsAnalyzerTestProject` (a project that instantiates an analyzer declared in a
-referenced, non-Roslyn assembly), and `GSharpProjectTransformer` recognizes the
+`IsAnalyzerTestProject` — a project that **declares an analyzer test harness**
+(`IsAnalyzerTestHarnessEntry`: a static method taking a `DiagnosticAnalyzer` and
+a source `string`) **and** instantiates an analyzer declared in a referenced,
+non-Roslyn assembly — and `GSharpProjectTransformer` recognizes the
 structural counterpart (a `ProjectReference` to an analyzer project that is not
 an `OutputItemType="Analyzer"` consumer reference) to inject the two assemblies
 the migrated tests bind — `GSharp.Core` and the verifier — both copied to the
 test output, because a test assembly is loaded by the test host rather than by
 gsc.
+
+Why the harness, and not instantiation alone (issue #3789): analyzer mode maps
+a project's **whole** `Microsoft.CodeAnalysis` surface, so it may only claim a
+project whose Roslyn use it can map. Constructing an analyzer is not enough
+evidence of that — `tools/cs2gs/Cs2Gs.Tests` runs the real GSA analyzers as a
+library to diff them against their translated counterparts, and its other
+~256 Roslyn uses are cs2gs machinery (`MetadataReference`, `CSharpCompilation`)
+that has, and should have, no analyzer-API mapping; claiming it turned a
+14-error compile wall into 98 translate gaps. The harness is the one member
+analyzer mode rewrites for a test project, so its presence is exactly the
+condition under which analyzer mode has something to offer, and the detector
+and the rewrite share one predicate. Rejected alternatives: keying on a
+reference to Roslyn's analyzer-testing package (the repo's own harness is
+hand-rolled and does not bind it, so the signal is a dead `PackageReference`
+that a cleanup would silently remove — and both projects reference the *G#*
+verifier, so that variant does not discriminate at all); a proportion
+threshold on analyzer-related surface (no defensible cut point, and any
+project above it still gaps on the remainder); and per-file claiming (it does
+not fix the case — `Cs2Gs.Tests`' analyzer instantiation sits in a file that
+is itself full of unmappable cs2gs machinery — while breaking the working
+case, since `AnalyzerTestHelper.cs` instantiates no analyzer and would stop
+being claimed).
 
 The remaining half is the **embedded C# snippets** — raw strings of analyzed
 code inside tests. For functional equivalence they must become G# snippets.

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3686AnalyzerTestHarnessTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3686AnalyzerTestHarnessTests.cs
@@ -65,6 +65,34 @@ public sealed class SampleAnalyzer : DiagnosticAnalyzer
 ";
 
     /// <summary>
+    /// Issue #3789: <c>tools/cs2gs/Cs2Gs.Tests</c>' shape — Roslyn used as a
+    /// LIBRARY, with an analyzer from a referenced assembly constructed
+    /// incidentally to diff its output. The <c>MetadataReference</c> parameter
+    /// is the real project's first analyzer-mode gap.
+    /// </summary>
+    private const string ToolingSource = @"
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Sample.Tooling;
+
+public static class ParityCheck
+{
+    public static int CountDiagnostics(string source, MetadataReference[] references)
+    {
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var compilation = CSharpCompilation.Create(""Corpus"", new[] { tree }, references);
+        var withAnalyzers = compilation.WithAnalyzers(
+            ImmutableArray.Create<DiagnosticAnalyzer>(new Sample.SampleAnalyzer()));
+        return withAnalyzers.GetAnalyzerDiagnosticsAsync().GetAwaiter().GetResult().Length;
+    }
+}
+";
+
+    /// <summary>
     /// The repo's own <c>AnalyzerTestHelper</c> shape, trimmed to the parts
     /// that matter: the Roslyn compilation pipeline, the metadata-reference
     /// plumbing, and the marker stripping.
@@ -145,7 +173,8 @@ internal static class AnalyzerTestHelper
     /// Anti-vacuity guard, and the real hazard of widening the detector:
     /// analyzer mode rewrites EVERY Microsoft.CodeAnalysis use in a project,
     /// so a project that merely consumes Roslyn (cs2gs itself does) must stay
-    /// out of it. Only instantiating an analyzer from another assembly counts.
+    /// out of it. Instantiating an analyzer from another assembly AND
+    /// declaring a harness for it is what counts (#3789).
     /// </summary>
     [Fact]
     public void ProjectThatOnlyUsesRoslyn_IsNotAnAnalyzerTestProject()
@@ -168,6 +197,95 @@ public static class Tool
 
         Assert.False(AnalyzerProjectDetector.IsAnalyzerProject(plain.Compilation));
         Assert.False(AnalyzerProjectDetector.IsAnalyzerTestProject(plain.Compilation));
+    }
+
+    /// <summary>
+    /// The third guard, issue #3789: <c>tools/cs2gs/Cs2Gs.Tests</c>' shape. It
+    /// runs the repo's real GSA analyzers as a LIBRARY — constructing one from
+    /// the project-referenced InternalAnalyzers to diff its diagnostics against
+    /// the translated analyzer's — while the rest of its ~256
+    /// Microsoft.CodeAnalysis uses are cs2gs's own machinery. Instantiation
+    /// alone therefore cannot be the signal; claiming this project turned its
+    /// 14-error compile wall into 98 translate gaps, the first being
+    /// "Microsoft.CodeAnalysis.MetadataReference has no G# analyzer-API
+    /// mapping". No harness, no claim.
+    /// </summary>
+    [Fact]
+    public void ProjectDrivingAnalyzersAsALibrary_IsNotAnAnalyzerTestProject()
+    {
+        LoadedCSharpProject tooling = LoadToolingProject();
+
+        Assert.False(AnalyzerProjectDetector.IsAnalyzerProject(tooling.Compilation));
+        Assert.False(AnalyzerProjectDetector.IsAnalyzerTestProject(tooling.Compilation));
+    }
+
+    /// <summary>
+    /// The mechanism behind #3789, executed rather than asserted: analyzer mode
+    /// over that project's Roslyn surface really does gap — it maps every
+    /// Microsoft.CodeAnalysis use, and <c>MetadataReference</c> has no
+    /// analyzer-API counterpart and should not have one. Translating it in the
+    /// mode the DETECTOR picks produces no such gap. The forced-mode half is
+    /// the anti-vacuity guard: it fails if the gap ever stops being produced,
+    /// so the clean half cannot pass for the wrong reason.
+    /// </summary>
+    [Fact]
+    public void AnalyzerModeOverALibraryConsumerGaps_TheDetectorsModeDoesNot()
+    {
+        LoadedCSharpProject tooling = LoadToolingProject();
+
+        IReadOnlyList<TranslationDiagnostic> forced = TranslateFile(tooling, "Tooling.cs", analyzerApiMode: true);
+        Assert.Contains(
+            forced,
+            d => d.Severity == TranslationSeverity.Unsupported
+                && d.Message.Contains("MetadataReference", StringComparison.Ordinal)
+                && d.Message.Contains("no G# analyzer-API mapping", StringComparison.Ordinal));
+
+        IReadOnlyList<TranslationDiagnostic> chosen = TranslateFile(
+            tooling,
+            "Tooling.cs",
+            AnalyzerProjectDetector.IsAnalyzerTestProject(tooling.Compilation));
+        Assert.DoesNotContain(
+            chosen,
+            d => d.Message.Contains("no G# analyzer-API mapping", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// The discriminator itself: the SAME library-consumer file, with an
+    /// analyzer test harness added beside it, IS claimed. So the rule keys on
+    /// the harness — the one member analyzer mode rewrites for a test project —
+    /// and not on the absence of unrelated Roslyn code, which would be a
+    /// proportion heuristic with no defensible cut point.
+    /// </summary>
+    [Fact]
+    public void AddingAHarnessToTheSameProject_FlipsTheMode()
+    {
+        LoadedCSharpProject withHarness = Load(
+            new[]
+            {
+                ("Tooling.cs", ToolingSource),
+                ("Harness.cs", HarnessSource),
+                ("Tests.cs", TestsUsing("new Sample.SampleAnalyzer()")),
+            },
+            CSharpProjectLoader.RuntimeReferences().Append(CompileAnalyzerToReference()).ToList());
+
+        Assert.True(AnalyzerProjectDetector.IsAnalyzerTestProject(withHarness.Compilation));
+    }
+
+    private static LoadedCSharpProject LoadToolingProject()
+        => Load(
+            new[] { ("Tooling.cs", ToolingSource) },
+            CSharpProjectLoader.RuntimeReferences().Append(CompileAnalyzerToReference()).ToList());
+
+    private static IReadOnlyList<TranslationDiagnostic> TranslateFile(
+        LoadedCSharpProject project,
+        string fileName,
+        bool analyzerApiMode)
+    {
+        var translator = new CSharpToGSharpTranslator(analyzerApiMode: analyzerApiMode);
+        LoadedDocument document = project.Documents.Single(d => Path.GetFileName(d.FilePath) == fileName);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        translator.TranslateDocument(document, context);
+        return context.Diagnostics;
     }
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Translator/Analyzers/AnalyzerProjectDetector.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/Analyzers/AnalyzerProjectDetector.cs
@@ -47,23 +47,41 @@ public static class AnalyzerProjectDetector
 
     /// <summary>
     /// Determines whether <paramref name="compilation"/> is the TEST project
-    /// of an analyzer project (ADR-0169 M5, issue #3686): it declares no
-    /// analyzer of its own, but instantiates one that lives in a referenced
-    /// first-party assembly. Without this, the two halves of one project pair
-    /// are translated against different analyzer APIs — the analyzer becomes a
-    /// <c>GSharpDiagnosticAnalyzer</c> while its tests keep Roslyn's
-    /// <c>DiagnosticAnalyzer</c> contract, and the migrated call sites fail
-    /// with GS0154.
+    /// of an analyzer project (ADR-0169 M5, issue #3686): it declares an
+    /// analyzer TEST HARNESS and instantiates an analyzer that lives in a
+    /// referenced first-party assembly. Without this, the two halves of one
+    /// project pair are translated against different analyzer APIs — the
+    /// analyzer becomes a <c>GSharpDiagnosticAnalyzer</c> while its tests keep
+    /// Roslyn's <c>DiagnosticAnalyzer</c> contract, and the migrated call sites
+    /// fail with GS0154.
     /// </summary>
     /// <remarks>
-    /// The probe is deliberately narrow: an <c>new SomeAnalyzer()</c> in
-    /// source, where the created type derives from
-    /// <c>DiagnosticAnalyzer</c> and comes from an assembly OTHER than this
-    /// compilation's own and other than Roslyn itself. Instantiation is the
-    /// load-bearing shape — a test that verifies an analyzer must construct
-    /// one — and merely *referencing* Roslyn (as most tooling projects here
-    /// do) must not flip a project into analyzer mode, because that mode
-    /// rewrites every Microsoft.CodeAnalysis use in the project.
+    /// <para>
+    /// Two signals must agree, because analyzer mode rewrites EVERY
+    /// Microsoft.CodeAnalysis use in the project and therefore may only claim
+    /// projects whose whole Roslyn surface it can map:
+    /// </para>
+    /// <list type="number">
+    /// <item>the project declares an analyzer test harness — see
+    /// <see cref="IsAnalyzerTestHarnessEntry"/>; and</item>
+    /// <item>it instantiates, in source, a type deriving from
+    /// <c>DiagnosticAnalyzer</c> that comes from an assembly OTHER than this
+    /// compilation's own and other than Roslyn itself.</item>
+    /// </list>
+    /// <para>
+    /// Issue #3789: instantiation ALONE is not the load-bearing shape. A
+    /// project can construct an analyzer incidentally while being about
+    /// something else — <c>tools/cs2gs/Cs2Gs.Tests</c> runs the repo's real
+    /// GSA analyzers as a library to diff them against their translated
+    /// counterparts, and its ~256 other Microsoft.CodeAnalysis uses are cs2gs
+    /// machinery (<c>MetadataReference</c>, <c>CSharpCompilation</c>, …) that
+    /// has, and should have, no analyzer-API mapping. Claiming it turned 14
+    /// compile errors into 98 translate gaps. The harness is what makes a
+    /// project an analyzer test project rather than an analyzer consumer, and
+    /// it is also the ONLY thing analyzer mode does for a test project beyond
+    /// what it does for an analyzer — so the detector and the rewrite share
+    /// one predicate and cannot drift apart.
+    /// </para>
     /// </remarks>
     /// <param name="compilation">The bound C# compilation.</param>
     /// <returns>True when analyzer translation mode should be enabled.</returns>
@@ -75,6 +93,11 @@ public static class AnalyzerProjectDetector
         }
 
         if (IsAnalyzerProject(compilation))
+        {
+            return false;
+        }
+
+        if (!DeclaresAnalyzerTestHarness(compilation))
         {
             return false;
         }
@@ -104,6 +127,74 @@ public static class AnalyzerProjectDetector
                     continue;
                 }
 
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Recognizes the entry point of a Roslyn analyzer TEST harness: a static
+    /// method that takes an analyzer and a source string, i.e. the repo's
+    /// <c>AnalyzerTestHelper.AssertDiagnosticsAsync(DiagnosticAnalyzer, string, …)</c>
+    /// shape. This is the one member analyzer mode rewrites specially for a
+    /// test project (onto <c>GSharpAnalyzerVerifier.VerifyAnalyzer</c>), so it
+    /// is exactly the surface whose presence justifies claiming the project:
+    /// no harness, nothing for analyzer mode to do that ordinary mode does not
+    /// do better. Lives here, next to the detector, so the two uses — deciding
+    /// the mode and performing the rewrite — cannot diverge (#3789).
+    /// </summary>
+    /// <param name="symbol">The candidate method.</param>
+    /// <returns>True when the method is an analyzer test harness entry point.</returns>
+    public static bool IsAnalyzerTestHarnessEntry(IMethodSymbol symbol)
+        => symbol is { IsStatic: true }
+           && symbol.Parameters.Length >= 2
+           && DerivesFromDiagnosticAnalyzer(symbol.Parameters[0].Type)
+           && symbol.Parameters[1].Type.SpecialType == SpecialType.System_String;
+
+    /// <summary>
+    /// True when the compilation's own source declares an analyzer test
+    /// harness entry point. Only declarations count: calling somebody else's
+    /// verifier is not a harness this translator can rewrite.
+    /// </summary>
+    /// <param name="compilation">The bound C# compilation.</param>
+    /// <returns>True when a harness entry point is declared in source.</returns>
+    private static bool DeclaresAnalyzerTestHarness(CSharpCompilation compilation)
+    {
+        foreach (SyntaxTree tree in compilation.SyntaxTrees)
+        {
+            SemanticModel model = compilation.GetSemanticModel(tree);
+            foreach (Microsoft.CodeAnalysis.CSharp.Syntax.MethodDeclarationSyntax method in
+                tree.GetRoot().DescendantNodes()
+                    .OfType<Microsoft.CodeAnalysis.CSharp.Syntax.MethodDeclarationSyntax>())
+            {
+                if (model.GetDeclaredSymbol(method) is IMethodSymbol symbol
+                    && IsAnalyzerTestHarnessEntry(symbol))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Walks a type's base chain looking for Roslyn's analyzer base class by
+    /// metadata name, so it works for symbols from any compilation (the
+    /// translator calls it with symbols it did not resolve itself).
+    /// </summary>
+    /// <param name="type">The type to test.</param>
+    /// <returns>True when the type derives from <c>DiagnosticAnalyzer</c>.</returns>
+    private static bool DerivesFromDiagnosticAnalyzer(ITypeSymbol type)
+    {
+        for (ITypeSymbol current = type; current is not null; current = current.BaseType)
+        {
+            if (current is INamedTypeSymbol named
+                && named.ContainingNamespace is { IsGlobalNamespace: false } ns
+                && $"{ns.ToDisplayString()}.{named.Name}" == DiagnosticAnalyzerMetadataName)
+            {
                 return true;
             }
         }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Analyzers.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Analyzers.cs
@@ -964,15 +964,18 @@ public sealed partial class CSharpToGSharpTranslator
         /// verifier, keeping the harness's own signature — so every call site
         /// in the migrated tests is untouched — and reports the substitution as
         /// a shape adaptation.
+        /// <para>
+        /// The shape test itself lives on <see cref="AnalyzerProjectDetector"/>
+        /// (issue #3789): the presence of a harness is also what decides
+        /// whether a project enters analyzer mode at all, and the two must be
+        /// one predicate — a project is claimed exactly when there is a harness
+        /// here to rewrite.
+        /// </para>
         /// </remarks>
         /// <param name="symbol">The method being translated.</param>
         /// <returns>True when this method is the harness entry point.</returns>
         private bool IsAnalyzerHarnessEntry(IMethodSymbol symbol)
-            => this.InAnalyzerApiMode
-               && symbol is { IsStatic: true }
-               && symbol.Parameters.Length >= 2
-               && DerivesFromDiagnosticAnalyzer(symbol.Parameters[0].Type)
-               && symbol.Parameters[1].Type.SpecialType == SpecialType.System_String;
+            => this.InAnalyzerApiMode && AnalyzerProjectDetector.IsAnalyzerTestHarnessEntry(symbol);
 
         /// <summary>
         /// True when <paramref name="method"/> is private plumbing that exists
@@ -1075,20 +1078,6 @@ public sealed partial class CSharpToGSharpTranslator
         private static bool ReturnsTask(IMethodSymbol symbol)
             => symbol.ReturnType is INamedTypeSymbol { Name: "Task" } returnType
                && returnType.ContainingNamespace?.ToDisplayString() == "System.Threading.Tasks";
-
-        private static bool DerivesFromDiagnosticAnalyzer(ITypeSymbol type)
-        {
-            for (ITypeSymbol current = type; current is not null; current = current.BaseType)
-            {
-                if (current is INamedTypeSymbol named
-                    && RoslynTypeMetadataName(named) == AnalyzerProjectDetector.DiagnosticAnalyzerMetadataName)
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
 
         private void ReportAnalyzerShapeIfAdapted(
             SyntaxNode site,


### PR DESCRIPTION
Fixes #3789. Regression from #3777 (`16fd62ef7`, ADR-0169 M5 / #3686); part of #3501.

## Mechanism, reproduced

Whole-repository `cs2gs migrate --translate-only` at `origin/main` (42cbee92f) reproduces the report exactly:

```
tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj      FAIL(98)
```

first gap, verbatim from the run's `translate-60d5f8f4a2ce.json`:

```
CS2GS-GAP  Roslyn API type 'Microsoft.CodeAnalysis.MetadataReference' has no
           G# analyzer-API mapping (ADR-0169).
           Adr0169AnalyzerTranslationTests.cs(937,21)
           .Append(MetadataReference.CreateFromFile(fixturePath))
```

Cause confirmed: `Cs2Gs.Tests` project-references `InternalAnalyzers` and constructs `new StructFieldDefsReadAnalyzer()` in `Adr0169AnalyzerParityTests.RunRoslynAnalyzer` — it runs the real GSA analyzers **as a library** to diff their diagnostics against the translated analyzers'. That matches `IsAnalyzerTestProject`'s "instantiates an analyzer from a referenced non-Roslyn assembly", so analyzer mode claims the project and tries to map its whole Roslyn surface, ~256 mentions of which are cs2gs's own machinery.

(The issue's premise held on every point I could check. One detail worth recording because it nearly misleads: `Cs2Gs.Tests` *does* contain `class MiniAnalyzer : DiagnosticAnalyzer` and friends — but only inside `const string` fixtures, so `IsAnalyzerProject` is correctly false and the test-project probe is what claims it.)

## Discriminator: the harness, not the instantiation

`IsAnalyzerTestProject` now requires **both** signals: a declared analyzer test harness (`IsAnalyzerTestHarnessEntry` — a static method taking a `DiagnosticAnalyzer` and a source `string`) **and** the existing referenced-analyzer instantiation.

The harness is the right key because it is the only thing analyzer mode does for a test project that it does not already do for an analyzer: #3777's whole M5 deliverable is rewriting that method's body onto `GSharpAnalyzerVerifier.VerifyAnalyzer`. No harness ⇒ analyzer mode has nothing to offer and only a whole Roslyn surface to mis-map. The predicate moved onto `AnalyzerProjectDetector` and the translator's `IsAnalyzerHarnessEntry` now calls it, so *claiming* and *rewriting* are one rule and cannot drift.

Against the issue's three candidates:

1. **Reference to the analyzer test harness / verifier.** Does not discriminate as stated: `Cs2Gs.Tests` project-references `GSharp.CodeAnalysis.Analyzers.Testing` — the G# verifier — just like the analyzer tests do. The only reference that separates the two is `InternalAnalyzers.Tests`' `Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit` package, which **nothing in that project binds against** (its harness is hand-rolled and drives Roslyn's analyzer driver directly). Hanging #3777's deliverable on a dead `PackageReference` means a routine cleanup silently un-fixes it, and an analyzer test project that rolls its own harness — precisely our case — would never be claimed.
2. **Proportion of analyzer-related surface.** No defensible cut point, and any project above the threshold still gaps on the remainder — the failure mode is unchanged, just rarer.
3. **Per-file claiming.** Does not fix this bug and breaks the working one. `Cs2Gs.Tests`' analyzer instantiation lives in `Adr0169AnalyzerParityTests.cs`, which is itself full of unmappable cs2gs machinery, so that file would still be claimed and still gap; meanwhile `AnalyzerTestHelper.cs` — the file that must be claimed — instantiates no analyzer at all and would stop being claimed.

No exclusion list; nothing is keyed on a project name.

## Measurement — whole-repository translate, before and after

Same `build/run-cs2gs-selfmig-migrate.sh` pass, Release gsc/SDK rebuilt on each side (the SDK moniker is `git describe`-stamped, so each side is a real commit: `42cbee92f` → `be79b89d5`).

| app | before (`origin/main`) | after |
|---|---|---|
| `tools/cs2gs/Cs2Gs.Tests` | **FAIL — 98 gaps** | **PASS** |
| `test/InternalAnalyzers.Tests` | PASS | PASS |
| `src/Analyzers/InternalAnalyzers` | PASS | PASS |
| whole repo | 49/51 | **50/51** |

The one remaining failure, `test/Interpreter.Tests` FAIL(1), is identical before and after and unrelated.

`Cs2Gs.Tests` returns to failing at **compile**, where it was before #3777; that ~14-error wall is pre-existing and out of scope here.

**#3777 is not regressed, by construction as well as by measurement:** the migrated `test/InternalAnalyzers.Tests` and `src/Analyzers/InternalAnalyzers` trees are **byte-identical** before and after — `diff -r` reports a single difference in each, the `Gsharp.NET.Sdk/<version>` moniker, which changes because the commit changed. Identical translated output means compile/ILVerify cannot have moved; the `cs2gs validate` run on the after-tree confirms translate/compile/ilverify PASS for the pair.

## Tests

`Issue3686AnalyzerTestHarnessTests` — 10 tests, all executing, all green.

Three new ones, in the file that already holds #3777's guards:

- `ProjectDrivingAnalyzersAsALibrary_IsNotAnAnalyzerTestProject` — the third guard case the issue asks for: `Cs2Gs.Tests`' shape (Roslyn as a library, `MetadataReference` in the signature, an analyzer from a referenced assembly constructed incidentally, no harness) is not claimed.
- `AnalyzerModeOverALibraryConsumerGaps_TheDetectorsModeDoesNot` — the mechanism, executed rather than asserted. Forcing analyzer mode over that source really does emit the `MetadataReference … has no G# analyzer-API mapping` gap; translating it in the mode the **detector** picks emits none. The forced half is the anti-vacuity guard — if the gap ever stops being produced, this test fails rather than passing for the wrong reason.
- `AddingAHarnessToTheSameProject_FlipsTheMode` — the same library-consumer file plus a harness **is** claimed, so the rule keys on the harness and not on the absence of unrelated Roslyn code.

### Failing-on-`origin/main` proof

One axis: with only the new `DeclaresAnalyzerTestHarness` guard disabled (everything else in this PR left in place), exactly the two tests above fail and the other eight pass:

```
[FAIL] AnalyzerModeOverALibraryConsumerGaps_TheDetectorsModeDoesNot
[FAIL] ProjectDrivingAnalyzersAsALibrary_IsNotAnAnalyzerTestProject
Failed: 2, Passed: 8
```

Honest labelling: `AnalyzerConsumerProject_IsNotTreatedAsATestProject`, `ProjectThatOnlyUsesRoslyn_IsNotAnAnalyzerTestProject`, `AnalyzerProject_IsNotItsOwnTestProject`, `TestProject_InstantiatingAReferencedAnalyzer_IsDetected` and the new `AddingAHarnessToTheSameProject_FlipsTheMode` pass with and without the fix — they are regression guards bounding the detector in the other direction, not proof of this change. The app-level before/after above is the proof.

## Known adjacent issue, deliberately not fixed here

`GSharpProjectTransformer` has its own, purely structural test for an analyzer test project (a plain `ProjectReference` to an analyzer project), so it still treats `Cs2Gs.Tests` as one and injects `GSharp.Core` + the verifier into its migrated `.gsproj`. That is inert for this app — it has no `Microsoft.CodeAnalysis` `PackageReference`s to strip, and it fails compile for unrelated pre-existing reasons — and the transformer has no compilation to consult, so unifying it with the semantic rule means threading the translate-stage verdict through the pipeline. Worth doing, but it is a different change from this regression fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
