### PR TITLE
gsc: a nil event handler is a no-op, not GS0155 (#3775)

### DIFF
--- a/docs/adr/0036-event-subscription.md
+++ b/docs/adr/0036-event-subscription.md
@@ -23,6 +23,12 @@ Key shape decisions:
 
 4. **Add vs. remove dispatch.** A single bound node carries an `IsAdd` bool. The evaluator dispatches to `EventInfo.AddEventHandler` / `RemoveEventHandler`; the emitter resolves the corresponding `add_X` / `remove_X` accessor via `EventInfo.GetAddMethod()` / `GetRemoveMethod()` and emits `callvirt` for reference receivers (or `call` for static/value-type receivers).
 
+5. **A nil handler is a no-op, not a conversion error** (issue #3775). `add_E` / `remove_E` forward to `Delegate.Combine` / `Delegate.Remove`, both of which are defined on a `null` operand and return the other operand unchanged, so C#'s `e += h` with `h == null` is a *silent no-op*. G# therefore accepts a nilable handler at a subscription site: the conversion target for the handler expression is widened from the event's declared delegate type `T` to `T?` when — and only when — the handler expression is itself nilable (or the literal `nil`) and `T`'s CLR representation is a managed reference. A method group, a lambda, a non-nilable handler, and a value-typed target are all unaffected, and nothing about the event's own declared type changes.
+
+   This mirrors the rule ADR-0030 records for a nil `using` resource (issue #3784 / PR #3787): both are positions where C# defines nil-tolerant behaviour and G# must not assume non-nil. The event case surfaced one step earlier — at bind time, as `GS0155 Cannot convert type 'System.EventHandler?' to 'System.EventHandler'` — which left `e += h!!` as the only spelling and so converted a defined no-op into a run-time throw.
+
+   The relaxation is deliberately *not* a general "nilable is assignable to non-nilable" hole: it is scoped to the subscription argument, where the CLR contract itself is nil-tolerant.
+
 ## Alternatives considered
 
 - **Extend `FieldAssignmentExpressionSyntax` with an operator token.** Rejected: the existing node models a single `Receiver: SyntaxToken`, so multi-segment LHS would still require a parallel shape. A dedicated node keeps both paths clean.

--- a/docs/adr/0052-event-declarations.md
+++ b/docs/adr/0052-event-declarations.md
@@ -93,6 +93,8 @@ func (b *MyButton) OnClick() {
 
 The backing field is accessible by name inside the declaring type (like C#). Outside the type, only `+=` / `-=` are permitted — direct invocation or assignment is an error. This access restriction is enforced by the binder.
 
+A user-declared event's `+=` / `-=` accepts a **nilable** handler, and a nil handler is a silent no-op — the synthesized `add_E` / `remove_E` accessors forward to `Delegate.Combine` / `Delegate.Remove`, which are defined on a null operand. The rule and its scope are recorded once, in ADR-0036 §5 (issue #3775); it applies identically to user-declared and imported CLR events.
+
 ### 4. Annotations and use-site targets
 
 Per ADR-0047, the `@event:` use-site target directs an annotation to the event metadata:

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
@@ -629,10 +629,55 @@ internal sealed partial class ExpressionBinder
         // the method-group branches above already apply.
         if (bound.Type != targetDelegateType && bound is not BoundErrorExpression)
         {
-            return conversions.BindConversion(handlerSyntax.Location, bound, targetDelegateType);
+            return conversions.BindConversion(
+                handlerSyntax.Location,
+                bound,
+                NilTolerantHandlerTarget(bound, targetDelegateType));
         }
 
         return bound;
+    }
+
+    /// <summary>
+    /// Issue #3775: <c>e += h</c> / <c>e -= h</c> where <c>h</c> is nil is a
+    /// silent no-op in C# — <c>add_E</c> forwards to
+    /// <see cref="Delegate.Combine(Delegate?, Delegate?)"/>, which returns the
+    /// other operand unchanged — so an <c>EventHandler?</c> handler is a legal
+    /// subscription argument, not a conversion error. Binding the handler
+    /// against the event's bare (non-nilable) delegate type rejected exactly
+    /// that shape with <c>GS0155</c>, which is the same defect class as the
+    /// unguarded <c>using</c> cleanup fixed in #3787: a position where the
+    /// lowering assumes non-nil while C# defines nil-tolerant behaviour. Here
+    /// the divergence surfaces at bind time rather than at run time, because
+    /// the only way to spell the subscription was a <c>!!</c> that throws.
+    /// <para>
+    /// The relaxation is scoped to the subscription argument alone: it widens
+    /// the conversion target to <c>T?</c> only when the handler expression is
+    /// already nilable (or the literal <c>nil</c>) and the delegate type's CLR
+    /// representation is a managed reference. A method group, a lambda, and a
+    /// non-nilable handler are all unaffected, and nothing about the event's
+    /// own declared type changes — the backing delegate stays exactly as
+    /// nilable as it always was.
+    /// </para>
+    /// </summary>
+    /// <param name="handler">The bound handler expression.</param>
+    /// <param name="targetDelegateType">The event's declared delegate type.</param>
+    /// <returns>The conversion target for the handler.</returns>
+    private static TypeSymbol NilTolerantHandlerTarget(BoundExpression handler, TypeSymbol targetDelegateType)
+    {
+        if (targetDelegateType is NullableTypeSymbol
+            || NullableTypeSymbol.GetEffectiveClrType(targetDelegateType) is { IsValueType: true })
+        {
+            // Already nilable, or not a managed reference at all: leave the
+            // target exactly as the caller computed it.
+            return targetDelegateType;
+        }
+
+        var isNilableHandler = handler.Type is NullableTypeSymbol
+            || handler.Type == TypeSymbol.Null
+            || handler is BoundLiteralExpression { Value: null };
+
+        return isNilableHandler ? NullableTypeSymbol.Get(targetDelegateType) : targetDelegateType;
     }
 
     /// <summary>

--- a/test/Compiler.Tests/Issue3775NilEventHandlerTests.cs
+++ b/test/Compiler.Tests/Issue3775NilEventHandlerTests.cs
@@ -154,6 +154,49 @@ Run()
             new[] { "tick", "tick", "done" },
         };
 
+        // The other two spellings of the subscription LHS: a bare event name
+        // inside the declaring type, and an event reached through a
+        // member-access chain, each with a nilable field as the handler.
+        yield return new object[]
+        {
+            "bare-name-and-member-access-handlers",
+            @"
+package P
+import System
+
+class Clock {
+    event Ticked EventHandler
+    var Stored EventHandler? = nil
+
+    func SubscribeSelf() {
+        Ticked += Stored
+    }
+
+    func Fire() {
+        Ticked?.Invoke(this, EventArgs.Empty)
+    }
+}
+
+class Holder {
+    var Handler EventHandler? = nil
+}
+
+func Run() {
+    let c = Clock()
+    let h = Holder()
+    c.Ticked += h.Handler
+    Console.WriteLine(""member-access-nil"")
+    c.SubscribeSelf()
+    Console.WriteLine(""bare-name-nil"")
+    c.Fire()
+    Console.WriteLine(""fired"")
+}
+
+Run()
+",
+            new[] { "member-access-nil", "bare-name-nil", "fired" },
+        };
+
         // ANTI-VACUITY (passes on main too): a plain non-nilable handler and a
         // lambda handler must keep binding and firing exactly as before. If
         // the relaxation had widened the handler position generally, these

--- a/test/Compiler.Tests/Issue3775NilEventHandlerTests.cs
+++ b/test/Compiler.Tests/Issue3775NilEventHandlerTests.cs
@@ -1,0 +1,299 @@
+// <copyright file="Issue3775NilEventHandlerTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests;
+
+/// <summary>
+/// Issue #3775: <c>e += h</c> / <c>e -= h</c> with a nil handler is a silent
+/// no-op in C# — the accessor forwards to
+/// <see cref="Delegate.Combine(Delegate?, Delegate?)"/> /
+/// <see cref="Delegate.Remove(Delegate?, Delegate?)"/>, both of which are
+/// defined on a null operand — so a nilable handler is a legal subscription
+/// argument. G# rejected exactly that shape with <c>GS0155 Cannot convert type
+/// 'System.EventHandler?' to 'System.EventHandler'</c>, leaving <c>h!!</c> as
+/// the only spelling, which throws at run time on the very path C# defines as
+/// doing nothing.
+/// <para>
+/// This is the same defect class as #3784 / PR #3787 (the unguarded
+/// <c>using</c> cleanup): a position where G#'s handling assumes non-nil while
+/// C# defines nil-tolerant behaviour. It surfaces one step earlier — at bind
+/// time rather than at run time — but the observable consequence is identical:
+/// the program cannot express what C# expresses.
+/// </para>
+/// <para>
+/// Every case EXECUTES and asserts on the program's own output. A
+/// binding-only assertion cannot tell a subscription that was accepted from
+/// one that was accepted AND wired the surviving handler correctly — the
+/// anti-vacuity cases below are the ones that check the second half.
+/// </para>
+/// </summary>
+public class Issue3775NilEventHandlerTests
+{
+    /// <summary>
+    /// Gets the executable cases: each is (name, source, expected stdout lines).
+    /// </summary>
+    /// <returns>The case data.</returns>
+    public static IEnumerable<object[]> Cases()
+    {
+        // The reduction of the defect: a nilable handler on a user-declared
+        // event, added and removed. Both statements are no-ops; neither is a
+        // conversion error and neither throws.
+        yield return new object[]
+        {
+            "user-event-nilable-handler",
+            @"
+package P
+import System
+
+class Clock {
+    event Ticked EventHandler
+    func Fire() {
+        Ticked?.Invoke(this, EventArgs.Empty)
+    }
+}
+
+func Run() {
+    let c = Clock()
+    let h EventHandler? = nil
+    c.Ticked += h
+    Console.WriteLine(""added"")
+    c.Ticked -= h
+    Console.WriteLine(""removed"")
+    c.Fire()
+    Console.WriteLine(""fired"")
+}
+
+Run()
+",
+            new[] { "added", "removed", "fired" },
+        };
+
+        // The same on a CLR (imported) event, and with the literal `nil`
+        // written directly at the subscription site — the shape cs2gs had to
+        // spell `c.PropertyChanged += h!!` to get past the binder.
+        yield return new object[]
+        {
+            "clr-event-nilable-and-literal-nil",
+            @"
+package P
+import System
+import System.ComponentModel
+
+class Model : INotifyPropertyChanged {
+    event PropertyChanged PropertyChangedEventHandler
+}
+
+func Run() {
+    let m = Model()
+    let h PropertyChangedEventHandler? = nil
+    m.PropertyChanged += h
+    Console.WriteLine(""clr-added"")
+    m.PropertyChanged -= h
+    Console.WriteLine(""clr-removed"")
+    m.PropertyChanged += nil
+    Console.WriteLine(""literal-nil"")
+}
+
+Run()
+",
+            new[] { "clr-added", "clr-removed", "literal-nil" },
+        };
+
+        // ANTI-VACUITY: accepting the nil subscription must not disturb the
+        // real one. A nil `+=` before and after a genuine handler leaves
+        // exactly one subscriber; the nil `-=` removes nothing; the real `-=`
+        // removes it. Three fires, and only the middle two print.
+        yield return new object[]
+        {
+            "nil-subscriptions-do-not-disturb-a-real-one",
+            @"
+package P
+import System
+
+class Clock {
+    event Ticked EventHandler
+    func Fire() {
+        Ticked?.Invoke(this, EventArgs.Empty)
+    }
+}
+
+class Sink {
+    func OnTick(sender object?, e EventArgs) {
+        Console.WriteLine(""tick"")
+    }
+}
+
+func Run() {
+    let c = Clock()
+    let s = Sink()
+    let h EventHandler? = nil
+    c.Ticked += h
+    c.Fire()
+    c.Ticked += s.OnTick
+    c.Ticked += h
+    c.Fire()
+    c.Ticked -= h
+    c.Fire()
+    c.Ticked -= s.OnTick
+    c.Fire()
+    Console.WriteLine(""done"")
+}
+
+Run()
+",
+            new[] { "tick", "tick", "done" },
+        };
+
+        // ANTI-VACUITY (passes on main too): a plain non-nilable handler and a
+        // lambda handler must keep binding and firing exactly as before. If
+        // the relaxation had widened the handler position generally, these
+        // would still pass — but if it had BROKEN the ordinary path, this is
+        // the case that says so.
+        yield return new object[]
+        {
+            "ordinary-handlers-unchanged",
+            @"
+package P
+import System
+
+class Clock {
+    event Ticked EventHandler
+    func Fire() {
+        Ticked?.Invoke(this, EventArgs.Empty)
+    }
+}
+
+class Sink {
+    func OnTick(sender object?, e EventArgs) {
+        Console.WriteLine(""method-group"")
+    }
+}
+
+func Run() {
+    let c = Clock()
+    let s = Sink()
+    c.Ticked += s.OnTick
+    c.Ticked += (sender object?, e EventArgs) -> { Console.WriteLine(""lambda"") }
+    c.Fire()
+    Console.WriteLine(""done"")
+}
+
+Run()
+",
+            new[] { "method-group", "lambda", "done" },
+        };
+    }
+
+    /// <summary>
+    /// Compiles each case to an executable, IL-verifies it, runs it, and
+    /// asserts the program's own output.
+    /// </summary>
+    /// <param name="name">The case name.</param>
+    /// <param name="source">The G# source.</param>
+    /// <param name="expectedLines">The expected stdout lines, in order.</param>
+    [Theory]
+    [MemberData(nameof(Cases))]
+    public void NilEventHandler_CompilesVerifiesAndRuns(string name, string source, string[] expectedLines)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_3775_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "Program.gs");
+            File.WriteAllText(srcPath, source);
+            var outPath = Path.Combine(tempDir, name + ".dll");
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+            };
+            foreach (var reference in TrustedPlatformAssemblies())
+            {
+                args.Add("/reference:" + reference);
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed for '{name}' (a GS0155 here is the #3775 defect: a nil "
+                    + $"handler rejected where C# defines a no-op):\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var (exit, output) = RunDotnet(outPath);
+            Assert.True(
+                exit == 0,
+                $"'{name}' must run to completion. Exit {exit}:\n{output}");
+
+            var lines = output
+                .Split('\n')
+                .Select(line => line.TrimEnd('\r'))
+                .Where(line => line.Length > 0)
+                .ToArray();
+            Assert.Equal(expectedLines, lines);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    private static (int Exit, string Output) RunDotnet(string assemblyPath)
+    {
+        var psi = new ProcessStartInfo("dotnet", $"\"{assemblyPath}\"")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = Path.GetDirectoryName(assemblyPath) ?? ".",
+        };
+
+        using var process = Process.Start(psi)
+            ?? throw new InvalidOperationException("could not start dotnet");
+        var output = new StringBuilder();
+        output.Append(process.StandardOutput.ReadToEnd());
+        output.Append(process.StandardError.ReadToEnd());
+        process.WaitForExit();
+        return (process.ExitCode, output.ToString());
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (string.IsNullOrEmpty(tpa))
+        {
+            return Enumerable.Empty<string>();
+        }
+
+        return tpa.Split(Path.PathSeparator).Where(File.Exists);
+    }
+}


### PR DESCRIPTION
Refs #3775. Follows the pattern set by #3787 (#3784).

## The class, enumerated first

#3775 asked whether `using (null)` and `e += null` are two items or a family. I probed **eighteen** constructs on the source-built compiler at `45342b455`. Every probe **compiles, runs, and asserts on the program's own output** — the standing rule on this effort, because binding-only assertions cannot see this family.

The answer: **the family is small, and G# is mostly right.** One genuine instance (the event case), one non-instance that looks like one, and a long tail where G# either agrees with C# at run time or refuses at compile time — which is a *safer* disagreement, not a silent one.

| construct | C# | G# (probed) | agree? |
|---|---|---|---|
| `e += h` / `e -= h`, `h` nil (user event) | silent no-op | **GS0155 at bind time** | ❌ **fixed here** |
| `e += h` / `e -= h`, `h` nil (imported CLR event) | silent no-op | **GS0155 at bind time** | ❌ **fixed here** |
| `e += nil` (literal) | silent no-op | **GS0155 at bind time** | ❌ **fixed here** |
| `lock (nil)` | throws `ArgumentNullException` | throws `ArgumentNullException` | ✅ |
| `await` a nil `Task` | throws `NullReferenceException` | throws `NullReferenceException` | ✅ |
| `d?.Invoke()`, `d` nil | no-op, yields null | no-op | ✅ |
| `s?.Length`, `s` nil | yields null | yields nil | ✅ |
| `t ?? "fallback"`, `t` nil | `"fallback"` | `"fallback"` | ✅ |
| `t ??= "set"`, `t` nil | assigns | assigns | ✅ |
| `o is string`, `o` nil | `false` | `false` | ✅ |
| `switch` on a nil subject | falls to default | falls to default | ✅ |
| `"a" + s`, `s` nil string | `"a"` | `"a"` | ✅ |
| `s + "x"` / `s + t`, both nil | `"x"` / `""` | `"x"` / `""` | ✅ |
| interpolation `"${s}"` / `"${o}"`, nil | `""` | `""` | ✅ |
| `list.Add(nil)`, `m["k"] = nil` | fine | fine | ✅ |
| `s == nil`, `s == t` both nil | defined | defined | ✅ |
| `defer p.Dispose()`, `p` nilable | n/a | **GS0159 at bind time** — `p?.Dispose()` required | ✅ safe |
| `for x in xs`, `xs` nil sequence | throws NRE | **GS0116 at bind time** | ✅ safe |
| `m["k"]`, `m` nil | throws NRE | **GS0116 at bind time** | ✅ safe |
| `Sum(arr)` into `...int32`, `arr` nil | param is null | **GS0154 at bind time** | ✅ safe |

**`defer` is clean, and for a structural reason worth recording.** #3787 fixed `using` because the resource's cleanup is *synthesized* — there is no user-written receiver for the binder's nil-check to fire on. `defer p.Dispose()` writes the receiver out, so the ordinary null-safety rule catches it (GS0159) and the programmer writes `p?.Dispose()`. The `using` bug existed precisely because the construct hides the call.

## The one genuine instance

`e += h` with a nil handler is a silent no-op in C#: `add_E` forwards to `Delegate.Combine`, `remove_E` to `Delegate.Remove`, and both are defined on a `null` operand and return the other operand unchanged. G# bound the handler expression against the event's **bare, non-nilable** delegate type, so a nilable handler was a conversion error:

```gsharp
let c = Clock()
let h EventHandler? = nil
c.Ticked += h        // error GS0155: Cannot convert type 'System.EventHandler?' to 'System.EventHandler'
c.Ticked += nil      // error GS0155: Cannot convert type 'nil' to 'System.EventHandler'
```

Same for an imported CLR event (`PropertyChangedEventHandler?`).

This is the same defect class as the unguarded `using` cleanup, one layer earlier: **a position where C# defines nil-tolerant behaviour and gsc assumes non-nil.** It surfaces at bind time rather than run time, which sounds milder but is not — the only way past the binder was `c.Ticked += h!!`, and that *throws*. A defined no-op became a run-time fault. That is exactly why #3775 notes deleting the `!!` yields GS0155 and concludes the fix is gsc-side.

## The fix

`BindEventSubscriptionHandler` widens the handler's conversion target from `T` to `T?` — **only** when the handler expression is itself nilable (or the literal `nil`) **and** `T`'s CLR representation is a managed reference. Method groups, lambdas, non-nilable handlers, and any value-typed target are untouched, and nothing about the event's own declared type changes.

This deliberately is not a general "nilable assigns to non-nilable" hole; it is scoped to the one argument position where the CLR contract is itself nil-tolerant. All subscription spellings funnel through this single method, so the bare-name (`Ticked += Stored`), member-access (`c.Ticked += h.Handler`), static, interface and constrained-type-parameter entry points are all covered by the one change.

Recorded in **ADR-0036 §5**, cross-referenced from **ADR-0052 §3**.

## Test evidence

`test/Compiler.Tests/Issue3775NilEventHandlerTests.cs` — five cases, each of which **compiles → ILVerify → runs → asserts stdout**.

Failing-on-`origin/main` proof, via `git checkout origin/main -- src/` with the test file kept:

```
Failed NilEventHandler_CompilesVerifiesAndRuns(name: "user-event-nilable-handler")
   error GS0155: Cannot convert type 'System.EventHandler?' to 'System.EventHandler'.
Failed NilEventHandler_CompilesVerifiesAndRuns(name: "clr-event-nilable-and-literal-nil")
   error GS0155: Cannot convert type 'System.ComponentModel.PropertyChangedEventHandler?' to '…'
   error GS0155: Cannot convert type 'nil' to '…PropertyChangedEventHandler'.
Failed NilEventHandler_CompilesVerifiesAndRuns(name: "nil-subscriptions-do-not-disturb-a-real-one")
Failed!  - Failed: 3, Passed: 1
```

Honest labelling of the guard rails:

- `ordinary-handlers-unchanged` (method group + lambda handler, both fired) **passes on `main` and on this branch** — it is the anti-vacuity case that would catch the relaxation breaking the ordinary path, not a proof of the fix.
- `nil-subscriptions-do-not-disturb-a-real-one` is the case that a binding-only assertion could not have written: it fires the event four times around interleaved nil and real `+=`/`-=`, and asserts the surviving subscriber list by counting the `tick` lines. Accepting the nil subscription is only half the requirement; wiring the real one correctly is the other half.

## Also found, filed not fixed

**#3792 — `d += handler` on a delegate-typed variable does not bind (`GS0129`).** This *looked* like a member of the family (`var d Action? = nil; d += h` → GS0129), but varying one axis kills that reading: dropping the `?` on both sides gives the same GS0129. Delegate combination is simply not modelled outside an event-subscription site. Real gap, common C# shape (it is the natural body of an explicit `add`/`remove` accessor, which ADR-0052 §2 permits but cannot currently express), but **not** a nil-tolerance defect. Filed with the probe evidence.

Two related non-findings, reported so they are not re-probed: `"str" + o` where `o` is `object?` fails GS0129 — but so does `"str" + o` where `o` is a non-nilable `object`, so that is the same general operator gap, not nullability. And `defer`'s cleanliness above is a real result, not an untested assumption.

## Scope

`src/Core` binding only — one method in `ExpressionBinder.Async.cs`, plus two ADRs and one new test file. No cs2gs changes; `tools/cs2gs/selfmig-baseline.json` untouched. No diagnostics added or changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
